### PR TITLE
feat: log to ~/.mesh-llm/mesh-llm.log alongside stderr

### DIFF
--- a/mesh-llm/Cargo.toml
+++ b/mesh-llm/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 anyhow = "1"

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -302,16 +302,49 @@ enum PluginCommand {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("mesh_inference=info".parse()?)
-                .add_directive("nostr_relay_pool=off".parse()?)
-                .add_directive("nostr_sdk=warn".parse()?)
-                .add_directive("noq_proto::connection=warn".parse()?),
-        )
-        .with_writer(std::io::stderr)
-        .init();
+    // Log to both stderr and ~/.mesh-llm/mesh-llm.log
+    let env_filter = tracing_subscriber::EnvFilter::from_default_env()
+        .add_directive("mesh_inference=info".parse()?)
+        .add_directive("nostr_relay_pool=off".parse()?)
+        .add_directive("nostr_sdk=warn".parse()?)
+        .add_directive("noq_proto::connection=warn".parse()?);
+
+    let log_dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".mesh-llm");
+    std::fs::create_dir_all(&log_dir).ok();
+    let log_path = log_dir.join("mesh-llm.log");
+
+    // Truncate log file on startup (keeps it from growing forever across restarts)
+    let log_file = std::fs::File::create(&log_path).ok();
+
+    if let Some(file) = log_file {
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        let (non_blocking, _guard) = tracing_appender::non_blocking(file);
+        // Leak the guard so it lives for the entire process
+        std::mem::forget(_guard);
+
+        let stderr_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_ansi(false)
+            .with_writer(non_blocking);
+
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(stderr_layer)
+            .with(file_layer)
+            .init();
+
+        tracing::info!("Logging to {}", log_path.display());
+    } else {
+        // Fallback: stderr only
+        tracing_subscriber::fmt()
+            .with_env_filter(env_filter)
+            .with_writer(std::io::stderr)
+            .init();
+    };
 
     // --help-advanced: print full help with all hidden options and commands visible
     if std::env::args().any(|a| a == "--help-advanced") {

--- a/mesh-llm/src/mesh.rs
+++ b/mesh-llm/src/mesh.rs
@@ -645,6 +645,7 @@ struct MeshState {
 /// Returns `true` if the given peer has completed gossip validation and is
 /// a full mesh member. Unadmitted peers are in `state.connections` but not
 /// in `state.peers` — they are quarantined until gossip succeeds.
+#[cfg(test)]
 pub(crate) fn is_peer_admitted(peers: &HashMap<EndpointId, PeerInfo>, id: &EndpointId) -> bool {
     peers.contains_key(id)
 }
@@ -2380,6 +2381,7 @@ impl Node {
         RoutingTable { hosts, mesh_id }
     }
 
+    #[cfg(test)]
     pub async fn request_route_table(&self, conn: &Connection) -> Result<RoutingTable> {
         use prost::Message as _;
         let protocol = connection_protocol(conn);


### PR DESCRIPTION
Adds a file log layer so mesh-llm output can be inspected remotely (e.g. via SSH) without needing access to the running terminal.

- Uses tracing-appender non-blocking writer to `~/.mesh-llm/mesh-llm.log`
- Truncates log on each startup (no unbounded growth)
- No ANSI codes in file output
- Falls back to stderr-only if file creation fails
- Fix dead code warnings for test-only `is_peer_admitted` and `request_route_table` in mesh.rs