### PR TITLE
[codex] Fix installer stdin entrypoint

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -722,6 +722,6 @@ main() {
     fi
 }
 
-if [[ "${BASH_SOURCE[0]-}" == "$0" ]]; then
+if [[ "${BASH_SOURCE[0]-}" == "$0" || ( -z "${BASH_SOURCE[0]-}" && "$0" == "bash" ) ]]; then
     main "$@"
 fi


### PR DESCRIPTION
## What changed
- allow the installer to run when it is piped into `bash`
- keep the existing behavior when the script is sourced

## Why
The previous entrypoint guard only called `main` when `BASH_SOURCE[0] == $0`. That works for `bash install.sh`, but not for `curl ... | bash`, where `$0` is `bash` and `BASH_SOURCE[0]` is empty. The result was a silent no-op.

## Impact
Users can install with the documented `curl -fsSL ... | bash` flow on macOS and other Bash environments without the script exiting before doing any work.

## Validation
- `bash -n install.sh`
- `bash install.sh -h`
- `cat install.sh | bash -s -- -h`
- `bash -lc 'source ./install.sh'`
