### PR TITLE
Add experimental MoE floor strategies

### DIFF
--- a/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/mesh-llm/src/cli/commands/moe/mod.rs
@@ -15,7 +15,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use crate::cli::moe::{HfJobArgs, MoeAnalyzeCommand, MoeCommand};
+use crate::cli::moe::{ExperimentalMoeFloorMode, HfJobArgs, MoeAnalyzeCommand, MoeCommand};
 use crate::cli::terminal_progress::start_spinner;
 use crate::cli::Cli;
 use crate::inference::moe;
@@ -52,6 +52,11 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
             max_vram,
             nodes,
             dataset_repo,
+            experimental_moe_floor_mode,
+            experimental_moe_topk_multiplier,
+            experimental_moe_mass_threshold,
+            experimental_moe_floor_min,
+            experimental_moe_floor_max,
         } => {
             run_plan(
                 model,
@@ -60,6 +65,11 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
                 max_vram.or(cli.max_vram),
                 *nodes,
                 dataset_repo,
+                *experimental_moe_floor_mode,
+                *experimental_moe_topk_multiplier,
+                *experimental_moe_mass_threshold,
+                *experimental_moe_floor_min,
+                *experimental_moe_floor_max,
             )
             .await
         }
@@ -104,6 +114,11 @@ async fn run_plan(
     max_vram: Option<f64>,
     nodes: Option<usize>,
     dataset_repo: &str,
+    floor_mode: ExperimentalMoeFloorMode,
+    topk_multiplier: Option<u32>,
+    mass_threshold: Option<f64>,
+    floor_min: Option<u32>,
+    floor_max: Option<u32>,
 ) -> Result<()> {
     if !json_output {
         eprintln!("📍 Resolving MoE model: {model}");
@@ -121,6 +136,20 @@ async fn run_plan(
         nodes,
         dataset_repo: dataset_repo.to_string(),
         progress: !json_output,
+        floor_strategy: moe_planner::MoeFloorStrategy {
+            mode: match floor_mode {
+                ExperimentalMoeFloorMode::Fixed50Pct => moe_planner::MoeFloorMode::Fixed50Pct,
+                ExperimentalMoeFloorMode::TopkMultiplier => {
+                    moe_planner::MoeFloorMode::TopkMultiplier
+                }
+                ExperimentalMoeFloorMode::MassThreshold => moe_planner::MoeFloorMode::MassThreshold,
+                ExperimentalMoeFloorMode::Hybrid => moe_planner::MoeFloorMode::Hybrid,
+            },
+            topk_multiplier,
+            mass_threshold,
+            floor_min,
+            floor_max,
+        },
     })
     .await?;
     moe_plan_formatter(json_output).render(&report)

--- a/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/mesh-llm/src/cli/commands/moe/mod.rs
@@ -137,14 +137,7 @@ async fn run_plan(
         dataset_repo: dataset_repo.to_string(),
         progress: !json_output,
         floor_strategy: moe_planner::MoeFloorStrategy {
-            mode: match floor_mode {
-                ExperimentalMoeFloorMode::Fixed50Pct => moe_planner::MoeFloorMode::Fixed50Pct,
-                ExperimentalMoeFloorMode::TopkMultiplier => {
-                    moe_planner::MoeFloorMode::TopkMultiplier
-                }
-                ExperimentalMoeFloorMode::MassThreshold => moe_planner::MoeFloorMode::MassThreshold,
-                ExperimentalMoeFloorMode::Hybrid => moe_planner::MoeFloorMode::Hybrid,
-            },
+            mode: floor_mode.into(),
             topk_multiplier,
             mass_threshold,
             floor_min,

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -3,7 +3,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use crate::cli::benchmark::BenchmarkCommand;
-use crate::cli::moe::MoeCommand;
+use crate::cli::moe::{ExperimentalMoeFloorMode, MoeCommand};
 use crate::cli::runtime::RuntimeCommand;
 use crate::crypto::TrustPolicy;
 
@@ -323,6 +323,31 @@ pub(crate) struct Cli {
     /// Cap VRAM used for planning, local-fit decisions, and mesh advertisement (GB).
     #[arg(long)]
     pub(crate) max_vram: Option<f64>,
+
+    /// Experimental shared-core floor strategy used by `serve` MoE preflight.
+    #[arg(
+        long,
+        value_enum,
+        default_value_t = ExperimentalMoeFloorMode::Fixed50Pct,
+        hide = true
+    )]
+    pub(crate) experimental_moe_floor_mode: ExperimentalMoeFloorMode,
+
+    /// Experimental multiplier applied to active top-k experts for `topk_multiplier` and `hybrid`.
+    #[arg(long, hide = true)]
+    pub(crate) experimental_moe_topk_multiplier: Option<u32>,
+
+    /// Experimental cumulative mass threshold in [0, 1] for `mass_threshold` and `hybrid`.
+    #[arg(long, hide = true)]
+    pub(crate) experimental_moe_mass_threshold: Option<f64>,
+
+    /// Optional lower clamp for the derived shared-core floor during `serve` preflight.
+    #[arg(long, hide = true)]
+    pub(crate) experimental_moe_floor_min: Option<u32>,
+
+    /// Optional upper clamp for the derived shared-core floor during `serve` preflight.
+    #[arg(long, hide = true)]
+    pub(crate) experimental_moe_floor_max: Option<u32>,
 
     /// Enumerate host hardware (GPU name, hostname) at startup.
     #[arg(long, hide = true)]

--- a/mesh-llm/src/cli/moe.rs
+++ b/mesh-llm/src/cli/moe.rs
@@ -22,6 +22,21 @@ pub(crate) enum MoeCommand {
         /// Published dataset repo used for MoE ranking lookup.
         #[arg(long, default_value = "meshllm/moe-rankings")]
         dataset_repo: String,
+        /// Experimental shared-core floor strategy used by `moe plan`.
+        #[arg(long, value_enum, default_value_t = ExperimentalMoeFloorMode::Fixed50Pct)]
+        experimental_moe_floor_mode: ExperimentalMoeFloorMode,
+        /// Experimental multiplier applied to active top-k experts for `topk_multiplier` and `hybrid`.
+        #[arg(long)]
+        experimental_moe_topk_multiplier: Option<u32>,
+        /// Experimental cumulative mass threshold in [0, 1] for `mass_threshold` and `hybrid`.
+        #[arg(long)]
+        experimental_moe_mass_threshold: Option<f64>,
+        /// Optional lower clamp for the derived shared-core floor.
+        #[arg(long)]
+        experimental_moe_floor_min: Option<u32>,
+        /// Optional upper clamp for the derived shared-core floor.
+        #[arg(long)]
+        experimental_moe_floor_max: Option<u32>,
     },
     /// Run local MoE analysis and cache the result.
     Analyze {
@@ -112,4 +127,16 @@ pub(crate) enum HfJobReleaseTarget {
     Cuda,
     Rocm,
     Vulkan,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum ExperimentalMoeFloorMode {
+    #[value(name = "fixed_50pct")]
+    Fixed50Pct,
+    #[value(name = "topk_multiplier")]
+    TopkMultiplier,
+    #[value(name = "mass_threshold")]
+    MassThreshold,
+    #[value(name = "hybrid")]
+    Hybrid,
 }

--- a/mesh-llm/src/cli/moe.rs
+++ b/mesh-llm/src/cli/moe.rs
@@ -140,3 +140,14 @@ pub(crate) enum ExperimentalMoeFloorMode {
     #[value(name = "hybrid")]
     Hybrid,
 }
+
+impl From<ExperimentalMoeFloorMode> for crate::system::moe_planner::MoeFloorMode {
+    fn from(value: ExperimentalMoeFloorMode) -> Self {
+        match value {
+            ExperimentalMoeFloorMode::Fixed50Pct => Self::Fixed50Pct,
+            ExperimentalMoeFloorMode::TopkMultiplier => Self::TopkMultiplier,
+            ExperimentalMoeFloorMode::MassThreshold => Self::MassThreshold,
+            ExperimentalMoeFloorMode::Hybrid => Self::Hybrid,
+        }
+    }
+}

--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -695,7 +695,7 @@ fn resolve_runtime_moe_config(
     };
 
     let started = std::time::Instant::now();
-    let (ranking, ranking_source, ranking_origin) = match options.ranking_strategy {
+    let (ranking, ranking_path, ranking_source, ranking_origin) = match options.ranking_strategy {
         moe::MoeRankingStrategy::Auto => {
             let model_path_for_ranking = model_path.to_path_buf();
             let resolved_ranking_result: anyhow::Result<
@@ -744,6 +744,7 @@ fn resolve_runtime_moe_config(
                     resolved.analyzer_id,
                     resolved.path.display()
                 );
+                let ranking_path = resolved.path.clone();
                 (
                     moe::load_cached_ranking(&resolved.path).ok_or_else(|| {
                         anyhow::anyhow!(
@@ -751,23 +752,34 @@ fn resolve_runtime_moe_config(
                             resolved.path.display()
                         )
                     })?,
+                    Some(ranking_path),
                     resolved.analyzer_id,
                     resolved.source.label().to_string(),
                 )
             } else {
                 if should_attempt_local_micro_analyze(model_path, model_name, local_vram_budget) {
                     match ensure_micro_analyze_ranking(bin_dir, model_name, model_path, options) {
-                        Ok(artifact) => (
-                            artifact.ranking,
-                            "micro-v1".to_string(),
-                            artifact.origin.label().to_string(),
-                        ),
+                        Ok(artifact) => {
+                            let cached_path = moe::micro_ranking_cache_path(
+                                model_path,
+                                options.micro_prompt_count,
+                                options.micro_tokens,
+                                options.micro_layer_scope,
+                            );
+                            (
+                                artifact.ranking,
+                                Some(cached_path),
+                                "micro-v1".to_string(),
+                                artifact.origin.label().to_string(),
+                            )
+                        }
                         Err(err) => {
                             eprintln!(
                                 "⚠ [{model_name}] micro-analyze failed ({err}); falling back to sequential expert order"
                             );
                             (
                                 (0..base.n_expert).collect(),
+                                None,
                                 "sequential-fallback".to_string(),
                                 "fallback".to_string(),
                             )
@@ -779,6 +791,7 @@ fn resolve_runtime_moe_config(
                     );
                     (
                         (0..base.n_expert).collect(),
+                        None,
                         "sequential-fallback".to_string(),
                         "fallback".to_string(),
                     )
@@ -790,14 +803,22 @@ fn resolve_runtime_moe_config(
             let artifact = ensure_full_analyze_ranking(bin_dir, model_name, model_path, &cached)?;
             (
                 artifact.ranking,
+                Some(cached),
                 "full-v1".to_string(),
                 artifact.origin.label().to_string(),
             )
         }
         moe::MoeRankingStrategy::MicroAnalyze => {
             let artifact = ensure_micro_analyze_ranking(bin_dir, model_name, model_path, options)?;
+            let cached_path = moe::micro_ranking_cache_path(
+                model_path,
+                options.micro_prompt_count,
+                options.micro_tokens,
+                options.micro_layer_scope,
+            );
             (
                 artifact.ranking,
+                Some(cached_path),
                 "micro-v1".to_string(),
                 artifact.origin.label().to_string(),
             )
@@ -812,8 +833,11 @@ fn resolve_runtime_moe_config(
         started.elapsed().as_secs_f64()
     );
 
+    let mut config = crate::models::catalog::MoeConfig { ranking, ..base };
+    apply_runtime_floor_strategy(model_name, options, ranking_path.as_deref(), &mut config)?;
+
     Ok(Some(ResolvedMoeConfig {
-        config: crate::models::catalog::MoeConfig { ranking, ..base },
+        config,
         ranking_strategy: options.ranking_strategy,
         ranking_source,
         ranking_origin,
@@ -823,6 +847,7 @@ fn resolve_runtime_moe_config(
 fn refresh_auto_moe_config_from_cache(
     model_name: &str,
     model_path: &Path,
+    options: &moe::MoeRuntimeOptions,
     cfg: &mut ResolvedMoeConfig,
 ) -> bool {
     if !matches!(cfg.ranking_strategy, moe::MoeRankingStrategy::Auto) {
@@ -846,7 +871,19 @@ fn refresh_auto_moe_config_from_cache(
     let Some(ranking) = moe::load_cached_ranking(&resolved.path) else {
         return false;
     };
-    if cfg.config.ranking == ranking
+    let mut next_config = cfg.config.clone();
+    next_config.ranking = ranking;
+    if let Err(err) =
+        apply_runtime_floor_strategy(model_name, options, Some(&resolved.path), &mut next_config)
+    {
+        eprintln!(
+            "⚠ [{model_name}] Failed to refresh MoE floor from cached ranking ({}): {err}",
+            resolved.path.display()
+        );
+        return false;
+    }
+    if cfg.config.ranking == next_config.ranking
+        && cfg.config.min_experts_per_node == next_config.min_experts_per_node
         && cfg.ranking_source == resolved.analyzer_id
         && cfg.ranking_origin == resolved.source.label()
     {
@@ -858,10 +895,33 @@ fn refresh_auto_moe_config_from_cache(
         resolved.source.label(),
         resolved.analyzer_id
     );
-    cfg.config.ranking = ranking;
+    cfg.config = next_config;
     cfg.ranking_source = resolved.analyzer_id;
     cfg.ranking_origin = resolved.source.label().to_string();
     true
+}
+
+fn apply_runtime_floor_strategy(
+    model_name: &str,
+    options: &moe::MoeRuntimeOptions,
+    ranking_path: Option<&Path>,
+    config: &mut crate::models::catalog::MoeConfig,
+) -> anyhow::Result<()> {
+    let required_experts_per_node = crate::system::moe_planner::resolve_required_experts_per_node(
+        &options.floor_strategy,
+        config.n_expert,
+        config.n_expert_used,
+        ranking_path,
+    )?;
+    if config.min_experts_per_node != required_experts_per_node {
+        eprintln!(
+            "🧩 [{model_name}] MoE floor={} -> {} shared experts per node",
+            options.floor_strategy.mode_label(),
+            required_experts_per_node
+        );
+        config.min_experts_per_node = required_experts_per_node;
+    }
+    Ok(())
 }
 
 fn print_runtime_submit_suggestion(model_name: &str, model_path: &Path, ranking_path: &Path) {
@@ -969,6 +1029,7 @@ struct MoeElectionParams {
     binary_flavor: Option<launch::BinaryFlavor>,
     ctx_size_override: Option<u32>,
     pinned_gpu: Option<crate::runtime::StartupPinnedGpuTarget>,
+    moe_runtime_options: moe::MoeRuntimeOptions,
     target_tx: Arc<watch::Sender<ModelTargets>>,
     stop_rx: watch::Receiver<bool>,
 }
@@ -1598,6 +1659,7 @@ pub async fn election_loop(
                     binary_flavor,
                     ctx_size_override,
                     pinned_gpu: pinned_gpu.clone(),
+                    moe_runtime_options: moe_runtime_options.clone(),
                     target_tx,
                     stop_rx,
                 },
@@ -1994,6 +2056,7 @@ async fn moe_election_loop(
         binary_flavor,
         ctx_size_override,
         pinned_gpu,
+        moe_runtime_options,
         target_tx,
         mut stop_rx,
     } = params;
@@ -2011,7 +2074,12 @@ async fn moe_election_loop(
         }
 
         if !currently_running {
-            let _ = refresh_auto_moe_config_from_cache(&model_name, &model, &mut moe_cfg);
+            let _ = refresh_auto_moe_config_from_cache(
+                &model_name,
+                &model,
+                &moe_runtime_options,
+                &mut moe_cfg,
+            );
         }
 
         let peers = node.peers().await;
@@ -2920,6 +2988,7 @@ mod tests {
     use super::*;
     use iroh::EndpointAddr;
     use iroh::SecretKey;
+    use std::path::{Path, PathBuf};
 
     /// Create a deterministic EndpointId from a byte seed.
     fn make_id(seed: u8) -> iroh::EndpointId {
@@ -2971,6 +3040,25 @@ mod tests {
             owner_attestation: None,
             owner_summary: crate::crypto::OwnershipSummary::default(),
         }
+    }
+
+    fn temp_case_dir(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("mesh-llm-election-{name}-{nanos}"));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_test_ranking(path: &Path, rows: &[(u32, f64)]) {
+        let mut content = String::from("expert,gate_mass,selection_count\n");
+        for (expert, gate_mass) in rows {
+            let selection_count = (*gate_mass * 10.0).round() as u64;
+            content.push_str(&format!("{expert},{gate_mass:.6},{selection_count}\n"));
+        }
+        std::fs::write(path, content).unwrap();
     }
 
     #[test]
@@ -3713,5 +3801,64 @@ mod tests {
         assert!(!should_use_row_split(Some(BinaryFlavor::Metal), 8));
         assert!(!should_use_row_split(Some(BinaryFlavor::Vulkan), 4));
         assert!(!should_use_row_split(Some(BinaryFlavor::Cpu), 4));
+    }
+
+    #[test]
+    fn runtime_floor_strategy_updates_shared_expert_floor() {
+        let mut config = crate::models::catalog::MoeConfig {
+            n_expert: 8,
+            n_expert_used: 2,
+            min_experts_per_node: 4,
+            ranking: (0..8).collect(),
+        };
+        let options = moe::MoeRuntimeOptions {
+            floor_strategy: crate::system::moe_planner::MoeFloorStrategy {
+                mode: crate::system::moe_planner::MoeFloorMode::TopkMultiplier,
+                topk_multiplier: Some(3),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        apply_runtime_floor_strategy("test-model", &options, None, &mut config).unwrap();
+
+        assert_eq!(config.min_experts_per_node, 6);
+    }
+
+    #[test]
+    fn runtime_floor_strategy_uses_ranking_mass_data() {
+        let dir = temp_case_dir("runtime-floor-mass");
+        let ranking_path = dir.join("ranking.csv");
+        write_test_ranking(
+            &ranking_path,
+            &[
+                (0, 40.0),
+                (1, 20.0),
+                (2, 10.0),
+                (3, 10.0),
+                (4, 10.0),
+                (5, 5.0),
+            ],
+        );
+        let mut config = crate::models::catalog::MoeConfig {
+            n_expert: 6,
+            n_expert_used: 2,
+            min_experts_per_node: 4,
+            ranking: (0..6).collect(),
+        };
+        let options = moe::MoeRuntimeOptions {
+            floor_strategy: crate::system::moe_planner::MoeFloorStrategy {
+                mode: crate::system::moe_planner::MoeFloorMode::MassThreshold,
+                mass_threshold: Some(0.70),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        apply_runtime_floor_strategy("test-model", &options, Some(&ranking_path), &mut config)
+            .unwrap();
+
+        assert_eq!(config.min_experts_per_node, 3);
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/mesh-llm/src/inference/moe.rs
+++ b/mesh-llm/src/inference/moe.rs
@@ -87,6 +87,7 @@ pub struct MoeRuntimeOptions {
     pub micro_prompt_count: usize,
     pub micro_tokens: u32,
     pub micro_layer_scope: MoeMicroLayerScope,
+    pub floor_strategy: crate::system::moe_planner::MoeFloorStrategy,
 }
 
 impl Default for MoeRuntimeOptions {
@@ -96,6 +97,7 @@ impl Default for MoeRuntimeOptions {
             micro_prompt_count: 1,
             micro_tokens: 8,
             micro_layer_scope: MoeMicroLayerScope::All,
+            floor_strategy: crate::system::moe_planner::MoeFloorStrategy::default(),
         }
     }
 }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -13,6 +13,7 @@ use self::local::{
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
+use crate::cli::moe::ExperimentalMoeFloorMode;
 use crate::cli::terminal_progress::start_spinner;
 use crate::cli::{Cli, Command, RuntimeSurface};
 use crate::crypto::{
@@ -492,7 +493,10 @@ pub(crate) async fn run() -> Result<()> {
         eprintln!();
         return Ok(());
     }
-    let mut startup_models = resolve_startup_models(&startup_specs, cli.max_vram).await?;
+    let startup_floor_strategy = serve_moe_floor_strategy(&cli);
+    moe_planner::validate_floor_strategy(&startup_floor_strategy)?;
+    let mut startup_models =
+        resolve_startup_models(&startup_specs, cli.max_vram, &startup_floor_strategy).await?;
     preflight_config_owned_startup_models(&config, &startup_specs, &mut startup_models)?;
     let resolved_models: Vec<PathBuf> = startup_models
         .iter()
@@ -603,12 +607,14 @@ fn build_startup_model_specs(
 async fn resolve_startup_models(
     specs: &[StartupModelSpec],
     max_vram_gb: Option<f64>,
+    floor_strategy: &moe_planner::MoeFloorStrategy,
 ) -> Result<Vec<StartupModelPlan>> {
     let mut plans = Vec::with_capacity(specs.len());
     let mut preflight_cache: HashMap<String, Option<moe_planner::MoeStartupFitEstimate>> =
         HashMap::new();
     for spec in specs {
-        preflight_remote_startup_model(spec, max_vram_gb, &mut preflight_cache).await?;
+        preflight_remote_startup_model(spec, max_vram_gb, floor_strategy, &mut preflight_cache)
+            .await?;
         let resolved_path = resolve_model(&spec.model_ref).await?;
         let mmproj_path = match spec.mmproj_ref.as_ref() {
             Some(mmproj) => Some(resolve_model(mmproj).await?),
@@ -629,6 +635,7 @@ async fn resolve_startup_models(
 async fn preflight_remote_startup_model(
     spec: &StartupModelSpec,
     max_vram_gb: Option<f64>,
+    floor_strategy: &moe_planner::MoeFloorStrategy,
     cache: &mut HashMap<String, Option<moe_planner::MoeStartupFitEstimate>>,
 ) -> Result<()> {
     if spec.model_ref.exists() {
@@ -643,7 +650,10 @@ async fn preflight_remote_startup_model(
         }
     }
 
-    let mut spinner = start_spinner(&format!("Checking published MoE fit for {declared_ref}"));
+    let mut spinner = start_spinner(&format!(
+        "Checking published MoE fit for {declared_ref} ({})",
+        floor_strategy.mode_label()
+    ));
     let identity = models::resolve_huggingface_model_identity(&declared_ref)
         .await
         .with_context(|| format!("Resolve model identity for {declared_ref}"))?;
@@ -652,9 +662,15 @@ async fn preflight_remote_startup_model(
         return Ok(());
     };
 
-    if let Some(cached) = cache.get(&identity.canonical_ref).cloned() {
+    let cache_key = remote_startup_preflight_cache_key(&identity.canonical_ref, floor_strategy);
+    if let Some(cached) = cache.get(&cache_key).cloned() {
         spinner.finish();
-        return apply_remote_startup_preflight(&declared_ref, &identity.local_file_name, cached);
+        return apply_remote_startup_preflight(
+            &declared_ref,
+            &identity.local_file_name,
+            floor_strategy,
+            cached,
+        );
     }
 
     spinner.set_message(format!(
@@ -666,6 +682,8 @@ async fn preflight_remote_startup_model(
     let source_revision = identity.revision.clone();
     let distribution_id = moe_planner::normalize_distribution_id(&identity.local_file_name);
     let target_vram_bytes = mesh::detect_vram_bytes_capped(max_vram_gb);
+    let floor_strategy = floor_strategy.clone();
+    let task_floor_strategy = floor_strategy.clone();
     let fetched = tokio::task::spawn_blocking(move || {
         moe_planner::fetch_remote_startup_fit(
             &dataset_repo,
@@ -674,6 +692,7 @@ async fn preflight_remote_startup_model(
             &distribution_id,
             target_vram_bytes,
             false,
+            &task_floor_strategy,
         )
     })
     .await;
@@ -694,13 +713,19 @@ async fn preflight_remote_startup_model(
             None
         }
     };
-    cache.insert(identity.canonical_ref.clone(), fit.clone());
-    apply_remote_startup_preflight(&declared_ref, &identity.local_file_name, fit)
+    cache.insert(cache_key, fit.clone());
+    apply_remote_startup_preflight(
+        &declared_ref,
+        &identity.local_file_name,
+        &floor_strategy,
+        fit,
+    )
 }
 
 fn apply_remote_startup_preflight(
     declared_ref: &str,
     model_label: &str,
+    floor_strategy: &moe_planner::MoeFloorStrategy,
     fit: Option<moe_planner::MoeStartupFitEstimate>,
 ) -> Result<()> {
     let Some(fit) = fit else {
@@ -708,12 +733,13 @@ fn apply_remote_startup_preflight(
     };
     if !fit.any_fit_exists() {
         anyhow::bail!(
-            "Published MoE preflight says '{}' will not fit locally before download: full model needs about {}, and the smallest conservative split still needs about {} per node with a 50% shared core ({} shared experts). Local budget is {}.",
+            "Published MoE preflight says '{}' will not fit locally before download: full model needs about {}, and the smallest conservative split still needs about {} per node with the `{}` shared-core floor ({} shared experts). Local budget is {}.",
             declared_ref,
             format_vram_gb(fit.full_model_launch_bytes),
             fit.predicted_max_shard_launch_bytes
                 .map(format_vram_gb)
                 .unwrap_or_else(|| "unknown".to_string()),
+            floor_strategy.mode_label(),
             fit.required_experts_per_node,
             format_vram_gb(fit.target_vram_bytes),
         );
@@ -721,10 +747,12 @@ fn apply_remote_startup_preflight(
 
     if fit.full_model_fits() {
         eprintln!(
-            "🧩 [{}] Published MoE preflight: full model should fit locally (~{} <= {}, mode={}, source={})",
+            "🧩 [{}] Published MoE preflight: full model should fit locally (~{} <= {}, floor={} with {} shared experts, mode={}, source={})",
             model_label,
             format_vram_gb(fit.full_model_launch_bytes),
             format_vram_gb(fit.target_vram_bytes),
+            floor_strategy.mode_label(),
+            fit.required_experts_per_node,
             fit.analyzer_id,
             fit.ranking_source,
         );
@@ -733,11 +761,13 @@ fn apply_remote_startup_preflight(
 
     if fit.shard_plan_fits() {
         eprintln!(
-            "🧩 [{}] Published MoE preflight: full model needs ~{}, but a conservative {}-node shard should fit here (~{}/node, mode={}, source={})",
+            "🧩 [{}] Published MoE preflight: full model needs ~{}, but a conservative {}-node shard should fit here (~{}/node, floor={} with {} shared experts, mode={}, source={})",
             model_label,
             format_vram_gb(fit.full_model_launch_bytes),
             fit.recommended_nodes.unwrap_or(1),
             format_vram_gb(fit.predicted_max_shard_launch_bytes.unwrap_or_default()),
+            floor_strategy.mode_label(),
+            fit.required_experts_per_node,
             fit.analyzer_id,
             fit.ranking_source,
         );
@@ -748,6 +778,36 @@ fn apply_remote_startup_preflight(
 
 fn format_vram_gb(bytes: u64) -> String {
     format!("{:.1}GB", bytes as f64 / 1e9)
+}
+
+fn serve_moe_floor_strategy(cli: &Cli) -> moe_planner::MoeFloorStrategy {
+    moe_planner::MoeFloorStrategy {
+        mode: match cli.experimental_moe_floor_mode {
+            ExperimentalMoeFloorMode::Fixed50Pct => moe_planner::MoeFloorMode::Fixed50Pct,
+            ExperimentalMoeFloorMode::TopkMultiplier => moe_planner::MoeFloorMode::TopkMultiplier,
+            ExperimentalMoeFloorMode::MassThreshold => moe_planner::MoeFloorMode::MassThreshold,
+            ExperimentalMoeFloorMode::Hybrid => moe_planner::MoeFloorMode::Hybrid,
+        },
+        topk_multiplier: cli.experimental_moe_topk_multiplier,
+        mass_threshold: cli.experimental_moe_mass_threshold,
+        floor_min: cli.experimental_moe_floor_min,
+        floor_max: cli.experimental_moe_floor_max,
+    }
+}
+
+fn remote_startup_preflight_cache_key(
+    canonical_ref: &str,
+    floor_strategy: &moe_planner::MoeFloorStrategy,
+) -> String {
+    format!(
+        "{}|{}|{:?}|{:?}|{:?}|{:?}",
+        canonical_ref,
+        floor_strategy.mode_label(),
+        floor_strategy.topk_multiplier,
+        floor_strategy.mass_threshold,
+        floor_strategy.floor_min,
+        floor_strategy.floor_max
+    )
 }
 
 fn preflight_config_owned_startup_models(

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -1418,6 +1418,7 @@ async fn run_auto(
     auto_join_candidates: Vec<(String, Option<String>)>,
 ) -> Result<()> {
     let resolved_plugins = resolve_plugins_from_config(&config, &cli)?;
+    let startup_floor_strategy = serve_moe_floor_strategy(&cli);
     let api_port = cli.port;
     // Export management API port for llama-server mesh hook callbacks.
     // Must be the console/management port (default 3131), NOT the proxy port
@@ -1958,7 +1959,10 @@ async fn run_auto(
     let console_state_for_primary_process = console_state.clone();
     let primary_process_model_name = model_name.clone();
     let primary_model_name_for_advertise = model_name.clone();
-    let moe_runtime_options = moe::MoeRuntimeOptions::default();
+    let moe_runtime_options = moe::MoeRuntimeOptions {
+        floor_strategy: startup_floor_strategy.clone(),
+        ..Default::default()
+    };
     let primary_mmproj = primary_startup_model
         .as_ref()
         .and_then(|model| model.mmproj_path.clone());
@@ -2114,7 +2118,10 @@ async fn run_auto(
             let extra_model_name = extra_name.clone();
             let api_port_extra = api_port;
             let extra_llama_flavor = cli.llama_flavor;
-            let extra_moe_runtime_options = moe::MoeRuntimeOptions::default();
+            let extra_moe_runtime_options = moe::MoeRuntimeOptions {
+                floor_strategy: startup_floor_strategy.clone(),
+                ..Default::default()
+            };
             let extra_console_state = console_state.clone();
             let extra_model_name_for_status = extra_model_name.clone();
             let extra_model_name_for_process = extra_model_name.clone();

--- a/mesh-llm/src/system/moe_planner.rs
+++ b/mesh-llm/src/system/moe_planner.rs
@@ -29,6 +29,7 @@ pub(crate) struct MoePlanArgs {
     pub nodes: Option<usize>,
     pub dataset_repo: String,
     pub progress: bool,
+    pub floor_strategy: MoeFloorStrategy,
 }
 
 #[derive(Clone, Debug)]
@@ -131,6 +132,44 @@ pub(crate) struct MoeStartupFitEstimate {
     pub predicted_max_shard_launch_bytes: Option<u64>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MoeFloorMode {
+    Fixed50Pct,
+    TopkMultiplier,
+    MassThreshold,
+    Hybrid,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct MoeFloorStrategy {
+    pub mode: MoeFloorMode,
+    pub topk_multiplier: Option<u32>,
+    pub mass_threshold: Option<f64>,
+    pub floor_min: Option<u32>,
+    pub floor_max: Option<u32>,
+}
+
+impl Default for MoeFloorStrategy {
+    fn default() -> Self {
+        Self {
+            mode: MoeFloorMode::Fixed50Pct,
+            topk_multiplier: None,
+            mass_threshold: None,
+            floor_min: None,
+            floor_max: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct MoeFloorDecision {
+    required_experts_per_node: u32,
+    unclamped_required_experts_per_node: u32,
+    topk_floor: Option<u32>,
+    mass_floor: Option<u32>,
+    strategy: MoeFloorStrategy,
+}
+
 impl MoeStartupFitEstimate {
     pub(crate) fn full_model_fits(&self) -> bool {
         self.full_model_launch_bytes <= self.target_vram_bytes
@@ -179,6 +218,7 @@ struct AggregatedTensorByteProfile {
 }
 
 pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
+    validate_floor_strategy(&args.floor_strategy)?;
     if let Some(nodes) = args.nodes {
         if nodes == 0 {
             bail!("--nodes must be at least 1");
@@ -199,6 +239,13 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
     let heuristic_recommended_nodes = ((model.total_model_bytes as f64) / target_vram_bytes as f64)
         .ceil()
         .max(1.0) as usize;
+    let floor_decision = derive_floor_decision(
+        &args.floor_strategy,
+        model.expert_count,
+        model.used_expert_count,
+        &ranking.path,
+    )?;
+    model.min_experts_per_node = floor_decision.required_experts_per_node;
     let analysis = ranking
         .analysis_path
         .as_deref()
@@ -215,9 +262,9 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
             target_vram_bytes,
             &ranking.analyzer_id,
             ranking.source.label(),
+            floor_decision.required_experts_per_node,
         )?;
         let required_experts_per_node = fit.required_experts_per_node;
-        model.min_experts_per_node = required_experts_per_node;
         let max_supported_nodes =
             (model.expert_count / required_experts_per_node.max(1)).max(1) as usize;
         let recommended_nodes = args
@@ -243,11 +290,13 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
                 fit.full_model_launch_bytes as f64 / 1e9,
                 target_vram_bytes as f64 / 1e9
             ),
-            format!(
-                "Shared core uses the current 50% planning heuristic: {} / {} experts per node",
-                required_experts_per_node, model.expert_count
-            ),
+            format!("{}", floor_decision.summary_line(model.expert_count)),
         ];
+        assumptions.extend(
+            floor_decision
+                .detail_lines(model.expert_count, model.used_expert_count)
+                .into_iter(),
+        );
         if recommended_nodes > 1 {
             let (_, predicted_max_shard_bytes, predicted_max_shard_launch_bytes) =
                 predict_plan_fit_for_nodes(
@@ -286,19 +335,21 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
         let max_supported_nodes =
             (model.expert_count / model.min_experts_per_node.max(1)).max(1) as usize;
         let feasible = recommended_nodes <= max_supported_nodes;
-        let assumptions = vec![
+        let mut assumptions = vec![
             format!(
                 "Minimum nodes estimated from total model bytes / target VRAM: {:.1}GB / {:.1}GB",
                 model.total_model_bytes as f64 / 1e9,
                 target_vram_bytes as f64 / 1e9
             ),
-            format!(
-                "Minimum experts per node falls back to local planner state: {}",
-                model.min_experts_per_node
-            ),
+            floor_decision.summary_line(model.expert_count),
             "No analysis.json was available, so shard byte fit uses the legacy heuristic."
                 .to_string(),
         ];
+        assumptions.extend(
+            floor_decision
+                .detail_lines(model.expert_count, model.used_expert_count)
+                .into_iter(),
+        );
         (
             recommended_nodes,
             max_supported_nodes,
@@ -1029,6 +1080,7 @@ pub(crate) fn estimate_startup_fit_from_analysis(
     target_vram_bytes: u64,
     analyzer_id: &str,
     ranking_source: &'static str,
+    required_experts_per_node: u32,
 ) -> Result<MoeStartupFitEstimate> {
     let ranking = moe::load_cached_ranking(ranking_path)
         .ok_or_else(|| anyhow::anyhow!("Could not parse ranking {}", ranking_path.display()))?;
@@ -1041,7 +1093,6 @@ pub(crate) fn estimate_startup_fit_from_analysis(
         );
     }
 
-    let required_experts_per_node = default_required_experts_per_node(analysis.model.expert_count);
     let full_model_launch_bytes = apply_model_load_headroom(analysis.memory.full_model_bytes);
     let mut estimate = MoeStartupFitEstimate {
         analyzer_id: analyzer_id.to_string(),
@@ -1124,6 +1175,7 @@ pub(crate) fn fetch_remote_startup_fit(
         target_vram_bytes,
         &ranking.analyzer_id,
         ranking.source.label(),
+        default_required_experts_per_node(analysis.model.expert_count),
     )?;
     Ok(Some(estimate))
 }
@@ -1204,6 +1256,173 @@ fn expert_bytes_json(expert_tensor_bytes: u64, expert_count: u32) -> Result<Valu
         "kind": "dense_per_expert",
         "values": values,
     }))
+}
+
+impl MoeFloorDecision {
+    fn summary_line(&self, expert_count: u32) -> String {
+        match self.strategy.mode {
+            MoeFloorMode::Fixed50Pct => format!(
+                "Shared core heuristic: fixed_50pct -> {} / {} experts per node",
+                self.required_experts_per_node, expert_count
+            ),
+            MoeFloorMode::TopkMultiplier => format!(
+                "Shared core heuristic: topk_multiplier -> {} experts per node",
+                self.required_experts_per_node
+            ),
+            MoeFloorMode::MassThreshold => format!(
+                "Shared core heuristic: mass_threshold -> {} experts per node",
+                self.required_experts_per_node
+            ),
+            MoeFloorMode::Hybrid => format!(
+                "Shared core heuristic: hybrid -> {} experts per node",
+                self.required_experts_per_node
+            ),
+        }
+    }
+
+    fn detail_lines(&self, expert_count: u32, used_expert_count: u32) -> Vec<String> {
+        let mut lines = Vec::new();
+        match self.strategy.mode {
+            MoeFloorMode::Fixed50Pct => {
+                lines.push(format!(
+                    "Fixed floor uses ceil(50% of total experts): {} / {}",
+                    self.required_experts_per_node, expert_count
+                ));
+            }
+            MoeFloorMode::TopkMultiplier => {
+                lines.push(format!(
+                    "Top-k floor uses active experts * multiplier: top-{} * {} = {}",
+                    used_expert_count,
+                    self.strategy
+                        .topk_multiplier
+                        .unwrap_or(DEFAULT_TOPK_MULTIPLIER),
+                    self.unclamped_required_experts_per_node
+                ));
+            }
+            MoeFloorMode::MassThreshold => {
+                lines.push(format!(
+                    "Mass floor uses smallest top-N reaching {:.1}% cumulative routing mass: {}",
+                    self.strategy
+                        .mass_threshold
+                        .unwrap_or(DEFAULT_MASS_THRESHOLD)
+                        * 100.0,
+                    self.unclamped_required_experts_per_node
+                ));
+            }
+            MoeFloorMode::Hybrid => {
+                lines.push(format!(
+                    "Hybrid floor uses max(top-k floor, mass floor): max({}, {}) = {}",
+                    self.topk_floor.unwrap_or_default(),
+                    self.mass_floor.unwrap_or_default(),
+                    self.unclamped_required_experts_per_node
+                ));
+                lines.push(format!(
+                    "Top-k floor: top-{} * {} = {}",
+                    used_expert_count,
+                    self.strategy
+                        .topk_multiplier
+                        .unwrap_or(DEFAULT_TOPK_MULTIPLIER),
+                    self.topk_floor.unwrap_or_default()
+                ));
+                lines.push(format!(
+                    "Mass floor: smallest top-N reaching {:.1}% cumulative routing mass = {}",
+                    self.strategy
+                        .mass_threshold
+                        .unwrap_or(DEFAULT_MASS_THRESHOLD)
+                        * 100.0,
+                    self.mass_floor.unwrap_or_default()
+                ));
+            }
+        }
+        if self.required_experts_per_node != self.unclamped_required_experts_per_node {
+            lines.push(format!(
+                "Applied floor clamps: raw {} -> final {} (min={:?}, max={:?})",
+                self.unclamped_required_experts_per_node,
+                self.required_experts_per_node,
+                self.strategy.floor_min,
+                self.strategy.floor_max
+            ));
+        }
+        lines
+    }
+}
+
+const DEFAULT_TOPK_MULTIPLIER: u32 = 4;
+const DEFAULT_MASS_THRESHOLD: f64 = 0.70;
+
+fn validate_floor_strategy(strategy: &MoeFloorStrategy) -> Result<()> {
+    if strategy.topk_multiplier.unwrap_or(DEFAULT_TOPK_MULTIPLIER) == 0 {
+        bail!("--experimental-moe-topk-multiplier must be at least 1");
+    }
+    let mass_threshold = strategy.mass_threshold.unwrap_or(DEFAULT_MASS_THRESHOLD);
+    if !(0.0..=1.0).contains(&mass_threshold) || mass_threshold <= 0.0 {
+        bail!("--experimental-moe-mass-threshold must be in the range (0, 1]");
+    }
+    if let (Some(min), Some(max)) = (strategy.floor_min, strategy.floor_max) {
+        if min > max {
+            bail!(
+                "--experimental-moe-floor-min cannot be greater than --experimental-moe-floor-max"
+            );
+        }
+    }
+    Ok(())
+}
+
+fn derive_floor_decision(
+    strategy: &MoeFloorStrategy,
+    expert_count: u32,
+    used_expert_count: u32,
+    ranking_path: &Path,
+) -> Result<MoeFloorDecision> {
+    let topk_multiplier = strategy.topk_multiplier.unwrap_or(DEFAULT_TOPK_MULTIPLIER);
+    let mass_threshold = strategy.mass_threshold.unwrap_or(DEFAULT_MASS_THRESHOLD);
+    let topk_floor = used_expert_count
+        .saturating_mul(topk_multiplier)
+        .clamp(1, expert_count.max(1));
+    let mass_floor = || -> Result<u32> {
+        let profile = load_analyze_mass_profile(ranking_path)?;
+        let target_mass = profile.total_mass * mass_threshold;
+        let mut cumulative = 0.0;
+        for (index, (_, gate_mass)) in profile.masses.iter().enumerate() {
+            cumulative += *gate_mass;
+            if cumulative + f64::EPSILON >= target_mass {
+                return Ok((index + 1) as u32);
+            }
+        }
+        Ok(expert_count.max(1))
+    };
+
+    let unclamped = match strategy.mode {
+        MoeFloorMode::Fixed50Pct => default_required_experts_per_node(expert_count),
+        MoeFloorMode::TopkMultiplier => topk_floor,
+        MoeFloorMode::MassThreshold => mass_floor()?,
+        MoeFloorMode::Hybrid => topk_floor.max(mass_floor()?),
+    };
+
+    let mut required = unclamped.clamp(1, expert_count.max(1));
+    if let Some(min) = strategy.floor_min {
+        required = required.max(min.clamp(1, expert_count.max(1)));
+    }
+    if let Some(max) = strategy.floor_max {
+        required = required.min(max.clamp(1, expert_count.max(1)));
+    }
+
+    Ok(MoeFloorDecision {
+        required_experts_per_node: required,
+        unclamped_required_experts_per_node: unclamped,
+        topk_floor: matches!(
+            strategy.mode,
+            MoeFloorMode::TopkMultiplier | MoeFloorMode::Hybrid
+        )
+        .then_some(topk_floor),
+        mass_floor: matches!(
+            strategy.mode,
+            MoeFloorMode::MassThreshold | MoeFloorMode::Hybrid
+        )
+        .then(|| mass_floor())
+        .transpose()?,
+        strategy: strategy.clone(),
+    })
 }
 
 fn default_required_experts_per_node(expert_count: u32) -> u32 {
@@ -1654,6 +1873,115 @@ mod tests {
     }
 
     #[test]
+    fn derive_floor_decision_uses_topk_multiplier() {
+        let dir = temp_case_dir("floor-topk");
+        let ranking_path = dir.join("ranking.csv");
+        write_test_ranking(
+            &ranking_path,
+            &[
+                (0, 40.0),
+                (1, 20.0),
+                (2, 10.0),
+                (3, 10.0),
+                (4, 10.0),
+                (5, 5.0),
+                (6, 3.0),
+                (7, 2.0),
+            ],
+        );
+
+        let decision = derive_floor_decision(
+            &MoeFloorStrategy {
+                mode: MoeFloorMode::TopkMultiplier,
+                topk_multiplier: Some(2),
+                ..Default::default()
+            },
+            8,
+            2,
+            &ranking_path,
+        )
+        .unwrap();
+
+        assert_eq!(decision.required_experts_per_node, 4);
+        assert_eq!(decision.topk_floor, Some(4));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn derive_floor_decision_uses_mass_threshold() {
+        let dir = temp_case_dir("floor-mass");
+        let ranking_path = dir.join("ranking.csv");
+        write_test_ranking(
+            &ranking_path,
+            &[
+                (0, 40.0),
+                (1, 20.0),
+                (2, 10.0),
+                (3, 10.0),
+                (4, 10.0),
+                (5, 5.0),
+                (6, 3.0),
+                (7, 2.0),
+            ],
+        );
+
+        let decision = derive_floor_decision(
+            &MoeFloorStrategy {
+                mode: MoeFloorMode::MassThreshold,
+                mass_threshold: Some(0.70),
+                ..Default::default()
+            },
+            8,
+            2,
+            &ranking_path,
+        )
+        .unwrap();
+
+        assert_eq!(decision.required_experts_per_node, 3);
+        assert_eq!(decision.mass_floor, Some(3));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn derive_floor_decision_hybrid_takes_max_and_applies_clamps() {
+        let dir = temp_case_dir("floor-hybrid");
+        let ranking_path = dir.join("ranking.csv");
+        write_test_ranking(
+            &ranking_path,
+            &[
+                (0, 40.0),
+                (1, 20.0),
+                (2, 10.0),
+                (3, 10.0),
+                (4, 10.0),
+                (5, 5.0),
+                (6, 3.0),
+                (7, 2.0),
+            ],
+        );
+
+        let decision = derive_floor_decision(
+            &MoeFloorStrategy {
+                mode: MoeFloorMode::Hybrid,
+                topk_multiplier: Some(2),
+                mass_threshold: Some(0.70),
+                floor_max: Some(3),
+                ..Default::default()
+            },
+            8,
+            2,
+            &ranking_path,
+        )
+        .unwrap();
+
+        assert_eq!(decision.topk_floor, Some(4));
+        assert_eq!(decision.mass_floor, Some(3));
+        assert_eq!(decision.unclamped_required_experts_per_node, 4);
+        assert_eq!(decision.required_experts_per_node, 3);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn estimate_startup_fit_reports_full_model_fit() {
         let dir = temp_case_dir("startup-fit-full");
         let ranking_path = dir.join("ranking.csv");
@@ -1665,6 +1993,7 @@ mod tests {
             9_000_000_000,
             "full-v1",
             "Hugging Face dataset",
+            2,
         )
         .unwrap();
 
@@ -1686,6 +2015,7 @@ mod tests {
             4_000_000_000,
             "full-v1",
             "Hugging Face dataset",
+            2,
         )
         .unwrap();
 
@@ -1708,6 +2038,7 @@ mod tests {
             3_800_000_000,
             "full-v1",
             "Hugging Face dataset",
+            2,
         )
         .unwrap();
 

--- a/mesh-llm/src/system/moe_planner.rs
+++ b/mesh-llm/src/system/moe_planner.rs
@@ -161,6 +161,17 @@ impl Default for MoeFloorStrategy {
     }
 }
 
+impl MoeFloorStrategy {
+    pub(crate) fn mode_label(&self) -> &'static str {
+        match self.mode {
+            MoeFloorMode::Fixed50Pct => "fixed_50pct",
+            MoeFloorMode::TopkMultiplier => "topk_multiplier",
+            MoeFloorMode::MassThreshold => "mass_threshold",
+            MoeFloorMode::Hybrid => "hybrid",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 struct MoeFloorDecision {
     required_experts_per_node: u32,
@@ -1154,7 +1165,9 @@ pub(crate) fn fetch_remote_startup_fit(
     distribution_id: &str,
     target_vram_bytes: u64,
     progress: bool,
+    floor_strategy: &MoeFloorStrategy,
 ) -> Result<Option<MoeStartupFitEstimate>> {
+    validate_floor_strategy(floor_strategy)?;
     let Some(ranking) = fetch_remote_ranking(
         dataset_repo_name,
         source_repo,
@@ -1169,13 +1182,19 @@ pub(crate) fn fetch_remote_startup_fit(
         return Ok(None);
     };
     let analysis = read_analysis_json(analysis_path)?;
+    let floor_decision = derive_floor_decision(
+        floor_strategy,
+        analysis.model.expert_count,
+        analysis.model.expert_used_count,
+        &ranking.path,
+    )?;
     let estimate = estimate_startup_fit_from_analysis(
         &ranking.path,
         &analysis,
         target_vram_bytes,
         &ranking.analyzer_id,
         ranking.source.label(),
-        default_required_experts_per_node(analysis.model.expert_count),
+        floor_decision.required_experts_per_node,
     )?;
     Ok(Some(estimate))
 }
@@ -1350,7 +1369,7 @@ impl MoeFloorDecision {
 const DEFAULT_TOPK_MULTIPLIER: u32 = 4;
 const DEFAULT_MASS_THRESHOLD: f64 = 0.70;
 
-fn validate_floor_strategy(strategy: &MoeFloorStrategy) -> Result<()> {
+pub(crate) fn validate_floor_strategy(strategy: &MoeFloorStrategy) -> Result<()> {
     if strategy.topk_multiplier.unwrap_or(DEFAULT_TOPK_MULTIPLIER) == 0 {
         bail!("--experimental-moe-topk-multiplier must be at least 1");
     }

--- a/mesh-llm/src/system/moe_planner.rs
+++ b/mesh-llm/src/system/moe_planner.rs
@@ -254,7 +254,7 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
         &args.floor_strategy,
         model.expert_count,
         model.used_expert_count,
-        &ranking.path,
+        Some(&ranking.path),
     )?;
     model.min_experts_per_node = floor_decision.required_experts_per_node;
     let analysis = ranking
@@ -1186,7 +1186,7 @@ pub(crate) fn fetch_remote_startup_fit(
         floor_strategy,
         analysis.model.expert_count,
         analysis.model.expert_used_count,
-        &ranking.path,
+        Some(&ranking.path),
     )?;
     let estimate = estimate_startup_fit_from_analysis(
         &ranking.path,
@@ -1387,11 +1387,23 @@ pub(crate) fn validate_floor_strategy(strategy: &MoeFloorStrategy) -> Result<()>
     Ok(())
 }
 
+pub(crate) fn resolve_required_experts_per_node(
+    strategy: &MoeFloorStrategy,
+    expert_count: u32,
+    used_expert_count: u32,
+    ranking_path: Option<&Path>,
+) -> Result<u32> {
+    Ok(
+        derive_floor_decision(strategy, expert_count, used_expert_count, ranking_path)?
+            .required_experts_per_node,
+    )
+}
+
 fn derive_floor_decision(
     strategy: &MoeFloorStrategy,
     expert_count: u32,
     used_expert_count: u32,
-    ranking_path: &Path,
+    ranking_path: Option<&Path>,
 ) -> Result<MoeFloorDecision> {
     let topk_multiplier = strategy.topk_multiplier.unwrap_or(DEFAULT_TOPK_MULTIPLIER);
     let mass_threshold = strategy.mass_threshold.unwrap_or(DEFAULT_MASS_THRESHOLD);
@@ -1399,6 +1411,12 @@ fn derive_floor_decision(
         .saturating_mul(topk_multiplier)
         .clamp(1, expert_count.max(1));
     let mass_floor = || -> Result<u32> {
+        let ranking_path = ranking_path.ok_or_else(|| {
+            anyhow::anyhow!(
+                "`{}` shared-core floor requires ranking mass data, but no runtime ranking file is available",
+                strategy.mode_label()
+            )
+        })?;
         let profile = load_analyze_mass_profile(ranking_path)?;
         let target_mass = profile.total_mass * mass_threshold;
         let mut cumulative = 0.0;
@@ -1917,7 +1935,7 @@ mod tests {
             },
             8,
             2,
-            &ranking_path,
+            Some(&ranking_path),
         )
         .unwrap();
 
@@ -1952,7 +1970,7 @@ mod tests {
             },
             8,
             2,
-            &ranking_path,
+            Some(&ranking_path),
         )
         .unwrap();
 
@@ -1989,7 +2007,7 @@ mod tests {
             },
             8,
             2,
-            &ranking_path,
+            Some(&ranking_path),
         )
         .unwrap();
 


### PR DESCRIPTION
This adds experimental MoE shared-core floor strategies to both `mesh-llm moe plan` and `mesh-llm serve`.

Users can now compare alternatives to the current fixed 50% heuristic without changing the default runtime behavior. That makes it possible to test more dynamic shard-floor policies against published `ranking.csv` and `analysis.json` artifacts before deciding whether any of them should become the default.

## What Users Can Do

Try these experimental floor modes in either `moe plan` or `serve`:
- `fixed_50pct`
- `topk_multiplier`
- `mass_threshold`
- `hybrid`

Optional tuning flags:
- `--experimental-moe-topk-multiplier`
- `--experimental-moe-mass-threshold`
- `--experimental-moe-floor-min`
- `--experimental-moe-floor-max`

Examples:

```bash
mesh-llm moe plan unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL \
  --experimental-moe-floor-mode hybrid \
  --experimental-moe-topk-multiplier 4 \
  --experimental-moe-mass-threshold 0.70
```

```bash
mesh-llm serve --model unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL \
  --experimental-moe-floor-mode mass_threshold \
  --experimental-moe-mass-threshold 0.70
```

## How It Works

The shared inputs are:
- `ranking.csv` for expert ordering and cumulative routing mass
- `analysis.json` for `expert_count`, `expert_used_count`, and shard byte accounting

This PR adds a floor-decision step before shard fit estimation. The derived `required_experts_per_node` is then passed into the existing assignment and byte-estimation flow.

Floor formulas:
- `fixed_50pct`: `ceil(expert_count * 0.5)`
- `topk_multiplier`: `expert_used_count * multiplier`
- `mass_threshold`: smallest top-N whose cumulative routing mass reaches the requested threshold
- `hybrid`: `max(topk_multiplier_result, mass_threshold_result)`

That floor is then used to:
- compute assignments with `compute_assignments_with_overlap(...)`
- estimate shard bytes from `analysis.json`
- report feasibility and recommended node count

## CLI Behavior

`moe plan` now:
- accepts the experimental floor flags
- prints the chosen floor strategy and derivation
- uses that derived floor when estimating shard fit

`serve` now:
- accepts the same experimental floor flags
- uses the selected strategy during published MoE preflight before download
- shows the floor mode in preflight progress and result messages
- caches preflight results per `(canonical model ref, floor strategy)` so alternate experiments do not reuse the wrong estimate

## Testing Plan

Goal: find a strategy that is safer and more efficient than `fixed_50pct` without recommending shard plans that fit on paper but fail or degrade badly in practice.

Test this initial strategy matrix:
- `fixed_50pct`
- `topk_multiplier` with `3`, `4`, `6`
- `mass_threshold` with `0.60`, `0.70`, `0.80`
- `hybrid` with:
  - `topk_multiplier=4`, `mass_threshold=0.60`
  - `topk_multiplier=4`, `mass_threshold=0.70`
  - `topk_multiplier=6`, `mass_threshold=0.70`

Use a small model set that includes:
- at least one highly concentrated MoE
- at least one flatter-routing MoE
- at least one smaller MoE
- at least one larger MoE
- at least one model that fits whole on a larger machine
- at least one model that only works as a split

Test each model across three VRAM classes:
- full-fit machine
- borderline machine where only some shard plans should fit
- no-fit machine where neither full model nor conservative split should fit

Phase 1: planner replay
- run `mesh-llm moe plan` for each `(model, VRAM budget, strategy)`
- capture:
  - derived `required_experts_per_node`
  - recommended node count
  - predicted max shard bytes
  - feasibility result

Phase 2: preflight behavior
- run `mesh-llm serve --model ...` with the same strategy matrix
- capture:
  - full-fit / shard-fit / no-fit decision
  - shared expert floor and node count
  - cache reuse on repeated runs
  - correct cache separation when the strategy changes
- `serve` and `moe plan` should agree for the same inputs

Phase 3: actual split validation
- for the most interesting predicted-fit cases, run the real split
- record:
  - predicted shard bytes
  - actual shard GGUF bytes
  - whether the shard actually launches on the target machine
- false positives are the main thing to avoid

Phase 4: quality spot checks
- for a smaller subset of fitted shard plans, run a fixed prompt suite
- compare against either:
  - full-model output on a larger machine, or
  - the current `fixed_50pct` baseline
- look for obvious failure modes:
  - incoherent output
  - repetition or degeneration
  - empty/broken answers
  - dramatic regression versus baseline

Record for each run:
- model and exact revision
- VRAM budget
- strategy and parameters
- derived shared expert floor
- recommended node count
- predicted shard bytes
- actual shard bytes, if tested
- preflight result
- launch result
- quality result

Decision rule:
1. minimize false-positive fit recommendations
2. among safe strategies, minimize required experts per node
3. among efficient safe strategies, prefer the simplest explanation

The most likely first default candidate to test is:
- `hybrid`
- `topk_multiplier=4`
- `mass_threshold=0.70`

## Scope

This PR is still experimental and flag-gated.

Default behavior does not change:
- `fixed_50pct` remains the default for both `moe plan` and `serve`
- users must opt in to other strategies explicitly

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- `cargo test -p mesh-llm derive_floor_decision_ -- --nocapture`
- `cargo test -p mesh-llm estimate_startup_fit_`
