### PR TITLE
Stop small models from looping in decode

### DIFF
--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -1164,6 +1164,18 @@ pub async fn start_llama_server(
         //   "chat_template_kwargs": {"enable_thinking": true}
         "--reasoning-budget".to_string(),
         "0".to_string(),
+        // Anti-repetition default. llama.cpp ships repeat_penalty off
+        // (1.0), which lets small quantized models fall into tight decode
+        // loops ("Ok 1 2 3 4 5 Ok 1 2 3 4 5 ...") on mildly adversarial
+        // prompts. 1.1 over a 256-token window is the conventional mild
+        // setting — it kills loops without measurably affecting normal
+        // prose. Per-request JSON fields (`repeat_penalty`, `repeat_last_n`)
+        // still override these, so clients that tune their own sampling are
+        // unaffected.
+        "--repeat-penalty".to_string(),
+        "1.1".to_string(),
+        "--repeat-last-n".to_string(),
+        "256".to_string(),
     ]);
 
     // Mesh hooks — tell llama-server where to call back.


### PR DESCRIPTION
Hosts now launch llama-server with a mild repeat penalty by default. Clients that set their own sampling are unaffected — per-request `repeat_penalty` / `repeat_last_n` still override.

## Why

A plain chat request to a small quantized model could drop into a tight decode loop when the client did not set a repeat penalty. Reproduced against the public mesh on `qwen2.5-3b-instruct-q4_k_m`: the baseline repeated "Ok 1 2 3 4 5" for the full `max_tokens` budget. With `--repeat-penalty 1.1 --repeat-last-n 256` the same prompt produced a clean linear response, and a control prose prompt was unchanged.

## Behaviour

- Sets `--repeat-penalty 1.1` and `--repeat-last-n 256` on every llama-server launch.
- Clients that pass `repeat_penalty` / `repeat_last_n` in the request JSON still win — llama-server uses the per-request value.
- No config, no flags.