### PR TITLE
fix(models): handle HF snapshot/ref mismatch in updates flow

### DIFF
--- a/mesh-client/src/models/gguf.rs
+++ b/mesh-client/src/models/gguf.rs
@@ -407,8 +407,8 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
         } else {
             meta.head_count
         };
-        if effective_kv > 0 {
-            meta.value_length = meta.embedding_size / effective_kv;
+        if let Some(value_length) = meta.embedding_size.checked_div(effective_kv) {
+            meta.value_length = value_length;
         }
     }
 

--- a/mesh-llm/src/models/maintenance.rs
+++ b/mesh-llm/src/models/maintenance.rs
@@ -405,14 +405,17 @@ fn cached_repo_files(repo: &CachedRepo) -> Result<Vec<String>> {
     }
 
     let mut snapshot_entries = Vec::new();
-    for entry in
-        std::fs::read_dir(&snapshots_dir).with_context(|| format!("Read {}", snapshots_dir.display()))?
+    for entry in std::fs::read_dir(&snapshots_dir)
+        .with_context(|| format!("Read {}", snapshots_dir.display()))?
     {
         let entry = entry?;
         if !entry.file_type()?.is_dir() {
             continue;
         }
-        snapshot_entries.push((entry.file_name().to_string_lossy().to_string(), entry.path()));
+        snapshot_entries.push((
+            entry.file_name().to_string_lossy().to_string(),
+            entry.path(),
+        ));
     }
 
     let mut snapshot_roots = Vec::new();

--- a/mesh-llm/src/models/maintenance.rs
+++ b/mesh-llm/src/models/maintenance.rs
@@ -1,4 +1,3 @@
-use super::local::huggingface_snapshot_path;
 use super::{build_hf_api, huggingface_hub_cache_dir, short_revision};
 use crate::cli::terminal_progress::{clear_stderr_line, DeterminateProgressLine};
 use anyhow::{Context, Result};
@@ -395,15 +394,59 @@ fn is_not_found_error(message: &str) -> bool {
 }
 
 fn cached_repo_files(repo: &CachedRepo) -> Result<Vec<String>> {
-    let root = huggingface_snapshot_path(&repo.repo_id, RepoType::Model, &repo.local_revision);
-    if !root.is_dir() {
+    let snapshots_dir = huggingface_hub_cache_dir()
+        .join(super::local::huggingface_repo_folder_name(
+            &repo.repo_id,
+            RepoType::Model,
+        ))
+        .join("snapshots");
+    if !snapshots_dir.is_dir() {
         return Ok(Vec::new());
     }
 
-    let mut files = Vec::new();
-    collect_snapshot_files(&root, &root, &mut files)?;
-    files.sort();
-    Ok(files)
+    let mut snapshot_roots = Vec::new();
+    let exact = snapshots_dir.join(&repo.local_revision);
+    if exact.is_dir() {
+        snapshot_roots.push(exact);
+    } else {
+        let mut prefix_matches = Vec::new();
+        for entry in
+            std::fs::read_dir(&snapshots_dir).with_context(|| format!("Read {}", snapshots_dir.display()))?
+        {
+            let entry = entry?;
+            if !entry.file_type()?.is_dir() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with(&repo.local_revision) || repo.local_revision.starts_with(&name) {
+                prefix_matches.push(entry.path());
+            }
+        }
+        prefix_matches.sort();
+        snapshot_roots.extend(prefix_matches);
+    }
+
+    if snapshot_roots.is_empty() {
+        let mut all = Vec::new();
+        for entry in
+            std::fs::read_dir(&snapshots_dir).with_context(|| format!("Read {}", snapshots_dir.display()))?
+        {
+            let entry = entry?;
+            if entry.file_type()?.is_dir() {
+                all.push(entry.path());
+            }
+        }
+        all.sort();
+        snapshot_roots = all;
+    }
+
+    let mut files = BTreeSet::new();
+    for root in snapshot_roots {
+        let mut collected = Vec::new();
+        collect_snapshot_files(&root, &root, &mut collected)?;
+        files.extend(collected);
+    }
+    Ok(files.into_iter().collect())
 }
 
 fn collect_snapshot_files(root: &Path, dir: &Path, files: &mut Vec<String>) -> Result<()> {
@@ -426,4 +469,59 @@ fn collect_snapshot_files(root: &Path, dir: &Path, files: &mut Vec<String>) -> R
         files.push(rel);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::ffi::OsString;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn restore_env(key: &str, value: Option<OsString>) {
+        if let Some(value) = value {
+            std::env::set_var(key, value);
+        } else {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn cached_repo_files_falls_back_to_matching_snapshot_prefix() {
+        let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+        let prev_hf_home = std::env::var_os("HF_HOME");
+        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+
+        let base = std::env::temp_dir().join(format!(
+            "mesh-llm-maintenance-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        let snapshot = base
+            .join("models--unsloth--Qwen3.6-35B-A3B-GGUF")
+            .join("snapshots")
+            .join("9280dd353ab5cafebabedeadbeef123456789abc");
+        std::fs::create_dir_all(snapshot.join("BF16")).unwrap();
+        std::fs::write(snapshot.join("BF16/model.gguf"), b"gguf").unwrap();
+
+        std::env::set_var("HF_HUB_CACHE", &base);
+        std::env::remove_var("HF_HOME");
+        std::env::remove_var("XDG_CACHE_HOME");
+
+        let repo = CachedRepo {
+            repo_id: "unsloth/Qwen3.6-35B-A3B-GGUF".to_string(),
+            ref_name: "main".to_string(),
+            local_revision: "9280dd353ab5".to_string(),
+        };
+        let files = cached_repo_files(&repo).expect("should collect snapshot files");
+        assert_eq!(files, vec!["BF16/model.gguf".to_string()]);
+
+        let _ = std::fs::remove_dir_all(&base);
+        restore_env("HF_HUB_CACHE", prev_hub_cache);
+        restore_env("HF_HOME", prev_hf_home);
+        restore_env("XDG_CACHE_HOME", prev_xdg);
+    }
 }

--- a/mesh-llm/src/models/maintenance.rs
+++ b/mesh-llm/src/models/maintenance.rs
@@ -404,38 +404,35 @@ fn cached_repo_files(repo: &CachedRepo) -> Result<Vec<String>> {
         return Ok(Vec::new());
     }
 
+    let mut snapshot_entries = Vec::new();
+    for entry in
+        std::fs::read_dir(&snapshots_dir).with_context(|| format!("Read {}", snapshots_dir.display()))?
+    {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        snapshot_entries.push((entry.file_name().to_string_lossy().to_string(), entry.path()));
+    }
+
     let mut snapshot_roots = Vec::new();
     let exact = snapshots_dir.join(&repo.local_revision);
     if exact.is_dir() {
         snapshot_roots.push(exact);
     } else {
-        let mut prefix_matches = Vec::new();
-        for entry in
-            std::fs::read_dir(&snapshots_dir).with_context(|| format!("Read {}", snapshots_dir.display()))?
-        {
-            let entry = entry?;
-            if !entry.file_type()?.is_dir() {
-                continue;
-            }
-            let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with(&repo.local_revision) || repo.local_revision.starts_with(&name) {
-                prefix_matches.push(entry.path());
-            }
-        }
+        let mut prefix_matches: Vec<PathBuf> = snapshot_entries
+            .iter()
+            .filter(|(name, _)| {
+                name.starts_with(&repo.local_revision) || repo.local_revision.starts_with(name)
+            })
+            .map(|(_, path)| path.clone())
+            .collect();
         prefix_matches.sort();
         snapshot_roots.extend(prefix_matches);
     }
 
     if snapshot_roots.is_empty() {
-        let mut all = Vec::new();
-        for entry in
-            std::fs::read_dir(&snapshots_dir).with_context(|| format!("Read {}", snapshots_dir.display()))?
-        {
-            let entry = entry?;
-            if entry.file_type()?.is_dir() {
-                all.push(entry.path());
-            }
-        }
+        let mut all: Vec<PathBuf> = snapshot_entries.into_iter().map(|(_, path)| path).collect();
         all.sort();
         snapshot_roots = all;
     }

--- a/mesh-llm/src/network/nostr.rs
+++ b/mesh-llm/src/network/nostr.rs
@@ -285,16 +285,27 @@ impl Publisher {
 ///
 /// If `max_clients` is set, delists when that many clients are connected
 /// and re-publishes when clients drop below the cap.
+pub struct PublishLoopOptions {
+    pub name: Option<String>,
+    pub region: Option<String>,
+    pub max_clients: Option<usize>,
+    pub interval_secs: u64,
+    pub status_tx: Option<tokio::sync::watch::Sender<Option<PublishStateUpdate>>>,
+}
+
 pub async fn publish_loop(
     node: crate::mesh::Node,
     keys: Keys,
     relays: Vec<String>,
-    name: Option<String>,
-    region: Option<String>,
-    max_clients: Option<usize>,
-    interval_secs: u64,
-    status_tx: Option<tokio::sync::watch::Sender<Option<PublishStateUpdate>>>,
+    options: PublishLoopOptions,
 ) {
+    let PublishLoopOptions {
+        name,
+        region,
+        max_clients,
+        interval_secs,
+        status_tx,
+    } = options;
     let mut last_reported = None;
     let publisher = match Publisher::new(keys.clone(), &relays).await {
         Ok(p) => p,
@@ -617,7 +628,19 @@ pub async fn publish_watchdog(
                         }
                     };
                     // Start publish loop (blocks forever)
-                    publish_loop(node, keys, relays, mesh_name, region, None, 60, status_tx).await;
+                    publish_loop(
+                        node,
+                        keys,
+                        relays,
+                        PublishLoopOptions {
+                            name: mesh_name,
+                            region,
+                            max_clients: None,
+                            interval_secs: 60,
+                            status_tx,
+                        },
+                    )
+                    .await;
                     return;
                 }
             }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -358,10 +358,10 @@ pub(crate) async fn run() -> Result<()> {
     // --mesh-name alone never implies publication (Issue #240).
 
     // Warn users who used to rely on --mesh-name auto-publishing
-    if cli.mesh_name.is_some() && !cli.publish {
+    if let Some(mesh_name) = cli.mesh_name.as_ref().filter(|_| !cli.publish) {
         eprintln!(
             "ℹ️  Mesh named '{}' — private by default. Add --publish to make it publicly discoverable.",
-            cli.mesh_name.as_ref().unwrap()
+            mesh_name
         );
     }
 
@@ -2285,11 +2285,13 @@ async fn run_auto(
                         pub_node,
                         nostr_keys,
                         relays,
-                        pub_name,
-                        pub_region,
-                        pub_max_clients,
-                        60,
-                        Some(status_tx),
+                        nostr::PublishLoopOptions {
+                            name: pub_name,
+                            region: pub_region,
+                            max_clients: pub_max_clients,
+                            interval_secs: 60,
+                            status_tx: Some(status_tx),
+                        },
                     )
                     .await;
                 }))
@@ -2576,11 +2578,13 @@ async fn run_passive(
                         pub_node,
                         nostr_keys,
                         relays,
-                        pub_name,
-                        pub_region,
-                        pub_max_clients,
-                        60,
-                        Some(status_tx),
+                        nostr::PublishLoopOptions {
+                            name: pub_name,
+                            region: pub_region,
+                            max_clients: pub_max_clients,
+                            interval_secs: 60,
+                            status_tx: Some(status_tx),
+                        },
                     )
                     .await;
                 });

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -21,7 +21,11 @@ fn run() -> DynResult<()> {
         [command, scope] if command == "repo-consistency" && scope == "release-targets" => {
             check_release_targets()
         }
-        _ => Err(format!("usage: cargo run -p xtask -- repo-consistency release-targets").into()),
+        _ => Err(
+            "usage: cargo run -p xtask -- repo-consistency release-targets"
+                .to_string()
+                .into(),
+        ),
     }
 }
 


### PR DESCRIPTION
Fix for #364 where `mesh-llm models updates <repo>` could report no cached files even when the repo was cached and `serve` had already warned that updates were available.

### What the user gets

`models updates` now works across common Hugging Face cache revision shapes:

- exact revision directory (existing behavior)
- short SHA in `refs/*` vs full SHA in `snapshots/*`
- fallback to available snapshot dirs when exact mapping is missing

So when cached files exist, refresh proceeds instead of incorrectly printing:

- `has no cached files to refresh`

### Root cause

Updater file discovery used a single exact snapshot path derived from the local revision.  
In some cache layouts, refs contain short SHAs while snapshot directories use full SHAs, so exact path resolution failed despite valid cached files.

### Changes

In `mesh-llm/src/models/maintenance.rs`:

- reworked `cached_repo_files()` snapshot resolution order:
  1. exact revision dir
  2. prefix-compatible snapshot matches
  3. fallback to all repo snapshot dirs
- deduplicated discovered files across matched snapshots
- added regression test:
  - `cached_repo_files_falls_back_to_matching_snapshot_prefix`

### Verification

Reproduced the issue with a synthetic HF cache layout where:

- `refs/main` contains a short revision (`9280dd353ab5`)
- snapshot directory uses a full SHA (`snapshots/9280dd353ab5cafebabedeadbeef123456789abc`)
- a GGUF file exists under that snapshot

#### Pre-fix behavior (bug)

`mesh-llm models updates unsloth/Qwen3.6-35B-A3B-GGUF` reported:

- `⚠️ unsloth/Qwen3.6-35B-A3B-GGUF has no cached files to refresh`
- `refreshed files: 0`

#### Post-fix behavior

Running the same repro now shows refresh starts against discovered cached files:

- `🧭 [1/1] unsloth/Qwen3.6-35B-A3B-GGUF`
- `   ref: main`
- `   current: 9280dd353ab5`
- `   ↻ [1/2] BF16/Qwen3.6-35B-A3B-BF16-00001-of-00002.gguf`

This confirms snapshot file discovery no longer fails on short-ref/full-snapshot mismatches.

#### Automated regression test

- ✅ `cargo test cached_repo_files_falls_back_to_matching_snapshot_prefix -- --nocapture`

Closes #364.