### PR TITLE
refactor(cli): invert enumerate-host to opt-out with --no-enumerate-host

### DIFF
--- a/mesh-llm/docs/DESIGN.md
+++ b/mesh-llm/docs/DESIGN.md
@@ -262,12 +262,12 @@ trait Collector {
 
 GGUF-derived metadata (architecture, quantization type, tokenizer, RoPE parameters, expert counts) is transported via `CompactModelMetadata` in the `available_model_metadata` field. This lets peers learn model capabilities without downloading the file. The `ScannedModel` type in the proto schema carries the same information for catalog-level model listings. Current gossip sanitization still strips `available_models`, `available_model_metadata`, and `available_model_sizes` before sending announcements on the wire, so these schema fields remain compatibility surface rather than a second transitive model-inventory source.
 
-### `--enumerate-host` Flag
+### `--no-enumerate-host` Flag
 
-Controls whether the host-identifying inventory fields (`gpu_name`, `hostname`, `gpu_vram`, and `gpu_reserved_bytes`) appear in gossip. `is_soc` is always sent. Benchmark-derived bandwidth and compute hints remain additive optional fields when available. `gpu_reserved_bytes` stays omitted on backends such as ROCm and Intel where the tooling does not report a true reserved/unavailable memory metric. Default: `false` (privacy-preserving; peers see VRAM totals but not GPU model or hostname).
+By default, nodes broadcast their GPU name, hostname, VRAM capacity, and reserved bytes to all mesh peers. Pass `--no-enumerate-host` to suppress this hardware identification. `is_soc` is always sent. Benchmark-derived bandwidth and compute hints remain additive optional fields when available. `gpu_reserved_bytes` stays omitted on backends such as ROCm and Intel where the tooling does not report a true reserved/unavailable memory metric.
 
 ```
---enumerate-host    # opt in: peers learn your GPU name and hostname
+--no-enumerate-host    # opt out: suppress GPU name and hostname from gossip
 ```
 
 ### API Shape
@@ -283,7 +283,7 @@ Controls whether the host-identifying inventory fields (`gpu_name`, `hostname`, 
 
 For ROCm and Intel hosts, `reserved_bytes` is omitted because their standard CLI telemetry exposes live used-memory counters rather than a true reserved/system-memory value.
 
-`peers[]` entries (only when peer has `--enumerate-host`):
+`peers[]` entries (only when peer has not passed `--no-enumerate-host`):
 ```json
 {"hostname": "lemony-28", "is_soc": true, "gpus": [{"name": "Tegra AGX Orin", "vram_bytes": 0}]}
 ```

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -328,9 +328,9 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) max_vram: Option<f64>,
 
-    /// Enumerate host hardware (GPU name, hostname) at startup.
-    #[arg(long, hide = true)]
-    pub(crate) enumerate_host: bool,
+    /// Disable broadcasting GPU name, hostname, VRAM, and reserved bytes to peers. By default all nodes announce this hardware info.
+    #[arg(long = "no-enumerate-host", hide = true)]
+    pub(crate) no_enumerate_host: bool,
 
     /// Path to rpc-server, llama-server, and llama-moe-split binaries.
     #[arg(long, hide = true)]

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -1547,7 +1547,7 @@ impl Node {
             owner_summary: Arc::new(Mutex::new(OwnershipSummary::default())),
             trust_store: Arc::new(Mutex::new(TrustStore::default())),
             trust_policy: TrustPolicy::Off,
-            enumerate_host: false,
+            enumerate_host: true,
             gpu_name: None,
             hostname: None,
             is_soc: Some(false),

--- a/mesh-llm/src/mesh/tests.rs
+++ b/mesh-llm/src/mesh/tests.rs
@@ -362,6 +362,7 @@ fn test_peer_payload_hw_fields() {
 
 #[test]
 fn test_enumerate_host_false_omits_hw_fields_in_announcement() {
+    // With enumerate_host: false (opt-out), hardware fields are NOT sent
     let enumerate_host = false;
     let gpu_name: Option<String> = Some("NVIDIA RTX 5090".to_string());
     let hostname: Option<String> = Some("carrack".to_string());
@@ -390,6 +391,7 @@ fn test_enumerate_host_false_omits_hw_fields_in_announcement() {
 
 #[test]
 fn test_enumerate_host_true_includes_hw_fields_in_announcement() {
+    // With enumerate_host: true (default), hardware fields ARE sent
     let enumerate_host = true;
     let gpu_name: Option<String> = Some("NVIDIA RTX 5090".to_string());
     let hostname: Option<String> = Some("carrack".to_string());
@@ -418,6 +420,7 @@ fn test_enumerate_host_true_includes_hw_fields_in_announcement() {
 
 #[test]
 fn test_is_soc_always_included_regardless_of_enumerate_host() {
+    // is_soc is always sent regardless of enumerate_host setting
     for enumerate_host in [false, true] {
         let is_soc: Option<bool> = Some(true);
         let gpu_name: Option<String> = Some("Tegra AGX Orin".to_string());

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -1328,7 +1328,7 @@ pub(crate) async fn run_plugin_mcp(cli: &Cli) -> Result<()> {
         &cli.relay,
         cli.bind_port,
         Some(0.0),
-        cli.enumerate_host,
+        !cli.no_enumerate_host,
         Some(owner_config),
         cli.config.as_deref(),
     )
@@ -1411,7 +1411,7 @@ async fn run_auto(
         &cli.relay,
         cli.bind_port,
         max_vram,
-        cli.enumerate_host,
+        !cli.no_enumerate_host,
         Some(owner_config),
         cli.config.as_deref(),
     )
@@ -1442,6 +1442,7 @@ async fn run_auto(
         let compute_fp32_arc = node.gpu_compute_tflops_fp32.clone();
         let compute_fp16_arc = node.gpu_compute_tflops_fp16.clone();
         let bin_dir_clone = bin_dir.clone();
+        let node_bench = node.clone();
         tokio::spawn(async move {
             let result = tokio::time::timeout(
                 std::time::Duration::from_secs(30),
@@ -1502,6 +1503,7 @@ async fn run_auto(
                 result.as_ref(),
             )
             .await;
+            node_bench.regossip().await;
         });
     } else {
         tracing::debug!("client node — skipping memory bandwidth benchmark");


### PR DESCRIPTION
## Summary
Inverts the `--enumerate-host` flag from opt-in to opt-out so nodes now broadcast their GPU name, hostname, VRAM, and reserved bytes to mesh peers by default. Users who want privacy can pass `--no-enumerate-host` to suppress this hardware identification. Also adds an immediate `regossip()` call after benchmark completes so TFLOP/bandwidth data propagates to peers within seconds rather than waiting up to 60s for the next heartbeat.

## Protocol
- No changes to gossip wire format or protobuf
- `hide = true` preserved on CLI flag
- TFLOP/bandwidth fields remain unconditional
- `is_soc` continues to send regardless of flag

## Changes
- **CLI**: Renamed `--enumerate-host` to `--no-enumerate-host` (hidden from help)
- **Runtime**: Passes `!cli.no_enumerate_host` at both call sites
- **Test helper**: Default flipped from `false` to `true`
- **Benchmark**: Clones node and calls `regossip().await` after `store_benchmark_metrics()`
- **Tests**: Updated comments to clarify opt-out semantics (both paths explicitly tested)
- **Docs**: DESIGN.md flag description updated for new behavior

## Verification
- Fmt: ✓ 
- Check: ✓ 
- Tests: 925 pass 
- Backward compat: 4 pass
