### PR TITLE
models: add --json flag for machine-parseable catalog and inventory

### DIFF
--- a/mesh-llm/src/cli/commands/models.rs
+++ b/mesh-llm/src/cli/commands/models.rs
@@ -138,7 +138,36 @@ pub async fn run_model_search(
     Ok(())
 }
 
-pub fn run_model_recommended() {
+pub fn run_model_recommended(json: bool) {
+    if json {
+        let models: Vec<serde_json::Value> = catalog::MODEL_CATALOG
+            .iter()
+            .map(|model| {
+                let caps = capabilities::infer_catalog_capabilities(model);
+                serde_json::json!({
+                    "name": model.name,
+                    "file": model.file,
+                    "size": model.size,
+                    "description": model.description,
+                    "draft": model.draft,
+                    "moe": model.moe.is_some(),
+                    "capabilities": {
+                        "vision": caps.vision_status(),
+                        "audio": caps.audio_status(),
+                        "reasoning": caps.reasoning_status(),
+                        "tool_use": caps.tool_use_status(),
+                        "multimodal": caps.multimodal_status(),
+                    },
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({ "models": models })).unwrap()
+        );
+        return;
+    }
+
     println!("📚 Recommended models");
     println!();
     for model in catalog::MODEL_CATALOG.iter() {
@@ -164,8 +193,47 @@ pub fn run_model_recommended() {
     }
 }
 
-pub fn run_model_installed() {
+pub fn run_model_installed(json: bool) {
     let installed = scan_installed_models();
+
+    if json {
+        let models: Vec<serde_json::Value> = installed
+            .iter()
+            .map(|name| {
+                let path = crate::models::find_model_path(name);
+                let size_bytes = std::fs::metadata(&path).map(|meta| meta.len()).ok();
+                let catalog_model = find_catalog_model_exact(name);
+                let caps = installed_model_capabilities(name);
+                serde_json::json!({
+                    "name": name,
+                    "path": path.to_string_lossy(),
+                    "size_bytes": size_bytes,
+                    "size": size_bytes.map(format_installed_size),
+                    "in_catalog": catalog_model.is_some(),
+                    "description": catalog_model.map(|m| m.description.as_str()),
+                    "draft": catalog_model.and_then(|m| m.draft.as_deref()),
+                    "moe": catalog_model.map(|m| m.moe.is_some()).unwrap_or(false),
+                    "capabilities": {
+                        "vision": caps.vision_status(),
+                        "audio": caps.audio_status(),
+                        "reasoning": caps.reasoning_status(),
+                        "tool_use": caps.tool_use_status(),
+                        "multimodal": caps.multimodal_status(),
+                    },
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "cache_dir": huggingface_hub_cache_dir().to_string_lossy(),
+                "models": models,
+            }))
+            .unwrap()
+        );
+        return;
+    }
+
     if installed.is_empty() {
         println!("📦 No installed models found");
         println!("   HF cache: {}", huggingface_hub_cache_dir().display());
@@ -352,8 +420,10 @@ fn fit_hint_for_size_label(size_label: &str) -> Option<String> {
 
 pub async fn dispatch_models_command(command: &ModelsCommand) -> Result<()> {
     match command {
-        ModelsCommand::Recommended | ModelsCommand::List => run_model_recommended(),
-        ModelsCommand::Installed => run_model_installed(),
+        ModelsCommand::Recommended { json } | ModelsCommand::List { json } => {
+            run_model_recommended(*json)
+        }
+        ModelsCommand::Installed { json } => run_model_installed(*json),
         ModelsCommand::Search {
             query,
             gguf,

--- a/mesh-llm/src/cli/models.rs
+++ b/mesh-llm/src/cli/models.rs
@@ -3,12 +3,24 @@ use clap::Subcommand;
 #[derive(Subcommand, Debug)]
 pub enum ModelsCommand {
     /// List built-in recommended models.
-    Recommended,
+    Recommended {
+        /// Output as JSON for machine consumption.
+        #[arg(long)]
+        json: bool,
+    },
     /// List installed local models from the HF cache.
-    Installed,
+    Installed {
+        /// Output as JSON for machine consumption.
+        #[arg(long)]
+        json: bool,
+    },
     /// List built-in catalog models.
     #[command(hide = true)]
-    List,
+    List {
+        /// Output as JSON for machine consumption.
+        #[arg(long)]
+        json: bool,
+    },
     /// Search for catalog models and downloadable GGUF/MLX artifacts on Hugging Face.
     Search {
         /// Search terms.

--- a/mesh-llm/src/models/catalog.rs
+++ b/mesh-llm/src/models/catalog.rs
@@ -15,13 +15,13 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncWriteExt;
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, serde::Serialize)]
 pub struct CatalogAsset {
     pub file: String,
     pub url: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct CatalogModel {
     pub name: String,
     pub file: String,
@@ -60,7 +60,7 @@ impl CatalogModel {
 
 /// Pre-computed MoE expert sharding configuration for a model.
 /// Derived from router gate mass analysis — determines which experts go where.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize)]
 pub struct MoeConfig {
     /// Total number of experts in the model
     pub n_expert: u32,


### PR DESCRIPTION
`mesh-llm models recommended` and `mesh-llm models installed` now accept `--json` to output structured JSON instead of human-readable text. This lets scripts and tools consume the model catalog and local inventory without needing a running mesh instance.

```bash
# List all recommended models as JSON
mesh-llm models recommended --json

# Filter installed models with jq
mesh-llm models installed --json | jq ".models[] | {name, size, in_catalog}"
```

### `recommended --json` output

```json
{
  "models": [
    {
      "name": "Qwen3-8B-Q4_K_M",
      "file": "Qwen3-8B-Q4_K_M.gguf",
      "size": "5.0GB",
      "description": "Qwen3 mid-tier, strong for its size",
      "draft": "Qwen3-0.6B-Q4_K_M",
      "moe": false,
      "capabilities": {
        "vision": "none",
        "audio": "none",
        "reasoning": "supported",
        "tool_use": "none",
        "multimodal": "none"
      }
    }
  ]
}
```

### `installed --json` output

Adds `path`, `size_bytes`, and `in_catalog`:

```json
{
  "cache_dir": "/Users/.../.cache/huggingface/hub",
  "models": [
    {
      "name": "Qwen3-8B-Q4_K_M",
      "path": "/Users/.../.cache/.../Qwen3-8B-Q4_K_M.gguf",
      "size_bytes": 4998131424,
      "size": "5.0GB",
      "in_catalog": true,
      "description": "Qwen3 mid-tier, strong for its size",
      "draft": "Qwen3-0.6B-Q4_K_M",
      "moe": false,
      "capabilities": {
        "vision": "none",
        "audio": "none",
        "reasoning": "supported",
        "tool_use": "none",
        "multimodal": "none"
      }
    }
  ]
}
```

Without `--json`, output is unchanged.