### PR TITLE
Run releases from GitHub Actions instead of tag pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,15 @@ on:
         required: true
         default: false
         type: boolean
-      target_ref:
-        description: Branch or ref to release from
+      target_branch:
+        description: Branch to release from
         required: true
         default: main
         type: string
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -33,7 +37,7 @@ jobs:
       tag: ${{ steps.release_meta.outputs.tag }}
       version: ${{ steps.release_meta.outputs.version }}
       prerelease: ${{ steps.release_meta.outputs.prerelease }}
-      target_ref: ${{ steps.release_meta.outputs.target_ref }}
+      target_branch: ${{ steps.release_meta.outputs.target_branch }}
       release_sha: ${{ steps.release_commit.outputs.release_sha }}
 
     steps:
@@ -42,7 +46,7 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_PRERELEASE: ${{ inputs.prerelease }}
-          INPUT_TARGET_REF: ${{ inputs.target_ref }}
+          INPUT_TARGET_BRANCH: ${{ inputs.target_branch }}
         shell: bash
         run: |
           set -euo pipefail
@@ -55,15 +59,25 @@ jobs:
 
           tag="v$version"
           prerelease="${INPUT_PRERELEASE}"
-          target_ref="${INPUT_TARGET_REF}"
+          target_branch="${INPUT_TARGET_BRANCH}"
 
           if [[ "$prerelease" != "true" && "$prerelease" != "false" ]]; then
             echo "Invalid prerelease flag: $prerelease" >&2
             exit 1
           fi
 
-          if [[ "$prerelease" == "false" && "$target_ref" != "main" ]]; then
-            echo "Stable releases must target main (got: $target_ref)" >&2
+          if [[ -z "$target_branch" || "$target_branch" == refs/* ]]; then
+            echo "target_branch must be a plain branch name under origin/ (got: $target_branch)" >&2
+            exit 1
+          fi
+
+          if ! git check-ref-format --branch "$target_branch" >/dev/null 2>&1; then
+            echo "Invalid branch name: $target_branch" >&2
+            exit 1
+          fi
+
+          if [[ "$prerelease" == "false" && "$target_branch" != "main" ]]; then
+            echo "Stable releases must target main (got: $target_branch)" >&2
             exit 1
           fi
 
@@ -81,12 +95,12 @@ jobs:
             echo "tag=$tag"
             echo "version=$version"
             echo "prerelease=$prerelease"
-            echo "target_ref=$target_ref"
+            echo "target_branch=$target_branch"
           } >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v5
         with:
-          ref: ${{ steps.release_meta.outputs.target_ref }}
+          ref: ${{ steps.release_meta.outputs.target_branch }}
           fetch-depth: 0
 
       - uses: taiki-e/install-action@just
@@ -104,12 +118,12 @@ jobs:
       - name: Verify release invariants
         run: just check-release
 
-      - name: Ensure target ref is a branch
+      - name: Ensure target branch exists on origin
         shell: bash
         run: |
           set -euo pipefail
-          if ! git show-ref --verify --quiet "refs/remotes/origin/${{ steps.release_meta.outputs.target_ref }}"; then
-            echo "Target ref must resolve to a remote branch under origin/ (got: ${{ steps.release_meta.outputs.target_ref }})" >&2
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${{ steps.release_meta.outputs.target_branch }}"; then
+            echo "target_branch must resolve to a remote branch under origin/ (got: ${{ steps.release_meta.outputs.target_branch }})" >&2
             exit 1
           fi
 
@@ -132,7 +146,7 @@ jobs:
         id: release_commit
         env:
           TAG: ${{ steps.release_meta.outputs.tag }}
-          TARGET_REF: ${{ steps.release_meta.outputs.target_ref }}
+          TARGET_BRANCH: ${{ steps.release_meta.outputs.target_branch }}
           PRERELEASE: ${{ steps.release_meta.outputs.prerelease }}
         shell: bash
         run: |
@@ -141,7 +155,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git checkout -B "$TARGET_REF" "origin/$TARGET_REF"
+          git checkout -B "$TARGET_BRANCH" "origin/$TARGET_BRANCH"
 
           scripts/release-version.sh "$TAG"
           git add -A
@@ -158,7 +172,7 @@ jobs:
           fi
 
           git tag "$TAG"
-          git push origin "HEAD:$TARGET_REF"
+          git push origin "HEAD:$TARGET_BRANCH"
           git push origin "$TAG"
 
           echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,22 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version, with or without a leading v
+        required: true
+        type: string
+      prerelease:
+        description: Mark this as a prerelease and allow releasing from a non-main branch
+        required: true
+        default: false
+        type: boolean
+      target_ref:
+        description: Branch or ref to release from
+        required: true
+        default: main
+        type: string
 
 permissions:
   contents: write
@@ -13,9 +26,147 @@ env:
   SCCACHE_GHA_ENABLED: "true"
 
 jobs:
+  prepare_release:
+    name: Prepare release commit and tag
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release_meta.outputs.tag }}
+      version: ${{ steps.release_meta.outputs.version }}
+      prerelease: ${{ steps.release_meta.outputs.prerelease }}
+      target_ref: ${{ steps.release_meta.outputs.target_ref }}
+      release_sha: ${{ steps.release_commit.outputs.release_sha }}
+
+    steps:
+      - name: Normalize release metadata
+        id: release_meta
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_PRERELEASE: ${{ inputs.prerelease }}
+          INPUT_TARGET_REF: ${{ inputs.target_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${INPUT_VERSION#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: $INPUT_VERSION" >&2
+            exit 1
+          fi
+
+          tag="v$version"
+          prerelease="${INPUT_PRERELEASE}"
+          target_ref="${INPUT_TARGET_REF}"
+
+          if [[ "$prerelease" != "true" && "$prerelease" != "false" ]]; then
+            echo "Invalid prerelease flag: $prerelease" >&2
+            exit 1
+          fi
+
+          if [[ "$prerelease" == "false" && "$target_ref" != "main" ]]; then
+            echo "Stable releases must target main (got: $target_ref)" >&2
+            exit 1
+          fi
+
+          if [[ "$prerelease" == "false" && "$tag" == *-* ]]; then
+            echo "Stable releases must not use prerelease semver tags (got: $tag)" >&2
+            exit 1
+          fi
+
+          if [[ "$prerelease" == "true" && "$tag" != *-* ]]; then
+            echo "Prereleases must include a semver prerelease suffix such as -rc.1 (got: $tag)" >&2
+            exit 1
+          fi
+
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "prerelease=$prerelease"
+            echo "target_ref=$target_ref"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.release_meta.outputs.target_ref }}
+          fetch-depth: 0
+
+      - uses: taiki-e/install-action@just
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            mesh-llm/ui/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Verify release invariants
+        run: just check-release
+
+      - name: Ensure target ref is a branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! git show-ref --verify --quiet "refs/remotes/origin/${{ steps.release_meta.outputs.target_ref }}"; then
+            echo "Target ref must resolve to a remote branch under origin/ (got: ${{ steps.release_meta.outputs.target_ref }})" >&2
+            exit 1
+          fi
+
+      - name: Ensure release tag does not already exist
+        env:
+          TAG: ${{ steps.release_meta.outputs.tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag already exists locally: $TAG" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists on origin: $TAG" >&2
+            exit 1
+          fi
+
+      - name: Create release commit and tag
+        id: release_commit
+        env:
+          TAG: ${{ steps.release_meta.outputs.tag }}
+          TARGET_REF: ${{ steps.release_meta.outputs.target_ref }}
+          PRERELEASE: ${{ steps.release_meta.outputs.prerelease }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$TARGET_REF" "origin/$TARGET_REF"
+
+          scripts/release-version.sh "$TAG"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "Release version update produced no changes for $TAG" >&2
+            exit 1
+          fi
+
+          if [[ "$PRERELEASE" == "true" ]]; then
+            git commit -m "$TAG: prerelease"
+          else
+            git commit -m "$TAG: release"
+          fi
+
+          git tag "$TAG"
+          git push origin "HEAD:$TARGET_REF"
+          git push origin "$TAG"
+
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
+    needs: prepare_release
     strategy:
       fail-fast: false
       matrix:
@@ -29,6 +180,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
 
       - uses: taiki-e/install-action@just
 
@@ -56,9 +209,11 @@ jobs:
 
       - name: Build release bundle
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
         run: |
           just --shell bash --shell-arg -lc release-build
-          just --shell bash --shell-arg -lc release-bundle "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-bundle "$RELEASE_TAG" dist
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v6
@@ -86,6 +241,7 @@ jobs:
 
   inference_smoke_tests:
     needs:
+      - prepare_release
       - build
     uses: ./.github/workflows/smoke.yml
     with:
@@ -97,9 +253,12 @@ jobs:
   build_linux_arm64:
     name: Build Linux ARM64 CPU
     runs-on: ubuntu-24.04-arm
+    needs: prepare_release
 
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
 
       - uses: taiki-e/install-action@just
 
@@ -126,9 +285,11 @@ jobs:
 
       - name: Build ARM64 CPU release bundle
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
         run: |
           just --shell bash --shell-arg -lc release-build-arm64
-          just --shell bash --shell-arg -lc release-bundle-arm64 "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-bundle-arm64 "$RELEASE_TAG" dist
 
       - name: Upload ARM64 CPU release artifacts
         uses: actions/upload-artifact@v6
@@ -144,6 +305,7 @@ jobs:
   build_linux_cuda:
     name: Build Linux CUDA
     runs-on: ubuntu-latest
+    needs: prepare_release
     container:
       image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.8.0' }}-devel-ubuntu22.04
 
@@ -165,6 +327,8 @@ jobs:
           rm -rf /var/lib/apt/lists/*
 
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
 
       - uses: actions/setup-node@v5
         with:
@@ -188,9 +352,11 @@ jobs:
 
       - name: Build CUDA release bundle
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
         run: |
           just --shell bash --shell-arg -lc release-build-cuda
-          just --shell bash --shell-arg -lc release-bundle-cuda "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-bundle-cuda "$RELEASE_TAG" dist
 
       - name: Upload CUDA release artifacts
         uses: actions/upload-artifact@v6
@@ -206,6 +372,7 @@ jobs:
   build_linux_rocm:
     name: Build Linux ROCm
     runs-on: ubuntu-latest
+    needs: prepare_release
     container:
       image: rocm/dev-ubuntu-24.04:7.0-complete
 
@@ -227,6 +394,8 @@ jobs:
           rm -rf /var/lib/apt/lists/*
 
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
 
       - uses: actions/setup-node@v5
         with:
@@ -250,9 +419,11 @@ jobs:
 
       - name: Build ROCm release bundle
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
         run: |
           just --shell bash --shell-arg -lc release-build-rocm
-          just --shell bash --shell-arg -lc release-bundle-rocm "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-bundle-rocm "$RELEASE_TAG" dist
 
       - name: Upload ROCm release artifacts
         uses: actions/upload-artifact@v6
@@ -268,6 +439,7 @@ jobs:
   build_linux_vulkan:
     name: Build Linux Vulkan
     runs-on: ubuntu-latest
+    needs: prepare_release
 
     steps:
       - name: Install Vulkan build packages
@@ -289,6 +461,8 @@ jobs:
           sudo rm -rf /var/lib/apt/lists/*
 
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
 
       - uses: actions/setup-node@v5
         with:
@@ -312,9 +486,11 @@ jobs:
 
       - name: Build Vulkan release bundle
         shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
         run: |
           just --shell bash --shell-arg -lc release-build-vulkan
-          just --shell bash --shell-arg -lc release-bundle-vulkan "${GITHUB_REF_NAME}" dist
+          just --shell bash --shell-arg -lc release-bundle-vulkan "$RELEASE_TAG" dist
 
       - name: Upload Vulkan release artifacts
         uses: actions/upload-artifact@v6
@@ -327,107 +503,17 @@ jobs:
         if: always()
         run: sccache --show-stats || true
 
-  # Windows release builds disabled until llama.cpp CUDA compile issue is resolved
-  # (mmvq.cu fails for compute_120a / Blackwell). Re-enable by uncommenting
-  # build_windows below and adding it back to publish.needs.
-  #
-  # build_windows:
-  #   name: Build Windows ${{ matrix.name }}
-  #   runs-on: windows-2022
-  #   env:
-  #     ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       include:
-  #         - name: CPU
-  #           backend: cpu
-  #           build_recipe: release-build-windows
-  #           bundle_recipe: release-bundle-windows
-  #           artifact_name: release-windows-cpu
-  #         - name: CUDA
-  #           backend: cuda
-  #           build_recipe: release-build-cuda-windows
-  #           bundle_recipe: release-bundle-cuda-windows
-  #           artifact_name: release-windows-cuda
-  #         - name: ROCm
-  #           backend: rocm
-  #           build_recipe: release-build-rocm-windows
-  #           bundle_recipe: release-bundle-rocm-windows
-  #           artifact_name: release-windows-rocm
-  #         - name: Vulkan
-  #           backend: vulkan
-  #           build_recipe: release-build-vulkan-windows
-  #           bundle_recipe: release-bundle-vulkan-windows
-  #           artifact_name: release-windows-vulkan
-  #
-  #   steps:
-  #     - uses: actions/checkout@v5
-  #
-  #     - uses: taiki-e/install-action@just
-  #
-  #     - uses: actions/setup-node@v5
-  #       with:
-  #         node-version: 24
-  #         cache: npm
-  #         cache-dependency-path: mesh-llm/ui/package-lock.json
-  #
-  #     - uses: dtolnay/rust-toolchain@stable
-  #
-  #     - uses: mozilla-actions/sccache-action@v0.0.9
-  #
-  #     - uses: Swatinem/rust-cache@v2
-  #       with:
-  #         workspaces: |
-  #           . -> target
-  #
-  #     - name: Cache Windows SDK installers
-  #       if: matrix.backend != 'cpu'
-  #       uses: actions/cache@v5
-  #       with:
-  #         path: ~\sdk-installer-cache\${{ matrix.backend }}
-  #         key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
-  #
-  #     - name: Install backend SDK
-  #       shell: pwsh
-  #       run: |
-  #         .\scripts\install-windows-sdk.ps1 `
-  #           -Backend '${{ matrix.backend }}' `
-  #           -RocmHipSdkFilename $env:ROCM_HIP_SDK_FILENAME `
-  #           -InstallerCacheDir (Join-Path $env:USERPROFILE 'sdk-installer-cache\${{ matrix.backend }}')
-  #
-  #     - name: Build Windows release bundle
-  #       shell: pwsh
-  #       run: |
-  #         just ${{ matrix.build_recipe }}
-  #         just ${{ matrix.bundle_recipe }} "${env:GITHUB_REF_NAME}" dist
-  #
-  #     - name: Upload Windows release artifacts
-  #       uses: actions/upload-artifact@v6
-  #       with:
-  #         name: ${{ matrix.artifact_name }}
-  #         path: dist/*
-  #         if-no-files-found: error
-  #
-  #     - name: Show sccache stats
-  #       if: always()
-  #       shell: pwsh
-  #       run: |
-  #         if (Get-Command sccache -ErrorAction SilentlyContinue) {
-  #           sccache --show-stats
-  #         }
-
   publish:
     name: Publish GitHub release
     runs-on: ubuntu-latest
     needs:
+      - prepare_release
       - build
       - build_linux_arm64
       - build_linux_cuda
       - build_linux_rocm
       - build_linux_vulkan
       - inference_smoke_tests
-      # - build_windows  # disabled until llama.cpp CUDA fix
 
     steps:
       - name: Download release artifacts
@@ -441,6 +527,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare_release.outputs.tag }}
+          PRERELEASE: ${{ needs.prepare_release.outputs.prerelease }}
         shell: bash
         run: |
           shopt -s nullglob
@@ -451,15 +539,42 @@ jobs:
           fi
 
           release_args=(--repo "$GH_REPO")
-          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+          if [[ "$PRERELEASE" == "true" ]]; then
             release_args+=(--prerelease --latest=false)
           fi
 
-          if gh release view "$GITHUB_REF_NAME" --repo "$GH_REPO" >/dev/null 2>&1; then
-            if [[ "$GITHUB_REF_NAME" == *-* ]]; then
-              gh release edit "$GITHUB_REF_NAME" --repo "$GH_REPO" --prerelease --latest=false
+          if gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null 2>&1; then
+            if [[ "$PRERELEASE" == "true" ]]; then
+              gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --prerelease --latest=false
             fi
-            gh release upload "$GITHUB_REF_NAME" "${files[@]}" --repo "$GH_REPO" --clobber
+            gh release upload "$RELEASE_TAG" "${files[@]}" --repo "$GH_REPO" --clobber
           else
-            gh release create "$GITHUB_REF_NAME" "${files[@]}" "${release_args[@]}" --generate-notes
+            gh release create "$RELEASE_TAG" "${files[@]}" "${release_args[@]}" --generate-notes
           fi
+  publish_crates:
+    name: Publish crates.io packages
+    runs-on: ubuntu-latest
+    needs:
+      - prepare_release
+      - publish
+    if: github.repository == 'Mesh-LLM/mesh-llm' && needs.prepare_release.outputs.prerelease != 'true'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare_release.outputs.release_sha }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish mesh-llm-client
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked -p mesh-llm-client
+
+      - name: Wait for crates.io index
+        run: sleep 30
+
+      - name: Publish mesh-api
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked -p mesh-api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -565,30 +565,3 @@ jobs:
           else
             gh release create "$RELEASE_TAG" "${files[@]}" "${release_args[@]}" --generate-notes
           fi
-  publish_crates:
-    name: Publish crates.io packages
-    runs-on: ubuntu-latest
-    needs:
-      - prepare_release
-      - publish
-    if: github.repository == 'Mesh-LLM/mesh-llm' && needs.prepare_release.outputs.prerelease != 'true'
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ needs.prepare_release.outputs.release_sha }}
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - name: Publish mesh-llm-client
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked -p mesh-llm-client
-
-      - name: Wait for crates.io index
-        run: sleep 30
-
-      - name: Publish mesh-api
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked -p mesh-api

--- a/Justfile
+++ b/Justfile
@@ -75,41 +75,6 @@ release-build-vulkan:
 release-build-vulkan-windows:
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend vulkan
 
-# Bump release version consistently across source and Cargo manifests.
-release-version version:
-    @scripts/release-version.sh "{{ version }}"
-
-# Releases are now orchestrated by the GitHub Actions Release workflow.
-release version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    tag="{{ version }}"
-    if [[ "$tag" != v* ]]; then
-        tag="v$tag"
-    fi
-    echo "Releases are now created by the GitHub Actions Release workflow." >&2
-    echo "Run it with:" >&2
-    echo "  gh workflow run release.yml -f version=$tag -f prerelease=false -f target_ref=main" >&2
-    exit 1
-
-# Prereleases are now orchestrated by the GitHub Actions Release workflow.
-prerelease version:
-    #!/usr/bin/env bash
-    set -euo pipefail
-    tag="{{ version }}"
-    if [[ "$tag" != v* ]]; then
-        tag="v$tag"
-    fi
-    current_branch="$(git branch --show-current)"
-    if [[ -z "$current_branch" ]]; then
-        echo "Error: prerelease workflow dispatch needs a branch, not detached HEAD." >&2
-        exit 1
-    fi
-    echo "Prereleases are now created by the GitHub Actions Release workflow." >&2
-    echo "Run it with:" >&2
-    echo "  gh workflow run release.yml -f version=$tag -f prerelease=true -f target_ref=$current_branch" >&2
-    exit 1
-
 # Download the default model (GLM-4.7-Flash Q4_K_M, 17GB)
 download-model:
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -79,60 +79,36 @@ release-build-vulkan-windows:
 release-version version:
     @scripts/release-version.sh "{{ version }}"
 
-# Tag and push a release. Bumps version, updates Cargo.lock, commits, tags, pushes.
-# CI builds and publishes the GitHub release automatically.
+# Releases are now orchestrated by the GitHub Actions Release workflow.
 release version:
     #!/usr/bin/env bash
     set -euo pipefail
-    current_branch="$(git branch --show-current)"
-    if [[ "$current_branch" != "main" ]]; then
-        echo "Error: release must be run from the 'main' branch (current: ${current_branch:-detached HEAD})" >&2
-        exit 1
-    fi
-    if [[ -n "$(git status --porcelain)" ]]; then
-        echo "Error: working tree is not clean. Commit or stash changes before releasing." >&2
-        exit 1
-    fi
-    just check-release
     tag="{{ version }}"
     if [[ "$tag" != v* ]]; then
         tag="v$tag"
     fi
-    scripts/release-version.sh "$tag"
-    git add -A
-    git commit -m "$tag: release"
-    git tag "$tag"
-    git push origin main
-    git push origin "$tag"
+    echo "Releases are now created by the GitHub Actions Release workflow." >&2
+    echo "Run it with:" >&2
+    echo "  gh workflow run release.yml -f version=$tag -f prerelease=false -f target_ref=main" >&2
+    exit 1
 
-# Tag and push a prerelease from the current branch. Bumps version, updates
-# Cargo.lock, commits, tags, and pushes the branch plus prerelease tag.
+# Prereleases are now orchestrated by the GitHub Actions Release workflow.
 prerelease version:
     #!/usr/bin/env bash
     set -euo pipefail
-    current_branch="$(git branch --show-current)"
-    if [[ -z "$current_branch" ]]; then
-        echo "Error: prerelease must be run from a branch, not detached HEAD." >&2
-        exit 1
-    fi
-    if [[ -n "$(git status --porcelain)" ]]; then
-        echo "Error: working tree is not clean. Commit or stash changes before prereleasing." >&2
-        exit 1
-    fi
     tag="{{ version }}"
     if [[ "$tag" != v* ]]; then
         tag="v$tag"
     fi
-    if [[ "$tag" != *-* ]]; then
-        echo "Error: prerelease tag must include a prerelease suffix such as -rc.1 (got: $tag)" >&2
+    current_branch="$(git branch --show-current)"
+    if [[ -z "$current_branch" ]]; then
+        echo "Error: prerelease workflow dispatch needs a branch, not detached HEAD." >&2
         exit 1
     fi
-    scripts/release-version.sh "$tag"
-    git add -A
-    git commit -m "$tag: prerelease"
-    git tag "$tag"
-    git push origin "$current_branch"
-    git push origin "$tag"
+    echo "Prereleases are now created by the GitHub Actions Release workflow." >&2
+    echo "Run it with:" >&2
+    echo "  gh workflow run release.yml -f version=$tag -f prerelease=true -f target_ref=$current_branch" >&2
+    exit 1
 
 # Download the default model (GLM-4.7-Flash Q4_K_M, 17GB)
 download-model:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,26 +79,27 @@ rm -rf /tmp/test-bundle
 ### 5. Release
 
 ```bash
-gh workflow run release.yml -f version=v0.X.0 -f prerelease=false -f target_ref=main
+gh workflow run release.yml -f version=v0.X.0 -f prerelease=false -f target_branch=main
 ```
 
-The Release workflow is now the source of truth for stable releases. It checks out `main`, runs the release consistency checks, bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, creates the release commit, creates and pushes the release tag, builds the release artifacts, publishes the GitHub release, and then publishes `mesh-llm-client` and `mesh-api` to crates.io.
+The Release workflow is now the source of truth for stable releases. It checks out `main`, runs the release consistency checks, bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, creates the release commit directly on `main`, creates and pushes the release tag, builds the release artifacts, publishes the GitHub release, and then publishes `mesh-llm-client` and `mesh-api` to crates.io.
 
 On native Windows, `just check-release` still runs the Rust/docs/workflow invariant checks, but it skips the Bash-only `install.sh` and `scripts/package-release.sh` parity checks. Run the release-target parity check on macOS or Linux before cutting a tag if you need full shell-script coverage.
 
 ### 5a. Prerelease
 
 ```bash
-gh workflow run release.yml -f version=v0.X.0-rc.1 -f prerelease=true -f target_ref=feature/your-branch
+gh workflow run release.yml -f version=v0.X.0-rc.1 -f prerelease=true -f target_branch=feature/your-branch
 ```
 
-The same Release workflow handles prereleases. Set `prerelease=true` and provide the branch you want to cut the prerelease from. The workflow creates the prerelease commit on that branch, pushes the branch update, creates and pushes the prerelease tag, builds the artifacts, and publishes a GitHub prerelease. It skips crates.io publishing for prerelease tags.
+The same Release workflow handles prereleases. Set `prerelease=true` and provide the branch you want to cut the prerelease from. The workflow creates the prerelease commit directly on that branch, pushes the branch update, creates and pushes the prerelease tag, builds the artifacts, and publishes a GitHub prerelease. It skips crates.io publishing for prerelease tags.
 
 ### 6. Let GitHub Actions build and publish the release
 
 Running `.github/workflows/release.yml` via `workflow_dispatch` triggers the release flow, which:
 
 - creates and pushes the release commit and tag before any build jobs start
+- serializes releases so two manual runs cannot race each other
 - builds release bundles on macOS, Linux CPU, Linux ARM64 CPU, Linux CUDA, Linux ROCm, and Linux Vulkan
 - keeps the Windows publish block commented out for now, so GitHub release publishing does not currently upload Windows bundles
 - still leaves the local Windows bundle recipes available in `Justfile` for manual builds
@@ -139,6 +140,7 @@ After the workflow finishes, verify:
 - The default Linux release bundle is a generic CPU build.
 - Windows source builds exist, and the `*-windows` release recipes in `Justfile` still generate local `.zip` artifacts.
 - The workflow is now responsible for creating and pushing release tags; pushing a tag manually does not trigger a release build anymore.
+- The workflow mutates the target branch by creating and pushing the release commit before it starts the build matrix.
 - Tagged GitHub releases do not currently publish Windows bundles because the Windows release job remains commented out in `.github/workflows/release.yml`.
 - Release bundles use flavor-specific `rpc-server-<flavor>` and `llama-server-<flavor>` names so multiple flavors can coexist in one install directory. Use `mesh-llm --llama-flavor <flavor>` to force a specific pair.
 - The CUDA Linux release bundle is built in CI with an explicit multi-arch `CMAKE_CUDA_ARCHITECTURES` list and is not runtime-tested during the workflow.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -79,25 +79,26 @@ rm -rf /tmp/test-bundle
 ### 5. Release
 
 ```bash
-just release v0.X.0
+gh workflow run release.yml -f version=v0.X.0 -f prerelease=false -f target_ref=main
 ```
 
-Run this from a clean local `main` branch. It bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, commits as `v0.X.0: release`, pushes `main`, and then pushes only the new release tag.
+The Release workflow is now the source of truth for stable releases. It checks out `main`, runs the release consistency checks, bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, creates the release commit, creates and pushes the release tag, builds the release artifacts, publishes the GitHub release, and then publishes `mesh-llm-client` and `mesh-api` to crates.io.
 
 On native Windows, `just check-release` still runs the Rust/docs/workflow invariant checks, but it skips the Bash-only `install.sh` and `scripts/package-release.sh` parity checks. Run the release-target parity check on macOS or Linux before cutting a tag if you need full shell-script coverage.
 
 ### 5a. Prerelease
 
 ```bash
-just prerelease v0.X.0-rc.1
+gh workflow run release.yml -f version=v0.X.0-rc.1 -f prerelease=true -f target_ref=feature/your-branch
 ```
 
-Run this from a clean branch. It bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, commits as `v0.X.0-rc.1: prerelease`, pushes the current branch, and then pushes the prerelease tag.
+The same Release workflow handles prereleases. Set `prerelease=true` and provide the branch you want to cut the prerelease from. The workflow creates the prerelease commit on that branch, pushes the branch update, creates and pushes the prerelease tag, builds the artifacts, and publishes a GitHub prerelease. It skips crates.io publishing for prerelease tags.
 
 ### 6. Let GitHub Actions build and publish the release
 
-Pushing a `v*` tag triggers `.github/workflows/release.yml`, which:
+Running `.github/workflows/release.yml` via `workflow_dispatch` triggers the release flow, which:
 
+- creates and pushes the release commit and tag before any build jobs start
 - builds release bundles on macOS, Linux CPU, Linux ARM64 CPU, Linux CUDA, Linux ROCm, and Linux Vulkan
 - keeps the Windows publish block commented out for now, so GitHub release publishing does not currently upload Windows bundles
 - still leaves the local Windows bundle recipes available in `Justfile` for manual builds
@@ -137,6 +138,7 @@ After the workflow finishes, verify:
 - The unversioned asset name `mesh-bundle.tar.gz` is still kept for compatibility with direct archive installs.
 - The default Linux release bundle is a generic CPU build.
 - Windows source builds exist, and the `*-windows` release recipes in `Justfile` still generate local `.zip` artifacts.
+- The workflow is now responsible for creating and pushing release tags; pushing a tag manually does not trigger a release build anymore.
 - Tagged GitHub releases do not currently publish Windows bundles because the Windows release job remains commented out in `.github/workflows/release.yml`.
 - Release bundles use flavor-specific `rpc-server-<flavor>` and `llama-server-<flavor>` names so multiple flavors can coexist in one install directory. Use `mesh-llm --llama-flavor <flavor>` to force a specific pair.
 - The CUDA Linux release bundle is built in CI with an explicit multi-arch `CMAKE_CUDA_ARCHITECTURES` list and is not runtime-tested during the workflow.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -82,7 +82,7 @@ rm -rf /tmp/test-bundle
 gh workflow run release.yml -f version=v0.X.0 -f prerelease=false -f target_branch=main
 ```
 
-The Release workflow is now the source of truth for stable releases. It checks out `main`, runs the release consistency checks, bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, creates the release commit directly on `main`, creates and pushes the release tag, builds the release artifacts, publishes the GitHub release, and then publishes `mesh-llm-client` and `mesh-api` to crates.io.
+The Release workflow is now the source of truth for stable releases. It checks out `main`, runs the release consistency checks, bumps the version in source + Cargo manifests, refreshes `Cargo.lock` without upgrading dependencies, creates the release commit directly on `main`, creates and pushes the release tag, builds the release artifacts, and publishes the GitHub release.
 
 On native Windows, `just check-release` still runs the Rust/docs/workflow invariant checks, but it skips the Bash-only `install.sh` and `scripts/package-release.sh` parity checks. Run the release-target parity check on macOS or Linux before cutting a tag if you need full shell-script coverage.
 
@@ -92,7 +92,7 @@ On native Windows, `just check-release` still runs the Rust/docs/workflow invari
 gh workflow run release.yml -f version=v0.X.0-rc.1 -f prerelease=true -f target_branch=feature/your-branch
 ```
 
-The same Release workflow handles prereleases. Set `prerelease=true` and provide the branch you want to cut the prerelease from. The workflow creates the prerelease commit directly on that branch, pushes the branch update, creates and pushes the prerelease tag, builds the artifacts, and publishes a GitHub prerelease. It skips crates.io publishing for prerelease tags.
+The same Release workflow handles prereleases. Set `prerelease=true` and provide the branch you want to cut the prerelease from. The workflow creates the prerelease commit directly on that branch, pushes the branch update, creates and pushes the prerelease tag, builds the artifacts, and publishes a GitHub prerelease.
 
 ### 6. Let GitHub Actions build and publish the release
 


### PR DESCRIPTION
This moves release orchestration into the GitHub Actions release workflow instead of relying on manually pushing a release tag first.

What changes:
- make the release workflow `workflow_dispatch` with `version`, `prerelease`, and `target_branch` inputs
- have the workflow create and push the release commit and tag before starting the build matrix
- serialize release runs so two manual releases cannot race
- require `target_branch` to be an actual branch name under `origin/`
- remove the old local `just release` and `just prerelease` entrypoints
- update `RELEASE.md` to document the new release flow and call out that the workflow mutates the target branch

Validation:
- parsed `.github/workflows/release.yml` successfully
- ran `git diff --check`

This PR is based on the latest `main`.