### PR TITLE
fix: release packaging EXIT trap references out-of-scope local variable

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -3,6 +3,8 @@
 set -euo pipefail
 
 RELEASE_FLAVOR="${MESH_RELEASE_FLAVOR:-}"
+_STAGING_DIR=""
+trap 'rm -rf "$_STAGING_DIR"' EXIT
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -328,7 +330,6 @@ main() {
     local version="$1"
     local output_dir="${2:-dist}"
     local os_name
-    local staging_dir
     local bundle_dir
     local versioned_asset
 
@@ -341,10 +342,9 @@ main() {
     os_name="$(release_os_name)"
 
     mkdir -p "$output_dir"
-    staging_dir="$(mktemp -d)"
-    trap 'rm -rf "$staging_dir"' EXIT
+    _STAGING_DIR="$(mktemp -d)"
 
-    bundle_dir="$staging_dir/mesh-bundle"
+    bundle_dir="$_STAGING_DIR/mesh-bundle"
     mkdir -p "$bundle_dir"
 
     cp "$RELEASE_BIN_DIR/mesh-llm${BIN_EXT}" "$bundle_dir/$(bundle_bin_name mesh-llm)"


### PR DESCRIPTION
PR #274 refactored `package-release.sh` into a `main()` function but the EXIT trap still referenced `staging_dir` as a local variable. When `main()` returns, the local goes out of scope and `set -u` reports it as unbound → exit code 1.

**This broke the v0.61.0 release.** All 6 platform builds compiled successfully and created archives, but the non-zero exit from the trap prevented the upload step from running. No GitHub release was created.

## Fix

Move `_STAGING_DIR` and the trap to file scope. The variable is initialized empty (satisfying `set -u`), and the trap fires after `main()` returns with the correct value.

## Introduced by

#274 (architecture-normalization) — @ndizazzo, merged April 14