### PR TITLE
Add unit tests for error body parsing and blob-URL retry suppression

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,14 +12,13 @@ This repo (`mesh-llm`) contains mesh-llm — a Rust binary that pools GPUs over 
 | `CONTRIBUTING.md` | Build from source, dev workflow, UI dev |
 | `RELEASE.md` | Release process (build, bundle, tag, GitHub release) |
 | `ROADMAP.md` | Future directions |
-| `PLAN.md` | Historical design notes and benchmarks |
 | `mesh-llm/TODO.md` | Current work items and backlog |
 | `mesh-llm/README.md` | Rust crate overview and file map |
 | `mesh-llm/docs/DESIGN.md` | Architecture, protocols, features |
 | `mesh-llm/docs/TESTING.md` | Test playbook, scenarios, remote deploy |
+| `mesh-llm/docs/MULTI_MODAL.md` | Multimodal design: capability model, blob plugin, console, routing |
 | `mesh-llm/docs/MoE_PLAN.md` | MoE expert sharding design |
 | `mesh-llm/docs/MoE_DEPLOY_DESIGN.md` | MoE auto-deploy UX |
-| `mesh-llm/docs/MoE_SPLIT_REPORT.md` | MoE splitting validation results |
 | `fly/README.md` | Fly.io deployment (console + API apps) |
 | `relay/README.md` | Self-hosted iroh relay on Fly |
 
@@ -127,14 +126,29 @@ Current structure notes.
 ## Key Source Files
 
 - `mesh-llm/src/main.rs` — CLI args, orchestration: `run_auto()`, `run_idle()`, `run_passive()`
-- `mesh-llm/src/mesh.rs` — `Node` struct, gossip, mesh_id, peer management
-- `mesh-llm/src/election.rs` — Host election, tensor split calculation
-- `mesh-llm/src/proxy.rs` — HTTP proxy: request parsing, model routing, response helpers
-- `mesh-llm/src/api.rs` — Management API (:3131): `/api/status`, `/api/events`, `/api/discover`, `/api/join`
-- `mesh-llm/src/nostr.rs` — Nostr discovery, `score_mesh()`, `smart_auto()`
-- `mesh-llm/src/download.rs` — Model catalog (`MODEL_CATALOG`), HuggingFace downloads
-- `mesh-llm/src/moe.rs` — MoE detection, expert rankings, split orchestration
-- `mesh-llm/src/launch.rs` — llama-server/rpc-server process management
+- `mesh-llm/src/mesh/mod.rs` — `Node` struct, gossip, mesh_id, peer management
+- `mesh-llm/src/inference/election.rs` — Host election, tensor split calculation
+- `mesh-llm/src/inference/launch.rs` — llama-server/rpc-server process management
+- `mesh-llm/src/inference/moe.rs` — MoE detection, expert rankings, split orchestration
+- `mesh-llm/src/network/proxy.rs` — HTTP proxy: request parsing, model routing, response helpers
+- `mesh-llm/src/network/router.rs` — Request classification, model scoring, multimodal routing
+- `mesh-llm/src/network/nostr.rs` — Nostr discovery, `score_mesh()`, `smart_auto()`
+- `mesh-llm/src/network/tunnel.rs` — TCP ↔ QUIC relay (RPC + HTTP)
+- `mesh-llm/src/api/mod.rs` — Management API (:3131): `/api/status`, `/api/events`, `/api/discover`, `/api/join`
+- `mesh-llm/src/models/catalog.rs` — Model catalog, HuggingFace downloads
+- `mesh-llm/src/models/capabilities.rs` — Multimodal/vision/audio/reasoning capability inference
+- `mesh-llm/src/plugins/blobstore/mod.rs` — Request-scoped media object storage for multimodal
+
+## Mesh Protocol Compatibility
+
+Mesh compatibility across versions is critical. Nodes in the wild run different versions and must interoperate.
+
+- The mesh supports mixed-version operation: QUIC ALPN `mesh-llm/1` (protobuf) and `mesh-llm/0` (legacy JSON) nodes coexist. Do not break this.
+- Gossip fields, stream types, and protobuf schemas must be additive. New fields should be optional and ignored by older nodes. Do not repurpose or remove existing fields.
+- When adding new gossip fields, stream types, or changing wire format, explicitly consider what happens when an older node receives the new data and when a newer node talks to an older peer.
+- Capability advertisement (vision, audio, multimodal, reasoning, tool_use, moe) is gossiped to all peers and consumed by routing, the API, and the UI. Changes to capability semantics affect the whole mesh, not just the local node.
+- If a change would break mixed-version meshes, explicitly flag it as a breaking protocol change and ask the developer before proceeding.
+- Test compatibility by running the current branch against a released binary on a second node. Verify gossip, routing, and inference work across the version boundary.
 
 ## Plugin Protocol Compatibility
 
@@ -151,6 +165,15 @@ For changes in `mesh-llm/ui/`, use components and compose interfaces consistentl
 ## Testing
 
 Read `mesh-llm/docs/TESTING.md` before running tests. It has all test scenarios, remote deploy instructions, and cleanup commands.
+
+Testing matters more than usual in this project because:
+
+- Nodes run on different machines with different hardware and OS versions. Bugs that don't reproduce locally can appear in real deployments.
+- The mesh protocol is a distributed system — gossip, election, and routing interact across nodes. Single-node unit tests don't catch protocol-level regressions.
+- The public mesh at anarchai.org runs continuously. Breaking changes that pass local tests can take down live inference for real users.
+- Multimodal, MoE splitting, and multi-model routing all have complex interaction paths that are hard to reason about statically.
+
+When making changes that touch gossip, routing, proxy, election, or capability advertisement, test against at least two nodes before merging. The deploy checklist above is not optional.
 
 ## Formatting
 

--- a/mesh-llm/TODO.md
+++ b/mesh-llm/TODO.md
@@ -8,7 +8,7 @@ Route different requests to specialized models based on task type. Instead of on
 
 The paper shows ensemble routing across heterogeneous models outperforms any single model. Our mesh already has the ingredients — multiple models, a router that classifies requests. The gap is making the router model-aware (which models are good at what) and potentially splitting complex requests across models.
 
-**Relates to:** Smart Router (below), Vision routing (vision requests → vision model), Multi-Model Per Host.
+**Relates to:** Smart Router (below), Multi-Model Per Host.
 
 ## Multi-Model Per Host
 
@@ -52,37 +52,18 @@ Design: [MoE_PLAN.md](docs/MoE_PLAN.md) · Auto-deploy: [MoE_DEPLOY_DESIGN.md](d
 - [ ] **Lazy `moe-analyze`** — auto-run ranking for unknown MoE models.
 - [ ] **Scale testing** — Mixtral 8×22B, Qwen3-235B-A22B across multi-node.
 
-## Thinking / Reasoning Budget ✅
-
-Shipped in v0.40.0. `--reasoning-budget 0` is set on all llama-servers — thinking off by default. API users can opt in per-request with `chat_template_kwargs: {"enable_thinking": true}`.
-
-See `tests/test_reasoning_compat.sh` for the contract tests validating this behavior.
-
-**Why off by default:** Qwen3.5-9B is broken with thinking (reasoning burns entire token budget, content always empty). MiniMax-M2.5 is 2-27x slower with thinking for no quality gain. Agentic eval with pi confirmed: same 3/4 accuracy, half the total time with thinking off.
-
 ## Smart Router
-- Design: [MULTI_MODAL.md](docs/MULTI_MODAL.md)
 - [ ] **Context-aware routing**: Hosts advertise `n_ctx` in gossip. Router estimates request token count and skips hosts that can't fit it. Today a long chat routed to a small-context host returns 400 with no fallback.
 - [ ] **Retry on 400**: If a host returns 400 (context overflow, bad request), try the next host instead of forwarding the error. Requires reading the response status before committing to the byte-pipe tunnel. Non-trivial — the current `relay_tcp_via_quic` is a blind bidirectional copy.
 - [ ] **Static speed estimates**: `tok_s: f64` on ModelProfile. Quick tasks prefer fast models.
 - [ ] **Response quality checks**: Detect empty/repetitive/truncated responses, retry with different model.
 - [ ] **MoM-aware routing**: Route by task type to best-suited model (see Mixture of Models above).
-- [ ] **Vision-aware routing**: Auto-route image requests to vision-capable models.
 
-## Multi-Modal
+## Multi-Modal — Remaining
 
-Design: [MULTI_MODAL.md](docs/MULTI_MODAL.md)
+Core multimodal is shipped: capability model, gossip advertisement, vision/audio-aware routing, blob plugin, console uploads with attachment state, multimodal `/v1/chat/completions` and `/v1/responses`. See [MULTI_MODAL.md](docs/MULTI_MODAL.md).
 
-- [ ] **Capability model**: Add `multimodal` and `audio` alongside `vision`.
-- [ ] **Protocol advertisement**: Surface multimodal/audio capability in gossip, `/api/status`, and `/v1/models`.
-- [ ] **Audio-aware routing**: Auto-route audio requests to audio-capable models.
-- [ ] **Structured media detection**: Detect image/audio/file inputs from content blocks, not just prompt keywords.
-- [ ] **Pipeline safety**: Skip or constrain pre-plan/pipeline behavior for media requests until multimodal-safe.
-- [ ] **Request-scoped blob plugin**: Ingress-local object storage with opaque tokens, no replication, request-bound cleanup.
-- [ ] **Console uploads**: Add audio/file upload UX, upload before dispatch, and send token references instead of large inline payloads.
-- [ ] **Console attachment state**: Show previews/badges, upload status, remove/retry actions, and no-compatible-model fallback.
-- [ ] **Console model UX**: Surface vision/audio/multimodal capability hints and let `auto` switch to compatible models when attachments are present.
-- [ ] **Responses compatibility**: Add multimodal `/v1/responses` support after chat completions are solid.
+- [ ] **Runtime vision validation**: When mmproj is missing at launch time, downgrade vision capability and re-gossip corrected descriptor. Today the node advertises `vision: supported` even when mmproj wasn't loaded.
 - [ ] **Audio transcription shim**: Optional `/v1/audio/transcriptions` compatibility layer.
 - [ ] **Realtime shim**: Optional `v1/realtime` compatibility layer for text and media session orchestration.
 

--- a/mesh-llm/docs/DESIGN.md
+++ b/mesh-llm/docs/DESIGN.md
@@ -9,17 +9,34 @@ just see local TCP sockets.
 
 ```
 src/
-├── main.rs        CLI, orchestration, startup flows (auto, idle, passive)
-├── mesh.rs        QUIC endpoint, gossip, peer management, mesh identity, request rates
-├── election.rs    Per-model host election, latency-aware tensor split, llama-server lifecycle
-├── proxy.rs       HTTP proxy plumbing: request parsing, model routing, response helpers
-├── api.rs         Mesh management API (:3131): status, events, discover, join
-├── tunnel.rs      TCP ↔ QUIC relay (RPC + HTTP), B2B rewrite map
-├── rewrite.rs     REGISTER_PEER interception and endpoint rewriting
-├── launch.rs      rpc-server and llama-server process management
-├── download.rs    Model catalog and HuggingFace download (reqwest, resume support)
-├── nostr.rs       Nostr publish/discover: mesh listings, smart auto-join, publish watchdog
-├── hardware.rs    GPU/host hardware detection: Collector trait, DefaultCollector, TegraCollector
+├── main.rs                  CLI args, orchestration (auto, idle, passive)
+├── lib.rs                   Crate root re-exports
+├── api/                     Management API (:3131): status, events, discover, join
+├── cli/                     Clap types, command parsing, command handlers
+├── crypto/                  Key management, envelope encryption, keychain
+├── inference/
+│   ├── election.rs          Per-model host election, tensor split, llama-server lifecycle
+│   ├── launch.rs            rpc-server and llama-server process management
+│   ├── moe.rs               MoE detection, expert rankings, split orchestration
+│   └── pipeline.rs          Inference pipeline coordination
+├── mesh/mod.rs              Node struct, QUIC endpoint, gossip, peer management, mesh identity
+├── models/
+│   ├── capabilities.rs      Vision/audio/multimodal/reasoning capability inference
+│   ├── catalog.rs           Model catalog and HuggingFace downloads
+│   ├── resolve.rs           Model path resolution, mmproj lookup
+│   └── ...                  GGUF parsing, inventory, search, topology
+├── network/
+│   ├── proxy.rs             HTTP proxy: request parsing, model routing, response helpers
+│   ├── router.rs            Request classification, model scoring, multimodal routing
+│   ├── tunnel.rs            TCP ↔ QUIC relay (RPC + HTTP), B2B rewrite map
+│   ├── nostr.rs             Nostr discovery, score_mesh(), smart_auto()
+│   ├── affinity.rs          Prefix-affinity request routing
+│   └── rewrite.rs           REGISTER_PEER interception and endpoint rewriting
+├── plugins/
+│   └── blobstore/           Request-scoped media object storage for multimodal
+├── protocol/                Wire protocol types, protobuf encoding/decoding
+├── runtime/                 Top-level process orchestration, startup coordination
+└── system/                  Hardware detection, benchmarking, self-update
 ```
 
 ## Node Roles

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1538,9 +1538,26 @@ export function App() {
       const MAX_RETRIES = 3;
       const RETRY_DELAYS = [1000, 2000, 4000];
       const RETRYABLE = new Set([500, 502, 503]);
+      // Detect multimodal requests — blob tokens are single-use so retrying
+      // with the same tokens will always fail with "Unknown or expired blob
+      // token".  Skip the retry loop for these requests.
+      const hasBlobContent = Array.isArray(requestInput) &&
+        requestInput.some(
+          (msg: Record<string, unknown>) =>
+            Array.isArray(msg.content) &&
+            (msg.content as Array<Record<string, unknown>>).some(
+              (block) =>
+                typeof block === "object" &&
+                block !== null &&
+                Object.values(block).some(
+                  (v) => typeof v === "string" && v.startsWith("mesh://blob/"),
+                ),
+            ),
+        );
+      const effectiveMaxRetries = hasBlobContent ? 1 : MAX_RETRIES;
       let response: Response | null = null;
 
-      for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      for (let attempt = 0; attempt < effectiveMaxRetries; attempt++) {
         response = await fetch("/api/responses", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -1556,13 +1573,32 @@ export function App() {
           }),
         });
         if (response.ok && response.body) break;
-        if (!RETRYABLE.has(response.status) || attempt === MAX_RETRIES - 1)
+        if (!RETRYABLE.has(response.status) || attempt === effectiveMaxRetries - 1)
           break;
         await new Promise((r) => setTimeout(r, RETRY_DELAYS[attempt]));
       }
 
-      if (!response?.ok || !response?.body)
-        throw new Error(`HTTP ${response?.status ?? "unknown"}`);
+      if (!response?.ok || !response?.body) {
+        // Try to extract the real error message from the response body
+        // instead of discarding it and showing only the status code.
+        let errorMessage = `HTTP ${response?.status ?? "unknown"}`;
+        if (response?.body) {
+          try {
+            const errorBody = await response.text();
+            const parsed = JSON.parse(errorBody);
+            if (parsed?.error?.message) {
+              errorMessage = parsed.error.message;
+            } else if (typeof parsed?.error === "string") {
+              errorMessage = parsed.error;
+            } else if (errorBody.length > 0 && errorBody.length < 500) {
+              errorMessage = errorBody;
+            }
+          } catch {
+            // Body wasn't JSON or couldn't be read — keep the status code message.
+          }
+        }
+        throw new Error(errorMessage);
+      }
 
       const reader = response.body.getReader();
       const decoder = new TextDecoder();

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1582,19 +1582,27 @@ export function App() {
         // Try to extract the real error message from the response body
         // instead of discarding it and showing only the status code.
         let errorMessage = `HTTP ${response?.status ?? "unknown"}`;
-        if (response?.body) {
+        if (response) {
           try {
             const errorBody = await response.text();
-            const parsed = JSON.parse(errorBody);
-            if (parsed?.error?.message) {
-              errorMessage = parsed.error.message;
-            } else if (typeof parsed?.error === "string") {
-              errorMessage = parsed.error;
-            } else if (errorBody.length > 0 && errorBody.length < 500) {
-              errorMessage = errorBody;
+            if (errorBody.length > 0) {
+              try {
+                const parsed = JSON.parse(errorBody);
+                if (parsed?.error?.message) {
+                  errorMessage = parsed.error.message;
+                } else if (typeof parsed?.error === "string") {
+                  errorMessage = parsed.error;
+                } else if (errorBody.length < 500) {
+                  errorMessage = errorBody;
+                }
+              } catch {
+                if (errorBody.length < 500) {
+                  errorMessage = errorBody;
+                }
+              }
             }
           } catch {
-            // Body wasn't JSON or couldn't be read — keep the status code message.
+            // Body couldn't be read — keep the status code message.
           }
         }
         throw new Error(errorMessage);

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -127,7 +127,7 @@ import {
   getAttachmentSendIssue,
   validateAttachmentFile,
 } from "./lib/attachments";
-import { createRafBatcher } from "./lib/streaming";
+import { createRafBatcher, hasBlobContent, parseApiErrorBody } from "./lib/streaming";
 import { cn } from "./lib/utils";
 import {
   TOPOLOGY_LAYOUT_OPTIONS,
@@ -1541,20 +1541,7 @@ export function App() {
       // Detect multimodal requests — blob tokens are single-use so retrying
       // with the same tokens will always fail with "Unknown or expired blob
       // token".  Skip the retry loop for these requests.
-      const hasBlobContent = Array.isArray(requestInput) &&
-        requestInput.some(
-          (msg: Record<string, unknown>) =>
-            Array.isArray(msg.content) &&
-            (msg.content as Array<Record<string, unknown>>).some(
-              (block) =>
-                typeof block === "object" &&
-                block !== null &&
-                Object.values(block).some(
-                  (v) => typeof v === "string" && v.startsWith("mesh://blob/"),
-                ),
-            ),
-        );
-      const effectiveMaxRetries = hasBlobContent ? 1 : MAX_RETRIES;
+      const effectiveMaxRetries = hasBlobContent(requestInput) ? 1 : MAX_RETRIES;
       let response: Response | null = null;
 
       for (let attempt = 0; attempt < effectiveMaxRetries; attempt++) {
@@ -1581,30 +1568,9 @@ export function App() {
       if (!response?.ok || !response?.body) {
         // Try to extract the real error message from the response body
         // instead of discarding it and showing only the status code.
-        let errorMessage = `HTTP ${response?.status ?? "unknown"}`;
-        if (response) {
-          try {
-            const errorBody = await response.text();
-            if (errorBody.length > 0) {
-              try {
-                const parsed = JSON.parse(errorBody);
-                if (parsed?.error?.message) {
-                  errorMessage = parsed.error.message;
-                } else if (typeof parsed?.error === "string") {
-                  errorMessage = parsed.error;
-                } else if (errorBody.length < 500) {
-                  errorMessage = errorBody;
-                }
-              } catch {
-                if (errorBody.length < 500) {
-                  errorMessage = errorBody;
-                }
-              }
-            }
-          } catch {
-            // Body couldn't be read — keep the status code message.
-          }
-        }
+        const errorMessage = response
+          ? await parseApiErrorBody(response)
+          : "HTTP unknown";
         throw new Error(errorMessage);
       }
 

--- a/mesh-llm/ui/src/lib/streaming.test.ts
+++ b/mesh-llm/ui/src/lib/streaming.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+
+import { hasBlobContent, parseApiErrorBody } from "./streaming";
+
+// ---------------------------------------------------------------------------
+// hasBlobContent
+// ---------------------------------------------------------------------------
+
+describe("hasBlobContent", () => {
+  it("returns false for non-array inputs", () => {
+    expect(hasBlobContent(null)).toBe(false);
+    expect(hasBlobContent(undefined)).toBe(false);
+    expect(hasBlobContent("string")).toBe(false);
+    expect(hasBlobContent({})).toBe(false);
+  });
+
+  it("returns false when no message has blob URLs", () => {
+    const input = [
+      { role: "user", content: "hello" },
+      {
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
+      },
+    ];
+    expect(hasBlobContent(input)).toBe(false);
+  });
+
+  it("returns false for empty array", () => {
+    expect(hasBlobContent([])).toBe(false);
+  });
+
+  it("returns true when an image_url block contains a mesh://blob/ URL", () => {
+    const input = [
+      {
+        role: "user",
+        content: [
+          { type: "input_text", text: "describe this" },
+          {
+            type: "input_image",
+            image_url: "mesh://blob/abc123",
+          },
+        ],
+      },
+    ];
+    expect(hasBlobContent(input)).toBe(true);
+  });
+
+  it("returns true for audio blob URLs", () => {
+    const input = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_audio",
+            audio_url: "mesh://blob/def456",
+          },
+        ],
+      },
+    ];
+    expect(hasBlobContent(input)).toBe(true);
+  });
+
+  it("returns true when only one of several messages has blob content", () => {
+    const input = [
+      { role: "user", content: "plain text message" },
+      {
+        role: "user",
+        content: [
+          { type: "input_image", image_url: "mesh://blob/xyz" },
+        ],
+      },
+    ];
+    expect(hasBlobContent(input)).toBe(true);
+  });
+
+  it("does not match non-blob URLs", () => {
+    const input = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_image",
+            image_url: "https://example.com/image.png",
+          },
+        ],
+      },
+    ];
+    expect(hasBlobContent(input)).toBe(false);
+  });
+
+  it("does not match data: URLs", () => {
+    const input = [
+      {
+        role: "user",
+        content: [
+          {
+            type: "input_image",
+            image_url: "data:image/png;base64,abc123",
+          },
+        ],
+      },
+    ];
+    expect(hasBlobContent(input)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseApiErrorBody
+// ---------------------------------------------------------------------------
+
+function makeResponse(body: string, status = 500): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("parseApiErrorBody", () => {
+  it("returns HTTP <status> for empty body", async () => {
+    const res = makeResponse("", 500);
+    expect(await parseApiErrorBody(res)).toBe("HTTP 500");
+  });
+
+  it('extracts message from {"error":{"message":"..."}}', async () => {
+    const res = makeResponse(
+      JSON.stringify({ error: { message: "image input is not supported" } }),
+      500,
+    );
+    expect(await parseApiErrorBody(res)).toBe("image input is not supported");
+  });
+
+  it('extracts message from {"error":"..."}', async () => {
+    const res = makeResponse(
+      JSON.stringify({ error: "model not loaded" }),
+      503,
+    );
+    expect(await parseApiErrorBody(res)).toBe("model not loaded");
+  });
+
+  it("returns raw body text for short non-JSON responses", async () => {
+    const res = makeResponse("Service Unavailable", 503);
+    expect(await parseApiErrorBody(res)).toBe("Service Unavailable");
+  });
+
+  it("returns HTTP status for long non-JSON body (>=500 chars)", async () => {
+    const longBody = "x".repeat(500);
+    const res = makeResponse(longBody, 502);
+    expect(await parseApiErrorBody(res)).toBe("HTTP 502");
+  });
+
+  it("returns HTTP status for long JSON body without recognised error shape", async () => {
+    const longPayload = JSON.stringify({ detail: "x".repeat(500) });
+    const res = makeResponse(longPayload, 500);
+    expect(await parseApiErrorBody(res)).toBe("HTTP 500");
+  });
+
+  it("returns raw body for short JSON without recognised error shape", async () => {
+    const body = JSON.stringify({ detail: "bad request" });
+    const res = makeResponse(body, 400);
+    expect(await parseApiErrorBody(res)).toBe(body);
+  });
+
+  it("returns HTTP status for unreadable body (consumed stream)", async () => {
+    const res = makeResponse('{"error":"oops"}', 500);
+    // Exhaust the body so reading it again throws
+    await res.text();
+    expect(await parseApiErrorBody(res)).toBe("HTTP 500");
+  });
+});

--- a/mesh-llm/ui/src/lib/streaming.ts
+++ b/mesh-llm/ui/src/lib/streaming.ts
@@ -6,6 +6,71 @@
  * browser only does one reconciliation + layout per vsync.
  */
 
+/**
+ * Returns true when the Responses API input array contains at least one
+ * content block whose URL starts with "mesh://blob/".  Blob tokens are
+ * single-use and request-scoped, so retrying with the same tokens always
+ * fails with "Unknown or expired blob token".
+ */
+export function hasBlobContent(input: unknown): boolean {
+  if (!Array.isArray(input)) return false;
+  return input.some(
+    (msg: unknown) =>
+      typeof msg === "object" &&
+      msg !== null &&
+      Array.isArray((msg as Record<string, unknown>).content) &&
+      ((msg as Record<string, unknown>).content as Array<unknown>).some(
+        (block) =>
+          typeof block === "object" &&
+          block !== null &&
+          Object.values(block as Record<string, unknown>).some(
+            (v) => typeof v === "string" && v.startsWith("mesh://blob/"),
+          ),
+      ),
+  );
+}
+
+/**
+ * Reads the response body and returns the most useful error string:
+ * - `parsed.error.message` if the body is `{"error":{"message":"..."}}`
+ * - `parsed.error` if the body is `{"error":"..."}`
+ * - The raw body text for short (<500 char) non-JSON responses
+ * - `"HTTP <status>"` as a final fallback
+ */
+export async function parseApiErrorBody(response: Response): Promise<string> {
+  const fallback = `HTTP ${response.status}`;
+  try {
+    const errorBody = await response.text();
+    if (errorBody.length === 0) return fallback;
+    try {
+      const parsed = JSON.parse(errorBody) as unknown;
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "error" in parsed
+      ) {
+        const err = (parsed as Record<string, unknown>).error;
+        if (
+          typeof err === "object" &&
+          err !== null &&
+          typeof (err as Record<string, unknown>).message === "string"
+        ) {
+          return (err as Record<string, unknown>).message as string;
+        }
+        if (typeof err === "string") {
+          return err;
+        }
+      }
+      if (errorBody.length < 500) return errorBody;
+    } catch {
+      if (errorBody.length < 500) return errorBody;
+    }
+  } catch {
+    // Body couldn't be read — keep the status code message.
+  }
+  return fallback;
+}
+
 /** Schedule a callback at most once per animation frame. */
 export function createRafBatcher(callback: (text: string) => void) {
   let raf = 0;


### PR DESCRIPTION
The new error-surfacing and multimodal retry-skip behaviors in `App.tsx` had no test coverage, risking silent regressions.

## Changes

- **Extract utilities** — `hasBlobContent` and `parseApiErrorBody` pulled out of the `streamAssistantReply` closure into `lib/streaming.ts` as named exports; `App.tsx` updated to import them (no behavior change).

- **New test file** `lib/streaming.test.ts` — 16 Vitest unit tests:
  - `parseApiErrorBody`: handles `{"error":{"message":"..."}}`, `{"error":"..."}`, short plain-text body, long body → `HTTP <status>` fallback, unrecognised JSON, consumed/unreadable body
  - `hasBlobContent`: returns `false` for non-arrays, plain text, `data:` and `https://` URLs; returns `true` for `mesh://blob/` image/audio blocks and mixed inputs

```ts
// structured error shape
await parseApiErrorBody(new Response(JSON.stringify({ error: { message: "image input is not supported" } }), { status: 500 }))
// → "image input is not supported"

// blob detection
hasBlobContent([{ role: "user", content: [{ type: "input_image", image_url: "mesh://blob/abc123" }] }])
// → true
```