### PR TITLE
Fix startup on nodes with pinned Tegra-based GPU SoCs

### DIFF
--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -797,6 +797,7 @@ fn pinned_startup_preflight_metrics() -> &'static [hardware::Metric] {
         hardware::Metric::GpuName,
         hardware::Metric::GpuFacts,
         hardware::Metric::VramBytes,
+        hardware::Metric::IsSoc,
     ]
 }
 
@@ -3088,10 +3089,11 @@ mod tests {
     fn pinned_gpu_startup_preflight_requests_per_gpu_vram_metrics() {
         let metrics = pinned_startup_preflight_metrics();
 
-        assert_eq!(metrics.len(), 3);
+        assert_eq!(metrics.len(), 4);
         assert!(metrics.contains(&hardware::Metric::GpuName));
         assert!(metrics.contains(&hardware::Metric::GpuFacts));
         assert!(metrics.contains(&hardware::Metric::VramBytes));
+        assert!(metrics.contains(&hardware::Metric::IsSoc));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
**Before:**

```
./target/release/mesh-llm serve --enumerate-host
Error: startup model 'gemma-4-31B-it-UD-Q4_K_XL' failed pinned GPU preflight

Caused by:
    startup model 'gemma-4-31B-it-UD-Q4_K_XL' resolved pinned GPU 'uuid:ddae9891-aaa8-5edd-bbf3-3a33c5adc75f' at index 0 without a backend_device
```
  
  
**After:**

```
./target/release/mesh-llm serve --enumerate-host
🧹 Reaped 0 orphan children from 3 dead instance(s)
Invite: some_token
Waiting for peers...
⏳ Starting rpc-server on port 36093... (logs: /run/user/1001/mesh-llm/runtime/45019/logs/rpc-server-36093.log.log)
🗳 [gemma-4-31B-it-UD-Q4_K_XL] Running as host (65.9GB capacity for 18.8GB model, serving entirely)
⏳ Starting llama-server...
  Serving entirely (66GB capacity)
⏳ Starting llama-server... (logs: /run/user/1001/mesh-llm/runtime/45019/logs/llama-server.log.log)
  API:     http://localhost:9337
  Console: http://localhost:3131

  pi:    pi --provider mesh --model gemma-4-31B-it-UD-Q4_K_XL
  goose: GOOSE_PROVIDER=openai OPENAI_HOST=http://localhost:9337 OPENAI_API_KEY=mesh GOOSE_MODEL=gemma-4-31B-it-UD-Q4_K_XL goose session
✅ [gemma-4-31B-it-UD-Q4_K_XL] llama-server ready on internal port 45285
```

## Screenshot
<img width="919" height="228" alt="image" src="https://github.com/user-attachments/assets/ee1eb1e8-9ffb-425d-ba35-714a09597c87" />