### PR TITLE
fix: blurry react-flow on GPU hover

### DIFF
--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -2750,10 +2750,10 @@ function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
                   />
                   <span className="text-muted-foreground">{data.info.isSoc ? "SoC" : "GPU"}</span>
                   <span className="relative inline-flex font-medium">
-                    <span className={`transition-opacity duration-200 group-hover/gpu:opacity-0`}>
+                    <span className="group-hover/gpu:invisible">
                       {model}
                     </span>
-                    <span className="absolute left-0 top-0 whitespace-nowrap opacity-0 transition-opacity duration-200 group-hover/gpu:opacity-100">
+                    <span className="invisible absolute left-0 top-0 whitespace-nowrap group-hover/gpu:visible">
                       {Math.round(vramGb)} GB
                     </span>
                   </span>


### PR DESCRIPTION
This was driving me nuts. It doesn't fix the underlying react-flow issue, but it makes it less prominent by not fading the GPU VRAM text.

The underlying seems to have to do with zoom levels and [sub-pixel rendering](https://github.com/xyflow/xyflow/issues/4074) not looking great with React Flow

## Before
<img width="570" height="380" alt="image" src="https://github.com/user-attachments/assets/d1c4c5d7-901b-4388-9549-96ae226ceba9" />


## After

<img width="663" height="506" alt="image" src="https://github.com/user-attachments/assets/41e75726-6ab2-4ffc-9daf-5b065e09054f" />
