### PR TITLE
Share split GGUF MoE rankings under stable distribution refs

### DIFF
--- a/mesh-llm/src/cli/commands/moe/hf_jobs.rs
+++ b/mesh-llm/src/cli/commands/moe/hf_jobs.rs
@@ -24,7 +24,7 @@ pub(crate) async fn submit_full_analyze_job(
 ) -> Result<()> {
     let identity = remote_identity(model_spec).await?;
     let spec = JobSubmissionSpec {
-        model_ref: identity.canonical_ref.clone(),
+        model_ref: identity.distribution_ref(),
         analyzer: RemoteAnalyzer::Full {
             context_size,
             n_gpu_layers,
@@ -56,7 +56,7 @@ pub(crate) async fn submit_micro_analyze_job(
 ) -> Result<()> {
     let identity = remote_identity(model_spec).await?;
     let spec = JobSubmissionSpec {
-        model_ref: identity.canonical_ref.clone(),
+        model_ref: identity.distribution_ref(),
         analyzer: RemoteAnalyzer::Micro {
             prompt_count,
             token_count,

--- a/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/mesh-llm/src/cli/commands/moe/mod.rs
@@ -360,7 +360,7 @@ fn print_submit_suggestion(model_path: &Path) {
         return;
     };
     println!("📤 Contribute this ranking to mesh-llm so other users can reuse it:");
-    println!("  mesh-llm moe share '{}'", identity.canonical_ref);
+    println!("  mesh-llm moe share '{}'", identity.distribution_ref());
 }
 
 async fn run_share(model: &str, ranking_file: Option<&Path>, dataset_repo: &str) -> Result<()> {

--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -879,7 +879,7 @@ fn print_runtime_submit_suggestion(model_name: &str, model_path: &Path, ranking_
     eprintln!("⚠️  [{model_name}] This run did not use a published ranking.");
     eprintln!(
         "📤 [{model_name}] Contribute it with: mesh-llm moe share '{}'",
-        identity.canonical_ref
+        identity.distribution_ref()
     );
 }
 

--- a/mesh-llm/src/models/local.rs
+++ b/mesh-llm/src/models/local.rs
@@ -16,6 +16,44 @@ pub struct HuggingFaceModelIdentity {
     pub local_file_name: String,
 }
 
+impl HuggingFaceModelIdentity {
+    pub fn distribution_ref(&self) -> String {
+        format!(
+            "{}@{}/{}",
+            self.repo_id,
+            self.revision,
+            distribution_ref_file(&self.file)
+        )
+    }
+}
+
+fn distribution_ref_file(file: &str) -> String {
+    let path = Path::new(file);
+    let file_name = path.file_name().and_then(|value| value.to_str());
+    let Some(file_name) = file_name else {
+        return file.to_string();
+    };
+    let Some(stem) = file_name.strip_suffix(".gguf") else {
+        return file.to_string();
+    };
+    let Some((prefix, suffix)) = stem.rsplit_once("-of-") else {
+        return file.to_string();
+    };
+    let Some((prefix, shard_no)) = prefix.rsplit_once('-') else {
+        return file.to_string();
+    };
+    if shard_no.len() != 5
+        || suffix.len() != 5
+        || !shard_no.chars().all(|ch| ch.is_ascii_digit())
+        || !suffix.chars().all(|ch| ch.is_ascii_digit())
+    {
+        return file.to_string();
+    }
+    path.with_file_name(prefix)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
 fn hf_hub_cache_override() -> Option<PathBuf> {
     let path = std::env::var("HF_HUB_CACHE").ok()?;
     let trimmed = path.trim();
@@ -869,6 +907,55 @@ mod tests {
         restore_env("HF_HUB_CACHE", prev_hub_cache);
         restore_env("HF_HOME", prev_hf_home);
         restore_env("XDG_CACHE_HOME", prev_xdg);
+    }
+
+    #[test]
+    fn distribution_ref_preserves_unsplit_exact_file() {
+        let identity = HuggingFaceModelIdentity {
+            repo_id: "unsloth/Qwen3.6-35B-A3B-GGUF".to_string(),
+            revision: "deadbeef".to_string(),
+            file: "BF16/Qwen3.6-35B-A3B-BF16.gguf".to_string(),
+            canonical_ref: "unsloth/Qwen3.6-35B-A3B-GGUF@deadbeef/BF16/Qwen3.6-35B-A3B-BF16.gguf"
+                .to_string(),
+            local_file_name: "Qwen3.6-35B-A3B-BF16.gguf".to_string(),
+        };
+
+        assert_eq!(
+            identity.distribution_ref(),
+            "unsloth/Qwen3.6-35B-A3B-GGUF@deadbeef/BF16/Qwen3.6-35B-A3B-BF16.gguf"
+        );
+    }
+
+    #[test]
+    fn distribution_ref_strips_split_suffix_for_split_gguf() {
+        let identity = HuggingFaceModelIdentity {
+            repo_id: "unsloth/Qwen3.6-35B-A3B-GGUF".to_string(),
+            revision: "deadbeef".to_string(),
+            file: "BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf".to_string(),
+            canonical_ref: "unsloth/Qwen3.6-35B-A3B-GGUF@deadbeef/BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf".to_string(),
+            local_file_name: "Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf".to_string(),
+        };
+
+        assert_eq!(
+            identity.distribution_ref(),
+            "unsloth/Qwen3.6-35B-A3B-GGUF@deadbeef/BF16/Qwen3.6-35B-A3B-BF16"
+        );
+    }
+
+    #[test]
+    fn distribution_ref_strips_non_first_split_suffix_for_split_gguf() {
+        let identity = HuggingFaceModelIdentity {
+            repo_id: "unsloth/Qwen3.6-35B-A3B-GGUF".to_string(),
+            revision: "deadbeef".to_string(),
+            file: "BF16/Qwen3.6-35B-A3B-BF16-00002-of-00002.gguf".to_string(),
+            canonical_ref: "unsloth/Qwen3.6-35B-A3B-GGUF@deadbeef/BF16/Qwen3.6-35B-A3B-BF16-00002-of-00002.gguf".to_string(),
+            local_file_name: "Qwen3.6-35B-A3B-BF16-00002-of-00002.gguf".to_string(),
+        };
+
+        assert_eq!(
+            identity.distribution_ref(),
+            "unsloth/Qwen3.6-35B-A3B-GGUF@deadbeef/BF16/Qwen3.6-35B-A3B-BF16"
+        );
     }
 
     fn restore_env(key: &str, value: Option<std::ffi::OsString>) {


### PR DESCRIPTION
Users can now share and submit MoE rankings for split GGUF models without publishing a shard-specific Hugging Face path.

This changes the share and HF job flows to normalize split GGUF files like `...-00001-of-00002.gguf` and `...-00002-of-00002.gguf` to the distribution ref instead of the individual shard path.

Example:
Before: `unsloth/Qwen3.6-35B-A3B-GGUF@<rev>/BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf`
After: `unsloth/Qwen3.6-35B-A3B-GGUF@<rev>/BF16/Qwen3.6-35B-A3B-BF16`

Changes:
- add `HuggingFaceModelIdentity::distribution_ref()` for canonical distribution-level refs
- use the normalized ref in `mesh-llm moe share` suggestions
- use the normalized ref for HF MoE analyze job submission
- add regression tests for unsplit and split GGUF refs

Validation:
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- `just build`