### PR TITLE
Add structured hardware info to peer announcements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,8 @@ Before committing, run the local checks most likely to fail in CI for the files 
 - Format only the changed Rust files from the repo root, for example with `cargo fmt --all -- path/to/file.rs`, and include those formatting changes in the commit.
 - After Rust changes, run `cargo check -p mesh-llm`.
 - If you touched tests, public APIs, routing, inference, gossip, plugin protocol, or CLI behavior, run the relevant tests before committing.
+- If you touched `proto/`, `mesh-llm/src/protocol/`, `mesh-llm/src/mesh/gossip.rs`, `mesh-llm/src/mesh/mod.rs`, routing, election, or API serialization, do not stop at build-only validation: run at least `cargo test -p mesh-llm --lib` and wait for it to exit successfully before committing.
+- Do not report a build or test step as complete until the command has actually exited with code `0`.
 - Run Rust validation serially. Do not run multiple `cargo` commands at the same time.
 
 ### UI changes

--- a/mesh-llm/proto/node.proto
+++ b/mesh-llm/proto/node.proto
@@ -13,10 +13,10 @@ message PeerAnnouncement {
   NodeRole role = 2;
   optional uint32 http_port = 3;
   optional string version = 4;
-  optional string gpu_name = 5;                      // Deprecated in v0.60.0: prefer gpus[].name
+  optional string gpu_name = 5;                      // Deprecated in v0.60.0: prefer hardware.gpus[].name
   optional string hostname = 6;                      // Deprecated in v0.60.0: prefer hardware.hostname
   optional bool is_soc = 7;                          // Deprecated in v0.60.0: prefer hardware.is_soc; true for system-on-chip / unified-memory hosts such as Apple Silicon and Jetson
-  optional string gpu_vram = 8;                      // Deprecated in v0.60.0: prefer gpus[].vram_bytes
+  optional string gpu_vram = 8;                      // Deprecated in v0.60.0: prefer hardware.gpus[].vram_bytes
   repeated string available_models = 9;              // Deprecated in v0.55.0 for protobuf gossip; compatibility surface only
   repeated string serving_models = 10;               // Deprecated in v0.55.0: prefer served_model_identities and served_model_runtime
   repeated string requested_models = 11;

--- a/mesh-llm/proto/node.proto
+++ b/mesh-llm/proto/node.proto
@@ -37,7 +37,11 @@ message PeerAnnouncement {
   repeated ServedModelIdentity served_model_identities = 26;
   repeated ModelRuntimeDescriptor served_model_runtime = 27;
   optional SignedNodeOwnership owner_attestation = 28;
-  optional HardwareInfo hardware = 29;              // Introduced in v0.60.0; preferred structured hardware inventory
+  optional string gpu_mem_bandwidth_gbps = 29;      // Deprecated in v0.60.0: prefer hardware.gpus[].mem_bandwidth_gbps
+  optional string gpu_compute_tflops_fp32 = 30;     // Deprecated in v0.60.0: prefer hardware.gpus[].compute_tflops_fp32
+  optional string gpu_compute_tflops_fp16 = 31;     // Deprecated in v0.60.0: prefer hardware.gpus[].compute_tflops_fp16
+  optional string gpu_reserved_bytes = 32;          // Deprecated in v0.60.0: prefer hardware.gpus[].reserved_bytes
+  optional HardwareInfo hardware = 33;              // Introduced in v0.60.0; preferred structured hardware inventory
 }
 
 message HardwareInfo {

--- a/mesh-llm/proto/node.proto
+++ b/mesh-llm/proto/node.proto
@@ -13,17 +13,17 @@ message PeerAnnouncement {
   NodeRole role = 2;
   optional uint32 http_port = 3;
   optional string version = 4;
-  optional string gpu_name = 5;
-  optional string hostname = 6;
-  optional bool is_soc = 7;
-  optional string gpu_vram = 8;
-  repeated string available_models = 9;
-  repeated string serving_models = 10;
+  optional string gpu_name = 5;                      // Deprecated in v0.60.0: prefer gpus[].name
+  optional string hostname = 6;                      // Deprecated in v0.60.0: prefer hardware.hostname
+  optional bool is_soc = 7;                          // Deprecated in v0.60.0: prefer hardware.is_soc; true for system-on-chip / unified-memory hosts such as Apple Silicon and Jetson
+  optional string gpu_vram = 8;                      // Deprecated in v0.60.0: prefer gpus[].vram_bytes
+  repeated string available_models = 9;              // Deprecated in v0.55.0 for protobuf gossip; compatibility surface only
+  repeated string serving_models = 10;               // Deprecated in v0.55.0: prefer served_model_identities and served_model_runtime
   repeated string requested_models = 11;
   repeated CompactModelMetadata available_model_metadata = 12;
   optional ExpertsSummary experts_summary = 13;
   optional uint32 rtt_ms = 14;
-  repeated string catalog_models = 15;              // GGUF model names (mesh catalog contribution; was JSON `models`)
+  repeated string catalog_models = 15;               // GGUF model names (mesh catalog contribution; was JSON `models`)
   uint64 vram_bytes = 16;                            // GPU VRAM in bytes
   optional string model_source = 17;                 // how to obtain this node's model
   optional string primary_serving = 18;              // primary serving model (backward compat; was JSON `serving`)
@@ -37,10 +37,22 @@ message PeerAnnouncement {
   repeated ServedModelIdentity served_model_identities = 26;
   repeated ModelRuntimeDescriptor served_model_runtime = 27;
   optional SignedNodeOwnership owner_attestation = 28;
-  optional string gpu_mem_bandwidth_gbps = 29;
-  optional string gpu_compute_tflops_fp32 = 30;
-  optional string gpu_compute_tflops_fp16 = 31;
-  optional string gpu_reserved_bytes = 32;
+  optional HardwareInfo hardware = 29;              // Introduced in v0.60.0; preferred structured hardware inventory
+}
+
+message HardwareInfo {
+  optional bool is_soc = 1;                          // True for system-on-chip / unified-memory hosts such as Apple Silicon and Jetson
+  optional string hostname = 2;
+  repeated GpuInfo gpus = 3;
+}
+
+message GpuInfo {
+  optional string name = 1;
+  optional string vram_bytes = 2;
+  optional string reserved_bytes = 3;
+  optional string mem_bandwidth_gbps = 4;
+  optional string compute_tflops_fp32 = 5;
+  optional string compute_tflops_fp16 = 6;
 }
 
 message SignedNodeOwnership {

--- a/mesh-llm/src/protocol/convert.rs
+++ b/mesh-llm/src/protocol/convert.rs
@@ -21,16 +21,24 @@ fn split_optional_csv(values: Option<&str>) -> Vec<Option<String>> {
 
 fn join_optional_csv(values: &[Option<String>]) -> Option<String> {
     if values.is_empty() {
-        None
-    } else {
-        Some(
-            values
-                .iter()
-                .map(|value| value.clone().unwrap_or_default())
-                .collect::<Vec<_>>()
-                .join(","),
-        )
+        return None;
     }
+
+    let has_present_value = values
+        .iter()
+        .any(|value| value.as_deref().is_some_and(|value| !value.trim().is_empty()));
+
+    if !has_present_value {
+        return None;
+    }
+
+    Some(
+        values
+            .iter()
+            .map(|value| value.clone().unwrap_or_default())
+            .collect::<Vec<_>>()
+            .join(","),
+    )
 }
 
 fn local_owner_attestation_to_proto(

--- a/mesh-llm/src/protocol/convert.rs
+++ b/mesh-llm/src/protocol/convert.rs
@@ -24,9 +24,11 @@ fn join_optional_csv(values: &[Option<String>]) -> Option<String> {
         return None;
     }
 
-    let has_present_value = values
-        .iter()
-        .any(|value| value.as_deref().is_some_and(|value| !value.trim().is_empty()));
+    let has_present_value = values.iter().any(|value| {
+        value
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+    });
 
     if !has_present_value {
         return None;
@@ -473,6 +475,10 @@ pub(crate) fn local_ann_to_proto_ann(
             .owner_attestation
             .as_ref()
             .and_then(local_owner_attestation_to_proto),
+        gpu_mem_bandwidth_gbps: ann.gpu_mem_bandwidth_gbps.clone(),
+        gpu_compute_tflops_fp32: ann.gpu_compute_tflops_fp32.clone(),
+        gpu_compute_tflops_fp16: ann.gpu_compute_tflops_fp16.clone(),
+        gpu_reserved_bytes: ann.gpu_reserved_bytes.clone(),
         hardware,
     }
 }
@@ -557,10 +563,11 @@ pub(crate) fn proto_ann_to_local(
             .or_else(|| pa.hostname.clone()),
         is_soc: hardware.and_then(|hardware| hardware.is_soc).or(pa.is_soc),
         gpu_vram: gpu_vram_from_gpus.or_else(|| pa.gpu_vram.clone()),
-        gpu_reserved_bytes: gpu_reserved_from_gpus,
-        gpu_mem_bandwidth_gbps: gpu_mem_bandwidth_from_gpus,
-        gpu_compute_tflops_fp32: gpu_fp32_from_gpus,
-        gpu_compute_tflops_fp16: gpu_fp16_from_gpus,
+        gpu_reserved_bytes: gpu_reserved_from_gpus.or_else(|| pa.gpu_reserved_bytes.clone()),
+        gpu_mem_bandwidth_gbps: gpu_mem_bandwidth_from_gpus
+            .or_else(|| pa.gpu_mem_bandwidth_gbps.clone()),
+        gpu_compute_tflops_fp32: gpu_fp32_from_gpus.or_else(|| pa.gpu_compute_tflops_fp32.clone()),
+        gpu_compute_tflops_fp16: gpu_fp16_from_gpus.or_else(|| pa.gpu_compute_tflops_fp16.clone()),
         available_model_metadata: Vec::new(),
         experts_summary: pa.experts_summary.clone(),
         available_model_sizes: HashMap::new(),

--- a/mesh-llm/src/protocol/convert.rs
+++ b/mesh-llm/src/protocol/convert.rs
@@ -475,6 +475,9 @@ pub(crate) fn local_ann_to_proto_ann(
             .owner_attestation
             .as_ref()
             .and_then(local_owner_attestation_to_proto),
+        // Legacy GPU metric fields (29-32) are populated alongside `hardware` so that
+        // pre-v0.60.0 peers that do not decode the new `hardware` block can still read
+        // bandwidth/tflops/reserved data from the flat fields they already know.
         gpu_mem_bandwidth_gbps: ann.gpu_mem_bandwidth_gbps.clone(),
         gpu_compute_tflops_fp32: ann.gpu_compute_tflops_fp32.clone(),
         gpu_compute_tflops_fp16: ann.gpu_compute_tflops_fp16.clone(),

--- a/mesh-llm/src/protocol/convert.rs
+++ b/mesh-llm/src/protocol/convert.rs
@@ -5,6 +5,34 @@ use crate::protocol::NODE_PROTOCOL_GENERATION;
 use iroh::{EndpointAddr, EndpointId};
 use std::collections::HashMap;
 
+fn split_optional_csv(values: Option<&str>) -> Vec<Option<String>> {
+    values
+        .map(|values| {
+            values
+                .split(',')
+                .map(|value| {
+                    let value = value.trim();
+                    (!value.is_empty()).then(|| value.to_string())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn join_optional_csv(values: &[Option<String>]) -> Option<String> {
+    if values.is_empty() {
+        None
+    } else {
+        Some(
+            values
+                .iter()
+                .map(|value| value.clone().unwrap_or_default())
+                .collect::<Vec<_>>()
+                .join(","),
+        )
+    }
+}
+
 fn local_owner_attestation_to_proto(
     attestation: &crate::crypto::SignedNodeOwnership,
 ) -> Option<crate::proto::node::SignedNodeOwnership> {
@@ -190,6 +218,117 @@ fn proto_runtime_descriptor_to_local(
     }
 }
 
+fn local_gpu_info_to_proto(ann: &PeerAnnouncement) -> Vec<crate::proto::node::GpuInfo> {
+    let legacy_field_count = [
+        split_optional_csv(ann.gpu_vram.as_deref()).len(),
+        split_optional_csv(ann.gpu_reserved_bytes.as_deref()).len(),
+        split_optional_csv(ann.gpu_mem_bandwidth_gbps.as_deref()).len(),
+        split_optional_csv(ann.gpu_compute_tflops_fp32.as_deref()).len(),
+        split_optional_csv(ann.gpu_compute_tflops_fp16.as_deref()).len(),
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(0);
+    let names =
+        crate::system::hardware::expand_gpu_names(ann.gpu_name.as_deref(), legacy_field_count);
+    let vram = split_optional_csv(ann.gpu_vram.as_deref());
+    let reserved = split_optional_csv(ann.gpu_reserved_bytes.as_deref());
+    let mem_bandwidth = split_optional_csv(ann.gpu_mem_bandwidth_gbps.as_deref());
+    let fp32 = split_optional_csv(ann.gpu_compute_tflops_fp32.as_deref());
+    let fp16 = split_optional_csv(ann.gpu_compute_tflops_fp16.as_deref());
+    let count = [
+        legacy_field_count,
+        names.len(),
+        vram.len(),
+        reserved.len(),
+        mem_bandwidth.len(),
+        fp32.len(),
+        fp16.len(),
+    ]
+    .into_iter()
+    .max()
+    .unwrap_or(0);
+
+    (0..count)
+        .map(|index| crate::proto::node::GpuInfo {
+            name: names.get(index).cloned(),
+            vram_bytes: vram.get(index).cloned().flatten(),
+            reserved_bytes: reserved.get(index).cloned().flatten(),
+            mem_bandwidth_gbps: mem_bandwidth.get(index).cloned().flatten(),
+            compute_tflops_fp32: fp32.get(index).cloned().flatten(),
+            compute_tflops_fp16: fp16.get(index).cloned().flatten(),
+        })
+        .collect()
+}
+
+fn local_hardware_info_to_proto(
+    ann: &PeerAnnouncement,
+) -> Option<crate::proto::node::HardwareInfo> {
+    let gpus = local_gpu_info_to_proto(ann);
+    if ann.hostname.is_none() && ann.is_soc.is_none() && gpus.is_empty() {
+        None
+    } else {
+        Some(crate::proto::node::HardwareInfo {
+            is_soc: ann.is_soc,
+            hostname: ann.hostname.clone(),
+            gpus,
+        })
+    }
+}
+
+fn proto_gpu_info_to_legacy_fields(
+    gpus: &[crate::proto::node::GpuInfo],
+) -> (
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+) {
+    let names: Vec<String> = gpus.iter().filter_map(|gpu| gpu.name.clone()).collect();
+    let gpu_name = crate::system::hardware::summarize_gpu_name(&names);
+    let gpu_vram = join_optional_csv(
+        &gpus
+            .iter()
+            .map(|gpu| gpu.vram_bytes.clone())
+            .collect::<Vec<_>>(),
+    );
+    let gpu_reserved_bytes = join_optional_csv(
+        &gpus
+            .iter()
+            .map(|gpu| gpu.reserved_bytes.clone())
+            .collect::<Vec<_>>(),
+    );
+    let gpu_mem_bandwidth_gbps = join_optional_csv(
+        &gpus
+            .iter()
+            .map(|gpu| gpu.mem_bandwidth_gbps.clone())
+            .collect::<Vec<_>>(),
+    );
+    let gpu_compute_tflops_fp32 = join_optional_csv(
+        &gpus
+            .iter()
+            .map(|gpu| gpu.compute_tflops_fp32.clone())
+            .collect::<Vec<_>>(),
+    );
+    let gpu_compute_tflops_fp16 = join_optional_csv(
+        &gpus
+            .iter()
+            .map(|gpu| gpu.compute_tflops_fp16.clone())
+            .collect::<Vec<_>>(),
+    );
+
+    (
+        gpu_name,
+        gpu_vram,
+        gpu_reserved_bytes,
+        gpu_mem_bandwidth_gbps,
+        gpu_compute_tflops_fp32,
+        gpu_compute_tflops_fp16,
+    )
+}
+
 /// Returns `true` when a proto descriptor carries a non-empty model name.
 /// Descriptors without a valid identity are discarded so a partial list
 /// cannot suppress the legacy-identity backfill fallback.
@@ -293,6 +432,7 @@ pub(crate) fn local_ann_to_proto_ann(
         .iter()
         .map(runtime_descriptor_to_proto)
         .collect();
+    let hardware = local_hardware_info_to_proto(&ann);
     crate::proto::node::PeerAnnouncement {
         endpoint_id: ann.addr.id.as_bytes().to_vec(),
         role: role_int,
@@ -302,10 +442,6 @@ pub(crate) fn local_ann_to_proto_ann(
         hostname: ann.hostname.clone(),
         is_soc: ann.is_soc,
         gpu_vram: ann.gpu_vram.clone(),
-        gpu_reserved_bytes: ann.gpu_reserved_bytes.clone(),
-        gpu_mem_bandwidth_gbps: ann.gpu_mem_bandwidth_gbps.clone(),
-        gpu_compute_tflops_fp32: ann.gpu_compute_tflops_fp32.clone(),
-        gpu_compute_tflops_fp16: ann.gpu_compute_tflops_fp16.clone(),
         available_models: ann.available_models.clone(),
         serving_models: ann.serving_models.clone(),
         requested_models: ann.requested_models.clone(),
@@ -329,6 +465,7 @@ pub(crate) fn local_ann_to_proto_ann(
             .owner_attestation
             .as_ref()
             .and_then(local_owner_attestation_to_proto),
+        hardware,
     }
 }
 
@@ -380,6 +517,19 @@ pub(crate) fn proto_ann_to_local(
         .hosted_models_known
         .unwrap_or(!pa.hosted_models.is_empty())
         .then(|| pa.hosted_models.clone());
+    let hardware = pa.hardware.as_ref();
+    let (
+        gpu_name_from_gpus,
+        gpu_vram_from_gpus,
+        gpu_reserved_from_gpus,
+        gpu_mem_bandwidth_from_gpus,
+        gpu_fp32_from_gpus,
+        gpu_fp16_from_gpus,
+    ) = proto_gpu_info_to_legacy_fields(
+        hardware
+            .map(|hardware| hardware.gpus.as_slice())
+            .unwrap_or(&[]),
+    );
     let mut ann = PeerAnnouncement {
         addr: addr.clone(),
         role,
@@ -393,14 +543,16 @@ pub(crate) fn proto_ann_to_local(
         version: pa.version.clone(),
         model_demand,
         mesh_id: pa.mesh_id.clone(),
-        gpu_name: pa.gpu_name.clone(),
-        hostname: pa.hostname.clone(),
-        is_soc: pa.is_soc,
-        gpu_vram: pa.gpu_vram.clone(),
-        gpu_reserved_bytes: pa.gpu_reserved_bytes.clone(),
-        gpu_mem_bandwidth_gbps: pa.gpu_mem_bandwidth_gbps.clone(),
-        gpu_compute_tflops_fp32: pa.gpu_compute_tflops_fp32.clone(),
-        gpu_compute_tflops_fp16: pa.gpu_compute_tflops_fp16.clone(),
+        gpu_name: gpu_name_from_gpus.or_else(|| pa.gpu_name.clone()),
+        hostname: hardware
+            .and_then(|hardware| hardware.hostname.clone())
+            .or_else(|| pa.hostname.clone()),
+        is_soc: hardware.and_then(|hardware| hardware.is_soc).or(pa.is_soc),
+        gpu_vram: gpu_vram_from_gpus.or_else(|| pa.gpu_vram.clone()),
+        gpu_reserved_bytes: gpu_reserved_from_gpus,
+        gpu_mem_bandwidth_gbps: gpu_mem_bandwidth_from_gpus,
+        gpu_compute_tflops_fp32: gpu_fp32_from_gpus,
+        gpu_compute_tflops_fp16: gpu_fp16_from_gpus,
         available_model_metadata: Vec::new(),
         experts_summary: pa.experts_summary.clone(),
         available_model_sizes: HashMap::new(),

--- a/mesh-llm/src/protocol/mod.rs
+++ b/mesh-llm/src/protocol/mod.rs
@@ -1552,7 +1552,6 @@ mod tests {
                     mem_bandwidth_gbps: Some("1948.70".to_string()),
                     compute_tflops_fp32: None,
                     compute_tflops_fp16: None,
-                    is_soc: Some(false),
                 }],
             }),
             ..Default::default()
@@ -1586,7 +1585,6 @@ mod tests {
                         mem_bandwidth_gbps: Some("1948.70".to_string()),
                         compute_tflops_fp32: Some("19.50".to_string()),
                         compute_tflops_fp16: Some("312.00".to_string()),
-                        is_soc: Some(false),
                     },
                     crate::proto::node::GpuInfo {
                         name: Some("NVIDIA A100".to_string()),
@@ -1595,7 +1593,6 @@ mod tests {
                         mem_bandwidth_gbps: Some("1948.70".to_string()),
                         compute_tflops_fp32: Some("19.50".to_string()),
                         compute_tflops_fp16: Some("312.00".to_string()),
-                        is_soc: Some(false),
                     },
                 ],
             }),

--- a/mesh-llm/src/protocol/mod.rs
+++ b/mesh-llm/src/protocol/mod.rs
@@ -1488,10 +1488,31 @@ mod tests {
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann);
-        assert_eq!(proto_pa.gpu_reserved_bytes.as_deref(), Some("1073741824"));
-        assert_eq!(proto_pa.gpu_mem_bandwidth_gbps.as_deref(), Some("1948.70"));
-        assert_eq!(proto_pa.gpu_compute_tflops_fp32.as_deref(), Some("19.50"));
-        assert_eq!(proto_pa.gpu_compute_tflops_fp16.as_deref(), Some("312.00"));
+        let hardware = proto_pa
+            .hardware
+            .as_ref()
+            .expect("hardware info must be present");
+        assert_eq!(hardware.hostname.as_deref(), Some("worker-01"));
+        assert_eq!(hardware.is_soc, Some(false));
+        assert_eq!(hardware.gpus.len(), 1);
+        assert_eq!(hardware.gpus[0].name.as_deref(), Some("NVIDIA A100"));
+        assert_eq!(hardware.gpus[0].vram_bytes.as_deref(), Some("51539607552"));
+        assert_eq!(
+            hardware.gpus[0].reserved_bytes.as_deref(),
+            Some("1073741824")
+        );
+        assert_eq!(
+            hardware.gpus[0].mem_bandwidth_gbps.as_deref(),
+            Some("1948.70")
+        );
+        assert_eq!(
+            hardware.gpus[0].compute_tflops_fp32.as_deref(),
+            Some("19.50")
+        );
+        assert_eq!(
+            hardware.gpus[0].compute_tflops_fp16.as_deref(),
+            Some("312.00")
+        );
 
         let (_, roundtripped) =
             proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
@@ -1521,10 +1542,19 @@ mod tests {
             role: NodeRole::Worker as i32,
             gpu_name: Some("NVIDIA A100".to_string()),
             gpu_vram: Some("51539607552".to_string()),
-            gpu_reserved_bytes: None,
-            gpu_mem_bandwidth_gbps: Some("1948.70".to_string()),
-            gpu_compute_tflops_fp32: None,
-            gpu_compute_tflops_fp16: None,
+            hardware: Some(crate::proto::node::HardwareInfo {
+                is_soc: Some(false),
+                hostname: None,
+                gpus: vec![crate::proto::node::GpuInfo {
+                    name: Some("NVIDIA A100".to_string()),
+                    vram_bytes: Some("51539607552".to_string()),
+                    reserved_bytes: None,
+                    mem_bandwidth_gbps: Some("1948.70".to_string()),
+                    compute_tflops_fp32: None,
+                    compute_tflops_fp16: None,
+                    is_soc: Some(false),
+                }],
+            }),
             ..Default::default()
         };
 
@@ -1537,6 +1567,66 @@ mod tests {
         );
         assert_eq!(roundtripped.gpu_compute_tflops_fp32, None);
         assert_eq!(roundtripped.gpu_compute_tflops_fp16, None);
+    }
+
+    #[test]
+    fn test_proto_gpu_info_preserves_legacy_fields_for_old_consumers() {
+        let peer_id = EndpointId::from(SecretKey::from_bytes(&[0xCE; 32]).public());
+        let proto_pa = crate::proto::node::PeerAnnouncement {
+            endpoint_id: peer_id.as_bytes().to_vec(),
+            role: NodeRole::Worker as i32,
+            hardware: Some(crate::proto::node::HardwareInfo {
+                is_soc: Some(false),
+                hostname: Some("worker-01".to_string()),
+                gpus: vec![
+                    crate::proto::node::GpuInfo {
+                        name: Some("NVIDIA A100".to_string()),
+                        vram_bytes: Some("51539607552".to_string()),
+                        reserved_bytes: Some("1073741824".to_string()),
+                        mem_bandwidth_gbps: Some("1948.70".to_string()),
+                        compute_tflops_fp32: Some("19.50".to_string()),
+                        compute_tflops_fp16: Some("312.00".to_string()),
+                        is_soc: Some(false),
+                    },
+                    crate::proto::node::GpuInfo {
+                        name: Some("NVIDIA A100".to_string()),
+                        vram_bytes: Some("51539607552".to_string()),
+                        reserved_bytes: None,
+                        mem_bandwidth_gbps: Some("1948.70".to_string()),
+                        compute_tflops_fp32: Some("19.50".to_string()),
+                        compute_tflops_fp16: Some("312.00".to_string()),
+                        is_soc: Some(false),
+                    },
+                ],
+            }),
+            ..Default::default()
+        };
+
+        let (_, roundtripped) =
+            proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
+        assert_eq!(roundtripped.hostname.as_deref(), Some("worker-01"));
+        assert_eq!(roundtripped.gpu_name.as_deref(), Some("2× NVIDIA A100"));
+        assert_eq!(
+            roundtripped.gpu_vram.as_deref(),
+            Some("51539607552,51539607552")
+        );
+        assert_eq!(
+            roundtripped.gpu_reserved_bytes.as_deref(),
+            Some("1073741824,")
+        );
+        assert_eq!(
+            roundtripped.gpu_mem_bandwidth_gbps.as_deref(),
+            Some("1948.70,1948.70")
+        );
+        assert_eq!(
+            roundtripped.gpu_compute_tflops_fp32.as_deref(),
+            Some("19.50,19.50")
+        );
+        assert_eq!(
+            roundtripped.gpu_compute_tflops_fp16.as_deref(),
+            Some("312.00,312.00")
+        );
+        assert_eq!(roundtripped.is_soc, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- introduce `HardwareInfo` and `GpuInfo` in protobuf peer announcements for structured host and GPU inventory
- keep legacy peer announcement fields as compatibility shims while preferring the new hardware block in protocol conversion
- add roundtrip coverage to verify new hardware data serializes correctly and still backfills legacy fields for older consumers

## Testing
- Not run (not requested)