### PR TITLE
fix installer tmpdir cleanup trap

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -684,7 +684,9 @@ main() {
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
-    trap 'rm -rf "$tmp_dir"' EXIT
+    local tmp_dir_escaped
+    printf -v tmp_dir_escaped '%q' "$tmp_dir"
+    trap "rm -rf -- $tmp_dir_escaped" EXIT
 
     local archive="$tmp_dir/$asset"
     echo "Installing flavor: $flavor"


### PR DESCRIPTION
## What changed
The installer now captures the temporary directory path when registering its `EXIT` trap instead of referencing the local variable name later.

## Why
`install.sh` runs with `set -euo pipefail`. The previous trap used `tmp_dir` directly:

```bash
trap 'rm -rf "$tmp_dir"' EXIT
```

Because the trap executes after `main()` returns, `tmp_dir` is out of scope by then and `bash` aborts with `tmp_dir: unbound variable` on successful installs.

## Impact
Piped installs like:

```bash
curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash
```

now complete without the post-install bash error.

## Validation
- `bash -n install.sh`
- `tmp_install_dir="$(mktemp -d)"; MESH_LLM_INSTALL_DIR="$tmp_install_dir" bash install.sh`
