### PR TITLE
Harden Nostr discovery: validate tokens, candidate fallback

### DIFF
--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -1763,9 +1763,17 @@ impl Node {
         });
     }
 
+    /// Decode an invite token into an [`EndpointAddr`] without connecting.
+    /// Returns `Err` if the token is not valid base64 or not valid JSON.
+    pub fn decode_invite_token(invite_token: &str) -> Result<EndpointAddr> {
+        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(invite_token)
+            .context("invalid invite token encoding")?;
+        serde_json::from_slice(&json).context("invalid invite token JSON")
+    }
+
     pub async fn join(&self, invite_token: &str) -> Result<()> {
-        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(invite_token)?;
-        let addr: EndpointAddr = serde_json::from_slice(&json)?;
+        let addr = Self::decode_invite_token(invite_token)?;
         // Clear dead status — explicit join should always attempt connection
         self.state.lock().await.dead_peers.remove(&addr.id);
         self.connect_to_peer(addr).await

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -765,8 +765,24 @@ pub async fn discover(
 
         let listing: MeshListing = match serde_json::from_str(&event.content) {
             Ok(l) => l,
-            Err(_) => continue,
+            Err(err) => {
+                tracing::warn!(
+                    "Skipping Nostr listing from {}: bad JSON: {err}",
+                    event.pubkey.to_bech32().unwrap_or_default()
+                );
+                continue;
+            }
         };
+
+        // Reject listings with invalid invite tokens before they enter the
+        // candidate pool — a bad token here would poison the entire auto-join.
+        if let Err(err) = crate::mesh::Node::decode_invite_token(&listing.invite_token) {
+            tracing::warn!(
+                "Skipping Nostr listing from {}: {err}",
+                event.pubkey.to_bech32().unwrap_or_default()
+            );
+            continue;
+        }
 
         let publisher_npub = event.pubkey.to_bech32().unwrap_or_default();
         let discovered = DiscoveredMesh {
@@ -1762,6 +1778,27 @@ mod key_file_tests {
 #[cfg(test)]
 mod integration_tests {
     use super::*;
+    use base64::Engine;
+
+    fn fake_invite_token() -> String {
+        // Build a syntactically valid invite token by encoding a minimal
+        // EndpointAddr JSON. We use Node::invite_token indirectly by just
+        // crafting the JSON that decode_invite_token expects.
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(1);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        // EndpointAddr serialises as {"id":"<base32>","addrs":[]}
+        // We need a valid 32-byte public key. Use a deterministic one.
+        let mut seed = [0u8; 32];
+        seed[..8].copy_from_slice(&n.to_le_bytes());
+        let key = iroh::SecretKey::from_bytes(&seed);
+        let addr = iroh::EndpointAddr {
+            id: iroh::EndpointId::from(key.public()),
+            addrs: Default::default(),
+        };
+        let json = serde_json::to_vec(&addr).expect("serialize");
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json)
+    }
 
     /// End-to-end: two publishers advertise the same mesh, a reusable
     /// DiscoveryClient finds both listings, and fields round-trip correctly.
@@ -1777,8 +1814,10 @@ mod integration_tests {
         let pub_a = Publisher::new(keys_a.clone(), &relays)
             .await
             .expect("pub_a");
+        let token_a = fake_invite_token();
+        let token_b = fake_invite_token();
         let listing_a = MeshListing {
-            invite_token: "invite-a".into(),
+            invite_token: token_a.clone(),
             serving: vec!["Qwen3-8B-Q4_K_M".into()],
             wanted: vec![],
             on_disk: vec![],
@@ -1798,7 +1837,7 @@ mod integration_tests {
             .await
             .expect("pub_b");
         let mut listing_b = listing_a.clone();
-        listing_b.invite_token = "invite-b".into();
+        listing_b.invite_token = token_b.clone();
         pub_b.publish(&listing_b, 120).await.expect("publish B");
 
         tokio::time::sleep(Duration::from_secs(3)).await;
@@ -1832,12 +1871,12 @@ mod integration_tests {
             .map(|m| m.listing.invite_token.as_str())
             .collect();
         assert!(
-            tokens.contains(&"invite-a"),
-            "missing invite-a in {tokens:?}"
+            tokens.contains(&token_a.as_str()),
+            "missing token_a in {tokens:?}"
         );
         assert!(
-            tokens.contains(&"invite-b"),
-            "missing invite-b in {tokens:?}"
+            tokens.contains(&token_b.as_str()),
+            "missing token_b in {tokens:?}"
         );
 
         // Second discover with same client still works

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -371,8 +371,8 @@ pub(crate) async fn run() -> Result<()> {
             nostr::AutoDecision::Join { candidates } => {
                 if cli.client {
                     // Clients skip health probe — joining itself is the test.
-                    // Use the best candidate.
-                    let (token, mesh) = &candidates[0];
+                    // Queue all candidates so we can fall back if the top one is unreachable.
+                    let (_, mesh) = &candidates[0];
                     if cli.mesh_name.is_none() {
                         if let Some(ref name) = mesh.listing.name {
                             cli.mesh_name = Some(name.clone());
@@ -389,7 +389,9 @@ pub(crate) async fn run() -> Result<()> {
                             .map(|r| format!(", region: {r}"))
                             .unwrap_or_default()
                     );
-                    cli.join.push(token.clone());
+                    for (token, _) in &candidates {
+                        cli.join.push(token.clone());
+                    }
                 } else {
                     // GPU nodes: try to join each candidate directly.
                     // No ephemeral probe — it fails when the target has a firewall
@@ -427,7 +429,7 @@ pub(crate) async fn run() -> Result<()> {
                             if let nostr::AutoDecision::Join { candidates } =
                                 nostr::smart_auto(&retry_meshes, my_vram_gb, target_name)
                             {
-                                let (token, mesh) = &candidates[0];
+                                let (_, mesh) = &candidates[0];
                                 if cli.mesh_name.is_none() {
                                     if let Some(ref name) = mesh.listing.name {
                                         cli.mesh_name = Some(name.clone());
@@ -439,7 +441,9 @@ pub(crate) async fn run() -> Result<()> {
                                     mesh.listing.node_count,
                                     mesh.listing.serving.len()
                                 );
-                                cli.join.push(token.clone());
+                                for (token, _) in &candidates {
+                                    cli.join.push(token.clone());
+                                }
                                 found = true;
                                 break;
                             }
@@ -1117,19 +1121,33 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
         let meshes = nostr::discover(&relays, &filter, None).await?;
         match nostr::smart_auto(&meshes, 0.0, target_name) {
             nostr::AutoDecision::Join { candidates } => {
-                let (token, mesh) = &candidates[0];
-                eprintln!(
-                    "✅ Joining: {} ({} nodes, {} models{})",
-                    mesh.listing.name.as_deref().unwrap_or("unnamed"),
-                    mesh.listing.node_count,
-                    mesh.listing.serving.len(),
-                    mesh.listing
-                        .region
-                        .as_ref()
-                        .map(|r| format!(", region: {r}"))
-                        .unwrap_or_default()
-                );
-                node.join(token).await?;
+                let mut last_err: Option<anyhow::Error> = None;
+                for (token, mesh) in &candidates {
+                    eprintln!(
+                        "✅ Joining: {} ({} nodes, {} models{})",
+                        mesh.listing.name.as_deref().unwrap_or("unnamed"),
+                        mesh.listing.node_count,
+                        mesh.listing.serving.len(),
+                        mesh.listing
+                            .region
+                            .as_ref()
+                            .map(|r| format!(", region: {r}"))
+                            .unwrap_or_default()
+                    );
+                    match node.join(token).await {
+                        Ok(()) => {
+                            last_err = None;
+                            break;
+                        }
+                        Err(err) => {
+                            tracing::warn!("Failed to join mesh candidate: {err}");
+                            last_err = Some(err);
+                        }
+                    }
+                }
+                if let Some(err) = last_err {
+                    return Err(err);
+                }
             }
             nostr::AutoDecision::StartNew { .. } => {
                 anyhow::bail!("No mesh found for MCP mode. Pass --join or start a mesh first.");


### PR DESCRIPTION
Simpler alternative to #268.

## What changed

Malformed Nostr listings (bad invite tokens) used to poison auto-join — the client would pick the top-ranked mesh, fail to decode its token, and give up. Now:

1. **`discover()` validates invite tokens before listings enter the candidate pool** — bad tokens are logged and skipped
2. **All candidates are queued**, not just the #1 pick — if the top mesh is unreachable, the client falls back to the next candidate
3. **`Node::decode_invite_token()`** extracted so tokens can be validated without connecting

## What's different from #268

- No typed `InviteTokenError` / `thiserror` — uses `anyhow::context()` (simpler, same result)
- No field-length validation (name, region, model list size) — those are nice-to-have but not the fix
- No `invalid_invite_token_message` branching at every join callsite — once `discover()` rejects bad tokens, downstream join loops won't hit them
- ~90 lines changed vs ~300

## Files

- `mesh/mod.rs` — `decode_invite_token()` + use it in `join()`
- `network/nostr.rs` — validate tokens in `discover()`, fix integration test to use valid tokens
- `runtime/mod.rs` — queue all candidates in client `--auto` path and MCP join path