### PR TITLE
[codex] Namespace server logs by mesh-llm PID

### DIFF
--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -996,7 +996,10 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[cfg(test)]
 mod tests {
-    use super::{compute_context_size, parse_available_devices, preferred_device, BinaryFlavor};
+    use super::{
+        compute_context_size, parse_available_devices, preferred_device, temp_log_path,
+        BinaryFlavor,
+    };
     use std::path::Path;
 
     #[test]
@@ -1082,7 +1085,7 @@ No devices found
     #[test]
     fn temp_log_path_includes_pid_and_suffix() {
         let suffix = "rpc-server.log";
-        let path = super::temp_log_path(suffix);
+        let path = temp_log_path(suffix);
         let file_name = path
             .file_name()
             .expect("temp_log_path should produce a filename")


### PR DESCRIPTION
## Summary
Users can now distinguish `llama-server` and `rpc-server` logs by the parent `mesh-llm` process that created them.

## What changed
- prefixed temp log filenames with the current `mesh-llm` PID
- kept the per-server filename suffixes so `rpc-server` logs still include their port
- applied the naming change to both `rpc-server` and `llama-server` launch paths

## Why
Multiple `mesh-llm` processes could previously write child server logs with overlapping generic names in the temp directory, which made it harder to trace logs back to the owning mesh process.

## Validation
- formatted `mesh-llm/src/inference/launch.rs`
- did not compile or run tests in this change
