### PR TITLE
Fix broken tests on main: add routing_metrics to StatusPayload test literals

### DIFF
--- a/mesh-llm/src/api/status.rs
+++ b/mesh-llm/src/api/status.rs
@@ -526,6 +526,7 @@ mod tests {
             my_is_soc: None,
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
+            routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
         };
 
         let json = serde_json::to_string(&status).expect("serialization failed");
@@ -569,6 +570,7 @@ mod tests {
             my_is_soc: None,
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
+            routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
         };
 
         let json = serde_json::to_value(&status).expect("serialization failed");
@@ -620,6 +622,7 @@ mod tests {
             my_is_soc: None,
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
+            routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
         };
 
         let json = serde_json::to_value(&status).expect("serialization failed");
@@ -665,6 +668,7 @@ mod tests {
             my_is_soc: None,
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
+            routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
         };
 
         let json = serde_json::to_value(&status).expect("serialization failed");


### PR DESCRIPTION
## Summary

`cargo test -p mesh-llm` and `cargo check -p mesh-llm --tests` currently fail on `main` with four `E0063: missing field \`routing_metrics\`` errors in `mesh-llm/src/api/status.rs`. This PR fixes those four test sites.

## Why this happened

Classic stale-branch merge:

| When (UTC) | PR | What happened |
|---|---|---|
| 2026-04-19 20:32 | #301 | Added required `routing_metrics` field to `StatusPayload`. CI ✅ |
| 2026-04-20 01:22 | #298 | Added 4 new `StatusPayload { ... }` test constructors. CI on its branch last ran ~8 h before #301 merged, so those constructors never saw the new field. CI ✅ |
| 2026-04-20 01:22 | post-merge main | `cargo test --lib --tests` ❌ on macos and linux ([run 24644101464](https://github.com/Mesh-LLM/mesh-llm/actions/runs/24644101464)) |

The merge itself was conflict-free — different lines in the file — but the result doesn't compile under the test cfg. The "Build mesh-llm binary (debug)" job passed because non-test code was fine; only "Unit tests" broke.

## Fix

Add `routing_metrics: metrics::RoutingMetricsStatusSnapshot::default()` to each of the four affected test `StatusPayload` literals. `RoutingMetricsStatusSnapshot` already implements `Default`, and `metrics` is already in scope in this file. Four-line diff, test-only.

## Validation

- `cargo fmt --all -- --check` ✅
- `cargo check -p mesh-llm --tests` ✅
- `cargo test -p mesh-llm --lib` → **959 passed, 0 failed**
- `cargo test -p mesh-llm --lib api::status::` → all 9 status tests pass

## Recommendation (follow-up, not part of this PR)

Turn on GitHub branch protection rule **"Require branches to be up to date before merging"** on `main`. That rule would have forced #298 to rebase on top of #301 and re-run CI, catching this before it hit main.