### PR TITLE
feature(ui-playground): add a UI playground and components

### DIFF
--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -610,6 +610,9 @@ export function App() {
         : filteredCommandBarModels.length === 0
           ? "No models match the current filters."
           : "No models match this search.";
+  const showPlayground = import.meta.env.DEV && section === "playground";
+  const showDashboard =
+    section === "dashboard" || (!import.meta.env.DEV && section === "playground");
   const modelCommandBarFilterBar = (
     <ModelCommandBarFilterBar
       capabilityFilters={modelCapabilityFilters}
@@ -699,7 +702,7 @@ export function App() {
                 </div>
               ) : null}
 
-              {section === "dashboard" ? (
+              {showDashboard ? (
                 <div className="min-h-0 flex-1 overflow-y-auto">
                   <div className="mx-auto w-full max-w-7xl p-4">
                     <DashboardPage
@@ -718,7 +721,7 @@ export function App() {
                 </div>
               ) : null}
 
-              {import.meta.env.DEV && section === "playground" ? (
+              {showPlayground ? (
                 <Suspense
                   fallback={
                     <div className="flex min-h-0 items-center justify-center p-8 text-muted-foreground">

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -1,13 +1,5 @@
-import {
-  Brain,
-  Boxes,
-  Cpu,
-  ImagePlus,
-  Network,
-  Sparkles,
-  Volume2,
-} from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Brain, Boxes, Cpu, ImagePlus, Network, Sparkles, Volume2 } from "lucide-react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState } from "react";
 
 import { Badge } from "./components/ui/badge";
 import {
@@ -61,6 +53,22 @@ import { cn } from "./lib/utils";
 import type { TopologyNode } from "./features/app-shell/lib/topology-types";
 import githubBlackLogo from "./assets/icons/github-invertocat-black.svg";
 import githubWhiteLogo from "./assets/icons/github-invertocat-white.svg";
+
+// Playground is dev-only. We conditionally create the lazy component based on import.meta.env.DEV
+// so Vite can completely exclude it from production builds (true tree-shaking).
+// In dev: creates lazy component for code-splitting + HMR
+// In prod: returns null immediately, zero bundle impact
+// CRITICAL: Must memoize at module scope to avoid creating new component type on every render
+const LazyPlaygroundPage = import.meta.env.DEV
+  ? lazy(() => import("./features/app-shell/playground/components/PlaygroundPage"))
+  : null;
+
+const DevOnlyPlayground = () => {
+  if (!LazyPlaygroundPage) {
+    return null; // Production: should never render
+  }
+  return <LazyPlaygroundPage />;
+};
 
 export {
   attachmentForMessage,
@@ -708,6 +716,18 @@ export function App() {
                     />
                   </div>
                 </div>
+              ) : null}
+
+              {import.meta.env.DEV && section === "playground" ? (
+                <Suspense
+                  fallback={
+                    <div className="flex min-h-0 items-center justify-center p-8 text-muted-foreground">
+                      Loading playground...
+                    </div>
+                  }
+                >
+                  <DevOnlyPlayground />
+                </Suspense>
               ) : null}
             </main>
             <footer

--- a/mesh-llm/ui/src/components/ErrorBoundary.tsx
+++ b/mesh-llm/ui/src/components/ErrorBoundary.tsx
@@ -1,0 +1,60 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+
+export class ErrorBoundary extends Component<{
+  children: ReactNode;
+  fallback?: ReactNode;
+}, {
+  hasError: boolean;
+  error: Error | null;
+}> {
+  constructor(props: { children: ReactNode; fallback?: ReactNode }) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): { hasError: true; error: Error } {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("❌ ERROR BOUNDARY CAUGHT:", error);
+    console.error("Error info:", errorInfo);
+    console.error("Component stack:", errorInfo.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="min-h-screen bg-destructive/10 p-8 text-destructive">
+          <div className="mx-auto max-w-2xl rounded-lg border border-destructive/50 bg-card p-6">
+            <h1 className="mb-4 text-2xl font-bold">Application Error</h1>
+            <pre className="whitespace-pre-wrap rounded bg-black/50 p-4 text-sm text-foreground">
+              {this.state.error?.message}
+            </pre>
+            {this.state.error?.stack && (
+              <details className="mt-4">
+                <summary className="cursor-pointer text-sm underline">Stack trace</summary>
+                <pre className="mt-2 overflow-auto whitespace-pre-wrap rounded bg-black/50 p-4 text-xs">
+                  {this.state.error.stack}
+                </pre>
+              </details>
+            )}
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-4 rounded bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
+            >
+              Reload Page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/mesh-llm/ui/src/components/ui/alert.tsx
+++ b/mesh-llm/ui/src/components/ui/alert.tsx
@@ -4,20 +4,23 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../lib/utils';
 
 const alertVariants = cva(
-  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-2px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
-  {
-    variants: {
-      variant: {
-        default: 'bg-background text-foreground',
-        destructive:
-          'border-destructive/50 bg-destructive/10 text-destructive [&>svg]:text-destructive dark:border-destructive/70 dark:bg-destructive/20 dark:text-red-100 dark:[&>svg]:text-red-200',
+    'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-2px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+    {
+      variants: {
+        variant: {
+          default: 'bg-background text-foreground',
+          primary: 'border-primary/20 bg-primary/5 text-foreground [&>svg]:text-primary',
+          amber: 'border-amber-500/30 bg-amber-500/5 text-foreground [&>svg]:text-amber-500',
+          blue: 'border-blue-500/30 bg-blue-500/5 text-foreground [&>svg]:text-blue-500',
+          destructive:
+            'border-destructive/50 bg-destructive/10 text-destructive [&>svg]:text-destructive dark:border-destructive/70 dark:bg-destructive/20 dark:text-red-100 dark:[&>svg]:text-red-200',
+        },
+      },
+      defaultVariants: {
+        variant: 'default',
       },
     },
-    defaultVariants: {
-      variant: 'default',
-    },
-  },
-);
+  );
 
 const Alert = React.forwardRef<
   HTMLDivElement,

--- a/mesh-llm/ui/src/features/app-shell/components/AppHeader.tsx
+++ b/mesh-llm/ui/src/features/app-shell/components/AppHeader.tsx
@@ -181,22 +181,35 @@ export function AppHeader({
           </NavigationMenuList>
         </NavigationMenu>
         <div className="ml-auto flex items-center gap-2">
+           {import.meta.env.DEV && (
+             <Button
+               variant="secondary"
+               size="sm"
+               onClick={(event) => {
+                 event.preventDefault();
+                 setSection("playground");
+               }}
+               className="h-8 text-xs"
+             >
+               Playground
+             </Button>
+           )}
            <Popover>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <PopoverTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="icon"
-                    aria-label="API access"
-                  >
-                    <Braces className="h-4 w-4" />
-                  </Button>
-                </PopoverTrigger>
-              </TooltipTrigger>
-              <TooltipContent>API</TooltipContent>
-            </Tooltip>
+             <Tooltip>
+               <TooltipTrigger asChild>
+                 <PopoverTrigger asChild>
+                   <Button
+                     type="button"
+                     variant="outline"
+                     size="icon"
+                     aria-label="API access"
+                   >
+                     <Braces className="h-4 w-4" />
+                   </Button>
+                 </PopoverTrigger>
+               </TooltipTrigger>
+               <TooltipContent>API</TooltipContent>
+             </Tooltip>
             <PopoverContent
               className="w-[calc(100vw-2rem)] max-w-[420px] space-y-3"
               align="end"

--- a/mesh-llm/ui/src/features/app-shell/hooks/useAppRouting.ts
+++ b/mesh-llm/ui/src/features/app-shell/hooks/useAppRouting.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import {
+  normalizeSection,
   pushRoute,
   readRouteFromLocation,
   replaceRoute,
@@ -38,10 +39,11 @@ export function useAppRouting() {
 
   const navigateToSection = useCallback(
     (next: TopSection, activeConversationId: string | null) => {
-      if (next === section) return;
-      const nextChatId = next === "chat" ? activeConversationId : null;
-      pushRoute({ section: next, chatId: nextChatId });
-      setSection(next);
+      const normalizedSection = normalizeSection(next);
+      if (normalizedSection === section) return;
+      const nextChatId = normalizedSection === "chat" ? activeConversationId : null;
+      pushRoute({ section: normalizedSection, chatId: nextChatId });
+      setSection(normalizedSection);
       setRoutedChatId(nextChatId);
     },
     [section],

--- a/mesh-llm/ui/src/features/app-shell/lib/routes.test.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/routes.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  normalizeSection,
+  pathnameForRoute,
+  readRouteFromLocation,
+  sectionFromPathname,
+} from "./routes";
+
+function setPath(path: string) {
+  window.history.replaceState({}, "", path);
+}
+
+afterEach(() => {
+  setPath("/");
+});
+
+describe("routes playground gating", () => {
+  it("treats /playground as a first-class route in dev", () => {
+    setPath("/playground");
+
+    expect(sectionFromPathname("/playground", true)).toBe("playground");
+    expect(readRouteFromLocation(true)).toEqual({ section: "playground", chatId: null });
+    expect(pathnameForRoute({ section: "playground", chatId: null }, true)).toBe("/playground");
+  });
+
+  it("normalizes /playground to dashboard in production", () => {
+    setPath("/playground");
+
+    expect(normalizeSection("playground", false)).toBe("dashboard");
+    expect(sectionFromPathname("/playground", false)).toBeNull();
+    expect(readRouteFromLocation(false)).toEqual({ section: "dashboard", chatId: null });
+    expect(pathnameForRoute({ section: "playground", chatId: null }, false)).toBe("/dashboard");
+  });
+});

--- a/mesh-llm/ui/src/features/app-shell/lib/routes.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/routes.ts
@@ -5,7 +5,28 @@ export type AppRoute = {
   chatId: string | null;
 };
 
-export function sectionFromPathname(pathname: string): TopSection | null {
+export function normalizeSection(
+  section: TopSection,
+  allowPlayground = import.meta.env.DEV,
+): TopSection {
+  if (!allowPlayground && section === "playground") {
+    return "dashboard";
+  }
+  return section;
+}
+
+function normalizeRoute(route: AppRoute, allowPlayground = import.meta.env.DEV): AppRoute {
+  const section = normalizeSection(route.section, allowPlayground);
+  if (section !== route.section) {
+    return { section, chatId: null };
+  }
+  return route;
+}
+
+export function sectionFromPathname(
+  pathname: string,
+  allowPlayground = import.meta.env.DEV,
+): TopSection | null {
   if (pathname === "/dashboard" || pathname === "/dashboard/") {
     return "dashboard";
   }
@@ -16,13 +37,13 @@ export function sectionFromPathname(pathname: string): TopSection | null {
   ) {
     return "chat";
   }
-  if (pathname === "/playground" || pathname === "/playground/") {
+  if (allowPlayground && (pathname === "/playground" || pathname === "/playground/")) {
     return "playground";
   }
   return null;
 }
 
-export function readRouteFromLocation(): AppRoute {
+export function readRouteFromLocation(allowPlayground = import.meta.env.DEV): AppRoute {
   if (typeof window === "undefined") {
     return { section: "dashboard", chatId: null };
   }
@@ -39,21 +60,26 @@ export function readRouteFromLocation(): AppRoute {
     const chatId = raw ? decodeURIComponent(raw.split("/")[0]) : null;
     return { section: "chat", chatId };
   }
-  if (pathname === "/playground" || pathname === "/playground/") {
+  if (allowPlayground && (pathname === "/playground" || pathname === "/playground/")) {
     return { section: "playground", chatId: null };
   }
 
   return { section: "dashboard", chatId: null };
 }
 
-export function pathnameForRoute(route: AppRoute): string {
-  if (route.section === "dashboard") {
+export function pathnameForRoute(
+  route: AppRoute,
+  allowPlayground = import.meta.env.DEV,
+): string {
+  const normalizedRoute = normalizeRoute(route, allowPlayground);
+
+  if (normalizedRoute.section === "dashboard") {
     return "/dashboard";
   }
-  if (route.section === "playground") {
+  if (normalizedRoute.section === "playground") {
     return "/playground";
   }
-  return route.chatId ? `/chat/${encodeURIComponent(route.chatId)}` : "/chat";
+  return normalizedRoute.chatId ? `/chat/${encodeURIComponent(normalizedRoute.chatId)}` : "/chat";
 }
 
 export function pushRoute(route: AppRoute) {

--- a/mesh-llm/ui/src/features/app-shell/lib/routes.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/routes.ts
@@ -1,4 +1,4 @@
-export type TopSection = "dashboard" | "chat";
+export type TopSection = "dashboard" | "chat" | "playground";
 
 export type AppRoute = {
   section: TopSection;
@@ -15,6 +15,9 @@ export function sectionFromPathname(pathname: string): TopSection | null {
     pathname.startsWith("/chat/")
   ) {
     return "chat";
+  }
+  if (pathname === "/playground" || pathname === "/playground/") {
+    return "playground";
   }
   return null;
 }
@@ -36,6 +39,9 @@ export function readRouteFromLocation(): AppRoute {
     const chatId = raw ? decodeURIComponent(raw.split("/")[0]) : null;
     return { section: "chat", chatId };
   }
+  if (pathname === "/playground" || pathname === "/playground/") {
+    return { section: "playground", chatId: null };
+  }
 
   return { section: "dashboard", chatId: null };
 }
@@ -43,6 +49,9 @@ export function readRouteFromLocation(): AppRoute {
 export function pathnameForRoute(route: AppRoute): string {
   if (route.section === "dashboard") {
     return "/dashboard";
+  }
+  if (route.section === "playground") {
+    return "/playground";
   }
   return route.chatId ? `/chat/${encodeURIComponent(route.chatId)}` : "/chat";
 }

--- a/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
@@ -49,20 +49,15 @@ describe("live node state helpers", () => {
     }
   });
 
-  it("rejects legacy live-state labels from formatter, tone, and tooltip paths", () => {
-    const legacyLabels = ["Idle", "Assigned", "Host", "Serving (split)", "Worker (split)"];
-
-    for (const label of legacyLabels) {
-      expect(() => formatLiveNodeState(label as LiveNodeState)).toThrow(
-        `Unsupported live node state: ${label}`,
-      );
-      expect(() => topologyStatusTone(label as LiveNodeState)).toThrow(
-        `Unsupported live node state: ${label}`,
-      );
-      expect(() => topologyStatusTooltip(label as LiveNodeState)).toThrow(
-        `Unsupported live node state: ${label}`,
-      );
-    }
+  it("handles invalid states gracefully without throwing", () => {
+    expect(formatLiveNodeState(undefined as any)).toBe("Unknown");
+    expect(formatLiveNodeState(null as any)).toBe("Unknown");
+    
+    expect(topologyStatusTone(undefined as any)).toBe("neutral");
+    expect(topologyStatusTone(null as any)).toBe("neutral");
+    
+    expect(topologyStatusTooltip(undefined as any)).toBe("Node state unavailable");
+    expect(topologyStatusTooltip(null as any)).toBe("Node state unavailable");
   });
 
   it("uses node_state as the local routable-model source of truth", () => {

--- a/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
@@ -48,15 +48,18 @@ export function overviewVramGb(isClient: boolean, vramGb?: number | null) {
   return Math.max(0, vramGb || 0);
 }
 
-function assertLiveNodeState(state: LiveNodeState): LiveNodeState {
-  if (!(state in LIVE_NODE_STATE_LABELS)) {
-    throw new Error(`Unsupported live node state: ${state}`);
+function assertLiveNodeState(state: LiveNodeState | undefined | null): LiveNodeState | null {
+  if (!state || !(state in LIVE_NODE_STATE_LABELS)) {
+    console.warn("Invalid or missing live node state:", state);
+    return null;
   }
   return state;
 }
 
-export function formatLiveNodeState(state: LiveNodeState): string {
-  return LIVE_NODE_STATE_LABELS[assertLiveNodeState(state)];
+export function formatLiveNodeState(state: LiveNodeState | undefined | null): string {
+  const validated = assertLiveNodeState(state);
+  if (!validated) return "Unknown";
+  return LIVE_NODE_STATE_LABELS[validated];
 }
 
 export function meshGpuVram(status: StatusPayload | null) {
@@ -116,9 +119,11 @@ export function formatLatency(value?: number | null) {
 }
 
 export function topologyStatusTone(
-  state: LiveNodeState,
+  state: LiveNodeState | undefined | null,
 ): "good" | "info" | "warn" | "bad" | "neutral" {
-  switch (assertLiveNodeState(state)) {
+  const validated = assertLiveNodeState(state);
+  if (!validated) return "neutral";
+  switch (validated) {
     case "serving":
       return "good";
     case "client":
@@ -130,8 +135,10 @@ export function topologyStatusTone(
   }
 }
 
-export function topologyStatusTooltip(state: LiveNodeState) {
-  switch (assertLiveNodeState(state)) {
+export function topologyStatusTooltip(state: LiveNodeState | undefined | null): string {
+  const validated = assertLiveNodeState(state);
+  if (!validated) return "Node state unavailable";
+  switch (validated) {
     case "serving":
       return "Actively serving a model.";
     case "loading":

--- a/mesh-llm/ui/src/features/app-shell/playground/components/PlaygroundBaseUI.tsx
+++ b/mesh-llm/ui/src/features/app-shell/playground/components/PlaygroundBaseUI.tsx
@@ -1,0 +1,379 @@
+import { useState } from "react";
+import { AlertCircle, Bell, AlertTriangle } from "lucide-react";
+import { Button, type ButtonProps } from "../../../../components/ui/button";
+import { Input } from "../../../../components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "../../../../components/ui/dialog";
+import { Badge } from "../../../../components/ui/badge";
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from "../../../../components/ui/toggle-group";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "../../../../components/ui/alert";
+
+type ButtonVariant = NonNullable<ButtonProps["variant"]>;
+type ButtonSize = NonNullable<ButtonProps["size"]>;
+
+const buttonVariants: ButtonVariant[] = [
+  "default",
+  "secondary",
+  "outline",
+  "destructive",
+];
+const buttonSizes: ButtonSize[] = ["sm", "default", "lg"];
+
+function PreviewCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border bg-card p-4 space-y-3">
+      <h3 className="font-medium text-sm">{title}</h3>
+      {children}
+    </div>
+  );
+}
+
+function ButtonPreview() {
+  const [variant, setVariant] = useState<ButtonVariant>("default");
+  const [size, setSize] = useState<ButtonSize>("default");
+  const [disabled, setDisabled] = useState(false);
+
+  return (
+    <PreviewCard title="Button">
+      <div className="flex items-center gap-2">
+        <Button variant={variant} size={size} disabled={disabled}>
+          Preview
+        </Button>
+      </div>
+
+      <div className="space-y-2">
+        <span className="block text-xs text-muted-foreground font-medium">
+          Variant
+        </span>
+        <ToggleGroup
+          type="single"
+          value={variant}
+          onValueChange={(v: string) => v && setVariant(v as ButtonVariant)}
+        >
+          {buttonVariants.map((v) => (
+            <ToggleGroupItem key={v} value={v} aria-label={v}>
+              {v}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+
+        <span className="block text-xs text-muted-foreground font-medium">
+          Size
+        </span>
+        <ToggleGroup
+          type="single"
+          value={size}
+          onValueChange={(v: string) => v && setSize(v as ButtonSize)}
+        >
+          {buttonSizes.map((s) => (
+            <ToggleGroupItem key={s} value={s} aria-label={s}>
+              {s}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+
+        <label className="flex items-center gap-2 text-sm cursor-pointer select-none">
+          Disabled
+          <input
+            type="checkbox"
+            checked={disabled}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setDisabled(e.target.checked)
+            }
+            className="h-4 w-4 rounded border-border accent-primary ml-auto"
+          />
+        </label>
+      </div>
+    </PreviewCard>
+  );
+}
+
+function InputPreview() {
+  const [placeholder, setPlaceholder] = useState("Enter some text…");
+  const [type, setType] = useState<"text" | "email" | "password">("text");
+  const [disabled, setDisabled] = useState(false);
+
+  return (
+    <PreviewCard title="Input">
+      <Input type={type} placeholder={placeholder} disabled={disabled} />
+
+      <div className="space-y-2">
+        <span className="block text-xs text-muted-foreground font-medium">
+          Type
+        </span>
+        <ToggleGroup
+          type="single"
+          value={type}
+          onValueChange={(v: string) =>
+            v && setType(v as "text" | "email" | "password")
+          }
+        >
+          {(["text", "email", "password"] as const).map((t) => (
+            <ToggleGroupItem key={t} value={t} aria-label={t}>
+              {t}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+
+      <div className="space-y-1.5">
+        <label
+          htmlFor="input-placeholder"
+          className="text-xs text-muted-foreground font-medium"
+        >
+          Placeholder
+        </label>
+        <Input
+          id="input-placeholder"
+          value={placeholder}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setPlaceholder(e.target.value)
+          }
+          className="h-8 text-xs"
+        />
+      </div>
+
+      <label className="flex items-center gap-2 text-sm cursor-pointer select-none">
+        <input
+          type="checkbox"
+          checked={disabled}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setDisabled(e.target.checked)
+          }
+          className="h-4 w-4 rounded border-border accent-primary"
+        />
+        Disabled
+      </label>
+    </PreviewCard>
+  );
+}
+
+function DialogPreview() {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("Dialog Title");
+  const [description, setDescription] = useState(
+    "A short description of this dialog.",
+  );
+
+  return (
+    <>
+      <PreviewCard title="Dialog">
+        <Button variant="outline" onClick={() => setOpen(true)}>
+          Open Dialog
+        </Button>
+
+        <div className="space-y-2">
+          <label
+            htmlFor="dialog-title"
+            className="text-xs text-muted-foreground font-medium"
+          >
+            Title
+          </label>
+          <Input
+            id="dialog-title"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setTitle(e.target.value)
+            }
+            className="h-8 text-xs"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="dialog-desc"
+            className="text-xs text-muted-foreground font-medium"
+          >
+            Description
+          </label>
+          <Input
+            id="dialog-desc"
+            value={description}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setDescription(e.target.value)
+            }
+            className="h-8 text-xs"
+          />
+        </div>
+      </PreviewCard>
+
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <div className="space-y-1.5 pb-2">
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{description}</DialogDescription>
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={() => setOpen(false)}>Confirm</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+type BadgeVariant = "default" | "secondary" | "outline";
+
+const badgeVariantStyles: Record<BadgeVariant, string> = {
+  default: "",
+  secondary: "bg-secondary text-secondary-foreground",
+  outline: "border-transparent bg-primary/10 text-primary",
+};
+
+function BadgePreview() {
+  const [variant, setVariant] = useState<BadgeVariant>("default");
+  const [label, setLabel] = useState("Badge");
+
+  return (
+    <PreviewCard title="Badge">
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-flex items-center rounded-full border border-border/70 px-2.5 py-1 text-xs font-medium ${badgeVariantStyles[variant]}`}
+        >
+          {label || "(empty)"}
+        </span>
+      </div>
+
+      <div className="space-y-2">
+        <span className="block text-xs text-muted-foreground font-medium">
+          Variant
+        </span>
+        <ToggleGroup
+          type="single"
+          value={variant}
+          onValueChange={(v: string) => v && setVariant(v as BadgeVariant)}
+        >
+          {(["default", "secondary", "outline"] as const).map((v) => (
+            <ToggleGroupItem key={v} value={v} aria-label={v}>
+              {v}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+
+        <span className="block text-xs text-muted-foreground font-medium">
+          Label
+        </span>
+        <Input
+          id="badge-label"
+          value={label}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            setLabel(e.target.value)
+          }
+          className="h-8 text-xs"
+        />
+      </div>
+    </PreviewCard>
+  );
+}
+
+function AlertPreview() {
+  const [variant, setVariant] = useState<
+    "default" | "primary" | "amber" | "destructive"
+  >("primary");
+  const [title, setTitle] = useState("Welcome to the public mesh");
+  const [description, setDescription] = useState(
+    "Mesh LLM is a project to let people contribute spare compute.",
+  );
+
+  return (
+    <PreviewCard title="Alert / Banner">
+      <Alert variant={variant}>
+        {variant === "destructive" ? (
+          <AlertCircle className="h-4 w-4" />
+        ) : variant === "amber" ? (
+          <AlertTriangle className="h-4 w-4" />
+        ) : (
+          <Bell className="h-4 w-4" />
+        )}
+        <AlertTitle>{title || "(empty)"}</AlertTitle>
+        <AlertDescription>{description || "(no description)"}</AlertDescription>
+      </Alert>
+
+      <div className="space-y-2">
+        <span className="block text-xs text-muted-foreground font-medium">
+          Variant
+        </span>
+        <ToggleGroup
+          type="single"
+          value={variant}
+          onValueChange={(v: string) =>
+            v &&
+            setVariant(v as "default" | "primary" | "amber" | "destructive")
+          }
+        >
+          {(["primary", "amber", "destructive"] as const).map((v) => (
+            <ToggleGroupItem key={v} value={v} aria-label={v}>
+              {v}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="alert-title"
+            className="text-xs text-muted-foreground font-medium"
+          >
+            Title
+          </label>
+          <Input
+            id="alert-title"
+            value={title}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setTitle(e.target.value)
+            }
+            className="h-8 text-xs"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <label
+            htmlFor="alert-desc"
+            className="text-xs text-muted-foreground font-medium"
+          >
+            Description
+          </label>
+          <Input
+            id="alert-desc"
+            value={description}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setDescription(e.target.value)
+            }
+            className="h-8 text-xs"
+          />
+        </div>
+      </div>
+    </PreviewCard>
+  );
+}
+
+export default function PlaygroundBaseUI() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 overflow-auto p-1">
+      <ButtonPreview />
+      <InputPreview />
+      <DialogPreview />
+      <BadgePreview />
+      <AlertPreview />
+    </div>
+  );
+}

--- a/mesh-llm/ui/src/features/app-shell/playground/components/PlaygroundCards.tsx
+++ b/mesh-llm/ui/src/features/app-shell/playground/components/PlaygroundCards.tsx
@@ -1,0 +1,159 @@
+import { useState } from "react";
+
+import { ModelCard } from "../../../dashboard/components/details";
+import { Input } from "../../../../components/ui/input";
+
+type ModelStatus = "warm" | "cold" | "loading";
+import { ToggleGroup, ToggleGroupItem } from "../../../../components/ui/toggle-group";
+
+const modelDisplayNames: Record<string, string> = {
+  "llama-3.2-1b": "Llama 3.2 1B",
+  "gemma-2-2b": "Gemma 2 2B",
+};
+
+function ModelPreview() {
+  const [modelName, setModelName] = useState("llama-3.2-1b");
+  const [subtitle, setSubtitle] = useState("");
+  const [sizeGb, setSizeGb] = useState(1.2);
+  const [nodeCount, setNodeCount] = useState(1);
+  const [status, setStatus] = useState<ModelStatus>("warm");
+  const [vision, setVision] = useState(false);
+  const [reasoning, setReasoning] = useState(false);
+  const [moe, setMoe] = useState(false);
+
+  const cardWidth = "w-[380px]";
+
+  return (
+    <div className="space-y-2">
+      <div className={`${cardWidth} mx-auto`}>
+        <ModelCard
+          name={modelName}
+          displayName={modelDisplayNames[modelName]}
+          subtitle={subtitle || undefined}
+          sizeGb={sizeGb}
+          nodeCount={nodeCount}
+          status={status}
+          vision={vision}
+          reasoning={reasoning}
+          moe={moe}
+        />
+      </div>
+
+      <hr className="my-2" />
+
+      <div className="space-y-3">
+<div className="space-y-1.5">
+            <label htmlFor="model-name-input" className="text-xs text-muted-foreground font-medium block">
+              Model Name
+            </label>
+            <Input
+              id="model-name-input"
+              value={modelName}
+              onChange={(e) => setModelName(e.target.value)}
+              className="h-8 text-xs"
+              placeholder="llama-3.2-1b"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="subtitle-input" className="text-xs text-muted-foreground font-medium block">
+              Subtitle (optional)
+            </label>
+            <Input
+              id="subtitle-input"
+              value={subtitle}
+              onChange={(e) => setSubtitle(e.target.value)}
+              className="h-8 text-xs"
+              placeholder="Custom subtitle or leave empty for model name"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+          <div className="space-y-1">
+            <label htmlFor="model-size" className="text-xs text-muted-foreground font-medium block">
+              Size (GB)
+            </label>
+            <Input
+              id="model-size"
+              type="number"
+              step="0.1"
+              value={sizeGb}
+              onChange={(e) => setSizeGb(Number(e.target.value))}
+              className="h-8 text-xs"
+            />
+          </div>
+          <div className="space-y-1">
+            <label htmlFor="node-count" className="text-xs text-muted-foreground font-medium block">
+              Node Count
+            </label>
+            <Input
+              id="node-count"
+              type="number"
+              value={nodeCount}
+              onChange={(e) => setNodeCount(Math.max(1, Number(e.target.value)))}
+              className="h-8 text-xs"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-1.5">
+          <span className="text-xs text-muted-foreground font-medium block">Status</span>
+          <ToggleGroup
+            type="single"
+            value={status}
+            onValueChange={(v: string) => v && setStatus(v as ModelStatus)}
+            className="grid grid-cols-3 w-full"
+          >
+            <ToggleGroupItem value="warm" className="text-xs h-7">
+              Warm
+            </ToggleGroupItem>
+            <ToggleGroupItem value="cold" className="text-xs h-7">
+              Cold
+            </ToggleGroupItem>
+            <ToggleGroupItem value="loading" className="text-xs h-7">
+              Loading
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={vision}
+              onChange={(e) => setVision(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-primary"
+            />
+            Vision 👁
+          </label>
+          <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={reasoning}
+              onChange={(e) => setReasoning(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-primary"
+            />
+            Reasoning 🧠
+          </label>
+          <label className="flex items-center gap-2 text-xs cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={moe}
+              onChange={(e) => setMoe(e.target.checked)}
+              className="h-3.5 w-3.5 rounded border-border accent-primary"
+            />
+            MoE 🧩
+          </label>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function PlaygroundCards() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6 overflow-auto p-1">
+      <ModelPreview />
+    </div>
+  );
+}

--- a/mesh-llm/ui/src/features/app-shell/playground/components/PlaygroundPage.tsx
+++ b/mesh-llm/ui/src/features/app-shell/playground/components/PlaygroundPage.tsx
@@ -1,0 +1,51 @@
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../../../../components/ui/tabs";
+
+type PlaygroundPageProps = Record<string, unknown>;
+
+import PlaygroundBaseUI from "./PlaygroundBaseUI";
+import PlaygroundCards from "./PlaygroundCards";
+
+export default function PlaygroundPage(_props: PlaygroundPageProps) {
+  if (!import.meta.env.DEV) {
+    return null;
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden p-4 md:p-6">
+      <div className="mb-4 shrink-0 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-3 py-2 text-sm text-yellow-700 dark:text-yellow-300">
+        🔬 Developer Playground — UI testing environment (dev builds only)
+      </div>
+
+      <Tabs defaultValue="base-ui" className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <TabsList className="mb-2 w-auto shrink-0" aria-label="Playground tabs">
+          <TabsTrigger value="base-ui" id="tab-base-ui" aria-controls="tabpanel-base-ui">
+            Base UI
+          </TabsTrigger>
+          <TabsTrigger value="cards" id="tab-cards" aria-controls="tabpanel-cards">
+            Cards
+          </TabsTrigger>
+        </TabsList>
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <TabsContent
+            value="base-ui"
+            id="tabpanel-base-ui"
+            aria-labelledby="tab-base-ui"
+            className="mt-0 h-full flex-1"
+          >
+            <PlaygroundBaseUI />
+          </TabsContent>
+
+          <TabsContent
+            value="cards"
+            id="tabpanel-cards"
+            aria-labelledby="tab-cards"
+            className="mt-0 h-full flex-1"
+          >
+            <PlaygroundCards />
+          </TabsContent>
+        </div>
+      </Tabs>
+    </div>
+  );
+}

--- a/mesh-llm/ui/src/features/app-shell/playground/components/index.ts
+++ b/mesh-llm/ui/src/features/app-shell/playground/components/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PlaygroundPage";

--- a/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
+++ b/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
@@ -24,6 +24,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "../../../components/ui/alert";
 import { Button } from "../../../components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "../../../components/ui/card";
+import { ModelCard } from "./details";
 import { ScrollArea } from "../../../components/ui/scroll-area";
 import {
   Select,
@@ -338,7 +339,7 @@ export function DashboardPage({
 
   return (
     <div className="space-y-4">
-      <Alert className="border-primary/20 bg-primary/5">
+      <Alert variant="primary">
         <Network className="h-4 w-4" />
         <AlertTitle className="text-sm font-medium">
           {isPublicMesh ? "Welcome to the public mesh" : "Your private mesh"}
@@ -367,10 +368,7 @@ export function DashboardPage({
         </AlertDescription>
       </Alert>
       {distinctMeshVersions.size >= 2 && (
-        <Alert
-          data-testid="mixed-version-banner"
-          className="border-amber-500/30 bg-amber-500/5"
-        >
+        <Alert data-testid="mixed-version-banner" variant="amber">
           <AlertTriangle className="h-4 w-4" />
           <AlertTitle className="text-sm font-medium">Mesh has mixed versions</AlertTitle>
           <AlertDescription className="text-xs text-muted-foreground">
@@ -380,10 +378,7 @@ export function DashboardPage({
         </Alert>
       )}
       {(status?.local_instances?.length ?? 0) >= 2 && (
-        <Alert
-          data-testid="multi-instance-banner"
-          className="border-blue-500/30 bg-blue-500/5"
-        >
+        <Alert data-testid="multi-instance-banner" variant="blue">
           <Info className="h-4 w-4" />
           <AlertTitle className="text-sm font-medium">
             Multiple mesh-llm instances on this host
@@ -533,76 +528,18 @@ export function DashboardPage({
               <div className="h-[360px] overflow-y-auto pr-2 md:h-[420px] lg:h-[460px] xl:h-[520px]">
                 <div className="space-y-2">
                   {filteredModels.map((model) => (
-                    <button
+                    <ModelCard
                       key={model.name}
-                      type="button"
+                      name={model.name}
+                      displayName={modelDisplayName(model)}
+                      sizeGb={model.size_gb}
+                      nodeCount={model.node_count}
+                      status={model.status}
+                      vision={model.vision}
+                      reasoning={model.reasoning}
+                      moe={model.moe}
                       onClick={() => openModelDetail(model.name)}
-                      className="block w-full rounded-md border p-3 text-left transition-colors hover:border-primary/35 hover:bg-muted/30"
-                    >
-                      <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-start">
-                        <div className="flex h-7 w-7 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
-                          <Sparkles className="h-3.5 w-3.5" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                          <div className="flex flex-wrap items-center gap-2">
-                            <div className="text-sm font-medium leading-5 [overflow-wrap:anywhere]">
-                              {shortName(modelDisplayName(model))}
-                            </div>
-                            <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
-                              {model.vision ? (
-                                <span role="img" aria-label="Vision">
-                                  👁
-                                </span>
-                              ) : null}
-                              {model.reasoning ? (
-                                <span role="img" aria-label="Reasoning">
-                                  🧠
-                                </span>
-                              ) : null}
-                              {model.moe ? (
-                                <span role="img" aria-label="Mixture of Experts">
-                                  🧩
-                                </span>
-                              ) : null}
-                            </div>
-                          </div>
-                          <div className="text-xs leading-4 text-muted-foreground [overflow-wrap:anywhere]">
-                            {model.name}
-                          </div>
-                        </div>
-                        <StatusPill
-                          className="self-start"
-                          label={
-                            model.status === "warm"
-                              ? "Warm"
-                              : model.status === "cold"
-                                ? "Cold"
-                                : model.status
-                          }
-                          tone={
-                            model.status === "warm"
-                              ? "warm"
-                              : model.status === "cold"
-                                ? "cold"
-                                : "neutral"
-                          }
-                          dot
-                        />
-                      </div>
-                      <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
-                        <span>
-                          {model.node_count} node{model.node_count === 1 ? "" : "s"}
-                        </span>
-                        <span className="flex items-center gap-2">
-                          {model.vision && (
-                            <span role="img" aria-label="Vision">
-                              👁
-                            </span>
-                          )}
-                          {model.size_gb.toFixed(1)} GB
-                        </span>
-                      </div>
-                    </button>
+                    />
                   ))}
                 </div>
               </div>

--- a/mesh-llm/ui/src/features/dashboard/components/details/ModelCard.tsx
+++ b/mesh-llm/ui/src/features/dashboard/components/details/ModelCard.tsx
@@ -1,0 +1,78 @@
+import { Sparkles } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Badge } from "../../../../components/ui/badge";
+import { StatusPill } from "./StatusPill";
+
+export type ModelStatus = "warm" | "cold" | "loading" | string;
+
+interface ModelCardProps {
+  name: string;
+  displayName?: string;
+  subtitle?: ReactNode;
+  sizeGb: number;
+  nodeCount: number;
+  status: ModelStatus;
+  vision?: boolean;
+  reasoning?: boolean;
+  moe?: boolean;
+  onClick?: () => void;
+}
+
+export function ModelCard({
+  name,
+  displayName,
+  subtitle,
+  sizeGb,
+  nodeCount,
+  status,
+  vision,
+  reasoning,
+  moe,
+  onClick,
+}: ModelCardProps) {
+  const shortName = (nameOrDisplay: string) => nameOrDisplay.split("/").pop() ?? nameOrDisplay;
+  const displayText = displayName ? shortName(displayName) : shortName(name);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="block w-full rounded-md border p-3 text-left transition-colors hover:border-primary/35 hover:bg-muted/30"
+    >
+      <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-start">
+        <div className="flex h-7 w-7 items-center justify-center rounded-md border bg-muted/40 text-muted-foreground">
+          <Sparkles className="h-3.5 w-3.5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="text-sm font-medium leading-5 [overflow-wrap:anywhere]">{displayText}</div>
+            <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+              {vision && <span role="img" aria-label="Vision">👁</span>}
+              {reasoning && <span role="img" aria-label="Reasoning">🧠</span>}
+              {moe && <span role="img" aria-label="Mixture of Experts">🧩</span>}
+            </div>
+          </div>
+          {subtitle ? (
+            <div className="text-xs leading-4 text-muted-foreground [overflow-wrap:anywhere]">{subtitle}</div>
+          ) : (
+            <div className="text-xs leading-4 text-muted-foreground [overflow-wrap:anywhere]">{name}</div>
+          )}
+        </div>
+        <StatusPill
+          className="self-start"
+          label={status === "warm" ? "Warm" : status === "cold" ? "Cold" : status}
+          tone={status === "warm" ? "warm" : status === "cold" ? "cold" : "neutral"}
+          dot
+        />
+      </div>
+      <div className="mt-2 flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+        <span>{nodeCount} node{nodeCount === 1 ? "" : "s"}</span>
+        <span className="flex items-center gap-2">
+          {vision && <span role="img" aria-label="Vision">👁</span>}
+          {sizeGb.toFixed(1)} GB
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/mesh-llm/ui/src/features/dashboard/components/details/index.ts
+++ b/mesh-llm/ui/src/features/dashboard/components/details/index.ts
@@ -2,6 +2,7 @@ export { CapabilityBadge } from "./CapabilityBadge";
 export { DashboardPanelEmpty } from "./DashboardPanelEmpty";
 export { EmptyPanel } from "./EmptyPanel";
 export { ModelFactCard } from "./ModelFactCard";
+export { ModelCard } from "./ModelCard";
 export { ModelSidebar } from "./ModelSidebar";
 export { ModelMetaItem } from "./ModelMetaItem";
 export { ModelMetaLinkItem } from "./ModelMetaLinkItem";

--- a/mesh-llm/ui/src/main.tsx
+++ b/mesh-llm/ui/src/main.tsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 import 'highlight.js/styles/github-dark.css';
 import './index.css';
 import { App } from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 type ThemeMode = 'auto' | 'light' | 'dark';
 
@@ -28,6 +29,8 @@ media.addEventListener('change', () => {
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
In #132, I'm breaking up the UI work into smaller, reviewable pieces. 

Part of this is to add it to a UI reviewers can examine:

<img width="846" height="1231" alt="Screenshot 2026-04-22 at 2 59 26 AM" src="https://github.com/user-attachments/assets/86c03bb1-dfda-4bd7-b975-93931817de3a" />
