### PR TITLE
Add local vLLM backend support and benchmark tooling

### DIFF
--- a/evals/backend-benchmark.py
+++ b/evals/backend-benchmark.py
@@ -241,12 +241,14 @@ def parse_concurrency_levels(raw: str) -> list[int]:
 
 
 def sidecar_comparison_key(model_path: Path) -> str | None:
-    sidecar = model_path.with_name(f"{model_path.name}.mesh.json")
+    sidecar = model_path.with_name(f"{model_path.name}.manifest.json")
     if not sidecar.exists():
         return None
     try:
         payload = json.loads(sidecar.read_text())
     except Exception:
+        return None
+    if payload.get("version") != 1:
         return None
 
     source = payload.get("source") or {}

--- a/mesh-llm/src/model_identity.rs
+++ b/mesh-llm/src/model_identity.rs
@@ -11,6 +11,7 @@ pub struct ModelIdentity {
 
 #[derive(Debug, Deserialize)]
 struct ProvenanceSidecar {
+    version: u32,
     identity: ProvenanceSidecarIdentity,
     source: ProvenanceSidecarSource,
 }
@@ -58,6 +59,9 @@ fn resolve_sidecar_identity(path: &Path) -> Option<ModelIdentity> {
     let sidecar_path = model_sidecar_path(path);
     let text = std::fs::read_to_string(sidecar_path).ok()?;
     let sidecar: ProvenanceSidecar = serde_json::from_str(&text).ok()?;
+    if sidecar.version != 1 {
+        return None;
+    }
     let mesh_name = match (&sidecar.source.repo, &sidecar.source.revision) {
         (Some(repo), Some(revision)) => format!("{repo}@{revision}"),
         (Some(repo), None) => repo.clone(),
@@ -77,7 +81,7 @@ fn model_sidecar_path(path: &Path) -> std::path::PathBuf {
         .file_name()
         .map(|value| value.to_string_lossy().into_owned())
         .unwrap_or_else(|| "model".to_string());
-    path.with_file_name(format!("{filename}.mesh.json"))
+    path.with_file_name(format!("{filename}.manifest.json"))
 }
 
 fn resolve_directory_identity(path: &Path) -> ModelIdentity {
@@ -248,8 +252,9 @@ mod tests {
         let model = dir.join("Qwen3-8B-Q4_K_M.gguf");
         std::fs::write(&model, b"gguf").unwrap();
         std::fs::write(
-            dir.join("Qwen3-8B-Q4_K_M.gguf.mesh.json"),
+            dir.join("Qwen3-8B-Q4_K_M.gguf.manifest.json"),
             br#"{
+                "version": 1,
                 "identity": {
                     "canonical_id": "huggingface:Qwen/Qwen3-8B-GGUF@abc123/Qwen3-8B-Q4_K_M.gguf",
                     "display_name": "Qwen3-8B-Q4_K_M.gguf"

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -109,7 +109,7 @@ pub enum ProvenanceRepairSource {
     HuggingFace,
 }
 
-const PROVENANCE_SIDECAR_SUFFIX: &str = ".mesh.json";
+const PROVENANCE_SIDECAR_SUFFIX: &str = ".manifest.json";
 const PROVENANCE_VERSION: u32 = 1;
 
 #[derive(Clone, Debug, Serialize)]
@@ -297,7 +297,7 @@ fn write_model_provenance(path: &Path, provenance: &ModelProvenance) -> Result<(
         sidecar
             .file_name()
             .and_then(|value| value.to_str())
-            .unwrap_or("model.mesh.json"),
+            .unwrap_or("model.manifest.json"),
         std::process::id()
     ));
     let json = serde_json::to_string_pretty(provenance).context("Serialize model provenance")?;


### PR DESCRIPTION
## What this adds for users

This PR adds local `vllm` backend support alongside the existing llama.cpp path.

### Backend behavior

- HuggingFace-style local model directories now run through the `vllm` backend.
- GGUF files continue to run through the `llama` backend.
- `mesh-llm` can launch either standard `vllm` or `vllm-metal`.
- Local model ids for HuggingFace directories are resolved more cleanly from model metadata or directory name.
- Status and runtime responses now expose backend-neutral fields such as `backend`, `backend_runtime`, and `inference_ready`.
- The console reflects the active backend/runtime instead of relying on llama-only naming.

### Docs and operator workflow

- The README and installer now explain that `vllm` / `vllm-metal` are user-supplied runtimes selected with `MESH_LLM_VLLM_BIN`.
- `mesh-llm --help-vllm` shows the `vllm`-specific options.
- A dedicated `mesh-llm/docs/VLLM_ROADMAP.md` document was added and linked from the roadmap and TODO list.

### Benchmarking

- A new benchmark harness was added at `evals/backend-benchmark.py` for comparing `llama` and `vllm` using matched model exports.
- The benchmark supports paired-export model checks, concurrency sweeps, and optional `vllm-metal` tuning flags on macOS.
- The current benchmark results were collected on macOS with `vllm-metal`, so they should not be treated as representative of CUDA performance.
- It would be useful for a contributor to run the same benchmark on Linux/CUDA and report the results.

### Current benchmark results

Paired-export benchmark using `Qwen2.5-0.5B-Instruct`:
- `vllm`: official HF snapshot
- `llama`: `F16` GGUF converted from the same snapshot
- `vllm-metal` settings: `VLLM_METAL_MEMORY_FRACTION=0.9`, `VLLM_MLX_DEVICE=gpu`
- concurrency sweep: `1,4,8`
- iterations: `3`
- warmup: `1`
- max tokens: `32`

```text
backend  llama  startup_s  8.064  model_id  Qwen2.5-0.5B-Instruct-f16
concurrency  avg_ttft_s  avg_total_s  avg_batch_wall_s  avg_decode_tok_s  avg_overall_tok_s  avg_batch_overall_tok_s
          1       0.023        0.642             0.650            51.744             49.882                   49.298
          4       0.076        0.798             0.808            44.331             40.266                  159.094
          8       0.407        1.110             1.483            45.623             32.287                  172.772

backend  vllm  startup_s  28.230  model_id  Qwen2.5-0.5B-Instruct
concurrency  avg_ttft_s  avg_total_s  avg_batch_wall_s  avg_decode_tok_s  avg_overall_tok_s  avg_batch_overall_tok_s
          1       0.417        1.235             1.235            39.171             25.980                   25.974
          4       1.370        3.740             3.761            14.454              8.656                   34.436
          8       2.981        7.098             7.111             8.468              4.590                   36.653
```

## Validation

- `just build`
- `target/release/mesh-llm --help-vllm`
- Targeted Rust tests for backend detection, runtime payloads, model identity, and `vllm` launch options
- Local paired-export benchmark using `Qwen2.5-0.5B-Instruct`
