### PR TITLE
feat: add built-in MiniMax cloud API plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,18 +764,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,35 +782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie_store"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
-dependencies = [
- "cookie",
- "document-features",
- "idna",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "time",
- "url",
 ]
 
 [[package]]
@@ -1366,12 +1325,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1864,26 +1817,8 @@ dependencies = [
 [[package]]
 name = "hf-hub"
 version = "0.5.0"
-source = "git+https://github.com/i386/hf-hub.git?rev=a123ed91f20317d117f83d943b204137d0d24c5e#a123ed91f20317d117f83d943b204137d0d24c5e"
 dependencies = [
  "dirs",
- "futures",
- "http",
- "indicatif",
- "libc",
- "log",
- "num_cpus",
- "rand 0.9.2",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "sha1",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tokio",
- "ureq",
- "walkdir",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2286,19 +2221,6 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
 ]
 
 [[package]]
@@ -3262,16 +3184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -4406,15 +4318,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4835,17 +4738,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "socks"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
-dependencies = [
- "byteorder",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -5483,22 +5375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "universal-hash"
@@ -5515,39 +5395,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
-dependencies = [
- "base64",
- "cookie_store",
- "flate2",
- "log",
- "percent-encoding",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "socks",
- "ureq-proto",
- "utf8-zero",
- "webpki-roots 1.0.6",
-]
-
-[[package]]
-name = "ureq-proto"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
-dependencies = [
- "base64",
- "http",
- "httparse",
- "log",
-]
 
 [[package]]
 name = "url"
@@ -5573,12 +5420,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -5668,16 +5509,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -5886,15 +5717,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/README.md
+++ b/README.md
@@ -374,6 +374,10 @@ curl -s http://localhost:9337/v1/models | jq '.data[].id'
 
 mesh-llm ships a built-in `lemonade` plugin that registers a local [Lemonade Server](https://lemonade-server.ai) as another OpenAI-compatible backend. For setup and verification steps, see [docs/USAGE.md](docs/USAGE.md#lemonade-integration).
 
+### MiniMax
+
+mesh-llm ships a built-in `minimax` plugin that routes requests to the [MiniMax cloud API](https://platform.minimax.io) through the same local endpoint. Enable it by adding `MINIMAX_API_KEY` to your environment and a `[[plugin]]` entry to `~/.mesh-llm/config.toml`. See [docs/USAGE.md](docs/USAGE.md#minimax-integration) for details.
+
 If you want the mesh to be discoverable via `--auto`, publish it:
 
 ```bash

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -243,6 +243,62 @@ Notes:
 - Use the exact model ID returned by Lemonade's `/api/v1/models`.
 - If you use the mesh-llm background service, add `MESH_LLM_LEMONADE_BASE_URL=...` to `~/.config/mesh-llm/service.env`.
 
+## MiniMax integration
+
+mesh-llm includes a built-in `minimax` plugin that routes requests to the [MiniMax cloud API](https://platform.minimax.io) through the same `http://localhost:9337/v1` endpoint that mesh-llm already exposes.
+
+Set your API key:
+
+```bash
+export MINIMAX_API_KEY=your_key_here
+```
+
+Enable the plugin in `~/.mesh-llm/config.toml`:
+
+```toml
+[[plugin]]
+name = "minimax"
+enabled = true
+```
+
+Start mesh-llm normally:
+
+```bash
+mesh-llm serve
+```
+
+After startup, mesh-llm includes the MiniMax models in its model list:
+
+```bash
+curl -s http://localhost:9337/v1/models | jq '.data[].id'
+# → "MiniMax-M2.7"
+# → "MiniMax-M2.7-highspeed"
+```
+
+Send a request:
+
+```bash
+curl http://localhost:9337/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "MiniMax-M2.7",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+To use a different base URL (for example, a private deployment), set:
+
+```bash
+export MINIMAX_BASE_URL=https://api.minimax.io/v1
+```
+
+Notes:
+
+- `MINIMAX_API_KEY` must be set before starting mesh-llm with the plugin enabled.
+- The plugin is disabled by default; add the `[[plugin]]` entry to enable it.
+- MiniMax-M2.7 and MiniMax-M2.7-highspeed are the models exposed by this plugin.
+- Streaming responses are supported; the plugin uses chunked transfer encoding.
+
 Useful model commands:
 
 ```bash

--- a/mesh-llm/src/plugin/config.rs
+++ b/mesh-llm/src/plugin/config.rs
@@ -1,4 +1,4 @@
-use super::{PluginSummary, BLACKBOARD_PLUGIN_ID, BLOBSTORE_PLUGIN_ID, LEMONADE_PLUGIN_ID};
+use super::{PluginSummary, BLACKBOARD_PLUGIN_ID, BLOBSTORE_PLUGIN_ID, LEMONADE_PLUGIN_ID, MINIMAX_PLUGIN_ID};
 use anyhow::{bail, Context, Result};
 use mesh_llm_plugin::MeshVisibility;
 use serde::Deserialize;
@@ -122,6 +122,7 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
     let mut blackboard_enabled = true;
     let mut blobstore_enabled = true;
     let mut lemonade_enabled = false;
+    let mut minimax_enabled = false;
     for entry in &config.plugins {
         if names.insert(entry.name.clone(), ()).is_some() {
             bail!("Duplicate plugin entry '{}'", entry.name);
@@ -157,6 +158,16 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
             lemonade_enabled = enabled;
             continue;
         }
+        if entry.name == MINIMAX_PLUGIN_ID {
+            if entry.command.is_some() || !entry.args.is_empty() {
+                bail!(
+                    "Plugin '{}' is served by mesh-llm itself; only `enabled` may be set",
+                    MINIMAX_PLUGIN_ID
+                );
+            }
+            minimax_enabled = enabled;
+            continue;
+        }
         if !enabled {
             continue;
         }
@@ -176,6 +187,9 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
     }
     if lemonade_enabled {
         externals.push(lemonade_plugin_spec()?);
+    }
+    if minimax_enabled {
+        externals.push(minimax_plugin_spec()?);
     }
     if blobstore_enabled {
         externals.push(blobstore_plugin_spec()?);
@@ -220,6 +234,18 @@ pub fn lemonade_plugin_spec() -> Result<ExternalPluginSpec> {
         name: LEMONADE_PLUGIN_ID.to_string(),
         command,
         args: vec!["--plugin".into(), LEMONADE_PLUGIN_ID.into()],
+    })
+}
+
+pub fn minimax_plugin_spec() -> Result<ExternalPluginSpec> {
+    let command = std::env::current_exe()
+        .context("Cannot determine mesh-llm executable path")?
+        .display()
+        .to_string();
+    Ok(ExternalPluginSpec {
+        name: MINIMAX_PLUGIN_ID.to_string(),
+        command,
+        args: vec!["--plugin".into(), MINIMAX_PLUGIN_ID.into()],
     })
 }
 
@@ -274,5 +300,57 @@ command = "/tmp/demo"
         };
         let err = validate_config(&config).unwrap_err();
         assert!(err.to_string().contains("not supported yet"));
+    }
+
+    #[test]
+    fn minimax_can_be_enabled_explicitly() {
+        let config = MeshConfig {
+            plugins: vec![PluginConfigEntry {
+                name: MINIMAX_PLUGIN_ID.into(),
+                enabled: Some(true),
+                command: None,
+                args: Vec::new(),
+            }],
+            ..MeshConfig::default()
+        };
+        let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
+        // blackboard + minimax + blobstore
+        assert_eq!(resolved.externals.len(), 3);
+        assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, MINIMAX_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
+    }
+
+    #[test]
+    fn minimax_is_disabled_by_default() {
+        let resolved = resolve_plugins(&MeshConfig::default(), private_host_mode()).unwrap();
+        assert!(!resolved
+            .externals
+            .iter()
+            .any(|e| e.name == MINIMAX_PLUGIN_ID));
+    }
+
+    #[test]
+    fn minimax_rejects_custom_command() {
+        let config = MeshConfig {
+            plugins: vec![PluginConfigEntry {
+                name: MINIMAX_PLUGIN_ID.into(),
+                enabled: Some(true),
+                command: Some("/usr/bin/custom".into()),
+                args: Vec::new(),
+            }],
+            ..MeshConfig::default()
+        };
+        let err = resolve_plugins(&config, private_host_mode()).unwrap_err();
+        assert!(
+            err.to_string().contains("only `enabled` may be set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    fn private_host_mode() -> PluginHostMode {
+        PluginHostMode {
+            mesh_visibility: mesh_llm_plugin::MeshVisibility::Private,
+        }
     }
 }

--- a/mesh-llm/src/plugin/mod.rs
+++ b/mesh-llm/src/plugin/mod.rs
@@ -45,6 +45,7 @@ use mesh_llm_plugin::MeshVisibility;
 pub const BLACKBOARD_PLUGIN_ID: &str = "blackboard";
 pub const BLOBSTORE_PLUGIN_ID: &str = "blobstore";
 pub const LEMONADE_PLUGIN_ID: &str = "lemonade";
+pub const MINIMAX_PLUGIN_ID: &str = "minimax";
 pub const BLACKBOARD_CAPABILITY: &str = "blackboard.v1";
 pub(crate) const PROTOCOL_VERSION: u32 = mesh_llm_plugin::PROTOCOL_VERSION;
 const CONNECT_TIMEOUT_SECS: u64 = 10;
@@ -1573,6 +1574,7 @@ pub async fn run_plugin_process(name: String) -> Result<()> {
         BLACKBOARD_PLUGIN_ID => crate::plugins::blackboard::run_plugin(name).await,
         BLOBSTORE_PLUGIN_ID => crate::plugins::blobstore::run_plugin(name).await,
         LEMONADE_PLUGIN_ID => crate::plugins::lemonade::run_plugin(name).await,
+        MINIMAX_PLUGIN_ID => crate::plugins::minimax::run_plugin(name).await,
         _ => bail!("Unknown built-in plugin '{}'", name),
     }
 }

--- a/mesh-llm/src/plugins/minimax/mod.rs
+++ b/mesh-llm/src/plugins/minimax/mod.rs
@@ -1,0 +1,361 @@
+//! Built-in MiniMax cloud API plugin.
+//!
+//! Registers the MiniMax inference API as an OpenAI-compatible endpoint inside
+//! mesh-llm.  Because the host proxy only forwards plain HTTP, this plugin
+//! starts a local HTTP proxy that injects the `Authorization: Bearer` header
+//! and forwards requests to `https://api.minimax.io/v1` (or a custom URL set
+//! via `MINIMAX_BASE_URL`).
+//!
+//! Enable by adding to `~/.mesh-llm/config.toml`:
+//! ```toml
+//! [[plugin]]
+//! name = "minimax"
+//! ```
+//! and setting `MINIMAX_API_KEY` in the environment.
+
+use anyhow::{Context, Result};
+use mesh_llm_plugin::{
+    capability, plugin_server_info, PluginMetadata, PluginRuntime, PluginStartupPolicy,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio_stream::StreamExt;
+
+const DEFAULT_MINIMAX_BASE_URL: &str = "https://api.minimax.io/v1";
+
+/// MiniMax models exposed through the plugin.
+const MINIMAX_MODELS: &[&str] = &["MiniMax-M2.7", "MiniMax-M2.7-highspeed"];
+
+/// Hardcoded `/v1/models` response body returned by the local proxy so that
+/// the host health-check does not need to call the MiniMax API.
+fn models_response_body() -> String {
+    let entries: Vec<String> = MINIMAX_MODELS
+        .iter()
+        .map(|id| {
+            format!(
+                r#"{{"id":"{id}","object":"model","owned_by":"minimax","capabilities":["text"]}}"#
+            )
+        })
+        .collect();
+    format!(r#"{{"object":"list","data":[{}]}}"#, entries.join(","))
+}
+
+fn minimax_api_key() -> Option<String> {
+    std::env::var("MINIMAX_API_KEY")
+        .ok()
+        .filter(|k| !k.is_empty())
+}
+
+fn minimax_base_url() -> String {
+    std::env::var("MINIMAX_BASE_URL")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| DEFAULT_MINIMAX_BASE_URL.to_string())
+}
+
+/// Start a local HTTP proxy and return the port it is listening on.
+async fn start_proxy(api_key: String, base_url: String) -> Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .context("MiniMax plugin: failed to bind local proxy port")?;
+    let port = listener
+        .local_addr()
+        .context("MiniMax plugin: local address unavailable")?
+        .port();
+    tokio::spawn(accept_loop(listener, api_key, base_url));
+    Ok(port)
+}
+
+/// Accept connections on the local proxy socket.
+async fn accept_loop(listener: TcpListener, api_key: String, base_url: String) {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(300))
+        .build()
+        .expect("MiniMax plugin: failed to build HTTP client");
+    loop {
+        let Ok((stream, _)) = listener.accept().await else {
+            break;
+        };
+        let api_key = api_key.clone();
+        let base_url = base_url.clone();
+        let client = client.clone();
+        tokio::spawn(async move {
+            let _ = handle_connection(stream, client, api_key, base_url).await;
+        });
+    }
+}
+
+const MAX_HEADERS: usize = 64;
+const MAX_REQUEST_BYTES: usize = 8 * 1024 * 1024; // 8 MiB
+
+/// Handle one inbound HTTP connection from the mesh-llm proxy.
+async fn handle_connection(
+    mut stream: tokio::net::TcpStream,
+    client: reqwest::Client,
+    api_key: String,
+    base_url: String,
+) -> Result<()> {
+    let _ = stream.set_nodelay(true);
+
+    // ── Read until we see the end of the HTTP headers ────────────────────────
+    let mut buf = vec![0u8; MAX_REQUEST_BYTES];
+    let mut total = 0usize;
+    loop {
+        let n = stream
+            .read(&mut buf[total..])
+            .await
+            .context("read from client")?;
+        if n == 0 {
+            return Ok(());
+        }
+        total += n;
+        if buf[..total].windows(4).any(|w| w == b"\r\n\r\n") {
+            break;
+        }
+        if total >= buf.len() {
+            return Ok(());
+        }
+    }
+
+    // ── Parse HTTP request headers ────────────────────────────────────────────
+    let mut headers_buf = [httparse::EMPTY_HEADER; MAX_HEADERS];
+    let mut req = httparse::Request::new(&mut headers_buf);
+    let header_len = match req.parse(&buf[..total])? {
+        httparse::Status::Complete(n) => n,
+        httparse::Status::Partial => return Ok(()),
+    };
+
+    let method = req.method.unwrap_or("POST").to_string();
+    let path = req.path.unwrap_or("/").to_string();
+
+    let mut content_length: Option<usize> = None;
+    let mut content_type = String::from("application/json");
+    for h in req.headers.iter() {
+        if h.name.eq_ignore_ascii_case("content-length") {
+            content_length = String::from_utf8_lossy(h.value).trim().parse().ok();
+        }
+        if h.name.eq_ignore_ascii_case("content-type") {
+            content_type = String::from_utf8_lossy(h.value).trim().to_string();
+        }
+    }
+
+    // ── Health-check shortcut: serve /v1/models locally ───────────────────────
+    if method.eq_ignore_ascii_case("GET") && path.contains("/models") {
+        let body = models_response_body();
+        let resp = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(resp.as_bytes()).await;
+        let _ = stream.shutdown().await;
+        return Ok(());
+    }
+
+    // ── Read request body ─────────────────────────────────────────────────────
+    let already_have = &buf[header_len..total];
+    let body: Vec<u8> = if let Some(cl) = content_length {
+        if cl <= already_have.len() {
+            already_have[..cl].to_vec()
+        } else {
+            let mut body = already_have.to_vec();
+            body.resize(cl, 0);
+            stream
+                .read_exact(&mut body[already_have.len()..])
+                .await
+                .context("read body from client")?;
+            body
+        }
+    } else {
+        already_have.to_vec()
+    };
+
+    // ── Forward to MiniMax ────────────────────────────────────────────────────
+    let upstream_url = format!("{}{}", base_url.trim_end_matches('/'), path);
+    let method_val =
+        reqwest::Method::from_bytes(method.as_bytes()).unwrap_or(reqwest::Method::POST);
+
+    let upstream_resp = client
+        .request(method_val, &upstream_url)
+        .header(
+            reqwest::header::AUTHORIZATION,
+            format!("Bearer {api_key}"),
+        )
+        .header(reqwest::header::CONTENT_TYPE, &content_type)
+        .body(body)
+        .send()
+        .await
+        .context("forward to MiniMax API")?;
+
+    let status = upstream_resp.status();
+    let resp_content_type = upstream_resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("application/json")
+        .to_string();
+
+    let is_streaming = resp_content_type.contains("text/event-stream");
+
+    if is_streaming {
+        // ── Streaming: chunked transfer encoding ──────────────────────────────
+        let header = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: {resp_content_type}\r\nTransfer-Encoding: chunked\r\nCache-Control: no-cache\r\n\r\n",
+        );
+        if stream.write_all(header.as_bytes()).await.is_err() {
+            return Ok(());
+        }
+        let mut byte_stream = upstream_resp.bytes_stream();
+        while let Some(chunk) = byte_stream.next().await {
+            match chunk {
+                Ok(bytes) if !bytes.is_empty() => {
+                    let chunk_header = format!("{:x}\r\n", bytes.len());
+                    if stream.write_all(chunk_header.as_bytes()).await.is_err() {
+                        break;
+                    }
+                    if stream.write_all(&bytes).await.is_err() {
+                        break;
+                    }
+                    if stream.write_all(b"\r\n").await.is_err() {
+                        break;
+                    }
+                }
+                Ok(_) => {}
+                Err(_) => break,
+            }
+        }
+        let _ = stream.write_all(b"0\r\n\r\n").await;
+    } else {
+        // ── Non-streaming: buffered response ──────────────────────────────────
+        let resp_bytes = upstream_resp
+            .bytes()
+            .await
+            .context("read response body from MiniMax")?;
+        let header = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: {resp_content_type}\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\n\r\n",
+            resp_bytes.len()
+        );
+        let _ = stream.write_all(header.as_bytes()).await;
+        let _ = stream.write_all(&resp_bytes).await;
+    }
+
+    let _ = stream.shutdown().await;
+    Ok(())
+}
+
+fn build_minimax_plugin(name: String, proxy_port: u16) -> mesh_llm_plugin::SimplePlugin {
+    let local_url = format!("http://127.0.0.1:{proxy_port}/v1");
+
+    mesh_llm_plugin::plugin! {
+        metadata: PluginMetadata::new(
+            name.clone(),
+            crate::VERSION,
+            plugin_server_info(
+                "mesh-minimax",
+                crate::VERSION,
+                "MiniMax Cloud API Plugin",
+                "Registers the MiniMax cloud inference API as an OpenAI-compatible endpoint.",
+                Some(
+                    "Proxies requests to api.minimax.io with MINIMAX_API_KEY authentication.",
+                ),
+            ),
+        ),
+        startup_policy: PluginStartupPolicy::Any,
+        provides: [
+            capability("endpoint:inference"),
+            capability("endpoint:inference/openai_compatible"),
+        ],
+        inference: [
+            mesh_llm_plugin::inference::provider("minimax", local_url),
+        ],
+        health: move |_context| {
+            let port = proxy_port;
+            Box::pin(async move {
+                Ok(format!("proxy_url=http://127.0.0.1:{port}/v1"))
+            })
+        },
+    }
+}
+
+pub(crate) async fn run_plugin(name: String) -> Result<()> {
+    let api_key = minimax_api_key().context(
+        "MINIMAX_API_KEY environment variable is not set; MiniMax plugin cannot start",
+    )?;
+    let base_url = minimax_base_url();
+    let proxy_port = start_proxy(api_key, base_url).await?;
+    PluginRuntime::run(build_minimax_plugin(name, proxy_port)).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn models_response_is_valid_json() {
+        let body = models_response_body();
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid JSON");
+        let data = parsed["data"].as_array().expect("data array");
+        assert_eq!(data.len(), MINIMAX_MODELS.len());
+        let ids: Vec<&str> = data
+            .iter()
+            .filter_map(|m| m["id"].as_str())
+            .collect();
+        for model in MINIMAX_MODELS {
+            assert!(ids.contains(model), "missing model {model}");
+        }
+    }
+
+    #[test]
+    fn minimax_base_url_defaults_to_api_minimax_io() {
+        // Without env var set the default should point to the international API.
+        // We cannot unset the env var in a test without unsafe, so we just verify
+        // the constant is correct.
+        assert!(
+            DEFAULT_MINIMAX_BASE_URL.starts_with("https://api.minimax.io"),
+            "default base URL must be the MiniMax international API"
+        );
+    }
+
+    #[test]
+    fn minimax_models_list_contains_m2_7() {
+        assert!(
+            MINIMAX_MODELS.contains(&"MiniMax-M2.7"),
+            "MiniMax-M2.7 must be in the model list"
+        );
+        assert!(
+            MINIMAX_MODELS.contains(&"MiniMax-M2.7-highspeed"),
+            "MiniMax-M2.7-highspeed must be in the model list"
+        );
+    }
+
+    #[tokio::test]
+    async fn proxy_serves_models_endpoint() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        // Start proxy with a dummy key (models endpoint doesn't need a real key)
+        let port = start_proxy("dummy-key".into(), DEFAULT_MINIMAX_BASE_URL.into())
+            .await
+            .expect("proxy starts");
+
+        // Connect and send a GET /v1/models request
+        let mut client = TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .expect("connect");
+        client
+            .write_all(b"GET /v1/models HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .await
+            .expect("send");
+
+        let mut resp = vec![0u8; 4096];
+        let n = client.read(&mut resp).await.expect("read");
+        let resp_str = String::from_utf8_lossy(&resp[..n]);
+
+        assert!(resp_str.starts_with("HTTP/1.1 200"), "expected 200, got: {resp_str}");
+        assert!(
+            resp_str.contains("MiniMax-M2.7"),
+            "response should list MiniMax-M2.7"
+        );
+    }
+}

--- a/mesh-llm/src/plugins/mod.rs
+++ b/mesh-llm/src/plugins/mod.rs
@@ -1,3 +1,4 @@
 pub mod blackboard;
 pub mod blobstore;
 pub mod lemonade;
+pub mod minimax;


### PR DESCRIPTION
## Summary

- Adds `minimax` built-in plugin that routes OpenAI-compatible requests to the MiniMax cloud API (`https://api.minimax.io/v1`) through a local HTTP proxy
- Exposes `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as inference providers through the existing `http://localhost:9337/v1` endpoint
- Plugin is disabled by default; enable with `[[plugin]] name = "minimax"` in `~/.mesh-llm/config.toml`

## Implementation details

The plugin follows the same pattern as the existing `lemonade` built-in plugin:

1. **Local HTTP proxy**: Binds to a random port on `127.0.0.1`, injects `Authorization: Bearer` header, and forwards requests to the MiniMax HTTPS API via `reqwest`
2. **Health-check endpoint**: Serves `GET /v1/models` locally without auth (hardcoded model list) so the mesh-llm proxy health probe succeeds
3. **Streaming support**: Uses chunked transfer encoding for SSE/streaming responses
4. **Config integration**: Registered as a built-in plugin in `plugin/config.rs` and `plugin/mod.rs`

## Configuration

```bash
export MINIMAX_API_KEY=your_key_here
```

```toml
# ~/.mesh-llm/config.toml
[[plugin]]
name = "minimax"
enabled = true
```

## Test plan

- [ ] Unit tests added in `mesh-llm/src/plugins/minimax/mod.rs` covering model list JSON, URL defaulting, and proxy models endpoint
- [ ] `minimax_can_be_enabled_explicitly` test in `plugin/config.rs` verifies plugin ordering (blackboard → minimax → blobstore)
- [ ] `minimax_is_disabled_by_default` confirms no accidental activation
- [ ] `minimax_rejects_custom_command` ensures built-in constraint is enforced
- [ ] End-to-end: set `MINIMAX_API_KEY`, enable plugin, verify models appear at `/v1/models` and completions proxy correctly