### PR TITLE
[codex] Fix remote model routing and tunnel replies

### DIFF
--- a/mesh-llm/src/api.rs
+++ b/mesh-llm/src/api.rs
@@ -286,6 +286,7 @@ impl MeshApi {
         let served = node.models_being_served().await;
         let active_demand = node.active_demand().await;
         let my_serving_models = node.serving_models().await;
+        let my_role = node.role().await;
         let now_ts = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -298,12 +299,15 @@ impl MeshApi {
                     let peer_count = all_peers
                         .iter()
                         .filter(|p| {
-                            p.serving_models.iter().any(|s| s == name)
-                                || p.serving.as_deref() == Some(name.as_str())
+                            matches!(p.role, mesh::NodeRole::Host { .. })
+                                && (p.serving_models.iter().any(|s| s == name)
+                                    || p.serving.as_deref() == Some(name.as_str()))
                         })
                         .count();
-                    // Count self: check all serving models, fall back to primary model_name
-                    let me = if my_serving_models.iter().any(|s| s == name) || *name == model_name {
+                    // Count self only when we are currently hosting.
+                    let me = if matches!(my_role, mesh::NodeRole::Host { .. })
+                        && (my_serving_models.iter().any(|s| s == name) || *name == model_name)
+                    {
                         1
                     } else {
                         0

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -27,7 +27,7 @@ use clap::{Parser, Subcommand};
 use mesh::NodeRole;
 use std::path::{Path, PathBuf};
 
-pub const VERSION: &str = "0.52.0";
+pub const VERSION: &str = "0.52.1";
 
 #[derive(Parser, Debug)]
 #[command(name = "mesh-llm", version = VERSION,
@@ -2013,7 +2013,7 @@ async fn api_proxy(
                 Ok(request) => {
                     let body_json = request.body_json.as_ref();
                     if proxy::is_models_list_request(&request.method, &request.path) {
-                        let models: Vec<String> = targets.targets.keys().cloned().collect();
+                        let models = node.models_being_served().await;
                         let _ = proxy::send_models_list(tcp_stream, &models).await;
                         return;
                     }
@@ -2038,11 +2038,9 @@ async fn api_proxy(
                     {
                         if let Some(body_json) = body_json {
                             let cl = router::classify(body_json);
-                            let available: Vec<(&str, f64)> = targets
-                                .targets
-                                .keys()
-                                .map(|name| (name.as_str(), 0.0))
-                                .collect();
+                            let served = node.models_being_served().await;
+                            let available: Vec<(&str, f64)> =
+                                served.iter().map(|name| (name.as_str(), 0.0)).collect();
                             let picked = router::pick_model_classified(&cl, &available);
                             if let Some(name) = picked {
                                 tracing::info!(
@@ -2147,8 +2145,49 @@ async fn api_proxy(
                         );
                         let t = selection.target.clone();
                         if matches!(t, election::InferenceTarget::None) {
-                            tracing::debug!("Model '{}' not found, trying first available", name);
-                            first_available_target(&targets)
+                            let remote_hosts = node.hosts_for_model(name).await;
+                            if remote_hosts.is_empty() {
+                                tracing::debug!("Model '{}' not found, returning 503", name);
+                                let _ = proxy::send_503(tcp_stream).await;
+                                return;
+                            }
+
+                            let prepared = affinity::prepare_remote_targets_for_request(
+                                name,
+                                &remote_hosts,
+                                body_json,
+                                &affinity,
+                            );
+                            let target = prepared
+                                .ordered
+                                .iter()
+                                .find(|target| {
+                                    matches!(target, election::InferenceTarget::Remote(_))
+                                })
+                                .cloned()
+                                .unwrap_or_else(|| {
+                                    election::InferenceTarget::Remote(remote_hosts[0])
+                                });
+
+                            let routed = proxy::route_to_target(
+                                node.clone(),
+                                tcp_stream,
+                                target.clone(),
+                                &request.raw,
+                            )
+                            .await;
+                            if routed {
+                                if let Some(prefix_hash) = prepared.learn_prefix_hash {
+                                    affinity.learn_target(name, prefix_hash, &target);
+                                }
+                            } else if let (Some(prefix_hash), Some(cached_target)) =
+                                (prepared.learn_prefix_hash, prepared.cached_target.as_ref())
+                            {
+                                if cached_target == &target {
+                                    affinity.forget_target(name, prefix_hash, &target);
+                                }
+                            }
+                            return;
                         } else {
                             let routed = proxy::route_to_target(
                                 node.clone(),
@@ -3434,6 +3473,38 @@ mod tests {
 
         proxy_handle.abort();
         let _ = upstream_handle.await;
+    }
+
+    #[tokio::test]
+    async fn test_api_proxy_explicit_missing_model_returns_503_without_fallback() {
+        let (upstream_port, upstream_rx, upstream_handle) =
+            spawn_capturing_upstream(r#"{"ok":true}"#).await;
+        let (proxy_addr, proxy_handle) =
+            spawn_api_proxy_test_harness(local_targets(&[("llama", upstream_port)])).await;
+
+        let body = json!({
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hello"}],
+        })
+        .to_string();
+        let request = format!(
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let response = send_request_and_read_response(proxy_addr, vec![request.into_bytes()]).await;
+
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.contains("No inference server available"));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(200), upstream_rx)
+                .await
+                .is_err()
+        );
+
+        proxy_handle.abort();
+        upstream_handle.abort();
     }
 
     #[tokio::test]

--- a/mesh-llm/src/mesh.rs
+++ b/mesh-llm/src/mesh.rs
@@ -1948,6 +1948,7 @@ impl Node {
 
     /// Get all models currently being served in the mesh (loaded in VRAM somewhere).
     pub async fn models_being_served(&self) -> Vec<String> {
+        let my_role = self.role.lock().await.clone();
         let my_serving_models = self.serving_models.lock().await.clone();
         let my_serving = self.serving.lock().await.clone();
         let peer_data: Vec<_> = {
@@ -1955,31 +1956,10 @@ impl Node {
             state
                 .peers
                 .values()
-                .map(|p| (p.serving_models.clone(), p.serving.clone()))
+                .map(|p| (p.role.clone(), p.serving_models.clone(), p.serving.clone()))
                 .collect()
         };
-        let mut served = std::collections::HashSet::new();
-        for s in &my_serving_models {
-            served.insert(s.clone());
-        }
-        if my_serving_models.is_empty() {
-            if let Some(ref s) = my_serving {
-                served.insert(s.clone());
-            }
-        }
-        for (sm, s) in &peer_data {
-            for m in sm {
-                served.insert(m.clone());
-            }
-            if sm.is_empty() {
-                if let Some(ref s) = s {
-                    served.insert(s.clone());
-                }
-            }
-        }
-        let mut result: Vec<String> = served.into_iter().collect();
-        result.sort();
-        result
+        models_currently_hosted(my_role, my_serving_models, my_serving, peer_data)
     }
 
     /// Find a host for a specific model, using hash-based selection for load distribution.
@@ -3131,6 +3111,40 @@ impl Node {
     }
 }
 
+fn models_currently_hosted(
+    my_role: NodeRole,
+    my_serving_models: Vec<String>,
+    my_serving: Option<String>,
+    peer_data: Vec<(NodeRole, Vec<String>, Option<String>)>,
+) -> Vec<String> {
+    let mut served = std::collections::HashSet::new();
+    if matches!(my_role, NodeRole::Host { .. }) {
+        for s in &my_serving_models {
+            served.insert(s.clone());
+        }
+        if my_serving_models.is_empty() {
+            if let Some(ref s) = my_serving {
+                served.insert(s.clone());
+            }
+        }
+    }
+    for (role, sm, s) in &peer_data {
+        if matches!(role, NodeRole::Host { .. }) {
+            for m in sm {
+                served.insert(m.clone());
+            }
+            if sm.is_empty() {
+                if let Some(ref s) = s {
+                    served.insert(s.clone());
+                }
+            }
+        }
+    }
+    let mut result: Vec<String> = served.into_iter().collect();
+    result.sort();
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3544,6 +3558,41 @@ mod tests {
         let decoded: TestAnnouncement = serde_json::from_str(json).unwrap();
 
         assert_eq!(decoded.gpu_bandwidth_gbps, None);
+    }
+
+    #[test]
+    fn test_models_currently_hosted_only_includes_hosts() {
+        let served = models_currently_hosted(
+            NodeRole::Worker,
+            vec!["LocalDeclared".into()],
+            Some("LocalDeclared".into()),
+            vec![
+                (
+                    NodeRole::Worker,
+                    vec!["WorkerDeclared".into()],
+                    Some("WorkerDeclared".into()),
+                ),
+                (
+                    NodeRole::Host { http_port: 9001 },
+                    vec!["RemoteReady".into()],
+                    Some("RemoteReady".into()),
+                ),
+            ],
+        );
+
+        assert_eq!(served, vec!["RemoteReady"]);
+    }
+
+    #[test]
+    fn test_models_currently_hosted_uses_primary_serving_when_list_empty() {
+        let served = models_currently_hosted(
+            NodeRole::Host { http_port: 9000 },
+            vec![],
+            Some("LocalReady".into()),
+            vec![],
+        );
+
+        assert_eq!(served, vec!["LocalReady"]);
     }
 }
 

--- a/mesh-llm/src/proxy.rs
+++ b/mesh-llm/src/proxy.rs
@@ -398,13 +398,14 @@ pub async fn handle_mesh_request(
         }
     }
 
-    // Resolve target hosts by model name, fall back to any host
+    // Resolve target hosts by model name. Explicit model requests must fail
+    // closed so we never answer with the wrong model.
     let target_hosts = if let Some(ref name) = effective_model {
         node.hosts_for_model(name).await
     } else {
         vec![]
     };
-    let target_hosts = if target_hosts.is_empty() {
+    let target_hosts = if target_hosts.is_empty() && effective_model.is_none() {
         match node.any_host().await {
             Some(p) => vec![p.id],
             None => {
@@ -412,6 +413,9 @@ pub async fn handle_mesh_request(
                 return;
             }
         }
+    } else if target_hosts.is_empty() {
+        let _ = send_503(tcp_stream).await;
+        return;
     } else {
         target_hosts
     };

--- a/mesh-llm/src/tunnel.rs
+++ b/mesh-llm/src/tunnel.rs
@@ -299,7 +299,11 @@ async fn handle_inbound_http_stream(
     let _inflight = node.begin_inflight_request();
 
     let (tcp_read, tcp_write) = tokio::io::split(tcp_stream);
-    relay_bidirectional(tcp_read, tcp_write, quic_send, quic_recv).await
+    let request_to_llama =
+        tokio::spawn(async move { relay_quic_to_tcp(quic_recv, tcp_write).await });
+    let response_to_peer =
+        tokio::spawn(async move { relay_tcp_to_quic(tcp_read, quic_send).await });
+    finish_request_then_drain_response(request_to_llama, response_to_peer, "inbound_http").await
 }
 
 pub async fn relay_tcp_via_quic(
@@ -338,21 +342,28 @@ pub async fn relay_bidirectional(
     quic_send: iroh::endpoint::SendStream,
     quic_recv: iroh::endpoint::RecvStream,
 ) -> Result<()> {
-    let mut t1 = tokio::spawn(async move { relay_tcp_to_quic(tcp_read, quic_send).await });
-    let mut t2 = tokio::spawn(async move { relay_quic_to_tcp(quic_recv, tcp_write).await });
-    // If the request side finishes first, keep draining the response side.
-    // This matters for HTTP where the client may finish sending the request
-    // before the server has produced the response.
+    let request_to_peer = tokio::spawn(async move { relay_tcp_to_quic(tcp_read, quic_send).await });
+    let response_to_client =
+        tokio::spawn(async move { relay_quic_to_tcp(quic_recv, tcp_write).await });
+    finish_request_then_drain_response(request_to_peer, response_to_client, "relay_bidirectional")
+        .await
+}
+
+async fn finish_request_then_drain_response(
+    mut request_task: tokio::task::JoinHandle<Result<()>>,
+    mut response_task: tokio::task::JoinHandle<Result<()>>,
+    context: &str,
+) -> Result<()> {
     tokio::select! {
-        r1 = &mut t1 => {
-            r1??;
-            tracing::debug!("relay_bidirectional: request side finished, waiting for response side");
-            t2.await??;
+        request = &mut request_task => {
+            request??;
+            tracing::debug!("{context}: request side finished, waiting for response side");
+            response_task.await??;
         }
-        r2 = &mut t2 => {
-            r2??;
-            t1.abort();
-            let _ = t1.await;
+        response = &mut response_task => {
+            response??;
+            request_task.abort();
+            let _ = request_task.await;
         }
     }
     Ok(())
@@ -455,6 +466,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::sync::oneshot;
 
     #[tokio::test]
     async fn relay_response_times_out_before_first_byte() {
@@ -546,5 +558,25 @@ mod tests {
             forwarded,
             b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"
         );
+    }
+
+    #[tokio::test]
+    async fn finish_request_then_drain_response_waits_for_response_after_request_eof() {
+        let (done_tx, done_rx) = oneshot::channel();
+        let request = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            Ok(())
+        });
+        let response = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(40)).await;
+            let _ = done_tx.send(());
+            Ok(())
+        });
+
+        finish_request_then_drain_response(request, response, "test")
+            .await
+            .unwrap();
+
+        done_rx.await.unwrap();
     }
 }


### PR DESCRIPTION
## What changed

This fixes remote model routing and HTTP proxy behavior in the mesh API path.

- explicit model requests now fail closed with `503` instead of falling through to an unrelated local model
- mesh model lists and warm-model status now only include active hosts
- full API proxy routing can resolve peer-only models via mesh host discovery
- inbound HTTP tunnel relay now continues draining the response after request EOF so healthy remote hosts do not return an empty reply

## Why

We were seeing two separate failures in remote chat flows:

1. requests for a missing or non-routable model could silently fall back to a different model
2. requests to a healthy remote peer could terminate with an empty HTTP reply because the tunnel closed the response side too early

## Validation

- `cargo test -p mesh-llm explicit_missing_model_returns_503_without_fallback`
- `cargo test -p mesh-llm models_currently_hosted`
- `cargo test -p mesh-llm finish_request_then_drain_response_waits_for_response_after_request_eof`
- `git diff --check`
- three-node private mesh retest with rebuilt `0.52.1` binaries on all machines:
  - local `mac.lan`: `Llama-3.2-1B-Instruct-Q4_K_M`, `Serving`, `llama_ready=true`
  - `build.local` / `macmini.lan`: `Qwen2.5-3B-Instruct-Q4_K_M`, `Serving`, `llama_ready=true`
  - `studio54.local` / `studio54.lan`: `GLM-4.7-Flash-Q4_K_M`, `Serving`, `llama_ready=true`
- chat-completions matrix on each node's local `:9337` API:
  - local -> Llama: `200 OK`
  - local -> GLM: `200 OK`
  - local -> Qwen: `200 OK`
  - `build.local` -> Llama: `200 OK`
  - `build.local` -> GLM: `200 OK`
  - `build.local` -> Qwen: `200 OK`
  - `studio54.local` -> Llama: `200 OK`
  - `studio54.local` -> GLM: `200 OK`
  - `studio54.local` -> Qwen: `200 OK`
