### PR TITLE
Add prerelease GitHub release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,10 +404,13 @@ jobs:
 
           release_args=(--repo "$GH_REPO")
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then
-            release_args+=(--prerelease)
+            release_args+=(--prerelease --latest=false)
           fi
 
           if gh release view "$GITHUB_REF_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
+            if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+              gh release edit "$GITHUB_REF_NAME" --repo "$GH_REPO" --prerelease --latest=false
+            fi
             gh release upload "$GITHUB_REF_NAME" "${files[@]}" --repo "$GH_REPO" --clobber
           else
             gh release create "$GITHUB_REF_NAME" "${files[@]}" "${release_args[@]}" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,8 +402,13 @@ jobs:
             exit 1
           fi
 
+          release_args=(--repo "$GH_REPO")
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+
           if gh release view "$GITHUB_REF_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
             gh release upload "$GITHUB_REF_NAME" "${files[@]}" --repo "$GH_REPO" --clobber
           else
-            gh release create "$GITHUB_REF_NAME" "${files[@]}" --repo "$GH_REPO" --generate-notes
+            gh release create "$GITHUB_REF_NAME" "${files[@]}" "${release_args[@]}" --generate-notes
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2734,6 +2734,7 @@ dependencies = [
  "rpassword",
  "rustls",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serial_test",

--- a/Justfile
+++ b/Justfile
@@ -100,6 +100,35 @@ release version:
     git push origin main
     git push origin "$tag"
 
+# Tag and push a prerelease from the current branch. Bumps version, updates
+# Cargo.lock, commits, tags, and pushes the branch plus prerelease tag.
+prerelease version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    current_branch="$(git branch --show-current)"
+    if [[ -z "$current_branch" ]]; then
+        echo "Error: prerelease must be run from a branch, not detached HEAD." >&2
+        exit 1
+    fi
+    if [[ -n "$(git status --porcelain)" ]]; then
+        echo "Error: working tree is not clean. Commit or stash changes before prereleasing." >&2
+        exit 1
+    fi
+    tag="{{ version }}"
+    if [[ "$tag" != v* ]]; then
+        tag="v$tag"
+    fi
+    if [[ "$tag" != *-* ]]; then
+        echo "Error: prerelease tag must include a prerelease suffix such as -rc.1 (got: $tag)" >&2
+        exit 1
+    fi
+    scripts/release-version.sh "$tag"
+    git add -A
+    git commit -m "$tag: prerelease"
+    git tag "$tag"
+    git push origin "$current_branch"
+    git push origin "$tag"
+
 # Download the default model (GLM-4.7-Flash Q4_K_M, 17GB)
 download-model:
     #!/usr/bin/env bash

--- a/README.md
+++ b/README.md
@@ -448,6 +448,12 @@ To update a bundle install to the latest release:
 mesh-llm update
 ```
 
+To install a specific bundled release tag:
+
+```bash
+mesh-llm update --version v0.X.Y
+```
+
 If you build from source, always use `just`:
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -115,7 +115,7 @@ Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
 
 - Stable releases still use GitHub's `releases/latest` endpoint, so ordinary installs only see stable releases.
 - GitHub prereleases are excluded from `releases/latest`, so publishing `v0.X.0-rc.1` does not advertise that prerelease to older stable clients.
-- This change updates mesh-llm's version comparison to proper semver ordering, so a prerelease binary such as `0.X.0-rc.1` will correctly upgrade to `0.X.0`, `0.X.1`, or a newer release candidate.
+- This change updates mesh-llm's version comparison to proper semver ordering, so a prerelease binary such as `0.X.0-rc.1` will correctly upgrade to the eventual stable `0.X.0` release, or to a specific tagged release when you run `mesh-llm update --version vX.Y.Z`.
 - Older binaries that predate this change use a dot-splitting numeric comparison instead of semver. If one of those binaries somehow carries a prerelease version string such as `0.X.0-rc.1`, it can mis-order versions and may fail to recognize `0.X.0` or `0.X.1` as newer. In practice that only affects manually produced prerelease builds, because the old release tooling did not support `-rc.N` tags.
 - Result: the change is backward compatible for existing stable users, and it fixes updater behavior for official prerelease builds going forward.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -84,6 +84,14 @@ just release v0.X.0
 
 Run this from a clean local `main` branch. It bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, commits as `v0.X.0: release`, pushes `main`, and then pushes only the new release tag.
 
+### 5a. Prerelease
+
+```bash
+just prerelease v0.X.0-rc.1
+```
+
+Run this from a clean branch. It bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, commits as `v0.X.0-rc.1: prerelease`, pushes the current branch, and then pushes the prerelease tag.
+
 ### 6. Let GitHub Actions build and publish the release
 
 Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
@@ -101,6 +109,15 @@ Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
 - uploads Windows Vulkan assets such as `mesh-llm-x86_64-pc-windows-msvc-vulkan.zip`
 - keeps the legacy macOS `mesh-bundle.tar.gz` asset available for direct archive installs
 - creates the GitHub release automatically with generated notes
+- marks hyphenated tags such as `v0.X.0-rc.1` as GitHub prereleases
+
+### 6a. Autoupdater behavior and compatibility
+
+- Stable releases still use GitHub's `releases/latest` endpoint, so ordinary installs only see stable releases.
+- GitHub prereleases are excluded from `releases/latest`, so publishing `v0.X.0-rc.1` does not advertise that prerelease to older stable clients.
+- This change updates mesh-llm's version comparison to proper semver ordering, so a prerelease binary such as `0.X.0-rc.1` will correctly upgrade to `0.X.0`, `0.X.1`, or a newer release candidate.
+- Older binaries that predate this change use a dot-splitting numeric comparison instead of semver. If one of those binaries somehow carries a prerelease version string such as `0.X.0-rc.1`, it can mis-order versions and may fail to recognize `0.X.0` or `0.X.1` as newer. In practice that only affects manually produced prerelease builds, because the old release tooling did not support `-rc.N` tags.
+- Result: the change is backward compatible for existing stable users, and it fixes updater behavior for official prerelease builds going forward.
 
 ### 7. Verify the release assets
 

--- a/mesh-llm/Cargo.toml
+++ b/mesh-llm/Cargo.toml
@@ -22,6 +22,7 @@ include_dir = "0.7"
 nostr-sdk = { version = "0.44.1", default-features = false }
 rustls = "0.23.36"
 reqwest = { version = "0.12", features = ["stream", "json"] }
+semver = "1"
 sha2 = "0.10"
 ed25519-dalek = { version = "=3.0.0-pre.1", features = ["rand_core"] }
 crypto_box = "0.9"

--- a/mesh-llm/src/cli/commands/mod.rs
+++ b/mesh-llm/src/cli/commands/mod.rs
@@ -39,7 +39,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::Download { name, draft } => {
             dispatch_download_command(name.as_deref(), *draft).await
         }
-        Command::Update => run_update(cli).await,
+        Command::Update { .. } => run_update(cli).await,
         Command::Gpus { json, command } => {
             dispatch_gpu_command(*json, command.as_ref())?;
             Ok(())

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -411,8 +411,12 @@ pub(crate) enum Command {
         #[arg(long)]
         draft: bool,
     },
-    /// Update mesh-llm to the latest bundled release and exit.
-    Update,
+    /// Update mesh-llm to a bundled release and exit.
+    Update {
+        /// Install this specific release tag or version (e.g. v0.60.0 or 0.60.0-rc.1).
+        #[arg(long)]
+        version: Option<String>,
+    },
     /// Inspect local GPUs, stable IDs, and cached bandwidth.
     #[command(alias = "gpu")]
     Gpus {

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -221,7 +221,7 @@ pub(crate) async fn run() -> Result<()> {
     let checked_updates = autoupdate::maybe_auto_update(&cli).await?;
 
     // Finish the release check before startup continues.
-    if !checked_updates && !matches!(cli.command, Some(Command::Update)) {
+    if !checked_updates && !matches!(cli.command, Some(Command::Update { .. })) {
         autoupdate::check_for_update().await;
     }
 

--- a/mesh-llm/src/system/autoupdate.rs
+++ b/mesh-llm/src/system/autoupdate.rs
@@ -34,6 +34,7 @@ enum PostInstallAction {
 }
 
 struct ReleaseInfo {
+    tag: String,
     version: String,
     assets: Vec<String>,
 }
@@ -119,10 +120,14 @@ pub(crate) async fn maybe_auto_update(cli: &Cli) -> Result<bool> {
 
 pub(crate) async fn run_update_command(cli: &Cli) -> Result<()> {
     let target = require_update_target(cli)?;
-    let Some(release) = latest_release_info().await else {
-        bail!("Could not check for a new release right now. Try again shortly.");
+    let requested_version = match &cli.command {
+        Some(Command::Update { version }) => version.as_deref(),
+        _ => None,
     };
-    if !version_newer(&release.version, VERSION) {
+    let Some(release) = resolve_release_info(requested_version).await? else {
+        bail!("Could not check for a release right now. Try again shortly.");
+    };
+    if requested_version.is_none() && !version_newer(&release.version, VERSION) {
         eprintln!("mesh-llm is already up to date (v{VERSION}).");
         return Ok(());
     }
@@ -132,7 +137,7 @@ pub(crate) async fn run_update_command(cli: &Cli) -> Result<()> {
         .any(|asset| asset == &target.asset_name)
     {
         bail!(
-            "Latest release v{} does not include {}.",
+            "Release v{} does not include {}.",
             release.version,
             target.asset_name
         );
@@ -142,13 +147,15 @@ pub(crate) async fn run_update_command(cli: &Cli) -> Result<()> {
     }
 
     eprintln!(
-        "⬇️ Updating mesh-llm v{VERSION} -> v{} ({})...",
+        "⬇️ {} mesh-llm v{VERSION} -> v{} ({})...",
+        describe_requested_update(&release.version, requested_version.is_some()),
         release.version,
         target.bundle_flavor.suffix()
     );
     match install_latest_bundle(
         &target.exe,
         &target.install_dir,
+        &release,
         &target.asset_name,
         target.bundle_flavor,
         PostInstallAction::ExitAfterInstall,
@@ -179,36 +186,26 @@ pub(crate) async fn latest_release_version() -> Option<String> {
 }
 
 async fn latest_release_info() -> Option<ReleaseInfo> {
+    fetch_release_info(&latest_release_api_url()).await
+}
+
+async fn release_info_for_tag(tag: &str) -> Option<ReleaseInfo> {
+    fetch_release_info(&release_api_url_for_tag(tag)).await
+}
+
+async fn fetch_release_info(url: &str) -> Option<ReleaseInfo> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()
         .ok()?;
     let resp = client
-        .get(latest_release_api_url())
+        .get(url)
         .header("User-Agent", "mesh-llm")
         .send()
         .await
         .ok()?;
     let body: serde_json::Value = resp.json().await.ok()?;
-    let tag = body["tag_name"].as_str()?;
-    let latest = tag.trim_start_matches('v').trim();
-    if latest.is_empty() {
-        None
-    } else {
-        let assets = body["assets"]
-            .as_array()
-            .map(|items| {
-                items
-                    .iter()
-                    .filter_map(|item| item["name"].as_str().map(str::to_string))
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
-        Some(ReleaseInfo {
-            version: latest.to_string(),
-            assets,
-        })
-    }
+    release_info_from_json(&body)
 }
 
 pub(crate) fn version_newer(a: &str, b: &str) -> bool {
@@ -221,7 +218,7 @@ pub(crate) fn version_newer(a: &str, b: &str) -> bool {
 fn should_attempt_auto_update(cli: &Cli) -> bool {
     cli.auto_update
         && cli.plugin.is_none()
-        && !matches!(cli.command, Some(Command::Update))
+        && !matches!(cli.command, Some(Command::Update { .. }))
         && std::env::var_os(SELF_UPDATE_ATTEMPTED_ENV).is_none()
 }
 
@@ -299,6 +296,7 @@ async fn apply_update_if_available(
     match install_latest_bundle(
         &target.exe,
         &target.install_dir,
+        &release,
         &target.asset_name,
         target.bundle_flavor,
         action,
@@ -427,11 +425,73 @@ fn latest_release_api_url() -> String {
     )
 }
 
-fn latest_release_asset_url(asset_name: &str) -> String {
+fn release_api_url_for_tag(tag: &str) -> String {
     format!(
-        "https://github.com/{}/releases/latest/download/{asset_name}",
+        "https://api.github.com/repos/{}/releases/tags/{tag}",
         release_repo()
     )
+}
+
+fn release_asset_url(tag: &str, asset_name: &str) -> String {
+    format!(
+        "https://github.com/{}/releases/download/{tag}/{asset_name}",
+        release_repo()
+    )
+}
+
+fn release_info_from_json(body: &serde_json::Value) -> Option<ReleaseInfo> {
+    let tag = body["tag_name"].as_str()?.trim();
+    let version = tag.trim_start_matches('v').trim();
+    if tag.is_empty() || version.is_empty() {
+        return None;
+    }
+
+    let assets = body["assets"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item["name"].as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    Some(ReleaseInfo {
+        tag: tag.to_string(),
+        version: version.to_string(),
+        assets,
+    })
+}
+
+async fn resolve_release_info(requested_version: Option<&str>) -> Result<Option<ReleaseInfo>> {
+    let Some(requested_version) = requested_version else {
+        return Ok(latest_release_info().await);
+    };
+    let tag = normalize_release_tag(requested_version)?;
+    Ok(release_info_for_tag(&tag).await)
+}
+
+fn normalize_release_tag(raw: &str) -> Result<String> {
+    let trimmed = raw.trim();
+    anyhow::ensure!(!trimmed.is_empty(), "release version must not be empty");
+    let version = trimmed.trim_start_matches('v');
+    semver::Version::parse(version).with_context(|| format!("Invalid release version: {raw}"))?;
+    Ok(format!("v{version}"))
+}
+
+fn describe_requested_update(target_version: &str, exact: bool) -> &'static str {
+    if !exact {
+        return "Updating";
+    }
+
+    match (
+        semver::Version::parse(target_version),
+        semver::Version::parse(VERSION),
+    ) {
+        (Ok(target), Ok(current)) if target < current => "Downgrading",
+        (Ok(target), Ok(current)) if target == current => "Reinstalling",
+        _ => "Installing",
+    }
 }
 
 fn path_is_writable(path: &Path) -> bool {
@@ -476,6 +536,7 @@ fn bundle_install_dir(
 async fn install_latest_bundle(
     exe: &Path,
     install_dir: &Path,
+    release: &ReleaseInfo,
     asset_name: &str,
     expected_flavor: launch::BinaryFlavor,
     action: PostInstallAction,
@@ -497,8 +558,11 @@ async fn install_latest_bundle(
         .with_context(|| format!("Failed to create update workspace {}", workspace.display()))?;
 
     let result = async {
-        crate::models::catalog::download_url(&latest_release_asset_url(asset_name), &archive)
-            .await?;
+        crate::models::catalog::download_url(
+            &release_asset_url(&release.tag, asset_name),
+            &archive,
+        )
+        .await?;
         extract_bundle_archive(&archive, &extracted)?;
         let staged_files = collect_bundle_files(&extracted, expected_flavor)?;
         finish_bundle_install(
@@ -1035,11 +1099,11 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_latest_release_asset_url() {
+    fn test_release_asset_url() {
         std::env::remove_var(SELF_UPDATE_REPO_ENV);
         assert_eq!(
-            latest_release_asset_url("mesh-llm-aarch64-apple-darwin.tar.gz"),
-            "https://github.com/michaelneale/mesh-llm/releases/latest/download/mesh-llm-aarch64-apple-darwin.tar.gz"
+            release_asset_url("v0.60.0", "mesh-llm-aarch64-apple-darwin.tar.gz"),
+            "https://github.com/michaelneale/mesh-llm/releases/download/v0.60.0/mesh-llm-aarch64-apple-darwin.tar.gz"
         );
     }
 
@@ -1064,10 +1128,32 @@ mod tests {
             "https://api.github.com/repos/jdumay/mesh-llm/releases/latest"
         );
         assert_eq!(
-            latest_release_asset_url("mesh-llm-x86_64-unknown-linux-gnu.tar.gz"),
-            "https://github.com/jdumay/mesh-llm/releases/latest/download/mesh-llm-x86_64-unknown-linux-gnu.tar.gz"
+            release_api_url_for_tag("v0.60.0"),
+            "https://api.github.com/repos/jdumay/mesh-llm/releases/tags/v0.60.0"
+        );
+        assert_eq!(
+            release_asset_url("v0.60.0", "mesh-llm-x86_64-unknown-linux-gnu.tar.gz"),
+            "https://github.com/jdumay/mesh-llm/releases/download/v0.60.0/mesh-llm-x86_64-unknown-linux-gnu.tar.gz"
         );
         std::env::remove_var(SELF_UPDATE_REPO_ENV);
+    }
+
+    #[test]
+    fn test_normalize_release_tag() {
+        assert_eq!(normalize_release_tag("v0.60.0").unwrap(), "v0.60.0");
+        assert_eq!(
+            normalize_release_tag("0.60.0-rc.1").unwrap(),
+            "v0.60.0-rc.1"
+        );
+        assert!(normalize_release_tag("latest").is_err());
+    }
+
+    #[test]
+    fn test_describe_requested_update() {
+        assert_eq!(describe_requested_update("0.60.0", false), "Updating");
+        assert_eq!(describe_requested_update(VERSION, true), "Reinstalling");
+        assert_eq!(describe_requested_update("0.0.1", true), "Downgrading");
+        assert_eq!(describe_requested_update("999.0.0", true), "Installing");
     }
 
     #[test]

--- a/mesh-llm/src/system/autoupdate.rs
+++ b/mesh-llm/src/system/autoupdate.rs
@@ -212,8 +212,10 @@ async fn latest_release_info() -> Option<ReleaseInfo> {
 }
 
 pub(crate) fn version_newer(a: &str, b: &str) -> bool {
-    let parse = |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse().ok()).collect() };
-    parse(a) > parse(b)
+    match (semver::Version::parse(a), semver::Version::parse(b)) {
+        (Ok(a), Ok(b)) => a > b,
+        _ => false,
+    }
 }
 
 fn should_attempt_auto_update(cli: &Cli) -> bool {
@@ -1026,6 +1028,9 @@ mod tests {
         assert!(version_newer("0.33.1", "0.33.0"));
         assert!(!version_newer("0.33.0", "0.33.0"));
         assert!(!version_newer("0.32.0", "0.33.0"));
+        assert!(version_newer("0.33.0", "0.33.0-rc.1"));
+        assert!(!version_newer("0.33.0-rc.1", "0.33.0"));
+        assert!(version_newer("0.33.0-rc.2", "0.33.0-rc.1"));
     }
 
     #[test]

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -10,9 +10,9 @@ fi
 raw_version="$1"
 version="${raw_version#v}"
 
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
     echo "invalid version: $raw_version" >&2
-    echo "expected semantic version like 0.49.0 or v0.49.0" >&2
+    echo "expected semantic version like 0.49.0, 0.49.0-rc.1, v0.49.0, or v0.49.0-rc.1" >&2
     exit 1
 fi
 


### PR DESCRIPTION
Users can now publish GitHub prereleases such as `v0.60.0-rc.1` through the existing release workflow, and bundle installs can be pinned to an exact tagged release with `mesh-llm update --version vX.Y.Z`.

## What changed
- add `just prerelease vX.Y.Z-rc.N` to bump versions, commit, tag, and push a prerelease from the current branch
- allow `scripts/release-version.sh` to accept semver prerelease strings
- treat hyphenated `v*` tags in `.github/workflows/release.yml` as GitHub prereleases, and keep that metadata idempotent on reruns
- add `mesh-llm update --version vX.Y.Z` to install an exact tagged bundled release
- switch autoupdater version comparison to semver ordering
- document the prerelease flow and updater behavior in `RELEASE.md` and `README.md`

## How it works
- Stable releases stay the same: `just release vX.Y.Z` from `main` creates a normal GitHub release.
- Prereleases use `just prerelease vX.Y.Z-rc.N` from a clean branch.
- That recipe updates the embedded crate/app version to `X.Y.Z-rc.N`, commits it, tags `vX.Y.Z-rc.N`, pushes the branch, and pushes the tag.
- The existing `release.yml` workflow still handles the build and packaging work.
- In the publish step, tags containing `-` are created as GitHub prereleases and explicitly kept non-latest on reruns; plain `vX.Y.Z` tags are created as normal releases.

## Autoupdater
- Plain `mesh-llm update` and `--auto-update` still check GitHub's `releases/latest` endpoint.
- GitHub excludes prereleases from `releases/latest`, so stable installs do not get pointed at `-rc.N` builds.
- A prerelease binary will therefore upgrade automatically when the corresponding stable release becomes `latest`, not to newer `-rc.N` builds through the normal updater path.
- `mesh-llm update --version vX.Y.Z` bypasses `releases/latest` and resolves `releases/tags/vX.Y.Z`, so it can install an exact stable release or prerelease tag.
- Version comparisons now use semver ordering, which fixes comparison behavior for binaries that themselves report prerelease versions.

## Compatibility
- Backward compatible for existing stable users: old stable binaries still query `releases/latest`, and GitHub does not surface prereleases there.
- Important old-updater behavior: binaries that predate this PR compare versions by splitting on dots instead of semver.
- If one of those older binaries somehow has a prerelease version string like `0.X.Y-rc.1`, it can mis-order versions and may fail to detect a newer stable release correctly.
- In practice that edge case only affects manually produced prerelease binaries, because the previous release tooling rejected `-rc.N` versions.

## Validation
- `cargo fmt --all -- mesh-llm/src/cli/mod.rs mesh-llm/src/cli/commands/mod.rs mesh-llm/src/runtime/mod.rs mesh-llm/src/system/autoupdate.rs`
- `cargo check -p mesh-llm`
- `cargo test -p mesh-llm autoupdate -- --nocapture`
