### PR TITLE
fix detect_bin_dir: correct off-by-one in cargo dev path

### DIFF
--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -2149,7 +2149,7 @@ fn detect_bin_dir() -> Result<PathBuf> {
     if dev.join("rpc-server").exists() && dev.join("llama-server").exists() {
         return Ok(dev.canonicalize()?);
     }
-    let cargo = dir.join("../../../llama.cpp/build/bin");
+    let cargo = dir.join("../../llama.cpp/build/bin");
     if cargo.join("rpc-server").exists() && cargo.join("llama-server").exists() {
         return Ok(cargo.canonicalize()?);
     }


### PR DESCRIPTION
## Problem

Running `target/release/mesh-llm --model ...` without `--bin-dir` fails:

```
Error: rpc-server not found at /Users/.../target/release/rpc-server. Build llama.cpp with -DGGML_RPC=ON first.
```

## Cause

`detect_bin_dir()` uses `dir` (the parent directory of the exe, i.e. `target/release/`), then joins `../../../llama.cpp/build/bin` — that's 3 `../` from `target/release/`, which lands **one level above** the repo root. It should be `../../llama.cpp/build/bin` (2 `../` to get back to the repo root).

This only affects the dev workflow (`cargo build` + direct invocation). Bundle/release is unaffected because all binaries are co-located and path 1 matches.

## Fix

Change `../../../llama.cpp/build/bin` → `../../llama.cpp/build/bin`.

## Testing

Verified `./target/release/mesh-llm --model Qwen3-0.6B-Q4_K_M --no-draft` starts successfully without `--bin-dir`, finding rpc-server and llama-server correctly.