### PR TITLE
Disable Windows release builds until llama.cpp CUDA fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -237,91 +237,95 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
-  build_windows:
-    name: Build Windows ${{ matrix.name }}
-    runs-on: windows-2022
-    env:
-      ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: CPU
-            backend: cpu
-            build_recipe: release-build-windows
-            bundle_recipe: release-bundle-windows
-            artifact_name: release-windows-cpu
-          - name: CUDA
-            backend: cuda
-            build_recipe: release-build-cuda-windows
-            bundle_recipe: release-bundle-cuda-windows
-            artifact_name: release-windows-cuda
-          - name: ROCm
-            backend: rocm
-            build_recipe: release-build-amd-windows
-            bundle_recipe: release-bundle-amd-windows
-            artifact_name: release-windows-rocm
-          - name: Vulkan
-            backend: vulkan
-            build_recipe: release-build-vulkan-windows
-            bundle_recipe: release-bundle-vulkan-windows
-            artifact_name: release-windows-vulkan
-
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: taiki-e/install-action@just
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: mesh-llm/ui/package-lock.json
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: |
-            . -> target
-
-      - name: Cache Windows SDK installers
-        if: matrix.backend != 'cpu'
-        uses: actions/cache@v5
-        with:
-          path: ~\sdk-installer-cache\${{ matrix.backend }}
-          key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
-
-      - name: Install backend SDK
-        shell: pwsh
-        run: |
-          .\scripts\install-windows-sdk.ps1 `
-            -Backend '${{ matrix.backend }}' `
-            -RocmHipSdkFilename $env:ROCM_HIP_SDK_FILENAME `
-            -InstallerCacheDir (Join-Path $env:USERPROFILE 'sdk-installer-cache\${{ matrix.backend }}')
-
-      - name: Build Windows release bundle
-        shell: pwsh
-        run: |
-          just ${{ matrix.build_recipe }}
-          just ${{ matrix.bundle_recipe }} "${env:GITHUB_REF_NAME}" dist
-
-      - name: Upload Windows release artifacts
-        uses: actions/upload-artifact@v6
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: dist/*
-          if-no-files-found: error
-
-      - name: Show sccache stats
-        if: always()
-        shell: pwsh
-        run: |
-          if (Get-Command sccache -ErrorAction SilentlyContinue) {
-            sccache --show-stats
-          }
+  # Windows release builds disabled until llama.cpp CUDA compile issue is resolved
+  # (mmvq.cu fails for compute_120a / Blackwell). Re-enable by uncommenting
+  # build_windows below and adding it back to publish.needs.
+  #
+  # build_windows:
+  #   name: Build Windows ${{ matrix.name }}
+  #   runs-on: windows-2022
+  #   env:
+  #     ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       include:
+  #         - name: CPU
+  #           backend: cpu
+  #           build_recipe: release-build-windows
+  #           bundle_recipe: release-bundle-windows
+  #           artifact_name: release-windows-cpu
+  #         - name: CUDA
+  #           backend: cuda
+  #           build_recipe: release-build-cuda-windows
+  #           bundle_recipe: release-bundle-cuda-windows
+  #           artifact_name: release-windows-cuda
+  #         - name: ROCm
+  #           backend: rocm
+  #           build_recipe: release-build-amd-windows
+  #           bundle_recipe: release-bundle-amd-windows
+  #           artifact_name: release-windows-rocm
+  #         - name: Vulkan
+  #           backend: vulkan
+  #           build_recipe: release-build-vulkan-windows
+  #           bundle_recipe: release-bundle-vulkan-windows
+  #           artifact_name: release-windows-vulkan
+  #
+  #   steps:
+  #     - uses: actions/checkout@v5
+  #
+  #     - uses: taiki-e/install-action@just
+  #
+  #     - uses: actions/setup-node@v5
+  #       with:
+  #         node-version: 24
+  #         cache: npm
+  #         cache-dependency-path: mesh-llm/ui/package-lock.json
+  #
+  #     - uses: dtolnay/rust-toolchain@stable
+  #
+  #     - uses: mozilla-actions/sccache-action@v0.0.9
+  #
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         workspaces: |
+  #           . -> target
+  #
+  #     - name: Cache Windows SDK installers
+  #       if: matrix.backend != 'cpu'
+  #       uses: actions/cache@v5
+  #       with:
+  #         path: ~\sdk-installer-cache\${{ matrix.backend }}
+  #         key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
+  #
+  #     - name: Install backend SDK
+  #       shell: pwsh
+  #       run: |
+  #         .\scripts\install-windows-sdk.ps1 `
+  #           -Backend '${{ matrix.backend }}' `
+  #           -RocmHipSdkFilename $env:ROCM_HIP_SDK_FILENAME `
+  #           -InstallerCacheDir (Join-Path $env:USERPROFILE 'sdk-installer-cache\${{ matrix.backend }}')
+  #
+  #     - name: Build Windows release bundle
+  #       shell: pwsh
+  #       run: |
+  #         just ${{ matrix.build_recipe }}
+  #         just ${{ matrix.bundle_recipe }} "${env:GITHUB_REF_NAME}" dist
+  #
+  #     - name: Upload Windows release artifacts
+  #       uses: actions/upload-artifact@v6
+  #       with:
+  #         name: ${{ matrix.artifact_name }}
+  #         path: dist/*
+  #         if-no-files-found: error
+  #
+  #     - name: Show sccache stats
+  #       if: always()
+  #       shell: pwsh
+  #       run: |
+  #         if (Get-Command sccache -ErrorAction SilentlyContinue) {
+  #           sccache --show-stats
+  #         }
 
   publish:
     name: Publish GitHub release
@@ -331,7 +335,7 @@ jobs:
       - build_linux_cuda
       - build_linux_amd
       - build_linux_vulkan
-      - build_windows
+      # - build_windows  # disabled until llama.cpp CUDA fix
 
     steps:
       - name: Download release artifacts


### PR DESCRIPTION
Windows CUDA release build fails on `mmvq.cu` for `compute_120a` (Blackwell arch). Since the publish job depends on all builds passing, this blocks the entire release.

Disable Windows release builds for now so Linux + macOS releases can ship. Windows CI builds (in ci.yml) still run on PRs.

Re-enable when the llama.cpp fork's CUDA 12 Blackwell support is fixed.