### PR TITLE
[codex] Add a pre-commit checklist for common CI failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,9 +179,33 @@ When making changes that touch gossip, routing, proxy, election, or capability a
 
 Run `cargo` commands serially. Do not run multiple `cargo` commands in parallel (including parallel test runs), because this repo frequently hits Cargo lock conflicts (`package cache` / `artifact directory`) under concurrent invocation.
 
-## Formatting
+## Pre-Commit Checklist
 
-Before committing Rust changes, format only the changed Rust files from the repo root, for example with `cargo fmt --all -- path/to/file.rs`, and include those formatting changes in the commit.
+Before committing, run the local checks most likely to fail in CI for the files you touched. Do not rely on CI to catch basic formatting, compile, or stale UI build issues.
+
+### Minimum bar before every commit
+
+- Rust-only change — format the changed Rust files and run `cargo check -p mesh-llm`.
+- UI-only change — run `just build`.
+- Mixed Rust and UI change — run `just build`.
+
+### Rust changes
+
+- Format only the changed Rust files from the repo root, for example with `cargo fmt --all -- path/to/file.rs`, and include those formatting changes in the commit.
+- After Rust changes, run `cargo check -p mesh-llm`.
+- If you touched tests, public APIs, routing, inference, gossip, plugin protocol, or CLI behavior, run the relevant tests before committing.
+- Run Rust validation serially. Do not run multiple `cargo` commands at the same time.
+
+### UI changes
+
+- Use the repo's supported workflow and run `just build`.
+- If `just build` fails on the UI step with `npm error Exit handler never called!`, run `just clean-ui` and then rerun `just build`.
+
+### Commit standard
+
+- Do not commit if formatting has not been applied.
+- Do not commit if basic local validation for your change type has not been run.
+- Do not commit known warnings in code you touched.
 
 ## Warnings
 


### PR DESCRIPTION
Users and agents now get an explicit pre-commit checklist in `AGENTS.md` that mirrors the most common CI failures we keep hitting locally.

## What changed
- replace the standalone formatting note with a concrete pre-commit checklist
- define a minimum validation bar for Rust-only, UI-only, and mixed changes
- call out `cargo check -p mesh-llm`, `just build`, and the existing `just clean-ui` recovery path
- make it explicit that basic formatting, compile, and stale UI build issues should be caught before CI

## Why
Recent CI failures have been caused by missing local validation for deterministic checks such as formatting and build health. Tightening the instructions makes the local workflow match the expected CI bar more closely.

## Validation
- documentation change only
- reviewed `AGENTS.md` diff locally
