### PR TITLE
[codex] Add CUDA release architectures 87, 100, and 103

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -502,7 +502,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            CUDA_ARCH=75;80;86;89;90;120
+            CUDA_ARCH=75;80;86;87;89;90;100;103;120
           cache-from: |
             type=gha,scope=docker-rust-deps-amd64-cuda
             type=gha,scope=docker-llama-cuda-amd64

--- a/Justfile
+++ b/Justfile
@@ -425,13 +425,13 @@ docker-build-cpu tag="mesh-llm:cpu":
 
 # Build the CUDA full-node Docker image
 [unix]
-docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;89;90;120":
+docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;87;89;90;100;103;120":
     DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.cuda \
         --build-arg CUDA_ARCH="{{ cuda_arch }}" \
         -t {{ tag }} .
 
 [windows]
-docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;89;90;120":
+docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;87;89;90;100;103;120":
     @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:DOCKER_BUILDKIT='1'; docker build -f docker/Dockerfile.cuda --build-arg CUDA_ARCH='{{ cuda_arch }}' -t '{{ tag }}' ."
 
 # Build the ROCm full-node Docker image

--- a/Justfile
+++ b/Justfile
@@ -55,10 +55,10 @@ release-build-windows:
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cpu
 
 # Build a Linux CUDA release artifact with an explicit architecture list.
-release-build-cuda cuda_arch="75;80;86;89;90;120":
+release-build-cuda cuda_arch="75;80;86;87;89;90;100;103;120":
     @scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
-release-build-cuda-windows cuda_arch="75;80;86;89;90;120":
+release-build-cuda-windows cuda_arch="75;80;86;87;89;90;100;103;120":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}"
 
 # Build a Linux ROCm release artifact with an explicit architecture list.

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -2,7 +2,7 @@
 # Linux/amd64 ONLY (NVIDIA cuda:*-devel images are amd64-only).
 #
 # Build:  DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.cuda -t mesh-llm:cuda .
-#         (optional) --build-arg CUDA_ARCH="75;80;86;89" for narrower compute list
+#         (optional) --build-arg CUDA_ARCH="75;80;86;87;89" for narrower compute list
 # Run (requires NVIDIA Container Toolkit):
 #         docker run --rm --gpus all -p 9337:9337 -v ~/.models:/root/.models -e APP_MODE=worker mesh-llm:cuda
 #
@@ -79,7 +79,7 @@ RUN cd llama.cpp && git rev-parse HEAD > /tmp/llama-sha.txt
 #   See ggml-org/llama.cpp#20866 — without this, asymmetric K/V quant hits
 #   BEST_FATTN_KERNEL_NONE and crashes rpc-server.
 #   Remove this flag ONLY once the fork is rebased past the upstream fix.
-ARG CUDA_ARCH="75;80;86;89;90;120"
+ARG CUDA_ARCH="75;80;86;87;89;90;100;103;120"
 RUN cd llama.cpp && \
     cmake -B build -G Ninja \
       -DGGML_RPC=ON \


### PR DESCRIPTION
⚠️ do not merge until we have faster runners ⚠️ 

## Summary

- add CUDA SM architectures 87, 100, and 103 to the release CUDA target defaults
- keep the Windows CUDA release recipe aligned with the same default architecture list

## Why

The release CUDA target default list was missing these architectures, so release builds would omit them unless overridden manually.

## Validation

- `just --dry-run release-build-cuda`
- `just --dry-run release-build-cuda-windows`
