### PR TITLE
Add auto model support for launchers and model listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Build-from-source and UI development instructions are in [CONTRIBUTING.md](CONTR
 
 ## Using with agents
 
-mesh-llm exposes an OpenAI-compatible API on `localhost:9337`. Any tool that supports custom OpenAI endpoints works. `/v1/models` lists available models; the `model` field in requests routes to the right node.
+mesh-llm exposes an OpenAI-compatible API on `localhost:9337`. Any tool that supports custom OpenAI endpoints works. `/v1/models` lists available models and includes `auto` whenever the mesh is serving at least one model; the `model` field in requests routes to the right node.
 
 For built-in launcher integrations (`goose`, `claude`):
 

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -1974,6 +1974,11 @@ async fn check_mesh(client: &reqwest::Client, port: u16, model: &Option<String>)
         );
     }
 
+    let routable_models: Vec<String> = models.iter()
+        .filter(|name| name.as_str() != "auto")
+        .cloned()
+        .collect();
+
     let chosen = if let Some(ref m) = model {
         if !models.iter().any(|n| n == m) {
             if let Some(mut c) = child {
@@ -1985,7 +1990,7 @@ async fn check_mesh(client: &reqwest::Client, port: u16, model: &Option<String>)
         m.clone()
     } else {
         // Pick the strongest tool-capable model for agentic work.
-        let available: Vec<(&str, f64)> = models.iter().map(|n| (n.as_str(), 0.0)).collect();
+        let available: Vec<(&str, f64)> = routable_models.iter().map(|n| (n.as_str(), 0.0)).collect();
         let agentic = router::Classification {
             category: router::Category::Code,
             complexity: router::Complexity::Deep,
@@ -1993,10 +1998,9 @@ async fn check_mesh(client: &reqwest::Client, port: u16, model: &Option<String>)
         };
         router::pick_model_classified(&agentic, &available)
             .map(|s| s.to_string())
-            .unwrap_or_else(|| models[0].clone())
+            .unwrap_or_else(|| routable_models.first().cloned().unwrap_or_else(|| models[0].clone()))
     };
     eprintln!("   Models: {}", models.join(", "));
-    eprintln!("   Using: {chosen}");
     Ok((models, chosen, child))
 }
 
@@ -2004,7 +2008,17 @@ async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
-    let (models, chosen, mut _mesh_child) = check_mesh(&client, port, &model).await?;
+    let (models, _chosen, mut _mesh_child) = check_mesh(&client, port, &model).await?;
+    let goose_model = model.unwrap_or_else(|| "auto".to_string());
+    let provider_model_names: Vec<String> = if models.iter().any(|name| name == "auto") {
+        models.clone()
+    } else {
+        let mut names = Vec::with_capacity(models.len() + 1);
+        names.push("auto".to_string());
+        names.extend(models.clone());
+        names
+    };
+    eprintln!("   Using: {goose_model}");
 
     // Write custom provider JSON
     let goose_config_dir = dirs::home_dir()
@@ -2014,7 +2028,7 @@ async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
         .join("custom_providers");
     std::fs::create_dir_all(&goose_config_dir)?;
 
-    let provider_models: Vec<serde_json::Value> = models.iter().map(|name| {
+    let provider_models: Vec<serde_json::Value> = provider_model_names.iter().map(|name| {
         serde_json::json!({"name": name, "context_limit": 65536})
     }).collect();
 
@@ -2043,7 +2057,7 @@ async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
             .arg("-a")
             .arg(goose_app)
             .env("GOOSE_PROVIDER", "mesh")
-            .env("GOOSE_MODEL", &chosen)
+            .env("GOOSE_MODEL", &goose_model)
             .spawn()?;
         // Goose.app is a GUI — can't wait for it. Mesh stays running.
         if _mesh_child.is_some() {
@@ -2054,7 +2068,7 @@ async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
         let status = std::process::Command::new("goose")
             .arg("session")
             .env("GOOSE_PROVIDER", "mesh")
-            .env("GOOSE_MODEL", &chosen)
+            .env("GOOSE_MODEL", &goose_model)
             .status();
         match status {
             Ok(s) if s.success() => {}
@@ -2062,7 +2076,7 @@ async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
             Err(_) => {
                 eprintln!("goose not found. Install: https://github.com/block/goose");
                 eprintln!("Or run manually:");
-                eprintln!("  GOOSE_PROVIDER=mesh GOOSE_MODEL={chosen} goose session");
+                eprintln!("  GOOSE_PROVIDER=mesh GOOSE_MODEL={goose_model} goose session");
             }
         }
         // CLI goose exited — clean up mesh if we started it
@@ -2079,7 +2093,8 @@ async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
-    let (_models, chosen, mut _mesh_child) = check_mesh(&client, port, &model).await?;
+    let (_models, _chosen, mut _mesh_child) = check_mesh(&client, port, &model).await?;
+    let claude_model = model.unwrap_or_else(|| "auto".to_string());
 
     // Configure and launch Claude Code
     // llama-server natively serves the Anthropic /v1/messages API, and
@@ -2094,11 +2109,11 @@ async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
         "env": {
             "ANTHROPIC_BASE_URL": &base_url,
             "ANTHROPIC_API_KEY": "",
-            "ANTHROPIC_MODEL": &chosen,
-            "ANTHROPIC_DEFAULT_OPUS_MODEL": &chosen,
-            "ANTHROPIC_DEFAULT_SONNET_MODEL": &chosen,
-            "ANTHROPIC_DEFAULT_HAIKU_MODEL": &chosen,
-            "CLAUDE_CODE_SUBAGENT_MODEL": &chosen,
+            "ANTHROPIC_MODEL": &claude_model,
+            "ANTHROPIC_DEFAULT_OPUS_MODEL": &claude_model,
+            "ANTHROPIC_DEFAULT_SONNET_MODEL": &claude_model,
+            "ANTHROPIC_DEFAULT_HAIKU_MODEL": &claude_model,
+            "CLAUDE_CODE_SUBAGENT_MODEL": &claude_model,
             "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "128000",
             "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
             "CLAUDE_CODE_ENABLE_TELEMETRY": "0",
@@ -2118,9 +2133,9 @@ async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
     });
     let settings_json = serde_json::to_string(&settings)?;
 
-    eprintln!("🚀 Launching Claude Code with {chosen} → {base_url}\n");
+    eprintln!("🚀 Launching Claude Code with {claude_model} → {base_url}\n");
     let status = std::process::Command::new("claude")
-        .args(["--model", &chosen, "--settings", &settings_json])
+        .args(["--model", &claude_model, "--settings", &settings_json])
         .status();
     match status {
         Ok(s) if s.success() => {}
@@ -2128,7 +2143,7 @@ async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
         Err(_) => {
             eprintln!("claude not found. Install: https://docs.anthropic.com/en/docs/claude-code");
             eprintln!("Or run manually:");
-            eprintln!("  ANTHROPIC_BASE_URL={base_url} ANTHROPIC_API_KEY= claude --model {chosen}");
+            eprintln!("  ANTHROPIC_BASE_URL={base_url} ANTHROPIC_API_KEY= claude --model {claude_model}");
         }
     }
     // Claude exited — clean up mesh if we started it

--- a/mesh-llm/src/proxy.rs
+++ b/mesh-llm/src/proxy.rs
@@ -220,25 +220,47 @@ pub async fn route_to_target(node: mesh::Node, tcp_stream: TcpStream, target: el
 
 // ── Response helpers ──
 
-pub async fn send_models_list(mut stream: TcpStream, models: &[String]) -> std::io::Result<()> {
-    let data: Vec<serde_json::Value> = models
-        .iter()
-        .map(|m| {
-            let has_vision = crate::download::MODEL_CATALOG.iter()
-                .find(|c| c.name == m.as_str()
-                    || c.file.strip_suffix(".gguf").unwrap_or(c.file) == m.as_str())
-                .map(|c| c.mmproj.is_some())
-                .unwrap_or(false);
-            let mut caps = vec!["text"];
-            if has_vision { caps.push("vision"); }
-            serde_json::json!({
-                "id": m,
-                "object": "model",
-                "owned_by": "mesh-llm",
-                "capabilities": caps,
-            })
+fn model_has_vision_capability(model: &str) -> bool {
+    crate::download::MODEL_CATALOG.iter()
+        .find(|c| c.name == model || c.file.strip_suffix(".gguf").unwrap_or(c.file) == model)
+        .map(|c| c.mmproj.is_some())
+        .unwrap_or(false)
+}
+
+fn build_models_list_data(models: &[String]) -> Vec<serde_json::Value> {
+    let mut data = Vec::with_capacity(models.len() + usize::from(!models.is_empty()));
+
+    if !models.is_empty() {
+        let mut auto_caps = vec!["text"];
+        if models.iter().any(|m| model_has_vision_capability(m)) {
+            auto_caps.push("vision");
+        }
+        data.push(serde_json::json!({
+            "id": "auto",
+            "object": "model",
+            "owned_by": "mesh-llm",
+            "capabilities": auto_caps,
+        }));
+    }
+
+    data.extend(models.iter().map(|m| {
+        let mut caps = vec!["text"];
+        if model_has_vision_capability(m) {
+            caps.push("vision");
+        }
+        serde_json::json!({
+            "id": m,
+            "object": "model",
+            "owned_by": "mesh-llm",
+            "capabilities": caps,
         })
-        .collect();
+    }));
+
+    data
+}
+
+pub async fn send_models_list(mut stream: TcpStream, models: &[String]) -> std::io::Result<()> {
+    let data = build_models_list_data(models);
     let body = serde_json::json!({ "object": "list", "data": data }).to_string();
     let resp = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}",
@@ -481,5 +503,26 @@ mod tests {
     fn test_extract_model_from_http_basic() {
         let req = b"POST /v1/chat/completions HTTP/1.1\r\n\r\n{\"model\":\"Qwen3-30B\"}";
         assert_eq!(extract_model_from_http(req), Some("Qwen3-30B".to_string()));
+    }
+
+    #[test]
+    fn test_build_models_list_data_includes_auto_when_models_served() {
+        let models = vec![
+            "Qwen3-8B-Q4_K_M".to_string(),
+            "Qwen3.5-0.8B-Q4_K_M".to_string(),
+        ];
+        let data = build_models_list_data(&models);
+
+        assert_eq!(data.len(), 3);
+        assert_eq!(data[0]["id"], "auto");
+        assert_eq!(data[0]["capabilities"], serde_json::json!(["text", "vision"]));
+        assert_eq!(data[1]["id"], "Qwen3-8B-Q4_K_M");
+        assert_eq!(data[2]["id"], "Qwen3.5-0.8B-Q4_K_M");
+    }
+
+    #[test]
+    fn test_build_models_list_data_omits_auto_when_no_models_served() {
+        let data = build_models_list_data(&[]);
+        assert!(data.is_empty());
     }
 }

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -173,6 +173,7 @@ const CHAT_SAVE_DEBOUNCE_MS = 500;
 const CHAT_MAX_CONVERSATIONS = 80;
 const CHAT_MAX_MESSAGES_PER_CONVERSATION = 240;
 const CHAT_MAX_TEXT_CHARS = 12000;
+const AUTO_MODEL_ID = 'auto';
 
 function sectionFromPathname(pathname: string): TopSection | null {
   if (pathname === '/dashboard' || pathname === '/dashboard/') return 'dashboard';
@@ -423,11 +424,12 @@ export function App() {
   );
   const messages = activeConversation?.messages ?? [];
 
+  const displayMeshModels = useMemo(() => sanitizeMeshModels(status?.mesh_models ?? []), [status?.mesh_models]);
   const warmModels = useMemo(() => {
-    const list = (status?.mesh_models ?? []).filter((m) => m.status === 'warm').map((m) => m.name);
+    const list = displayMeshModels.filter((m) => m.status === 'warm').map((m) => m.name);
     if (!list.length && status?.model_name) list.push(status.model_name);
-    return list;
-  }, [status]);
+    return [...new Set(list.filter((name) => name && name !== AUTO_MODEL_ID))];
+  }, [displayMeshModels, status?.model_name]);
   const modelStatsByName = useMemo<Record<string, ModelServingStat>>(() => {
     const stats: Record<string, ModelServingStat> = {};
     for (const model of warmModels) stats[model] = { nodes: 0, vramGb: 0 };
@@ -445,25 +447,25 @@ export function App() {
       addServingNode(peer.serving, peer.vram_gb);
     }
 
-    for (const model of status.mesh_models ?? []) {
+    for (const model of displayMeshModels) {
       if (!stats[model.name]) continue;
       if (stats[model.name].nodes === 0) stats[model.name].nodes = Math.max(0, model.node_count || 0);
     }
 
     return stats;
-  }, [status, warmModels]);
+  }, [displayMeshModels, status, warmModels]);
   const selectedChatModel = selectedModel || warmModels[0] || status?.model_name || '';
   const visionModels = useMemo(() => {
     const set = new Set<string>();
-    for (const m of status?.mesh_models ?? []) {
+    for (const m of displayMeshModels) {
       if (m.vision) set.add(m.name);
     }
     return set;
-  }, [status?.mesh_models]);
+  }, [displayMeshModels]);
   const selectedModelVision = useMemo(() => {
     if (selectedModel) return visionModels.has(selectedModel);
-    return (status?.mesh_models ?? []).some((m) => m.status === 'warm' && m.vision);
-  }, [status?.mesh_models, selectedModel, visionModels]);
+    return displayMeshModels.some((m) => m.status === 'warm' && m.vision);
+  }, [displayMeshModels, selectedModel, visionModels]);
   const selectedModelStat = selectedChatModel ? modelStatsByName[selectedChatModel] : undefined;
   const selectedModelNodeCount = selectedModelStat ? selectedModelStat.nodes : null;
   const selectedModelVramGb = selectedModelStat ? selectedModelStat.vramGb : null;
@@ -2142,12 +2144,12 @@ function DashboardPage({
 }) {
   const [modelFilter, setModelFilter] = useState<'all' | 'warm' | 'cold'>('all');
   const [isMeshOverviewFullscreen, setIsMeshOverviewFullscreen] = useState(false);
+  const displayMeshModels = useMemo(() => sanitizeMeshModels(status?.mesh_models ?? []), [status?.mesh_models]);
   const filteredModels = useMemo(() => {
-    const models = status?.mesh_models ?? [];
-    return [...models]
+    return [...displayMeshModels]
       .filter((m) => (modelFilter === 'all' ? true : m.status === modelFilter))
       .sort((a, b) => (b.node_count - a.node_count) || a.name.localeCompare(b.name));
-  }, [status?.mesh_models, modelFilter]);
+  }, [displayMeshModels, modelFilter]);
   const totalMeshVramGb = useMemo(() => meshGpuVram(status), [status]);
   const sortedPeers = useMemo(() => {
     return [...(status?.peers ?? [])].sort((a, b) => (b.vram_gb - a.vram_gb) || a.id.localeCompare(b.id));
@@ -2235,7 +2237,7 @@ function DashboardPage({
         />
         <StatCard
           title="Active Models"
-          value={`${(status?.mesh_models ?? []).filter((m) => m.status === 'warm').length}`}
+          value={`${displayMeshModels.filter((m) => m.status === 'warm').length}`}
           icon={<Sparkles className="h-4 w-4" />}
           tooltip="Models currently loaded and serving across the mesh."
         />
@@ -2355,8 +2357,8 @@ function DashboardPage({
             ) : (
               <DashboardPanelEmpty
                 icon={<Sparkles className="h-4 w-4" />}
-                title={(status?.mesh_models.length ?? 0) > 0 ? `No ${modelFilter} models` : 'No model catalog data'}
-                description={(status?.mesh_models.length ?? 0) > 0 ? 'Try changing the model filter.' : 'Model metadata will appear once the mesh reports available models.'}
+                title={displayMeshModels.length > 0 ? `No ${modelFilter} models` : 'No model catalog data'}
+                description={displayMeshModels.length > 0 ? 'Try changing the model filter.' : 'Model metadata will appear once the mesh reports available models.'}
               />
             )}
           </CardContent>
@@ -3133,6 +3135,16 @@ function DashboardPanelEmpty({
 function meshGpuVram(status: StatusPayload | null) {
   if (!status) return 0;
   return (status.is_client ? 0 : status.my_vram_gb || 0) + (status.peers || []).filter((p) => p.role !== 'Client').reduce((s, p) => s + p.vram_gb, 0);
+}
+
+function sanitizeMeshModels(models: MeshModel[]) {
+  const seen = new Set<string>();
+  return models.filter((model) => {
+    const name = (model.name || '').trim();
+    if (!name || name === AUTO_MODEL_ID || seen.has(name)) return false;
+    seen.add(name);
+    return true;
+  });
 }
 
 function shortName(name: string) {


### PR DESCRIPTION
- Added a synthetic `"auto"` entry to the `/v1/models` API response, but only when at least one real model is being served. It appears first and inherits `"vision"` capability if any served model supports vision.
- Kept `"auto"` as a routing directive, not a real backend model. Demand tracking and internal routing still treat it specially rather than as a served model.
- Updated the README to document that `/v1/models` can include `"auto"` when the mesh has at least one served model.
- Kept the UI’s existing hard-coded `Auto` dropdown behavior unchanged.
- Added a UI-side sanitization guard so if the backend now reports `"auto"`, the UI filters it out and does not show a duplicate `Auto` option.
- Applied that UI sanitization to both the chat model picker and the dashboard model catalog/counts, and also de-duplicated repeated model names.
- Changed `mesh-llm goose` so omitting `--model` now defaults Goose to literal `"auto"` instead of preselecting one concrete model.
- Changed `mesh-llm goose` to always include `"auto"` in the Goose provider model list, even if the connected mesh server does not yet expose `"auto"` in `/v1/models`.
- Changed `mesh-llm claude` so omitting `--model` now defaults Claude to literal `"auto"` as well.
- Hardened the shared launcher selection logic so when it needs a real fallback model internally, it ignores the synthetic `"auto"` entry and only considers actual models.
- Adjusted launcher logging so Goose/Claude report the real launched default (`auto` when omitted) instead of a misleading precomputed concrete model.