### PR TITLE
Add installer support for prerelease builds

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -12,6 +12,12 @@ Install the latest release bundle:
 curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash
 ```
 
+To opt into the latest published prerelease bundle instead:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash -s -- --pre-release
+```
+
 The installer probes your machine, recommends a flavor, and asks what to install.
 
 For a non-interactive install, set the flavor explicitly:

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ REPO="${MESH_LLM_INSTALL_REPO:-michaelneale/mesh-llm}"
 REPO_REF="${MESH_LLM_INSTALL_REF:-main}"
 INSTALL_DIR="${MESH_LLM_INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_FLAVOR="${MESH_LLM_INSTALL_FLAVOR:-}"
+INSTALL_PRERELEASE="${MESH_LLM_INSTALL_PRERELEASE:-0}"
 INSTALL_SERVICE="${MESH_LLM_INSTALL_SERVICE:-0}"
 INSTALL_SERVICE_ARGS="${MESH_LLM_INSTALL_SERVICE_ARGS:-}"
 INSTALL_SERVICE_START="${MESH_LLM_INSTALL_SERVICE_START:-1}"
@@ -52,9 +53,10 @@ bool_is_true() {
 
 usage() {
     cat <<EOF
-Usage: install.sh [--service] [--no-start-service]
+Usage: install.sh [--pre-release] [--service] [--no-start-service]
 
 Options:
+  --pre-release              Install the latest published GitHub prerelease instead of the latest stable release.
   --service                  Install a per-user background service for this platform.
   --no-start-service         Install the service files but do not start them yet.
   -h, --help                 Show this help text.
@@ -62,6 +64,7 @@ Options:
 Environment overrides:
   MESH_LLM_INSTALL_DIR
   MESH_LLM_INSTALL_FLAVOR
+  MESH_LLM_INSTALL_PRERELEASE=1
   MESH_LLM_INSTALL_REF=main
   MESH_LLM_INSTALL_SERVICE=1
   MESH_LLM_INSTALL_SERVICE_START=0
@@ -71,6 +74,9 @@ EOF
 parse_args() {
     while (($# > 0)); do
         case "$1" in
+            --pre-release)
+                INSTALL_PRERELEASE=1
+                ;;
             --service)
                 INSTALL_SERVICE=1
                 ;;
@@ -283,6 +289,103 @@ asset_name() {
             exit 1
             ;;
     esac
+}
+
+latest_prerelease_tag() {
+    local api_url="https://api.github.com/repos/${REPO}/releases?per_page=20"
+    local response
+    response="$(curl -fsSL \
+        -H 'Accept: application/vnd.github+json' \
+        -H 'X-GitHub-Api-Version: 2022-11-28' \
+        "$api_url")"
+
+    local tag
+    tag="$(
+        printf '%s' "$response" | awk '
+            BEGIN {
+                in_string = 0
+                escape = 0
+                depth = 0
+                capture = 0
+                object = ""
+            }
+            {
+                for (i = 1; i <= length($0); i++) {
+                    c = substr($0, i, 1)
+
+                    if (capture) {
+                        object = object c
+                    }
+
+                    if (escape) {
+                        escape = 0
+                        continue
+                    }
+
+                    if (c == "\\") {
+                        if (in_string) {
+                            escape = 1
+                        }
+                        continue
+                    }
+
+                    if (c == "\"") {
+                        in_string = !in_string
+                        continue
+                    }
+
+                    if (in_string) {
+                        continue
+                    }
+
+                    if (c == "{") {
+                        depth++
+                        if (depth == 1) {
+                            capture = 1
+                            object = "{"
+                        }
+                        continue
+                    }
+
+                    if (c == "}") {
+                        if (depth == 1 && capture) {
+                            if (object ~ /"prerelease":true/ && object !~ /"draft":true/) {
+                                value = object
+                                sub(/^.*"tag_name":"/, "", value)
+                                sub(/".*$/, "", value)
+                                if (value != "") {
+                                    print value
+                                    exit
+                                }
+                            }
+                            capture = 0
+                            object = ""
+                        }
+                        depth--
+                    }
+                }
+            }
+        '
+    )"
+
+    if [[ -z "$tag" ]]; then
+        echo "error: could not find a published prerelease for ${REPO}" >&2
+        exit 1
+    fi
+
+    printf '%s\n' "$tag"
+}
+
+release_url() {
+    local asset="$1"
+    if bool_is_true "$INSTALL_PRERELEASE"; then
+        local tag
+        tag="$(latest_prerelease_tag)"
+        printf 'https://github.com/%s/releases/download/%s/%s\n' "$REPO" "$tag" "$asset"
+        return 0
+    fi
+
+    printf 'https://github.com/%s/releases/latest/download/%s\n' "$REPO" "$asset"
 }
 
 stale_binary_names() {
@@ -564,7 +667,8 @@ main() {
     flavor="$(choose_flavor)"
     local asset
     asset="$(asset_name "$flavor")"
-    local url="https://github.com/${REPO}/releases/latest/download/${asset}"
+    local url
+    url="$(release_url "$asset")"
 
     local tmp_dir
     tmp_dir="$(mktemp -d)"
@@ -574,6 +678,11 @@ main() {
 
     local archive="$tmp_dir/$asset"
     echo "Installing flavor: $flavor"
+    if bool_is_true "$INSTALL_PRERELEASE"; then
+        echo "Release channel: prerelease"
+    else
+        echo "Release channel: stable"
+    fi
     echo "Downloading $url"
     curl -fsSL "$url" -o "$archive"
 


### PR DESCRIPTION
## Summary
Users can opt into the latest published prerelease from `install.sh` without changing the default stable install path.

## Changes
- add `--pre-release` and `MESH_LLM_INSTALL_PRERELEASE=1` to the installer
- resolve prerelease installs through the latest published GitHub prerelease tag
- document prerelease install usage in `docs/USAGE.md`

## Validation
- `bash -n install.sh`
- `bash install.sh --help`
- mocked prerelease tag parser check