### PR TITLE
Trigger PR restore proof for debug slim cache (just a test)

### DIFF
--- a/.github/workflows/debug-slim-cache.yml
+++ b/.github/workflows/debug-slim-cache.yml
@@ -2,6 +2,7 @@ name: Debug slim cache visibility
 
 # Temporary workflow for proving GitHub Actions cache save/list/restore behavior
 # on the same cache path used by the slim llama.cpp lanes.
+# PR proof trigger comment: no behavior change.
 
 on:
   push:

--- a/.github/workflows/debug-slim-cache.yml
+++ b/.github/workflows/debug-slim-cache.yml
@@ -269,7 +269,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 -c 'import json; main_data=json.load(open("/tmp/debug-cache-main.json", "r", encoding="utf-8")); current_data=json.load(open("/tmp/debug-cache-current.json", "r", encoding="utf-8")); main_count=int(main_data.get("total_count", 0) or 0); current_count=int(current_data.get("total_count", 0) or 0); print(f"main_inventory_count={main_count}"); print(f"current_ref_inventory_count={current_count}"); raise SystemExit("ERROR: expected at least one exact-key cache on refs/heads/main before restore") if main_count < 1 else None'
+          python3 -c 'import json, sys; main_data=json.load(open("/tmp/debug-cache-main.json", "r", encoding="utf-8")); current_data=json.load(open("/tmp/debug-cache-current.json", "r", encoding="utf-8")); main_count=int(main_data.get("total_count", 0) or 0); current_count=int(current_data.get("total_count", 0) or 0); print(f"main_inventory_count={main_count}"); print(f"current_ref_inventory_count={current_count}"); sys.exit("ERROR: expected at least one exact-key cache on refs/heads/main before restore" if main_count < 1 else 0)'
 
       - name: Clarify restore proof mode
         shell: bash

--- a/mesh-llm/src/main.rs
+++ b/mesh-llm/src/main.rs
@@ -1,3 +1,4 @@
+// No-op Rust touch to force CI cache validation on PR #284.
 use anyhow::Result;
 
 #[tokio::main]


### PR DESCRIPTION
## Summary
- trigger the debug slim cache workflow on pull_request with a no-op workflow comment
- validate that the PR run restores the exact cache key previously warmed on main
- capture marker provenance proving the restored cache came from refs/heads/main