### PR TITLE
Update CI and release workflows to use packaged artifacts and gated inference smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,11 @@ jobs:
           cp linux-binaries/mesh-llm target/debug/mesh-llm
           cp linux-binaries/rpc-server llama.cpp/build/bin/rpc-server
           cp linux-binaries/llama-server llama.cpp/build/bin/llama-server
-          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split 2>/dev/null || true
+          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split
+          test -x target/debug/mesh-llm
+          test -x llama.cpp/build/bin/rpc-server
+          test -x llama.cpp/build/bin/llama-server
+          test -x llama.cpp/build/bin/llama-moe-split
 
       - name: Cache integration model
         id: cache-model

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # ── UI ──
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -84,32 +85,49 @@ jobs:
       - name: Install Python SDKs
         run: python -m pip install --upgrade pip -r ci/requirements-ci-python.txt
 
+      # ── System dependencies ──
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
 
+      # ── Rust ──
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
+      # Workspace `. -> target` because the cargo workspace is at repo root
+      # (`Cargo.toml` members = ["mesh-llm", ...]) and cargo writes to
+      # `./target/`, NOT `mesh-llm/target/`. Using `workspaces: mesh-llm`
+      # silently caches an empty dir and gives zero PR cache hits — we
+      # measured a 4-minute regression from this exact misconfiguration.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
+      # Early-fail gate: runs before expensive compile/test work.
       - name: Check formatting
         working-directory: mesh-llm
         run: cargo fmt -- --check
 
-      - name: Build mesh-llm
-        run: cargo build --release -p mesh-llm --bin mesh-llm
+      # Build in dev/debug profile, NOT release. Two reasons:
+      #  1. Build + Unit tests steps share one target/ subdir and one
+      #     incremental cache — zero duplicated codegen.
+      #  2. debug has `incremental = true`; release has `incremental = false`.
+      #     Warm rebuild after a lib edit: release ~43s, debug ~4s (M4 Pro).
+      # mesh-llm is a thin orchestrator around llama-server; the hot loop is
+      # inside llama-server C++, so debug vs release binary perf is
+      # negligible for smoke tests. Integration steps below use target/debug.
+      - name: Build mesh-llm binary (debug)
+        run: cargo build -p mesh-llm --bin mesh-llm
 
       - name: Unit tests
-        run: cargo test --release
+        run: cargo test --lib --tests
 
       - name: Clippy
         working-directory: mesh-llm
         run: cargo clippy -- -D warnings || true
 
+      # ── llama.cpp (CPU-only for CI) ──
       - name: Clone llama.cpp fork
         run: git clone -b upstream-latest --depth 1 https://github.com/michaelneale/llama.cpp.git llama.cpp
 
@@ -135,7 +153,7 @@ jobs:
       - name: Package Linux binaries
         run: |
           mkdir -p ci-artifacts/linux-binaries
-          cp target/release/mesh-llm ci-artifacts/linux-binaries/
+          cp target/debug/mesh-llm ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/llama-server ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/ 2>/dev/null || true
@@ -150,11 +168,11 @@ jobs:
 
       - name: CLI smoke test
         run: |
-          target/release/mesh-llm --version
-          target/release/mesh-llm --help | head -5
+          target/debug/mesh-llm --version
+          target/debug/mesh-llm --help | head -5
 
       - name: Client-auto boot test
-        run: scripts/ci-client-auto-test.sh target/release/mesh-llm
+        run: scripts/ci-client-auto-test.sh target/debug/mesh-llm
 
       - name: Show sccache stats
         if: always()
@@ -167,6 +185,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # ── UI ──
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -179,21 +198,25 @@ jobs:
         working-directory: mesh-llm/ui
         run: npm ci && npm run build
 
+      # ── Rust ──
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
+      # See linux job for explanation of `. -> target`.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
-      - name: Build mesh-llm
-        run: cargo build --release -p mesh-llm --bin mesh-llm
+      # See linux job for rationale on building in dev/debug, not release.
+      - name: Build mesh-llm binary (debug)
+        run: cargo build -p mesh-llm --bin mesh-llm
 
       - name: Unit tests
-        run: cargo test --release
+        run: cargo test -p mesh-llm --lib --tests
 
+      # ── llama.cpp (Metal + RPC) ──
       - name: Clone llama.cpp fork
         run: git clone -b upstream-latest --depth 1 https://github.com/michaelneale/llama.cpp.git llama.cpp
 
@@ -218,7 +241,7 @@ jobs:
       - name: Package macOS binaries
         run: |
           mkdir -p ci-artifacts/macos-binaries
-          cp target/release/mesh-llm ci-artifacts/macos-binaries/
+          cp target/debug/mesh-llm ci-artifacts/macos-binaries/
           cp llama.cpp/build/bin/rpc-server ci-artifacts/macos-binaries/
           cp llama.cpp/build/bin/llama-server ci-artifacts/macos-binaries/
           cp llama.cpp/build/bin/llama-moe-split ci-artifacts/macos-binaries/ 2>/dev/null || true
@@ -239,11 +262,11 @@ jobs:
 
       - name: CLI smoke test
         run: |
-          target/release/mesh-llm --version
-          target/release/mesh-llm --help | head -5
+          target/debug/mesh-llm --version
+          target/debug/mesh-llm --help | head -5
 
       - name: Client-auto boot test
-        run: scripts/ci-client-auto-test.sh target/release/mesh-llm
+        run: scripts/ci-client-auto-test.sh target/debug/mesh-llm
 
       - name: Show sccache stats
         if: always()
@@ -287,8 +310,8 @@ jobs:
 
       - name: Stage binaries for inference smokes
         run: |
-          mkdir -p target/release llama.cpp/build/bin
-          cp linux-binaries/mesh-llm target/release/mesh-llm
+          mkdir -p target/debug llama.cpp/build/bin
+          cp linux-binaries/mesh-llm target/debug/mesh-llm
           cp linux-binaries/rpc-server llama.cpp/build/bin/rpc-server
           cp linux-binaries/llama-server llama.cpp/build/bin/llama-server
           cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split 2>/dev/null || true
@@ -310,21 +333,21 @@ jobs:
       - name: Smoke test (real inference)
         run: |
           scripts/ci-smoke-test.sh \
-            target/release/mesh-llm \
+            target/debug/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MODEL_FILE
 
       - name: OpenAI Python compat smoke
         run: |
           scripts/ci-compat-smoke.sh \
-            target/release/mesh-llm \
+            target/debug/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MODEL_FILE
 
       - name: Split-mode test (host/worker routing)
         run: |
           scripts/ci-split-test.sh \
-            target/release/mesh-llm \
+            target/debug/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MODEL_FILE
 
@@ -351,7 +374,7 @@ jobs:
       - name: MoE mesh test (expert sharding end-to-end)
         run: |
           scripts/ci-moe-mesh-test.sh \
-            target/release/mesh-llm \
+            target/debug/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MOE_MODEL_FILE
 
@@ -409,6 +432,42 @@ jobs:
             . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
+      # ── Cross-PR llama.cpp / CUDA slim artifact cache (read-only consumer) ──
+      #
+      # Goal: every PR gets a "warm" llama.cpp CUDA build for free. Without
+      # this cache the CUDA job pays ~194s warm (sccache hit) or ~26m cold
+      # (sccache eviction) on every PR. With it, the llama.cpp build is
+      # skipped entirely on cache hit and the only remaining work is the
+      # mesh-llm cargo build.
+      #
+      # This job RESTORES ONLY. It never writes the cache. All writes
+      # happen in .github/workflows/warm-caches.yml, which runs on push
+      # to main (paths-filtered) and on workflow_dispatch. Splitting the
+      # writer into its own workflow prevents PR runs from polluting
+      # PR-scoped cache storage with a ~500 MB `llama.cpp/build/bin`
+      # entry on every push, and lets the warmup workflow prune old
+      # versions (see warm-caches.yml for the retention policy).
+      #
+      # The cache key MUST stay byte-identical to the one in
+      # warm-caches.yml or PRs will never hit the main-warmed entry.
+      # Any change to the hashFiles() list or literal suffix must be
+      # mirrored in both files in the same commit.
+      #
+      # Cross-branch read: pushes to `main` write the cache under
+      # `refs/heads/main`. PR runs on `refs/pull/<N>/merge` automatically
+      # fall back to the base branch's cache scope, so PRs hit the
+      # main-warmed cache without needing any cache to exist on the PR
+      # ref itself.
+      #
+      # The cache key embeds EVERY input that affects the produced binaries:
+      #   - llama.cpp upstream commit SHA, resolved at workflow time below
+      #     via `git ls-remote`.
+      #   - hash of the build inputs in this repo: scripts/build-linux.sh,
+      #     Justfile, ci.yml, warm-caches.yml, gpu-warm-cache-job.yml,
+      #     cache-version.txt.
+      #   - the CUDA arch literal (`arch89`), the GGML_CUDA_FA_ALL_QUANTS
+      #     state (`fa-off`), and the CUDA toolkit version pulled from the
+      #     container image.
       - name: Resolve llama.cpp upstream SHA
         id: llama_sha
         shell: bash
@@ -422,6 +481,11 @@ jobs:
           echo "Resolved llama.cpp upstream-latest SHA: $SHA"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
+      # `actions/cache/restore@v5` (NOT `actions/cache@v5`): restore-only,
+      # never saves. PR runs on `refs/pull/<N>/merge` never write anything
+      # to PR-scoped cache storage. The only writer is warm-caches.yml.
+      # On cache miss the full llama.cpp build still runs to prove the
+      # change works, but the result is discarded at job end.
       - name: Restore llama.cpp CUDA cache
         id: llama_cuda_cache
         uses: actions/cache/restore@v5
@@ -429,7 +493,32 @@ jobs:
           path: llama.cpp/build/bin
           key: ${{ env.CACHE_NAMESPACE }}-llama-cuda-slim-${{ steps.llama_sha.outputs.sha }}-${{ hashFiles('scripts/build-linux.sh', 'Justfile', '.github/workflows/ci.yml', '.github/workflows/warm-caches.yml', '.github/workflows/gpu-warm-cache-job.yml', '.github/cache-version.txt') }}-arch89-fa-off-cuda12.8
 
-      - name: Build Linux CUDA backend (cache miss)
+      # CI is a validation build only: we only need to prove CUDA compiles
+      # and the Rust binary runs. User-facing release artifacts are produced
+      # by release.yml which keeps the full default cuda_arch list, release
+      # profile, and GGML_CUDA_FA_ALL_QUANTS=ON. Here we pass four CI-only
+      # opt-outs, all documented in scripts/build-linux.sh:
+      #   1. single cuda_arch 89 (Ada Lovelace) — ~3.7x faster llama.cpp build
+      #   2. MESH_LLM_BUILD_PROFILE=dev — debug profile for mesh-llm itself
+      #   3. MESH_LLM_CUDA_FA_ALL_QUANTS=off — skip the full FlashAttention
+      #      kernel matrix. Safe ONLY because the CUDA smoke test is
+      #      `mesh-llm --version` — the asymmetric K/V cache path that would
+      #      crash rpc-server with BEST_FATTN_KERNEL_NONE is never exercised.
+      #      NEVER set this in release.yml.
+      #   4. MESH_LLM_LLAMA_PIN_SHA — pin the llama.cpp checkout to the SHA
+      #      embedded in the artifact cache key (above). NEVER set this in
+      #      release.yml; release artifacts must build the current
+      #      upstream-latest tip.
+      #
+      # Split into two mutually exclusive steps keyed off the artifact cache:
+      #
+      #   - Cache miss → do the fast PR-only llama.cpp + mesh-llm build via the
+      #     build script. This validates the same arch89/fa-off shape that
+      #     main warms, but PR runs never write the shared cache.
+      #   - Cache hit  → skip llama.cpp entirely (we already proved it builds
+      #     at this SHA + flag combo) and run only the mesh-llm cargo build.
+      #     This is the warm path every PR hits when main has already run.
+      - name: Build Linux CUDA backend (cache miss — full llama.cpp build)
         if: steps.llama_cuda_cache.outputs.cache-hit != 'true'
         shell: bash
         env:
@@ -439,9 +528,11 @@ jobs:
         run: |
           just --shell bash --shell-arg -lc release-build-cuda 89
 
-      - name: Build mesh-llm release binary (cache hit)
+      - name: Build mesh-llm binary only (cache hit — llama.cpp skipped)
         if: steps.llama_cuda_cache.outputs.cache-hit == 'true'
         shell: bash
+        env:
+          MESH_LLM_BUILD_PROFILE: dev
         run: |
           set -euo pipefail
           echo "✓ llama.cpp CUDA build restored from cache (SHA ${{ steps.llama_sha.outputs.sha }})"
@@ -454,25 +545,20 @@ jobs:
             exit 1
           fi
           ls -lh llama.cpp/build/bin/ | head -20
-          cargo build --release -p mesh-llm --bin mesh-llm
-          ls -lh target/release/mesh-llm
-
-      - name: Build mesh-llm release binary (cache miss)
-        if: steps.llama_cuda_cache.outputs.cache-hit != 'true'
-        shell: bash
-        run: cargo build --release -p mesh-llm --bin mesh-llm
+          cargo build -p mesh-llm --bin mesh-llm
+          ls -lh target/debug/mesh-llm
 
       - name: CLI smoke test
         shell: bash
         run: |
-          target/release/mesh-llm --version
-          target/release/mesh-llm --help | head -5
+          target/debug/mesh-llm --version
+          target/debug/mesh-llm --help | head -5
 
       - name: Package Linux CUDA binaries
         shell: bash
         run: |
           mkdir -p ci-artifacts/linux-cuda-binaries
-          cp target/release/mesh-llm ci-artifacts/linux-cuda-binaries/
+          cp target/debug/mesh-llm ci-artifacts/linux-cuda-binaries/
           cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-cuda-binaries/
           cp llama.cpp/build/bin/llama-server ci-artifacts/linux-cuda-binaries/
           cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-cuda-binaries/ 2>/dev/null || true
@@ -563,13 +649,19 @@ jobs:
           path: llama.cpp/build/bin
           key: ${{ env.CACHE_NAMESPACE }}-llama-rocm-slim-${{ steps.llama_sha.outputs.sha }}-${{ hashFiles('scripts/build-linux-rocm.sh', 'Justfile', '.github/workflows/ci.yml', '.github/workflows/warm-caches.yml', '.github/workflows/gpu-warm-cache-job.yml', '.github/cache-version.txt') }}-gfx1100-rocm7.0
 
-      - name: Build Linux ROCm backend (cache miss)
+      # This lane is compile-only plus a CLI smoke check (`--version`/`--help`).
+      # It does not exercise ROCm inference on real AMD hardware, so restrict
+      # the build to one representative target instead of compiling the full
+      # default AMDGPU target matrix.
+      - name: Build Linux ROCm backend (cache miss — full llama.cpp build)
         if: steps.llama_rocm_cache.outputs.cache-hit != 'true'
         shell: bash
+        env:
+          MESH_LLM_LLAMA_PIN_SHA: ${{ steps.llama_sha.outputs.sha }}
         run: |
           just --shell bash --shell-arg -lc release-build-amd gfx1100
 
-      - name: Build mesh-llm release binary (cache hit)
+      - name: Build mesh-llm binary only (cache hit — llama.cpp skipped)
         if: steps.llama_rocm_cache.outputs.cache-hit == 'true'
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,11 +251,9 @@ jobs:
           cp llama.cpp/build/bin/llama-moe-split ci-artifacts/macos-binaries/
           shopt -s nullglob
           dylibs=(llama.cpp/build/bin/*.dylib)
-          if [ "${#dylibs[@]}" -eq 0 ]; then
-            echo "Expected macOS artifacts missing: no .dylib files found in llama.cpp/build/bin/" >&2
-            exit 1
+          if [ "${#dylibs[@]}" -gt 0 ]; then
+            cp "${dylibs[@]}" ci-artifacts/macos-binaries/
           fi
-          cp "${dylibs[@]}" ci-artifacts/macos-binaries/
           metallibs=(
             target/debug/build/mlx-sys-*/out/build/lib/mlx.metallib
             target/release/build/mlx-sys-*/out/build/lib/mlx.metallib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
   linux_cuda:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' }}
-    name: Linux CUDA
+    name: Linux CUDA slim
     runs-on: ubuntu-latest
     container:
       image: nvidia/cuda:12.8.0-devel-ubuntu22.04
@@ -578,7 +578,7 @@ jobs:
   linux_rocm:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' }}
-    name: Linux ROCm
+    name: Linux ROCm slim
     runs-on: ubuntu-latest
     container:
       image: rocm/dev-ubuntu-24.04:7.0-complete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # ── UI ──
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -85,49 +84,32 @@ jobs:
       - name: Install Python SDKs
         run: python -m pip install --upgrade pip -r ci/requirements-ci-python.txt
 
-      # ── System dependencies ──
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
 
-      # ── Rust ──
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      # Workspace `. -> target` because the cargo workspace is at repo root
-      # (`Cargo.toml` members = ["mesh-llm", ...]) and cargo writes to
-      # `./target/`, NOT `mesh-llm/target/`. Using `workspaces: mesh-llm`
-      # silently caches an empty dir and gives zero PR cache hits — we
-      # measured a 4-minute regression from this exact misconfiguration.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
-      # Early-fail gate: runs before expensive compile/test work.
       - name: Check formatting
         working-directory: mesh-llm
         run: cargo fmt -- --check
 
-      # Build in dev/debug profile, NOT release. Two reasons:
-      #  1. Build + Unit tests steps share one target/ subdir and one
-      #     incremental cache — zero duplicated codegen.
-      #  2. debug has `incremental = true`; release has `incremental = false`.
-      #     Warm rebuild after a lib edit: release ~43s, debug ~4s (M4 Pro).
-      # mesh-llm is a thin orchestrator around llama-server; the hot loop is
-      # inside llama-server C++, so debug vs release binary perf is
-      # negligible for smoke tests. Integration steps below use target/debug.
-      - name: Build mesh-llm binary (debug)
-        run: cargo build -p mesh-llm --bin mesh-llm
+      - name: Build mesh-llm
+        run: cargo build --release -p mesh-llm --bin mesh-llm
 
       - name: Unit tests
-        run: cargo test --lib --tests
+        run: cargo test --release
 
       - name: Clippy
         working-directory: mesh-llm
         run: cargo clippy -- -D warnings || true
 
-      # ── llama.cpp (CPU-only for CI) ──
       - name: Clone llama.cpp fork
         run: git clone -b upstream-latest --depth 1 https://github.com/michaelneale/llama.cpp.git llama.cpp
 
@@ -143,84 +125,36 @@ jobs:
           cmake -B llama.cpp/build -S llama.cpp \
             -DGGML_METAL=OFF \
             -DGGML_CUDA=OFF \
+            -DGGML_NATIVE=OFF \
             -DGGML_RPC=ON \
             -DBUILD_SHARED_LIBS=OFF \
             -DLLAMA_OPENSSL=OFF \
             "${CACHE_FLAGS[@]}"
           cmake --build llama.cpp/build --config Release -j$(nproc) --target rpc-server llama-server llama-moe-split
 
-      # ── Download model ──
-      - name: Cache model
-        id: cache-model
-        uses: actions/cache@v5
+      - name: Package Linux binaries
+        run: |
+          mkdir -p ci-artifacts/linux-binaries
+          cp target/release/mesh-llm ci-artifacts/linux-binaries/
+          cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-binaries/
+          cp llama.cpp/build/bin/llama-server ci-artifacts/linux-binaries/
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/ 2>/dev/null || true
+          tar -czf ci-artifacts/linux-binaries.tgz -C ci-artifacts linux-binaries
+
+      - name: Upload Linux binaries
+        uses: actions/upload-artifact@v6
         with:
-          path: ~/.models/${{ env.MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
-
-      - name: Download model
-        if: steps.cache-model.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.models
-          curl -fSL "$MODEL_URL" -o ~/.models/$MODEL_FILE
-          ls -lh ~/.models/$MODEL_FILE
-
-      # ── Integration smoke test ──
-      - name: Smoke test (real inference)
-        run: |
-          scripts/ci-smoke-test.sh \
-            target/debug/mesh-llm \
-            llama.cpp/build/bin \
-            ~/.models/$MODEL_FILE
-
-      - name: OpenAI Python compat smoke
-        run: |
-          scripts/ci-compat-smoke.sh \
-            target/debug/mesh-llm \
-            llama.cpp/build/bin \
-            ~/.models/$MODEL_FILE
-
-      - name: Split-mode test (host/worker routing)
-        run: |
-          scripts/ci-split-test.sh \
-            target/debug/mesh-llm \
-            llama.cpp/build/bin \
-            ~/.models/$MODEL_FILE
-
-      # ── MoE split test ──
-      - name: Cache MoE model
-        id: cache-moe-model
-        uses: actions/cache@v5
-        with:
-          path: ~/.models/${{ env.MOE_MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MOE_MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
-
-      - name: Download MoE model
-        if: steps.cache-moe-model.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/.models
-          curl -fSL "$MOE_MODEL_URL" -o ~/.models/$MOE_MODEL_FILE
-          ls -lh ~/.models/$MOE_MODEL_FILE
-
-      - name: MoE split test (expert sharding)
-        run: |
-          scripts/ci-moe-split-test.sh \
-            llama.cpp/build/bin \
-            ~/.models/$MOE_MODEL_FILE
-
-      - name: MoE mesh test (expert sharding end-to-end)
-        run: |
-          scripts/ci-moe-mesh-test.sh \
-            target/debug/mesh-llm \
-            llama.cpp/build/bin \
-            ~/.models/$MOE_MODEL_FILE
+          name: linux-binaries
+          path: ci-artifacts/linux-binaries.tgz
+          if-no-files-found: error
 
       - name: CLI smoke test
         run: |
-          target/debug/mesh-llm --version
-          target/debug/mesh-llm --help | head -5
+          target/release/mesh-llm --version
+          target/release/mesh-llm --help | head -5
 
       - name: Client-auto boot test
-        run: scripts/ci-client-auto-test.sh target/debug/mesh-llm
+        run: scripts/ci-client-auto-test.sh target/release/mesh-llm
 
       - name: Show sccache stats
         if: always()
@@ -233,7 +167,6 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # ── UI ──
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -246,30 +179,21 @@ jobs:
         working-directory: mesh-llm/ui
         run: npm ci && npm run build
 
-      # ── Rust ──
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
-      # See linux job for explanation of `. -> target`.
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
-      # Early-fail gate: runs before expensive compile/test work.
-      - name: Check formatting
-        working-directory: mesh-llm
-        run: cargo fmt -- --check
-
-      # See linux job for rationale on building in dev/debug, not release.
-      - name: Build mesh-llm binary (debug)
-        run: cargo build -p mesh-llm --bin mesh-llm
+      - name: Build mesh-llm
+        run: cargo build --release -p mesh-llm --bin mesh-llm
 
       - name: Unit tests
-        run: cargo test -p mesh-llm --lib --tests
+        run: cargo test --release
 
-      # ── llama.cpp (Metal + RPC) ──
       - name: Clone llama.cpp fork
         run: git clone -b upstream-latest --depth 1 https://github.com/michaelneale/llama.cpp.git llama.cpp
 
@@ -284,43 +208,126 @@ jobs:
           fi
           cmake -B llama.cpp/build -S llama.cpp \
             -DGGML_METAL=OFF \
+            -DGGML_NATIVE=OFF \
             -DGGML_RPC=ON \
             -DBUILD_SHARED_LIBS=OFF \
             -DLLAMA_OPENSSL=OFF \
             "${CACHE_FLAGS[@]}"
           cmake --build llama.cpp/build --config Release -j$(sysctl -n hw.ncpu) --target rpc-server llama-server llama-moe-split
 
-      # ── Download model ──
-      - name: Cache model
+      - name: Package macOS binaries
+        run: |
+          mkdir -p ci-artifacts/macos-binaries
+          cp target/release/mesh-llm ci-artifacts/macos-binaries/
+          cp llama.cpp/build/bin/rpc-server ci-artifacts/macos-binaries/
+          cp llama.cpp/build/bin/llama-server ci-artifacts/macos-binaries/
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/macos-binaries/ 2>/dev/null || true
+          cp llama.cpp/build/bin/*.dylib ci-artifacts/macos-binaries/ 2>/dev/null || true
+          shopt -s nullglob
+          metallibs=(target/release/build/mlx-sys-*/out/build/lib/mlx.metallib)
+          if [ "${#metallibs[@]}" -gt 0 ]; then
+            cp "${metallibs[0]}" ci-artifacts/macos-binaries/mlx.metallib
+          fi
+          tar -czf ci-artifacts/macos-binaries.tgz -C ci-artifacts macos-binaries
+
+      - name: Upload macOS binaries
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-binaries
+          path: ci-artifacts/macos-binaries.tgz
+          if-no-files-found: error
+
+      - name: CLI smoke test
+        run: |
+          target/release/mesh-llm --version
+          target/release/mesh-llm --help | head -5
+
+      - name: Client-auto boot test
+        run: scripts/ci-client-auto-test.sh target/release/mesh-llm
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  inference_smoke_tests:
+    needs: [changes, linux]
+    if: ${{ needs.linux.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
+    name: Inference Smoke Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            mesh-llm/ui/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            .github/cache-version.txt
+            ci/requirements-ci-python.txt
+
+      - name: Install Python SDKs
+        run: python -m pip install --upgrade pip -r ci/requirements-ci-python.txt
+
+      - name: Download Linux binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: linux-binaries
+          path: ci-artifacts
+
+      - name: Extract Linux binaries
+        run: tar -xzf ci-artifacts/linux-binaries.tgz
+
+      - name: Stage binaries for inference smokes
+        run: |
+          mkdir -p target/release llama.cpp/build/bin
+          cp linux-binaries/mesh-llm target/release/mesh-llm
+          cp linux-binaries/rpc-server llama.cpp/build/bin/rpc-server
+          cp linux-binaries/llama-server llama.cpp/build/bin/llama-server
+          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split 2>/dev/null || true
+
+      - name: Cache integration model
         id: cache-model
         uses: actions/cache@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
           key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
 
-      - name: Download model
+      - name: Download integration model
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: |
           mkdir -p ~/.models
           curl -fSL "$MODEL_URL" -o ~/.models/$MODEL_FILE
           ls -lh ~/.models/$MODEL_FILE
 
-      # ── Integration smoke test ──
       - name: Smoke test (real inference)
         run: |
           scripts/ci-smoke-test.sh \
-            target/debug/mesh-llm \
+            target/release/mesh-llm \
+            llama.cpp/build/bin \
+            ~/.models/$MODEL_FILE
+
+      - name: OpenAI Python compat smoke
+        run: |
+          scripts/ci-compat-smoke.sh \
+            target/release/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MODEL_FILE
 
       - name: Split-mode test (host/worker routing)
         run: |
           scripts/ci-split-test.sh \
-            target/debug/mesh-llm \
+            target/release/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MODEL_FILE
 
-      # ── MoE split test ──
       - name: Cache MoE model
         id: cache-moe-model
         uses: actions/cache@v5
@@ -344,26 +351,14 @@ jobs:
       - name: MoE mesh test (expert sharding end-to-end)
         run: |
           scripts/ci-moe-mesh-test.sh \
-            target/debug/mesh-llm \
+            target/release/mesh-llm \
             llama.cpp/build/bin \
             ~/.models/$MOE_MODEL_FILE
-
-      - name: CLI smoke test
-        run: |
-          target/debug/mesh-llm --version
-          target/debug/mesh-llm --help | head -5
-
-      - name: Client-auto boot test
-        run: scripts/ci-client-auto-test.sh target/debug/mesh-llm
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats || true
 
   linux_cuda:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' }}
-    name: Linux CUDA slim
+    name: Linux CUDA
     runs-on: ubuntu-latest
     container:
       image: nvidia/cuda:12.8.0-devel-ubuntu22.04
@@ -414,42 +409,6 @@ jobs:
             . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
-      # ── Cross-PR llama.cpp / CUDA slim artifact cache (read-only consumer) ──
-      #
-      # Goal: every PR gets a "warm" llama.cpp CUDA build for free. Without
-      # this cache the CUDA job pays ~194s warm (sccache hit) or ~26m cold
-      # (sccache eviction) on every PR. With it, the llama.cpp build is
-      # skipped entirely on cache hit and the only remaining work is the
-      # mesh-llm cargo build.
-      #
-      # This job RESTORES ONLY. It never writes the cache. All writes
-      # happen in .github/workflows/warm-caches.yml, which runs on push
-      # to main (paths-filtered) and on workflow_dispatch. Splitting the
-      # writer into its own workflow prevents PR runs from polluting
-      # PR-scoped cache storage with a ~500 MB `llama.cpp/build/bin`
-      # entry on every push, and lets the warmup workflow prune old
-      # versions (see warm-caches.yml for the retention policy).
-      #
-      # The cache key MUST stay byte-identical to the one in
-      # warm-caches.yml or PRs will never hit the main-warmed entry.
-      # Any change to the hashFiles() list or literal suffix must be
-      # mirrored in both files in the same commit.
-      #
-      # Cross-branch read: pushes to `main` write the cache under
-      # `refs/heads/main`. PR runs on `refs/pull/<N>/merge` automatically
-      # fall back to the base branch's cache scope, so PRs hit the
-      # main-warmed cache without needing any cache to exist on the PR
-      # ref itself.
-      #
-      # The cache key embeds EVERY input that affects the produced binaries:
-      #   - llama.cpp upstream commit SHA, resolved at workflow time below
-      #     via `git ls-remote`.
-      #   - hash of the build inputs in this repo: scripts/build-linux.sh,
-      #     Justfile, ci.yml, warm-caches.yml, gpu-warm-cache-job.yml,
-      #     cache-version.txt.
-      #   - the CUDA arch literal (`arch89`), the GGML_CUDA_FA_ALL_QUANTS
-      #     state (`fa-off`), and the CUDA toolkit version pulled from the
-      #     container image.
       - name: Resolve llama.cpp upstream SHA
         id: llama_sha
         shell: bash
@@ -463,11 +422,6 @@ jobs:
           echo "Resolved llama.cpp upstream-latest SHA: $SHA"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
-      # `actions/cache/restore@v5` (NOT `actions/cache@v5`): restore-only,
-      # never saves. PR runs on `refs/pull/<N>/merge` never write anything
-      # to PR-scoped cache storage. The only writer is warm-caches.yml.
-      # On cache miss the full llama.cpp build still runs to prove the
-      # change works, but the result is discarded at job end.
       - name: Restore llama.cpp CUDA cache
         id: llama_cuda_cache
         uses: actions/cache/restore@v5
@@ -475,32 +429,7 @@ jobs:
           path: llama.cpp/build/bin
           key: ${{ env.CACHE_NAMESPACE }}-llama-cuda-slim-${{ steps.llama_sha.outputs.sha }}-${{ hashFiles('scripts/build-linux.sh', 'Justfile', '.github/workflows/ci.yml', '.github/workflows/warm-caches.yml', '.github/workflows/gpu-warm-cache-job.yml', '.github/cache-version.txt') }}-arch89-fa-off-cuda12.8
 
-      # CI is a validation build only: we only need to prove CUDA compiles
-      # and the Rust binary runs. User-facing release artifacts are produced
-      # by release.yml which keeps the full default cuda_arch list, release
-      # profile, and GGML_CUDA_FA_ALL_QUANTS=ON. Here we pass four CI-only
-      # opt-outs, all documented in scripts/build-linux.sh:
-      #   1. single cuda_arch 89 (Ada Lovelace) — ~3.7x faster llama.cpp build
-      #   2. MESH_LLM_BUILD_PROFILE=dev — debug profile for mesh-llm itself
-      #   3. MESH_LLM_CUDA_FA_ALL_QUANTS=off — skip the full FlashAttention
-      #      kernel matrix. Safe ONLY because the CUDA smoke test is
-      #      `mesh-llm --version` — the asymmetric K/V cache path that would
-      #      crash rpc-server with BEST_FATTN_KERNEL_NONE is never exercised.
-      #      NEVER set this in release.yml.
-      #   4. MESH_LLM_LLAMA_PIN_SHA — pin the llama.cpp checkout to the SHA
-      #      embedded in the artifact cache key (above). NEVER set this in
-      #      release.yml; release artifacts must build the current
-      #      upstream-latest tip.
-      #
-      # Split into two mutually exclusive steps keyed off the artifact cache:
-      #
-      #   - Cache miss → do the fast PR-only llama.cpp + mesh-llm build via the
-      #     build script. This validates the same arch89/fa-off shape that
-      #     main warms, but PR runs never write the shared cache.
-      #   - Cache hit  → skip llama.cpp entirely (we already proved it builds
-      #     at this SHA + flag combo) and run only the mesh-llm cargo build.
-      #     This is the warm path every PR hits when main has already run.
-      - name: Build Linux CUDA backend (cache miss — full llama.cpp build)
+      - name: Build Linux CUDA backend (cache miss)
         if: steps.llama_cuda_cache.outputs.cache-hit != 'true'
         shell: bash
         env:
@@ -510,11 +439,9 @@ jobs:
         run: |
           just --shell bash --shell-arg -lc release-build-cuda 89
 
-      - name: Build mesh-llm binary only (cache hit — llama.cpp skipped)
+      - name: Build mesh-llm release binary (cache hit)
         if: steps.llama_cuda_cache.outputs.cache-hit == 'true'
         shell: bash
-        env:
-          MESH_LLM_BUILD_PROFILE: dev
         run: |
           set -euo pipefail
           echo "✓ llama.cpp CUDA build restored from cache (SHA ${{ steps.llama_sha.outputs.sha }})"
@@ -527,14 +454,36 @@ jobs:
             exit 1
           fi
           ls -lh llama.cpp/build/bin/ | head -20
-          cargo build -p mesh-llm --bin mesh-llm
-          ls -lh target/debug/mesh-llm
+          cargo build --release -p mesh-llm --bin mesh-llm
+          ls -lh target/release/mesh-llm
+
+      - name: Build mesh-llm release binary (cache miss)
+        if: steps.llama_cuda_cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: cargo build --release -p mesh-llm --bin mesh-llm
 
       - name: CLI smoke test
         shell: bash
         run: |
-          target/debug/mesh-llm --version
-          target/debug/mesh-llm --help | head -5
+          target/release/mesh-llm --version
+          target/release/mesh-llm --help | head -5
+
+      - name: Package Linux CUDA binaries
+        shell: bash
+        run: |
+          mkdir -p ci-artifacts/linux-cuda-binaries
+          cp target/release/mesh-llm ci-artifacts/linux-cuda-binaries/
+          cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-cuda-binaries/
+          cp llama.cpp/build/bin/llama-server ci-artifacts/linux-cuda-binaries/
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-cuda-binaries/ 2>/dev/null || true
+          tar -czf ci-artifacts/linux-cuda-binaries.tgz -C ci-artifacts linux-cuda-binaries
+
+      - name: Upload Linux CUDA binaries
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-cuda-binaries
+          path: ci-artifacts/linux-cuda-binaries.tgz
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()
@@ -543,7 +492,7 @@ jobs:
   linux_rocm:
     needs: changes
     if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' }}
-    name: Linux ROCm slim
+    name: Linux ROCm
     runs-on: ubuntu-latest
     container:
       image: rocm/dev-ubuntu-24.04:7.0-complete
@@ -614,19 +563,13 @@ jobs:
           path: llama.cpp/build/bin
           key: ${{ env.CACHE_NAMESPACE }}-llama-rocm-slim-${{ steps.llama_sha.outputs.sha }}-${{ hashFiles('scripts/build-linux-rocm.sh', 'Justfile', '.github/workflows/ci.yml', '.github/workflows/warm-caches.yml', '.github/workflows/gpu-warm-cache-job.yml', '.github/cache-version.txt') }}-gfx1100-rocm7.0
 
-      # This lane is compile-only plus a CLI smoke check (`--version`/`--help`).
-      # It does not exercise ROCm inference on real AMD hardware, so restrict
-      # the build to one representative target instead of compiling the full
-      # default AMDGPU target matrix.
-      - name: Build Linux ROCm backend (cache miss — full llama.cpp build)
+      - name: Build Linux ROCm backend (cache miss)
         if: steps.llama_rocm_cache.outputs.cache-hit != 'true'
         shell: bash
-        env:
-          MESH_LLM_LLAMA_PIN_SHA: ${{ steps.llama_sha.outputs.sha }}
         run: |
-          just --shell bash --shell-arg -lc release-build-rocm gfx1100
+          just --shell bash --shell-arg -lc release-build-amd gfx1100
 
-      - name: Build mesh-llm binary only (cache hit — llama.cpp skipped)
+      - name: Build mesh-llm release binary (cache hit)
         if: steps.llama_rocm_cache.outputs.cache-hit == 'true'
         shell: bash
         run: |
@@ -649,6 +592,23 @@ jobs:
         run: |
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
+
+      - name: Package Linux ROCm binaries
+        shell: bash
+        run: |
+          mkdir -p ci-artifacts/linux-rocm-binaries
+          cp target/release/mesh-llm ci-artifacts/linux-rocm-binaries/
+          cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-rocm-binaries/
+          cp llama.cpp/build/bin/llama-server ci-artifacts/linux-rocm-binaries/
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-rocm-binaries/ 2>/dev/null || true
+          tar -czf ci-artifacts/linux-rocm-binaries.tgz -C ci-artifacts linux-rocm-binaries
+
+      - name: Upload Linux ROCm binaries
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-rocm-binaries
+          path: ci-artifacts/linux-rocm-binaries.tgz
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()
@@ -718,6 +678,23 @@ jobs:
         run: |
           target/release/mesh-llm --version
           target/release/mesh-llm --help | head -5
+
+      - name: Package Linux Vulkan binaries
+        shell: bash
+        run: |
+          mkdir -p ci-artifacts/linux-vulkan-binaries
+          cp target/release/mesh-llm ci-artifacts/linux-vulkan-binaries/
+          cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-vulkan-binaries/
+          cp llama.cpp/build/bin/llama-server ci-artifacts/linux-vulkan-binaries/
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-vulkan-binaries/ 2>/dev/null || true
+          tar -czf ci-artifacts/linux-vulkan-binaries.tgz -C ci-artifacts linux-vulkan-binaries
+
+      - name: Upload Linux Vulkan binaries
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-vulkan-binaries
+          path: ci-artifacts/linux-vulkan-binaries.tgz
+          if-no-files-found: error
 
       - name: Show sccache stats
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
           cp target/debug/mesh-llm ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/llama-server ci-artifacts/linux-binaries/
-          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/ 2>/dev/null || true
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/
           tar -czf ci-artifacts/linux-binaries.tgz -C ci-artifacts linux-binaries
 
       - name: Upload Linux binaries
@@ -659,7 +659,7 @@ jobs:
         env:
           MESH_LLM_LLAMA_PIN_SHA: ${{ steps.llama_sha.outputs.sha }}
         run: |
-          just --shell bash --shell-arg -lc release-build-amd gfx1100
+          just --shell bash --shell-arg -lc release-build-rocm gfx1100
 
       - name: Build mesh-llm binary only (cache hit — llama.cpp skipped)
         if: steps.llama_rocm_cache.outputs.cache-hit == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,9 +244,18 @@ jobs:
           cp target/debug/mesh-llm ci-artifacts/macos-binaries/
           cp llama.cpp/build/bin/rpc-server ci-artifacts/macos-binaries/
           cp llama.cpp/build/bin/llama-server ci-artifacts/macos-binaries/
-          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/macos-binaries/ 2>/dev/null || true
-          cp llama.cpp/build/bin/*.dylib ci-artifacts/macos-binaries/ 2>/dev/null || true
+          if [[ ! -f llama.cpp/build/bin/llama-moe-split ]]; then
+            echo "Expected macOS artifact missing: llama.cpp/build/bin/llama-moe-split" >&2
+            exit 1
+          fi
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/macos-binaries/
           shopt -s nullglob
+          dylibs=(llama.cpp/build/bin/*.dylib)
+          if [ "${#dylibs[@]}" -eq 0 ]; then
+            echo "Expected macOS artifacts missing: no .dylib files found in llama.cpp/build/bin/" >&2
+            exit 1
+          fi
+          cp "${dylibs[@]}" ci-artifacts/macos-binaries/
           metallibs=(
             target/debug/build/mlx-sys-*/out/build/lib/mlx.metallib
             target/release/build/mlx-sys-*/out/build/lib/mlx.metallib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,7 +247,10 @@ jobs:
           cp llama.cpp/build/bin/llama-moe-split ci-artifacts/macos-binaries/ 2>/dev/null || true
           cp llama.cpp/build/bin/*.dylib ci-artifacts/macos-binaries/ 2>/dev/null || true
           shopt -s nullglob
-          metallibs=(target/release/build/mlx-sys-*/out/build/lib/mlx.metallib)
+          metallibs=(
+            target/debug/build/mlx-sys-*/out/build/lib/mlx.metallib
+            target/release/build/mlx-sys-*/out/build/lib/mlx.metallib
+          )
           if [ "${#metallibs[@]}" -gt 0 ]; then
             cp "${metallibs[0]}" ci-artifacts/macos-binaries/mlx.metallib
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -422,7 +422,11 @@ jobs:
           cp linux-binaries/mesh-llm target/release/mesh-llm
           cp linux-binaries/rpc-server llama.cpp/build/bin/rpc-server
           cp linux-binaries/llama-server llama.cpp/build/bin/llama-server
-          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split 2>/dev/null || true
+          if [ ! -x linux-binaries/llama-moe-split ]; then
+            echo "Required binary linux-binaries/llama-moe-split is missing or not executable after artifact extraction" >&2
+            exit 1
+          fi
+          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split
 
       - name: Cache integration model
         id: cache-model

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,20 +19,9 @@ env:
   MOE_MODEL_FILE: qwen3.5-moe-0.87B-d0.8B-Q2_K.gguf
 
 jobs:
-  build:
-    name: Build ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: Linux CPU
-            os: ubuntu-latest
-            artifact_name: release-linux-cpu
-          - name: macOS
-            os: macos-14
-            artifact_name: release-macos
-
+  build_linux_cpu:
+    name: Build Linux CPU
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -46,8 +35,7 @@ jobs:
             .github/cache-version.txt
             mesh-llm/ui/package-lock.json
 
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
+      - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
 
       - uses: dtolnay/rust-toolchain@stable
@@ -71,7 +59,6 @@ jobs:
           just --shell bash --shell-arg -lc release-bundle "${GITHUB_REF_NAME}" dist
 
       - name: Package Linux inference binaries
-        if: runner.os == 'Linux'
         shell: bash
         run: |
           mkdir -p ci-artifacts/linux-binaries
@@ -82,11 +69,15 @@ jobs:
             echo "Required binary llama.cpp/build/bin/llama-moe-split is missing; cannot package Linux inference binaries." >&2
             exit 1
           fi
+          chmod +x llama.cpp/build/bin/llama-moe-split
+          if [ ! -x llama.cpp/build/bin/llama-moe-split ]; then
+            echo "Required binary llama.cpp/build/bin/llama-moe-split is not executable; cannot package Linux inference binaries." >&2
+            exit 1
+          fi
           cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/
           tar -czf ci-artifacts/linux-binaries.tgz -C ci-artifacts linux-binaries
 
       - name: Upload Linux inference binaries
-        if: runner.os == 'Linux'
         uses: actions/upload-artifact@v6
         with:
           name: ci-linux-inference-binaries
@@ -96,7 +87,50 @@ jobs:
       - name: Upload release artifacts
         uses: actions/upload-artifact@v6
         with:
-          name: ${{ matrix.artifact_name }}
+          name: release-linux-cpu
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  build_macos:
+    name: Build macOS
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: taiki-e/install-action@just
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            mesh-llm/ui/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+          prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+
+      - name: Build release bundle
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-build
+          just --shell bash --shell-arg -lc release-bundle "${GITHUB_REF_NAME}" dist
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-macos
           path: dist/*
           if-no-files-found: error
 
@@ -384,7 +418,7 @@ jobs:
     name: Inference Smoke Tests
     runs-on: ubuntu-latest
     needs:
-      - build
+      - build_linux_cpu
     steps:
       - uses: actions/checkout@v5
 
@@ -419,14 +453,25 @@ jobs:
       - name: Stage binaries for inference smokes
         run: |
           mkdir -p target/release llama.cpp/build/bin
-          cp linux-binaries/mesh-llm target/release/mesh-llm
-          cp linux-binaries/rpc-server llama.cpp/build/bin/rpc-server
-          cp linux-binaries/llama-server llama.cpp/build/bin/llama-server
-          if [ ! -x linux-binaries/llama-moe-split ]; then
-            echo "Required binary linux-binaries/llama-moe-split is missing or not executable after artifact extraction" >&2
-            exit 1
-          fi
-          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split
+          for spec in \
+            "linux-binaries/mesh-llm:target/release/mesh-llm" \
+            "linux-binaries/rpc-server:llama.cpp/build/bin/rpc-server" \
+            "linux-binaries/llama-server:llama.cpp/build/bin/llama-server" \
+            "linux-binaries/llama-moe-split:llama.cpp/build/bin/llama-moe-split"
+          do
+            src="${spec%%:*}"
+            dst="${spec#*:}"
+            if [ ! -x "$src" ]; then
+              echo "Required binary $src is missing or not executable after artifact extraction" >&2
+              exit 1
+            fi
+            cp "$src" "$dst"
+            chmod +x "$dst"
+            if [ ! -x "$dst" ]; then
+              echo "Staged binary $dst is not executable" >&2
+              exit 1
+            fi
+          done
 
       - name: Cache integration model
         id: cache-model
@@ -494,7 +539,8 @@ jobs:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs:
-      - build
+      - build_linux_cpu
+      - build_macos
       - build_linux_cuda
       - build_linux_rocm
       - build_linux_vulkan

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         if: runner.os == 'Linux'
         uses: actions/upload-artifact@v6
         with:
-          name: release-linux-inference-binaries
+          name: ci-linux-inference-binaries
           path: ci-artifacts/linux-binaries.tgz
           if-no-files-found: error
 
@@ -410,7 +410,7 @@ jobs:
       - name: Download Linux inference binaries
         uses: actions/download-artifact@v7
         with:
-          name: release-linux-inference-binaries
+          name: ci-linux-inference-binaries
           path: ci-artifacts
 
       - name: Extract Linux inference binaries

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ permissions:
 env:
   CACHE_NAMESPACE: mesh-llm
   SCCACHE_GHA_ENABLED: "true"
+  # Tiny model for integration tests (~138MB Q8_0, has chat template)
+  MODEL_URL: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf
+  MODEL_FILE: SmolLM2-135M-Instruct-Q8_0.gguf
+  # Small MoE model for MoE split tests (~598MB Q2_K, qwen35moe architecture)
+  MOE_MODEL_URL: https://huggingface.co/Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF/resolve/main/qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf
+  MOE_MODEL_FILE: qwen3.5-moe-0.87B-d0.8B-Q2_K.gguf
 
 jobs:
   build:
@@ -58,7 +64,30 @@ jobs:
         shell: bash
         run: |
           just --shell bash --shell-arg -lc release-build
+
+      - name: Bundle release artifacts
+        shell: bash
+        run: |
           just --shell bash --shell-arg -lc release-bundle "${GITHUB_REF_NAME}" dist
+
+      - name: Package Linux inference binaries
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          mkdir -p ci-artifacts/linux-binaries
+          cp target/release/mesh-llm ci-artifacts/linux-binaries/
+          cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-binaries/
+          cp llama.cpp/build/bin/llama-server ci-artifacts/linux-binaries/
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/ 2>/dev/null || true
+          tar -czf ci-artifacts/linux-binaries.tgz -C ci-artifacts linux-binaries
+
+      - name: Upload Linux inference binaries
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-inference-binaries
+          path: ci-artifacts/linux-binaries.tgz
+          if-no-files-found: error
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v6
@@ -133,8 +162,8 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
-  build_linux_rocm:
-    name: Build Linux ROCm
+  build_linux_amd:
+    name: Build Linux AMD ROCm
     runs-on: ubuntu-latest
     container:
       image: rocm/dev-ubuntu-24.04:7.0-complete
@@ -178,13 +207,13 @@ jobs:
             . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
-      - name: Build ROCm release bundle
+      - name: Build AMD ROCm release bundle
         shell: bash
         run: |
-          just --shell bash --shell-arg -lc release-build-rocm
-          just --shell bash --shell-arg -lc release-bundle-rocm "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-build-amd
+          just --shell bash --shell-arg -lc release-bundle-amd "${GITHUB_REF_NAME}" dist
 
-      - name: Upload ROCm release artifacts
+      - name: Upload AMD ROCm release artifacts
         uses: actions/upload-artifact@v6
         with:
           name: release-linux-rocm
@@ -282,8 +311,8 @@ jobs:
   #           artifact_name: release-windows-cuda
   #         - name: ROCm
   #           backend: rocm
-  #           build_recipe: release-build-rocm-windows
-  #           bundle_recipe: release-bundle-rocm-windows
+  #           build_recipe: release-build-amd-windows
+  #           bundle_recipe: release-bundle-amd-windows
   #           artifact_name: release-windows-rocm
   #         - name: Vulkan
   #           backend: vulkan
@@ -347,14 +376,121 @@ jobs:
   #           sccache --show-stats
   #         }
 
+  inference_smoke_tests:
+    name: Inference Smoke Tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            mesh-llm/ui/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            .github/cache-version.txt
+            ci/requirements-ci-python.txt
+
+      - name: Install Python SDKs
+        run: python -m pip install --upgrade pip -r ci/requirements-ci-python.txt
+
+      - name: Download Linux inference binaries
+        uses: actions/download-artifact@v7
+        with:
+          name: release-linux-inference-binaries
+          path: ci-artifacts
+
+      - name: Extract Linux inference binaries
+        run: tar -xzf ci-artifacts/linux-binaries.tgz
+
+      - name: Stage binaries for inference smokes
+        run: |
+          mkdir -p target/release llama.cpp/build/bin
+          cp linux-binaries/mesh-llm target/release/mesh-llm
+          cp linux-binaries/rpc-server llama.cpp/build/bin/rpc-server
+          cp linux-binaries/llama-server llama.cpp/build/bin/llama-server
+          cp linux-binaries/llama-moe-split llama.cpp/build/bin/llama-moe-split 2>/dev/null || true
+
+      - name: Cache integration model
+        id: cache-model
+        uses: actions/cache@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: release-${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/release.yml') }}
+
+      - name: Download integration model
+        if: steps.cache-model.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.models
+          curl -fSL "$MODEL_URL" -o ~/.models/$MODEL_FILE
+          ls -lh ~/.models/$MODEL_FILE
+
+      - name: Smoke test (real inference)
+        run: |
+          scripts/ci-smoke-test.sh \
+            target/release/mesh-llm \
+            llama.cpp/build/bin \
+            ~/.models/$MODEL_FILE
+
+      - name: OpenAI Python compat smoke
+        run: |
+          scripts/ci-compat-smoke.sh \
+            target/release/mesh-llm \
+            llama.cpp/build/bin \
+            ~/.models/$MODEL_FILE
+
+      - name: Split-mode test (host/worker routing)
+        run: |
+          scripts/ci-split-test.sh \
+            target/release/mesh-llm \
+            llama.cpp/build/bin \
+            ~/.models/$MODEL_FILE
+
+      - name: Cache MoE model
+        id: cache-moe-model
+        uses: actions/cache@v5
+        with:
+          path: ~/.models/${{ env.MOE_MODEL_FILE }}
+          key: release-${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MOE_MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/release.yml') }}
+
+      - name: Download MoE model
+        if: steps.cache-moe-model.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.models
+          curl -fSL "$MOE_MODEL_URL" -o ~/.models/$MOE_MODEL_FILE
+          ls -lh ~/.models/$MOE_MODEL_FILE
+
+      - name: MoE split test (expert sharding)
+        run: |
+          scripts/ci-moe-split-test.sh \
+            llama.cpp/build/bin \
+            ~/.models/$MOE_MODEL_FILE
+
+      - name: MoE mesh test (expert sharding end-to-end)
+        run: |
+          scripts/ci-moe-mesh-test.sh \
+            target/release/mesh-llm \
+            llama.cpp/build/bin \
+            ~/.models/$MOE_MODEL_FILE
+
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs:
       - build
       - build_linux_cuda
-      - build_linux_rocm
+      - build_linux_amd
       - build_linux_vulkan
+      - inference_smoke_tests
       # - build_windows  # disabled until llama.cpp CUDA fix
 
     steps:
@@ -366,8 +502,19 @@ jobs:
           merge-multiple: true
 
       - name: Publish release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          shopt -s nullglob
+          files=(dist/*)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No release files found under dist/"
+            exit 1
+          fi
+
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "${files[@]}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${files[@]}" --generate-notes
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,10 @@ env:
   CACHE_NAMESPACE: mesh-llm
   SCCACHE_GHA_ENABLED: "true"
   # Tiny model for integration tests (~138MB Q8_0, has chat template)
-  MODEL_URL: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q8_0.gguf
+  MODEL_URL: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
   MODEL_FILE: SmolLM2-135M-Instruct-Q8_0.gguf
   # Small MoE model for MoE split tests (~598MB Q2_K, qwen35moe architecture)
-  MOE_MODEL_URL: https://huggingface.co/Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF/resolve/main/qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf
+  MOE_MODEL_URL: https://huggingface.co/Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF/resolve/a9b8adbec2cc87479c772dac1944f313b4036c26/qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf
   MOE_MODEL_FILE: qwen3.5-moe-0.87B-d0.8B-Q2_K.gguf
 
 jobs:
@@ -78,7 +78,11 @@ jobs:
           cp target/release/mesh-llm ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/rpc-server ci-artifacts/linux-binaries/
           cp llama.cpp/build/bin/llama-server ci-artifacts/linux-binaries/
-          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/ 2>/dev/null || true
+          if [ ! -f llama.cpp/build/bin/llama-moe-split ]; then
+            echo "Required binary llama.cpp/build/bin/llama-moe-split is missing; cannot package Linux inference binaries." >&2
+            exit 1
+          fi
+          cp llama.cpp/build/bin/llama-moe-split ci-artifacts/linux-binaries/
           tar -czf ci-artifacts/linux-binaries.tgz -C ci-artifacts linux-binaries
 
       - name: Upload Linux inference binaries
@@ -162,8 +166,8 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
-  build_linux_amd:
-    name: Build Linux AMD ROCm
+  build_linux_rocm:
+    name: Build Linux ROCm
     runs-on: ubuntu-latest
     container:
       image: rocm/dev-ubuntu-24.04:7.0-complete
@@ -207,13 +211,13 @@ jobs:
             . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
 
-      - name: Build AMD ROCm release bundle
+      - name: Build ROCm release bundle
         shell: bash
         run: |
-          just --shell bash --shell-arg -lc release-build-amd
-          just --shell bash --shell-arg -lc release-bundle-amd "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-build-rocm
+          just --shell bash --shell-arg -lc release-bundle-rocm "${GITHUB_REF_NAME}" dist
 
-      - name: Upload AMD ROCm release artifacts
+      - name: Upload ROCm release artifacts
         uses: actions/upload-artifact@v6
         with:
           name: release-linux-rocm
@@ -488,7 +492,7 @@ jobs:
     needs:
       - build
       - build_linux_cuda
-      - build_linux_amd
+      - build_linux_rocm
       - build_linux_vulkan
       - inference_smoke_tests
       # - build_windows  # disabled until llama.cpp CUDA fix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,8 +315,8 @@ jobs:
   #           artifact_name: release-windows-cuda
   #         - name: ROCm
   #           backend: rocm
-  #           build_recipe: release-build-amd-windows
-  #           bundle_recipe: release-bundle-amd-windows
+  #           build_recipe: release-build-rocm-windows
+  #           bundle_recipe: release-bundle-rocm-windows
   #           artifact_name: release-windows-rocm
   #         - name: Vulkan
   #           backend: vulkan

--- a/Justfile
+++ b/Justfile
@@ -60,14 +60,8 @@ release-build-cuda-windows cuda_arch="75;80;86;89;90;120":
 release-build-rocm rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
     @scripts/build-linux-rocm.sh "{{ rocm_arch }}"
 
-release-build-amd rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
-    @just release-build-rocm "{{ rocm_arch }}"
-
 release-build-rocm-windows rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend rocm -RocmArch "{{rocm_arch}}"
-
-release-build-amd-windows rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
-    @just release-build-rocm-windows "{{ rocm_arch }}"
 
 # Build a Linux Vulkan release artifact.
 release-build-vulkan:
@@ -249,14 +243,8 @@ release-bundle-cuda-windows version output="dist":
 release-bundle-rocm version output="dist":
     MESH_RELEASE_FLAVOR=rocm scripts/package-release.sh "{{ version }}" "{{ output }}"
 
-release-bundle-amd version output="dist":
-    @just release-bundle-rocm "{{ version }}" "{{ output }}"
-
 release-bundle-rocm-windows version output="dist":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1 -Version "{{version}}" -OutputDir "{{output}}" -Flavor rocm
-
-release-bundle-amd-windows version output="dist":
-    @just release-bundle-rocm-windows "{{ version }}" "{{ output }}"
 
 # Create Linux Vulkan release archive(s).
 release-bundle-vulkan version output="dist":

--- a/Justfile
+++ b/Justfile
@@ -60,8 +60,14 @@ release-build-cuda-windows cuda_arch="75;80;86;89;90;120":
 release-build-rocm rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
     @scripts/build-linux-rocm.sh "{{ rocm_arch }}"
 
+release-build-amd rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
+    @just release-build-rocm "{{ rocm_arch }}"
+
 release-build-rocm-windows rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend rocm -RocmArch "{{rocm_arch}}"
+
+release-build-amd-windows rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
+    @just release-build-rocm-windows "{{ rocm_arch }}"
 
 # Build a Linux Vulkan release artifact.
 release-build-vulkan:
@@ -243,8 +249,14 @@ release-bundle-cuda-windows version output="dist":
 release-bundle-rocm version output="dist":
     MESH_RELEASE_FLAVOR=rocm scripts/package-release.sh "{{ version }}" "{{ output }}"
 
+release-bundle-amd version output="dist":
+    @just release-bundle-rocm "{{ version }}" "{{ output }}"
+
 release-bundle-rocm-windows version output="dist":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1 -Version "{{version}}" -OutputDir "{{output}}" -Flavor rocm
+
+release-bundle-amd-windows version output="dist":
+    @just release-bundle-rocm-windows "{{ version }}" "{{ output }}"
 
 # Create Linux Vulkan release archive(s).
 release-bundle-vulkan version output="dist":


### PR DESCRIPTION
## Summary
- split CI so build jobs package and upload platform binaries, then run inference smoke tests in a dedicated follow-up job
- update release publishing to reuse packaged Linux inference binaries and gate release publication on successful inference smoke tests
- carry over the AMD ROCm workflow/job naming and release bundle commands, plus binary artifact uploads for CUDA, ROCm, and Vulkan lanes
- keep the warmed CUDA and ROCm cache restore paths in CI while switching the smoke path to release binaries

## Testing
- Not run (not requested)