### PR TITLE
fix: prevent detail panel from being pushed when in fullscreen mode

### DIFF
--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -4014,6 +4014,7 @@ function DashboardPage({
   }, [activeDetail, status, topologyNodes, totalMeshVramGb]);
 
   function pushDetail(entry: DetailPanelEntry) {
+    if (isMeshOverviewFullscreen) return;
     setDetailPanelStack((prev) => {
       const current = prev[prev.length - 1];
       const isSameEntry =
@@ -4498,7 +4499,7 @@ function DashboardPage({
           )
         : null}
 
-      <Sheet open={detailPanelStack.length > 0} onOpenChange={(open) => !open && closeDetailPanel()}>
+      <Sheet open={detailPanelStack.length > 0 && !isMeshOverviewFullscreen} onOpenChange={(open) => !open && closeDetailPanel()}>
         <SheetContent side="right" className="w-full overflow-y-auto border-l bg-background/95 p-0 backdrop-blur sm:max-w-2xl" onOpenAutoFocus={(e) => { e.preventDefault(); (e.currentTarget as HTMLElement).focus(); }}>
           {activeDetail?.kind === "node" && activeNode ? (
             <NodeSidebar


### PR DESCRIPTION
I was playing around with the UI visualization and noticed a problem when selecting a node when in fullscreen mode. 

The fix is pretty straightforward, It's to prevent pushing the detail panel into view when the react-flow node visualization is already fullscreen.