### PR TITLE
Remove client nodes from topology visualization

### DIFF
--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -4165,9 +4165,11 @@ function MeshTopologyFlow({
   );
 }
 
+type TopologyRowBucket = "serving" | "worker";
+
 type TopologyRow = {
   nodes: TopologyNode[];
-  bucket: PositionedTopologyNode["bucket"];
+  bucket: TopologyRowBucket;
 };
 
 function layoutTopologyNodes(
@@ -4177,7 +4179,7 @@ function layoutTopologyNodes(
 ): PositionedTopologyNode[] {
   const chunkRows = (
     rowNodes: TopologyNode[],
-    bucket: TopologyRow["bucket"],
+    bucket: TopologyRowBucket,
     maxPerRow: number,
   ): TopologyRow[] => {
     if (!rowNodes.length) return [];


### PR DESCRIPTION
## Summary
- filter client-only nodes out of the mesh topology diagram and node count shown in the dashboard
- update the empty state to clarify when no host or worker nodes are visible
- replace the ring-based placement with balanced row layout logic to reduce node card overlap
- simplify topology edge rendering now that client nodes are excluded

## Testing
- `just build`