### PR TITLE
fix: Update docker publish contract for multi-arch tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
               - 'Justfile'
               - 'scripts/**'
               - '.github/cache-version.txt'
-              - '.github/workflows/**'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/smoke.yml'
             benchmarks:
               - 'mesh-llm/benchmarks/**'
               - '.github/workflows/ci.yml'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -232,7 +232,7 @@ jobs:
             type=ref,event=branch,suffix=-cpu
             type=ref,event=pr,suffix=-cpu
             type=semver,pattern={{version}}-cpu
-            type=sha,prefix=sha-,format=short,suffix=-cpu
+            type=sha,prefix=sha-,format=short,suffix=-cpu-amd64
       - name: Build and push (non-PR)
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
@@ -282,7 +282,7 @@ jobs:
             type=ref,event=branch,suffix=-cpu
             type=ref,event=pr,suffix=-cpu
             type=semver,pattern={{version}}-cpu
-            type=sha,prefix=sha-,format=short,suffix=-cpu
+            type=sha,prefix=sha-,format=short,suffix=-cpu-arm64
       - name: Build and push (non-PR)
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
@@ -358,7 +358,7 @@ jobs:
             type=ref,event=branch,suffix=-vulkan
             type=ref,event=pr,suffix=-vulkan
             type=semver,pattern={{version}}-vulkan
-            type=sha,prefix=sha-,format=short,suffix=-vulkan
+            type=sha,prefix=sha-,format=short,suffix=-vulkan-amd64
       - name: Build and push (non-PR)
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
@@ -408,7 +408,7 @@ jobs:
             type=ref,event=branch,suffix=-vulkan
             type=ref,event=pr,suffix=-vulkan
             type=semver,pattern={{version}}-vulkan
-            type=sha,prefix=sha-,format=short,suffix=-vulkan
+            type=sha,prefix=sha-,format=short,suffix=-vulkan-arm64
       - name: Build and push (non-PR)
         if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6

--- a/docs/CI_GUIDANCE.md
+++ b/docs/CI_GUIDANCE.md
@@ -87,6 +87,22 @@ Keep CI validation shape separate from release shape.
 - Release-only settings such as broader GPU matrices or safer full release defaults must remain release-only.
 - Do not silently disable release safety settings for shipping artifacts.
 
+## Docker publish contract
+
+`.github/workflows/docker.yml` publishes to `ghcr.io/<owner>/mesh-llm` with two classes of tags:
+
+- **Public tags** are the stable tags users pull: `latest`, `client`, `<version>`, `sha-<short>`, `cpu`, `<version>-cpu`, `sha-<short>-cpu`, `vulkan`, `<version>-vulkan`, `sha-<short>-vulkan`, `cuda`, `<version>-cuda`, `sha-<short>-cuda`, `rocm`, `<version>-rocm`, and `sha-<short>-rocm`.
+- **Merge-source tags** are internal per-architecture tags used only so the merge jobs can assemble multi-arch manifests.
+
+Keep these merge-source edges intact:
+
+- `docker-client-merge` consumes `sha-<short>-amd64` and `sha-<short>-arm64`.
+- `docker-cpu-merge` consumes `sha-<short>-cpu-amd64` and `sha-<short>-cpu-arm64`.
+- `docker-vulkan-merge` consumes `sha-<short>-vulkan-amd64` and `sha-<short>-vulkan-arm64`.
+- `docker-cuda` and `docker-rocm` are amd64-only publishers, so they do not have merge jobs.
+
+`latest` must continue to resolve to the merged `client` image. Any workflow change is incorrect if a merge job references a source tag that its producer jobs do not push exactly.
+
 ## Script expectations
 
 The workflow design depends on the build scripts preserving the distinction between CI-friendly and release-friendly builds.


### PR DESCRIPTION
## Summary
This fixes the Docker publish tag contract for the CPU and Vulkan images so the multi-arch merge jobs can complete successfully.

- Make the CPU per-architecture build jobs publish the exact SHA tags that `docker-cpu-merge` consumes: `sha-<short>-cpu-amd64` and `sha-<short>-cpu-arm64`
- Make the Vulkan per-architecture build jobs publish the exact SHA tags that `docker-vulkan-merge` consumes: `sha-<short>-vulkan-amd64` and `sha-<short>-vulkan-arm64`
- Document the Docker publish contract in `docs/CI_GUIDANCE.md`, including the public tags, the internal merge-source tags, and the rule that `latest` continues to point at the merged `client` image

## Validation
- [x] Verified the workflow diff is limited to the four producer SHA tag suffixes plus the CI guidance doc update
- [x] Manually checked the workflow contract so each merge job now consumes source tags that the corresponding producer jobs publish exactly