### PR TITLE
Fix: Update AMD device naming from HIP to ROCm to match upstream llama.cpp

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -98,7 +98,7 @@ RUN cd llama.cpp && \
 
 FROM rocm/dev-ubuntu-24.04:7.0 AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libgomp1 libdbus-1-3 \
+    ca-certificates libgomp1 libdbus-1-3 hipblas rocblas rocm-smi \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=rust-builder /out/mesh-llm /usr/local/bin/mesh-llm
 COPY --from=llama-builder-rocm /out/rpc-server-rocm /usr/local/lib/mesh-llm/bin/rpc-server-rocm

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -336,7 +336,7 @@ pub(crate) struct Cli {
     #[arg(long, value_enum)]
     pub(crate) llama_flavor: Option<crate::inference::launch::BinaryFlavor>,
 
-    /// Device for rpc-server (e.g. MTL0, CUDA0, HIP0, Vulkan0, CPU).
+    /// Device for rpc-server (e.g. MTL0, CUDA0, ROCm0, Vulkan0, CPU).
     #[arg(long, hide = true)]
     pub(crate) device: Option<String>,
 

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -682,7 +682,7 @@ fn resolve_device_for_binary(
             if available.iter().any(|candidate| candidate == device) {
                 return Ok(device.to_string());
             }
-            
+
             // Dual support for ROCm/HIP transition
             let is_amd_requested = device.starts_with("ROCm") || device.starts_with("HIP");
             if is_amd_requested {

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -66,7 +66,7 @@ impl BinaryFlavor {
         match self {
             BinaryFlavor::Cpu => &["CPU"],
             BinaryFlavor::Cuda => &["CUDA0", "CPU"],
-            BinaryFlavor::Rocm => &["ROCm0", "CPU"],
+            BinaryFlavor::Rocm => &["ROCm0", "HIP0", "CPU"],
             BinaryFlavor::Vulkan => &["Vulkan0", "CPU"],
             BinaryFlavor::Metal => &["MTL0", "CPU"],
         }
@@ -659,7 +659,7 @@ fn preferred_device(available: &[String], flavor: Option<BinaryFlavor>) -> Optio
     let candidates: &[&str] = if let Some(flavor) = flavor {
         flavor.preferred_devices()
     } else {
-        &["MTL0", "CUDA0", "ROCm0", "Vulkan0", "CPU"]
+        &["MTL0", "CUDA0", "ROCm0", "HIP0", "Vulkan0", "CPU"]
     };
 
     for candidate in candidates {
@@ -678,7 +678,24 @@ fn resolve_device_for_binary(
     let available = probe_available_devices(binary);
 
     if let Some(device) = requested {
-        if !available.is_empty() && !available.iter().any(|candidate| candidate == device) {
+        if !available.is_empty() {
+            if available.iter().any(|candidate| candidate == device) {
+                return Ok(device.to_string());
+            }
+            
+            // Dual support for ROCm/HIP transition
+            let is_amd_requested = device.starts_with("ROCm") || device.starts_with("HIP");
+            if is_amd_requested {
+                let alt_device = if device.starts_with("ROCm") {
+                    device.replace("ROCm", "HIP")
+                } else {
+                    device.replace("HIP", "ROCm")
+                };
+                if available.iter().any(|candidate| candidate == &alt_device) {
+                    return Ok(alt_device);
+                }
+            }
+
             anyhow::bail!(
                 "requested device {device} is not supported by {}. Available devices: {}",
                 binary.display(),

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -66,7 +66,7 @@ impl BinaryFlavor {
         match self {
             BinaryFlavor::Cpu => &["CPU"],
             BinaryFlavor::Cuda => &["CUDA0", "CPU"],
-            BinaryFlavor::Rocm => &["HIP0", "CPU"],
+            BinaryFlavor::Rocm => &["ROCm0", "CPU"],
             BinaryFlavor::Vulkan => &["Vulkan0", "CPU"],
             BinaryFlavor::Metal => &["MTL0", "CPU"],
         }
@@ -659,7 +659,7 @@ fn preferred_device(available: &[String], flavor: Option<BinaryFlavor>) -> Optio
     let candidates: &[&str] = if let Some(flavor) = flavor {
         flavor.preferred_devices()
     } else {
-        &["MTL0", "CUDA0", "HIP0", "Vulkan0", "CPU"]
+        &["MTL0", "CUDA0", "ROCm0", "Vulkan0", "CPU"]
     };
 
     for candidate in candidates {
@@ -1532,7 +1532,7 @@ fn detect_device() -> String {
 
     // ROCm/HIP
     if has_rocm_backend() {
-        return "HIP0".to_string();
+        return "ROCm0".to_string();
     }
 
     // Vulkan

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -859,8 +859,21 @@ fn startup_rpc_backend_device<'a>(
         .map(|gpu| gpu.backend_device.as_str());
 
     if let (Some(cli_device), Some(pinned_device)) = (cli_device, pinned_device) {
+        let is_match = cli_device == pinned_device;
+        let is_lenient_match = is_match || {
+            let is_amd_cli = cli_device.starts_with("ROCm") || cli_device.starts_with("HIP");
+            let is_amd_pinned = pinned_device.starts_with("ROCm") || pinned_device.starts_with("HIP");
+            if is_amd_cli && is_amd_pinned {
+                let cli_idx = cli_device.trim_start_matches("ROCm").trim_start_matches("HIP");
+                let pinned_idx = pinned_device.trim_start_matches("ROCm").trim_start_matches("HIP");
+                cli_idx == pinned_idx && !cli_idx.is_empty()
+            } else {
+                false
+            }
+        };
+
         anyhow::ensure!(
-            cli_device == pinned_device,
+            is_lenient_match,
             "explicit --device '{cli_device}' conflicts with pinned startup GPU backend device '{pinned_device}'"
         );
         return Ok(Some(cli_device));
@@ -3262,6 +3275,34 @@ mod tests {
         assert!(err
             .to_string()
             .contains("conflicts with pinned startup GPU backend device"));
+    }
+
+    #[test]
+    fn pinned_gpu_startup_rpc_device_allows_lenient_amd_match() {
+        let primary_startup_model = StartupModelPlan {
+            declared_ref: "Qwen3-8B-Q4_K_M".into(),
+            resolved_path: PathBuf::from("/tmp/Qwen3-8B-Q4_K_M.gguf"),
+            mmproj_path: None,
+            ctx_size: Some(8192),
+            gpu_id: Some("pci:0000:65:00.0".into()),
+            pinned_gpu: Some(StartupPinnedGpuTarget {
+                index: 0,
+                stable_id: "pci:0000:65:00.0".into(),
+                backend_device: "ROCm0".into(),
+                vram_bytes: 24_000_000_000,
+            }),
+        };
+
+        let device1 =
+            startup_rpc_backend_device(Some("HIP0"), Some(&primary_startup_model)).unwrap();
+        assert_eq!(device1, Some("HIP0"));
+
+        let mut model_hip = primary_startup_model.clone();
+        model_hip.pinned_gpu.as_mut().unwrap().backend_device = "HIP1".into();
+
+        let device2 =
+            startup_rpc_backend_device(Some("ROCm1"), Some(&model_hip)).unwrap();
+        assert_eq!(device2, Some("ROCm1"));
     }
 
     #[test]

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -862,10 +862,15 @@ fn startup_rpc_backend_device<'a>(
         let is_match = cli_device == pinned_device;
         let is_lenient_match = is_match || {
             let is_amd_cli = cli_device.starts_with("ROCm") || cli_device.starts_with("HIP");
-            let is_amd_pinned = pinned_device.starts_with("ROCm") || pinned_device.starts_with("HIP");
+            let is_amd_pinned =
+                pinned_device.starts_with("ROCm") || pinned_device.starts_with("HIP");
             if is_amd_cli && is_amd_pinned {
-                let cli_idx = cli_device.trim_start_matches("ROCm").trim_start_matches("HIP");
-                let pinned_idx = pinned_device.trim_start_matches("ROCm").trim_start_matches("HIP");
+                let cli_idx = cli_device
+                    .trim_start_matches("ROCm")
+                    .trim_start_matches("HIP");
+                let pinned_idx = pinned_device
+                    .trim_start_matches("ROCm")
+                    .trim_start_matches("HIP");
                 cli_idx == pinned_idx && !cli_idx.is_empty()
             } else {
                 false
@@ -3300,8 +3305,7 @@ mod tests {
         let mut model_hip = primary_startup_model.clone();
         model_hip.pinned_gpu.as_mut().unwrap().backend_device = "HIP1".into();
 
-        let device2 =
-            startup_rpc_backend_device(Some("ROCm1"), Some(&model_hip)).unwrap();
+        let device2 = startup_rpc_backend_device(Some("ROCm1"), Some(&model_hip)).unwrap();
         assert_eq!(device2, Some("ROCm1"));
     }
 

--- a/mesh-llm/src/system/hardware.rs
+++ b/mesh-llm/src/system/hardware.rs
@@ -1012,7 +1012,7 @@ fn backend_device_for_name_for_platform(
         || upper.contains("INSTINCT")
         || upper.starts_with("MI")
     {
-        Some(format!("HIP{index}"))
+        Some(format!("ROCm{index}"))
     } else {
         None
     }

--- a/scripts/detect-llama-device.sh
+++ b/scripts/detect-llama-device.sh
@@ -51,14 +51,14 @@ detect_host_device() {
 
     if command -v rocm-smi &>/dev/null; then
         if rocm-smi --showproductname 2>/dev/null | grep -q '^GPU\['; then
-            echo HIP0
+            echo ROCm0
             return 0
         fi
     fi
 
     if command -v rocminfo &>/dev/null; then
         if rocminfo 2>/dev/null | grep -q 'gfx'; then
-            echo HIP0
+            echo ROCm0
             return 0
         fi
     fi
@@ -77,7 +77,7 @@ pick_preferred_available_device() {
     local available=("$@")
     local candidate
 
-    for candidate in MTL0 CUDA0 HIP0 Vulkan0 CPU; do
+    for candidate in MTL0 CUDA0 ROCm0 HIP0 Vulkan0 CPU; do
         local device
         for device in "${available[@]}"; do
             if [[ "$device" == "$candidate" ]]; then


### PR DESCRIPTION
### What does this PR do?
Updates the AMD device naming convention to support the new `ROCm` identifier (e.g., `HIP0` -> `ROCm0`) introduced by upstream `llama.cpp`, while maintaining lenient fallback support for existing `HIP` configurations during the transition. It ensures full dual-support across the Rust backend, internal bash scripts, and CLI surfaces.

### Why is this needed?
Upstream `llama.cpp` recently changed how it identifies and logs AMD/ROCm devices, dropping the `HIP` prefix in favor of `ROCm`. Because `mesh-llm` was still auto-detecting and passing `--device HIP0`, the bundled `llama-server` crashed on startup with `error: unknown device: HIP0`.

Flipping the identifier abruptly carries regression risks for users with existing `HIP{index}` values pinned in their `~/.mesh-llm/config.toml`, or internal pathways expecting the legacy string. To fix the crash safely, this PR aligns the default inventory mapping to `ROCm` while introducing dual/lenient matching in the validation paths so that `HIP` and `ROCm` resolve interchangeably.

### Changes made
**Core Logic & Validation:**
- **`src/system/hardware.rs`**: Updated the hardware inventory format from `HIP{index}` to `ROCm{index}`.
- **`src/inference/launch.rs`**: 
  - Updated primary device candidates to use `ROCm0`.
  - Re-added `HIP0` into the fallback candidate lists (`preferred_devices`) for backward compatibility.
  - Added lenient matching to `resolve_device_for_binary` to safely translate requested `ROCm` <-> `HIP` strings depending on what the underlying binary exposes.
- **`src/runtime/mod.rs`**: 
  - Relaxed the exact-match requirement in `startup_rpc_backend_device`. Pinned startup configs using `HIP<N>` will now gracefully match an explicit/resolved `ROCm<N>` device without throwing a conflict error.
  - Added test coverage (`pinned_gpu_startup_rpc_device_allows_lenient_amd_match`) for the lenient config matching.

**Scripts, CLI & Build Paths:**
- **`scripts/detect-llama-device.sh`**: The host detection and device probing logic now correctly returns and prioritizes `ROCm0`. `HIP0` is retained as a fallback in the preferred candidate list for compatibility with older binaries.
- **`src/cli/mod.rs`**: Modified the CLI help description for the `--device` flag to use `ROCm0` as the standard AMD example.
- **Verified Internal Mappings**: Confirmed that build scripts and Windows SDK paths correctly handle the transition, using `rocm` as the primary backend name while preserving necessary `hip` references for SDK/compiler paths.

### How was this tested?
- Compiled and tested locally using `Dockerfile.rocm` on a machine with an AMD Radeon RX 7900 XTX.
- Verified that `mesh-llm serve` successfully loads and serves both the main model and draft models on `ROCm0`.
- Ran `cargo test -p mesh-llm` to verify the new dual-matching and backward compatibility logic passes all existing and newly added unit tests.