### PR TITLE
update hf-hub to checksum verification rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -951,7 +951,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1111,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1489,7 +1489,7 @@ dependencies = [
 [[package]]
 name = "hf-hub"
 version = "0.5.0"
-source = "git+https://github.com/i386/hf-hub.git?rev=3afec18e119569d21083b13b682e8629bb874dea#3afec18e119569d21083b13b682e8629bb874dea"
+source = "git+https://github.com/i386/hf-hub.git?rev=a123ed91f20317d117f83d943b204137d0d24c5e#a123ed91f20317d117f83d943b204137d0d24c5e"
 dependencies = [
  "dirs",
  "futures",
@@ -1502,6 +1502,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha1",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "ureq",
@@ -1698,7 +1700,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2554,7 +2556,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -2597,7 +2599,7 @@ checksum = "bb9be4fedd6b98f3ba82ccd3506f4d0219fb723c3f97c67e12fe1494aa020e44"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -2700,7 +2702,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3358,7 +3360,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3395,9 +3397,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3676,7 +3678,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3871,7 +3873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4286,7 +4288,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5084,7 +5086,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/mesh-llm/Cargo.toml
+++ b/mesh-llm/Cargo.toml
@@ -32,7 +32,7 @@ schemars = "1"
 prost = "0.14"
 toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-hf-hub = { git = "https://github.com/i386/hf-hub.git", rev = "3afec18e119569d21083b13b682e8629bb874dea", default-features = false, features = ["ureq", "tokio", "rustls-tls", "cache-manager"] }
+hf-hub = { git = "https://github.com/i386/hf-hub.git", rev = "a123ed91f20317d117f83d943b204137d0d24c5e", default-features = false, features = ["ureq", "tokio", "rustls-tls", "cache-manager"] }
 
 [dev-dependencies]
 serial_test = "3"


### PR DESCRIPTION
## Summary
- update `mesh-llm` to `hf-hub` commit `a123ed91f20317d117f83d943b204137d0d24c5e`
- pull in the upstream download verification change so Hub-managed downloads verify completed files against Hub etags
- refresh `Cargo.lock` for the new git revision and its resolved transitive dependency set

## Why
`mesh-llm` already relies on `hf-hub` for Hub-backed model downloads and cache management. This rev adds post-download verification in `hf-hub` for both common Hub object-id forms:
- 64-hex SHA-256 LFS blob ids
- 40-hex git blob ids for regular tracked files

That closes the silent-corruption gap in completed downloads without adding a separate verification layer inside `mesh-llm`.

## Validation
- `cargo update -p hf-hub`
- upstream `hf-hub`: `cargo test --features tokio,ureq --lib -- --nocapture`
- attempted `just build` here, but the run stalled in the initial `llama.cpp` clone/bootstrap step before reaching dependency integration validation
