### PR TITLE
Always handle images and PDFs in the browser

### DIFF
--- a/mesh-llm/ui/src/App.test.tsx
+++ b/mesh-llm/ui/src/App.test.tsx
@@ -1,7 +1,13 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 
-import { App, ChatPage } from "./App";
+import {
+  App,
+  attachmentForMessage,
+  ChatPage,
+  describeImageAttachmentForPrompt,
+  describeRenderedPagesAsText,
+} from "./App";
 
 function buildProps(
   overrides: Partial<Parameters<typeof ChatPage>[0]> = {},
@@ -32,13 +38,12 @@ function buildProps(
     setSelectedModel: vi.fn(),
     selectedModelNodeCount: 1,
     selectedModelVramGb: 12,
-    selectedModelVision: true,
     selectedModelAudio: true,
     selectedModelMultimodal: true,
     composerError: null,
     setComposerError: vi.fn(),
     attachmentSendIssue: null,
-    imageDescriptionInProgress: false,
+    attachmentPreparationMessage: null,
     pendingAttachments: [],
     setPendingAttachments: vi.fn(),
     conversations: [
@@ -253,6 +258,55 @@ describe("ChatPage", () => {
     );
   });
 
+  it("shows attachment preparation progress and disables send", () => {
+    render(
+      <ChatPage
+        {...buildProps({
+          attachmentPreparationMessage: "Preparing PDF in browser…",
+          pendingAttachments: [
+            {
+              id: "att-pdf",
+              kind: "file",
+              dataUrl: "data:application/pdf;base64,abc",
+              mimeType: "application/pdf",
+              fileName: "scan.pdf",
+              status: "uploading",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Preparing PDF in browser…")).toBeInTheDocument();
+    expect(screen.getByTestId("chat-send")).toBeDisabled();
+  });
+
+  it("shows failed image-description state with retry affordance", () => {
+    render(
+      <ChatPage
+        {...buildProps({
+          pendingAttachments: [
+            {
+              id: "att-image-failed",
+              kind: "image",
+              dataUrl: "data:image/png;base64,abc",
+              mimeType: "image/png",
+              fileName: "legacy.png",
+              status: "failed",
+              extractionSummary: "Image description failed — retry or send placeholder text",
+              error: "Image description failed: model init failed",
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText("Retry")).toBeInTheDocument();
+    expect(
+      screen.getByText("Image description failed — retry or send placeholder text"),
+    ).toBeInTheDocument();
+  });
+
   it("shows Queue button label and calls onSubmit when isSending=true", () => {
     const onSubmit = vi.fn();
     render(
@@ -381,5 +435,96 @@ describe("App routing and status", () => {
     const input = await screen.findByTestId("chat-input");
     expect(input).toBeDisabled();
     expect(input).toHaveAttribute("placeholder", "Waiting for a warm model...");
+  });
+});
+
+describe("describeRenderedPagesAsText", () => {
+  it("combines page descriptions and preserves failures as placeholders", async () => {
+    const describe = vi
+      .fn<
+        (dataUrl: string) => Promise<{
+          combinedText: string;
+          description: string;
+          ocrText: string;
+        }>
+      >()
+      .mockResolvedValueOnce({
+        combinedText: "First page OCR",
+        description: "First page OCR",
+        ocrText: "First page OCR",
+      })
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({
+        combinedText: "",
+        description: "",
+        ocrText: "",
+      });
+
+    const text = await describeRenderedPagesAsText(
+      [
+        "data:image/png;base64,one",
+        "data:image/png;base64,two",
+        "data:image/png;base64,three",
+      ],
+      { describe },
+    );
+
+    expect(text).toContain("[Page 1]\nFirst page OCR");
+    expect(text).toContain("[Page 2]\n[Unable to describe page]");
+    expect(text).toContain("[Page 3]\n[Unable to describe page]");
+  });
+});
+
+describe("describeImageAttachmentForPrompt", () => {
+  it("returns image text and summary on success", async () => {
+    const describe = vi.fn<typeof describeImageAttachmentForPrompt extends never ? never : any>().mockResolvedValue({
+      combinedText: "A cat on a chair",
+      description: "A cat on a chair",
+      ocrText: "",
+    });
+
+    const result = await describeImageAttachmentForPrompt(
+      "data:image/png;base64,abc",
+      { describe },
+    );
+
+    expect(result).toEqual({
+      imageDescription: "A cat on a chair",
+      extractionSummary: "Described by local vision",
+    });
+  });
+
+  it("returns a visible warning payload on failure", async () => {
+    const describe = vi.fn().mockRejectedValue(new Error("boom"));
+
+    const result = await describeImageAttachmentForPrompt(
+      "data:image/png;base64,abc",
+      { describe },
+    );
+
+    expect(result.imageDescription).toBeUndefined();
+    expect(result.extractionSummary).toBe(
+      "Image description failed — retry or send placeholder text",
+    );
+    expect(result.error).toContain("Image description failed: boom");
+  });
+});
+
+describe("attachmentForMessage", () => {
+  it("drops rendered page images once extracted text exists", () => {
+    const attachment = attachmentForMessage({
+      id: "att-pdf",
+      kind: "file",
+      dataUrl: "data:application/pdf;base64,abc",
+      mimeType: "application/pdf",
+      fileName: "scan.pdf",
+      status: "pending",
+      extractedText: "Recovered text",
+      renderedPageImages: ["data:image/png;base64,one"],
+      extractionSummary: "1 page described",
+    });
+
+    expect(attachment.extractedText).toBe("Recovered text");
+    expect(attachment.renderedPageImages).toBeUndefined();
   });
 });

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -130,7 +130,6 @@ import {
   validateAttachmentFile,
 } from "./lib/attachments";
 import {
-  canRunBrowserVision,
   describeImage,
 } from "./lib/image-describe";
 import {
@@ -674,6 +673,83 @@ function parseDataUrl(dataUrl: string): { mimeType: string; base64: string } | n
   return { mimeType: match[1], base64: match[2] };
 }
 
+type ImageDescriptionResult = Awaited<ReturnType<typeof describeImage>>;
+type AttachmentStatePatch = Partial<
+  Pick<
+    ChatAttachment,
+    "status" | "error" | "extractionSummary" | "imageDescription" | "renderedPageImages"
+  >
+>;
+
+export async function describeImageAttachmentForPrompt(
+  dataUrl: string,
+  options?: {
+    describe?: typeof describeImage;
+    onProgress?: (message: string) => void;
+  },
+): Promise<{
+  imageDescription?: string;
+  extractionSummary: string;
+  error?: string;
+}> {
+  const describe = options?.describe ?? describeImage;
+  try {
+    const result = await describe(dataUrl, options?.onProgress);
+    const imageDescription = result.combinedText.trim();
+    return {
+      imageDescription: imageDescription || undefined,
+      extractionSummary: result.ocrText
+        ? "Described + OCR extracted"
+        : "Described by local vision",
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      imageDescription: undefined,
+      extractionSummary: "Image description failed — retry or send placeholder text",
+      error: `Image description failed: ${message}`,
+    };
+  }
+}
+
+export async function describeRenderedPagesAsText(
+  renderedPageImages: string[],
+  options?: {
+    describe?: (dataUrl: string) => Promise<ImageDescriptionResult>;
+    onProgress?: (message: string) => void;
+  },
+): Promise<string> {
+  const describe = options?.describe ?? ((dataUrl: string) => describeImage(dataUrl));
+  const pageSections: string[] = [];
+
+  for (const [index, pageDataUrl] of renderedPageImages.entries()) {
+    options?.onProgress?.(
+      `Describing scanned PDF page ${index + 1}/${renderedPageImages.length}...`,
+    );
+    try {
+      const result = await describe(pageDataUrl);
+      const combinedText = result.combinedText.trim();
+      pageSections.push(
+        `[Page ${index + 1}]\n${combinedText || "[Unable to describe page]"}`,
+      );
+    } catch {
+      pageSections.push(`[Page ${index + 1}]\n[Unable to describe page]`);
+    }
+  }
+
+  return pageSections.join("\n\n");
+}
+
+export function attachmentForMessage(
+  attachment: ChatAttachment,
+): Omit<ChatAttachment, "status" | "error"> {
+  const { status, error, ...persistedAttachment } = attachment;
+  if (persistedAttachment.extractedText) {
+    persistedAttachment.renderedPageImages = undefined;
+  }
+  return persistedAttachment;
+}
+
 function sanitizeAttachment(raw: unknown): ChatAttachment | null {
   if (!raw || typeof raw !== "object") return null;
   const item = raw as Record<string, unknown>;
@@ -1062,13 +1138,6 @@ export function App() {
   }, [status, warmModels, meshModels]);
   const selectedChatModel =
     selectedModel || warmModels[0] || status?.model_name || "";
-  const visionModels = useMemo(() => {
-    const set = new Set<string>();
-    for (const m of meshModels) {
-      if (m.vision) set.add(m.name);
-    }
-    return set;
-  }, [meshModels]);
   const audioModels = useMemo(() => {
     const set = new Set<string>();
     for (const m of meshModels) {
@@ -1083,10 +1152,6 @@ export function App() {
     }
     return set;
   }, [meshModels]);
-  const selectedModelVision = useMemo(() => {
-    if (selectedModel) return visionModels.has(selectedModel);
-    return meshModels.some((m) => m.status === "warm" && m.vision);
-  }, [meshModels, selectedModel, visionModels]);
   const selectedModelAudio = useMemo(() => {
     if (selectedModel) return audioModels.has(selectedModel);
     return meshModels.some((m) => m.status === "warm" && m.audio);
@@ -1098,54 +1163,50 @@ export function App() {
   const pendingKinds = useMemo(() => {
     const kinds = new Set<"image" | "audio" | "file">();
     for (const attachment of pendingAttachments) {
-      // PDFs with extracted text or rendered page images don't need
-      // model multimodal support — they'll be sent as input_text or
-      // input_image blocks, not input_file.
-      if (attachment.extractedText || attachment.renderedPageImages?.length) {
-        if (attachment.renderedPageImages?.length) kinds.add("image");
-        continue;
-      }
-      // Images with a browser-generated description (or one in progress)
-      // will be sent as input_text — no vision model needed.
-      if (
-        attachment.kind === "image" &&
-        (attachment.imageDescription || attachment.status === "uploading")
-      ) {
-        continue;
-      }
+      // PDFs with extracted text don't need model support — sent as input_text.
+      if (attachment.extractedText) continue;
+      // Images are always described in-browser via Florence-2 — no model needed.
+      if (attachment.kind === "image") continue;
+      // Scanned PDFs being described don't need model support.
+      if (attachment.renderedPageImages?.length) continue;
       kinds.add(attachment.kind);
     }
     return kinds;
   }, [pendingAttachments]);
-  const imageDescriptionInProgress = useMemo(
-    () =>
-      pendingAttachments.some(
-        (a) =>
-          a.kind === "image" &&
-          a.status === "uploading" &&
-          !a.imageDescription,
-      ),
-    [pendingAttachments],
-  );
+  const attachmentPreparationMessage = useMemo(() => {
+    const preparingAttachment = pendingAttachments.find(
+      (attachment) => attachment.status === "uploading",
+    );
+    if (!preparingAttachment) return null;
+    if (preparingAttachment.kind === "image") {
+      return "Describing image in browser… (first time downloads ~230 MB model)";
+    }
+    if (
+      isPdfMimeType(preparingAttachment.mimeType) ||
+      preparingAttachment.fileName?.toLowerCase().endsWith(".pdf")
+    ) {
+      return "Preparing PDF in browser…";
+    }
+    return "Preparing attachment…";
+  }, [pendingAttachments]);
   const attachmentSendIssue = useMemo(() => {
     if (!pendingAttachments.length || !status) return null;
-    if (imageDescriptionInProgress) return "Describing image...";
+    if (attachmentPreparationMessage) return attachmentPreparationMessage;
     return getAttachmentSendIssue({
       pendingKinds,
       selectedModel,
       warmModels,
-      visionModels,
       audioModels,
       multimodalModels,
     });
   }, [
+    attachmentPreparationMessage,
     audioModels,
     multimodalModels,
     pendingAttachments.length,
     pendingKinds,
     selectedModel,
     status,
-    visionModels,
     warmModels,
   ]);
   const meshModelByName = useMemo(() => {
@@ -1480,7 +1541,7 @@ export function App() {
 
   function markComposerAttachment(
     attachmentId: string,
-    patch: Partial<Pick<ChatAttachment, "status" | "error">>,
+    patch: AttachmentStatePatch,
   ) {
     setPendingAttachments((prev) =>
       prev.map((attachment) =>
@@ -1516,15 +1577,13 @@ export function App() {
     attachments: ChatAttachment[],
     requestId: string,
     clientId: string,
-    onStatusChange?: (
-      attachmentId: string,
-      patch: Partial<Pick<ChatAttachment, "status" | "error">>,
-    ) => void,
+    onStatusChange?: (attachmentId: string, patch: AttachmentStatePatch) => void,
   ) {
     const contentBlocks: Array<Record<string, unknown>> = [];
     for (const attachment of attachments) {
       // PDF with extracted text → inject as input_text (no upload needed).
       if (attachment.extractedText) {
+        attachment.renderedPageImages = undefined;
         const label = attachment.fileName
           ? `[Content from ${attachment.fileName}]`
           : "[Extracted PDF content]";
@@ -1535,38 +1594,66 @@ export function App() {
         continue;
       }
 
-      // Image described locally → inject description as input_text.
-      if (attachment.kind === "image" && attachment.imageDescription) {
+      if (attachment.renderedPageImages?.length) {
+        onStatusChange?.(attachment.id, { status: "uploading", error: undefined });
+        const label = attachment.fileName
+          ? `[Content from ${attachment.fileName}]`
+          : "[Extracted PDF content]";
+        const text = await describeRenderedPagesAsText(attachment.renderedPageImages);
+        attachment.extractedText = text;
+        attachment.renderedPageImages = undefined;
         contentBlocks.push({
           type: "input_text",
-          text: attachment.imageDescription,
+          text: `${label}\n\n${text}`,
         });
-        continue;
-      }
-
-      // Scanned PDF rendered as images → inject each page as input_image.
-      if (attachment.renderedPageImages?.length) {
-        for (const pageDataUrl of attachment.renderedPageImages) {
-          onStatusChange?.(attachment.id, {
-            status: "uploading",
-            error: undefined,
-          });
-          const upload = await uploadRequestObject({
-            requestId,
-            dataUrl: pageDataUrl,
-            fileName: attachment.fileName,
-          });
-          const url = `mesh://blob/${clientId}/${upload.token}`;
-          contentBlocks.push({ type: "input_image", image_url: url });
-        }
         onStatusChange?.(attachment.id, {
           status: "pending",
           error: undefined,
+          renderedPageImages: undefined,
+          extractionSummary: "Described scanned PDF pages in browser",
         });
         continue;
       }
 
-      // Regular attachment (image, audio, non-PDF file).
+      // Image described locally → inject description as input_text.
+      // Images are always described in-browser; if description failed
+      // we still send a placeholder rather than uploading the blob.
+      if (attachment.kind === "image") {
+        let imageDescription = attachment.imageDescription?.trim() ?? "";
+        if (!imageDescription) {
+          onStatusChange?.(attachment.id, {
+            status: "uploading",
+            error: undefined,
+            extractionSummary: "Describing image...",
+          });
+          const result = await describeImageAttachmentForPrompt(attachment.dataUrl, {
+            onProgress: (message) => {
+              onStatusChange?.(attachment.id, {
+                status: "uploading",
+                error: undefined,
+                extractionSummary: message,
+              });
+            },
+          });
+          imageDescription = result.imageDescription?.trim() ?? "";
+          attachment.imageDescription = result.imageDescription;
+          attachment.extractionSummary = result.extractionSummary;
+          attachment.error = result.error;
+          onStatusChange?.(attachment.id, {
+            status: result.error ? "failed" : "pending",
+            error: result.error,
+            extractionSummary: result.extractionSummary,
+            imageDescription: result.imageDescription,
+          });
+        }
+        contentBlocks.push({
+          type: "input_text",
+          text: imageDescription || "[Image attached but could not be described]",
+        });
+        continue;
+      }
+
+      // Regular attachment (audio, non-PDF file).
       onStatusChange?.(attachment.id, { status: "uploading", error: undefined });
       try {
         const upload = await uploadRequestObject({
@@ -1575,12 +1662,7 @@ export function App() {
           fileName: attachment.fileName,
         });
         const url = `mesh://blob/${clientId}/${upload.token}`;
-        if (attachment.kind === "image") {
-          contentBlocks.push({
-            type: "input_image",
-            image_url: url,
-          });
-        } else if (attachment.kind === "audio") {
+        if (attachment.kind === "audio") {
           contentBlocks.push({
             type: "input_audio",
             audio_url: url,
@@ -1890,6 +1972,7 @@ export function App() {
       return;
     }
     if (attachmentSendIssue) {
+      if (attachmentPreparationMessage) return;
       setComposerError(attachmentSendIssue);
       return;
     }
@@ -1897,17 +1980,13 @@ export function App() {
     // Prefer an explicitly compatible model when sending media with model=auto.
     let model = selectedModel || status.model_name;
     if (pendingAttachments.length > 0 && (!model || model === "auto")) {
-      const multimodalModel = warmModels.find(
+      const compatibleModel = warmModels.find(
         (m) =>
-          (!pendingKinds.has("image") || visionModels.has(m)) &&
           (!pendingKinds.has("audio") || audioModels.has(m)) &&
           (!pendingKinds.has("file") || multimodalModels.has(m)),
       );
-      if (multimodalModel) {
-        model = multimodalModel;
-      } else if (pendingKinds.has("image")) {
-        const visionModel = warmModels.find((m) => visionModels.has(m));
-        if (visionModel) model = visionModel;
+      if (compatibleModel) {
+        model = compatibleModel;
       } else if (pendingKinds.has("audio")) {
         const audioModel = warmModels.find((m) => audioModels.has(m));
         if (audioModel) model = audioModel;
@@ -1918,34 +1997,38 @@ export function App() {
     }
     setComposerError(null);
     const conversationId = activeConversation?.id ?? randomId();
-    const userMessage: ChatMessage = {
-      id: randomId(),
-      role: "user",
-      content: trimmed,
-      model,
-      attachments:
-        pendingAttachments.length > 0
-          ? pendingAttachments.map(({ status, error, ...attachment }) => attachment)
-          : undefined,
-    };
+    const normalizedPendingAttachments = pendingAttachments.map((attachment) => ({
+      ...attachment,
+    }));
+    const userMessageId = randomId();
     const requestId = randomId();
     const clientId = chatClientIdRef.current;
     let prebuiltContentByMessageId: Record<string, Array<Record<string, unknown>>> | undefined;
-    if (pendingAttachments.length > 0) {
+    if (normalizedPendingAttachments.length > 0) {
       try {
         const blocks = await buildAttachmentBlocks(
-          pendingAttachments,
+          normalizedPendingAttachments,
           requestId,
           clientId,
           (attachmentId, patch) => markComposerAttachment(attachmentId, patch),
         );
-        prebuiltContentByMessageId = { [userMessage.id]: blocks };
+        prebuiltContentByMessageId = { [userMessageId]: blocks };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         setComposerError(`Attachment upload failed: ${message}`);
         return;
       }
     }
+    const userMessage: ChatMessage = {
+      id: userMessageId,
+      role: "user",
+      content: trimmed,
+      model,
+      attachments:
+        normalizedPendingAttachments.length > 0
+          ? normalizedPendingAttachments.map(attachmentForMessage)
+          : undefined,
+    };
     const assistantId = randomId();
     const assistantMessage: ChatMessage = {
       id: assistantId,
@@ -2207,7 +2290,7 @@ export function App() {
   }
 
   function handleSubmit() {
-    if (!canChat) return;
+    if (!canChat || attachmentPreparationMessage) return;
     void sendMessage(input);
   }
 
@@ -2246,13 +2329,12 @@ export function App() {
                   setSelectedModel={setSelectedModel}
                   selectedModelNodeCount={selectedModelNodeCount}
                   selectedModelVramGb={selectedModelVramGb}
-                  selectedModelVision={selectedModelVision}
                   selectedModelAudio={selectedModelAudio}
                   selectedModelMultimodal={selectedModelMultimodal}
                   composerError={composerError}
                   setComposerError={setComposerError}
                   attachmentSendIssue={attachmentSendIssue}
-                  imageDescriptionInProgress={imageDescriptionInProgress}
+                  attachmentPreparationMessage={attachmentPreparationMessage}
                   pendingAttachments={pendingAttachments}
                   setPendingAttachments={setPendingAttachments}
                   conversations={conversations}
@@ -2873,13 +2955,12 @@ export function ChatPage(props: {
   setSelectedModel: (v: string) => void;
   selectedModelNodeCount: number | null;
   selectedModelVramGb: number | null;
-  selectedModelVision: boolean;
   selectedModelAudio: boolean;
   selectedModelMultimodal: boolean;
   composerError: string | null;
   setComposerError: React.Dispatch<React.SetStateAction<string | null>>;
   attachmentSendIssue: string | null;
-  imageDescriptionInProgress: boolean;
+  attachmentPreparationMessage: string | null;
   pendingAttachments: ChatAttachment[];
   setPendingAttachments: React.Dispatch<React.SetStateAction<ChatAttachment[]>>;
   conversations: ChatConversation[];
@@ -2915,13 +2996,12 @@ export function ChatPage(props: {
     setSelectedModel,
     selectedModelNodeCount,
     selectedModelVramGb,
-    selectedModelVision,
     selectedModelAudio,
     selectedModelMultimodal,
     composerError,
     setComposerError,
     attachmentSendIssue,
-    imageDescriptionInProgress,
+    attachmentPreparationMessage,
     pendingAttachments,
     setPendingAttachments,
     conversations,
@@ -2962,7 +3042,7 @@ export function ChatPage(props: {
 
   function markPendingAttachment(
     attachmentId: string,
-    patch: Partial<Pick<ChatAttachment, "status" | "error">>,
+    patch: AttachmentStatePatch,
   ) {
     setPendingAttachments((prev) =>
       prev.map((attachment) =>
@@ -2991,7 +3071,23 @@ export function ChatPage(props: {
   }
 
   function resetAttachmentStatus(attachmentId: string) {
-    markPendingAttachment(attachmentId, { status: "pending", error: undefined });
+    const attachment = pendingAttachments.find((item) => item.id === attachmentId);
+    if (!attachment) return;
+    if (attachment.kind === "image" && !attachment.imageDescription) {
+      markPendingAttachment(attachmentId, {
+        status: "uploading",
+        error: undefined,
+        extractionSummary: "Describing image...",
+      });
+      void describeImageAttachment(attachmentId, attachment.dataUrl);
+      setComposerError(null);
+      return;
+    }
+    markPendingAttachment(attachmentId, {
+      status: "pending",
+      error: undefined,
+      extractionSummary: undefined,
+    });
     setComposerError(null);
   }
 
@@ -3002,24 +3098,21 @@ export function ChatPage(props: {
    */
   function addImageAttachment(attachment: Omit<ChatAttachment, "id" | "status" | "error">) {
     const attachmentId = randomId();
-    const needsDescription = !selectedModelVision && canRunBrowserVision();
     setPendingAttachments((prev) => [
       ...prev,
       {
         id: attachmentId,
-        status: needsDescription ? "uploading" : "pending",
-        extractionSummary: needsDescription ? "Describing image..." : undefined,
+        status: "uploading",
+        extractionSummary: "Describing image...",
         ...attachment,
       },
     ]);
-    if (needsDescription) {
-      void describeImageAttachment(attachmentId, attachment.dataUrl);
-    }
+    void describeImageAttachment(attachmentId, attachment.dataUrl);
   }
 
   async function describeImageAttachment(attachmentId: string, dataUrl: string) {
-    try {
-      const result = await describeImage(dataUrl, (message) => {
+    const result = await describeImageAttachmentForPrompt(dataUrl, {
+      onProgress: (message) => {
         setPendingAttachments((prev) =>
           prev.map((a) =>
             a.id === attachmentId
@@ -3027,37 +3120,23 @@ export function ChatPage(props: {
               : a,
           ),
         );
-      });
-      setPendingAttachments((prev) =>
-        prev.map((a) =>
-          a.id === attachmentId
-            ? {
-                ...a,
-                status: "pending",
-                imageDescription: result.combinedText,
-                extractionSummary: result.ocrText
-                  ? "Described + OCR extracted"
-                  : "Described by local vision",
-              }
-            : a,
-        ),
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      setPendingAttachments((prev) =>
-        prev.map((a) =>
-          a.id === attachmentId
-            ? {
-                ...a,
-                status: "pending",
-                extractionSummary: undefined,
-                // Don't fail the attachment — it can still be sent if
-                // the user switches to a vision model.
-              }
-            : a,
-        ),
-      );
-      console.warn("Image description failed:", message);
+      },
+    });
+    setPendingAttachments((prev) =>
+      prev.map((a) =>
+        a.id === attachmentId
+          ? {
+              ...a,
+              status: result.error ? "failed" : "pending",
+              imageDescription: result.imageDescription,
+              extractionSummary: result.extractionSummary,
+              error: result.error,
+            }
+          : a,
+      ),
+    );
+    if (result.error) {
+      console.warn(result.error);
     }
   }
 
@@ -3208,52 +3287,58 @@ export function ChatPage(props: {
                   ...a,
                   status: "pending",
                   extractedText: result.text,
+                  renderedPageImages: undefined,
                   extractionSummary: summary,
                 }
               : a,
           ),
         );
       } else {
-        // Scanned PDF or negligible text — try rendering pages as images.
-        const hasVisionModel =
-          warmModels.some((m) => meshModelByName[m]?.vision) ||
-          Object.values(meshModelByName).some((m) => m.vision);
-        if (hasVisionModel) {
-          const images = await renderPdfPagesToImages(buffer, {
-            maxPages: 8,
-          });
-          if (images.length > 0) {
-            const summary = `${result.pageCount} page${result.pageCount !== 1 ? "s" : ""}, rendered as ${images.length} image${images.length !== 1 ? "s" : ""} (scanned PDF)`;
-            setPendingAttachments((prev) =>
-              prev.map((a) =>
-                a.id === attachmentId
-                  ? {
-                      ...a,
-                      status: "pending",
-                      renderedPageImages: images,
-                      extractionSummary: summary,
-                    }
-                  : a,
-              ),
-            );
-          } else {
-            throw new Error("Could not render PDF pages");
-          }
-        } else {
-          // No vision model and no text — can't do much.
+        // Scanned PDF or negligible text — render pages as images and
+        // describe each one via the in-browser Florence-2 model so any
+        // text model can reason about the content.
+        const images = await renderPdfPagesToImages(buffer, {
+          maxPages: 8,
+        });
+        if (images.length > 0) {
           setPendingAttachments((prev) =>
             prev.map((a) =>
               a.id === attachmentId
                 ? {
                     ...a,
-                    status: "failed",
-                    error:
-                      "This PDF appears to be scanned (no text content). A vision model is needed to read it.",
-                    extractionSummary: "No text found",
+                    renderedPageImages: images,
+                    extractionSummary: `Describing ${images.length} page${images.length !== 1 ? "s" : ""}...`,
                   }
                 : a,
             ),
           );
+          const combinedText = await describeRenderedPagesAsText(images, {
+            onProgress: (message) => {
+              setPendingAttachments((prev) =>
+                prev.map((a) =>
+                  a.id === attachmentId
+                    ? { ...a, extractionSummary: message }
+                    : a,
+                ),
+              );
+            },
+          });
+          const summary = `${result.pageCount} page${result.pageCount !== 1 ? "s" : ""}, ${images.length} page${images.length !== 1 ? "s" : ""} described (scanned PDF)`;
+          setPendingAttachments((prev) =>
+            prev.map((a) =>
+              a.id === attachmentId
+                ? {
+                    ...a,
+                    status: "pending",
+                    extractedText: combinedText,
+                    renderedPageImages: undefined,
+                    extractionSummary: summary,
+                  }
+                : a,
+            ),
+          );
+        } else {
+          throw new Error("Could not render PDF pages");
         }
       }
     } catch (err) {
@@ -3778,7 +3863,7 @@ export function ChatPage(props: {
                         {attachment.status === "uploading" ? (
                           <div className="absolute inset-0 flex items-center justify-center rounded-md bg-background/70 text-xs">
                             <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                            {attachment.extractionSummary || "Uploading"}
+                            {attachment.extractionSummary || "Describing…"}
                           </div>
                         ) : attachment.status === "failed" ? (
                           <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-md bg-background/80 text-xs">
@@ -3851,10 +3936,10 @@ export function ChatPage(props: {
                   )}
                 </div>
               ) : null}
-              {imageDescriptionInProgress && !composerError ? (
+              {attachmentPreparationMessage && !composerError ? (
                 <div className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2 text-sm text-muted-foreground">
                   <Loader2 className="h-3.5 w-3.5 animate-spin shrink-0" />
-                  <span>Analyzing image with local vision model… (first time downloads ~230 MB)</span>
+                  <span>{attachmentPreparationMessage}</span>
                 </div>
               ) : composerError || attachmentSendIssue ? (
                 <Alert variant="destructive" data-testid="composer-error">
@@ -4010,7 +4095,8 @@ export function ChatPage(props: {
                     data-testid="chat-send"
                     disabled={
                       !props.canChat ||
-                      (!input.trim() && pendingAttachments.length === 0)
+                      (!input.trim() && pendingAttachments.length === 0) ||
+                      !!attachmentPreparationMessage
                     }
                   >
                     {isSending ? (
@@ -5311,14 +5397,25 @@ function TopologyClientDot({ data }: NodeProps<TopologyFlowDiagramNode>) {
   const isHorizontal = data.layoutDirection === "horizontal";
   const handleStyle = { opacity: 0, width: 1, height: 1, border: 0, pointerEvents: "none" as const };
   return (
-    <div className={cn("flex flex-col items-center gap-0.5", data.selected ? "opacity-100" : "opacity-40")}>
-      <div className={cn("relative h-3.5 w-3.5 rounded-full border bg-muted", data.selected ? "border-ring ring-1 ring-ring/50" : "border-border")}>
+    <div className="relative w-[120px]">
+      <div className={cn("relative mx-auto h-5 w-5 rounded-full border-2 bg-muted", data.selected ? "border-ring" : "border-border")}>
         <Handle type="target" position={isHorizontal ? Position.Left : Position.Top} style={handleStyle} />
         <Handle type="source" position={isHorizontal ? Position.Right : Position.Bottom} style={handleStyle} />
       </div>
-      <span className={cn("max-w-[60px] truncate text-[8px] leading-none", data.selected ? "text-foreground" : "text-muted-foreground")}>
-        {data.node.hostname || data.node.id.slice(0, 8)}
-      </span>
+      <div className={cn(
+        "mt-1 rounded-md border bg-card p-1.5",
+        data.selected ? "border-ring ring-1 ring-ring/50" : "border-border/90",
+      )}>
+        <div className="flex items-center justify-between gap-1">
+          <div className="flex items-center gap-1 min-w-0">
+            <Laptop className="h-3 w-3 shrink-0 text-muted-foreground" />
+            <span className="truncate text-[10px] font-medium leading-3">
+              {data.node.hostname || data.node.id.slice(0, 8)}
+            </span>
+          </div>
+        </div>
+        <div className="mt-1 text-[9px] leading-none text-muted-foreground">Client</div>
+      </div>
     </div>
   );
 }
@@ -5578,8 +5675,8 @@ function MeshTopologyFlow({
     ): BucketedTopologyNode => ({
       ...node,
       bucket,
-      width: node.client ? 64 : TOPOLOGY_NODE_WIDTH,
-      height: node.client ? 28 : estimateTopologyNodeHeight(node, nodeInfoById.get(node.id)),
+      width: node.client ? 120 : TOPOLOGY_NODE_WIDTH,
+      height: node.client ? 64 : estimateTopologyNodeHeight(node, nodeInfoById.get(node.id)),
     });
 
     return [

--- a/mesh-llm/ui/src/lib/attachments.test.ts
+++ b/mesh-llm/ui/src/lib/attachments.test.ts
@@ -47,18 +47,17 @@ describe("validateAttachmentFile", () => {
 });
 
 describe("getAttachmentSendIssue", () => {
-  it("returns selected-model mismatch errors", () => {
+  it("returns selected-model mismatch errors for audio", () => {
     expect(
       getAttachmentSendIssue({
         pendingKinds: new Set(["audio"]),
-        selectedModel: "vision-only",
-        warmModels: ["vision-only"],
-        visionModels: new Set(["vision-only"]),
+        selectedModel: "text-only",
+        warmModels: ["text-only"],
         audioModels: new Set<string>(),
-        multimodalModels: new Set(["vision-only"]),
+        multimodalModels: new Set<string>(),
       }),
     ).toBe(
-      "vision-only doesn't support audio. Choose an audio-capable model or remove the attachment.",
+      "text-only doesn't support audio. Choose an audio-capable model or remove the attachment.",
     );
   });
 
@@ -68,7 +67,6 @@ describe("getAttachmentSendIssue", () => {
         pendingKinds: new Set(["file"]),
         selectedModel: "auto",
         warmModels: ["text-only"],
-        visionModels: new Set<string>(),
         audioModels: new Set<string>(),
         multimodalModels: new Set<string>(),
       }),
@@ -77,15 +75,27 @@ describe("getAttachmentSendIssue", () => {
     );
   });
 
-  it("allows supported attachments", () => {
+  it("returns null when no media kinds need model support", () => {
+    // Images are handled in-browser, so pendingKinds should be empty.
     expect(
       getAttachmentSendIssue({
-        pendingKinds: new Set(["image", "file"]),
+        pendingKinds: new Set(),
         selectedModel: "auto",
-        warmModels: ["multi"],
-        visionModels: new Set(["multi"]),
+        warmModels: ["text-only"],
         audioModels: new Set<string>(),
-        multimodalModels: new Set(["multi"]),
+        multimodalModels: new Set<string>(),
+      }),
+    ).toBeNull();
+  });
+
+  it("allows supported audio attachments", () => {
+    expect(
+      getAttachmentSendIssue({
+        pendingKinds: new Set(["audio"]),
+        selectedModel: "auto",
+        warmModels: ["audio-model"],
+        audioModels: new Set(["audio-model"]),
+        multimodalModels: new Set<string>(),
       }),
     ).toBeNull();
   });

--- a/mesh-llm/ui/src/lib/attachments.ts
+++ b/mesh-llm/ui/src/lib/attachments.ts
@@ -11,12 +11,12 @@ type FileLike = {
 
 type AttachmentSupportOptions = {
   /** The *effective* media kinds that still need model support.
-   *  PDFs with extracted text should NOT be included here since
-   *  they will be sent as input_text, not input_file. */
+   *  Images and PDFs are always handled in-browser (Florence-2 / pdf.js)
+   *  so they should NOT appear here. Only audio and generic files need
+   *  model support. */
   pendingKinds: ReadonlySet<AttachmentKind>;
   selectedModel: string;
   warmModels: readonly string[];
-  visionModels: ReadonlySet<string>;
   audioModels: ReadonlySet<string>;
   multimodalModels: ReadonlySet<string>;
 };
@@ -56,28 +56,21 @@ export function getAttachmentSendIssue({
   pendingKinds,
   selectedModel,
   warmModels,
-  visionModels,
   audioModels,
   multimodalModels,
 }: AttachmentSupportOptions): string | null {
+  // Images and PDFs are always handled in the browser (described via
+  // Florence-2 / extracted via pdf.js) so they never require model support.
+  // Only audio and generic file attachments still need a capable model.
   if (!pendingKinds.size) return null;
 
   const modelSupports = (modelName: string) =>
-    (!pendingKinds.has("image") || visionModels.has(modelName)) &&
     (!pendingKinds.has("audio") || audioModels.has(modelName)) &&
     (!pendingKinds.has("file") || multimodalModels.has(modelName));
 
   if (selectedModel && selectedModel !== "auto") {
     if (modelSupports(selectedModel)) return null;
 
-    // Provide a specific hint depending on what's missing.
-    if (pendingKinds.has("image") && !visionModels.has(selectedModel)) {
-      const warmVision = warmModels.filter((m) => visionModels.has(m));
-      if (warmVision.length > 0) {
-        return `${selectedModel} doesn't support images. Switch to ${warmVision[0]} or set model to Auto.`;
-      }
-      return `${selectedModel} doesn't support images. Switch to a vision model (e.g. Qwen2-VL, LLaVA) or set model to Auto.`;
-    }
     if (pendingKinds.has("audio") && !audioModels.has(selectedModel)) {
       return `${selectedModel} doesn't support audio. Choose an audio-capable model or remove the attachment.`;
     }
@@ -87,9 +80,6 @@ export function getAttachmentSendIssue({
   if (warmModels.some(modelSupports)) return null;
 
   // Auto mode but no warm model supports it.
-  if (pendingKinds.has("image")) {
-    return "No warm model supports images. Warm a vision model (e.g. Qwen2-VL, LLaVA) to use image attachments.";
-  }
   if (pendingKinds.has("audio")) {
     return "No warm model supports audio input. Warm an audio-capable model to use audio attachments.";
   }


### PR DESCRIPTION
Images and PDFs attached in the web console are now always processed in the browser — no vision or multimodal model is required.

- **Images**: Always described via Florence-2 (in-browser WASM). The image thumbnail still displays in the chat, but only the text description is sent to the model.
- **Text PDFs**: Extracted via pdf.js as before (no change).
- **Scanned PDFs**: Pages rendered to images, each described via Florence-2, combined text injected. No longer fails with "A vision model is needed".

This removes the conditional logic that checked for warm vision models before deciding how to handle image attachments, simplifying the attachment flow.