### PR TITLE
feat(hardware): modular hardware detection with GPU name, hostname, Tegra/SoC support

### DIFF
--- a/mesh-llm/README.md
+++ b/mesh-llm/README.md
@@ -14,6 +14,7 @@ src/
 ├── launch.rs      rpc-server and llama-server process management
 ├── download.rs    Model catalog and HuggingFace download (reqwest, resume support)
 ├── nostr.rs       Nostr publish/discover: mesh listings, smart auto-join, publish watchdog
+├── hardware.rs    GPU/host hardware detection: Collector trait, DefaultCollector, TegraCollector
 ├── blackboard.rs      Shared ephemeral messages across the mesh (in-memory, gossip, PII filter)
 ├── blackboard_mcp.rs  MCP server (stdio) for blackboard — agents post, search, read feed
 ```

--- a/mesh-llm/docs/DESIGN.md
+++ b/mesh-llm/docs/DESIGN.md
@@ -19,6 +19,7 @@ src/
 ├── launch.rs      rpc-server and llama-server process management
 ├── download.rs    Model catalog and HuggingFace download (reqwest, resume support)
 ├── nostr.rs       Nostr publish/discover: mesh listings, smart auto-join, publish watchdog
+├── hardware.rs    GPU/host hardware detection: Collector trait, DefaultCollector, TegraCollector
 ```
 
 ## Node Roles
@@ -150,6 +151,60 @@ preserved for sticky mesh preference, but the node is invisible until it joins.
 
 All join paths converge: `--auto`, `--join TOKEN`, and idle→console join end up
 in the same connect → assign → serve flow.
+
+## Hardware Detection
+
+`hardware.rs` collects GPU and host info at startup via the `Collector` trait:
+
+```rust
+trait Collector {
+    fn collect(&self) -> Vec<Metric>;
+}
+```
+
+| Implementation | Platform | Source |
+|---|---|---|
+| `DefaultCollector` | macOS (Metal/CPU) | `system_profiler`, `vm_stat` |
+| `DefaultCollector` | Linux NVIDIA | `/proc/driver/nvidia`, `nvidia-smi` |
+| `DefaultCollector` | Linux AMD | `/sys/class/drm`, `rocm-smi` |
+| `TegraCollector` | Jetson / Tegra | sysfs + `tegrastats` |
+
+`survey()` calls all applicable collectors and returns a `HardwareSurvey` with `gpu_name`, `gpu_vram` (per-GPU bytes), `vram_bytes` (total), `hostname`, and `is_soc`.
+
+### Gossip Fields
+
+Four new `PeerAnnouncement` fields (all `#[serde(default)]` for backward compat):
+
+| Field | Type | Description |
+|---|---|---|
+| `gpu_name` | `Option<String>` | Comma-separated GPU model names |
+| `hostname` | `Option<String>` | System hostname |
+| `is_soc` | `Option<bool>` | True for Tegra/Jetson (unified memory) |
+| `gpu_vram` | `Option<String>` | Comma-separated per-GPU VRAM in bytes |
+
+### `--enumerate-host` Flag
+
+Controls whether `gpu_name`, `hostname`, and `gpu_vram` appear in gossip. `is_soc` is always sent. Default: `false` (privacy-preserving; peers see VRAM totals but not GPU model or hostname).
+
+```
+--enumerate-host    # opt in: peers learn your GPU name and hostname
+```
+
+### API Shape
+
+`GET /api/status` — self node:
+```json
+{
+  "my_hostname": "carrack",
+  "my_is_soc": false,
+  "gpus": [{"name": "NVIDIA RTX 5090", "vram_bytes": 34359738368}]
+}
+```
+
+`peers[]` entries (only when peer has `--enumerate-host`):
+```json
+{"hostname": "lemony-28", "is_soc": true, "gpus": [{"name": "Tegra AGX Orin", "vram_bytes": 0}]}
+```
 
 ## Nostr Discovery
 

--- a/mesh-llm/src/api.rs
+++ b/mesh-llm/src/api.rs
@@ -47,6 +47,36 @@ struct ApiInner {
 }
 
 #[derive(Serialize)]
+struct GpuEntry {
+    name: String,
+    vram_bytes: u64,
+}
+
+fn build_gpus(gpu_name: Option<&str>, gpu_vram: Option<&str>) -> Vec<GpuEntry> {
+    let names: Vec<&str> = gpu_name
+        .map(|s| s.split(", ").collect())
+        .unwrap_or_default();
+    if names.is_empty() {
+        return vec![];
+    }
+    let vrams: Vec<u64> = gpu_vram
+        .map(|s| {
+            s.split(',')
+                .filter_map(|v| v.trim().parse::<u64>().ok())
+                .collect()
+        })
+        .unwrap_or_default();
+    names
+        .into_iter()
+        .enumerate()
+        .map(|(i, name)| GpuEntry {
+            name: name.to_string(),
+            vram_bytes: vrams.get(i).copied().unwrap_or(0),
+        })
+        .collect()
+}
+
+#[derive(Serialize)]
 struct StatusPayload {
     version: String,
     latest_version: Option<String>,
@@ -73,6 +103,9 @@ struct StatusPayload {
     mesh_name: Option<String>,
     /// true when this node found the mesh via Nostr discovery (community/public mesh)
     nostr_discovery: bool,
+    my_hostname: Option<String>,
+    my_is_soc: Option<bool>,
+    gpus: Vec<GpuEntry>,
 }
 
 #[derive(Serialize)]
@@ -84,6 +117,9 @@ struct PeerPayload {
     serving: Option<String>,
     serving_models: Vec<String>,
     rtt_ms: Option<u32>,
+    hostname: Option<String>,
+    is_soc: Option<bool>,
+    gpus: Vec<GpuEntry>,
 }
 
 #[derive(Serialize)]
@@ -202,6 +238,9 @@ impl MeshApi {
                 serving: p.serving.clone(),
                 serving_models: p.serving_models.clone(),
                 rtt_ms: p.rtt_ms,
+                hostname: p.hostname.clone(),
+                is_soc: p.is_soc,
+                gpus: build_gpus(p.gpu_name.as_deref(), p.gpu_vram.as_deref()),
             })
             .collect();
 
@@ -321,6 +360,9 @@ impl MeshApi {
             mesh_id,
             mesh_name,
             nostr_discovery,
+            my_hostname: node.hostname.clone(),
+            my_is_soc: node.is_soc,
+            gpus: build_gpus(node.gpu_name.as_deref(), node.gpu_vram.as_deref()),
         }
     }
 
@@ -777,4 +819,68 @@ async fn respond_bytes_cached(
     stream.write_all(header.as_bytes()).await?;
     stream.write_all(body).await?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_gpus_both_none() {
+        let result = build_gpus(None, None);
+        assert!(result.is_empty(), "expected empty vec when no gpu_name");
+    }
+
+    #[test]
+    fn test_build_gpus_single_no_vram() {
+        let result = build_gpus(Some("NVIDIA RTX 5090"), None);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "NVIDIA RTX 5090");
+        assert_eq!(result[0].vram_bytes, 0);
+    }
+
+    #[test]
+    fn test_build_gpus_single_with_vram() {
+        let result = build_gpus(Some("NVIDIA RTX 5090"), Some("34359738368")); // 32 GiB in bytes
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "NVIDIA RTX 5090");
+        assert_eq!(result[0].vram_bytes, 34_359_738_368);
+    }
+
+    #[test]
+    fn test_build_gpus_multi_full_vram() {
+        let result = build_gpus(
+            Some("NVIDIA RTX 5090, NVIDIA RTX 3080"),
+            Some("34359738368,10737418240"),
+        );
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "NVIDIA RTX 5090");
+        assert_eq!(result[0].vram_bytes, 34_359_738_368);
+        assert_eq!(result[1].name, "NVIDIA RTX 3080");
+        assert_eq!(result[1].vram_bytes, 10_737_418_240);
+    }
+
+    #[test]
+    fn test_build_gpus_multi_partial_vram() {
+        let result = build_gpus(
+            Some("NVIDIA RTX 5090, NVIDIA RTX 3080"),
+            Some("34359738368"),
+        );
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].vram_bytes, 34_359_738_368);
+        assert_eq!(result[1].vram_bytes, 0, "missing VRAM entry should default to 0");
+    }
+
+    #[test]
+    fn test_build_gpus_vram_no_gpu_name() {
+        let result = build_gpus(None, Some("34359738368"));
+        assert!(result.is_empty(), "no gpu_name means no entries even if vram present");
+    }
+
+    #[test]
+    fn test_build_gpus_vram_whitespace_trimmed() {
+        let result = build_gpus(Some("NVIDIA RTX 4090"), Some(" 25769803776 "));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vram_bytes, 25_769_803_776);
+    }
 }

--- a/mesh-llm/src/hardware.rs
+++ b/mesh-llm/src/hardware.rs
@@ -1,0 +1,662 @@
+/// Hardware detection via Collector trait pattern.
+/// VRAM formula preserved byte-identical from mesh.rs:detect_vram_bytes().
+
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct HardwareSurvey {
+    pub vram_bytes: u64,
+    pub gpu_name: Option<String>,
+    pub gpu_count: u8,
+    pub hostname: Option<String>,
+    pub is_soc: bool,
+    /// Per-GPU VRAM in bytes, same order as gpu_name list.
+    /// Unified-memory SoCs report a single entry.
+    pub gpu_vram: Vec<u64>,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Metric {
+    GpuName,
+    VramBytes,
+    GpuCount,
+    Hostname,
+    IsSoc,
+}
+
+pub trait Collector {
+    fn collect(&self, metrics: &[Metric]) -> HardwareSurvey;
+}
+
+struct DefaultCollector;
+
+#[cfg(target_os = "linux")]
+struct TegraCollector;
+
+/// Parse `nvidia-smi --query-gpu=name --format=csv,noheader` output → GPU name list.
+#[cfg(any(target_os = "linux", test))]
+pub fn parse_nvidia_gpu_names(output: &str) -> Vec<String> {
+    output
+        .lines()
+        .map(|l| l.trim())
+        .filter(|l| !l.is_empty())
+        .map(|l| l.to_string())
+        .collect()
+}
+
+/// Parse `sysctl -n machdep.cpu.brand_string` output → CPU brand string.
+#[cfg(any(target_os = "macos", test))]
+pub fn parse_macos_cpu_brand(output: &str) -> Option<String> {
+    let s = output.trim();
+    if s.is_empty() { None } else { Some(s.to_string()) }
+}
+
+/// Parse `rocm-smi --showproductname` output → GPU name from "Card series:" line.
+#[cfg(any(target_os = "linux", test))]
+pub fn parse_rocm_gpu_name(output: &str) -> Option<String> {
+    for line in output.lines() {
+        if let Some(pos) = line.find("Card series:") {
+            let val = line[pos + "Card series:".len()..].trim();
+            if !val.is_empty() {
+                return Some(val.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Summarize GPU names: empty→None, 1→name, N identical→"N× name", N mixed→"a, b".
+#[cfg(any(target_os = "linux", test))]
+pub fn summarize_gpu_name(names: &[String]) -> Option<String> {
+    match names.len() {
+        0 => None,
+        1 => Some(names[0].clone()),
+        n => {
+            let first = &names[0];
+            if names.iter().all(|name| name == first) {
+                Some(format!("{}× {}", n, first))
+            } else {
+                Some(names.join(", "))
+            }
+        }
+    }
+}
+
+/// Check if a null-separated `/proc/device-tree/compatible` string contains a Tegra entry.
+#[cfg(any(target_os = "linux", test))]
+pub fn is_tegra(compatible: &str) -> bool {
+    compatible.split('\0').any(|entry| entry.contains("tegra"))
+}
+
+/// Parse `/sys/firmware/devicetree/base/model` (null-terminated) → clean Jetson name.
+/// Strips "NVIDIA " prefix and " Developer Kit" suffix.
+#[cfg(any(target_os = "linux", test))]
+pub fn parse_tegra_model_name(model: &str) -> Option<String> {
+    let s = model.trim_matches('\0').trim();
+    if s.is_empty() { return None; }
+    let s = s.strip_prefix("NVIDIA ").unwrap_or(s);
+    let s = s.strip_suffix(" Developer Kit").unwrap_or(s);
+    Some(s.to_string())
+}
+
+/// Parse a `tegrastats` output line → total RAM bytes.
+/// Handles optional timestamp prefix. No regex crate — plain string search.
+#[cfg(any(target_os = "linux", test))]
+pub fn parse_tegrastats_ram(output: &str) -> Option<u64> {
+    let ram_pos = output.find("RAM ")?;
+    let after_ram = &output[ram_pos + 4..];
+    let slash_pos = after_ram.find('/')?;
+    let after_slash = &after_ram[slash_pos + 1..];
+    let mb_end = after_slash.find('M')?;
+    let mb: u64 = after_slash[..mb_end].trim().parse().ok()?;
+    Some(mb * 1024 * 1024)
+}
+
+/// Parse `hostname` command output → trimmed hostname string.
+pub fn parse_hostname(output: &str) -> Option<String> {
+    let s = output.trim();
+    if s.is_empty() { None } else { Some(s.to_string()) }
+}
+
+fn detect_hostname() -> Option<String> {
+    let out = std::process::Command::new("hostname").output().ok()?;
+    if !out.status.success() { return None; }
+    parse_hostname(&String::from_utf8(out.stdout).ok()?)
+}
+
+#[cfg(target_os = "linux")]
+fn read_system_ram_bytes() -> u64 {
+    (|| -> Option<u64> {
+        let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+        for line in meminfo.lines() {
+            if line.starts_with("MemTotal:") {
+                let kb = line.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+                return Some(kb * 1024);
+            }
+        }
+        None
+    })()
+    .unwrap_or(0)
+}
+
+#[cfg(target_os = "linux")]
+fn try_tegrastats_ram() -> Option<u64> {
+    use std::io::BufRead;
+    let mut child = std::process::Command::new("tegrastats")
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .ok()?;
+    let stdout = child.stdout.take()?;
+    let line = std::io::BufReader::new(stdout).lines().next()?.ok()?;
+    let _ = child.kill();
+    let _ = child.wait();
+    parse_tegrastats_ram(&line)
+}
+
+impl Collector for DefaultCollector {
+    fn collect(&self, metrics: &[Metric]) -> HardwareSurvey {
+        let mut survey = HardwareSurvey::default();
+
+        #[cfg(target_os = "macos")]
+        {
+            if metrics.contains(&Metric::IsSoc) {
+                survey.is_soc = true;
+            }
+            if metrics.contains(&Metric::VramBytes) {
+                let out = std::process::Command::new("sysctl")
+                    .args(["-n", "hw.memsize"])
+                    .output()
+                    .ok();
+                if let Some(out) = out {
+                    if let Ok(s) = String::from_utf8(out.stdout) {
+                        if let Ok(bytes) = s.trim().parse::<u64>() {
+                            // ~75% usable for Metal on unified memory (mesh.rs:263)
+                            survey.vram_bytes = (bytes as f64 * 0.75) as u64;
+                            survey.gpu_vram = vec![bytes];
+                        }
+                    }
+                }
+            }
+            if metrics.contains(&Metric::GpuName) {
+                let out = std::process::Command::new("sysctl")
+                    .args(["-n", "machdep.cpu.brand_string"])
+                    .output()
+                    .ok();
+                if let Some(out) = out {
+                    if let Ok(s) = String::from_utf8(out.stdout) {
+                        survey.gpu_name = parse_macos_cpu_brand(&s);
+                    }
+                }
+            }
+            if metrics.contains(&Metric::GpuCount) {
+                survey.gpu_count = 1;
+            }
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            let system_ram = read_system_ram_bytes();
+
+            if metrics.contains(&Metric::VramBytes) {
+                // Try NVIDIA (mesh.rs:284-316)
+                let nvidia_vram: Option<(u64, Vec<u64>)> = (|| {
+                    let out = std::process::Command::new("nvidia-smi")
+                        .args(["--query-gpu=memory.total", "--format=csv,noheader,nounits"])
+                        .output()
+                        .ok()?;
+                    if !out.status.success() { return None; }
+                    let s = String::from_utf8(out.stdout).ok()?;
+                    let per_gpu: Vec<u64> = s
+                        .lines()
+                        .filter_map(|line| {
+                            let mib = line.trim().parse::<u64>().ok()?;
+                            Some(mib * 1024 * 1024)
+                        })
+                        .collect();
+                    let total: u64 = per_gpu.iter().sum();
+                    if total > 0 { Some((total, per_gpu)) } else { None }
+                })();
+
+                if let Some((vram, per_gpu)) = nvidia_vram {
+                    survey.gpu_vram = per_gpu;
+                    let ram_offload = system_ram.saturating_sub(vram);
+                    survey.vram_bytes = vram + (ram_offload as f64 * 0.75) as u64;
+                } else {
+                    // Try AMD ROCm (mesh.rs:295-316)
+                    let rocm_vram: Option<u64> = (|| {
+                        let out = std::process::Command::new("rocm-smi")
+                            .args(["--showmeminfo", "vram", "--csv"])
+                            .output()
+                            .ok()?;
+                        if !out.status.success() { return None; }
+                        let s = String::from_utf8(out.stdout).ok()?;
+                        for line in s.lines().skip(1) {
+                            if let Some(total) = line.split(',').nth(1) {
+                                if let Ok(bytes) = total.trim().parse::<u64>() {
+                                    return Some(bytes);
+                                }
+                            }
+                        }
+                        None
+                    })();
+
+                    if let Some(vram) = rocm_vram {
+                        survey.gpu_vram = vec![vram];
+                        let ram_offload = system_ram.saturating_sub(vram);
+                        survey.vram_bytes = vram + (ram_offload as f64 * 0.75) as u64;
+                    } else if system_ram > 0 {
+                        // CPU-only (mesh.rs:320-322)
+                        survey.vram_bytes = (system_ram as f64 * 0.75) as u64;
+                    }
+                }
+            }
+
+            if metrics.contains(&Metric::GpuName) || metrics.contains(&Metric::GpuCount) {
+                let nvidia_names: Option<Vec<String>> = (|| {
+                    let out = std::process::Command::new("nvidia-smi")
+                        .args(["--query-gpu=name", "--format=csv,noheader"])
+                        .output()
+                        .ok()?;
+                    if !out.status.success() { return None; }
+                    let s = String::from_utf8(out.stdout).ok()?;
+                    let names = parse_nvidia_gpu_names(&s);
+                    if names.is_empty() { None } else { Some(names) }
+                })();
+
+                if let Some(ref names) = nvidia_names {
+                    if metrics.contains(&Metric::GpuName) {
+                        survey.gpu_name = summarize_gpu_name(names);
+                    }
+                    if metrics.contains(&Metric::GpuCount) {
+                        survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
+                    }
+                } else {
+                    let out = std::process::Command::new("rocm-smi")
+                        .args(["--showproductname"])
+                        .output()
+                        .ok();
+                    if let Some(out) = out {
+                        if out.status.success() {
+                            if let Ok(s) = String::from_utf8(out.stdout) {
+                                if metrics.contains(&Metric::GpuName) {
+                                    survey.gpu_name = parse_rocm_gpu_name(&s);
+                                }
+                                if metrics.contains(&Metric::GpuCount) {
+                                    let count = s
+                                        .lines()
+                                        .filter(|l| l.trim_start().starts_with("GPU["))
+                                        .count();
+                                    survey.gpu_count =
+                                        u8::try_from(count).unwrap_or(u8::MAX);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        survey
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Collector for TegraCollector {
+    fn collect(&self, metrics: &[Metric]) -> HardwareSurvey {
+        let mut survey = HardwareSurvey::default();
+
+        if metrics.contains(&Metric::IsSoc) {
+            survey.is_soc = true;
+        }
+
+        if metrics.contains(&Metric::GpuName) {
+            if let Ok(model) =
+                std::fs::read_to_string("/sys/firmware/devicetree/base/model")
+            {
+                survey.gpu_name = parse_tegra_model_name(&model);
+            }
+        }
+
+        if metrics.contains(&Metric::VramBytes) {
+            let total_ram = (|| -> Option<u64> {
+                let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
+                for line in meminfo.lines() {
+                    if line.starts_with("MemTotal:") {
+                        let kb = line.split_whitespace().nth(1)?.parse::<u64>().ok()?;
+                        return Some(kb * 1024);
+                    }
+                }
+                None
+            })()
+            .or_else(try_tegrastats_ram);
+            if let Some(ram) = total_ram {
+                survey.vram_bytes = (ram as f64 * 0.75) as u64;
+                survey.gpu_vram = vec![ram];
+            }
+        }
+
+        if metrics.contains(&Metric::GpuCount) {
+            survey.gpu_count = 1;
+        }
+
+        survey
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn detect_collector_impl() -> Box<dyn Collector> {
+    Box::new(DefaultCollector)
+}
+
+#[cfg(target_os = "linux")]
+fn detect_collector_impl() -> Box<dyn Collector> {
+    if cfg!(target_arch = "aarch64") {
+        if let Ok(compat) = std::fs::read_to_string("/proc/device-tree/compatible") {
+            if is_tegra(&compat) {
+                return Box::new(TegraCollector);
+            }
+        }
+    }
+    Box::new(DefaultCollector)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn detect_collector_impl() -> Box<dyn Collector> {
+    Box::new(DefaultCollector)
+}
+
+fn detect_collector() -> Box<dyn Collector> {
+    detect_collector_impl()
+}
+
+/// Collect only the requested hardware metrics.
+pub fn query(metrics: &[Metric]) -> HardwareSurvey {
+    let collector = detect_collector();
+    let mut survey = collector.collect(metrics);
+    if metrics.contains(&Metric::Hostname) {
+        survey.hostname = detect_hostname();
+    }
+    survey
+}
+
+pub fn survey() -> HardwareSurvey {
+    query(&[
+        Metric::GpuName,
+        Metric::VramBytes,
+        Metric::GpuCount,
+        Metric::Hostname,
+        Metric::IsSoc,
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_nvidia_gpu_name_single() {
+        let names = parse_nvidia_gpu_names("NVIDIA A100-SXM4-80GB\n");
+        assert_eq!(names, vec!["NVIDIA A100-SXM4-80GB"]);
+    }
+
+    #[test]
+    fn test_parse_nvidia_gpu_name_multi_identical() {
+        let names = parse_nvidia_gpu_names("NVIDIA A100\nNVIDIA A100\n");
+        assert_eq!(names.len(), 2);
+        assert_eq!(names[0], "NVIDIA A100");
+        assert_eq!(names[1], "NVIDIA A100");
+    }
+
+    #[test]
+    fn test_parse_nvidia_gpu_name_multi_mixed() {
+        let names = parse_nvidia_gpu_names("NVIDIA A100\nNVIDIA RTX 4090\n");
+        assert_eq!(names.len(), 2);
+        assert_eq!(names[0], "NVIDIA A100");
+        assert_eq!(names[1], "NVIDIA RTX 4090");
+    }
+
+    #[test]
+    fn test_parse_nvidia_gpu_name_empty() {
+        assert!(parse_nvidia_gpu_names("").is_empty());
+    }
+
+    #[test]
+    fn test_parse_macos_cpu_brand() {
+        assert_eq!(
+            parse_macos_cpu_brand("Apple M4 Max\n"),
+            Some("Apple M4 Max".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_macos_cpu_brand_empty() {
+        assert_eq!(parse_macos_cpu_brand(""), None);
+    }
+
+    #[test]
+    fn test_parse_rocm_gpu_name() {
+        let fixture = "\
+======================= ROCm System Management Interface =======================
+================================= Product Info =================================
+GPU[0]\t\t: Card series:\t\t\tNavi31 [Radeon RX 7900 XTX]
+================================================================================";
+        assert_eq!(
+            parse_rocm_gpu_name(fixture),
+            Some("Navi31 [Radeon RX 7900 XTX]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_summarize_gpu_name_single() {
+        assert_eq!(
+            summarize_gpu_name(&["A100".to_string()]),
+            Some("A100".to_string())
+        );
+    }
+
+    #[test]
+    fn test_summarize_gpu_name_identical() {
+        assert_eq!(
+            summarize_gpu_name(&["A100".to_string(), "A100".to_string()]),
+            Some("2\u{00D7} A100".to_string())
+        );
+    }
+
+    #[test]
+    fn test_summarize_gpu_name_mixed() {
+        assert_eq!(
+            summarize_gpu_name(&["A100".to_string(), "RTX 4090".to_string()]),
+            Some("A100, RTX 4090".to_string())
+        );
+    }
+
+    #[test]
+    fn test_summarize_gpu_name_empty() {
+        assert_eq!(summarize_gpu_name(&[]), None);
+    }
+
+    #[test]
+    fn test_hardware_survey_default() {
+        let s = HardwareSurvey::default();
+        assert_eq!(s.vram_bytes, 0);
+        assert_eq!(s.gpu_name, None);
+        assert_eq!(s.gpu_count, 0);
+        assert_eq!(s.hostname, None);
+    }
+
+    #[test]
+    fn test_query_gpu_name_only() {
+        let result = query(&[Metric::GpuName]);
+        assert_eq!(result.vram_bytes, 0);
+        assert_eq!(result.hostname, None);
+    }
+
+    #[test]
+    fn test_query_vram_only() {
+        let result = query(&[Metric::VramBytes]);
+        assert_eq!(result.gpu_name, None);
+        assert_eq!(result.hostname, None);
+    }
+
+    #[test]
+    fn test_query_multiple_metrics() {
+        let result = query(&[Metric::GpuName, Metric::VramBytes]);
+        assert_eq!(result.hostname, None);
+        assert_eq!(result.gpu_count, 0);
+    }
+
+    #[test]
+    fn test_survey_returns_all_metrics() {
+        let s = survey();
+        let q = query(&[
+            Metric::GpuName,
+            Metric::VramBytes,
+            Metric::GpuCount,
+            Metric::Hostname,
+        ]);
+        assert_eq!(s.vram_bytes, q.vram_bytes);
+        assert_eq!(s.gpu_name, q.gpu_name);
+        assert_eq!(s.gpu_count, q.gpu_count);
+        assert_eq!(s.hostname.is_some(), q.hostname.is_some());
+    }
+
+    #[test]
+    fn test_is_tegra_positive() {
+        assert!(is_tegra("nvidia,p3737-0000+p3701-0005\0nvidia,tegra234\0"));
+    }
+
+    #[test]
+    fn test_is_tegra_negative_arm() {
+        assert!(!is_tegra("raspberrypi,4-model-b\0"));
+    }
+
+    #[test]
+    fn test_parse_tegra_model_name() {
+        assert_eq!(
+            parse_tegra_model_name("NVIDIA Jetson AGX Orin Developer Kit\0"),
+            Some("Jetson AGX Orin".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_tegra_model_name_nano() {
+        assert_eq!(
+            parse_tegra_model_name("NVIDIA Jetson Orin Nano Developer Kit\0"),
+            Some("Jetson Orin Nano".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_tegra_model_name_no_prefix() {
+        assert_eq!(
+            parse_tegra_model_name("Jetson Xavier NX\0"),
+            Some("Jetson Xavier NX".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_tegrastats_ram() {
+        let line =
+            "RAM 14640/62838MB (lfb 11x4MB) CPU [0%@729,off,off,off,0%@729,off,off,off]";
+        assert_eq!(parse_tegrastats_ram(line), Some(62838u64 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_parse_tegrastats_ram_with_timestamp() {
+        let line = "12-27-2022 13:48:01 RAM 14640/62838MB (lfb 11x4MB)";
+        assert_eq!(parse_tegrastats_ram(line), Some(62838u64 * 1024 * 1024));
+    }
+
+    #[test]
+    fn test_parse_tegrastats_ram_empty() {
+        assert_eq!(parse_tegrastats_ram(""), None);
+    }
+
+    #[test]
+    fn test_parse_hostname() {
+        assert_eq!(
+            parse_hostname("lemony-28\n"),
+            Some("lemony-28".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_hostname_empty() {
+        assert_eq!(parse_hostname(""), None);
+    }
+
+    #[test]
+    fn test_parse_hostname_whitespace() {
+        assert_eq!(
+            parse_hostname("  carrack  \n"),
+            Some("carrack".to_string())
+        );
+    }
+
+    #[test]
+    fn test_is_tegra_negative_x86() {
+        assert!(!is_tegra(""));
+    }
+
+    #[test]
+    fn test_query_hostname_only() {
+        let result = query(&[Metric::Hostname]);
+        assert_eq!(result.gpu_name, None);
+        assert_eq!(result.gpu_count, 0);
+        assert_eq!(result.vram_bytes, 0);
+    }
+
+    #[test]
+    fn test_detect_collector_returns_default_on_non_tegra() {
+        let collector = detect_collector();
+        let s = collector.collect(&[Metric::VramBytes]);
+        let _ = s.vram_bytes;
+    }
+
+    #[test]
+    fn test_query_is_soc_only() {
+        let result = query(&[Metric::IsSoc]);
+        assert_eq!(result.vram_bytes, 0);
+        assert_eq!(result.gpu_name, None);
+        assert_eq!(result.gpu_count, 0);
+        assert_eq!(result.hostname, None);
+        let _ = result.is_soc;
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn test_macos_is_soc_true() {
+        let result = DefaultCollector.collect(&[Metric::IsSoc]);
+        assert!(result.is_soc, "macOS DefaultCollector must report is_soc=true");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_tegra_is_soc_true() {
+        let result = TegraCollector.collect(&[Metric::IsSoc]);
+        assert!(result.is_soc, "TegraCollector must report is_soc=true");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_linux_discrete_is_soc_false() {
+        let result = DefaultCollector.collect(&[Metric::IsSoc]);
+        assert!(!result.is_soc, "Linux DefaultCollector must report is_soc=false");
+    }
+
+    #[test]
+    fn test_default_collector_nvidia_fixture() {
+        let names = parse_nvidia_gpu_names("NVIDIA A100\n");
+        assert_eq!(names, vec!["NVIDIA A100"]);
+        assert_eq!(
+            summarize_gpu_name(&["NVIDIA A100".to_string()]),
+            Some("NVIDIA A100".to_string())
+        );
+    }
+
+    #[test]
+    fn test_tegra_collector_sysfs_fixture() {
+        assert_eq!(
+            parse_tegra_model_name("NVIDIA Jetson AGX Orin Developer Kit\0"),
+            Some("Jetson AGX Orin".to_string())
+        );
+    }
+}

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -3,6 +3,7 @@ mod download;
 mod election;
 mod blackboard;
 mod blackboard_mcp;
+mod hardware;
 mod launch;
 mod mesh;
 mod moe;
@@ -101,6 +102,10 @@ struct Cli {
     /// Limit VRAM advertised to the mesh (GB).
     #[arg(long, hide = true)]
     max_vram: Option<f64>,
+
+    /// Enumerate host hardware (GPU name, hostname) at startup.
+    #[arg(long, hide = true)]
+    enumerate_host: bool,
 
     /// Path to rpc-server and llama-server binaries.
     #[arg(long, hide = true)]
@@ -866,7 +871,7 @@ async fn run_auto(mut cli: Cli, resolved_models: Vec<PathBuf>, requested_model_n
     let role = if is_client { NodeRole::Client } else { NodeRole::Worker };
     // Clients report 0 VRAM so they're never assigned a model to serve
     let max_vram = if is_client { Some(0.0) } else { cli.max_vram };
-    let (node, channels) = mesh::Node::start(role, &cli.relay, cli.bind_port, max_vram).await?;
+    let (node, channels) = mesh::Node::start(role, &cli.relay, cli.bind_port, max_vram, cli.enumerate_host).await?;
     node.start_accepting();
     let token = node.invite_token();
 
@@ -1350,7 +1355,7 @@ async fn run_idle(cli: Cli, _bin_dir: PathBuf) -> Result<()> {
     eprintln!();
 
     // Start a dormant node just for the console
-    let (node, _channels) = mesh::Node::start(NodeRole::Worker, &cli.relay, cli.bind_port, cli.max_vram).await?;
+    let (node, _channels) = mesh::Node::start(NodeRole::Worker, &cli.relay, cli.bind_port, cli.max_vram, cli.enumerate_host).await?;
     node.set_available_models(local_models).await;
 
     let cs = api::MeshApi::new(node.clone(), "(idle)".into(), cli.port, 0);

--- a/mesh-llm/src/mesh.rs
+++ b/mesh-llm/src/mesh.rs
@@ -112,6 +112,16 @@ struct PeerAnnouncement {
     /// Stable mesh identity — only populated on the self entry.
     #[serde(default)]
     mesh_id: Option<String>,
+    /// GPU name/model (e.g. "NVIDIA A100", "Apple M4 Max")
+    #[serde(default)]
+    gpu_name: Option<String>,
+    /// Hostname of the node
+    #[serde(default)]
+    hostname: Option<String>,
+    #[serde(default)]
+    is_soc: Option<bool>,
+    #[serde(default)]
+    gpu_vram: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +147,12 @@ pub struct PeerInfo {
     pub last_seen: std::time::Instant,
     /// mesh-llm version (e.g. "0.23.0")
     pub version: Option<String>,
+    /// GPU name/model (e.g. "NVIDIA A100", "Apple M4 Max")
+    pub gpu_name: Option<String>,
+    /// Hostname of the node
+    pub hostname: Option<String>,
+    pub is_soc: Option<bool>,
+    pub gpu_vram: Option<String>,
 }
 
 /// Peers not directly verified within this window are considered stale
@@ -240,7 +256,7 @@ pub fn find_model_path(stem: &str) -> std::path::PathBuf {
 /// "VRAM" is a misnomer — on macOS unified memory and Linux CPU-only, this
 /// is system RAM. On Linux with a GPU, it's actual GPU VRAM.
 pub fn detect_vram_bytes_capped(max_vram_gb: Option<f64>) -> u64 {
-    let mut detected = detect_vram_bytes();
+    let mut detected = crate::hardware::survey().vram_bytes;
     if let Some(cap) = max_vram_gb {
         let cap_bytes = (cap * 1e9) as u64;
         if cap_bytes < detected { detected = cap_bytes; }
@@ -248,138 +264,6 @@ pub fn detect_vram_bytes_capped(max_vram_gb: Option<f64>) -> u64 {
     detected
 }
 
-pub fn detect_vram_bytes() -> u64 {
-    #[cfg(target_os = "macos")]
-    {
-        // sysctl hw.memsize returns total physical RAM
-        let output = std::process::Command::new("sysctl")
-            .args(["-n", "hw.memsize"])
-            .output()
-            .ok();
-        if let Some(out) = output {
-            if let Ok(s) = String::from_utf8(out.stdout) {
-                if let Ok(bytes) = s.trim().parse::<u64>() {
-                    // ~75% usable for Metal on unified memory
-                    return (bytes as f64 * 0.75) as u64;
-                }
-            }
-        }
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        // Read system RAM from /proc/meminfo (always available on Linux)
-        let system_ram = (|| -> Option<u64> {
-            let meminfo = std::fs::read_to_string("/proc/meminfo").ok()?;
-            for line in meminfo.lines() {
-                if line.starts_with("MemTotal:") {
-                    let kb = line.split_whitespace().nth(1)?.parse::<u64>().ok()?;
-                    return Some(kb * 1024);
-                }
-            }
-            None
-        })().unwrap_or(0);
-
-        // Try NVIDIA GPU (nvidia-smi)
-        let gpu_vram = (|| -> Option<u64> {
-            let out = std::process::Command::new("nvidia-smi")
-                .args(["--query-gpu=memory.total", "--format=csv,noheader,nounits"])
-                .output().ok()?;
-            if !out.status.success() { return None; }
-            let s = String::from_utf8(out.stdout).ok()?;
-            let total_mib: u64 = s.lines()
-                .filter_map(|line| line.trim().parse::<u64>().ok())
-                .sum();
-            if total_mib > 0 { Some(total_mib * 1024 * 1024) } else { None }
-        })().or_else(|| {
-            // Try AMD ROCm (rocm-smi)
-            let out = std::process::Command::new("rocm-smi")
-                .args(["--showmeminfo", "vram", "--csv"])
-                .output().ok()?;
-            if !out.status.success() { return None; }
-            let s = String::from_utf8(out.stdout).ok()?;
-            for line in s.lines().skip(1) {
-                if let Some(total) = line.split(',').nth(1) {
-                    if let Ok(bytes) = total.trim().parse::<u64>() {
-                        return Some(bytes);
-                    }
-                }
-            }
-            None
-        });
-
-        if let Some(vram) = gpu_vram {
-            // GPU + RAM offload: full VRAM + 75% of remaining system RAM.
-            // llama.cpp offloads layers that don't fit in VRAM to system RAM
-            // (-ngl 99 loads as many layers as fit on GPU, rest stay in RAM).
-            let ram_offload = system_ram.saturating_sub(vram);
-            return vram + (ram_offload as f64 * 0.75) as u64;
-        }
-
-        // No GPU — CPU-only inference uses system RAM.
-        if system_ram > 0 {
-            return (system_ram as f64 * 0.75) as u64;
-        }
-
-        // Fallback: try NVIDIA Tegra/Jetson (tegrastats — unified memory, no nvidia-smi)
-        if let Some(total_mb) = tegrastats_ram_total_mb() {
-            if total_mb > 0 {
-                // Jetson uses unified memory; return full total so the caller can cap via --max-vram
-                return total_mb * 1024 * 1024;
-            }
-        }
-    }
-
-    0
-}
-
-/// Spawn `tegrastats --interval 1`, read the first output line, then kill the process.
-/// Returns the total unified RAM in MB parsed from the line, or `None` on any failure.
-///
-/// tegrastats output example:
-///   `03-25-2026 18:27:55 RAM 10400/62838MB (lfb 729x4MB) CPU [...] GR3D_FREQ 0% ...`
-#[cfg(target_os = "linux")]
-fn tegrastats_ram_total_mb() -> Option<u64> {
-    use std::io::{BufRead, BufReader};
-    use std::process::{Command, Stdio};
-
-    let mut child = Command::new("tegrastats")
-        .args(["--interval", "1"])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-        .ok()?;
-
-    let stdout = child.stdout.take()?;
-    let mut reader = BufReader::new(stdout);
-    let mut line = String::new();
-    let _ = reader.read_line(&mut line);
-    let _ = child.kill();
-    let _ = child.wait();
-
-    parse_tegrastats_ram_mb(&line)
-}
-
-/// Extract total RAM in MB from a tegrastats output line.
-///
-/// Looks for the `RAM used/totalMB` token, e.g. `RAM 10400/62838MB`.
-#[cfg(target_os = "linux")]
-fn parse_tegrastats_ram_mb(line: &str) -> Option<u64> {
-    // Locate the "RAM " token
-    let after_ram = line.split_once("RAM ")?.1;
-    // Expect "used/totalMB" — skip the used portion
-    let after_slash = after_ram.split_once('/')?.1;
-    // Strip the "MB" suffix
-    let total_str = after_slash.split_once("MB")?.0;
-    total_str.trim().parse::<u64>().ok()
-}
-
-/// Return `true` if this line was produced by tegrastats on a Tegra/Jetson device.
-/// Presence of `GR3D_FREQ` confirms an on-chip GPU.
-#[cfg(target_os = "linux")]
-fn tegrastats_line_has_gpu(line: &str) -> bool {
-    line.contains("GR3D_FREQ")
-}
 
 /// Lightweight routing table for passive nodes (clients + standby GPU).
 /// Contains just enough info to route requests to the right host.
@@ -506,6 +390,11 @@ pub struct Node {
     tunnel_http_tx: tokio::sync::mpsc::Sender<(iroh::endpoint::SendStream, iroh::endpoint::RecvStream)>,
     pub blackboard: crate::blackboard::BlackboardStore,
     blackboard_name: Arc<Mutex<Option<String>>>,
+    pub enumerate_host: bool,
+    pub gpu_name: Option<String>,
+    pub hostname: Option<String>,
+    pub is_soc: Option<bool>,
+    pub gpu_vram: Option<String>,
 }
 
 struct MeshState {
@@ -566,7 +455,7 @@ impl Node {
         self.inflight_change_tx.subscribe()
     }
 
-    pub async fn start(role: NodeRole, relay_urls: &[String], bind_port: Option<u16>, max_vram_gb: Option<f64>) -> Result<(Self, TunnelChannels)> {
+    pub async fn start(role: NodeRole, relay_urls: &[String], bind_port: Option<u16>, max_vram_gb: Option<f64>, enumerate_host: bool) -> Result<(Self, TunnelChannels)> {
         // Clients use an ephemeral key so they get a unique identity even
         // when running on the same machine as a GPU node.
         let secret_key = if matches!(role, NodeRole::Client) || std::env::var("MESH_LLM_EPHEMERAL_KEY").is_ok() {
@@ -633,7 +522,16 @@ impl Node {
         let (tunnel_tx, tunnel_rx) = tokio::sync::mpsc::channel(256);
         let (tunnel_http_tx, tunnel_http_rx) = tokio::sync::mpsc::channel(256);
 
-        let mut vram = detect_vram_bytes();
+        let hw = crate::hardware::survey();
+        let mut vram = hw.vram_bytes;
+        let gpu_name = if matches!(role, NodeRole::Client) { None } else { hw.gpu_name };
+        let hostname = hw.hostname;
+        let is_soc = Some(hw.is_soc);
+        let gpu_vram = if hw.gpu_vram.is_empty() {
+            None
+        } else {
+            Some(hw.gpu_vram.iter().map(|b| b.to_string()).collect::<Vec<_>>().join(","))
+        };
         if let Some(max_gb) = max_vram_gb {
             let max_bytes = (max_gb * 1e9) as u64;
             if max_bytes < vram {
@@ -675,6 +573,11 @@ impl Node {
             tunnel_http_tx,
             blackboard: crate::blackboard::BlackboardStore::new(false),
             blackboard_name: Arc::new(Mutex::new(None)),
+            enumerate_host,
+            gpu_name,
+            hostname,
+            is_soc,
+            gpu_vram,
         };
 
         // Accept loop starts but waits for start_accepting() before processing connections.
@@ -2126,6 +2029,10 @@ impl Node {
             existing.requested_models = ann.requested_models.clone();
             existing.last_seen = std::time::Instant::now();
             if ann.version.is_some() { existing.version = ann.version.clone(); }
+            existing.gpu_name = ann.gpu_name.clone();
+            existing.hostname = ann.hostname.clone();
+            existing.is_soc = ann.is_soc;
+            existing.gpu_vram = ann.gpu_vram.clone();
             if role_changed || serving_changed {
                 let count = state.peers.len();
                 drop(state);
@@ -2148,6 +2055,10 @@ impl Node {
             requested_models: ann.requested_models.clone(),
             last_seen: std::time::Instant::now(),
             version: ann.version.clone(),
+            gpu_name: ann.gpu_name.clone(),
+            hostname: ann.hostname.clone(),
+            is_soc: ann.is_soc,
+            gpu_vram: ann.gpu_vram.clone(),
         });
         let count = state.peers.len();
         drop(state);
@@ -2173,6 +2084,10 @@ impl Node {
             existing.vram_bytes = ann.vram_bytes;
             if !addr.addrs.is_empty() { existing.addr = addr.clone(); }
             if ann.version.is_some() { existing.version = ann.version.clone(); }
+            if ann.gpu_name.is_some() { existing.gpu_name = ann.gpu_name.clone(); }
+            if ann.hostname.is_some() { existing.hostname = ann.hostname.clone(); }
+            if ann.is_soc.is_some() { existing.is_soc = ann.is_soc; }
+            if ann.gpu_vram.is_some() { existing.gpu_vram = ann.gpu_vram.clone(); }
             if serving_changed {
                 let count = state.peers.len();
                 drop(state);
@@ -2194,6 +2109,10 @@ impl Node {
                 requested_models: ann.requested_models.clone(),
                 last_seen: std::time::Instant::now(),
                 version: ann.version.clone(),
+                gpu_name: ann.gpu_name.clone(),
+                hostname: ann.hostname.clone(),
+                is_soc: ann.is_soc,
+                gpu_vram: ann.gpu_vram.clone(),
             });
         }
     }
@@ -2227,6 +2146,10 @@ impl Node {
                     version: p.version.clone(),
                     model_demand: HashMap::new(),
                     mesh_id: None,
+                    gpu_name: p.gpu_name.clone(),
+                    hostname: p.hostname.clone(),
+                    is_soc: p.is_soc,
+                    gpu_vram: p.gpu_vram.clone(),
                 })
                 .collect()
         };
@@ -2244,6 +2167,10 @@ impl Node {
             version: Some(crate::VERSION.to_string()),
             model_demand: my_demand,
             mesh_id: my_mesh_id,
+            gpu_name: if self.enumerate_host { self.gpu_name.clone() } else { None },
+            hostname: if self.enumerate_host { self.hostname.clone() } else { None },
+            is_soc: self.is_soc,
+            gpu_vram: if self.enumerate_host { self.gpu_vram.clone() } else { None },
         });
         announcements
     }
@@ -2371,6 +2298,176 @@ mod tests {
         assert_eq!(split_gguf_base_name("Qwen3-8B-Q4_K_M"), None);
         assert_eq!(split_gguf_base_name("model-001-of-003"), None); // wrong digit count
         assert_eq!(split_gguf_base_name("model-00001-of-00003"), Some("model"));
+    }
+
+    #[test]
+    fn test_peer_announcement_gpu_serde_roundtrip() {
+        // Test that gpu_name and hostname fields serialize and deserialize correctly
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct TestAnnouncement {
+            #[serde(default)]
+            gpu_name: Option<String>,
+            #[serde(default)]
+            hostname: Option<String>,
+        }
+
+        let test = TestAnnouncement {
+            gpu_name: Some("NVIDIA A100".to_string()),
+            hostname: Some("worker-01".to_string()),
+        };
+
+        let json = serde_json::to_string(&test).unwrap();
+        let decoded: TestAnnouncement = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.gpu_name, Some("NVIDIA A100".to_string()));
+        assert_eq!(decoded.hostname, Some("worker-01".to_string()));
+    }
+
+    #[test]
+    fn test_peer_announcement_backward_compat_no_hw_fields() {
+        // Simulate old gossip message without gpu_name or hostname
+        #[derive(Deserialize, Debug)]
+        struct TestAnnouncement {
+            #[serde(default)]
+            gpu_name: Option<String>,
+            #[serde(default)]
+            hostname: Option<String>,
+        }
+
+        let json = r#"{"other_field": "value"}"#;
+        let decoded: TestAnnouncement = serde_json::from_str(json).unwrap();
+
+        assert_eq!(decoded.gpu_name, None);
+        assert_eq!(decoded.hostname, None);
+    }
+
+    #[test]
+    fn test_peer_announcement_backward_compat_with_hw_fields() {
+        // Simulate new gossip message with gpu_name and hostname
+        #[derive(Deserialize, Debug)]
+        struct TestAnnouncement {
+            #[serde(default)]
+            gpu_name: Option<String>,
+            #[serde(default)]
+            hostname: Option<String>,
+        }
+
+        let json = r#"{"gpu_name": "NVIDIA H100", "hostname": "gpu-server-02"}"#;
+        let decoded: TestAnnouncement = serde_json::from_str(json).unwrap();
+
+        assert_eq!(decoded.gpu_name, Some("NVIDIA H100".to_string()));
+        assert_eq!(decoded.hostname, Some("gpu-server-02".to_string()));
+    }
+
+    #[test]
+    fn test_peer_announcement_hostname_serde_roundtrip() {
+        // Test hostname-only roundtrip
+        #[derive(Serialize, Deserialize, Debug, PartialEq)]
+        struct TestAnnouncement {
+            #[serde(default)]
+            gpu_name: Option<String>,
+            #[serde(default)]
+            hostname: Option<String>,
+        }
+
+        let test = TestAnnouncement {
+            gpu_name: None,
+            hostname: Some("compute-node-42".to_string()),
+        };
+
+        let json = serde_json::to_string(&test).unwrap();
+        let decoded: TestAnnouncement = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.hostname, Some("compute-node-42".to_string()));
+        assert_eq!(decoded.gpu_name, None);
+    }
+
+    #[test]
+    fn test_peer_payload_hw_fields() {
+        // Test that PeerPayload includes gpu_name and hostname fields
+        #[derive(Serialize, Debug)]
+        struct TestPeerPayload {
+            id: String,
+            gpu_name: Option<String>,
+            hostname: Option<String>,
+        }
+
+        let payload = TestPeerPayload {
+            id: "peer-123".to_string(),
+            gpu_name: Some("NVIDIA A100".to_string()),
+            hostname: Some("worker-01".to_string()),
+        };
+
+        let json = serde_json::to_string(&payload).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value["gpu_name"], "NVIDIA A100");
+        assert_eq!(value["hostname"], "worker-01");
+    }
+
+    #[test]
+    fn test_enumerate_host_false_omits_hw_fields_in_announcement() {
+        let enumerate_host = false;
+        let gpu_name: Option<String> = Some("NVIDIA RTX 5090".to_string());
+        let hostname: Option<String> = Some("carrack".to_string());
+        let gpu_vram: Option<String> = Some("34359738368".to_string());
+
+        let gossip_gpu_name = if enumerate_host { gpu_name.clone() } else { None };
+        let gossip_hostname = if enumerate_host { hostname.clone() } else { None };
+        let gossip_gpu_vram = if enumerate_host { gpu_vram.clone() } else { None };
+
+        assert_eq!(gossip_gpu_name, None);
+        assert_eq!(gossip_hostname, None);
+        assert_eq!(gossip_gpu_vram, None);
+    }
+
+    #[test]
+    fn test_enumerate_host_true_includes_hw_fields_in_announcement() {
+        let enumerate_host = true;
+        let gpu_name: Option<String> = Some("NVIDIA RTX 5090".to_string());
+        let hostname: Option<String> = Some("carrack".to_string());
+        let gpu_vram: Option<String> = Some("34359738368".to_string());
+
+        let gossip_gpu_name = if enumerate_host { gpu_name.clone() } else { None };
+        let gossip_hostname = if enumerate_host { hostname.clone() } else { None };
+        let gossip_gpu_vram = if enumerate_host { gpu_vram.clone() } else { None };
+
+        assert_eq!(gossip_gpu_name, Some("NVIDIA RTX 5090".to_string()));
+        assert_eq!(gossip_hostname, Some("carrack".to_string()));
+        assert_eq!(gossip_gpu_vram, Some("34359738368".to_string()));
+    }
+
+    #[test]
+    fn test_is_soc_always_included_regardless_of_enumerate_host() {
+        for enumerate_host in [false, true] {
+            let is_soc: Option<bool> = Some(true);
+            let gpu_name: Option<String> = Some("Tegra AGX Orin".to_string());
+
+            let gossip_gpu_name = if enumerate_host { gpu_name.clone() } else { None };
+
+            assert_eq!(is_soc, Some(true), "is_soc must always be sent");
+            if enumerate_host {
+                assert!(gossip_gpu_name.is_some());
+            } else {
+                assert!(gossip_gpu_name.is_none());
+            }
+        }
+    }
+
+    #[test]
+    fn test_peer_announcement_backward_compat_is_soc_gpu_vram() {
+        #[derive(Deserialize, Debug)]
+        struct TestAnnouncement {
+            #[serde(default)]
+            is_soc: Option<bool>,
+            #[serde(default)]
+            gpu_vram: Option<String>,
+        }
+
+        let json = r#"{"other_field": "value"}"#;
+        let decoded: TestAnnouncement = serde_json::from_str(json).unwrap();
+        assert_eq!(decoded.is_soc, None, "old nodes without is_soc should default to None");
+        assert_eq!(decoded.gpu_vram, None, "old nodes without gpu_vram should default to None");
     }
 }
 

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -20,18 +20,21 @@ import {
   Copy,
   Cpu,
   Gauge,
+  Gpu,
   Hash,
   ImagePlus,
   Laptop,
   Loader2,
   MessageSquarePlus,
   Maximize2,
+  MemoryStick,
   Minimize2,
   Moon,
   Network,
   Pencil,
   RotateCcw,
   Send,
+  Server,
   Square,
   Sparkles,
   Sun,
@@ -91,6 +94,9 @@ type Peer = {
   serving?: string | null;
   serving_models?: string[];
   rtt_ms?: number | null;
+  hostname?: string;
+  is_soc?: boolean;
+  gpus?: { name: string; vram_bytes: number }[];
 };
 
 type StatusPayload = {
@@ -114,6 +120,9 @@ type StatusPayload = {
   launch_pi?: string | null;
   launch_goose?: string | null;
   nostr_discovery?: boolean;
+  my_hostname?: string;
+  my_is_soc?: boolean;
+  gpus?: { name: string; vram_bytes: number }[];
 };
 
 type ChatMessage = {
@@ -162,6 +171,9 @@ type TopologyNode = {
   servingModels: string[];
   statusLabel: string;
   latencyMs?: number | null;
+  hostname?: string;
+  isSoc?: boolean;
+  gpus?: { name: string; vram_bytes: number }[];
 };
 
 type ThemeMode = 'auto' | 'light' | 'dark';
@@ -982,6 +994,9 @@ export function App() {
           : (status.model_name ? [status.model_name] : []),
         statusLabel: status.node_status || (status.is_client ? 'Client' : status.is_host ? 'Host' : 'Idle'),
         latencyMs: null,
+        hostname: status.my_hostname,
+        isSoc: status.my_is_soc,
+        gpus: status.gpus,
       });
     }
     for (const p of status.peers ?? []) {
@@ -996,6 +1011,9 @@ export function App() {
         servingModels: pModels,
         statusLabel: peerStatusLabel(p),
         latencyMs: p.rtt_ms ?? null,
+        hostname: p.hostname,
+        isSoc: p.is_soc,
+        gpus: p.gpus,
       });
     }
     return nodes;
@@ -2591,6 +2609,9 @@ type TopologyNodeInfo = {
   loadedModels: string[];
   vramGb: number;
   vramSharePct: number;
+  hostname?: string;
+  isSoc?: boolean;
+  gpus?: { name: string; vram_bytes: number }[];
 };
 
 type TopologyFlowNodeData = {
@@ -2665,6 +2686,13 @@ function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
         </div>
 
         <div className="mt-2 flex flex-wrap gap-1.5 text-[10px] leading-3">
+          {data.info.hostname && (
+            <div className="inline-flex items-center gap-1 rounded-full border bg-muted/30 px-2 py-1">
+              <Server className="h-3 w-3 text-muted-foreground" />
+              <span className="text-muted-foreground">Host</span>
+              <span className="font-medium">{data.info.hostname}</span>
+            </div>
+          )}
           <div className="inline-flex items-center gap-1 rounded-full border bg-muted/30 px-2 py-1">
             <Network className="h-3 w-3 text-muted-foreground" />
             <span className="text-muted-foreground">Role</span>
@@ -2678,7 +2706,7 @@ function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
             </div>
           ) : null}
           <div className="inline-flex items-center gap-1 rounded-full border bg-muted/30 px-2 py-1">
-            <Cpu className="h-3 w-3 text-muted-foreground" />
+            <MemoryStick className="h-3 w-3 text-muted-foreground" />
             <span className="text-muted-foreground">VRAM</span>
             <span className="font-medium">{data.info.vramGb.toFixed(1)} GB</span>
           </div>
@@ -2687,6 +2715,51 @@ function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
             <span className="text-muted-foreground">Share</span>
             <span className="whitespace-nowrap font-medium">{data.info.vramSharePct}%</span>
           </div>
+          {data.info.gpus?.map((gpu, i) => {
+              const lower = gpu.name.toLowerCase();
+              const isNvidia = lower.includes("nvidia") || lower.includes("jetson");
+              const isAmd = lower.includes("amd");
+              const isIntel = lower.includes("intel");
+              const iconColor = isNvidia
+                ? "#76b900"
+                : isAmd
+                  ? "#ED1C24"
+                  : isIntel
+                    ? "#0071C5"
+                    : undefined;
+              const model = gpu.name
+                .replace(/^NVIDIA GeForce\s+/i, "")
+                .replace(/^NVIDIA Quadro\s+/i, "")
+                .replace(/^NVIDIA\s+/i, "")
+                .replace(/^AMD Radeon\s+/i, "")
+                .replace(/^AMD\s+/i, "")
+                .replace(/^Intel Arc\s+/i, "")
+                .replace(/^Intel\s+/i, "")
+                .replace(/^Apple\s+/i, "")
+                .trim();
+              const vramGb = gpu.vram_bytes / (1024 * 1024 * 1024);
+              const GpuIcon = data.info.isSoc ? Cpu : Gpu;
+              return (
+                <div
+                  key={`${gpu.name}-${i}`}
+                  className="group/gpu inline-flex items-center gap-1 rounded-full border bg-muted/30 px-2 py-1"
+                >
+                  <GpuIcon
+                    className="h-3 w-3"
+                    style={iconColor ? { color: iconColor } : undefined}
+                  />
+                  <span className="text-muted-foreground">{data.info.isSoc ? "SoC" : "GPU"}</span>
+                  <span className="relative inline-flex font-medium">
+                    <span className={`transition-opacity duration-200 group-hover/gpu:opacity-0`}>
+                      {model}
+                    </span>
+                    <span className="absolute left-0 top-0 whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover/gpu:opacity-100">
+                      {Math.round(vramGb)} GB
+                    </span>
+                  </span>
+                </div>
+              );
+            })}
         </div>
       </div>
     </div>
@@ -2786,6 +2859,9 @@ function MeshTopologyFlow({
         loadedModels: node.client ? [] : servingModels.length > 0 ? servingModels : (servingModel ? [servingModel] : []),
         vramGb: Math.max(0, node.vram),
         vramSharePct,
+        hostname: node.hostname,
+        isSoc: node.isSoc,
+        gpus: node.gpus,
       });
     }
     return out;


### PR DESCRIPTION
## What
Extracts hardware detection into a dedicated hardware.rs module with a Collector trait, DefaultCollector (macOS/Linux NVIDIA/AMD), and TegraCollector (Jetson sysfs + tegrastats). Hardware info is surfaced in gossip and the management API.

Being able to define a specific collector for future platforms, or platforms that are problematic will be helpful in the future.

## Why
Mesh nodes are opaque, you can see a peer's VRAM total and model, but not what hardware is behind it. This is fine in a public mesh, but somewhat limiting on a private one.

This PR gives operators and UIs the raw signal to answer those questions, while keeping disclosure opt-in so nodes on untrusted or public meshes aren't fingerprinted by default.

## Changes
- hardware.rs — new module; Collector trait, platform collectors, HardwareSurvey, query()/survey() API
- --enumerate-host flag — opt-in broadcast of gpu_name and hostname in gossip; is_soc is always sent
- API shape — StatusPayload.gpus: Vec<GpuEntry> (renamed from my_gpus), my_hostname, my_is_soc; peers carry hostname, is_soc, gpus
- UI — per-GPU VRAM hover, SoC/CPU icons, GiB display

## Tested on a mixed mesh
carrack (x86_64, RTX 5090 + RTX 3080, --enumerate-host) 
lemony (Jetson AGX Orin, no flag). Gossip correctly withholds hostname/gpus when flag is absent; is_soc propagates regardless. 

Split inference confirmed working across all nodes.

## Screens
**With enumerate-hosts**
<img width="1139" height="849" alt="image" src="https://github.com/user-attachments/assets/c509dd67-103c-43ac-9d9e-b026e9e109b9" />

**Public nodes without enumerate-hosts**
<img width="1139" height="849" alt="image" src="https://github.com/user-attachments/assets/4d4b189d-0897-4fbc-a6fd-3863a9b92a35" />
