### PR TITLE
[codex] Cache the Vite UI build

### DIFF
--- a/scripts/build-linux-amd.sh
+++ b/scripts/build-linux-amd.sh
@@ -90,8 +90,7 @@ echo "llama.cpp ROCm build complete: $BUILD_DIR/bin/"
 
 if [[ -d "$MESH_DIR" ]]; then
     if [[ -d "$UI_DIR" ]]; then
-        echo "Building mesh-llm UI..."
-        (cd "$UI_DIR" && npm ci && npm run build)
+        "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
     fi
     echo "Building mesh-llm..."
     (cd "$REPO_ROOT" && cargo build --release --locked -p mesh-llm)

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -312,8 +312,7 @@ echo "llama.cpp build complete: $BUILD_DIR/bin/"
 
 if [[ -d "$MESH_DIR" ]]; then
     if [[ -d "$UI_DIR" ]]; then
-        echo "Building mesh-llm UI..."
-        (cd "$UI_DIR" && npm ci && npm run build)
+        "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
     fi
     echo "Building mesh-llm..."
     (cd "$MESH_DIR" && cargo build --release)

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -90,12 +90,7 @@ echo "Build complete: $BUILD_DIR/bin/"
 if [[ -d "$MESH_DIR" ]]; then
     echo "Building mesh-llm..."
     if [[ -d "$UI_DIR" ]]; then
-        echo "Building mesh-llm UI..."
-        (
-            cd "$UI_DIR"
-            npm ci
-            npm run build
-        )
+        "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
     fi
 
     if [[ -n "$rustc_wrapper" ]]; then

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -101,11 +101,7 @@ echo "Building llama.cpp..."
 cmake --build "$BUILD_DIR" --config Release --parallel "$(detect_jobs)"
 
 echo "Building UI..."
-(
-    cd "$UI_DIR"
-    npm ci
-    npm run build
-)
+"$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
 
 echo "Building mesh-llm..."
 (

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+UI_DIR="${1:?usage: build-ui.sh /path/to/ui}"
+DIST_DIR="$UI_DIR/dist"
+NODE_MODULES_DIR="$UI_DIR/node_modules"
+
+ui_build_inputs=(
+    "$UI_DIR/package.json"
+    "$UI_DIR/package-lock.json"
+    "$UI_DIR/vite.config.ts"
+    "$UI_DIR/tsconfig.json"
+    "$UI_DIR/postcss.config.cjs"
+    "$UI_DIR/tailwind.config.ts"
+    "$UI_DIR/index.html"
+    "$UI_DIR/src"
+    "$UI_DIR/public"
+)
+
+dist_has_output() {
+    [[ -d "$DIST_DIR" ]] && find "$DIST_DIR" -type f -print -quit | grep -q .
+}
+
+ui_build_is_stale() {
+    if ! dist_has_output; then
+        return 0
+    fi
+
+    for path in "${ui_build_inputs[@]}"; do
+        [[ -e "$path" ]] || continue
+        if find "$path" -type f -newer "$DIST_DIR" -print -quit | grep -q .; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+npm_install_is_stale() {
+    if [[ ! -d "$NODE_MODULES_DIR" ]]; then
+        return 0
+    fi
+
+    local manifest
+    for manifest in "$UI_DIR/package.json" "$UI_DIR/package-lock.json"; do
+        [[ -e "$manifest" ]] || continue
+        if [[ "$manifest" -nt "$NODE_MODULES_DIR" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+if ui_build_is_stale; then
+    echo "Building mesh-llm UI..."
+    cd "$UI_DIR"
+
+    if npm_install_is_stale; then
+        npm ci
+    fi
+
+    npm run build
+else
+    echo "Skipping mesh-llm UI build; dist is up to date."
+fi

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -102,6 +102,85 @@ function Invoke-NativeCommand {
     }
 }
 
+function Test-UiBuildRequired {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$UiDirectory
+    )
+
+    $distDir = Join-Path $UiDirectory "dist"
+    if (-not (Test-Path $distDir)) {
+        return $true
+    }
+
+    $distFiles = Get-ChildItem -Path $distDir -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $distFiles) {
+        return $true
+    }
+
+    $distTimestampUtc = (Get-Item $distDir).LastWriteTimeUtc
+    $uiBuildInputs = @(
+        (Join-Path $UiDirectory "package.json"),
+        (Join-Path $UiDirectory "package-lock.json"),
+        (Join-Path $UiDirectory "vite.config.ts"),
+        (Join-Path $UiDirectory "tsconfig.json"),
+        (Join-Path $UiDirectory "postcss.config.cjs"),
+        (Join-Path $UiDirectory "tailwind.config.ts"),
+        (Join-Path $UiDirectory "index.html"),
+        (Join-Path $UiDirectory "src"),
+        (Join-Path $UiDirectory "public")
+    )
+
+    foreach ($path in $uiBuildInputs) {
+        if (-not (Test-Path $path)) {
+            continue
+        }
+
+        $item = Get-Item $path
+        if ($item.PSIsContainer) {
+            $newerInput = Get-ChildItem -Path $path -File -Recurse -ErrorAction SilentlyContinue |
+                Where-Object { $_.LastWriteTimeUtc -gt $distTimestampUtc } |
+                Select-Object -First 1
+            if ($newerInput) {
+                return $true
+            }
+            continue
+        }
+
+        if ($item.LastWriteTimeUtc -gt $distTimestampUtc) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
+function Test-NpmInstallRequired {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$UiDirectory
+    )
+
+    $nodeModulesDir = Join-Path $UiDirectory "node_modules"
+    if (-not (Test-Path $nodeModulesDir)) {
+        return $true
+    }
+
+    $nodeModulesTimestampUtc = (Get-Item $nodeModulesDir).LastWriteTimeUtc
+    foreach ($manifestName in @("package.json", "package-lock.json")) {
+        $manifestPath = Join-Path $UiDirectory $manifestName
+        if (-not (Test-Path $manifestPath)) {
+            continue
+        }
+
+        if ((Get-Item $manifestPath).LastWriteTimeUtc -gt $nodeModulesTimestampUtc) {
+            return $true
+        }
+    }
+
+    return $false
+}
+
 function Normalize-RecipeArgument {
     param(
         [AllowEmptyString()]
@@ -594,13 +673,19 @@ Invoke-InRepo {
     Write-Host "Build complete: $buildDir\bin\"
 
     if (Test-Path $meshUiDir) {
-        Write-Host "Building mesh-llm UI..."
-        Push-Location $meshUiDir
-        try {
-            Invoke-NativeCommand "npm" @("ci")
-            Invoke-NativeCommand "npm" @("run", "build")
-        } finally {
-            Pop-Location
+        if (Test-UiBuildRequired -UiDirectory $meshUiDir) {
+            Write-Host "Building mesh-llm UI..."
+            Push-Location $meshUiDir
+            try {
+                if (Test-NpmInstallRequired -UiDirectory $meshUiDir) {
+                    Invoke-NativeCommand "npm" @("ci")
+                }
+                Invoke-NativeCommand "npm" @("run", "build")
+            } finally {
+                Pop-Location
+            }
+        } else {
+            Write-Host "Skipping mesh-llm UI build; dist is up to date."
         }
     }
 


### PR DESCRIPTION
## Summary
- add a shared UI build helper that skips `vite build` when `mesh-llm/ui/dist` is already current
- avoid rerunning `npm ci` unless `node_modules` is missing or the package manifests changed
- wire the cache check into the macOS, Linux, Linux AMD, release, and Windows build scripts

## Why
Local `just build` paths were rebuilding the UI unconditionally even when the Vite output was already up to date, which added unnecessary frontend work to backend-focused rebuilds.

## Validation
- `bash -n scripts/build-ui.sh scripts/build-linux.sh scripts/build-linux-amd.sh scripts/build-release.sh`
- `zsh -n scripts/build-mac.sh`
- ran `scripts/build-ui.sh mesh-llm/ui` twice; first run built the UI, second run skipped with `dist` up to date
- Windows PowerShell syntax was not validated in this environment because `pwsh` is unavailable
