### PR TITLE
client: only surface models that can actually serve requests

### DIFF
--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -89,6 +89,59 @@ fn likely_reasoning_model(name: &str, description: Option<&str>) -> bool {
         .any(|needle| haystack.contains(needle))
 }
 
+#[derive(Debug, Default, PartialEq)]
+struct HttpRouteStats {
+    node_count: usize,
+    active_nodes: Vec<String>,
+    mesh_vram_gb: f64,
+}
+
+fn http_route_stats(
+    model_name: &str,
+    peers: &[mesh::PeerInfo],
+    my_hosted_models: &[String],
+    my_hostname: Option<&str>,
+    my_vram_gb: f64,
+) -> HttpRouteStats {
+    let mut active_nodes = Vec::new();
+    let mut node_count = 0usize;
+    let mut mesh_vram_gb = 0.0;
+
+    if my_hosted_models.iter().any(|hosted| hosted == model_name) {
+        node_count += 1;
+        mesh_vram_gb += my_vram_gb;
+        active_nodes.push(
+            my_hostname
+                .filter(|hostname| !hostname.trim().is_empty())
+                .unwrap_or("This node")
+                .to_string(),
+        );
+    }
+
+    for peer in peers {
+        if !peer.routes_http_model(model_name) {
+            continue;
+        }
+        node_count += 1;
+        mesh_vram_gb += peer.vram_bytes as f64 / 1e9;
+        active_nodes.push(
+            peer.hostname
+                .clone()
+                .filter(|hostname| !hostname.trim().is_empty())
+                .unwrap_or_else(|| peer.id.fmt_short().to_string()),
+        );
+    }
+
+    active_nodes.sort();
+    active_nodes.dedup();
+
+    HttpRouteStats {
+        node_count,
+        active_nodes,
+        mesh_vram_gb,
+    }
+}
+
 fn likely_vision_model(name: &str, description: Option<&str>) -> bool {
     let haystack = format!("{} {}", name, description.unwrap_or_default()).to_ascii_lowercase();
     ["vision", "-vl", "llava", "omni", "qwen2.5-vl", "mllama"]
@@ -373,59 +426,27 @@ impl MeshApi {
                     || my_serving_models.iter().any(|s| s == name)
                     || name == &model_name;
                 let display_name = crate::models::installed_model_display_name(name);
-                let node_count = if is_warm {
-                    let peer_count = all_peers.iter().filter(|p| p.routes_model(name)).count();
-                    let me = if my_hosted_models.iter().any(|s| s == name) {
-                        1
-                    } else {
-                        0
-                    };
-                    peer_count + me
-                } else {
-                    0
-                };
-                let active_nodes: Vec<String> = if is_warm {
-                    let mut nodes = Vec::new();
-                    if my_hosted_models.iter().any(|s| s == name) {
-                        nodes.push(
-                            node.hostname
-                                .clone()
-                                .filter(|hostname| !hostname.trim().is_empty())
-                                .unwrap_or_else(|| "This node".to_string()),
-                        );
-                    }
-                    nodes.extend(all_peers.iter().filter_map(|peer| {
-                        if !peer.routes_model(name) {
-                            return None;
-                        }
-                        Some(
-                            peer.hostname
-                                .clone()
-                                .filter(|hostname| !hostname.trim().is_empty())
-                                .unwrap_or_else(|| peer.id.fmt_short().to_string()),
-                        )
-                    }));
-                    nodes.sort();
-                    nodes.dedup();
-                    nodes
-                } else {
-                    Vec::new()
-                };
-                let mesh_vram_gb = if is_warm {
-                    let peer_vram = all_peers
-                        .iter()
-                        .filter(|p| p.routes_model(name))
-                        .map(|p| p.vram_bytes as f64 / 1e9)
-                        .sum::<f64>();
-                    let my_vram = if my_hosted_models.iter().any(|s| s == name) {
-                        my_vram_gb
-                    } else {
-                        0.0
-                    };
-                    peer_vram + my_vram
-                } else {
-                    0.0
-                };
+                let route_stats = is_warm.then(|| {
+                    http_route_stats(
+                        name,
+                        &all_peers,
+                        &my_hosted_models,
+                        node.hostname.as_deref(),
+                        my_vram_gb,
+                    )
+                });
+                let node_count = route_stats
+                    .as_ref()
+                    .map(|stats| stats.node_count)
+                    .unwrap_or(0);
+                let active_nodes = route_stats
+                    .as_ref()
+                    .map(|stats| stats.active_nodes.clone())
+                    .unwrap_or_default();
+                let mesh_vram_gb = route_stats
+                    .as_ref()
+                    .map(|stats| stats.mesh_vram_gb)
+                    .unwrap_or(0.0);
                 let size_gb = if name == &model_name && model_size_bytes > 0 {
                     model_size_bytes as f64 / 1e9
                 } else {
@@ -1382,6 +1403,48 @@ mod tests {
         serde_json::from_str(body).unwrap_or(serde_json::Value::Null)
     }
 
+    fn make_test_peer(
+        seed: u8,
+        role: mesh::NodeRole,
+        serving_models: Vec<&str>,
+        hosted_models: Vec<&str>,
+        hosted_models_known: bool,
+    ) -> mesh::PeerInfo {
+        let peer_id = iroh::EndpointId::from(iroh::SecretKey::from_bytes(&[seed; 32]).public());
+        mesh::PeerInfo {
+            id: peer_id,
+            addr: iroh::EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            },
+            tunnel_port: None,
+            role,
+            models: Vec::new(),
+            vram_bytes: 24_000_000_000,
+            rtt_ms: None,
+            model_source: None,
+            serving_models: serving_models.into_iter().map(str::to_string).collect(),
+            hosted_models: hosted_models.into_iter().map(str::to_string).collect(),
+            hosted_models_known,
+            available_models: Vec::new(),
+            requested_models: Vec::new(),
+            last_seen: std::time::Instant::now(),
+            moe_recovered_at: None,
+            version: None,
+            gpu_name: None,
+            hostname: None,
+            is_soc: None,
+            gpu_vram: None,
+            gpu_bandwidth_gbps: None,
+            available_model_metadata: Vec::new(),
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: Vec::new(),
+            served_model_runtime: Vec::new(),
+            owner_id: None,
+        }
+    }
+
     #[derive(Clone)]
     struct BlobstoreApiTestBridge {
         plugin_name: String,
@@ -1824,6 +1887,34 @@ mod tests {
         assert!(models_body.get("mesh_models").is_some());
 
         models_handle.abort();
+    }
+
+    #[test]
+    fn test_http_route_stats_only_count_http_callable_legacy_hosts() {
+        let peers = vec![
+            make_test_peer(
+                0x41,
+                mesh::NodeRole::Host { http_port: 9337 },
+                vec!["legacy-host-model"],
+                Vec::new(),
+                false,
+            ),
+            make_test_peer(
+                0x42,
+                mesh::NodeRole::Worker,
+                vec!["worker-only-model"],
+                Vec::new(),
+                false,
+            ),
+        ];
+
+        let host_stats = http_route_stats("legacy-host-model", &peers, &[], None, 0.0);
+        assert_eq!(host_stats.node_count, 1);
+        assert_eq!(host_stats.active_nodes.len(), 1);
+        assert!(host_stats.mesh_vram_gb > 0.0);
+
+        let worker_stats = http_route_stats("worker-only-model", &peers, &[], None, 0.0);
+        assert_eq!(worker_stats, HttpRouteStats::default());
     }
 
     #[tokio::test]

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -1168,6 +1168,22 @@ impl PeerInfo {
         }
     }
 
+    pub fn accepts_http_inference(&self) -> bool {
+        matches!(self.role, NodeRole::Host { .. })
+    }
+
+    pub fn http_routable_models(&self) -> Vec<String> {
+        if self.accepts_http_inference() {
+            self.routable_models()
+        } else {
+            Vec::new()
+        }
+    }
+
+    pub fn routes_http_model(&self, model: &str) -> bool {
+        self.accepts_http_inference() && self.routes_model(model)
+    }
+
     pub fn moe_recovery_ready(&self) -> bool {
         moe_recovery_ready_at(self.moe_recovered_at, std::time::Instant::now())
     }
@@ -1707,7 +1723,6 @@ impl Node {
         ))
     }
 
-    #[cfg(test)]
     #[cfg(test)]
     pub async fn new_for_tests(role: NodeRole) -> Result<Self> {
         use iroh::endpoint::QuicTransportConfig;
@@ -3034,7 +3049,11 @@ impl Node {
             .collect()
     }
 
-    /// Get all models currently being served in the mesh (loaded in VRAM somewhere).
+    /// Get all models currently reachable via the mesh HTTP/API ingress.
+    ///
+    /// This is intentionally stricter than "loaded in VRAM somewhere": split
+    /// workers may contribute compute for a model but cannot accept chat
+    /// requests directly.
     pub async fn models_being_served(&self) -> Vec<String> {
         let my_hosted_models = self.hosted_models.lock().await.clone();
         let peer_data: Vec<_> = {
@@ -3046,7 +3065,7 @@ impl Node {
             served.insert(s.clone());
         }
         for peer in &peer_data {
-            for m in peer.routable_models() {
+            for m in peer.http_routable_models() {
                 served.insert(m.clone());
             }
         }
@@ -3064,7 +3083,7 @@ impl Node {
         let mut hosts: Vec<EndpointId> = state
             .peers
             .values()
-            .filter(|p| p.routes_model(model))
+            .filter(|p| p.routes_http_model(model))
             .map(|p| p.id)
             .collect();
         hosts.sort();
@@ -3087,7 +3106,7 @@ impl Node {
         state
             .peers
             .values()
-            .find(|p| !p.routable_models().is_empty())
+            .find(|p| !p.http_routable_models().is_empty())
             .cloned()
     }
 
@@ -3115,7 +3134,7 @@ impl Node {
 
         // Include peers that are serving through their local API proxies
         for peer in &peer_data {
-            for model in peer.routable_models() {
+            for model in peer.http_routable_models() {
                 hosts.push(RouteEntry {
                     model,
                     node_id: format!("{}", peer.id.fmt_short()),
@@ -7176,6 +7195,32 @@ mod tests {
             "passive client must reject stale RouteTable: {:?}",
             err
         );
+    }
+
+    #[test]
+    fn worker_only_legacy_models_are_excluded_from_http_routes() {
+        let host_id = EndpointId::from(iroh::SecretKey::from_bytes(&[0xD2; 32]).public());
+        let worker_id = EndpointId::from(iroh::SecretKey::from_bytes(&[0xD3; 32]).public());
+
+        let mut legacy_host = make_test_peer_info(host_id);
+        legacy_host.role = super::NodeRole::Host { http_port: 9337 };
+        legacy_host.serving_models = vec!["legacy-host-model".to_string()];
+        legacy_host.hosted_models_known = false;
+
+        let mut legacy_worker = make_test_peer_info(worker_id);
+        legacy_worker.role = super::NodeRole::Worker;
+        legacy_worker.serving_models = vec!["worker-only-model".to_string()];
+        legacy_worker.hosted_models_known = false;
+
+        assert!(legacy_host.accepts_http_inference());
+        assert!(!legacy_worker.accepts_http_inference());
+        assert_eq!(
+            legacy_host.http_routable_models(),
+            vec!["legacy-host-model".to_string()]
+        );
+        assert!(legacy_host.routes_http_model("legacy-host-model"));
+        assert!(legacy_worker.http_routable_models().is_empty());
+        assert!(!legacy_worker.routes_http_model("worker-only-model"));
     }
 
     /// Verifies that dead-peer cleanup prevents re-admission: after a peer is cleaned

--- a/mesh-llm/src/runtime/proxy.rs
+++ b/mesh-llm/src/runtime/proxy.rs
@@ -52,7 +52,7 @@ pub(super) async fn api_proxy(
                 Ok(request) => {
                     let body_json = request.body_json.as_ref();
                     if proxy::is_models_list_request(&request.method, &request.path) {
-                        let mut models: Vec<String> = targets.targets.keys().cloned().collect();
+                        let mut models = callable_models(&targets);
                         if let Some(plugin_manager) = plugin_manager.as_ref() {
                             if let Ok(mut external_models) = plugin_manager.inference_models().await
                             {
@@ -137,8 +137,7 @@ pub(super) async fn api_proxy(
                     {
                         if let Some(body_json) = body_json {
                             let cl = router::classify(body_json);
-                            let mut available_models: Vec<String> =
-                                targets.targets.keys().cloned().collect();
+                            let mut available_models = callable_models(&targets);
                             if let Some(plugin_manager) = plugin_manager.as_ref() {
                                 if let Ok(external_models) = plugin_manager.inference_models().await
                                 {
@@ -416,6 +415,22 @@ fn first_available_target(targets: &election::ModelTargets) -> election::Inferen
         }
     }
     election::InferenceTarget::None
+}
+
+fn callable_models(targets: &election::ModelTargets) -> Vec<String> {
+    let mut models: Vec<String> = targets
+        .targets
+        .iter()
+        .filter_map(|(model, candidates)| {
+            candidates
+                .iter()
+                .any(|target| !matches!(target, election::InferenceTarget::None))
+                .then(|| model.clone())
+        })
+        .collect();
+    models.sort();
+    models.dedup();
+    models
 }
 
 #[cfg(test)]

--- a/mesh-llm/src/runtime/proxy/tests.rs
+++ b/mesh-llm/src/runtime/proxy/tests.rs
@@ -443,6 +443,15 @@ fn local_targets(entries: &[(&str, u16)]) -> election::ModelTargets {
     targets
 }
 
+fn unavailable_targets(models: &[&str]) -> election::ModelTargets {
+    let mut targets = election::ModelTargets::default();
+    targets.targets = models
+        .iter()
+        .map(|model| ((*model).to_string(), vec![election::InferenceTarget::None]))
+        .collect();
+    targets
+}
+
 fn single_model_targets(model: &str, ports: &[u16]) -> election::ModelTargets {
     let mut targets = election::ModelTargets::default();
     targets.targets.insert(
@@ -799,6 +808,15 @@ async fn test_api_proxy_lists_registered_inference_models() {
     assert!(entries.iter().any(|entry| entry["id"] == "lemonade-test"));
 
     proxy_handle.abort();
+}
+
+#[test]
+fn test_callable_models_excludes_none_only_targets() {
+    let mut targets = local_targets(&[("ready-model", 1234)]);
+    targets
+        .targets
+        .extend(unavailable_targets(&["warming-model"]).targets);
+    assert_eq!(callable_models(&targets), vec!["ready-model".to_string()]);
 }
 
 #[tokio::test]

--- a/mesh-llm/ui/src/App.test.tsx
+++ b/mesh-llm/ui/src/App.test.tsx
@@ -98,7 +98,8 @@ const statusTemplate = {
   gpus: [] as unknown[],
 };
 
-const modelsPayload = { mesh_models: [] };
+let statusPayload = createStatusPayload();
+let modelsPayload = { mesh_models: [] as Array<Record<string, unknown>> };
 const mockFetch = vi.fn();
 
 function createStatusPayload() {
@@ -131,7 +132,7 @@ function setupFetchMock() {
   mockFetch.mockImplementation((input: RequestInfo | URL) => {
     const url = getRequestUrl(input);
     if (url.endsWith("/api/status")) {
-      return Promise.resolve(createResponse(createStatusPayload()));
+      return Promise.resolve(createResponse(statusPayload));
     }
     if (url.endsWith("/api/models")) {
       return Promise.resolve(createResponse(modelsPayload));
@@ -194,6 +195,8 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  statusPayload = createStatusPayload();
+  modelsPayload = { mesh_models: [] };
   setupFetchMock();
   Object.defineProperty(window, "EventSource", {
     configurable: true,
@@ -359,5 +362,23 @@ describe("App routing and status", () => {
       ),
     );
     await screen.findByText("Mesh LLM v1.0.0");
+  });
+
+  it("keeps client chat disabled until /api/models reports a warm model", async () => {
+    statusPayload = {
+      ...createStatusPayload(),
+      is_client: true,
+      is_host: false,
+      llama_ready: false,
+      model_name: "ghost-model",
+      hosted_models: [],
+      serving_models: [],
+    };
+    setPath("/chat");
+    render(<App />);
+
+    const input = await screen.findByTestId("chat-input");
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute("placeholder", "Waiting for a warm model...");
   });
 });

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -968,12 +968,10 @@ export function App() {
   const meshModels = modelsPayload?.mesh_models ?? [];
 
   const warmModels = useMemo(() => {
-    const list = meshModels
+    return meshModels
       .filter((m) => m.status === "warm")
       .map((m) => m.name);
-    if (!list.length && status?.model_name) list.push(status.model_name);
-    return list;
-  }, [meshModels, status?.model_name]);
+  }, [meshModels]);
   const modelStatsByName = useMemo<Record<string, ModelServingStat>>(() => {
     const stats: Record<string, ModelServingStat> = {};
     for (const model of warmModels) stats[model] = { nodes: 0, vramGb: 0 };


### PR DESCRIPTION
## Summary
Passive and public mesh clients now only surface models that can actually accept HTTP inference requests. `/api/models`, `/v1/models`, and the console stay aligned when worker-only legacy peers or placeholder targets are present.

## Why
Passive clients could previously advertise models that were only present on worker-only peers or only resolved to `InferenceTarget::None`. That made the console look ready even though the next request could still fail with a `503`.

## What Changed
- treat only `Host` peers as HTTP-callable inference targets for user-facing availability
- compute warm status, node counts, active nodes, and mesh VRAM in `/api/models` from HTTP-callable routes only
- filter `/v1/models` and passive auto-routing candidates so models backed only by `InferenceTarget::None` are not advertised as available
- keep the chat composer disabled until `/api/models` reports a warm model instead of falling back to `status.model_name`

## Example
```bash
mesh-llm --client --auto
curl -s http://localhost:9337/v1/models
curl -s http://localhost:3131/api/models
```

With this change, those surfaces only report models that a passive client can actually route to successfully.

## Architecture
The mesh catalog remains broader than immediate routability: cold catalog entries still appear in `/api/models`, but only HTTP-callable hosts contribute warm state and route statistics. This keeps discovery intact while making client readiness and model availability honest.

## Validation
- `cargo fmt --all`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-passive-visible cargo test -p mesh-llm test_http_route_stats_only_count_http_callable_legacy_hosts`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-passive-visible cargo test -p mesh-llm worker_only_legacy_models_are_excluded_from_http_routes`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-passive-visible cargo test -p mesh-llm test_callable_models_excludes_none_only_targets`
- `npm test -- App.test.tsx`
- `npm run typecheck`
- `npm run build`
- `git diff --check`

## UI
The console now waits for a warm model from `/api/models` before enabling chat on passive clients.
