### PR TITLE
scripts: fix silent build exit when neither ccache nor sccache is installed

### DIFF
--- a/scripts/build-linux-rocm.sh
+++ b/scripts/build-linux-rocm.sh
@@ -44,7 +44,7 @@ configure_compiler_cache() {
     elif command -v ccache >/dev/null 2>&1; then
         cache_bin="ccache"
     else
-        return
+        return 0
     fi
 
     echo "Using compiler cache: $cache_bin"

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -164,7 +164,7 @@ configure_compiler_cache() {
     elif command -v ccache >/dev/null 2>&1; then
         cache_bin="ccache"
     else
-        return
+        return 0
     fi
 
     echo "Using compiler cache: $cache_bin"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -28,7 +28,7 @@ configure_compiler_cache() {
     elif command -v ccache >/dev/null 2>&1; then
         cache_bin="ccache"
     else
-        return
+        return 0
     fi
 
     echo "Using compiler cache: $cache_bin"


### PR DESCRIPTION
Closes #303.

## Summary

`configure_compiler_cache()` in `scripts/build-linux.sh` (and its identical copies in `scripts/build-linux-rocm.sh` and `scripts/build-release.sh`) has a bare `return` in the `else` branch. Under the calling script's `set -euo pipefail`, the bare `return` carries the non-zero exit status from the preceding failed `command -v ccache` check and kills the entire build with no diagnostic output — just ~3 seconds after llama.cpp is cloned.

## Fix

Explicit `return 0` so the no-op "neither cache tool installed" path doesn't poison `$?`. One-line change, applied identically across all three backend scripts that carry the copy-pasted helper.

## Reproduction (from #303)

In an otherwise-complete builder container that deliberately lacks `ccache`/`sccache`:

```
Cloning Mesh-LLM/llama.cpp pinned to ...
HEAD is now at ed279fa ...
error: Recipe `release-build-cuda` failed on line 59 with exit code 1
```

`bash -x scripts/build-linux.sh --backend cuda --cuda-arch 80` confirms the last trace is `+ return` from `configure_compiler_cache`, with the script exiting immediately after (no cmake output). With this patch, the builder proceeds past `configure_compiler_cache` and `cmake` runs normally.

## Test

Verified locally on a fresh `nvidia/cuda:12.6.3-devel-ubuntu24.04` container without ccache/sccache installed: before the patch, `just release-build-cuda "80"` dies silently in 3 s; after the patch, it proceeds to cmake and compiles. Also re-verified the happy path (ccache installed) still reaches the `Using compiler cache: ccache` message.