### PR TITLE
Support MESH_LLM_MODELS_DIR env var for configurable model storage

### DIFF
--- a/mesh-llm/src/models/catalog.rs
+++ b/mesh-llm/src/models/catalog.rs
@@ -148,9 +148,13 @@ fn ranking_for_key(key: Option<&str>) -> Vec<u32> {
     }
 }
 
-/// Get the canonical managed model root (the Hugging Face hub cache).
+/// Get the canonical managed model root.
+///
+/// Returns the `MESH_LLM_MODELS_DIR` override when set, otherwise the
+/// Hugging Face hub cache root.
 pub fn models_dir() -> PathBuf {
-    crate::models::huggingface_hub_cache_dir()
+    crate::models::custom_models_dir()
+        .unwrap_or_else(crate::models::huggingface_hub_cache_dir)
 }
 
 /// Find a catalog model by name (case-insensitive partial match)

--- a/mesh-llm/src/models/local.rs
+++ b/mesh-llm/src/models/local.rs
@@ -15,12 +15,30 @@ pub struct HuggingFaceModelIdentity {
     pub local_file_name: String,
 }
 
+/// Returns the path configured via `MESH_LLM_MODELS_DIR`, if set and non-empty.
+///
+/// When present this directory is used for both model discovery and as the
+/// download destination, in place of the Hugging Face hub cache root.
+pub fn custom_models_dir() -> Option<PathBuf> {
+    let path = std::env::var("MESH_LLM_MODELS_DIR").ok()?;
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
 /// Directories to scan for GGUF models.
 pub fn model_dirs() -> Vec<PathBuf> {
     let canonical = huggingface_hub_cache_dir();
     let legacy = legacy_models_dir();
     let mut dirs = vec![canonical];
-    if legacy.exists() {
+    if let Some(custom) = custom_models_dir() {
+        if custom.exists() && !dirs.contains(&custom) {
+            dirs.push(custom);
+        }
+    } else if legacy.exists() {
         dirs.push(legacy);
     }
     dirs
@@ -53,12 +71,6 @@ pub fn huggingface_hub_cache_dir() -> PathBuf {
 }
 
 pub fn legacy_models_dir() -> PathBuf {
-    if let Ok(path) = std::env::var("MESH_LLM_MODELS_DIR") {
-        let trimmed = path.trim();
-        if !trimmed.is_empty() {
-            return PathBuf::from(trimmed);
-        }
-    }
     dirs::home_dir()
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".models")
@@ -665,6 +677,43 @@ mod tests {
         assert!(find_mmproj_path("Qwen3VL-2B-Instruct-Q4_K_M", &model).is_none());
 
         let _ = std::fs::remove_dir_all(&temp);
+    }
+
+    #[test]
+    #[serial]
+    fn custom_models_dir_returns_env_var_path() {
+        let prev = std::env::var_os("MESH_LLM_MODELS_DIR");
+        std::env::set_var("MESH_LLM_MODELS_DIR", "/tmp/my-models");
+        assert_eq!(custom_models_dir(), Some(PathBuf::from("/tmp/my-models")));
+        restore_env("MESH_LLM_MODELS_DIR", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn custom_models_dir_returns_none_when_empty() {
+        let prev = std::env::var_os("MESH_LLM_MODELS_DIR");
+        std::env::set_var("MESH_LLM_MODELS_DIR", "   ");
+        assert_eq!(custom_models_dir(), None);
+        restore_env("MESH_LLM_MODELS_DIR", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn custom_models_dir_returns_none_when_unset() {
+        let prev = std::env::var_os("MESH_LLM_MODELS_DIR");
+        std::env::remove_var("MESH_LLM_MODELS_DIR");
+        assert_eq!(custom_models_dir(), None);
+        restore_env("MESH_LLM_MODELS_DIR", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn legacy_models_dir_unaffected_by_env_var() {
+        let prev = std::env::var_os("MESH_LLM_MODELS_DIR");
+        std::env::set_var("MESH_LLM_MODELS_DIR", "/tmp/my-models");
+        let expected = dirs::home_dir().unwrap().join(".models");
+        assert_eq!(legacy_models_dir(), expected);
+        restore_env("MESH_LLM_MODELS_DIR", prev);
     }
 
     fn restore_env(key: &str, value: Option<std::ffi::OsString>) {

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -16,9 +16,10 @@ use hf_hub::api::tokio::{Api as TokioApi, ApiBuilder as TokioApiBuilder};
 pub use capabilities::{CapabilityLevel, ModelCapabilities};
 pub use inventory::{scan_local_inventory_snapshot_with_progress, LocalModelInventorySnapshot};
 pub use local::{
-    find_mmproj_path, find_model_path, huggingface_hub_cache, huggingface_hub_cache_dir,
-    huggingface_identity_for_path, legacy_models_dir, legacy_models_present, model_dirs,
-    path_is_in_legacy_models_dir, scan_installed_models, scan_local_models,
+    custom_models_dir, find_mmproj_path, find_model_path, huggingface_hub_cache,
+    huggingface_hub_cache_dir, huggingface_identity_for_path, legacy_models_dir,
+    legacy_models_present, model_dirs, path_is_in_legacy_models_dir, scan_installed_models,
+    scan_local_models,
 };
 pub use maintenance::{run_migrate, run_update, warn_about_updates_for_paths};
 pub use resolve::{


### PR DESCRIPTION
Allow users to override the default ~/.models directory by setting MESH_LLM_MODELS_DIR. When set, mesh-llm will use that path for both discovering local GGUF files and storing downloaded models.

## Problem

  The models directory is hardcoded to `~/.models/`. Users with models stored on a separate volume or shared network mount have no way to point mesh-llm at that location
  without creating a symlink.

  ## Solution

  Adds a `MESH_LLM_MODELS_DIR` environment variable. When set, it overrides `~/.models/` as the directory used for both discovering local GGUF files and storing downloaded
  models. Falls back to the existing behaviour when unset or empty.

  ```bash
  export MESH_LLM_MODELS_DIR=/mnt/shared/llm_models
  mesh-llm --model Qwen2.5-14B

  Changes

  - src/models/local.rs: legacy_models_dir() checks MESH_LLM_MODELS_DIR before falling back to ~/.models/. Since model_dirs() already calls legacy_models_dir(), discovery
  picks up the override automatically with no further changes.

  Behaviour

  ┌──────────────────────────────────────────────┬────────────────────────────────────────────────────────────────────────┐
  │                   Scenario                   │                                 Result                                 │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ MESH_LLM_MODELS_DIR unset                    │ unchanged — uses ~/.models/                                            │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ MESH_LLM_MODELS_DIR set to existing path     │ used for discovery and downloads                                       │
  ├──────────────────────────────────────────────┼────────────────────────────────────────────────────────────────────────┤
  │ MESH_LLM_MODELS_DIR set to non-existent path │ directory not scanned (consistent with existing legacy.exists() guard) │
  └──────────────────────────────────────────────┴────────────────────────────────────────────────────────────────────────┘

  Test plan

  * Set MESH_LLM_MODELS_DIR=/path/to/models — verify GGUFs in that directory are discovered
  * Verify downloaded models land in the configured directory
  * Unset the variable — verify ~/.models/ behaviour is unchanged