### PR TITLE
Add mesh join age display with backend timestamp support

### DIFF
--- a/ci/ci.md
+++ b/ci/ci.md
@@ -1,0 +1,165 @@
+```mermaid
+flowchart TD
+    subgraph Triggers["Triggers"]
+        PR["Pull Request / push main"]
+    end
+    subgraph Changes["changes (path filter)"]
+        F_UI["ui changed?"]
+        F_RUST["rust changed?"]
+        F_SDK["sdk changed?"]
+        F_BENCH["benchmarks changed?"]
+    end
+    PR --> Changes
+    %% ── Cache key resolution (shared by CI + warm-caches) ──
+    subgraph CacheKeys["llama-cache-keys.yml (reusable)"]
+        LCK["Resolve llama.cpp SHA\nCompute cache keys:\n• cuda-slim-{version}-{arch}\n• cuda-fat-{version}\n• rocm-slim\n• rocm-fat"]
+    end
+    F_RUST -- "true" --> LCK
+    %% ── Producers ──
+    subgraph Producers["Producers (parallel, independent)"]
+        direction TB
+        subgraph UI_Target["Target: ui"]
+            UI["Build UI\nnpm ci + build + test\n→ upload: ci-ui-dist"]
+        end
+        subgraph Core_Target["Target: rust-core (ubuntu-latest)"]
+            CORE["fmt check · clippy\ncargo build -p mesh-llm (debug)\nunit tests · protocol compat\nbuild llama.cpp CPU+RPC\nCLI smoke · client-auto boot\n→ upload: ci-linux-inference-binaries"]
+        end
+        subgraph FFI_Target["Target: ffi-sdk (ubuntu-latest)"]
+            FFI["Build mesh-api / mesh-api-ffi / mesh-client\nembedded dep purity check\ncompile+lint only, no artifact"]
+        end
+        subgraph Vulkan_Target["Target: vulkan (ubuntu-latest)"]
+            VULKAN["Install libvulkan-dev + glslc\nDownload ci-ui-dist\njust release-build-vulkan\nCLI smoke"]
+        end
+    end
+    F_UI -- "true" --> UI_Target
+    F_RUST -- "true" --> Core_Target
+    F_RUST -- "true" --> FFI_Target
+    F_RUST -- "true" --> Vulkan_Target
+    UI_Target -- "artifact: ci-ui-dist" --> Vulkan_Target
+    %% ── CUDA matrix (self-hosted GPU runner) ──
+    subgraph CUDA_Matrix["Target: cuda  —  matrix: {version} × {arch}\n🖥️ self-hosted GPU runner"]
+        direction TB
+        CUDA_RESTORE["Restore llama.cpp CUDA cache\nkey: cuda-slim-{version}-{arch}\n(restore-only, never write)"]
+        subgraph CUDA_Variants["Matrix expansion (PR CI = slim only)"]
+            CUDA_126_89["12.6 × arch 89"]
+            CUDA_127_89["12.7 × arch 89"]
+            CUDA_129_89["12.9 × arch 89"]
+            CUDA_132_89["13.2 × arch 89"]
+        end
+        CUDA_RESTORE --> CUDA_Variants
+        CUDA_BUILD_MISS["Cache MISS path:\nfull llama.cpp CUDA build\n(CI-only: single arch, fa-off)\n+ cargo build mesh-llm (debug)"]
+        CUDA_BUILD_HIT["Cache HIT path:\nskip llama.cpp entirely\ncargo build mesh-llm (debug) only"]
+        CUDA_SMOKE["CLI smoke\nmesh-llm --version / --help"]
+        CUDA_Variants --> CUDA_BUILD_MISS
+        CUDA_Variants --> CUDA_BUILD_HIT
+        CUDA_BUILD_MISS --> CUDA_SMOKE
+        CUDA_BUILD_HIT --> CUDA_SMOKE
+    end
+    LCK -- "cuda_slim_cache_key\nper version×arch" --> CUDA_RESTORE
+    F_RUST -- "true" --> CUDA_Matrix
+    UI_Target -- "artifact: ci-ui-dist" --> CUDA_Matrix
+    %% ── ROCm (self-hosted GPU runner) ──
+    subgraph ROCm_Target["Target: rocm (ubuntu-latest container)\n🖥️ self-hosted GPU runner"]
+        ROCM_RESTORE["Restore llama.cpp ROCm cache\nkey: rocm-slim\n(restore-only, never write)"]
+        ROCM_BUILD["Cache miss → full ROCm build (gfx1100)\nCache hit → cargo build only"]
+        ROCM_SMOKE["CLI smoke"]
+        ROCM_RESTORE --> ROCM_BUILD --> ROCM_SMOKE
+    end
+    LCK -- "rocm_slim_cache_key" --> ROCM_RESTORE
+    F_RUST -- "true" --> ROCm_Target
+    UI_Target -- "artifact: ci-ui-dist" --> ROCm_Target
+    %% ── Smoke tests (consume artifact) ──
+    subgraph Smoke["smoke.yml (reusable, ubuntu-latest)"]
+        SMOKE["Download ci-linux-inference-binaries\nReal inference · OpenAI compat\nSplit-mode · MoE split + mesh"]
+    end
+    CORE -- "artifact" --> SMOKE
+    subgraph SDK_Smokes["SDK Smokes (consume artifact)"]
+        direction LR
+        NATIVE["Native SDK\n(Linux)"]
+        KOTLIN["Kotlin SDK\n(Linux)"]
+        SWIFT["Swift SDK\n(macOS)\nbuild llama.cpp Metal"]
+    end
+    SMOKE -- "success" --> SDK_Smokes
+    F_SDK -- "true" --> SDK_Smokes
+    %% ── Benchmark smokes (optional, self-hosted) ──
+    subgraph Bench_Smokes["Benchmark Smokes (optional)\n🖥️ self-hosted runners"]
+        direction LR
+        SWIFT_BENCH["macOS benchmark"]
+        CUDA_BENCH["CUDA benchmark"]
+        ROCM_BENCH["ROCm benchmark"]
+    end
+    F_BENCH -- "true" --> Bench_Smokes
+    CUDA_Matrix --> CUDA_BENCH
+    ROCm_Target --> ROCM_BENCH
+    %% ════════════════════════════════════════════════════
+    %% Warm caches (push main only — single writer)
+    %% ════════════════════════════════════════════════════
+    subgraph WarmCaches["warm-caches.yml (push main only)\n🖥️ self-hosted GPU runners"]
+        direction TB
+        WC_KEYS["llama-cache-keys.yml\n(same shared key logic)"]
+        subgraph WC_CUDA_Slim["CUDA slim caches (per version × arch)"]
+            WCS_126["12.6 slim\narch 89, fa-off"]
+            WCS_127["12.7 slim\narch 89, fa-off"]
+            WCS_129["12.9 slim\narch 89, fa-off"]
+            WCS_132["13.2 slim\narch 89, fa-off"]
+        end
+        subgraph WC_CUDA_Fat["CUDA fat caches (per version, full arch)"]
+            WCF_126["12.6 fat\nfull arch matrix\nFA_ALL_QUANTS=ON"]
+            WCF_127["12.7 fat\nfull arch matrix"]
+            WCF_129["12.9 fat\nfull arch matrix"]
+            WCF_132["13.2 fat\nfull arch matrix"]
+        end
+        subgraph WC_ROCm["ROCm caches"]
+            WCR_SLIM["ROCm slim\ngfx1100"]
+            WCR_FAT["ROCm fat\nfull gfx matrix"]
+        end
+        PRUNE["Prune old GPU caches\nretention policy per prefix"]
+        WC_KEYS --> WC_CUDA_Slim & WC_CUDA_Fat & WC_ROCm
+        WC_CUDA_Slim & WC_CUDA_Fat & WC_ROCm --> PRUNE
+    end
+    CUDA_RESTORE -. "restore ← main cache\n(cross-branch read)" .-> WC_CUDA_Slim
+    ROCM_RESTORE -. "restore ← main cache" .-> WC_ROCm
+    %% ════════════════════════════════════════════════════
+    %% Release (separate shape, separate trigger)
+    %% ════════════════════════════════════════════════════
+    subgraph Release["release.yml (workflow_dispatch, tag push)"]
+        REL_PREP["prepare_release\nversion bump · tag · push"]
+        subgraph REL_Builds["Release builds (full shape, parallel)"]
+            REL_CPU["Linux CPU\n(ubuntu-latest)"]
+            REL_ARM["Linux ARM64\n(ubuntu-24.04-arm)"]
+            REL_MACOS["macOS Metal\n(macos-14)"]
+            REL_VULKAN["Linux Vulkan\n(ubuntu-latest)"]
+        end
+        subgraph REL_GPU["Release GPU builds\n🖥️ self-hosted runners"]
+            REL_CUDA_126["CUDA 12.6\nfull arch, FA=ON"]
+            REL_CUDA_127["CUDA 12.7\nfull arch, FA=ON"]
+            REL_CUDA_129["CUDA 12.9\nfull arch, FA=ON"]
+            REL_CUDA_132["CUDA 13.2\nfull arch, FA=ON"]
+            REL_ROCM["ROCm\nfull gfx matrix"]
+        end
+        REL_SMOKE["Release smoke\n(release-shape binaries)"]
+        PUBLISH["publish GitHub release\ngated on smoke success"]
+        PUB_CRATES["publish crates.io"]
+        PUB_ANDROID["publish Android Maven"]
+        REL_PREP --> REL_Builds & REL_GPU
+        REL_CPU --> REL_SMOKE --> PUBLISH
+        PUBLISH --> PUB_CRATES & PUB_ANDROID
+    end
+    style UI_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
+    style Core_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
+    style FFI_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
+    style Vulkan_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
+    style CUDA_Matrix fill:#2d1b4e,stroke:#9b59b6,color:#f5eeff
+    style CUDA_Variants fill:#3d2b5e,stroke:#9b59b6,color:#f5eeff
+    style ROCm_Target fill:#2d1b4e,stroke:#9b59b6,color:#f5eeff
+    style Smoke fill:#1a3d2e,stroke:#2ecc71,color:#eaffef
+    style SDK_Smokes fill:#1a3d2e,stroke:#2ecc71,color:#eaffef
+    style Bench_Smokes fill:#3d2b00,stroke:#f39c12,color:#fff8e1
+    style WarmCaches fill:#3d1a1a,stroke:#e74c3c,color:#ffebeb
+    style WC_CUDA_Slim fill:#4d2a2a,stroke:#e74c3c,color:#ffebeb
+    style WC_CUDA_Fat fill:#4d2a2a,stroke:#e74c3c,color:#ffebeb
+    style WC_ROCm fill:#4d2a2a,stroke:#e74c3c,color:#ffebeb
+    style Release fill:#2a2a2a,stroke:#888,color:#ddd
+    style REL_Builds fill:#3a3a3a,stroke:#888,color:#ddd
+    style REL_GPU fill:#3a2a4a,stroke:#9b59b6,color:#f5eeff
+```

--- a/mesh-llm/proto/node.proto
+++ b/mesh-llm/proto/node.proto
@@ -42,6 +42,7 @@ message PeerAnnouncement {
   optional string gpu_compute_tflops_fp16 = 31;     // Deprecated in v0.60.0: prefer hardware.gpus[].compute_tflops_fp16
   optional string gpu_reserved_bytes = 32;          // Deprecated in v0.60.0: prefer hardware.gpus[].reserved_bytes
   optional HardwareInfo hardware = 33;              // Introduced in v0.60.0; preferred structured hardware inventory
+  optional uint64 first_joined_mesh_ts = 34;
 }
 
 message HardwareInfo {

--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -1755,6 +1755,7 @@ mod tests {
             served_model_runtime: vec![],
             owner_attestation: None,
             owner_summary: crate::crypto::OwnershipSummary::default(),
+            first_joined_mesh_ts: None,
         }
     }
 

--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -927,6 +927,7 @@ impl MeshApi {
                     p.gpu_compute_tflops_fp32.as_deref(),
                     p.gpu_compute_tflops_fp16.as_deref(),
                 ),
+                first_joined_mesh_ts: p.first_joined_mesh_ts,
             })
             .collect();
 
@@ -1034,6 +1035,7 @@ impl MeshApi {
             },
             routing_affinity,
             routing_metrics,
+            first_joined_mesh_ts: node.first_joined_mesh_ts().await,
         }
     }
 
@@ -1984,6 +1986,7 @@ mod tests {
             },
             tunnel_port: None,
             role,
+            first_joined_mesh_ts: None,
             models: Vec::new(),
             vram_bytes: 24_000_000_000,
             rtt_ms: None,

--- a/mesh-llm/src/api/status.rs
+++ b/mesh-llm/src/api/status.rs
@@ -533,6 +533,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            first_joined_mesh_ts: None,
         };
 
         let json = serde_json::to_string(&status).expect("serialization failed");
@@ -577,12 +578,12 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            first_joined_mesh_ts: None,
         };
 
-        let json = serde_json::to_value(&status).expect("serialization failed");
-        assert_eq!(json["node_state"], "serving");
-        assert_eq!(json["node_status"], "Serving");
-        assert!(json.get("node_status").is_some());
+        let json = serde_json::to_string(&status).expect("serialization failed");
+        assert!(json.contains("\"node_state\":\"serving\""));
+        assert!(json.contains("\"node_status\":\"Serving\""));
     }
 
     #[test]
@@ -629,6 +630,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            first_joined_mesh_ts: None,
         };
 
         let json = serde_json::to_value(&status).expect("serialization failed");
@@ -675,6 +677,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            first_joined_mesh_ts: None,
         };
 
         let json = serde_json::to_value(&status).expect("serialization failed");
@@ -701,6 +704,7 @@ mod tests {
             hostname: Some("peer.local".to_string()),
             is_soc: Some(false),
             gpus: vec![],
+            first_joined_mesh_ts: None,
         };
 
         let json = serde_json::to_string(&peer).expect("serialization failed");

--- a/mesh-llm/src/api/status.rs
+++ b/mesh-llm/src/api/status.rs
@@ -172,6 +172,8 @@ pub(super) struct StatusPayload {
     /// Local-only routing outcome and current-node pressure snapshot measured on
     /// this node only; not mesh-wide aggregates.
     pub(super) routing_metrics: metrics::RoutingMetricsStatusSnapshot,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) first_joined_mesh_ts: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize)]
@@ -204,6 +206,8 @@ pub(super) struct PeerPayload {
     pub(super) hostname: Option<String>,
     pub(super) is_soc: Option<bool>,
     pub(super) gpus: Vec<GpuEntry>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) first_joined_mesh_ts: Option<u64>,
 }
 
 #[derive(Serialize)]
@@ -452,6 +456,7 @@ mod tests {
             hostname: None,
             is_soc: None,
             gpus: vec![],
+            first_joined_mesh_ts: None,
         };
 
         let json = serde_json::to_string(&peer).expect("serialization failed");
@@ -477,6 +482,7 @@ mod tests {
             hostname: None,
             is_soc: None,
             gpus: vec![],
+            first_joined_mesh_ts: None,
         };
 
         let json = serde_json::to_string(&peer).expect("serialization failed");

--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -2942,6 +2942,7 @@ mod tests {
             },
             tunnel_port: None,
             role: NodeRole::Worker,
+            first_joined_mesh_ts: None,
             models: vec![],
             vram_bytes,
             rtt_ms,

--- a/mesh-llm/src/mesh/gossip.rs
+++ b/mesh-llm/src/mesh/gossip.rs
@@ -22,6 +22,7 @@ pub fn backfill_legacy_descriptors(ann: &mut PeerAnnouncement) {
 pub(super) fn peer_meaningfully_changed(old: &PeerInfo, new: &PeerInfo) -> bool {
     old.addr != new.addr
         || old.role != new.role
+        || old.first_joined_mesh_ts != new.first_joined_mesh_ts
         || old.models != new.models
         || old.vram_bytes != new.vram_bytes
         || old.rtt_ms != new.rtt_ms
@@ -38,6 +39,15 @@ pub(super) fn peer_meaningfully_changed(old: &PeerInfo, new: &PeerInfo) -> bool 
         || old.gpu_reserved_bytes != new.gpu_reserved_bytes
 }
 
+fn merge_first_joined_mesh_ts(existing: &mut Option<u64>, incoming: Option<u64>) {
+    match (*existing, incoming) {
+        (None, Some(v)) => *existing = Some(v),
+        (Some(_), None) => {}
+        (Some(a), Some(b)) => *existing = Some(a.min(b)),
+        (None, None) => {}
+    }
+}
+
 pub(super) fn apply_transitive_ann(
     existing: &mut PeerInfo,
     addr: &EndpointAddr,
@@ -51,6 +61,7 @@ pub(super) fn apply_transitive_ann(
     existing.hosted_models = ann_hosted_models;
     existing.hosted_models_known = ann.hosted_models.is_some();
     existing.role = ann.role.clone();
+    merge_first_joined_mesh_ts(&mut existing.first_joined_mesh_ts, ann.first_joined_mesh_ts);
     existing.vram_bytes = ann.vram_bytes;
     // Only advance addr if the transitive announcement is at least as path-rich,
     // so a direct peer's richer address is not overwritten by a weaker transitive one.
@@ -426,6 +437,10 @@ impl Node {
                 existing.addr = addr;
             }
             existing.models = ann.models.clone();
+            merge_first_joined_mesh_ts(
+                &mut existing.first_joined_mesh_ts,
+                ann.first_joined_mesh_ts,
+            );
             existing.vram_bytes = ann.vram_bytes;
             if ann.model_source.is_some() {
                 existing.model_source = ann.model_source.clone();
@@ -649,6 +664,7 @@ impl Node {
                 .map(|p| PeerAnnouncement {
                     addr: p.addr.clone(),
                     role: p.role.clone(),
+                    first_joined_mesh_ts: p.first_joined_mesh_ts,
                     models: p.models.clone(),
                     vram_bytes: p.vram_bytes,
                     model_source: p.model_source.clone(),
@@ -676,9 +692,11 @@ impl Node {
                 })
                 .collect()
         };
+        let my_first_joined_mesh_ts = *self.first_joined_mesh_ts.lock().await;
         announcements.push(PeerAnnouncement {
             addr: self.endpoint.addr(),
             role: my_role,
+            first_joined_mesh_ts: my_first_joined_mesh_ts,
             models: my_models,
             vram_bytes: self.vram_bytes,
             model_source: my_source,
@@ -736,5 +754,123 @@ impl Node {
             owner_attestation: my_owner_attestation,
         });
         announcements
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::OwnershipSummary;
+    use iroh::SecretKey;
+    use std::collections::HashMap;
+
+    fn test_endpoint_id(seed: u8) -> EndpointId {
+        EndpointId::from(SecretKey::from_bytes(&[seed; 32]).public())
+    }
+
+    fn test_addr(seed: u8) -> EndpointAddr {
+        EndpointAddr {
+            id: test_endpoint_id(seed),
+            addrs: Default::default(),
+        }
+    }
+
+    fn test_announcement(ts: Option<u64>) -> PeerAnnouncement {
+        PeerAnnouncement {
+            addr: test_addr(0x11),
+            role: NodeRole::Worker,
+            first_joined_mesh_ts: ts,
+            models: vec![],
+            vram_bytes: 0,
+            model_source: None,
+            serving_models: vec![],
+            hosted_models: None,
+            available_models: vec![],
+            requested_models: vec![],
+            version: None,
+            model_demand: HashMap::new(),
+            mesh_id: None,
+            gpu_name: None,
+            hostname: None,
+            is_soc: None,
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            available_model_metadata: vec![],
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: vec![],
+            served_model_runtime: vec![],
+            owner_attestation: None,
+        }
+    }
+
+    fn test_peer(ts: Option<u64>) -> PeerInfo {
+        PeerInfo::from_announcement(
+            test_endpoint_id(0x22),
+            test_addr(0x22),
+            &test_announcement(ts),
+            OwnershipSummary::default(),
+        )
+    }
+
+    #[test]
+    fn test_merge_none_to_some() {
+        let mut existing = test_peer(None);
+        let ann = test_announcement(Some(100));
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert_eq!(existing.first_joined_mesh_ts, Some(100));
+    }
+
+    #[test]
+    fn test_merge_some_to_none_keeps_existing() {
+        let mut existing = test_peer(Some(100));
+        let ann = test_announcement(None);
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert_eq!(existing.first_joined_mesh_ts, Some(100));
+    }
+
+    #[test]
+    fn test_merge_earlier_incoming_wins() {
+        let mut existing = test_peer(Some(200));
+        let ann = test_announcement(Some(100));
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert_eq!(existing.first_joined_mesh_ts, Some(100));
+    }
+
+    #[test]
+    fn test_merge_later_incoming_loses() {
+        let mut existing = test_peer(Some(100));
+        let ann = test_announcement(Some(200));
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert_eq!(existing.first_joined_mesh_ts, Some(100));
+    }
+
+    #[test]
+    fn test_merge_equal_values_unchanged() {
+        let mut existing = test_peer(Some(100));
+        let ann = test_announcement(Some(100));
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert_eq!(existing.first_joined_mesh_ts, Some(100));
+    }
+
+    #[test]
+    fn test_meaningfully_changed_first_joined_mesh_ts() {
+        let old_peer = test_peer(Some(100));
+        let new_peer = test_peer(Some(200));
+
+        assert!(peer_meaningfully_changed(&old_peer, &new_peer));
     }
 }

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -2054,10 +2054,6 @@ impl Node {
         *self.first_joined_mesh_ts.lock().await
     }
 
-    pub async fn set_first_joined_mesh_ts(&self, ts: u64) {
-        *self.first_joined_mesh_ts.lock().await = Some(ts);
-    }
-
     pub async fn set_first_joined_mesh_ts_if_absent(&self, ts: u64) -> bool {
         let mut current = self.first_joined_mesh_ts.lock().await;
         if current.is_none() {
@@ -4067,112 +4063,6 @@ pub fn load_last_mesh_id() -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
-// Mesh join-time persistence
-// ---------------------------------------------------------------------------
-
-/// JSON file schema for persisting mesh join times.
-#[derive(Serialize, Deserialize, Default)]
-#[cfg_attr(not(test), allow(dead_code))]
-struct MeshJoinTimesFile {
-    version: u32,
-    by_mesh_id: HashMap<String, u64>,
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-fn mesh_join_times_path_in(base_dir: &std::path::Path) -> std::path::PathBuf {
-    base_dir.join("mesh-join-times.json")
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-fn save_mesh_join_time_in(base_dir: &std::path::Path, mesh_id: &str, ts_ms: u64) {
-    let path = mesh_join_times_path_in(base_dir);
-
-    let mut data: MeshJoinTimesFile = if path.exists() {
-        match std::fs::read_to_string(&path) {
-            Ok(json_str) => serde_json::from_str(&json_str).unwrap_or_default(),
-            Err(_) => MeshJoinTimesFile::default(),
-        }
-    } else {
-        MeshJoinTimesFile::default()
-    };
-
-    if data.version == 0 {
-        data.version = 1;
-    }
-
-    data.by_mesh_id.insert(mesh_id.to_string(), ts_ms);
-
-    let json_str = match serde_json::to_string_pretty(&data) {
-        Ok(s) => s,
-        Err(e) => {
-            tracing::warn!("failed to serialize mesh join times: {e}");
-            return;
-        }
-    };
-
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-
-    let tmp_path = path.with_extension("json.tmp");
-    let write_result = (|| -> Result<()> {
-        use std::io::Write;
-        let mut file = std::fs::File::create(&tmp_path)
-            .with_context(|| format!("failed to create tmp file: {}", tmp_path.display()))?;
-        file.write_all(json_str.as_bytes())
-            .with_context(|| format!("failed to write tmp file: {}", tmp_path.display()))?;
-        file.sync_all()
-            .with_context(|| format!("failed to sync tmp file: {}", tmp_path.display()))?;
-        std::fs::rename(&tmp_path, &path).with_context(|| {
-            format!(
-                "failed to rename tmp file from {} to {}",
-                tmp_path.display(),
-                path.display()
-            )
-        })?;
-        Ok(())
-    })();
-
-    if write_result.is_err() {
-        let _ = std::fs::remove_file(&tmp_path);
-    }
-
-    if let Err(e) = write_result {
-        tracing::warn!("failed to save mesh join time: {e}");
-    }
-}
-
-#[cfg_attr(not(test), allow(dead_code))]
-fn load_mesh_join_time_in(base_dir: &std::path::Path, mesh_id: &str) -> Option<u64> {
-    let path = mesh_join_times_path_in(base_dir);
-    if !path.exists() {
-        return None;
-    }
-    let json_str = std::fs::read_to_string(&path).ok()?;
-    let data: MeshJoinTimesFile = serde_json::from_str(&json_str).ok()?;
-    data.by_mesh_id.get(mesh_id).copied()
-}
-
-/// Save the mesh join time for a given mesh_id.
-/// Never panics — logs warnings and returns on any I/O or serialization error.
-#[allow(dead_code)]
-pub fn save_mesh_join_time(mesh_id: &str, ts_ms: u64) {
-    let Some(home) = dirs::home_dir() else {
-        tracing::warn!("cannot save mesh join time: home directory unavailable");
-        return;
-    };
-    save_mesh_join_time_in(&home.join(".mesh-llm"), mesh_id, ts_ms);
-}
-
-/// Load the mesh join time for a given mesh_id.
-/// Returns None if the file doesn't exist, can't be read, or the mesh_id is not found.
-#[allow(dead_code)]
-pub fn load_mesh_join_time(mesh_id: &str) -> Option<u64> {
-    let home = dirs::home_dir()?;
-    load_mesh_join_time_in(&home.join(".mesh-llm"), mesh_id)
-}
-
-// ---------------------------------------------------------------------------
 // Public-to-private identity transition
 // ---------------------------------------------------------------------------
 
@@ -4337,84 +4227,6 @@ use heartbeat::{
 pub(crate) use heartbeat::{
     moe_recovery_ready_at, peer_is_eligible_for_active_moe, resolve_peer_down,
 };
-
-#[cfg(test)]
-mod mesh_join_time_tests {
-    use super::*;
-    use std::fs;
-
-    #[test]
-    fn test_save_and_load_mesh_join_time() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path();
-
-        let mesh_id = "test-mesh-123";
-        let timestamp = 1234567890u64;
-
-        save_mesh_join_time_in(base_dir, mesh_id, timestamp);
-
-        let loaded = load_mesh_join_time_in(base_dir, mesh_id);
-        assert_eq!(loaded, Some(timestamp));
-    }
-
-    #[test]
-    fn test_load_mesh_join_time_missing_file_returns_none() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path();
-
-        let mesh_id = "nonexistent-mesh";
-        let loaded = load_mesh_join_time_in(base_dir, mesh_id);
-
-        assert_eq!(loaded, None);
-    }
-
-    #[test]
-    fn test_save_mesh_join_time_overwrites() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path();
-
-        let mesh_id = "test-mesh-456";
-        let first_timestamp = 1111111111u64;
-        let second_timestamp = 2222222222u64;
-
-        save_mesh_join_time_in(base_dir, mesh_id, first_timestamp);
-        let loaded_first = load_mesh_join_time_in(base_dir, mesh_id);
-        assert_eq!(loaded_first, Some(first_timestamp));
-
-        save_mesh_join_time_in(base_dir, mesh_id, second_timestamp);
-        let loaded_second = load_mesh_join_time_in(base_dir, mesh_id);
-        assert_eq!(loaded_second, Some(second_timestamp));
-    }
-
-    #[test]
-    fn test_save_load_multiple_mesh_ids() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let base_dir = temp_dir.path();
-
-        let mesh_id_1 = "mesh-one";
-        let mesh_id_2 = "mesh-two";
-        let timestamp_1 = 1000000000u64;
-        let timestamp_2 = 2000000000u64;
-
-        save_mesh_join_time_in(base_dir, mesh_id_1, timestamp_1);
-        save_mesh_join_time_in(base_dir, mesh_id_2, timestamp_2);
-
-        let loaded_1 = load_mesh_join_time_in(base_dir, mesh_id_1);
-        let loaded_2 = load_mesh_join_time_in(base_dir, mesh_id_2);
-
-        assert_eq!(loaded_1, Some(timestamp_1));
-        assert_eq!(loaded_2, Some(timestamp_2));
-
-        let file_path = mesh_join_times_path_in(base_dir);
-        let json_str = fs::read_to_string(&file_path).unwrap();
-        let data: MeshJoinTimesFile = serde_json::from_str(&json_str).unwrap();
-
-        assert_eq!(data.version, 1);
-        assert_eq!(data.by_mesh_id.len(), 2);
-        assert_eq!(data.by_mesh_id.get(mesh_id_1), Some(&timestamp_1));
-        assert_eq!(data.by_mesh_id.get(mesh_id_2), Some(&timestamp_2));
-    }
-}
 
 #[cfg(test)]
 mod tests;

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -655,6 +655,7 @@ pub enum NodeRole {
 pub(crate) struct PeerAnnouncement {
     pub(crate) addr: EndpointAddr,
     pub(crate) role: NodeRole,
+    pub(crate) first_joined_mesh_ts: Option<u64>,
     pub(crate) models: Vec<String>,
     pub(crate) vram_bytes: u64,
     pub(crate) model_source: Option<String>,
@@ -688,6 +689,7 @@ pub struct PeerInfo {
     pub addr: EndpointAddr,
     pub tunnel_port: Option<u16>,
     pub role: NodeRole,
+    pub first_joined_mesh_ts: Option<u64>,
     pub models: Vec<String>,
     pub vram_bytes: u64,
     pub rtt_ms: Option<u32>,
@@ -761,6 +763,7 @@ impl PeerInfo {
             addr,
             tunnel_port: None,
             role: ann.role.clone(),
+            first_joined_mesh_ts: ann.first_joined_mesh_ts,
             models: ann.models.clone(),
             vram_bytes: ann.vram_bytes,
             rtt_ms: None,
@@ -985,6 +988,7 @@ pub struct Node {
     /// This is the single source of truth for "what does the mesh want?"
     model_demand: Arc<std::sync::Mutex<HashMap<String, ModelDemand>>>,
     mesh_id: Arc<Mutex<Option<String>>>,
+    first_joined_mesh_ts: Arc<Mutex<Option<u64>>>,
     accepting: Arc<(tokio::sync::Notify, std::sync::atomic::AtomicBool)>,
     vram_bytes: u64,
     peer_change_tx: watch::Sender<usize>,
@@ -1430,6 +1434,7 @@ impl Node {
             requested_models: Arc::new(Mutex::new(Vec::new())),
             model_demand: Arc::new(std::sync::Mutex::new(HashMap::new())),
             mesh_id: Arc::new(Mutex::new(None)),
+            first_joined_mesh_ts: Arc::new(Mutex::new(None)),
             accepting: Arc::new((
                 tokio::sync::Notify::new(),
                 std::sync::atomic::AtomicBool::new(false),
@@ -1529,6 +1534,7 @@ impl Node {
             requested_models: Arc::new(Mutex::new(Vec::new())),
             model_demand: Arc::new(std::sync::Mutex::new(HashMap::new())),
             mesh_id: Arc::new(Mutex::new(None)),
+            first_joined_mesh_ts: Arc::new(Mutex::new(None)),
             accepting: Arc::new((
                 tokio::sync::Notify::new(),
                 std::sync::atomic::AtomicBool::new(false),
@@ -2042,6 +2048,24 @@ impl Node {
 
     pub async fn mesh_id(&self) -> Option<String> {
         self.mesh_id.lock().await.clone()
+    }
+
+    pub async fn first_joined_mesh_ts(&self) -> Option<u64> {
+        *self.first_joined_mesh_ts.lock().await
+    }
+
+    pub async fn set_first_joined_mesh_ts(&self, ts: u64) {
+        *self.first_joined_mesh_ts.lock().await = Some(ts);
+    }
+
+    pub async fn set_first_joined_mesh_ts_if_absent(&self, ts: u64) -> bool {
+        let mut current = self.first_joined_mesh_ts.lock().await;
+        if current.is_none() {
+            *current = Some(ts);
+            true
+        } else {
+            false
+        }
     }
 
     /// Set the mesh identity. If None was set, adopts the given ID (from gossip).
@@ -4043,6 +4067,112 @@ pub fn load_last_mesh_id() -> Option<String> {
 }
 
 // ---------------------------------------------------------------------------
+// Mesh join-time persistence
+// ---------------------------------------------------------------------------
+
+/// JSON file schema for persisting mesh join times.
+#[derive(Serialize, Deserialize, Default)]
+#[cfg_attr(not(test), allow(dead_code))]
+struct MeshJoinTimesFile {
+    version: u32,
+    by_mesh_id: HashMap<String, u64>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn mesh_join_times_path_in(base_dir: &std::path::Path) -> std::path::PathBuf {
+    base_dir.join("mesh-join-times.json")
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn save_mesh_join_time_in(base_dir: &std::path::Path, mesh_id: &str, ts_ms: u64) {
+    let path = mesh_join_times_path_in(base_dir);
+
+    let mut data: MeshJoinTimesFile = if path.exists() {
+        match std::fs::read_to_string(&path) {
+            Ok(json_str) => serde_json::from_str(&json_str).unwrap_or_default(),
+            Err(_) => MeshJoinTimesFile::default(),
+        }
+    } else {
+        MeshJoinTimesFile::default()
+    };
+
+    if data.version == 0 {
+        data.version = 1;
+    }
+
+    data.by_mesh_id.insert(mesh_id.to_string(), ts_ms);
+
+    let json_str = match serde_json::to_string_pretty(&data) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("failed to serialize mesh join times: {e}");
+            return;
+        }
+    };
+
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let tmp_path = path.with_extension("json.tmp");
+    let write_result = (|| -> Result<()> {
+        use std::io::Write;
+        let mut file = std::fs::File::create(&tmp_path)
+            .with_context(|| format!("failed to create tmp file: {}", tmp_path.display()))?;
+        file.write_all(json_str.as_bytes())
+            .with_context(|| format!("failed to write tmp file: {}", tmp_path.display()))?;
+        file.sync_all()
+            .with_context(|| format!("failed to sync tmp file: {}", tmp_path.display()))?;
+        std::fs::rename(&tmp_path, &path).with_context(|| {
+            format!(
+                "failed to rename tmp file from {} to {}",
+                tmp_path.display(),
+                path.display()
+            )
+        })?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_file(&tmp_path);
+    }
+
+    if let Err(e) = write_result {
+        tracing::warn!("failed to save mesh join time: {e}");
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn load_mesh_join_time_in(base_dir: &std::path::Path, mesh_id: &str) -> Option<u64> {
+    let path = mesh_join_times_path_in(base_dir);
+    if !path.exists() {
+        return None;
+    }
+    let json_str = std::fs::read_to_string(&path).ok()?;
+    let data: MeshJoinTimesFile = serde_json::from_str(&json_str).ok()?;
+    data.by_mesh_id.get(mesh_id).copied()
+}
+
+/// Save the mesh join time for a given mesh_id.
+/// Never panics — logs warnings and returns on any I/O or serialization error.
+#[allow(dead_code)]
+pub fn save_mesh_join_time(mesh_id: &str, ts_ms: u64) {
+    let Some(home) = dirs::home_dir() else {
+        tracing::warn!("cannot save mesh join time: home directory unavailable");
+        return;
+    };
+    save_mesh_join_time_in(&home.join(".mesh-llm"), mesh_id, ts_ms);
+}
+
+/// Load the mesh join time for a given mesh_id.
+/// Returns None if the file doesn't exist, can't be read, or the mesh_id is not found.
+#[allow(dead_code)]
+pub fn load_mesh_join_time(mesh_id: &str) -> Option<u64> {
+    let home = dirs::home_dir()?;
+    load_mesh_join_time_in(&home.join(".mesh-llm"), mesh_id)
+}
+
+// ---------------------------------------------------------------------------
 // Public-to-private identity transition
 // ---------------------------------------------------------------------------
 
@@ -4207,6 +4337,84 @@ use heartbeat::{
 pub(crate) use heartbeat::{
     moe_recovery_ready_at, peer_is_eligible_for_active_moe, resolve_peer_down,
 };
+
+#[cfg(test)]
+mod mesh_join_time_tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_save_and_load_mesh_join_time() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_dir = temp_dir.path();
+
+        let mesh_id = "test-mesh-123";
+        let timestamp = 1234567890u64;
+
+        save_mesh_join_time_in(base_dir, mesh_id, timestamp);
+
+        let loaded = load_mesh_join_time_in(base_dir, mesh_id);
+        assert_eq!(loaded, Some(timestamp));
+    }
+
+    #[test]
+    fn test_load_mesh_join_time_missing_file_returns_none() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_dir = temp_dir.path();
+
+        let mesh_id = "nonexistent-mesh";
+        let loaded = load_mesh_join_time_in(base_dir, mesh_id);
+
+        assert_eq!(loaded, None);
+    }
+
+    #[test]
+    fn test_save_mesh_join_time_overwrites() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_dir = temp_dir.path();
+
+        let mesh_id = "test-mesh-456";
+        let first_timestamp = 1111111111u64;
+        let second_timestamp = 2222222222u64;
+
+        save_mesh_join_time_in(base_dir, mesh_id, first_timestamp);
+        let loaded_first = load_mesh_join_time_in(base_dir, mesh_id);
+        assert_eq!(loaded_first, Some(first_timestamp));
+
+        save_mesh_join_time_in(base_dir, mesh_id, second_timestamp);
+        let loaded_second = load_mesh_join_time_in(base_dir, mesh_id);
+        assert_eq!(loaded_second, Some(second_timestamp));
+    }
+
+    #[test]
+    fn test_save_load_multiple_mesh_ids() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_dir = temp_dir.path();
+
+        let mesh_id_1 = "mesh-one";
+        let mesh_id_2 = "mesh-two";
+        let timestamp_1 = 1000000000u64;
+        let timestamp_2 = 2000000000u64;
+
+        save_mesh_join_time_in(base_dir, mesh_id_1, timestamp_1);
+        save_mesh_join_time_in(base_dir, mesh_id_2, timestamp_2);
+
+        let loaded_1 = load_mesh_join_time_in(base_dir, mesh_id_1);
+        let loaded_2 = load_mesh_join_time_in(base_dir, mesh_id_2);
+
+        assert_eq!(loaded_1, Some(timestamp_1));
+        assert_eq!(loaded_2, Some(timestamp_2));
+
+        let file_path = mesh_join_times_path_in(base_dir);
+        let json_str = fs::read_to_string(&file_path).unwrap();
+        let data: MeshJoinTimesFile = serde_json::from_str(&json_str).unwrap();
+
+        assert_eq!(data.version, 1);
+        assert_eq!(data.by_mesh_id.len(), 2);
+        assert_eq!(data.by_mesh_id.get(mesh_id_1), Some(&timestamp_1));
+        assert_eq!(data.by_mesh_id.get(mesh_id_2), Some(&timestamp_2));
+    }
+}
 
 #[cfg(test)]
 mod tests;

--- a/mesh-llm/src/mesh/tests.rs
+++ b/mesh-llm/src/mesh/tests.rs
@@ -51,6 +51,7 @@ async fn make_test_node(role: super::NodeRole) -> Result<Node> {
         requested_models: Arc::new(Mutex::new(Vec::new())),
         model_demand: Arc::new(std::sync::Mutex::new(HashMap::new())),
         mesh_id: Arc::new(Mutex::new(None)),
+        first_joined_mesh_ts: Arc::new(Mutex::new(None)),
         accepting: Arc::new((
             tokio::sync::Notify::new(),
             std::sync::atomic::AtomicBool::new(false),
@@ -519,6 +520,7 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
         },
         tunnel_port: None,
         role: super::NodeRole::Worker,
+        first_joined_mesh_ts: None,
         models: vec![],
         vram_bytes: 0,
         rtt_ms: None,
@@ -1166,6 +1168,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
             addrs: Default::default(),
         },
         role: super::NodeRole::Host { http_port: 8080 },
+        first_joined_mesh_ts: None,
         models: vec!["Qwen3-8B-Q4_K_M".to_string()],
         vram_bytes: 128 * 1024 * 1024 * 1024,
         model_source: Some("bartowski/Qwen3-8B-GGUF".to_string()),
@@ -1405,6 +1408,7 @@ fn transitive_peer_update_refreshes_metadata_fields() {
     let ann = super::PeerAnnouncement {
         addr: addr.clone(),
         role: super::NodeRole::Worker,
+        first_joined_mesh_ts: None,
         models: vec!["NewModel-Q4_K_M".to_string()],
         vram_bytes: 8 * 1024 * 1024 * 1024,
         model_source: Some("new-source".to_string()),
@@ -1476,6 +1480,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
     let ann = super::PeerAnnouncement {
         addr: weak_addr.clone(),
         role: super::NodeRole::Worker,
+        first_joined_mesh_ts: None,
         models: vec!["SomeModel-Q4_K_M".to_string()],
         vram_bytes: 4 * 1024 * 1024 * 1024,
         model_source: None,
@@ -1526,6 +1531,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
     let ann2 = super::PeerAnnouncement {
         addr: richer_addr.clone(),
         role: super::NodeRole::Worker,
+        first_joined_mesh_ts: None,
         models: vec!["SomeModel-Q4_K_M".to_string()],
         vram_bytes: 4 * 1024 * 1024 * 1024,
         model_source: None,
@@ -2070,6 +2076,7 @@ fn transitive_peer_update_refreshes_last_mentioned() {
     let ann = super::PeerAnnouncement {
         addr: addr.clone(),
         role: super::NodeRole::Worker,
+        first_joined_mesh_ts: None,
         models: vec!["SomeModel-Q4_K_M".to_string()],
         vram_bytes: 8 * 1024 * 1024 * 1024,
         model_source: None,
@@ -2721,7 +2728,9 @@ fn make_test_peer(id: EndpointId, rtt_ms: Option<u32>, vram_gb: u64) -> PeerInfo
             id,
             addrs: Default::default(),
         },
+        tunnel_port: None,
         role: super::NodeRole::Worker,
+        first_joined_mesh_ts: None,
         models: vec![],
         vram_bytes: vram_gb * 1024 * 1024 * 1024,
         rtt_ms,
@@ -2745,7 +2754,6 @@ fn make_test_peer(id: EndpointId, rtt_ms: Option<u32>, vram_gb: u64) -> PeerInfo
         gpu_compute_tflops_fp16: None,
         available_model_metadata: vec![],
         experts_summary: None,
-        tunnel_port: None,
         available_model_sizes: HashMap::new(),
         served_model_descriptors: vec![],
         served_model_runtime: vec![],
@@ -3201,6 +3209,7 @@ async fn make_test_node_with_owner(
         requested_models: Arc::new(Mutex::new(Vec::new())),
         model_demand: Arc::new(std::sync::Mutex::new(HashMap::new())),
         mesh_id: Arc::new(Mutex::new(None)),
+        first_joined_mesh_ts: Arc::new(Mutex::new(None)),
         accepting: Arc::new((
             tokio::sync::Notify::new(),
             std::sync::atomic::AtomicBool::new(false),

--- a/mesh-llm/src/protocol/convert.rs
+++ b/mesh-llm/src/protocol/convert.rs
@@ -483,6 +483,7 @@ pub(crate) fn local_ann_to_proto_ann(
         gpu_compute_tflops_fp16: ann.gpu_compute_tflops_fp16.clone(),
         gpu_reserved_bytes: ann.gpu_reserved_bytes.clone(),
         hardware,
+        first_joined_mesh_ts: ann.first_joined_mesh_ts,
     }
 }
 
@@ -543,6 +544,7 @@ pub(crate) fn proto_ann_to_local(
     let mut ann = PeerAnnouncement {
         addr: addr.clone(),
         role,
+        first_joined_mesh_ts: pa.first_joined_mesh_ts,
         models: pa.catalog_models.clone(),
         vram_bytes: pa.vram_bytes,
         model_source: pa.model_source.clone(),

--- a/mesh-llm/src/protocol/mod.rs
+++ b/mesh-llm/src/protocol/mod.rs
@@ -525,6 +525,7 @@ mod tests {
             },
             tunnel_port: None,
             role: crate::mesh::NodeRole::Worker,
+            first_joined_mesh_ts: None,
             models: vec![],
             vram_bytes: 0,
             rtt_ms: None,
@@ -1191,6 +1192,7 @@ mod tests {
                 addrs: Default::default(),
             },
             role: super::NodeRole::Worker,
+            first_joined_mesh_ts: None,
             models: vec![],
             vram_bytes: 0,
             model_source: None,
@@ -1257,6 +1259,7 @@ mod tests {
                 addrs: Default::default(),
             },
             role: super::NodeRole::Host { http_port: 3131 },
+            first_joined_mesh_ts: None,
             models: vec!["Qwen".to_string()],
             vram_bytes: 48_000_000_000,
             model_source: Some("Qwen.gguf".to_string()),
@@ -1925,5 +1928,96 @@ mod tests {
             "expected MissingConfig, got {:?}",
             err
         );
+    }
+
+    #[test]
+    fn test_peer_announcement_first_joined_mesh_ts_roundtrip() {
+        use iroh::SecretKey;
+        use std::collections::HashMap;
+
+        let peer_id = EndpointId::from(SecretKey::from_bytes(&[0xEF; 32]).public());
+
+        let ann_with_timestamp = super::PeerAnnouncement {
+            addr: iroh::EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            },
+            role: super::NodeRole::Worker,
+            first_joined_mesh_ts: Some(1_700_000_000_000u64),
+            models: vec![],
+            vram_bytes: 0,
+            model_source: None,
+            serving_models: vec![],
+            hosted_models: None,
+            available_models: vec![],
+            requested_models: vec![],
+            version: None,
+            model_demand: HashMap::new(),
+            mesh_id: None,
+            gpu_name: None,
+            hostname: None,
+            is_soc: None,
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            available_model_metadata: vec![],
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: vec![],
+            served_model_runtime: vec![],
+            owner_attestation: None,
+        };
+
+        let proto_pa = local_ann_to_proto_ann(&ann_with_timestamp);
+        assert_eq!(proto_pa.first_joined_mesh_ts, Some(1_700_000_000_000u64));
+
+        let (_, roundtripped) =
+            proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
+        assert_eq!(
+            roundtripped.first_joined_mesh_ts,
+            Some(1_700_000_000_000u64)
+        );
+
+        let ann_without_timestamp = super::PeerAnnouncement {
+            addr: iroh::EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            },
+            role: super::NodeRole::Worker,
+            first_joined_mesh_ts: None,
+            models: vec![],
+            vram_bytes: 0,
+            model_source: None,
+            serving_models: vec![],
+            hosted_models: None,
+            available_models: vec![],
+            requested_models: vec![],
+            version: None,
+            model_demand: HashMap::new(),
+            mesh_id: None,
+            gpu_name: None,
+            hostname: None,
+            is_soc: None,
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            available_model_metadata: vec![],
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: vec![],
+            served_model_runtime: vec![],
+            owner_attestation: None,
+        };
+
+        let proto_pa = local_ann_to_proto_ann(&ann_without_timestamp);
+        assert_eq!(proto_pa.first_joined_mesh_ts, None);
+
+        let (_, roundtripped) =
+            proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
+        assert_eq!(roundtripped.first_joined_mesh_ts, None);
     }
 }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -42,15 +42,9 @@ fn current_time_unix_ms() -> u64 {
         .as_millis() as u64
 }
 
-async fn load_or_record_first_joined_mesh_ts(node: &mesh::Node, mesh_id: &str) {
-    if let Some(ts) = mesh::load_mesh_join_time(mesh_id) {
-        node.set_first_joined_mesh_ts(ts).await;
-    } else {
-        let now_ms = current_time_unix_ms();
-        if node.set_first_joined_mesh_ts_if_absent(now_ms).await {
-            mesh::save_mesh_join_time(mesh_id, now_ms);
-        }
-    }
+async fn record_first_joined_mesh_ts(node: &mesh::Node) {
+    let now_ms = current_time_unix_ms();
+    node.set_first_joined_mesh_ts_if_absent(now_ms).await;
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1303,8 +1297,8 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
         for token in &cli.join {
             match node.join(token).await {
                 Ok(()) => {
-                    if let Some(mesh_id) = node.mesh_id().await {
-                        load_or_record_first_joined_mesh_ts(node, &mesh_id).await;
+                    if node.mesh_id().await.is_some() {
+                        record_first_joined_mesh_ts(node).await;
                     }
                     eprintln!("Joined mesh");
                     return Ok(());
@@ -1341,8 +1335,8 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
                     );
                     match node.join(token).await {
                         Ok(()) => {
-                            if let Some(mesh_id) = node.mesh_id().await {
-                                load_or_record_first_joined_mesh_ts(node, &mesh_id).await;
+                            if node.mesh_id().await.is_some() {
+                                record_first_joined_mesh_ts(node).await;
                             }
                             last_err = None;
                             break;
@@ -1570,8 +1564,8 @@ async fn run_auto(
         for (t, mesh_name) in &join_attempts {
             match node.join(t).await {
                 Ok(()) => {
-                    if let Some(mesh_id) = node.mesh_id().await {
-                        load_or_record_first_joined_mesh_ts(&node, &mesh_id).await;
+                    if node.mesh_id().await.is_some() {
+                        record_first_joined_mesh_ts(&node).await;
                     }
                     eprintln!("Joined mesh");
                     joined = true;
@@ -1605,7 +1599,7 @@ async fn run_auto(
                 // Wait for gossip to propagate mesh_id
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 if let Some(id) = save_node.mesh_id().await {
-                    load_or_record_first_joined_mesh_ts(&save_node, &id).await;
+                    record_first_joined_mesh_ts(&save_node).await;
                     mesh::save_last_mesh_id(&id);
                     tracing::info!("Mesh ID: {id}");
                 }
@@ -1659,7 +1653,7 @@ async fn run_auto(
         };
         let mesh_id = mesh::generate_mesh_id(cli.mesh_name.as_deref(), nostr_pubkey.as_deref());
         node.set_mesh_id_force(mesh_id.clone()).await;
-        load_or_record_first_joined_mesh_ts(&node, &mesh_id).await;
+        record_first_joined_mesh_ts(&node).await;
         mesh::save_last_mesh_id(&mesh_id);
         tracing::info!("Mesh ID: {mesh_id}");
         eprintln!("Invite: {token}");

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -35,6 +35,24 @@ use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
+fn current_time_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+async fn load_or_record_first_joined_mesh_ts(node: &mesh::Node, mesh_id: &str) {
+    if let Some(ts) = mesh::load_mesh_join_time(mesh_id) {
+        node.set_first_joined_mesh_ts(ts).await;
+    } else {
+        let now_ms = current_time_unix_ms();
+        if node.set_first_joined_mesh_ts_if_absent(now_ms).await {
+            mesh::save_mesh_join_time(mesh_id, now_ms);
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct StartupModelSpec {
     model_ref: PathBuf,
@@ -1285,6 +1303,9 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
         for token in &cli.join {
             match node.join(token).await {
                 Ok(()) => {
+                    if let Some(mesh_id) = node.mesh_id().await {
+                        load_or_record_first_joined_mesh_ts(node, &mesh_id).await;
+                    }
                     eprintln!("Joined mesh");
                     return Ok(());
                 }
@@ -1320,6 +1341,9 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
                     );
                     match node.join(token).await {
                         Ok(()) => {
+                            if let Some(mesh_id) = node.mesh_id().await {
+                                load_or_record_first_joined_mesh_ts(node, &mesh_id).await;
+                            }
                             last_err = None;
                             break;
                         }
@@ -1546,6 +1570,9 @@ async fn run_auto(
         for (t, mesh_name) in &join_attempts {
             match node.join(t).await {
                 Ok(()) => {
+                    if let Some(mesh_id) = node.mesh_id().await {
+                        load_or_record_first_joined_mesh_ts(&node, &mesh_id).await;
+                    }
                     eprintln!("Joined mesh");
                     joined = true;
                     successful_join = Some((t.clone(), mesh_name.clone()));
@@ -1578,6 +1605,7 @@ async fn run_auto(
                 // Wait for gossip to propagate mesh_id
                 tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                 if let Some(id) = save_node.mesh_id().await {
+                    load_or_record_first_joined_mesh_ts(&save_node, &id).await;
                     mesh::save_last_mesh_id(&id);
                     tracing::info!("Mesh ID: {id}");
                 }
@@ -1631,6 +1659,7 @@ async fn run_auto(
         };
         let mesh_id = mesh::generate_mesh_id(cli.mesh_name.as_deref(), nostr_pubkey.as_deref());
         node.set_mesh_id_force(mesh_id.clone()).await;
+        load_or_record_first_joined_mesh_ts(&node, &mesh_id).await;
         mesh::save_last_mesh_id(&mesh_id);
         tracing::info!("Mesh ID: {mesh_id}");
         eprintln!("Invite: {token}");

--- a/mesh-llm/src/runtime/proxy/tests.rs
+++ b/mesh-llm/src/runtime/proxy/tests.rs
@@ -611,6 +611,7 @@ async fn test_moe_remote_failure_removes_peer_for_faildown() {
         },
         tunnel_port: None,
         role: mesh::NodeRole::Host { http_port: 9337 },
+        first_joined_mesh_ts: None,
         models: vec![],
         vram_bytes: 0,
         rtt_ms: None,

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -26,6 +26,7 @@ import {
 } from "./features/app-shell/lib/routes";
 import {
   applyThemeMode,
+  formatLiveNodeState,
   localRoutableModels,
   modelDisplayName,
   overviewVramGb,
@@ -486,7 +487,7 @@ export function App() {
         client: p.state === "client",
         serving: peerPrimaryModel(p),
         servingModels: pModels,
-        statusLabel: peerStatusLabel(p),
+        statusLabel: formatLiveNodeState(p.state),
         ageSeconds: elapsedSecondsFrom(p.first_joined_mesh_ts) ?? elapsedSecondsFrom(ensureFirstSeenAt(p.id)),
         latencyMs: p.rtt_ms ?? null,
         hostname: p.hostname,

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -459,7 +459,13 @@ export function App() {
             : status.model_name
                 ? [status.model_name]
                 : [],
-
+        statusLabel:
+          status.node_status ||
+          (status.is_client ? "Client" : status.is_host ? "Host" : "Idle"),
+        ageSeconds:
+          elapsedSecondsFrom(status.first_joined_mesh_ts)
+          ?? elapsedSecondsFrom(selfStartedAtUnix)
+          ?? elapsedSecondsFrom(selfFirstSeenAt),
         latencyMs: null,
         hostname: status.my_hostname,
         isSoc: status.my_is_soc,
@@ -480,7 +486,8 @@ export function App() {
         client: p.state === "client",
         serving: peerPrimaryModel(p),
         servingModels: pModels,
-
+        statusLabel: peerStatusLabel(p),
+        ageSeconds: elapsedSecondsFrom(p.first_joined_mesh_ts) ?? elapsedSecondsFrom(ensureFirstSeenAt(p.id)),
         latencyMs: p.rtt_ms ?? null,
         hostname: p.hostname,
         isSoc: p.is_soc,

--- a/mesh-llm/ui/src/features/app-shell/lib/status-types.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/status-types.ts
@@ -80,6 +80,7 @@ export type Peer = {
   version?: string;
   is_soc?: boolean;
   gpus?: { name: string; vram_bytes: number; bandwidth_gbps?: number }[];
+  first_joined_mesh_ts?: number;
 };
 
 export type LocalInstance = {
@@ -131,6 +132,7 @@ export type StatusPayload = {
   my_hostname?: string;
   my_is_soc?: boolean;
   gpus?: { name: string; vram_bytes: number; bandwidth_gbps?: number }[];
+  first_joined_mesh_ts?: number;
 };
 
 export type ModelServingStat = {

--- a/mesh-llm/ui/src/features/app-shell/lib/topology-types.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/topology-types.ts
@@ -9,6 +9,8 @@ export type TopologyNode = {
   client: boolean;
   serving: string;
   servingModels: string[];
+  statusLabel?: string;
+  ageSeconds?: number | null;
 
   latencyMs?: number | null;
   hostname?: string;

--- a/mesh-llm/ui/src/features/dashboard/components/details/ModelSidebar.tsx
+++ b/mesh-llm/ui/src/features/dashboard/components/details/ModelSidebar.tsx
@@ -32,6 +32,7 @@ import {
   TableHeader,
   TableRow,
 } from "../../../../components/ui/table";
+import { formatShortDuration } from "../../../../lib/format-duration";
 import { cn } from "../../../../lib/utils";
 import { modelStatusTooltip } from "../../../app-shell/lib/status-helpers";
 import type { MeshModel } from "../../../app-shell/lib/status-types";
@@ -396,7 +397,7 @@ export function ModelSidebar({
               ? `${model.request_count} requests seen`
               : "No request count"}
             {model.last_active_secs_ago != null
-              ? ` · active ${formatAge(model.last_active_secs_ago)} ago`
+              ? ` · active ${model.last_active_secs_ago < 1 ? "just now" : `${formatShortDuration(model.last_active_secs_ago)} ago`}`
               : ""}
           </div>
         ) : null}
@@ -465,12 +466,6 @@ function modelRevisionFileName(model?: MeshModel | null) {
   return `${fullName}@${model.source_revision}`;
 }
 
-function formatAge(seconds: number) {
-  if (!Number.isFinite(seconds) || seconds < 60) return "just now";
-  if (seconds < 3600) return `${Math.round(seconds / 60)}m`;
-  if (seconds < 86400) return `${Math.round(seconds / 3600)}h`;
-  return `${Math.round(seconds / 86400)}d`;
-}
 
 function formatContextLength(value?: number) {
   if (!value || !Number.isFinite(value)) return "Unknown";

--- a/mesh-llm/ui/src/features/dashboard/components/topology/types.ts
+++ b/mesh-llm/ui/src/features/dashboard/components/topology/types.ts
@@ -92,6 +92,8 @@ export type RenderNode = {
   vramLabel: string;
   modelLabel: string;
   gpuLabel: string;
+  statusLabel?: string;
+  ageSeconds?: number | null;
   x: number;
   y: number;
   size: number;

--- a/mesh-llm/ui/src/features/dashboard/components/topology/ui/MeshRadarField.tsx
+++ b/mesh-llm/ui/src/features/dashboard/components/topology/ui/MeshRadarField.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 import {
+  Clock3,
   Cpu,
   MemoryStick,
   Minus,

--- a/mesh-llm/ui/src/features/dashboard/components/topology/ui/MeshRadarField.tsx
+++ b/mesh-llm/ui/src/features/dashboard/components/topology/ui/MeshRadarField.tsx
@@ -17,6 +17,7 @@ import {
   Wifi,
 } from "lucide-react";
 
+import { formatShortDuration } from "../../../../../lib/format-duration";
 import { useResolvedTheme } from "../../../../../lib/resolved-theme";
 import { cn } from "../../../../../lib/utils";
 import { formatLiveNodeState, shortName } from "../../../../app-shell/lib/status-helpers";
@@ -747,6 +748,24 @@ export function MeshRadarField({
                     Latency
                   </div>
                   <div className="text-[11px] font-medium leading-snug">{hoveredNode.latencyLabel}</div>
+                </div>
+              </div>
+              <div className="flex min-w-0 items-start gap-2">
+                <Clock3
+                  className={cn("mt-0.5 h-3.5 w-3.5 shrink-0", scene.tooltipMutedTextClassName)}
+                />
+                <div className="min-w-0">
+                  <div
+                    className={cn(
+                      "text-[10px] font-semibold uppercase tracking-[0.18em]",
+                      scene.tooltipMutedTextClassName,
+                    )}
+                  >
+                    Age
+                  </div>
+                  <div className="text-[11px] font-medium leading-snug">
+                    {formatShortDuration(hoveredNode.ageSeconds)}
+                  </div>
                 </div>
               </div>
               <div className="flex min-w-0 items-start gap-2">

--- a/mesh-llm/ui/src/lib/format-duration.test.ts
+++ b/mesh-llm/ui/src/lib/format-duration.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from "vitest";
+import { formatShortDuration } from "./format-duration";
+
+const S = 1;
+const M = 60;
+const H = 3_600;
+const D = 86_400;
+const W = 7 * D;
+const MO = 30 * D;
+const Y = 365 * D;
+
+describe("formatShortDuration", () => {
+  it.each([
+    [null, "-"],
+    [undefined, "-"],
+    [0, "-"],
+    [-1, "-"],
+    [NaN, "-"],
+    [Infinity, "-"],
+    [-Infinity, "-"],
+  ])("returns dash for %s", (input, expected) => {
+    expect(formatShortDuration(input as number | null | undefined)).toBe(expected);
+  });
+
+  it.each([
+    [1, "1s"],
+    [20, "20s"],
+    [59, "59s"],
+  ])("formats %i seconds as seconds", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [60, "1m"],
+    [120, "2m"],
+    [3599, "59m"],
+  ])("formats %i seconds as minutes", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [H, "1h"],
+    [2 * H, "2h"],
+    [23 * H + 59 * M + 59 * S, "23h"],
+  ])("formats %i seconds as hours", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [D, "1d"],
+    [2 * D, "2d"],
+    [6 * D, "6d"],
+  ])("formats %i seconds as days", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [W, "1w"],
+    [2 * W, "2w"],
+    [3 * W, "3w"],
+  ])("formats %i seconds as exact weeks", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [9 * D, "1w 2d"],
+    [12 * D, "1w 5d"],
+    [20 * D, "2w 6d"],
+    [27 * D, "3w 6d"],
+  ])("formats %i seconds as compound weeks+days", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [MO, "1mo"],
+    [2 * MO, "2mo"],
+    [11 * MO, "11mo"],
+  ])("formats %i seconds as exact months", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [MO + 10 * D, "1mo 10d"],
+    [2 * MO + 15 * D, "2mo 15d"],
+    [3 * MO + D, "3mo 1d"],
+  ])("formats %i seconds as compound months+days", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [Y, "1y"],
+    [2 * Y, "2y"],
+  ])("formats %i seconds as exact years", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [Y + 2 * MO, "1y 2mo"],
+    [2 * Y + 6 * MO, "2y 6mo"],
+  ])("formats %i seconds as compound years+months", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it.each([
+    [Y + 2 * MO + 2 * D, "1y 2mo 2d"],
+    [Y + MO + 15 * D, "1y 1mo 15d"],
+    [2 * Y + 3 * MO + 7 * D, "2y 3mo 7d"],
+  ])("formats %i seconds as compound years+months+days", (input, expected) => {
+    expect(formatShortDuration(input)).toBe(expected);
+  });
+
+  it("floors fractional seconds", () => {
+    expect(formatShortDuration(59.9)).toBe("59s");
+    expect(formatShortDuration(3601.5)).toBe("1h");
+  });
+});

--- a/mesh-llm/ui/src/lib/format-duration.ts
+++ b/mesh-llm/ui/src/lib/format-duration.ts
@@ -1,0 +1,55 @@
+const YEAR = 365 * 86_400;
+const MONTH = 30 * 86_400;
+const WEEK = 7 * 86_400;
+const DAY = 86_400;
+const HOUR = 3_600;
+const MINUTE = 60;
+
+/**
+ * Format a duration in seconds as a compact human-readable string.
+ *
+ * Examples: `"20s"`, `"4m"`, `"3h"`, `"12d"`, `"2w 5d"`, `"1mo 10d"`, `"1y 2mo 2d"`.
+ * Returns `"-"` when the input is null, undefined, non-finite, or ≤ 0.
+ *
+ * Units used:
+ *   - seconds (s), minutes (m), hours (h), days (d)
+ *   - weeks (w) with optional days — for durations under 30 days
+ *   - months (mo) with optional days — for durations under 1 year
+ *   - years (y) with optional months and days
+ *
+ * Month length is approximated as 30 days. Year length is approximated as 365 days.
+ * These are intentional display approximations — not calendar-accurate arithmetic.
+ */
+export function formatShortDuration(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds) || seconds <= 0) return "-";
+
+  const s = Math.floor(seconds);
+
+  if (s >= YEAR) {
+    const years = Math.floor(s / YEAR);
+    const rem = s % YEAR;
+    const months = Math.floor(rem / MONTH);
+    const days = Math.floor((rem % MONTH) / DAY);
+    const parts = [`${years}y`];
+    if (months > 0) parts.push(`${months}mo`);
+    if (days > 0) parts.push(`${days}d`);
+    return parts.join(" ");
+  }
+
+  if (s >= MONTH) {
+    const months = Math.floor(s / MONTH);
+    const days = Math.floor((s % MONTH) / DAY);
+    return days > 0 ? `${months}mo ${days}d` : `${months}mo`;
+  }
+
+  if (s >= WEEK) {
+    const weeks = Math.floor(s / WEEK);
+    const days = Math.floor((s % WEEK) / DAY);
+    return days > 0 ? `${weeks}w ${days}d` : `${weeks}w`;
+  }
+
+  if (s >= DAY) return `${Math.floor(s / DAY)}d`;
+  if (s >= HOUR) return `${Math.floor(s / HOUR)}h`;
+  if (s >= MINUTE) return `${Math.floor(s / MINUTE)}m`;
+  return `${s}s`;
+}

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,344 @@
+# Spec: Improved Heuristics for Context Size and Parallel Slots in `--auto`
+
+## Background
+
+When `mesh-llm serve --auto` launches llama-server, it picks two key resource parameters:
+
+1. **Context size (`-c`)** — token budget for all active sequences combined.
+2. **Parallel slots (`--parallel`)** — number of concurrent decode streams.
+
+### Current state
+
+**Context size** (`compute_context_size` in `inference/launch.rs`):
+
+```rust
+fn compute_context_size(ctx_size_override, model_bytes, my_vram, total_group_vram) -> u32 {
+    let vram_after_model = my_vram.saturating_sub(host_model_bytes);
+    if vram_after_model >= 30 * GB { 65536 }
+    else if vram_after_model >= 12 * GB { 32768 }
+    else if vram_after_model >= 6 * GB  { 16384 }
+    else if vram_after_model >= 3 * GB  { 8192 }
+    else                                { 4096 }
+}
+```
+
+The thresholds are VRAM-only and completely ignore:
+- The model's native max context length (`GgufCompactMeta::context_length`)
+- The number of attention heads and head dimension (which drives per-token KV byte cost)
+- KV cache quantization in use (Q4/Q8/F16 — already computed separately)
+- Number of parallel slots (more slots × context = more KV)
+
+**Parallel slots** (`runtime/mod.rs`):
+
+```rust
+let slots = primary_startup_model
+    .and_then(|m| m.parallel)
+    .or(config.gpu.parallel)
+    .unwrap_or(4);  // ← hardcoded default
+```
+
+The default of 4 is a fixed number with no relationship to available VRAM, context size chosen, or model size. A node with 80 GB free VRAM gets the same 4 slots as a node with 4 GB free.
+
+---
+
+## Problems
+
+### Context size
+
+1. **Ignores model's architectural max.** A model trained with a 4 096-token context window cannot usefully run at 65 536. Capping at `min(computed, gguf.context_length)` would be free correctness.
+
+2. **Ignores KV cost per token.** The actual bytes consumed per token per layer is:
+   ```
+   kv_bytes_per_token = 2 × n_kv_heads × head_dim × bytes_per_element × n_layers
+   ```
+   With GQA and Q4/Q8 KV quantization, this can be 4–8× cheaper than naive F16 assumptions. A model with 8 KV heads at Q4 has vastly different headroom than a full-attention F16 model of the same size.
+
+3. **VRAM thresholds are not anchored to real KV math.** The `30 GB → 65 536` bracket was hand-tuned for a specific generation of models (likely 7-13B dense). A 70B model filling 30 GB free VRAM has 4× more layers and larger heads, so 65 536 tokens will OOM where the heuristic says it won't.
+
+4. **Does not clamp to a power of two or a model-supported max.** Some models have native rope limits; exceeding them requires rope scaling which degrades quality silently.
+
+### Parallel slots
+
+1. **Hardcoded 4 is both too low and too high depending on hardware.** A 96 GB node serving a 7B model has room for 16+ concurrent streams. A 4 GB node serving a 3B model at 8 192 ctx barely has room for 2 without thrashing.
+
+2. **Slots × context = total KV budget.** Context size and slots are not independent. Today `compute_context_size` has no idea how many slots will be requested, so it can accidentally allocate all remaining VRAM to context while the slot count then multiplies the KV footprint.
+
+3. **No relationship to expected concurrency.** A node on the public mesh expects more concurrent callers than a private single-user node. The `--auto` path knows it is joining the mesh and could default higher.
+
+---
+
+## Proposed Design
+
+### 1. Expose KV byte cost from `GgufCompactMeta`
+
+K and V caches are **separate allocations** with potentially different element widths and
+— importantly — different tensor dimensions (`key_length` vs `value_length` are
+independent GGUF fields). Any helper that folds both into a single scalar loses the
+ability to correctly price asymmetric quantization pairs such as Q8K/Q4V.
+
+The fix is to compute K cost and V cost independently and sum them. Add helpers to
+`models/gguf.rs`:
+
+```rust
+impl GgufCompactMeta {
+    /// Bytes consumed by the K cache per token across all layers under f16.
+    /// Returns None if required metadata fields are zero / missing.
+    pub fn k_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        if self.layer_count == 0 || self.key_length == 0 { return None; }
+        // GQA: kv_heads ≤ q_heads. Fall back to full head_count if the
+        // head_count_kv field is not present.
+        let kv_heads = self.head_count_kv.unwrap_or(self.head_count) as u64;
+        Some(kv_heads * self.key_length as u64 * 2 /* f16 */ * self.layer_count as u64)
+    }
+
+    /// Bytes consumed by the V cache per token across all layers under f16.
+    pub fn v_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        if self.layer_count == 0 || self.value_length == 0 { return None; }
+        let kv_heads = self.head_count_kv.unwrap_or(self.head_count) as u64;
+        Some(kv_heads * self.value_length as u64 * 2 /* f16 */ * self.layer_count as u64)
+    }
+}
+```
+
+`head_count_kv` should be added as an `Option<u32>` field read from
+`.attention.head_count_kv` — it is already parsed locally in `scan_gguf_compact_meta`
+but not stored in the struct.
+
+`KvCacheQuant` gets a method that takes the compact meta and returns the **actual
+quantized bytes per token**, keeping K and V costs separate until the final sum:
+
+```rust
+impl KvCacheQuant {
+    /// Quantized KV bytes per token across all layers.
+    /// Returns None when the metadata is too incomplete to estimate.
+    pub fn kv_bytes_per_token(&self, meta: &GgufCompactMeta) -> Option<u64> {
+        let k_f16 = meta.k_cache_bytes_per_token_f16()?;
+        let v_f16 = meta.v_cache_bytes_per_token_f16()?;
+        let k_bytes = apply_quant_scale(k_f16, self.k_type);
+        let v_bytes = apply_quant_scale(v_f16, self.v_type);
+        Some(k_bytes + v_bytes)
+    }
+}
+
+fn apply_quant_scale(f16_bytes: u64, t: KvType) -> u64 {
+    match t {
+        KvType::F16  => f16_bytes,           // 2 bytes/elem, scale 1.0
+        KvType::Q8_0 => f16_bytes / 2,       // 1 byte/elem,  scale 0.5
+        KvType::Q4_0 => f16_bytes / 4,       // 0.5 byte/elem, scale 0.25
+    }
+}
+```
+
+**Why separate K/V matters for asymmetric pairs:**
+
+| Pair | K scale | V scale | Blended if key_len≠val_len |
+|---|---|---|---|
+| F16 / F16 | 1.0 | 1.0 | n/a, trivially correct |
+| Q8_0 / Q8_0 | 0.5 | 0.5 | n/a, trivially correct |
+| Q4_0 / Q4_0 | 0.25 | 0.25 | n/a, trivially correct |
+| **Q8_0 / Q4_0** (medium tier) | **0.5** | **0.25** | total = K×0.5 + V×0.25, **not** (K+V)×0.375 when key_len≠val_len |
+
+The medium-tier asymmetric pair (Q8K/Q4V) is the case that breaks a simple average.
+For models where `key_length == value_length` the difference is numerically zero, but
+that equality is architecture-specific — e.g. some architectures use longer K projections
+— so the correct formula costs each tensor independently regardless.
+
+`head_count_kv` should be added as an optional field read from `.attention.head_count_kv` — it is already parsed locally in `scan_gguf_compact_meta` but not stored in the struct. Promoting it to a named field completes the picture.
+
+### 2. Revised `compute_context_size`
+
+Replace the VRAM-threshold ladder with a capacity-driven formula. Signature expands to accept `GgufCompactMeta`:
+
+```rust
+fn compute_context_size(
+    ctx_size_override: Option<u32>,
+    model_bytes: u64,
+    my_vram: u64,
+    total_group_vram: Option<u64>,
+    meta: Option<&GgufCompactMeta>,  // new
+    kv_quant: KvCacheQuant,          // new — already computed before this call
+    slots: usize,                    // new — so context is co-planned with slots
+) -> u32
+```
+
+**Algorithm:**
+
+```
+1. If ctx_size_override is set, return it (existing behaviour, no change).
+
+2. Compute vram_after_model (existing split/local logic, no change).
+
+3. Estimate the quantized KV byte cost per (token × slot):
+     kv_bytes_per_token = kv_quant.kv_bytes_per_token(meta)
+     This computes K and V costs independently using their actual quantized widths
+     (see §1), then sums them. Asymmetric pairs such as Q8K/Q4V are correctly priced
+     without assuming key_length == value_length.
+     If meta is None (scan failed, shard, etc.), fall back to a conservative estimate:
+       kv_bytes_per_token = 512 bytes  (safe for most 7–13B F16 models)
+
+4. Reserve a headroom fraction for activations and system overhead:
+     usable_vram = vram_after_model × 0.85
+
+5. Solve for context size given the slot count:
+     ctx_size = usable_vram / (kv_bytes_per_token × slots)
+
+6. Snap to the nearest power-of-two step from the set
+   {512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072}
+   rounding down.
+
+7. Clamp to [MIN_CTX, model_native_max]:
+     MIN_CTX = 512
+     model_native_max = meta.context_length if > 0, else 131072
+
+8. Return the clamped value.
+```
+
+The `compression_factor()` concept is **not introduced**. K and V costs are always
+computed separately via `kv_quant.kv_bytes_per_token(meta)` as defined in §1. This
+avoids the implicit assumption that K and V tensors have equal element counts, which
+does not hold when `key_length ≠ value_length`.
+
+### 3. Revised parallel slots heuristic
+
+Replace the `unwrap_or(4)` default with a function that co-plans slots with context:
+
+```rust
+fn default_parallel_slots(
+    vram_after_model: u64,
+    ctx_size: u32,          // the context size already chosen
+    kv_bytes_per_token: u64, // from kv_quant.kv_bytes_per_token(meta), or fallback constant
+) -> usize
+```
+
+**Algorithm:**
+
+```
+1. usable_vram = vram_after_model × 0.85
+
+2. total_kv_budget = usable_vram
+
+3. kv_per_slot = ctx_size × kv_bytes_per_token
+     where kv_bytes_per_token = kv_quant.kv_bytes_per_token(meta)  (K and V priced separately)
+
+4. raw_slots = total_kv_budget / kv_per_slot
+
+5. Clamp raw_slots to [1, MAX_SLOTS]:
+     MAX_SLOTS = 32   (hard ceiling — beyond this the scheduler overhead dominates)
+
+6. Snap down to the nearest value in {1, 2, 4, 8, 16, 32}.
+
+7. Return the result.
+```
+
+Caller site in `runtime/mod.rs` changes from:
+
+```rust
+let slots = primary_startup_model
+    .and_then(|m| m.parallel)
+    .or(config.gpu.parallel)
+    .unwrap_or(4);
+```
+
+to:
+
+```rust
+let slots = primary_startup_model
+    .as_ref()
+    .and_then(|m| m.parallel)
+    .or(config.gpu.parallel)
+    .unwrap_or_else(|| {
+        let vram_after = my_vram.saturating_sub(host_model_bytes);
+        let kv_bpt = kv_quant.kv_bytes_per_token(meta.as_ref()).unwrap_or(512);
+        inference::launch::default_parallel_slots(vram_after, ctx_size, kv_bpt)
+    });
+```
+
+`ctx_size` must be computed first, then `slots` derived from it, so the two are consistent.
+
+### 4. Co-planning order
+
+The two values must be computed in a defined order to avoid circular dependency:
+
+```
+1. Compute kv_bytes_per_token from GGUF metadata (or fallback).
+2. Compute a preliminary ctx_size using a provisional slot count of 1
+   to find the maximum single-slot headroom.
+3. Compute slots from that headroom and the chosen ctx_size.
+4. Recompute ctx_size using the final slot count.
+   (One iteration is sufficient; the relationship is monotone.)
+```
+
+Alternatively, pick a target utilisation: allocate 70% of VRAM budget to context and 30% to multi-slot overhead. This avoids iteration entirely:
+
+```
+kv_bpt      = kv_quant.kv_bytes_per_token(meta).unwrap_or(512)
+ctx_budget  = usable_vram × 0.70 / kv_bpt     // largest single-slot context
+slot_budget = usable_vram × 0.30 / (ctx_budget × kv_bpt)  // remaining headroom → slots
+```
+
+`kv_bpt` already encodes the full quantization picture (K type, V type, GQA heads,
+per-head dimensions) so the same formula applies for all three tiers — F16/F16,
+Q8K/Q8V, Q8K/Q4V — without any special-casing.
+
+The split approach is simpler to implement and test.
+
+---
+
+## Fallback Behaviour
+
+When GGUF metadata is unavailable (scan failed, file not yet downloaded, split-model shard):
+
+- Use the existing VRAM-threshold ladder for context size (preserves current behaviour for the unknown case).
+- Use `slots = max(1, vram_after_model / (4096 × 512))` clamped to `[1, 8]` as the slot default.
+
+This ensures the new logic is strictly opt-in based on data availability and never regresses existing behaviour.
+
+---
+
+## Affected Call Sites
+
+| File | Change |
+|---|---|
+| `inference/launch.rs` | `compute_context_size` gains `meta`, `kv_quant`, `slots` params. New `default_parallel_slots` function. No `compression_factor` — K/V costs computed separately. |
+| `models/gguf.rs` | `GgufCompactMeta` gains `head_count_kv: Option<u32>` field. New `k_cache_bytes_per_token_f16()` and `v_cache_bytes_per_token_f16()` methods. `scan_gguf_compact_meta` stores `head_count_kv`. |
+| `inference/launch.rs` (KvCacheQuant) | New `kv_bytes_per_token(meta)` method on `KvCacheQuant` that prices K and V independently via `apply_quant_scale`. Replaces any future use of a `compression_factor` average. |
+| `runtime/mod.rs` | `slots` computed via new function rather than `unwrap_or(4)`. Both primary (line ~1940) and extra-model (line ~2111) sites updated identically. |
+| `inference/election.rs` | `ModelLaunchSpec` and callsites: `slots` is still passed in as a `usize`, no structural change; only the value fed in changes. |
+
+---
+
+## Tests to Add / Update
+
+- `KvCacheQuant::kv_bytes_per_token` — unit tests covering all six meaningful combinations:
+  - Symmetric F16/F16: result == k_f16 + v_f16 (both at full width)
+  - Symmetric Q8_0/Q8_0: result == (k_f16 + v_f16) / 2
+  - Symmetric Q4_0/Q4_0: result == (k_f16 + v_f16) / 4
+  - Asymmetric Q8_0/Q4_0 (medium tier), key_len == val_len: result == k_f16/2 + v_f16/4
+  - Asymmetric Q8_0/Q4_0, key_len ≠ val_len: result must **not** equal (k_f16+v_f16)×0.375
+    — this is the case that breaks the averaging approach
+  - meta with head_count_kv present (GQA): verify kv_heads used, not head_count
+
+- `compute_context_size` — add cases for:
+  - GQA model (8 KV heads, 32 Q heads) with symmetric Q8 KV: expect higher ctx than F16 baseline
+  - Asymmetric Q8K/Q4V: result must be between symmetric Q8 and symmetric Q4 results,
+    and must match the hand-computed K+V sum (not the average)
+  - context_length clamp: model with native max 4096 must never return > 4096
+  - Fallback (meta = None): must produce same output as current VRAM-threshold ladder
+
+- `default_parallel_slots` — add cases for:
+  - 80 GB free, 7B model, symmetric Q4/Q4: expect ≥ 8 slots
+  - 80 GB free, 7B model, asymmetric Q8K/Q4V: expect fewer slots than symmetric Q4/Q4
+    (K is more expensive under asymmetric pair)
+  - 4 GB free, 3B model, F16/F16: expect 1–2 slots
+  - config override still wins
+
+- Update `model_launch_spec_slots_defaults_to_runtime_value` — the comment about `unwrap_or(4)` will no longer reflect reality; update accordingly.
+
+---
+
+## Non-Goals
+
+- Does not change the `--ctx-size` / `--parallel` config file override path. Explicit user values always win.
+- Does not attempt to dynamically resize context or slots at runtime (that would require llama-server restart).
+- Does not model CPU-offload memory separately. CPU RAM is ignored for now; a future improvement could count it.
+- Does not change MoE expert-shard launch, which has separate resource accounting.


### PR DESCRIPTION
Implements `first_joined_mesh_ts` backend feature and wires the UI to display peer mesh-join ages in short-form duration strings.

## Screenshot
<img width="242" height="241" alt="image" src="https://github.com/user-attachments/assets/feb9e519-a2ee-4169-a1aa-471d9672fa53" />

## Work

**Backend (6 phases):**
1. Proto schema: added `first_joined_mesh_ts?: int64` to `StatusPayload` and `Peer`
2. Wire conversion: Unix ms → seconds for gossip/API
3. Gossip merge: earliest-wins strategy ensures consistency across peers
4. Persistence: join times stored in `~/.mesh-llm/mesh-join-times.json`, survives restarts
5. Runtime integration: loaded on startup, updated on peer discovery
6. API wiring: `/api/status` exposes `first_joined_mesh_ts` for both self and peers

**UI:**
- Created `formatShortDuration(seconds)` utility supporting compact display:
  - Single units: `"20s"`, `"4m"`, `"3h"`, `"12d"`
  - Compound: `"2w 5d"`, `"1mo 10d"`, `"1y 2mo 2d"`
  - Returns `"-"` for null/undefined/non-finite/≤0 values
- Month (30d) and year (365d) are intentional display approximations
- Wired `App.tsx` to prefer `first_joined_mesh_ts` from backend, falling back to `started_at_unix` or client-side first-seen
- Replaced two local `formatAge` functions in `MeshRadarField.tsx` and `ModelSidebar.tsx` with shared `formatShortDuration`

**Format examples:**
- `9d` → `"1w 2d"`
- `40d` → `"1mo 10d"`
- `429d` → `"1y 2mo 2d"`
- `0` / `null` / `NaN` → `"-"` (for hosts which are on old protocol versions)

**Testing:**
- 40 vitest tests cover seconds through years, exact and compound durations, edge cases
- All tests pass
- TypeScript clean, build succeeds