### PR TITLE
fix: one-command release flow, fix Cargo.lock drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,10 +129,11 @@ Current release flow:
    just build
    just bundle
    ```
-2. Release (bumps version, updates Cargo.lock, commits, tags, pushes):
+2. Release from a clean local `main` branch:
    ```bash
    just release v0.X.Y
    ```
+   This bumps the version, refreshes `Cargo.lock` without upgrading dependencies, commits as `v0.X.Y: release`, pushes `main`, and then pushes only the new release tag.
 3. Pushing a `v*` tag triggers `.github/workflows/release.yml`, which builds the release artifacts on Linux CPU, Linux CUDA, and macOS and creates the GitHub release automatically.
 
 ## Credentials

--- a/Justfile
+++ b/Justfile
@@ -55,11 +55,25 @@ release-version version:
 release version:
     #!/usr/bin/env bash
     set -euo pipefail
-    scripts/release-version.sh "{{ version }}"
+    current_branch="$(git branch --show-current)"
+    if [[ "$current_branch" != "main" ]]; then
+        echo "Error: release must be run from the 'main' branch (current: ${current_branch:-detached HEAD})" >&2
+        exit 1
+    fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Error: working tree is not clean. Commit or stash changes before releasing." >&2
+        exit 1
+    fi
+    tag="{{ version }}"
+    if [[ "$tag" != v* ]]; then
+        tag="v$tag"
+    fi
+    scripts/release-version.sh "$tag"
     git add -A
-    git commit -m "{{ version }}: release"
-    git tag "{{ version }}"
-    git push origin main --tags
+    git commit -m "$tag: release"
+    git tag "$tag"
+    git push origin main
+    git push origin "$tag"
 
 # Download the default model (GLM-4.7-Flash Q4_K_M, 17GB)
 download-model:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -61,7 +61,7 @@ rm -rf /tmp/test-bundle
 just release v0.X.0
 ```
 
-This bumps the version in source + Cargo manifests, updates `Cargo.lock`, commits, tags, and pushes — all in one step.
+Run this from a clean local `main` branch. It bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, commits as `v0.X.0: release`, pushes `main`, and then pushes only the new release tag.
 
 ### 6. Let GitHub Actions build and publish the release
 

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -37,8 +37,8 @@ do
     perl -0pi -e 's/^version = "[^"]+"/version = "'"$version"'"/m' "$manifest"
 done
 
-echo "Updating Cargo.lock..."
-(cd "$REPO_ROOT" && cargo update --workspace)
+echo "Refreshing Cargo.lock workspace package versions..."
+(cd "$REPO_ROOT" && cargo metadata --format-version 1 >/dev/null)
 
 files+=("$REPO_ROOT/Cargo.lock")
 


### PR DESCRIPTION
## Problem

`just release-version` bumps version in source files and Cargo.toml but doesn't update `Cargo.lock`. CI builds with `--locked` and rejects the stale lockfile. This broke the v0.52.0 release.

## Fix

1. **`scripts/release-version.sh`** now runs `cargo update --workspace` after bumping versions, keeping Cargo.lock in sync.

2. **New `just release v0.X.Y`** command does the entire release in one step:
   - Bumps version in source + Cargo manifests
   - Updates Cargo.lock
   - Commits
   - Tags
   - Pushes main + tag

3. **Updated docs** — RELEASE.md and AGENTS.md now show the single-command flow.

## Before
```bash
just release-version v0.X.Y
git add -A && git commit -m "v0.X.Y: ..."
git tag v0.X.Y
git push origin main --tags
# hope you didn't forget cargo update
```

## After
```bash
just release v0.X.Y
```