### PR TITLE
Ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ llama.cpp.bak/
 private-note.txt
 mesh-bundle.tar.gz
 .idea/
+.DS_Store
 mesh-llm/ui/dist/
 evals/results/


### PR DESCRIPTION
## What changed
- add `.DS_Store` to the root `.gitignore`

## Why
- keep Finder metadata files out of the repository and avoid accidental local noise in git status

## Impact
- developers on macOS will no longer see `.DS_Store` as an untracked file in this repo

## Validation
- no tests run; change is limited to ignore rules
