### PR TITLE
crypto: owner keystore and signed+encrypted message primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +348,15 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "blake3"
@@ -708,12 +729,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto_box"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16182b4f39a82ec8a6851155cc4c0cda3065bb1db33651726a29e1951de0f009"
+dependencies = [
+ "aead",
+ "crypto_secretbox",
+ "curve25519-dalek 4.1.3",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto_secretbox"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
+dependencies = [
+ "aead",
+ "cipher",
+ "generic-array",
+ "poly1305",
+ "salsa20",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto 0.2.9",
+ "rustc_version",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -726,7 +791,7 @@ dependencies = [
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.11.0-rc.10",
- "fiat-crypto",
+ "fiat-crypto 0.3.0",
  "rand_core 0.9.5",
  "rustc_version",
  "serde",
@@ -1032,7 +1097,7 @@ version = "3.0.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad207ed88a133091f83224265eac21109930db09bedcad05d5252f2af2de20a1"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0-pre.1",
  "ed25519",
  "rand_core 0.9.5",
  "serde",
@@ -1131,6 +1196,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fiat-crypto"
@@ -1346,6 +1417,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2016,7 +2088,7 @@ version = "0.97.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55a354e3396b62c14717ee807dfee9a7f43f6dad47e4ac0fd1d49f1ffad14ef0"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 5.0.0-pre.1",
  "data-encoding",
  "derive_more",
  "digest 0.11.0-rc.10",
@@ -2260,10 +2332,15 @@ name = "mesh-llm"
 version = "0.55.1"
 dependencies = [
  "anyhow",
+ "argon2",
  "base64",
  "biip",
+ "chacha20poly1305",
+ "chrono",
  "clap",
+ "crypto_box",
  "dirs",
+ "ed25519-dalek",
  "hex",
  "hf-hub",
  "httparse",
@@ -2279,17 +2356,20 @@ dependencies = [
  "regex-lite",
  "reqwest",
  "rmcp",
+ "rpassword",
  "rustls",
  "schemars",
  "serde",
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "zeroize",
  "zip",
 ]
 
@@ -3649,6 +3729,16 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rpassword"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -5084,7 +5174,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/mesh-llm/Cargo.toml
+++ b/mesh-llm/Cargo.toml
@@ -23,6 +23,14 @@ nostr-sdk = { version = "0.44.1", default-features = false }
 rustls = "0.23.36"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 sha2 = "0.10"
+ed25519-dalek = { version = "=3.0.0-pre.1", features = ["rand_core"] }
+crypto_box = "0.9"
+chacha20poly1305 = "0.10"
+argon2 = "0.5"
+thiserror = "2"
+zeroize = { version = "1", features = ["derive"] }
+rpassword = "5"
+chrono = { version = "0.4", features = ["serde"] }
 httparse = "1"
 tokio-stream = "0.1"
 libc = "0.2.183"

--- a/mesh-llm/src/cli/commands/auth.rs
+++ b/mesh-llm/src/cli/commands/auth.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Result};
+
+use crate::crypto::{
+    default_keystore_path, keystore_exists, keystore_metadata, load_keystore, save_keystore,
+    OwnerKeypair,
+};
+
+/// Run `mesh-llm auth init`.
+pub(crate) fn run_init(
+    owner_key: Option<PathBuf>,
+    force: bool,
+    no_passphrase: bool,
+) -> Result<()> {
+    let path = match owner_key {
+        Some(p) => p,
+        None => default_keystore_path()?,
+    };
+
+    if keystore_exists(&path) && !force {
+        bail!(
+            "Owner keystore already exists at {}\nUse --force to overwrite.",
+            path.display()
+        );
+    }
+
+    let passphrase = if no_passphrase {
+        None
+    } else {
+        let pass = rpassword::prompt_password_stderr("Enter passphrase (empty for none): ")?;
+        if pass.is_empty() {
+            None
+        } else {
+            let confirm = rpassword::prompt_password_stderr("Confirm passphrase: ")?;
+            if pass != confirm {
+                bail!("Passphrases do not match.");
+            }
+            Some(pass)
+        }
+    };
+
+    let keypair = OwnerKeypair::generate();
+    let owner_id = keypair.owner_id();
+    let sign_pk = hex::encode(keypair.verifying_key().as_bytes());
+    let enc_pk = hex::encode(keypair.encryption_public_key().as_bytes());
+
+    save_keystore(&path, &keypair, passphrase.as_deref())?;
+
+    eprintln!();
+    eprintln!("Owner keystore created.");
+    eprintln!("Owner ID:        {owner_id}");
+    eprintln!("Signing key:     {sign_pk}");
+    eprintln!("Encryption key:  {enc_pk}");
+    eprintln!("Path:            {}", path.display());
+    eprintln!("Encrypted:       {}", if passphrase.is_some() { "yes" } else { "no" });
+    eprintln!();
+    eprintln!("Next steps:");
+    eprintln!("- Copy this keystore to other trusted nodes that should share the same owner identity.");
+    eprintln!("- Start mesh-llm with --owner-key {}", path.display());
+
+    Ok(())
+}
+
+/// Run `mesh-llm auth status`.
+pub(crate) fn run_status(owner_key: Option<PathBuf>) -> Result<()> {
+    let path = match owner_key {
+        Some(p) => p,
+        None => default_keystore_path()?,
+    };
+
+    if !keystore_exists(&path) {
+        eprintln!("No owner keystore found at {}", path.display());
+        eprintln!("Run `mesh-llm auth init` to create one.");
+        return Ok(());
+    }
+
+    let info = keystore_metadata(&path)?;
+
+    eprintln!("Owner keystore:  {}", path.display());
+    eprintln!("Status:          present");
+    eprintln!("Encrypted:       {}", if info.encrypted { "yes" } else { "no" });
+    eprintln!("Owner ID:        {}", info.owner_id);
+    if let Some(ref spk) = info.signing_public_key {
+        eprintln!("Signing key:     {spk}");
+    }
+    if let Some(ref epk) = info.encryption_public_key {
+        eprintln!("Encryption key:  {epk}");
+    }
+    eprintln!("Created:         {}", info.created_at);
+
+    // If not encrypted, verify we can load the full keypair.
+    if !info.encrypted {
+        match load_keystore(&path, None) {
+            Ok(_) => eprintln!("Keystore:        valid (keys loaded successfully)"),
+            Err(e) => eprintln!("Keystore:        ERROR loading keys: {e}"),
+        }
+    }
+
+    Ok(())
+}

--- a/mesh-llm/src/cli/commands/mod.rs
+++ b/mesh-llm/src/cli/commands/mod.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod blackboard;
 mod discover;
 mod download;
@@ -15,7 +16,7 @@ use crate::cli::commands::integrations::{run_claude, run_goose};
 use crate::cli::commands::models::dispatch_models_command;
 use crate::cli::commands::plugin::run_plugin_command;
 use crate::cli::commands::runtime::{dispatch_runtime_command, run_drop, run_load, run_status};
-use crate::cli::{Cli, Command};
+use crate::cli::{AuthCommand, Cli, Command};
 use crate::network::nostr;
 
 pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
@@ -80,6 +81,16 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
             }
         }
         Command::Plugin { command } => run_plugin_command(command, cli).await,
+        Command::Auth { command } => {
+            match command {
+                AuthCommand::Init {
+                    owner_key,
+                    force,
+                    no_passphrase,
+                } => auth::run_init(owner_key.clone(), *force, *no_passphrase),
+                AuthCommand::Status { owner_key } => auth::run_status(owner_key.clone()),
+            }
+        }
     }?;
     Ok(true)
 }

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -3,6 +3,29 @@ use std::path::PathBuf;
 
 use crate::cli::runtime::RuntimeCommand;
 
+#[derive(Subcommand, Debug)]
+pub(crate) enum AuthCommand {
+    /// Generate a new owner keypair and save to keystore.
+    Init {
+        /// Path to the keystore file (default: ~/.mesh-llm/owner-keystore.json).
+        #[arg(long)]
+        owner_key: Option<PathBuf>,
+        /// Overwrite an existing keystore.
+        #[arg(long)]
+        force: bool,
+        /// Skip passphrase prompt (store keys unencrypted).
+        #[arg(long)]
+        no_passphrase: bool,
+    },
+    /// Show current owner identity status.
+    Status {
+        /// Path to the keystore file.
+        #[arg(long)]
+        owner_key: Option<PathBuf>,
+    },
+}
+
+
 pub(crate) mod commands;
 pub mod models;
 pub(crate) mod runtime;
@@ -289,6 +312,11 @@ pub(crate) enum Command {
     Plugin {
         #[command(subcommand)]
         command: PluginCommand,
+    },
+    /// Manage owner identity and keystore.
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
     },
 }
 

--- a/mesh-llm/src/crypto/envelope.rs
+++ b/mesh-llm/src/crypto/envelope.rs
@@ -1,0 +1,346 @@
+use crypto_box::aead::{Aead, AeadCore, OsRng as CryptoOsRng};
+use crypto_box::SalsaBox;
+use ed25519_dalek::{Signer, Verifier};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::error::CryptoError;
+use super::keys::OwnerKeypair;
+
+/// A signed-then-encrypted envelope for confidential control messages.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct SignedEncryptedEnvelope {
+    pub version: u32,
+    pub sender_owner_id: String,
+    pub sender_sign_public_key: String,
+    pub sender_box_public_key: String,
+    pub recipient_box_public_key: String,
+    pub message_type: String,
+    pub timestamp_unix_ms: u64,
+    pub nonce: String,
+    pub ciphertext: String,
+}
+
+/// The decrypted and verified message contents.
+#[derive(Debug)]
+pub struct OpenedMessage {
+    pub sender_owner_id: String,
+    pub sender_sign_public_key: [u8; 32],
+    pub sender_box_public_key: [u8; 32],
+    pub message_type: String,
+    pub timestamp_unix_ms: u64,
+    pub payload: Vec<u8>,
+}
+
+/// Inner plaintext: payload + detached signature.
+#[derive(Serialize, Deserialize)]
+struct InnerPayload {
+    payload: Vec<u8>,
+    signature: Vec<u8>,
+}
+
+/// Build the canonical bytes that get signed.
+///
+/// Includes all metadata fields + a hash of the payload to bind the signature
+/// to both the envelope context and the message content.
+fn canonical_signed_bytes(
+    version: u32,
+    sender_owner_id: &str,
+    sender_box_public_key: &[u8],
+    recipient_box_public_key: &[u8],
+    message_type: &str,
+    timestamp_unix_ms: u64,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    // Domain separation tag to prevent cross-protocol signature reuse.
+    buf.extend_from_slice(b"mesh-llm-envelope-v1:");
+    buf.extend_from_slice(&version.to_le_bytes());
+    buf.extend_from_slice(sender_owner_id.as_bytes());
+    buf.extend_from_slice(sender_box_public_key);
+    buf.extend_from_slice(recipient_box_public_key);
+    buf.extend_from_slice(message_type.as_bytes());
+    buf.extend_from_slice(&timestamp_unix_ms.to_le_bytes());
+    // Include a hash of the payload rather than the raw payload to keep
+    // the signed data compact for large payloads.
+    let payload_hash = Sha256::digest(payload);
+    buf.extend_from_slice(&payload_hash);
+    buf
+}
+
+/// Sign and encrypt a message for a specific recipient.
+pub fn seal_message(
+    sender: &OwnerKeypair,
+    recipient_box_public_key: &crypto_box::PublicKey,
+    message_type: &str,
+    payload: &[u8],
+    timestamp_unix_ms: u64,
+) -> Result<SignedEncryptedEnvelope, CryptoError> {
+    let version = 1u32;
+    let sender_owner_id = sender.owner_id();
+    let sender_box_pk = sender.encryption_public_key();
+
+    // 1. Build canonical bytes and sign.
+    let signed_bytes = canonical_signed_bytes(
+        version,
+        &sender_owner_id,
+        sender_box_pk.as_bytes(),
+        recipient_box_public_key.as_bytes(),
+        message_type,
+        timestamp_unix_ms,
+        payload,
+    );
+    let signature = sender.signing.sign(&signed_bytes);
+
+    // 2. Build inner payload with detached signature.
+    let inner = InnerPayload {
+        payload: payload.to_vec(),
+        signature: signature.to_bytes().to_vec(),
+    };
+    let inner_bytes = serde_json::to_vec(&inner)?;
+
+    // 3. Encrypt with crypto_box (XSalsa20Poly1305).
+    let salsa_box = SalsaBox::new(recipient_box_public_key, &sender.encryption);
+    let nonce = SalsaBox::generate_nonce(&mut CryptoOsRng);
+    let ct = salsa_box
+        .encrypt(&nonce, inner_bytes.as_ref())
+        .map_err(|_| CryptoError::VerificationFailed {
+            reason: "encryption failed".into(),
+        })?;
+
+    Ok(SignedEncryptedEnvelope {
+        version,
+        sender_owner_id,
+        sender_sign_public_key: hex::encode(sender.verifying_key().as_bytes()),
+        sender_box_public_key: hex::encode(sender_box_pk.as_bytes()),
+        recipient_box_public_key: hex::encode(recipient_box_public_key.as_bytes()),
+        message_type: message_type.to_string(),
+        timestamp_unix_ms,
+        nonce: hex::encode(nonce),
+        ciphertext: hex::encode(ct),
+    })
+}
+
+/// Decrypt and verify an envelope addressed to this recipient.
+pub fn open_message(
+    recipient: &OwnerKeypair,
+    envelope: &SignedEncryptedEnvelope,
+) -> Result<OpenedMessage, CryptoError> {
+    // 0. Reject unknown envelope versions.
+    if envelope.version != 1 {
+        return Err(CryptoError::VerificationFailed {
+            reason: format!("unsupported envelope version: {}", envelope.version),
+        });
+    }
+
+    // 1. Parse sender public keys.
+    let sender_sign_pk_bytes: [u8; 32] =
+        hex::decode(&envelope.sender_sign_public_key)
+            .map_err(|_| CryptoError::InvalidKeyMaterial {
+                reason: "bad sender signing key hex".into(),
+            })?
+            .try_into()
+            .map_err(|_| CryptoError::InvalidKeyMaterial {
+                reason: "sender signing key must be 32 bytes".into(),
+            })?;
+
+    let sender_box_pk_bytes: [u8; 32] =
+        hex::decode(&envelope.sender_box_public_key)
+            .map_err(|_| CryptoError::InvalidKeyMaterial {
+                reason: "bad sender box key hex".into(),
+            })?
+            .try_into()
+            .map_err(|_| CryptoError::InvalidKeyMaterial {
+                reason: "sender box key must be 32 bytes".into(),
+            })?;
+
+    let recipient_box_pk_bytes: [u8; 32] =
+        hex::decode(&envelope.recipient_box_public_key)
+            .map_err(|_| CryptoError::InvalidKeyMaterial {
+                reason: "bad recipient box key hex".into(),
+            })?
+            .try_into()
+            .map_err(|_| CryptoError::InvalidKeyMaterial {
+                reason: "recipient box key must be 32 bytes".into(),
+            })?;
+
+    let sender_box_pk = crypto_box::PublicKey::from(sender_box_pk_bytes);
+
+    // 2. Verify sender_owner_id matches the signing key (prevents identity spoofing).
+    let sender_verifying_key = ed25519_dalek::VerifyingKey::from_bytes(&sender_sign_pk_bytes)
+        .map_err(|_| CryptoError::InvalidSignature)?;
+    let expected_owner_id =
+        super::keys::owner_id_from_verifying_key(&sender_verifying_key);
+    if envelope.sender_owner_id != expected_owner_id {
+        return Err(CryptoError::VerificationFailed {
+            reason: "sender_owner_id does not match signing public key".into(),
+        });
+    }
+
+    // 3. Decrypt.
+    let nonce_bytes = hex::decode(&envelope.nonce).map_err(|_| CryptoError::DecryptionFailed)?;
+    if nonce_bytes.len() != 24 {
+        return Err(CryptoError::DecryptionFailed);
+    }
+    let nonce = crypto_box::Nonce::from_slice(&nonce_bytes);
+    let ct = hex::decode(&envelope.ciphertext).map_err(|_| CryptoError::DecryptionFailed)?;
+
+    let salsa_box = SalsaBox::new(&sender_box_pk, &recipient.encryption);
+    let inner_bytes = salsa_box
+        .decrypt(nonce, ct.as_ref())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    // 4. Parse inner payload.
+    let inner: InnerPayload =
+        serde_json::from_slice(&inner_bytes).map_err(|_| CryptoError::DecryptionFailed)?;
+
+    // 5. Verify signature.
+    let signed_bytes = canonical_signed_bytes(
+        envelope.version,
+        &envelope.sender_owner_id,
+        &sender_box_pk_bytes,
+        &recipient_box_pk_bytes,
+        &envelope.message_type,
+        envelope.timestamp_unix_ms,
+        &inner.payload,
+    );
+
+    let sig_bytes: [u8; 64] = inner
+        .signature
+        .try_into()
+        .map_err(|_| CryptoError::InvalidSignature)?;
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_bytes);
+
+    sender_verifying_key
+        .verify(&signed_bytes, &signature)
+        .map_err(|_| CryptoError::InvalidSignature)?;
+
+    Ok(OpenedMessage {
+        sender_owner_id: expected_owner_id,
+        sender_sign_public_key: sender_sign_pk_bytes,
+        sender_box_public_key: sender_box_pk_bytes,
+        message_type: envelope.message_type.clone(),
+        timestamp_unix_ms: envelope.timestamp_unix_ms,
+        payload: inner.payload,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seal_open_round_trip() {
+        let sender = OwnerKeypair::generate();
+        let recipient = OwnerKeypair::generate();
+
+        let payload = b"hello, mesh-llm!";
+        let timestamp = 1_700_000_000_000u64;
+
+        let envelope = seal_message(
+            &sender,
+            &recipient.encryption_public_key(),
+            "test.message",
+            payload,
+            timestamp,
+        )
+        .unwrap();
+
+        let opened = open_message(&recipient, &envelope).unwrap();
+        assert_eq!(opened.payload, payload);
+        assert_eq!(opened.message_type, "test.message");
+        assert_eq!(opened.timestamp_unix_ms, timestamp);
+        assert_eq!(opened.sender_owner_id, sender.owner_id());
+    }
+
+    #[test]
+    fn wrong_recipient_cannot_decrypt() {
+        let sender = OwnerKeypair::generate();
+        let recipient = OwnerKeypair::generate();
+        let wrong_recipient = OwnerKeypair::generate();
+
+        let envelope = seal_message(
+            &sender,
+            &recipient.encryption_public_key(),
+            "secret",
+            b"classified",
+            0,
+        )
+        .unwrap();
+
+        let result = open_message(&wrong_recipient, &envelope);
+        assert!(result.is_err(), "wrong recipient should fail to decrypt");
+    }
+
+    #[test]
+    fn tampered_ciphertext_fails() {
+        let sender = OwnerKeypair::generate();
+        let recipient = OwnerKeypair::generate();
+
+        let mut envelope = seal_message(
+            &sender,
+            &recipient.encryption_public_key(),
+            "test",
+            b"payload",
+            0,
+        )
+        .unwrap();
+
+        // Flip a byte in the ciphertext.
+        let mut ct_bytes = hex::decode(&envelope.ciphertext).unwrap();
+        if let Some(byte) = ct_bytes.last_mut() {
+            *byte ^= 0xff;
+        }
+        envelope.ciphertext = hex::encode(&ct_bytes);
+
+        let result = open_message(&recipient, &envelope);
+        assert!(result.is_err(), "tampered ciphertext should fail");
+    }
+
+    #[test]
+    fn spoofed_owner_id_rejected() {
+        let sender = OwnerKeypair::generate();
+        let recipient = OwnerKeypair::generate();
+
+        let mut envelope = seal_message(
+            &sender,
+            &recipient.encryption_public_key(),
+            "test",
+            b"payload",
+            0,
+        )
+        .unwrap();
+
+        // Spoof the owner_id to a different value.
+        envelope.sender_owner_id = "0000000000000000000000000000000000000000000000000000000000000000".into();
+
+        let result = open_message(&recipient, &envelope);
+        assert!(
+            matches!(result, Err(CryptoError::VerificationFailed { .. })),
+            "spoofed owner_id should be rejected"
+        );
+    }
+
+    #[test]
+    fn unknown_envelope_version_rejected() {
+        let sender = OwnerKeypair::generate();
+        let recipient = OwnerKeypair::generate();
+
+        let mut envelope = seal_message(
+            &sender,
+            &recipient.encryption_public_key(),
+            "test",
+            b"payload",
+            0,
+        )
+        .unwrap();
+
+        envelope.version = 99;
+
+        let result = open_message(&recipient, &envelope);
+        assert!(
+            matches!(result, Err(CryptoError::VerificationFailed { .. })),
+            "unknown version should be rejected"
+        );
+    }
+}

--- a/mesh-llm/src/crypto/error.rs
+++ b/mesh-llm/src/crypto/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CryptoError {
+    #[error("keystore not found at {path}")]
+    KeystoreNotFound { path: String },
+
+    #[error("keystore already exists at {path} (use --force to overwrite)")]
+    KeystoreAlreadyExists { path: String },
+
+    #[error("wrong passphrase or corrupted keystore")]
+    DecryptionFailed,
+
+    #[error("invalid signature")]
+    InvalidSignature,
+
+    #[error("unsupported keystore version: {version}")]
+    UnsupportedVersion { version: u32 },
+
+    #[error("envelope verification failed: {reason}")]
+    VerificationFailed { reason: String },
+
+    #[error("invalid key material: {reason}")]
+    InvalidKeyMaterial { reason: String },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}

--- a/mesh-llm/src/crypto/keys.rs
+++ b/mesh-llm/src/crypto/keys.rs
@@ -1,0 +1,131 @@
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use sha2::{Digest, Sha256};
+
+use super::error::CryptoError;
+
+/// Owner keypair: Ed25519 signing key + X25519 encryption key.
+#[derive(Debug)]
+pub struct OwnerKeypair {
+    pub(crate) signing: SigningKey,
+    pub(crate) encryption: crypto_box::SecretKey,
+}
+
+impl OwnerKeypair {
+    /// Generate a new random owner keypair.
+    pub fn generate() -> Self {
+        // ed25519-dalek (rand_core 0.9) and crypto_box (rand_core 0.6)
+        // need different RNG types due to version mismatch.
+        let signing = SigningKey::generate(&mut rand::rng());
+        let encryption = crypto_box::SecretKey::generate(&mut crypto_box::aead::OsRng);
+        Self {
+            signing,
+            encryption,
+        }
+    }
+
+    /// Derive the stable owner ID from the signing public key.
+    ///
+    /// Returns `sha256(signing_public_key_bytes)` as a 64-char lowercase hex string.
+    pub fn owner_id(&self) -> String {
+        owner_id_from_verifying_key(&self.signing.verifying_key())
+    }
+
+    /// The Ed25519 verifying (public) key for signature verification.
+    pub fn verifying_key(&self) -> VerifyingKey {
+        self.signing.verifying_key()
+    }
+
+    /// The X25519 public key for encrypting messages to this owner.
+    pub fn encryption_public_key(&self) -> crypto_box::PublicKey {
+        self.encryption.public_key()
+    }
+
+    /// Reconstruct from raw key bytes (used by keystore deserialization).
+    pub(crate) fn from_bytes(
+        signing_bytes: &[u8],
+        encryption_bytes: &[u8],
+    ) -> Result<Self, CryptoError> {
+        let signing_arr: [u8; 32] = signing_bytes.try_into().map_err(|_| {
+            CryptoError::InvalidKeyMaterial {
+                reason: "signing key must be 32 bytes".into(),
+            }
+        })?;
+        let encryption_arr: [u8; 32] =
+            encryption_bytes
+                .try_into()
+                .map_err(|_| CryptoError::InvalidKeyMaterial {
+                    reason: "encryption key must be 32 bytes".into(),
+                })?;
+
+        let signing = SigningKey::from_bytes(&signing_arr);
+        let encryption = crypto_box::SecretKey::from(encryption_arr);
+
+        Ok(Self {
+            signing,
+            encryption,
+        })
+    }
+
+    /// Raw signing secret key bytes (for keystore serialization).
+    pub(crate) fn signing_bytes(&self) -> &[u8; 32] {
+        self.signing.as_bytes()
+    }
+
+    /// Raw encryption secret key bytes (for keystore serialization).
+    pub(crate) fn encryption_bytes(&self) -> [u8; 32] {
+        self.encryption.to_bytes()
+    }
+}
+
+// Both ed25519_dalek::SigningKey and crypto_box::SecretKey implement Zeroize on drop.
+
+/// Derive owner ID from a verifying key (public operation, no secret needed).
+pub fn owner_id_from_verifying_key(vk: &VerifyingKey) -> String {
+    let hash = Sha256::digest(vk.as_bytes());
+    hex::encode(hash)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_generation_produces_valid_owner_id() {
+        let kp = OwnerKeypair::generate();
+        let id = kp.owner_id();
+        assert_eq!(id.len(), 64, "owner_id should be 64 hex chars");
+        assert!(
+            id.chars().all(|c| c.is_ascii_hexdigit()),
+            "owner_id should be hex"
+        );
+    }
+
+    #[test]
+    fn owner_id_is_deterministic_from_public_key() {
+        let kp = OwnerKeypair::generate();
+        let id1 = kp.owner_id();
+        let id2 = owner_id_from_verifying_key(&kp.verifying_key());
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn different_keypairs_produce_different_owner_ids() {
+        let kp1 = OwnerKeypair::generate();
+        let kp2 = OwnerKeypair::generate();
+        assert_ne!(kp1.owner_id(), kp2.owner_id());
+    }
+
+    #[test]
+    fn round_trip_from_bytes() {
+        let kp = OwnerKeypair::generate();
+        let signing = kp.signing_bytes().to_vec();
+        let encryption = kp.encryption_bytes().to_vec();
+
+        let restored = OwnerKeypair::from_bytes(&signing, &encryption).unwrap();
+        assert_eq!(kp.owner_id(), restored.owner_id());
+        assert_eq!(
+            kp.encryption_public_key().as_bytes(),
+            restored.encryption_public_key().as_bytes()
+        );
+    }
+}

--- a/mesh-llm/src/crypto/keystore.rs
+++ b/mesh-llm/src/crypto/keystore.rs
@@ -1,0 +1,365 @@
+use std::path::{Path, PathBuf};
+
+use argon2::Argon2;
+use chacha20poly1305::aead::{Aead, AeadCore, OsRng};
+use chacha20poly1305::{ChaCha20Poly1305, KeyInit};
+use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
+
+use super::error::CryptoError;
+use super::keys::OwnerKeypair;
+
+const KEYSTORE_VERSION: u32 = 1;
+
+/// On-disk keystore format (JSON).
+#[derive(Serialize, Deserialize)]
+struct KeystoreV1 {
+    version: u32,
+    owner_id: String,
+    created_at: String,
+    encrypted: bool,
+
+    // Present when encrypted == false
+    signing_secret_key: Option<String>,
+    signing_public_key: Option<String>,
+    encryption_secret_key: Option<String>,
+    encryption_public_key: Option<String>,
+
+    // Present when encrypted == true
+    kdf: Option<String>,
+    argon2_salt: Option<String>,
+    nonce: Option<String>,
+    ciphertext: Option<String>,
+}
+
+/// Plaintext inner payload that gets encrypted when passphrase is set.
+#[derive(Serialize, Deserialize)]
+struct SecretPayload {
+    signing_secret_key: String,
+    encryption_secret_key: String,
+}
+
+/// Return the default keystore path: `~/.mesh-llm/owner-keystore.json`.
+pub fn default_keystore_path() -> Result<PathBuf, CryptoError> {
+    let home = dirs::home_dir().ok_or_else(|| CryptoError::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "cannot determine home directory",
+    )))?;
+    Ok(home.join(".mesh-llm").join("owner-keystore.json"))
+}
+
+/// Check if a keystore file exists at the given path.
+pub fn keystore_exists(path: &Path) -> bool {
+    path.exists()
+}
+
+/// Save an owner keypair to disk.
+///
+/// If `passphrase` is `Some`, the secret keys are encrypted with Argon2id + ChaCha20Poly1305.
+/// File permissions are set to 0600 on Unix.
+pub fn save_keystore(
+    path: &Path,
+    keypair: &OwnerKeypair,
+    passphrase: Option<&str>,
+) -> Result<(), CryptoError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let keystore = if let Some(pass) = passphrase {
+        build_encrypted_keystore(keypair, pass)?
+    } else {
+        build_plaintext_keystore(keypair)
+    };
+
+    let json = serde_json::to_string_pretty(&keystore)?;
+    std::fs::write(path, json)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(path)?.permissions();
+        perms.set_mode(0o600);
+        std::fs::set_permissions(path, perms)?;
+    }
+
+    Ok(())
+}
+
+/// Load an owner keypair from disk.
+///
+/// If the keystore is encrypted, `passphrase` must be provided.
+pub fn load_keystore(
+    path: &Path,
+    passphrase: Option<&str>,
+) -> Result<OwnerKeypair, CryptoError> {
+    if !path.exists() {
+        return Err(CryptoError::KeystoreNotFound {
+            path: path.display().to_string(),
+        });
+    }
+
+    let raw = std::fs::read_to_string(path)?;
+    let ks: KeystoreV1 = serde_json::from_str(&raw)?;
+
+    if ks.version != KEYSTORE_VERSION {
+        return Err(CryptoError::UnsupportedVersion { version: ks.version });
+    }
+
+    if ks.encrypted {
+        decrypt_keystore(&ks, passphrase)
+    } else {
+        plaintext_keystore(&ks)
+    }
+}
+
+/// Read keystore metadata without decrypting secret keys.
+pub fn keystore_metadata(path: &Path) -> Result<KeystoreInfo, CryptoError> {
+    if !path.exists() {
+        return Err(CryptoError::KeystoreNotFound {
+            path: path.display().to_string(),
+        });
+    }
+    let raw = std::fs::read_to_string(path)?;
+    let ks: KeystoreV1 = serde_json::from_str(&raw)?;
+    Ok(KeystoreInfo {
+        owner_id: ks.owner_id,
+        created_at: ks.created_at,
+        encrypted: ks.encrypted,
+        signing_public_key: ks.signing_public_key,
+        encryption_public_key: ks.encryption_public_key,
+    })
+}
+
+/// Public metadata about a keystore (no secrets).
+pub struct KeystoreInfo {
+    pub owner_id: String,
+    pub created_at: String,
+    pub encrypted: bool,
+    pub signing_public_key: Option<String>,
+    pub encryption_public_key: Option<String>,
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+fn build_plaintext_keystore(keypair: &OwnerKeypair) -> KeystoreV1 {
+    KeystoreV1 {
+        version: KEYSTORE_VERSION,
+        owner_id: keypair.owner_id(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        encrypted: false,
+        signing_secret_key: Some(hex::encode(keypair.signing_bytes())),
+        signing_public_key: Some(hex::encode(keypair.verifying_key().as_bytes())),
+        encryption_secret_key: Some(hex::encode(keypair.encryption_bytes())),
+        encryption_public_key: Some(hex::encode(keypair.encryption_public_key().as_bytes())),
+        kdf: None,
+        argon2_salt: None,
+        nonce: None,
+        ciphertext: None,
+    }
+}
+
+fn build_encrypted_keystore(
+    keypair: &OwnerKeypair,
+    passphrase: &str,
+) -> Result<KeystoreV1, CryptoError> {
+    let salt: [u8; 16] = rand::random();
+
+    // Derive a 32-byte symmetric key from the passphrase.
+    let sym_key = derive_key(passphrase, &salt)?;
+
+    // Encrypt the secret keys.
+    let payload = SecretPayload {
+        signing_secret_key: hex::encode(keypair.signing_bytes()),
+        encryption_secret_key: hex::encode(keypair.encryption_bytes()),
+    };
+    let plaintext = serde_json::to_vec(&payload)?;
+
+    let cipher = ChaCha20Poly1305::new(chacha20poly1305::Key::from_slice(sym_key.as_ref()));
+    let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+    let ct = cipher
+        .encrypt(&nonce, plaintext.as_ref())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    Ok(KeystoreV1 {
+        version: KEYSTORE_VERSION,
+        owner_id: keypair.owner_id(),
+        created_at: chrono::Utc::now().to_rfc3339(),
+        encrypted: true,
+        signing_secret_key: None,
+        signing_public_key: Some(hex::encode(keypair.verifying_key().as_bytes())),
+        encryption_secret_key: None,
+        encryption_public_key: Some(hex::encode(keypair.encryption_public_key().as_bytes())),
+        kdf: Some("argon2id-chacha20poly1305".into()),
+        argon2_salt: Some(hex::encode(salt)),
+        nonce: Some(hex::encode(nonce)),
+        ciphertext: Some(hex::encode(ct)),
+    })
+}
+
+fn plaintext_keystore(ks: &KeystoreV1) -> Result<OwnerKeypair, CryptoError> {
+    let sign_hex = ks
+        .signing_secret_key
+        .as_deref()
+        .ok_or(CryptoError::InvalidKeyMaterial {
+            reason: "missing signing_secret_key in plaintext keystore".into(),
+        })?;
+    let enc_hex = ks
+        .encryption_secret_key
+        .as_deref()
+        .ok_or(CryptoError::InvalidKeyMaterial {
+            reason: "missing encryption_secret_key in plaintext keystore".into(),
+        })?;
+
+    let sign_bytes = hex::decode(sign_hex).map_err(|e| CryptoError::InvalidKeyMaterial {
+        reason: format!("bad signing key hex: {e}"),
+    })?;
+    let enc_bytes = hex::decode(enc_hex).map_err(|e| CryptoError::InvalidKeyMaterial {
+        reason: format!("bad encryption key hex: {e}"),
+    })?;
+
+    OwnerKeypair::from_bytes(&sign_bytes, &enc_bytes)
+}
+
+fn decrypt_keystore(
+    ks: &KeystoreV1,
+    passphrase: Option<&str>,
+) -> Result<OwnerKeypair, CryptoError> {
+    let pass = passphrase.ok_or(CryptoError::DecryptionFailed)?;
+
+    let salt = hex::decode(ks.argon2_salt.as_deref().unwrap_or_default())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+    let nonce_bytes = hex::decode(ks.nonce.as_deref().unwrap_or_default())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+    let ct = hex::decode(ks.ciphertext.as_deref().unwrap_or_default())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    let sym_key = derive_key(pass, &salt)?;
+
+    if nonce_bytes.len() != 12 {
+        return Err(CryptoError::DecryptionFailed);
+    }
+    let cipher = ChaCha20Poly1305::new(chacha20poly1305::Key::from_slice(sym_key.as_ref()));
+    let nonce = chacha20poly1305::Nonce::from_slice(&nonce_bytes);
+    let plaintext = cipher
+        .decrypt(nonce, ct.as_ref())
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    let payload: SecretPayload = serde_json::from_slice(&plaintext)
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    let sign_bytes =
+        hex::decode(&payload.signing_secret_key).map_err(|_| CryptoError::DecryptionFailed)?;
+    let enc_bytes = hex::decode(&payload.encryption_secret_key)
+        .map_err(|_| CryptoError::DecryptionFailed)?;
+
+    OwnerKeypair::from_bytes(&sign_bytes, &enc_bytes)
+}
+
+fn derive_key(passphrase: &str, salt: &[u8]) -> Result<Zeroizing<[u8; 32]>, CryptoError> {
+    let mut key = Zeroizing::new([0u8; 32]);
+    Argon2::default()
+        .hash_password_into(passphrase.as_bytes(), salt, key.as_mut())
+        .map_err(|e| CryptoError::InvalidKeyMaterial {
+            reason: format!("argon2 KDF failed: {e}"),
+        })?;
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn temp_keystore_path() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("mesh-llm-test-{}", rand::random::<u64>()));
+        fs::create_dir_all(&dir).unwrap();
+        dir.join("owner-keystore.json")
+    }
+
+    #[test]
+    fn round_trip_plaintext() {
+        let path = temp_keystore_path();
+        let kp = OwnerKeypair::generate();
+        let original_id = kp.owner_id();
+
+        save_keystore(&path, &kp, None).unwrap();
+        let loaded = load_keystore(&path, None).unwrap();
+
+        assert_eq!(original_id, loaded.owner_id());
+        assert_eq!(kp.signing_bytes(), loaded.signing_bytes());
+        assert_eq!(kp.encryption_bytes(), loaded.encryption_bytes());
+
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn round_trip_encrypted() {
+        let path = temp_keystore_path();
+        let kp = OwnerKeypair::generate();
+        let original_id = kp.owner_id();
+
+        save_keystore(&path, &kp, Some("test-passphrase")).unwrap();
+        let loaded = load_keystore(&path, Some("test-passphrase")).unwrap();
+
+        assert_eq!(original_id, loaded.owner_id());
+        assert_eq!(kp.signing_bytes(), loaded.signing_bytes());
+        assert_eq!(kp.encryption_bytes(), loaded.encryption_bytes());
+
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn wrong_passphrase_fails() {
+        let path = temp_keystore_path();
+        let kp = OwnerKeypair::generate();
+
+        save_keystore(&path, &kp, Some("correct")).unwrap();
+
+        let result = load_keystore(&path, Some("wrong"));
+        assert!(
+            matches!(result, Err(CryptoError::DecryptionFailed)),
+            "expected DecryptionFailed, got {result:?}"
+        );
+
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn missing_passphrase_for_encrypted_fails() {
+        let path = temp_keystore_path();
+        let kp = OwnerKeypair::generate();
+
+        save_keystore(&path, &kp, Some("secret")).unwrap();
+
+        let result = load_keystore(&path, None);
+        assert!(
+            matches!(result, Err(CryptoError::DecryptionFailed)),
+            "expected DecryptionFailed, got {result:?}"
+        );
+
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn keystore_not_found() {
+        let path = PathBuf::from("/tmp/nonexistent-keystore.json");
+        let result = load_keystore(&path, None);
+        assert!(matches!(result, Err(CryptoError::KeystoreNotFound { .. })));
+    }
+
+    #[test]
+    fn metadata_without_decryption() {
+        let path = temp_keystore_path();
+        let kp = OwnerKeypair::generate();
+        let expected_id = kp.owner_id();
+
+        save_keystore(&path, &kp, Some("secret")).unwrap();
+
+        let info = keystore_metadata(&path).unwrap();
+        assert_eq!(info.owner_id, expected_id);
+        assert!(info.encrypted);
+
+        fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+}

--- a/mesh-llm/src/crypto/mod.rs
+++ b/mesh-llm/src/crypto/mod.rs
@@ -1,0 +1,12 @@
+mod error;
+mod keys;
+mod keystore;
+mod envelope;
+
+pub use self::error::CryptoError;
+pub use self::keys::{owner_id_from_verifying_key, OwnerKeypair};
+pub use self::keystore::{
+    default_keystore_path, keystore_exists, keystore_metadata, load_keystore, save_keystore,
+    KeystoreInfo,
+};
+pub use self::envelope::{open_message, seal_message, OpenedMessage, SignedEncryptedEnvelope};

--- a/mesh-llm/src/lib.rs
+++ b/mesh-llm/src/lib.rs
@@ -1,5 +1,6 @@
 mod api;
 mod cli;
+pub mod crypto;
 mod inference;
 mod mesh;
 mod models;

--- a/mesh-llm/src/plugin/mod.rs
+++ b/mesh-llm/src/plugin/mod.rs
@@ -25,6 +25,8 @@ use self::support::{format_args_for_log, format_slice_for_log, format_tool_names
 use self::transport::make_instance_id;
 #[cfg(all(test, unix))]
 use self::transport::unix_socket_path;
+#[cfg(all(test, windows))]
+use self::transport::windows_pipe_name;
 #[cfg(test)]
 use mesh_llm_plugin::MeshVisibility;
 

--- a/mesh-llm/src/plugin/transport.rs
+++ b/mesh-llm/src/plugin/transport.rs
@@ -241,7 +241,7 @@ pub(crate) fn unix_socket_path(instance_id: &str, name: &str) -> Result<PathBuf>
 }
 
 #[cfg(windows)]
-fn windows_pipe_name(instance_id: &str, name: &str) -> String {
+pub(crate) fn windows_pipe_name(instance_id: &str, name: &str) -> String {
     format!(r"\\.\pipe\mesh-llm-{instance_id}-{name}")
 }
 


### PR DESCRIPTION
## Summary

Implements the crypto foundation for owner identity per issue #134.

- **`src/crypto/keys.rs`**: `OwnerKeypair` with Ed25519 signing + X25519 encryption keypairs. Owner ID derived as `sha256(signing_public_key)`.
- **`src/crypto/keystore.rs`**: Versioned JSON keystore format with optional Argon2id + ChaCha20Poly1305 passphrase protection. File permissions locked to 0600 on Unix.
- **`src/crypto/envelope.rs`**: `seal_message()` / `open_message()` — sign-then-encrypt with domain separation, identity binding (sender_owner_id verified against signing key), and version checking.
- **`src/crypto/error.rs`**: Structured `CryptoError` enum via `thiserror`.
- **`src/cli/commands/auth.rs`**: `mesh-llm auth init` and `mesh-llm auth status` CLI commands.

### Design decisions

- **Pure Rust**: Uses `ed25519-dalek` (pinned to match iroh's version) + `crypto_box` + `chacha20poly1305`. No C FFI, wire-compatible with libsodium NaCl primitives.
- **Separate keypairs**: Signing and encryption keys are independent per the issue spec — clearer trust boundaries, easier future rotation.
- **JSON keystore**: Human-readable, debuggable. KDF algorithm stored explicitly (`"kdf": "argon2id-chacha20poly1305"`) for forward compatibility.
- **Identity binding**: `open_message()` recomputes `owner_id` from the signing public key and rejects mismatches, preventing identity spoofing.
- **Domain separation**: Canonical signed bytes include a `mesh-llm-envelope-v1:` prefix to prevent cross-protocol signature reuse.

### Relationship to #130

This creates `src/crypto/` as a new module alongside (not replacing) the existing auth work in PR #130. The migration path per #132 will swap auth.rs callers to use the crypto module in a follow-up.

## Test plan

- [x] 15 unit tests passing (`cargo test -- crypto`):
  - Key generation, owner_id determinism, byte round-trip
  - Keystore save/load (plaintext + encrypted), wrong passphrase rejection
  - Envelope seal/open round-trip, wrong recipient, tampered ciphertext
  - **Owner-id spoofing rejection** and **unknown version rejection**
- [x] `cargo build` clean (no new warnings)
- [ ] Manual: `mesh-llm auth init --no-passphrase` creates keystore, `auth status` reads it

Also includes a drive-by fix for a pre-existing Windows test compilation issue in `plugin/mod.rs` (missing `#[cfg(windows)]` import for `windows_pipe_name`).

Closes #134