### PR TITLE
fix: Connected Peers table scroll clipping

### DIFF
--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -2454,33 +2454,35 @@ function DashboardPage({
         </CardHeader>
         <CardContent className="min-h-0 pt-0">
           {peerRows.length > 0 ? (
-            <ScrollArea horizontal className="max-h-[18rem] pr-3 md:max-h-[20rem]">
-              <Table className="min-w-[920px]">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>ID</TableHead>
-                    <TableHead>Role</TableHead>
-                    <TableHead>Status</TableHead>
-                    <TableHead>Model</TableHead>
-                    <TableHead className="text-right">Latency</TableHead>
-                    <TableHead className="text-right">VRAM</TableHead>
-                    <TableHead className="text-right whitespace-nowrap">Share</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {peerRows.map((peer) => (
-                    <TableRow key={peer.id}>
-                      <TableCell className="font-mono text-xs">{peer.id}</TableCell>
-                      <TableCell>{peer.role}</TableCell>
-                      <TableCell>{peer.statusLabel}</TableCell>
-                      <TableCell className="max-w-[180px] truncate">{peer.modelLabel}</TableCell>
-                      <TableCell className="text-right">{peer.latencyLabel}</TableCell>
-                      <TableCell className="text-right">{peer.vram_gb.toFixed(1)} GB</TableCell>
-                      <TableCell className="text-right whitespace-nowrap">{peer.shareLabel}</TableCell>
+            <ScrollArea horizontal className="max-h-[18rem] md:max-h-[20rem]">
+              <div className="pr-3">
+                <Table className="min-w-[920px]">
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>ID</TableHead>
+                      <TableHead>Role</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Model</TableHead>
+                      <TableHead className="text-right">Latency</TableHead>
+                      <TableHead className="text-right">VRAM</TableHead>
+                      <TableHead className="text-right whitespace-nowrap">Share</TableHead>
                     </TableRow>
-                  ))}
-                </TableBody>
-              </Table>
+                  </TableHeader>
+                  <TableBody>
+                    {peerRows.map((peer) => (
+                      <TableRow key={peer.id}>
+                        <TableCell className="font-mono text-xs">{peer.id}</TableCell>
+                        <TableCell>{peer.role}</TableCell>
+                        <TableCell>{peer.statusLabel}</TableCell>
+                        <TableCell className="max-w-[180px] truncate">{peer.modelLabel}</TableCell>
+                        <TableCell className="text-right">{peer.latencyLabel}</TableCell>
+                        <TableCell className="text-right">{peer.vram_gb.toFixed(1)} GB</TableCell>
+                        <TableCell className="text-right whitespace-nowrap">{peer.shareLabel}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
             </ScrollArea>
           ) : (
             <DashboardPanelEmpty

--- a/mesh-llm/ui/src/components/ui/scroll-area.tsx
+++ b/mesh-llm/ui/src/components/ui/scroll-area.tsx
@@ -8,7 +8,7 @@ const ScrollArea = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & { horizontal?: boolean }
 >(({ className, children, horizontal = false, ...props }, ref) => (
   <ScrollAreaPrimitive.Root ref={ref} className={cn('relative overflow-hidden', className)} {...props}>
-    <ScrollAreaPrimitive.Viewport className={cn('h-full w-full rounded-[inherit]', !horizontal && 'overflow-x-hidden')}>
+    <ScrollAreaPrimitive.Viewport className={cn('max-h-[inherit] w-full rounded-[inherit]', !horizontal && 'overflow-x-hidden')}>
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
### Summary
The ScrollArea viewport used `h-full` which prevented proper scrolling when content exceeded `max-h`. Changed to `max-h-[inherit]` to allow dynamic sizing. Also moved `pr-3` padding to wrapper div inside `ScrollArea` to prevent scrollbar position issues.