### PR TITLE
Chat: image & PDF support, interrupt-on-queue, stop UX

### DIFF
--- a/mesh-llm/ui/package-lock.json
+++ b/mesh-llm/ui/package-lock.json
@@ -8,6 +8,7 @@
       "name": "mesh-llm-console-ui",
       "version": "0.0.1",
       "dependencies": {
+        "@huggingface/transformers": "^3.8.1",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-navigation-menu": "^1.2.14",
@@ -24,6 +25,7 @@
         "highlight.js": "^11.11.1",
         "katex": "^0.16.40",
         "lucide-react": "^0.542.0",
+        "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -457,6 +459,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
@@ -876,6 +888,552 @@
       "version": "0.2.11",
       "license": "MIT"
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.6.tgz",
+      "integrity": "sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
+      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.3",
+        "onnxruntime-node": "1.21.0",
+        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
+        "sharp": "^0.34.1"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "dev": true,
@@ -916,6 +1474,271 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-x64": "0.1.97",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+      "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "dev": true,
@@ -947,6 +1770,70 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -2391,6 +3278,15 @@
       "version": "2.1.0",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "license": "MIT"
@@ -2729,6 +3625,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "dev": true,
@@ -2908,6 +3811,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/class-variance-authority": {
@@ -3128,12 +4040,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -3180,11 +4141,35 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -3319,6 +4304,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "dev": true,
@@ -3375,6 +4366,81 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
@@ -3783,6 +4849,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "dev": true,
@@ -3830,6 +4902,12 @@
       "version": "1.2.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -3911,6 +4989,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -4722,6 +5824,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -4787,6 +5910,58 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
+      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
+      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.21.0",
+        "tar": "^7.0.1"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.22.0-dev.20250409-89f8206ba4",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
+      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "license": "MIT"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "license": "MIT",
@@ -4840,6 +6015,18 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "dev": true,
@@ -4871,6 +6058,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.5.8",
@@ -5043,6 +6236,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {
@@ -5362,6 +6579,23 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "dev": true,
@@ -5467,6 +6701,83 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "dev": true,
@@ -5487,6 +6798,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -5614,6 +6931,31 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/thenify": {
@@ -5801,6 +7143,18 @@
       "version": "2.8.1",
       "license": "0BSD"
     },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -5812,6 +7166,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/mesh-llm/ui/package.json
+++ b/mesh-llm/ui/package.json
@@ -16,6 +16,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@huggingface/transformers": "^3.8.1",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-navigation-menu": "^1.2.14",
@@ -32,6 +33,7 @@
     "highlight.js": "^11.11.1",
     "katex": "^0.16.40",
     "lucide-react": "^0.542.0",
+    "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/mesh-llm/ui/src/App.test.tsx
+++ b/mesh-llm/ui/src/App.test.tsx
@@ -38,6 +38,7 @@ function buildProps(
     composerError: null,
     setComposerError: vi.fn(),
     attachmentSendIssue: null,
+    imageDescriptionInProgress: false,
     pendingAttachments: [],
     setPendingAttachments: vi.fn(),
     conversations: [

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -128,6 +128,10 @@ import {
   validateAttachmentFile,
 } from "./lib/attachments";
 import {
+  canRunBrowserVision,
+  describeImage,
+} from "./lib/image-describe";
+import {
   dataUrlToArrayBuffer,
   extractPdfText,
   isPdfMimeType,
@@ -386,6 +390,8 @@ type ChatAttachment = {
   extractionSummary?: string;
   /** Page images rendered from a scanned PDF (data URLs). */
   renderedPageImages?: string[];
+  /** Browser-generated image description (when no vision model is warm). */
+  imageDescription?: string;
 };
 
 type ChatMessage = {
@@ -1060,6 +1066,11 @@ export function App() {
         if (attachment.renderedPageImages?.length) kinds.add("image");
         continue;
       }
+      // Images with a browser-generated description will be sent as
+      // input_text — no vision model needed.
+      if (attachment.kind === "image" && attachment.imageDescription) {
+        continue;
+      }
       kinds.add(attachment.kind);
     }
     return kinds;
@@ -1471,6 +1482,15 @@ export function App() {
         continue;
       }
 
+      // Image described locally → inject description as input_text.
+      if (attachment.kind === "image" && attachment.imageDescription) {
+        contentBlocks.push({
+          type: "input_text",
+          text: attachment.imageDescription,
+        });
+        continue;
+      }
+
       // Scanned PDF rendered as images → inject each page as input_image.
       if (attachment.renderedPageImages?.length) {
         for (const pageDataUrl of attachment.renderedPageImages) {
@@ -1849,6 +1869,7 @@ export function App() {
                 extractedText,
                 extractionSummary,
                 renderedPageImages,
+                imageDescription,
                 ...attachment
               }) => attachment,
             )
@@ -2918,6 +2939,76 @@ export function ChatPage(props: {
     setComposerError(null);
   }
 
+  /** Check if any warm model in the mesh has vision support. */
+  function hasWarmVisionModel(): boolean {
+    return warmModels.some((m) => meshModelByName[m]?.vision);
+  }
+
+  /**
+   * Add an image attachment, then auto-describe it via a browser-local
+   * vision model if no warm vision model is available in the mesh.
+   */
+  function addImageAttachment(attachment: Omit<ChatAttachment, "id" | "status" | "error">) {
+    const attachmentId = randomId();
+    const needsDescription = !hasWarmVisionModel() && canRunBrowserVision();
+    setPendingAttachments((prev) => [
+      ...prev,
+      {
+        id: attachmentId,
+        status: needsDescription ? "uploading" : "pending",
+        extractionSummary: needsDescription ? "Describing image..." : undefined,
+        ...attachment,
+      },
+    ]);
+    if (needsDescription) {
+      void describeImageAttachment(attachmentId, attachment.dataUrl);
+    }
+  }
+
+  async function describeImageAttachment(attachmentId: string, dataUrl: string) {
+    try {
+      const result = await describeImage(dataUrl, (message) => {
+        setPendingAttachments((prev) =>
+          prev.map((a) =>
+            a.id === attachmentId
+              ? { ...a, extractionSummary: message }
+              : a,
+          ),
+        );
+      });
+      setPendingAttachments((prev) =>
+        prev.map((a) =>
+          a.id === attachmentId
+            ? {
+                ...a,
+                status: "pending",
+                imageDescription: result.combinedText,
+                extractionSummary: result.ocrText
+                  ? "Described + OCR extracted"
+                  : "Described by local vision",
+              }
+            : a,
+        ),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setPendingAttachments((prev) =>
+        prev.map((a) =>
+          a.id === attachmentId
+            ? {
+                ...a,
+                status: "pending",
+                extractionSummary: undefined,
+                // Don't fail the attachment — it can still be sent if
+                // the user switches to a vision model.
+              }
+            : a,
+        ),
+      );
+      console.warn("Image description failed:", message);
+    }
+  }
+
   function handleImageSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
@@ -2946,7 +3037,7 @@ export function ChatPage(props: {
         canvas.height = height;
         const ctx = canvas.getContext("2d");
         if (!ctx) {
-          addPendingAttachment({
+          addImageAttachment({
             kind: "image",
             dataUrl: src,
             mimeType: parseDataUrl(src)?.mimeType || file.type || "image/jpeg",
@@ -2955,7 +3046,7 @@ export function ChatPage(props: {
           return;
         }
         ctx.drawImage(img, 0, 0, width, height);
-        addPendingAttachment({
+        addImageAttachment({
           kind: "image",
           dataUrl: canvas.toDataURL("image/jpeg", 0.85),
           mimeType: "image/jpeg",
@@ -2964,7 +3055,7 @@ export function ChatPage(props: {
       };
       img.onerror = () => {
         // Canvas resize failed — send original (may be large but better than nothing)
-        addPendingAttachment({
+        addImageAttachment({
           kind: "image",
           dataUrl: src,
           mimeType: parseDataUrl(src)?.mimeType || file.type || "image/jpeg",
@@ -3629,7 +3720,7 @@ export function ChatPage(props: {
                         {attachment.status === "uploading" ? (
                           <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/70 text-xs">
                             <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                            Uploading
+                            {attachment.extractionSummary || "Uploading"}
                           </div>
                         ) : attachment.status === "failed" ? (
                           <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-background/80 text-xs">
@@ -3643,6 +3734,11 @@ export function ChatPage(props: {
                             >
                               Retry
                             </Button>
+                          </div>
+                        ) : null}
+                        {attachment.extractionSummary && attachment.status !== "uploading" ? (
+                          <div className="absolute inset-x-0 bottom-0 rounded-b-md bg-background/80 px-1.5 py-0.5 text-[10px] text-muted-foreground truncate">
+                            {attachment.extractionSummary}
                           </div>
                         ) : null}
                       </div>

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -2963,7 +2963,7 @@ export function ChatPage(props: {
    */
   function addImageAttachment(attachment: Omit<ChatAttachment, "id" | "status" | "error">) {
     const attachmentId = randomId();
-    const needsDescription = canRunBrowserVision();
+    const needsDescription = !selectedModelVision && canRunBrowserVision();
     setPendingAttachments((prev) => [
       ...prev,
       {

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1847,23 +1847,6 @@ export function App() {
 
     // Prefer an explicitly compatible model when sending media with model=auto.
     let model = selectedModel || status.model_name;
-    const isAuto = !model || model === "auto";
-    if (isAuto) {
-      // If this conversation already used a vision model (because images
-      // were sent), stick with that model for continuity — don't let auto
-      // bounce to a text-only model that can't see the earlier images.
-      const existingMessages = activeConversation?.messages ?? [];
-      const priorVisionModel = existingMessages.find(
-        (m) =>
-          m.role === "assistant" &&
-          m.model &&
-          visionModels.has(m.model) &&
-          warmModels.includes(m.model),
-      )?.model;
-      if (priorVisionModel) {
-        model = priorVisionModel;
-      }
-    }
     if (pendingAttachments.length > 0 && (!model || model === "auto")) {
       const multimodalModel = warmModels.find(
         (m) =>
@@ -2974,25 +2957,13 @@ export function ChatPage(props: {
   }
 
   /**
-   * Check if the image will be sent to a vision-capable model.
-   * True when the selected model has vision, or auto mode and a warm
-   * vision model exists.
-   */
-  function willUseVisionModel(): boolean {
-    if (selectedModelVision) return true;
-    if (!selectedModel || selectedModel === "auto") {
-      return warmModels.some((m) => meshModelByName[m]?.vision);
-    }
-    return false;
-  }
-
-  /**
-   * Add an image attachment, then auto-describe it via a browser-local
-   * vision model if the image won't be handled by a real vision model.
+   * Add an image attachment and describe it via Florence-2 running
+   * locally in the browser. The description is injected as text so
+   * any model can reason about the image — no vision model needed.
    */
   function addImageAttachment(attachment: Omit<ChatAttachment, "id" | "status" | "error">) {
     const attachmentId = randomId();
-    const needsDescription = !willUseVisionModel() && canRunBrowserVision();
+    const needsDescription = canRunBrowserVision();
     setPendingAttachments((prev) => [
       ...prev,
       {

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -3758,29 +3758,25 @@ export function ChatPage(props: {
                   >
                     <File className="h-4 w-4" />
                   </Button>
-                  {selectedModelVision && (
-                    <>
-                      <input
-                        ref={imageInputRef}
-                        type="file"
-                        accept="image/*"
-                        className="hidden"
-                        data-testid="chat-image-input"
-                        onChange={handleImageSelect}
-                      />
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="icon"
-                        onClick={() => imageInputRef.current?.click()}
-                        disabled={!props.canChat || isSending}
-                        title="Attach image"
-                        aria-label="Attach image"
-                      >
-                        <ImagePlus className="h-4 w-4" />
-                      </Button>
-                    </>
-                  )}
+                  <input
+                    ref={imageInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    data-testid="chat-image-input"
+                    onChange={handleImageSelect}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => imageInputRef.current?.click()}
+                    disabled={!props.canChat || isSending}
+                    title="Attach image"
+                    aria-label="Attach image"
+                  >
+                    <ImagePlus className="h-4 w-4" />
+                  </Button>
                   {selectedModelAudio && (
                     <>
                       <input

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -2230,6 +2230,7 @@ export function App() {
                   composerError={composerError}
                   setComposerError={setComposerError}
                   attachmentSendIssue={attachmentSendIssue}
+                  imageDescriptionInProgress={imageDescriptionInProgress}
                   pendingAttachments={pendingAttachments}
                   setPendingAttachments={setPendingAttachments}
                   conversations={conversations}
@@ -2856,6 +2857,7 @@ export function ChatPage(props: {
   composerError: string | null;
   setComposerError: React.Dispatch<React.SetStateAction<string | null>>;
   attachmentSendIssue: string | null;
+  imageDescriptionInProgress: boolean;
   pendingAttachments: ChatAttachment[];
   setPendingAttachments: React.Dispatch<React.SetStateAction<ChatAttachment[]>>;
   conversations: ChatConversation[];
@@ -2897,6 +2899,7 @@ export function ChatPage(props: {
     composerError,
     setComposerError,
     attachmentSendIssue,
+    imageDescriptionInProgress,
     pendingAttachments,
     setPendingAttachments,
     conversations,
@@ -3832,7 +3835,12 @@ export function ChatPage(props: {
                   )}
                 </div>
               ) : null}
-              {composerError || attachmentSendIssue ? (
+              {imageDescriptionInProgress && !composerError ? (
+                <div className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
+                  <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
+                  <span>Analyzing image with local vision model… (first time downloads ~230 MB)</span>
+                </div>
+              ) : composerError || attachmentSendIssue ? (
                 <Alert variant="destructive" data-testid="composer-error">
                   <AlertTitle>Attachment Issue</AlertTitle>
                   <AlertDescription>

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -2956,18 +2956,26 @@ export function ChatPage(props: {
     setComposerError(null);
   }
 
-  /** Check if any warm model in the mesh has vision support. */
-  function hasWarmVisionModel(): boolean {
-    return warmModels.some((m) => meshModelByName[m]?.vision);
+  /**
+   * Check if the image will be sent to a vision-capable model.
+   * True when the selected model has vision, or auto mode and a warm
+   * vision model exists.
+   */
+  function willUseVisionModel(): boolean {
+    if (selectedModelVision) return true;
+    if (!selectedModel || selectedModel === "auto") {
+      return warmModels.some((m) => meshModelByName[m]?.vision);
+    }
+    return false;
   }
 
   /**
    * Add an image attachment, then auto-describe it via a browser-local
-   * vision model if no warm vision model is available in the mesh.
+   * vision model if the image won't be handled by a real vision model.
    */
   function addImageAttachment(attachment: Omit<ChatAttachment, "id" | "status" | "error">) {
     const attachmentId = randomId();
-    const needsDescription = !hasWarmVisionModel() && canRunBrowserVision();
+    const needsDescription = !willUseVisionModel() && canRunBrowserVision();
     setPendingAttachments((prev) => [
       ...prev,
       {

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1066,17 +1066,31 @@ export function App() {
         if (attachment.renderedPageImages?.length) kinds.add("image");
         continue;
       }
-      // Images with a browser-generated description will be sent as
-      // input_text — no vision model needed.
-      if (attachment.kind === "image" && attachment.imageDescription) {
+      // Images with a browser-generated description (or one in progress)
+      // will be sent as input_text — no vision model needed.
+      if (
+        attachment.kind === "image" &&
+        (attachment.imageDescription || attachment.status === "uploading")
+      ) {
         continue;
       }
       kinds.add(attachment.kind);
     }
     return kinds;
   }, [pendingAttachments]);
+  const imageDescriptionInProgress = useMemo(
+    () =>
+      pendingAttachments.some(
+        (a) =>
+          a.kind === "image" &&
+          a.status === "uploading" &&
+          !a.imageDescription,
+      ),
+    [pendingAttachments],
+  );
   const attachmentSendIssue = useMemo(() => {
     if (!pendingAttachments.length || !status) return null;
+    if (imageDescriptionInProgress) return "Describing image...";
     return getAttachmentSendIssue({
       pendingKinds,
       selectedModel,

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -127,6 +127,12 @@ import {
   getAttachmentSendIssue,
   validateAttachmentFile,
 } from "./lib/attachments";
+import {
+  dataUrlToArrayBuffer,
+  extractPdfText,
+  isPdfMimeType,
+  renderPdfPagesToImages,
+} from "./lib/pdf";
 import { createRafBatcher } from "./lib/streaming";
 import { cn } from "./lib/utils";
 import {
@@ -374,6 +380,12 @@ type ChatAttachment = {
   fileName?: string;
   status?: ChatAttachmentStatus;
   error?: string;
+  /** Extracted text from a PDF (populated at attach time). */
+  extractedText?: string;
+  /** Summary for the attachment preview (e.g. "12 pages, 4,230 words"). */
+  extractionSummary?: string;
+  /** Page images rendered from a scanned PDF (data URLs). */
+  renderedPageImages?: string[];
 };
 
 type ChatMessage = {
@@ -1038,10 +1050,20 @@ export function App() {
     if (selectedModel) return multimodalModels.has(selectedModel);
     return meshModels.some((m) => m.status === "warm" && m.multimodal);
   }, [meshModels, multimodalModels, selectedModel]);
-  const pendingKinds = useMemo(
-    () => new Set(pendingAttachments.map((attachment) => attachment.kind)),
-    [pendingAttachments],
-  );
+  const pendingKinds = useMemo(() => {
+    const kinds = new Set<"image" | "audio" | "file">();
+    for (const attachment of pendingAttachments) {
+      // PDFs with extracted text or rendered page images don't need
+      // model multimodal support — they'll be sent as input_text or
+      // input_image blocks, not input_file.
+      if (attachment.extractedText || attachment.renderedPageImages?.length) {
+        if (attachment.renderedPageImages?.length) kinds.add("image");
+        continue;
+      }
+      kinds.add(attachment.kind);
+    }
+    return kinds;
+  }, [pendingAttachments]);
   const attachmentSendIssue = useMemo(() => {
     if (!pendingAttachments.length || !status) return null;
     return getAttachmentSendIssue({
@@ -1437,6 +1459,41 @@ export function App() {
   ) {
     const contentBlocks: Array<Record<string, unknown>> = [];
     for (const attachment of attachments) {
+      // PDF with extracted text → inject as input_text (no upload needed).
+      if (attachment.extractedText) {
+        const label = attachment.fileName
+          ? `[Content from ${attachment.fileName}]`
+          : "[Extracted PDF content]";
+        contentBlocks.push({
+          type: "input_text",
+          text: `${label}\n\n${attachment.extractedText}`,
+        });
+        continue;
+      }
+
+      // Scanned PDF rendered as images → inject each page as input_image.
+      if (attachment.renderedPageImages?.length) {
+        for (const pageDataUrl of attachment.renderedPageImages) {
+          onStatusChange?.(attachment.id, {
+            status: "uploading",
+            error: undefined,
+          });
+          const upload = await uploadRequestObject({
+            requestId,
+            dataUrl: pageDataUrl,
+            fileName: attachment.fileName,
+          });
+          const url = `mesh://blob/${clientId}/${upload.token}`;
+          contentBlocks.push({ type: "input_image", image_url: url });
+        }
+        onStatusChange?.(attachment.id, {
+          status: "pending",
+          error: undefined,
+        });
+        continue;
+      }
+
+      // Regular attachment (image, audio, non-PDF file).
       onStatusChange?.(attachment.id, { status: "uploading", error: undefined });
       try {
         const upload = await uploadRequestObject({
@@ -1785,7 +1842,16 @@ export function App() {
       model,
       attachments:
         pendingAttachments.length > 0
-          ? pendingAttachments.map(({ status, error, ...attachment }) => attachment)
+          ? pendingAttachments.map(
+              ({
+                status,
+                error,
+                extractedText,
+                extractionSummary,
+                renderedPageImages,
+                ...attachment
+              }) => attachment,
+            )
           : undefined,
     };
     const requestId = randomId();
@@ -2815,6 +2881,7 @@ export function ChatPage(props: {
   const imageInputRef = useRef<HTMLInputElement | null>(null);
   const audioInputRef = useRef<HTMLInputElement | null>(null);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const pdfInputRef = useRef<HTMLInputElement | null>(null);
 
   function markPendingAttachment(
     attachmentId: string,
@@ -2936,6 +3003,7 @@ export function ChatPage(props: {
   function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (!file) return;
+    const mimeType = file.type || "application/octet-stream";
     const validationError = validateAttachmentFile(file, "file");
     if (validationError) {
       setComposerError(validationError);
@@ -2945,18 +3013,110 @@ export function ChatPage(props: {
     const reader = new FileReader();
     reader.onload = () => {
       const dataUrl = reader.result as string;
-      addPendingAttachment({
-        kind: "file",
-        dataUrl,
-        mimeType:
-          file.type ||
-          parseDataUrl(dataUrl)?.mimeType ||
-          "application/octet-stream",
-        fileName: file.name,
-      });
+      if (isPdfMimeType(mimeType)) {
+        handlePdfAttachment(dataUrl, file.name);
+      } else {
+        addPendingAttachment({
+          kind: "file",
+          dataUrl,
+          mimeType:
+            parseDataUrl(dataUrl)?.mimeType || mimeType,
+          fileName: file.name,
+        });
+      }
     };
     reader.readAsDataURL(file);
     e.target.value = "";
+  }
+
+  async function handlePdfAttachment(dataUrl: string, fileName: string) {
+    // Add a placeholder attachment immediately so the user sees progress.
+    const attachmentId = randomId();
+    setPendingAttachments((prev) => [
+      ...prev,
+      {
+        id: attachmentId,
+        kind: "file",
+        dataUrl,
+        mimeType: "application/pdf",
+        fileName,
+        status: "uploading",
+        extractionSummary: "Extracting text...",
+      },
+    ]);
+
+    try {
+      const buffer = dataUrlToArrayBuffer(dataUrl);
+      const result = await extractPdfText(buffer);
+
+      if (result.pagesWithText > 0 && result.wordCount > 20) {
+        // Extracted meaningful text — store it for injection at send time.
+        const summary = `${result.pageCount} page${result.pageCount !== 1 ? "s" : ""}, ~${result.wordCount.toLocaleString()} words extracted`;
+        setPendingAttachments((prev) =>
+          prev.map((a) =>
+            a.id === attachmentId
+              ? {
+                  ...a,
+                  status: "pending",
+                  extractedText: result.text,
+                  extractionSummary: summary,
+                }
+              : a,
+          ),
+        );
+      } else {
+        // Scanned PDF or negligible text — try rendering pages as images.
+        const hasVisionModel =
+          warmModels.some((m) => meshModelByName[m]?.vision) ||
+          Object.values(meshModelByName).some((m) => m.vision);
+        if (hasVisionModel) {
+          const images = await renderPdfPagesToImages(buffer, {
+            maxPages: 8,
+          });
+          if (images.length > 0) {
+            const summary = `${result.pageCount} page${result.pageCount !== 1 ? "s" : ""}, rendered as ${images.length} image${images.length !== 1 ? "s" : ""} (scanned PDF)`;
+            setPendingAttachments((prev) =>
+              prev.map((a) =>
+                a.id === attachmentId
+                  ? {
+                      ...a,
+                      status: "pending",
+                      renderedPageImages: images,
+                      extractionSummary: summary,
+                    }
+                  : a,
+              ),
+            );
+          } else {
+            throw new Error("Could not render PDF pages");
+          }
+        } else {
+          // No vision model and no text — can't do much.
+          setPendingAttachments((prev) =>
+            prev.map((a) =>
+              a.id === attachmentId
+                ? {
+                    ...a,
+                    status: "failed",
+                    error:
+                      "This PDF appears to be scanned (no text content). A vision model is needed to read it.",
+                    extractionSummary: "No text found",
+                  }
+                : a,
+            ),
+          );
+        }
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setPendingAttachments((prev) =>
+        prev.map((a) =>
+          a.id === attachmentId
+            ? { ...a, status: "failed", error: `PDF extraction failed: ${message}` }
+            : a,
+        ),
+      );
+    }
   }
 
   useEffect(() => {
@@ -3497,25 +3657,33 @@ export function ChatPage(props: {
                         ) : (
                           <File className="h-4 w-4 shrink-0 text-muted-foreground" />
                         )}
-                        <span className="truncate">
-                          {attachment.fileName ||
-                            (attachment.kind === "audio"
-                              ? "Audio attachment"
-                              : "File attachment")}
-                        </span>
+                        <div className="min-w-0 flex flex-col">
+                          <span className="truncate">
+                            {attachment.fileName ||
+                              (attachment.kind === "audio"
+                                ? "Audio attachment"
+                                : "File attachment")}
+                          </span>
+                          {attachment.extractionSummary ? (
+                            <span className="text-xs text-muted-foreground truncate">
+                              {attachment.extractionSummary}
+                            </span>
+                          ) : null}
+                        </div>
                         {attachment.status === "uploading" ? (
                           <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                         ) : null}
                         {attachment.status === "failed" ? (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs"
-                            onClick={() => resetAttachmentStatus(attachment.id)}
-                          >
-                            Retry
-                          </Button>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <span className="text-xs text-destructive cursor-help">
+                                Failed
+                              </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="max-w-xs">
+                              {attachment.error || "Upload failed"}
+                            </TooltipContent>
+                          </Tooltip>
                         ) : null}
                         <button
                           onClick={() => removePendingAttachment(attachment.id)}
@@ -3571,6 +3739,25 @@ export function ChatPage(props: {
                     : "Enter to send. Shift+Enter for newline."}
                 </div>
                 <div className="flex items-center gap-2">
+                  <input
+                    ref={pdfInputRef}
+                    type="file"
+                    accept="application/pdf"
+                    className="hidden"
+                    data-testid="chat-pdf-input"
+                    onChange={handleFileSelect}
+                  />
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    onClick={() => pdfInputRef.current?.click()}
+                    disabled={!props.canChat || isSending}
+                    title="Attach PDF"
+                    aria-label="Attach PDF"
+                  >
+                    <File className="h-4 w-4" />
+                  </Button>
                   {selectedModelVision && (
                     <>
                       <input

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -674,6 +674,21 @@ function sanitizeAttachment(raw: unknown): ChatAttachment | null {
         ? item.status
         : undefined,
     error: typeof item.error === "string" ? item.error : undefined,
+    extractedText:
+      typeof item.extractedText === "string" ? item.extractedText : undefined,
+    extractionSummary:
+      typeof item.extractionSummary === "string"
+        ? item.extractionSummary
+        : undefined,
+    renderedPageImages:
+      Array.isArray(item.renderedPageImages) &&
+      item.renderedPageImages.every((v) => typeof v === "string")
+        ? (item.renderedPageImages as string[])
+        : undefined,
+    imageDescription:
+      typeof item.imageDescription === "string"
+        ? item.imageDescription
+        : undefined,
   };
 }
 
@@ -1876,17 +1891,7 @@ export function App() {
       model,
       attachments:
         pendingAttachments.length > 0
-          ? pendingAttachments.map(
-              ({
-                status,
-                error,
-                extractedText,
-                extractionSummary,
-                renderedPageImages,
-                imageDescription,
-                ...attachment
-              }) => attachment,
-            )
+          ? pendingAttachments.map(({ status, error, ...attachment }) => attachment)
           : undefined,
     };
     const requestId = randomId();
@@ -3117,7 +3122,13 @@ export function ChatPage(props: {
     const reader = new FileReader();
     reader.onload = () => {
       const dataUrl = reader.result as string;
-      if (isPdfMimeType(mimeType)) {
+      // Detect PDFs by MIME type, data URL content type, or file extension —
+      // file.type can be empty in some browsers/OSes for PDF files.
+      const detectedMime = parseDataUrl(dataUrl)?.mimeType ?? mimeType;
+      const isPdf =
+        isPdfMimeType(detectedMime) ||
+        file.name.toLowerCase().endsWith(".pdf");
+      if (isPdf) {
         handlePdfAttachment(dataUrl, file.name);
       } else {
         addPendingAttachment({

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1833,6 +1833,23 @@ export function App() {
 
     // Prefer an explicitly compatible model when sending media with model=auto.
     let model = selectedModel || status.model_name;
+    const isAuto = !model || model === "auto";
+    if (isAuto) {
+      // If this conversation already used a vision model (because images
+      // were sent), stick with that model for continuity — don't let auto
+      // bounce to a text-only model that can't see the earlier images.
+      const existingMessages = activeConversation?.messages ?? [];
+      const priorVisionModel = existingMessages.find(
+        (m) =>
+          m.role === "assistant" &&
+          m.model &&
+          visionModels.has(m.model) &&
+          warmModels.includes(m.model),
+      )?.model;
+      if (priorVisionModel) {
+        model = priorVisionModel;
+      }
+    }
     if (pendingAttachments.length > 0 && (!model || model === "auto")) {
       const multimodalModel = warmModels.find(
         (m) =>

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1740,11 +1740,13 @@ export function App() {
     if ((!trimmed && pendingAttachments.length === 0) || !status)
       return;
     if (isSending) {
+      // Interrupt the current stream and slot this message in immediately.
+      // The abort handler sets isSending=false, which triggers the drain
+      // effect to pick up the queued message.
       queuedInputRef.current = trimmed;
-      // For attachment-only sends trimmed is ""; show a placeholder so the
-      // queued-message UI indicator is visible.
       setQueuedText(trimmed || "📎 Attachment");
       setInput("");
+      currentAbortRef.current?.abort();
       return;
     }
     if (attachmentSendIssue) {
@@ -3410,10 +3412,19 @@ export function ChatPage(props: {
                   ))}
 
                   {isSending ? (
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" /> Streaming
-                      response...
-                    </div>
+                    <button
+                      type="button"
+                      onClick={onStop}
+                      className="group flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+                      title="Click to stop (Esc)"
+                    >
+                      <Loader2 className="h-3.5 w-3.5 animate-spin group-hover:hidden" />
+                      <Square className="hidden h-3.5 w-3.5 group-hover:block" />
+                      <span>
+                        <span className="group-hover:hidden">Streaming response...</span>
+                        <span className="hidden group-hover:inline">Stop generating</span>
+                      </span>
+                    </button>
                   ) : null}
 
                   {queuedText ? (
@@ -3538,6 +3549,10 @@ export function ChatPage(props: {
                     e.preventDefault();
                     onSubmit();
                   }
+                  if (e.key === "Escape" && isSending) {
+                    e.preventDefault();
+                    onStop();
+                  }
                 }}
                 data-testid="chat-input"
                 rows={2}
@@ -3551,7 +3566,9 @@ export function ChatPage(props: {
               />
               <div className="flex items-center justify-between gap-2">
                 <div className="hidden md:block text-xs text-muted-foreground">
-                  Enter to send. Shift+Enter for newline.
+                  {isSending
+                    ? "Esc to stop. Enter to interrupt and send."
+                    : "Enter to send. Shift+Enter for newline."}
                 </div>
                 <div className="flex items-center gap-2">
                   {selectedModelVision && (
@@ -3625,12 +3642,13 @@ export function ChatPage(props: {
                   {isSending ? (
                     <Button
                       type="button"
-                      variant="outline"
-                      size="icon"
+                      variant="destructive"
                       onClick={onStop}
-                      aria-label="Stop"
+                      aria-label="Stop generating"
+                      className="gap-1.5"
                     >
                       <Square className="h-3.5 w-3.5" />
+                      <span className="hidden sm:inline">Stop</span>
                     </Button>
                   ) : (
                     <Button

--- a/mesh-llm/ui/src/lib/attachments.test.ts
+++ b/mesh-llm/ui/src/lib/attachments.test.ts
@@ -58,7 +58,7 @@ describe("getAttachmentSendIssue", () => {
         multimodalModels: new Set(["vision-only"]),
       }),
     ).toBe(
-      "Selected model does not support the attached media. Choose a compatible model or remove the attachment.",
+      "vision-only doesn't support audio. Choose an audio-capable model or remove the attachment.",
     );
   });
 

--- a/mesh-llm/ui/src/lib/attachments.ts
+++ b/mesh-llm/ui/src/lib/attachments.ts
@@ -10,6 +10,9 @@ type FileLike = {
 };
 
 type AttachmentSupportOptions = {
+  /** The *effective* media kinds that still need model support.
+   *  PDFs with extracted text should NOT be included here since
+   *  they will be sent as input_text, not input_file. */
   pendingKinds: ReadonlySet<AttachmentKind>;
   selectedModel: string;
   warmModels: readonly string[];
@@ -65,12 +68,30 @@ export function getAttachmentSendIssue({
     (!pendingKinds.has("file") || multimodalModels.has(modelName));
 
   if (selectedModel && selectedModel !== "auto") {
-    return modelSupports(selectedModel)
-      ? null
-      : "Selected model does not support the attached media. Choose a compatible model or remove the attachment.";
+    if (modelSupports(selectedModel)) return null;
+
+    // Provide a specific hint depending on what's missing.
+    if (pendingKinds.has("image") && !visionModels.has(selectedModel)) {
+      const warmVision = warmModels.filter((m) => visionModels.has(m));
+      if (warmVision.length > 0) {
+        return `${selectedModel} doesn't support images. Switch to ${warmVision[0]} or set model to Auto.`;
+      }
+      return `${selectedModel} doesn't support images. Switch to a vision model (e.g. Qwen2-VL, LLaVA) or set model to Auto.`;
+    }
+    if (pendingKinds.has("audio") && !audioModels.has(selectedModel)) {
+      return `${selectedModel} doesn't support audio. Choose an audio-capable model or remove the attachment.`;
+    }
+    return "Selected model does not support the attached media. Choose a compatible model or remove the attachment.";
   }
 
-  return warmModels.some(modelSupports)
-    ? null
-    : "No warm model supports the attached media. Warm a compatible model or remove the attachment.";
+  if (warmModels.some(modelSupports)) return null;
+
+  // Auto mode but no warm model supports it.
+  if (pendingKinds.has("image")) {
+    return "No warm model supports images. Warm a vision model (e.g. Qwen2-VL, LLaVA) to use image attachments.";
+  }
+  if (pendingKinds.has("audio")) {
+    return "No warm model supports audio input. Warm an audio-capable model to use audio attachments.";
+  }
+  return "No warm model supports the attached media. Warm a compatible model or remove the attachment.";
 }

--- a/mesh-llm/ui/src/lib/image-describe.ts
+++ b/mesh-llm/ui/src/lib/image-describe.ts
@@ -1,0 +1,145 @@
+/**
+ * Browser-side image description via Transformers.js + Florence-2.
+ *
+ * Lazy-loads the library from CDN on first use — zero bundle cost.
+ * The model (~230MB quantized) is fetched from Hugging Face and cached
+ * in the browser's Cache API / IndexedDB for instant subsequent loads.
+ *
+ * Used as a fallback when the user attaches an image but no vision
+ * model is warm in the mesh — we describe the image locally and inject
+ * the description as text so any text model can reason about it.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const TRANSFORMERS_CDN =
+  "https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.8.1";
+
+const MODEL_ID = "onnx-community/Florence-2-base-ft";
+
+let pipelineCache: any | null = null;
+let loadingPromise: Promise<any> | null = null;
+
+/**
+ * Load transformers.js and initialize the Florence-2 pipeline.
+ * Subsequent calls return the cached pipeline instantly.
+ */
+async function getDescriptionPipeline(): Promise<any> {
+  if (pipelineCache) return pipelineCache;
+  if (loadingPromise) return loadingPromise;
+
+  loadingPromise = (async () => {
+    try {
+      const { Florence2ForConditionalGeneration, AutoProcessor, AutoTokenizer, RawImage } =
+        await import(/* @vite-ignore */ TRANSFORMERS_CDN);
+
+      const [model, processor, tokenizer] = await Promise.all([
+        Florence2ForConditionalGeneration.from_pretrained(MODEL_ID, {
+          dtype: "fp32",
+          device: "wasm",
+        }),
+        AutoProcessor.from_pretrained(MODEL_ID),
+        AutoTokenizer.from_pretrained(MODEL_ID),
+      ]);
+
+      pipelineCache = { model, processor, tokenizer, RawImage };
+      return pipelineCache;
+    } catch (err) {
+      loadingPromise = null;
+      throw err;
+    }
+  })();
+
+  return loadingPromise;
+}
+
+export type ImageDescriptionResult = {
+  /** Detailed description of the image. */
+  description: string;
+  /** Any text/OCR content found in the image. */
+  ocrText: string | null;
+  /** Combined text for injection into the LLM context. */
+  combinedText: string;
+};
+
+/**
+ * Describe an image using Florence-2 running locally in the browser.
+ *
+ * @param imageSource - A data URL, blob URL, or HTMLImageElement.
+ * @param onProgress - Optional callback for loading progress messages.
+ * @returns Description and OCR text extracted from the image.
+ */
+export async function describeImage(
+  imageSource: string,
+  onProgress?: (message: string) => void,
+): Promise<ImageDescriptionResult> {
+  onProgress?.("Loading vision model...");
+  const { model, processor, tokenizer, RawImage } = await getDescriptionPipeline();
+  onProgress?.("Analyzing image...");
+
+  const image = await RawImage.fromURL(imageSource);
+
+  // Run detailed captioning.
+  const captionPrompt = "<MORE_DETAILED_CAPTION>";
+  const captionInputs = await processor(image, captionPrompt);
+  const captionIds = await model.generate({
+    ...captionInputs,
+    max_new_tokens: 256,
+  });
+  // Slice off the prompt tokens from the generated output.
+  const captionGenerated = captionIds.slice(
+    null,
+    [captionInputs.input_ids.dims.at(-1), null],
+  );
+  const description = tokenizer
+    .batch_decode(captionGenerated, { skip_special_tokens: true })[0]
+    ?.trim() ?? "";
+
+  // Run OCR to extract any text in the image.
+  let ocrText: string | null = null;
+  try {
+    const ocrPrompt = "<OCR>";
+    const ocrInputs = await processor(image, ocrPrompt);
+    const ocrIds = await model.generate({
+      ...ocrInputs,
+      max_new_tokens: 256,
+    });
+    const ocrGenerated = ocrIds.slice(
+      null,
+      [ocrInputs.input_ids.dims.at(-1), null],
+    );
+    const raw = tokenizer
+      .batch_decode(ocrGenerated, { skip_special_tokens: true })[0]
+      ?.trim() ?? "";
+    if (raw.length > 3) ocrText = raw;
+  } catch {
+    // OCR is best-effort.
+  }
+
+  // Build the combined text for LLM injection.
+  const parts: string[] = [];
+  if (description) {
+    parts.push(`[Image description: ${description}]`);
+  }
+  if (ocrText) {
+    parts.push(`[Text visible in image: ${ocrText}]`);
+  }
+  const combinedText = parts.join("\n") || "[Unable to describe image]";
+
+  return { description, ocrText, combinedText };
+}
+
+/**
+ * Check if the browser can run the vision model.
+ * Requires WebAssembly at minimum.
+ */
+export function canRunBrowserVision(): boolean {
+  return typeof WebAssembly !== "undefined";
+}
+
+/**
+ * Check if the model has been loaded (cached) previously.
+ */
+export function isModelLoaded(): boolean {
+  return pipelineCache != null;
+}

--- a/mesh-llm/ui/src/lib/image-describe.ts
+++ b/mesh-llm/ui/src/lib/image-describe.ts
@@ -1,9 +1,10 @@
 /**
  * Browser-side image description via Transformers.js + Florence-2.
  *
- * Lazy-loads the library from CDN on first use — zero bundle cost.
- * The model (~230MB quantized) is fetched from Hugging Face and cached
- * in the browser's Cache API / IndexedDB for instant subsequent loads.
+ * Lazy-loads the library from the app bundle on first use — zero bundle cost
+ * until the feature is actually used. The model (~230MB quantized) is fetched
+ * from Hugging Face and cached in the browser's Cache API / IndexedDB for
+ * instant subsequent loads.
  *
  * Used as a fallback when the user attaches an image but no vision
  * model is warm in the mesh — we describe the image locally and inject
@@ -12,13 +13,10 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-const TRANSFORMERS_CDN =
-  "https://cdn.jsdelivr.net/npm/@huggingface/transformers@3.8.1";
-
-const MODEL_ID = "onnx-community/Florence-2-base-ft";
-
 let pipelineCache: any | null = null;
 let loadingPromise: Promise<any> | null = null;
+
+const MODEL_ID = "onnx-community/Florence-2-base-ft";
 
 /**
  * Load transformers.js and initialize the Florence-2 pipeline.
@@ -31,7 +29,7 @@ async function getDescriptionPipeline(): Promise<any> {
   loadingPromise = (async () => {
     try {
       const { Florence2ForConditionalGeneration, AutoProcessor, AutoTokenizer, RawImage } =
-        await import(/* @vite-ignore */ TRANSFORMERS_CDN);
+        await import("@huggingface/transformers");
 
       const [model, processor, tokenizer] = await Promise.all([
         Florence2ForConditionalGeneration.from_pretrained(MODEL_ID, {

--- a/mesh-llm/ui/src/lib/pdf.ts
+++ b/mesh-llm/ui/src/lib/pdf.ts
@@ -1,0 +1,138 @@
+/**
+ * PDF text extraction via pdf.js, loaded lazily from CDN.
+ *
+ * Only fetched when a user actually attaches a PDF — zero bundle cost
+ * otherwise.  Falls back gracefully if the CDN is unreachable (offline,
+ * air-gapped network, etc.).
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const PDFJS_CDN =
+  "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.min.mjs";
+const PDFJS_WORKER_CDN =
+  "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.worker.min.mjs";
+
+let pdfjsLib: any | null = null;
+
+async function loadPdfJs(): Promise<any> {
+  if (pdfjsLib) return pdfjsLib;
+  try {
+    pdfjsLib = await import(/* @vite-ignore */ PDFJS_CDN);
+    pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_CDN;
+    return pdfjsLib;
+  } catch {
+    throw new Error(
+      "Could not load PDF.js. Check your network connection.",
+    );
+  }
+}
+
+export type PdfExtractionResult = {
+  /** Concatenated text across all pages. */
+  text: string;
+  /** Number of pages in the PDF. */
+  pageCount: number;
+  /** Number of pages that yielded meaningful text. */
+  pagesWithText: number;
+  /** Approximate word count. */
+  wordCount: number;
+};
+
+/**
+ * Extract text from a PDF provided as an ArrayBuffer.
+ *
+ * Uses pdf.js to read every page's text content and concatenates it with
+ * page markers so the LLM can reference "page N".
+ */
+export async function extractPdfText(
+  buffer: ArrayBuffer,
+): Promise<PdfExtractionResult> {
+  const lib = await loadPdfJs();
+  const doc = await lib.getDocument({ data: new Uint8Array(buffer) }).promise;
+  const pageCount: number = doc.numPages;
+
+  const pages: string[] = [];
+  let pagesWithText = 0;
+
+  for (let i = 1; i <= pageCount; i++) {
+    const page = await doc.getPage(i);
+    const content = await page.getTextContent();
+    const items: Array<{ str: string; hasEOL?: boolean }> = content.items;
+
+    // Join text items, respecting line breaks the PDF declares.
+    let pageText = "";
+    for (const item of items) {
+      pageText += item.str;
+      if (item.hasEOL) pageText += "\n";
+    }
+
+    const trimmed = pageText.trim();
+    if (trimmed.length > 0) {
+      pagesWithText++;
+      pages.push(`--- Page ${i} ---\n${trimmed}`);
+    }
+  }
+
+  const text = pages.join("\n\n");
+  const wordCount = text.split(/\s+/).filter(Boolean).length;
+
+  return { text, pageCount, pagesWithText, wordCount };
+}
+
+/**
+ * Render PDF pages as JPEG images.
+ *
+ * Useful for scanned PDFs that have no extractable text — if a vision
+ * model is available we can send the pages as images instead.
+ *
+ * Returns an array of data URLs (image/jpeg), one per page.
+ */
+export async function renderPdfPagesToImages(
+  buffer: ArrayBuffer,
+  opts?: { maxPages?: number; scale?: number; quality?: number },
+): Promise<string[]> {
+  const lib = await loadPdfJs();
+  const doc = await lib.getDocument({ data: new Uint8Array(buffer) }).promise;
+  const pageCount: number = doc.numPages;
+  const maxPages = opts?.maxPages ?? 10;
+  const scale = opts?.scale ?? 1.5; // ~150 DPI for typical PDFs
+  const quality = opts?.quality ?? 0.85;
+
+  const images: string[] = [];
+
+  for (let i = 1; i <= Math.min(pageCount, maxPages); i++) {
+    const page = await doc.getPage(i);
+    const viewport = page.getViewport({ scale });
+    const canvas = document.createElement("canvas");
+    canvas.width = viewport.width;
+    canvas.height = viewport.height;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) continue;
+    await page.render({ canvasContext: ctx, viewport }).promise;
+    images.push(canvas.toDataURL("image/jpeg", quality));
+  }
+
+  return images;
+}
+
+/**
+ * True if the given MIME type is a PDF.
+ */
+export function isPdfMimeType(mimeType: string): boolean {
+  return mimeType === "application/pdf" || mimeType === "application/x-pdf";
+}
+
+/**
+ * Convert a data URL to an ArrayBuffer.
+ */
+export function dataUrlToArrayBuffer(dataUrl: string): ArrayBuffer {
+  const base64 = dataUrl.split(",")[1];
+  if (!base64) throw new Error("Invalid data URL");
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}

--- a/mesh-llm/ui/src/lib/pdf.ts
+++ b/mesh-llm/ui/src/lib/pdf.ts
@@ -117,14 +117,18 @@ export async function renderPdfPagesToImages(
 
     for (let i = 1; i <= Math.min(pageCount, maxPages); i++) {
       const page = await doc.getPage(i);
-      const viewport = page.getViewport({ scale });
-      const canvas = document.createElement("canvas");
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-      const ctx = canvas.getContext("2d");
-      if (!ctx) continue;
-      await page.render({ canvasContext: ctx, viewport }).promise;
-      images.push(canvas.toDataURL("image/jpeg", quality));
+      try {
+        const viewport = page.getViewport({ scale });
+        const canvas = document.createElement("canvas");
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) continue;
+        await page.render({ canvasContext: ctx, viewport }).promise;
+        images.push(canvas.toDataURL("image/jpeg", quality));
+      } finally {
+        page.cleanup();
+      }
     }
 
     return images;

--- a/mesh-llm/ui/src/lib/pdf.ts
+++ b/mesh-llm/ui/src/lib/pdf.ts
@@ -1,29 +1,25 @@
 /**
- * PDF text extraction via pdf.js, loaded lazily from CDN.
+ * PDF text extraction via pdf.js, loaded lazily from the app bundle.
  *
- * Only fetched when a user actually attaches a PDF — zero bundle cost
- * otherwise.  Falls back gracefully if the CDN is unreachable (offline,
- * air-gapped network, etc.).
+ * Only loaded when a user actually attaches a PDF, so initial bundle cost
+ * stays low while avoiding runtime execution of third-party CDN code.
  */
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-const PDFJS_CDN =
-  "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.min.mjs";
-const PDFJS_WORKER_CDN =
-  "https://cdn.jsdelivr.net/npm/pdfjs-dist@4.10.38/build/pdf.worker.min.mjs";
+import pdfjsWorkerSrc from "pdfjs-dist/build/pdf.worker.min.mjs?url";
 
 let pdfjsLib: any | null = null;
 
 async function loadPdfJs(): Promise<any> {
   if (pdfjsLib) return pdfjsLib;
   try {
-    pdfjsLib = await import(/* @vite-ignore */ PDFJS_CDN);
-    pdfjsLib.GlobalWorkerOptions.workerSrc = PDFJS_WORKER_CDN;
+    pdfjsLib = await import("pdfjs-dist");
+    pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorkerSrc;
     return pdfjsLib;
   } catch {
     throw new Error(
-      "Could not load PDF.js. Check your network connection.",
+      "Could not load PDF.js. Check that the application assets are available.",
     );
   }
 }
@@ -49,35 +45,51 @@ export async function extractPdfText(
   buffer: ArrayBuffer,
 ): Promise<PdfExtractionResult> {
   const lib = await loadPdfJs();
-  const doc = await lib.getDocument({ data: new Uint8Array(buffer) }).promise;
-  const pageCount: number = doc.numPages;
+  let doc: any | null = null;
 
-  const pages: string[] = [];
-  let pagesWithText = 0;
+  try {
+    doc = await lib.getDocument({ data: new Uint8Array(buffer) }).promise;
+    const pageCount: number = doc.numPages;
 
-  for (let i = 1; i <= pageCount; i++) {
-    const page = await doc.getPage(i);
-    const content = await page.getTextContent();
-    const items: Array<{ str: string; hasEOL?: boolean }> = content.items;
+    const pages: string[] = [];
+    let pagesWithText = 0;
 
-    // Join text items, respecting line breaks the PDF declares.
-    let pageText = "";
-    for (const item of items) {
-      pageText += item.str;
-      if (item.hasEOL) pageText += "\n";
+    for (let i = 1; i <= pageCount; i++) {
+      const page = await doc.getPage(i);
+      try {
+        const content = await page.getTextContent();
+        const items = content.items;
+
+        // Join text items, respecting line breaks the PDF declares.
+        // Guard against non-text entries (e.g. marked-content items) that
+        // lack a `str` field.
+        let pageText = "";
+        for (const item of items) {
+          if (typeof (item as any).str === "string") {
+            pageText += (item as any).str;
+            if ((item as any).hasEOL) pageText += "\n";
+          }
+        }
+
+        const trimmed = pageText.trim();
+        if (trimmed.length > 0) {
+          pagesWithText++;
+          pages.push(`--- Page ${i} ---\n${trimmed}`);
+        }
+      } finally {
+        page.cleanup();
+      }
     }
 
-    const trimmed = pageText.trim();
-    if (trimmed.length > 0) {
-      pagesWithText++;
-      pages.push(`--- Page ${i} ---\n${trimmed}`);
+    const text = pages.join("\n\n");
+    const wordCount = text.split(/\s+/).filter(Boolean).length;
+
+    return { text, pageCount, pagesWithText, wordCount };
+  } finally {
+    if (doc) {
+      await doc.destroy();
     }
   }
-
-  const text = pages.join("\n\n");
-  const wordCount = text.split(/\s+/).filter(Boolean).length;
-
-  return { text, pageCount, pagesWithText, wordCount };
 }
 
 /**
@@ -94,26 +106,31 @@ export async function renderPdfPagesToImages(
 ): Promise<string[]> {
   const lib = await loadPdfJs();
   const doc = await lib.getDocument({ data: new Uint8Array(buffer) }).promise;
-  const pageCount: number = doc.numPages;
-  const maxPages = opts?.maxPages ?? 10;
-  const scale = opts?.scale ?? 1.5; // ~150 DPI for typical PDFs
-  const quality = opts?.quality ?? 0.85;
 
-  const images: string[] = [];
+  try {
+    const pageCount: number = doc.numPages;
+    const maxPages = opts?.maxPages ?? 10;
+    const scale = opts?.scale ?? 1.5; // ~150 DPI for typical PDFs
+    const quality = opts?.quality ?? 0.85;
 
-  for (let i = 1; i <= Math.min(pageCount, maxPages); i++) {
-    const page = await doc.getPage(i);
-    const viewport = page.getViewport({ scale });
-    const canvas = document.createElement("canvas");
-    canvas.width = viewport.width;
-    canvas.height = viewport.height;
-    const ctx = canvas.getContext("2d");
-    if (!ctx) continue;
-    await page.render({ canvasContext: ctx, viewport }).promise;
-    images.push(canvas.toDataURL("image/jpeg", quality));
+    const images: string[] = [];
+
+    for (let i = 1; i <= Math.min(pageCount, maxPages); i++) {
+      const page = await doc.getPage(i);
+      const viewport = page.getViewport({ scale });
+      const canvas = document.createElement("canvas");
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) continue;
+      await page.render({ canvasContext: ctx, viewport }).promise;
+      images.push(canvas.toDataURL("image/jpeg", quality));
+    }
+
+    return images;
+  } finally {
+    await doc.destroy();
   }
-
-  return images;
 }
 
 /**


### PR DESCRIPTION
Attach images and PDFs to any model in chat.

**Images** are described locally in the browser using Florence-2 (~230MB, lazy-loaded from HF CDN on first use). The description is injected as text so any text model can answer questions about images — no vision model needed. If you explicitly select a vision model, images are sent natively instead.

**PDFs** are converted to text client-side via pdf.js (lazy-loaded from CDN). Digital PDFs extract cleanly; scanned PDFs with no text render pages as images and describe them via Florence-2.

**Interrupt-on-queue** — sending a message while the model is streaming aborts the current generation and sends the new message immediately.

**Stop UX** — Escape key stops generation, streaming indicator is clickable (hover → 'Stop generating'), stop button uses destructive styling with label.

All changes are UI-only (React/TypeScript). No Rust changes. Zero bundle cost for PDF/image features until first use.

## Changes
- `mesh-llm/ui/src/lib/image-describe.ts` — new: Florence-2 via Transformers.js CDN
- `mesh-llm/ui/src/lib/pdf.ts` — new: pdf.js CDN text extraction + page rendering
- `mesh-llm/ui/src/App.tsx` — attachment flow, interrupt, stop UX
- `mesh-llm/ui/src/lib/attachments.ts` — model-specific error messages