### PR TITLE
models: inspect and clean up mesh-managed cache entries safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ mesh-llm discover                          # browse available meshes
 mesh-llm gpus                              # inspect local GPUs and stable IDs
 ```
 
+### Inspect and clean the shared model cache
+```bash
+mesh-llm models installed
+mesh-llm models cleanup --unused-since 30d
+mesh-llm models cleanup --unused-since 30d --yes
+```
+
+`models installed` now shows whether a cached model is mesh-managed or external plus the last time mesh-llm used it. `models cleanup` only removes model files that mesh-llm explicitly marked as mesh-managed; by default it prints a dry run preview and requires `--yes` to delete anything.
+
 ### Multi-model
 ```bash
 mesh-llm serve --model Qwen2.5-32B --model GLM-4.7-Flash

--- a/mesh-llm/src/cli/commands/models/formatters.rs
+++ b/mesh-llm/src/cli/commands/models/formatters.rs
@@ -4,6 +4,7 @@ use crate::models::{
 };
 use crate::system::hardware;
 use anyhow::Result;
+use chrono::{DateTime, Utc};
 use serde_json::{json, Value};
 use std::path::{Path, PathBuf};
 
@@ -46,6 +47,8 @@ pub(crate) struct InstalledRow {
     pub(crate) size: Option<u64>,
     pub(crate) catalog_model: Option<&'static catalog::CatalogModel>,
     pub(crate) capabilities: ModelCapabilities,
+    pub(crate) managed_by_mesh: bool,
+    pub(crate) last_used_at: Option<String>,
 }
 
 pub(crate) trait ModelsFormatter: SearchFormatter {
@@ -137,6 +140,22 @@ pub(crate) fn format_installed_size(bytes: u64) -> String {
     } else {
         format!("{}B", bytes)
     }
+}
+
+pub(crate) fn format_relative_timestamp(value: &str) -> Option<String> {
+    let parsed = DateTime::parse_from_rfc3339(value).ok()?;
+    let parsed = parsed.with_timezone(&Utc);
+    let age = Utc::now().signed_duration_since(parsed);
+    let age_label = if age.num_days() >= 1 {
+        format!("{}d ago", age.num_days())
+    } else if age.num_hours() >= 1 {
+        format!("{}h ago", age.num_hours())
+    } else if age.num_minutes() >= 1 {
+        format!("{}m ago", age.num_minutes())
+    } else {
+        "just now".to_string()
+    };
+    Some(format!("{value} ({age_label})"))
 }
 
 pub(crate) fn installed_model_kind(path: &Path) -> &'static str {

--- a/mesh-llm/src/cli/commands/models/formatters_console.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_console.rs
@@ -1,8 +1,8 @@
 use super::formatters::{
     catalog_model_capabilities, filter_label, fit_hint_for_size_label, format_count,
-    format_installed_size, format_source_label, huggingface_cache_dir, huggingface_repo_url,
-    installed_model_kind, model_kind_code, sort_label, variant_selector_label, ConsoleFormatter,
-    InstalledRow, ModelsFormatter, SearchFormatter,
+    format_installed_size, format_relative_timestamp, format_source_label, huggingface_cache_dir,
+    huggingface_repo_url, installed_model_kind, model_kind_code, sort_label,
+    variant_selector_label, ConsoleFormatter, InstalledRow, ModelsFormatter, SearchFormatter,
 };
 use crate::models::{catalog, ModelDetails, SearchArtifactFilter, SearchHit, SearchSort};
 use anyhow::Result;
@@ -184,6 +184,19 @@ impl ModelsFormatter for ConsoleFormatter {
             println!("   type: {}", installed_model_kind(&row.path));
             if let Some(bytes) = row.size {
                 println!("   size: {} 📏", format_installed_size(bytes));
+            }
+            println!(
+                "   owner: {}",
+                if row.managed_by_mesh {
+                    "mesh-managed"
+                } else {
+                    "external"
+                }
+            );
+            if let Some(last_used_at) = row.last_used_at.as_deref() {
+                if let Some(label) = format_relative_timestamp(last_used_at) {
+                    println!("   last used: {}", label);
+                }
             }
             let mut caps = vec!["💬 text".to_string()];
             if row.capabilities.multimodal_label().is_some() {

--- a/mesh-llm/src/cli/commands/models/formatters_json.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_json.rs
@@ -164,6 +164,8 @@ impl ModelsFormatter for JsonFormatter {
                     "type": installed_model_kind_code(&row.path),
                     "size_bytes": row.size,
                     "size": row.size.map(super::formatters::format_installed_size),
+                    "mesh_managed": row.managed_by_mesh,
+                    "last_used_at": row.last_used_at,
                     "capabilities": capabilities_json(row.capabilities),
                     "ref": row.model_ref,
                     "show": format!("mesh-llm models show {}", row.model_ref),

--- a/mesh-llm/src/cli/commands/models/mod.rs
+++ b/mesh-llm/src/cli/commands/models/mod.rs
@@ -7,16 +7,20 @@ use crate::cli::models::ModelsCommand;
 use crate::cli::terminal_progress::{clear_stderr_line, start_spinner, DeterminateProgressLine};
 use crate::models::{
     catalog, download_model_ref_with_progress_details, find_catalog_model_exact,
-    installed_model_capabilities, scan_installed_models, search_catalog_models, search_huggingface,
-    show_exact_model, show_model_variants_with_progress, SearchArtifactFilter, SearchProgress,
-    SearchSort, ShowVariantsProgress,
+    installed_model_capabilities, load_model_usage_record_for_path, model_usage_cache_dir,
+    plan_model_cleanup, scan_installed_models, search_catalog_models, search_huggingface,
+    show_exact_model, show_model_variants_with_progress, ModelCleanupPlan, ModelCleanupResult,
+    SearchArtifactFilter, SearchProgress, SearchSort, ShowVariantsProgress,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
+use serde_json::json;
 use std::io::IsTerminal;
+use std::time::Duration;
 use std::time::Instant;
 
 use formatters::{
-    catalog_model_is_mlx, model_kind_code, models_formatter, search_formatter, InstalledRow,
+    catalog_model_is_mlx, format_installed_size, format_relative_timestamp, model_kind_code,
+    models_formatter, search_formatter, InstalledRow,
 };
 
 pub async fn run_model_search(
@@ -129,9 +133,8 @@ pub fn run_model_recommended(json_output: bool) -> Result<()> {
     formatter.render_recommended(&models)
 }
 
-pub fn run_model_installed(json_output: bool) -> Result<()> {
-    let formatter = models_formatter(json_output);
-    let rows: Vec<InstalledRow> = scan_installed_models()
+fn build_installed_rows() -> Vec<InstalledRow> {
+    scan_installed_models()
         .into_iter()
         .map(|name| {
             let path = crate::models::find_model_path(&name);
@@ -154,6 +157,7 @@ pub fn run_model_installed(json_output: bool) -> Result<()> {
                 std::fs::metadata(&path).map(|meta| meta.len()).ok()
             };
             let capabilities = installed_model_capabilities(&name);
+            let usage = load_model_usage_record_for_path(&path);
             InstalledRow {
                 name: display_name,
                 model_ref,
@@ -161,10 +165,35 @@ pub fn run_model_installed(json_output: bool) -> Result<()> {
                 size,
                 catalog_model,
                 capabilities,
+                managed_by_mesh: usage.as_ref().is_some_and(|record| record.mesh_managed),
+                last_used_at: usage.and_then(|record| Some(record.last_used_at)),
             }
         })
-        .collect();
+        .collect()
+}
+
+pub fn run_model_installed(json_output: bool) -> Result<()> {
+    let formatter = models_formatter(json_output);
+    let rows = build_installed_rows();
     formatter.render_installed(&rows)
+}
+
+pub fn run_model_cleanup(unused_since: Option<&str>, yes: bool, json_output: bool) -> Result<()> {
+    let unused_duration = unused_since.map(parse_cleanup_age).transpose()?;
+    let plan = plan_model_cleanup(unused_duration)?;
+    if yes {
+        let result = crate::models::execute_model_cleanup(unused_duration)?;
+        if json_output {
+            render_cleanup_json(unused_since, &plan, Some(&result))?;
+        } else {
+            render_cleanup_console(unused_since, &plan, Some(&result))?;
+        }
+    } else if json_output {
+        render_cleanup_json(unused_since, &plan, None)?;
+    } else {
+        render_cleanup_console(unused_since, &plan, None)?;
+    }
+    Ok(())
 }
 
 pub async fn run_model_show(model_ref: &str, json_output: bool) -> Result<()> {
@@ -271,6 +300,11 @@ pub async fn dispatch_models_command(command: &ModelsCommand) -> Result<()> {
             run_model_recommended(*json)?
         }
         ModelsCommand::Installed { json } => run_model_installed(*json)?,
+        ModelsCommand::Cleanup {
+            unused_since,
+            yes,
+            json,
+        } => run_model_cleanup(unused_since.as_deref(), *yes, *json)?,
         ModelsCommand::Search {
             query,
             gguf,
@@ -306,6 +340,175 @@ pub async fn dispatch_models_command(command: &ModelsCommand) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn parse_cleanup_age(value: &str) -> Result<Duration> {
+    let value = value.trim();
+    if value.is_empty() {
+        bail!("Cleanup age must not be empty");
+    }
+    let split_index = value
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(value.len());
+    if split_index == 0 || split_index == value.len() {
+        bail!("Use a cleanup age like 12h, 7d, or 30m");
+    }
+    let amount: u64 = value[..split_index]
+        .parse()
+        .map_err(|_| anyhow!("Invalid cleanup age: {value}"))?;
+    let unit = value[split_index..].to_ascii_lowercase();
+    let seconds = match unit.as_str() {
+        "m" | "min" | "mins" | "minute" | "minutes" => amount.saturating_mul(60),
+        "h" | "hr" | "hrs" | "hour" | "hours" => amount.saturating_mul(60 * 60),
+        "d" | "day" | "days" => amount.saturating_mul(60 * 60 * 24),
+        "w" | "week" | "weeks" => amount.saturating_mul(60 * 60 * 24 * 7),
+        _ => bail!("Unsupported cleanup age unit '{unit}'. Use m, h, d, or w."),
+    };
+    Ok(Duration::from_secs(seconds))
+}
+
+fn render_cleanup_console(
+    unused_since: Option<&str>,
+    plan: &ModelCleanupPlan,
+    result: Option<&ModelCleanupResult>,
+) -> Result<()> {
+    let executed = result.is_some();
+    if executed {
+        println!("✅ Model cleanup complete");
+    } else {
+        println!("🧹 Model cleanup preview");
+    }
+    println!(
+        "📁 HF cache: {}",
+        crate::models::huggingface_hub_cache_dir().display()
+    );
+    println!("📁 Mesh cache: {}", model_usage_cache_dir().display());
+    println!("🛡️ Scope: mesh-managed records only");
+    if let Some(unused_since) = unused_since {
+        println!("⏱️ Filter: unused for at least {}", unused_since);
+    }
+    println!();
+
+    if plan.candidates.is_empty() {
+        println!("No mesh-managed models matched the cleanup filters.");
+    } else {
+        for candidate in &plan.candidates {
+            println!("📦 {}", candidate.display_name);
+            if candidate.stale_record_only {
+                println!("   would remove: stale usage record only");
+            } else {
+                println!(
+                    "   would remove: {} across {} file{}",
+                    format_installed_size(candidate.total_bytes),
+                    candidate.file_count,
+                    if candidate.file_count == 1 { "" } else { "s" }
+                );
+            }
+            if let Some(model_ref) = candidate.model_ref.as_deref() {
+                println!("   ref: {}", model_ref);
+            }
+            println!("   source: {}", candidate.source);
+            if let Some(label) = format_relative_timestamp(&candidate.last_used_at) {
+                println!("   last used: {}", label);
+            }
+            println!("   path: {}", candidate.primary_path.display());
+            if candidate.stale_record_only {
+                println!("   note: no managed files remain on disk; cleanup only removes the usage record");
+            }
+            println!();
+        }
+    }
+
+    if let Some(result) = result {
+        println!("Removed model records: {}", result.removed_candidates);
+        println!("Removed files: {}", result.removed_files);
+        println!(
+            "Removed metadata cache files: {}",
+            result.removed_metadata_files
+        );
+        println!("Removed usage records: {}", result.removed_records);
+        println!(
+            "Reclaimed: {}",
+            format_installed_size(result.reclaimed_bytes)
+        );
+    } else {
+        println!(
+            "Would remove: {} across {} file{}",
+            format_installed_size(plan.total_bytes),
+            plan.total_files,
+            if plan.total_files == 1 { "" } else { "s" }
+        );
+        if plan.stale_record_only > 0 {
+            println!(
+                "Would also clear {} stale usage record{}",
+                plan.stale_record_only,
+                if plan.stale_record_only == 1 { "" } else { "s" }
+            );
+        }
+        if plan.skipped_recent > 0 {
+            println!(
+                "Skipped recent mesh-managed record{}: {}",
+                if plan.skipped_recent == 1 { "" } else { "s" },
+                plan.skipped_recent
+            );
+        }
+        println!();
+        println!("Apply with:");
+        print!("  mesh-llm models cleanup");
+        if let Some(unused_since) = unused_since {
+            print!(" --unused-since {}", unused_since);
+        }
+        println!(" --yes");
+    }
+    Ok(())
+}
+
+fn render_cleanup_json(
+    unused_since: Option<&str>,
+    plan: &ModelCleanupPlan,
+    result: Option<&ModelCleanupResult>,
+) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "hf_cache_dir": crate::models::huggingface_hub_cache_dir(),
+            "mesh_cache_dir": model_usage_cache_dir(),
+            "mesh_managed_only": true,
+            "unused_since": unused_since,
+            "dry_run": result.is_none(),
+            "plan": plan,
+            "result": result,
+        }))?
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_cleanup_age;
+
+    #[test]
+    fn cleanup_age_parser_accepts_common_units() {
+        assert_eq!(
+            parse_cleanup_age("30m").expect("minutes should parse"),
+            std::time::Duration::from_secs(30 * 60)
+        );
+        assert_eq!(
+            parse_cleanup_age("12h").expect("hours should parse"),
+            std::time::Duration::from_secs(12 * 60 * 60)
+        );
+        assert_eq!(
+            parse_cleanup_age("7d").expect("days should parse"),
+            std::time::Duration::from_secs(7 * 24 * 60 * 60)
+        );
+    }
+
+    #[test]
+    fn cleanup_age_parser_rejects_missing_or_unknown_units() {
+        assert!(parse_cleanup_age("30").is_err());
+        assert!(parse_cleanup_age("2months").is_err());
+        assert!(parse_cleanup_age("").is_err());
+    }
 }
 
 fn map_search_sort(sort: ModelSearchSort) -> SearchSort {

--- a/mesh-llm/src/cli/models.rs
+++ b/mesh-llm/src/cli/models.rs
@@ -25,6 +25,18 @@ pub enum ModelsCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Preview or remove mesh-managed models from the Hugging Face cache.
+    Cleanup {
+        /// Only include models that mesh-llm has not used for the given age (for example 30d or 12h).
+        #[arg(long)]
+        unused_since: Option<String>,
+        /// Remove the selected files instead of printing a dry run preview.
+        #[arg(long)]
+        yes: bool,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
     /// List built-in catalog models.
     #[command(hide = true)]
     List {

--- a/mesh-llm/src/models/catalog.rs
+++ b/mesh-llm/src/models/catalog.rs
@@ -1,5 +1,6 @@
 //! Built-in model catalog plus managed acquisition helpers.
 
+use super::track_managed_model_usage;
 use crate::cli::terminal_progress::{start_spinner, SpinnerHandle};
 use anyhow::{Context, Result};
 use hf_hub::{DownloadEvent, Progress, ProgressEvent, ProgressHandler, RepoDownloadFileParams};
@@ -770,14 +771,32 @@ pub async fn download_hf_repo_file_with_progress_label(
     };
     let mut paths = download_hf_assets(label, vec![asset.clone()], progress).await?;
     paths.sort();
-    paths
+    let path = paths
         .into_iter()
         .find(|path| path_suffix_matches_ignore_case(path, &asset.file))
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "Downloaded Hugging Face asset not found in cache: {repo}/{file}@{revision}"
             )
-        })
+        })?;
+    let display_name = Path::new(&asset.file)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or(&asset.file);
+    let model_ref = format!("{repo}@{revision}/{file}");
+    if let Err(err) = track_managed_model_usage(
+        &path,
+        std::slice::from_ref(&path),
+        display_name,
+        Some(&model_ref),
+        "huggingface",
+    ) {
+        tracing::warn!(
+            "failed to record managed model usage for {}: {err}",
+            path.display()
+        );
+    }
+    Ok(path)
 }
 
 /// Download a model into the managed model store with resume support.
@@ -797,14 +816,27 @@ pub async fn download_model_with_progress(model: &CatalogModel, progress: bool) 
         let source = model.source_file().unwrap_or(model.file.as_str());
         let mut paths = download_hf_assets(&model.name, assets, progress).await?;
         paths.sort();
+        let managed_paths = paths.clone();
         if let Some(path) = paths
             .iter()
             .find(|path| path_suffix_matches_ignore_case(path, source))
             .cloned()
         {
+            if let Err(err) = track_managed_model_usage(
+                &path,
+                &managed_paths,
+                &model.name,
+                Some(&model.name),
+                "catalog",
+            ) {
+                tracing::warn!(
+                    "failed to record managed model usage for {}: {err}",
+                    path.display()
+                );
+            }
             return Ok(path);
         }
-        return paths
+        let path = paths
             .into_iter()
             .find(|path| path_suffix_matches_ignore_case(path, &model.file))
             .ok_or_else(|| {
@@ -812,7 +844,20 @@ pub async fn download_model_with_progress(model: &CatalogModel, progress: bool) 
                     "Downloaded model path not found in cache for {}",
                     model.name
                 )
-            });
+            })?;
+        if let Err(err) = track_managed_model_usage(
+            &path,
+            &managed_paths,
+            &model.name,
+            Some(&model.name),
+            "catalog",
+        ) {
+            tracing::warn!(
+                "failed to record managed model usage for {}: {err}",
+                path.display()
+            );
+        }
+        return Ok(path);
     }
 
     let dir = models_dir();
@@ -827,6 +872,7 @@ pub async fn download_model_with_progress(model: &CatalogModel, progress: bool) 
     if let Some(asset) = &model.mmproj {
         files.push((asset.file.as_str(), asset.url.as_str()));
     }
+    let all_paths: Vec<PathBuf> = files.iter().map(|(file, _)| dir.join(file)).collect();
 
     let mut all_present = true;
     let mut total_size: u64 = 0;
@@ -851,6 +897,14 @@ pub async fn download_model_with_progress(model: &CatalogModel, progress: bool) 
                 total_size as f64 / 1e9,
                 files.len(),
                 if files.len() > 1 { "s" } else { "" },
+            );
+        }
+        if let Err(err) =
+            track_managed_model_usage(&dest, &all_paths, &model.name, Some(&model.name), "catalog")
+        {
+            tracing::warn!(
+                "failed to record managed model usage for {}: {err}",
+                dest.display()
             );
         }
         return Ok(dest);
@@ -910,6 +964,14 @@ pub async fn download_model_with_progress(model: &CatalogModel, progress: bool) 
 
     if progress {
         eprintln!("✅ Downloaded {} to {}", model.name, dir.display());
+    }
+    if let Err(err) =
+        track_managed_model_usage(&dest, &all_paths, &model.name, Some(&model.name), "catalog")
+    {
+        tracing::warn!(
+            "failed to record managed model usage for {}: {err}",
+            dest.display()
+        );
     }
     Ok(dest)
 }
@@ -1008,8 +1070,21 @@ pub async fn download_hf_split_gguf(url: &str, filename: &str) -> Result<PathBuf
                 handle.await??;
             }
         }
-
-        return Ok(dir.join(filename));
+        let primary = dir.join(filename);
+        let all_paths: Vec<PathBuf> = files.iter().map(|(file, _)| dir.join(file)).collect();
+        let display_name = Path::new(filename)
+            .file_stem()
+            .and_then(|value| value.to_str())
+            .unwrap_or(filename);
+        if let Err(err) =
+            track_managed_model_usage(&primary, &all_paths, display_name, Some(url), "url")
+        {
+            tracing::warn!(
+                "failed to record managed model usage for {}: {err}",
+                primary.display()
+            );
+        }
+        return Ok(primary);
     }
 
     // Not a split file — single download
@@ -1022,11 +1097,43 @@ pub async fn download_hf_split_gguf(url: &str, filename: &str) -> Result<PathBuf
                 filename,
                 size as f64 / 1e9
             );
+            let display_name = Path::new(filename)
+                .file_stem()
+                .and_then(|value| value.to_str())
+                .unwrap_or(filename);
+            if let Err(err) = track_managed_model_usage(
+                &dest,
+                std::slice::from_ref(&dest),
+                display_name,
+                Some(url),
+                "url",
+            ) {
+                tracing::warn!(
+                    "failed to record managed model usage for {}: {err}",
+                    dest.display()
+                );
+            }
             return Ok(dest);
         }
     }
     eprintln!("📥 Downloading {filename}...");
     download_with_resume(&dest, url).await?;
+    let display_name = Path::new(filename)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .unwrap_or(filename);
+    if let Err(err) = track_managed_model_usage(
+        &dest,
+        std::slice::from_ref(&dest),
+        display_name,
+        Some(url),
+        "url",
+    ) {
+        tracing::warn!(
+            "failed to record managed model usage for {}: {err}",
+            dest.display()
+        );
+    }
     Ok(dest)
 }
 

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -7,6 +7,7 @@ mod maintenance;
 mod resolve;
 pub mod search;
 pub mod topology;
+mod usage;
 
 use anyhow::{Context, Result};
 use hf_hub::{HFClient, HFClientBuilder, HFClientSync};
@@ -30,6 +31,11 @@ pub use search::{
     SearchSort,
 };
 pub use topology::{infer_local_model_topology, ModelMoeInfo, ModelTopology};
+pub use usage::{
+    execute_model_cleanup, load_model_usage_record_for_path, model_usage_cache_dir,
+    plan_model_cleanup, track_managed_model_usage, track_model_usage, ModelCleanupPlan,
+    ModelCleanupResult,
+};
 
 pub(crate) fn build_hf_api(_progress: bool) -> Result<HFClientSync> {
     let mut builder = HFClientBuilder::new().cache_dir(huggingface_hub_cache_dir());

--- a/mesh-llm/src/models/resolve/mod.rs
+++ b/mesh-llm/src/models/resolve/mod.rs
@@ -1,6 +1,9 @@
 use super::local::HuggingFaceModelIdentity;
 use super::ModelCapabilities;
-use super::{capabilities, catalog, find_model_path, format_size_bytes};
+use super::{
+    capabilities, catalog, find_model_path, format_size_bytes, huggingface_identity_for_path,
+    track_model_usage,
+};
 use crate::cli::terminal_progress::start_spinner;
 use anyhow::{anyhow, bail, Context, Result};
 use hf_hub::{ListModelsParams, RepoInfo, RepoInfoParams};
@@ -137,6 +140,7 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
     let raw = input.to_string_lossy();
 
     if input.exists() {
+        record_resolved_model_usage(input, Some(raw.as_ref()));
         return Ok(input.to_path_buf());
     }
 
@@ -144,6 +148,10 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
         let installed_name = raw.strip_suffix(".gguf").unwrap_or(&raw);
         let installed_path = find_model_path(installed_name);
         if installed_path.exists() {
+            let model_ref = huggingface_identity_for_path(&installed_path)
+                .map(|identity| identity.canonical_ref)
+                .unwrap_or_else(|| installed_name.to_string());
+            record_resolved_model_usage(&installed_path, Some(&model_ref));
             return Ok(installed_path);
         }
         if let Some(entry) = catalog::find_model(&raw) {
@@ -166,6 +174,12 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
         .await
         .with_context(|| format!("Resolve model spec {raw}"))?;
     Ok(path)
+}
+
+fn record_resolved_model_usage(path: &Path, model_ref: Option<&str>) {
+    if let Err(err) = track_model_usage(path, None, model_ref, Some("resolve")) {
+        tracing::warn!("failed to record model usage for {}: {err}", path.display());
+    }
 }
 
 pub async fn show_exact_model(input: &str) -> Result<ModelDetails> {

--- a/mesh-llm/src/models/usage.rs
+++ b/mesh-llm/src/models/usage.rs
@@ -1,0 +1,635 @@
+use super::local::{
+    gguf_metadata_cache_path, huggingface_hub_cache_dir, huggingface_identity_for_path,
+};
+use anyhow::{Context, Result};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub struct ModelUsageRecord {
+    pub lookup_key: String,
+    pub display_name: String,
+    pub model_ref: Option<String>,
+    pub source: String,
+    pub mesh_managed: bool,
+    pub primary_path: PathBuf,
+    pub managed_paths: Vec<PathBuf>,
+    pub first_seen_at: String,
+    pub last_used_at: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ModelCleanupCandidate {
+    pub display_name: String,
+    pub model_ref: Option<String>,
+    pub source: String,
+    pub primary_path: PathBuf,
+    pub mesh_managed: bool,
+    pub last_used_at: String,
+    pub file_count: usize,
+    pub total_bytes: u64,
+    pub stale_record_only: bool,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct ModelCleanupPlan {
+    pub candidates: Vec<ModelCleanupCandidate>,
+    pub total_files: usize,
+    pub total_bytes: u64,
+    pub skipped_recent: usize,
+    pub stale_record_only: usize,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct ModelCleanupResult {
+    pub removed_candidates: usize,
+    pub removed_files: usize,
+    pub removed_records: usize,
+    pub removed_metadata_files: usize,
+    pub reclaimed_bytes: u64,
+}
+
+#[derive(Clone, Debug)]
+struct CleanupEntry {
+    record: ModelUsageRecord,
+    record_path: PathBuf,
+    removable_paths: Vec<PathBuf>,
+    total_bytes: u64,
+    stale_record_only: bool,
+}
+
+pub fn model_usage_cache_dir() -> PathBuf {
+    super::mesh_llm_cache_dir().join("model-usage")
+}
+
+pub fn load_model_usage_record_for_path(path: &Path) -> Option<ModelUsageRecord> {
+    let usage_dir = model_usage_cache_dir();
+    let root = huggingface_hub_cache_dir();
+    let lookup_key = usage_lookup_key(path, &root)?;
+    let record_path = usage_record_path(&usage_dir, &lookup_key);
+    read_usage_record(&record_path)
+}
+
+pub fn track_model_usage(
+    path: &Path,
+    display_name: Option<&str>,
+    model_ref: Option<&str>,
+    source: Option<&str>,
+) -> Result<()> {
+    let usage_dir = model_usage_cache_dir();
+    let root = huggingface_hub_cache_dir();
+    record_model_usage_in_dir(
+        &usage_dir,
+        &root,
+        path,
+        &[],
+        display_name,
+        model_ref,
+        source,
+        false,
+    )
+}
+
+pub fn track_managed_model_usage(
+    primary_path: &Path,
+    managed_paths: &[PathBuf],
+    display_name: &str,
+    model_ref: Option<&str>,
+    source: &str,
+) -> Result<()> {
+    let usage_dir = model_usage_cache_dir();
+    let root = huggingface_hub_cache_dir();
+    record_model_usage_in_dir(
+        &usage_dir,
+        &root,
+        primary_path,
+        managed_paths,
+        Some(display_name),
+        model_ref,
+        Some(source),
+        true,
+    )
+}
+
+pub fn plan_model_cleanup(unused_since: Option<Duration>) -> Result<ModelCleanupPlan> {
+    let usage_dir = model_usage_cache_dir();
+    let root = huggingface_hub_cache_dir();
+    plan_model_cleanup_in_dir(&usage_dir, &root, unused_since)
+}
+
+pub fn execute_model_cleanup(unused_since: Option<Duration>) -> Result<ModelCleanupResult> {
+    let usage_dir = model_usage_cache_dir();
+    let root = huggingface_hub_cache_dir();
+    let records = load_model_usage_records_from_dir(&usage_dir);
+    let cutoff = unused_since
+        .map(ChronoDuration::from_std)
+        .transpose()?
+        .map(|age| Utc::now() - age);
+    let mut skipped_recent = 0usize;
+    let entries = plan_cleanup_entries(records, &usage_dir, &root, cutoff, &mut skipped_recent);
+    execute_model_cleanup_entries(entries)
+}
+
+fn load_model_usage_records_from_dir(dir: &Path) -> Vec<ModelUsageRecord> {
+    let mut records = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return records;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("json") {
+            continue;
+        }
+        if let Some(record) = read_usage_record(&path) {
+            records.push(record);
+        }
+    }
+    records
+}
+
+fn read_usage_record(path: &Path) -> Option<ModelUsageRecord> {
+    let bytes = std::fs::read(path).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn record_model_usage_in_dir(
+    usage_dir: &Path,
+    track_root: &Path,
+    path: &Path,
+    managed_paths: &[PathBuf],
+    display_name: Option<&str>,
+    model_ref: Option<&str>,
+    source: Option<&str>,
+    mesh_managed: bool,
+) -> Result<()> {
+    let Some(lookup_key) = usage_lookup_key(path, track_root) else {
+        return Ok(());
+    };
+
+    let now = Utc::now().to_rfc3339();
+    let record_path = usage_record_path(usage_dir, &lookup_key);
+    let existing = read_usage_record(&record_path);
+    let primary_path = normalize_path(path);
+    let existing_display_name = existing
+        .as_ref()
+        .map(|record| record.display_name.as_str())
+        .filter(|value| !value.is_empty());
+    let existing_source = existing
+        .as_ref()
+        .map(|record| record.source.as_str())
+        .filter(|value| !value.is_empty());
+    let existing_model_ref = existing
+        .as_ref()
+        .and_then(|record| record.model_ref.as_deref());
+
+    let mut merged_paths = existing
+        .as_ref()
+        .map(|record| record.managed_paths.clone())
+        .unwrap_or_default();
+    if mesh_managed {
+        if managed_paths.is_empty() {
+            merged_paths.push(primary_path.clone());
+        } else {
+            merged_paths.extend(managed_paths.iter().map(|path| normalize_path(path)));
+        }
+    }
+    merged_paths = unique_paths(merged_paths);
+
+    let record = ModelUsageRecord {
+        lookup_key: lookup_key.clone(),
+        display_name: display_name
+            .or(existing_display_name)
+            .map(str::to_string)
+            .unwrap_or_else(|| default_display_name(&primary_path)),
+        model_ref: model_ref
+            .or(existing_model_ref)
+            .map(str::to_string)
+            .or_else(|| default_model_ref(&primary_path)),
+        source: source
+            .or(existing_source)
+            .map(str::to_string)
+            .unwrap_or_else(|| default_source(&primary_path)),
+        mesh_managed: mesh_managed || existing.as_ref().is_some_and(|record| record.mesh_managed),
+        primary_path,
+        managed_paths: merged_paths,
+        first_seen_at: existing
+            .as_ref()
+            .map(|record| record.first_seen_at.clone())
+            .unwrap_or_else(|| now.clone()),
+        last_used_at: now,
+    };
+
+    std::fs::create_dir_all(usage_dir)
+        .with_context(|| format!("Create {}", usage_dir.display()))?;
+    let bytes = serde_json::to_vec_pretty(&record)?;
+    std::fs::write(&record_path, bytes)
+        .with_context(|| format!("Write {}", record_path.display()))?;
+    Ok(())
+}
+
+fn plan_model_cleanup_in_dir(
+    usage_dir: &Path,
+    track_root: &Path,
+    unused_since: Option<Duration>,
+) -> Result<ModelCleanupPlan> {
+    let records = load_model_usage_records_from_dir(usage_dir);
+    let cutoff = unused_since
+        .map(ChronoDuration::from_std)
+        .transpose()?
+        .map(|age| Utc::now() - age);
+    let mut skipped_recent = 0usize;
+    let entries = plan_cleanup_entries(records, usage_dir, track_root, cutoff, &mut skipped_recent);
+    let mut plan = ModelCleanupPlan::default();
+    plan.skipped_recent = skipped_recent;
+    for entry in entries {
+        if entry.stale_record_only {
+            plan.stale_record_only += 1;
+        }
+        plan.total_files += entry.removable_paths.len();
+        plan.total_bytes += entry.total_bytes;
+        plan.candidates.push(ModelCleanupCandidate {
+            display_name: entry.record.display_name,
+            model_ref: entry.record.model_ref,
+            source: entry.record.source,
+            primary_path: entry.record.primary_path,
+            mesh_managed: entry.record.mesh_managed,
+            last_used_at: entry.record.last_used_at,
+            file_count: entry.removable_paths.len(),
+            total_bytes: entry.total_bytes,
+            stale_record_only: entry.stale_record_only,
+        });
+    }
+    plan.candidates.sort_by(|left, right| {
+        left.last_used_at
+            .cmp(&right.last_used_at)
+            .then_with(|| left.display_name.cmp(&right.display_name))
+    });
+    Ok(plan)
+}
+
+fn plan_cleanup_entries(
+    records: Vec<ModelUsageRecord>,
+    usage_dir: &Path,
+    track_root: &Path,
+    cutoff: Option<DateTime<Utc>>,
+    skipped_recent: &mut usize,
+) -> Vec<CleanupEntry> {
+    let mut entries = Vec::new();
+
+    for record in records {
+        if !record.mesh_managed {
+            continue;
+        }
+        let last_used =
+            parse_timestamp(&record.last_used_at).unwrap_or(DateTime::<Utc>::UNIX_EPOCH);
+        if let Some(cutoff) = cutoff {
+            if last_used > cutoff {
+                *skipped_recent += 1;
+                continue;
+            }
+        }
+
+        let removable_paths: Vec<PathBuf> = unique_paths(record.managed_paths.clone())
+            .into_iter()
+            .filter(|path| is_trackable_path(path, track_root))
+            .filter(|path| path.exists())
+            .collect();
+        let total_bytes = removable_paths
+            .iter()
+            .filter_map(|path| std::fs::metadata(path).ok().map(|meta| meta.len()))
+            .sum();
+        let stale_record_only = removable_paths.is_empty();
+        let record_path = usage_record_path(usage_dir, &record.lookup_key);
+
+        entries.push(CleanupEntry {
+            record,
+            record_path,
+            removable_paths,
+            total_bytes,
+            stale_record_only,
+        });
+    }
+
+    entries.sort_by(|left, right| {
+        left.record
+            .last_used_at
+            .cmp(&right.record.last_used_at)
+            .then_with(|| left.record.display_name.cmp(&right.record.display_name))
+    });
+    entries
+}
+
+fn execute_model_cleanup_entries(entries: Vec<CleanupEntry>) -> Result<ModelCleanupResult> {
+    let mut result = ModelCleanupResult::default();
+    for entry in entries {
+        for path in &entry.removable_paths {
+            if let Ok(meta) = std::fs::metadata(path) {
+                result.reclaimed_bytes += meta.len();
+            }
+            if path.exists() {
+                std::fs::remove_file(path).with_context(|| format!("Remove {}", path.display()))?;
+                result.removed_files += 1;
+            }
+            if let Some(cache_path) = gguf_metadata_cache_path(path) {
+                if cache_path.exists() {
+                    std::fs::remove_file(&cache_path).with_context(|| {
+                        format!("Remove metadata cache {}", cache_path.display())
+                    })?;
+                    result.removed_metadata_files += 1;
+                }
+            }
+            prune_empty_ancestors(path, &huggingface_hub_cache_dir());
+        }
+        if entry.record_path.exists() {
+            std::fs::remove_file(&entry.record_path)
+                .with_context(|| format!("Remove {}", entry.record_path.display()))?;
+            result.removed_records += 1;
+        }
+        result.removed_candidates += 1;
+    }
+    Ok(result)
+}
+
+fn usage_lookup_key(path: &Path, track_root: &Path) -> Option<String> {
+    if !is_trackable_path(path, track_root) {
+        return None;
+    }
+    if let Some(identity) = huggingface_identity_for_path(path) {
+        return Some(format!("hf:{}", identity.canonical_ref));
+    }
+    Some(format!(
+        "path:{}",
+        normalize_path(path).to_string_lossy().replace('\\', "/")
+    ))
+}
+
+fn usage_record_path(usage_dir: &Path, lookup_key: &str) -> PathBuf {
+    let digest = Sha256::digest(lookup_key.as_bytes());
+    usage_dir.join(format!("{digest:x}.json"))
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn unique_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut unique = Vec::new();
+    for path in paths {
+        let normalized = normalize_path(&path);
+        if seen.insert(normalized.clone()) {
+            unique.push(normalized);
+        }
+    }
+    unique.sort();
+    unique
+}
+
+fn parse_timestamp(value: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(value)
+        .ok()
+        .map(|parsed| parsed.with_timezone(&Utc))
+}
+
+fn default_display_name(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|value| value.to_str())
+        .or_else(|| path.file_name().and_then(|value| value.to_str()))
+        .unwrap_or("model")
+        .to_string()
+}
+
+fn default_model_ref(path: &Path) -> Option<String> {
+    huggingface_identity_for_path(path).map(|identity| identity.canonical_ref)
+}
+
+fn default_source(path: &Path) -> String {
+    if huggingface_identity_for_path(path).is_some() {
+        "huggingface-cache".to_string()
+    } else {
+        "local-cache".to_string()
+    }
+}
+
+fn is_trackable_path(path: &Path, track_root: &Path) -> bool {
+    let path = normalize_path(path);
+    let root = normalize_path(track_root);
+    path.starts_with(&root)
+}
+
+fn prune_empty_ancestors(path: &Path, stop_at: &Path) {
+    let stop_at = normalize_path(stop_at);
+    let mut current = path.parent().map(normalize_path);
+    while let Some(dir) = current {
+        if dir == stop_at {
+            break;
+        }
+        let Ok(mut entries) = std::fs::read_dir(&dir) else {
+            break;
+        };
+        if entries.next().is_some() {
+            break;
+        }
+        if std::fs::remove_dir(&dir).is_err() {
+            break;
+        }
+        current = dir.parent().map(normalize_path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_dir(prefix: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "{prefix}-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("system time should be after epoch")
+                .as_nanos()
+        ))
+    }
+
+    fn write_record(dir: &Path, record: &ModelUsageRecord) {
+        std::fs::create_dir_all(dir).expect("usage dir should be created");
+        let path = usage_record_path(dir, &record.lookup_key);
+        std::fs::write(
+            path,
+            serde_json::to_vec_pretty(record).expect("record JSON should serialize"),
+        )
+        .expect("record should be written");
+    }
+
+    #[test]
+    fn record_model_usage_merges_managed_paths() {
+        let usage_dir = temp_dir("mesh-llm-usage-dir");
+        let cache_root = temp_dir("mesh-llm-hf-cache");
+        let primary = cache_root
+            .join("models--Org--Demo")
+            .join("snapshots")
+            .join("rev1")
+            .join("Demo-Q4_K_M.gguf");
+        let shard = cache_root
+            .join("models--Org--Demo")
+            .join("snapshots")
+            .join("rev1")
+            .join("Demo-Q4_K_M-00002-of-00002.gguf");
+        std::fs::create_dir_all(primary.parent().expect("primary path should have parent"))
+            .expect("primary parent should exist");
+        std::fs::write(&primary, b"primary").expect("primary model should be written");
+        std::fs::write(&shard, b"shard").expect("shard model should be written");
+
+        record_model_usage_in_dir(
+            &usage_dir,
+            &cache_root,
+            &primary,
+            &[primary.clone(), shard.clone()],
+            Some("Demo-Q4_K_M"),
+            Some("Org/Demo@rev1/Demo-Q4_K_M.gguf"),
+            Some("catalog"),
+            true,
+        )
+        .expect("managed usage should be recorded");
+
+        let records = load_model_usage_records_from_dir(&usage_dir);
+        assert_eq!(records.len(), 1);
+        assert!(records[0].mesh_managed);
+        assert_eq!(records[0].managed_paths.len(), 2);
+        assert_eq!(records[0].display_name, "Demo-Q4_K_M");
+
+        let _ = std::fs::remove_dir_all(&usage_dir);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+
+    #[test]
+    fn cleanup_plan_filters_recent_and_external_records() {
+        let usage_dir = temp_dir("mesh-llm-usage-dir");
+        let cache_root = temp_dir("mesh-llm-hf-cache");
+        let old_path = cache_root
+            .join("models--Org--Old")
+            .join("snapshots")
+            .join("rev1")
+            .join("Old-Q4_K_M.gguf");
+        let recent_path = cache_root
+            .join("models--Org--Recent")
+            .join("snapshots")
+            .join("rev1")
+            .join("Recent-Q4_K_M.gguf");
+        let external_path = cache_root
+            .join("models--Org--External")
+            .join("snapshots")
+            .join("rev1")
+            .join("External-Q4_K_M.gguf");
+
+        for path in [&old_path, &recent_path, &external_path] {
+            std::fs::create_dir_all(path.parent().expect("test path should have parent"))
+                .expect("test parent should exist");
+            std::fs::write(path, vec![0_u8; 16]).expect("test model should be written");
+        }
+
+        write_record(
+            &usage_dir,
+            &ModelUsageRecord {
+                lookup_key: usage_lookup_key(&old_path, &cache_root).expect("old path should key"),
+                display_name: "Old".to_string(),
+                model_ref: None,
+                source: "catalog".to_string(),
+                mesh_managed: true,
+                primary_path: old_path.clone(),
+                managed_paths: vec![old_path.clone()],
+                first_seen_at: "2026-04-01T00:00:00Z".to_string(),
+                last_used_at: "2026-04-01T00:00:00Z".to_string(),
+            },
+        );
+        write_record(
+            &usage_dir,
+            &ModelUsageRecord {
+                lookup_key: usage_lookup_key(&recent_path, &cache_root)
+                    .expect("recent path should key"),
+                display_name: "Recent".to_string(),
+                model_ref: None,
+                source: "catalog".to_string(),
+                mesh_managed: true,
+                primary_path: recent_path.clone(),
+                managed_paths: vec![recent_path.clone()],
+                first_seen_at: Utc::now().to_rfc3339(),
+                last_used_at: Utc::now().to_rfc3339(),
+            },
+        );
+        write_record(
+            &usage_dir,
+            &ModelUsageRecord {
+                lookup_key: usage_lookup_key(&external_path, &cache_root)
+                    .expect("external path should key"),
+                display_name: "External".to_string(),
+                model_ref: None,
+                source: "local-cache".to_string(),
+                mesh_managed: false,
+                primary_path: external_path.clone(),
+                managed_paths: vec![],
+                first_seen_at: "2026-04-01T00:00:00Z".to_string(),
+                last_used_at: "2026-04-01T00:00:00Z".to_string(),
+            },
+        );
+
+        let plan =
+            plan_model_cleanup_in_dir(&usage_dir, &cache_root, Some(Duration::from_secs(60)))
+                .expect("cleanup plan should succeed");
+        assert_eq!(plan.candidates.len(), 1);
+        assert_eq!(plan.candidates[0].display_name, "Old");
+        assert_eq!(plan.skipped_recent, 1);
+
+        let _ = std::fs::remove_dir_all(&usage_dir);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+
+    #[test]
+    fn execute_cleanup_removes_files_and_records() {
+        let usage_dir = temp_dir("mesh-llm-usage-dir");
+        let cache_root = temp_dir("mesh-llm-hf-cache");
+        let primary = cache_root
+            .join("models--Org--Cleanup")
+            .join("snapshots")
+            .join("rev1")
+            .join("Cleanup-Q4_K_M.gguf");
+        std::fs::create_dir_all(primary.parent().expect("cleanup path should have parent"))
+            .expect("cleanup parent should exist");
+        std::fs::write(&primary, vec![0_u8; 32]).expect("cleanup model should be written");
+
+        let record = ModelUsageRecord {
+            lookup_key: usage_lookup_key(&primary, &cache_root).expect("cleanup path should key"),
+            display_name: "Cleanup".to_string(),
+            model_ref: Some("Org/Cleanup@rev1/Cleanup-Q4_K_M.gguf".to_string()),
+            source: "catalog".to_string(),
+            mesh_managed: true,
+            primary_path: primary.clone(),
+            managed_paths: vec![primary.clone()],
+            first_seen_at: "2026-04-01T00:00:00Z".to_string(),
+            last_used_at: "2026-04-01T00:00:00Z".to_string(),
+        };
+        write_record(&usage_dir, &record);
+
+        let mut skipped_recent = 0usize;
+        let entries = plan_cleanup_entries(
+            vec![record],
+            &usage_dir,
+            &cache_root,
+            None,
+            &mut skipped_recent,
+        );
+        let result = execute_model_cleanup_entries(entries).expect("cleanup should succeed");
+        assert_eq!(result.removed_candidates, 1);
+        assert_eq!(result.removed_files, 1);
+        assert_eq!(result.removed_records, 1);
+        assert!(!primary.exists());
+        assert!(load_model_usage_records_from_dir(&usage_dir).is_empty());
+
+        let _ = std::fs::remove_dir_all(&usage_dir);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+}

--- a/mesh-llm/src/models/usage.rs
+++ b/mesh-llm/src/models/usage.rs
@@ -18,6 +18,10 @@ pub struct ModelUsageRecord {
     pub mesh_managed: bool,
     pub primary_path: PathBuf,
     pub managed_paths: Vec<PathBuf>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hf_repo_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hf_revision: Option<String>,
     pub first_seen_at: String,
     pub last_used_at: String,
 }
@@ -62,6 +66,26 @@ struct CleanupEntry {
     stale_record_only: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RecordLocation {
+    lookup_key: String,
+    record_path: PathBuf,
+    record: Option<ModelUsageRecord>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct HuggingFaceRecordIdentity {
+    repo_id: String,
+    revision: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PathHuggingFaceIdentity {
+    repo_id: String,
+    revision: String,
+    canonical_ref: String,
+}
+
 pub fn model_usage_cache_dir() -> PathBuf {
     super::mesh_llm_cache_dir().join("model-usage")
 }
@@ -70,8 +94,7 @@ pub fn load_model_usage_record_for_path(path: &Path) -> Option<ModelUsageRecord>
     let usage_dir = model_usage_cache_dir();
     let root = huggingface_hub_cache_dir();
     let lookup_key = usage_lookup_key(path, &root)?;
-    let record_path = usage_record_path(&usage_dir, &lookup_key);
-    read_usage_record(&record_path)
+    resolve_record_location(&usage_dir, &lookup_key, &[normalize_path(path)]).record
 }
 
 pub fn track_model_usage(
@@ -169,11 +192,13 @@ fn record_model_usage_in_dir(
     let Some(lookup_key) = usage_lookup_key(path, track_root) else {
         return Ok(());
     };
-
     let now = Utc::now().to_rfc3339();
-    let record_path = usage_record_path(usage_dir, &lookup_key);
-    let existing = read_usage_record(&record_path);
     let primary_path = normalize_path(path);
+    let normalized_managed_paths = unique_paths(managed_paths.to_vec());
+    let candidate_paths = usage_record_candidate_paths(&primary_path, &normalized_managed_paths);
+    let location = resolve_record_location(usage_dir, &lookup_key, &candidate_paths);
+    let record_path = location.record_path;
+    let existing = location.record;
     let existing_display_name = existing
         .as_ref()
         .map(|record| record.display_name.as_str())
@@ -191,16 +216,18 @@ fn record_model_usage_in_dir(
         .map(|record| record.managed_paths.clone())
         .unwrap_or_default();
     if mesh_managed {
-        if managed_paths.is_empty() {
+        if normalized_managed_paths.is_empty() {
             merged_paths.push(primary_path.clone());
         } else {
-            merged_paths.extend(managed_paths.iter().map(|path| normalize_path(path)));
+            merged_paths.extend(normalized_managed_paths.iter().cloned());
         }
     }
     merged_paths = unique_paths(merged_paths);
+    let hf_identity = infer_record_hf_identity(&primary_path, &merged_paths, track_root)
+        .or_else(|| existing.as_ref().and_then(record_hf_identity));
 
     let record = ModelUsageRecord {
-        lookup_key: lookup_key.clone(),
+        lookup_key: location.lookup_key,
         display_name: display_name
             .or(existing_display_name)
             .map(str::to_string)
@@ -216,6 +243,12 @@ fn record_model_usage_in_dir(
         mesh_managed: mesh_managed || existing.as_ref().is_some_and(|record| record.mesh_managed),
         primary_path,
         managed_paths: merged_paths,
+        hf_repo_id: hf_identity
+            .as_ref()
+            .map(|identity| identity.repo_id.clone()),
+        hf_revision: hf_identity
+            .as_ref()
+            .map(|identity| identity.revision.clone()),
         first_seen_at: existing
             .as_ref()
             .map(|record| record.first_seen_at.clone())
@@ -296,6 +329,7 @@ fn plan_cleanup_entries(
         let removable_paths: Vec<PathBuf> = unique_paths(record.managed_paths.clone())
             .into_iter()
             .filter(|path| is_trackable_path(path, track_root))
+            .filter(|path| path_matches_record_identity(&record, path, track_root))
             .filter(|path| path.exists())
             .collect();
         let total_bytes = removable_paths
@@ -358,6 +392,9 @@ fn usage_lookup_key(path: &Path, track_root: &Path) -> Option<String> {
     if !is_trackable_path(path, track_root) {
         return None;
     }
+    if let Some(identity) = hf_identity_for_path_in_root(path, track_root) {
+        return Some(format!("hf:{}", identity.canonical_ref));
+    }
     if let Some(identity) = huggingface_identity_for_path(path) {
         return Some(format!("hf:{}", identity.canonical_ref));
     }
@@ -365,6 +402,137 @@ fn usage_lookup_key(path: &Path, track_root: &Path) -> Option<String> {
         "path:{}",
         normalize_path(path).to_string_lossy().replace('\\', "/")
     ))
+}
+
+fn resolve_record_location(
+    usage_dir: &Path,
+    direct_lookup_key: &str,
+    candidate_paths: &[PathBuf],
+) -> RecordLocation {
+    let direct_record_path = usage_record_path(usage_dir, direct_lookup_key);
+    if let Some(record) = read_usage_record(&direct_record_path) {
+        return RecordLocation {
+            lookup_key: direct_lookup_key.to_string(),
+            record_path: direct_record_path,
+            record: Some(record),
+        };
+    }
+
+    let Some(existing) = find_usage_record_by_paths(usage_dir, candidate_paths) else {
+        return RecordLocation {
+            lookup_key: direct_lookup_key.to_string(),
+            record_path: direct_record_path,
+            record: None,
+        };
+    };
+
+    let record_path = usage_record_path(usage_dir, &existing.lookup_key);
+    RecordLocation {
+        lookup_key: existing.lookup_key.clone(),
+        record_path,
+        record: Some(existing),
+    }
+}
+
+fn find_usage_record_by_paths(
+    usage_dir: &Path,
+    candidate_paths: &[PathBuf],
+) -> Option<ModelUsageRecord> {
+    let candidate_paths = unique_paths(candidate_paths.to_vec());
+    if candidate_paths.is_empty() {
+        return None;
+    }
+    let candidate_set: HashSet<PathBuf> = candidate_paths.iter().cloned().collect();
+    load_model_usage_records_from_dir(usage_dir)
+        .into_iter()
+        .find(|record| record_matches_any_path(record, &candidate_set))
+}
+
+fn record_matches_any_path(record: &ModelUsageRecord, candidate_paths: &HashSet<PathBuf>) -> bool {
+    let primary_path = normalize_path(&record.primary_path);
+    if candidate_paths.contains(&primary_path) {
+        return true;
+    }
+    if record
+        .managed_paths
+        .iter()
+        .map(|path| normalize_path(path))
+        .any(|path| candidate_paths.contains(&path))
+    {
+        return true;
+    }
+    false
+}
+
+fn usage_record_candidate_paths(primary_path: &Path, managed_paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut paths = vec![primary_path.to_path_buf()];
+    paths.extend(managed_paths.iter().cloned());
+    unique_paths(paths)
+}
+
+fn infer_record_hf_identity(
+    primary_path: &Path,
+    managed_paths: &[PathBuf],
+    track_root: &Path,
+) -> Option<HuggingFaceRecordIdentity> {
+    let mut paths = usage_record_candidate_paths(primary_path, managed_paths).into_iter();
+    let first = paths
+        .find_map(|path| hf_identity_for_path_in_root(&path, track_root))
+        .map(|identity| HuggingFaceRecordIdentity {
+            repo_id: identity.repo_id,
+            revision: identity.revision,
+        })?;
+
+    for path in usage_record_candidate_paths(primary_path, managed_paths) {
+        let Some(identity) = hf_identity_for_path_in_root(&path, track_root) else {
+            continue;
+        };
+        if identity.repo_id != first.repo_id || identity.revision != first.revision {
+            return None;
+        }
+    }
+    Some(first)
+}
+
+fn record_hf_identity(record: &ModelUsageRecord) -> Option<HuggingFaceRecordIdentity> {
+    Some(HuggingFaceRecordIdentity {
+        repo_id: record.hf_repo_id.clone()?,
+        revision: record.hf_revision.clone()?,
+    })
+}
+
+fn path_matches_record_identity(record: &ModelUsageRecord, path: &Path, track_root: &Path) -> bool {
+    let Some(record_identity) = record_hf_identity(record) else {
+        return true;
+    };
+    hf_identity_for_path_in_root(path, track_root).is_some_and(|identity| {
+        identity.repo_id == record_identity.repo_id && identity.revision == record_identity.revision
+    })
+}
+
+fn hf_identity_for_path_in_root(path: &Path, track_root: &Path) -> Option<PathHuggingFaceIdentity> {
+    let path = normalize_path(path);
+    let root = normalize_path(track_root);
+    let relative = path.strip_prefix(&root).ok()?;
+    let mut components = relative.components();
+    let repo_dir = components.next()?.as_os_str().to_str()?;
+    let repo_id = repo_dir.strip_prefix("models--")?.replace("--", "/");
+    if components.next()?.as_os_str() != "snapshots" {
+        return None;
+    }
+    let revision = components.next()?.as_os_str().to_str()?.to_string();
+    let relative_file = components
+        .map(|component| component.as_os_str().to_str())
+        .collect::<Option<Vec<_>>>()?
+        .join("/");
+    if relative_file.is_empty() {
+        return None;
+    }
+    Some(PathHuggingFaceIdentity {
+        repo_id: repo_id.clone(),
+        revision: revision.clone(),
+        canonical_ref: format!("{repo_id}@{revision}/{relative_file}"),
+    })
 }
 
 fn usage_record_path(usage_dir: &Path, lookup_key: &str) -> PathBuf {
@@ -444,10 +612,16 @@ fn prune_empty_ancestors(path: &Path, stop_at: &Path) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn temp_dir(prefix: &str) -> PathBuf {
+        let sequence = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!(
-            "{prefix}-{}",
+            "{prefix}-{}-{}-{}",
+            std::process::id(),
+            sequence,
             std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("system time should be after epoch")
@@ -501,6 +675,110 @@ mod tests {
         assert!(records[0].mesh_managed);
         assert_eq!(records[0].managed_paths.len(), 2);
         assert_eq!(records[0].display_name, "Demo-Q4_K_M");
+        assert_eq!(records[0].hf_repo_id.as_deref(), Some("Org/Demo"));
+        assert_eq!(records[0].hf_revision.as_deref(), Some("rev1"));
+
+        let _ = std::fs::remove_dir_all(&usage_dir);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+
+    #[test]
+    fn load_model_usage_record_for_split_shard_returns_bundle_record() {
+        let usage_dir = temp_dir("mesh-llm-usage-dir");
+        let cache_root = temp_dir("mesh-llm-hf-cache");
+        let primary = cache_root
+            .join("models--Org--Bundle")
+            .join("snapshots")
+            .join("rev1")
+            .join("Bundle-Q4_K_M-00001-of-00002.gguf");
+        let shard = cache_root
+            .join("models--Org--Bundle")
+            .join("snapshots")
+            .join("rev1")
+            .join("Bundle-Q4_K_M-00002-of-00002.gguf");
+        std::fs::create_dir_all(primary.parent().expect("primary path should have parent"))
+            .expect("primary parent should exist");
+        std::fs::write(&primary, b"primary").expect("primary model should be written");
+        std::fs::write(&shard, b"shard").expect("shard model should be written");
+
+        record_model_usage_in_dir(
+            &usage_dir,
+            &cache_root,
+            &primary,
+            &[primary.clone(), shard.clone()],
+            Some("Bundle-Q4_K_M"),
+            Some("Org/Bundle@rev1/Bundle-Q4_K_M-00001-of-00002.gguf"),
+            Some("catalog"),
+            true,
+        )
+        .expect("managed usage should be recorded");
+
+        let record = find_usage_record_by_paths(&usage_dir, &[shard.clone()])
+            .expect("split shard should resolve back to the bundle record");
+        assert_eq!(
+            record.lookup_key,
+            usage_lookup_key(&primary, &cache_root).expect("primary path should key")
+        );
+        assert_eq!(record.managed_paths.len(), 2);
+
+        let _ = std::fs::remove_dir_all(&usage_dir);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+
+    #[test]
+    fn record_model_usage_updates_last_used_at_by_managed_identity() {
+        let usage_dir = temp_dir("mesh-llm-usage-dir");
+        let cache_root = temp_dir("mesh-llm-hf-cache");
+        let primary = cache_root
+            .join("models--Org--Bundle")
+            .join("snapshots")
+            .join("rev1")
+            .join("Bundle-Q4_K_M-00001-of-00002.gguf");
+        let shard = cache_root
+            .join("models--Org--Bundle")
+            .join("snapshots")
+            .join("rev1")
+            .join("Bundle-Q4_K_M-00002-of-00002.gguf");
+        std::fs::create_dir_all(primary.parent().expect("primary path should have parent"))
+            .expect("primary parent should exist");
+        std::fs::write(&primary, b"primary").expect("primary model should be written");
+        std::fs::write(&shard, b"shard").expect("shard model should be written");
+
+        let lookup_key = usage_lookup_key(&primary, &cache_root).expect("primary path should key");
+        write_record(
+            &usage_dir,
+            &ModelUsageRecord {
+                lookup_key: lookup_key.clone(),
+                display_name: "Bundle-Q4_K_M".to_string(),
+                model_ref: Some("Org/Bundle@rev1/Bundle-Q4_K_M-00001-of-00002.gguf".to_string()),
+                source: "catalog".to_string(),
+                mesh_managed: true,
+                primary_path: primary.clone(),
+                managed_paths: vec![primary.clone(), shard.clone()],
+                hf_repo_id: Some("Org/Bundle".to_string()),
+                hf_revision: Some("rev1".to_string()),
+                first_seen_at: "2026-04-01T00:00:00Z".to_string(),
+                last_used_at: "2026-04-01T00:00:00Z".to_string(),
+            },
+        );
+
+        record_model_usage_in_dir(
+            &usage_dir,
+            &cache_root,
+            &shard,
+            &[],
+            None,
+            None,
+            Some("resolve"),
+            false,
+        )
+        .expect("usage refresh should succeed");
+
+        let records = load_model_usage_records_from_dir(&usage_dir);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].lookup_key, lookup_key);
+        assert_eq!(records[0].managed_paths.len(), 2);
+        assert_ne!(records[0].last_used_at, "2026-04-01T00:00:00Z");
 
         let _ = std::fs::remove_dir_all(&usage_dir);
         let _ = std::fs::remove_dir_all(&cache_root);
@@ -542,6 +820,8 @@ mod tests {
                 mesh_managed: true,
                 primary_path: old_path.clone(),
                 managed_paths: vec![old_path.clone()],
+                hf_repo_id: Some("Org/Old".to_string()),
+                hf_revision: Some("rev1".to_string()),
                 first_seen_at: "2026-04-01T00:00:00Z".to_string(),
                 last_used_at: "2026-04-01T00:00:00Z".to_string(),
             },
@@ -557,6 +837,8 @@ mod tests {
                 mesh_managed: true,
                 primary_path: recent_path.clone(),
                 managed_paths: vec![recent_path.clone()],
+                hf_repo_id: Some("Org/Recent".to_string()),
+                hf_revision: Some("rev1".to_string()),
                 first_seen_at: Utc::now().to_rfc3339(),
                 last_used_at: Utc::now().to_rfc3339(),
             },
@@ -572,6 +854,8 @@ mod tests {
                 mesh_managed: false,
                 primary_path: external_path.clone(),
                 managed_paths: vec![],
+                hf_repo_id: Some("Org/External".to_string()),
+                hf_revision: Some("rev1".to_string()),
                 first_seen_at: "2026-04-01T00:00:00Z".to_string(),
                 last_used_at: "2026-04-01T00:00:00Z".to_string(),
             },
@@ -609,6 +893,8 @@ mod tests {
             mesh_managed: true,
             primary_path: primary.clone(),
             managed_paths: vec![primary.clone()],
+            hf_repo_id: Some("Org/Cleanup".to_string()),
+            hf_revision: Some("rev1".to_string()),
             first_seen_at: "2026-04-01T00:00:00Z".to_string(),
             last_used_at: "2026-04-01T00:00:00Z".to_string(),
         };
@@ -628,6 +914,51 @@ mod tests {
         assert_eq!(result.removed_records, 1);
         assert!(!primary.exists());
         assert!(load_model_usage_records_from_dir(&usage_dir).is_empty());
+
+        let _ = std::fs::remove_dir_all(&usage_dir);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+
+    #[test]
+    fn cleanup_skips_paths_that_no_longer_match_record_identity() {
+        let usage_dir = temp_dir("mesh-llm-usage-dir");
+        let cache_root = temp_dir("mesh-llm-hf-cache");
+        let old_path = cache_root
+            .join("models--Org--Actual")
+            .join("snapshots")
+            .join("rev2")
+            .join("Actual-Q4_K_M.gguf");
+        std::fs::create_dir_all(old_path.parent().expect("cleanup path should have parent"))
+            .expect("cleanup parent should exist");
+        std::fs::write(&old_path, vec![0_u8; 32]).expect("cleanup model should be written");
+
+        let record = ModelUsageRecord {
+            lookup_key: "hf:Org/Expected@rev1/Expected-Q4_K_M.gguf".to_string(),
+            display_name: "Expected".to_string(),
+            model_ref: Some("Org/Expected@rev1/Expected-Q4_K_M.gguf".to_string()),
+            source: "catalog".to_string(),
+            mesh_managed: true,
+            primary_path: old_path.clone(),
+            managed_paths: vec![old_path.clone()],
+            hf_repo_id: Some("Org/Expected".to_string()),
+            hf_revision: Some("rev1".to_string()),
+            first_seen_at: "2026-04-01T00:00:00Z".to_string(),
+            last_used_at: "2026-04-01T00:00:00Z".to_string(),
+        };
+        write_record(&usage_dir, &record);
+
+        let mut skipped_recent = 0usize;
+        let entries = plan_cleanup_entries(
+            vec![record],
+            &usage_dir,
+            &cache_root,
+            None,
+            &mut skipped_recent,
+        );
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].removable_paths.is_empty());
+        assert!(entries[0].stale_record_only);
+        assert!(old_path.exists());
 
         let _ = std::fs::remove_dir_all(&usage_dir);
         let _ = std::fs::remove_dir_all(&cache_root);


### PR DESCRIPTION
## Summary

Users can now tell which cached models are mesh-managed versus external, see when mesh-llm last used them, and safely preview or remove only mesh-managed cache entries with `mesh-llm models cleanup`.

## Why

The shared Hugging Face cache can grow quickly, but today it is hard to tell which files mesh-llm actually downloaded or used and which ones belong to other tools. That makes cleanup risky and leaves users guessing about disk usage.

Related: #256

## Diff scope

- add mesh-owned model usage records under the mesh cache directory
- mark model usage from catalog downloads, exact-ref downloads, and cache-backed model resolution paths
- enrich `mesh-llm models installed` with `mesh-managed` vs `external` ownership and `last used`
- add `mesh-llm models cleanup` with dry-run-by-default behavior, `--unused-since`, and `--yes`
- remove only paths that mesh-llm explicitly marked as mesh-managed; external Hugging Face cache entries are never deleted
- update the README with the new cache inspection and cleanup workflow

## Example

```bash
mesh-llm models installed
mesh-llm models cleanup --unused-since 30d
mesh-llm models cleanup --unused-since 30d --yes
```

Representative output:

```text
Qwen2.5-3B-Instruct-Q4_K_M
  ownership: mesh-managed
  last used: 2h ago

Previewing cleanup candidates older than 30d
  would remove: Qwen2.5-3B-Instruct-Q4_K_M
```

## Architecture

- usage and ownership metadata live under the mesh-owned cache, not inside Hugging Face cache internals
- cleanup is keyed off explicit mesh usage records rather than filename heuristics
- tracked usage is limited to cache-backed model paths so arbitrary local files are not pulled into cleanup scope

## Protocol

Not applicable — no wire format or protocol changes.

## Validation

- `cd mesh-llm/ui && npm ci`
- `cd mesh-llm/ui && npm run build`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-model-cleanup-target cargo check -p mesh-llm`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-model-cleanup-target cargo test -p mesh-llm models::usage -- --nocapture` -> `3 passed; 0 failed`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-model-cleanup-target cargo test -p mesh-llm cleanup_age_parser -- --nocapture` -> `2 passed; 0 failed`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-model-cleanup-target cargo test -p mesh-llm models::catalog::tests -- --nocapture` -> `21 passed; 0 failed`
- `CARGO_HOME=/tmp/mesh-llm-cargo-home CARGO_TARGET_DIR=/tmp/mesh-llm-model-cleanup-target cargo test -p mesh-llm models::resolve::tests -- --nocapture` -> `37 passed; 0 failed`
- `git diff --check`

## Known residual risks

- the broader crate test suite still has unrelated existing failures in this environment outside the touched model/cache paths
- cleanup only removes cache entries that mesh-llm explicitly marked as mesh-managed; it does not try to infer ownership for pre-existing third-party cache files
