### PR TITLE
Add delete option to model CLI flags to remove just a single managed model

### DIFF
--- a/mesh-llm/src/cli/commands/models/formatters.rs
+++ b/mesh-llm/src/cli/commands/models/formatters.rs
@@ -2,6 +2,7 @@ use crate::models::{
     capabilities, catalog, huggingface_hub_cache_dir, ModelCapabilities, ModelDetails,
     SearchArtifactFilter, SearchHit, SearchSort,
 };
+use crate::models::{DeleteResult as CliDeleteResult, ResolvedModel as CliResolvedModel};
 use crate::system::hardware;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -64,6 +65,8 @@ pub(crate) trait ModelsFormatter: SearchFormatter {
         draft: Option<(&str, &Path)>,
     ) -> Result<()>;
     fn render_updates_status(&self, repo: Option<&str>, all: bool, check: bool) -> Result<()>;
+    fn render_delete_preview(&self, resolved: &CliResolvedModel) -> Result<()>;
+    fn render_delete_result(&self, result: &CliDeleteResult) -> Result<()>;
 }
 
 pub(crate) struct ConsoleFormatter;

--- a/mesh-llm/src/cli/commands/models/formatters_console.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_console.rs
@@ -184,6 +184,10 @@ impl ModelsFormatter for ConsoleFormatter {
 
         println!("💾 Installed models");
         println!("📁 HF cache: {}", huggingface_cache_dir().display());
+        println!(
+            "🗑️ Delete example: mesh-llm models delete {}",
+            rows[0].model_ref
+        );
         println!();
         for row in rows {
             println!("📦 {}", row.name);
@@ -370,11 +374,7 @@ impl ModelsFormatter for ConsoleFormatter {
         println!();
         println!("Name: {}", resolved.display_name);
         println!("Path: {}", resolved.path.display());
-        if resolved.is_exact_path {
-            println!("Mode: exact path provided");
-        } else {
-            println!("Mode: stem name resolution");
-        }
+        println!("Mode: installed model ref resolution");
         let file_size = std::fs::metadata(&resolved.path)
             .map(|m| m.len())
             .unwrap_or(0);

--- a/mesh-llm/src/cli/commands/models/formatters_console.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_console.rs
@@ -4,7 +4,10 @@ use super::formatters::{
     huggingface_repo_url, installed_model_kind, model_kind_code, sort_label,
     variant_selector_label, ConsoleFormatter, InstalledRow, ModelsFormatter, SearchFormatter,
 };
-use crate::models::{catalog, ModelDetails, SearchArtifactFilter, SearchHit, SearchSort};
+use crate::models::{
+    catalog, DeleteResult as CliDeleteResult, ModelDetails, ResolvedModel as CliResolvedModel,
+    SearchArtifactFilter, SearchHit, SearchSort,
+};
 use anyhow::Result;
 use std::io::Write;
 use tabwriter::TabWriter;
@@ -221,6 +224,7 @@ impl ModelsFormatter for ConsoleFormatter {
             println!("   ref: {}", row.model_ref);
             println!("   show: mesh-llm models show {}", row.model_ref);
             println!("   download: mesh-llm models download {}", row.model_ref);
+            println!("   delete: mesh-llm models delete {}", row.model_ref);
             println!("   path: {}", row.path.display());
             if let Some(model) = row.catalog_model {
                 println!("   about: {}", model.description);
@@ -358,6 +362,52 @@ impl ModelsFormatter for ConsoleFormatter {
     }
 
     fn render_updates_status(&self, _repo: Option<&str>, _all: bool, _check: bool) -> Result<()> {
+        Ok(())
+    }
+
+    fn render_delete_preview(&self, resolved: &CliResolvedModel) -> Result<()> {
+        println!("🗑️ Model delete preview");
+        println!();
+        println!("Name: {}", resolved.display_name);
+        println!("Path: {}", resolved.path.display());
+        if resolved.is_exact_path {
+            println!("Mode: exact path provided");
+        } else {
+            println!("Mode: stem name resolution");
+        }
+        let file_size = std::fs::metadata(&resolved.path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        println!("Size: {}", format_installed_size(file_size));
+        if !resolved.matched_records.is_empty() {
+            println!();
+            println!("{} usage record(s) found:", resolved.matched_records.len());
+            for record in &resolved.matched_records {
+                println!(
+                    "  - {} (last used: {})",
+                    record.lookup_key, record.last_used_at
+                );
+            }
+        }
+        println!();
+        println!("To confirm deletion, run with --yes flag.");
+        Ok(())
+    }
+
+    fn render_delete_result(&self, result: &CliDeleteResult) -> Result<()> {
+        println!("✅ Model deleted successfully");
+        println!();
+        println!("Deleted paths:");
+        for p in &result.deleted_paths {
+            println!("  {}", p.display());
+        }
+        println!();
+        println!(
+            "Reclaimed: {}",
+            format_installed_size(result.reclaimed_bytes)
+        );
+        println!("Metadata files removed: {}", result.removed_metadata_files);
+        println!("Usage records purged: {}", result.removed_usage_records);
         Ok(())
     }
 }

--- a/mesh-llm/src/cli/commands/models/formatters_json.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_json.rs
@@ -220,6 +220,9 @@ impl ModelsFormatter for JsonFormatter {
             .collect();
         print_json(json!({
             "cache_dir": huggingface_cache_dir(),
+            "delete_example": rows
+                .first()
+                .map(|row| format!("mesh-llm models delete {}", row.model_ref)),
             "results": models,
         }))
     }

--- a/mesh-llm/src/cli/commands/models/formatters_json.rs
+++ b/mesh-llm/src/cli/commands/models/formatters_json.rs
@@ -1,10 +1,11 @@
 use super::formatters::{
     capabilities_json, catalog_model_capabilities, catalog_model_kind_code, filter_name,
-    fit_code_for_size_label, huggingface_cache_dir, huggingface_repo_url,
+    fit_code_for_size_label, format_installed_size, huggingface_cache_dir, huggingface_repo_url,
     installed_model_kind_code, local_capacity_json, model_kind_code, moe_json, print_json,
     sort_name, InstalledRow, JsonFormatter, ModelsFormatter, SearchFormatter,
 };
 use crate::models::{catalog, ModelDetails, SearchArtifactFilter, SearchHit, SearchSort};
+use crate::models::{DeleteResult as CliDeleteResult, ResolvedModel as CliResolvedModel};
 use anyhow::Result;
 use serde_json::{json, Value};
 use std::path::Path;
@@ -209,6 +210,7 @@ impl ModelsFormatter for JsonFormatter {
                     "ref": row.model_ref,
                     "show": format!("mesh-llm models show {}", row.model_ref),
                     "download": format!("mesh-llm models download {}", row.model_ref),
+                    "delete": format!("mesh-llm models delete {}", row.model_ref),
                     "path": row.path,
                     "about": row.catalog_model.map(|m| m.description.clone()),
                     "draft": row.catalog_model.and_then(|m| m.draft.clone()),
@@ -260,6 +262,35 @@ impl ModelsFormatter for JsonFormatter {
                 "repo": repo,
                 "all": all,
             },
+        }))
+    }
+
+    fn render_delete_preview(&self, resolved: &CliResolvedModel) -> Result<()> {
+        let file_size = std::fs::metadata(&resolved.path)
+            .map(|m| m.len())
+            .unwrap_or(0);
+        print_json(json!({
+            "display_name": resolved.display_name,
+            "path": resolved.path,
+            "is_exact_path": resolved.is_exact_path,
+            "file_size_bytes": file_size,
+            "file_size_human": format_installed_size(file_size),
+            "matched_records": resolved.matched_records.iter().map(|r| json!({
+                "lookup_key": r.lookup_key,
+                "display_name": r.display_name,
+                "last_used_at": r.last_used_at,
+            })).collect::<Vec<_>>(),
+            "dry_run": true,
+        }))
+    }
+
+    fn render_delete_result(&self, result: &CliDeleteResult) -> Result<()> {
+        print_json(json!({
+            "deleted_paths": result.deleted_paths.iter().map(|p| p.to_string_lossy().to_string()).collect::<Vec<_>>(),
+            "reclaimed_bytes": result.reclaimed_bytes,
+            "reclaimed_bytes_human": format_installed_size(result.reclaimed_bytes),
+            "removed_metadata_files": result.removed_metadata_files,
+            "removed_usage_records": result.removed_usage_records,
         }))
     }
 }

--- a/mesh-llm/src/cli/commands/models/mod.rs
+++ b/mesh-llm/src/cli/commands/models/mod.rs
@@ -489,34 +489,34 @@ fn render_cleanup_json(
 }
 
 pub async fn run_model_delete(model: &str, yes: bool, json_output: bool) -> Result<()> {
-    let is_path = model.contains('/') || model.contains('\\');
-    let resolved_path = if is_path {
-        std::path::PathBuf::from(model)
-    } else {
-        crate::models::find_model_path(model)
+    let paths = match delete::resolve_model_identifier(model) {
+        Ok(p) => p,
+        Err(e) => bail!("{}", e.to_string()),
     };
 
-    if !resolved_path.exists() {
+    if paths.is_empty() {
         bail!("Model not found: {}", model);
     }
 
-    let resolved = crate::models::ResolvedModel {
-        path: resolved_path.clone(),
-        display_name: resolved_path
+    if !yes {
+        let display_name = paths[0]
             .file_stem()
             .and_then(|s| s.to_str())
             .unwrap_or("unknown")
-            .to_string(),
-        is_exact_path: is_path,
-        matched_records: vec![],
-    };
+            .to_string();
 
-    if !yes {
+        let resolved = crate::models::ResolvedModel {
+            path: paths[0].clone(),
+            display_name,
+            is_exact_path: model.contains('/'),
+            matched_records: vec![],
+        };
+
         let formatter = models_formatter(json_output);
         return formatter.render_delete_preview(&resolved);
     }
 
-    let result = delete::delete_model_at_path(model, false).await?;
+    let result = delete::delete_model_by_identifier(model).await?;
     let formatter = models_formatter(json_output);
     formatter.render_delete_result(&result)
 }

--- a/mesh-llm/src/cli/commands/models/mod.rs
+++ b/mesh-llm/src/cli/commands/models/mod.rs
@@ -489,7 +489,7 @@ fn render_cleanup_json(
 }
 
 pub async fn run_model_delete(model: &str, yes: bool, json_output: bool) -> Result<()> {
-    let paths = match delete::resolve_model_identifier(model) {
+    let paths = match delete::resolve_model_identifier(model).await {
         Ok(p) => p,
         Err(e) => bail!("{}", e.to_string()),
     };
@@ -508,7 +508,7 @@ pub async fn run_model_delete(model: &str, yes: bool, json_output: bool) -> Resu
         let resolved = crate::models::ResolvedModel {
             path: paths[0].clone(),
             display_name,
-            is_exact_path: model.contains('/'),
+            is_exact_path: false,
             matched_records: vec![],
         };
 

--- a/mesh-llm/src/cli/commands/models/mod.rs
+++ b/mesh-llm/src/cli/commands/models/mod.rs
@@ -6,7 +6,7 @@ use crate::cli::models::ModelSearchSort;
 use crate::cli::models::ModelsCommand;
 use crate::cli::terminal_progress::{clear_stderr_line, start_spinner, DeterminateProgressLine};
 use crate::models::{
-    catalog, download_model_ref_with_progress_details, find_catalog_model_exact,
+    catalog, delete, download_model_ref_with_progress_details, find_catalog_model_exact,
     installed_model_capabilities, load_model_usage_record_for_path, model_usage_cache_dir,
     plan_model_cleanup, scan_installed_models, search_catalog_models, search_huggingface,
     show_exact_model, show_model_variants_with_progress, ModelCleanupPlan, ModelCleanupResult,
@@ -196,6 +196,8 @@ pub fn run_model_cleanup(unused_since: Option<&str>, yes: bool, json_output: boo
     Ok(())
 }
 
+// Delete command integration will be implemented in Task 2.
+
 pub async fn run_model_show(model_ref: &str, json_output: bool) -> Result<()> {
     let formatter = models_formatter(json_output);
     let interactive = !json_output && std::io::stdout().is_terminal();
@@ -337,6 +339,9 @@ pub async fn dispatch_models_command(command: &ModelsCommand) -> Result<()> {
                 let formatter = models_formatter(*json);
                 formatter.render_updates_status(repo_for_render.as_deref(), all, check)?;
             }
+        }
+        ModelsCommand::Delete { model, yes, json } => {
+            run_model_delete(model.as_str(), *yes, *json).await?
         }
     }
     Ok(())
@@ -481,6 +486,39 @@ fn render_cleanup_json(
         }))?
     );
     Ok(())
+}
+
+pub async fn run_model_delete(model: &str, yes: bool, json_output: bool) -> Result<()> {
+    let is_path = model.contains('/') || model.contains('\\');
+    let resolved_path = if is_path {
+        std::path::PathBuf::from(model)
+    } else {
+        crate::models::find_model_path(model)
+    };
+
+    if !resolved_path.exists() {
+        bail!("Model not found: {}", model);
+    }
+
+    let resolved = crate::models::ResolvedModel {
+        path: resolved_path.clone(),
+        display_name: resolved_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("unknown")
+            .to_string(),
+        is_exact_path: is_path,
+        matched_records: vec![],
+    };
+
+    if !yes {
+        let formatter = models_formatter(json_output);
+        return formatter.render_delete_preview(&resolved);
+    }
+
+    let result = delete::delete_model_at_path(model, false).await?;
+    let formatter = models_formatter(json_output);
+    formatter.render_delete_result(&result)
 }
 
 #[cfg(test)]

--- a/mesh-llm/src/cli/models.rs
+++ b/mesh-llm/src/cli/models.rs
@@ -37,6 +37,7 @@ pub enum ModelsCommand {
         #[arg(long)]
         json: bool,
     },
+    // Delete variant defined with explicit clap args later in file (existing block).
     /// List built-in catalog models.
     #[command(hide = true)]
     List {
@@ -98,6 +99,18 @@ pub enum ModelsCommand {
         /// Check for newer upstream revisions without refreshing local cache.
         #[arg(long)]
         check: bool,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Delete a specific model from local storage.
+    Delete {
+        /// Model stem name (e.g. Qwen3.5-9B-BF16) or exact file path to delete.
+        #[arg(required = true)]
+        model: String,
+        /// Skip dry-run preview and delete immediately.
+        #[arg(long)]
+        yes: bool,
         /// Emit JSON output.
         #[arg(long)]
         json: bool,

--- a/mesh-llm/src/cli/models.rs
+++ b/mesh-llm/src/cli/models.rs
@@ -105,7 +105,7 @@ pub enum ModelsCommand {
     },
     /// Delete a specific model from local storage.
     Delete {
-        /// Model stem name (e.g. Qwen3.5-9B-BF16) or exact file path to delete.
+        /// Installed model stem or Hugging Face ref (e.g. `Qwen3.5-9B-BF16`, `org/repo`, or `org/repo:BF16`).
         #[arg(required = true)]
         model: String,
         /// Skip dry-run preview and delete immediately.

--- a/mesh-llm/src/models/delete.rs
+++ b/mesh-llm/src/models/delete.rs
@@ -1,10 +1,13 @@
+use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
+use hf_hub::types::cache::HFCacheInfo;
 
-use crate::models::usage::delete_model_by_path;
+use crate::models::local::{huggingface_hub_cache_dir, scan_hf_cache_info, split_gguf_base_name};
+use crate::models::usage;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct DeleteResult {
     pub deleted_paths: Vec<PathBuf>,
     pub reclaimed_bytes: u64,
@@ -12,36 +15,293 @@ pub struct DeleteResult {
     pub removed_usage_records: usize,
 }
 
-pub async fn delete_model_at_path(identifier: &str, _dry_run: bool) -> Result<DeleteResult> {
-    let is_path = identifier.contains('/') || identifier.contains('\\');
-    let path: std::path::PathBuf = if is_path {
-        std::path::PathBuf::from(identifier)
-    } else {
-        crate::models::find_model_path(identifier)
+/// Resolve a user-facing identifier to the set of all GGUF file paths that belong to that model.
+///
+/// Resolution strategy:
+/// - If `identifier` contains `/`, treat it as a HF repo ID and scan HFCacheInfo for any gguf files
+///   in repos whose repo_id starts with `identifier`.
+/// - Otherwise, treat it as a stem (filename base without `.gguf`) and look for exact filename
+///   matches OR split-GGUF patterns (`stem-00001-of-NNNNN.gguf`).
+///
+/// Returns an error if zero files match (NotFound), or if multiple distinct repos match
+/// and cannot be disambiguated by stem analysis (Ambiguous).
+pub fn resolve_model_identifier(identifier: &str) -> Result<Vec<PathBuf>> {
+    let cache_root = huggingface_hub_cache_dir();
+    let Some(cache_info) = scan_hf_cache_info(&cache_root) else {
+        bail!("Model not found: {}", identifier);
     };
 
-    if !path.exists() {
-        bail!("Model not found: {}", identifier);
-    }
-    if path.extension().and_then(|e| e.to_str()) != Some("gguf") {
-        bail!("Not a GGUF file: {}", path.display());
+    let stem_matches = find_stem_matches(&cache_info, identifier);
+    if !stem_matches.is_empty() {
+        return Ok(stem_matches);
     }
 
-    let hf_root = crate::models::huggingface_hub_cache_dir();
-    let mesh_root = crate::models::model_usage_cache_dir();
-    if !path.starts_with(&hf_root) && !path.starts_with(&mesh_root) {
+    let repo_matches = find_repo_prefix_matches(&cache_info, identifier);
+    if !repo_matches.is_empty() {
+        return Ok(repo_matches);
+    }
+
+    bail!("Model not found: {}", identifier);
+}
+
+/// Find GGUF file paths whose filename (or split-GGUF base name) matches the given stem.
+fn find_stem_matches(cache_info: &HFCacheInfo, stem: &str) -> Vec<PathBuf> {
+    let mut results: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for repo in &cache_info.repos {
+        use hf_hub::RepoType;
+        if repo.repo_type != RepoType::Model {
+            continue;
+        }
+        for revision in &repo.revisions {
+            for file in &revision.files {
+                if !file.file_name.ends_with(".gguf") {
+                    continue;
+                }
+                let file_stem = file
+                    .file_name
+                    .strip_suffix(".gguf")
+                    .unwrap_or(&file.file_name);
+
+                if file_stem.eq_ignore_ascii_case(stem) {
+                    results.insert(file.file_path.clone());
+                    continue;
+                }
+
+                if let Some(shard_prefix) = extract_shard_prefix(stem) {
+                    let prefix_pattern = format!("{}-", shard_prefix);
+                    if file.file_name.starts_with(&prefix_pattern)
+                        && file.file_name.ends_with(".gguf")
+                    {
+                        results.insert(file.file_path.clone());
+                    }
+                }
+
+                if let Some(base) = split_gguf_base_name(stem) {
+                    let base_lower = base.to_ascii_lowercase();
+                    if file_stem.to_ascii_lowercase() == base_lower {
+                        results.insert(file.file_path.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    results.into_iter().collect()
+}
+
+/// Extract the shard prefix from a filename like "Qwen3-8B-Q4_K_M-00001".
+fn extract_shard_prefix(filename: &str) -> Option<&str> {
+    let dash = filename.rfind('-')?;
+    let num_part = &filename[dash + 1..];
+    if num_part.len() != 5 || !num_part.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    Some(&filename[..dash])
+}
+
+/// Find GGUF files in repos whose repo_id starts with the given identifier.
+fn find_repo_prefix_matches(cache_info: &HFCacheInfo, prefix: &str) -> Vec<PathBuf> {
+    let mut results: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for repo in &cache_info.repos {
+        use hf_hub::RepoType;
+        if repo.repo_type != RepoType::Model {
+            continue;
+        }
+        if !repo.repo_id.starts_with(prefix) {
+            continue;
+        }
+        for revision in &repo.revisions {
+            for file in &revision.files {
+                if file.file_name.ends_with(".gguf") {
+                    results.insert(file.file_path.clone());
+                }
+            }
+        }
+    }
+
+    results.into_iter().collect()
+}
+
+/// Collect all paths that should be deleted for a model identified by its primary path.
+/// This includes managed_paths from usage records and any sidecar GGUF files (mmproj, etc.)
+/// found in the same directory as the primary model file.
+pub fn collect_delete_paths(primary_path: &PathBuf) -> Result<Vec<PathBuf>> {
+    let mut to_delete: BTreeSet<PathBuf> = BTreeSet::new();
+
+    if let Some(record) = usage::load_model_usage_record_for_path(primary_path) {
+        if record.mesh_managed && !record.managed_paths.is_empty() {
+            for p in &record.managed_paths {
+                to_delete.insert(p.clone());
+            }
+            return Ok(to_delete.into_iter().collect());
+        }
+    }
+
+    let parent = primary_path.parent().context("No parent dir")?;
+
+    let filename = primary_path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .context("No filename")?;
+
+    let base_stem = split_gguf_base_name(filename)
+        .unwrap_or(filename.strip_suffix(".gguf").unwrap_or(filename));
+
+    let entries = std::fs::read_dir(parent)
+        .with_context(|| format!("Cannot read directory: {}", parent.display()))?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() && !path.is_symlink() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("gguf") {
+            continue;
+        }
+
+        let entry_stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+
+        if entry_stem.eq_ignore_ascii_case(base_stem)
+            || entry_stem.starts_with(&format!("{}-", base_stem))
+            || (split_gguf_base_name(entry_stem).is_some()
+                && split_gguf_base_name(entry_stem).unwrap() == base_stem)
+        {
+            to_delete.insert(path);
+        }
+    }
+
+    Ok(to_delete.into_iter().collect())
+}
+
+/// Execute a model deletion by identifier, collecting and removing ALL files.
+pub async fn delete_model_by_identifier(identifier: &str) -> Result<DeleteResult> {
+    let primary_paths = resolve_model_identifier(identifier)?;
+
+    if primary_paths.is_empty() {
+        bail!("Model not found: {}", identifier);
+    }
+
+    let primary_path = &primary_paths[0];
+
+    let all_paths = collect_delete_paths(primary_path)?;
+
+    if all_paths.is_empty() {
         bail!(
-            "Deletion target outside known model roots: {}",
-            path.display()
+            "No GGUF files found at resolved path: {}",
+            primary_path.display()
         );
     }
 
-    let cleanup_result = delete_model_by_path(&path).context("delete model")?;
+    let mut reclaimed_bytes: u64 = 0;
+    let mut removed_metadata_files: usize = 0;
+    let mut removed_usage_records: usize = 0;
+    let mut deleted_paths: Vec<PathBuf> = Vec::new();
+
+    for path in &all_paths {
+        if path.exists() {
+            if let Ok(meta) = std::fs::metadata(path) {
+                reclaimed_bytes += meta.len();
+            }
+            std::fs::remove_file(path).with_context(|| format!("Remove {}", path.display()))?;
+            deleted_paths.push(path.clone());
+
+            if let Some(metadata_path) = crate::models::local::gguf_metadata_cache_path(path) {
+                if metadata_path.exists() {
+                    std::fs::remove_file(&metadata_path).with_context(|| {
+                        format!("Remove metadata cache {}", metadata_path.display())
+                    })?;
+                    removed_metadata_files += 1;
+                }
+            }
+
+            prune_empty_ancestors(path, &huggingface_hub_cache_dir());
+        }
+    }
+
+    if let Some(record) = load_model_usage_record_for_path(primary_path) {
+        let usage_dir = usage::model_usage_cache_dir();
+        let record_path = usage::usage_record_path(&usage_dir, &record.lookup_key);
+        if record_path.exists() {
+            std::fs::remove_file(&record_path)
+                .with_context(|| format!("Remove usage record {}", record_path.display()))?;
+            removed_usage_records += 1;
+        }
+    }
 
     Ok(DeleteResult {
-        deleted_paths: vec![path],
-        reclaimed_bytes: cleanup_result.reclaimed_bytes,
-        removed_metadata_files: cleanup_result.removed_metadata_files,
-        removed_usage_records: cleanup_result.removed_records,
+        deleted_paths,
+        reclaimed_bytes,
+        removed_metadata_files,
+        removed_usage_records,
     })
+}
+
+/// Load a model usage record for a given path.
+fn load_model_usage_record_for_path(path: &std::path::Path) -> Option<usage::ModelUsageRecord> {
+    usage::load_model_usage_record_for_path(path)
+}
+
+/// Prune empty ancestor directories up to (but not including) stop_at.
+fn prune_empty_ancestors(path: &std::path::Path, stop_at: &std::path::Path) {
+    let stop_at = normalize_path(stop_at);
+    let mut current = path.parent().map(normalize_path);
+    while let Some(dir) = current {
+        if dir == stop_at {
+            break;
+        }
+        let Ok(mut entries) = std::fs::read_dir(&dir) else {
+            break;
+        };
+        if entries.next().is_some() {
+            break;
+        }
+        if std::fs::remove_dir(&dir).is_err() {
+            break;
+        }
+        current = dir.parent().map(normalize_path);
+    }
+}
+
+fn normalize_path(path: &std::path::Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_shard_prefix_valid() {
+        assert_eq!(
+            extract_shard_prefix("Qwen3-8B-Q4_K_M-00001"),
+            Some("Qwen3-8B-Q4_K_M")
+        );
+        assert_eq!(extract_shard_prefix("model-00001"), Some("model"));
+    }
+
+    #[test]
+    fn test_extract_shard_prefix_invalid() {
+        assert_eq!(extract_shard_prefix("model-001"), None);
+        assert_eq!(extract_shard_prefix("model00001"), None);
+        assert_eq!(extract_shard_prefix("model-abcde"), None);
+    }
+
+    #[test]
+    fn test_split_gguf_base_name_single_file() {
+        assert_eq!(split_gguf_base_name("Qwen3-8B-Q4_K_M"), None);
+    }
+
+    #[test]
+    fn test_split_gguf_base_name_first_shard() {
+        let base = split_gguf_base_name("GLM-5-UD-IQ2_XXS-00001-of-00006");
+        assert_eq!(base, Some("GLM-5-UD-IQ2_XXS"));
+    }
+
+    #[test]
+    fn test_split_gguf_base_name_last_shard() {
+        let base = split_gguf_base_name("GLM-5-UD-IQ2_XXS-00006-of-00006");
+        assert_eq!(base, Some("GLM-5-UD-IQ2_XXS"));
+    }
 }

--- a/mesh-llm/src/models/delete.rs
+++ b/mesh-llm/src/models/delete.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+
+use anyhow::{bail, Context, Result};
+
+use crate::models::usage::delete_model_by_path;
+
+#[derive(Debug, Default)]
+pub struct DeleteResult {
+    pub deleted_paths: Vec<PathBuf>,
+    pub reclaimed_bytes: u64,
+    pub removed_metadata_files: usize,
+    pub removed_usage_records: usize,
+}
+
+pub async fn delete_model_at_path(identifier: &str, _dry_run: bool) -> Result<DeleteResult> {
+    let is_path = identifier.contains('/') || identifier.contains('\\');
+    let path: std::path::PathBuf = if is_path {
+        std::path::PathBuf::from(identifier)
+    } else {
+        crate::models::find_model_path(identifier)
+    };
+
+    if !path.exists() {
+        bail!("Model not found: {}", identifier);
+    }
+    if path.extension().and_then(|e| e.to_str()) != Some("gguf") {
+        bail!("Not a GGUF file: {}", path.display());
+    }
+
+    let hf_root = crate::models::huggingface_hub_cache_dir();
+    let mesh_root = crate::models::model_usage_cache_dir();
+    if !path.starts_with(&hf_root) && !path.starts_with(&mesh_root) {
+        bail!("Deletion target outside known model roots: {}", path.display());
+    }
+
+    let cleanup_result = delete_model_by_path(&path).context("delete model")?;
+
+    Ok(DeleteResult {
+        deleted_paths: vec![path],
+        reclaimed_bytes: cleanup_result.reclaimed_bytes,
+        removed_metadata_files: cleanup_result.removed_metadata_files,
+        removed_usage_records: cleanup_result.removed_records,
+    })
+}

--- a/mesh-llm/src/models/delete.rs
+++ b/mesh-llm/src/models/delete.rs
@@ -1,10 +1,16 @@
 use std::collections::BTreeSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use hf_hub::types::cache::HFCacheInfo;
 
-use crate::models::local::{huggingface_hub_cache_dir, scan_hf_cache_info, split_gguf_base_name};
+use crate::models::local::{
+    gguf_metadata_cache_path, huggingface_hub_cache_dir, huggingface_identity_for_path,
+    mesh_llm_cache_dir, scan_hf_cache_info, split_gguf_base_name,
+};
+use crate::models::resolve::{
+    parse_delete_model_ref, resolve_huggingface_file_from_sibling_entries, DeleteModelRef,
+};
 use crate::models::usage;
 
 #[derive(Debug)]
@@ -15,106 +21,123 @@ pub struct DeleteResult {
     pub removed_usage_records: usize,
 }
 
-/// Resolve a user-facing identifier to the set of all GGUF file paths that belong to that model.
-///
-/// Resolution strategy:
-/// - If `identifier` contains `/`, treat it as a HF repo ID and scan HFCacheInfo for any gguf files
-///   in repos whose repo_id starts with `identifier`.
-/// - Otherwise, treat it as a stem (filename base without `.gguf`) and look for exact filename
-///   matches OR split-GGUF patterns (`stem-00001-of-NNNNN.gguf`).
-///
-/// Returns an error if zero files match (NotFound), or if multiple distinct repos match
-/// and cannot be disambiguated by stem analysis (Ambiguous).
-pub fn resolve_model_identifier(identifier: &str) -> Result<Vec<PathBuf>> {
-    let cache_root = huggingface_hub_cache_dir();
-    let Some(cache_info) = scan_hf_cache_info(&cache_root) else {
-        bail!("Model not found: {}", identifier);
-    };
-
-    let stem_matches = find_stem_matches(&cache_info, identifier);
-    if !stem_matches.is_empty() {
-        return Ok(stem_matches);
+pub async fn resolve_model_identifier(identifier: &str) -> Result<Vec<PathBuf>> {
+    match parse_delete_model_ref(identifier).await? {
+        DeleteModelRef::LocalStem(stem) => {
+            let path = crate::models::find_model_path(&stem);
+            if !path.exists() {
+                bail!("Model not found: {}", identifier);
+            }
+            let mut resolved = BTreeSet::from([normalize_path(&path)]);
+            if let Some(cache_info) = scan_hf_cache_info(&huggingface_hub_cache_dir()) {
+                resolved.extend(find_related_hf_cache_paths(&cache_info, &path));
+            }
+            Ok(resolved.into_iter().collect())
+        }
+        DeleteModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => resolve_cached_hf_ref(&repo, revision.as_deref(), &file)
+            .await
+            .with_context(|| format!("Resolve installed model ref {identifier}")),
     }
-
-    let repo_matches = find_repo_prefix_matches(&cache_info, identifier);
-    if !repo_matches.is_empty() {
-        return Ok(repo_matches);
-    }
-
-    bail!("Model not found: {}", identifier);
 }
 
-/// Find GGUF file paths whose filename (or split-GGUF base name) matches the given stem.
-fn find_stem_matches(cache_info: &HFCacheInfo, stem: &str) -> Vec<PathBuf> {
-    let mut results: BTreeSet<PathBuf> = BTreeSet::new();
+fn normalized_gguf_stem(stem: &str) -> &str {
+    let stem = stem.strip_suffix(".gguf").unwrap_or(stem);
+    split_gguf_base_name(stem).unwrap_or(stem)
+}
+
+async fn resolve_cached_hf_ref(
+    repo_id: &str,
+    revision: Option<&str>,
+    file: &str,
+) -> Result<Vec<PathBuf>> {
+    let cache_root = huggingface_hub_cache_dir();
+    let Some(cache_info) = scan_hf_cache_info(&cache_root) else {
+        bail!("Model not found: {repo_id}");
+    };
 
     for repo in &cache_info.repos {
         use hf_hub::RepoType;
-        if repo.repo_type != RepoType::Model {
+        if repo.repo_type != RepoType::Model || repo.repo_id != repo_id {
+            continue;
+        }
+        for cached_revision in &repo.revisions {
+            if revision.is_some_and(|requested| {
+                requested != cached_revision.commit_hash
+                    && !cached_revision.refs.iter().any(|r| r == requested)
+            }) {
+                continue;
+            }
+            let sibling_entries: Vec<(String, Option<u64>)> = cached_revision
+                .files
+                .iter()
+                .map(|entry| {
+                    let size = std::fs::metadata(&entry.file_path)
+                        .ok()
+                        .map(|meta| meta.len());
+                    (entry.file_name.clone(), size)
+                })
+                .collect();
+            let resolved_file = resolve_huggingface_file_from_sibling_entries(
+                repo_id,
+                revision.or_else(|| cached_revision.refs.first().map(String::as_str)),
+                file,
+                &sibling_entries,
+            )
+            .await?;
+            if !resolved_file.ends_with(".gguf") {
+                bail!("Delete only supports GGUF models: {repo_id}");
+            }
+            let expected = normalized_gguf_stem(&resolved_file);
+            let mut matches: Vec<PathBuf> = cached_revision
+                .files
+                .iter()
+                .filter(|entry| entry.file_name.ends_with(".gguf"))
+                .filter(|entry| {
+                    normalized_gguf_stem(&entry.file_name).eq_ignore_ascii_case(expected)
+                })
+                .map(|entry| entry.file_path.clone())
+                .collect();
+            if !matches.is_empty() {
+                matches.sort();
+                return Ok(matches);
+            }
+        }
+    }
+
+    bail!("Model not found: {repo_id}")
+}
+
+fn find_related_hf_cache_paths(cache_info: &HFCacheInfo, path: &Path) -> Vec<PathBuf> {
+    let mut results = BTreeSet::new();
+    let Some(identity) = huggingface_identity_for_path(path) else {
+        return Vec::new();
+    };
+    let Some(file_name) = Path::new(&identity.file)
+        .file_name()
+        .and_then(|value| value.to_str())
+    else {
+        return Vec::new();
+    };
+    let expected = normalized_gguf_stem(file_name);
+
+    for repo in &cache_info.repos {
+        use hf_hub::RepoType;
+        if repo.repo_type != RepoType::Model || repo.repo_id != identity.repo_id {
             continue;
         }
         for revision in &repo.revisions {
+            if revision.commit_hash != identity.revision {
+                continue;
+            }
             for file in &revision.files {
                 if !file.file_name.ends_with(".gguf") {
                     continue;
                 }
-                let file_stem = file
-                    .file_name
-                    .strip_suffix(".gguf")
-                    .unwrap_or(&file.file_name);
-
-                if file_stem.eq_ignore_ascii_case(stem) {
-                    results.insert(file.file_path.clone());
-                    continue;
-                }
-
-                if let Some(shard_prefix) = extract_shard_prefix(stem) {
-                    let prefix_pattern = format!("{}-", shard_prefix);
-                    if file.file_name.starts_with(&prefix_pattern)
-                        && file.file_name.ends_with(".gguf")
-                    {
-                        results.insert(file.file_path.clone());
-                    }
-                }
-
-                if let Some(base) = split_gguf_base_name(stem) {
-                    let base_lower = base.to_ascii_lowercase();
-                    if file_stem.to_ascii_lowercase() == base_lower {
-                        results.insert(file.file_path.clone());
-                    }
-                }
-            }
-        }
-    }
-
-    results.into_iter().collect()
-}
-
-/// Extract the shard prefix from a filename like "Qwen3-8B-Q4_K_M-00001".
-fn extract_shard_prefix(filename: &str) -> Option<&str> {
-    let dash = filename.rfind('-')?;
-    let num_part = &filename[dash + 1..];
-    if num_part.len() != 5 || !num_part.chars().all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    Some(&filename[..dash])
-}
-
-/// Find GGUF files in repos whose repo_id starts with the given identifier.
-fn find_repo_prefix_matches(cache_info: &HFCacheInfo, prefix: &str) -> Vec<PathBuf> {
-    let mut results: BTreeSet<PathBuf> = BTreeSet::new();
-
-    for repo in &cache_info.repos {
-        use hf_hub::RepoType;
-        if repo.repo_type != RepoType::Model {
-            continue;
-        }
-        if !repo.repo_id.starts_with(prefix) {
-            continue;
-        }
-        for revision in &repo.revisions {
-            for file in &revision.files {
-                if file.file_name.ends_with(".gguf") {
+                if normalized_gguf_stem(&file.file_name).eq_ignore_ascii_case(expected) {
                     results.insert(file.file_path.clone());
                 }
             }
@@ -124,73 +147,42 @@ fn find_repo_prefix_matches(cache_info: &HFCacheInfo, prefix: &str) -> Vec<PathB
     results.into_iter().collect()
 }
 
-/// Collect all paths that should be deleted for a model identified by its primary path.
-/// This includes managed_paths from usage records and any sidecar GGUF files (mmproj, etc.)
-/// found in the same directory as the primary model file.
-pub fn collect_delete_paths(primary_path: &PathBuf) -> Result<Vec<PathBuf>> {
+pub fn collect_delete_paths(resolved_paths: &[PathBuf]) -> Result<Vec<PathBuf>> {
     let mut to_delete: BTreeSet<PathBuf> = BTreeSet::new();
+    if resolved_paths.is_empty() {
+        return Ok(Vec::new());
+    }
 
+    for path in resolved_paths {
+        ensure_delete_path_allowed(path)?;
+        to_delete.insert(normalize_path(path));
+    }
+
+    let primary_path = &resolved_paths[0];
     if let Some(record) = usage::load_model_usage_record_for_path(primary_path) {
         if record.mesh_managed && !record.managed_paths.is_empty() {
             for p in &record.managed_paths {
-                to_delete.insert(p.clone());
+                to_delete.insert(normalize_path(p));
             }
-            return Ok(to_delete.into_iter().collect());
-        }
-    }
-
-    let parent = primary_path.parent().context("No parent dir")?;
-
-    let filename = primary_path
-        .file_name()
-        .and_then(|f| f.to_str())
-        .context("No filename")?;
-
-    let base_stem = split_gguf_base_name(filename)
-        .unwrap_or(filename.strip_suffix(".gguf").unwrap_or(filename));
-
-    let entries = std::fs::read_dir(parent)
-        .with_context(|| format!("Cannot read directory: {}", parent.display()))?;
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !path.is_file() && !path.is_symlink() {
-            continue;
-        }
-        if path.extension().and_then(|e| e.to_str()) != Some("gguf") {
-            continue;
-        }
-
-        let entry_stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
-
-        if entry_stem.eq_ignore_ascii_case(base_stem)
-            || entry_stem.starts_with(&format!("{}-", base_stem))
-            || (split_gguf_base_name(entry_stem).is_some()
-                && split_gguf_base_name(entry_stem).unwrap() == base_stem)
-        {
-            to_delete.insert(path);
         }
     }
 
     Ok(to_delete.into_iter().collect())
 }
 
-/// Execute a model deletion by identifier, collecting and removing ALL files.
 pub async fn delete_model_by_identifier(identifier: &str) -> Result<DeleteResult> {
-    let primary_paths = resolve_model_identifier(identifier)?;
+    let resolved_paths = resolve_model_identifier(identifier).await?;
 
-    if primary_paths.is_empty() {
+    if resolved_paths.is_empty() {
         bail!("Model not found: {}", identifier);
     }
 
-    let primary_path = &primary_paths[0];
-
-    let all_paths = collect_delete_paths(primary_path)?;
+    let all_paths = collect_delete_paths(&resolved_paths)?;
 
     if all_paths.is_empty() {
         bail!(
             "No GGUF files found at resolved path: {}",
-            primary_path.display()
+            resolved_paths[0].display()
         );
     }
 
@@ -198,6 +190,7 @@ pub async fn delete_model_by_identifier(identifier: &str) -> Result<DeleteResult
     let mut removed_metadata_files: usize = 0;
     let mut removed_usage_records: usize = 0;
     let mut deleted_paths: Vec<PathBuf> = Vec::new();
+    let mut removed_record_paths = BTreeSet::new();
 
     for path in &all_paths {
         if path.exists() {
@@ -207,7 +200,7 @@ pub async fn delete_model_by_identifier(identifier: &str) -> Result<DeleteResult
             std::fs::remove_file(path).with_context(|| format!("Remove {}", path.display()))?;
             deleted_paths.push(path.clone());
 
-            if let Some(metadata_path) = crate::models::local::gguf_metadata_cache_path(path) {
+            if let Some(metadata_path) = gguf_metadata_cache_path(path) {
                 if metadata_path.exists() {
                     std::fs::remove_file(&metadata_path).with_context(|| {
                         format!("Remove metadata cache {}", metadata_path.display())
@@ -220,13 +213,15 @@ pub async fn delete_model_by_identifier(identifier: &str) -> Result<DeleteResult
         }
     }
 
-    if let Some(record) = load_model_usage_record_for_path(primary_path) {
-        let usage_dir = usage::model_usage_cache_dir();
-        let record_path = usage::usage_record_path(&usage_dir, &record.lookup_key);
-        if record_path.exists() {
-            std::fs::remove_file(&record_path)
-                .with_context(|| format!("Remove usage record {}", record_path.display()))?;
-            removed_usage_records += 1;
+    for path in &all_paths {
+        if let Some(record) = load_model_usage_record_for_path(path) {
+            let usage_dir = usage::model_usage_cache_dir();
+            let record_path = usage::usage_record_path(&usage_dir, &record.lookup_key);
+            if removed_record_paths.insert(record_path.clone()) && record_path.exists() {
+                std::fs::remove_file(&record_path)
+                    .with_context(|| format!("Remove usage record {}", record_path.display()))?;
+                removed_usage_records += 1;
+            }
         }
     }
 
@@ -241,6 +236,20 @@ pub async fn delete_model_by_identifier(identifier: &str) -> Result<DeleteResult
 /// Load a model usage record for a given path.
 fn load_model_usage_record_for_path(path: &std::path::Path) -> Option<usage::ModelUsageRecord> {
     usage::load_model_usage_record_for_path(path)
+}
+
+fn ensure_delete_path_allowed(path: &Path) -> Result<()> {
+    let normalized = normalize_path(path);
+    let hf_root = normalize_path(&huggingface_hub_cache_dir());
+    let mesh_root = normalize_path(&mesh_llm_cache_dir());
+    if normalized.starts_with(&hf_root) || normalized.starts_with(&mesh_root) {
+        Ok(())
+    } else {
+        bail!(
+            "Deletion target outside known model roots: {}",
+            normalized.display()
+        );
+    }
 }
 
 /// Prune empty ancestor directories up to (but not including) stop_at.
@@ -273,35 +282,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_extract_shard_prefix_valid() {
+    fn normalized_gguf_stem_collapses_split_shards() {
         assert_eq!(
-            extract_shard_prefix("Qwen3-8B-Q4_K_M-00001"),
-            Some("Qwen3-8B-Q4_K_M")
+            normalized_gguf_stem("GLM-5-UD-IQ2_XXS-00001-of-00006.gguf"),
+            "GLM-5-UD-IQ2_XXS"
         );
-        assert_eq!(extract_shard_prefix("model-00001"), Some("model"));
-    }
-
-    #[test]
-    fn test_extract_shard_prefix_invalid() {
-        assert_eq!(extract_shard_prefix("model-001"), None);
-        assert_eq!(extract_shard_prefix("model00001"), None);
-        assert_eq!(extract_shard_prefix("model-abcde"), None);
-    }
-
-    #[test]
-    fn test_split_gguf_base_name_single_file() {
-        assert_eq!(split_gguf_base_name("Qwen3-8B-Q4_K_M"), None);
-    }
-
-    #[test]
-    fn test_split_gguf_base_name_first_shard() {
-        let base = split_gguf_base_name("GLM-5-UD-IQ2_XXS-00001-of-00006");
-        assert_eq!(base, Some("GLM-5-UD-IQ2_XXS"));
-    }
-
-    #[test]
-    fn test_split_gguf_base_name_last_shard() {
-        let base = split_gguf_base_name("GLM-5-UD-IQ2_XXS-00006-of-00006");
-        assert_eq!(base, Some("GLM-5-UD-IQ2_XXS"));
+        assert_eq!(normalized_gguf_stem("Qwen3-8B-Q4_K_M"), "Qwen3-8B-Q4_K_M");
     }
 }

--- a/mesh-llm/src/models/delete.rs
+++ b/mesh-llm/src/models/delete.rs
@@ -30,7 +30,10 @@ pub async fn delete_model_at_path(identifier: &str, _dry_run: bool) -> Result<De
     let hf_root = crate::models::huggingface_hub_cache_dir();
     let mesh_root = crate::models::model_usage_cache_dir();
     if !path.starts_with(&hf_root) && !path.starts_with(&mesh_root) {
-        bail!("Deletion target outside known model roots: {}", path.display());
+        bail!(
+            "Deletion target outside known model roots: {}",
+            path.display()
+        );
     }
 
     let cleanup_result = delete_model_by_path(&path).context("delete model")?;

--- a/mesh-llm/src/models/delete_tests.rs
+++ b/mesh-llm/src/models/delete_tests.rs
@@ -1,0 +1,171 @@
+use std::fs;
+use std::path::PathBuf;
+
+use crate::models::delete::{delete_model_at_path, resolve_model_identifier, ResolveError};
+use crate::models::local::mesh_llm_cache_dir;
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    // Place temp files inside mesh_llm cache so safety gate accepts them.
+    let base = mesh_llm_cache_dir();
+    let _ = fs::create_dir_all(&base);
+    let dir = base.join(format!("test-{prefix}-{}", std::process::id()));
+    let _ = fs::create_dir_all(&dir);
+    dir
+}
+
+#[test]
+fn test_resolve_exact_path_found() {
+    let tmp = temp_dir("exact-found");
+    let model_file = tmp.join("test-model.gguf");
+    fs::write(&model_file, vec![0u8; 100]).expect("should create temp file");
+
+    let result = resolve_model_identifier(model_file.to_str().unwrap());
+    assert!(
+        result.is_ok(),
+        "resolved exact path should succeed: {:?}",
+        result.err()
+    );
+    let resolved = result.unwrap();
+    assert_eq!(resolved.path, model_file);
+    assert!(resolved.is_exact_path);
+    assert_eq!(resolved.display_name, "test-model");
+}
+
+#[test]
+fn test_resolve_exact_path_not_found() {
+    let result = resolve_model_identifier("/nonexistent/path/model.gguf");
+    assert!(result.is_err(), "should error for nonexistent path");
+    match result.unwrap_err() {
+        ResolveError::NotFound(msg) => {
+            assert!(msg.contains("/nonexistent/path/model.gguf"));
+        }
+        other => panic!("expected NotFound, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_resolve_exact_path_no_gguf_extension() {
+    let tmp = temp_dir("no-gguf-ext");
+    let txt_file = tmp.join("test.txt");
+    fs::write(&txt_file, "not a gguf").expect("should create temp file");
+
+    let result = resolve_model_identifier(txt_file.to_str().unwrap());
+    assert!(result.is_err(), "should reject non-.gguf extension");
+    match result.unwrap_err() {
+        ResolveError::NotFound(msg) => {
+            assert!(
+                msg.to_lowercase().contains("gguf"),
+                "error should mention .gguf requirement"
+            );
+        }
+        other => panic!("expected NotFound, got: {:?}", other),
+    }
+}
+
+#[test]
+fn test_resolve_stem_single_match() {
+    // Use find_model_path with a stem that matches an existing model on the dev machine.
+    // If no real models exist, it will return a path that doesn't exist — which means
+    // our resolution should detect zero matches and return NotFound.
+    let result = resolve_model_identifier("Qwen3-8B-Q4_K_M");
+    // Either resolves to an actual path (if installed) or returns NotFound
+    match result {
+        Ok(resolved) => {
+            assert!(!resolved.path.as_os_str().is_empty());
+            assert!(!resolved.is_exact_path);
+        }
+        Err(ResolveError::NotFound(_)) => {
+            // Expected if no matching GGUF files are found in cache
+        }
+        Err(ResolveError::Ambiguous(candidates)) => {
+            // Also valid - multiple matches found
+            assert!(candidates.len() >= 2);
+        }
+    }
+}
+
+#[test]
+fn test_resolve_stem_no_match() {
+    let result = resolve_model_identifier("this-stem-does-not-exist-xyz-abc123");
+    assert!(result.is_err(), "should error for non-existent stem");
+    match result.unwrap_err() {
+        ResolveError::NotFound(msg) => {
+            assert!(msg.to_lowercase().contains("no model found") || msg.contains("this-stem"));
+        }
+        other => panic!("expected NotFound, got: {:?}", other),
+    }
+}
+
+async fn setup_mock_delete_dir(prefix: &str) -> (PathBuf, PathBuf) {
+    let tmp = temp_dir(prefix);
+    let model_file = tmp.join("mock-model.gguf");
+    fs::write(&model_file, vec![0u8; 2048]).expect("should create mock file");
+    (tmp, model_file)
+}
+
+#[tokio::test]
+async fn test_delete_dry_run_does_not_modify() {
+    let (_tmp, model_file) = setup_mock_delete_dir("dryrun").await;
+
+    // Dry-run should not modify anything
+    let original_content = fs::read(&model_file).expect("file should exist before dry run");
+
+    let result = delete_model_at_path(model_file.to_str().unwrap(), true).await;
+
+    assert!(result.is_ok());
+    let del_result = result.unwrap();
+    // In dry-run mode, no files are actually deleted but paths may be recorded
+    // The key assertion is the file still exists with same content
+    let current_content = fs::read(&model_file).expect("file should exist after dry run");
+    assert_eq!(
+        original_content, current_content,
+        "file content must not change in dry-run"
+    );
+    assert!(del_result.deleted_paths.iter().any(|p| p == &model_file));
+}
+
+#[tokio::test]
+async fn test_delete_actually_removes_files() {
+    let (_tmp, model_file) = setup_mock_delete_dir("actual-delete").await;
+
+    // Verify file exists before deletion
+    assert!(
+        model_file.exists(),
+        "mock file should exist before deletion"
+    );
+
+    let result = delete_model_at_path(model_file.to_str().unwrap(), false).await;
+
+    assert!(
+        result.is_ok(),
+        "deletion should succeed: {:?}",
+        result.err()
+    );
+    let del_result = result.unwrap();
+    assert!(
+        !model_file.exists(),
+        "model file should be removed after deletion"
+    );
+    assert_eq!(del_result.deleted_paths.len(), 1);
+}
+
+#[tokio::test]
+async fn test_delete_reported_bytes_are_accurate() {
+    let (tmp, model_file) = setup_mock_delete_dir("byte-count").await;
+
+    // Create a file of known size by writing exactly 2048 bytes
+    fs::write(&model_file, vec![0u8; 2048]).expect("should write exact bytes");
+
+    let result = delete_model_at_path(model_file.to_str().unwrap(), true).await;
+
+    assert!(result.is_ok());
+    let del_result = result.unwrap();
+    assert_eq!(
+        del_result.reclaimed_bytes, 2048,
+        "reclaimed bytes should match actual file size"
+    );
+
+    // Cleanup temp dir since we're in dry-run mode
+    let _ = tmp.read_dir();
+    let _ = fs::remove_dir_all(&tmp);
+}

--- a/mesh-llm/src/models/delete_tests.rs
+++ b/mesh-llm/src/models/delete_tests.rs
@@ -1,171 +1,280 @@
-use std::fs;
-use std::path::PathBuf;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
-use crate::models::delete::{delete_model_at_path, resolve_model_identifier, ResolveError};
-use crate::models::local::mesh_llm_cache_dir;
+use serial_test::serial;
 
-fn temp_dir(prefix: &str) -> PathBuf {
-    // Place temp files inside mesh_llm cache so safety gate accepts them.
-    let base = mesh_llm_cache_dir();
-    let _ = fs::create_dir_all(&base);
-    let dir = base.join(format!("test-{prefix}-{}", std::process::id()));
-    let _ = fs::create_dir_all(&dir);
-    dir
+use crate::models::delete::{delete_model_by_identifier, resolve_model_identifier};
+use crate::models::resolve::resolve_huggingface_file_from_sibling_entries;
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("mesh-llm-{prefix}-{stamp}"))
 }
 
-#[test]
-fn test_resolve_exact_path_found() {
-    let tmp = temp_dir("exact-found");
-    let model_file = tmp.join("test-model.gguf");
-    fs::write(&model_file, vec![0u8; 100]).expect("should create temp file");
-
-    let result = resolve_model_identifier(model_file.to_str().unwrap());
-    assert!(
-        result.is_ok(),
-        "resolved exact path should succeed: {:?}",
-        result.err()
-    );
-    let resolved = result.unwrap();
-    assert_eq!(resolved.path, model_file);
-    assert!(resolved.is_exact_path);
-    assert_eq!(resolved.display_name, "test-model");
-}
-
-#[test]
-fn test_resolve_exact_path_not_found() {
-    let result = resolve_model_identifier("/nonexistent/path/model.gguf");
-    assert!(result.is_err(), "should error for nonexistent path");
-    match result.unwrap_err() {
-        ResolveError::NotFound(msg) => {
-            assert!(msg.contains("/nonexistent/path/model.gguf"));
-        }
-        other => panic!("expected NotFound, got: {:?}", other),
+fn restore_env(key: &str, previous: Option<OsString>) {
+    if let Some(value) = previous {
+        std::env::set_var(key, value);
+    } else {
+        std::env::remove_var(key);
     }
 }
 
-#[test]
-fn test_resolve_exact_path_no_gguf_extension() {
-    let tmp = temp_dir("no-gguf-ext");
-    let txt_file = tmp.join("test.txt");
-    fs::write(&txt_file, "not a gguf").expect("should create temp file");
+fn create_cache_repo_file(
+    root: &Path,
+    repo_id: &str,
+    revision: &str,
+    relative_file: &str,
+    size_bytes: usize,
+) -> PathBuf {
+    let repo_dir = root.join(format!("models--{}", repo_id.replace('/', "--")));
+    let refs_dir = repo_dir.join("refs");
+    let snapshot_dir = repo_dir.join("snapshots").join(revision);
+    std::fs::create_dir_all(&refs_dir).unwrap();
+    std::fs::create_dir_all(
+        snapshot_dir.join(Path::new(relative_file).parent().unwrap_or(Path::new(""))),
+    )
+    .unwrap();
+    std::fs::write(refs_dir.join("main"), revision).unwrap();
 
-    let result = resolve_model_identifier(txt_file.to_str().unwrap());
-    assert!(result.is_err(), "should reject non-.gguf extension");
-    match result.unwrap_err() {
-        ResolveError::NotFound(msg) => {
-            assert!(
-                msg.to_lowercase().contains("gguf"),
-                "error should mention .gguf requirement"
-            );
-        }
-        other => panic!("expected NotFound, got: {:?}", other),
-    }
-}
-
-#[test]
-fn test_resolve_stem_single_match() {
-    // Use find_model_path with a stem that matches an existing model on the dev machine.
-    // If no real models exist, it will return a path that doesn't exist — which means
-    // our resolution should detect zero matches and return NotFound.
-    let result = resolve_model_identifier("Qwen3-8B-Q4_K_M");
-    // Either resolves to an actual path (if installed) or returns NotFound
-    match result {
-        Ok(resolved) => {
-            assert!(!resolved.path.as_os_str().is_empty());
-            assert!(!resolved.is_exact_path);
-        }
-        Err(ResolveError::NotFound(_)) => {
-            // Expected if no matching GGUF files are found in cache
-        }
-        Err(ResolveError::Ambiguous(candidates)) => {
-            // Also valid - multiple matches found
-            assert!(candidates.len() >= 2);
-        }
-    }
-}
-
-#[test]
-fn test_resolve_stem_no_match() {
-    let result = resolve_model_identifier("this-stem-does-not-exist-xyz-abc123");
-    assert!(result.is_err(), "should error for non-existent stem");
-    match result.unwrap_err() {
-        ResolveError::NotFound(msg) => {
-            assert!(msg.to_lowercase().contains("no model found") || msg.contains("this-stem"));
-        }
-        other => panic!("expected NotFound, got: {:?}", other),
-    }
-}
-
-async fn setup_mock_delete_dir(prefix: &str) -> (PathBuf, PathBuf) {
-    let tmp = temp_dir(prefix);
-    let model_file = tmp.join("mock-model.gguf");
-    fs::write(&model_file, vec![0u8; 2048]).expect("should create mock file");
-    (tmp, model_file)
+    let path = snapshot_dir.join(relative_file);
+    std::fs::write(&path, vec![0u8; size_bytes]).unwrap();
+    path
 }
 
 #[tokio::test]
-async fn test_delete_dry_run_does_not_modify() {
-    let (_tmp, model_file) = setup_mock_delete_dir("dryrun").await;
-
-    // Dry-run should not modify anything
-    let original_content = fs::read(&model_file).expect("file should exist before dry run");
-
-    let result = delete_model_at_path(model_file.to_str().unwrap(), true).await;
-
-    assert!(result.is_ok());
-    let del_result = result.unwrap();
-    // In dry-run mode, no files are actually deleted but paths may be recorded
-    // The key assertion is the file still exists with same content
-    let current_content = fs::read(&model_file).expect("file should exist after dry run");
-    assert_eq!(
-        original_content, current_content,
-        "file content must not change in dry-run"
-    );
-    assert!(del_result.deleted_paths.iter().any(|p| p == &model_file));
+async fn resolve_model_identifier_rejects_filesystem_paths() {
+    let err = resolve_model_identifier("/tmp/model.gguf")
+        .await
+        .unwrap_err();
+    assert!(err
+        .to_string()
+        .contains("does not support filesystem paths"));
 }
 
 #[tokio::test]
-async fn test_delete_actually_removes_files() {
-    let (_tmp, model_file) = setup_mock_delete_dir("actual-delete").await;
-
-    // Verify file exists before deletion
-    assert!(
-        model_file.exists(),
-        "mock file should exist before deletion"
-    );
-
-    let result = delete_model_at_path(model_file.to_str().unwrap(), false).await;
-
-    assert!(
-        result.is_ok(),
-        "deletion should succeed: {:?}",
-        result.err()
-    );
-    let del_result = result.unwrap();
-    assert!(
-        !model_file.exists(),
-        "model file should be removed after deletion"
-    );
-    assert_eq!(del_result.deleted_paths.len(), 1);
+async fn resolve_model_identifier_rejects_direct_urls() {
+    let err = resolve_model_identifier("https://huggingface.co/org/repo/resolve/main/model.gguf")
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("does not support direct URLs"));
 }
 
 #[tokio::test]
-async fn test_delete_reported_bytes_are_accurate() {
-    let (tmp, model_file) = setup_mock_delete_dir("byte-count").await;
+#[serial]
+async fn resolve_model_identifier_returns_all_split_shards_from_selector_ref() {
+    let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+    let prev_hf_home = std::env::var_os("HF_HOME");
+    let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
 
-    // Create a file of known size by writing exactly 2048 bytes
-    fs::write(&model_file, vec![0u8; 2048]).expect("should write exact bytes");
-
-    let result = delete_model_at_path(model_file.to_str().unwrap(), true).await;
-
-    assert!(result.is_ok());
-    let del_result = result.unwrap();
-    assert_eq!(
-        del_result.reclaimed_bytes, 2048,
-        "reclaimed bytes should match actual file size"
+    let temp = unique_temp_dir("delete-split-resolve");
+    let shard1 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-00001-of-00002.gguf",
+        4,
+    );
+    let shard2 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-00002-of-00002.gguf",
+        4,
+    );
+    let unrelated = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-Q4_K_M.gguf",
+        4,
     );
 
-    // Cleanup temp dir since we're in dry-run mode
-    let _ = tmp.read_dir();
-    let _ = fs::remove_dir_all(&tmp);
+    std::env::set_var("HF_HUB_CACHE", &temp);
+    std::env::remove_var("HF_HOME");
+    std::env::remove_var("XDG_CACHE_HOME");
+
+    let resolved = resolve_model_identifier("bartowski/GLM-5-UD-IQ2_XXS-GGUF:UD-IQ2_XXS")
+        .await
+        .unwrap();
+    assert_eq!(resolved, vec![shard1.clone(), shard2.clone()]);
+    assert!(unrelated.exists());
+
+    let _ = std::fs::remove_dir_all(&temp);
+    restore_env("HF_HUB_CACHE", prev_hub_cache);
+    restore_env("HF_HOME", prev_hf_home);
+    restore_env("XDG_CACHE_HOME", prev_xdg);
+}
+
+#[tokio::test]
+#[serial]
+async fn delete_model_by_identifier_removes_only_the_resolved_split_shards() {
+    let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+    let prev_hf_home = std::env::var_os("HF_HOME");
+    let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+
+    let temp = unique_temp_dir("delete-split-target");
+    let shard1 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-00001-of-00002.gguf",
+        4,
+    );
+    let shard2 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-00002-of-00002.gguf",
+        4,
+    );
+    let unrelated = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-Q4_K_M.gguf",
+        4,
+    );
+
+    std::env::set_var("HF_HUB_CACHE", &temp);
+    std::env::remove_var("HF_HOME");
+    std::env::remove_var("XDG_CACHE_HOME");
+
+    let expected_deleted = vec![
+        shard1.canonicalize().unwrap(),
+        shard2.canonicalize().unwrap(),
+    ];
+    let result = delete_model_by_identifier("bartowski/GLM-5-UD-IQ2_XXS-GGUF:UD-IQ2_XXS")
+        .await
+        .unwrap();
+    assert_eq!(result.deleted_paths, expected_deleted);
+    assert!(!shard1.exists());
+    assert!(!shard2.exists());
+    assert!(unrelated.exists());
+
+    let _ = std::fs::remove_dir_all(&temp);
+    restore_env("HF_HUB_CACHE", prev_hub_cache);
+    restore_env("HF_HOME", prev_hf_home);
+    restore_env("XDG_CACHE_HOME", prev_xdg);
+}
+
+#[tokio::test]
+#[serial]
+async fn delete_model_by_identifier_supports_dotted_quant_selector_refs() {
+    let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+    let prev_hf_home = std::env::var_os("HF_HOME");
+    let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+
+    let temp = unique_temp_dir("delete-dotted-selector");
+    let q2 = create_cache_repo_file(
+        &temp,
+        "Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF",
+        "a9b8adbec2cc87479c772dac1944f313b4036c26",
+        "qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf",
+        4,
+    );
+    let q4 = create_cache_repo_file(
+        &temp,
+        "Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF",
+        "a9b8adbec2cc87479c772dac1944f313b4036c26",
+        "qwen3.5-moe-0.87B-d0.8B.Q4_K_M.gguf",
+        4,
+    );
+
+    std::env::set_var("HF_HUB_CACHE", &temp);
+    std::env::remove_var("HF_HOME");
+    std::env::remove_var("XDG_CACHE_HOME");
+
+    let resolved =
+        resolve_model_identifier("Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF:Q2_K")
+            .await
+            .unwrap();
+    assert_eq!(resolved, vec![q2.clone()]);
+
+    let expected_deleted = vec![q2.canonicalize().unwrap()];
+    let result =
+        delete_model_by_identifier("Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF:Q2_K")
+            .await
+            .unwrap();
+    assert_eq!(result.deleted_paths, expected_deleted);
+    assert!(!q2.exists());
+    assert!(q4.exists());
+
+    let _ = std::fs::remove_dir_all(&temp);
+    restore_env("HF_HUB_CACHE", prev_hub_cache);
+    restore_env("HF_HOME", prev_hf_home);
+    restore_env("XDG_CACHE_HOME", prev_xdg);
+}
+
+#[tokio::test]
+#[serial]
+async fn resolve_model_identifier_repo_ref_matches_shared_resolver_semantics() {
+    let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+    let prev_hf_home = std::env::var_os("HF_HOME");
+    let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+
+    let temp = unique_temp_dir("delete-default-repo");
+    let shard1 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-00001-of-00002.gguf",
+        64,
+    );
+    let shard2 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "GLM-5-UD-IQ2_XXS-00002-of-00002.gguf",
+        64,
+    );
+    let bf16 = create_cache_repo_file(
+        &temp,
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        "abcdef1234567890",
+        "BF16/GLM-5-UD-BF16.gguf",
+        128,
+    );
+
+    std::env::set_var("HF_HUB_CACHE", &temp);
+    std::env::remove_var("HF_HOME");
+    std::env::remove_var("XDG_CACHE_HOME");
+
+    let sibling_entries = vec![
+        ("GLM-5-UD-IQ2_XXS-00001-of-00002.gguf".to_string(), Some(64)),
+        ("GLM-5-UD-IQ2_XXS-00002-of-00002.gguf".to_string(), Some(64)),
+        ("BF16/GLM-5-UD-BF16.gguf".to_string(), Some(128)),
+    ];
+    let selected = resolve_huggingface_file_from_sibling_entries(
+        "bartowski/GLM-5-UD-IQ2_XXS-GGUF",
+        Some("main"),
+        "",
+        &sibling_entries,
+    )
+    .await
+    .unwrap();
+
+    let resolved = resolve_model_identifier("bartowski/GLM-5-UD-IQ2_XXS-GGUF")
+        .await
+        .unwrap();
+    let resolved: Vec<PathBuf> = resolved
+        .into_iter()
+        .map(|path| path.canonicalize().unwrap())
+        .collect();
+    let expected = if selected == "BF16/GLM-5-UD-BF16.gguf" {
+        vec![bf16.canonicalize().unwrap()]
+    } else {
+        vec![
+            shard1.canonicalize().unwrap(),
+            shard2.canonicalize().unwrap(),
+        ]
+    };
+    assert_eq!(resolved, expected);
+
+    let _ = std::fs::remove_dir_all(&temp);
+    restore_env("HF_HUB_CACHE", prev_hub_cache);
+    restore_env("HF_HOME", prev_hf_home);
+    restore_env("XDG_CACHE_HOME", prev_xdg);
 }

--- a/mesh-llm/src/models/local.rs
+++ b/mesh-llm/src/models/local.rs
@@ -438,7 +438,7 @@ fn find_hf_cache_model_path(root: &Path, stem: &str) -> Option<PathBuf> {
 /// Extract the base model name from a split GGUF stem.
 /// "GLM-5-UD-IQ2_XXS-00001-of-00006" → Some("GLM-5-UD-IQ2_XXS")
 /// "Qwen3-8B-Q4_K_M" → None (not a split file)
-fn split_gguf_base_name(stem: &str) -> Option<&str> {
+pub(crate) fn split_gguf_base_name(stem: &str) -> Option<&str> {
     let suffix = stem.rfind("-of-")?;
     let part_num = &stem[suffix + 4..];
     if part_num.len() != 5 || !part_num.chars().all(|c| c.is_ascii_digit()) {

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -1,10 +1,13 @@
 pub mod capabilities;
 pub mod catalog;
+pub mod delete;
+pub use delete::DeleteResult;
 pub mod gguf;
 pub mod inventory;
 pub mod local;
 mod maintenance;
-mod resolve;
+pub mod resolve;
+pub use resolve::ResolvedModel;
 pub mod search;
 pub mod topology;
 mod usage;
@@ -32,9 +35,9 @@ pub use search::{
 };
 pub use topology::{infer_local_model_topology, ModelMoeInfo, ModelTopology};
 pub use usage::{
-    execute_model_cleanup, load_model_usage_record_for_path, model_usage_cache_dir,
-    plan_model_cleanup, track_managed_model_usage, track_model_usage, ModelCleanupPlan,
-    ModelCleanupResult,
+    execute_model_cleanup, load_model_usage_record_for_path,
+    model_usage_cache_dir, plan_model_cleanup, track_managed_model_usage, track_model_usage,
+    ModelCleanupPlan, ModelCleanupResult,
 };
 
 pub(crate) fn build_hf_api(_progress: bool) -> Result<HFClientSync> {

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -8,6 +8,8 @@ pub mod local;
 mod maintenance;
 pub mod resolve;
 pub use resolve::ResolvedModel;
+#[cfg(test)]
+mod delete_tests;
 pub mod search;
 pub mod topology;
 mod usage;

--- a/mesh-llm/src/models/mod.rs
+++ b/mesh-llm/src/models/mod.rs
@@ -35,9 +35,9 @@ pub use search::{
 };
 pub use topology::{infer_local_model_topology, ModelMoeInfo, ModelTopology};
 pub use usage::{
-    execute_model_cleanup, load_model_usage_record_for_path,
-    model_usage_cache_dir, plan_model_cleanup, track_managed_model_usage, track_model_usage,
-    ModelCleanupPlan, ModelCleanupResult,
+    execute_model_cleanup, load_model_usage_record_for_path, model_usage_cache_dir,
+    plan_model_cleanup, track_managed_model_usage, track_model_usage, ModelCleanupPlan,
+    ModelCleanupResult,
 };
 
 pub(crate) fn build_hf_api(_progress: bool) -> Result<HFClientSync> {

--- a/mesh-llm/src/models/resolve/mod.rs
+++ b/mesh-llm/src/models/resolve/mod.rs
@@ -58,6 +58,16 @@ enum ExactModelRef {
     },
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum DeleteModelRef {
+    LocalStem(String),
+    HuggingFace {
+        repo: String,
+        revision: Option<String>,
+        file: String,
+    },
+}
+
 pub(super) fn merge_capabilities(
     left: ModelCapabilities,
     right: ModelCapabilities,
@@ -579,6 +589,53 @@ pub fn installed_model_huggingface_ref(identity: &HuggingFaceModelIdentity) -> S
     format_huggingface_display_ref(&identity.repo_id, None, &identity.file)
 }
 
+pub(crate) async fn parse_delete_model_ref(input: &str) -> Result<DeleteModelRef> {
+    if input.starts_with("http://") || input.starts_with("https://") {
+        bail!("Delete does not support direct URLs. Use a model stem or Hugging Face ref.");
+    }
+    if Path::new(input).is_absolute()
+        || input.contains('\\')
+        || input.starts_with("./")
+        || input.starts_with("../")
+        || input.starts_with("~/")
+    {
+        bail!("Delete does not support filesystem paths. Use a model stem or Hugging Face ref.");
+    }
+
+    if let Some(model) = find_catalog_model_exact(input) {
+        let stem = model.file.trim_end_matches(".gguf");
+        if find_model_path(stem).exists() {
+            return Ok(DeleteModelRef::LocalStem(stem.to_string()));
+        }
+    }
+
+    if !input.contains('/') {
+        let installed_name = input.strip_suffix(".gguf").unwrap_or(input);
+        if find_model_path(installed_name).exists() {
+            return Ok(DeleteModelRef::LocalStem(installed_name.to_string()));
+        }
+    }
+
+    let canonical = canonicalize_model_ref_input(input).await?;
+    match parse_exact_model_ref(&canonical)? {
+        ExactModelRef::Catalog(model) => Ok(DeleteModelRef::LocalStem(
+            model.file.trim_end_matches(".gguf").to_string(),
+        )),
+        ExactModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        } => Ok(DeleteModelRef::HuggingFace {
+            repo,
+            revision,
+            file,
+        }),
+        ExactModelRef::Url { .. } => {
+            bail!("Delete does not support direct URLs. Use a model stem or Hugging Face ref.")
+        }
+    }
+}
+
 pub(super) fn catalog_hf_asset_ref(
     model: &'static catalog::CatalogModel,
     file_name: &str,
@@ -1021,7 +1078,9 @@ fn gguf_matches_quant_selector(file_lower: &str, selector_lower: &str) -> bool {
     }
     file_lower.contains(&format!("/{selector_lower}/"))
         || file_lower.contains(&format!("-{selector_lower}-"))
+        || file_lower.contains(&format!(".{selector_lower}-"))
         || file_lower.ends_with(&format!("-{selector_lower}.gguf"))
+        || file_lower.ends_with(&format!(".{selector_lower}.gguf"))
         || file_lower.ends_with(&format!("/{selector_lower}.gguf"))
 }
 
@@ -1268,10 +1327,11 @@ async fn fetch_repo_sibling_entries(
         .collect())
 }
 
-async fn resolve_huggingface_file(
+pub(crate) async fn resolve_huggingface_file_from_sibling_entries(
     repo: &str,
     revision: Option<&str>,
     file: &str,
+    sibling_entries: &[(String, Option<u64>)],
 ) -> Result<String> {
     if file.ends_with(".gguf")
         || file.ends_with(".safetensors")
@@ -1281,7 +1341,6 @@ async fn resolve_huggingface_file(
     }
 
     let revision = revision.unwrap_or("main");
-    let sibling_entries = fetch_repo_sibling_entries(repo, revision).await?;
     let siblings: Vec<String> = sibling_entries.iter().map(|(f, _)| f.clone()).collect();
     let has_mlx_weights = siblings
         .iter()
@@ -1291,7 +1350,7 @@ async fn resolve_huggingface_file(
         let gguf_only = repo_prefers_gguf_only(repo);
         if gguf_only {
             if let Some(resolved) =
-                select_default_hf_file_fit_aware(repo, Some(revision), &sibling_entries).await
+                select_default_hf_file_fit_aware(repo, Some(revision), sibling_entries).await
             {
                 return Ok(resolved);
             }
@@ -1303,7 +1362,7 @@ async fn resolve_huggingface_file(
         }
 
         if let Some(resolved) =
-            select_default_hf_file_fit_aware(repo, Some(revision), &sibling_entries).await
+            select_default_hf_file_fit_aware(repo, Some(revision), sibling_entries).await
         {
             return Ok(resolved);
         }
@@ -1321,6 +1380,17 @@ async fn resolve_huggingface_file(
     bail!(
         "No model file matching stem '{file}' in {repo}@{revision}. Use a full ref like org/repo/file.gguf or org/repo/model.safetensors."
     )
+}
+
+async fn resolve_huggingface_file(
+    repo: &str,
+    revision: Option<&str>,
+    file: &str,
+) -> Result<String> {
+    let revision = revision.unwrap_or("main");
+    let sibling_entries = fetch_repo_sibling_entries(repo, revision).await?;
+    resolve_huggingface_file_from_sibling_entries(repo, Some(revision), file, &sibling_entries)
+        .await
 }
 
 pub(super) fn huggingface_resolve_url(repo: &str, revision: Option<&str>, file: &str) -> String {

--- a/mesh-llm/src/models/resolve/mod.rs
+++ b/mesh-llm/src/models/resolve/mod.rs
@@ -5,14 +5,25 @@ use super::{
     track_model_usage,
 };
 use crate::cli::terminal_progress::start_spinner;
+use crate::models::usage::ModelUsageRecord;
 use anyhow::{anyhow, bail, Context, Result};
 use hf_hub::{ListModelsParams, RepoInfo, RepoInfoParams};
 use std::cmp::Ordering;
 use std::collections::HashSet;
+// std imports kept minimal; filesystem ops via std::fs::read_dir used in helper
 use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::{Arc, LazyLock, Mutex};
 use tokio_stream::StreamExt;
+
+// Resolver result type for model identifier resolution
+#[derive(Clone, Debug)]
+pub struct ResolvedModel {
+    pub path: PathBuf,
+    pub display_name: String,
+    pub is_exact_path: bool,
+    pub matched_records: Vec<ModelUsageRecord>,
+}
 
 #[derive(Clone, Debug)]
 pub struct ModelDetails {

--- a/mesh-llm/src/models/resolve/tests.rs
+++ b/mesh-llm/src/models/resolve/tests.rs
@@ -180,6 +180,16 @@ fn quant_selector_resolves_to_single_file_gguf() {
 }
 
 #[test]
+fn dotted_quant_selector_resolves_to_single_file_gguf() {
+    let siblings = vec![
+        "qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf".to_string(),
+        "qwen3.5-moe-0.87B-d0.8B.Q4_K_M.gguf".to_string(),
+    ];
+    let resolved = resolve_hf_file_from_siblings("Q2_K", &siblings).unwrap();
+    assert_eq!(resolved, "qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf");
+}
+
+#[test]
 fn gemma_bf16_selector_resolves_to_first_split_shard() {
     let fixture = load_gemma_live_fixture();
     let resolved = resolve_hf_file_from_siblings("BF16", &fixture.siblings).unwrap();
@@ -388,6 +398,10 @@ fn quant_selector_from_gguf_file_extracts_expected_forms() {
     assert_eq!(
         quant_selector_from_gguf_file("gemma-4-31B-it-Q4_0.gguf"),
         Some("Q4_0".to_string())
+    );
+    assert_eq!(
+        quant_selector_from_gguf_file("qwen3.5-moe-0.87B-d0.8B.Q2_K.gguf"),
+        Some("Q2_K".to_string())
     );
 }
 

--- a/mesh-llm/src/models/usage.rs
+++ b/mesh-llm/src/models/usage.rs
@@ -157,78 +157,6 @@ pub fn execute_model_cleanup(unused_since: Option<Duration>) -> Result<ModelClea
     execute_model_cleanup_entries(entries)
 }
 
-pub fn delete_model_by_path(path: &Path) -> Result<ModelCleanupResult> {
-    let usage_dir = model_usage_cache_dir();
-    let normalized = normalize_path(path);
-
-    let records = load_model_usage_records_from_dir(&usage_dir);
-    let entry = match records
-        .into_iter()
-        .find(|r| r.mesh_managed && r.primary_path == normalized)
-    {
-        Some(record) => {
-            let removable_paths: Vec<PathBuf> = unique_paths(record.managed_paths.clone())
-                .into_iter()
-                .filter(|p| p.exists())
-                .collect();
-            let total_bytes = removable_paths
-                .iter()
-                .filter_map(|p| std::fs::metadata(p).ok().map(|m| m.len()))
-                .sum();
-            let stale_record_only = removable_paths.is_empty();
-            let record_path = usage_record_path(&usage_dir, &record.lookup_key);
-
-            CleanupEntry {
-                record,
-                record_path,
-                removable_paths,
-                total_bytes,
-                stale_record_only,
-            }
-        }
-        None => {
-            let record = ModelUsageRecord {
-                lookup_key: format!("path:{}", normalized.display()),
-                display_name: normalized
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or("unknown")
-                    .to_string(),
-                model_ref: None,
-                source: "direct".to_string(),
-                primary_path: normalized.clone(),
-                managed_paths: vec![],
-                mesh_managed: false,
-                hf_repo_id: None,
-                hf_revision: None,
-                first_seen_at: Utc::now().to_rfc3339(),
-                last_used_at: Utc::now().to_rfc3339(),
-            };
-            let removable_paths = if normalized.exists() {
-                vec![normalized.clone()]
-            } else {
-                vec![]
-            };
-            let stale_record_only = removable_paths.is_empty();
-            let total_bytes = removable_paths
-                .iter()
-                .filter_map(|p| std::fs::metadata(p).ok().map(|m| m.len()))
-                .sum();
-            let record_path = usage_record_path(&usage_dir, &record.lookup_key);
-
-            CleanupEntry {
-                record,
-                record_path,
-                removable_paths,
-                total_bytes,
-                stale_record_only,
-            }
-        }
-    };
-
-    execute_model_cleanup_entries(vec![entry])
-}
-
 fn load_model_usage_records_from_dir(dir: &Path) -> Vec<ModelUsageRecord> {
     let mut records = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
@@ -610,7 +538,7 @@ fn hf_identity_for_path_in_root(path: &Path, track_root: &Path) -> Option<PathHu
     })
 }
 
-fn usage_record_path(usage_dir: &Path, lookup_key: &str) -> PathBuf {
+pub(crate) fn usage_record_path(usage_dir: &Path, lookup_key: &str) -> PathBuf {
     let digest = Sha256::digest(lookup_key.as_bytes());
     usage_dir.join(format!("{digest:x}.json"))
 }

--- a/mesh-llm/src/models/usage.rs
+++ b/mesh-llm/src/models/usage.rs
@@ -157,6 +157,78 @@ pub fn execute_model_cleanup(unused_since: Option<Duration>) -> Result<ModelClea
     execute_model_cleanup_entries(entries)
 }
 
+pub fn delete_model_by_path(path: &Path) -> Result<ModelCleanupResult> {
+    let usage_dir = model_usage_cache_dir();
+    let normalized = normalize_path(path);
+
+    let records = load_model_usage_records_from_dir(&usage_dir);
+    let entry = match records
+        .into_iter()
+        .find(|r| r.mesh_managed && r.primary_path == normalized)
+    {
+        Some(record) => {
+            let removable_paths: Vec<PathBuf> = unique_paths(record.managed_paths.clone())
+                .into_iter()
+                .filter(|p| p.exists())
+                .collect();
+            let total_bytes = removable_paths
+                .iter()
+                .filter_map(|p| std::fs::metadata(p).ok().map(|m| m.len()))
+                .sum();
+            let stale_record_only = removable_paths.is_empty();
+            let record_path = usage_record_path(&usage_dir, &record.lookup_key);
+
+            CleanupEntry {
+                record,
+                record_path,
+                removable_paths,
+                total_bytes,
+                stale_record_only,
+            }
+        }
+        None => {
+            let record = ModelUsageRecord {
+                lookup_key: format!("path:{}", normalized.display()),
+                display_name: normalized
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("unknown")
+                    .to_string(),
+                model_ref: None,
+                source: "direct".to_string(),
+                primary_path: normalized.clone(),
+                managed_paths: vec![],
+                mesh_managed: false,
+                hf_repo_id: None,
+                hf_revision: None,
+                first_seen_at: Utc::now().to_rfc3339(),
+                last_used_at: Utc::now().to_rfc3339(),
+            };
+            let removable_paths = if normalized.exists() {
+                vec![normalized.clone()]
+            } else {
+                vec![]
+            };
+            let stale_record_only = removable_paths.is_empty();
+            let total_bytes = removable_paths
+                .iter()
+                .filter_map(|p| std::fs::metadata(p).ok().map(|m| m.len()))
+                .sum();
+            let record_path = usage_record_path(&usage_dir, &record.lookup_key);
+
+            CleanupEntry {
+                record,
+                record_path,
+                removable_paths,
+                total_bytes,
+                stale_record_only,
+            }
+        }
+    };
+
+    execute_model_cleanup_entries(vec![entry])
+}
+
 fn load_model_usage_records_from_dir(dir: &Path) -> Vec<ModelUsageRecord> {
     let mut records = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {


### PR DESCRIPTION
Users can now remove an installed model from the local Hugging Face cache from the `models` CLI, using the same refs that `models installed` prints.

This change keeps delete aligned with the existing model resolver semantics instead of introducing separate path heuristics, and it deletes only the exact matched GGUF file set from the HF cache.

## How delete works

- `mesh-llm models installed` prints a delete-ready ref for each installed model.
- `mesh-llm models delete <ref>` resolves that input through the existing model resolver semantics.
- Supported delete inputs are the installed forms we already understand, including local installed stems and Hugging Face refs like `org/repo` and `org/repo:VARIANT`.
- For HF-backed installs, delete uses `huggingface_hub_rust` cache metadata to find the exact cached repo revision and matched GGUF file(s).
- If the selected variant is a split GGUF, delete removes the whole matched shard set and does not widen the deletion to unrelated sibling variants in the same snapshot.
- Direct URLs and filesystem paths are rejected for delete.

## Example output

```text
$ ./target/release/mesh-llm models installed
📦 qwen3.5-moe-0.87B-d0.8B.Q2_K
   type: 🦙 GGUF
   size: 627MB 📏
   owner: external
   capabilities: 💬 text
   ref: Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF:Q2_K
   show: mesh-llm models show Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF:Q2_K
   download: mesh-llm models download Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF:Q2_K
   delete: mesh-llm models delete Flexan/kshitijthakkar-qwen3.5-moe-0.87B-d0.8B-GGUF:Q2_K
```

That printed `delete` command is valid for dotted GGUF quant names like `Q2_K`, and split GGUF selector refs remove only the matching shard set.

## Why

The original delete path drifted away from the shared resolver and then expanded deletion from one resolved file into directory-prefix based sibling deletion. That created two problems:

- installed refs shown by the CLI were not always accepted by delete
- delete could remove extra GGUFs that were not part of the resolved match

This change moves delete back onto the shared resolver semantics and keeps the final deletion set driven by exact HF cache matches.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- `cargo test -p mesh-llm models::delete_tests --lib -- --nocapture`
- `cargo test -p mesh-llm models::resolve::tests::dotted_quant_selector_resolves_to_single_file_gguf --lib -- --nocapture`

`cargo check` and tests still show the same pre-existing unrelated warnings in `mesh-llm/src/inference/election.rs` and `mesh-llm/src/runtime/local.rs`.
