### PR TITLE
Add per-model `parallel` config to control the number of parallel request slots per model

### DIFF
--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -971,6 +971,7 @@ struct MoeElectionParams {
     pinned_gpu: Option<crate::runtime::StartupPinnedGpuTarget>,
     target_tx: Arc<watch::Sender<ModelTargets>>,
     stop_rx: watch::Receiver<bool>,
+    slots: usize,
 }
 
 struct StartLlamaParams<'a> {
@@ -988,6 +989,7 @@ struct StartLlamaParams<'a> {
     binary_flavor: Option<launch::BinaryFlavor>,
     ctx_size_override: Option<u32>,
     pinned_gpu: Option<&'a crate::runtime::StartupPinnedGpuTarget>,
+    slots: usize,
 }
 
 pub struct ElectionLoopParams {
@@ -1009,6 +1011,7 @@ pub struct ElectionLoopParams {
     pub moe_runtime_options: moe::MoeRuntimeOptions,
     pub target_tx: Arc<watch::Sender<ModelTargets>>,
     pub stop_rx: watch::Receiver<bool>,
+    pub slots: usize,
 }
 
 fn spawn_moe_analysis_spinner(
@@ -1516,6 +1519,7 @@ pub async fn election_loop(
         moe_runtime_options,
         target_tx,
         mut stop_rx,
+        slots,
     } = params;
     let mut peer_rx = node.peer_change_rx.clone();
 
@@ -1600,6 +1604,7 @@ pub async fn election_loop(
                     pinned_gpu: pinned_gpu.clone(),
                     target_tx,
                     stop_rx,
+                    slots,
                 },
                 &mut on_change,
                 &mut on_process,
@@ -1823,6 +1828,7 @@ pub async fn election_loop(
                 binary_flavor,
                 ctx_size_override,
                 pinned_gpu: pinned_gpu.as_ref(),
+                slots,
             })
             .await
             {
@@ -1996,6 +2002,7 @@ async fn moe_election_loop(
         pinned_gpu,
         target_tx,
         mut stop_rx,
+        slots,
     } = params;
     let mut peer_rx = node.peer_change_rx.clone();
     let mut currently_running = false;
@@ -2253,6 +2260,7 @@ async fn moe_election_loop(
                     ctx_size_override,
                     total_group_vram: None,
                     selected_gpu: pinned_gpu.as_ref(),
+                    slots,
                 },
             )
             .await
@@ -2360,6 +2368,7 @@ async fn moe_election_loop(
                         ctx_size_override,
                         total_group_vram: None,
                         selected_gpu: pinned_gpu.as_ref(),
+                        slots,
                     },
                 )
                 .await
@@ -2522,6 +2531,7 @@ async fn moe_election_loop(
                     ctx_size_override,
                     total_group_vram: None,
                     selected_gpu: pinned_gpu.as_ref(),
+                    slots,
                 },
             )
             .await
@@ -2739,6 +2749,7 @@ async fn start_llama(
         binary_flavor,
         ctx_size_override,
         pinned_gpu,
+        slots,
     } = params;
     let my_vram = node.vram_bytes();
     let local_launch_vram = effective_local_launch_vram(my_vram, pinned_gpu);
@@ -2896,6 +2907,7 @@ async fn start_llama(
             ctx_size_override,
             total_group_vram: group_vram,
             selected_gpu: pinned_gpu,
+            slots,
         },
     )
     .await

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -325,6 +325,7 @@ pub struct ModelLaunchSpec<'a> {
     pub ctx_size_override: Option<u32>,
     pub total_group_vram: Option<u64>,
     pub selected_gpu: Option<&'a crate::runtime::StartupPinnedGpuTarget>,
+    pub slots: usize,
 }
 
 pub(crate) const GB: u64 = 1_000_000_000;
@@ -1161,7 +1162,6 @@ pub async fn start_llama_server(
     // occupy all slots for minutes while new requests pile up invisibly.
     // The backend proxy enforces a matching inflight cap so the deferred
     // queue never actually fills. See network/openai/backend.rs.
-    const LLAMA_PARALLEL_SLOTS: usize = 4;
     args.extend_from_slice(&[
         "-ngl".to_string(),
         "99".to_string(),
@@ -1171,7 +1171,7 @@ pub async fn start_llama_server(
         "off".to_string(),
         "--no-mmap".to_string(),
         "--parallel".to_string(),
-        LLAMA_PARALLEL_SLOTS.to_string(),
+        spec.slots.to_string(),
         "--host".to_string(),
         "0.0.0.0".to_string(),
         "--port".to_string(),
@@ -2091,6 +2091,89 @@ No devices found
         assert!(
             !runtime_src.contains(&orphan_func),
             "legacy orphan cleanup function reference still present in runtime module"
+        );
+    }
+
+    // ── parallel slots tests ──────────────────────────────────────────
+
+    #[test]
+    fn model_launch_spec_slots_field_carries_value() {
+        use super::ModelLaunchSpec;
+        let spec = ModelLaunchSpec {
+            model: Path::new("test.gguf"),
+            http_port: 8080,
+            tunnel_ports: &[],
+            tensor_split: None,
+            split_mode: None,
+            draft: None,
+            draft_max: 0,
+            model_bytes: 0,
+            my_vram: 0,
+            mmproj: None,
+            ctx_size_override: None,
+            total_group_vram: None,
+            selected_gpu: None,
+            slots: 8,
+        };
+        assert_eq!(
+            spec.slots, 8,
+            "slots field should carry the value it was constructed with"
+        );
+    }
+
+    #[test]
+    fn model_launch_spec_slots_defaults_to_runtime_value() {
+        use super::ModelLaunchSpec;
+        // The default parallel slots value used throughout the codebase is 4
+        // (from config.gpu.parallel.unwrap_or(4)). ModelLaunchSpec should
+        // receive that same default when no config override is set.
+        let spec = ModelLaunchSpec {
+            model: Path::new("test.gguf"),
+            http_port: 8080,
+            tunnel_ports: &[],
+            tensor_split: None,
+            split_mode: None,
+            draft: None,
+            draft_max: 0,
+            model_bytes: 0,
+            my_vram: 0,
+            mmproj: None,
+            ctx_size_override: None,
+            total_group_vram: None,
+            selected_gpu: None,
+            slots: 4, // default from config.gpu.parallel.unwrap_or(4)
+        };
+        assert_eq!(
+            spec.slots, 4,
+            "default slots should be 4 matching unwrap_or(4)"
+        );
+    }
+
+    #[test]
+    fn parallel_arg_uses_spec_slots() {
+        // Source-scanning test (same pattern as no_pkill_f_in_source_tree):
+        // verifies the --parallel arg is built from spec.slots, not a
+        // hardcoded constant. If someone reintroduces a hardcoded value,
+        // this test will catch it.
+        let src = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/inference/launch.rs"
+        ))
+        .unwrap();
+
+        // The code should build --parallel from spec.slots
+        let parallel_from_spec = "spec.slots.to_string()";
+        assert!(
+            src.contains(parallel_from_spec),
+            "expected '--parallel' arg to be built from spec.slots.to_string(), \
+             but that pattern was not found — someone may have reverted to a hardcoded value"
+        );
+
+        let hardcoded = format!("{}_{}_{}", "LLAMA", "PARALLEL", "SLOTS");
+        assert!(
+            !src.contains(&hardcoded),
+            "found {} constant — the --parallel arg should use spec.slots instead",
+            hardcoded
         );
     }
 }

--- a/mesh-llm/src/mesh/tests.rs
+++ b/mesh-llm/src/mesh/tests.rs
@@ -3525,12 +3525,14 @@ async fn config_subscribe_rejects_pinned_snapshot_for_older_peer() -> Result<()>
                 version: Some(1),
                 gpu: crate::plugin::GpuConfig {
                     assignment: crate::plugin::GpuAssignment::Pinned,
+                    ..Default::default()
                 },
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: Some("pci:0000:65:00.0".into()),
+                    parallel: None,
                 }],
                 plugins: vec![],
             },
@@ -3621,12 +3623,14 @@ async fn config_subscribe_rejects_pinned_snapshot_for_malformed_peer_version() -
                 version: Some(1),
                 gpu: crate::plugin::GpuConfig {
                     assignment: crate::plugin::GpuAssignment::Pinned,
+                    ..Default::default()
                 },
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: Some("pci:0000:65:00.0".into()),
+                    parallel: None,
                 }],
                 plugins: vec![],
             },
@@ -3715,12 +3719,14 @@ async fn config_subscribe_allows_pinned_snapshot_for_same_release_prerelease_pee
                 version: Some(1),
                 gpu: crate::plugin::GpuConfig {
                     assignment: crate::plugin::GpuAssignment::Pinned,
+                    ..Default::default()
                 },
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: Some("pci:0000:65:00.0".into()),
+                    parallel: None,
                 }],
                 plugins: vec![],
             },
@@ -3888,12 +3894,14 @@ async fn config_subscribe_closes_when_revision_becomes_pinned_for_malformed_peer
                 version: Some(1),
                 gpu: crate::plugin::GpuConfig {
                     assignment: crate::plugin::GpuAssignment::Pinned,
+                    ..Default::default()
                 },
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: Some("pci:0000:65:00.0".into()),
+                    parallel: None,
                 }],
                 plugins: vec![],
             },
@@ -3986,12 +3994,14 @@ async fn config_subscribe_closes_when_revision_becomes_pinned_for_older_peer() -
                 version: Some(1),
                 gpu: crate::plugin::GpuConfig {
                     assignment: crate::plugin::GpuAssignment::Pinned,
+                    ..Default::default()
                 },
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: Some("pci:0000:65:00.0".into()),
+                    parallel: None,
                 }],
                 plugins: vec![],
             },
@@ -4085,12 +4095,14 @@ async fn config_subscribe_keeps_stream_open_when_revision_becomes_pinned_for_sam
                 version: Some(1),
                 gpu: crate::plugin::GpuConfig {
                     assignment: crate::plugin::GpuAssignment::Pinned,
+                    ..Default::default()
                 },
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: Some("pci:0000:65:00.0".into()),
+                    parallel: None,
                 }],
                 plugins: vec![],
             },
@@ -4489,12 +4501,14 @@ fn pinned_gpu_runtime_push_rejects_invalid_pushed_pinned_config_before_apply() {
     let config = crate::plugin::MeshConfig {
         gpu: crate::plugin::GpuConfig {
             assignment: crate::plugin::GpuAssignment::Pinned,
+            ..Default::default()
         },
         models: vec![crate::plugin::ModelConfigEntry {
             model: "Qwen3-8B-Q4_K_M".into(),
             mmproj: None,
             ctx_size: Some(8192),
             gpu_id: Some("pci:0000:b3:00.0".into()),
+            parallel: None,
         }],
         ..crate::plugin::MeshConfig::default()
     };
@@ -4528,12 +4542,14 @@ fn pinned_gpu_runtime_push_accepts_valid_pushed_pinned_config() {
     let config = crate::plugin::MeshConfig {
         gpu: crate::plugin::GpuConfig {
             assignment: crate::plugin::GpuAssignment::Pinned,
+            ..Default::default()
         },
         models: vec![crate::plugin::ModelConfigEntry {
             model: "Qwen3-8B-Q4_K_M".into(),
             mmproj: None,
             ctx_size: Some(8192),
             gpu_id: Some("uuid:GPU-123".into()),
+            parallel: None,
         }],
         ..crate::plugin::MeshConfig::default()
     };
@@ -4563,12 +4579,14 @@ fn pinned_gpu_runtime_push_rejects_resolved_gpu_without_backend_device() {
     let config = crate::plugin::MeshConfig {
         gpu: crate::plugin::GpuConfig {
             assignment: crate::plugin::GpuAssignment::Pinned,
+            ..Default::default()
         },
         models: vec![crate::plugin::ModelConfigEntry {
             model: "Qwen3-8B-Q4_K_M".into(),
             mmproj: None,
             ctx_size: Some(8192),
             gpu_id: Some("uuid:GPU-123".into()),
+            parallel: None,
         }],
         ..crate::plugin::MeshConfig::default()
     };

--- a/mesh-llm/src/plugin/config.rs
+++ b/mesh-llm/src/plugin/config.rs
@@ -21,6 +21,8 @@ pub struct MeshConfig {
 pub struct GpuConfig {
     #[serde(default)]
     pub assignment: GpuAssignment,
+    #[serde(default)]
+    pub parallel: Option<usize>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -40,6 +42,8 @@ pub struct ModelConfigEntry {
     pub ctx_size: Option<u32>,
     #[serde(default)]
     pub gpu_id: Option<String>,
+    #[serde(default)]
+    pub parallel: Option<usize>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -101,6 +105,11 @@ pub(crate) fn validate_config(config: &MeshConfig) -> Result<()> {
             bail!("unsupported config version {version}; expected version = 1");
         }
     }
+    if let Some(parallel) = config.gpu.parallel {
+        if parallel < 1 {
+            bail!("gpu.parallel must be at least 1, got {parallel}");
+        }
+    }
     for (index, model) in config.models.iter().enumerate() {
         if model.model.trim().is_empty() {
             bail!("models[{index}].model must not be empty");
@@ -108,6 +117,11 @@ pub(crate) fn validate_config(config: &MeshConfig) -> Result<()> {
         if let Some(mmproj) = &model.mmproj {
             if mmproj.trim().is_empty() {
                 bail!("models[{index}].mmproj must not be empty when set");
+            }
+        }
+        if let Some(parallel) = model.parallel {
+            if parallel < 1 {
+                bail!("models[{index}].parallel must be at least 1, got {parallel}");
             }
         }
         match config.gpu.assignment {
@@ -306,12 +320,14 @@ ctx_size = 8192
         let config = MeshConfig {
             gpu: GpuConfig {
                 assignment: GpuAssignment::Pinned,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".into(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: None,
+                parallel: None,
             }],
             ..MeshConfig::default()
         };
@@ -327,12 +343,14 @@ ctx_size = 8192
         let config = MeshConfig {
             gpu: GpuConfig {
                 assignment: GpuAssignment::Pinned,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".into(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: Some("  \t  ".into()),
+                parallel: None,
             }],
             ..MeshConfig::default()
         };
@@ -348,12 +366,14 @@ ctx_size = 8192
         let config = MeshConfig {
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".into(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: Some("pci:0000:65:00.0".into()),
+                parallel: None,
             }],
             ..MeshConfig::default()
         };
@@ -374,7 +394,7 @@ assignment = "pinned"
 
 [[models]]
 model = "Qwen3-8B-Q4_K_M"
-gpu_id = "  pci:0000:65:00.0  "
+gpu_id = " pci:0000:65:00.0 "
 "#;
 
         let config: MeshConfig = toml::from_str(raw).unwrap();
@@ -382,7 +402,189 @@ gpu_id = "  pci:0000:65:00.0  "
 
         assert_eq!(
             config.models[0].gpu_id.as_deref(),
-            Some("  pci:0000:65:00.0  ")
+            Some(" pci:0000:65:00.0 ")
         );
+    }
+
+    // ── gpu.parallel validation ──
+
+    #[test]
+    fn gpu_parallel_field_deserializes_from_toml() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+
+[gpu]
+assignment = "auto"
+parallel = 8
+
+[[models]]
+model = "Qwen3-8B-Q4_K_M"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.gpu.parallel, Some(8));
+    }
+
+    #[test]
+    fn gpu_parallel_defaults_to_none_when_omitted() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+
+[gpu]
+assignment = "auto"
+
+[[models]]
+model = "Qwen3-8B-Q4_K_M"
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.gpu.parallel, None);
+    }
+
+    #[test]
+    fn gpu_parallel_zero_rejected() {
+        let config = MeshConfig {
+            gpu: GpuConfig {
+                assignment: GpuAssignment::Auto,
+                parallel: Some(0),
+            },
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        let err = validate_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("gpu.parallel must be at least 1, got 0"),
+            "unexpected error message: {err}"
+        );
+    }
+
+    #[test]
+    fn gpu_parallel_one_accepted() {
+        let config = MeshConfig {
+            gpu: GpuConfig {
+                assignment: GpuAssignment::Auto,
+                parallel: Some(1),
+            },
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn gpu_parallel_none_accepted() {
+        let config = MeshConfig {
+            gpu: GpuConfig {
+                assignment: GpuAssignment::Auto,
+                parallel: None,
+            },
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn gpu_parallel_large_value_accepted() {
+        let config = MeshConfig {
+            gpu: GpuConfig {
+                assignment: GpuAssignment::Auto,
+                parallel: Some(64),
+            },
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn gpu_parallel_unwrap_or_default_is_4() {
+        assert_eq!(None::<usize>.unwrap_or(4), 4);
+        assert_eq!(Some(1usize).unwrap_or(4), 1);
+        assert_eq!(Some(8usize).unwrap_or(4), 8);
+        assert_eq!(Some(64usize).unwrap_or(4), 64);
+    }
+
+    #[test]
+    fn per_model_parallel_valid_value_accepted() {
+        let config = MeshConfig {
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: Some(8),
+            }],
+            ..MeshConfig::default()
+        };
+        validate_config(&config).unwrap();
+    }
+
+    #[test]
+    fn per_model_parallel_zero_rejected() {
+        let config = MeshConfig {
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: Some(0),
+            }],
+            ..MeshConfig::default()
+        };
+        let err = validate_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("models[0].parallel must be at least 1"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn per_model_parallel_none_accepted() {
+        let config = MeshConfig {
+            models: vec![ModelConfigEntry {
+                model: "Qwen3-8B-Q4_K_M".into(),
+                mmproj: None,
+                ctx_size: None,
+                gpu_id: None,
+                parallel: None,
+            }],
+            ..MeshConfig::default()
+        };
+        validate_config(&config).unwrap();
     }
 }

--- a/mesh-llm/src/protocol/convert.rs
+++ b/mesh-llm/src/protocol/convert.rs
@@ -740,6 +740,7 @@ pub(crate) fn proto_config_to_mesh(
             mmproj: declared_ref_or_none(m.mmproj_ref.as_ref()).or_else(|| m.mmproj.clone()),
             ctx_size: m.ctx_size,
             gpu_id: m.gpu_id.clone(),
+            parallel: None,
         })
         .collect();
     let plugins = snapshot
@@ -754,7 +755,10 @@ pub(crate) fn proto_config_to_mesh(
         .collect();
     MeshConfig {
         version: Some(snapshot.version),
-        gpu: GpuConfig { assignment },
+        gpu: GpuConfig {
+            assignment,
+            parallel: None,
+        },
         models,
         plugins,
     }

--- a/mesh-llm/src/protocol/mod.rs
+++ b/mesh-llm/src/protocol/mod.rs
@@ -1564,12 +1564,14 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B.gguf".to_string(),
                 mmproj: Some("mm.gguf".to_string()),
                 ctx_size: Some(8192),
                 gpu_id: Some("pci:0000:65:00.0".to_string()),
+                parallel: None,
             }],
             plugins: vec![PluginConfigEntry {
                 name: "blackboard".to_string(),
@@ -1612,12 +1614,14 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "test.gguf".to_string(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: None,
+                parallel: None,
             }],
             plugins: vec![],
         };
@@ -1631,12 +1635,14 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "other.gguf".to_string(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: None,
+                parallel: None,
             }],
             plugins: vec![],
         };
@@ -1653,12 +1659,14 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Pinned,
+                parallel: None,
             },
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".to_string(),
                 mmproj: Some("mmproj-f16.gguf".to_string()),
                 ctx_size: Some(8192),
                 gpu_id: Some("pci:0000:65:00.0".to_string()),
+                parallel: None,
             }],
             plugins: vec![],
         };

--- a/mesh-llm/src/runtime/config_state.rs
+++ b/mesh-llm/src/runtime/config_state.rs
@@ -229,6 +229,7 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![],
             plugins: vec![],
@@ -346,12 +347,14 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![crate::plugin::ModelConfigEntry {
                 model: model.to_string(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: None,
+                parallel: None,
             }],
             plugins: vec![],
         };
@@ -378,12 +381,14 @@ mod tests {
             version: Some(1),
             gpu: GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![crate::plugin::ModelConfigEntry {
                 model: "test.gguf".to_string(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: None,
+                parallel: None,
             }],
             plugins: vec![],
         };
@@ -417,12 +422,14 @@ mod tests {
             version: Some(1),
             gpu: crate::plugin::GpuConfig {
                 assignment: GpuAssignment::Auto,
+                parallel: None,
             },
             models: vec![crate::plugin::ModelConfigEntry {
                 model: "noop-test.gguf".to_string(),
                 mmproj: None,
                 ctx_size: None,
                 gpu_id: None,
+                parallel: None,
             }],
             plugins: vec![],
         };

--- a/mesh-llm/src/runtime/local.rs
+++ b/mesh-llm/src/runtime/local.rs
@@ -169,6 +169,7 @@ pub(super) async fn start_runtime_local_model(
     model_path: &Path,
     mmproj_override: Option<&Path>,
     ctx_size_override: Option<u32>,
+    slots: usize,
 ) -> Result<(
     String,
     LocalRuntimeModelHandle,
@@ -204,6 +205,7 @@ pub(super) async fn start_runtime_local_model(
             ctx_size_override,
             total_group_vram: None,
             selected_gpu: None,
+            slots,
         },
     )
     .await?;

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -42,6 +42,7 @@ struct StartupModelSpec {
     ctx_size: Option<u32>,
     gpu_id: Option<String>,
     config_owned: bool,
+    parallel: Option<usize>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -60,6 +61,7 @@ struct StartupModelPlan {
     ctx_size: Option<u32>,
     gpu_id: Option<String>,
     pinned_gpu: Option<StartupPinnedGpuTarget>,
+    parallel: Option<usize>,
 }
 
 fn resolve_runtime_owner_key_path(cli: &Cli) -> Result<Option<PathBuf>> {
@@ -592,6 +594,7 @@ fn build_startup_model_specs(
                 ctx_size: cli.ctx_size,
                 gpu_id: None,
                 config_owned: false,
+                parallel: None,
             });
         }
         for model in &cli.model {
@@ -601,6 +604,7 @@ fn build_startup_model_specs(
                 ctx_size: cli.ctx_size,
                 gpu_id: None,
                 config_owned: false,
+                parallel: None,
             });
         }
         if let Some(mmproj) = &cli.mmproj {
@@ -618,6 +622,7 @@ fn build_startup_model_specs(
             ctx_size: cli.ctx_size.or(model.ctx_size),
             gpu_id: model.gpu_id.clone(),
             config_owned: true,
+            parallel: model.parallel,
         });
     }
     Ok(specs)
@@ -644,6 +649,7 @@ async fn resolve_startup_models(
             ctx_size: spec.ctx_size,
             gpu_id: spec.gpu_id.clone(),
             pinned_gpu: None,
+            parallel: spec.parallel,
         });
     }
     Ok(plans)
@@ -1927,6 +1933,11 @@ async fn run_auto(
     let model2 = model.clone();
     let draft2 = cli.draft.clone();
     let draft_max = cli.draft_max;
+    let slots = primary_startup_model
+        .as_ref()
+        .and_then(|m| m.parallel)
+        .or(config.gpu.parallel)
+        .unwrap_or(4);
     let force_split = cli.split;
     let llama_flavor = cli.llama_flavor;
     let cb_console_port = console_port;
@@ -1973,6 +1984,7 @@ async fn run_auto(
                 moe_runtime_options,
                 target_tx: primary_target_tx,
                 stop_rx: primary_stop_rx,
+                slots,
             },
             move |is_host, llama_ready| {
                 let advertise_node = node_for_cb.clone();
@@ -2096,6 +2108,7 @@ async fn run_auto(
             let extra_model_name = extra_name.clone();
             let api_port_extra = api_port;
             let extra_llama_flavor = cli.llama_flavor;
+            let slots = extra_model.parallel.or(config.gpu.parallel).unwrap_or(4);
             let extra_moe_runtime_options = moe::MoeRuntimeOptions::default();
             let extra_console_state = console_state.clone();
             let extra_model_name_for_status = extra_model_name.clone();
@@ -2129,6 +2142,7 @@ async fn run_auto(
                         moe_runtime_options: extra_moe_runtime_options,
                         target_tx: extra_target_tx,
                         stop_rx: extra_stop_rx,
+                        slots,
                     },
                     move |is_host, llama_ready| {
                         let advertise_node = extra_node_for_advertise.clone();
@@ -2227,6 +2241,7 @@ async fn run_auto(
 
     // Wait for SIGINT/SIGTERM or runtime model control commands.
     let primary_model_name = model_name.clone();
+    let slots = config.gpu.parallel.unwrap_or(4);
     loop {
         tokio::select! {
             _ = wait_shutdown_signal() => {
@@ -2258,6 +2273,7 @@ async fn run_auto(
                                 &model_path,
                                 None,
                                 cli.ctx_size,
+                                slots,
                             )
                             .await?;
 
@@ -2951,6 +2967,7 @@ mod tests {
                 mmproj: Some("/tmp/ignored-mmproj.gguf".into()),
                 ctx_size: Some(8192),
                 gpu_id: None,
+                parallel: None,
             }],
             ..plugin::MeshConfig::default()
         };
@@ -2974,12 +2991,14 @@ mod tests {
                     mmproj: None,
                     ctx_size: Some(8192),
                     gpu_id: None,
+                    parallel: None,
                 },
                 plugin::ModelConfigEntry {
                     model: "bartowski/Qwen2.5-VL/model.gguf".into(),
                     mmproj: Some("bartowski/Qwen2.5-VL/mmproj.gguf".into()),
                     ctx_size: Some(16384),
                     gpu_id: None,
+                    parallel: None,
                 },
             ],
             ..plugin::MeshConfig::default()
@@ -3009,6 +3028,7 @@ mod tests {
                 mmproj: None,
                 ctx_size: Some(8192),
                 gpu_id: None,
+                parallel: None,
             }],
             ..plugin::MeshConfig::default()
         };
@@ -3023,12 +3043,14 @@ mod tests {
         let config = plugin::MeshConfig {
             gpu: plugin::GpuConfig {
                 assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
             },
             models: vec![plugin::ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".into(),
                 mmproj: None,
                 ctx_size: Some(8192),
                 gpu_id: Some("pci:0000:65:00.0".into()),
+                parallel: None,
             }],
             ..plugin::MeshConfig::default()
         };
@@ -3040,6 +3062,7 @@ mod tests {
             ctx_size: Some(8192),
             gpu_id: specs[0].gpu_id.clone(),
             pinned_gpu: None,
+            parallel: None,
         }];
         let gpus = vec![
             synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0")),
@@ -3077,12 +3100,14 @@ mod tests {
         let config = plugin::MeshConfig {
             gpu: plugin::GpuConfig {
                 assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
             },
             models: vec![plugin::ModelConfigEntry {
                 model: "Ignored-Model".into(),
                 mmproj: None,
                 ctx_size: Some(8192),
                 gpu_id: Some("pci:0000:65:00.0".into()),
+                parallel: None,
             }],
             ..plugin::MeshConfig::default()
         };
@@ -3094,6 +3119,7 @@ mod tests {
             ctx_size: None,
             gpu_id: specs[0].gpu_id.clone(),
             pinned_gpu: None,
+            parallel: None,
         }];
         let gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
 
@@ -3111,6 +3137,7 @@ mod tests {
         let config = plugin::MeshConfig {
             gpu: plugin::GpuConfig {
                 assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
             },
             ..plugin::MeshConfig::default()
         };
@@ -3120,6 +3147,7 @@ mod tests {
             ctx_size: None,
             gpu_id: None,
             config_owned: true,
+            parallel: None,
         }];
         let mut plans = vec![StartupModelPlan {
             declared_ref: "Qwen3-8B-Q4_K_M".into(),
@@ -3128,6 +3156,7 @@ mod tests {
             ctx_size: None,
             gpu_id: None,
             pinned_gpu: None,
+            parallel: None,
         }];
         let gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
 
@@ -3145,6 +3174,7 @@ mod tests {
         let config = plugin::MeshConfig {
             gpu: plugin::GpuConfig {
                 assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
             },
             ..plugin::MeshConfig::default()
         };
@@ -3154,6 +3184,7 @@ mod tests {
             ctx_size: Some(4096),
             gpu_id: Some("uuid:GPU-123".into()),
             config_owned: true,
+            parallel: None,
         }];
         let mut plans = vec![StartupModelPlan {
             declared_ref: "Qwen3-8B-Q4_K_M".into(),
@@ -3162,6 +3193,7 @@ mod tests {
             ctx_size: Some(4096),
             gpu_id: Some("uuid:GPU-123".into()),
             pinned_gpu: None,
+            parallel: None,
         }];
         let gpus = vec![synthetic_gpu(3, Some("uuid:GPU-123"), Some("CUDA3"))];
 
@@ -3180,6 +3212,7 @@ mod tests {
         let config = plugin::MeshConfig {
             gpu: plugin::GpuConfig {
                 assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
             },
             ..plugin::MeshConfig::default()
         };
@@ -3189,6 +3222,7 @@ mod tests {
             ctx_size: Some(4096),
             gpu_id: Some("uuid:GPU-123".into()),
             config_owned: true,
+            parallel: None,
         }];
         let mut plans = vec![StartupModelPlan {
             declared_ref: "Qwen3-8B-Q4_K_M".into(),
@@ -3197,6 +3231,7 @@ mod tests {
             ctx_size: Some(4096),
             gpu_id: Some("uuid:GPU-123".into()),
             pinned_gpu: None,
+            parallel: None,
         }];
         let gpus = vec![synthetic_gpu(3, Some("uuid:GPU-123"), None)];
 
@@ -3214,6 +3249,7 @@ mod tests {
         let config = plugin::MeshConfig {
             gpu: plugin::GpuConfig {
                 assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
             },
             ..plugin::MeshConfig::default()
         };
@@ -3223,6 +3259,7 @@ mod tests {
             ctx_size: None,
             gpu_id: Some("pci:0000:b3:00.0".into()),
             config_owned: true,
+            parallel: None,
         }];
         let mut plans = vec![StartupModelPlan {
             declared_ref: "Qwen3-8B-Q4_K_M".into(),
@@ -3231,6 +3268,7 @@ mod tests {
             ctx_size: None,
             gpu_id: Some("pci:0000:b3:00.0".into()),
             pinned_gpu: None,
+            parallel: None,
         }];
         let gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
 
@@ -3264,6 +3302,7 @@ mod tests {
                 backend_device: "CUDA0".into(),
                 vram_bytes: 24_000_000_000,
             }),
+            parallel: None,
         };
 
         let device =
@@ -3286,6 +3325,7 @@ mod tests {
                 backend_device: "CUDA0".into(),
                 vram_bytes: 24_000_000_000,
             }),
+            parallel: None,
         };
 
         let device = startup_rpc_backend_device(None, Some(&primary_startup_model)).unwrap();
@@ -3307,6 +3347,7 @@ mod tests {
                 backend_device: "CUDA0".into(),
                 vram_bytes: 24_000_000_000,
             }),
+            parallel: None,
         };
 
         let err =
@@ -3331,6 +3372,7 @@ mod tests {
                 backend_device: "ROCm0".into(),
                 vram_bytes: 24_000_000_000,
             }),
+            parallel: None,
         };
 
         let device1 =
@@ -3365,6 +3407,7 @@ mod tests {
             ctx_size: None,
             gpu_id: None,
             config_owned: false,
+            parallel: None,
         }];
 
         assert!(!should_show_serve_config_help(


### PR DESCRIPTION
## Summary

Add per-model `parallel` config to control the number of parallel request slots per model. The global `[gpu].parallel` setting still works as a fallback, but each `[[models]]` entry can now override it independently.

## Background

The number of parallel slots was previously hardcoded at 4. Each parallel slot consumes `n_ctx / parallel_slots` tokens of context window. A node running multiple models at different scales may need different parallelism per model, a large 70B model might need only 1 slot while a small 4B model can handle 8.

### Problem

- A single global `parallel` value forces all models on the node to use the same slot count
- GPU-constrained nodes (like RTX 3080 with 10GB VRAM) may want 1 slot for a large model but 4 for a small one
- No way to express per-model concurrency without running separate node instances

## What changed

Users can now set `parallel` per model in `~/.mesh-llm/config.toml`:

```toml
version = 1

[gpu]
assignment = "auto"
parallel = 4        # global fallback; defaults to 4 when omitted

[[models]]
model = "Qwen3-70B-Q4_K_M"
parallel = 1        # this model gets 1 slot (overrides global)

[[models]]
model = "Qwen3-4B-Q4_K_M"
parallel = 8        # this model gets 8 slots (overrides global)
```

- `parallel: Option<usize>` added to `ModelConfigEntry` in `[[models]]`. Omitting it falls back to `[gpu].parallel`, which itself falls back to 4.
- Setting `parallel = 0` on a model is rejected at validation time with a clear error: `models[N].parallel must be at least 1, got 0`.
- The value propagates: `ModelConfigEntry.parallel` → `StartupModelSpec.parallel` → `StartupModelPlan.parallel` → `ElectionLoopParams.slots` → `ModelLaunchSpec.slots` → `--parallel` CLI arg to llama-server.
- Dynamic/runtime-loaded models (not declared in config) continue to use `[gpu].parallel` as before.

## Precedence

| Input | Behavior |
|-------|----------|
| `[[models]].parallel = N` | Use N slots for that model |
| No per-model `parallel`; `[gpu].parallel = M` | All models use M slots |
| Neither set | Default to 4 |

## Protocol

No wire format changes. `parallel` is a local-only config field — it is not gossiped to peers and does not affect mesh protocol compatibility. Older nodes that lack the field will continue to use their own default of 4 slots.

## Compatibility

Non-breaking. Omitting `parallel` on all models preserves existing behavior. Existing configs with only `[gpu].parallel` continue to work unchanged.

## Example

Multi-model node with mixed GPU budgets:

```toml
version = 1

[gpu]
assignment = "pinned"

[[models]]
model = "Qwen3-70B-A3B-UD-Q4_K_XL"
gpu_id = "pci:00000000:01:00.0"
ctx_size = 65536
parallel = 1        # single slot — large model, tight VRAM

[[models]]
model = "Qwen3-4B-Q4_K_M"
gpu_id = "pci:00000000:06:00.0"
ctx_size = 32768
parallel = 8        # 8 slots — small model, plenty of headroom
```