### PR TITLE
Harden Nostr mesh discovery

### DIFF
--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -12,6 +12,7 @@ use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
+use thiserror::Error;
 
 use tokio::sync::{watch, Mutex};
 
@@ -22,6 +23,14 @@ use crate::crypto::{
 };
 use crate::inference::moe;
 use crate::protocol::*;
+
+#[derive(Debug, Error)]
+pub enum InviteTokenError {
+    #[error("invalid invite token encoding: {0}")]
+    Decode(base64::DecodeError),
+    #[error("invalid invite token JSON: {0}")]
+    Json(serde_json::Error),
+}
 
 /// Demand signal for a model — tracks interest via API requests and --model declarations.
 /// Gossiped across the mesh and merged via max(). Decays naturally when last_active gets old.
@@ -1611,6 +1620,15 @@ impl Node {
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&json)
     }
 
+    pub fn decode_invite_token(
+        invite_token: &str,
+    ) -> std::result::Result<EndpointAddr, InviteTokenError> {
+        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(invite_token)
+            .map_err(InviteTokenError::Decode)?;
+        serde_json::from_slice(&json).map_err(InviteTokenError::Json)
+    }
+
     #[cfg(test)]
     pub async fn sync_from_peer_for_tests(&self, remote: &Self) {
         let remote_id = remote.endpoint.id();
@@ -1673,8 +1691,7 @@ impl Node {
     }
 
     pub async fn join(&self, invite_token: &str) -> Result<()> {
-        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(invite_token)?;
-        let addr: EndpointAddr = serde_json::from_slice(&json)?;
+        let addr = Self::decode_invite_token(invite_token)?;
         // Clear dead status — explicit join should always attempt connection
         self.state.lock().await.dead_peers.remove(&addr.id);
         self.connect_to_peer(addr).await

--- a/mesh-llm/src/mesh/tests.rs
+++ b/mesh-llm/src/mesh/tests.rs
@@ -4487,6 +4487,29 @@ async fn config_subscribe_matching_owner_receives_snapshot() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn invite_token_round_trips_to_endpoint_addr() -> Result<()> {
+    let node = make_test_node(super::NodeRole::Client).await?;
+    let token = node.invite_token();
+    let decoded = Node::decode_invite_token(&token).expect("invite token should decode");
+
+    assert_eq!(decoded.id, node.id());
+    assert_eq!(decoded.addrs, node.endpoint.addr().addrs);
+
+    Ok(())
+}
+
+#[test]
+fn invalid_invite_token_reports_json_error() {
+    let bad_payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"not-json");
+    let err = Node::decode_invite_token(&bad_payload).expect_err("token must be rejected");
+
+    match err {
+        InviteTokenError::Json(_) => {}
+        other => panic!("expected JSON invite token error, got {other:?}"),
+    }
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn config_subscribe_wrong_owner_returns_error() -> Result<()> {
     let server_owner = test_owner_keypair(0x22, 0x23);

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -1219,11 +1219,12 @@ mod auto_pack_tests {
 #[cfg(test)]
 mod scoring_tests {
     use super::*;
+    use base64::Engine;
     use iroh::{EndpointAddr, EndpointId, SecretKey};
 
     pub(super) fn valid_invite_token(_label: &str) -> String {
         let addr = EndpointAddr {
-            id: EndpointId::from(SecretKey::generate(&mut rand::rng()).public()),
+            id: EndpointId::from(SecretKey::generate(&mut ::rand::rng()).public()),
             addrs: Default::default(),
         };
         let json = serde_json::to_vec(&addr).expect("endpoint addr should serialize");

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -64,6 +64,61 @@ pub struct DiscoveredMesh {
     pub expires_at: Option<u64>,
 }
 
+fn validate_listing(listing: &MeshListing) -> std::result::Result<(), String> {
+    const MAX_INVITE_TOKEN_LEN: usize = 16 * 1024;
+    const MAX_NAME_LEN: usize = 128;
+    const MAX_REGION_LEN: usize = 64;
+    const MAX_MODEL_ENTRIES: usize = 256;
+
+    if listing.invite_token.is_empty() {
+        return Err("missing invite token".into());
+    }
+    if listing.invite_token.len() > MAX_INVITE_TOKEN_LEN {
+        return Err(format!(
+            "invite token too large ({} bytes)",
+            listing.invite_token.len()
+        ));
+    }
+    crate::mesh::Node::decode_invite_token(&listing.invite_token)
+        .map_err(|err| format!("invalid invite token ({err})"))?;
+
+    if let Some(name) = &listing.name {
+        if name.len() > MAX_NAME_LEN {
+            return Err(format!("mesh name too long ({} bytes)", name.len()));
+        }
+    }
+    if let Some(region) = &listing.region {
+        if region.len() > MAX_REGION_LEN {
+            return Err(format!("region too long ({} bytes)", region.len()));
+        }
+    }
+
+    if listing.serving.len() > MAX_MODEL_ENTRIES {
+        return Err(format!(
+            "too many serving models ({})",
+            listing.serving.len()
+        ));
+    }
+    if listing.wanted.len() > MAX_MODEL_ENTRIES {
+        return Err(format!("too many wanted models ({})", listing.wanted.len()));
+    }
+    if listing.on_disk.len() > MAX_MODEL_ENTRIES {
+        return Err(format!(
+            "too many on-disk models ({})",
+            listing.on_disk.len()
+        ));
+    }
+
+    if listing.max_clients > 0 && listing.client_count > listing.max_clients.saturating_mul(8) {
+        return Err(format!(
+            "client count {} is implausible for max_clients {}",
+            listing.client_count, listing.max_clients
+        ));
+    }
+
+    Ok(())
+}
+
 impl std::fmt::Display for DiscoveredMesh {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let vram_gb = self.listing.total_vram_bytes as f64 / 1e9;
@@ -765,8 +820,23 @@ pub async fn discover(
 
         let listing: MeshListing = match serde_json::from_str(&event.content) {
             Ok(l) => l,
-            Err(_) => continue,
+            Err(err) => {
+                tracing::warn!(
+                    "Skipping Nostr mesh listing from {}: invalid listing JSON: {err}",
+                    event.pubkey.to_bech32().unwrap_or_default()
+                );
+                continue;
+            }
         };
+
+        if let Err(reason) = validate_listing(&listing) {
+            tracing::warn!(
+                "Skipping Nostr mesh listing from {}: {}",
+                event.pubkey.to_bech32().unwrap_or_default(),
+                reason
+            );
+            continue;
+        }
 
         let publisher_npub = event.pubkey.to_bech32().unwrap_or_default();
         let discovered = DiscoveredMesh {
@@ -1149,6 +1219,16 @@ mod auto_pack_tests {
 #[cfg(test)]
 mod scoring_tests {
     use super::*;
+    use iroh::{EndpointAddr, EndpointId, SecretKey};
+
+    pub(super) fn valid_invite_token(_label: &str) -> String {
+        let addr = EndpointAddr {
+            id: EndpointId::from(SecretKey::generate(&mut rand::rng()).public()),
+            addrs: Default::default(),
+        };
+        let json = serde_json::to_vec(&addr).expect("endpoint addr should serialize");
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json)
+    }
 
     fn make_mesh(
         name: Option<&str>,
@@ -1161,7 +1241,7 @@ mod scoring_tests {
     ) -> DiscoveredMesh {
         DiscoveredMesh {
             listing: MeshListing {
-                invite_token: format!("invite-{}", mesh_id.unwrap_or("test")),
+                invite_token: valid_invite_token(mesh_id.unwrap_or("test")),
                 serving: serving.iter().map(|s| s.to_string()).collect(),
                 wanted: vec![],
                 on_disk: vec![],
@@ -1193,6 +1273,29 @@ mod scoring_tests {
         let score = score_mesh(&mesh, 1500, None);
         // base(100) + community(300) + headroom + nodes(15) + models(10)
         assert!(score > 400, "community mesh should score high, got {score}");
+    }
+
+    #[test]
+    fn validate_listing_rejects_bad_invite_token() {
+        let listing = MeshListing {
+            invite_token: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"not-json"),
+            serving: vec![],
+            wanted: vec![],
+            on_disk: vec![],
+            total_vram_bytes: 0,
+            node_count: 1,
+            client_count: 0,
+            max_clients: 0,
+            name: None,
+            region: None,
+            mesh_id: None,
+        };
+
+        let err = validate_listing(&listing).expect_err("listing must be rejected");
+        assert!(
+            err.contains("invalid invite token"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]
@@ -1778,7 +1881,7 @@ mod integration_tests {
             .await
             .expect("pub_a");
         let listing_a = MeshListing {
-            invite_token: "invite-a".into(),
+            invite_token: scoring_tests::valid_invite_token("publish-a"),
             serving: vec!["Qwen3-8B-Q4_K_M".into()],
             wanted: vec![],
             on_disk: vec![],
@@ -1798,7 +1901,7 @@ mod integration_tests {
             .await
             .expect("pub_b");
         let mut listing_b = listing_a.clone();
-        listing_b.invite_token = "invite-b".into();
+        listing_b.invite_token = scoring_tests::valid_invite_token("publish-b");
         pub_b.publish(&listing_b, 120).await.expect("publish B");
 
         tokio::time::sleep(Duration::from_secs(3)).await;
@@ -1832,12 +1935,12 @@ mod integration_tests {
             .map(|m| m.listing.invite_token.as_str())
             .collect();
         assert!(
-            tokens.contains(&"invite-a"),
-            "missing invite-a in {tokens:?}"
+            tokens.contains(&listing_a.invite_token.as_str()),
+            "missing listing_a token in {tokens:?}"
         );
         assert!(
-            tokens.contains(&"invite-b"),
-            "missing invite-b in {tokens:?}"
+            tokens.contains(&listing_b.invite_token.as_str()),
+            "missing listing_b token in {tokens:?}"
         );
 
         // Second discover with same client still works

--- a/mesh-llm/src/runtime/discovery.rs
+++ b/mesh-llm/src/runtime/discovery.rs
@@ -112,7 +112,11 @@ pub(super) async fn nostr_rediscovery(
                     rejoined = true;
                 }
                 Err(e) => {
-                    eprintln!("⚠️  Re-join failed: {e}");
+                    if let Some(invite_err) = e.downcast_ref::<mesh::InviteTokenError>() {
+                        eprintln!("⚠️  Re-join skipped: invalid Nostr invite token ({invite_err})");
+                    } else {
+                        eprintln!("⚠️  Re-join failed: {e}");
+                    }
                 }
             }
             if rejoined {

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -359,13 +359,8 @@ pub(crate) async fn run() -> Result<()> {
             nostr::AutoDecision::Join { candidates } => {
                 if cli.client {
                     // Clients skip health probe — joining itself is the test.
-                    // Use the best candidate.
-                    let (token, mesh) = &candidates[0];
-                    if cli.mesh_name.is_none() {
-                        if let Some(ref name) = mesh.listing.name {
-                            cli.mesh_name = Some(name.clone());
-                        }
-                    }
+                    // Keep all candidates so a stale top-ranked invite can fall back.
+                    let (_, mesh) = &candidates[0];
                     eprintln!(
                         "✅ Joining: {} ({} nodes, {} models{})",
                         mesh.listing.name.as_deref().unwrap_or("unnamed"),
@@ -377,7 +372,7 @@ pub(crate) async fn run() -> Result<()> {
                             .map(|r| format!(", region: {r}"))
                             .unwrap_or_default()
                     );
-                    cli.join.push(token.clone());
+                    queue_auto_join_candidates(&mut cli, &mut auto_join_candidates, &candidates);
                 } else {
                     // GPU nodes: try to join each candidate directly.
                     // No ephemeral probe — it fails when the target has a firewall
@@ -415,19 +410,18 @@ pub(crate) async fn run() -> Result<()> {
                             if let nostr::AutoDecision::Join { candidates } =
                                 nostr::smart_auto(&retry_meshes, my_vram_gb, target_name)
                             {
-                                let (token, mesh) = &candidates[0];
-                                if cli.mesh_name.is_none() {
-                                    if let Some(ref name) = mesh.listing.name {
-                                        cli.mesh_name = Some(name.clone());
-                                    }
-                                }
+                                let (_, mesh) = &candidates[0];
                                 eprintln!(
                                     "✅ Joining: {} ({} nodes, {} models)",
                                     mesh.listing.name.as_deref().unwrap_or("unnamed"),
                                     mesh.listing.node_count,
                                     mesh.listing.serving.len()
                                 );
-                                cli.join.push(token.clone());
+                                queue_auto_join_candidates(
+                                    &mut cli,
+                                    &mut auto_join_candidates,
+                                    &candidates,
+                                );
                                 found = true;
                                 break;
                             }
@@ -957,6 +951,31 @@ fn plugin_host_mode(cli: &Cli) -> plugin::PluginHostMode {
     }
 }
 
+fn queue_auto_join_candidates(
+    cli: &mut Cli,
+    auto_join_candidates: &mut Vec<(String, Option<String>)>,
+    candidates: &[(String, nostr::DiscoveredMesh)],
+) {
+    if cli.mesh_name.is_none() {
+        if let Some((_, best_mesh)) = candidates.first() {
+            if let Some(ref name) = best_mesh.listing.name {
+                cli.mesh_name = Some(name.clone());
+            }
+        }
+    }
+
+    auto_join_candidates.extend(
+        candidates
+            .iter()
+            .map(|(token, mesh)| (token.clone(), mesh.listing.name.clone())),
+    );
+}
+
+fn invalid_invite_token_message(err: &anyhow::Error) -> Option<String> {
+    err.downcast_ref::<mesh::InviteTokenError>()
+        .map(|invite_err| format!("invalid Nostr invite token ({invite_err})"))
+}
+
 fn node_display_name(cli: &Cli, node: &mesh::Node) -> String {
     cli.name
         .clone()
@@ -973,7 +992,13 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
                     eprintln!("Joined mesh");
                     return Ok(());
                 }
-                Err(err) => tracing::warn!("Failed to join via token: {err}"),
+                Err(err) => {
+                    if let Some(message) = invalid_invite_token_message(&err) {
+                        eprintln!("⚠️  Skipping mesh candidate: {message}");
+                    } else {
+                        tracing::warn!("Failed to join via token: {err}");
+                    }
+                }
             }
         }
         anyhow::bail!("Failed to join any peer for MCP mode");
@@ -990,19 +1015,35 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
         let meshes = nostr::discover(&relays, &filter, None).await?;
         match nostr::smart_auto(&meshes, 0.0, target_name) {
             nostr::AutoDecision::Join { candidates } => {
-                let (token, mesh) = &candidates[0];
-                eprintln!(
-                    "✅ Joining: {} ({} nodes, {} models{})",
-                    mesh.listing.name.as_deref().unwrap_or("unnamed"),
-                    mesh.listing.node_count,
-                    mesh.listing.serving.len(),
-                    mesh.listing
-                        .region
-                        .as_ref()
-                        .map(|r| format!(", region: {r}"))
-                        .unwrap_or_default()
-                );
-                node.join(token).await?;
+                let mut last_err: Option<anyhow::Error> = None;
+                for (token, mesh) in &candidates {
+                    eprintln!(
+                        "✅ Joining: {} ({} nodes, {} models{})",
+                        mesh.listing.name.as_deref().unwrap_or("unnamed"),
+                        mesh.listing.node_count,
+                        mesh.listing.serving.len(),
+                        mesh.listing
+                            .region
+                            .as_ref()
+                            .map(|r| format!(", region: {r}"))
+                            .unwrap_or_default()
+                    );
+                    match node.join(token).await {
+                        Ok(()) => return Ok(()),
+                        Err(err) => {
+                            if let Some(message) = invalid_invite_token_message(&err) {
+                                eprintln!("⚠️  Skipping mesh candidate: {message}");
+                            } else {
+                                tracing::warn!("Failed to join via token: {err}");
+                            }
+                            last_err = Some(err);
+                        }
+                    }
+                }
+                if let Some(err) = last_err {
+                    return Err(err);
+                }
+                anyhow::bail!("No valid mesh candidates found for MCP mode");
             }
             nostr::AutoDecision::StartNew { .. } => {
                 anyhow::bail!("No mesh found for MCP mode. Pass --join or start a mesh first.");
@@ -1218,7 +1259,13 @@ async fn run_auto(
                     successful_join = Some((t.clone(), mesh_name.clone()));
                     break;
                 }
-                Err(e) => tracing::warn!("Failed to join via token: {e}"),
+                Err(e) => {
+                    if let Some(message) = invalid_invite_token_message(&e) {
+                        eprintln!("⚠️  Skipping mesh candidate: {message}");
+                    } else {
+                        tracing::warn!("Failed to join via token: {e}");
+                    }
+                }
             }
         }
 
@@ -2390,6 +2437,27 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
+    fn discovered_mesh(name: Option<&str>) -> nostr::DiscoveredMesh {
+        nostr::DiscoveredMesh {
+            listing: nostr::MeshListing {
+                invite_token: "published-token".into(),
+                serving: vec!["Qwen".into()],
+                wanted: Vec::new(),
+                on_disk: Vec::new(),
+                total_vram_bytes: 64_000_000_000,
+                node_count: 2,
+                client_count: 0,
+                max_clients: 0,
+                name: name.map(str::to_string),
+                region: None,
+                mesh_id: None,
+            },
+            publisher_npub: "npub1test".into(),
+            published_at: 0,
+            expires_at: None,
+        }
+    }
+
     fn restore_env(key: &str, value: Option<std::ffi::OsString>) {
         if let Some(value) = value {
             std::env::set_var(key, value);
@@ -2699,6 +2767,46 @@ mod tests {
             &cli,
             &startup_specs
         ));
+    }
+
+    #[test]
+    fn queue_auto_join_candidates_keeps_all_discovered_tokens() {
+        let mut cli = Cli::parse_from(["mesh-llm", "--client", "--auto"]);
+        let mut auto_join_candidates = Vec::new();
+        let candidates = vec![
+            ("token-a".to_string(), discovered_mesh(Some("Alpha"))),
+            ("token-b".to_string(), discovered_mesh(Some("Beta"))),
+        ];
+
+        queue_auto_join_candidates(&mut cli, &mut auto_join_candidates, &candidates);
+
+        assert_eq!(
+            auto_join_candidates,
+            vec![
+                ("token-a".to_string(), Some("Alpha".to_string())),
+                ("token-b".to_string(), Some("Beta".to_string())),
+            ]
+        );
+        assert_eq!(cli.mesh_name.as_deref(), Some("Alpha"));
+        assert!(
+            cli.join.is_empty(),
+            "auto join fallback should use candidate queue"
+        );
+    }
+
+    #[test]
+    fn queue_auto_join_candidates_preserves_explicit_mesh_name() {
+        let mut cli = Cli::parse_from(["mesh-llm", "--client", "--auto", "--mesh-name", "Pinned"]);
+        let mut auto_join_candidates = Vec::new();
+        let candidates = vec![("token-a".to_string(), discovered_mesh(Some("Alpha")))];
+
+        queue_auto_join_candidates(&mut cli, &mut auto_join_candidates, &candidates);
+
+        assert_eq!(cli.mesh_name.as_deref(), Some("Pinned"));
+        assert_eq!(
+            auto_join_candidates,
+            vec![("token-a".to_string(), Some("Alpha".to_string()))]
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Clients now recover when Nostr discovery returns malformed mesh listings or bad invite tokens instead of failing the whole auto-join flow.

## What Changed
- validate discovered Nostr listings before ranking or attempting joins
- reject malformed invite tokens and other obviously broken listing data early
- skip invalid mesh candidates during auto-join and Nostr re-discovery instead of aborting
- log warnings when bad Nostr data is encountered
- add invite-token round-trip and invalid-token tests

## Root Cause
Nostr listing content was being treated as trustworthy enough to defer validation until join time. A malformed `invite_token` could survive discovery, get selected as a candidate, and then fail with a JSON parse error or force the client into a bad fallback path.

## Impact
- malformed or malicious Nostr publishes no longer poison mesh discovery as easily
- clients continue trying other meshes when a candidate's token is invalid
- logs now make it clearer when the failure is bad Nostr data versus a live peer handshake failure

## Validation
- `cargo fmt --all -- mesh-llm/src/network/nostr.rs mesh-llm/src/mesh/mod.rs mesh-llm/src/mesh/tests.rs mesh-llm/src/runtime/mod.rs mesh-llm/src/runtime/discovery.rs`
- manual run: `/Users/jdumay/.local/bin/mesh-llm client --auto --port 19337 --console 13131`
- `just build` is in progress to restore local UI assets for full repo validation
- `cargo check -p mesh-llm` was previously blocked because `mesh-llm/ui/dist` was missing in this worktree
