### PR TITLE
Fix Fly console OOM: bump to 1GB RAM, fix Docker builds for xtask

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -38,6 +38,8 @@ COPY mesh-llm/plugin/build.rs mesh-llm/plugin/build.rs
 COPY mesh-llm/proto/ mesh-llm/proto/
 COPY mesh-llm/src/ mesh-llm/src/
 COPY mesh-llm/plugin/src/ mesh-llm/plugin/src/
+COPY tools/xtask/Cargo.toml tools/xtask/Cargo.toml
+COPY tools/xtask/src/ tools/xtask/src/
 RUN mkdir -p mesh-llm/ui/dist && echo '<html></html>' > mesh-llm/ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -42,6 +42,8 @@ COPY mesh-llm/plugin/build.rs mesh-llm/plugin/build.rs
 COPY mesh-llm/proto/ mesh-llm/proto/
 COPY mesh-llm/src/ mesh-llm/src/
 COPY mesh-llm/plugin/src/ mesh-llm/plugin/src/
+COPY tools/xtask/Cargo.toml tools/xtask/Cargo.toml
+COPY tools/xtask/src/ tools/xtask/src/
 RUN mkdir -p mesh-llm/ui/dist && echo '<html></html>' > mesh-llm/ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -41,6 +41,8 @@ COPY mesh-llm/plugin/build.rs mesh-llm/plugin/build.rs
 COPY mesh-llm/proto/ mesh-llm/proto/
 COPY mesh-llm/src/ mesh-llm/src/
 COPY mesh-llm/plugin/src/ mesh-llm/plugin/src/
+COPY tools/xtask/Cargo.toml tools/xtask/Cargo.toml
+COPY tools/xtask/src/ tools/xtask/src/
 RUN mkdir -p mesh-llm/ui/dist && echo '<html></html>' > mesh-llm/ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -40,6 +40,8 @@ COPY mesh-llm/plugin/build.rs mesh-llm/plugin/build.rs
 COPY mesh-llm/proto/ mesh-llm/proto/
 COPY mesh-llm/src/ mesh-llm/src/
 COPY mesh-llm/plugin/src/ mesh-llm/plugin/src/
+COPY tools/xtask/Cargo.toml tools/xtask/Cargo.toml
+COPY tools/xtask/src/ tools/xtask/src/
 RUN mkdir -p mesh-llm/ui/dist && echo '<html></html>' > mesh-llm/ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/docker/Dockerfile.vulkan
+++ b/docker/Dockerfile.vulkan
@@ -37,6 +37,8 @@ COPY mesh-llm/plugin/build.rs mesh-llm/plugin/build.rs
 COPY mesh-llm/proto/ mesh-llm/proto/
 COPY mesh-llm/src/ mesh-llm/src/
 COPY mesh-llm/plugin/src/ mesh-llm/plugin/src/
+COPY tools/xtask/Cargo.toml tools/xtask/Cargo.toml
+COPY tools/xtask/src/ tools/xtask/src/
 RUN mkdir -p mesh-llm/ui/dist && echo '<html></html>' > mesh-llm/ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -41,6 +41,8 @@ COPY mesh-llm/plugin/build.rs mesh-llm/plugin/build.rs
 COPY mesh-llm/proto/ mesh-llm/proto/
 COPY mesh-llm/src/ mesh-llm/src/
 COPY mesh-llm/plugin/src/ mesh-llm/plugin/src/
+COPY tools/xtask/Cargo.toml tools/xtask/Cargo.toml
+COPY tools/xtask/src/ tools/xtask/src/
 RUN mkdir -p mesh-llm/ui/dist && echo '<html></html>' > mesh-llm/ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
 RUN --mount=type=cache,target=/root/.cargo/registry \

--- a/fly/console/fly.toml
+++ b/fly/console/fly.toml
@@ -15,4 +15,4 @@ primary_region = "syd"
 
 [[vm]]
   size = "shared-cpu-1x"
-  memory = "512mb"
+  memory = "1024mb"


### PR DESCRIPTION
## What changed

The Fly console app at mesh-llm-console.fly.dev was getting OOM-killed in a loop. The Linux kernel killed the mesh-llm process at ~393MB RSS in a 512MB VM, Fly restarted it, and the cycle repeated every ~13 minutes.

### Fixes

- **Bump Fly VM memory from 512MB → 1GB** — the client-mode mesh-llm process needs headroom for QUIC peer connections, gossip state, and SSE streams to web console visitors
- **Add missing `tools/xtask` workspace member to all Dockerfiles** — `cargo-chef prepare` fails without it since xtask was added to the workspace

### Files changed

| File | Change |
|---|---|
| `fly/console/fly.toml` | `memory = "512mb"` → `"1024mb"` |
| `fly/Dockerfile` | Add xtask COPY |
| `docker/Dockerfile.client` | Add xtask COPY |
| `docker/Dockerfile.cpu` | Add xtask COPY |
| `docker/Dockerfile.cuda` | Add xtask COPY |
| `docker/Dockerfile.rocm` | Add xtask COPY |
| `docker/Dockerfile.vulkan` | Add xtask COPY |

### Validation

Already deployed to Fly with the 1GB config — console is up and serving traffic.