### PR TITLE
[codex] fix explicit model chat routing

### DIFF
--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -2142,35 +2142,41 @@ async fn api_proxy(
                             .get_moe_target(&session_hint)
                             .unwrap_or(first_available_target(&targets))
                     } else if let Some(ref name) = effective_model {
-                        let selection = affinity::select_model_target_for_request(
+                        let selection = match select_explicit_model_target(
                             &targets, name, body_json, &affinity,
-                        );
-                        let t = selection.target.clone();
-                        if matches!(t, election::InferenceTarget::None) {
-                            tracing::debug!("Model '{}' not found, trying first available", name);
-                            first_available_target(&targets)
-                        } else {
-                            let routed = proxy::route_to_target(
-                                node.clone(),
-                                tcp_stream,
-                                t.clone(),
-                                &request.raw,
-                            )
-                            .await;
-                            if routed {
-                                if let Some(prefix_hash) = selection.learn_prefix_hash {
-                                    affinity.learn_target(name, prefix_hash, &t);
-                                }
-                            } else if let (Some(prefix_hash), Some(cached_target)) = (
-                                selection.learn_prefix_hash,
-                                selection.cached_target.as_ref(),
-                            ) {
-                                if cached_target == &t {
-                                    affinity.forget_target(name, prefix_hash, &t);
-                                }
+                        ) {
+                            Ok(selection) => selection,
+                            Err(msg) => {
+                                tracing::warn!(
+                                    "Model '{}' not available in current target map",
+                                    name
+                                );
+                                let _ = proxy::send_400(tcp_stream, &msg).await;
+                                return;
                             }
-                            return;
+                        };
+                        let t = selection.target.clone();
+
+                        let routed = proxy::route_to_target(
+                            node.clone(),
+                            tcp_stream,
+                            t.clone(),
+                            &request.raw,
+                        )
+                        .await;
+                        if routed {
+                            if let Some(prefix_hash) = selection.learn_prefix_hash {
+                                affinity.learn_target(name, prefix_hash, &t);
+                            }
+                        } else if let (Some(prefix_hash), Some(cached_target)) = (
+                            selection.learn_prefix_hash,
+                            selection.cached_target.as_ref(),
+                        ) {
+                            if cached_target == &t {
+                                affinity.forget_target(name, prefix_hash, &t);
+                            }
                         }
+                        return;
                     } else {
                         first_available_target(&targets)
                     };
@@ -2236,6 +2242,20 @@ fn first_available_target(targets: &election::ModelTargets) -> election::Inferen
         }
     }
     election::InferenceTarget::None
+}
+
+fn select_explicit_model_target(
+    targets: &election::ModelTargets,
+    model: &str,
+    body_json: Option<&serde_json::Value>,
+    affinity: &affinity::AffinityRouter,
+) -> std::result::Result<affinity::TargetSelection, String> {
+    let selection = affinity::select_model_target_for_request(targets, model, body_json, affinity);
+    if matches!(selection.target, election::InferenceTarget::None) {
+        Err(format!("model not available: {model}"))
+    } else {
+        Ok(selection)
+    }
 }
 
 fn bundled_bin_names(name: &str) -> Vec<String> {
@@ -3794,5 +3814,54 @@ mod tests {
             .unwrap();
 
         proxy_handle.abort();
+    }
+
+    #[test]
+    fn test_select_explicit_model_target_rejects_missing_model_instead_of_fallback() {
+        let mut targets = election::ModelTargets::default();
+        targets.targets.insert(
+            "Llama-3.2-1B-Instruct-Q4_K_M".to_string(),
+            vec![election::InferenceTarget::Local(9337)],
+        );
+
+        let err = select_explicit_model_target(
+            &targets,
+            "Qwen3-8B-Q4_K_M",
+            Some(&json!({
+                "model": "Qwen3-8B-Q4_K_M",
+                "messages": [{ "role": "user", "content": "hi" }]
+            })),
+            &affinity::AffinityRouter::default(),
+        )
+        .err()
+        .unwrap();
+
+        assert_eq!(err, "model not available: Qwen3-8B-Q4_K_M");
+        assert_eq!(
+            first_available_target(&targets),
+            election::InferenceTarget::Local(9337)
+        );
+    }
+
+    #[test]
+    fn test_select_explicit_model_target_returns_selected_target_when_present() {
+        let mut targets = election::ModelTargets::default();
+        targets.targets.insert(
+            "Qwen3-8B-Q4_K_M".to_string(),
+            vec![election::InferenceTarget::Local(4242)],
+        );
+
+        let selection = select_explicit_model_target(
+            &targets,
+            "Qwen3-8B-Q4_K_M",
+            Some(&json!({
+                "model": "Qwen3-8B-Q4_K_M",
+                "messages": [{ "role": "user", "content": "hi" }]
+            })),
+            &affinity::AffinityRouter::default(),
+        )
+        .unwrap();
+
+        assert_eq!(selection.target, election::InferenceTarget::Local(4242));
     }
 }

--- a/mesh-llm/src/tunnel.rs
+++ b/mesh-llm/src/tunnel.rs
@@ -109,6 +109,12 @@ impl Manager {
                 let port = http_port_ref.load(Ordering::Relaxed);
                 if port == 0 {
                     tracing::warn!("Inbound HTTP tunnel but no llama-server running, dropping");
+                    tokio::spawn(async move {
+                        if let Err(e) = send_http_unavailable(send, "LLM host not ready").await {
+                            tracing::warn!("Failed to send HTTP tunnel unavailable response: {e}");
+                        }
+                        drop(recv);
+                    });
                     continue;
                 }
                 let node = http_node.clone();
@@ -294,12 +300,32 @@ async fn handle_inbound_http_stream(
     http_port: u16,
 ) -> Result<()> {
     tracing::info!("Inbound HTTP tunnel stream → llama-server :{http_port}");
-    let tcp_stream = TcpStream::connect(format!("127.0.0.1:{http_port}")).await?;
+    let tcp_stream = match TcpStream::connect(format!("127.0.0.1:{http_port}")).await {
+        Ok(stream) => stream,
+        Err(e) => {
+            tracing::warn!("Inbound HTTP tunnel can't reach llama-server :{http_port}: {e}");
+            send_http_unavailable(quic_send, "LLM host unavailable").await?;
+            drop(quic_recv);
+            return Ok(());
+        }
+    };
     tcp_stream.set_nodelay(true)?;
     let _inflight = node.begin_inflight_request();
 
     let (tcp_read, tcp_write) = tokio::io::split(tcp_stream);
     relay_bidirectional(tcp_read, tcp_write, quic_send, quic_recv).await
+}
+
+async fn send_http_unavailable(mut quic_send: iroh::endpoint::SendStream, msg: &str) -> Result<()> {
+    let body = format!("{{\"error\":\"{msg}\"}}");
+    let resp = format!(
+        "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    quic_send.write_all(resp.as_bytes()).await?;
+    quic_send.finish()?;
+    Ok(())
 }
 
 pub async fn relay_tcp_via_quic(


### PR DESCRIPTION
## What changed

This fixes chat requests made with an explicitly selected model so they no longer silently fall back to the first available target when that model is missing from the proxy target map.

It also makes inbound HTTP tunnel failures return a real `503` JSON response when a remote host advertises a model but has no ready HTTP backend, instead of closing the stream with an empty reply.

## Why

On the running node chat UI, switching from one model to another could fail in two bad ways:

- the selected model could be unavailable in the current target map and the proxy would route the request to some other model anyway
- a remote host without a ready HTTP backend would drop the tunnel, which surfaced to the client as `fetch failed` / empty reply

That combination made model switching unreliable and misleading.

## Impact

Users now get explicit failure for unavailable selected models instead of a wrong-model response, and remote-host readiness failures come back as HTTP `503` responses that the chat client can surface cleanly.

## Root cause

The API proxy treated explicit model selection the same way as implicit routing fallback. When `select_model_target_for_request()` returned `InferenceTarget::None`, the code fell through to `first_available_target()`. Separately, inbound HTTP tunnel setup dropped requests when `http_port == 0` or the target backend could not be reached, but did not write an HTTP response.

## Validation

- `cargo test --release select_explicit_model_target_rejects_missing_model_instead_of_fallback`
- `cargo test --release select_explicit_model_target_returns_selected_target_when_present`
