### PR TITLE
fix(ui): fix the unintended blue line in dark mode

### DIFF
--- a/mesh-llm/ui/src/components/ui/sheet.tsx
+++ b/mesh-llm/ui/src/components/ui/sheet.tsx
@@ -29,7 +29,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500 focus:outline-none',
   {
     variants: {
       side: {


### PR DESCRIPTION
The browser was focusing the side panel, this PR corrects display so the focus does not highlight the panel when it opens

## Bug Screenshot
<img width="304" height="1961" alt="image" src="https://github.com/user-attachments/assets/e2b7ed08-6a7c-4315-8630-b6e5bb064444" />
