### PR TITLE
crypto: native OS keychain backend for owner keystore unlock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +515,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +690,15 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "console"
@@ -905,6 +1033,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2 0.10.9",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1317,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1346,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1380,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1667,6 +1872,15 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
 ]
 
 [[package]]
@@ -2265,6 +2479,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2281,6 +2511,15 @@ name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libm"
@@ -2380,6 +2619,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mesh-llm"
 version = "0.55.1"
 dependencies = [
@@ -2398,6 +2646,7 @@ dependencies = [
  "httparse",
  "include_dir",
  "iroh",
+ "keyring",
  "libc",
  "mesh-llm-plugin",
  "nostr-sdk",
@@ -2556,7 +2805,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -2671,6 +2920,19 @@ dependencies = [
  "windows",
  "windows-result",
  "wmi",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2836,10 +3098,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -3017,6 +3343,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "papaya"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,6 +3487,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkarr"
 version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3209,6 +3556,20 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3987,6 +4348,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4099,6 +4492,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -4319,6 +4723,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
@@ -4853,6 +5263,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -5706,6 +6127,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5748,6 +6179,62 @@ name = "z32"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2164e798d9e3d84ee2c91139ace54638059a3b23e361f5c11781c2c6459bde0f"
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
+]
 
 [[package]]
 name = "zerocopy"
@@ -5876,4 +6363,41 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]

--- a/mesh-llm/Cargo.toml
+++ b/mesh-llm/Cargo.toml
@@ -30,6 +30,7 @@ argon2 = "0.5"
 thiserror = "2"
 zeroize = { version = "1", features = ["derive"] }
 rpassword = "5"
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust"] }
 chrono = { version = "0.4", features = ["serde"] }
 httparse = "1"
 tokio-stream = "0.1"

--- a/mesh-llm/src/cli/commands/auth.rs
+++ b/mesh-llm/src/cli/commands/auth.rs
@@ -1,15 +1,22 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Result};
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
 use crate::crypto::{
     default_keystore_path, keystore_exists, keystore_metadata, load_keystore, save_keystore,
-    OwnerKeypair,
+    OwnerKeypair, DEFAULT_OWNER_ACCOUNT, KEYCHAIN_SERVICE,
 };
 
 /// Run `mesh-llm auth init`.
-pub(crate) fn run_init(owner_key: Option<PathBuf>, force: bool, no_passphrase: bool) -> Result<()> {
+pub(crate) fn run_init(
+    owner_key: Option<PathBuf>,
+    force: bool,
+    no_passphrase: bool,
+    keychain: bool,
+) -> Result<()> {
     let path = match owner_key {
         Some(p) => p,
         None => default_keystore_path()?,
@@ -22,21 +29,42 @@ pub(crate) fn run_init(owner_key: Option<PathBuf>, force: bool, no_passphrase: b
         );
     }
 
-    let passphrase = if no_passphrase {
-        None
+    let (passphrase, source): (Option<Zeroizing<String>>, PassphraseSource) = if no_passphrase {
+        (None, PassphraseSource::None)
+    } else if keychain {
+        if !crate::crypto::keychain_available() {
+            bail!(
+                "No OS keychain backend is available on this host.\n\
+                 Retry without --keychain to set a passphrase, or with --no-passphrase \
+                 to store keys unencrypted."
+            );
+        }
+        let account = keychain_account_for_path(&path);
+        // Capture any existing keychain entry so we can roll back cleanly if
+        // the keystore write fails after we overwrite it.
+        let previous = crate::crypto::keychain_get(KEYCHAIN_SERVICE, &account)
+            .ok()
+            .flatten()
+            .map(Zeroizing::new);
+        let generated = Zeroizing::new(generate_random_passphrase());
+        crate::crypto::keychain_set(KEYCHAIN_SERVICE, &account, generated.as_str())?;
+        (
+            Some(generated),
+            PassphraseSource::Keychain { account, previous },
+        )
     } else {
         let pass = Zeroizing::new(rpassword::prompt_password_stderr(
             "Enter passphrase (empty for none): ",
         )?);
         if pass.is_empty() {
-            None
+            (None, PassphraseSource::None)
         } else {
             let confirm =
                 Zeroizing::new(rpassword::prompt_password_stderr("Confirm passphrase: ")?);
             if pass.as_str() != confirm.as_str() {
                 bail!("Passphrases do not match.");
             }
-            Some(pass)
+            (Some(pass), PassphraseSource::Prompt)
         }
     };
     let encrypted = passphrase.is_some();
@@ -46,12 +74,27 @@ pub(crate) fn run_init(owner_key: Option<PathBuf>, force: bool, no_passphrase: b
     let sign_pk = hex::encode(keypair.verifying_key().as_bytes());
     let enc_pk = hex::encode(keypair.encryption_public_key().as_bytes());
 
-    save_keystore(
+    // If save fails after we've written to the keychain, roll back so we
+    // don't orphan a new entry (no previous) or strand an existing keystore
+    // whose previous unlock secret we just overwrote.
+    if let Err(e) = save_keystore(
         &path,
         &keypair,
         passphrase.as_ref().map(|pass| pass.as_str()),
         force,
-    )?;
+    ) {
+        if let PassphraseSource::Keychain { account, previous } = &source {
+            match previous {
+                Some(prev) => {
+                    let _ = crate::crypto::keychain_set(KEYCHAIN_SERVICE, account, prev.as_str());
+                }
+                None => {
+                    let _ = crate::crypto::keychain_delete(KEYCHAIN_SERVICE, account);
+                }
+            }
+        }
+        return Err(e.into());
+    }
 
     eprintln!();
     eprintln!("Owner keystore created.");
@@ -60,11 +103,33 @@ pub(crate) fn run_init(owner_key: Option<PathBuf>, force: bool, no_passphrase: b
     eprintln!("Encryption key:  {enc_pk}");
     eprintln!("Path:            {}", path.display());
     eprintln!("Encrypted:       {}", if encrypted { "yes" } else { "no" });
+    match &source {
+        PassphraseSource::Keychain { account, .. } => {
+            eprintln!("Unlock:          OS keychain (service={KEYCHAIN_SERVICE}, account={account})");
+        }
+        PassphraseSource::Prompt => {
+            eprintln!("Unlock:          passphrase prompt");
+        }
+        PassphraseSource::None => {}
+    }
     eprintln!();
     eprintln!("Next steps:");
-    eprintln!(
-        "- Copy this keystore to other trusted nodes that should share the same owner identity."
-    );
+    match &source {
+        PassphraseSource::Keychain { account, .. } => {
+            eprintln!(
+                "- This keystore is unlock-bound to this machine's keychain. To share the same \
+                 owner identity on another node, retrieve the passphrase from your OS keychain \
+                 (service={KEYCHAIN_SERVICE}, account={account}) and enter it there, or re-run \
+                 `auth init` with a manual passphrase so the same passphrase can be used \
+                 everywhere."
+            );
+        }
+        PassphraseSource::Prompt | PassphraseSource::None => {
+            eprintln!(
+                "- Copy this keystore to other trusted nodes that should share the same owner identity."
+            );
+        }
+    }
     eprintln!("- Start mesh-llm with --owner-key {}", path.display());
 
     Ok(())
@@ -100,13 +165,298 @@ pub(crate) fn run_status(owner_key: Option<PathBuf>) -> Result<()> {
     }
     eprintln!("Created:         {}", info.created_at);
 
-    // If not encrypted, verify we can load the full keypair.
-    if !info.encrypted {
-        match load_keystore(&path, None) {
-            Ok(_) => eprintln!("Keystore:        valid (keys loaded successfully)"),
-            Err(e) => eprintln!("Keystore:        ERROR loading keys: {e}"),
+    // Attempt to load so we can report whether this node has the unlock
+    // secret (keychain or plaintext) ready for use.
+    let load_result = if info.encrypted {
+        load_with_keychain(&path)
+    } else {
+        load_keystore(&path, None)
+            .map(|kp| (kp, UnlockSource::Plain))
+            .map_err(KeychainLoadError::Crypto)
+    };
+
+    match load_result {
+        Ok((_, UnlockSource::Plain)) => {
+            eprintln!("Keystore:        valid (keys loaded successfully)");
+        }
+        Ok((_, UnlockSource::Keychain)) => {
+            eprintln!("Keystore:        valid (unlocked from OS keychain)");
+        }
+        Err(KeychainLoadError::NoEntry) => {
+            eprintln!(
+                "Keystore:        encrypted (no keychain entry for this path; \
+                 provide the passphrase when the owner keystore is consumed)"
+            );
+        }
+        Err(KeychainLoadError::Crypto(crate::crypto::CryptoError::KeychainUnavailable {
+            reason,
+        })) => {
+            eprintln!("Keystore:        encrypted (keychain unavailable: {reason})");
+        }
+        Err(KeychainLoadError::Crypto(e)) => {
+            eprintln!("Keystore:        ERROR loading keys: {e}");
         }
     }
 
     Ok(())
+}
+
+// ── Internal helpers ────────────────────────────────────────────────
+
+#[derive(Debug)]
+enum PassphraseSource {
+    None,
+    Prompt,
+    Keychain {
+        account: String,
+        previous: Option<Zeroizing<String>>,
+    },
+}
+
+#[derive(Debug)]
+enum UnlockSource {
+    Plain,
+    Keychain,
+}
+
+#[derive(Debug)]
+enum KeychainLoadError {
+    NoEntry,
+    Crypto(crate::crypto::CryptoError),
+}
+
+/// Try to load an encrypted keystore using a passphrase stored in the OS
+/// keychain under the account derived from the keystore path.
+fn load_with_keychain(path: &Path) -> Result<(OwnerKeypair, UnlockSource), KeychainLoadError> {
+    if !crate::crypto::keychain_available() {
+        return Err(KeychainLoadError::Crypto(
+            crate::crypto::CryptoError::KeychainUnavailable {
+                reason: "no backend reachable on this host".into(),
+            },
+        ));
+    }
+    let account = keychain_account_for_path(path);
+    let pass = crate::crypto::keychain_get(KEYCHAIN_SERVICE, &account)
+        .map_err(KeychainLoadError::Crypto)?;
+    let pass = match pass {
+        Some(p) => Zeroizing::new(p),
+        None => return Err(KeychainLoadError::NoEntry),
+    };
+    let kp = load_keystore(path, Some(pass.as_str())).map_err(KeychainLoadError::Crypto)?;
+    Ok((kp, UnlockSource::Keychain))
+}
+
+/// Derive a stable keychain account name from a keystore path.
+///
+/// Form: `owner-keystore:<16 hex chars of sha256(normalized_absolute_path)>`.
+/// The prefix matches `DEFAULT_OWNER_ACCOUNT` so users can identify mesh-llm
+/// entries. The hash bounds the length and avoids leaking full paths into
+/// keychain account fields, while still giving every keystore path its own
+/// slot.
+///
+/// Uses `std::path::absolute` rather than `canonicalize` so the result is
+/// consistent whether the file exists yet (during `auth init`) or already
+/// exists (during status/load). `canonicalize` would resolve symlinks and
+/// only succeed on existing files, producing different account names for
+/// the same logical path at different lifecycle points.
+///
+/// On Windows the path is lowercased before hashing, because the default
+/// filesystem (NTFS) is case-insensitive — without this, `Owner-Keystore.json`
+/// and `owner-keystore.json` would map to different keychain entries despite
+/// being the same file.
+fn keychain_account_for_path(path: &Path) -> String {
+    let absolute = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    let path_str = absolute.to_string_lossy();
+    #[cfg(windows)]
+    let normalized = path_str.to_lowercase();
+    #[cfg(not(windows))]
+    let normalized = path_str.into_owned();
+    let hash = Sha256::digest(normalized.as_bytes());
+    format!("{}:{}", DEFAULT_OWNER_ACCOUNT, &hex::encode(hash)[..16])
+}
+
+/// Generate a cryptographically random passphrase with 256 bits of entropy,
+/// encoded as base64 (no padding) for storage in the keychain.
+fn generate_random_passphrase() -> String {
+    let bytes: [u8; 32] = rand::random();
+    base64::engine::general_purpose::STANDARD_NO_PAD.encode(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn generated_passphrase_has_expected_entropy() {
+        let p1 = generate_random_passphrase();
+        let p2 = generate_random_passphrase();
+        assert_ne!(p1, p2, "two passphrases should not collide");
+        // 32 bytes → 43 chars base64 no-pad.
+        assert_eq!(p1.len(), 43);
+        assert_eq!(p2.len(), 43);
+    }
+
+    #[test]
+    fn account_name_is_deterministic_for_same_path() {
+        let a1 = keychain_account_for_path(Path::new("/tmp/does-not-exist-1.json"));
+        let a2 = keychain_account_for_path(Path::new("/tmp/does-not-exist-1.json"));
+        assert_eq!(a1, a2);
+    }
+
+    #[test]
+    fn account_names_differ_for_different_paths() {
+        let a1 = keychain_account_for_path(Path::new("/tmp/keystore-a.json"));
+        let a2 = keychain_account_for_path(Path::new("/tmp/keystore-b.json"));
+        assert_ne!(a1, a2);
+    }
+
+    #[test]
+    fn account_name_shape() {
+        let a = keychain_account_for_path(Path::new("/tmp/x.json"));
+        assert!(a.starts_with(DEFAULT_OWNER_ACCOUNT));
+        assert!(a.contains(':'));
+        // prefix + ':' + 16 hex chars
+        assert_eq!(a.len(), DEFAULT_OWNER_ACCOUNT.len() + 1 + 16);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn account_name_is_case_insensitive_on_windows() {
+        let lower = keychain_account_for_path(Path::new(r"C:\tmp\Owner\keystore.json"));
+        let upper = keychain_account_for_path(Path::new(r"C:\TMP\OWNER\KEYSTORE.JSON"));
+        assert_eq!(lower, upper, "NTFS paths differing only in case must hash the same");
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn account_name_is_case_sensitive_on_unix() {
+        let lower = keychain_account_for_path(Path::new("/tmp/owner/keystore.json"));
+        let upper = keychain_account_for_path(Path::new("/tmp/OWNER/KEYSTORE.JSON"));
+        assert_ne!(lower, upper, "POSIX paths differing in case must not collide");
+    }
+
+    #[test]
+    #[serial]
+    fn force_keychain_save_failure_restores_previous_secret() {
+        if !crate::crypto::keychain_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+
+        // Use a path whose parent is a FILE rather than a directory. That
+        // makes the save_keystore call fail at create_dir_all, triggering
+        // our rollback logic.
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "mesh-llm-force-rollback-{}",
+            rand::random::<u64>()
+        ));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let blocking_file = tmp_dir.join("blocker");
+        std::fs::write(&blocking_file, b"not a directory").unwrap();
+        // This path uses `blocker` (a regular file) as if it were a parent
+        // directory, so any attempt to create_dir_all against it fails.
+        let bad_path = blocking_file.join("owner-keystore.json");
+
+        // Seed the keychain with a "previous" unlock secret at the account
+        // that run_init will compute for bad_path.
+        let account = keychain_account_for_path(&bad_path);
+        let previous_secret = "previous-unlock-secret-do-not-lose";
+        crate::crypto::keychain_set(KEYCHAIN_SERVICE, &account, previous_secret).unwrap();
+
+        // Force-init with keychain. Expected to fail because the parent of
+        // bad_path is a regular file. Our rollback should restore the
+        // previous secret we seeded.
+        let result = run_init(Some(bad_path.clone()), true, false, true);
+        assert!(result.is_err(), "run_init must fail when save cannot succeed");
+
+        let restored = crate::crypto::keychain_get(KEYCHAIN_SERVICE, &account).unwrap();
+        assert_eq!(
+            restored.as_deref(),
+            Some(previous_secret),
+            "previous keychain secret must be restored after failed force-init"
+        );
+
+        // Cleanup.
+        crate::crypto::keychain_delete(KEYCHAIN_SERVICE, &account).ok();
+        std::fs::remove_dir_all(&tmp_dir).ok();
+    }
+
+    #[test]
+    #[serial]
+    fn fresh_keychain_save_failure_leaves_no_orphan() {
+        if !crate::crypto::keychain_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+
+        let tmp_dir = std::env::temp_dir().join(format!(
+            "mesh-llm-fresh-rollback-{}",
+            rand::random::<u64>()
+        ));
+        std::fs::create_dir_all(&tmp_dir).unwrap();
+        let blocking_file = tmp_dir.join("blocker");
+        std::fs::write(&blocking_file, b"not a directory").unwrap();
+        let bad_path = blocking_file.join("owner-keystore.json");
+
+        let account = keychain_account_for_path(&bad_path);
+
+        // Make sure no entry exists at that account before we start.
+        crate::crypto::keychain_delete(KEYCHAIN_SERVICE, &account).ok();
+
+        let result = run_init(Some(bad_path.clone()), false, false, true);
+        assert!(result.is_err(), "run_init must fail when save cannot succeed");
+
+        let residual = crate::crypto::keychain_get(KEYCHAIN_SERVICE, &account).unwrap();
+        assert_eq!(
+            residual, None,
+            "a fresh init failure must leave no keychain entry behind"
+        );
+
+        std::fs::remove_dir_all(&tmp_dir).ok();
+    }
+
+    #[test]
+    #[serial]
+    fn init_with_keychain_then_load_round_trip() {
+        if !crate::crypto::keychain_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+
+        // Use a unique temp path per run so tests can be repeated / run in
+        // parallel without stomping each other.
+        let dir = std::env::temp_dir().join(format!(
+            "mesh-llm-keychain-rt-{}",
+            rand::random::<u64>()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("owner-keystore.json");
+
+        run_init(Some(path.clone()), false, false, true)
+            .expect("auth init --keychain should succeed");
+
+        // Keystore file exists and is encrypted.
+        assert!(path.exists(), "keystore file should exist");
+        let info = keystore_metadata(&path).unwrap();
+        assert!(info.encrypted, "keystore should be encrypted when using keychain");
+
+        // Keychain has an entry for this path's account.
+        let account = keychain_account_for_path(&path);
+        let stored = crate::crypto::keychain_get(KEYCHAIN_SERVICE, &account).unwrap();
+        assert!(
+            stored.is_some(),
+            "keychain must have a passphrase entry for this keystore path"
+        );
+
+        // Loading through the keychain helper succeeds and yields the same
+        // owner id the keystore metadata advertises.
+        let (kp, src) = load_with_keychain(&path).expect("load via keychain must succeed");
+        assert_eq!(kp.owner_id(), info.owner_id);
+        assert!(matches!(src, UnlockSource::Keychain));
+
+        // Cleanup: remove keychain entry + temp dir.
+        crate::crypto::keychain_delete(KEYCHAIN_SERVICE, &account).ok();
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/mesh-llm/src/cli/commands/mod.rs
+++ b/mesh-llm/src/cli/commands/mod.rs
@@ -89,7 +89,8 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
                 owner_key,
                 force,
                 no_passphrase,
-            } => auth::run_init(owner_key.clone(), *force, *no_passphrase),
+                keychain,
+            } => auth::run_init(owner_key.clone(), *force, *no_passphrase, *keychain),
             AuthCommand::Status { owner_key } => auth::run_status(owner_key.clone()),
         },
     }?;

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -14,8 +14,13 @@ pub(crate) enum AuthCommand {
         #[arg(long)]
         force: bool,
         /// Skip passphrase prompt (store keys unencrypted).
-        #[arg(long)]
+        #[arg(long, conflicts_with = "keychain")]
         no_passphrase: bool,
+        /// Store a random unlock passphrase in the OS keychain (macOS Keychain,
+        /// Windows Credential Manager, Linux Secret Service) instead of
+        /// prompting. The keystore file stays on disk and remains portable.
+        #[arg(long)]
+        keychain: bool,
     },
     /// Show current owner identity status.
     Status {

--- a/mesh-llm/src/crypto/error.rs
+++ b/mesh-llm/src/crypto/error.rs
@@ -23,6 +23,9 @@ pub enum CryptoError {
     #[error("invalid key material: {reason}")]
     InvalidKeyMaterial { reason: String },
 
+    #[error("OS keychain unavailable: {reason}")]
+    KeychainUnavailable { reason: String },
+
     #[error(transparent)]
     Io(#[from] std::io::Error),
 

--- a/mesh-llm/src/crypto/keychain.rs
+++ b/mesh-llm/src/crypto/keychain.rs
@@ -1,0 +1,156 @@
+//! Thin wrapper around `keyring` for storing the owner keystore unlock secret
+//! in the OS-native credential store (macOS Keychain, Windows Credential
+//! Manager, Linux Secret Service).
+//!
+//! This module is backend-neutral: it stores and retrieves opaque UTF-8
+//! strings by (service, account) key. Callers decide whether the stored value
+//! is a passphrase, hex-encoded key bytes, or something else.
+
+use keyring::Entry;
+
+use super::error::CryptoError;
+
+/// Service name used for all mesh-llm keychain entries.
+pub const KEYCHAIN_SERVICE: &str = "mesh-llm";
+
+/// Default account name for the owner keystore unlock secret.
+pub const DEFAULT_OWNER_ACCOUNT: &str = "owner-keystore";
+
+/// Store a secret in the OS keychain under (service, account).
+///
+/// Overwrites any existing entry with the same (service, account) pair.
+pub fn set_secret(service: &str, account: &str, secret: &str) -> Result<(), CryptoError> {
+    let entry = Entry::new(service, account).map_err(map_err)?;
+    entry.set_password(secret).map_err(map_err)
+}
+
+/// Retrieve a secret from the OS keychain by (service, account).
+///
+/// Returns `Ok(None)` when no entry exists for the given pair. Returns
+/// `Err(CryptoError)` when the keychain backend is unavailable or errored.
+pub fn get_secret(service: &str, account: &str) -> Result<Option<String>, CryptoError> {
+    let entry = Entry::new(service, account).map_err(map_err)?;
+    match entry.get_password() {
+        Ok(s) => Ok(Some(s)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+/// Delete a secret from the OS keychain by (service, account).
+///
+/// Returns `Ok(false)` when no entry existed to delete, `Ok(true)` when an
+/// entry was removed.
+pub fn delete_secret(service: &str, account: &str) -> Result<bool, CryptoError> {
+    let entry = Entry::new(service, account).map_err(map_err)?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(true),
+        Err(keyring::Error::NoEntry) => Ok(false),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+/// Probe whether a native keychain backend is reachable on this host.
+///
+/// On Linux this typically means a Secret Service daemon (gnome-keyring,
+/// KWallet) is running and reachable over D-Bus. On macOS and Windows the
+/// backend is effectively always available.
+///
+/// Implementation: attempts a read on a probe account. `NoEntry` counts as
+/// available (the backend answered). A `PlatformFailure` or similar counts as
+/// unavailable.
+pub fn is_available() -> bool {
+    const PROBE_ACCOUNT: &str = "__availability-probe__";
+    let entry = match Entry::new(KEYCHAIN_SERVICE, PROBE_ACCOUNT) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    match entry.get_password() {
+        Ok(_) => true,
+        Err(keyring::Error::NoEntry) => true,
+        Err(_) => false,
+    }
+}
+
+fn map_err(e: keyring::Error) -> CryptoError {
+    CryptoError::KeychainUnavailable {
+        reason: e.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    // Keychain tests hit the real OS credential store, so use a unique account
+    // per test run and clean up afterward. They run serially because some
+    // backends (e.g. Windows Credential Manager) don't handle concurrent
+    // mutations from the same process cleanly. Tests skip themselves when
+    // no keychain backend is reachable (e.g. CI without a Secret Service).
+    fn test_account(tag: &str) -> String {
+        format!("test-{}-{}", tag, rand::random::<u64>())
+    }
+
+    #[test]
+    #[serial]
+    fn round_trip_set_get_delete() {
+        if !is_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+        let account = test_account("round-trip");
+        let secret = "correct horse battery staple";
+
+        set_secret(KEYCHAIN_SERVICE, &account, secret).unwrap();
+        let got = get_secret(KEYCHAIN_SERVICE, &account).unwrap();
+        assert_eq!(got.as_deref(), Some(secret));
+
+        let removed = delete_secret(KEYCHAIN_SERVICE, &account).unwrap();
+        assert!(removed);
+
+        let after = get_secret(KEYCHAIN_SERVICE, &account).unwrap();
+        assert_eq!(after, None);
+    }
+
+    #[test]
+    #[serial]
+    fn get_missing_entry_returns_none() {
+        if !is_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+        let account = test_account("missing");
+        let got = get_secret(KEYCHAIN_SERVICE, &account).unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[test]
+    #[serial]
+    fn delete_missing_entry_returns_false() {
+        if !is_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+        let account = test_account("delete-missing");
+        let removed = delete_secret(KEYCHAIN_SERVICE, &account).unwrap();
+        assert!(!removed);
+    }
+
+    #[test]
+    #[serial]
+    fn overwrite_existing_entry() {
+        if !is_available() {
+            eprintln!("keychain backend unavailable, skipping");
+            return;
+        }
+        let account = test_account("overwrite");
+        set_secret(KEYCHAIN_SERVICE, &account, "first").unwrap();
+        set_secret(KEYCHAIN_SERVICE, &account, "second").unwrap();
+
+        let got = get_secret(KEYCHAIN_SERVICE, &account).unwrap();
+        assert_eq!(got.as_deref(), Some("second"));
+
+        delete_secret(KEYCHAIN_SERVICE, &account).ok();
+    }
+}

--- a/mesh-llm/src/crypto/mod.rs
+++ b/mesh-llm/src/crypto/mod.rs
@@ -1,10 +1,15 @@
 mod envelope;
 mod error;
+mod keychain;
 mod keys;
 mod keystore;
 
 pub use self::envelope::{open_message, seal_message, OpenedMessage, SignedEncryptedEnvelope};
 pub use self::error::CryptoError;
+pub use self::keychain::{
+    delete_secret as keychain_delete, get_secret as keychain_get, is_available as keychain_available,
+    set_secret as keychain_set, DEFAULT_OWNER_ACCOUNT, KEYCHAIN_SERVICE,
+};
 pub use self::keys::{owner_id_from_verifying_key, OwnerKeypair};
 pub use self::keystore::{
     default_keystore_path, keystore_exists, keystore_metadata, load_keystore, save_keystore,


### PR DESCRIPTION
Implements the design proposed in #179 (Option A). Adds a `--keychain` flag to `mesh-llm auth init` that stores a random unlock passphrase in the OS-native credential store (macOS Keychain, Windows Credential Manager, Linux Secret Service via `keyring-rs` v3) instead of prompting.

The file keystore from #156 is unchanged — this is just a new source for the unlock passphrase. No format changes, no crypto changes, no migration path needed.

## What's new

- `mesh-llm auth init --keychain` generates a random 256-bit passphrase, stores it in the OS keychain, and uses it to encrypt the existing JSON keystore via the existing Argon2id + ChaCha20Poly1305 path.
- `mesh-llm auth status` auto-detects when a keystore can be unlocked via the keychain and reports the unlock source explicitly (plain / keychain / no-entry / backend-unavailable).
- `--keychain` and `--no-passphrase` are clap `conflicts_with` — can't mix.
- Each keystore path gets its own keychain slot: account name is `owner-keystore:<sha256(absolute_path)[:16]>`. Lowercased on Windows for NTFS case-insensitivity, preserved on Unix. Uses `std::path::absolute` rather than `canonicalize` so the account name is stable whether the file exists yet (init) or already exists (status/load).

## Rollback safety

`auth init --force --keychain` on an existing keystore overwrites any prior keychain entry at that slot. If the subsequent `save_keystore` call fails, the prior entry is restored (or a fresh entry is deleted), so a failed force-init can't strand an existing keystore with a lost unlock secret.

## Portability note (correct by design)

A keychain-unlocked keystore is bound to the machine whose keychain holds the passphrase. Next-steps text in `auth init --keychain` reflects this accurately — it tells the user the `(service, account)` pair to retrieve from, and suggests using a manual passphrase init if the same identity needs to unlock on multiple nodes without extracting the random secret.

## Tests

8 new tests:
- `init_with_keychain_then_load_round_trip` — end-to-end: init → verify keystore encrypted → verify keychain entry → load via keychain → cleanup.
- `force_keychain_save_failure_restores_previous_secret` — seeds a keychain entry, triggers a save failure, verifies the prior secret is restored.
- `fresh_keychain_save_failure_leaves_no_orphan` — save failure with no prior entry leaves the keychain clean.
- `account_name_is_case_insensitive_on_windows` / `account_name_is_case_sensitive_on_unix` — platform-appropriate path hashing.
- Plus 4 tests on the `crypto::keychain` wrapper (set/get/delete/overwrite) hitting the real backend.

All keychain-touching tests use `#[serial]` (from the existing `serial_test` dev-dep) since Windows Credential Manager doesn't handle concurrent access from the same process cleanly. 33 crypto+auth tests pass, zero regressions against the existing suite.

## Runtime scope

`load_keystore` is currently only called from `auth.rs` — the runtime doesn't consume the owner keystore yet. When it does (slice 3 in #132's plan, covered by #135), that loader can use the same `load_with_keychain` helper this PR introduces.

## Try it

```
mesh-llm auth init --keychain
# ... generates random passphrase, stashes in keychain, creates encrypted keystore
mesh-llm auth status
# Keystore:        valid (unlocked from OS keychain)
```