### PR TITLE
URGENT: Fix client --auto join hang (connect_to_peer regression)

### DIFF
--- a/mesh-llm/src/mesh.rs
+++ b/mesh-llm/src/mesh.rs
@@ -6928,6 +6928,52 @@ mod tests {
 
         Ok(())
     }
+
+    /// Regression test: connect_to_peer must skip peers already in state.peers,
+    /// even if there's no QUIC connection yet (transitive peers from gossip).
+    /// If this check uses state.connections instead, every transitive peer
+    /// triggers a 15s dial timeout and --client --auto hangs.
+    /// See: d631c8d (broke it), 6ece4d1 (first revert).
+    #[tokio::test]
+    async fn test_connect_to_peer_skips_known_peer_without_connection() -> Result<()> {
+        let node = make_test_node(super::NodeRole::Client).await?;
+        let peer_key = SecretKey::generate(&mut rand::rng());
+        let peer_id = EndpointId::from(peer_key.public());
+
+        // Simulate a transitive peer: in state.peers but NOT in state.connections
+        {
+            let mut state = node.state.lock().await;
+            state
+                .peers
+                .insert(peer_id, make_test_peer(peer_id, Some(50), 8));
+            assert!(
+                !state.connections.contains_key(&peer_id),
+                "setup: peer must not have a connection"
+            );
+        }
+
+        // connect_to_peer must return Ok immediately (peer already known).
+        // If it tries to dial, it will either timeout (15s) or fail — both wrong.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            node.connect_to_peer(super::EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            }),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "connect_to_peer must not attempt to dial a peer already in state.peers"
+        );
+        assert!(
+            result.unwrap().is_ok(),
+            "connect_to_peer must return Ok for known peers"
+        );
+
+        Ok(())
+    }
 }
 
 /// Generate a mesh ID for a new mesh.


### PR DESCRIPTION
## Problem

`--client --auto` joins hang indefinitely on current `main` (v0.54.0). Connected to peers but never reaches "Joined mesh" / "API ready".

## Root Cause

Commit d631c8d ("Fix passive client host discovery") changed the early-return guard in `connect_to_peer` from:
```rust
if state.peers.contains_key(&peer_id) { return Ok(()); }
```
to:
```rust
if state.connections.contains_key(&peer_id) { return Ok(()); }
```

This breaks because transitive peers learned via gossip are in `state.peers` but NOT in `state.connections`. With the `connections` check, every gossip partner mentioning a dead/unreachable peer triggers a fresh 15s connection timeout. With 4 peers all reporting the same dead peer, that is 60s+ of blocking sequential timeouts before the join completes.

## Why `peers` is correct

- `initiate_gossip_inner` runs a discover loop calling `connect_to_peer` for each transitive peer
- Transitive peers are added to `state.peers` during gossip processing (via `update_transitive_peer`)
- The `peers` check makes the discover loop a no-op for already-known peers — this is intentional
- `open_http_tunnel` (mesh.rs:2477) already creates on-demand connections when actually routing inference requests — no proactive dialling needed

## History

This exact change was **previously reverted** in commit 6ece4d1 with the message: *"The original code does not have an O(clients²) connection problem"*. PR #56 reintroduced it.

## Fix

One-line revert: `connections` → `peers` in `connect_to_peer` (mesh.rs:3134).

## Testing

- Before fix: `--client --auto` hangs 20+ minutes, never serves
- After fix: API ready in ~12s, 3 models visible, inference works