### PR TITLE
Misc. vuln fixes

### DIFF
--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -9321,7 +9321,6 @@ async fn load_or_create_key_at(dir: &std::path::Path) -> Result<SecretKey> {
     tokio::task::spawn_blocking(move || {
         ensure_private_identity_dir(&dir)?;
         let key_path = dir.join("key");
-
         if key_path.exists() {
             ensure_private_identity_file(&key_path)?;
             let hex = std::fs::read_to_string(&key_path)?;
@@ -9333,7 +9332,6 @@ async fn load_or_create_key_at(dir: &std::path::Path) -> Result<SecretKey> {
             tracing::info!("Loaded key from {}", key_path.display());
             return Ok(key);
         }
-
         let key = SecretKey::generate(&mut rand::rng());
         crate::crypto::write_keystore_bytes_atomically(
             &key_path,

--- a/mesh-llm/src/models/gguf.rs
+++ b/mesh-llm/src/models/gguf.rs
@@ -132,8 +132,24 @@ fn skip_gguf_value_with_depth(
                 std::io::Error::new(std::io::ErrorKind::InvalidData, "bad array type")
             })?;
             let count = read_bounded_len(f, MAX_GGUF_ARRAY_ELEMENTS, "array")?;
-            for _ in 0..count {
-                skip_gguf_value_with_depth(f, elem_type, depth + 1)?;
+            if let Some(elem_size) = elem_type.fixed_size() {
+                let total_bytes = count.checked_mul(elem_size).ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "array byte span too large",
+                    )
+                })?;
+                let offset = i64::try_from(total_bytes).map_err(|_| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "array byte span too large",
+                    )
+                })?;
+                f.seek(SeekFrom::Current(offset))?;
+            } else {
+                for _ in 0..count {
+                    skip_gguf_value_with_depth(f, elem_type, depth + 1)?;
+                }
             }
         }
         other => {

--- a/mesh-llm/src/network/proxy.rs
+++ b/mesh-llm/src/network/proxy.rs
@@ -61,6 +61,16 @@ pub struct BufferedHttpRequest {
     pub response_adapter: ResponseAdapter,
 }
 
+pub(crate) struct BufferedHttpRequestHead {
+    raw: Vec<u8>,
+    header_end: usize,
+    pub(crate) method: String,
+    pub(crate) path: String,
+    content_length: Option<usize>,
+    is_chunked: bool,
+    expects_continue: bool,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseAdapter {
     None,
@@ -111,11 +121,34 @@ pub async fn read_http_request(stream: &mut TcpStream) -> Result<BufferedHttpReq
     read_http_request_with_limits(stream, HTTP_READ_LIMITS, None).await
 }
 
-pub(crate) async fn read_http_request_from_reader<R>(reader: &mut R) -> Result<BufferedHttpRequest>
+pub(crate) async fn read_http_request_head_from_reader<R>(
+    reader: &mut R,
+) -> Result<BufferedHttpRequestHead>
 where
     R: AsyncRead + Unpin,
 {
-    read_http_request_with_limits_from_reader(reader, HTTP_READ_LIMITS).await
+    let mut raw = Vec::with_capacity(8192);
+    let parsed =
+        read_until_headers_parsed(reader, &mut raw, HTTP_READ_LIMITS.max_header_bytes).await?;
+    Ok(BufferedHttpRequestHead {
+        raw,
+        header_end: parsed.header_end,
+        method: parsed.method,
+        path: parsed.path,
+        content_length: parsed.content_length,
+        is_chunked: parsed.is_chunked,
+        expects_continue: parsed.expects_continue,
+    })
+}
+
+pub(crate) async fn read_http_request_from_reader_with_head<R>(
+    reader: &mut R,
+    head: BufferedHttpRequestHead,
+) -> Result<BufferedHttpRequest>
+where
+    R: AsyncRead + Unpin,
+{
+    read_http_request_with_limits_from_reader(reader, HTTP_READ_LIMITS, head).await
 }
 
 pub async fn read_http_request_with_plugin_manager(
@@ -236,19 +269,26 @@ async fn read_http_request_with_limits(
 async fn read_http_request_with_limits_from_reader<R>(
     reader: &mut R,
     limits: HttpReadLimits,
+    head: BufferedHttpRequestHead,
 ) -> Result<BufferedHttpRequest>
 where
     R: AsyncRead + Unpin,
 {
-    let mut raw = Vec::with_capacity(8192);
-    let parsed = read_until_headers_parsed(reader, &mut raw, limits.max_header_bytes).await?;
-    if parsed.expects_continue {
+    let BufferedHttpRequestHead {
+        mut raw,
+        header_end,
+        method,
+        path,
+        content_length,
+        is_chunked,
+        expects_continue,
+    } = head;
+    if expects_continue {
         bail!("Expect: 100-continue is not supported over mesh tunnels");
     }
-    let body_limits = body_limits_for_path(&parsed.path, limits);
-    let header_end = parsed.header_end;
+    let body_limits = body_limits_for_path(&path, limits);
 
-    let body = if parsed.is_chunked {
+    let body = if is_chunked {
         loop {
             if let Some((consumed, decoded)) =
                 try_decode_chunked_body(&raw[header_end..], body_limits.max_body_bytes)?
@@ -264,7 +304,7 @@ where
                 );
             }
         }
-    } else if let Some(content_length) = parsed.content_length {
+    } else if let Some(content_length) = content_length {
         if content_length > body_limits.max_body_bytes {
             bail!("HTTP body exceeds {} bytes", body_limits.max_body_bytes);
         }
@@ -284,10 +324,10 @@ where
     } else {
         serde_json::from_slice(&body).ok()
     };
-    let mut request_path = parsed.path.clone();
+    let mut request_path = path.clone();
     let mut response_adapter = ResponseAdapter::None;
     let rewritten_body = if let Some(body_json) = body_json.as_mut() {
-        let normalization = normalize_openai_compat_request(&parsed.path, body_json)?;
+        let normalization = normalize_openai_compat_request(&path, body_json)?;
         if let Some(rewritten_path) = normalization.rewritten_path {
             request_path = rewritten_path;
         }
@@ -312,7 +352,7 @@ where
 
     Ok(BufferedHttpRequest {
         raw,
-        method: parsed.method,
+        method,
         path: request_path,
         body_json,
         model_name,

--- a/mesh-llm/src/network/proxy.rs
+++ b/mesh-llm/src/network/proxy.rs
@@ -1617,10 +1617,20 @@ pub fn is_models_list_request(method: &str, path: &str) -> bool {
     method == "GET" && (path == "/v1/models" || path == "/models")
 }
 
-pub(crate) fn is_tunneled_http_request(method: &str, path: &str) -> bool {
+pub fn is_completions_request(method: &str, path: &str) -> bool {
     let path = path.split('?').next().unwrap_or(path);
+    method == "POST" && path == "/v1/chat/completions"
+}
+
+pub fn is_responses_request(method: &str, path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+    method == "POST" && path == "/v1/responses"
+}
+
+pub(crate) fn is_tunneled_http_request(method: &str, path: &str) -> bool {
     is_models_list_request(method, path)
-        || (method == "POST" && matches!(path, "/v1/chat/completions" | "/v1/responses"))
+        || is_completions_request(method, path)
+        || is_responses_request(method, path)
 }
 
 pub fn is_drop_request(method: &str, path: &str) -> bool {
@@ -2958,6 +2968,17 @@ mod tests {
     fn test_pipeline_request_supported_rejects_other_endpoint() {
         let body = serde_json::json!({"messages":[{"role":"user","content":"hi"}]});
         assert!(!pipeline_request_supported("/v1/responses", &body));
+    }
+
+    #[test]
+    fn test_tunneled_http_request_uses_endpoint_helpers() {
+        assert!(is_tunneled_http_request("GET", "/v1/models?refresh=1"));
+        assert!(is_tunneled_http_request(
+            "POST",
+            "/v1/chat/completions?stream=1"
+        ));
+        assert!(is_tunneled_http_request("POST", "/v1/responses?stream=1"));
+        assert!(!is_tunneled_http_request("POST", "/api/status"));
     }
 
     #[test]

--- a/mesh-llm/src/network/proxy.rs
+++ b/mesh-llm/src/network/proxy.rs
@@ -111,6 +111,13 @@ pub async fn read_http_request(stream: &mut TcpStream) -> Result<BufferedHttpReq
     read_http_request_with_limits(stream, HTTP_READ_LIMITS, None).await
 }
 
+pub(crate) async fn read_http_request_from_reader<R>(reader: &mut R) -> Result<BufferedHttpRequest>
+where
+    R: AsyncRead + Unpin,
+{
+    read_http_request_with_limits_from_reader(reader, HTTP_READ_LIMITS).await
+}
+
 pub async fn read_http_request_with_plugin_manager(
     stream: &mut TcpStream,
     plugin_manager: Option<&plugin::PluginManager>,
@@ -226,6 +233,95 @@ async fn read_http_request_with_limits(
     })
 }
 
+async fn read_http_request_with_limits_from_reader<R>(
+    reader: &mut R,
+    limits: HttpReadLimits,
+) -> Result<BufferedHttpRequest>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut raw = Vec::with_capacity(8192);
+    let parsed = read_until_headers_parsed(reader, &mut raw, limits.max_header_bytes).await?;
+    if parsed.expects_continue {
+        bail!("Expect: 100-continue is not supported over mesh tunnels");
+    }
+    let body_limits = body_limits_for_path(&parsed.path, limits);
+    let header_end = parsed.header_end;
+
+    let body = if parsed.is_chunked {
+        loop {
+            if let Some((consumed, decoded)) =
+                try_decode_chunked_body(&raw[header_end..], body_limits.max_body_bytes)?
+            {
+                raw.truncate(header_end + consumed);
+                break decoded;
+            }
+            read_more(reader, &mut raw).await?;
+            if raw.len().saturating_sub(header_end) > body_limits.max_chunked_wire_bytes {
+                bail!(
+                    "HTTP chunked wire body exceeds {} bytes",
+                    body_limits.max_chunked_wire_bytes
+                );
+            }
+        }
+    } else if let Some(content_length) = parsed.content_length {
+        if content_length > body_limits.max_body_bytes {
+            bail!("HTTP body exceeds {} bytes", body_limits.max_body_bytes);
+        }
+        let body_end = header_end + content_length;
+        while raw.len() < body_end {
+            read_more(reader, &mut raw).await?;
+        }
+        raw.truncate(body_end);
+        raw[header_end..body_end].to_vec()
+    } else {
+        raw.truncate(header_end);
+        Vec::new()
+    };
+
+    let mut body_json = if body.is_empty() {
+        None
+    } else {
+        serde_json::from_slice(&body).ok()
+    };
+    let mut request_path = parsed.path.clone();
+    let mut response_adapter = ResponseAdapter::None;
+    let rewritten_body = if let Some(body_json) = body_json.as_mut() {
+        let normalization = normalize_openai_compat_request(&parsed.path, body_json)?;
+        if let Some(rewritten_path) = normalization.rewritten_path {
+            request_path = rewritten_path;
+        }
+        response_adapter = normalization.response_adapter;
+        normalization.changed.then(|| {
+            serde_json::to_vec(body_json)
+                .context("serialize normalized OpenAI-compatible request body")
+        })
+    } else {
+        None
+    }
+    .transpose()?;
+    let model_name = body_json.as_ref().and_then(extract_model_from_json);
+    let session_hint = body_json.as_ref().and_then(extract_session_hint_from_json);
+    let raw = finalize_forwarded_request(
+        raw,
+        header_end,
+        false,
+        Some(&request_path),
+        rewritten_body.as_deref(),
+    )?;
+
+    Ok(BufferedHttpRequest {
+        raw,
+        method: parsed.method,
+        path: request_path,
+        body_json,
+        model_name,
+        session_hint,
+        request_object_request_ids: Vec::new(),
+        response_adapter,
+    })
+}
+
 fn body_limits_for_path(path: &str, default: HttpReadLimits) -> HttpReadLimits {
     let path_only = path.split('?').next().unwrap_or(path);
     if path_only == "/api/objects" {
@@ -291,11 +387,14 @@ fn finalize_forwarded_request(
 /// Read from the stream until httparse can fully parse the request headers.
 /// Returns parsed metadata; `buf` contains all bytes read so far (headers +
 /// any trailing body bytes that arrived in the same read).
-async fn read_until_headers_parsed(
-    stream: &mut TcpStream,
+async fn read_until_headers_parsed<R>(
+    stream: &mut R,
     buf: &mut Vec<u8>,
     max_header_bytes: usize,
-) -> Result<ParsedHeaders> {
+) -> Result<ParsedHeaders>
+where
+    R: AsyncRead + Unpin,
+{
     loop {
         let mut headers_buf = [httparse::EMPTY_HEADER; MAX_HEADERS];
         let mut req = httparse::Request::new(&mut headers_buf);
@@ -356,7 +455,10 @@ async fn read_until_headers_parsed(
     }
 }
 
-async fn read_more(stream: &mut TcpStream, buf: &mut Vec<u8>) -> Result<()> {
+async fn read_more<R>(stream: &mut R, buf: &mut Vec<u8>) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
     let mut chunk = [0u8; 8192];
     let n = stream.read(&mut chunk).await?;
     if n == 0 {
@@ -1473,6 +1575,12 @@ async fn relay_translated_responses_json<R: AsyncRead + Unpin>(
 pub fn is_models_list_request(method: &str, path: &str) -> bool {
     let path = path.split('?').next().unwrap_or(path);
     method == "GET" && (path == "/v1/models" || path == "/models")
+}
+
+pub(crate) fn is_tunneled_http_request(method: &str, path: &str) -> bool {
+    let path = path.split('?').next().unwrap_or(path);
+    is_models_list_request(method, path)
+        || (method == "POST" && matches!(path, "/v1/chat/completions" | "/v1/responses"))
 }
 
 pub fn is_drop_request(method: &str, path: &str) -> bool {

--- a/mesh-llm/src/network/rewrite.rs
+++ b/mesh-llm/src/network/rewrite.rs
@@ -198,11 +198,13 @@ where
     R: AsyncRead + Unpin,
 {
     let remaining = deadline_remaining(started, deadline)?;
-    Ok(Some(
-        tokio::time::timeout(remaining, reader.read(buf))
-            .await
-            .map_err(|_| anyhow::anyhow!("RPC payload read timed out"))??,
-    ))
+    let n = tokio::time::timeout(remaining, reader.read(buf))
+        .await
+        .map_err(|_| anyhow::anyhow!("RPC payload read timed out"))??;
+    if n == 0 {
+        return Ok(None);
+    }
+    Ok(Some(n))
 }
 
 fn deadline_remaining(started: Instant, deadline: Duration) -> Result<Duration> {
@@ -304,5 +306,36 @@ mod tests {
         let mut forwarded = Vec::new();
         target_read.read_to_end(&mut forwarded).await.unwrap();
         assert!(forwarded.is_empty());
+    }
+
+    #[tokio::test]
+    async fn relay_with_rewrite_errors_on_eof_mid_payload() {
+        let port_map = new_rewrite_map();
+        let (mut source_write, source_read) = tokio::io::duplex(128);
+        let (target_write, mut target_read) = tokio::io::duplex(128);
+        let sender = tokio::spawn(async move {
+            let mut frame = vec![0x01];
+            frame.extend_from_slice(&16u64.to_le_bytes());
+            frame.extend_from_slice(b"short");
+            source_write.write_all(&frame).await.unwrap();
+        });
+
+        let err = relay_with_rewrite_inner(source_read, target_write, port_map)
+            .await
+            .unwrap_err();
+        sender.await.unwrap();
+        assert!(err.to_string().contains("stream closed mid-payload"));
+
+        let mut forwarded = Vec::new();
+        target_read.read_to_end(&mut forwarded).await.unwrap();
+        assert_eq!(&forwarded[..9], &frame_prefix(0x01, 16));
+        assert_eq!(&forwarded[9..], b"short");
+    }
+
+    fn frame_prefix(cmd: u8, payload_size: u64) -> [u8; 9] {
+        let mut prefix = [0u8; 9];
+        prefix[0] = cmd;
+        prefix[1..].copy_from_slice(&payload_size.to_le_bytes());
+        prefix
     }
 }

--- a/mesh-llm/src/network/tunnel.rs
+++ b/mesh-llm/src/network/tunnel.rs
@@ -327,18 +327,26 @@ where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
-    let request = match proxy::read_http_request_from_reader(reader).await {
-        Ok(request) => request,
+    let head = match proxy::read_http_request_head_from_reader(reader).await {
+        Ok(head) => head,
         Err(err) => {
             write_http_error(writer, 400, &format!("bad tunneled HTTP request: {err}")).await?;
             return Ok(None);
         }
     };
 
-    if !proxy::is_tunneled_http_request(&request.method, &request.path) {
+    if !proxy::is_tunneled_http_request(&head.method, &head.path) {
         write_http_error(writer, 403, "mesh peers may only tunnel inference routes").await?;
         return Ok(None);
     }
+
+    let request = match proxy::read_http_request_from_reader_with_head(reader, head).await {
+        Ok(request) => request,
+        Err(err) => {
+            write_http_error(writer, 400, &format!("bad tunneled HTTP request: {err}")).await?;
+            return Ok(None);
+        }
+    };
 
     Ok(Some(request))
 }
@@ -710,6 +718,34 @@ mod tests {
         let sender = tokio::spawn(async move {
             client_write
                 .write_all(b"GET /api/status HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        let request = receive_tunneled_http_request(&mut server_read, &mut server_write)
+            .await
+            .unwrap();
+        assert!(request.is_none());
+        server_write.shutdown().await.unwrap();
+        sender.await.unwrap();
+
+        let mut response = Vec::new();
+        client_read.read_to_end(&mut response).await.unwrap();
+        let response = String::from_utf8_lossy(&response);
+        assert!(response.starts_with("HTTP/1.1 403 Forbidden"));
+        assert!(response.contains("mesh peers may only tunnel inference routes"));
+    }
+
+    #[tokio::test]
+    async fn receive_tunneled_http_request_rejects_management_routes_before_reading_body() {
+        let (mut client_write, mut server_read) = tokio::io::duplex(4096);
+        let (mut server_write, mut client_read) = tokio::io::duplex(4096);
+
+        let sender = tokio::spawn(async move {
+            client_write
+                .write_all(
+                    b"POST /api/objects HTTP/1.1\r\nHost: localhost\r\nContent-Length: 1048576\r\n\r\n",
+                )
                 .await
                 .unwrap();
         });

--- a/mesh-llm/src/network/tunnel.rs
+++ b/mesh-llm/src/network/tunnel.rs
@@ -11,7 +11,10 @@
 //! 3. Bidirectionally relay
 
 use crate::mesh::Node;
-use crate::network::rewrite::{self, PortRewriteMap};
+use crate::network::{
+    proxy,
+    rewrite::{self, PortRewriteMap},
+};
 use anyhow::Result;
 use iroh::EndpointId;
 use std::collections::HashMap;
@@ -287,20 +290,78 @@ async fn handle_inbound_stream(
 }
 
 /// Handle an inbound HTTP tunnel bi-stream: connect directly to the local llama-server and relay.
-/// Plain byte relay — the client proxy already normalized the request before tunneling.
+/// Only the inference surface is allowed over this path. Peer-local management
+/// routes stay loopback-only even after mesh admission.
 async fn handle_inbound_http_stream(
     node: Node,
-    quic_send: iroh::endpoint::SendStream,
-    quic_recv: iroh::endpoint::RecvStream,
+    mut quic_send: iroh::endpoint::SendStream,
+    mut quic_recv: iroh::endpoint::RecvStream,
     http_port: u16,
 ) -> Result<()> {
-    tracing::info!("Inbound HTTP tunnel stream → llama-server :{http_port}");
-    let tcp_stream = TcpStream::connect(format!("127.0.0.1:{http_port}")).await?;
-    tcp_stream.set_nodelay(true)?;
-    let _inflight = node.begin_inflight_request();
+    let Some(request) = receive_tunneled_http_request(&mut quic_recv, &mut quic_send).await? else {
+        quic_send.finish()?;
+        return Ok(());
+    };
 
-    let (tcp_read, tcp_write) = tokio::io::split(tcp_stream);
-    relay_bidirectional(tcp_read, tcp_write, quic_send, quic_recv).await
+    tracing::info!("Inbound HTTP tunnel stream → llama-server :{http_port}");
+    let _inflight = node.begin_inflight_request();
+    let mut tcp_stream = TcpStream::connect(format!("127.0.0.1:{http_port}")).await?;
+    tcp_stream.set_nodelay(true)?;
+    tcp_stream.write_all(&request.raw).await?;
+    tcp_stream.shutdown().await?;
+    relay_response_with_first_byte_timeout(
+        &mut tcp_stream,
+        &mut quic_send,
+        quic_response_first_byte_timeout(),
+    )
+    .await?;
+    quic_send.finish()?;
+    Ok(())
+}
+
+async fn receive_tunneled_http_request<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<Option<proxy::BufferedHttpRequest>>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let request = match proxy::read_http_request_from_reader(reader).await {
+        Ok(request) => request,
+        Err(err) => {
+            write_http_error(writer, 400, &format!("bad tunneled HTTP request: {err}")).await?;
+            return Ok(None);
+        }
+    };
+
+    if !proxy::is_tunneled_http_request(&request.method, &request.path) {
+        write_http_error(writer, 403, "mesh peers may only tunnel inference routes").await?;
+        return Ok(None);
+    }
+
+    Ok(Some(request))
+}
+
+async fn write_http_error<W>(writer: &mut W, code: u16, msg: &str) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    let status = match code {
+        400 => "Bad Request",
+        403 => "Forbidden",
+        405 => "Method Not Allowed",
+        _ => "Error",
+    };
+    let body = serde_json::to_vec(&serde_json::json!({ "error": msg }))?;
+    let header = format!(
+        "HTTP/1.1 {code} {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+        body.len()
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(&body).await?;
+    writer.flush().await?;
+    Ok(())
 }
 
 /// Bidirectional relay between a TCP stream and a QUIC bi-stream.
@@ -639,5 +700,64 @@ mod tests {
             forwarded,
             b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"
         );
+    }
+
+    #[tokio::test]
+    async fn receive_tunneled_http_request_rejects_management_routes() {
+        let (mut client_write, mut server_read) = tokio::io::duplex(1024);
+        let (mut server_write, mut client_read) = tokio::io::duplex(1024);
+
+        let sender = tokio::spawn(async move {
+            client_write
+                .write_all(b"GET /api/status HTTP/1.1\r\nHost: localhost\r\n\r\n")
+                .await
+                .unwrap();
+        });
+
+        let request = receive_tunneled_http_request(&mut server_read, &mut server_write)
+            .await
+            .unwrap();
+        assert!(request.is_none());
+        server_write.shutdown().await.unwrap();
+        sender.await.unwrap();
+
+        let mut response = Vec::new();
+        client_read.read_to_end(&mut response).await.unwrap();
+        let response = String::from_utf8_lossy(&response);
+        assert!(response.starts_with("HTTP/1.1 403 Forbidden"));
+        assert!(response.contains("mesh peers may only tunnel inference routes"));
+    }
+
+    #[tokio::test]
+    async fn receive_tunneled_http_request_accepts_inference_routes() {
+        let (mut client_write, mut server_read) = tokio::io::duplex(4096);
+        let (mut server_write, mut client_read) = tokio::io::duplex(4096);
+
+        let sender = tokio::spawn(async move {
+            client_write
+                .write_all(
+                    b"POST /v1/responses HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: 29\r\n\r\n{\"model\":\"auto\",\"input\":\"hi\"}",
+                )
+                .await
+                .unwrap();
+        });
+
+        let request = receive_tunneled_http_request(&mut server_read, &mut server_write)
+            .await
+            .unwrap()
+            .expect("inference request should be accepted");
+        server_write.shutdown().await.unwrap();
+        sender.await.unwrap();
+
+        let mut response = Vec::new();
+        client_read.read_to_end(&mut response).await.unwrap();
+        assert!(
+            response.is_empty(),
+            "accepted requests should not emit an error"
+        );
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/v1/chat/completions");
+        assert!(String::from_utf8_lossy(&request.raw)
+            .starts_with("POST /v1/chat/completions HTTP/1.1\r\n"));
     }
 }


### PR DESCRIPTION
This PR fixes a few vulns in separate commits.

## Commits

### `Restrict peer tunnels to inference traffic`
This commit fixes a trust-boundary bug where an admitted mesh peer could use the HTTP tunnel to reach peer-local management routes.

The management API is meant to stay behind a local control boundary. Before this change, tunneled HTTP was forwarded too generically, which let an already-admitted peer drive routes that should have remained local-only.

What changed:
- Tunneled HTTP requests are parsed before forwarding.
- Only inference routes are allowed through the mesh tunnel.
- Malformed requests get a `400` response instead of being proxied.
- Disallowed routes get a `403` response instead of reaching the peer-local API.
- Rewritten RPC frames now reject malformed `REGISTER_PEER` payloads and oversized payloads instead of passing them through.

### `Write identity secrets with private permissions`
This commit fixes a local secret-handling bug where the node identity secret was created world-readable.

What changed:
- Mesh identity directories are hardened to private permissions on Unix.
- Existing key files are permission-corrected before reuse.
- New identity files are written atomically with private permissions.
- The same permission hardening is applied to the persisted Nostr key path.

### `Bound GGUF metadata parsing`
This commit fixes a parser hardening issue where crafted GGUF headers could crash the process via unbounded recursion.

An attacker-controlled model file or URL could force the metadata scanner into excessive recursion while inspecting GGUF structure, causing a deterministic denial of service during model scanning.

What changed:
- GGUF string lengths, array sizes, and nesting depth are now bounded.
- Malicious metadata returns a clean parse failure instead of recursing until abort.
- MoE detection now reuses the single hardened GGUF parser instead of using a second copy of the parsing logic.
