### PR TITLE
Add support to output to multiple different log files by port for llamacpp servers

### DIFF
--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -1102,7 +1102,7 @@ pub async fn start_llama_server(
         rpc_arg
     );
 
-let llama_log = runtime.log_path(&format!("llama-server-{}", http_port));
+    let llama_log = runtime.log_path(&format!("llama-server-{}", http_port));
     eprintln!(
         "⏳ Starting llama-server on :{http_port}... (logs: {})",
         llama_log.display()
@@ -1407,7 +1407,8 @@ let llama_log = runtime.log_path(&format!("llama-server-{}", http_port));
                 ),
                 runtime_dir: runtime.dir().to_path_buf(),
             };
-            let pidfile_guard = runtime.write_pidfile(&format!("llama-server-{}", http_port), &metadata)?;
+            let pidfile_guard =
+                runtime.write_pidfile(&format!("llama-server-{}", http_port), &metadata)?;
             let expected_exit = Arc::new(AtomicBool::new(false));
             let handle = InferenceServerHandle {
                 pid,

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -1102,9 +1102,9 @@ pub async fn start_llama_server(
         rpc_arg
     );
 
-    let llama_log = runtime.log_path("llama-server");
+let llama_log = runtime.log_path(&format!("llama-server-{}", http_port));
     eprintln!(
-        "⏳ Starting llama-server... (logs: {})",
+        "⏳ Starting llama-server on :{http_port}... (logs: {})",
         llama_log.display()
     );
     let log_file = std::fs::File::create(&llama_log).with_context(|| {
@@ -1407,7 +1407,7 @@ pub async fn start_llama_server(
                 ),
                 runtime_dir: runtime.dir().to_path_buf(),
             };
-            let pidfile_guard = runtime.write_pidfile("llama-server", &metadata)?;
+            let pidfile_guard = runtime.write_pidfile(&format!("llama-server-{}", http_port), &metadata)?;
             let expected_exit = Arc::new(AtomicBool::new(false));
             let handle = InferenceServerHandle {
                 pid,
@@ -1417,7 +1417,7 @@ pub async fn start_llama_server(
                 _pidfile_guard: Some(pidfile_guard),
             };
             let (death_tx, death_rx) = tokio::sync::oneshot::channel();
-            let pidfile_path = runtime.pidfile_path("llama-server");
+            let pidfile_path = runtime.pidfile_path(&format!("llama-server-{}", http_port));
             tokio::spawn(async move {
                 let _ = child.wait().await;
                 let _ = std::fs::remove_file(&pidfile_path);

--- a/mesh-llm/src/runtime/instance.rs
+++ b/mesh-llm/src/runtime/instance.rs
@@ -14,7 +14,7 @@
 //! - `lock` — `flock(2)` advisory lock file held by the owning mesh-llm
 //! - `owner.json` — metadata about the owning instance (pid, version, api_port, started_at)
 //! - `pidfiles/` — JSON pidfiles for child processes (`llama-server.json`, `rpc-server-{port}.json`)
-//! - `logs/` — stdout/stderr logs for each child (`llama-server.log`, `rpc-server-{port}.log`)
+//! - `logs/` — stdout/stderr logs for each child (`llama-server-{port}.log`, `rpc-server-{port}.log`)
 //!
 //! **FORBIDDEN** under `runtime_dir/`:
 //! - Application state, configuration, or catalog caches (live elsewhere under `~/.mesh-llm/`)


### PR DESCRIPTION
When running two models locally on dual GPUs, I noticed one server's logs would overwrite the others, so I split these output destinations by port.

<img width="937" height="195" alt="image" src="https://github.com/user-attachments/assets/8c599819-4b78-4fbb-949a-948f31fdf73a" />
