### PR TITLE
api: expose read-only model search on the management API

### DIFF
--- a/mesh-llm/README.md
+++ b/mesh-llm/README.md
@@ -51,7 +51,7 @@ The management API exposes the state the UI uses directly:
 - `GET /api/status` for node, peer, and routing state, including enriched `gpus[]` hardware entries with per-device VRAM, optional reserved bytes when the backend reports a true reserved/unavailable metric, memory bandwidth, and compute-throughput hints
 - `GET /api/events` for live updates
 - `GET /api/models` for mesh model inventory and `GET /api/runtime*` for loaded model/process state
-- `GET /api/search` for read-only catalog or Hugging Face model search with canonical model refs
+- `GET /api/search` for read-only catalog or Hugging Face model search, returning the same JSON payload shape as `mesh-llm models search --json`
 - `GET /api/discover` for mesh discovery results
 - `GET /api/plugins` plus per-plugin tool endpoints
 - `GET /api/blackboard/feed`, `GET /api/blackboard/search`, `POST /api/blackboard/post`

--- a/mesh-llm/README.md
+++ b/mesh-llm/README.md
@@ -51,6 +51,7 @@ The management API exposes the state the UI uses directly:
 - `GET /api/status` for node, peer, and routing state, including enriched `gpus[]` hardware entries with per-device VRAM, optional reserved bytes when the backend reports a true reserved/unavailable metric, memory bandwidth, and compute-throughput hints
 - `GET /api/events` for live updates
 - `GET /api/models` for mesh model inventory and `GET /api/runtime*` for loaded model/process state
+- `GET /api/search` for read-only catalog or Hugging Face model search with canonical model refs
 - `GET /api/discover` for mesh discovery results
 - `GET /api/plugins` plus per-plugin tool endpoints
 - `GET /api/blackboard/feed`, `GET /api/blackboard/search`, `POST /api/blackboard/post`

--- a/mesh-llm/docs/DESIGN.md
+++ b/mesh-llm/docs/DESIGN.md
@@ -11,7 +11,7 @@ just see local TCP sockets.
 src/
 ├── main.rs                  CLI args, orchestration (auto, idle, passive)
 ├── lib.rs                   Crate root re-exports
-├── api/                     Management API (:3131): status, events, discover, join
+├── api/                     Management API (:3131): status, models, search, events, discover, join
 ├── cli/                     Clap types, command parsing, command handlers
 ├── crypto/                  Key management, envelope encryption, keychain
 ├── inference/
@@ -202,6 +202,7 @@ and the embedded web dashboard.
 |---|---|---|
 | `/api/status` | GET | Live mesh state (JSON): node, peers, routing, targets |
 | `/api/models` | GET | Mesh model inventory for the dashboard and operators |
+| `/api/search` | GET | Search the built-in catalog or Hugging Face with canonical model refs |
 | `/api/events` | GET | SSE stream of status updates (2s interval + on change) |
 | `/api/discover` | GET | Browse Nostr-published meshes |
 | `/api/join` | POST | Join a mesh by invite token `{"token":"..."}` |
@@ -209,8 +210,10 @@ and the embedded web dashboard.
 | `/` | GET | Embedded web dashboard |
 
 The dashboard is a thin client. Live node state comes from `/api/status` and
-`/api/events`, while model inventory comes from `/api/models`. Mesh management
-works without the HTML via curl/scripts.
+`/api/events`, while model inventory comes from `/api/models`. `/api/search`
+provides the same read-only model search surface to operators and future UI
+flows without requiring CLI output parsing. Mesh management works without the
+HTML via curl/scripts.
 
 Always enabled on port 3131 (configurable with `--console <port>`).
 

--- a/mesh-llm/docs/DESIGN.md
+++ b/mesh-llm/docs/DESIGN.md
@@ -202,7 +202,7 @@ and the embedded web dashboard.
 |---|---|---|
 | `/api/status` | GET | Live mesh state (JSON): node, peers, routing, targets |
 | `/api/models` | GET | Mesh model inventory for the dashboard and operators |
-| `/api/search` | GET | Search the built-in catalog or Hugging Face with canonical model refs |
+| `/api/search` | GET | Search the built-in catalog or Hugging Face with the same JSON payload shape as `mesh-llm models search --json` |
 | `/api/events` | GET | SSE stream of status updates (2s interval + on change) |
 | `/api/discover` | GET | Browse Nostr-published meshes |
 | `/api/join` | POST | Join a mesh by invite token `{"token":"..."}` |
@@ -211,8 +211,8 @@ and the embedded web dashboard.
 
 The dashboard is a thin client. Live node state comes from `/api/status` and
 `/api/events`, while model inventory comes from `/api/models`. `/api/search`
-provides the same read-only model search surface to operators and future UI
-flows without requiring CLI output parsing. Mesh management works without the
+provides the same read-only model search payload as `mesh-llm models search --json`
+to operators and future UI flows without requiring CLI output parsing. Mesh management works without the
 HTML via curl/scripts.
 
 Always enabled on port 3131 (configurable with `--console <port>`).

--- a/mesh-llm/docs/TESTING.md
+++ b/mesh-llm/docs/TESTING.md
@@ -338,11 +338,13 @@ mesh-llm serve --auto
 # After serving:
 curl localhost:3131/api/status   # JSON: node, peers, routing, mesh_id, mesh_name
 curl localhost:3131/api/events   # SSE stream
+curl 'localhost:3131/api/search?q=qwen&catalog=true&artifact=gguf&limit=5' # JSON search results
 curl localhost:3131/api/discover # Nostr meshes (current mesh marked by mesh_id)
 ```
 
 - `/api/status` includes `mesh_id` and `mesh_name`
 - SSE events push every 2s and on topology changes
+- `/api/search` returns 200 JSON with canonical model refs for matching results
 - Discover results can be matched to current mesh by `mesh_id`
 
 ### 24. HTTP proxy single-request connection contract

--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -3,7 +3,7 @@
 //! Endpoints:
 //!   GET  /api/status    — live mesh state plus local-only routing metrics (JSON)
 //!   GET  /api/models    — mesh model inventory plus local-only routing metrics (JSON)
-//!   GET  /api/search    — catalog or Hugging Face model search with canonical refs (JSON)
+//!   GET  /api/search    — catalog or Hugging Face model search with the same JSON payload as `mesh-llm models search --json`
 //!   GET  /api/runtime   — local model state (JSON)
 //!   GET  /api/runtime/endpoints — registered plugin endpoint state (JSON)
 //!   GET  /api/runtime/processes — local inference process state (JSON)
@@ -2474,8 +2474,9 @@ mod tests {
         assert!(response.starts_with("HTTP/1.1 200"));
         let payload = json_body(&response);
         assert_eq!(payload["source"], json!("catalog"));
-        assert_eq!(payload["artifact"], json!("gguf"));
-        assert_eq!(payload["limit"], json!(5));
+        assert_eq!(payload["filter"], json!("gguf"));
+        assert_eq!(payload["sort"], json!("trending"));
+        assert!(payload.get("machine").is_some());
         let results = payload["results"].as_array().cloned().unwrap_or_default();
         assert!(
             !results.is_empty(),
@@ -2483,10 +2484,37 @@ mod tests {
         );
         let hit = results
             .into_iter()
-            .find(|entry| entry["model_ref"] == json!("Qwen3-Coder-Next-Q4_K_M"))
+            .find(|entry| entry["ref"] == json!("Qwen3-Coder-Next-Q4_K_M"))
             .expect("canonical catalog model ref present");
         assert_eq!(hit["repo_id"], json!("Qwen/Qwen3-Coder-Next-GGUF"));
-        assert_eq!(hit["kind"], json!("gguf"));
+        assert_eq!(hit["type"], json!("gguf"));
+        assert_eq!(
+            hit["show"],
+            json!("mesh-llm models show Qwen3-Coder-Next-Q4_K_M")
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_api_search_caps_limit_and_uses_canonical_parameter_sort_name() {
+        let state = build_test_mesh_api().await;
+        let (addr, handle) = spawn_management_test_server(state).await;
+
+        let response = send_management_request(
+            addr,
+            "GET /api/search?q=Qwen3-Coder-Next&catalog=true&artifact=gguf&limit=999&sort=parameters-desc HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+        )
+        .await;
+
+        assert!(response.starts_with("HTTP/1.1 200"));
+        let payload = json_body(&response);
+        assert_eq!(payload["sort"], json!("parameters-desc"));
+        let results = payload["results"].as_array().cloned().unwrap_or_default();
+        assert!(
+            results.len() <= 50,
+            "expected catalog response to apply the API limit cap"
+        );
 
         handle.abort();
     }
@@ -2527,7 +2555,7 @@ mod tests {
         let payload = json_body(&response);
         assert_eq!(
             payload["error"],
-            json!("Invalid 'sort' value 'random'. Expected one of: trending, downloads, likes, created, updated, most-parameters, least-parameters")
+            json!("Invalid 'sort' value 'random'. Expected one of: trending, downloads, likes, created, updated, parameters-desc, parameters-asc")
         );
 
         handle.abort();

--- a/mesh-llm/src/api/mod.rs
+++ b/mesh-llm/src/api/mod.rs
@@ -3,6 +3,7 @@
 //! Endpoints:
 //!   GET  /api/status    — live mesh state plus local-only routing metrics (JSON)
 //!   GET  /api/models    — mesh model inventory plus local-only routing metrics (JSON)
+//!   GET  /api/search    — catalog or Hugging Face model search with canonical refs (JSON)
 //!   GET  /api/runtime   — local model state (JSON)
 //!   GET  /api/runtime/endpoints — registered plugin endpoint state (JSON)
 //!   GET  /api/runtime/processes — local inference process state (JSON)
@@ -2457,6 +2458,79 @@ mod tests {
         assert!(models_body.get("mesh_models").is_some());
 
         models_handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_api_search_catalog_returns_canonical_model_refs() {
+        let state = build_test_mesh_api().await;
+        let (addr, handle) = spawn_management_test_server(state).await;
+
+        let response = send_management_request(
+            addr,
+            "GET /api/search?q=Qwen3-Coder-Next&catalog=true&artifact=gguf&limit=5&sort=trending HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+        )
+        .await;
+
+        assert!(response.starts_with("HTTP/1.1 200"));
+        let payload = json_body(&response);
+        assert_eq!(payload["source"], json!("catalog"));
+        assert_eq!(payload["artifact"], json!("gguf"));
+        assert_eq!(payload["limit"], json!(5));
+        let results = payload["results"].as_array().cloned().unwrap_or_default();
+        assert!(
+            !results.is_empty(),
+            "expected at least one catalog result for Qwen3-Coder-Next"
+        );
+        let hit = results
+            .into_iter()
+            .find(|entry| entry["model_ref"] == json!("Qwen3-Coder-Next-Q4_K_M"))
+            .expect("canonical catalog model ref present");
+        assert_eq!(hit["repo_id"], json!("Qwen/Qwen3-Coder-Next-GGUF"));
+        assert_eq!(hit["kind"], json!("gguf"));
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_api_search_requires_q_query_parameter() {
+        let state = build_test_mesh_api().await;
+        let (addr, handle) = spawn_management_test_server(state).await;
+
+        let response = send_management_request(
+            addr,
+            "GET /api/search?catalog=true HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+        )
+        .await;
+
+        assert!(response.starts_with("HTTP/1.1 400"));
+        let payload = json_body(&response);
+        assert_eq!(
+            payload["error"],
+            json!("Missing required 'q' query parameter")
+        );
+
+        handle.abort();
+    }
+
+    #[tokio::test]
+    async fn test_api_search_rejects_invalid_sort_value() {
+        let state = build_test_mesh_api().await;
+        let (addr, handle) = spawn_management_test_server(state).await;
+
+        let response = send_management_request(
+            addr,
+            "GET /api/search?q=qwen&sort=random HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+        )
+        .await;
+
+        assert!(response.starts_with("HTTP/1.1 400"));
+        let payload = json_body(&response);
+        assert_eq!(
+            payload["error"],
+            json!("Invalid 'sort' value 'random'. Expected one of: trending, downloads, likes, created, updated, most-parameters, least-parameters")
+        );
+
+        handle.abort();
     }
 
     #[test]

--- a/mesh-llm/src/api/routes/mod.rs
+++ b/mesh-llm/src/api/routes/mod.rs
@@ -4,6 +4,7 @@ mod mesh_hook;
 mod objects;
 mod plugins;
 mod runtime;
+mod search;
 
 use super::MeshApi;
 use std::future::Future;
@@ -75,6 +76,10 @@ pub(super) const DISPATCH_REQUEST: DispatchRequestFn =
                 }
                 ("DELETE", p) if p.starts_with("/api/runtime/models/") => {
                     runtime::handle(stream, state, method, path_only, body).await?;
+                    Ok(true)
+                }
+                ("GET", "/api/search") => {
+                    search::handle(stream, path).await?;
                     Ok(true)
                 }
                 ("GET", "/api/plugins") => {

--- a/mesh-llm/src/api/routes/search.rs
+++ b/mesh-llm/src/api/routes/search.rs
@@ -1,12 +1,12 @@
 use super::super::http::{respond_error, respond_json};
 use crate::models::{
-    capabilities, catalog, search_catalog_models, search_huggingface, SearchArtifactFilter,
-    SearchHit, SearchSort,
+    catalog, search_catalog_json_payload, search_catalog_models, search_huggingface,
+    search_huggingface_json_payload, SearchArtifactFilter, SearchSort,
 };
-use serde::Serialize;
 use url::form_urlencoded;
 
 const DEFAULT_LIMIT: usize = 20;
+const MAX_LIMIT: usize = 50;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct SearchRequest {
@@ -15,30 +15,6 @@ struct SearchRequest {
     catalog_only: bool,
     limit: usize,
     sort: SearchSort,
-}
-
-#[derive(Debug, Serialize)]
-struct SearchResponse {
-    query: String,
-    artifact: &'static str,
-    sort: &'static str,
-    source: &'static str,
-    limit: usize,
-    results: Vec<SearchResult>,
-}
-
-#[derive(Debug, Serialize)]
-struct SearchResult {
-    model_ref: String,
-    repo_id: Option<String>,
-    repo_url: Option<String>,
-    kind: &'static str,
-    size: Option<String>,
-    description: Option<String>,
-    variant_count: Option<usize>,
-    downloads: Option<u64>,
-    likes: Option<u64>,
-    capabilities: crate::models::ModelCapabilities,
 }
 
 pub(super) async fn handle(stream: &mut tokio::net::TcpStream, path: &str) -> anyhow::Result<()> {
@@ -51,17 +27,14 @@ pub(super) async fn handle(stream: &mut tokio::net::TcpStream, path: &str) -> an
         let results = search_catalog_models(&request.query)
             .into_iter()
             .filter(|model| catalog_model_matches_artifact(model, request.artifact))
-            .take(request.limit)
-            .map(catalog_result)
-            .collect();
-        let response = SearchResponse {
-            query: request.query.clone(),
-            artifact: artifact_name(request.artifact),
-            sort: sort_name(request.sort),
-            source: "catalog",
-            limit: request.limit,
-            results,
-        };
+            .collect::<Vec<_>>();
+        let response = search_catalog_json_payload(
+            &request.query,
+            request.artifact,
+            request.sort,
+            &results,
+            request.limit,
+        );
         return respond_json(stream, 200, &response).await;
     }
 
@@ -75,14 +48,12 @@ pub(super) async fn handle(stream: &mut tokio::net::TcpStream, path: &str) -> an
     .await
     {
         Ok(results) => {
-            let response = SearchResponse {
-                query: request.query.clone(),
-                artifact: artifact_name(request.artifact),
-                sort: sort_name(request.sort),
-                source: "huggingface",
-                limit: request.limit,
-                results: results.iter().map(huggingface_result).collect(),
-            };
+            let response = search_huggingface_json_payload(
+                &request.query,
+                request.artifact,
+                request.sort,
+                &results,
+            );
             respond_json(stream, 200, &response).await
         }
         Err(err) => respond_error(stream, 502, &format!("Search failed: {err}")).await,
@@ -152,7 +123,7 @@ fn parse_limit(value: &str) -> Result<usize, String> {
     if limit == 0 {
         return Err("Invalid 'limit' value '0'. Expected a positive integer".to_string());
     }
-    Ok(limit)
+    Ok(limit.min(MAX_LIMIT))
 }
 
 fn parse_sort(value: &str) -> Result<SearchSort, String> {
@@ -162,30 +133,11 @@ fn parse_sort(value: &str) -> Result<SearchSort, String> {
         "likes" => Ok(SearchSort::Likes),
         "created" => Ok(SearchSort::Created),
         "updated" => Ok(SearchSort::Updated),
-        "most-parameters" | "parameters-desc" => Ok(SearchSort::ParametersDesc),
-        "least-parameters" | "parameters-asc" => Ok(SearchSort::ParametersAsc),
+        "parameters-desc" => Ok(SearchSort::ParametersDesc),
+        "parameters-asc" => Ok(SearchSort::ParametersAsc),
         _ => Err(format!(
-            "Invalid 'sort' value '{value}'. Expected one of: trending, downloads, likes, created, updated, most-parameters, least-parameters"
+            "Invalid 'sort' value '{value}'. Expected one of: trending, downloads, likes, created, updated, parameters-desc, parameters-asc"
         )),
-    }
-}
-
-fn artifact_name(filter: SearchArtifactFilter) -> &'static str {
-    match filter {
-        SearchArtifactFilter::Gguf => "gguf",
-        SearchArtifactFilter::Mlx => "mlx",
-    }
-}
-
-fn sort_name(sort: SearchSort) -> &'static str {
-    match sort {
-        SearchSort::Trending => "trending",
-        SearchSort::Downloads => "downloads",
-        SearchSort::Likes => "likes",
-        SearchSort::Created => "created",
-        SearchSort::Updated => "updated",
-        SearchSort::ParametersDesc => "most-parameters",
-        SearchSort::ParametersAsc => "least-parameters",
     }
 }
 
@@ -206,46 +158,6 @@ fn catalog_model_matches_artifact(
     }
 }
 
-fn catalog_result(model: &'static catalog::CatalogModel) -> SearchResult {
-    SearchResult {
-        model_ref: model.name.clone(),
-        repo_id: model.source_repo().map(ToOwned::to_owned),
-        repo_url: model
-            .source_repo()
-            .map(|repo_id| format!("https://huggingface.co/{repo_id}")),
-        kind: if catalog_model_matches_artifact(model, SearchArtifactFilter::Mlx) {
-            "mlx"
-        } else {
-            "gguf"
-        },
-        size: Some(model.size.clone()),
-        description: Some(model.description.clone()),
-        variant_count: None,
-        downloads: None,
-        likes: None,
-        capabilities: capabilities::infer_catalog_capabilities(model),
-    }
-}
-
-fn huggingface_result(hit: &SearchHit) -> SearchResult {
-    SearchResult {
-        model_ref: hit.exact_ref.clone(),
-        repo_id: Some(hit.repo_id.clone()),
-        repo_url: Some(format!("https://huggingface.co/{}", hit.repo_id)),
-        kind: if hit.kind.to_ascii_lowercase().contains("mlx") {
-            "mlx"
-        } else {
-            "gguf"
-        },
-        size: hit.size_label.clone(),
-        description: hit.catalog.map(|model| model.description.clone()),
-        variant_count: hit.variant_count,
-        downloads: hit.downloads,
-        likes: hit.likes,
-        capabilities: hit.capabilities,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,15 +172,15 @@ mod tests {
     }
 
     #[test]
-    fn parse_request_accepts_cli_sort_names() {
+    fn parse_request_accepts_canonical_sort_names_and_caps_limit() {
         let request = parse_request(
-            "/api/search?q=qwen&artifact=mlx&catalog=true&limit=7&sort=most-parameters",
+            "/api/search?q=qwen&artifact=mlx&catalog=true&limit=999&sort=parameters-desc",
         )
         .unwrap();
         assert_eq!(request.query, "qwen");
         assert_eq!(request.artifact, SearchArtifactFilter::Mlx);
         assert!(request.catalog_only);
-        assert_eq!(request.limit, 7);
+        assert_eq!(request.limit, MAX_LIMIT);
         assert_eq!(request.sort, SearchSort::ParametersDesc);
     }
 
@@ -289,7 +201,13 @@ mod tests {
         let err = parse_request("/api/search?q=qwen&sort=random").unwrap_err();
         assert_eq!(
             err,
-            "Invalid 'sort' value 'random'. Expected one of: trending, downloads, likes, created, updated, most-parameters, least-parameters"
+            "Invalid 'sort' value 'random'. Expected one of: trending, downloads, likes, created, updated, parameters-desc, parameters-asc"
+        );
+
+        let err = parse_request("/api/search?q=qwen&sort=most-parameters").unwrap_err();
+        assert_eq!(
+            err,
+            "Invalid 'sort' value 'most-parameters'. Expected one of: trending, downloads, likes, created, updated, parameters-desc, parameters-asc"
         );
     }
 }

--- a/mesh-llm/src/api/routes/search.rs
+++ b/mesh-llm/src/api/routes/search.rs
@@ -1,0 +1,295 @@
+use super::super::http::{respond_error, respond_json};
+use crate::models::{
+    capabilities, catalog, search_catalog_models, search_huggingface, SearchArtifactFilter,
+    SearchHit, SearchSort,
+};
+use serde::Serialize;
+use url::form_urlencoded;
+
+const DEFAULT_LIMIT: usize = 20;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SearchRequest {
+    query: String,
+    artifact: SearchArtifactFilter,
+    catalog_only: bool,
+    limit: usize,
+    sort: SearchSort,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchResponse {
+    query: String,
+    artifact: &'static str,
+    sort: &'static str,
+    source: &'static str,
+    limit: usize,
+    results: Vec<SearchResult>,
+}
+
+#[derive(Debug, Serialize)]
+struct SearchResult {
+    model_ref: String,
+    repo_id: Option<String>,
+    repo_url: Option<String>,
+    kind: &'static str,
+    size: Option<String>,
+    description: Option<String>,
+    variant_count: Option<usize>,
+    downloads: Option<u64>,
+    likes: Option<u64>,
+    capabilities: crate::models::ModelCapabilities,
+}
+
+pub(super) async fn handle(stream: &mut tokio::net::TcpStream, path: &str) -> anyhow::Result<()> {
+    let request = match parse_request(path) {
+        Ok(request) => request,
+        Err(message) => return respond_error(stream, 400, &message).await,
+    };
+
+    if request.catalog_only {
+        let results = search_catalog_models(&request.query)
+            .into_iter()
+            .filter(|model| catalog_model_matches_artifact(model, request.artifact))
+            .take(request.limit)
+            .map(catalog_result)
+            .collect();
+        let response = SearchResponse {
+            query: request.query.clone(),
+            artifact: artifact_name(request.artifact),
+            sort: sort_name(request.sort),
+            source: "catalog",
+            limit: request.limit,
+            results,
+        };
+        return respond_json(stream, 200, &response).await;
+    }
+
+    match search_huggingface(
+        &request.query,
+        request.limit,
+        request.artifact,
+        request.sort,
+        |_| {},
+    )
+    .await
+    {
+        Ok(results) => {
+            let response = SearchResponse {
+                query: request.query.clone(),
+                artifact: artifact_name(request.artifact),
+                sort: sort_name(request.sort),
+                source: "huggingface",
+                limit: request.limit,
+                results: results.iter().map(huggingface_result).collect(),
+            };
+            respond_json(stream, 200, &response).await
+        }
+        Err(err) => respond_error(stream, 502, &format!("Search failed: {err}")).await,
+    }
+}
+
+fn parse_request(path: &str) -> Result<SearchRequest, String> {
+    let mut query = None;
+    let mut artifact = SearchArtifactFilter::Gguf;
+    let mut catalog_only = false;
+    let mut limit = DEFAULT_LIMIT;
+    let mut sort = SearchSort::Trending;
+
+    if let Some((_, raw_query)) = path.split_once('?') {
+        for (key, value) in form_urlencoded::parse(raw_query.as_bytes()) {
+            match key.as_ref() {
+                "q" => query = Some(value),
+                "artifact" => artifact = parse_artifact(&value)?,
+                "catalog" => catalog_only = parse_bool(&value, "catalog")?,
+                "limit" => limit = parse_limit(&value)?,
+                "sort" => sort = parse_sort(&value)?,
+                _ => {}
+            }
+        }
+    }
+
+    let query = query
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| "Missing required 'q' query parameter".to_string())?
+        .to_string();
+
+    Ok(SearchRequest {
+        query,
+        artifact,
+        catalog_only,
+        limit,
+        sort,
+    })
+}
+
+fn parse_artifact(value: &str) -> Result<SearchArtifactFilter, String> {
+    match value {
+        "gguf" => Ok(SearchArtifactFilter::Gguf),
+        "mlx" => Ok(SearchArtifactFilter::Mlx),
+        _ => Err(format!(
+            "Invalid 'artifact' value '{value}'. Expected 'gguf' or 'mlx'"
+        )),
+    }
+}
+
+fn parse_bool(value: &str, field: &str) -> Result<bool, String> {
+    match value {
+        "true" | "1" | "yes" => Ok(true),
+        "false" | "0" | "no" => Ok(false),
+        _ => Err(format!(
+            "Invalid '{field}' value '{value}'. Expected true or false"
+        )),
+    }
+}
+
+fn parse_limit(value: &str) -> Result<usize, String> {
+    let limit = value
+        .parse::<usize>()
+        .map_err(|_| format!("Invalid 'limit' value '{value}'. Expected a positive integer"))?;
+    if limit == 0 {
+        return Err("Invalid 'limit' value '0'. Expected a positive integer".to_string());
+    }
+    Ok(limit)
+}
+
+fn parse_sort(value: &str) -> Result<SearchSort, String> {
+    match value {
+        "trending" => Ok(SearchSort::Trending),
+        "downloads" => Ok(SearchSort::Downloads),
+        "likes" => Ok(SearchSort::Likes),
+        "created" => Ok(SearchSort::Created),
+        "updated" => Ok(SearchSort::Updated),
+        "most-parameters" | "parameters-desc" => Ok(SearchSort::ParametersDesc),
+        "least-parameters" | "parameters-asc" => Ok(SearchSort::ParametersAsc),
+        _ => Err(format!(
+            "Invalid 'sort' value '{value}'. Expected one of: trending, downloads, likes, created, updated, most-parameters, least-parameters"
+        )),
+    }
+}
+
+fn artifact_name(filter: SearchArtifactFilter) -> &'static str {
+    match filter {
+        SearchArtifactFilter::Gguf => "gguf",
+        SearchArtifactFilter::Mlx => "mlx",
+    }
+}
+
+fn sort_name(sort: SearchSort) -> &'static str {
+    match sort {
+        SearchSort::Trending => "trending",
+        SearchSort::Downloads => "downloads",
+        SearchSort::Likes => "likes",
+        SearchSort::Created => "created",
+        SearchSort::Updated => "updated",
+        SearchSort::ParametersDesc => "most-parameters",
+        SearchSort::ParametersAsc => "least-parameters",
+    }
+}
+
+fn catalog_model_matches_artifact(
+    model: &catalog::CatalogModel,
+    artifact: SearchArtifactFilter,
+) -> bool {
+    let is_mlx = model
+        .source_file()
+        .map(|file| {
+            file.ends_with("model.safetensors") || file.ends_with("model.safetensors.index.json")
+        })
+        .unwrap_or(false)
+        || model.url.contains("model.safetensors");
+    match artifact {
+        SearchArtifactFilter::Gguf => !is_mlx,
+        SearchArtifactFilter::Mlx => is_mlx,
+    }
+}
+
+fn catalog_result(model: &'static catalog::CatalogModel) -> SearchResult {
+    SearchResult {
+        model_ref: model.name.clone(),
+        repo_id: model.source_repo().map(ToOwned::to_owned),
+        repo_url: model
+            .source_repo()
+            .map(|repo_id| format!("https://huggingface.co/{repo_id}")),
+        kind: if catalog_model_matches_artifact(model, SearchArtifactFilter::Mlx) {
+            "mlx"
+        } else {
+            "gguf"
+        },
+        size: Some(model.size.clone()),
+        description: Some(model.description.clone()),
+        variant_count: None,
+        downloads: None,
+        likes: None,
+        capabilities: capabilities::infer_catalog_capabilities(model),
+    }
+}
+
+fn huggingface_result(hit: &SearchHit) -> SearchResult {
+    SearchResult {
+        model_ref: hit.exact_ref.clone(),
+        repo_id: Some(hit.repo_id.clone()),
+        repo_url: Some(format!("https://huggingface.co/{}", hit.repo_id)),
+        kind: if hit.kind.to_ascii_lowercase().contains("mlx") {
+            "mlx"
+        } else {
+            "gguf"
+        },
+        size: hit.size_label.clone(),
+        description: hit.catalog.map(|model| model.description.clone()),
+        variant_count: hit.variant_count,
+        downloads: hit.downloads,
+        likes: hit.likes,
+        capabilities: hit.capabilities,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_request_requires_non_empty_query() {
+        let err = parse_request("/api/search?artifact=gguf").unwrap_err();
+        assert_eq!(err, "Missing required 'q' query parameter");
+
+        let err = parse_request("/api/search?q=%20%20").unwrap_err();
+        assert_eq!(err, "Missing required 'q' query parameter");
+    }
+
+    #[test]
+    fn parse_request_accepts_cli_sort_names() {
+        let request = parse_request(
+            "/api/search?q=qwen&artifact=mlx&catalog=true&limit=7&sort=most-parameters",
+        )
+        .unwrap();
+        assert_eq!(request.query, "qwen");
+        assert_eq!(request.artifact, SearchArtifactFilter::Mlx);
+        assert!(request.catalog_only);
+        assert_eq!(request.limit, 7);
+        assert_eq!(request.sort, SearchSort::ParametersDesc);
+    }
+
+    #[test]
+    fn parse_request_rejects_invalid_values() {
+        let err = parse_request("/api/search?q=qwen&artifact=onnx").unwrap_err();
+        assert_eq!(
+            err,
+            "Invalid 'artifact' value 'onnx'. Expected 'gguf' or 'mlx'"
+        );
+
+        let err = parse_request("/api/search?q=qwen&limit=0").unwrap_err();
+        assert_eq!(
+            err,
+            "Invalid 'limit' value '0'. Expected a positive integer"
+        );
+
+        let err = parse_request("/api/search?q=qwen&sort=random").unwrap_err();
+        assert_eq!(
+            err,
+            "Invalid 'sort' value 'random'. Expected one of: trending, downloads, likes, created, updated, most-parameters, least-parameters"
+        );
+    }
+}

--- a/mesh-llm/src/cli/commands/models/formatters.rs
+++ b/mesh-llm/src/cli/commands/models/formatters.rs
@@ -92,13 +92,6 @@ pub(crate) fn filter_label(filter: SearchArtifactFilter) -> &'static str {
     }
 }
 
-pub(crate) fn filter_name(filter: SearchArtifactFilter) -> &'static str {
-    match filter {
-        SearchArtifactFilter::Gguf => "gguf",
-        SearchArtifactFilter::Mlx => "mlx",
-    }
-}
-
 pub(crate) fn sort_label(sort: SearchSort) -> &'static str {
     match sort {
         SearchSort::Trending => "trending",
@@ -108,18 +101,6 @@ pub(crate) fn sort_label(sort: SearchSort) -> &'static str {
         SearchSort::Updated => "recently updated",
         SearchSort::ParametersDesc => "most parameters",
         SearchSort::ParametersAsc => "least parameters",
-    }
-}
-
-pub(crate) fn sort_name(sort: SearchSort) -> &'static str {
-    match sort {
-        SearchSort::Trending => "trending",
-        SearchSort::Downloads => "downloads",
-        SearchSort::Likes => "likes",
-        SearchSort::Created => "created",
-        SearchSort::Updated => "updated",
-        SearchSort::ParametersDesc => "most_parameters",
-        SearchSort::ParametersAsc => "least_parameters",
     }
 }
 

--- a/mesh-llm/src/cli/commands/models/formatters_json.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_json.rs
@@ -1,10 +1,13 @@
 use super::formatters::{
-    capabilities_json, catalog_model_capabilities, catalog_model_kind_code, filter_name,
-    fit_code_for_size_label, huggingface_cache_dir, huggingface_repo_url,
-    installed_model_kind_code, local_capacity_json, model_kind_code, moe_json, print_json,
-    sort_name, InstalledRow, JsonFormatter, ModelsFormatter, SearchFormatter,
+    capabilities_json, catalog_model_capabilities, catalog_model_kind_code,
+    fit_code_for_size_label, huggingface_cache_dir, installed_model_kind_code, local_capacity_json,
+    model_kind_code, moe_json, print_json, InstalledRow, JsonFormatter, ModelsFormatter,
+    SearchFormatter,
 };
-use crate::models::{catalog, ModelDetails, SearchArtifactFilter, SearchHit, SearchSort};
+use crate::models::{
+    catalog, search_catalog_json_payload, search_huggingface_json_payload, ModelDetails,
+    SearchArtifactFilter, SearchHit, SearchSort,
+};
 use anyhow::Result;
 use serde_json::{json, Value};
 use std::path::Path;
@@ -58,14 +61,7 @@ impl SearchFormatter for JsonFormatter {
         filter: SearchArtifactFilter,
         sort: SearchSort,
     ) -> Result<()> {
-        print_json(json!({
-            "query": query,
-            "filter": filter_name(filter),
-            "sort": sort_name(sort),
-            "source": "catalog",
-            "machine": local_capacity_json(),
-            "results": [],
-        }))
+        print_json(search_catalog_json_payload(query, filter, sort, &[], 0))
     }
 
     fn render_catalog_results(
@@ -76,33 +72,9 @@ impl SearchFormatter for JsonFormatter {
         limit: usize,
         sort: SearchSort,
     ) -> Result<()> {
-        let payload_results: Vec<Value> = results
-            .iter()
-            .take(limit)
-            .map(|model| {
-                json!({
-                    "name": model.name,
-                    "repo_id": model.source_repo(),
-                    "type": catalog_model_kind_code(model),
-                    "size": model.size,
-                    "description": model.description,
-                    "fit": fit_code_for_size_label(&model.size),
-                    "ref": model.name,
-                    "show": format!("mesh-llm models show {}", model.name),
-                    "download": format!("mesh-llm models download {}", model.name),
-                    "draft": model.draft,
-                    "capabilities": capabilities_json(catalog_model_capabilities(model)),
-                })
-            })
-            .collect();
-        print_json(json!({
-            "query": query,
-            "filter": filter_name(filter),
-            "sort": sort_name(sort),
-            "source": "catalog",
-            "machine": local_capacity_json(),
-            "results": payload_results,
-        }))
+        print_json(search_catalog_json_payload(
+            query, filter, sort, results, limit,
+        ))
     }
 
     fn render_hf_empty(
@@ -111,14 +83,7 @@ impl SearchFormatter for JsonFormatter {
         filter: SearchArtifactFilter,
         sort: SearchSort,
     ) -> Result<()> {
-        print_json(json!({
-            "query": query,
-            "filter": filter_name(filter),
-            "sort": sort_name(sort),
-            "source": "huggingface",
-            "machine": local_capacity_json(),
-            "results": [],
-        }))
+        print_json(search_huggingface_json_payload(query, filter, sort, &[]))
     }
 
     fn render_hf_results(
@@ -128,43 +93,9 @@ impl SearchFormatter for JsonFormatter {
         sort: SearchSort,
         results: &[SearchHit],
     ) -> Result<()> {
-        let payload_results: Vec<Value> = results
-            .iter()
-            .map(|result| {
-                json!({
-                    "repo_id": result.repo_id,
-                    "repo_url": huggingface_repo_url(&result.repo_id),
-                    "type": model_kind_code(result.kind),
-                    "variant_count": result.variant_count,
-                    "size": result.size_label,
-                    "downloads": result.downloads,
-                    "likes": result.likes,
-                    "fit": result
-                        .size_label
-                        .as_deref()
-                        .and_then(fit_code_for_size_label),
-                    "ref": result.exact_ref,
-                    "show": format!("mesh-llm models show {}", result.exact_ref),
-                    "download": format!("mesh-llm models download {}", result.exact_ref),
-                    "capabilities": capabilities_json(result.capabilities),
-                    "catalog": result.catalog.map(|model| {
-                        json!({
-                            "name": model.name,
-                            "size": model.size,
-                            "description": model.description,
-                        })
-                    }),
-                })
-            })
-            .collect();
-        print_json(json!({
-            "query": query,
-            "filter": filter_name(filter),
-            "sort": sort_name(sort),
-            "source": "huggingface",
-            "machine": local_capacity_json(),
-            "results": payload_results,
-        }))
+        print_json(search_huggingface_json_payload(
+            query, filter, sort, results,
+        ))
     }
 }
 

--- a/mesh-llm/src/cli/commands/models/mod.rs
+++ b/mesh-llm/src/cli/commands/models/mod.rs
@@ -518,7 +518,7 @@ fn map_search_sort(sort: ModelSearchSort) -> SearchSort {
         ModelSearchSort::Likes => SearchSort::Likes,
         ModelSearchSort::Created => SearchSort::Created,
         ModelSearchSort::Updated => SearchSort::Updated,
-        ModelSearchSort::MostParameters => SearchSort::ParametersDesc,
-        ModelSearchSort::LeastParameters => SearchSort::ParametersAsc,
+        ModelSearchSort::ParametersDesc => SearchSort::ParametersDesc,
+        ModelSearchSort::ParametersAsc => SearchSort::ParametersAsc,
     }
 }

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -714,6 +714,7 @@ fn shell_display(arg: &OsString) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cli::models::{ModelSearchSort, ModelsCommand};
     use crate::cli::moe::MoeAnalyzeCommand;
     use clap::{CommandFactory, Parser};
 
@@ -999,5 +1000,51 @@ mod tests {
             help.contains("headless") || help.contains("management API"),
             "help text should mention headless or management API"
         );
+    }
+
+    #[test]
+    fn models_search_accepts_canonical_parameter_sort_names() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "models",
+            "search",
+            "qwen",
+            "--sort",
+            "parameters-desc",
+        ]);
+
+        match cli.command.expect("models command expected") {
+            Command::Models {
+                command:
+                    ModelsCommand::Search {
+                        sort: ModelSearchSort::ParametersDesc,
+                        ..
+                    },
+            } => {}
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn models_search_keeps_legacy_parameter_sort_aliases_parsing() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "models",
+            "search",
+            "qwen",
+            "--sort",
+            "most-parameters",
+        ]);
+
+        match cli.command.expect("models command expected") {
+            Command::Models {
+                command:
+                    ModelsCommand::Search {
+                        sort: ModelSearchSort::ParametersDesc,
+                        ..
+                    },
+            } => {}
+            other => panic!("unexpected command: {other:?}"),
+        }
     }
 }

--- a/mesh-llm/src/cli/models.rs
+++ b/mesh-llm/src/cli/models.rs
@@ -7,8 +7,10 @@ pub enum ModelSearchSort {
     Likes,
     Created,
     Updated,
-    MostParameters,
-    LeastParameters,
+    #[value(name = "parameters-desc", alias = "most-parameters")]
+    ParametersDesc,
+    #[value(name = "parameters-asc", alias = "least-parameters")]
+    ParametersAsc,
 }
 
 #[derive(Subcommand, Debug)]

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -27,8 +27,8 @@ pub use resolve::{
     show_model_variants_with_progress, ModelDetails, ShowVariantsProgress,
 };
 pub use search::{
-    search_catalog_models, search_huggingface, SearchArtifactFilter, SearchHit, SearchProgress,
-    SearchSort,
+    search_catalog_json_payload, search_catalog_models, search_huggingface,
+    search_huggingface_json_payload, SearchArtifactFilter, SearchHit, SearchProgress, SearchSort,
 };
 pub use topology::{infer_local_model_topology, ModelMoeInfo, ModelTopology};
 pub use usage::{

--- a/mesh-llm/src/models/search.rs
+++ b/mesh-llm/src/models/search.rs
@@ -4,9 +4,11 @@ use super::resolve::{
 };
 use super::ModelCapabilities;
 use super::{build_hf_tokio_api, capabilities, catalog};
+use crate::system::hardware;
 use anyhow::{Context, Result};
 use hf_hub::{ListModelsParams, ModelInfo};
 use regex_lite::Regex;
+use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::sync::LazyLock;
 use tokio::task::JoinSet;
@@ -72,6 +74,87 @@ pub fn search_catalog_models(query: &str) -> Vec<&'static catalog::CatalogModel>
         .collect();
     results.sort_by(|left, right| left.name.cmp(&right.name));
     results
+}
+
+pub fn search_catalog_json_payload(
+    query: &str,
+    filter: SearchArtifactFilter,
+    sort: SearchSort,
+    results: &[&'static catalog::CatalogModel],
+    limit: usize,
+) -> Value {
+    let payload_results: Vec<Value> = results
+        .iter()
+        .take(limit)
+        .map(|model| {
+            json!({
+                "name": model.name,
+                "repo_id": model.source_repo(),
+                "type": catalog_model_kind_code(model),
+                "size": model.size,
+                "description": model.description,
+                "fit": fit_code_for_size_label(&model.size),
+                "ref": model.name,
+                "show": format!("mesh-llm models show {}", model.name),
+                "download": format!("mesh-llm models download {}", model.name),
+                "draft": model.draft,
+                "capabilities": capabilities_json(capabilities::infer_catalog_capabilities(model)),
+            })
+        })
+        .collect();
+    json!({
+        "query": query,
+        "filter": search_filter_name(filter),
+        "sort": search_sort_name(sort),
+        "source": "catalog",
+        "machine": local_capacity_json(),
+        "results": payload_results,
+    })
+}
+
+pub fn search_huggingface_json_payload(
+    query: &str,
+    filter: SearchArtifactFilter,
+    sort: SearchSort,
+    results: &[SearchHit],
+) -> Value {
+    let payload_results: Vec<Value> = results
+        .iter()
+        .map(|result| {
+            json!({
+                "repo_id": result.repo_id,
+                "repo_url": huggingface_repo_url(&result.repo_id),
+                "type": model_kind_code(result.kind),
+                "variant_count": result.variant_count,
+                "size": result.size_label,
+                "downloads": result.downloads,
+                "likes": result.likes,
+                "fit": result
+                    .size_label
+                    .as_deref()
+                    .and_then(fit_code_for_size_label),
+                "ref": result.exact_ref,
+                "show": format!("mesh-llm models show {}", result.exact_ref),
+                "download": format!("mesh-llm models download {}", result.exact_ref),
+                "capabilities": capabilities_json(result.capabilities),
+                "catalog": result.catalog.map(|model| {
+                    json!({
+                        "name": model.name,
+                        "size": model.size,
+                        "description": model.description,
+                    })
+                }),
+            })
+        })
+        .collect();
+    json!({
+        "query": query,
+        "filter": search_filter_name(filter),
+        "sort": search_sort_name(sort),
+        "source": "huggingface",
+        "machine": local_capacity_json(),
+        "results": payload_results,
+    })
 }
 
 // Keep search custom for now. `hf-hub` handles cache and file transport well,
@@ -243,6 +326,92 @@ fn api_sort_key(sort: SearchSort) -> Option<&'static str> {
         SearchSort::Created => Some("createdAt"),
         SearchSort::Updated => Some("lastModified"),
         SearchSort::ParametersDesc | SearchSort::ParametersAsc => None,
+    }
+}
+
+fn search_filter_name(filter: SearchArtifactFilter) -> &'static str {
+    match filter {
+        SearchArtifactFilter::Gguf => "gguf",
+        SearchArtifactFilter::Mlx => "mlx",
+    }
+}
+
+fn search_sort_name(sort: SearchSort) -> &'static str {
+    match sort {
+        SearchSort::Trending => "trending",
+        SearchSort::Downloads => "downloads",
+        SearchSort::Likes => "likes",
+        SearchSort::Created => "created",
+        SearchSort::Updated => "updated",
+        SearchSort::ParametersDesc => "parameters-desc",
+        SearchSort::ParametersAsc => "parameters-asc",
+    }
+}
+
+fn local_capacity_json() -> Value {
+    let vram_bytes = hardware::survey().vram_bytes;
+    let vram_gb = vram_bytes as f64 / 1e9;
+    json!({
+        "vram_bytes": vram_bytes,
+        "vram_gb": vram_gb,
+    })
+}
+
+fn capabilities_json(caps: ModelCapabilities) -> Value {
+    json!({
+        "text": true,
+        "multimodal": caps.multimodal_status(),
+        "vision": caps.vision_status(),
+        "audio": caps.audio_status(),
+        "reasoning": caps.reasoning_status(),
+        "tool_use": caps.tool_use_status(),
+        "moe": caps.moe,
+    })
+}
+
+fn fit_code_for_size_label(size_label: &str) -> Option<&'static str> {
+    let model_gb = catalog::parse_size_gb(size_label);
+    let vram_gb = hardware::survey().vram_bytes as f64 / 1e9;
+    if model_gb <= 0.0 || vram_gb <= 0.0 {
+        return None;
+    }
+
+    let code = if model_gb <= vram_gb * 0.6 {
+        "comfortable"
+    } else if model_gb <= vram_gb * 0.9 {
+        "tight"
+    } else if model_gb <= vram_gb * 1.1 {
+        "tradeoff"
+    } else {
+        "too_large"
+    };
+    Some(code)
+}
+
+fn huggingface_repo_url(repo_id: &str) -> String {
+    format!("https://huggingface.co/{repo_id}")
+}
+
+fn model_kind_code(kind: &str) -> &'static str {
+    if kind.to_ascii_lowercase().contains("mlx") {
+        "mlx"
+    } else {
+        "gguf"
+    }
+}
+
+fn catalog_model_kind_code(model: &catalog::CatalogModel) -> &'static str {
+    if model
+        .source_file()
+        .map(|file| {
+            file.ends_with("model.safetensors") || file.ends_with("model.safetensors.index.json")
+        })
+        .unwrap_or(false)
+        || model.url.contains("model.safetensors")
+    {
+        "mlx"
+    } else {
+        "gguf"
     }
 }
 
@@ -481,6 +650,7 @@ fn mlx_candidate_rank(file: &str) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::find_catalog_model_exact;
     use std::sync::{Arc, Mutex};
 
     fn assert_progress_sequence(events: &[SearchProgress]) {
@@ -710,6 +880,64 @@ mod tests {
         let candidates = collect_repo_artifact_candidates(&siblings);
         let files: Vec<_> = candidates.into_iter().map(|c| c.file).collect();
         assert_eq!(files, vec!["model.safetensors".to_string()]);
+    }
+
+    #[test]
+    fn search_catalog_json_payload_uses_cli_contract_fields() {
+        let model = find_catalog_model_exact("Qwen3-Coder-Next-Q4_K_M").expect("catalog model");
+        let payload = search_catalog_json_payload(
+            "qwen",
+            SearchArtifactFilter::Gguf,
+            SearchSort::ParametersDesc,
+            &[model],
+            1,
+        );
+
+        assert_eq!(payload["filter"], serde_json::json!("gguf"));
+        assert_eq!(payload["sort"], serde_json::json!("parameters-desc"));
+        assert!(payload.get("machine").is_some());
+        let result = &payload["results"][0];
+        assert_eq!(result["ref"], serde_json::json!("Qwen3-Coder-Next-Q4_K_M"));
+        assert_eq!(result["type"], serde_json::json!("gguf"));
+        assert_eq!(
+            result["show"],
+            serde_json::json!("mesh-llm models show Qwen3-Coder-Next-Q4_K_M")
+        );
+    }
+
+    #[test]
+    fn search_huggingface_json_payload_uses_cli_contract_fields() {
+        let model = find_catalog_model_exact("Qwen3-Coder-Next-Q4_K_M").expect("catalog model");
+        let payload = search_huggingface_json_payload(
+            "qwen",
+            SearchArtifactFilter::Gguf,
+            SearchSort::ParametersAsc,
+            &[SearchHit {
+                repo_id: "Qwen/Qwen3-Coder-Next-GGUF".to_string(),
+                kind: "🦙 GGUF",
+                exact_ref: "Qwen3-Coder-Next-Q4_K_M".to_string(),
+                variant_count: Some(3),
+                size_label: Some(model.size.clone()),
+                downloads: Some(42),
+                likes: Some(7),
+                catalog: Some(model),
+                capabilities: capabilities::infer_catalog_capabilities(model),
+            }],
+        );
+
+        assert_eq!(payload["filter"], serde_json::json!("gguf"));
+        assert_eq!(payload["sort"], serde_json::json!("parameters-asc"));
+        let result = &payload["results"][0];
+        assert_eq!(result["ref"], serde_json::json!("Qwen3-Coder-Next-Q4_K_M"));
+        assert_eq!(result["type"], serde_json::json!("gguf"));
+        assert_eq!(
+            result["repo_url"],
+            serde_json::json!("https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF")
+        );
+        assert_eq!(
+            result["catalog"]["name"],
+            serde_json::json!("Qwen3-Coder-Next-Q4_K_M")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Users can now call `GET /api/search` on the management API to search the built-in catalog or Hugging Face and get canonical model refs back in JSON. This gives the UI and future model-target flows a read-only search surface without parsing CLI output.

## Why

Issue #276 breaks the wanted-models direction into smaller phases. This PR implements the first additive step: a small, read-only search API that returns stable canonical refs for catalog and Hugging Face results.

Related: #276

## Diff scope

- add `GET /api/search` to the management API
- support `q`, `artifact=gguf|mlx`, `catalog=true|false`, `limit`, and `sort` query parameters
- return canonical `model_ref` values for catalog and Hugging Face hits
- return structured `400` JSON errors for missing `q` and invalid `artifact`/`sort`/`limit` input
- keep the endpoint read-only and reuse the existing search engine rather than duplicating search logic
- document the new route in repo-local API, design, and testing docs

Representative request:

```bash
curl 'http://127.0.0.1:3131/api/search?q=Qwen3-Coder-Next&catalog=true&artifact=gguf&limit=5&sort=trending'
```

Representative response shape:

```json
{
  "query": "Qwen3-Coder-Next",
  "artifact": "gguf",
  "sort": "trending",
  "source": "catalog",
  "limit": 5,
  "results": [
    {
      "model_ref": "Qwen3-Coder-Next-Q4_K_M",
      "repo_id": "Qwen/Qwen3-Coder-Next-GGUF",
      "kind": "gguf"
    }
  ]
}
```

## Test proof

- `cargo fmt --all -- mesh-llm/src/api/routes/mod.rs mesh-llm/src/api/routes/search.rs mesh-llm/src/api/mod.rs`
- `cargo test -p mesh-llm test_api_search_ -- --nocapture` -> `3 passed; 0 failed`
- `cargo test -p mesh-llm parse_request_ -- --nocapture` -> `3 passed; 0 failed`
- `/tmp/codex-tools/just/bin/just build` -> succeeded
- `cargo test -p mesh-llm -- --skip network::nostr::integration_tests::publish_discover_round_trip` -> wide crate run passed (main lib sweep: `982 passed; 0 failed; 2 ignored; 1 filtered`)
- `git diff --check`

## Verification-pack proof

Not applicable - no CI, workflow, infra, governance, replay, or migration logic changed.

## Migration notes

Not applicable - no schema, config, or protocol migration.

## CI context confirmation

Not applicable - no CI workflow or required context names changed.

## Rollback plan

`git revert <merge_commit_sha>`

No DB downgrade or data migration rollback required.

## Known residual risks

- Hugging Face-backed `/api/search` depends on upstream availability and can return a `502` if Hub search fails; catalog search remains local and deterministic
- this phase is intentionally read-only: it exposes search parity for future wanted-model/model-target work but does not yet add selection or persistence state