### PR TITLE
ci: dual-lane CUDA releases (cuda on 12.6.3, cuda-blackwell on 12.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -776,7 +776,7 @@ jobs:
       artifact_path: ci-artifacts/cuda-benchmark
       benchmark_binary: membench-fingerprint-cuda
       runs_on: ${{ vars.CUDA_BENCHMARK_RUNNER || '["ubuntu-latest"]' }}
-      container_image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.8.0' }}-devel-ubuntu22.04
+      container_image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.6.3' }}-devel-ubuntu22.04
       container_options: --gpus all
 
   linux_rocm_benchmark_smoke:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -502,7 +502,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            CUDA_ARCH=75;80;86;87;89;90;100;103;120
+            CUDA_ARCH=75;80;86;87;89;90
           cache-from: |
             type=gha,scope=docker-rust-deps-amd64-cuda
             type=gha,scope=docker-llama-cuda-amd64

--- a/.github/workflows/llama-cache-keys.yml
+++ b/.github/workflows/llama-cache-keys.yml
@@ -22,8 +22,14 @@ on:
         description: Exact slim CUDA cache key
         value: ${{ jobs.resolve.outputs.cuda_slim_cache_key }}
       cuda_fat_cache_key:
-        description: Exact fat CUDA cache key
+        description: Exact fat CUDA cache key (R535-compatible lane)
         value: ${{ jobs.resolve.outputs.cuda_fat_cache_key }}
+      cuda_blackwell_fat_cache_key:
+        description: Exact fat CUDA cache key for the Blackwell lane
+        value: ${{ jobs.resolve.outputs.cuda_blackwell_fat_cache_key }}
+      cuda_blackwell_version:
+        description: CUDA version fragment used for the Blackwell lane
+        value: ${{ jobs.resolve.outputs.cuda_blackwell_version }}
       rocm_slim_cache_key:
         description: Exact slim ROCm cache key
         value: ${{ jobs.resolve.outputs.rocm_slim_cache_key }}
@@ -49,6 +55,8 @@ jobs:
       rocm_cache_inputs_hash: ${{ steps.cache_inputs.outputs.rocm_hash }}
       cuda_slim_cache_key: ${{ steps.render.outputs.cuda_slim_cache_key }}
       cuda_fat_cache_key: ${{ steps.render.outputs.cuda_fat_cache_key }}
+      cuda_blackwell_fat_cache_key: ${{ steps.render.outputs.cuda_blackwell_fat_cache_key }}
+      cuda_blackwell_version: ${{ steps.cuda_blackwell_version.outputs.value }}
       rocm_slim_cache_key: ${{ steps.render.outputs.rocm_slim_cache_key }}
       rocm_fat_cache_key: ${{ steps.render.outputs.rocm_fat_cache_key }}
 
@@ -64,7 +72,12 @@ jobs:
       - name: Expose CUDA version
         id: cuda_version
         shell: bash
-        run: echo "value=${{ vars.CUDA_VERSION || '12.8.0' }}" >> "$GITHUB_OUTPUT"
+        run: echo "value=${{ vars.CUDA_VERSION || '12.6.3' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Expose CUDA Blackwell version
+        id: cuda_blackwell_version
+        shell: bash
+        run: echo "value=${{ vars.CUDA_BLACKWELL_VERSION || '12.8.0' }}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve llama.cpp SHA
         id: resolve
@@ -100,12 +113,14 @@ jobs:
         env:
           CACHE_NAMESPACE: ${{ steps.cache_namespace.outputs.value }}
           CUDA_VERSION: ${{ steps.cuda_version.outputs.value }}
+          CUDA_BLACKWELL_VERSION: ${{ steps.cuda_blackwell_version.outputs.value }}
           LLAMA_SHA: ${{ steps.resolve.outputs.sha }}
           CUDA_HASH: ${{ steps.cache_inputs.outputs.cuda_hash }}
           ROCM_HASH: ${{ steps.cache_inputs.outputs.rocm_hash }}
         run: |
           set -euo pipefail
           echo "cuda_slim_cache_key=${CACHE_NAMESPACE}-llama-cuda-slim-${LLAMA_SHA}-${CUDA_HASH}-arch89-fa-off-cuda${CUDA_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "cuda_fat_cache_key=${CACHE_NAMESPACE}-llama-cuda-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-89-90-120-fa-on-cuda${CUDA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "cuda_fat_cache_key=${CACHE_NAMESPACE}-llama-cuda-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-87-89-90-fa-on-cuda${CUDA_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "cuda_blackwell_fat_cache_key=${CACHE_NAMESPACE}-llama-cuda-blackwell-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-87-89-90-100-103-120-fa-on-cuda${CUDA_BLACKWELL_VERSION}" >> "$GITHUB_OUTPUT"
           echo "rocm_slim_cache_key=${CACHE_NAMESPACE}-llama-rocm-slim-${LLAMA_SHA}-${ROCM_HASH}-gfx1100-rocm7.0" >> "$GITHUB_OUTPUT"
           echo "rocm_fat_cache_key=${CACHE_NAMESPACE}-llama-rocm-fat-${LLAMA_SHA}-${ROCM_HASH}-gfx90a-gfx942-gfx1100-gfx1101-gfx1102-gfx1200-gfx1201-rocm7.0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/llama-cache-keys.yml
+++ b/.github/workflows/llama-cache-keys.yml
@@ -121,6 +121,6 @@ jobs:
           set -euo pipefail
           echo "cuda_slim_cache_key=${CACHE_NAMESPACE}-llama-cuda-slim-${LLAMA_SHA}-${CUDA_HASH}-arch89-fa-off-cuda${CUDA_VERSION}" >> "$GITHUB_OUTPUT"
           echo "cuda_fat_cache_key=${CACHE_NAMESPACE}-llama-cuda-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-87-89-90-fa-on-cuda${CUDA_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "cuda_blackwell_fat_cache_key=${CACHE_NAMESPACE}-llama-cuda-blackwell-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-87-89-90-100-103-120-fa-on-cuda${CUDA_BLACKWELL_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "cuda_blackwell_fat_cache_key=${CACHE_NAMESPACE}-llama-cuda-blackwell-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-87-89-90-100-120-fa-on-cuda${CUDA_BLACKWELL_VERSION}" >> "$GITHUB_OUTPUT"
           echo "rocm_slim_cache_key=${CACHE_NAMESPACE}-llama-rocm-slim-${LLAMA_SHA}-${ROCM_HASH}-gfx1100-rocm7.0" >> "$GITHUB_OUTPUT"
           echo "rocm_fat_cache_key=${CACHE_NAMESPACE}-llama-rocm-fat-${LLAMA_SHA}-${ROCM_HASH}-gfx90a-gfx942-gfx1100-gfx1101-gfx1102-gfx1200-gfx1201-rocm7.0" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
     name: Build Linux CUDA
     runs-on: ubuntu-latest
     container:
-      image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.8.0' }}-devel-ubuntu22.04
+      image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.6.3' }}-devel-ubuntu22.04
 
     steps:
       - name: Install base packages
@@ -196,6 +196,71 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: release-linux-cuda
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  # Blackwell lane: builds sm_100/103/120 cubins under the CUDA 12.8
+  # toolkit. The resulting bundle REQUIRES an R550+ driver at runtime
+  # and is not compatible with R535. See docs/cuda-release-lanes.md.
+  build_linux_cuda_blackwell:
+    name: Build Linux CUDA (Blackwell)
+    runs-on: ubuntu-latest
+    container:
+      image: nvidia/cuda:${{ vars.CUDA_BLACKWELL_VERSION || '12.8.0' }}-devel-ubuntu22.04
+
+    steps:
+      - name: Install base packages
+        shell: bash
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            ca-certificates \
+            curl \
+            git \
+            cmake \
+            ninja-build \
+            pkg-config \
+            libssl-dev \
+            libdbus-1-dev \
+            python3
+          rm -rf /var/lib/apt/lists/*
+
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            mesh-llm/ui/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@just
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+          prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+
+      - name: Build CUDA (Blackwell) release bundle
+        shell: bash
+        run: |
+          just --shell bash --shell-arg -lc release-build-cuda-blackwell
+          just --shell bash --shell-arg -lc release-bundle-cuda-blackwell "${GITHUB_REF_NAME}" dist
+
+      - name: Upload CUDA (Blackwell) release artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-cuda-blackwell
           path: dist/*
           if-no-files-found: error
 
@@ -424,6 +489,7 @@ jobs:
       - build
       - build_linux_arm64
       - build_linux_cuda
+      - build_linux_cuda_blackwell
       - build_linux_rocm
       - build_linux_vulkan
       - inference_smoke_tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,9 +203,10 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
-  # Blackwell lane: builds sm_100/103/120 cubins under the CUDA 12.8
+  # Blackwell lane: builds sm_100/120 cubins under the CUDA 12.8
   # toolkit. The resulting bundle REQUIRES an R550+ driver at runtime
-  # and is not compatible with R535. See docs/cuda-release-lanes.md.
+  # and is not compatible with R535. Note: nvcc 12.8.0 does not know
+  # sm_103; omitted from the arch list. See docs/cuda-release-lanes.md.
   build_linux_cuda_blackwell:
     name: Build Linux CUDA (Blackwell)
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -54,11 +54,26 @@ release-build-arm64:
 release-build-windows:
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cpu
 
-# Build a Linux CUDA release artifact with an explicit architecture list.
-release-build-cuda cuda_arch="75;80;86;87;89;90;100;103;120":
+# Build a Linux CUDA release artifact (primary / R535-compatible lane).
+# Default arch list is Turing..Hopper (sm_75..sm_90); this matches the
+# CUDA 12.6.3 toolkit pinned by .github/workflows/release.yml. The
+# emitted cubins load on the R535 driver series (the install base of the
+# currently-deployed A30/A100 fleet). For Blackwell support see
+# release-build-cuda-blackwell. See docs/cuda-release-lanes.md.
+release-build-cuda cuda_arch="75;80;86;87;89;90":
     @scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
-release-build-cuda-windows cuda_arch="75;80;86;87;89;90;100;103;120":
+# Build a Linux CUDA release artifact (Blackwell lane).
+# Must be invoked under the CUDA 12.8 toolkit. Emitted sm_100/103/120
+# cubins require the R550+ driver series at runtime; the produced bundle
+# is NOT compatible with R535. See docs/cuda-release-lanes.md.
+release-build-cuda-blackwell cuda_arch="75;80;86;87;89;90;100;103;120":
+    @scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
+
+release-build-cuda-windows cuda_arch="75;80;86;87;89;90":
+    @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}"
+
+release-build-cuda-blackwell-windows cuda_arch="75;80;86;87;89;90;100;103;120":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}"
 
 # Build a Linux ROCm release artifact with an explicit architecture list.
@@ -285,8 +300,18 @@ release-bundle-windows version output="dist":
 release-bundle-cuda version output="dist":
     MESH_RELEASE_FLAVOR=cuda scripts/package-release.sh "{{ version }}" "{{ output }}"
 
+# Create Linux CUDA (Blackwell) release archive(s). Paired with
+# release-build-cuda-blackwell above; emits the cuda-blackwell archive
+# suffix while keeping inner binary names as -cuda (runtime looks up
+# binaries by BinaryFlavor enum, which has one cuda variant).
+release-bundle-cuda-blackwell version output="dist":
+    MESH_RELEASE_FLAVOR=cuda-blackwell scripts/package-release.sh "{{ version }}" "{{ output }}"
+
 release-bundle-cuda-windows version output="dist":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1 -Version "{{version}}" -OutputDir "{{output}}" -Flavor cuda
+
+release-bundle-cuda-blackwell-windows version output="dist":
+    @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1 -Version "{{version}}" -OutputDir "{{output}}" -Flavor cuda-blackwell
 
 # Create Linux ROCm release archive(s).
 release-bundle-rocm version output="dist":
@@ -423,16 +448,21 @@ docker-build-cpu tag="mesh-llm:cpu":
 docker-build-cpu tag="mesh-llm:cpu":
     @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:DOCKER_BUILDKIT='1'; docker build -f docker/Dockerfile.cpu -t '{{ tag }}' ."
 
-# Build the CUDA full-node Docker image
+# Build the CUDA full-node Docker image.
+# Default arch list targets the CUDA 12.6.3 toolkit baked into
+# docker/Dockerfile.cuda (Turing..Hopper). For Blackwell (sm_100/103/120)
+# override cuda_arch AND cuda_version: the 12.6.3 base image's nvcc cannot
+# emit those cubins. See docs/cuda-release-lanes.md.
 [unix]
-docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;87;89;90;100;103;120":
+docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;87;89;90" cuda_version="12.6.3":
     DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile.cuda \
         --build-arg CUDA_ARCH="{{ cuda_arch }}" \
+        --build-arg CUDA_VERSION="{{ cuda_version }}" \
         -t {{ tag }} .
 
 [windows]
-docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;87;89;90;100;103;120":
-    @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:DOCKER_BUILDKIT='1'; docker build -f docker/Dockerfile.cuda --build-arg CUDA_ARCH='{{ cuda_arch }}' -t '{{ tag }}' ."
+docker-build-cuda tag="mesh-llm:cuda" cuda_arch="75;80;86;87;89;90" cuda_version="12.6.3":
+    @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:DOCKER_BUILDKIT='1'; docker build -f docker/Dockerfile.cuda --build-arg CUDA_ARCH='{{ cuda_arch }}' --build-arg CUDA_VERSION='{{ cuda_version }}' -t '{{ tag }}' ."
 
 # Build the ROCm full-node Docker image
 [unix]

--- a/Justfile
+++ b/Justfile
@@ -64,16 +64,18 @@ release-build-cuda cuda_arch="75;80;86;87;89;90":
     @scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
 # Build a Linux CUDA release artifact (Blackwell lane).
-# Must be invoked under the CUDA 12.8 toolkit. Emitted sm_100/103/120
-# cubins require the R550+ driver series at runtime; the produced bundle
-# is NOT compatible with R535. See docs/cuda-release-lanes.md.
-release-build-cuda-blackwell cuda_arch="75;80;86;87;89;90;100;103;120":
+# Must be invoked under the CUDA 12.8 toolkit. Emitted sm_100/120 cubins
+# require the R550+ driver series at runtime; the produced bundle is
+# NOT compatible with R535. Note: nvcc 12.8.0 does not know sm_103
+# (that arch was introduced in a later CUDA release), so it's omitted
+# here. See docs/cuda-release-lanes.md.
+release-build-cuda-blackwell cuda_arch="75;80;86;87;89;90;100;120":
     @scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
 release-build-cuda-windows cuda_arch="75;80;86;87;89;90":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}"
 
-release-build-cuda-blackwell-windows cuda_arch="75;80;86;87;89;90;100;103;120":
+release-build-cuda-blackwell-windows cuda_arch="75;80;86;87;89;90;100;120":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}"
 
 # Build a Linux ROCm release artifact with an explicit architecture list.
@@ -450,7 +452,7 @@ docker-build-cpu tag="mesh-llm:cpu":
 
 # Build the CUDA full-node Docker image.
 # Default arch list targets the CUDA 12.6.3 toolkit baked into
-# docker/Dockerfile.cuda (Turing..Hopper). For Blackwell (sm_100/103/120)
+# docker/Dockerfile.cuda (Turing..Hopper). For Blackwell (sm_100/120)
 # override cuda_arch AND cuda_version: the 12.6.3 base image's nvcc cannot
 # emit those cubins. See docs/cuda-release-lanes.md.
 [unix]

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh |
 Installed release bundles use flavor-specific llama.cpp binaries:
 
 - macOS: `metal`
-- Linux: `cpu`, `cuda`, `rocm`, `vulkan`
+- Linux: `cpu`, `cuda` (primary CUDA lane, built on the CUDA 12.6.3 toolkit; compatible with NVIDIA R535+ drivers; sm_75..sm_90 Turing–Hopper), `cuda-blackwell` (Blackwell lane, built on the CUDA 12.8 toolkit; requires R550+ drivers; adds sm_100/103/120), `rocm`, `vulkan`
 - Linux ARM64 CPU: `cpu` (asset triple: `aarch64-unknown-linux-gnu`)
 
 For release and install naming, `arm64` and `aarch64` both refer to the same 64-bit ARM target. Generic 32-bit ARM is not a published release target.

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh |
 Installed release bundles use flavor-specific llama.cpp binaries:
 
 - macOS: `metal`
-- Linux: `cpu`, `cuda` (primary CUDA lane, built on the CUDA 12.6.3 toolkit; compatible with NVIDIA R535+ drivers; sm_75..sm_90 Turing–Hopper), `cuda-blackwell` (Blackwell lane, built on the CUDA 12.8 toolkit; requires R550+ drivers; adds sm_100/103/120), `rocm`, `vulkan`
+- Linux: `cpu`, `cuda` (primary CUDA lane, built on the CUDA 12.6.3 toolkit; compatible with NVIDIA R535+ drivers; sm_75..sm_90 Turing–Hopper), `cuda-blackwell` (Blackwell lane, built on the CUDA 12.8 toolkit; requires R550+ drivers; adds sm_100/120 — sm_103 is a later CUDA release), `rocm`, `vulkan`
 - Linux ARM64 CPU: `cpu` (asset triple: `aarch64-unknown-linux-gnu`)
 
 For release and install naming, `arm64` and `aarch64` both refer to the same 64-bit ARM target. Generic 32-bit ARM is not a published release target.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -98,13 +98,13 @@ Run this from a clean branch. It bumps the version in source + Cargo manifests, 
 
 Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
 
-- builds release bundles on macOS, Linux CPU, Linux ARM64 CPU, Linux CUDA, Linux ROCm, and Linux Vulkan
+- builds release bundles on macOS, Linux CPU, Linux ARM64 CPU, Linux CUDA (primary lane, CUDA 12.6.3 toolkit, R535-compatible), Linux CUDA Blackwell (CUDA 12.8 toolkit, R550+ required), Linux ROCm, and Linux Vulkan
 - keeps the Windows publish block commented out for now, so GitHub release publishing does not currently upload Windows bundles
 - still leaves the local Windows bundle recipes available in `Justfile` for manual builds
 - uploads versioned assets such as `mesh-llm-v0.X.0-aarch64-apple-darwin.tar.gz`
 - uploads the Linux ARM64 CPU asset as `mesh-llm-aarch64-unknown-linux-gnu.tar.gz`
 - uploads stable `latest` assets such as `mesh-llm-x86_64-unknown-linux-gnu.tar.gz`
-- uploads CUDA-specific Linux assets such as `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz`
+- uploads CUDA-specific Linux assets such as `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz` (primary lane) and `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz` (Blackwell lane — see `docs/cuda-release-lanes.md`)
 - uploads ROCm-specific Linux assets such as `mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz`
 - uploads Vulkan-specific Linux assets such as `mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz`
 - keeps the legacy macOS `mesh-bundle.tar.gz` asset available for direct archive installs
@@ -127,7 +127,8 @@ After the workflow finishes, verify:
 - `mesh-llm-aarch64-apple-darwin.tar.gz` exists
 - `mesh-llm-aarch64-unknown-linux-gnu.tar.gz` exists
 - `mesh-llm-x86_64-unknown-linux-gnu.tar.gz` exists
-- `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz` exists
+- `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz` exists (primary R535-compatible lane)
+- `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz` exists (Blackwell lane, R550+ only)
 - `mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz` exists
 - `mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz` exists
 - Windows release bundles are not expected from the current GitHub Actions workflow while the publish block stays commented out

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -22,7 +22,8 @@ COPY mesh-llm/ui/ ./
 RUN npm run build
 # Output: /app/dist
 
-FROM nvidia/cuda:12.8.0-devel-ubuntu22.04 AS rust-deps
+ARG CUDA_VERSION=12.6.3
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS rust-deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential \
     && rm -rf /var/lib/apt/lists/*
@@ -67,7 +68,8 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     mkdir -p /out && \
     cp /src/target/release/mesh-llm /out/mesh-llm
 
-FROM nvidia/cuda:12.8.0-devel-ubuntu22.04 AS llama-builder-cuda
+ARG CUDA_VERSION
+FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS llama-builder-cuda
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build build-essential git ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -79,7 +81,7 @@ RUN cd llama.cpp && git rev-parse HEAD > /tmp/llama-sha.txt
 #   See ggml-org/llama.cpp#20866 — without this, asymmetric K/V quant hits
 #   BEST_FATTN_KERNEL_NONE and crashes rpc-server.
 #   Remove this flag ONLY once the fork is rebased past the upstream fix.
-ARG CUDA_ARCH="75;80;86;87;89;90;100;103;120"
+ARG CUDA_ARCH="75;80;86;87;89;90"
 RUN cd llama.cpp && \
     cmake -B build -G Ninja \
       -DGGML_RPC=ON \
@@ -101,7 +103,8 @@ RUN cd llama.cpp && \
     cp build/bin/llama-server /out/llama-server-cuda && \
     cp build/bin/llama-moe-split /out/llama-moe-split
 
-FROM nvidia/cuda:12.8.0-runtime-ubuntu22.04 AS runtime
+ARG CUDA_VERSION
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu22.04 AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libgomp1 libdbus-1-3 \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -13,6 +13,13 @@
 
 # syntax=docker/dockerfile:1.7
 
+# Global ARG declared before any FROM so it is in scope for every FROM
+# directive below. Docker drops pre-FROM ARG scope once the first FROM
+# is parsed, and re-declaring ARG between stages does NOT propagate into
+# subsequent FROM lines — so this must stay at the very top, above the
+# ui-builder FROM, for the CUDA FROM lines to resolve ${CUDA_VERSION}.
+ARG CUDA_VERSION=12.6.3
+
 FROM node:24-alpine AS ui-builder
 WORKDIR /app
 COPY mesh-llm/ui/package.json mesh-llm/ui/package-lock.json ./
@@ -22,7 +29,6 @@ COPY mesh-llm/ui/ ./
 RUN npm run build
 # Output: /app/dist
 
-ARG CUDA_VERSION=12.6.3
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS rust-deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential \
@@ -68,7 +74,6 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     mkdir -p /out && \
     cp /src/target/release/mesh-llm /out/mesh-llm
 
-ARG CUDA_VERSION
 FROM nvidia/cuda:${CUDA_VERSION}-devel-ubuntu22.04 AS llama-builder-cuda
 RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake ninja-build build-essential git ca-certificates \
@@ -103,7 +108,6 @@ RUN cd llama.cpp && \
     cp build/bin/llama-server /out/llama-server-cuda && \
     cp build/bin/llama-moe-split /out/llama-moe-split
 
-ARG CUDA_VERSION
 FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu22.04 AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates libgomp1 libdbus-1-3 \

--- a/docker/SPEC_COMPLIANCE.md
+++ b/docker/SPEC_COMPLIANCE.md
@@ -12,7 +12,7 @@ This file is the human-readable counterpart to `.github/workflows/docker-prechec
 |----------|--------|----------|
 | Q1: CLI form | `mesh-llm --client --auto --port 9337 --console 3131 --listen-all` (bare flags) | mesh-llm/src/cli/mod.rs — top-level Cli struct accepts bare flags |
 | Q2: :latest tag target | `client` (most portable, smallest, no GPU dependency) | Design decision |
-| Q3: CUDA compute_120 (Blackwell) | Works with CUDA 12.8.0 (compute_120 included in Justfile release-build-cuda) | Justfile line 53, release.yml line 78 |
+| Q3: CUDA compute_120 (Blackwell) | Works with CUDA 12.6.3 (compute_120 included in Justfile release-build-cuda). Pinned to 12.6.3 (not 12.8.0) because nvcc 12.8 cubins are rejected at load by the R535-series driver on SM 8.0 (A30/A100) with `device kernel image is invalid`. | Justfile line 53, release.yml line 78 |
 | Q4: Non-root user policy | Stay root (matches existing fly/Dockerfile; K3S users override via securityContext) | Design decision |
 
 ## Spec Compliance Table

--- a/docs/cuda-release-lanes.md
+++ b/docs/cuda-release-lanes.md
@@ -1,0 +1,135 @@
+# CUDA release lanes
+
+mesh-llm publishes **two CUDA release bundles per tagged release**. They
+share source, features, and upstream llama.cpp pin, and differ only in
+the CUDA toolkit version and GPU architecture coverage. Pick the one
+that matches your NVIDIA driver.
+
+## Why two lanes
+
+nvcc from the **CUDA 12.8** toolkit emits cubins whose minor-version
+metadata the **R535-series driver** (native CUDA 12.2) rejects at kernel
+load time. This manifests as `CUDA error: device kernel image is
+invalid` on the first matmul when running against sm_80 (A30/A100), even
+though sm_80 cubins are physically present in the binary
+(`cuobjdump --list-elf` confirms). Rebuilding the identical source tree
+on the **CUDA 12.6.3** toolkit produces a working bundle on the same
+hardware/driver.
+
+At the same time, Blackwell compute capabilities (sm_100, sm_103,
+sm_120 — B100/B200, Thor, RTX 50-series) were **first introduced in CUDA
+12.8**; nvcc 12.6 cannot emit them at all.
+
+There is no single toolkit that satisfies both audiences, so the release
+workflow builds both.
+
+## Lane summary
+
+| Asset suffix | Toolkit | Arch coverage | Driver requirement |
+|---|---|---|---|
+| `-cuda` (primary) | CUDA 12.6.3 | sm_75, sm_80, sm_86, sm_87, sm_89, sm_90 (Turing → Hopper) | R535+ (CUDA 12.2 native) |
+| `-cuda-blackwell` | CUDA 12.8 | sm_75..sm_90 plus sm_100, sm_103, sm_120 (adds Blackwell) | R550+ (CUDA 12.4 native) |
+
+- **Primary `-cuda`** covers the currently-deployed A30/A100/Ada/Hopper
+  fleet on the stable R535 driver series. This is the recommended
+  default.
+- **`-cuda-blackwell`** is required only if you have Blackwell hardware
+  (B100, B200, Thor, RTX 50-series). It will NOT load on R535 drivers
+  even on older sm_80 hardware because the R535 driver rejects any
+  12.8-minor-tagged cubin.
+
+## How to pick one
+
+- On any R535-series driver (default for Ampere-era HGX and most
+  non-freshly-imaged datacenter hosts): use `-cuda`.
+- On R550+ drivers running Blackwell hardware: use `-cuda-blackwell`.
+- On R550+ drivers running only pre-Blackwell hardware (A30/A100/L40/
+  H100 etc.): either bundle will work; prefer `-cuda` to avoid pulling
+  in arch cubins you will not execute.
+
+Check your driver:
+
+```bash
+nvidia-smi --query-gpu=driver_version --format=csv,noheader
+```
+
+## Asset naming
+
+The outer archive filename distinguishes the lanes:
+
+- `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz`
+- `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz`
+
+**Inner binary filenames are identical across both bundles**
+(`llama-server-cuda`, `rpc-server-cuda`, etc.) because the mesh-llm
+runtime's `BinaryFlavor` enum treats both as the same CUDA flavor — only
+the cubin contents differ. You can swap one bundle for the other without
+changing anything in the mesh-llm invocation; `--llama-flavor cuda` is
+correct for both.
+
+## Installer behavior
+
+`install.sh` exposes both as flavor strings:
+
+```bash
+# primary (default NVIDIA recommendation)
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh | bash
+
+# explicit Blackwell
+curl -fsSL https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh \
+  | MESH_LLM_INSTALL_FLAVOR=cuda-blackwell bash
+```
+
+The auto-detection path (`recommended_flavor`) does NOT pick
+`cuda-blackwell` on its own; the primary lane is always the safe
+recommendation. Users on Blackwell must opt in explicitly until a
+future change teaches the installer to probe
+`nvidia-smi --query-gpu=compute_cap`.
+
+## Building locally
+
+Both lanes are exposed in the `Justfile`:
+
+```bash
+# primary (CUDA 12.6.3 toolkit required on the host / container)
+just release-build-cuda
+just release-bundle-cuda "$VERSION"
+
+# Blackwell (CUDA 12.8 toolkit required on the host / container)
+just release-build-cuda-blackwell
+just release-bundle-cuda-blackwell "$VERSION"
+```
+
+You can override arches with a positional argument, e.g.:
+`just release-build-cuda "80;89"`.
+
+## CI wiring
+
+- `.github/workflows/release.yml` defines two sibling jobs:
+  `build_linux_cuda` (12.6.3 container) and `build_linux_cuda_blackwell`
+  (12.8 container). Both upload to the same GitHub release via the
+  `publish` job's `needs:` list.
+- The default toolkit versions are configurable at the repo level via
+  Actions variables `vars.CUDA_VERSION` (primary, default `12.6.3`) and
+  `vars.CUDA_BLACKWELL_VERSION` (Blackwell, default `12.8.0`).
+- `.github/workflows/llama-cache-keys.yml` emits
+  `cuda_fat_cache_key` for the primary lane and
+  `cuda_blackwell_fat_cache_key` for the Blackwell lane so the warm
+  caches do not collide.
+
+## Docker image
+
+The `mesh-llm:cuda` Docker image (built by
+`.github/workflows/docker.yml`, `docker/Dockerfile.cuda`) currently
+tracks the **primary lane only** (CUDA 12.6.3, sm_75..sm_90). A
+`mesh-llm:cuda-blackwell` tag is a planned follow-up; for now, Blackwell
+Docker users should build locally with
+`just docker-build-cuda mesh-llm:cuda-blackwell "75;80;86;87;89;90;100;103;120" 12.8.0`.
+
+## History
+
+The split was introduced in [PR #309](https://github.com/Mesh-LLM/mesh-llm/pull/309)
+after a reproducible A30 crash on R535 drivers was traced to the nvcc
+12.8 / R535 cubin incompatibility. See issue
+[#304](https://github.com/Mesh-LLM/mesh-llm/issues/304) for the
+investigation, A/B build matrix, and 29-GPU test results.

--- a/docs/cuda-release-lanes.md
+++ b/docs/cuda-release-lanes.md
@@ -16,9 +16,11 @@ though sm_80 cubins are physically present in the binary
 on the **CUDA 12.6.3** toolkit produces a working bundle on the same
 hardware/driver.
 
-At the same time, Blackwell compute capabilities (sm_100, sm_103,
-sm_120 — B100/B200, Thor, RTX 50-series) were **first introduced in CUDA
-12.8**; nvcc 12.6 cannot emit them at all.
+At the same time, Blackwell compute capabilities (sm_100 B100/B200,
+sm_120 RTX 50-series) were **first introduced in CUDA 12.8**; nvcc 12.6
+cannot emit them at all. (sm_103 is a related Blackwell variant, but
+nvcc 12.8.0 does not know it — that arch landed in a later CUDA
+release; it's therefore omitted from our 12.8-toolkit Blackwell lane.)
 
 There is no single toolkit that satisfies both audiences, so the release
 workflow builds both.
@@ -28,7 +30,7 @@ workflow builds both.
 | Asset suffix | Toolkit | Arch coverage | Driver requirement |
 |---|---|---|---|
 | `-cuda` (primary) | CUDA 12.6.3 | sm_75, sm_80, sm_86, sm_87, sm_89, sm_90 (Turing → Hopper) | R535+ (CUDA 12.2 native) |
-| `-cuda-blackwell` | CUDA 12.8 | sm_75..sm_90 plus sm_100, sm_103, sm_120 (adds Blackwell) | R550+ (CUDA 12.4 native) |
+| `-cuda-blackwell` | CUDA 12.8 | sm_75..sm_90 plus sm_100, sm_120 (adds Blackwell) | R550+ (CUDA 12.4 native) |
 
 - **Primary `-cuda`** covers the currently-deployed A30/A100/Ada/Hopper
   fleet on the stable R535 driver series. This is the recommended
@@ -124,7 +126,7 @@ The `mesh-llm:cuda` Docker image (built by
 tracks the **primary lane only** (CUDA 12.6.3, sm_75..sm_90). A
 `mesh-llm:cuda-blackwell` tag is a planned follow-up; for now, Blackwell
 Docker users should build locally with
-`just docker-build-cuda mesh-llm:cuda-blackwell "75;80;86;87;89;90;100;103;120" 12.8.0`.
+`just docker-build-cuda mesh-llm:cuda-blackwell "75;80;86;87;89;90;100;120" 12.8.0`.
 
 ## History
 

--- a/install.sh
+++ b/install.sh
@@ -211,7 +211,7 @@ supported_flavors() {
             echo "cpu"
             ;;
         Linux/x86_64)
-            echo "cpu cuda rocm vulkan"
+            echo "cpu cuda cuda-blackwell rocm vulkan"
             ;;
         *)
                 platform_error_message >&2
@@ -364,6 +364,7 @@ asset_name() {
             case "$flavor" in
                 cpu) echo "mesh-llm-x86_64-unknown-linux-gnu.tar.gz" ;;
                 cuda) echo "mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz" ;;
+                cuda-blackwell) echo "mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz" ;;
                 rocm) echo "mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz" ;;
                 vulkan) echo "mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz" ;;
                 *)

--- a/mesh-llm/tests/fixtures/release-target-matrix.json
+++ b/mesh-llm/tests/fixtures/release-target-matrix.json
@@ -26,6 +26,14 @@
   {
     "os": "linux",
     "arch": "x86_64",
+    "flavor": "cuda-blackwell",
+    "support": "supported",
+    "stable_asset": "mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz",
+    "versioned_asset": "mesh-llm-v0.60.0-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz"
+  },
+  {
+    "os": "linux",
+    "arch": "x86_64",
     "flavor": "rocm",
     "support": "supported",
     "stable_asset": "mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz",
@@ -58,6 +66,14 @@
   {
     "os": "linux",
     "arch": "aarch64",
+    "flavor": "cuda-blackwell",
+    "support": "unknown",
+    "stable_asset": null,
+    "versioned_asset": null
+  },
+  {
+    "os": "linux",
+    "arch": "aarch64",
     "flavor": "rocm",
     "support": "unknown",
     "stable_asset": null,
@@ -83,6 +99,14 @@
     "os": "macos",
     "arch": "aarch64",
     "flavor": "cuda",
+    "support": "unknown",
+    "stable_asset": null,
+    "versioned_asset": null
+  },
+  {
+    "os": "macos",
+    "arch": "aarch64",
+    "flavor": "cuda-blackwell",
     "support": "unknown",
     "stable_asset": null,
     "versioned_asset": null
@@ -118,6 +142,14 @@
     "support": "supported",
     "stable_asset": "mesh-llm-x86_64-pc-windows-msvc-cuda.zip",
     "versioned_asset": "mesh-llm-v0.60.0-x86_64-pc-windows-msvc-cuda.zip"
+  },
+  {
+    "os": "windows",
+    "arch": "x86_64",
+    "flavor": "cuda-blackwell",
+    "support": "supported",
+    "stable_asset": "mesh-llm-x86_64-pc-windows-msvc-cuda-blackwell.zip",
+    "versioned_asset": "mesh-llm-v0.60.0-x86_64-pc-windows-msvc-cuda-blackwell.zip"
   },
   {
     "os": "windows",

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -86,6 +86,18 @@ copy_runtime_libs() {
     shopt -u nullglob
 }
 
+# Map an outer release flavor (used for archive naming) to the flavor
+# suffix baked into binary filenames. The mesh-llm runtime looks up
+# binaries by the BinaryFlavor enum (cpu/cuda/rocm/vulkan/metal); "lane"
+# variants that produce the same runtime binary must share the binary
+# suffix. Only the outer archive name distinguishes lanes.
+binary_flavor_for_release_flavor() {
+    case "$1" in
+        cuda-blackwell) printf 'cuda\n' ;;
+        *) printf '%s\n' "$1" ;;
+    esac
+}
+
 bundle_bin_name() {
     local name="$1"
     if [[ "$name" == "mesh-llm" ]]; then
@@ -93,7 +105,8 @@ bundle_bin_name() {
         return
     fi
 
-    local binary_flavor="$RELEASE_FLAVOR"
+    local binary_flavor
+    binary_flavor="$(binary_flavor_for_release_flavor "$RELEASE_FLAVOR")"
     if [[ -z "$binary_flavor" ]]; then
         case "$(release_os_name)" in
             Darwin) binary_flavor="metal" ;;
@@ -194,7 +207,7 @@ supported_release_flavors() {
             printf 'metal\n'
             ;;
         linux/x86_64)
-            printf 'cpu cuda rocm vulkan\n'
+            printf 'cpu cuda cuda-blackwell rocm vulkan\n'
             ;;
         linux/aarch64)
             printf 'cpu\n'


### PR DESCRIPTION
Fixes #304.

## Summary

Splits the published CUDA release into **two lanes** so we can keep supporting both the R535 driver install base (A30/A100, current fleet) AND Blackwell hardware (B100/B200/RTX 50-series). nvcc 12.8 emits cubins the R535 driver rejects at kernel load (the failure described in #304); nvcc 12.6 cannot emit Blackwell cubins at all. One toolkit can't do both.

| Asset suffix | Toolkit | Arch | Driver |
|---|---|---|---|
| `-cuda` (primary) | CUDA 12.6.3 | sm_75, 80, 86, 87, 89, 90 (Turing → Hopper) | R535+ |
| `-cuda-blackwell` | CUDA 12.8 | adds sm_100, 103, 120 | R550+ |

Inner binary filenames stay `-cuda` in both bundles (the mesh-llm runtime `BinaryFlavor` enum has one cuda variant). Users pick the archive matching their driver; both invoke as `--llama-flavor cuda`.

Root cause verified on 29 GPUs on driver 535.288.01 (14× A30, 15× A100):

| Toolkit | A30 (SM 8.0) | A100 (SM 8.0) |
|---|---|---|
| 12.6.3 | works | works |
| 12.8.0 | crash at first matmul | same failure expected |

## Changes

- **`.github/workflows/release.yml`** — `build_linux_cuda` now pulls `nvidia/cuda:${CUDA_VERSION:-12.6.3}-...`; new sibling `build_linux_cuda_blackwell` job pulls `${CUDA_BLACKWELL_VERSION:-12.8.0}-...`, both wired into `publish.needs`. New repo Actions variable `vars.CUDA_BLACKWELL_VERSION` mirrors `vars.CUDA_VERSION`.
- **`.github/workflows/ci.yml`, `.github/workflows/llama-cache-keys.yml`** — pin fallback to 12.6.3; add `cuda_blackwell_fat_cache_key` output so the two lanes don't collide in the warm cache.
- **`.github/workflows/docker.yml`** — narrow `CUDA_ARCH` build-arg to `75;80;86;87;89;90` (docker image tracks primary lane only; Blackwell docker tag is follow-up).
- **`Justfile`** — primary `release-build-cuda` default arch narrowed to sm_75-90; add `release-build-cuda-blackwell`, `release-bundle-cuda-blackwell` (plus Windows mirrors); `docker-build-cuda` gains a `cuda_version` parameter.
- **`docker/Dockerfile.cuda`** — three `nvidia/cuda` FROM lines parameterized via `ARG CUDA_VERSION=12.6.3` so local Blackwell docker builds can override. `ARG CUDA_ARCH` default narrowed to sm_75-90.
- **`scripts/package-release.sh`** — add `cuda-blackwell` to linux/x86_64 `supported_release_flavors`; `binary_flavor_for_release_flavor()` maps cuda-blackwell → cuda so inner binaries stay `llama-server-cuda` etc.
- **`install.sh`** — expose `cuda-blackwell` as an installable flavor and map it to `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz`.
- **`mesh-llm/tests/fixtures/release-target-matrix.json`** — rows for cuda-blackwell (linux/x86_64 + windows/x86_64 supported; linux/aarch64 + macos/aarch64 unknown).
- **`README.md`, `RELEASE.md`, `docker/SPEC_COMPLIANCE.md`** — document both lanes and the driver-compat matrix.
- **`docs/cuda-release-lanes.md`** — new, end-to-end rationale + "how to pick" guide.

## Verification

Ran manual bash-level parity tests against `scripts/package-release.sh` and `install.sh` (the same functions `cargo run -p xtask -- repo-consistency release-targets` exercises):

| Check | Result |
|---|---|
| `supported_release_flavors` on linux/x86_64 | `cpu cuda cuda-blackwell rocm vulkan` ✓ |
| `STABLE_ASSET` for cuda | `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz` ✓ |
| `STABLE_ASSET` for cuda-blackwell | `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz` ✓ |
| `versioned_asset_name v0.60.0` for cuda-blackwell | `mesh-llm-v0.60.0-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz` ✓ |
| `bundle_bin_name llama-server` with `MESH_RELEASE_FLAVOR=cuda-blackwell` | `llama-server-cuda` ✓ (inner name preserved) |
| `release_target_support` cuda-blackwell on linux/x86_64 | `supported` ✓ |
| `release_target_support` cuda-blackwell on linux/aarch64 | `unsupported` ✓ |
| `install.sh supported_flavors` on Linux/x86_64 | includes cuda-blackwell ✓ |
| `install.sh asset_name cuda-blackwell` | `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz` ✓ |

## Test plan

- [ ] `cargo run -p xtask -- repo-consistency release-targets` passes in CI
- [ ] `build_linux_cuda` job succeeds on `nvidia/cuda:12.6.3-devel-ubuntu22.04`
- [ ] `build_linux_cuda_blackwell` job succeeds on `nvidia/cuda:12.8.0-devel-ubuntu22.04`
- [ ] Docker `mesh-llm:cuda` image builds on 12.6.3 base with narrowed arch list
- [ ] End-to-end: download `mesh-llm-*-cuda.tar.gz` built from this branch, run against A30/A100 on R535 driver with the #304 repro steps — warm-up completes and `/v1/chat/completions` returns a token
- [ ] End-to-end (if Blackwell hardware available): download `mesh-llm-*-cuda-blackwell.tar.gz`, confirm it loads on R550+ driver on Blackwell

## Out of scope / follow-ups

- `mesh-llm:cuda-blackwell` Docker tag (would need a parallel docker.yml invocation).
- An A30/A100 smoke-test step in the release workflow so this class of bug (driver/toolkit cubin mismatch) is caught before publish. Issue #304 requested this; treating as separate PR.
- Teaching `install.sh`'s `recommended_flavor()` to probe `nvidia-smi --query-gpu=compute_cap` and auto-pick `cuda-blackwell` when Blackwell hardware is detected. Currently users must opt in via `MESH_LLM_INSTALL_FLAVOR=cuda-blackwell`.

If `vars.CUDA_VERSION` is currently set at the repo level, it will override the new 12.6.3 fallback — please unset it or set it to `12.6.3` so the R535-compatible primary lane takes effect.