### PR TITLE
Update all references from michaelneale/mesh-llm to Mesh-LLM/mesh-llm

### DIFF
--- a/PLUGINS_PLAN.md
+++ b/PLUGINS_PLAN.md
@@ -168,9 +168,9 @@ These plugins should validate:
 
 The llama pluginization work should move the current local llama-style serving path behind the new plugin-hosted inference endpoint contract.
 
-The MLX plugin should then take inspiration from the in-process inference-server work in [PR #103](https://github.com/michaelneale/mesh-llm/pull/103), but implemented using the new plugin endpoint registration architecture rather than direct built-in runtime ownership in core.
+The MLX plugin should then take inspiration from the in-process inference-server work in [PR #103](https://github.com/Mesh-LLM/mesh-llm/pull/103), but implemented using the new plugin endpoint registration architecture rather than direct built-in runtime ownership in core.
 
-After that, add an attached external inference plugin, with Lemonade as the first target for that mode. That should take inspiration from [PR #150](https://github.com/michaelneale/mesh-llm/pull/150), but implemented using endpoint registration rather than ad hoc `inference/register` notifications in the transport layer.
+After that, add an attached external inference plugin, with Lemonade as the first target for that mode. That should take inspiration from [PR #150](https://github.com/Mesh-LLM/mesh-llm/pull/150), but implemented using endpoint registration rather than ad hoc `inference/register` notifications in the transport layer.
 
 ### Phase 9: Host-Owned Plugin Crypto API
 
@@ -252,7 +252,7 @@ The pluginized llama backend should prove that the current built-in serving path
 
 The MLX plugin should then prove that a second plugin-hosted backend can use the same contract while owning its own runtime behavior.
 
-Take implementation cues from the current llama runtime behavior first, and then from [PR #103](https://github.com/michaelneale/mesh-llm/pull/103):
+Take implementation cues from the current llama runtime behavior first, and then from [PR #103](https://github.com/Mesh-LLM/mesh-llm/pull/103):
 
 - plugin-hosted local model serving with llama semantics
 - plugin-hosted local inference serving

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If a model fits on one machine, it runs there. If it does not, Mesh LLM automati
 Install the latest release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash
 ```
 
 Then start a node:
@@ -82,7 +82,7 @@ This starts serving a model, opens the local API and console, and prints an invi
 ### 3. Build from source
 
 ```bash
-git clone https://github.com/michaelneale/mesh-llm
+git clone https://github.com/Mesh-LLM/mesh-llm
 cd mesh-llm
 just build
 ```
@@ -250,7 +250,7 @@ Does not start the console or bind any ports. Use the CLI flags shown in `--help
 To install it as a per-user background service:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash -s -- --service
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash -s -- --service
 ```
 
 Service installs are user-scoped:
@@ -434,7 +434,7 @@ The installer currently targets macOS and Linux release bundles. Windows coming 
 To force a specific bundled flavor during install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | MESH_LLM_INSTALL_FLAVOR=vulkan bash
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | MESH_LLM_INSTALL_FLAVOR=vulkan bash
 ```
 
 Installed release bundles use flavor-specific llama.cpp binaries:
@@ -457,7 +457,7 @@ mesh-llm update --version v0.X.Y
 If you build from source, always use `just`:
 
 ```bash
-git clone https://github.com/michaelneale/mesh-llm
+git clone https://github.com/Mesh-LLM/mesh-llm
 cd mesh-llm
 just build
 ```

--- a/docker/SPEC_COMPLIANCE.md
+++ b/docker/SPEC_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # Issue #115 Spec Compliance Tracker
 
-**Issue**: https://github.com/michaelneale/mesh-llm/issues/115
+**Issue**: https://github.com/Mesh-LLM/mesh-llm/issues/115
 
 This file is the human-readable counterpart to `.github/workflows/docker-precheck.yml`. Both must agree. If they disagree, the reusable workflow is authoritative.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -9,13 +9,13 @@ For command-by-command CLI usage, model resolution rules, and JSON automation ex
 Install the latest release bundle:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash
 ```
 
 To opt into the latest published prerelease bundle instead:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash -s -- --pre-release
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash -s -- --pre-release
 ```
 
 The installer probes your machine, recommends a flavor, and asks what to install.
@@ -23,7 +23,7 @@ The installer probes your machine, recommends a flavor, and asks what to install
 For a non-interactive install, set the flavor explicitly:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | MESH_LLM_INSTALL_FLAVOR=vulkan bash
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | MESH_LLM_INSTALL_FLAVOR=vulkan bash
 ```
 
 Release bundles install flavor-specific llama.cpp binaries:
@@ -43,7 +43,7 @@ mesh-llm serve --llama-flavor vulkan --model Qwen2.5-32B
 Source builds must use `just`:
 
 ```bash
-git clone https://github.com/michaelneale/mesh-llm
+git clone https://github.com/Mesh-LLM/mesh-llm
 cd mesh-llm
 just build
 ```
@@ -83,7 +83,7 @@ Bare `mesh-llm serve` loads startup models from `[[models]]` in `~/.mesh-llm/con
 To install Mesh LLM as a per-user background service:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh | bash -s -- --service
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash -s -- --service
 ```
 
 Service installs are user-scoped:

--- a/docs/index.html
+++ b/docs/index.html
@@ -61,7 +61,7 @@
             <a href="#agents">Agents</a>
             <a href="#blackboard">Blackboard</a>
             <a href="#features">Features</a>
-            <a href="https://github.com/michaelneale/mesh-llm">GitHub</a>
+            <a href="https://github.com/Mesh-LLM/mesh-llm">GitHub</a>
         </div>
     </nav>
 
@@ -71,7 +71,7 @@
         <p>Turn spare capacity into an auto-configured p2p inference cloud. Serve many models, access your private models from anywhere, or share compute with others, let your agents collaborate p2p.</p>
         <div class="hero-ctas">
             <a href="https://www.anarchai.org/dashboard" class="btn btn-primary">Try it now</a>
-            <a href="https://github.com/michaelneale/mesh-llm" class="btn btn-secondary">View on GitHub</a>
+            <a href="https://github.com/Mesh-LLM/mesh-llm" class="btn btn-secondary">View on GitHub</a>
         </div>
 
         <div class="mesh-demo">
@@ -195,9 +195,9 @@
 
         <div class="code-block">
             <span class="comment"># Install on macOS (downloads ~18MB bundle)</span><br>
-            <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="val">https://github.com/michaelneale/mesh-llm/releases/latest/download/mesh-bundle.tar.gz</span> | <span class="cmd">tar</span> xz &amp;&amp; mkdir -p ~/.local/bin &amp;&amp; mv mesh-bundle/* ~/.local/bin/<br><br>
+            <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="val">https://github.com/Mesh-LLM/mesh-llm/releases/latest/download/mesh-bundle.tar.gz</span> | <span class="cmd">tar</span> xz &amp;&amp; mkdir -p ~/.local/bin &amp;&amp; mv mesh-bundle/* ~/.local/bin/<br><br>
             <span class="comment"># Install on Linux (build from source — needs just, cmake, nvcc, Rust, Node.js)</span><br>
-            <span class="cmd">git clone</span> <span class="val">https://github.com/michaelneale/mesh-llm</span> &amp;&amp; <span class="cmd">cd</span> mesh-llm &amp;&amp; <span class="cmd">just</span> build<br><br>
+            <span class="cmd">git clone</span> <span class="val">https://github.com/Mesh-LLM/mesh-llm</span> &amp;&amp; <span class="cmd">cd</span> mesh-llm &amp;&amp; <span class="cmd">just</span> build<br><br>
             <span class="comment"># Join the public mesh — instant chat, zero config</span><br>
             <span class="cmd">mesh-llm</span> <span class="flag">--auto</span><br><br>
             <span class="comment"># Or start your own mesh with a model</span><br>
@@ -396,8 +396,8 @@
         <div class="cta-buttons">
             <a href="https://www.anarchai.org/dashboard" class="btn btn-primary">Try it now</a>
             <a href="#install" class="btn btn-secondary">Install</a>
-            <a href="https://github.com/michaelneale/mesh-llm" class="btn btn-secondary">GitHub →</a>
-            <a href="https://github.com/michaelneale/mesh-llm/blob/main/ROADMAP.md" class="btn btn-secondary">Roadmap</a>
+            <a href="https://github.com/Mesh-LLM/mesh-llm" class="btn btn-secondary">GitHub →</a>
+            <a href="https://github.com/Mesh-LLM/mesh-llm/blob/main/ROADMAP.md" class="btn btn-secondary">Roadmap</a>
         </div>
     </section>
 
@@ -409,7 +409,7 @@
             <li><a href="https://arxiv.org/pdf/2601.16863" style="color:#646cff;">Mixture of Models / NSED</a> — self-evaluating deliberation across models (Peeramid Labs)</li>
             <li><a href="https://nvidianews.nvidia.com/news/nvidia-launches-nemotron-coalition-of-leading-global-ai-labs-to-advance-open-frontier-models" style="color:#646cff;">NVIDIA Nemotron Coalition</a> — advancing open frontier models across leading AI labs</li>
         </ul>
-        <p>For current plans and work items, see the <a href="https://github.com/michaelneale/mesh-llm/blob/main/ROADMAP.md" style="color:#646cff;">Roadmap</a> and <a href="https://github.com/michaelneale/mesh-llm/blob/main/mesh-llm/TODO.md" style="color:#646cff;">TODO</a> on GitHub.</p>
+        <p>For current plans and work items, see the <a href="https://github.com/Mesh-LLM/mesh-llm/blob/main/ROADMAP.md" style="color:#646cff;">Roadmap</a> and <a href="https://github.com/Mesh-LLM/mesh-llm/blob/main/mesh-llm/TODO.md" style="color:#646cff;">TODO</a> on GitHub.</p>
         <p style="margin-top:0.8rem;">Come say hi on <a href="https://github.com/block/goose?tab=readme-ov-file#goose-around-with-us" style="color:#646cff;">Discord</a> — we're in the goose community.</p>
     </section>
 

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -6,7 +6,7 @@
 #
 # If you modify this file, also update docker/Dockerfile.client and vice versa.
 # They should be structurally identical to avoid drift between the Fly deploy
-# and the published ghcr.io/michaelneale/mesh-llm:client image.
+# and the published ghcr.io/mesh-llm/mesh-llm:client image.
 #
 # Deploy:
 #   fly deploy --config fly/console/fly.toml --dockerfile fly/Dockerfile

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-REPO="${MESH_LLM_INSTALL_REPO:-michaelneale/mesh-llm}"
+REPO="${MESH_LLM_INSTALL_REPO:-Mesh-LLM/mesh-llm}"
 REPO_REF="${MESH_LLM_INSTALL_REF:-main}"
 INSTALL_DIR="${MESH_LLM_INSTALL_DIR:-$HOME/.local/bin}"
 INSTALL_FLAVOR="${MESH_LLM_INSTALL_FLAVOR:-}"

--- a/mesh-llm/src/cli/commands/blackboard.rs
+++ b/mesh-llm/src/cli/commands/blackboard.rs
@@ -24,7 +24,7 @@ pub(crate) async fn run_blackboard(
         eprintln!("  Join a mesh:   mesh-llm client --join <token>");
         eprintln!("  Public mesh:   mesh-llm client --auto");
         eprintln!();
-        eprintln!("See https://github.com/michaelneale/mesh-llm for setup guide.");
+        eprintln!("See https://github.com/Mesh-LLM/mesh-llm for setup guide.");
         std::process::exit(1);
     }
 

--- a/mesh-llm/src/cli/moe.rs
+++ b/mesh-llm/src/cli/moe.rs
@@ -96,7 +96,7 @@ pub(crate) struct HfJobArgs {
     #[arg(long)]
     pub(crate) hf_job_namespace: Option<String>,
     /// GitHub repo that hosts the mesh-llm release bundle used by the remote job.
-    #[arg(long, default_value = "michaelneale/mesh-llm")]
+    #[arg(long, default_value = "Mesh-LLM/mesh-llm")]
     pub(crate) hf_job_release_repo: String,
     /// Release tag to download inside the remote job. Use `latest` for the latest GitHub release.
     #[arg(long, default_value = "latest")]

--- a/mesh-llm/src/system/autoupdate.rs
+++ b/mesh-llm/src/system/autoupdate.rs
@@ -10,11 +10,11 @@ use crate::cli::{Cli, Command};
 use crate::inference::launch;
 use crate::VERSION;
 
-const DEFAULT_RELEASE_REPO: &str = "michaelneale/mesh-llm";
+const DEFAULT_RELEASE_REPO: &str = "Mesh-LLM/mesh-llm";
 #[cfg(not(windows))]
 const INSTALL_SCRIPT_URL: &str =
-    "https://raw.githubusercontent.com/michaelneale/mesh-llm/main/install.sh";
-const RELEASES_URL: &str = "https://github.com/michaelneale/mesh-llm/releases/latest";
+    "https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh";
+const RELEASES_URL: &str = "https://github.com/Mesh-LLM/mesh-llm/releases/latest";
 const SELF_UPDATE_ATTEMPTED_ENV: &str = "MESH_LLM_SELF_UPDATE_ATTEMPTED";
 const SELF_UPDATE_REPO_ENV: &str = "MESH_LLM_SELF_UPDATE_REPO";
 
@@ -1103,7 +1103,7 @@ mod tests {
         std::env::remove_var(SELF_UPDATE_REPO_ENV);
         assert_eq!(
             release_asset_url("v0.60.0", "mesh-llm-aarch64-apple-darwin.tar.gz"),
-            "https://github.com/michaelneale/mesh-llm/releases/download/v0.60.0/mesh-llm-aarch64-apple-darwin.tar.gz"
+            "https://github.com/Mesh-LLM/mesh-llm/releases/download/v0.60.0/mesh-llm-aarch64-apple-darwin.tar.gz"
         );
     }
 
@@ -1111,10 +1111,10 @@ mod tests {
     #[serial]
     fn test_release_repo_defaults_to_main_repo() {
         std::env::remove_var(SELF_UPDATE_REPO_ENV);
-        assert_eq!(release_repo(), "michaelneale/mesh-llm");
+        assert_eq!(release_repo(), "Mesh-LLM/mesh-llm");
         assert_eq!(
             latest_release_api_url(),
-            "https://api.github.com/repos/michaelneale/mesh-llm/releases/latest"
+            "https://api.github.com/repos/Mesh-LLM/mesh-llm/releases/latest"
         );
     }
 

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -2394,7 +2394,7 @@ export function App() {
                 <>
                   <span>·</span>
                   <a
-                    href="https://github.com/michaelneale/mesh-llm/releases"
+                    href="https://github.com/Mesh-LLM/mesh-llm/releases"
                     target="_blank"
                     rel="noreferrer"
                     className="underline-offset-2 hover:text-foreground hover:underline"
@@ -2408,7 +2408,7 @@ export function App() {
               ) : null}
               <span>·</span>
               <a
-                href="https://github.com/michaelneale/mesh-llm"
+                href="https://github.com/Mesh-LLM/mesh-llm"
                 target="_blank"
                 rel="noreferrer"
                 className="inline-flex h-5 w-5 items-center justify-center hover:text-foreground"
@@ -4634,7 +4634,7 @@ function DashboardPage({
           </a>
           {" · "}
           <a
-            href="https://github.com/michaelneale/mesh-llm"
+            href="https://github.com/Mesh-LLM/mesh-llm"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 underline hover:text-foreground"


### PR DESCRIPTION
The repo was transferred to the **Mesh-LLM** org. This PR updates all references so install scripts, auto-update, CLI defaults, the docs site, and UI links point to the new org.

## What changes

- **Install script** (`install.sh`) — default repo is now `Mesh-LLM/mesh-llm`
- **Auto-update** (`autoupdate.rs`) — release API URL, install script URL, and releases URL
- **CLI defaults** — `--hf-job-release-repo` default, blackboard help text
- **UI** (`App.tsx`) — GitHub links in footer and update banner
- **Docs site** (`docs/index.html`) — all GitHub links and download URLs
- **README + USAGE.md** — install commands, clone URLs
- **Docker/Fly** — container image reference, issue link
- **PLUGINS_PLAN.md** — PR links

## Intentionally unchanged

- **`michaelneale/llama.cpp`** — the llama.cpp fork has not been transferred; all build scripts, Dockerfiles, and CI workflows that clone it are correct as-is
- **`relay.michaelneale.mesh-llm.iroh.link`** — this is an iroh relay domain, not a GitHub reference
- **`llama.cpp/`** submodule contents — upstream, not our code

## Also done (not in PR)

- Updated local git remote to `git@github.com:Mesh-LLM/mesh-llm.git`