### PR TITLE
Fix UI build to fail on TypeScript compile errors

### DIFF
--- a/mesh-llm/ui/package.json
+++ b/mesh-llm/ui/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "build": "npm run typecheck && vite build",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -18,6 +18,7 @@ import {
   type Edge,
   type Node,
   type NodeProps,
+  type NodeTypes,
   type ReactFlowInstance,
 } from "@xyflow/react";
 import {
@@ -385,13 +386,14 @@ function sanitizeMessages(raw: unknown): ChatMessage[] {
       typeof content !== "string"
     )
       return [];
+    const safeRole: ChatMessage["role"] = role;
     return [
       {
         id:
           typeof (item as { id?: unknown }).id === "string"
             ? (item as { id: string }).id
             : randomId(),
-        role,
+        role: safeRole,
         content: clampText(content, CHAT_MAX_TEXT_CHARS) ?? "",
         reasoning: clampText(
           typeof (item as { reasoning?: unknown }).reasoning === "string"
@@ -1398,6 +1400,7 @@ export function App() {
                 isFlyHosted={isFlyHosted}
                 inflightRequests={status?.inflight_requests ?? 0}
                 warmModels={warmModels}
+                meshModelByName={meshModelByName}
                 modelStatsByName={modelStatsByName}
                 selectedModel={selectedModel}
                 setSelectedModel={setSelectedModel}
@@ -2018,6 +2021,7 @@ function ChatPage(props: {
   isFlyHosted: boolean;
   inflightRequests: number;
   warmModels: string[];
+  meshModelByName: Record<string, MeshModel>;
   modelStatsByName: Record<string, ModelServingStat>;
   selectedModel: string;
   setSelectedModel: (v: string) => void;
@@ -2052,6 +2056,7 @@ function ChatPage(props: {
   const {
     inviteToken,
     warmModels,
+    meshModelByName,
     modelStatsByName,
     selectedModel,
     setSelectedModel,
@@ -2379,9 +2384,8 @@ function ChatPage(props: {
                     ? "✨ Auto (router picks best)"
                     : selectedModelValue
                       ? shortName(
-                          modelDisplayName(
-                            meshModelByName[selectedModelValue],
-                          ) || selectedModelValue,
+                          modelDisplayName(meshModelByName[selectedModelValue]) ||
+                            selectedModelValue,
                         )
                       : undefined}
                 </SelectValue>
@@ -2403,9 +2407,7 @@ function ChatPage(props: {
                 ) : null}
                 {warmModels.map((model) => {
                   const modelStats = modelStatsByName[model];
-                  const selectedMeshModel = (status?.mesh_models ?? []).find(
-                    (m) => m.name === model,
-                  );
+                  const selectedMeshModel = meshModelByName[model];
                   const displayName =
                     modelDisplayName(selectedMeshModel) || model;
                   const visionInfo = visionBadge(selectedMeshModel);
@@ -3462,7 +3464,9 @@ type TopologyFlowNodeData = {
   sameModelAsCurrent: boolean;
 };
 
-function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
+type TopologyFlowDiagramNode = Node<TopologyFlowNodeData, "topologyNode">;
+
+function TopologyFlowNode({ data }: NodeProps<TopologyFlowDiagramNode>) {
   const isCenter = data.node.bucket === "center";
   const dotClass = isCenter
     ? "bg-primary border-primary"
@@ -3490,7 +3494,6 @@ function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
         <span className="break-all">{data.node.id}</span>
         {data.node.self ? (
           <Badge
-            variant="outline"
             className="h-4 rounded-full border-sky-500/45 bg-sky-500/10 px-1.5 text-[9px] font-medium text-sky-700 dark:border-sky-400/55 dark:bg-sky-400/15 dark:text-sky-200"
           >
             You
@@ -3635,7 +3638,7 @@ function TopologyFlowNode({ data }: NodeProps<TopologyFlowNodeData>) {
   );
 }
 
-const topologyNodeTypes = { topologyNode: TopologyFlowNode };
+const topologyNodeTypes = { topologyNode: TopologyFlowNode } as NodeTypes;
 
 function MeshTopologyDiagram({
   status,
@@ -3811,7 +3814,9 @@ function MeshTopologyFlow({
     [fullscreen, positioned],
   );
   const flowContainerRef = useRef<HTMLDivElement | null>(null);
-  const flowInstanceRef = useRef<ReactFlowInstance | null>(null);
+  const flowInstanceRef = useRef<
+    ReactFlowInstance<TopologyFlowDiagramNode, Edge> | null
+  >(null);
   const [containerReady, setContainerReady] = useState(false);
   const fitViewOptions = useMemo(() => ({ padding: 0.12, maxZoom: 1.45 }), []);
   const fitDuration = fullscreen ? 220 : 0;
@@ -3851,7 +3856,7 @@ function MeshTopologyFlow({
     return () => observer.disconnect();
   }, [fitViewOptions, flowLayoutKey, containerStyle, heightClass]);
 
-  const flowNodes = useMemo<Node<TopologyFlowNodeData>[]>(() => {
+  const flowNodes = useMemo<TopologyFlowDiagramNode[]>(() => {
     return positioned.map((p) => ({
       id: p.id,
       type: "topologyNode",
@@ -3926,7 +3931,7 @@ function MeshTopologyFlow({
       style={containerStyle}
     >
       {containerReady ? (
-        <ReactFlow
+        <ReactFlow<TopologyFlowDiagramNode, Edge>
           key={flowLayoutKey}
           className="h-full w-full"
           style={{ width: "100%", height: "100%" }}

--- a/mesh-llm/ui/src/vite-env.d.ts
+++ b/mesh-llm/ui/src/vite-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="vite/client" />
+
+declare module "*.svg" {
+  const src: string;
+  export default src;
+}


### PR DESCRIPTION
## Why

When iterating we were often getting breaks to the console. This is because we never had any type checking of the React console UI at build time. 

## Summary
- add a `typecheck` script for the UI using `tsc --noEmit`
- run type checking before `vite build` so React and TypeScript scope/type errors fail the build
- make the normal UI build path enforce real compile validation instead of bundling-only checks

## Testing
- Not run (not requested)