### PR TITLE
Deflake CI smoke tests

### DIFF
--- a/scripts/ci-compat-smoke.sh
+++ b/scripts/ci-compat-smoke.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# ci-compat-smoke.sh — start 2 mesh nodes + 1 lite client, then run SDK compatibility smokes.
+# ci-compat-smoke.sh — start a single mesh-llm node, then run SDK compatibility smokes.
+#
+# This test validates that openai-python, openai-node, litellm, and langchain-openai
+# all work correctly against mesh-llm's OpenAI-compatible API. It uses a solo node
+# (no split, no mesh) since split-mode routing is already tested by ci-split-test.sh.
 #
 # Usage: scripts/ci-compat-smoke.sh <mesh-llm-binary> <bin-dir> <model-path>
 
@@ -14,23 +18,11 @@ NPM_BIN="${NPM_BIN:-npm}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-HOST_API_PORT=9337
-HOST_CONSOLE_PORT=3131
-HOST_BIND_PORT=7842
-
-WORKER_API_PORT=9437
-WORKER_CONSOLE_PORT=4131
-WORKER_BIND_PORT=7843
-
-CLIENT_API_PORT=9555
-CLIENT_CONSOLE_PORT=5131
-CLIENT_BIND_PORT=7844
-
+API_PORT=9337
+CONSOLE_PORT=3131
 MAX_WAIT=240
 WORKDIR="$(mktemp -d)"
-HOST_LOG="$WORKDIR/host.log"
-WORKER_LOG="$WORKDIR/worker.log"
-CLIENT_LOG="$WORKDIR/client.log"
+LOG="$WORKDIR/mesh-llm.log"
 NODE_SDK_DIR="$WORKDIR/openai-node"
 
 echo "=== Compat Smoke Test ==="
@@ -46,18 +38,14 @@ fi
 
 cleanup() {
     set +e
-    for pid in "${CLIENT_PID:-}" "${WORKER_PID:-}" "${HOST_PID:-}"; do
-        if [ -n "${pid:-}" ]; then
-            kill "$pid" 2>/dev/null || true
-            pkill -P "$pid" 2>/dev/null || true
-        fi
-    done
+    if [ -n "${MESH_PID:-}" ]; then
+        kill "$MESH_PID" 2>/dev/null || true
+        pkill -P "$MESH_PID" 2>/dev/null || true
+    fi
     sleep 2
-    for pid in "${CLIENT_PID:-}" "${WORKER_PID:-}" "${HOST_PID:-}"; do
-        if [ -n "${pid:-}" ]; then
-            kill -9 "$pid" 2>/dev/null || true
-        fi
-    done
+    if [ -n "${MESH_PID:-}" ]; then
+        kill -9 "$MESH_PID" 2>/dev/null || true
+    fi
     pkill -9 -f "[/]rpc-server" 2>/dev/null || true
     pkill -9 -f "[/]llama-server" 2>/dev/null || true
     rm -rf "$WORKDIR"
@@ -67,12 +55,8 @@ trap cleanup EXIT
 fail_with_logs() {
     local message="$1"
     echo "❌ $message"
-    echo "--- host log ---"
-    tail -80 "$HOST_LOG" 2>/dev/null || true
-    echo "--- worker log ---"
-    tail -80 "$WORKER_LOG" 2>/dev/null || true
-    echo "--- client log ---"
-    tail -80 "$CLIENT_LOG" 2>/dev/null || true
+    echo "--- mesh-llm log ---"
+    tail -80 "$LOG" 2>/dev/null || true
     exit 1
 }
 
@@ -84,174 +68,77 @@ assert_pid_alive() {
     fi
 }
 
-json_field() {
-    local url="$1"
-    local field="$2"
-    curl -sf "$url" | "$PYTHON_BIN" -c '
-import json
-import sys
+# ── Start solo node ──
 
-field = sys.argv[1]
-data = json.load(sys.stdin)
-value = data
-for part in field.split("."):
-    if part.isdigit():
-        value = value[int(part)]
-    else:
-        value = value.get(part)
-print("" if value is None else value)
-' "$field"
-}
+echo "Starting mesh-llm (solo)..."
+"$MESH_LLM" \
+    --model "$MODEL" \
+    --no-draft \
+    --bin-dir "$BIN_DIR" \
+    --device CPU \
+    --port "$API_PORT" \
+    --console "$CONSOLE_PORT" \
+    >"$LOG" 2>&1 &
+MESH_PID=$!
 
-json_len() {
-    local url="$1"
-    local field="$2"
-    curl -sf "$url" | "$PYTHON_BIN" -c '
-import json
-import sys
+echo "Waiting for model to load (up to ${MAX_WAIT}s)..."
+for i in $(seq 1 "$MAX_WAIT"); do
+    assert_pid_alive "$MESH_PID" "mesh-llm"
+    READY=$("$PYTHON_BIN" -c '
+import json, sys, urllib.request
+try:
+    r = urllib.request.urlopen("http://127.0.0.1:'"$CONSOLE_PORT"'/api/status", timeout=2)
+    print(json.load(r).get("llama_ready", False))
+except Exception:
+    print("False")
+' 2>/dev/null || echo "False")
+    if [ "$READY" = "True" ]; then
+        echo "✅ Model loaded in ${i}s"
+        break
+    fi
+    if [ "$i" -eq "$MAX_WAIT" ]; then
+        fail_with_logs "model did not load within ${MAX_WAIT}s"
+    fi
+    if [ $((i % 20)) -eq 0 ]; then
+        echo "  Still waiting... (${i}s)"
+    fi
+    sleep 1
+done
 
-field = sys.argv[1]
-data = json.load(sys.stdin)
-value = data
-for part in field.split("."):
-    if part.isdigit():
-        value = value[int(part)]
-    else:
-        value = value.get(part)
-print(len(value) if value is not None else 0)
-' "$field"
-}
+# Verify inference works before running SDK smokes
+echo "Verifying inference readiness..."
+for i in $(seq 1 30); do
+    RESPONSE=$(curl -s --max-time 10 -w '\n%{http_code}' \
+        "http://127.0.0.1:${API_PORT}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d '{
+            "model": "any",
+            "messages": [{"role": "user", "content": "Reply with the single word ready."}],
+            "max_tokens": 8,
+            "temperature": 0
+        }' 2>/dev/null || true)
+    HTTP_CODE=$(printf '%s\n' "$RESPONSE" | tail -n 1)
+    if [ "$HTTP_CODE" = "200" ]; then
+        echo "✅ Inference ready"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        fail_with_logs "inference never became ready (last HTTP $HTTP_CODE)"
+    fi
+    sleep 1
+done
 
-wait_for_status() {
-    local port="$1"
-    local pid="$2"
-    local name="$3"
-    for i in $(seq 1 "$MAX_WAIT"); do
-        assert_pid_alive "$pid" "$name"
-        if curl -sf "http://127.0.0.1:${port}/api/status" >/dev/null 2>&1; then
-            return 0
-        fi
-        sleep 1
-    done
-    fail_with_logs "status endpoint on :$port for $name never came up"
-}
+# Get the model name
+MODEL_NAME=$(curl -sf "http://127.0.0.1:${API_PORT}/v1/models" | "$PYTHON_BIN" -c '
+import json, sys
+data = json.load(sys.stdin).get("data", [])
+if not data:
+    raise SystemExit("no models returned")
+print(data[0]["id"])
+')
+echo "Using model: $MODEL_NAME"
 
-wait_for_llama_ready() {
-    local port="$1"
-    local name="$2"
-    local pid="$3"
-    for i in $(seq 1 "$MAX_WAIT"); do
-        assert_pid_alive "$pid" "$name"
-        local ready
-        ready="$(json_field "http://127.0.0.1:${port}/api/status" "llama_ready" 2>/dev/null || true)"
-        if [ "$ready" = "True" ]; then
-            echo "✅ $name ready after ${i}s"
-            return 0
-        fi
-        if [ $((i % 20)) -eq 0 ]; then
-            echo "  Waiting for $name model load... (${i}s)"
-        fi
-        sleep 1
-    done
-    fail_with_logs "$name did not become ready"
-}
-
-wait_for_client_mesh() {
-    for i in $(seq 1 "$MAX_WAIT"); do
-        assert_pid_alive "$CLIENT_PID" "client"
-        assert_pid_alive "$HOST_PID" "host"
-        assert_pid_alive "$WORKER_PID" "worker"
-        local peers
-        local models
-        peers="$(json_len "http://127.0.0.1:${CLIENT_CONSOLE_PORT}/api/status" "peers" 2>/dev/null || echo 0)"
-        models="$(curl -sf "http://127.0.0.1:${CLIENT_API_PORT}/v1/models" 2>/dev/null | "$PYTHON_BIN" -c 'import json,sys; print(len(json.load(sys.stdin).get("data", [])))' 2>/dev/null || echo 0)"
-        if [ "$peers" -ge 2 ] && [ "$models" -ge 1 ]; then
-            echo "✅ Client sees mesh: peers=$peers models=$models"
-            return 0
-        fi
-        if [ $((i % 15)) -eq 0 ]; then
-            echo "  Waiting for client mesh visibility... (${i}s, peers=$peers, models=$models)"
-        fi
-        sleep 1
-    done
-    fail_with_logs "client never saw both mesh nodes and models"
-}
-
-wait_for_split_mesh() {
-    for i in $(seq 1 "$MAX_WAIT"); do
-        assert_pid_alive "$HOST_PID" "host"
-        assert_pid_alive "$WORKER_PID" "worker"
-        local host_is_host
-        local host_ready
-        local host_peers
-        local worker_is_host
-        local worker_ready
-        local worker_peers
-
-        host_is_host="$(json_field "http://127.0.0.1:${HOST_CONSOLE_PORT}/api/status" "is_host" 2>/dev/null || true)"
-        host_ready="$(json_field "http://127.0.0.1:${HOST_CONSOLE_PORT}/api/status" "llama_ready" 2>/dev/null || true)"
-        host_peers="$(json_len "http://127.0.0.1:${HOST_CONSOLE_PORT}/api/status" "peers" 2>/dev/null || echo 0)"
-
-        worker_is_host="$(json_field "http://127.0.0.1:${WORKER_CONSOLE_PORT}/api/status" "is_host" 2>/dev/null || true)"
-        worker_ready="$(json_field "http://127.0.0.1:${WORKER_CONSOLE_PORT}/api/status" "llama_ready" 2>/dev/null || true)"
-        worker_peers="$(json_len "http://127.0.0.1:${WORKER_CONSOLE_PORT}/api/status" "peers" 2>/dev/null || echo 0)"
-
-        if [ "$host_is_host" = "True" ] && [ "$host_ready" = "True" ] && [ "$host_peers" -ge 1 ]; then
-            echo "✅ Split mesh formed with host on :$HOST_CONSOLE_PORT after ${i}s"
-            return 0
-        fi
-        if [ "$worker_is_host" = "True" ] && [ "$worker_ready" = "True" ] && [ "$worker_peers" -ge 1 ]; then
-            echo "✅ Split mesh formed with host on :$WORKER_CONSOLE_PORT after ${i}s"
-            return 0
-        fi
-
-        if [ $((i % 15)) -eq 0 ]; then
-            echo "  Waiting for split mesh to elect a ready host... (${i}s)"
-        fi
-        sleep 1
-    done
-    fail_with_logs "split mesh never formed a ready host"
-}
-
-wait_for_routed_inference() {
-    local model="$1"
-    for i in $(seq 1 "$MAX_WAIT"); do
-        assert_pid_alive "$CLIENT_PID" "client"
-        assert_pid_alive "$HOST_PID" "host"
-        assert_pid_alive "$WORKER_PID" "worker"
-
-        local response
-        local http_code
-        local body
-        response="$(curl -s --max-time 20 -w '\n%{http_code}' \
-            "http://127.0.0.1:${CLIENT_API_PORT}/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -d "{
-                \"model\": \"${model}\",
-                \"messages\": [{\"role\": \"user\", \"content\": \"Reply with the single word ready.\"}],
-                \"max_tokens\": 8,
-                \"temperature\": 0
-            }" 2>/dev/null || true)"
-        http_code="$(printf '%s\n' "$response" | tail -n 1)"
-        body="$(printf '%s\n' "$response" | sed '$d')"
-
-        if [ "$http_code" = "200" ]; then
-            echo "✅ Routed inference ready after ${i}s"
-            return 0
-        fi
-
-        if [ "$http_code" != "503" ] && [ "$http_code" != "000" ] && [ -n "$http_code" ]; then
-            echo "Unexpected readiness probe response ($http_code): $body"
-            fail_with_logs "routed inference probe failed unexpectedly"
-        fi
-
-        if [ $((i % 10)) -eq 0 ]; then
-            echo "  Waiting for routed inference readiness... (${i}s, last status=${http_code:-none})"
-        fi
-        sleep 1
-    done
-    fail_with_logs "routed inference never became ready"
-}
+# ── SDK smoke helper ──
 
 ensure_openai_node_sdk() {
     if ! command -v "$NODE_BIN" >/dev/null 2>&1; then
@@ -264,92 +151,29 @@ ensure_openai_node_sdk() {
     "$NPM_BIN" install --silent --prefix "$NODE_SDK_DIR" openai >/dev/null
 }
 
-model_id() {
-    curl -sf "http://127.0.0.1:${CLIENT_API_PORT}/v1/models" | "$PYTHON_BIN" -c '
-import json
-import sys
+# ── Run SDK smokes (all hit the solo node directly — no tunnel) ──
 
-data = json.load(sys.stdin).get("data", [])
-if not data:
-    raise SystemExit("no models returned")
-print(data[0]["id"])
-'
-}
-
-echo "Starting host..."
-MESH_LLM_EPHEMERAL_KEY=1 "$MESH_LLM" \
-    --model "$MODEL" \
-    --split \
-    --no-draft \
-    --bin-dir "$BIN_DIR" \
-    --device CPU \
-    --port "$HOST_API_PORT" \
-    --console "$HOST_CONSOLE_PORT" \
-    --bind-port "$HOST_BIND_PORT" \
-    >"$HOST_LOG" 2>&1 &
-HOST_PID=$!
-
-wait_for_status "$HOST_CONSOLE_PORT" "$HOST_PID" "host"
-TOKEN="$(json_field "http://127.0.0.1:${HOST_CONSOLE_PORT}/api/status" "token")"
-if [ -z "$TOKEN" ]; then
-    fail_with_logs "host did not expose an invite token"
-fi
-wait_for_llama_ready "$HOST_CONSOLE_PORT" "host" "$HOST_PID"
-
-echo "Starting worker..."
-MESH_LLM_EPHEMERAL_KEY=1 "$MESH_LLM" \
-    --model "$MODEL" \
-    --split \
-    --no-draft \
-    --bin-dir "$BIN_DIR" \
-    --device CPU \
-    --port "$WORKER_API_PORT" \
-    --console "$WORKER_CONSOLE_PORT" \
-    --bind-port "$WORKER_BIND_PORT" \
-    --join "$TOKEN" \
-    >"$WORKER_LOG" 2>&1 &
-WORKER_PID=$!
-
-wait_for_status "$WORKER_CONSOLE_PORT" "$WORKER_PID" "worker"
-wait_for_split_mesh
-
-echo "Starting lite client..."
-MESH_LLM_EPHEMERAL_KEY=1 "$MESH_LLM" \
-    --client \
-    --no-draft \
-    --port "$CLIENT_API_PORT" \
-    --console "$CLIENT_CONSOLE_PORT" \
-    --bind-port "$CLIENT_BIND_PORT" \
-    --join "$TOKEN" \
-    >"$CLIENT_LOG" 2>&1 &
-CLIENT_PID=$!
-
-wait_for_status "$CLIENT_CONSOLE_PORT" "$CLIENT_PID" "client"
-wait_for_client_mesh
-ROUTED_MODEL="$(model_id)"
-
-echo "Using routed model: $ROUTED_MODEL"
-wait_for_routed_inference "$ROUTED_MODEL"
+BASE_URL="http://127.0.0.1:${API_PORT}/v1"
 
 echo "Running official openai-python smoke..."
 "$PYTHON_BIN" "$REPO_ROOT/scripts/ci-openai-python-smoke.py" \
-    --base-url "http://127.0.0.1:${CLIENT_API_PORT}/v1"
+    --base-url "$BASE_URL"
 
 echo "Running official openai-node smoke..."
 ensure_openai_node_sdk
 NODE_PATH="$NODE_SDK_DIR/node_modules" "$NODE_BIN" \
     "$REPO_ROOT/scripts/ci-openai-node-smoke.cjs" \
-    --base-url "http://127.0.0.1:${CLIENT_API_PORT}/v1"
+    --base-url "$BASE_URL"
 
 echo "Running LiteLLM smoke..."
 "$PYTHON_BIN" "$REPO_ROOT/scripts/ci-litellm-smoke.py" \
-    --base-url "http://127.0.0.1:${CLIENT_API_PORT}/v1" \
-    --model "$ROUTED_MODEL"
+    --base-url "$BASE_URL" \
+    --model "$MODEL_NAME"
 
 echo "Running langchain-openai smoke..."
 "$PYTHON_BIN" "$REPO_ROOT/scripts/ci-langchain-openai-smoke.py" \
-    --base-url "http://127.0.0.1:${CLIENT_API_PORT}/v1" \
-    --model "$ROUTED_MODEL"
+    --base-url "$BASE_URL" \
+    --model "$MODEL_NAME"
 
 echo ""
 echo "=== Compat smoke passed ==="

--- a/scripts/ci-split-test.sh
+++ b/scripts/ci-split-test.sh
@@ -27,7 +27,7 @@ C_API_PORT=9349
 C_CONSOLE_PORT=3143
 MAX_WAIT=180
 MAX_CLIENT_ROUTE_WAIT=60
-MAX_INFERENCE_ATTEMPTS=8
+MAX_INFERENCE_ATTEMPTS=15
 LOG_A=/tmp/mesh-llm-split-a.log
 LOG_B=/tmp/mesh-llm-split-b.log
 LOG_C=/tmp/mesh-llm-split-c.log
@@ -252,6 +252,7 @@ done
 echo ""
 echo "Waiting for host API (port $HOST_API) to accept direct inference..."
 HOST_READY=""
+BACKOFF=2
 for i in $(seq 1 "$MAX_INFERENCE_ATTEMPTS"); do
     HOST_RESPONSE=$(curl -s --max-time 30 -w "\n%{http_code}" "http://localhost:${HOST_API}/v1/chat/completions" \
         -H "Content-Type: application/json" \
@@ -272,11 +273,14 @@ for i in $(seq 1 "$MAX_INFERENCE_ATTEMPTS"); do
             break
         fi
     else
-        echo "  ⚠️  Host attempt $i: HTTP $HOST_HTTP_CODE (still starting)"
+        echo "  ⚠️  Host attempt $i: HTTP $HOST_HTTP_CODE (retrying in ${BACKOFF}s)"
     fi
 
     if [ "$i" -lt "$MAX_INFERENCE_ATTEMPTS" ]; then
-        sleep 3
+        sleep "$BACKOFF"
+        # Exponential backoff: 2, 3, 4, 6, 9, 13, ... capped at 15s
+        BACKOFF=$(( BACKOFF + BACKOFF / 2 ))
+        [ "$BACKOFF" -gt 15 ] && BACKOFF=15
     fi
 done
 
@@ -306,8 +310,9 @@ echo "Testing /v1/chat/completions through Client (port $C_API_PORT)..."
 echo "  Client has no local inference — must route to a peer."
 echo "  If it picks the Worker (rpc-server only), this fails."
 
-# Retry a few times — tunnel establishment can take a moment
+# Retry with exponential backoff — tunnel establishment can take a while on slow CI runners
 CONTENT=""
+BACKOFF=2
 for attempt in $(seq 1 "$MAX_INFERENCE_ATTEMPTS"); do
     RESPONSE=$(curl -s --max-time 30 -w "\n%{http_code}" "http://localhost:${C_API_PORT}/v1/chat/completions" \
         -H "Content-Type: application/json" \
@@ -330,11 +335,14 @@ for attempt in $(seq 1 "$MAX_INFERENCE_ATTEMPTS"); do
         echo "  ⚠️  Attempt $attempt: 200 but empty content — split routing bug?"
         echo "  Raw: $BODY"
     else
-        echo "  ⚠️  Attempt $attempt: HTTP $HTTP_CODE (tunnel may not be ready)"
+        echo "  ⚠️  Attempt $attempt: HTTP $HTTP_CODE (tunnel may not be ready, retrying in ${BACKOFF}s)"
     fi
 
     if [ "$attempt" -lt "$MAX_INFERENCE_ATTEMPTS" ]; then
-        sleep 3
+        sleep "$BACKOFF"
+        # Exponential backoff: 2, 3, 4, 6, 9, 13, 15, 15, ... capped at 15s
+        BACKOFF=$(( BACKOFF + BACKOFF / 2 ))
+        [ "$BACKOFF" -gt 15 ] && BACKOFF=15
     fi
 done
 
@@ -342,10 +350,12 @@ if [ -z "$CONTENT" ]; then
     echo "❌ Client inference failed after ${MAX_INFERENCE_ATTEMPTS} attempts"
     echo "  Last HTTP code: $HTTP_CODE"
     echo "  Last body: $BODY"
+    echo "--- Client status ---"
+    curl -sf "http://localhost:${C_CONSOLE_PORT}/api/status" | python3 -m json.tool 2>/dev/null || echo "(unavailable)"
     echo "--- Client log tail ---"
     tail -30 "$LOG_C" || true
     echo "--- Host log tail ---"
-    tail -20 /tmp/mesh-llm-split-a.log /tmp/mesh-llm-split-b.log || true
+    tail -20 "$LOG_A" "$LOG_B" || true
     exit 1
 fi
 


### PR DESCRIPTION
The compat smoke and split-mode tests have been flaking on CI with transient 503s ("No inference server available — election in progress"). The root cause is tunnel establishment timing on slow GitHub Actions runners.

## Changes

**Compat smoke → solo node**: The compat test was running a full 3-node split mesh (host + worker + client) just to get an endpoint for SDK compatibility checks. Split routing is already tested by `ci-split-test.sh` on both linux and macOS. Now it starts a single solo node — no mesh, no tunnel, no flake.

**Split test → exponential backoff**: Retry budget goes from 8 × 3s (24s) to 15 attempts with exponential backoff (2s → 3s → 4s → 6s → 9s → 13s → 15s cap, ~172s total). Fast path is unchanged; the long tail handles slow runners. Also dumps client `/api/status` JSON on failure for better diagnostics.