### PR TITLE
Rename PR github copilot instructions

### DIFF
--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -1,1 +1,4 @@
+---
+applyTo: '**'
+---
 When doing work on pull requests, do not re-title the PR to reflect the latest changes, and do not edit the PR's description with the most recent update. Instead, use inline comments to summarize your work and the changes that were made ONLY IF THERE IS NON-OBVIOUS INFORMATION THAT NEEDS TO BE CONVEYED.


### PR DESCRIPTION
Fix #337 (see issue for details on changes and reasons). This does not (obviously) edit the git history, so any commit between 9142fed03356ba3e9a81dd585a07ebb0fb4e0640 and f67e53b8423ffda764d13f99b57e1120c20e1ca9 will not be able to be checked out on a Windows machine.