### PR TITLE
Trim CUDA slim CI llama.cpp targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,6 +466,7 @@ jobs:
           MESH_LLM_BUILD_PROFILE: dev
           MESH_LLM_CUDA_FA_ALL_QUANTS: off
           MESH_LLM_LLAMA_PIN_SHA: ${{ steps.llama_sha.outputs.sha }}
+          MESH_LLM_LLAMA_TARGETS: "rpc-server llama-server llama-moe-analyze llama-moe-split"
         run: |
           just --shell bash --shell-arg -lc release-build-cuda 89
 

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -131,6 +131,7 @@ jobs:
       build_args: 89
       extra_env: |
         MESH_LLM_CUDA_FA_ALL_QUANTS=off
+        MESH_LLM_LLAMA_TARGETS=rpc-server llama-server llama-moe-analyze llama-moe-split
 
   warm_llama_cuda_fat:
     needs: resolve_llama_sha

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -27,6 +27,7 @@ CLEAN=0
 BACKEND=""
 CUDA_ARCH=""
 ROCM_ARCH=""
+LLAMA_TARGETS="${MESH_LLM_LLAMA_TARGETS:-}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -391,7 +392,21 @@ if [[ "$BACKEND" == "cuda" ]]; then
     fi
 fi
 
-cmake --build "$BUILD_DIR" --config Release -j"$(nproc)"
+build_args=(
+    --build "$BUILD_DIR"
+    --config Release
+    -j"$(nproc)"
+)
+
+if [[ -n "$LLAMA_TARGETS" ]]; then
+    read -r -a target_array <<< "$LLAMA_TARGETS"
+    if [[ "${#target_array[@]}" -gt 0 ]]; then
+        echo "Limiting llama.cpp build targets to: ${target_array[*]}"
+        build_args+=(--target "${target_array[@]}")
+    fi
+fi
+
+cmake "${build_args[@]}"
 echo "llama.cpp build complete: $BUILD_DIR/bin/"
 
 if [[ -d "$MESH_DIR" ]]; then


### PR DESCRIPTION
## Summary

Linux CUDA slim CI now builds only the `llama.cpp` binaries that `mesh-llm` actually needs.

This avoids the GitHub runner disk exhaustion we hit while linking the full `llama.cpp` example and test set in the CUDA slim job.

## What Changed

- add optional `MESH_LLM_LLAMA_TARGETS` support to `scripts/build-linux.sh`
- use that override in the CUDA slim CI job
- mirror the same target list in the CUDA slim warm-cache workflow so cache contents stay aligned with CI

## Why

The failing job was:
- `Linux CUDA slim`
- build step: `Build Linux CUDA backend (cache miss — full llama.cpp build)`

The actual failure was:
- `/usr/bin/ld: final link failed: No space left on device`

That happened while linking extra `llama.cpp` example/test binaries that the slim CI path does not need.

## Validation

- `bash -n scripts/build-linux.sh`
