### PR TITLE
feat: TTFT inference performance tracker

### DIFF
--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -37,7 +37,7 @@ use self::status::{
 };
 use crate::inference::election;
 use crate::mesh;
-use crate::network::{affinity, nostr, proxy};
+use crate::network::{affinity, nostr, perf, proxy};
 use crate::plugin;
 use std::sync::Arc;
 use tokio::net::{TcpListener, TcpStream};
@@ -215,12 +215,14 @@ impl MeshApi {
         model_size_bytes: u64,
         plugin_manager: plugin::PluginManager,
         affinity_router: affinity::AffinityRouter,
+        perf_tracker: perf::InferenceTracker,
     ) -> Self {
         MeshApi {
             inner: Arc::new(Mutex::new(ApiInner {
                 node,
                 plugin_manager,
                 affinity_router,
+                perf_tracker,
                 is_host: false,
                 is_client: false,
                 llama_ready: false,
@@ -736,6 +738,7 @@ impl MeshApi {
             my_vram_gb,
             inflight_requests,
             routing_affinity,
+            inference_perf,
             model_name,
             model_size_bytes,
             llama_ready,
@@ -757,6 +760,7 @@ impl MeshApi {
                 inner.node.vram_bytes() as f64 / 1e9,
                 inner.node.inflight_requests(),
                 inner.affinity_router.stats_snapshot(),
+                inner.perf_tracker.snapshot(),
                 inner.model_name.clone(),
                 inner.model_size_bytes,
                 inner.llama_ready,
@@ -944,6 +948,7 @@ impl MeshApi {
                 )
             },
             routing_affinity,
+            inference_perf,
         }
     }
 
@@ -1608,6 +1613,7 @@ mod tests {
             0,
             plugin_manager,
             affinity::AffinityRouter::default(),
+            perf::InferenceTracker::default(),
         )
     }
 
@@ -1629,6 +1635,7 @@ mod tests {
             0,
             plugin_manager,
             affinity::AffinityRouter::default(),
+            perf::InferenceTracker::default(),
         )
     }
 

--- a/mesh-llm/src/api/routes/plugins.rs
+++ b/mesh-llm/src/api/routes/plugins.rs
@@ -468,7 +468,7 @@ mod tests {
     use super::*;
     use crate::api::MeshApi;
     use crate::mesh::{Node, NodeRole};
-    use crate::network::affinity;
+    use crate::network::{affinity, perf};
     use crate::plugin::{self};
     use tokio::io::AsyncReadExt;
     use tokio::net::TcpListener;
@@ -571,6 +571,7 @@ mod tests {
             0,
             plugin_manager,
             affinity::AffinityRouter::default(),
+            perf::InferenceTracker::default(),
         )
     }
 

--- a/mesh-llm/src/api/state.rs
+++ b/mesh-llm/src/api/state.rs
@@ -1,5 +1,5 @@
 use crate::mesh;
-use crate::network::affinity;
+use crate::network::{affinity, perf};
 use crate::plugin;
 use serde::Serialize;
 use std::sync::Arc;
@@ -42,6 +42,7 @@ pub(super) struct ApiInner {
     pub(super) node: mesh::Node,
     pub(super) plugin_manager: plugin::PluginManager,
     pub(super) affinity_router: affinity::AffinityRouter,
+    pub(super) perf_tracker: perf::InferenceTracker,
     pub(super) is_host: bool,
     pub(super) is_client: bool,
     pub(super) llama_ready: bool,

--- a/mesh-llm/src/api/status.rs
+++ b/mesh-llm/src/api/status.rs
@@ -1,6 +1,6 @@
 use super::{RuntimeModelPayload, RuntimeProcessPayload};
 use crate::crypto::{OwnershipStatus, OwnershipSummary};
-use crate::network::affinity;
+use crate::network::{affinity, perf};
 use crate::system::hardware::expand_gpu_names;
 use serde::Serialize;
 
@@ -140,6 +140,7 @@ pub(super) struct StatusPayload {
     pub(super) my_is_soc: Option<bool>,
     pub(super) gpus: Vec<GpuEntry>,
     pub(super) routing_affinity: affinity::AffinityStatsSnapshot,
+    pub(super) inference_perf: perf::InferencePerfSnapshot,
 }
 
 #[derive(Serialize)]

--- a/mesh-llm/src/network/mod.rs
+++ b/mesh-llm/src/network/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod affinity;
 pub(crate) mod nostr;
+pub(crate) mod perf;
 pub(crate) mod proxy;
 pub(crate) mod rewrite;
 pub(crate) mod router;

--- a/mesh-llm/src/network/perf.rs
+++ b/mesh-llm/src/network/perf.rs
@@ -1,0 +1,390 @@
+//! Inference performance tracker — locally observed TTFT per model + target.
+//!
+//! Each node tracks the time-to-first-token it observes when proxying inference
+//! requests. This is purely local data (not gossiped) and feeds into routing
+//! decisions to prefer faster hosts and avoid slow ones.
+//!
+//! Design:
+//! - Ring buffer of the last N samples per (model, target) pair
+//! - Reported TTFT is the best of the last 3 samples (filters outliers)
+//! - Entries expire after 30 minutes of no updates
+//! - Background probes populate cold entries when new hosts appear
+
+use crate::inference::election::InferenceTarget;
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const MAX_SAMPLES: usize = 8;
+const BEST_OF_N: usize = 3;
+const ENTRY_TTL: Duration = Duration::from_secs(30 * 60);
+const MAX_ENTRIES: usize = 512;
+
+/// Compact target identifier for map keys (EndpointId is 32 bytes, port is 2).
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum TargetKey {
+    Local(u16),
+    Remote([u8; 32]),
+}
+
+impl TargetKey {
+    fn from_inference_target(target: &InferenceTarget) -> Option<Self> {
+        match target {
+            InferenceTarget::Local(port) | InferenceTarget::MoeLocal(port) => {
+                Some(TargetKey::Local(*port))
+            }
+            InferenceTarget::Remote(id) | InferenceTarget::MoeRemote(id) => {
+                Some(TargetKey::Remote(*id.as_bytes()))
+            }
+            InferenceTarget::None => None,
+        }
+    }
+
+    fn display_short(&self) -> String {
+        match self {
+            TargetKey::Local(port) => format!("local:{port}"),
+            TargetKey::Remote(bytes) => {
+                // Same format as iroh's fmt_short: first 5 bytes hex
+                format!(
+                    "{}",
+                    bytes[..5]
+                        .iter()
+                        .map(|b| format!("{b:02x}"))
+                        .collect::<String>()
+                )
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct PerfKey {
+    model: String,
+    target: TargetKey,
+}
+
+#[derive(Clone, Debug)]
+struct Sample {
+    ttft_ms: u64,
+    _recorded_at: Instant,
+}
+
+#[derive(Clone, Debug)]
+struct PerfEntry {
+    samples: Vec<Sample>,
+    last_updated: Instant,
+}
+
+impl PerfEntry {
+    fn new() -> Self {
+        Self {
+            samples: Vec::with_capacity(MAX_SAMPLES),
+            last_updated: Instant::now(),
+        }
+    }
+
+    fn push(&mut self, ttft_ms: u64) {
+        self.last_updated = Instant::now();
+        if self.samples.len() >= MAX_SAMPLES {
+            self.samples.remove(0);
+        }
+        self.samples.push(Sample {
+            ttft_ms,
+            _recorded_at: Instant::now(),
+        });
+    }
+
+    fn is_expired(&self) -> bool {
+        self.last_updated.elapsed() > ENTRY_TTL
+    }
+
+    /// Best (lowest) TTFT among the last N samples.
+    /// Uses the most recent `BEST_OF_N` samples, returns the minimum.
+    /// This filters out transient spikes from contention or cold cache.
+    fn best_ttft_ms(&self) -> Option<u64> {
+        if self.samples.is_empty() {
+            return None;
+        }
+        let recent_count = self.samples.len().min(BEST_OF_N);
+        let start = self.samples.len() - recent_count;
+        self.samples[start..].iter().map(|s| s.ttft_ms).min()
+    }
+
+    fn sample_count(&self) -> usize {
+        self.samples.len()
+    }
+}
+
+#[derive(Default)]
+struct TrackerState {
+    entries: HashMap<PerfKey, PerfEntry>,
+}
+
+impl TrackerState {
+    fn prune_expired(&mut self) {
+        self.entries.retain(|_, entry| !entry.is_expired());
+        // Hard cap to prevent unbounded growth
+        if self.entries.len() > MAX_ENTRIES {
+            // Remove oldest entries
+            let mut by_age: Vec<_> = self
+                .entries
+                .iter()
+                .map(|(k, v)| (k.clone(), v.last_updated))
+                .collect();
+            by_age.sort_by_key(|(_, t)| *t);
+            let to_remove = self.entries.len() - MAX_ENTRIES;
+            for (key, _) in by_age.into_iter().take(to_remove) {
+                self.entries.remove(&key);
+            }
+        }
+    }
+}
+
+/// Thread-safe inference performance tracker.
+/// Clone-cheap (inner Arc).
+#[derive(Clone, Default)]
+pub struct InferenceTracker {
+    inner: Arc<Mutex<TrackerState>>,
+}
+
+impl InferenceTracker {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record an observed TTFT for a (model, target) pair.
+    pub fn record_ttft(&self, model: &str, target: &InferenceTarget, ttft_ms: u64) {
+        let Some(target_key) = TargetKey::from_inference_target(target) else {
+            return;
+        };
+        let key = PerfKey {
+            model: model.to_string(),
+            target: target_key,
+        };
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired();
+        let entry = state.entries.entry(key).or_insert_with(PerfEntry::new);
+        entry.push(ttft_ms);
+    }
+
+    /// Get the best observed TTFT for a model across all targets.
+    /// Used by routing to prefer faster models (will be wired in a follow-up).
+    #[allow(dead_code)]
+    pub fn best_ttft_for_model(&self, model: &str) -> Option<u64> {
+        let state = self.inner.lock().unwrap();
+        state
+            .entries
+            .iter()
+            .filter(|(k, v)| k.model == model && !v.is_expired())
+            .filter_map(|(_, v)| v.best_ttft_ms())
+            .min()
+    }
+
+    /// Get the best observed TTFT for a specific (model, target) pair.
+    /// Used by routing to prefer faster targets (will be wired in a follow-up).
+    #[allow(dead_code)]
+    pub fn best_ttft_for_target(&self, model: &str, target: &InferenceTarget) -> Option<u64> {
+        let target_key = TargetKey::from_inference_target(target)?;
+        let key = PerfKey {
+            model: model.to_string(),
+            target: target_key,
+        };
+        let state = self.inner.lock().unwrap();
+        state
+            .entries
+            .get(&key)
+            .filter(|e| !e.is_expired())
+            .and_then(|e| e.best_ttft_ms())
+    }
+
+    /// Snapshot for API exposure.
+    pub fn snapshot(&self) -> InferencePerfSnapshot {
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired();
+
+        // Aggregate by model: for each model, find best target + overall stats
+        let mut by_model: HashMap<String, Vec<(&PerfKey, &PerfEntry)>> = HashMap::new();
+        for (key, entry) in &state.entries {
+            by_model
+                .entry(key.model.clone())
+                .or_default()
+                .push((key, entry));
+        }
+
+        let mut models = Vec::new();
+        for (model_name, entries) in &by_model {
+            let mut best_ttft: Option<u64> = None;
+            let mut best_target: Option<String> = None;
+            let mut total_samples: usize = 0;
+            let mut targets = Vec::new();
+
+            for (key, entry) in entries {
+                let ttft = entry.best_ttft_ms();
+                let count = entry.sample_count();
+                total_samples += count;
+
+                targets.push(ModelTargetPerf {
+                    target: key.target.display_short(),
+                    best_ttft_ms: ttft,
+                    samples: count,
+                });
+
+                if let Some(t) = ttft {
+                    if best_ttft.map(|b| t < b).unwrap_or(true) {
+                        best_ttft = Some(t);
+                        best_target = Some(key.target.display_short());
+                    }
+                }
+            }
+
+            targets.sort_by_key(|t| t.best_ttft_ms.unwrap_or(u64::MAX));
+
+            models.push(ModelPerfSummary {
+                model: model_name.clone(),
+                best_ttft_ms: best_ttft,
+                best_target,
+                total_samples,
+                targets,
+            });
+        }
+
+        models.sort_by(|a, b| a.model.cmp(&b.model));
+
+        InferencePerfSnapshot { models }
+    }
+}
+
+// ── API types ───────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct InferencePerfSnapshot {
+    pub models: Vec<ModelPerfSummary>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ModelPerfSummary {
+    pub model: String,
+    pub best_ttft_ms: Option<u64>,
+    pub best_target: Option<String>,
+    pub total_samples: usize,
+    pub targets: Vec<ModelTargetPerf>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ModelTargetPerf {
+    pub target: String,
+    pub best_ttft_ms: Option<u64>,
+    pub samples: usize,
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iroh::SecretKey;
+
+    fn make_remote(seed: u8) -> InferenceTarget {
+        let mut bytes = [0u8; 32];
+        bytes[0] = seed;
+        InferenceTarget::Remote(SecretKey::from_bytes(&bytes).public())
+    }
+
+    #[test]
+    fn test_record_and_retrieve() {
+        let tracker = InferenceTracker::new();
+        let target = InferenceTarget::Local(8080);
+        tracker.record_ttft("qwen", &target, 500);
+        tracker.record_ttft("qwen", &target, 300);
+        tracker.record_ttft("qwen", &target, 800);
+
+        // Best of last 3: min(500, 300, 800) = 300
+        assert_eq!(tracker.best_ttft_for_target("qwen", &target), Some(300));
+        assert_eq!(tracker.best_ttft_for_model("qwen"), Some(300));
+    }
+
+    #[test]
+    fn test_best_of_3_filters_spikes() {
+        let tracker = InferenceTracker::new();
+        let target = InferenceTarget::Local(8080);
+
+        // First few samples include a spike
+        tracker.record_ttft("model", &target, 200);
+        tracker.record_ttft("model", &target, 5000); // spike
+        tracker.record_ttft("model", &target, 250);
+
+        // Best of last 3: min(200, 5000, 250) = 200
+        assert_eq!(tracker.best_ttft_for_target("model", &target), Some(200));
+    }
+
+    #[test]
+    fn test_multiple_targets_same_model() {
+        let tracker = InferenceTracker::new();
+        let fast = InferenceTarget::Local(8080);
+        let slow = make_remote(1);
+
+        tracker.record_ttft("qwen", &fast, 100);
+        tracker.record_ttft("qwen", &slow, 2000);
+
+        assert_eq!(tracker.best_ttft_for_target("qwen", &fast), Some(100));
+        assert_eq!(tracker.best_ttft_for_target("qwen", &slow), Some(2000));
+        assert_eq!(tracker.best_ttft_for_model("qwen"), Some(100));
+    }
+
+    #[test]
+    fn test_ring_buffer_eviction() {
+        let tracker = InferenceTracker::new();
+        let target = InferenceTarget::Local(8080);
+
+        // Push more than MAX_SAMPLES
+        for i in 0..MAX_SAMPLES + 5 {
+            tracker.record_ttft("m", &target, (i as u64 + 1) * 100);
+        }
+
+        let state = tracker.inner.lock().unwrap();
+        let key = PerfKey {
+            model: "m".to_string(),
+            target: TargetKey::Local(8080),
+        };
+        assert_eq!(state.entries[&key].samples.len(), MAX_SAMPLES);
+    }
+
+    #[test]
+    fn test_snapshot_structure() {
+        let tracker = InferenceTracker::new();
+        let local = InferenceTarget::Local(8080);
+        let remote = make_remote(1);
+
+        tracker.record_ttft("modelA", &local, 200);
+        tracker.record_ttft("modelA", &remote, 500);
+        tracker.record_ttft("modelB", &local, 150);
+
+        let snap = tracker.snapshot();
+        assert_eq!(snap.models.len(), 2);
+
+        let a = snap.models.iter().find(|m| m.model == "modelA").unwrap();
+        assert_eq!(a.best_ttft_ms, Some(200));
+        assert_eq!(a.targets.len(), 2);
+        assert_eq!(a.total_samples, 2);
+
+        let b = snap.models.iter().find(|m| m.model == "modelB").unwrap();
+        assert_eq!(b.best_ttft_ms, Some(150));
+        assert_eq!(b.targets.len(), 1);
+    }
+
+    #[test]
+    fn test_none_target_ignored() {
+        let tracker = InferenceTracker::new();
+        tracker.record_ttft("model", &InferenceTarget::None, 100);
+        assert_eq!(tracker.best_ttft_for_model("model"), None);
+    }
+
+    #[test]
+    fn test_empty_tracker() {
+        let tracker = InferenceTracker::new();
+        assert_eq!(tracker.best_ttft_for_model("nonexistent"), None);
+        let snap = tracker.snapshot();
+        assert!(snap.models.is_empty());
+    }
+}

--- a/mesh-llm/src/network/proxy.rs
+++ b/mesh-llm/src/network/proxy.rs
@@ -8,6 +8,7 @@ use crate::mesh;
 use crate::network::affinity::{
     prepare_remote_targets_for_request, AffinityRouter, PreparedTargets,
 };
+use crate::network::perf;
 use crate::network::router;
 use crate::plugin;
 use anyhow::{anyhow, bail, Context, Result};
@@ -78,7 +79,11 @@ pub enum PipelineProxyResult {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum RouteAttemptResult {
-    Delivered { status_code: u16 },
+    Delivered {
+        status_code: u16,
+        /// Observed time-to-first-token in milliseconds (only for 2xx responses).
+        ttft_ms: Option<u64>,
+    },
     RetryableUnavailable,
     RetryableContextOverflow,
 }
@@ -1320,6 +1325,7 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
         let _ = tcp_stream.shutdown().await;
         return Ok(RouteAttemptResult::Delivered {
             status_code: probe.status_code,
+            ttft_ms: None,
         });
     }
 
@@ -1434,6 +1440,7 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
     let _ = tcp_stream.shutdown().await;
     Ok(RouteAttemptResult::Delivered {
         status_code: probe.status_code,
+        ttft_ms: None,
     })
 }
 
@@ -1454,6 +1461,7 @@ async fn relay_translated_responses_json<R: AsyncRead + Unpin>(
         let _ = tcp_stream.shutdown().await;
         return Ok(RouteAttemptResult::Delivered {
             status_code: probe.status_code,
+            ttft_ms: None,
         });
     }
 
@@ -1469,6 +1477,7 @@ async fn relay_translated_responses_json<R: AsyncRead + Unpin>(
     let _ = tcp_stream.shutdown().await;
     Ok(RouteAttemptResult::Delivered {
         status_code: probe.status_code,
+        ttft_ms: None,
     })
 }
 
@@ -1643,6 +1652,7 @@ async fn relay_probed_response<R: AsyncRead + Unpin>(
     let _ = tcp_stream.shutdown().await;
     Ok(RouteAttemptResult::Delivered {
         status_code: probe.status_code,
+        ttft_ms: None,
     })
 }
 
@@ -1658,6 +1668,7 @@ async fn route_local_attempt(
         Ok(mut upstream) => {
             let _inflight = node.begin_inflight_request();
             let _ = upstream.set_nodelay(true);
+            let ttft_start = std::time::Instant::now();
             if let Err(err) = upstream.write_all(prefetched).await {
                 tracing::warn!(
                     "API proxy: failed to forward buffered request to local llama-server on {port}: {err}"
@@ -1666,6 +1677,7 @@ async fn route_local_attempt(
             }
             match probe_http_response_local(&mut upstream).await {
                 Ok(probe) => {
+                    let ttft_ms = ttft_start.elapsed().as_millis() as u64;
                     let status_code = probe.status_code;
                     match relay_probed_response(
                         tcp_stream,
@@ -1676,10 +1688,24 @@ async fn route_local_attempt(
                     )
                     .await
                     {
-                        Ok(result) => result,
+                        Ok(_result) => RouteAttemptResult::Delivered {
+                            status_code,
+                            ttft_ms: if (200..300).contains(&status_code) {
+                                Some(ttft_ms)
+                            } else {
+                                None
+                            },
+                        },
                         Err(err) => {
                             tracing::debug!("API proxy (local) ended after commit: {err}");
-                            RouteAttemptResult::Delivered { status_code }
+                            RouteAttemptResult::Delivered {
+                                status_code,
+                                ttft_ms: if (200..300).contains(&status_code) {
+                                    Some(ttft_ms)
+                                } else {
+                                    None
+                                },
+                            }
                         }
                     }
                 }
@@ -1708,6 +1734,7 @@ async fn route_remote_attempt(
 ) -> RouteAttemptResult {
     match node.open_http_tunnel(host_id).await {
         Ok((mut quic_send, mut quic_recv)) => {
+            let ttft_start = std::time::Instant::now();
             if let Err(err) = quic_send.write_all(prefetched).await {
                 tracing::warn!(
                     "API proxy: failed to forward buffered request to host {}: {err}",
@@ -1717,6 +1744,7 @@ async fn route_remote_attempt(
             }
             match probe_http_response(&mut quic_recv).await {
                 Ok(probe) => {
+                    let ttft_ms = ttft_start.elapsed().as_millis() as u64;
                     let status_code = probe.status_code;
                     match relay_probed_response(
                         tcp_stream,
@@ -1727,10 +1755,24 @@ async fn route_remote_attempt(
                     )
                     .await
                     {
-                        Ok(result) => result,
+                        Ok(_result) => RouteAttemptResult::Delivered {
+                            status_code,
+                            ttft_ms: if (200..300).contains(&status_code) {
+                                Some(ttft_ms)
+                            } else {
+                                None
+                            },
+                        },
                         Err(err) => {
                             tracing::debug!("API proxy (remote) ended after commit: {err}");
-                            RouteAttemptResult::Delivered { status_code }
+                            RouteAttemptResult::Delivered {
+                                status_code,
+                                ttft_ms: if (200..300).contains(&status_code) {
+                                    Some(ttft_ms)
+                                } else {
+                                    None
+                                },
+                            }
                         }
                     }
                 }
@@ -1826,7 +1868,10 @@ async fn route_http_endpoint_attempt(
                             tracing::debug!(
                                 "API proxy (external endpoint) ended after commit: {err}"
                             );
-                            RouteAttemptResult::Delivered { status_code }
+                            RouteAttemptResult::Delivered {
+                                status_code,
+                                ttft_ms: None,
+                            }
                         }
                     }
                 }
@@ -1936,6 +1981,7 @@ pub async fn handle_mesh_request(
     tcp_stream: TcpStream,
     track_demand: bool,
     affinity: AffinityRouter,
+    perf_tracker: perf::InferenceTracker,
 ) {
     let mut tcp_stream = tcp_stream;
     let plugin_manager = node.plugin_manager().await;
@@ -2103,13 +2149,19 @@ pub async fn handle_mesh_request(
         )
         .await
         {
-            RouteAttemptResult::Delivered { status_code } => {
+            RouteAttemptResult::Delivered {
+                status_code,
+                ttft_ms,
+            } => {
                 if should_learn_affinity(status_code) {
+                    let target = election::InferenceTarget::Remote(*target_host);
                     if let (Some(name), Some(prefix_hash)) =
                         (effective_model.as_ref(), prepared.learn_prefix_hash)
                     {
-                        let target = election::InferenceTarget::Remote(*target_host);
                         affinity.learn_target(name, prefix_hash, &target);
+                    }
+                    if let (Some(name), Some(ms)) = (effective_model.as_ref(), ttft_ms) {
+                        perf_tracker.record_ttft(name, &target, ms);
                     }
                 }
                 release_request_objects(&node, &request.request_object_request_ids).await;
@@ -2216,10 +2268,19 @@ type RouteModelRequestFn = for<'a> fn(
     &'a [u8],
     ResponseAdapter,
     &'a AffinityRouter,
+    &'a perf::InferenceTracker,
 ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>>;
 
 pub const ROUTE_MODEL_REQUEST: RouteModelRequestFn =
-    |node, tcp_stream, targets, model, parsed_body, prefetched, response_adapter, affinity| {
+    |node,
+     tcp_stream,
+     targets,
+     model,
+     parsed_body,
+     prefetched,
+     response_adapter,
+     affinity,
+     perf_tracker| {
         Box::pin(async move {
             let mut tcp_stream = tcp_stream;
             let ordered_candidates =
@@ -2287,10 +2348,16 @@ pub const ROUTE_MODEL_REQUEST: RouteModelRequestFn =
                 )
                 .await
                 {
-                    RouteAttemptResult::Delivered { status_code } => {
+                    RouteAttemptResult::Delivered {
+                        status_code,
+                        ttft_ms,
+                    } => {
                         if should_learn_affinity(status_code) {
                             if let Some(prefix_hash) = selection.learn_prefix_hash {
                                 affinity.learn_target(model, prefix_hash, &target);
+                            }
+                            if let Some(ms) = ttft_ms {
+                                perf_tracker.record_ttft(model, &target, ms);
                             }
                         }
                         return true;

--- a/mesh-llm/src/network/proxy.rs
+++ b/mesh-llm/src/network/proxy.rs
@@ -1688,7 +1688,7 @@ async fn route_local_attempt(
                     )
                     .await
                     {
-                        Ok(_result) => RouteAttemptResult::Delivered {
+                        Ok(RouteAttemptResult::Delivered { .. }) => RouteAttemptResult::Delivered {
                             status_code,
                             ttft_ms: if (200..300).contains(&status_code) {
                                 Some(ttft_ms)
@@ -1696,6 +1696,12 @@ async fn route_local_attempt(
                                 None
                             },
                         },
+                        Ok(RouteAttemptResult::RetryableContextOverflow) => {
+                            RouteAttemptResult::RetryableContextOverflow
+                        }
+                        Ok(RouteAttemptResult::RetryableUnavailable) => {
+                            RouteAttemptResult::RetryableUnavailable
+                        }
                         Err(err) => {
                             tracing::debug!("API proxy (local) ended after commit: {err}");
                             RouteAttemptResult::Delivered {
@@ -1755,7 +1761,7 @@ async fn route_remote_attempt(
                     )
                     .await
                     {
-                        Ok(_result) => RouteAttemptResult::Delivered {
+                        Ok(RouteAttemptResult::Delivered { .. }) => RouteAttemptResult::Delivered {
                             status_code,
                             ttft_ms: if (200..300).contains(&status_code) {
                                 Some(ttft_ms)
@@ -1763,6 +1769,12 @@ async fn route_remote_attempt(
                                 None
                             },
                         },
+                        Ok(RouteAttemptResult::RetryableContextOverflow) => {
+                            RouteAttemptResult::RetryableContextOverflow
+                        }
+                        Ok(RouteAttemptResult::RetryableUnavailable) => {
+                            RouteAttemptResult::RetryableUnavailable
+                        }
                         Err(err) => {
                             tracing::debug!("API proxy (remote) ended after commit: {err}");
                             RouteAttemptResult::Delivered {

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -23,7 +23,7 @@ use crate::mesh;
 use crate::mesh::NodeRole;
 use crate::models;
 use crate::models::catalog;
-use crate::network::{affinity, nostr, router, tunnel};
+use crate::network::{affinity, nostr, perf, router, tunnel};
 use crate::plugin;
 use crate::system::{autoupdate, benchmark, hardware};
 use anyhow::{Context, Result};
@@ -1468,6 +1468,7 @@ async fn run_auto(
     }
 
     let affinity_router = affinity::AffinityRouter::new();
+    let perf_tracker = perf::InferenceTracker::new();
 
     // Start bootstrap proxy if joining an existing mesh.
     // This gives instant API access via tunnel while our GPU loads.
@@ -1477,8 +1478,17 @@ async fn run_auto(
         let boot_node = node.clone();
         let boot_port = api_port;
         let boot_affinity = affinity_router.clone();
+        let boot_perf = perf_tracker.clone();
         tokio::spawn(async move {
-            bootstrap_proxy(boot_node, boot_port, stop_rx, cli.listen_all, boot_affinity).await;
+            bootstrap_proxy(
+                boot_node,
+                boot_port,
+                stop_rx,
+                cli.listen_all,
+                boot_affinity,
+                boot_perf,
+            )
+            .await;
         });
         Some(stop_tx)
     } else {
@@ -1647,6 +1657,7 @@ async fn run_auto(
     let proxy_node = node.clone();
     let proxy_rx = target_rx.clone();
     let proxy_affinity = affinity_router.clone();
+    let proxy_perf = perf_tracker.clone();
     let api_control_tx = control_tx.clone();
     tokio::spawn(async move {
         api_proxy(
@@ -1657,6 +1668,7 @@ async fn run_auto(
             existing_listener,
             cli.listen_all,
             proxy_affinity,
+            proxy_perf,
         )
         .await;
     });
@@ -1672,6 +1684,7 @@ async fn run_auto(
             model_size_bytes,
             plugin_manager.clone(),
             affinity_router.clone(),
+            perf_tracker.clone(),
         );
         cs.set_primary_backend("llama".into()).await;
         cs.set_runtime_control(control_tx.clone()).await;
@@ -2249,6 +2262,7 @@ async fn run_passive(
 ) -> Result<Option<String>> {
     let local_port = cli.port;
     let affinity_router = affinity::AffinityRouter::new();
+    let perf_tracker = perf::InferenceTracker::new();
     node.set_display_name(node_display_name(cli, &node)).await;
 
     // Nostr publishing (if --publish, for standby GPU nodes advertising capacity)
@@ -2321,6 +2335,7 @@ async fn run_passive(
             0,
             plugin_manager,
             affinity_router.clone(),
+            perf_tracker.clone(),
         );
         cs.set_nostr_relays(nostr_relays(&cli.nostr_relay)).await;
         cs.set_nostr_discovery(cli.nostr_discovery).await;
@@ -2386,8 +2401,9 @@ async fn run_passive(
                 tracing::info!("Connection from {addr}");
                 let node = node.clone();
                 let affinity = affinity_router.clone();
+                let perf = perf_tracker.clone();
                 tokio::spawn(crate::network::proxy::handle_mesh_request(
-                    node, tcp_stream, true, affinity,
+                    node, tcp_stream, true, affinity, perf,
                 ));
             }
             Some(model_name) = promote_rx.recv() => {

--- a/mesh-llm/src/runtime/proxy.rs
+++ b/mesh-llm/src/runtime/proxy.rs
@@ -1,7 +1,7 @@
 use crate::api;
 use crate::inference::{election, pipeline};
 use crate::mesh;
-use crate::network::{affinity, proxy, router};
+use crate::network::{affinity, perf, proxy, router};
 
 /// Model-aware API proxy. Parses the "model" field from POST request bodies
 /// and routes to the correct host. Falls back to the first available target
@@ -14,6 +14,7 @@ pub(super) async fn api_proxy(
     existing_listener: Option<tokio::net::TcpListener>,
     listen_all: bool,
     affinity: affinity::AffinityRouter,
+    perf_tracker: perf::InferenceTracker,
 ) {
     let listener = match existing_listener {
         Some(l) => l,
@@ -39,6 +40,7 @@ pub(super) async fn api_proxy(
         let targets = target_rx.borrow().clone();
         let node = node.clone();
         let affinity = affinity.clone();
+        let perf_tracker = perf_tracker.clone();
         let control_tx = control_tx.clone();
         tokio::spawn(async move {
             let mut tcp_stream = tcp_stream;
@@ -329,6 +331,7 @@ pub(super) async fn api_proxy(
                                 &request.raw,
                                 request.response_adapter,
                                 &affinity,
+                                &perf_tracker,
                             )
                             .await;
                             proxy::release_request_objects(
@@ -370,6 +373,7 @@ pub(super) async fn bootstrap_proxy(
     mut stop_rx: tokio::sync::mpsc::Receiver<tokio::sync::oneshot::Sender<tokio::net::TcpListener>>,
     listen_all: bool,
     affinity: affinity::AffinityRouter,
+    perf_tracker: perf::InferenceTracker,
 ) {
     let addr = if listen_all { "0.0.0.0" } else { "127.0.0.1" };
     let listener = match tokio::net::TcpListener::bind(format!("{addr}:{port}")).await {
@@ -392,7 +396,8 @@ pub(super) async fn bootstrap_proxy(
                 let _ = tcp_stream.set_nodelay(true);
                 let node = node.clone();
                 let affinity = affinity.clone();
-                tokio::spawn(proxy::handle_mesh_request(node, tcp_stream, true, affinity));
+                let perf = perf_tracker.clone();
+                tokio::spawn(proxy::handle_mesh_request(node, tcp_stream, true, affinity, perf));
             }
             resp_tx = stop_rx.recv() => {
                 if let Some(tx) = resp_tx {

--- a/mesh-llm/src/runtime/proxy/tests.rs
+++ b/mesh-llm/src/runtime/proxy/tests.rs
@@ -30,6 +30,7 @@ async fn spawn_api_proxy_test_harness(
         Some(listener),
         false,
         affinity::AffinityRouter::default(),
+        perf::InferenceTracker::default(),
     ));
     (addr, handle)
 }
@@ -54,6 +55,7 @@ async fn spawn_api_proxy_test_harness_with_plugin_manager(
         Some(listener),
         false,
         affinity::AffinityRouter::default(),
+        perf::InferenceTracker::default(),
     ));
     (addr, handle)
 }


### PR DESCRIPTION
## What

Nodes now locally track **time-to-first-token (TTFT)** for every inference request they proxy, per model and per target host.

This gives visibility into which models/hosts are fast vs slow, and provides the data foundation for smarter routing — preferring fast hosts and avoiding slow ones.

### How it works

- Timing is captured in the proxy's `route_local_attempt()` and `route_remote_attempt()` — the interval between sending the request and receiving the first response bytes
- Only successful (2xx) responses are recorded
- Each (model, target) pair keeps a ring buffer of the last 8 samples
- Reported TTFT is the **best of the last 3** samples — this filters out transient spikes from cold KV cache, contention, or network blips
- Entries expire after 30 minutes with no updates; hard cap of 512 entries

### API

Exposed on `/api/status` as `inference_perf`:
```json
{
  "inference_perf": {
    "models": [
      {
        "model": "Qwen3-8B-Q4_K_M",
        "best_ttft_ms": 200,
        "best_target": "local:8080",
        "total_samples": 5,
        "targets": [
          { "target": "local:8080", "best_ttft_ms": 200, "samples": 3 },
          { "target": "a1b2c3d4e5", "best_ttft_ms": 1200, "samples": 2 }
        ]
      }
    ]
  }
}
```

### What's next (not in this PR)

- **Feed TTFT into routing**: `pick_model_classified()` already accepts a `tok_s` param (always 0.0 today). Use observed TTFT to prefer faster models for auto-routing.
- **Target ordering**: When multiple hosts serve the same model, prefer lower-TTFT hosts over hash-based selection.
- **Background probes**: Send tiny synthetic requests to new hosts on discovery to get a TTFT baseline without waiting for real traffic.

## Scope

Purely local, no protocol changes, no gossip additions. Safe for mixed-version meshes — older nodes just won't have the `inference_perf` field in their status.