### PR TITLE
fix: build-mac.sh breaks on zsh 5.9 (macOS Sequoia)

### DIFF
--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -29,7 +29,7 @@ configure_compiler_cache() {
     elif (( $+commands[ccache] )); then
         cache_bin="ccache"
     else
-        return
+        return 0
     fi
 
     echo "Using compiler cache: $cache_bin"


### PR DESCRIPTION
## Problem

`just build` fails silently on macOS with zsh 5.9:

```
Pulling latest rebase-upstream-master from origin...
Already up to date.
error: Recipe `build-mac` failed on line 25 with exit code 1
```

## Root Cause

zsh 5.9 (shipped with macOS Sequoia) changed how bare `return` behaves under `setopt errexit`. In `configure_compiler_cache()`, when neither sccache nor ccache is installed, the control flow is:

```zsh
if (( $+commands[sccache] )); then    # (( 0 )) → exit code 1, falls through
    ...
elif (( $+commands[ccache] )); then   # (( 0 )) → exit code 1, falls through
    ...
else
    return    # ← bare return propagates exit code 1 from the last (( ))
fi
```

Bare `return` returns the exit status of the last command — which was `(( 0 ))` (exit code 1). With `errexit`, the script dies.

This didn't affect CI (Linux/bash) or devs on older zsh versions.

## Fix

`return` → `return 0`