### PR TITLE
display: rename misleading VRAM labels to capacity

### DIFF
--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -114,14 +114,14 @@ fn fit_hint_for_machine(size_gb: f64, my_vram_gb: f64) -> (String, String) {
     if size_gb <= 0.0 || my_vram_gb <= 0.0 {
         return (
             "Unknown".into(),
-            "No local VRAM signal is available for this machine yet.".into(),
+            "No local capacity signal is available for this machine yet.".into(),
         );
     }
     if size_gb * 1.2 <= my_vram_gb {
         return (
             "Likely comfortable".into(),
             format!(
-                "This machine has {:.1} GB VRAM, which should handle a {:.1} GB model comfortably.",
+                "This machine has {:.1} GB capacity, which should handle a {:.1} GB model comfortably.",
                 my_vram_gb, size_gb
             ),
         );
@@ -130,7 +130,7 @@ fn fit_hint_for_machine(size_gb: f64, my_vram_gb: f64) -> (String, String) {
         return (
             "Likely fits".into(),
             format!(
-                "This machine has {:.1} GB VRAM. A {:.1} GB model should fit, but headroom will be tight.",
+                "This machine has {:.1} GB capacity. A {:.1} GB model should fit, but headroom will be tight.",
                 my_vram_gb, size_gb
             ),
         );
@@ -139,7 +139,7 @@ fn fit_hint_for_machine(size_gb: f64, my_vram_gb: f64) -> (String, String) {
         return (
             "Possible with tradeoffs".into(),
             format!(
-                "This machine has {:.1} GB VRAM. A {:.1} GB model may load, but expect tighter memory pressure.",
+                "This machine has {:.1} GB capacity. A {:.1} GB model may load, but expect tighter memory pressure.",
                 my_vram_gb, size_gb
             ),
         );
@@ -147,7 +147,7 @@ fn fit_hint_for_machine(size_gb: f64, my_vram_gb: f64) -> (String, String) {
     (
         "Likely too large".into(),
         format!(
-            "This machine has {:.1} GB VRAM, which is likely not enough for a {:.1} GB model locally.",
+            "This machine has {:.1} GB capacity, which is likely not enough for a {:.1} GB model locally.",
             my_vram_gb, size_gb
         ),
     )

--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -562,7 +562,7 @@ fn should_attempt_local_micro_analyze(
     let fits_with_headroom = local_vram_budget >= (model_bytes as f64 * 1.1) as u64;
     if !fits_with_headroom {
         eprintln!(
-            "🧩 [{model_name}] Skipping local micro-analyze: model needs about {:.1}GB with headroom, local VRAM is {:.1}GB",
+            "🧩 [{model_name}] Skipping local micro-analyze: model needs about {:.1}GB with headroom, local capacity is {:.1}GB",
             model_bytes as f64 * 1.1 / 1e9,
             local_vram_budget as f64 / 1e9
         );
@@ -1263,7 +1263,7 @@ pub async fn election_loop(
             return;
         } else {
             eprintln!(
-                "🧩 [{}] MoE model fits locally ({:.1}GB VRAM for {:.1}GB model) — no split needed",
+                "🧩 [{}] MoE model fits locally ({:.1}GB capacity for {:.1}GB model) — no split needed",
                 model_name,
                 my_vram as f64 / 1e9,
                 model_bytes as f64 / 1e9
@@ -1427,7 +1427,7 @@ pub async fn election_loop(
 
                 if total_vram < min_vram {
                     eprintln!(
-                        "⏳ [{}] Waiting for more peers — need {:.1}GB VRAM, have {:.1}GB",
+                        "⏳ [{}] Waiting for more peers — need {:.1}GB capacity, have {:.1}GB",
                         model_name,
                         min_vram as f64 / 1e9,
                         total_vram as f64 / 1e9
@@ -1443,7 +1443,7 @@ pub async fn election_loop(
                 }
 
                 eprintln!(
-                    "🗳 [{}] Elected as host ({:.1}GB VRAM for {:.1}GB model, {} node(s), split)",
+                    "🗳 [{}] Elected as host ({:.1}GB capacity for {:.1}GB model, {} node(s), split)",
                     model_name,
                     total_vram as f64 / 1e9,
                     model_bytes as f64 / 1e9,
@@ -1451,7 +1451,7 @@ pub async fn election_loop(
                 );
             } else {
                 eprintln!(
-                    "🗳 [{}] Running as host ({:.1}GB VRAM for {:.1}GB model, serving entirely)",
+                    "🗳 [{}] Running as host ({:.1}GB capacity for {:.1}GB model, serving entirely)",
                     model_name,
                     my_vram as f64 / 1e9,
                     model_bytes as f64 / 1e9
@@ -1917,7 +1917,7 @@ async fn moe_election_loop(
                     .await;
                 node.regossip().await;
                 eprintln!(
-                    "🧩 [{}] MoE model — serving entirely ({:.1}GB fits in {:.1}GB VRAM)",
+                    "🧩 [{}] MoE model — serving entirely ({:.1}GB fits in {:.1}GB capacity)",
                     model_name,
                     model_bytes as f64 / 1e9,
                     my_vram as f64 / 1e9
@@ -1995,7 +1995,7 @@ async fn moe_election_loop(
                 node.set_model_runtime_context_length(&model_name, None)
                     .await;
                 node.regossip().await;
-                eprintln!("⚠️  [{}] MoE model too large to serve entirely ({:.1}GB model, {:.1}GB VRAM) — waiting for peers",
+                eprintln!("⚠️  [{}] MoE model too large to serve entirely ({:.1}GB model, {:.1}GB capacity) — waiting for peers",
                     model_name, model_bytes as f64 / 1e9, my_vram as f64 / 1e9);
                 on_change(false, false);
             }
@@ -2334,7 +2334,7 @@ async fn start_llama(
                 .map(|r| format!("{}ms", r))
                 .unwrap_or("?ms".to_string());
             eprintln!(
-                "  ✓ Adding {} — {:.1}GB VRAM, RTT {rtt_str}",
+                "  ✓ Adding {} — {:.1}GB capacity, RTT {rtt_str}",
                 p.id.fmt_short(),
                 p.vram_bytes as f64 / 1e9
             );
@@ -2342,7 +2342,7 @@ async fn start_llama(
         }
         if accumulated_vram < min_vram {
             eprintln!(
-                "  ⚠ Total VRAM {:.1}GB still short of {:.1}GB — using all {} candidates",
+                "  ⚠ Total capacity {:.1}GB still short of {:.1}GB — using all {} candidates",
                 accumulated_vram as f64 / 1e9,
                 min_vram as f64 / 1e9,
                 candidates.len()
@@ -2358,7 +2358,7 @@ async fn start_llama(
             .count();
         if worker_count > 0 {
             eprintln!(
-                "  Model fits on host ({:.1}GB VRAM for {:.1}GB model) — serving entirely",
+                "  Model fits on host ({:.1}GB capacity for {:.1}GB model) — serving entirely",
                 my_vram as f64 / 1e9,
                 model_bytes as f64 / 1e9
             );
@@ -2426,7 +2426,7 @@ async fn start_llama(
         );
         Some(split_str)
     } else {
-        eprintln!("  Serving entirely ({:.0}GB VRAM)", my_vram_f / 1e9);
+        eprintln!("  Serving entirely ({:.0}GB capacity)", my_vram_f / 1e9);
         None
     };
 

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -901,7 +901,7 @@ pub async fn start_llama_server(
     let vram_after_model = my_vram.saturating_sub(host_model_bytes);
     let ctx_size = compute_context_size(ctx_size_override, model_bytes, my_vram, total_group_vram);
     tracing::info!(
-        "Context size: {ctx_size} tokens (model {:.1}GB, host weights ~{:.1}GB, {:.0}GB VRAM, {:.1}GB free{})",
+        "Context size: {ctx_size} tokens (model {:.1}GB, host weights ~{:.1}GB, {:.0}GB capacity, {:.1}GB free{})",
         model_bytes as f64 / GB as f64,
         host_model_bytes as f64 / GB as f64,
         my_vram as f64 / GB as f64,

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -1612,20 +1612,20 @@ impl Node {
             let max_bytes = (max_gb * 1e9) as u64;
             if max_bytes < vram {
                 tracing::info!(
-                    "Detected VRAM: {:.1} GB, capped to {:.1} GB (--max-vram)",
+                    "Detected capacity: {:.1} GB, capped to {:.1} GB (--max-vram)",
                     vram as f64 / 1e9,
                     max_gb
                 );
                 vram = max_bytes;
             } else {
                 tracing::info!(
-                    "Detected VRAM: {:.1} GB (--max-vram {:.1} has no effect)",
+                    "Detected capacity: {:.1} GB (--max-vram {:.1} has no effect)",
                     vram as f64 / 1e9,
                     max_gb
                 );
             }
         } else {
-            tracing::info!("Detected VRAM: {:.1} GB", vram as f64 / 1e9);
+            tracing::info!("Detected capacity: {:.1} GB", vram as f64 / 1e9);
         }
 
         let config_state_init = {

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -74,7 +74,7 @@ impl std::fmt::Display for DiscoveredMesh {
         };
         write!(
             f,
-            "{}  {} node(s), {:.0}GB VRAM  serving: {}",
+            "{}  {} node(s), {:.0}GB capacity  serving: {}",
             self.listing.name.as_deref().unwrap_or("(unnamed)"),
             self.listing.node_count,
             vram_gb,

--- a/mesh-llm/src/runtime/discovery.rs
+++ b/mesh-llm/src/runtime/discovery.rs
@@ -144,7 +144,7 @@ pub(super) fn start_new_mesh(
     } else {
         eprintln!("   Serving: {primary}");
     }
-    eprintln!("   VRAM: {:.0}GB", my_vram_gb);
+    eprintln!("   Capacity: {:.0}GB", my_vram_gb);
     if !has_startup_models && cli.model.is_empty() {
         cli.model.push(primary.into());
     }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -1109,7 +1109,7 @@ async fn run_auto(
             let pack = nostr::auto_model_pack(node.vram_bytes() as f64 / 1e9);
             if !pack.is_empty() {
                 eprintln!(
-                    "📋 No unserved demand — serving {} for {:.0}GB VRAM",
+                    "📋 No unserved demand — serving {} for {:.0}GB capacity",
                     pack[0],
                     node.vram_bytes() as f64 / 1e9
                 );
@@ -1143,7 +1143,7 @@ async fn run_auto(
             } else {
                 eprintln!("💤 No matching model on disk — running as standby GPU node");
                 eprintln!(
-                    "   VRAM: {:.1}GB, models on disk: {:?}",
+                    "   Capacity: {:.1}GB, models on disk: {:?}",
                     node.vram_bytes() as f64 / 1e9,
                     local_models
                 );


### PR DESCRIPTION
Fixes #219.

`vram_bytes` isn't raw GPU VRAM — it's `gpu_vram + 0.75 * (system_ram - gpu_vram)`, which accounts for llama.cpp's ability to offload layers to system RAM. The formula is intentional and correct, but the label was wrong. A machine with 17GB GPU VRAM and 96GB system RAM reports ~78GB, which is accurate as a capacity number but confusing when it says "78.2GB VRAM."

Changed "VRAM" to "capacity" in all user-visible log and display strings that pass `vram_bytes`. Internal variable names and the `--max-vram` flag are untouched.