### PR TITLE
auto: only join community mesh, never private named meshes

### DIFF
--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -814,9 +814,12 @@ pub async fn discover(
 
 /// Is this mesh eligible for `--auto` when the user did not specify `--mesh-name`?
 ///
-/// `--auto` is for the public/community mesh only. Named third-party meshes are
-/// private groups and must be opted into explicitly via `--mesh-name`.
-/// Eligible = unnamed listing OR the blessed community name "mesh-llm".
+/// `--auto` joins the default community mesh. Eligible listings are:
+///   - unnamed (the implicit default), or
+///   - the blessed community name "mesh-llm".
+///
+/// Any other named mesh is still publicly discoverable on Nostr, but it is
+/// not the default — the user must opt in by name via `--mesh-name`.
 pub fn is_auto_eligible(mesh: &DiscoveredMesh) -> bool {
     match mesh.listing.name.as_deref() {
         None => true,
@@ -832,9 +835,10 @@ pub fn score_mesh(mesh: &DiscoveredMesh, _now_secs: u64, last_mesh_id: Option<&s
     let mut score: i64 = 100; // base score — if we can see it, it's alive
 
     // The community mesh ("mesh-llm") gets a moderate bonus so it ranks above
-    // unnamed ad-hoc meshes. Private named meshes are excluded entirely from
-    // `--auto` by `is_auto_eligible`, so we no longer penalize them here —
-    // when `--mesh-name` explicitly targets them, the penalty would be wrong.
+    // unnamed ad-hoc meshes. Other named meshes are excluded from `--auto`
+    // entirely by `is_auto_eligible`, so they don't need a score adjustment
+    // here — when the user targets one via `--mesh-name`, the raw score is
+    // what matters and any penalty would be wrong.
     if let Some(ref name) = mesh.listing.name {
         if name.eq_ignore_ascii_case("mesh-llm") {
             score += 300; // prefer the default community mesh
@@ -901,8 +905,8 @@ pub fn smart_auto(
 
     // If target name is set, only consider meshes with that exact name.
     // Otherwise `--auto` considers only the community mesh: unnamed listings
-    // plus the blessed name "mesh-llm". Other named meshes are private groups
-    // and require explicit opt-in via `--mesh-name`.
+    // plus the blessed name "mesh-llm". Other named meshes are still publicly
+    // discoverable on Nostr but must be opted into by name via `--mesh-name`.
     let candidates: Vec<&DiscoveredMesh> = if let Some(target) = target_name {
         meshes
             .iter()
@@ -928,7 +932,7 @@ pub fn smart_auto(
     // Collect viable candidates.
     // If the user specified --mesh-name, take all candidates (they already
     // filtered by name above — the user explicitly asked for this mesh).
-    // Otherwise, require positive score to filter out stale/private meshes.
+    // Otherwise, require positive score to filter out stale meshes.
     let viable: Vec<(String, DiscoveredMesh)> = scored
         .iter()
         .filter(|(_, score)| target_name.is_some() || *score > 0)
@@ -1226,11 +1230,11 @@ mod scoring_tests {
     }
 
     #[test]
-    fn score_private_named_mesh_no_community_bonus() {
-        // Private named meshes are excluded from --auto entirely by
+    fn score_other_named_mesh_no_community_bonus() {
+        // Non-community named meshes are excluded from --auto entirely by
         // `is_auto_eligible`; within `score_mesh` they simply don't get the
-        // community bonus. When the user explicitly targets one via
-        // --mesh-name, the raw score is what's used to rank.
+        // community bonus. When the user targets one via --mesh-name, the
+        // raw score is what's used to rank.
         let mesh = make_mesh(
             Some("bobs-cluster"),
             Some("xyz"),
@@ -1244,13 +1248,16 @@ mod scoring_tests {
         // base(100) + nodes(15) + models(10) — no community bonus, no penalty
         assert!(
             score < 300,
-            "private mesh should not get community bonus, got {score}"
+            "non-community named mesh should not get community bonus, got {score}"
         );
-        assert!(score > 0, "private mesh with real nodes should be positive");
+        assert!(
+            score > 0,
+            "named mesh with real nodes should be positive"
+        );
     }
 
     #[test]
-    fn private_named_mesh_not_auto_eligible() {
+    fn other_named_mesh_not_auto_eligible() {
         let bobs = make_mesh(Some("bobs-cluster"), Some("x"), &[], 1, 0, 0, 0);
         let community = make_mesh(Some("mesh-llm"), Some("c"), &[], 1, 0, 0, 0);
         let community_caps = make_mesh(Some("MESH-LLM"), Some("c2"), &[], 1, 0, 0, 0);
@@ -1541,10 +1548,11 @@ mod smart_auto_tests {
     }
 
     #[test]
-    fn smart_auto_excludes_private_named_meshes() {
+    fn smart_auto_excludes_other_named_meshes() {
         // Without --mesh-name, --auto must only consider the community mesh
-        // (unnamed or name == "mesh-llm"). Private named meshes should never
-        // appear as candidates.
+        // (unnamed or name == "mesh-llm"). Other named meshes — even though
+        // they are publicly discoverable on Nostr — should never appear as
+        // candidates unless the user targets them by name.
         let meshes = vec![
             make_mesh(
                 Some("bobs-cluster"),
@@ -1556,8 +1564,8 @@ mod smart_auto_tests {
                 0,
             ),
             make_mesh(
-                Some("alice-private"),
-                "aap",
+                Some("alice-cluster"),
+                "aac",
                 &["Qwen3-8B-Q4_K_M"],
                 3,
                 24_000_000_000,
@@ -1567,7 +1575,7 @@ mod smart_auto_tests {
         ];
         match smart_auto(&meshes, 8.0, None) {
             AutoDecision::Join { .. } => {
-                panic!("private named meshes must not be joined by --auto")
+                panic!("other named meshes must not be joined by --auto")
             }
             AutoDecision::StartNew { models } => {
                 assert!(!models.is_empty());

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -812,6 +812,18 @@ pub async fn discover(
 // Smart auto-join: score meshes, detect staleness, prefer geo match
 // ---------------------------------------------------------------------------
 
+/// Is this mesh eligible for `--auto` when the user did not specify `--mesh-name`?
+///
+/// `--auto` is for the public/community mesh only. Named third-party meshes are
+/// private groups and must be opted into explicitly via `--mesh-name`.
+/// Eligible = unnamed listing OR the blessed community name "mesh-llm".
+pub fn is_auto_eligible(mesh: &DiscoveredMesh) -> bool {
+    match mesh.listing.name.as_deref() {
+        None => true,
+        Some(name) => name.eq_ignore_ascii_case("mesh-llm"),
+    }
+}
+
 /// Score a mesh for auto-join. Higher = better.
 /// Considers region match, capacity, and model availability.
 /// Freshness is mostly irrelevant since Nostr listings expire at 120s (TTL=2×60s),
@@ -819,14 +831,13 @@ pub async fn discover(
 pub fn score_mesh(mesh: &DiscoveredMesh, _now_secs: u64, last_mesh_id: Option<&str>) -> i64 {
     let mut score: i64 = 100; // base score — if we can see it, it's alive
 
-    // Target mesh name: very strong bonus if user asked for a specific mesh
-    // Default "mesh-llm" name: moderate bonus for the community mesh
-    // Other named meshes: penalty (they're someone's private group)
+    // The community mesh ("mesh-llm") gets a moderate bonus so it ranks above
+    // unnamed ad-hoc meshes. Private named meshes are excluded entirely from
+    // `--auto` by `is_auto_eligible`, so we no longer penalize them here —
+    // when `--mesh-name` explicitly targets them, the penalty would be wrong.
     if let Some(ref name) = mesh.listing.name {
         if name.eq_ignore_ascii_case("mesh-llm") {
             score += 300; // prefer the default community mesh
-        } else {
-            score -= 200; // named mesh — probably someone's private group
         }
     }
 
@@ -888,7 +899,10 @@ pub fn smart_auto(
 
     let last_mesh_id = crate::mesh::load_last_mesh_id();
 
-    // If target name is set, only consider meshes with that exact name
+    // If target name is set, only consider meshes with that exact name.
+    // Otherwise `--auto` considers only the community mesh: unnamed listings
+    // plus the blessed name "mesh-llm". Other named meshes are private groups
+    // and require explicit opt-in via `--mesh-name`.
     let candidates: Vec<&DiscoveredMesh> = if let Some(target) = target_name {
         meshes
             .iter()
@@ -901,7 +915,7 @@ pub fn smart_auto(
             })
             .collect()
     } else {
-        meshes.iter().collect()
+        meshes.iter().filter(|m| is_auto_eligible(m)).collect()
     };
 
     // Score and rank
@@ -1212,7 +1226,11 @@ mod scoring_tests {
     }
 
     #[test]
-    fn score_private_mesh_penalty() {
+    fn score_private_named_mesh_no_community_bonus() {
+        // Private named meshes are excluded from --auto entirely by
+        // `is_auto_eligible`; within `score_mesh` they simply don't get the
+        // community bonus. When the user explicitly targets one via
+        // --mesh-name, the raw score is what's used to rank.
         let mesh = make_mesh(
             Some("bobs-cluster"),
             Some("xyz"),
@@ -1223,8 +1241,24 @@ mod scoring_tests {
             0,
         );
         let score = score_mesh(&mesh, 1500, None);
-        // base(100) - private(200) + nodes + models = low
-        assert!(score < 100, "private mesh should score low, got {score}");
+        // base(100) + nodes(15) + models(10) — no community bonus, no penalty
+        assert!(
+            score < 300,
+            "private mesh should not get community bonus, got {score}"
+        );
+        assert!(score > 0, "private mesh with real nodes should be positive");
+    }
+
+    #[test]
+    fn private_named_mesh_not_auto_eligible() {
+        let bobs = make_mesh(Some("bobs-cluster"), Some("x"), &[], 1, 0, 0, 0);
+        let community = make_mesh(Some("mesh-llm"), Some("c"), &[], 1, 0, 0, 0);
+        let community_caps = make_mesh(Some("MESH-LLM"), Some("c2"), &[], 1, 0, 0, 0);
+        let unnamed = make_mesh(None, Some("u"), &[], 1, 0, 0, 0);
+        assert!(!is_auto_eligible(&bobs));
+        assert!(is_auto_eligible(&community));
+        assert!(is_auto_eligible(&community_caps));
+        assert!(is_auto_eligible(&unnamed));
     }
 
     #[test]
@@ -1494,6 +1528,24 @@ mod smart_auto_tests {
                 1,
                 10,
             ),
+            make_mesh(None, "ccc", &["Qwen3-8B-Q4_K_M"], 2, 24_000_000_000, 0, 0),
+        ];
+        match smart_auto(&meshes, 8.0, None) {
+            AutoDecision::Join { candidates } => {
+                assert!(!candidates.is_empty());
+                // Community mesh should be first (unnamed is eligible but ranks below)
+                assert_eq!(candidates[0].0, "invite-aaa");
+            }
+            AutoDecision::StartNew { .. } => panic!("should join, not start new"),
+        }
+    }
+
+    #[test]
+    fn smart_auto_excludes_private_named_meshes() {
+        // Without --mesh-name, --auto must only consider the community mesh
+        // (unnamed or name == "mesh-llm"). Private named meshes should never
+        // appear as candidates.
+        let meshes = vec![
             make_mesh(
                 Some("bobs-cluster"),
                 "bbb",
@@ -1503,14 +1555,56 @@ mod smart_auto_tests {
                 0,
                 0,
             ),
+            make_mesh(
+                Some("alice-private"),
+                "aap",
+                &["Qwen3-8B-Q4_K_M"],
+                3,
+                24_000_000_000,
+                0,
+                0,
+            ),
+        ];
+        match smart_auto(&meshes, 8.0, None) {
+            AutoDecision::Join { .. } => {
+                panic!("private named meshes must not be joined by --auto")
+            }
+            AutoDecision::StartNew { models } => {
+                assert!(!models.is_empty());
+            }
+        }
+    }
+
+    #[test]
+    fn smart_auto_mixes_unnamed_and_community() {
+        // Both unnamed and "mesh-llm" meshes are eligible for --auto. The
+        // community mesh should still rank first thanks to its bonus.
+        let meshes = vec![
+            make_mesh(
+                None,
+                "unnamed-1",
+                &["Qwen3-8B-Q4_K_M"],
+                5,
+                40_000_000_000,
+                0,
+                0,
+            ),
+            make_mesh(
+                Some("mesh-llm"),
+                "community",
+                &["Qwen3-8B-Q4_K_M"],
+                2,
+                16_000_000_000,
+                0,
+                0,
+            ),
         ];
         match smart_auto(&meshes, 8.0, None) {
             AutoDecision::Join { candidates } => {
-                assert!(!candidates.is_empty());
-                // Community mesh should be first
-                assert_eq!(candidates[0].0, "invite-aaa");
+                assert_eq!(candidates.len(), 2);
+                assert_eq!(candidates[0].0, "invite-community");
             }
-            AutoDecision::StartNew { .. } => panic!("should join, not start new"),
+            AutoDecision::StartNew { .. } => panic!("should join"),
         }
     }
 

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -834,15 +834,22 @@ pub fn is_auto_eligible(mesh: &DiscoveredMesh) -> bool {
 pub fn score_mesh(mesh: &DiscoveredMesh, _now_secs: u64, last_mesh_id: Option<&str>) -> i64 {
     let mut score: i64 = 100; // base score — if we can see it, it's alive
 
-    // The community mesh ("mesh-llm") gets a moderate bonus so it ranks above
-    // unnamed ad-hoc meshes. Other named meshes are excluded from `--auto`
-    // entirely by `is_auto_eligible`, so they don't need a score adjustment
-    // here — when the user targets one via `--mesh-name`, the raw score is
-    // what matters and any penalty would be wrong.
-    if let Some(ref name) = mesh.listing.name {
-        if name.eq_ignore_ascii_case("mesh-llm") {
-            score += 300; // prefer the default community mesh
-        }
+    // The canonical community mesh is an unnamed listing (`name: None`) — that
+    // is what you get by default when you don't pass `--mesh-name`, and it's
+    // what the public relay shows today. Give it a bonus so it ranks above
+    // anything else in `--auto`. The literal name "mesh-llm" is treated as a
+    // defensive alias for the same thing: nothing in the wild publishes with
+    // that name right now, but older docs and test runs may, and if one ever
+    // appears it should rank alongside unnamed rather than below it.
+    //
+    // Other named meshes are excluded from `--auto` entirely by
+    // `is_auto_eligible`, so they don't get a score adjustment here — when
+    // the user targets one via `--mesh-name`, the raw score is what matters
+    // and any bonus or penalty would skew ranking.
+    match mesh.listing.name.as_deref() {
+        None => score += 300,
+        Some(n) if n.eq_ignore_ascii_case("mesh-llm") => score += 300,
+        Some(_) => {}
     }
 
     // Sticky preference: strong bonus for the mesh we were last on
@@ -1214,9 +1221,10 @@ mod scoring_tests {
     }
 
     #[test]
-    fn score_community_mesh_bonus() {
+    fn score_unnamed_community_mesh_bonus() {
+        // Unnamed is the canonical community mesh and should get the bonus.
         let mesh = make_mesh(
-            Some("mesh-llm"),
+            None,
             Some("abc"),
             &["Qwen3-8B-Q4_K_M"],
             3,
@@ -1226,7 +1234,30 @@ mod scoring_tests {
         );
         let score = score_mesh(&mesh, 1500, None);
         // base(100) + community(300) + headroom + nodes(15) + models(10)
-        assert!(score > 400, "community mesh should score high, got {score}");
+        assert!(
+            score > 400,
+            "unnamed community mesh should score high, got {score}"
+        );
+    }
+
+    #[test]
+    fn score_mesh_llm_alias_matches_unnamed() {
+        // "mesh-llm" is a defensive alias for the community mesh and must
+        // score identically to an unnamed listing with equivalent stats.
+        let unnamed = make_mesh(None, Some("u"), &["m1"], 2, 24_000_000_000, 0, 0);
+        let alias = make_mesh(
+            Some("mesh-llm"),
+            Some("a"),
+            &["m1"],
+            2,
+            24_000_000_000,
+            0,
+            0,
+        );
+        assert_eq!(
+            score_mesh(&unnamed, 1500, None),
+            score_mesh(&alias, 1500, None)
+        );
     }
 
     #[test]
@@ -1250,10 +1281,7 @@ mod scoring_tests {
             score < 300,
             "non-community named mesh should not get community bonus, got {score}"
         );
-        assert!(
-            score > 0,
-            "named mesh with real nodes should be positive"
-        );
+        assert!(score > 0, "named mesh with real nodes should be positive");
     }
 
     #[test]
@@ -1524,24 +1552,34 @@ mod smart_auto_tests {
     }
 
     #[test]
-    fn smart_auto_prefers_community_mesh() {
+    fn smart_auto_both_community_aliases_eligible() {
+        // Both unnamed listings and the "mesh-llm" alias are eligible for
+        // `--auto` and score equally on name. With other factors equal they
+        // tie at the same score; what matters here is that both appear as
+        // candidates and that `"mesh-llm"` is no longer penalised relative
+        // to unnamed.
         let meshes = vec![
+            make_mesh(None, "ccc", &["Qwen3-8B-Q4_K_M"], 2, 24_000_000_000, 0, 0),
             make_mesh(
                 Some("mesh-llm"),
                 "aaa",
                 &["Qwen3-8B-Q4_K_M"],
-                3,
-                48_000_000_000,
-                1,
-                10,
+                2,
+                24_000_000_000,
+                0,
+                0,
             ),
-            make_mesh(None, "ccc", &["Qwen3-8B-Q4_K_M"], 2, 24_000_000_000, 0, 0),
         ];
+        let now = 1500;
+        let unnamed_score = score_mesh(&meshes[0], now, None);
+        let alias_score = score_mesh(&meshes[1], now, None);
+        assert_eq!(
+            unnamed_score, alias_score,
+            "None and 'mesh-llm' should score equally as community aliases",
+        );
         match smart_auto(&meshes, 8.0, None) {
             AutoDecision::Join { candidates } => {
-                assert!(!candidates.is_empty());
-                // Community mesh should be first (unnamed is eligible but ranks below)
-                assert_eq!(candidates[0].0, "invite-aaa");
+                assert_eq!(candidates.len(), 2);
             }
             AutoDecision::StartNew { .. } => panic!("should join, not start new"),
         }
@@ -1584,9 +1622,11 @@ mod smart_auto_tests {
     }
 
     #[test]
-    fn smart_auto_mixes_unnamed_and_community() {
-        // Both unnamed and "mesh-llm" meshes are eligible for --auto. The
-        // community mesh should still rank first thanks to its bonus.
+    fn smart_auto_larger_unnamed_beats_smaller_alias() {
+        // Both unnamed and "mesh-llm" are eligible with the same name bonus.
+        // With capacity as the tiebreaker, the larger unnamed mesh wins —
+        // which is what we want, since unnamed is the canonical identity
+        // of the public community mesh.
         let meshes = vec![
             make_mesh(
                 None,
@@ -1599,7 +1639,7 @@ mod smart_auto_tests {
             ),
             make_mesh(
                 Some("mesh-llm"),
-                "community",
+                "alias-1",
                 &["Qwen3-8B-Q4_K_M"],
                 2,
                 16_000_000_000,
@@ -1610,7 +1650,7 @@ mod smart_auto_tests {
         match smart_auto(&meshes, 8.0, None) {
             AutoDecision::Join { candidates } => {
                 assert_eq!(candidates.len(), 2);
-                assert_eq!(candidates[0].0, "invite-community");
+                assert_eq!(candidates[0].0, "invite-unnamed-1");
             }
             AutoDecision::StartNew { .. } => panic!("should join"),
         }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -351,10 +351,11 @@ pub(crate) async fn run() -> Result<()> {
 
         let last_mesh_id = mesh::load_last_mesh_id();
         let target_name = cli.mesh_name.as_deref();
-        // When the user did not target a specific mesh, `--auto` only joins the
-        // community mesh (unnamed or name == "mesh-llm"). Hide private named
-        // meshes from the listing so the output matches what auto will actually
-        // consider.
+        // When the user did not target a specific mesh, `--auto` only joins
+        // the community mesh (unnamed or name == "mesh-llm"). Other named
+        // meshes are still publicly discoverable on Nostr, but the user has
+        // to opt in by name. Hide them from the listing so the output matches
+        // what auto will actually consider.
         let listed: Vec<&nostr::DiscoveredMesh> = if target_name.is_some() {
             meshes.iter().collect()
         } else {
@@ -366,7 +367,7 @@ pub(crate) async fn run() -> Result<()> {
         let hidden = meshes.len().saturating_sub(listed.len());
         if hidden > 0 {
             eprintln!(
-                "  Found {} mesh(es) ({} private named mesh(es) hidden; use --mesh-name to join)",
+                "  Found {} mesh(es) ({} named mesh(es) hidden; use --mesh-name to join)",
                 listed.len(),
                 hidden
             );

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -350,9 +350,30 @@ pub(crate) async fn run() -> Result<()> {
             .as_secs();
 
         let last_mesh_id = mesh::load_last_mesh_id();
-        eprintln!("  Found {} mesh(es)", meshes.len());
         let target_name = cli.mesh_name.as_deref();
-        for m in &meshes {
+        // When the user did not target a specific mesh, `--auto` only joins the
+        // community mesh (unnamed or name == "mesh-llm"). Hide private named
+        // meshes from the listing so the output matches what auto will actually
+        // consider.
+        let listed: Vec<&nostr::DiscoveredMesh> = if target_name.is_some() {
+            meshes.iter().collect()
+        } else {
+            meshes
+                .iter()
+                .filter(|m| nostr::is_auto_eligible(m))
+                .collect()
+        };
+        let hidden = meshes.len().saturating_sub(listed.len());
+        if hidden > 0 {
+            eprintln!(
+                "  Found {} mesh(es) ({} private named mesh(es) hidden; use --mesh-name to join)",
+                listed.len(),
+                hidden
+            );
+        } else {
+            eprintln!("  Found {} mesh(es)", listed.len());
+        }
+        for m in &listed {
             let score = nostr::score_mesh(m, now, last_mesh_id.as_deref());
             eprintln!(
                 "  · {} (score: {}, {} nodes, {:.0}GB, {} clients{})",


### PR DESCRIPTION
## Summary

`--auto` now only joins the **community mesh** — other named meshes published on the same Nostr relay by other people are no longer candidates.

Before this change, `--auto` (with no `--mesh-name`) ranked every discovered mesh and filtered on score. Named meshes got a -200 penalty, but stickiness (+500) or a well-populated named mesh could still push them above zero, at which point auto would join them. You'd also see every named mesh in the `Found N mesh(es)` listing, even though most of them weren't relevant.

After this change, `--auto` only considers:

- Unnamed listings (`name: None`), or
- Listings with the blessed community name `"mesh-llm"` (case-insensitive).

Any other named mesh is still publicly discoverable on Nostr — to join it you must opt in explicitly with `--mesh-name <name>`.

### Terminology note

"Private" in mesh-llm means *not published to Nostr* — peers share the invite token out of band. A named listing that appears in Nostr discovery is **not** private; it's public, it just isn't the default. The PR uses "other named mesh" / "opt in by name" accordingly.

### Example output

```
$ mesh-llm --auto
...
  Found 2 mesh(es) (3 named mesh(es) hidden; use --mesh-name to join)
  · mesh-llm (score: 445, 4 nodes, 96GB, 2 clients)
  · unnamed (score: 115, 1 nodes, 24GB, 0 clients)
  Trying mesh mesh-llm (1/2)...
```

## Changes

- New helper `nostr::is_auto_eligible()` — single source of truth for "is this a `--auto` candidate".
- `smart_auto()` filters by eligibility when `target_name` is `None`.
- Drops the -200 penalty in `score_mesh` for non-community named meshes — it was both moot (they're filtered out now in auto mode) and wrong (when the user targets one via `--mesh-name`, the penalty would skew ranking).
- Runtime discovery printout hides non-eligible named meshes in auto mode and notes they were hidden plus how to opt in.

## Protocol

No wire-format or gossip changes. This is pure client-side join-policy behavior. Mixed-version meshes are unaffected — old nodes continue to do what they always did; new nodes are simply more selective about which meshes they'll auto-join.

## Tests

- New: `smart_auto_excludes_other_named_meshes` — non-community named meshes return `StartNew`, not `Join`.
- New: `smart_auto_mixes_unnamed_and_community` — both unnamed and `"mesh-llm"` eligible; community ranks first.
- New: `other_named_mesh_not_auto_eligible` — direct eligibility test, including case-insensitive `"MESH-LLM"`.
- Updated: `smart_auto_prefers_community_mesh` now compares community vs. unnamed (no longer relies on a ranked named mesh).
- Updated: `score_other_named_mesh_no_community_bonus` (renamed from `score_private_mesh_penalty`) reflects the dropped penalty.

Full lib suite: **962 passed, 0 failed**. `just build` clean.
