### PR TITLE
feat: auto-enable row split for local multi-GPU (tensor parallelism)

### DIFF
--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -18,19 +18,35 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::watch;
 
+/// Returns `true` when `flavor` and `gpu_count` together call for row-split
+/// tensor parallelism.
+///
+/// Row split requires a backend that implements `ggml_backend_split_buffer_type`
+/// (CUDA and ROCm).  When no flavor is specified the binary may still be a CUDA
+/// or ROCm build discovered automatically, so `None` is treated as potentially
+/// supported; if the binary turns out to be CPU/Metal/Vulkan, llama.cpp falls
+/// back safely.
+fn should_use_row_split(flavor: Option<BinaryFlavor>, gpu_count: u8) -> bool {
+    let backend_supported = matches!(
+        flavor,
+        Some(BinaryFlavor::Cuda) | Some(BinaryFlavor::Rocm) | None
+    );
+    backend_supported && gpu_count > 1
+}
+
 /// Returns `Some(SplitMode::Row)` when the local machine has multiple GPUs and
 /// the llama.cpp backend supports row-level tensor parallelism (CUDA, ROCm).
 ///
 /// Row split shards weight matrices across local GPUs so all GPUs are active on
 /// every token — faster than layer (pipeline) split where GPUs take turns.
 /// This does NOT work over RPC (network) — only for GPUs on the same machine.
-fn local_multi_gpu_split_mode(flavor: Option<BinaryFlavor>) -> Option<SplitMode> {
-    let supports_row = matches!(flavor, Some(BinaryFlavor::Cuda) | Some(BinaryFlavor::Rocm));
-    if !supports_row {
-        return None;
-    }
+///
+/// When no explicit flavor is provided the resolved binary may still be CUDA/ROCm
+/// (auto-detected from the binary name), so `None` is treated as potentially
+/// supported.
+pub(crate) fn local_multi_gpu_split_mode(flavor: Option<BinaryFlavor>) -> Option<SplitMode> {
     let hw = hardware::query(&[hardware::Metric::GpuCount]);
-    if hw.gpu_count > 1 {
+    if should_use_row_split(flavor, hw.gpu_count) {
         tracing::info!(
             "Local multi-GPU detected ({} GPUs) — using row split for tensor parallelism",
             hw.gpu_count
@@ -1661,5 +1677,46 @@ mod tests {
         let targets = ModelTargets::default();
         let result = targets.pick_from(&[]);
         assert_eq!(result, InferenceTarget::None);
+    }
+
+    // ── Row-split / tensor-parallelism selection ──
+
+    #[test]
+    fn row_split_enabled_for_cuda_multi_gpu() {
+        assert!(should_use_row_split(Some(BinaryFlavor::Cuda), 2));
+        assert!(should_use_row_split(Some(BinaryFlavor::Cuda), 8));
+    }
+
+    #[test]
+    fn row_split_enabled_for_rocm_multi_gpu() {
+        assert!(should_use_row_split(Some(BinaryFlavor::Rocm), 2));
+    }
+
+    #[test]
+    fn row_split_enabled_for_unknown_flavor_multi_gpu() {
+        // None means auto-detected; the resolved binary may still be CUDA/ROCm.
+        assert!(should_use_row_split(None, 2));
+        assert!(should_use_row_split(None, 4));
+    }
+
+    #[test]
+    fn row_split_disabled_for_single_gpu() {
+        assert!(!should_use_row_split(Some(BinaryFlavor::Cuda), 1));
+        assert!(!should_use_row_split(Some(BinaryFlavor::Rocm), 1));
+        assert!(!should_use_row_split(None, 1));
+    }
+
+    #[test]
+    fn row_split_disabled_for_zero_gpus() {
+        assert!(!should_use_row_split(Some(BinaryFlavor::Cuda), 0));
+        assert!(!should_use_row_split(None, 0));
+    }
+
+    #[test]
+    fn row_split_disabled_for_non_cuda_backends() {
+        // Metal, Vulkan, CPU don't support ggml_backend_split_buffer_type.
+        assert!(!should_use_row_split(Some(BinaryFlavor::Metal), 8));
+        assert!(!should_use_row_split(Some(BinaryFlavor::Vulkan), 4));
+        assert!(!should_use_row_split(Some(BinaryFlavor::Cpu), 4));
     }
 }

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -754,7 +754,20 @@ pub async fn start_llama_server(
     if let Some(mode) = split_mode {
         args.push("--split-mode".to_string());
         args.push(mode.as_arg().to_string());
-        tracing::info!("Split mode: {} (tensor parallelism across local GPUs)", mode.as_arg());
+        match mode {
+            SplitMode::Layer => {
+                tracing::info!(
+                    "Split mode: {} (layer-based / pipeline parallelism)",
+                    mode.as_arg()
+                );
+            }
+            SplitMode::Row => {
+                tracing::info!(
+                    "Split mode: {} (tensor parallelism across local GPUs)",
+                    mode.as_arg()
+                );
+            }
+        }
     }
     let local_device = resolve_device_for_binary(&llama_server.path, llama_server.flavor, None)?;
     if let Some(draft_path) = draft {
@@ -1029,7 +1042,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 mod tests {
     use super::{
         compute_context_size, parse_available_devices, preferred_device, temp_log_path,
-        BinaryFlavor,
+        BinaryFlavor, SplitMode,
     };
     use std::path::Path;
 
@@ -1131,5 +1144,17 @@ No devices found
             file_name.contains(suffix),
             "expected filename '{file_name}' to contain suffix '{suffix}'"
         );
+    }
+
+    // ── SplitMode ──
+
+    #[test]
+    fn split_mode_layer_arg() {
+        assert_eq!(SplitMode::Layer.as_arg(), "layer");
+    }
+
+    #[test]
+    fn split_mode_row_arg() {
+        assert_eq!(SplitMode::Row.as_arg(), "row");
     }
 }

--- a/mesh-llm/src/runtime/local.rs
+++ b/mesh-llm/src/runtime/local.rs
@@ -181,7 +181,7 @@ pub(super) async fn start_runtime_local_model(
             http_port: port,
             tunnel_ports: &[],
             tensor_split: None,
-            split_mode: None,
+            split_mode: election::local_multi_gpu_split_mode(binary_flavor),
             draft: None,
             draft_max: 0,
             model_bytes,


### PR DESCRIPTION
## What

When a machine has multiple local GPUs (e.g. DGX with 8× H100, or a desktop with 2× RTX 4090), automatically pass `--split-mode row` to llama-server instead of the default layer split.

## Why

Row split (true tensor parallelism) shards weight **matrices** across GPUs — all GPUs compute on every token. This is faster than layer/pipeline split, where GPUs take turns processing layers sequentially.

llama.cpp already supports `--split-mode row` on CUDA and SYCL backends, but mesh-llm never passed the flag, so it always defaulted to `--split-mode layer` even on multi-GPU machines where row split would be faster.

## How

- Added `SplitMode` enum (`Layer` / `Row`) to `launch.rs`
- Added `split_mode: Option<SplitMode>` to `ModelLaunchSpec`
- Added `local_multi_gpu_split_mode()` helper in `election.rs` that checks:
  1. Binary flavor is CUDA or ROCm (backends that implement `ggml_backend_split_buffer_type`)
  2. `gpu_count > 1` (detected via `HardwareSurvey`)
- Applied to all solo launch paths (no RPC workers): normal solo, MoE solo, MoE shard
- RPC (network) splits are **not** affected — they continue to use pipeline parallelism since the RPC backend does not support row split

## Scope

- 3 files changed, 66 insertions
- No new CLI flags — detection is automatic
- No changes to network split, MoE split logic, or API
- All 366 existing tests pass