### PR TITLE
Run rustfmt

### DIFF
--- a/mesh-llm/src/download.rs
+++ b/mesh-llm/src/download.rs
@@ -975,7 +975,11 @@ mod tests {
 
         #[cfg(unix)]
         {
-            assert!(free.is_some(), "should get free space for {}", path.display());
+            assert!(
+                free.is_some(),
+                "should get free space for {}",
+                path.display()
+            );
             let bytes = free.unwrap();
             assert!(bytes > 1_000_000_000, "should have >1GB free, got {bytes}");
         }

--- a/mesh-llm/src/election.rs
+++ b/mesh-llm/src/election.rs
@@ -1091,7 +1091,11 @@ async fn start_llama(
     // In split mode (pipeline parallel), pass total group VRAM so context size
     // accounts for the host only holding its share of layers. KV cache is also
     // distributed — each node holds KV for its own layers.
-    let group_vram = if !rpc_ports.is_empty() { Some(total as u64) } else { None };
+    let group_vram = if !rpc_ports.is_empty() {
+        Some(total as u64)
+    } else {
+        None
+    };
 
     match launch::start_llama_server(
         bin_dir,

--- a/mesh-llm/src/hardware.rs
+++ b/mesh-llm/src/hardware.rs
@@ -263,7 +263,11 @@ impl Collector for DefaultCollector {
                         }
                         let s = String::from_utf8(out.stdout).ok()?;
                         let vrams = parse_rocm_gpu_vrams(&s);
-                        if vrams.is_empty() { None } else { Some(vrams) }
+                        if vrams.is_empty() {
+                            None
+                        } else {
+                            Some(vrams)
+                        }
                     })();
 
                     if let Some(per_gpu) = rocm_vram {
@@ -504,7 +508,10 @@ card0,25753026560,416378880";
 device,VRAM Total Memory (B),VRAM Total Used Memory (B)
 card0,25753026560,416378880
 card1,25753026560,512000000";
-        assert_eq!(parse_rocm_gpu_vrams(fixture), vec![25753026560, 25753026560]);
+        assert_eq!(
+            parse_rocm_gpu_vrams(fixture),
+            vec![25753026560, 25753026560]
+        );
     }
 
     #[test]

--- a/mesh-llm/src/launch.rs
+++ b/mesh-llm/src/launch.rs
@@ -301,8 +301,11 @@ pub async fn start_rpc_server(
         .stderr(std::process::Stdio::from(rpc_log_file2))
         .spawn()
         .with_context(|| {
-        format!("Failed to start rpc-server at {}", rpc_server.path.display())
-    })?;
+            format!(
+                "Failed to start rpc-server at {}",
+                rpc_server.path.display()
+            )
+        })?;
 
     // Wait for it to be listening
     for _ in 0..startup_polls {
@@ -550,8 +553,7 @@ pub async fn start_llama_server(
         args.push("--tensor-split".to_string());
         args.push(ts.to_string());
     }
-    let local_device =
-        resolve_device_for_binary(&llama_server.path, llama_server.flavor, None)?;
+    let local_device = resolve_device_for_binary(&llama_server.path, llama_server.flavor, None)?;
     if let Some(draft_path) = draft {
         if draft_path.exists() {
             if local_device != "CPU" {
@@ -599,7 +601,12 @@ pub async fn start_llama_server(
         .stdout(std::process::Stdio::from(log_file))
         .stderr(std::process::Stdio::from(log_file2))
         .spawn()
-        .with_context(|| format!("Failed to start llama-server at {}", llama_server.path.display()))?;
+        .with_context(|| {
+            format!(
+                "Failed to start llama-server at {}",
+                llama_server.path.display()
+            )
+        })?;
 
     // Wait for health check
     let url = format!("http://localhost:{http_port}/health");


### PR DESCRIPTION
## What changed
- ran `cargo fmt --all`
- committed the resulting Rust formatting-only updates in four source files

## Why
- ⚠️ stop agents from running the formatter on these files then having to undo them all the time
- isolate formatter output in its own PR so later functional changes stay easier to review

## Impact
- no intended behavior change
- keeps follow-up diffs focused on code changes rather than style churn

## Validation
- `cargo fmt --all`
- `cargo fmt --all --check`
