### PR TITLE
Show GGUF variants on show and variant counts in search results

### DIFF
--- a/mesh-llm/src/cli/commands/models/formatters_console.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_console.rs
@@ -92,6 +92,9 @@ impl SearchFormatter for ConsoleFormatter {
         for (index, result) in results.iter().enumerate() {
             println!("{}. 📦 {}", index + 1, result.repo_id);
             println!("   type: {}", result.kind);
+            if let Some(variant_count) = result.variant_count {
+                println!("   🧬 variants: {} available", variant_count);
+            }
             let mut stats = Vec::new();
             if let Some(size) = &result.size_label {
                 stats.push(format!("size: {} 📏", size));

--- a/mesh-llm/src/cli/commands/models/formatters_json.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_json.rs
@@ -9,6 +9,44 @@ use anyhow::Result;
 use serde_json::{json, Value};
 use std::path::Path;
 
+fn show_payload(details: &ModelDetails, variants: Option<&[ModelDetails]>) -> Value {
+    json!({
+        "display_name": details.exact_ref,
+        "ref": details.exact_ref,
+        "type": model_kind_code(details.kind),
+        "source": details.source,
+        "size": details.size_label,
+        "fit": details
+            .size_label
+            .as_deref()
+            .and_then(fit_code_for_size_label),
+        "description": details.description,
+        "draft": details.draft,
+        "capabilities": capabilities_json(details.capabilities),
+        "moe": moe_json(details.moe.as_ref()),
+        "download_url": details.download_url,
+        "machine": local_capacity_json(),
+        "variants": variants
+            .unwrap_or_default()
+            .iter()
+            .map(|variant| {
+                json!({
+                    "display_name": variant.exact_ref,
+                    "ref": variant.exact_ref,
+                    "type": model_kind_code(variant.kind),
+                    "source": variant.source,
+                    "size": variant.size_label,
+                    "fit": variant
+                        .size_label
+                        .as_deref()
+                        .and_then(fit_code_for_size_label),
+                    "download_url": variant.download_url,
+                })
+            })
+            .collect::<Vec<_>>(),
+    })
+}
+
 impl SearchFormatter for JsonFormatter {
     fn is_json(&self) -> bool {
         true
@@ -97,6 +135,7 @@ impl SearchFormatter for JsonFormatter {
                     "repo_id": result.repo_id,
                     "repo_url": huggingface_repo_url(&result.repo_id),
                     "type": model_kind_code(result.kind),
+                    "variant_count": result.variant_count,
                     "size": result.size_label,
                     "downloads": result.downloads,
                     "likes": result.likes,
@@ -184,41 +223,7 @@ impl ModelsFormatter for JsonFormatter {
     }
 
     fn render_show(&self, details: &ModelDetails, variants: Option<&[ModelDetails]>) -> Result<()> {
-        print_json(json!({
-            "display_name": details.exact_ref,
-            "ref": details.exact_ref,
-            "type": model_kind_code(details.kind),
-            "source": details.source,
-            "size": details.size_label,
-            "fit": details
-                .size_label
-                .as_deref()
-                .and_then(fit_code_for_size_label),
-            "description": details.description,
-            "draft": details.draft,
-            "capabilities": capabilities_json(details.capabilities),
-            "moe": moe_json(details.moe.as_ref()),
-            "download_url": details.download_url,
-            "machine": local_capacity_json(),
-            "variants": variants
-                .unwrap_or_default()
-                .iter()
-                .map(|variant| {
-                    json!({
-                        "display_name": variant.exact_ref,
-                        "ref": variant.exact_ref,
-                        "type": model_kind_code(variant.kind),
-                        "source": variant.source,
-                        "size": variant.size_label,
-                        "fit": variant
-                            .size_label
-                            .as_deref()
-                            .and_then(fit_code_for_size_label),
-                        "download_url": variant.download_url,
-                    })
-                })
-                .collect::<Vec<_>>(),
-        }))
+        print_json(show_payload(details, variants))
     }
 
     fn render_download(
@@ -256,5 +261,67 @@ impl ModelsFormatter for JsonFormatter {
                 "all": all,
             },
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::ModelCapabilities;
+
+    #[test]
+    fn show_payload_includes_variants_for_selected_gguf_ref() {
+        let details = ModelDetails {
+            display_name: "Qwen3.6-35B-A3B-BF16.gguf".to_string(),
+            exact_ref: "unsloth/Qwen3.6-35B-A3B-GGUF:BF16".to_string(),
+            source: "huggingface",
+            kind: "🦙 GGUF",
+            download_url: "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf".to_string(),
+            size_label: Some("49.9GB".to_string()),
+            description: None,
+            draft: None,
+            capabilities: ModelCapabilities::default(),
+            moe: None,
+        };
+        let variants = vec![
+            ModelDetails {
+                display_name: "Qwen3.6-35B-A3B-BF16.gguf".to_string(),
+                exact_ref: "unsloth/Qwen3.6-35B-A3B-GGUF:BF16".to_string(),
+                source: "huggingface",
+                kind: "🦙 GGUF",
+                download_url: "https://example.invalid/bf16.gguf".to_string(),
+                size_label: Some("49.9GB".to_string()),
+                description: None,
+                draft: None,
+                capabilities: ModelCapabilities::default(),
+                moe: None,
+            },
+            ModelDetails {
+                display_name: "Qwen3.6-35B-A3B-Q4_K_M.gguf".to_string(),
+                exact_ref: "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_M".to_string(),
+                source: "huggingface",
+                kind: "🦙 GGUF",
+                download_url: "https://example.invalid/q4_k_m.gguf".to_string(),
+                size_label: Some("21.3GB".to_string()),
+                description: None,
+                draft: None,
+                capabilities: ModelCapabilities::default(),
+                moe: None,
+            },
+        ];
+
+        let payload = show_payload(&details, Some(&variants));
+        let emitted_variants = payload["variants"].as_array().expect("variants array");
+
+        assert_eq!(payload["ref"], "unsloth/Qwen3.6-35B-A3B-GGUF:BF16");
+        assert_eq!(emitted_variants.len(), 2);
+        assert_eq!(
+            emitted_variants[0]["ref"],
+            "unsloth/Qwen3.6-35B-A3B-GGUF:BF16"
+        );
+        assert_eq!(
+            emitted_variants[1]["ref"],
+            "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_M"
+        );
     }
 }

--- a/mesh-llm/src/models/resolve/mod.rs
+++ b/mesh-llm/src/models/resolve/mod.rs
@@ -407,36 +407,11 @@ where
 {
     let input = canonicalize_model_ref_input(input).await?;
     let parsed = parse_huggingface_repo_ref(&input).or_else(|| parse_huggingface_repo_url(&input));
-    let Some((repo, revision, selector)) = parsed else {
+    let Some((repo, revision, _selector)) = parsed else {
         return Ok(None);
     };
-    if selector.is_some() {
-        return Ok(None);
-    }
-
-    let api = super::build_hf_tokio_api(false)?;
     let revision_ref = revision.as_deref().unwrap_or("main");
-    let (owner, name) = repo.split_once('/').unwrap_or(("", repo.as_str()));
-    let detail = api
-        .model(owner, name)
-        .info(
-            &RepoInfoParams::builder()
-                .revision(revision_ref.to_string())
-                .build(),
-        )
-        .await
-        .with_context(|| format!("Fetch Hugging Face repo {repo}"))?;
-    let RepoInfo::Model(detail) = detail else {
-        return Ok(Some(Vec::new()));
-    };
-
-    let sibling_entries: Vec<(String, Option<u64>)> = detail
-        .siblings
-        .clone()
-        .unwrap_or_default()
-        .iter()
-        .map(|sibling| (sibling.rfilename.clone(), sibling.size))
-        .collect();
+    let sibling_entries = fetch_repo_sibling_entries(&repo, revision_ref).await?;
     let available_bytes = crate::system::hardware::survey().vram_bytes;
     let variants = collect_show_gguf_variants_from_siblings(&sibling_entries, available_bytes);
     if variants.is_empty() {
@@ -466,7 +441,9 @@ where
         }
         let size_label = match size_bytes {
             Some(bytes) => Some(format_size_bytes(bytes)),
-            None => remote_hf_size_label_with_api(&api, &repo, revision.as_deref(), &file).await,
+            None => {
+                remote_size_label(&huggingface_resolve_url(&repo, revision.as_deref(), &file)).await
+            }
         };
         out.push(ModelDetails {
             display_name: Path::new(&file)

--- a/mesh-llm/src/models/resolve/tests.rs
+++ b/mesh-llm/src/models/resolve/tests.rs
@@ -485,6 +485,39 @@ async fn download_exact_ref_bf16_shorthand_downloads_full_split_model() {
     );
 }
 
+#[tokio::test]
+async fn show_model_variants_accepts_selected_quant_ref() {
+    let fixture = load_gemma_live_fixture();
+    let _siblings_guard = RepoSiblingEntriesOverrideGuard::set(Arc::new({
+        let repo = fixture.repo.clone();
+        let siblings = fixture
+            .siblings
+            .iter()
+            .map(|file| (file.clone(), fixture.size_bytes.get(file).copied()))
+            .collect::<Vec<_>>();
+        move |requested_repo, requested_revision| {
+            if requested_repo == repo && requested_revision == "main" {
+                Some(siblings.clone())
+            } else {
+                None
+            }
+        }
+    }));
+
+    let variants = show_model_variants_with_progress("unsloth/gemma-4-31B-it-GGUF:BF16", |_| {})
+        .await
+        .unwrap()
+        .expect("repo-backed GGUF refs should enumerate variants");
+
+    assert!(!variants.is_empty());
+    assert!(variants
+        .iter()
+        .any(|variant| { variant.exact_ref == "unsloth/gemma-4-31B-it-GGUF:BF16" }));
+    assert!(variants
+        .iter()
+        .any(|variant| { variant.exact_ref == "unsloth/gemma-4-31B-it-GGUF:UD-Q4_K_XL" }));
+}
+
 #[test]
 fn format_huggingface_display_ref_prefers_repo_form_for_mlx() {
     assert_eq!(

--- a/mesh-llm/src/models/search.rs
+++ b/mesh-llm/src/models/search.rs
@@ -7,6 +7,7 @@ use super::{build_hf_tokio_api, capabilities, catalog};
 use anyhow::{Context, Result};
 use hf_hub::{ListModelsParams, ModelInfo};
 use regex_lite::Regex;
+use std::collections::HashSet;
 use std::sync::LazyLock;
 use tokio::task::JoinSet;
 use tokio_stream::StreamExt;
@@ -16,6 +17,7 @@ pub struct SearchHit {
     pub repo_id: String,
     pub kind: &'static str,
     pub exact_ref: String,
+    pub variant_count: Option<usize>,
     pub size_label: Option<String>,
     pub downloads: Option<u64>,
     pub likes: Option<u64>,
@@ -197,6 +199,7 @@ async fn build_search_hit(
     }
 
     let candidate = &matching_candidates[0];
+    let variant_count = search_hit_variant_count(filter, &repo_id, &matching_candidates);
     let remote_metadata = capabilities::fetch_remote_hf_metadata_jsons(&repo_id, None).await;
     let catalog = matching_catalog_model_for_huggingface(&repo_id, None, &candidate.file);
     let size_label = match catalog {
@@ -223,6 +226,7 @@ async fn build_search_hit(
         repo_id: repo_id.clone(),
         kind: repo_artifact_kind_label(candidate.kind),
         exact_ref: display_exact_ref(&repo_id, candidate.kind, &candidate.file),
+        variant_count,
         size_label,
         downloads: detail.downloads.or(repo_downloads),
         likes: detail.likes.or(repo_likes),
@@ -415,6 +419,29 @@ fn collect_repo_artifact_candidates(siblings: &[String]) -> Vec<RepoArtifactCand
     gguf
 }
 
+fn gguf_variant_count_from_candidates(repo: &str, candidates: &[RepoArtifactCandidate]) -> usize {
+    candidates
+        .iter()
+        .filter(|candidate| candidate.kind == RepoArtifactKind::Gguf)
+        .filter_map(|candidate| {
+            quant_selector_from_gguf_file(&candidate.file)
+                .map(|_| display_exact_ref(repo, RepoArtifactKind::Gguf, &candidate.file))
+        })
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+fn search_hit_variant_count(
+    filter: SearchArtifactFilter,
+    repo: &str,
+    candidates: &[RepoArtifactCandidate],
+) -> Option<usize> {
+    match filter {
+        SearchArtifactFilter::Gguf => Some(gguf_variant_count_from_candidates(repo, candidates)),
+        SearchArtifactFilter::Mlx => None,
+    }
+}
+
 fn is_split_mlx_weight_file(file: &str) -> bool {
     let Some(rest) = file.strip_prefix("model-") else {
         return false;
@@ -535,6 +562,52 @@ mod tests {
         let candidates = collect_repo_artifact_candidates(&siblings);
         let files: Vec<_> = candidates.into_iter().map(|c| c.file).collect();
         assert_eq!(files, vec!["gemma-4-26B-A4B-it-UD-Q3_K_S.gguf".to_string()]);
+    }
+
+    #[test]
+    fn gguf_variant_count_from_candidates_counts_selectable_variants() {
+        let siblings = vec![
+            "mmproj-BF16.gguf".to_string(),
+            "BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf".to_string(),
+            "BF16/Qwen3.6-35B-A3B-BF16-00002-of-00002.gguf".to_string(),
+            "Qwen3.6-35B-A3B-Q8_0.gguf".to_string(),
+            "Qwen3.6-35B-A3B-Q4_K_M.gguf".to_string(),
+        ];
+        let candidates = collect_repo_artifact_candidates(&siblings);
+        assert_eq!(
+            gguf_variant_count_from_candidates("unsloth/Qwen3.6-35B-A3B-GGUF", &candidates),
+            3
+        );
+    }
+
+    #[test]
+    fn search_hit_variant_count_only_applies_to_gguf_results() {
+        let gguf_candidates = collect_repo_artifact_candidates(&[
+            "BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf".to_string(),
+            "BF16/Qwen3.6-35B-A3B-BF16-00002-of-00002.gguf".to_string(),
+            "Qwen3.6-35B-A3B-Q4_K_M.gguf".to_string(),
+        ]);
+        assert_eq!(
+            search_hit_variant_count(
+                SearchArtifactFilter::Gguf,
+                "unsloth/Qwen3.6-35B-A3B-GGUF",
+                &gguf_candidates
+            ),
+            Some(2)
+        );
+
+        let mlx_candidates = collect_repo_artifact_candidates(&[
+            "model.safetensors".to_string(),
+            "model.safetensors.index.json".to_string(),
+        ]);
+        assert_eq!(
+            search_hit_variant_count(
+                SearchArtifactFilter::Mlx,
+                "mlx-community/Foo-4bit",
+                &mlx_candidates
+            ),
+            None
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Show a GGUF variant count in `models search` output without adding extra Hub calls.
- Preserve `models show` variant listing for repo refs with or without an explicit selector.
- Add regression tests for `show` variant resolution, `show` output payloads, and search variant counting.

## Example Commands
### `models search`
```bash
mesh-llm models search 'unsloth/Qwen3.6'
```

```text
🔎 Hugging Face GGUF matches for 'unsloth/Qwen3.6' (trending)
🖥️ This machine: ~103.1GB available

1. 📦 unsloth/Qwen3.6-35B-A3B-GGUF
   type: 🦙 GGUF
   🧬 variants: 22 available
   size: 49.9GB 📏  ⬇️ 153,019  ❤️ 373
   capabilities: 💬 text  🎛️ multimodal  👁️ vision (yes)
   repo: https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF
   ref: unsloth/Qwen3.6-35B-A3B-GGUF:BF16
   show: mesh-llm models show unsloth/Qwen3.6-35B-A3B-GGUF:BF16
   download: mesh-llm models download unsloth/Qwen3.6-35B-A3B-GGUF:BF16
   ✅ likely comfortable here
```

### `models show`
```bash
mesh-llm models show 'unsloth/Qwen3.6-35B-A3B-GGUF:BF16'
```

```text
🔎 Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf
🖥️ This machine: ~103.1GB available

Ref: unsloth/Qwen3.6-35B-A3B-GGUF:BF16
Type: 🦙 GGUF
Source: Hugging Face
Size: 49.9GB
Fit: ✅ likely comfortable here
Capabilities:
  💬 text
📥 Download:
   https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf

Variants:
sel  quant      size    fit                         ref
---  -----      ----    ---                         ---
*    BF16       49.9GB  ✅ likely comfortable here  unsloth/Qwen3.6-35B-A3B-GGUF:BF16
     UD-Q4_K_M  22.1GB  ✅ likely comfortable here  unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M
     UD-Q4_K_S  20.9GB  ✅ likely comfortable here  unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_S
     UD-Q5_K_M  26.5GB  ✅ likely comfortable here  unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q5_K_M
     UD-Q5_K_S  24.9GB  ✅ likely comfortable here  unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q5_K_S
```

## Testing
- `cargo test -p mesh-llm gguf_variant_count_from_candidates_counts_selectable_variants -- --nocapture`
- `cargo test -p mesh-llm search_hit_variant_count_only_applies_to_gguf_results -- --nocapture`
- `cargo test -p mesh-llm show_model_variants_accepts_selected_quant_ref -- --nocapture`
- `cargo test -p mesh-llm show_payload_includes_variants_for_selected_gguf_ref -- --nocapture`
- `cargo check -p mesh-llm`
