### PR TITLE
feature(opencode): add OpenCode support to mesh-llm as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Build-from-source and UI development instructions are in [CONTRIBUTING.md](CONTR
 
 mesh-llm exposes an OpenAI-compatible API on `localhost:9337`. Any tool that supports custom OpenAI endpoints works. `/v1/models` lists available models; the `model` field in requests routes to the right node.
 
-For built-in launcher integrations (`goose`, `claude`):
+For built-in launcher integrations (`goose`, `claude`, `opencode`):
 
 - If a mesh is already running locally on `--port`, it is reused.
 - If not, `mesh-llm` auto-starts a background client node that auto-joins the mesh.
@@ -370,6 +370,20 @@ mesh-llm goose --model MiniMax-M2.5-Q4_K_M
 ```
 
 This command writes/updates `~/.config/goose/custom_providers/mesh.json` and launches Goose.
+
+### opencode
+
+OpenCode uses a temporary provider config injected by Mesh, so you don't need to edit local config files by hand. For the full advanced or manual setup, see [docs/AGENTS.md](docs/AGENTS.md).
+
+```bash
+mesh-llm opencode
+```
+
+Use a specific model (example: MiniMax):
+
+```bash
+mesh-llm opencode --model MiniMax-M2.5-Q4_K_M
+```
 
 ### pi
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,7 +6,7 @@ Mesh LLM exposes an OpenAI-compatible API on `http://localhost:9337/v1`, so most
 
 ## Built-in launcher integrations
 
-For built-in launcher commands such as `goose` and `claude`:
+For built-in launcher commands such as `goose`, `claude`, and `opencode`:
 
 - if a mesh is already running locally on the chosen port, it is reused
 - otherwise Mesh LLM starts a background client node and auto-joins a mesh
@@ -41,6 +41,45 @@ Use a specific model:
 
 ```bash
 mesh-llm claude --model MiniMax-M2.5-Q4_K_M
+```
+
+## OpenCode
+
+Launch OpenCode directly through Mesh LLM:
+
+```bash
+mesh-llm opencode
+```
+
+Use a specific model:
+
+```bash
+mesh-llm opencode --model MiniMax-M2.5-Q4_K_M
+```
+
+Mesh LLM injects a temporary OpenCode config with `OPENCODE_CONFIG_CONTENT` when it launches OpenCode, so it does not edit your persistent OpenCode config files.
+
+If you want to rerun OpenCode manually, use the same config contract Mesh LLM generates:
+
+```bash
+OPENCODE_CONFIG_CONTENT='{
+  "$schema": "https://opencode.ai/config.json",
+  "provider": {
+    "mesh": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "mesh-llm",
+      "options": {
+        "baseURL": "http://127.0.0.1:9337/v1",
+        "apiKey": "{env:OPENAI_API_KEY}"
+      },
+      "models": {
+        "MiniMax-M2.5-Q4_K_M": {
+          "name": "MiniMax-M2.5-Q4_K_M"
+        }
+      }
+    }
+  }
+}' OPENAI_API_KEY=dummy opencode -m mesh/MiniMax-M2.5-Q4_K_M
 ```
 
 ## pi
@@ -93,12 +132,6 @@ pi --model mesh/MiniMax-M2.5-Q4_K_M
 ```
 
 You can switch models interactively with `Ctrl+M` inside pi.
-
-## OpenCode
-
-```bash
-OPENAI_API_KEY=dummy OPENAI_BASE_URL=http://localhost:9337/v1 opencode -m openai/GLM-4.7-Flash-Q4_K_M
-```
 
 ## curl or any OpenAI client
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -274,6 +274,17 @@ Switches:
 - `--model <MODEL>`: model id from `/v1/models`.
 - `--port <PORT>`: mesh-llm API port (default `9337`).
 
+### `opencode`
+
+Use this to launch OpenCode already wired to mesh-llm’s OpenAI-compatible endpoint.
+
+It injects a temporary OpenCode config through `OPENCODE_CONFIG_CONTENT` at launch time, so it does not edit persistent OpenCode config files.
+
+Switches:
+
+- `--model <MODEL>`: model id from `/v1/models`.
+- `--port <PORT>`: mesh-llm API port (default `9337`).
+
 ### `stop`
 
 Use this to stop local `mesh-llm`, `llama-server`, and `rpc-server` processes.

--- a/mesh-llm/src/cli/commands/integrations.rs
+++ b/mesh-llm/src/cli/commands/integrations.rs
@@ -2,6 +2,83 @@ use anyhow::Result;
 
 use crate::runtime;
 
+const OPENCODE_PROVIDER_ID: &str = "mesh";
+const OPENCODE_CONFIG_ENV: &str = "OPENCODE_CONFIG_CONTENT";
+const OPENCODE_API_KEY_ENV: &str = "OPENAI_API_KEY";
+const OPENCODE_API_KEY_VALUE: &str = "dummy";
+const OPENCODE_INSTALL_HINT: &str = "curl -fsSL https://opencode.ai/install | bash";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct OpenCodeLaunchSpec {
+    provider_id: &'static str,
+    model: String,
+    config_content: String,
+    api_key_env: &'static str,
+    api_key_value: &'static str,
+    install_hint: &'static str,
+}
+
+fn build_opencode_launch_spec(
+    model_names: &[String],
+    resolved_model: &str,
+    port: u16,
+) -> OpenCodeLaunchSpec {
+    let mut models = serde_json::Map::new();
+    for model in model_names {
+        models.insert(
+            model.clone(),
+            serde_json::json!({
+                "name": model,
+            }),
+        );
+    }
+
+    let config = serde_json::json!({
+        "$schema": "https://opencode.ai/config.json",
+        "provider": {
+            OPENCODE_PROVIDER_ID: {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "mesh-llm",
+                "options": {
+                    "baseURL": format!("http://127.0.0.1:{port}/v1"),
+                    "apiKey": format!("{{env:{OPENCODE_API_KEY_ENV}}}"),
+                },
+                "models": models,
+            }
+        }
+    });
+
+    OpenCodeLaunchSpec {
+        provider_id: OPENCODE_PROVIDER_ID,
+        model: format!("{OPENCODE_PROVIDER_ID}/{resolved_model}"),
+        config_content: config.to_string(),
+        api_key_env: OPENCODE_API_KEY_ENV,
+        api_key_value: OPENCODE_API_KEY_VALUE,
+        install_hint: OPENCODE_INSTALL_HINT,
+    }
+}
+
+fn opencode_missing_binary_guidance(
+    chosen: &str,
+    port: u16,
+    spec: &OpenCodeLaunchSpec,
+) -> Vec<String> {
+    vec![
+        "opencode not found in PATH".to_string(),
+        spec.install_hint.to_string(),
+        "Manual rerun examples:".to_string(),
+        format!("  mesh-llm opencode --port {port} --model {chosen}"),
+        format!(
+            "  {}='{}' {}='{}' opencode -m {}",
+            OPENCODE_CONFIG_ENV,
+            spec.config_content,
+            spec.api_key_env,
+            spec.api_key_value,
+            spec.model,
+        ),
+    ]
+}
+
 pub(crate) async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
@@ -130,4 +207,138 @@ pub(crate) async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
         let _ = c.wait();
     }
     Ok(())
+}
+
+pub(crate) async fn run_opencode(model: Option<String>, port: u16) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    let (models, chosen, mut mesh_child) = runtime::check_mesh(&client, port, &model).await?;
+    let spec = build_opencode_launch_spec(&models, &chosen, port);
+
+    eprintln!(
+        "🚀 Launching OpenCode with {} → http://127.0.0.1:{port}/v1\n",
+        chosen
+    );
+    let status = std::process::Command::new("opencode")
+        .args(["-m", &spec.model])
+        .env(OPENCODE_CONFIG_ENV, &spec.config_content)
+        .env(spec.api_key_env, spec.api_key_value)
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => eprintln!("opencode exited with {s}"),
+        Err(_) => {
+            for line in opencode_missing_binary_guidance(&chosen, port, &spec) {
+                eprintln!("{line}");
+            }
+        }
+    }
+    if let Some(ref mut c) = mesh_child {
+        eprintln!("🧹 Stopping mesh-llm node we started...");
+        let _ = c.kill();
+        let _ = c.wait();
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        build_opencode_launch_spec, opencode_missing_binary_guidance, OPENCODE_INSTALL_HINT,
+    };
+
+    #[test]
+    fn opencode_launch_spec_uses_mesh_provider_and_v1_base_url() {
+        let spec = build_opencode_launch_spec(
+            &[
+                "GLM-4.7-Flash-Q4_K_M".to_string(),
+                "bartowski/DeepSeek-R1.gguf".to_string(),
+            ],
+            "GLM-4.7-Flash-Q4_K_M",
+            9337,
+        );
+        let config: serde_json::Value =
+            serde_json::from_str(&spec.config_content).expect("valid OpenCode config JSON");
+
+        assert_eq!(spec.provider_id, "mesh");
+        assert_eq!(spec.api_key_env, "OPENAI_API_KEY");
+        assert_eq!(spec.api_key_value, "dummy");
+        assert_eq!(config["$schema"], "https://opencode.ai/config.json");
+        assert_eq!(
+            config["provider"]["mesh"]["npm"],
+            "@ai-sdk/openai-compatible"
+        );
+        assert_eq!(config["provider"]["mesh"]["name"], "mesh-llm");
+        assert_eq!(
+            config["provider"]["mesh"]["options"]["baseURL"],
+            "http://127.0.0.1:9337/v1"
+        );
+        assert_eq!(
+            config["provider"]["mesh"]["options"]["apiKey"],
+            "{env:OPENAI_API_KEY}"
+        );
+        assert_eq!(
+            config["provider"]["mesh"]["models"]["GLM-4.7-Flash-Q4_K_M"]["name"],
+            "GLM-4.7-Flash-Q4_K_M"
+        );
+        assert_eq!(
+            config["provider"]["mesh"]["models"]["bartowski/DeepSeek-R1.gguf"]["name"],
+            "bartowski/DeepSeek-R1.gguf"
+        );
+        assert_eq!(
+            config["provider"]["mesh"]["models"]
+                .as_object()
+                .map(|m| m.len()),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn opencode_launch_spec_uses_mesh_prefixed_model() {
+        let spec = build_opencode_launch_spec(
+            &[
+                "GLM-4.7-Flash-Q4_K_M".to_string(),
+                "bartowski/DeepSeek-R1.gguf".to_string(),
+            ],
+            "bartowski/DeepSeek-R1.gguf",
+            8080,
+        );
+
+        assert_eq!(spec.provider_id, "mesh");
+        assert_eq!(spec.model, "mesh/bartowski/DeepSeek-R1.gguf");
+    }
+
+    #[test]
+    fn opencode_install_hint_mentions_official_install_url() {
+        assert!(OPENCODE_INSTALL_HINT.contains("https://opencode.ai/install"));
+        assert_eq!(
+            OPENCODE_INSTALL_HINT,
+            "curl -fsSL https://opencode.ai/install | bash"
+        );
+    }
+
+    #[test]
+    fn opencode_missing_binary_reports_official_install_hint() {
+        let spec = build_opencode_launch_spec(
+            &[
+                "GLM-4.7-Flash-Q4_K_M".to_string(),
+                "bartowski/DeepSeek-R1.gguf".to_string(),
+            ],
+            "GLM-4.7-Flash-Q4_K_M",
+            9337,
+        );
+        let lines = opencode_missing_binary_guidance("GLM-4.7-Flash-Q4_K_M", 9337, &spec);
+
+        assert_eq!(lines[0], "opencode not found in PATH");
+        assert_eq!(lines[1], OPENCODE_INSTALL_HINT);
+        assert_eq!(lines[2], "Manual rerun examples:");
+        assert_eq!(
+            lines[3],
+            "  mesh-llm opencode --port 9337 --model GLM-4.7-Flash-Q4_K_M"
+        );
+        assert!(lines[4].contains("opencode -m mesh/GLM-4.7-Flash-Q4_K_M"));
+        assert!(lines[4].contains("OPENCODE_CONFIG_CONTENT='{"));
+        assert!(lines[4].contains("OPENAI_API_KEY='dummy'"));
+    }
 }

--- a/mesh-llm/src/cli/commands/integrations.rs
+++ b/mesh-llm/src/cli/commands/integrations.rs
@@ -66,16 +66,10 @@ fn opencode_missing_binary_guidance(
     vec![
         "opencode not found in PATH".to_string(),
         spec.install_hint.to_string(),
-        "Manual rerun examples:".to_string(),
+        "Then rerun through mesh-llm:".to_string(),
         format!("  mesh-llm opencode --port {port} --model {chosen}"),
-        format!(
-            "  {}='{}' {}='{}' opencode -m {}",
-            OPENCODE_CONFIG_ENV,
-            spec.config_content,
-            spec.api_key_env,
-            spec.api_key_value,
-            spec.model,
-        ),
+        "mesh-llm injects OPENCODE_CONFIG_CONTENT automatically when launching OpenCode."
+            .to_string(),
     ]
 }
 
@@ -332,13 +326,14 @@ mod tests {
 
         assert_eq!(lines[0], "opencode not found in PATH");
         assert_eq!(lines[1], OPENCODE_INSTALL_HINT);
-        assert_eq!(lines[2], "Manual rerun examples:");
+        assert_eq!(lines[2], "Then rerun through mesh-llm:");
         assert_eq!(
             lines[3],
             "  mesh-llm opencode --port 9337 --model GLM-4.7-Flash-Q4_K_M"
         );
-        assert!(lines[4].contains("opencode -m mesh/GLM-4.7-Flash-Q4_K_M"));
-        assert!(lines[4].contains("OPENCODE_CONFIG_CONTENT='{"));
-        assert!(lines[4].contains("OPENAI_API_KEY='dummy'"));
+        assert_eq!(
+            lines[4],
+            "mesh-llm injects OPENCODE_CONFIG_CONTENT automatically when launching OpenCode."
+        );
     }
 }

--- a/mesh-llm/src/cli/commands/mod.rs
+++ b/mesh-llm/src/cli/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::cli::commands::blackboard::{install_skill, run_blackboard};
 use crate::cli::commands::discover::{run_discover, run_stop};
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
-use crate::cli::commands::integrations::{run_claude, run_goose};
+use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode};
 use crate::cli::commands::models::dispatch_models_command;
 use crate::cli::commands::moe::dispatch_moe_command;
 use crate::cli::commands::plugin::run_plugin_command;
@@ -69,6 +69,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::RotateKey => nostr::rotate_keys(),
         Command::Goose { model, port } => run_goose(model.clone(), *port).await,
         Command::Claude { model, port } => run_claude(model.clone(), *port).await,
+        Command::Opencode { model, port } => run_opencode(model.clone(), *port).await,
         Command::Blackboard {
             text,
             search,

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -505,6 +505,18 @@ pub(crate) enum Command {
         #[arg(long, default_value = "9337")]
         port: u16,
     },
+    /// Launch OpenCode with mesh-llm as the inference provider.
+    ///
+    /// If no mesh is running on --port, this auto-joins the mesh as a client.
+    #[command(name = "opencode")]
+    Opencode {
+        /// Model id to use from /v1/models (default: auto = mesh picks best)
+        #[arg(long)]
+        model: Option<String>,
+        /// API port for mesh-llm (default: 9337)
+        #[arg(long, default_value = "9337")]
+        port: u16,
+    },
     /// Stop all running mesh-llm, llama-server, and rpc-server processes.
     Stop,
     /// Blackboard — post, search, and read messages shared across the mesh.

--- a/mesh-llm/ui/src/features/app-shell/components/AppHeader.test.tsx
+++ b/mesh-llm/ui/src/features/app-shell/components/AppHeader.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { TooltipProvider } from "../../../components/ui/tooltip";
+import { AppHeader } from "./AppHeader";
+
+class MockResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+function renderHeader(overrides: Partial<Parameters<typeof AppHeader>[0]> = {}) {
+  return render(
+    <TooltipProvider>
+      <AppHeader
+        sections={[
+          { key: "dashboard", label: "Network" },
+          { key: "chat", label: "Chat" },
+        ]}
+        section="dashboard"
+        setSection={vi.fn()}
+        themeMode="auto"
+        setThemeMode={vi.fn()}
+        statusError={null}
+        inviteWithModelCommand="mesh-llm --join invite-token --model GLM-4.7-Flash-Q4_K_M"
+        inviteWithModelName="GLM-4.7-Flash-Q4_K_M"
+        inviteClientCommand="mesh-llm --client --join invite-token"
+        inviteToken="invite-token"
+        apiDirectUrl=""
+        isPublicMesh={false}
+        {...overrides}
+      />
+    </TooltipProvider>,
+  );
+}
+
+describe("AppHeader", () => {
+  beforeAll(() => {
+    Object.defineProperty(window, "ResizeObserver", {
+      configurable: true,
+      writable: true,
+      value: MockResizeObserver,
+    });
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows and copies the OpenCode launcher for public meshes", async () => {
+    renderHeader({ isPublicMesh: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "API access" }));
+
+    await screen.findByText("mesh-llm opencode");
+    fireEvent.click(screen.getByRole("button", { name: "Copy opencode command" }));
+
+    await waitFor(() =>
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith("mesh-llm opencode"),
+    );
+    expect(screen.getByText("mesh-llm claude")).toBeInTheDocument();
+    expect(screen.getByText("mesh-llm goose")).toBeInTheDocument();
+  });
+
+  it("keeps private meshes focused on invite flows without OpenCode", async () => {
+    renderHeader({ isPublicMesh: false, inviteToken: "private-token" });
+
+    fireEvent.click(screen.getByRole("button", { name: "API access" }));
+
+    await screen.findByText("mesh-llm claude --join private-token");
+    expect(screen.getByText("mesh-llm goose --join private-token")).toBeInTheDocument();
+    expect(screen.queryByText(/mesh-llm opencode/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy opencode command" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/mesh-llm/ui/src/features/app-shell/components/AppHeader.tsx
+++ b/mesh-llm/ui/src/features/app-shell/components/AppHeader.tsx
@@ -46,6 +46,9 @@ type AppHeaderSection = {
   label: string;
 };
 
+const PUBLIC_AGENT_LAUNCHERS = ["claude", "goose", "opencode"] as const;
+const PRIVATE_AGENT_LAUNCHERS = ["claude", "goose"] as const;
+
 function isPlainLeftClick(event: React.MouseEvent<HTMLAnchorElement>) {
   return (
     event.button === 0 &&
@@ -83,6 +86,9 @@ export function AppHeader({
   apiDirectUrl: string;
   isPublicMesh: boolean;
 }) {
+  const agentLaunchers = isPublicMesh
+    ? PUBLIC_AGENT_LAUNCHERS
+    : PRIVATE_AGENT_LAUNCHERS;
   const [inviteWithModelCopied, setInviteWithModelCopied] = useState(false);
   const [inviteClientCopied, setInviteClientCopied] = useState(false);
   const [tokenCopied, setTokenCopied] = useState(false);
@@ -266,7 +272,7 @@ export function AppHeader({
               <div className="space-y-2 pt-1">
                 <div className="text-xs font-medium">Use with agents</div>
                 <div className="space-y-1">
-                  {["claude", "goose"].map((agent) => {
+                  {agentLaunchers.map((agent) => {
                     const cmd = isPublicMesh
                       ? `mesh-llm ${agent}`
                       : `mesh-llm ${agent} --join ${inviteToken || "(token)"}`;


### PR DESCRIPTION
## Summary

You can now launch OpenCode directly through Mesh LLM with:

```bash
mesh-llm opencode
```

This adds OpenCode as a first-class built-in launcher, alongside Goose and Claude Code, and wires it to Mesh LLM's local OpenAI-compatible endpoint automatically.

It also fixes the OpenCode provider model picker so it shows the full list of models available on the joined mesh, while still preselecting the default chosen model at launch.

## Screenshot
<img width="540" height="299" alt="Screenshot 2026-04-14 at 4 22 11 AM" src="https://github.com/user-attachments/assets/784b7302-4517-4652-b3f3-3d870fce293a" />


## What changed

- added a new `mesh-llm opencode` CLI subcommand
- wired `opencode` through command dispatch
- added OpenCode launch-spec helpers and tests
- implemented `run_opencode(...)` using the existing `check_mesh(...)` startup and model-selection flow
- injects OpenCode config at runtime with `OPENCODE_CONFIG_CONTENT` instead of requiring persistent local config edits
- exposes `mesh-llm opencode` in the UI header launcher copy for public meshes
- documents the built-in OpenCode workflow in `docs/CLI.md`, `docs/AGENTS.md`, and `README.md`
- populates the OpenCode provider with all mesh models, not just the default selected one

## User-facing behavior

### Launch OpenCode through Mesh LLM
```bash
mesh-llm opencode
mesh-llm opencode --model MiniMax-M2.5-Q4_K_M
```

### Public mesh UI affordance
The header "Use with agents" section now includes `mesh-llm opencode` for public meshes.

### OpenCode model picker
The injected `mesh` provider now includes the full `/v1/models` list from the joined mesh, so multiple available models appear in OpenCode instead of only one.

## Config contract

The launcher uses an injected OpenCode provider config with:

- provider id: `mesh`
- provider package: `@ai-sdk/openai-compatible`
- base URL: `http://127.0.0.1:<port>/v1`
- API key source: `{env:OPENAI_API_KEY}`
- model format: `mesh/<resolved-model>`

This keeps the integration runtime-scoped and avoids editing persistent OpenCode config files.

## Validation

```bash
cargo test -p mesh-llm opencode_
cargo check -p mesh-llm
cargo run -p mesh-llm -- --help
cargo run -p mesh-llm -- opencode --help
npm --prefix mesh-llm/ui exec vitest run src/features/app-shell/components/AppHeader.test.tsx
just build
```

## Notes

- private-mesh launcher behavior was intentionally left unchanged
- no status-payload expansion or generic launcher abstraction was added
- no protocol changes

Closes #238 