### PR TITLE
Let moe analyze share rankings automatically

### DIFF
--- a/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/mesh-llm/src/cli/commands/moe/mod.rs
@@ -66,12 +66,14 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
         MoeCommand::Analyze { command } => match command {
             MoeAnalyzeCommand::Full {
                 model,
+                share,
                 context_size,
                 n_gpu_layers,
                 hf_job,
-            } => run_analyze_full(model, *context_size, *n_gpu_layers, hf_job).await,
+            } => run_analyze_full(model, *share, *context_size, *n_gpu_layers, hf_job).await,
             MoeAnalyzeCommand::Micro {
                 model,
+                share,
                 prompt_count,
                 token_count,
                 context_size,
@@ -80,6 +82,7 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
             } => {
                 run_analyze_micro(
                     model,
+                    *share,
                     *prompt_count,
                     *token_count,
                     *context_size,
@@ -128,6 +131,7 @@ async fn run_plan(
 
 async fn run_analyze_full(
     model: &str,
+    share: bool,
     context_size: u32,
     n_gpu_layers: u32,
     hf_job: &HfJobArgs,
@@ -168,12 +172,17 @@ async fn run_analyze_full(
     println!("  Ranking: {}", output_path.display());
     println!("  Analysis: {}", analysis_path.display());
     println!("  Log: {}", log_path.display());
-    print_submit_suggestion(&resolved.path);
+    if share {
+        auto_share_ranking(&resolved, &output_path, &hf_job.dataset_repo).await?;
+    } else {
+        print_submit_suggestion(&resolved.path);
+    }
     Ok(())
 }
 
 async fn run_analyze_micro(
     model: &str,
+    share: bool,
     prompt_count: usize,
     token_count: u32,
     context_size: u32,
@@ -311,8 +320,28 @@ async fn run_analyze_micro(
         );
     }
     println!("  Log: {}", log_path.display());
-    print_submit_suggestion(&resolved.path);
+    if share {
+        auto_share_ranking(&resolved, cache_path.as_path(), &hf_job.dataset_repo).await?;
+    } else {
+        print_submit_suggestion(&resolved.path);
+    }
     Ok(())
+}
+
+async fn auto_share_ranking(
+    resolved: &moe_planner::MoeModelContext,
+    ranking_path: &Path,
+    dataset_repo: &str,
+) -> Result<()> {
+    println!("📤 Auto-sharing ranking...");
+    run_share_resolved(resolved, Some(ranking_path), dataset_repo)
+        .await
+        .with_context(|| {
+            format!(
+                "Automatic share failed after analyze completed for {}",
+                resolved.display_name
+            )
+        })
 }
 
 fn write_canonical_micro_ranking(
@@ -368,14 +397,22 @@ fn print_submit_suggestion(model_path: &Path) {
 }
 
 async fn run_share(model: &str, ranking_file: Option<&Path>, dataset_repo: &str) -> Result<()> {
+    let resolved = moe_planner::resolve_model_context(model).await?;
+    run_share_resolved(&resolved, ranking_file, dataset_repo).await
+}
+
+async fn run_share_resolved(
+    resolved: &moe_planner::MoeModelContext,
+    ranking_file: Option<&Path>,
+    dataset_repo: &str,
+) -> Result<()> {
     let share_error = |title: &str, detail: &str| -> anyhow::Error {
         eprintln!("❌ {title}");
         eprintln!("   {detail}");
         anyhow::anyhow!("{title}: {detail}")
     };
 
-    let resolved = moe_planner::resolve_model_context(model).await?;
-    let ranking = moe_planner::local_submit_ranking(&resolved, ranking_file)?;
+    let ranking = moe_planner::local_submit_ranking(resolved, ranking_file)?;
     moe_planner::validate_ranking(&resolved, &ranking).with_context(|| {
         format!(
             "Validate ranking {} against model {}",

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -710,6 +710,7 @@ fn shell_display(arg: &OsString) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::moe::MoeAnalyzeCommand;
     use clap::Parser;
 
     #[test]
@@ -857,6 +858,65 @@ mod tests {
             Command::Gpus { json, command } => {
                 assert!(!json);
                 assert!(command.is_none());
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn moe_analyze_full_accepts_share_flag() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "moe",
+            "analyze",
+            "full",
+            "Qwen/Qwen3",
+            "--share",
+            "--dataset-repo",
+            "meshllm/custom-rankings",
+        ]);
+
+        match cli.command.expect("moe command expected") {
+            Command::Moe {
+                command:
+                    MoeCommand::Analyze {
+                        command:
+                            MoeAnalyzeCommand::Full {
+                                share,
+                                hf_job,
+                                model,
+                                ..
+                            },
+                    },
+            } => {
+                assert!(share);
+                assert_eq!(model, "Qwen/Qwen3");
+                assert_eq!(hf_job.dataset_repo, "meshllm/custom-rankings");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn moe_analyze_micro_accepts_share_flag() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "moe",
+            "analyze",
+            "micro",
+            "Qwen/Qwen3",
+            "--share",
+        ]);
+
+        match cli.command.expect("moe command expected") {
+            Command::Moe {
+                command:
+                    MoeCommand::Analyze {
+                        command: MoeAnalyzeCommand::Micro { share, model, .. },
+                    },
+            } => {
+                assert!(share);
+                assert_eq!(model, "Qwen/Qwen3");
             }
             other => panic!("unexpected command: {other:?}"),
         }

--- a/mesh-llm/src/cli/moe.rs
+++ b/mesh-llm/src/cli/moe.rs
@@ -48,6 +48,9 @@ pub(crate) enum MoeAnalyzeCommand {
     Full {
         /// Model spec: local path, catalog name, HF exact ref, HF repo selector like `org/repo:BF16@main`, or HF URL.
         model: String,
+        /// Automatically run `mesh-llm moe share` after a successful local analysis.
+        #[arg(long)]
+        share: bool,
         /// Override context size passed to llama-moe-analyze.
         #[arg(long, default_value = "4096")]
         context_size: u32,
@@ -61,6 +64,9 @@ pub(crate) enum MoeAnalyzeCommand {
     Micro {
         /// Model spec: local path, catalog name, HF exact ref, HF repo selector like `org/repo:BF16@main`, or HF URL.
         model: String,
+        /// Automatically run `mesh-llm moe share` after a successful local analysis.
+        #[arg(long)]
+        share: bool,
         /// Number of canonical prompts to use.
         #[arg(long, default_value = "8")]
         prompt_count: usize,
@@ -83,7 +89,7 @@ pub(crate) struct HfJobArgs {
     /// Submit this MoE analyze run to Hugging Face Jobs instead of running locally.
     #[arg(long)]
     pub(crate) hf_job: bool,
-    /// Dataset repo to contribute to when the remote analysis succeeds.
+    /// Dataset repo to contribute to when auto-sharing or when the remote analysis succeeds.
     #[arg(long, default_value = "meshllm/moe-rankings")]
     pub(crate) dataset_repo: String,
     /// HF Jobs hardware flavor, e.g. cpu-xl, cpu-performance, l40sx1.


### PR DESCRIPTION
## Summary
Users can now add `--share` to `mesh-llm moe analyze full` and `mesh-llm moe analyze micro` to automatically open the MoE ranking contribution flow as soon as local analysis succeeds.

## What Changed
- added a `--share` flag to both local `moe analyze` subcommands
- reused the existing `moe share` implementation after analyze completes instead of duplicating dataset contribution logic
- shared the exact ranking artifact produced by the current analyze run so micro runs do not accidentally publish a different cached artifact
- added CLI parser tests for the new flag on both `full` and `micro`

## Why
Running `moe analyze` and then manually invoking `moe share` is an extra step in the common contribution flow. This change makes the happy path one command while preserving the existing manual share path.

## Impact
- local MoE analysis can immediately contribute rankings with one command
- existing `--hf-job` behavior stays intact
- users can still run analyze without `--share` and get the existing share suggestion output

## Validation
- `cargo fmt --all -- --check`
- `just build`
- `cargo test -p mesh-llm moe_analyze_`

## Notes
`cargo check -p mesh-llm` initially failed in this worktree before `just build` because `mesh-llm/ui/dist` had not been generated yet; the supported build flow completed successfully afterward.
