### PR TITLE
[codex] Keep Linux release binaries portable across runners

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -76,6 +76,8 @@ case "$os_name" in
             -DGGML_CUDA=OFF
             -DGGML_HIP=OFF
             -DGGML_METAL=OFF
+            # Release Linux CPU artifacts must stay portable across GitHub runners.
+            -DGGML_NATIVE=OFF
             -DGGML_VULKAN=OFF
         )
         ;;


### PR DESCRIPTION
## Summary
Linux CPU release artifacts now disable `GGML_NATIVE`, matching the portable CI CPU build configuration.

This keeps release binaries runnable across different GitHub runners instead of inheriting host-specific CPU instructions from the machine that built them.

## Root Cause
The reusable inference smoke workflow runs the packaged Linux release binaries rather than rebuilding them.
When the Linux release build allows native CPU tuning, the produced artifact can depend on instructions that are not available on the smoke-test runner.

## Validation
- `bash -n scripts/build-release.sh`
