### PR TITLE
[codex] add CI artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,15 @@ jobs:
         with:
           workspaces: mesh-llm
 
+      - name: Stamp CI version
+        shell: bash
+        run: |
+          base_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' mesh-llm/Cargo.toml | head -n1)"
+          short_sha="${GITHUB_SHA::7}"
+          ci_version="${base_version}-${short_sha}-${GITHUB_RUN_NUMBER}"
+          echo "CI_VERSION=$ci_version" >> "$GITHUB_ENV"
+          scripts/set-workspace-version.sh "$ci_version"
+
       - name: Unit tests
         run: cargo test --release
 
@@ -129,6 +138,18 @@ jobs:
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
 
+      - name: Package CI artifacts
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-bundle "${CI_VERSION}" dist
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-linux-cpu
+          path: dist/*
+          if-no-files-found: error
+
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -157,6 +178,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: mesh-llm
+
+      - name: Stamp CI version
+        shell: bash
+        run: |
+          base_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' mesh-llm/Cargo.toml | head -n1)"
+          short_sha="${GITHUB_SHA::7}"
+          ci_version="${base_version}-${short_sha}-${GITHUB_RUN_NUMBER}"
+          echo "CI_VERSION=$ci_version" >> "$GITHUB_ENV"
+          scripts/set-workspace-version.sh "$ci_version"
 
       - name: Unit tests
         run: cargo test --release
@@ -220,6 +250,18 @@ jobs:
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
 
+      - name: Package CI artifacts
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-bundle "${CI_VERSION}" dist
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-macos
+          path: dist/*
+          if-no-files-found: error
+
       - name: Show sccache stats
         if: always()
         run: sccache --show-stats || true
@@ -272,6 +314,15 @@ jobs:
           workspaces: |
             . -> target
 
+      - name: Stamp CI version
+        shell: bash
+        run: |
+          base_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' mesh-llm/Cargo.toml | head -n1)"
+          short_sha="${GITHUB_SHA::7}"
+          ci_version="${base_version}-${short_sha}-${GITHUB_RUN_NUMBER}"
+          echo "CI_VERSION=$ci_version" >> "$GITHUB_ENV"
+          scripts/set-workspace-version.sh "$ci_version"
+
       - name: Build Linux CUDA backend
         shell: bash
         run: |
@@ -282,6 +333,18 @@ jobs:
         run: |
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
+
+      - name: Package CI artifacts
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-bundle-cuda "${CI_VERSION}" dist
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-linux-cuda
+          path: dist/*
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()
@@ -335,6 +398,15 @@ jobs:
           workspaces: |
             . -> target
 
+      - name: Stamp CI version
+        shell: bash
+        run: |
+          base_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' mesh-llm/Cargo.toml | head -n1)"
+          short_sha="${GITHUB_SHA::7}"
+          ci_version="${base_version}-${short_sha}-${GITHUB_RUN_NUMBER}"
+          echo "CI_VERSION=$ci_version" >> "$GITHUB_ENV"
+          scripts/set-workspace-version.sh "$ci_version"
+
       - name: Build Linux ROCm backend
         shell: bash
         run: |
@@ -345,6 +417,18 @@ jobs:
         run: |
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
+
+      - name: Package CI artifacts
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-bundle-amd "${CI_VERSION}" dist
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-linux-rocm
+          path: dist/*
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()
@@ -398,6 +482,15 @@ jobs:
           workspaces: |
             . -> target
 
+      - name: Stamp CI version
+        shell: bash
+        run: |
+          base_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' mesh-llm/Cargo.toml | head -n1)"
+          short_sha="${GITHUB_SHA::7}"
+          ci_version="${base_version}-${short_sha}-${GITHUB_RUN_NUMBER}"
+          echo "CI_VERSION=$ci_version" >> "$GITHUB_ENV"
+          scripts/set-workspace-version.sh "$ci_version"
+
       - name: Build Linux Vulkan backend
         shell: bash
         run: |
@@ -408,6 +501,18 @@ jobs:
         run: |
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
+
+      - name: Package CI artifacts
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-bundle-vulkan "${CI_VERSION}" dist
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-linux-vulkan
+          path: dist/*
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()
@@ -459,6 +564,15 @@ jobs:
         with:
           workspaces: |
             . -> target
+
+      - name: Stamp CI version
+        shell: pwsh
+        run: |
+          $baseVersion = (Select-String -Path 'mesh-llm/Cargo.toml' -Pattern '^version = "([^"]+)"').Matches[0].Groups[1].Value
+          $shortSha = "${env:GITHUB_SHA}".Substring(0, 7)
+          $ciVersion = "$baseVersion-$shortSha-${env:GITHUB_RUN_NUMBER}"
+          "CI_VERSION=$ciVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          bash scripts/set-workspace-version.sh $ciVersion
 
       - name: Cache Windows SDK installers
         if: matrix.backend != 'cpu'
@@ -514,6 +628,26 @@ jobs:
         run: |
           target\release\mesh-llm.exe --version
           target\release\mesh-llm.exe --help | Select-Object -First 5
+
+      - name: Package CI artifacts
+        shell: pwsh
+        run: |
+          if ('${{ matrix.backend }}' -eq 'cpu') {
+            just release-bundle-windows $env:CI_VERSION dist
+          } elseif ('${{ matrix.backend }}' -eq 'cuda') {
+            just release-bundle-cuda-windows $env:CI_VERSION dist
+          } elseif ('${{ matrix.backend }}' -eq 'rocm') {
+            just release-bundle-amd-windows $env:CI_VERSION dist
+          } else {
+            just release-bundle-vulkan-windows $env:CI_VERSION dist
+          }
+
+      - name: Upload CI artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-windows-${{ matrix.backend }}
+          path: dist/*
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -34,7 +34,7 @@ use clap::{Parser, Subcommand};
 use mesh::NodeRole;
 use std::path::{Path, PathBuf};
 
-pub const VERSION: &str = "0.53.1";
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Parser, Debug)]
 #[command(name = "mesh-llm", version = VERSION,

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -17,32 +17,6 @@ if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+"$SCRIPT_DIR/set-workspace-version.sh" "$version"
 
-files=(
-    "$REPO_ROOT/mesh-llm/src/main.rs"
-    "$REPO_ROOT/mesh-llm/Cargo.toml"
-    "$REPO_ROOT/mesh-llm/plugin/Cargo.toml"
-    "$REPO_ROOT/mesh-llm/src/plugins/example/Cargo.toml"
-)
-
-perl -0pi -e 's/pub const VERSION: &str = "\K[^"]+(?=";)/'"$version"'/g' \
-    "$REPO_ROOT/mesh-llm/src/main.rs"
-
-for manifest in \
-    "$REPO_ROOT/mesh-llm/Cargo.toml" \
-    "$REPO_ROOT/mesh-llm/plugin/Cargo.toml" \
-    "$REPO_ROOT/mesh-llm/src/plugins/example/Cargo.toml"
-do
-    perl -0pi -e 's/^version = "[^"]+"/version = "'"$version"'"/m' "$manifest"
-done
-
-echo "Refreshing Cargo.lock workspace package versions..."
-(cd "$REPO_ROOT" && cargo metadata --format-version 1 >/dev/null)
-
-files+=("$REPO_ROOT/Cargo.lock")
-
-echo "Updated release version to $version:"
-for file in "${files[@]}"; do
-    echo "  $file"
-done
+echo "Updated release version to $version."

--- a/scripts/set-workspace-version.sh
+++ b/scripts/set-workspace-version.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "usage: scripts/set-workspace-version.sh <version>" >&2
+    exit 1
+fi
+
+version="$1"
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+    echo "invalid version: $version" >&2
+    echo "expected semver like 0.53.1 or 0.53.1-deadbeef-123" >&2
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+files=(
+    "$REPO_ROOT/mesh-llm/Cargo.toml"
+    "$REPO_ROOT/mesh-llm/plugin/Cargo.toml"
+    "$REPO_ROOT/mesh-llm/src/plugins/example/Cargo.toml"
+)
+
+for manifest in "${files[@]}"; do
+    perl -0pi -e 's/^version = "[^"]+"/version = "'"$version"'"/m' "$manifest"
+done
+
+if command -v cargo >/dev/null 2>&1; then
+    echo "Refreshing Cargo.lock workspace package versions..."
+    (cd "$REPO_ROOT" && cargo metadata --format-version 1 >/dev/null)
+else
+    echo "cargo not available yet; skipping Cargo.lock refresh"
+fi
+
+echo "Updated workspace version to $version:"
+for file in "${files[@]}" "$REPO_ROOT/Cargo.lock"; do
+    echo "  $file"
+done


### PR DESCRIPTION
## What changed

This updates CI to package and upload build artifacts for each job, including Linux CPU/CUDA/ROCm/Vulkan, macOS, and the Windows backend matrix.

It also stamps CI builds with a version derived from the workspace semver, the short commit SHA, and the GitHub run number, and makes the runtime binary version come from Cargo package metadata.

## Why

The CI workflow was building binaries but not attaching downloadable artifacts. It also relied on a duplicated hardcoded runtime version constant, which made CI-specific build identifiers awkward to propagate consistently into binaries and packaged archives.

## Impact

Developers can now download CI-produced artifacts directly from workflow runs, and the binary/package version reported in CI builds will match the `0.x.x-<commit>-<run>` stamped package version.

Release versioning keeps using the existing release flow, now through the shared workspace version helper.

## Validation

- `bash -n scripts/release-version.sh scripts/set-workspace-version.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml ok"'`
- `cargo metadata --format-version 1 >/dev/null`
