### PR TITLE
[codex] Fix release publishing for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,6 +392,7 @@ jobs:
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         shell: bash
         run: |
           shopt -s nullglob
@@ -401,8 +402,8 @@ jobs:
             exit 1
           fi
 
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            gh release upload "$GITHUB_REF_NAME" "${files[@]}" --clobber
+          if gh release view "$GITHUB_REF_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "${files[@]}" --repo "$GH_REPO" --clobber
           else
-            gh release create "$GITHUB_REF_NAME" "${files[@]}" --generate-notes
+            gh release create "$GITHUB_REF_NAME" "${files[@]}" --repo "$GH_REPO" --generate-notes
           fi


### PR DESCRIPTION
## Summary

Fix the release publish job so tagged releases can be created without checking out the repository.

## Root cause

The publish job was changed from `softprops/action-gh-release` to raw `gh release` commands, but that job only downloads artifacts and does not run `actions/checkout`.

Without a local `.git` directory, `gh release view/create` tried to infer repository context from Git and failed with `fatal: not a git repository`.

## What changed

- pass `GH_REPO: ${{ github.repository }}` into the publish step
- add `--repo "$GH_REPO"` to the `gh release view`, `gh release upload`, and `gh release create` calls

## Validation

- inspected failed run `24269689785` and confirmed the failure came from missing git repo context in the publish job
- verified the workflow diff is limited to `.github/workflows/release.yml`
