### PR TITLE
Fix missing llama-moe-split in bundles

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -180,11 +180,12 @@ bundle output="/tmp/mesh-bundle.tar.gz":
     cp {{ mesh_bin }} "$BUNDLE/"
     cp {{ build_dir }}/bin/rpc-server "$BUNDLE/$rpc_name"
     cp {{ build_dir }}/bin/llama-server "$BUNDLE/$llama_name"
+    cp {{ build_dir }}/bin/llama-moe-split "$BUNDLE/"
     for lib in {{ build_dir }}/bin/*.dylib; do
         cp "$lib" "$BUNDLE/" 2>/dev/null || true
     done
     # Fix rpaths for portability
-    for bin in "$BUNDLE/mesh-llm" "$BUNDLE/$rpc_name" "$BUNDLE/$llama_name"; do
+    for bin in "$BUNDLE/mesh-llm" "$BUNDLE/$rpc_name" "$BUNDLE/$llama_name" "$BUNDLE/llama-moe-split"; do
         [ -f "$bin" ] || continue
         install_name_tool -add_rpath @executable_path/ "$bin" 2>/dev/null || true
     done

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,7 @@ Each should only show the binary name — no `/opt/homebrew/` paths.
 just bundle
 ```
 
-Creates `/tmp/mesh-bundle.tar.gz` containing `mesh-llm` plus flavor-specific llama.cpp binaries.
+Creates `/tmp/mesh-bundle.tar.gz` containing `mesh-llm`, flavor-specific llama.cpp runtime binaries, and `llama-moe-split` for MoE shard generation.
 
 Bundle naming now follows the same convention everywhere:
 
@@ -97,6 +97,6 @@ After the workflow finishes, verify:
 - The ROCm and Vulkan Linux release bundles are compile-tested in CI, but not runtime-tested against real GPUs during the workflow.
 - `codesign` and `xattr` may be needed on the receiving machine if macOS Gatekeeper blocks unsigned binaries:
   ```bash
-  codesign -s - /usr/local/bin/mesh-llm /usr/local/bin/rpc-server /usr/local/bin/llama-server
-  xattr -cr /usr/local/bin/mesh-llm /usr/local/bin/rpc-server /usr/local/bin/llama-server
+  codesign -s - /usr/local/bin/mesh-llm /usr/local/bin/rpc-server /usr/local/bin/llama-server /usr/local/bin/llama-moe-split
+  xattr -cr /usr/local/bin/mesh-llm /usr/local/bin/rpc-server /usr/local/bin/llama-server /usr/local/bin/llama-moe-split
   ```

--- a/install.sh
+++ b/install.sh
@@ -213,6 +213,7 @@ stale_binary_names() {
 mesh-llm
 rpc-server
 llama-server
+llama-moe-split
 rpc-server-cpu
 llama-server-cpu
 rpc-server-cuda

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -124,7 +124,7 @@ struct Cli {
     #[arg(long, hide = true)]
     enumerate_host: bool,
 
-    /// Path to rpc-server and llama-server binaries.
+    /// Path to rpc-server, llama-server, and llama-moe-split binaries.
     #[arg(long, hide = true)]
     bin_dir: Option<PathBuf>,
 

--- a/mesh-llm/src/moe.rs
+++ b/mesh-llm/src/moe.rs
@@ -351,6 +351,26 @@ pub fn split_path(model_path: &Path, n_nodes: usize, node_index: usize) -> PathB
         .join(format!("node-{node_index}.gguf"))
 }
 
+fn resolve_split_binary(bin_dir: &Path) -> anyhow::Result<PathBuf> {
+    let candidates = [
+        bin_dir.join("llama-moe-split"),
+        bin_dir.join("../llama.cpp/build/bin/llama-moe-split"),
+        bin_dir.join("../../llama.cpp/build/bin/llama-moe-split"),
+        bin_dir.join("../../../llama.cpp/build/bin/llama-moe-split"),
+    ];
+
+    for candidate in candidates {
+        if candidate.exists() {
+            return Ok(candidate.canonicalize().unwrap_or(candidate));
+        }
+    }
+
+    anyhow::bail!(
+        "llama-moe-split not found in {} or nearby llama.cpp/build/bin directories",
+        bin_dir.display()
+    );
+}
+
 /// Run llama-moe-split to produce a split GGUF for one node.
 pub fn run_split(
     bin_dir: &Path,
@@ -363,7 +383,8 @@ pub fn run_split(
     }
 
     let expert_list = expert_list_arg(assignment);
-    let status = std::process::Command::new(bin_dir.join("llama-moe-split"))
+    let split_bin = resolve_split_binary(bin_dir)?;
+    let status = std::process::Command::new(&split_bin)
         .args([
             "-m",
             &model_path.to_string_lossy(),
@@ -373,7 +394,7 @@ pub fn run_split(
             &output_path.to_string_lossy(),
         ])
         .status()
-        .map_err(|e| anyhow::anyhow!("Failed to run llama-moe-split: {e}"))?;
+        .map_err(|e| anyhow::anyhow!("Failed to run {}: {e}", split_bin.display()))?;
 
     anyhow::ensure!(status.success(), "llama-moe-split exited with {status}");
     Ok(())

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -146,10 +146,11 @@ mkdir -p "$bundle_dir"
 cp "$RELEASE_BIN_DIR/mesh-llm${BIN_EXT}" "$bundle_dir/$(bundle_bin_name mesh-llm)"
 cp "$BUILD_BIN_DIR/rpc-server${BIN_EXT}" "$bundle_dir/$(bundle_bin_name rpc-server)"
 cp "$BUILD_BIN_DIR/llama-server${BIN_EXT}" "$bundle_dir/$(bundle_bin_name llama-server)"
+cp "$BUILD_BIN_DIR/llama-moe-split${BIN_EXT}" "$bundle_dir/llama-moe-split"
 copy_runtime_libs "$bundle_dir"
 
 if [[ "$os_name" == "Darwin" ]]; then
-    for bin in "$bundle_dir/mesh-llm" "$bundle_dir/rpc-server" "$bundle_dir/llama-server"; do
+    for bin in "$bundle_dir/mesh-llm" "$bundle_dir/rpc-server" "$bundle_dir/llama-server" "$bundle_dir/llama-moe-split"; do
         [[ -f "$bin" ]] || continue
         install_name_tool -add_rpath @executable_path/ "$bin" 2>/dev/null || true
     done


### PR DESCRIPTION
## Summary
- include `llama-moe-split` in local and release bundles
- resolve the split helper explicitly at runtime for MoE shard generation
- clean installer/release docs so the extra helper binary is preserved and codesigned

## Root cause
MoE startup shells out to `llama-moe-split`, but the bundle/release packaging only shipped `mesh-llm`, `rpc-server`, and `llama-server`. Installed nodes could join a mesh and reach MoE split mode, then fail with `No such file or directory (os error 2)` when shard generation started.

## Validation
- `cargo test -p mesh-llm`
- `just build`
- `just bundle /tmp/mesh-bundle-pr-fix.tar.gz`
- `tar tzf /tmp/mesh-bundle-pr-fix.tar.gz | sort` shows `mesh-bundle/llama-moe-split`
