### PR TITLE
Reduce PR cache pressure and harden GPU cache warming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
         with:
           workspaces: . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Early-fail gate: runs before expensive compile/test work.
       - name: Check formatting
@@ -238,6 +239,7 @@ jobs:
         with:
           workspaces: . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Early-fail gate: runs before expensive compile/test work.
       - name: Check formatting
@@ -281,7 +283,7 @@ jobs:
       - name: Cache model
         if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true' }}
         id: cache-model
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
           key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
@@ -292,6 +294,13 @@ jobs:
           mkdir -p ~/.models
           curl -fSL "$MODEL_URL" -o ~/.models/$MODEL_FILE
           ls -lh ~/.models/$MODEL_FILE
+
+      - name: Save model cache
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true') && steps.cache-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ steps.cache-model.outputs.cache-primary-key }}
 
       # ── Integration smoke test ──
       - name: Smoke test (real inference)
@@ -314,7 +323,7 @@ jobs:
       - name: Cache MoE model
         if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true' }}
         id: cache-moe-model
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MOE_MODEL_FILE }}
           key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MOE_MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
@@ -325,6 +334,13 @@ jobs:
           mkdir -p ~/.models
           curl -fSL "$MOE_MODEL_URL" -o ~/.models/$MOE_MODEL_FILE
           ls -lh ~/.models/$MOE_MODEL_FILE
+
+      - name: Save MoE model cache
+        if: ${{ github.ref == 'refs/heads/main' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true') && steps.cache-moe-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MOE_MODEL_FILE }}
+          key: ${{ steps.cache-moe-model.outputs.cache-primary-key }}
 
       - name: MoE split test (expert sharding)
         if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true' }}
@@ -440,6 +456,7 @@ jobs:
           workspaces: |
             . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # ── Cross-PR llama.cpp / CUDA slim artifact cache (read-only consumer) ──
       #
@@ -657,6 +674,7 @@ jobs:
           workspaces: |
             . -> target
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Resolve llama.cpp upstream SHA
         if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' }}

--- a/.github/workflows/gpu-warm-cache-job.yml
+++ b/.github/workflows/gpu-warm-cache-job.yml
@@ -31,6 +31,7 @@ on:
         default: ''
 
 permissions:
+  actions: read
   contents: read
 
 env:
@@ -162,3 +163,51 @@ jobs:
           key: ${{ steps.llama_cache.outputs.cache-primary-key }}
           lookup-only: true
           fail-on-cache-miss: true
+
+      - name: Verify llama.cpp ${{ inputs.cache_label }} cache is visible on main
+        if: ${{ github.ref == 'refs/heads/main' && steps.llama_cache.outputs.cache-hit != 'true' }}
+        uses: actions/github-script@v8
+        env:
+          EXPECTED_KEY: ${{ steps.llama_cache.outputs.cache-primary-key }}
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const key = process.env.EXPECTED_KEY;
+            const ref = 'refs/heads/main';
+            const attempts = 6;
+            const delayMs = 30000;
+
+            for (let attempt = 1; attempt <= attempts; attempt += 1) {
+              const { data } = await github.request(
+                'GET /repos/{owner}/{repo}/actions/caches',
+                {
+                  owner,
+                  repo,
+                  key,
+                  ref,
+                  per_page: 100,
+                },
+              );
+
+              const matches = data.actions_caches || [];
+              core.notice(
+                `Main visibility probe ${attempt}/${attempts} for ${key}: ${matches.length} match(es)`
+              );
+
+              if (matches.length > 0) {
+                const cache = matches[0];
+                core.notice(
+                  `Visible on ${ref}: id=${cache.id} size=${cache.size_in_bytes} created_at=${cache.created_at}`
+                );
+                return;
+              }
+
+              if (attempt < attempts) {
+                await new Promise((resolve) => setTimeout(resolve, delayMs));
+              }
+            }
+
+            core.setFailed(
+              `Warmed cache ${key} never became visible on ${ref} within ${attempts * delayMs / 1000}s`
+            );

--- a/.github/workflows/reset-caches.yml
+++ b/.github/workflows/reset-caches.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       restart_ci:
-        description: Run CI after deleting caches to prewarm them again.
+        description: Run the GPU cache warmer after deleting caches.
         required: false
         default: true
         type: boolean
@@ -82,7 +82,7 @@ jobs:
 
             return String(caches.length);
 
-      - name: Trigger CI repopulation run
+      - name: Trigger GPU cache warm run
         if: ${{ inputs.restart_ci }}
         uses: actions/github-script@v8
         env:
@@ -93,13 +93,13 @@ jobs:
             const repo = context.repo.repo;
             const ref = process.env.CI_REF;
 
-            core.notice(`Dispatching ci.yml on ${ref} to repopulate caches.`);
+            core.notice(`Dispatching warm-caches.yml on ${ref} to repopulate GPU caches.`);
             await github.request(
               "POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches",
               {
                 owner,
                 repo,
-                workflow_id: "ci.yml",
+                workflow_id: "warm-caches.yml",
                 ref,
               },
             );
@@ -115,8 +115,8 @@ jobs:
             echo
             echo "- Deleted caches: ${DELETED_COUNT}"
             if [ "${RESTART_CI}" = "true" ]; then
-              echo "- CI dispatched on ref: ${CI_REF}"
+              echo "- GPU cache warm dispatched on ref: ${CI_REF}"
             else
-              echo "- CI dispatched: no"
+              echo "- GPU cache warm dispatched: no"
             fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Cache integration model
         id: cache-model
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
           key: ${{ inputs.cache_key_prefix }}${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/smoke.yml', inputs.workflow_cache_file) }}
@@ -81,6 +81,13 @@ jobs:
           mkdir -p ~/.models
           curl -fSL "$MODEL_URL" -o ~/.models/$MODEL_FILE
           ls -lh ~/.models/$MODEL_FILE
+
+      - name: Save integration model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ steps.cache-model.outputs.cache-primary-key }}
 
       - name: Smoke test (real inference)
         run: |
@@ -105,7 +112,7 @@ jobs:
 
       - name: Cache MoE model
         id: cache-moe-model
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MOE_MODEL_FILE }}
           key: ${{ inputs.cache_key_prefix }}${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MOE_MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/smoke.yml', inputs.workflow_cache_file) }}
@@ -116,6 +123,13 @@ jobs:
           mkdir -p ~/.models
           curl -fSL "$MOE_MODEL_URL" -o ~/.models/$MOE_MODEL_FILE
           ls -lh ~/.models/$MOE_MODEL_FILE
+
+      - name: Save MoE model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-moe-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MOE_MODEL_FILE }}
+          key: ${{ steps.cache-moe-model.outputs.cache-primary-key }}
 
       - name: MoE split test (expert sharding)
         run: |


### PR DESCRIPTION
## Summary
- stop saving the large Rust and model caches from PR merge refs so they stop crowding out the shared GPU caches
- make reset-caches repopulate the real GPU warmer instead of restore-only CI
- fail the GPU warm path if a newly saved main cache never becomes visible in Actions cache inventory