### PR TITLE
Use stable macOS release artifact in installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ asset_name() {
     local flavor="$1"
     case "$(platform_id)" in
         Darwin/arm64)
-            echo "mesh-bundle.tar.gz"
+            echo "mesh-llm-aarch64-apple-darwin.tar.gz"
             ;;
         Linux/x86_64)
             case "$flavor" in


### PR DESCRIPTION
## Summary
- update the macOS installer path to download the stable release artifact
- stop relying on the legacy `mesh-bundle.tar.gz` alias in `install.sh`

## Why
The release pipeline publishes a stable macOS artifact alongside the legacy alias. The installer should target the stable artifact directly so it matches the canonical release naming.

## Validation
- `bash -n install.sh`
