### PR TITLE
Fix client join hang on unresponsive gossip peer

### DIFF
--- a/mesh-llm/src/mesh/gossip.rs
+++ b/mesh-llm/src/mesh/gossip.rs
@@ -102,7 +102,22 @@ pub(super) fn apply_transitive_ann(
 impl Node {
     /// Open a gossip stream on an existing connection to exchange peer info.
     pub(super) async fn initiate_gossip(&self, conn: Connection, remote: EndpointId) -> Result<()> {
-        self.initiate_gossip_inner(conn, remote, true).await
+        // Timeout the entire gossip exchange. A misbehaving peer may accept the
+        // QUIC connection and even the bi-stream but never send a gossip response,
+        // blocking the join path indefinitely and preventing fallback to other
+        // candidates. The 15s budget matches the QUIC connect timeout.
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            self.initiate_gossip_inner(conn, remote, true),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => anyhow::bail!(
+                "gossip exchange with {} timed out (15s)",
+                remote.fmt_short()
+            ),
+        }
     }
 
     pub(super) async fn initiate_gossip_inner(

--- a/mesh-llm/src/mesh/gossip.rs
+++ b/mesh-llm/src/mesh/gossip.rs
@@ -102,20 +102,25 @@ pub(super) fn apply_transitive_ann(
 impl Node {
     /// Open a gossip stream on an existing connection to exchange peer info.
     pub(super) async fn initiate_gossip(&self, conn: Connection, remote: EndpointId) -> Result<()> {
-        // Timeout the entire gossip exchange. A misbehaving peer may accept the
+        // Timeout only the gossip round-trip. A misbehaving peer may accept the
         // QUIC connection and even the bi-stream but never send a gossip response,
         // blocking the join path indefinitely and preventing fallback to other
-        // candidates. The 15s budget matches the QUIC connect timeout.
+        // candidates.
         match tokio::time::timeout(
-            std::time::Duration::from_secs(15),
-            self.initiate_gossip_inner(conn, remote, true),
+            PEER_CONNECT_AND_GOSSIP_TIMEOUT,
+            self.gossip_round_trip(&conn, remote),
         )
         .await
         {
-            Ok(result) => result,
+            Ok(Ok((their_announcements, rtt_ms))) => {
+                self.apply_gossip_announcements(remote, rtt_ms, &their_announcements, true)
+                    .await
+            }
+            Ok(Err(e)) => Err(e),
             Err(_) => anyhow::bail!(
-                "gossip exchange with {} timed out (15s)",
-                remote.fmt_short()
+                "gossip exchange with {} timed out ({}s)",
+                remote.fmt_short(),
+                PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS
             ),
         }
     }
@@ -126,6 +131,16 @@ impl Node {
         remote: EndpointId,
         discover_peers: bool,
     ) -> Result<()> {
+        let (their_announcements, rtt_ms) = self.gossip_round_trip(&conn, remote).await?;
+        self.apply_gossip_announcements(remote, rtt_ms, &their_announcements, discover_peers)
+            .await
+    }
+
+    async fn gossip_round_trip(
+        &self,
+        conn: &Connection,
+        remote: EndpointId,
+    ) -> Result<(Vec<(EndpointAddr, PeerAnnouncement)>, u32)> {
         let protocol = connection_protocol(&conn);
         let t0 = std::time::Instant::now();
         let (mut send, mut recv) = conn.open_bi().await?;
@@ -141,8 +156,17 @@ impl Node {
 
         let _ = recv.read_to_end(0).await;
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        Ok((their_announcements, rtt_ms))
+    }
 
-        for (addr, ann) in &their_announcements {
+    async fn apply_gossip_announcements(
+        &self,
+        remote: EndpointId,
+        rtt_ms: u32,
+        their_announcements: &[(EndpointAddr, PeerAnnouncement)],
+        discover_peers: bool,
+    ) -> Result<()> {
+        for (addr, ann) in their_announcements {
             let peer_id = addr.id;
             if peer_id == self.endpoint.id() {
                 continue;
@@ -190,7 +214,7 @@ impl Node {
 
         if discover_peers {
             let my_role = self.role.lock().await.clone();
-            for (addr, ann) in &their_announcements {
+            for (addr, ann) in their_announcements {
                 let peer_id = addr.id;
                 if peer_id == self.endpoint.id() {
                     continue;

--- a/mesh-llm/src/mesh/gossip.rs
+++ b/mesh-llm/src/mesh/gossip.rs
@@ -120,7 +120,7 @@ impl Node {
             Err(_) => anyhow::bail!(
                 "gossip exchange with {} timed out ({}s)",
                 remote.fmt_short(),
-                PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS
+                PEER_CONNECT_AND_GOSSIP_TIMEOUT.as_secs()
             ),
         }
     }

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -43,9 +43,8 @@ fn current_time_unix_ms() -> u64 {
 }
 
 const MIN_PINNED_GPU_CONFIG_PEER_VERSION: &str = "0.59.0";
-pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS: u64 = 15;
 pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT: std::time::Duration =
-    std::time::Duration::from_secs(PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS);
+    std::time::Duration::from_secs(15);
 
 fn config_uses_pinned_gpu(config: &crate::plugin::MeshConfig) -> bool {
     config.gpu.assignment == crate::plugin::GpuAssignment::Pinned
@@ -3783,7 +3782,7 @@ impl Node {
                 anyhow::bail!(
                     "Timeout connecting to {} ({}s)",
                     peer_id.fmt_short(),
-                    PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS
+                    PEER_CONNECT_AND_GOSSIP_TIMEOUT.as_secs()
                 );
             }
         };

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -43,6 +43,9 @@ fn current_time_unix_ms() -> u64 {
 }
 
 const MIN_PINNED_GPU_CONFIG_PEER_VERSION: &str = "0.59.0";
+pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS: u64 = 15;
+pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT: std::time::Duration =
+    std::time::Duration::from_secs(PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS);
 
 fn config_uses_pinned_gpu(config: &crate::plugin::MeshConfig) -> bool {
     config.gpu.assignment == crate::plugin::GpuAssignment::Pinned
@@ -3767,7 +3770,7 @@ impl Node {
 
         tracing::info!("Connecting to peer {}...", peer_id.fmt_short());
         let conn = match tokio::time::timeout(
-            std::time::Duration::from_secs(15),
+            PEER_CONNECT_AND_GOSSIP_TIMEOUT,
             connect_mesh(&self.endpoint, addr.clone()),
         )
         .await
@@ -3777,7 +3780,11 @@ impl Node {
                 anyhow::bail!("Failed to connect to {}: {e}", peer_id.fmt_short());
             }
             Err(_) => {
-                anyhow::bail!("Timeout connecting to {} (15s)", peer_id.fmt_short());
+                anyhow::bail!(
+                    "Timeout connecting to {} ({}s)",
+                    peer_id.fmt_short(),
+                    PEER_CONNECT_AND_GOSSIP_TIMEOUT_SECS
+                );
             }
         };
 


### PR DESCRIPTION
## What changed

When `mesh-llm client --auto` joins a mesh, the gossip exchange with the bootstrap peer had no timeout. If the peer accepted the QUIC connection but never responded to the gossip stream, the join blocked forever — the management API never came up and fallback candidates were never tried.

## Root cause

Traced on a Mac Mini (M4 16GB) that consistently failed to join. The Nostr discovery returned 3 mesh candidates. Candidate 0 (peer b42128e8cc) accepted the QUIC connection and bi-stream but never sent a gossip response. `read_len_prefixed` (which calls `recv.read_exact`) hung indefinitely. The join loop never reached candidates 1 or 2.

Debugging sequence:
- `Node::start` — OK
- `PluginManager::start` — OK
- QUIC connect to peer — OK
- `open_bi()` — OK
- Write gossip payload — OK
- `read_len_prefixed` (read gossip response) — **hangs forever**

The blackboard plugin child process also prints `Error: early eof` to inherited stderr when it exits, which made the failure look like the parent process was crashing. The parent was actually alive but stuck on the gossip read.

The reconnect path in `_dispatch_streams` already had a 10s timeout around `initiate_gossip` — only the initial join path was missing it.

## Fix

Wrap `initiate_gossip` in a 15s timeout (matching the existing QUIC connect timeout). On timeout, the error propagates to the join loop, which catches it and tries the next candidate.

## Verified

Deployed to the Mac Mini that was consistently failing:
- Before: hangs forever on peer b42128e8cc, API never comes up
- After: gossip times out after 15s, falls through to candidate 1, joins mesh, API comes up