### PR TITLE
Fix Docker image name casing for OCI registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,9 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository_owner }}/mesh-llm
+  # repository_owner preserves GitHub org casing (e.g. "Mesh-LLM") but OCI
+  # registries require fully-lowercase image references.
+  IMAGE_NAME: mesh-llm/mesh-llm
 
 permissions:
   contents: read

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,9 +20,11 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  # repository_owner preserves GitHub org casing (e.g. "Mesh-LLM") but OCI
-  # registries require fully-lowercase image references.
-  IMAGE_NAME: mesh-llm/mesh-llm
+  # `github.repository` preserves GitHub org/repo casing, but OCI registries
+  # require fully-lowercase image references. Allow forks and renamed repos
+  # to override this with a lowercase repo/org Actions variable while keeping
+  # the current upstream path as the default.
+  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'mesh-llm/mesh-llm' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Docker builds fail during the multi-arch manifest merge step with:

```
failed to parse source "ghcr.io/Mesh-LLM/mesh-llm:sha-cdf372b-amd64": repository name (Mesh-LLM/mesh-llm) must be lowercase
```

`github.repository_owner` preserves the GitHub org's original casing (`Mesh-LLM`), but OCI registries require fully-lowercase image references. Hardcodes the image name to `mesh-llm/mesh-llm` in the `env` block where shell lowercasing isn't available.