### PR TITLE
Fix split GGUF shorthand resolution to download full model shards

### DIFF
--- a/mesh-llm/src/models/catalog.rs
+++ b/mesh-llm/src/models/catalog.rs
@@ -349,11 +349,21 @@ type DownloadHfAssetsOverrideFn =
     Arc<dyn Fn(&str, Vec<HfAsset>) -> Result<Vec<PathBuf>> + Send + Sync>;
 
 #[cfg(test)]
+type DownloadPlanObserverFn = Arc<dyn Fn(&str, Vec<(bool, String)>) + Send + Sync>;
+
+#[cfg(test)]
 static DOWNLOAD_HF_ASSETS_OVERRIDE: LazyLock<Mutex<HashMap<String, DownloadHfAssetsOverrideFn>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(test)]
-struct DownloadHfAssetsOverrideGuard(String);
+static DOWNLOAD_PLAN_OBSERVER: LazyLock<Mutex<Option<DownloadPlanObserverFn>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[cfg(test)]
+pub(crate) struct DownloadHfAssetsOverrideGuard(String);
+
+#[cfg(test)]
+pub(crate) struct DownloadPlanObserverGuard;
 
 #[cfg(test)]
 impl DownloadHfAssetsOverrideGuard {
@@ -365,10 +375,49 @@ impl DownloadHfAssetsOverrideGuard {
 }
 
 #[cfg(test)]
+pub(crate) fn set_download_hf_assets_label_override(
+    label: String,
+    func: Arc<dyn Fn(&str) -> Result<Vec<PathBuf>> + Send + Sync>,
+) -> DownloadHfAssetsOverrideGuard {
+    DownloadHfAssetsOverrideGuard::set(
+        label,
+        Arc::new(move |label, assets| {
+            if let Some(observer) = DOWNLOAD_PLAN_OBSERVER.lock().unwrap().clone() {
+                let plan = initial_download_plan_for_assets(assets)?;
+                observer(
+                    label,
+                    plan.into_iter()
+                        .map(|(required, asset)| (required, asset.file))
+                        .collect(),
+                );
+            }
+            func(label)
+        }),
+    )
+}
+
+#[cfg(test)]
+impl DownloadPlanObserverGuard {
+    pub(crate) fn set(func: DownloadPlanObserverFn) -> Self {
+        let mut slot = DOWNLOAD_PLAN_OBSERVER.lock().unwrap();
+        *slot = Some(func);
+        Self
+    }
+}
+
+#[cfg(test)]
 impl Drop for DownloadHfAssetsOverrideGuard {
     fn drop(&mut self) {
         let mut map = DOWNLOAD_HF_ASSETS_OVERRIDE.lock().unwrap();
         map.remove(&self.0);
+    }
+}
+
+#[cfg(test)]
+impl Drop for DownloadPlanObserverGuard {
+    fn drop(&mut self) {
+        let mut slot = DOWNLOAD_PLAN_OBSERVER.lock().unwrap();
+        *slot = None;
     }
 }
 
@@ -479,15 +528,7 @@ fn download_hf_assets_blocking(
 ) -> Result<Vec<PathBuf>> {
     let api = super::build_hf_api(false)?;
     let cache = crate::models::huggingface_hub_cache();
-    let mut download_plan = std::collections::BTreeSet::new();
-    let mut config_repos = std::collections::BTreeSet::new();
-
-    for asset in assets {
-        for expanded in expand_split_asset(&asset)? {
-            config_repos.insert((expanded.repo.clone(), expanded.revision.clone()));
-            download_plan.insert((true, expanded));
-        }
-    }
+    let mut download_plan = initial_download_plan_for_assets(assets)?;
     let current_plan: Vec<(bool, HfAsset)> = download_plan.iter().cloned().collect();
     for (_, asset) in current_plan {
         if !is_mlx_primary_asset(&asset.file) {
@@ -505,19 +546,22 @@ fn download_hf_assets_blocking(
             download_plan.insert((true, shard));
         }
     }
-    for (repo, revision) in config_repos {
-        download_plan.insert((
-            false,
-            HfAsset {
-                repo,
-                revision,
-                file: "config.json".to_string(),
-            },
-        ));
-    }
 
     if progress {
         eprintln!("📥 Ensuring {} is available locally...", label);
+    }
+
+    #[cfg(test)]
+    {
+        if let Some(observer) = DOWNLOAD_PLAN_OBSERVER.lock().unwrap().clone() {
+            observer(
+                label,
+                download_plan
+                    .iter()
+                    .map(|(required, asset)| (*required, asset.file.clone()))
+                    .collect(),
+            );
+        }
     }
 
     let mut primary_paths = Vec::new();
@@ -581,6 +625,33 @@ fn download_hf_assets_blocking(
     Ok(primary_paths)
 }
 
+fn initial_download_plan_for_assets(
+    assets: Vec<HfAsset>,
+) -> Result<std::collections::BTreeSet<(bool, HfAsset)>> {
+    let mut download_plan = std::collections::BTreeSet::new();
+    let mut config_repos = std::collections::BTreeSet::new();
+
+    for asset in assets {
+        for expanded in expand_split_asset(&asset)? {
+            config_repos.insert((expanded.repo.clone(), expanded.revision.clone()));
+            download_plan.insert((true, expanded));
+        }
+    }
+
+    for (repo, revision) in config_repos {
+        download_plan.insert((
+            false,
+            HfAsset {
+                repo,
+                revision,
+                file: "config.json".to_string(),
+            },
+        ));
+    }
+
+    Ok(download_plan)
+}
+
 pub async fn download_hf_repo_file(
     repo: &str,
     revision: Option<&str>,
@@ -595,18 +666,30 @@ pub async fn download_hf_repo_file_with_progress(
     file: &str,
     progress: bool,
 ) -> Result<PathBuf> {
+    download_hf_repo_file_with_progress_label(
+        repo,
+        revision,
+        file,
+        &format!("{repo}/{file}@{}", revision.unwrap_or("main")),
+        progress,
+    )
+    .await
+}
+
+pub async fn download_hf_repo_file_with_progress_label(
+    repo: &str,
+    revision: Option<&str>,
+    file: &str,
+    label: &str,
+    progress: bool,
+) -> Result<PathBuf> {
     let revision = revision.unwrap_or("main").to_string();
     let asset = HfAsset {
         repo: repo.to_string(),
         revision: revision.clone(),
         file: file.to_string(),
     };
-    let mut paths = download_hf_assets(
-        &format!("{repo}/{file}@{revision}"),
-        vec![asset.clone()],
-        progress,
-    )
-    .await?;
+    let mut paths = download_hf_assets(label, vec![asset.clone()], progress).await?;
     paths.sort();
     paths
         .into_iter()
@@ -1469,6 +1552,36 @@ mod tests {
         };
         let shards = expand_split_mlx_first_shard(&asset);
         assert!(shards.is_empty());
+    }
+
+    #[test]
+    fn gemma_bf16_first_shard_plans_full_split_download() {
+        let plan = initial_download_plan_for_assets(vec![HfAsset {
+            repo: "unsloth/gemma-4-31B-it-GGUF".to_string(),
+            revision: "main".to_string(),
+            file: "BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf".to_string(),
+        }])
+        .unwrap();
+
+        let files: Vec<_> = plan
+            .into_iter()
+            .map(|(required, asset)| (required, asset.file))
+            .collect();
+
+        assert_eq!(
+            files,
+            vec![
+                (false, "config.json".to_string()),
+                (
+                    true,
+                    "BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf".to_string()
+                ),
+                (
+                    true,
+                    "BF16/gemma-4-31B-it-BF16-00002-of-00002.gguf".to_string()
+                ),
+            ]
+        );
     }
 
     #[test]

--- a/mesh-llm/src/models/resolve/mod.rs
+++ b/mesh-llm/src/models/resolve/mod.rs
@@ -6,6 +6,8 @@ use hf_hub::{Repo, RepoType};
 use std::cmp::Ordering;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::{Arc, LazyLock, Mutex};
 
 #[derive(Clone, Debug)]
 pub struct ModelDetails {
@@ -84,10 +86,11 @@ pub async fn download_exact_ref_with_progress(input: &str, progress: bool) -> Re
             {
                 return catalog::download_model_with_progress(model, progress).await;
             }
-            catalog::download_hf_repo_file_with_progress(
+            catalog::download_hf_repo_file_with_progress_label(
                 &repo,
                 revision.as_deref(),
                 &file,
+                &input,
                 progress,
             )
             .await
@@ -1154,6 +1157,65 @@ fn repo_prefers_gguf_only(repo: &str) -> bool {
     repo.to_ascii_lowercase().contains("gguf")
 }
 
+#[cfg(test)]
+type RepoSiblingEntriesOverrideFn =
+    Arc<dyn Fn(&str, &str) -> Option<Vec<(String, Option<u64>)>> + Send + Sync>;
+
+#[cfg(test)]
+static REPO_SIBLING_ENTRIES_OVERRIDE: LazyLock<Mutex<Option<RepoSiblingEntriesOverrideFn>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+#[cfg(test)]
+struct RepoSiblingEntriesOverrideGuard;
+
+#[cfg(test)]
+impl RepoSiblingEntriesOverrideGuard {
+    fn set(func: RepoSiblingEntriesOverrideFn) -> Self {
+        let mut slot = REPO_SIBLING_ENTRIES_OVERRIDE.lock().unwrap();
+        *slot = Some(func);
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for RepoSiblingEntriesOverrideGuard {
+    fn drop(&mut self) {
+        let mut slot = REPO_SIBLING_ENTRIES_OVERRIDE.lock().unwrap();
+        *slot = None;
+    }
+}
+
+async fn fetch_repo_sibling_entries(
+    repo: &str,
+    revision: &str,
+) -> Result<Vec<(String, Option<u64>)>> {
+    #[cfg(test)]
+    {
+        let func = REPO_SIBLING_ENTRIES_OVERRIDE.lock().unwrap().clone();
+        if let Some(func) = func {
+            if let Some(entries) = func(repo, revision) {
+                return Ok(entries);
+            }
+        }
+    }
+
+    let api = super::build_hf_tokio_api(false)?;
+    let detail = api
+        .repo(Repo::with_revision(
+            repo.to_string(),
+            RepoType::Model,
+            revision.to_string(),
+        ))
+        .info()
+        .await
+        .with_context(|| format!("Fetch Hugging Face repo {repo}@{revision}"))?;
+    Ok(detail
+        .siblings
+        .iter()
+        .map(|sibling| (sibling.rfilename.clone(), sibling.size))
+        .collect())
+}
+
 async fn resolve_huggingface_file(
     repo: &str,
     revision: Option<&str>,
@@ -1167,21 +1229,7 @@ async fn resolve_huggingface_file(
     }
 
     let revision = revision.unwrap_or("main");
-    let api = super::build_hf_tokio_api(false)?;
-    let detail = api
-        .repo(Repo::with_revision(
-            repo.to_string(),
-            RepoType::Model,
-            revision.to_string(),
-        ))
-        .info()
-        .await
-        .with_context(|| format!("Fetch Hugging Face repo {repo}@{revision}"))?;
-    let sibling_entries: Vec<(String, Option<u64>)> = detail
-        .siblings
-        .iter()
-        .map(|sibling| (sibling.rfilename.clone(), sibling.size))
-        .collect();
+    let sibling_entries = fetch_repo_sibling_entries(repo, revision).await?;
     let siblings: Vec<String> = sibling_entries.iter().map(|(f, _)| f.clone()).collect();
     let has_mlx_weights = siblings
         .iter()
@@ -1281,493 +1329,4 @@ pub(super) async fn remote_hf_size_label_with_api(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use serde::Deserialize;
-    use std::collections::HashMap;
-
-    #[derive(Debug, Deserialize)]
-    struct HfRepoFixture {
-        repo: String,
-        siblings: Vec<String>,
-        size_bytes: HashMap<String, u64>,
-    }
-
-    fn load_gemma_live_fixture() -> HfRepoFixture {
-        serde_json::from_str(include_str!(
-            "testdata/unsloth_gemma_4_31b_it_gguf.live.json"
-        ))
-        .expect("parse live Hugging Face fixture")
-    }
-
-    #[test]
-    fn primary_hf_ref_maps_to_full_catalog_download() {
-        let model = matching_catalog_primary_for_huggingface(
-            "unsloth/Qwen3.5-0.8B-GGUF",
-            Some("main"),
-            "Qwen3.5-0.8B-Q4_K_M.gguf",
-        )
-        .expect("primary model file should map to catalog download");
-        assert_eq!(model.name, "Qwen3.5-0.8B-Vision-Q4_K_M");
-        assert!(model.mmproj.is_some());
-    }
-
-    #[test]
-    fn mmproj_hf_ref_does_not_expand_to_full_catalog_download() {
-        assert!(matching_catalog_primary_for_huggingface(
-            "unsloth/Qwen3.5-0.8B-GGUF",
-            Some("main"),
-            "mmproj-BF16.gguf",
-        )
-        .is_none());
-    }
-
-    #[test]
-    fn primary_url_maps_to_full_catalog_download() {
-        let model = matching_catalog_primary_for_url(
-            "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf",
-        )
-        .expect("primary model url should map to catalog download");
-        assert_eq!(model.name, "Qwen3.5-0.8B-Vision-Q4_K_M");
-        assert!(model.mmproj.is_some());
-    }
-
-    #[test]
-    fn mmproj_url_does_not_expand_to_full_catalog_download() {
-        assert!(matching_catalog_primary_for_url(
-            "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-BF16.gguf",
-        )
-        .is_none());
-    }
-
-    #[test]
-    fn split_stem_resolves_to_first_part() {
-        let siblings = vec![
-            "zai-org.GLM-5.1.Q2_K-00002-of-00018.gguf".to_string(),
-            "zai-org.GLM-5.1.Q2_K-00001-of-00018.gguf".to_string(),
-        ];
-        let resolved = resolve_hf_file_from_siblings("zai-org.GLM-5.1.Q2_K", &siblings).unwrap();
-        assert_eq!(resolved, "zai-org.GLM-5.1.Q2_K-00001-of-00018.gguf");
-    }
-
-    #[test]
-    fn stem_without_split_resolves_to_gguf() {
-        let siblings = vec![
-            "Qwen3-8B-Q4_K_M.gguf".to_string(),
-            "Qwen3-8B-Q8_0.gguf".to_string(),
-        ];
-        let resolved = resolve_hf_file_from_siblings("Qwen3-8B-Q4_K_M", &siblings).unwrap();
-        assert_eq!(resolved, "Qwen3-8B-Q4_K_M.gguf");
-    }
-
-    #[test]
-    fn mlx_stem_resolves_to_model_safetensors() {
-        let siblings = vec![
-            "model.safetensors.index.json".to_string(),
-            "model.safetensors".to_string(),
-        ];
-        let resolved = resolve_hf_file_from_siblings("model", &siblings).unwrap();
-        assert_eq!(resolved, "model.safetensors");
-    }
-
-    #[test]
-    fn mlx_stem_resolves_to_first_split_shard() {
-        let siblings = vec![
-            "model-00002-of-00048.safetensors".to_string(),
-            "model-00001-of-00048.safetensors".to_string(),
-            "model.safetensors.index.json".to_string(),
-        ];
-        let resolved = resolve_hf_file_from_siblings("model", &siblings).unwrap();
-        assert_eq!(resolved, "model-00001-of-00048.safetensors");
-    }
-
-    #[test]
-    fn repo_only_resolution_prefers_mlx_model_safetensors() {
-        let siblings = vec![
-            "Qwen3-8B-Q4_K_M.gguf".to_string(),
-            "model.safetensors".to_string(),
-            "model.safetensors.index.json".to_string(),
-        ];
-        let resolved = resolve_hf_file_from_siblings("", &siblings).unwrap();
-        assert_eq!(resolved, "model.safetensors");
-    }
-
-    #[test]
-    fn repo_only_resolution_falls_back_to_gguf_when_no_mlx_weights() {
-        let siblings = vec![
-            "Qwen3-8B-Q8_0.gguf".to_string(),
-            "Qwen3-8B-Q4_K_M.gguf".to_string(),
-        ];
-        let resolved = resolve_hf_file_from_siblings("", &siblings).unwrap();
-        assert_eq!(resolved, "Qwen3-8B-Q4_K_M.gguf");
-    }
-
-    #[test]
-    fn parse_huggingface_ref_rejects_http_url() {
-        assert!(parse_huggingface_ref("https://example.com/model.gguf").is_none());
-    }
-
-    #[test]
-    fn parse_huggingface_repo_ref_parses_repo_only() {
-        let parsed = parse_huggingface_repo_ref("GreenBitAI/Llama-2-7B-layer-mix-bpw-2.2-mlx");
-        assert_eq!(
-            parsed,
-            Some((
-                "GreenBitAI/Llama-2-7B-layer-mix-bpw-2.2-mlx".to_string(),
-                None,
-                None
-            ))
-        );
-    }
-
-    #[test]
-    fn parse_huggingface_repo_ref_parses_quant_selector() {
-        let parsed = parse_huggingface_repo_ref("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL");
-        assert_eq!(
-            parsed,
-            Some((
-                "unsloth/gemma-4-31B-it-GGUF".to_string(),
-                None,
-                Some("UD-Q4_K_XL".to_string())
-            ))
-        );
-    }
-
-    #[test]
-    fn parse_huggingface_repo_url_parses_repo_only() {
-        let parsed =
-            parse_huggingface_repo_url("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF");
-        assert_eq!(
-            parsed,
-            Some(("unsloth/gemma-4-31B-it-GGUF".to_string(), None, None))
-        );
-    }
-
-    #[test]
-    fn parse_huggingface_repo_url_parses_tree_revision() {
-        let parsed = parse_huggingface_repo_url(
-            "https://huggingface.co/unsloth/gemma-4-31B-it-GGUF/tree/main",
-        );
-        assert_eq!(
-            parsed,
-            Some((
-                "unsloth/gemma-4-31B-it-GGUF".to_string(),
-                Some("main".to_string()),
-                None
-            ))
-        );
-    }
-
-    #[test]
-    fn quant_selector_resolves_to_first_matching_split_gguf() {
-        let fixture = load_gemma_live_fixture();
-        let resolved = resolve_hf_file_from_siblings("UD-Q4_K_XL", &fixture.siblings).unwrap();
-        assert_eq!(resolved, "gemma-4-31B-it-UD-Q4_K_XL.gguf");
-    }
-
-    #[test]
-    fn fit_aware_gguf_prefers_largest_comfortable_candidate() {
-        let available = 20_000_000_000u64;
-        let ordering = compare_gguf_candidates_by_fit(
-            "repo/model-q4.gguf",
-            Some(12_000_000_000),
-            "repo/model-q5.gguf",
-            Some(17_000_000_000),
-            available,
-        );
-        assert_eq!(ordering, Ordering::Greater);
-    }
-
-    #[test]
-    fn fit_aware_gguf_prefers_smaller_when_both_too_large() {
-        let available = 20_000_000_000u64;
-        let ordering = compare_gguf_candidates_by_fit(
-            "repo/model-q8.gguf",
-            Some(29_000_000_000),
-            "repo/model-bf16.gguf",
-            Some(35_000_000_000),
-            available,
-        );
-        assert_eq!(ordering, Ordering::Less);
-    }
-
-    #[test]
-    fn gemma_repo_default_prefers_q4_over_bf16_at_local_fit_budget() {
-        // Uses captured live HF artifact sizes from the fixture:
-        // at ~19.3GB available, prefer Q4_0 over BF16.
-        let fixture = load_gemma_live_fixture();
-        let q4 = fixture
-            .size_bytes
-            .get("gemma-4-31B-it-Q4_0.gguf")
-            .copied()
-            .expect("fixture Q4_0 size");
-        let bf16 = fixture
-            .size_bytes
-            .get("BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf")
-            .copied()
-            .expect("fixture BF16 size");
-        let available = 19_300_000_000u64;
-        let ordering = compare_gguf_candidates_by_fit(
-            "unsloth/gemma-4-31B-it-GGUF/gemma-4-31B-it-Q4_0.gguf",
-            Some(q4),
-            "unsloth/gemma-4-31B-it-GGUF/BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf",
-            Some(bf16),
-            available,
-        );
-        assert_eq!(ordering, Ordering::Less);
-    }
-
-    #[test]
-    fn repo_name_can_signal_gguf_intent() {
-        assert!(repo_prefers_gguf_only("unsloth/gemma-4-31B-it-GGUF"));
-        assert!(!repo_prefers_gguf_only(
-            "mlx-community/Llama-3.2-3B-Instruct-4bit"
-        ));
-    }
-
-    #[test]
-    fn parse_exact_model_ref_accepts_unsloth_gemma_repo_ref() {
-        let parsed = parse_exact_model_ref("unsloth/gemma-4-31B-it-GGUF").unwrap();
-        match parsed {
-            ExactModelRef::HuggingFace {
-                repo,
-                revision,
-                file,
-            } => {
-                assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
-                assert_eq!(revision, None);
-                assert_eq!(file, "");
-            }
-            other => panic!("expected HuggingFace repo ref, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_exact_model_ref_accepts_unsloth_gemma_repo_url() {
-        let parsed =
-            parse_exact_model_ref("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF").unwrap();
-        match parsed {
-            ExactModelRef::HuggingFace {
-                repo,
-                revision,
-                file,
-            } => {
-                assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
-                assert_eq!(revision, None);
-                assert_eq!(file, "");
-            }
-            other => panic!("expected HuggingFace repo ref from URL, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn parse_exact_model_ref_accepts_unsloth_gemma_quant_selector() {
-        let parsed = parse_exact_model_ref("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL").unwrap();
-        match parsed {
-            ExactModelRef::HuggingFace {
-                repo,
-                revision,
-                file,
-            } => {
-                assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
-                assert_eq!(revision, None);
-                assert_eq!(file, "UD-Q4_K_XL");
-            }
-            other => panic!("expected HuggingFace quant selector ref, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn simulated_name_and_repo_quant_inputs_converge_to_same_ref() {
-        // Replay two user inputs against captured live siblings:
-        // 1) gemma-4-31B-it-GGUF:UD-Q4_K_XL (after repo discovery)
-        // 2) unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL
-        let fixture = load_gemma_live_fixture();
-        let discovered_repo = fixture.repo.as_str();
-        let selector = "UD-Q4_K_XL";
-
-        let from_name = format!(
-            "{}/{}",
-            discovered_repo,
-            resolve_hf_file_from_siblings(selector, &fixture.siblings).unwrap()
-        );
-        let from_repo = format!(
-            "{}/{}",
-            discovered_repo,
-            resolve_hf_file_from_siblings(selector, &fixture.siblings).unwrap()
-        );
-
-        assert_eq!(
-            from_name,
-            "unsloth/gemma-4-31B-it-GGUF/gemma-4-31B-it-UD-Q4_K_XL.gguf"
-        );
-        assert_eq!(from_name, from_repo);
-    }
-
-    #[test]
-    fn parse_exact_model_ref_accepts_unsloth_gemma_repo_url_with_quant_selector() {
-        let parsed =
-            parse_exact_model_ref("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL")
-                .unwrap();
-        match parsed {
-            ExactModelRef::HuggingFace {
-                repo,
-                revision,
-                file,
-            } => {
-                assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
-                assert_eq!(revision, None);
-                assert_eq!(file, "UD-Q4_K_XL");
-            }
-            other => panic!("expected HuggingFace repo URL quant selector ref, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn split_bare_name_selector_supports_name_quant_shorthand() {
-        assert_eq!(
-            split_bare_name_selector("gemma-4-31B-it-GGUF:UD-Q4_K_XL"),
-            ("gemma-4-31B-it-GGUF", Some("UD-Q4_K_XL"))
-        );
-        assert_eq!(
-            split_bare_name_selector("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL"),
-            ("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL", None)
-        );
-    }
-
-    #[test]
-    fn select_strong_repo_hit_prefers_exact_leaf_name() {
-        let repos = vec![
-            "ggml-org/gemma-4-31B-it-GGUF".to_string(),
-            "unsloth/gemma-4-31B-it-GGUF".to_string(),
-            "bartowski/google_gemma-4-31B-it-GGUF".to_string(),
-        ];
-        let picked = select_strong_repo_hit("gemma-4-31B-it-GGUF", &repos);
-        assert_eq!(picked, Some("ggml-org/gemma-4-31B-it-GGUF".to_string()));
-    }
-
-    #[test]
-    fn bare_name_quant_can_be_formatted_with_discovered_repo() {
-        let (name, selector) = split_bare_name_selector("gemma-4-31B-it-GGUF:UD-Q4_K_XL");
-        assert_eq!(name, "gemma-4-31B-it-GGUF");
-        let selector = selector.expect("selector");
-        let canonical = format!("{}:{}", "unsloth/gemma-4-31B-it-GGUF", selector);
-        assert_eq!(canonical, "unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL");
-    }
-
-    #[test]
-    fn quant_selector_from_gguf_file_extracts_expected_forms() {
-        assert_eq!(
-            quant_selector_from_gguf_file("gemma-4-31B-it-UD-Q4_K_XL.gguf"),
-            Some("UD-Q4_K_XL".to_string())
-        );
-        assert_eq!(
-            quant_selector_from_gguf_file("BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf"),
-            Some("BF16".to_string())
-        );
-        assert_eq!(
-            quant_selector_from_gguf_file("gemma-4-31B-it-Q4_0.gguf"),
-            Some("Q4_0".to_string())
-        );
-    }
-
-    #[test]
-    fn format_huggingface_display_ref_prefers_selector_form_for_gguf() {
-        assert_eq!(
-            format_huggingface_display_ref(
-                "unsloth/gemma-4-31B-it-GGUF",
-                None,
-                "gemma-4-31B-it-UD-Q4_K_XL.gguf"
-            ),
-            "unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL"
-        );
-    }
-
-    #[test]
-    fn format_huggingface_display_ref_prefers_repo_form_for_mlx() {
-        assert_eq!(
-            format_huggingface_display_ref(
-                "mlx-community/SmolLM-135M-8bit",
-                None,
-                "model.safetensors"
-            ),
-            "mlx-community/SmolLM-135M-8bit"
-        );
-        assert_eq!(
-            format_huggingface_display_ref(
-                "avlp12/GLM-5.1-Alis-MLX-Dynamic-2.7bpw",
-                None,
-                "model-00001-of-00010.safetensors"
-            ),
-            "avlp12/GLM-5.1-Alis-MLX-Dynamic-2.7bpw"
-        );
-    }
-
-    #[test]
-    fn parse_exact_model_ref_accepts_legacy_mlx_model_path_shape() {
-        let parsed = parse_exact_model_ref("mlx-community/SmolLM-135M-8bit/model").unwrap();
-        match parsed {
-            ExactModelRef::HuggingFace {
-                repo,
-                revision,
-                file,
-            } => {
-                assert_eq!(repo, "mlx-community/SmolLM-135M-8bit");
-                assert_eq!(revision, None);
-                assert_eq!(file, "model");
-            }
-            _ => panic!("expected HuggingFace ref"),
-        }
-    }
-
-    #[test]
-    fn collect_show_gguf_variants_excludes_mmproj_and_nonfirst_split() {
-        let siblings = vec![
-            ("mmproj-BF16.gguf".to_string(), Some(1_200_000_000)),
-            (
-                "gemma-4-26B-A4B-it-UD-Q3_K_S-00002-of-00009.gguf".to_string(),
-                Some(12_500_000_000),
-            ),
-            (
-                "gemma-4-26B-A4B-it-UD-Q3_K_S-00001-of-00009.gguf".to_string(),
-                Some(12_500_000_000),
-            ),
-            (
-                "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf".to_string(),
-                Some(16_900_000_000),
-            ),
-        ];
-        let files: Vec<_> = collect_show_gguf_variants_from_siblings(&siblings, 0)
-            .into_iter()
-            .map(|(file, _)| file)
-            .collect();
-        assert_eq!(
-            files,
-            vec![
-                "gemma-4-26B-A4B-it-UD-Q3_K_S-00001-of-00009.gguf".to_string(),
-                "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf".to_string(),
-            ]
-        );
-    }
-
-    #[test]
-    fn collect_show_gguf_variants_orders_by_fit_when_memory_known() {
-        let siblings = vec![
-            ("model-UD-Q5_K_M.gguf".to_string(), Some(21_200_000_000)),
-            ("model-UD-Q4_K_M.gguf".to_string(), Some(16_900_000_000)),
-            ("model-UD-Q3_K_S.gguf".to_string(), Some(12_500_000_000)),
-        ];
-        let files: Vec<_> = collect_show_gguf_variants_from_siblings(&siblings, 19_300_000_000)
-            .into_iter()
-            .map(|(file, _)| file)
-            .collect();
-        assert_eq!(
-            files,
-            vec![
-                "model-UD-Q4_K_M.gguf".to_string(),
-                "model-UD-Q3_K_S.gguf".to_string(),
-                "model-UD-Q5_K_M.gguf".to_string(),
-            ]
-        );
-    }
-}
+mod tests;

--- a/mesh-llm/src/models/resolve/tests.rs
+++ b/mesh-llm/src/models/resolve/tests.rs
@@ -1,0 +1,558 @@
+use super::*;
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Debug, Deserialize)]
+struct HfRepoFixture {
+    repo: String,
+    siblings: Vec<String>,
+    size_bytes: HashMap<String, u64>,
+}
+
+fn load_gemma_live_fixture() -> HfRepoFixture {
+    serde_json::from_str(include_str!(
+        "../testdata/unsloth_gemma_4_31b_it_gguf.live.json"
+    ))
+    .expect("parse live Hugging Face fixture")
+}
+
+#[test]
+fn primary_hf_ref_maps_to_full_catalog_download() {
+    let model = matching_catalog_primary_for_huggingface(
+        "unsloth/Qwen3.5-0.8B-GGUF",
+        Some("main"),
+        "Qwen3.5-0.8B-Q4_K_M.gguf",
+    )
+    .expect("primary model file should map to catalog download");
+    assert_eq!(model.name, "Qwen3.5-0.8B-Vision-Q4_K_M");
+    assert!(model.mmproj.is_some());
+}
+
+#[test]
+fn mmproj_hf_ref_does_not_expand_to_full_catalog_download() {
+    assert!(matching_catalog_primary_for_huggingface(
+        "unsloth/Qwen3.5-0.8B-GGUF",
+        Some("main"),
+        "mmproj-BF16.gguf",
+    )
+    .is_none());
+}
+
+#[test]
+fn primary_url_maps_to_full_catalog_download() {
+    let model = matching_catalog_primary_for_url(
+        "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf",
+    )
+    .expect("primary model url should map to catalog download");
+    assert_eq!(model.name, "Qwen3.5-0.8B-Vision-Q4_K_M");
+    assert!(model.mmproj.is_some());
+}
+
+#[test]
+fn mmproj_url_does_not_expand_to_full_catalog_download() {
+    assert!(matching_catalog_primary_for_url(
+        "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-BF16.gguf",
+    )
+    .is_none());
+}
+
+#[test]
+fn split_stem_resolves_to_first_part() {
+    let siblings = vec![
+        "zai-org.GLM-5.1.Q2_K-00002-of-00018.gguf".to_string(),
+        "zai-org.GLM-5.1.Q2_K-00001-of-00018.gguf".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("zai-org.GLM-5.1.Q2_K", &siblings).unwrap();
+    assert_eq!(resolved, "zai-org.GLM-5.1.Q2_K-00001-of-00018.gguf");
+}
+
+#[test]
+fn stem_without_split_resolves_to_gguf() {
+    let siblings = vec![
+        "Qwen3-8B-Q4_K_M.gguf".to_string(),
+        "Qwen3-8B-Q8_0.gguf".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("Qwen3-8B-Q4_K_M", &siblings).unwrap();
+    assert_eq!(resolved, "Qwen3-8B-Q4_K_M.gguf");
+}
+
+#[test]
+fn mlx_stem_resolves_to_model_safetensors() {
+    let siblings = vec![
+        "model.safetensors.index.json".to_string(),
+        "model.safetensors".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("model", &siblings).unwrap();
+    assert_eq!(resolved, "model.safetensors");
+}
+
+#[test]
+fn mlx_stem_resolves_to_first_split_shard() {
+    let siblings = vec![
+        "model-00002-of-00048.safetensors".to_string(),
+        "model-00001-of-00048.safetensors".to_string(),
+        "model.safetensors.index.json".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("model", &siblings).unwrap();
+    assert_eq!(resolved, "model-00001-of-00048.safetensors");
+}
+
+#[test]
+fn repo_only_resolution_prefers_mlx_model_safetensors() {
+    let siblings = vec![
+        "Qwen3-8B-Q4_K_M.gguf".to_string(),
+        "model.safetensors".to_string(),
+        "model.safetensors.index.json".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("", &siblings).unwrap();
+    assert_eq!(resolved, "model.safetensors");
+}
+
+#[test]
+fn repo_only_resolution_falls_back_to_gguf_when_no_mlx_weights() {
+    let siblings = vec![
+        "Qwen3-8B-Q8_0.gguf".to_string(),
+        "Qwen3-8B-Q4_K_M.gguf".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("", &siblings).unwrap();
+    assert_eq!(resolved, "Qwen3-8B-Q4_K_M.gguf");
+}
+
+#[test]
+fn parse_huggingface_ref_rejects_http_url() {
+    assert!(parse_huggingface_ref("https://example.com/model.gguf").is_none());
+}
+
+#[test]
+fn parse_huggingface_repo_ref_parses_repo_only() {
+    let parsed = parse_huggingface_repo_ref("GreenBitAI/Llama-2-7B-layer-mix-bpw-2.2-mlx");
+    assert_eq!(
+        parsed,
+        Some((
+            "GreenBitAI/Llama-2-7B-layer-mix-bpw-2.2-mlx".to_string(),
+            None,
+            None
+        ))
+    );
+}
+
+#[test]
+fn parse_huggingface_repo_ref_parses_quant_selector() {
+    let parsed = parse_huggingface_repo_ref("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL");
+    assert_eq!(
+        parsed,
+        Some((
+            "unsloth/gemma-4-31B-it-GGUF".to_string(),
+            None,
+            Some("UD-Q4_K_XL".to_string())
+        ))
+    );
+}
+
+#[test]
+fn parse_huggingface_repo_url_parses_repo_only() {
+    let parsed = parse_huggingface_repo_url("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF");
+    assert_eq!(
+        parsed,
+        Some(("unsloth/gemma-4-31B-it-GGUF".to_string(), None, None))
+    );
+}
+
+#[test]
+fn parse_huggingface_repo_url_parses_tree_revision() {
+    let parsed =
+        parse_huggingface_repo_url("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF/tree/main");
+    assert_eq!(
+        parsed,
+        Some((
+            "unsloth/gemma-4-31B-it-GGUF".to_string(),
+            Some("main".to_string()),
+            None
+        ))
+    );
+}
+
+#[test]
+fn quant_selector_resolves_to_single_file_gguf() {
+    let fixture = load_gemma_live_fixture();
+    let resolved = resolve_hf_file_from_siblings("UD-Q4_K_XL", &fixture.siblings).unwrap();
+    assert_eq!(resolved, "gemma-4-31B-it-UD-Q4_K_XL.gguf");
+}
+
+#[test]
+fn gemma_bf16_selector_resolves_to_first_split_shard() {
+    let fixture = load_gemma_live_fixture();
+    let resolved = resolve_hf_file_from_siblings("BF16", &fixture.siblings).unwrap();
+    assert_eq!(resolved, "BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf");
+}
+
+#[test]
+fn fit_aware_gguf_prefers_largest_comfortable_candidate() {
+    let available = 20_000_000_000u64;
+    let ordering = compare_gguf_candidates_by_fit(
+        "repo/model-q4.gguf",
+        Some(12_000_000_000),
+        "repo/model-q5.gguf",
+        Some(17_000_000_000),
+        available,
+    );
+    assert_eq!(ordering, Ordering::Greater);
+}
+
+#[test]
+fn fit_aware_gguf_prefers_smaller_when_both_too_large() {
+    let available = 20_000_000_000u64;
+    let ordering = compare_gguf_candidates_by_fit(
+        "repo/model-q8.gguf",
+        Some(29_000_000_000),
+        "repo/model-bf16.gguf",
+        Some(35_000_000_000),
+        available,
+    );
+    assert_eq!(ordering, Ordering::Less);
+}
+
+#[test]
+fn gemma_repo_default_prefers_q4_over_bf16_at_local_fit_budget() {
+    let fixture = load_gemma_live_fixture();
+    let q4 = fixture
+        .size_bytes
+        .get("gemma-4-31B-it-Q4_0.gguf")
+        .copied()
+        .expect("fixture Q4_0 size");
+    let bf16 = fixture
+        .size_bytes
+        .get("BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf")
+        .copied()
+        .expect("fixture BF16 size");
+    let available = 19_300_000_000u64;
+    let ordering = compare_gguf_candidates_by_fit(
+        "unsloth/gemma-4-31B-it-GGUF/gemma-4-31B-it-Q4_0.gguf",
+        Some(q4),
+        "unsloth/gemma-4-31B-it-GGUF/BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf",
+        Some(bf16),
+        available,
+    );
+    assert_eq!(ordering, Ordering::Less);
+}
+
+#[test]
+fn repo_name_can_signal_gguf_intent() {
+    assert!(repo_prefers_gguf_only("unsloth/gemma-4-31B-it-GGUF"));
+    assert!(!repo_prefers_gguf_only(
+        "mlx-community/Llama-3.2-3B-Instruct-4bit"
+    ));
+}
+
+#[test]
+fn parse_exact_model_ref_accepts_unsloth_gemma_repo_ref() {
+    let parsed = parse_exact_model_ref("unsloth/gemma-4-31B-it-GGUF").unwrap();
+    match parsed {
+        ExactModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => {
+            assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
+            assert_eq!(revision, None);
+            assert_eq!(file, "");
+        }
+        other => panic!("expected HuggingFace repo ref, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_exact_model_ref_accepts_unsloth_gemma_repo_url() {
+    let parsed =
+        parse_exact_model_ref("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF").unwrap();
+    match parsed {
+        ExactModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => {
+            assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
+            assert_eq!(revision, None);
+            assert_eq!(file, "");
+        }
+        other => panic!("expected HuggingFace repo ref from URL, got {other:?}"),
+    }
+}
+
+#[test]
+fn parse_exact_model_ref_accepts_unsloth_gemma_quant_selector() {
+    let parsed = parse_exact_model_ref("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL").unwrap();
+    match parsed {
+        ExactModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => {
+            assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
+            assert_eq!(revision, None);
+            assert_eq!(file, "UD-Q4_K_XL");
+        }
+        other => panic!("expected HuggingFace quant selector ref, got {other:?}"),
+    }
+}
+
+#[test]
+fn simulated_name_and_repo_quant_inputs_converge_to_same_ref() {
+    let fixture = load_gemma_live_fixture();
+    let discovered_repo = fixture.repo.as_str();
+    let selector = "UD-Q4_K_XL";
+
+    let from_name = format!(
+        "{}/{}",
+        discovered_repo,
+        resolve_hf_file_from_siblings(selector, &fixture.siblings).unwrap()
+    );
+    let from_repo = format!(
+        "{}/{}",
+        discovered_repo,
+        resolve_hf_file_from_siblings(selector, &fixture.siblings).unwrap()
+    );
+
+    assert_eq!(
+        from_name,
+        "unsloth/gemma-4-31B-it-GGUF/gemma-4-31B-it-UD-Q4_K_XL.gguf"
+    );
+    assert_eq!(from_name, from_repo);
+}
+
+#[test]
+fn parse_exact_model_ref_accepts_unsloth_gemma_repo_url_with_quant_selector() {
+    let parsed =
+        parse_exact_model_ref("https://huggingface.co/unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL")
+            .unwrap();
+    match parsed {
+        ExactModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => {
+            assert_eq!(repo, "unsloth/gemma-4-31B-it-GGUF");
+            assert_eq!(revision, None);
+            assert_eq!(file, "UD-Q4_K_XL");
+        }
+        other => panic!("expected HuggingFace repo URL quant selector ref, got {other:?}"),
+    }
+}
+
+#[test]
+fn split_bare_name_selector_supports_name_quant_shorthand() {
+    assert_eq!(
+        split_bare_name_selector("gemma-4-31B-it-GGUF:UD-Q4_K_XL"),
+        ("gemma-4-31B-it-GGUF", Some("UD-Q4_K_XL"))
+    );
+    assert_eq!(
+        split_bare_name_selector("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL"),
+        ("unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL", None)
+    );
+}
+
+#[test]
+fn select_strong_repo_hit_prefers_exact_leaf_name() {
+    let repos = vec![
+        "ggml-org/gemma-4-31B-it-GGUF".to_string(),
+        "unsloth/gemma-4-31B-it-GGUF".to_string(),
+        "bartowski/google_gemma-4-31B-it-GGUF".to_string(),
+    ];
+    let picked = select_strong_repo_hit("gemma-4-31B-it-GGUF", &repos);
+    assert_eq!(picked, Some("ggml-org/gemma-4-31B-it-GGUF".to_string()));
+}
+
+#[test]
+fn bare_name_quant_can_be_formatted_with_discovered_repo() {
+    let (name, selector) = split_bare_name_selector("gemma-4-31B-it-GGUF:UD-Q4_K_XL");
+    assert_eq!(name, "gemma-4-31B-it-GGUF");
+    let selector = selector.expect("selector");
+    let canonical = format!("{}:{}", "unsloth/gemma-4-31B-it-GGUF", selector);
+    assert_eq!(canonical, "unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL");
+}
+
+#[test]
+fn quant_selector_from_gguf_file_extracts_expected_forms() {
+    assert_eq!(
+        quant_selector_from_gguf_file("gemma-4-31B-it-UD-Q4_K_XL.gguf"),
+        Some("UD-Q4_K_XL".to_string())
+    );
+    assert_eq!(
+        quant_selector_from_gguf_file("BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf"),
+        Some("BF16".to_string())
+    );
+    assert_eq!(
+        quant_selector_from_gguf_file("gemma-4-31B-it-Q4_0.gguf"),
+        Some("Q4_0".to_string())
+    );
+}
+
+#[test]
+fn format_huggingface_display_ref_prefers_selector_form_for_gguf() {
+    assert_eq!(
+        format_huggingface_display_ref(
+            "unsloth/gemma-4-31B-it-GGUF",
+            None,
+            "gemma-4-31B-it-UD-Q4_K_XL.gguf"
+        ),
+        "unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL"
+    );
+}
+
+#[test]
+fn format_huggingface_display_ref_uses_selector_for_split_gguf() {
+    assert_eq!(
+        format_huggingface_display_ref(
+            "unsloth/gemma-4-31B-it-GGUF",
+            None,
+            "BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf"
+        ),
+        "unsloth/gemma-4-31B-it-GGUF:BF16"
+    );
+}
+
+#[tokio::test]
+async fn download_exact_ref_bf16_shorthand_downloads_full_split_model() {
+    let fixture = load_gemma_live_fixture();
+    let _siblings_guard = RepoSiblingEntriesOverrideGuard::set(Arc::new({
+        let repo = fixture.repo.clone();
+        let siblings = fixture
+            .siblings
+            .iter()
+            .map(|file| (file.clone(), fixture.size_bytes.get(file).copied()))
+            .collect::<Vec<_>>();
+        move |requested_repo, requested_revision| {
+            if requested_repo == repo && requested_revision == "main" {
+                Some(siblings.clone())
+            } else {
+                None
+            }
+        }
+    }));
+
+    let planned = Arc::new(Mutex::new(Vec::<(bool, String)>::new()));
+    let _plan_guard = catalog::DownloadPlanObserverGuard::set(Arc::new({
+        let planned = Arc::clone(&planned);
+        move |label, entries| {
+            if label == "unsloth/gemma-4-31B-it-GGUF:BF16" {
+                *planned.lock().unwrap() = entries;
+            }
+        }
+    }));
+    let _download_guard = catalog::set_download_hf_assets_label_override(
+        "unsloth/gemma-4-31B-it-GGUF:BF16".to_string(),
+        Arc::new(|_| {
+            Ok(vec![
+                PathBuf::from("/tmp/BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf"),
+                PathBuf::from("/tmp/BF16/gemma-4-31B-it-BF16-00002-of-00002.gguf"),
+            ])
+        }),
+    );
+
+    let resolved = download_exact_ref_with_progress("unsloth/gemma-4-31B-it-GGUF:BF16", false)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resolved,
+        PathBuf::from("/tmp/BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf")
+    );
+    assert_eq!(
+        *planned.lock().unwrap(),
+        vec![
+            (false, "config.json".to_string()),
+            (
+                true,
+                "BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf".to_string()
+            ),
+            (
+                true,
+                "BF16/gemma-4-31B-it-BF16-00002-of-00002.gguf".to_string()
+            ),
+        ]
+    );
+}
+
+#[test]
+fn format_huggingface_display_ref_prefers_repo_form_for_mlx() {
+    assert_eq!(
+        format_huggingface_display_ref("mlx-community/SmolLM-135M-8bit", None, "model.safetensors"),
+        "mlx-community/SmolLM-135M-8bit"
+    );
+    assert_eq!(
+        format_huggingface_display_ref(
+            "avlp12/GLM-5.1-Alis-MLX-Dynamic-2.7bpw",
+            None,
+            "model-00001-of-00010.safetensors"
+        ),
+        "avlp12/GLM-5.1-Alis-MLX-Dynamic-2.7bpw"
+    );
+}
+
+#[test]
+fn parse_exact_model_ref_accepts_legacy_mlx_model_path_shape() {
+    let parsed = parse_exact_model_ref("mlx-community/SmolLM-135M-8bit/model").unwrap();
+    match parsed {
+        ExactModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => {
+            assert_eq!(repo, "mlx-community/SmolLM-135M-8bit");
+            assert_eq!(revision, None);
+            assert_eq!(file, "model");
+        }
+        _ => panic!("expected HuggingFace ref"),
+    }
+}
+
+#[test]
+fn collect_show_gguf_variants_excludes_mmproj_and_nonfirst_split() {
+    let siblings = vec![
+        ("mmproj-BF16.gguf".to_string(), Some(1_200_000_000)),
+        (
+            "gemma-4-26B-A4B-it-UD-Q3_K_S-00002-of-00009.gguf".to_string(),
+            Some(12_500_000_000),
+        ),
+        (
+            "gemma-4-26B-A4B-it-UD-Q3_K_S-00001-of-00009.gguf".to_string(),
+            Some(12_500_000_000),
+        ),
+        (
+            "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf".to_string(),
+            Some(16_900_000_000),
+        ),
+    ];
+    let files: Vec<_> = collect_show_gguf_variants_from_siblings(&siblings, 0)
+        .into_iter()
+        .map(|(file, _)| file)
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "gemma-4-26B-A4B-it-UD-Q3_K_S-00001-of-00009.gguf".to_string(),
+            "gemma-4-26B-A4B-it-UD-Q4_K_M.gguf".to_string(),
+        ]
+    );
+}
+
+#[test]
+fn collect_show_gguf_variants_orders_by_fit_when_memory_known() {
+    let siblings = vec![
+        ("model-UD-Q5_K_M.gguf".to_string(), Some(21_200_000_000)),
+        ("model-UD-Q4_K_M.gguf".to_string(), Some(16_900_000_000)),
+        ("model-UD-Q3_K_S.gguf".to_string(), Some(12_500_000_000)),
+    ];
+    let files: Vec<_> = collect_show_gguf_variants_from_siblings(&siblings, 19_300_000_000)
+        .into_iter()
+        .map(|(file, _)| file)
+        .collect();
+    assert_eq!(
+        files,
+        vec![
+            "model-UD-Q4_K_M.gguf".to_string(),
+            "model-UD-Q3_K_S.gguf".to_string(),
+            "model-UD-Q5_K_M.gguf".to_string(),
+        ]
+    );
+}


### PR DESCRIPTION
## Summary
- keep Hugging Face repo and quant shorthand semantics focused on the full model, even when the selected GGUF is split
- resolve split GGUF shorthand through the first shard as an internal entrypoint, then expand the download plan to include all shards and required metadata
- move `models::resolve` tests into a dedicated `resolve/tests.rs` module and add end-to-end coverage for BF16 Gemma split resolution

## Behaviour
The behavior change is narrow: Hugging Face repo and quant shorthand still mean the whole model, but for split GGUFs the resolver now treats the first shard as the internal entrypoint and the download layer expands that to the full split.

In practice, resolution now works in two stages:
- `resolve_huggingface_file(...)` maps shorthand like `repo:BF16` to the concrete artifact llama.cpp needs to start from. For split GGUFs, that is the first shard.
- `download_hf_assets_blocking(...)` expands a first-shard GGUF like `...-00001-of-00002.gguf` into all shards plus `config.json`, so the full model is downloaded.

## Examples
- `mesh-llm serve --model unsloth/gemma-4-31B-it-GGUF`
  Resolution picks the default GGUF variant for that repo, based on the existing fit-aware and default logic. If that chosen variant is split, the full split is downloaded, not just shard 1.
- `mesh-llm serve --model unsloth/gemma-4-31B-it-GGUF:BF16`
  Resolution maps `:BF16` to `BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf`. Download planning then expands that to:
  - `config.json`
  - `BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf`
  - `BF16/gemma-4-31B-it-BF16-00002-of-00002.gguf`
- `mesh-llm serve --model gemma-4-31B-it-GGUF:BF16`
  Bare-name discovery first canonicalizes to `unsloth/gemma-4-31B-it-GGUF:BF16`, then follows the same path above.
- `mesh-llm serve --model unsloth/gemma-4-31B-it-GGUF/BF16/gemma-4-31B-it-BF16-00001-of-00002.gguf`
  Exact file refs still work. Because that file is shard 1, the download layer still expands it to the full split.

What changed from the broken behavior is that `repo:BF16` is no longer semantically treated as “just shard 1”. It only resolves to shard 1 internally as the split entrypoint.

## Testing
- `cargo test -p mesh-llm models::resolve::tests -- --nocapture`
- `cargo test -p mesh-llm models::catalog::tests -- --nocapture`
- `cargo check -p mesh-llm`
