### PR TITLE
Fix Windows CUDA builds and dashboard VRAM display

### DIFF
--- a/mesh-llm/plugin/src/io.rs
+++ b/mesh-llm/plugin/src/io.rs
@@ -1,5 +1,6 @@
 use anyhow::{bail, Context, Result};
 use prost::Message;
+#[cfg(unix)]
 use std::path::PathBuf;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -983,7 +983,9 @@ pub(crate) enum ProcessSignal {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SignalOutcome {
     Sent,
+    #[cfg(not(windows))]
     AlreadyDead,
+    #[cfg(not(windows))]
     Skipped,
     Failed,
 }
@@ -1018,6 +1020,7 @@ fn send_signal_if_matches(
 
     #[cfg(windows)]
     {
+        let _ = expected_start_time;
         tracing::debug!(
             pid,
             expected_comm,
@@ -1085,10 +1088,13 @@ pub(crate) fn terminate_process_blocking(
         ProcessSignal::Terminate,
     ) {
         SignalOutcome::Sent => {}
+        #[cfg(not(windows))]
         SignalOutcome::AlreadyDead => return true,
         // Identity mismatch: the PID belongs to a different process; do not
         // claim a successful stop.
-        SignalOutcome::Skipped | SignalOutcome::Failed => return false,
+        #[cfg(not(windows))]
+        SignalOutcome::Skipped => return false,
+        SignalOutcome::Failed => return false,
     }
 
     for _ in 0..20 {
@@ -1100,10 +1106,12 @@ pub(crate) fn terminate_process_blocking(
         }
     }
 
-    matches!(
-        send_signal_if_matches(pid, expected_comm, expected_start_time, ProcessSignal::Kill),
-        SignalOutcome::Sent | SignalOutcome::AlreadyDead
-    )
+    match send_signal_if_matches(pid, expected_comm, expected_start_time, ProcessSignal::Kill) {
+        SignalOutcome::Sent => true,
+        #[cfg(not(windows))]
+        SignalOutcome::AlreadyDead => true,
+        _ => false,
+    }
 }
 
 async fn terminate_process_with_wait(
@@ -1120,7 +1128,9 @@ async fn terminate_process_with_wait(
         ProcessSignal::Terminate,
     ) {
         SignalOutcome::Sent => {}
-        SignalOutcome::AlreadyDead | SignalOutcome::Skipped | SignalOutcome::Failed => return,
+        #[cfg(not(windows))]
+        SignalOutcome::AlreadyDead | SignalOutcome::Skipped => return,
+        SignalOutcome::Failed => return,
     }
 
     for _ in 0..attempts {

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -211,6 +211,78 @@ fn resolve_binary_path(
     }
 }
 
+fn child_library_search_paths(binary_path: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Some(parent) = binary_path.parent() {
+        paths.push(parent.to_path_buf());
+    }
+    paths.extend(platform_runtime_library_paths());
+    paths
+}
+
+#[cfg(windows)]
+fn platform_runtime_library_paths() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(cuda_path) = std::env::var_os("CUDA_PATH").filter(|value| !value.is_empty()) {
+        roots.push(PathBuf::from(cuda_path));
+    }
+    if let Some(program_files) = std::env::var_os("ProgramFiles").filter(|value| !value.is_empty())
+    {
+        let toolkit_root = PathBuf::from(program_files)
+            .join("NVIDIA GPU Computing Toolkit")
+            .join("CUDA");
+        if let Ok(entries) = std::fs::read_dir(toolkit_root) {
+            let mut discovered = entries
+                .filter_map(Result::ok)
+                .filter_map(|entry| match entry.file_type() {
+                    Ok(file_type) if file_type.is_dir() => Some(entry.path()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            discovered.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+            roots.extend(discovered);
+        }
+    }
+
+    let mut paths = Vec::new();
+    for root in roots {
+        paths.push(root.join("bin"));
+        paths.push(root.join("bin").join("x64"));
+    }
+    paths
+}
+
+#[cfg(not(windows))]
+fn platform_runtime_library_paths() -> Vec<PathBuf> {
+    Vec::new()
+}
+
+fn prepend_child_library_paths(command: &mut Command, binary_path: &Path) {
+    let mut paths = child_library_search_paths(binary_path);
+    if let Some(existing) = std::env::var_os("PATH") {
+        paths.extend(std::env::split_paths(&existing));
+    }
+
+    paths.retain(|path| path.exists());
+    dedup_paths(&mut paths);
+
+    if let Ok(joined) = std::env::join_paths(paths) {
+        command.env("PATH", joined);
+    }
+}
+
+fn dedup_paths(paths: &mut Vec<PathBuf>) {
+    let mut seen = std::collections::HashSet::new();
+    paths.retain(|path| {
+        let key = path.to_string_lossy();
+        #[cfg(windows)]
+        let key = key.to_ascii_lowercase();
+        #[cfg(not(windows))]
+        let key = key.to_string();
+        seen.insert(key)
+    });
+}
+
 #[derive(Debug)]
 pub struct InferenceServerHandle {
     pid: u32,
@@ -808,7 +880,8 @@ pub async fn start_rpc_server(
         );
     }
 
-    let mut child = Command::new(&rpc_server.path)
+    let mut command = Command::new(&rpc_server.path);
+    command
         .args(&args)
         .env("MESH_LLM_OWNER_PID", std::process::id().to_string())
         .env(
@@ -816,14 +889,15 @@ pub async fn start_rpc_server(
             runtime.dir().to_string_lossy().to_string(),
         )
         .stdout(std::process::Stdio::from(rpc_log_file))
-        .stderr(std::process::Stdio::from(rpc_log_file2))
-        .spawn()
-        .with_context(|| {
-            format!(
-                "Failed to start rpc-server at {}",
-                rpc_server.path.display()
-            )
-        })?;
+        .stderr(std::process::Stdio::from(rpc_log_file2));
+    prepend_child_library_paths(&mut command, &rpc_server.path);
+
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "Failed to start rpc-server at {}",
+            rpc_server.path.display()
+        )
+    })?;
 
     let pid = child.id().context("rpc-server did not expose a PID")?;
     if pid == 0 {
@@ -1324,7 +1398,8 @@ pub async fn start_llama_server(
             tracing::warn!("mmproj not found at {}, skipping vision", proj.display());
         }
     }
-    let mut child = Command::new(&llama_server.path)
+    let mut command = Command::new(&llama_server.path);
+    command
         .args(&args)
         .env("MESH_LLM_OWNER_PID", std::process::id().to_string())
         .env(
@@ -1332,14 +1407,15 @@ pub async fn start_llama_server(
             runtime.dir().to_string_lossy().to_string(),
         )
         .stdout(std::process::Stdio::from(log_file))
-        .stderr(std::process::Stdio::from(log_file2))
-        .spawn()
-        .with_context(|| {
-            format!(
-                "Failed to start llama-server at {}",
-                llama_server.path.display()
-            )
-        })?;
+        .stderr(std::process::Stdio::from(log_file2));
+    prepend_child_library_paths(&mut command, &llama_server.path);
+
+    let mut child = command.spawn().with_context(|| {
+        format!(
+            "Failed to start llama-server at {}",
+            llama_server.path.display()
+        )
+    })?;
 
     // Wait for health check — scale timeout by model size so large MoE shards
     // don't hit a fixed ceiling. 120s per GB gives plenty of headroom for slow

--- a/mesh-llm/src/plugin/mcp.rs
+++ b/mesh-llm/src/plugin/mcp.rs
@@ -215,6 +215,7 @@ impl ExternalMcpClient {
                 }
                 #[cfg(not(unix))]
                 {
+                    let _ = path;
                     Err(anyhow!(
                         "Unix socket MCP endpoint '{}:{}' is unsupported on this platform",
                         endpoint.plugin_name,
@@ -222,7 +223,7 @@ impl ExternalMcpClient {
                     ))
                 }
             }
-            ExternalMcpTransport::NamedPipe { name: _ } => {
+            ExternalMcpTransport::NamedPipe { name } => {
                 #[cfg(windows)]
                 {
                     let client = tokio::net::windows::named_pipe::ClientOptions::new()
@@ -237,6 +238,7 @@ impl ExternalMcpClient {
                 }
                 #[cfg(not(windows))]
                 {
+                    let _ = name;
                     Err(anyhow!(
                         "Named pipe MCP endpoint '{}:{}' is unsupported on this platform",
                         endpoint.plugin_name,

--- a/mesh-llm/src/plugin/transport.rs
+++ b/mesh-llm/src/plugin/transport.rs
@@ -5,6 +5,7 @@ use rand::RngExt;
 use rmcp::model::ErrorCode;
 use std::collections::HashMap;
 use std::future::Future;
+#[cfg(unix)]
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::Arc;

--- a/mesh-llm/src/runtime/instance.rs
+++ b/mesh-llm/src/runtime/instance.rs
@@ -29,7 +29,7 @@
 //!
 //! 1. `MESH_LLM_RUNTIME_ROOT` environment variable (highest; used by tests)
 //! 2. `$XDG_RUNTIME_DIR/mesh-llm/runtime` (systemd services, rootless containers)
-//! 3. `$HOME/.mesh-llm/runtime` (default interactive use)
+//! 3. Platform home directory (`$HOME` on Unix, Windows profile directory on Windows)
 //! 4. Fails fast with a clear error if none of the above are set
 //!
 //! # Liveness detection
@@ -227,8 +227,8 @@ impl Drop for PidfileGuard {
 /// Precedence:
 /// 1. `MESH_LLM_RUNTIME_ROOT` environment variable (test override / custom deployment)
 /// 2. `$XDG_RUNTIME_DIR/mesh-llm/runtime`
-/// 3. `$HOME/.mesh-llm/runtime` (via [`dirs::home_dir`])
-/// 4. [`anyhow::bail!`] — at least one of the above must be set
+/// 3. The platform home directory from [`dirs::home_dir`]
+/// 4. [`anyhow::bail!`] - at least one of the above must be set
 pub fn runtime_root() -> Result<PathBuf> {
     // 1. Explicit override — always wins (also used by tests to avoid touching ~)
     if let Ok(root) = std::env::var("MESH_LLM_RUNTIME_ROOT") {
@@ -240,15 +240,16 @@ pub fn runtime_root() -> Result<PathBuf> {
         return Ok(PathBuf::from(xdg).join("mesh-llm").join("runtime"));
     }
 
-    // 3. $HOME/.mesh-llm/runtime — only when HOME env var is explicitly set
-    if std::env::var_os("HOME").is_some_and(|h| !h.is_empty()) {
-        if let Some(home) = dirs::home_dir() {
-            return Ok(home.join(".mesh-llm").join("runtime"));
-        }
+    // 3. Platform home directory. On Windows this can be available even when
+    // HOME is unset in the launching shell.
+    if let Some(home) = dirs::home_dir() {
+        return Ok(home.join(".mesh-llm").join("runtime"));
     }
 
-    // 4. Nothing usable — fail fast with a clear message
-    anyhow::bail!("mesh-llm requires HOME, XDG_RUNTIME_DIR, or MESH_LLM_RUNTIME_ROOT to be set")
+    // 4. Nothing usable - fail fast with a clear message.
+    anyhow::bail!(
+        "mesh-llm requires a home directory, XDG_RUNTIME_DIR, or MESH_LLM_RUNTIME_ROOT to be set"
+    )
 }
 
 /// A scoped runtime directory for a single mesh-llm process instance.
@@ -1605,6 +1606,7 @@ mod tests {
         assert_eq!(root, dir.path().join("mesh-llm").join("runtime"));
     }
 
+    #[cfg(not(windows))]
     #[test]
     #[serial]
     fn runtime_root_falls_back_to_home() {
@@ -1617,6 +1619,20 @@ mod tests {
         assert_eq!(root, dir.path().join(".mesh-llm").join("runtime"));
     }
 
+    #[cfg(windows)]
+    #[test]
+    #[serial]
+    fn runtime_root_falls_back_to_windows_profile_without_home() {
+        let _g_mesh = EnvGuard::save_and_remove("MESH_LLM_RUNTIME_ROOT");
+        let _g_xdg = EnvGuard::save_and_remove("XDG_RUNTIME_DIR");
+        let _g_home = EnvGuard::save_and_remove("HOME");
+
+        let home = dirs::home_dir().expect("Windows profile directory should be available");
+        let root = runtime_root().expect("runtime_root should succeed without HOME on Windows");
+        assert_eq!(root, home.join(".mesh-llm").join("runtime"));
+    }
+
+    #[cfg(not(windows))]
     #[test]
     #[serial]
     fn runtime_root_bails_when_unset() {

--- a/mesh-llm/src/runtime/instance.rs
+++ b/mesh-llm/src/runtime/instance.rs
@@ -230,6 +230,10 @@ impl Drop for PidfileGuard {
 /// 3. The platform home directory from [`dirs::home_dir`]
 /// 4. [`anyhow::bail!`] - at least one of the above must be set
 pub fn runtime_root() -> Result<PathBuf> {
+    runtime_root_with_home(dirs::home_dir())
+}
+
+fn runtime_root_with_home(home: Option<PathBuf>) -> Result<PathBuf> {
     // 1. Explicit override — always wins (also used by tests to avoid touching ~)
     if let Ok(root) = std::env::var("MESH_LLM_RUNTIME_ROOT") {
         return Ok(PathBuf::from(root));
@@ -242,7 +246,7 @@ pub fn runtime_root() -> Result<PathBuf> {
 
     // 3. Platform home directory. On Windows this can be available even when
     // HOME is unset in the launching shell.
-    if let Some(home) = dirs::home_dir() {
+    if let Some(home) = home {
         return Ok(home.join(".mesh-llm").join("runtime"));
     }
 
@@ -1634,17 +1638,14 @@ mod tests {
         assert_eq!(root, home.join(".mesh-llm").join("runtime"));
     }
 
-    #[cfg(not(windows))]
     #[test]
     #[serial]
     fn runtime_root_bails_when_unset() {
-        // dirs 6.x only checks the HOME env var — no passwd fallback — so
-        // removing HOME is sufficient to make dirs::home_dir() return None.
         let _g_mesh = EnvGuard::save_and_remove("MESH_LLM_RUNTIME_ROOT");
         let _g_xdg = EnvGuard::save_and_remove("XDG_RUNTIME_DIR");
         let _g_home = EnvGuard::save_and_remove("HOME");
 
-        let result = runtime_root();
+        let result = runtime_root_with_home(None);
         assert!(
             result.is_err(),
             "runtime_root must bail when no path source is set"

--- a/mesh-llm/src/runtime/instance.rs
+++ b/mesh-llm/src/runtime/instance.rs
@@ -389,38 +389,30 @@ impl InstanceRuntime {
 /// - Returns `false` on any other error (file missing, permission denied, etc.)
 ///   to treat unknown states as "not locked" (callers must validate independently).
 ///
-/// On non-Unix platforms always returns `false`.
+/// Only Unix currently supports probing the runtime flock.
+#[cfg(unix)]
 pub fn is_locked(lock_path: &Path) -> bool {
-    #[cfg(unix)]
+    use std::os::unix::io::AsRawFd;
+
+    let file = match fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(lock_path)
     {
-        use std::os::unix::io::AsRawFd;
+        Ok(f) => f,
+        Err(_) => return false,
+    };
 
-        let file = match fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(lock_path)
-        {
-            Ok(f) => f,
-            Err(_) => return false,
-        };
-
-        let fd = file.as_raw_fd();
-        // SAFETY: flock is safe to call with a valid fd
-        let ret = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
-        if ret != 0 {
-            let err = std::io::Error::last_os_error();
-            return err.raw_os_error() == Some(libc::EWOULDBLOCK);
-        }
-
-        drop(file);
-        false
+    let fd = file.as_raw_fd();
+    // SAFETY: flock is safe to call with a valid fd.
+    let ret = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        return err.raw_os_error() == Some(libc::EWOULDBLOCK);
     }
 
-    #[cfg(not(unix))]
-    {
-        let _ = lock_path;
-        false
-    }
+    drop(file);
+    false
 }
 
 /// Portable process identity validation.
@@ -726,6 +718,7 @@ pub mod validate {
     /// 2. A start time within [`START_TIME_TOLERANCE_SECS`] of `expected_started_at_unix`.
     ///
     /// Returns `false` on any error or mismatch.
+    #[cfg(not(windows))]
     pub fn validate_pid_matches(
         pid: u32,
         expected_comm: &str,
@@ -777,6 +770,7 @@ pub mod reap {
     struct ScanResult {
         summary: ReapSummary,
         pending_actions: Vec<PendingAction>,
+        #[cfg(unix)]
         stale_runtime_dirs: Vec<PathBuf>,
     }
 
@@ -838,8 +832,10 @@ pub mod reap {
     #[derive(Debug, Clone, Copy, Default)]
     pub struct ReapSummary {
         /// Number of runtime directories scanned.
+        #[cfg(unix)]
         pub dirs_scanned: usize,
         /// Number of directories skipped because the owner is still alive.
+        #[cfg(unix)]
         pub dirs_skipped_alive: usize,
         /// Number of directories that were garbage collected.
         pub dirs_gc_d: usize,
@@ -868,93 +864,98 @@ pub mod reap {
             return Ok(ReapSummary::default());
         }
 
-        if !root.exists() {
-            return Ok(ReapSummary::default());
-        }
+        #[cfg(unix)]
+        {
+            if !root.exists() {
+                return Ok(ReapSummary::default());
+            }
 
-        let root = root.to_path_buf();
-        let my_runtime_dir = my_runtime_dir.to_path_buf();
-        let scan =
-            tokio::task::spawn_blocking(move || scan_cross_runtime_orphans(&root, &my_runtime_dir))
-                .await
-                .context("cross-runtime reap scan task panicked")??;
+            let root = root.to_path_buf();
+            let my_runtime_dir = my_runtime_dir.to_path_buf();
+            let scan = tokio::task::spawn_blocking(move || {
+                scan_cross_runtime_orphans(&root, &my_runtime_dir)
+            })
+            .await
+            .context("cross-runtime reap scan task panicked")??;
 
-        let mut summary = scan.summary;
-        let pending_actions = scan.pending_actions;
-        let stale_runtime_dirs = scan.stale_runtime_dirs;
-        let mut pidfiles_to_remove = Vec::new();
+            let mut summary = scan.summary;
+            let pending_actions = scan.pending_actions;
+            let stale_runtime_dirs = scan.stale_runtime_dirs;
+            let mut pidfiles_to_remove = Vec::new();
 
-        for action in &pending_actions {
-            match &action.kind {
-                PendingActionKind::KillChildAndRemovePidfile {
-                    child_pid,
-                    cmd_name,
-                    child_started_at_unix,
-                } => {
-                    // Treat 0 as "unknown start time" (detection failed at pidfile creation).
-                    let start_time_hint = if *child_started_at_unix == 0 {
-                        None
-                    } else {
-                        Some(*child_started_at_unix)
-                    };
-                    let terminated = crate::inference::launch::terminate_process(
-                        *child_pid,
+            for action in &pending_actions {
+                match &action.kind {
+                    PendingActionKind::KillChildAndRemovePidfile {
+                        child_pid,
                         cmd_name,
-                        start_time_hint,
-                    )
-                    .await;
-                    let exited = crate::inference::launch::wait_for_exit(*child_pid, 5000).await;
-                    let force_killed = if exited {
-                        false
-                    } else {
-                        crate::inference::launch::force_kill_process(
+                        child_started_at_unix,
+                    } => {
+                        // Treat 0 as "unknown start time" (detection failed at pidfile creation).
+                        let start_time_hint = if *child_started_at_unix == 0 {
+                            None
+                        } else {
+                            Some(*child_started_at_unix)
+                        };
+                        let terminated = crate::inference::launch::terminate_process(
                             *child_pid,
                             cmd_name,
                             start_time_hint,
                         )
-                        .await
-                    };
-                    let exited_after_force = if exited {
-                        true
-                    } else {
-                        crate::inference::launch::wait_for_exit(*child_pid, 5000).await
-                    };
+                        .await;
+                        let exited =
+                            crate::inference::launch::wait_for_exit(*child_pid, 5000).await;
+                        let force_killed = if exited {
+                            false
+                        } else {
+                            crate::inference::launch::force_kill_process(
+                                *child_pid,
+                                cmd_name,
+                                start_time_hint,
+                            )
+                            .await
+                        };
+                        let exited_after_force = if exited {
+                            true
+                        } else {
+                            crate::inference::launch::wait_for_exit(*child_pid, 5000).await
+                        };
 
-                    if (terminated || force_killed) && exited_after_force {
-                        summary.children_killed += 1;
+                        if (terminated || force_killed) && exited_after_force {
+                            summary.children_killed += 1;
+                            summary.pidfiles_removed += 1;
+                            pidfiles_to_remove.push(action.pidfile_path.clone());
+                        } else {
+                            tracing::warn!(
+                                pid = *child_pid,
+                                cmd_name,
+                                terminated,
+                                exited,
+                                force_killed,
+                                exited_after_force,
+                                "failed to reap orphan child; keeping pidfile"
+                            );
+                        }
+                    }
+                    PendingActionKind::RemovePidfileOnly => {
                         summary.pidfiles_removed += 1;
                         pidfiles_to_remove.push(action.pidfile_path.clone());
-                    } else {
-                        tracing::warn!(
-                            pid = *child_pid,
-                            cmd_name,
-                            terminated,
-                            exited,
-                            force_killed,
-                            exited_after_force,
-                            "failed to reap orphan child; keeping pidfile"
-                        );
                     }
                 }
-                PendingActionKind::RemovePidfileOnly => {
-                    summary.pidfiles_removed += 1;
-                    pidfiles_to_remove.push(action.pidfile_path.clone());
+            }
+
+            tokio::task::spawn_blocking(move || {
+                for path in pidfiles_to_remove {
+                    let _ = std::fs::remove_file(path);
                 }
-            }
+                for path in stale_runtime_dirs {
+                    let _ = std::fs::remove_dir_all(path);
+                }
+            })
+            .await
+            .context("cross-runtime reap cleanup task panicked")?;
+
+            Ok(summary)
         }
-
-        tokio::task::spawn_blocking(move || {
-            for path in pidfiles_to_remove {
-                let _ = std::fs::remove_file(path);
-            }
-            for path in stale_runtime_dirs {
-                let _ = std::fs::remove_dir_all(path);
-            }
-        })
-        .await
-        .context("cross-runtime reap cleanup task panicked")?;
-
-        Ok(summary)
     }
 
     /// Drain stale pidfiles from our own runtime directory.
@@ -1046,6 +1047,7 @@ pub mod reap {
         Ok(summary)
     }
 
+    #[cfg(unix)]
     fn scan_cross_runtime_orphans(
         root: &Path,
         my_runtime_dir: &Path,
@@ -1677,6 +1679,7 @@ mod tests {
 
     #[test]
     #[serial]
+    #[cfg(unix)]
     fn acquire_holds_flock() {
         let dir = tempdir().unwrap();
         let _g = EnvGuard::save_and_set("MESH_LLM_RUNTIME_ROOT", dir.path().to_str().unwrap());
@@ -1713,6 +1716,7 @@ mod tests {
 
     #[test]
     #[serial]
+    #[cfg(unix)]
     fn is_locked_returns_true_while_held() {
         let dir = tempdir().unwrap();
         let _g = EnvGuard::save_and_set("MESH_LLM_RUNTIME_ROOT", dir.path().to_str().unwrap());
@@ -1728,6 +1732,7 @@ mod tests {
 
     #[test]
     #[serial]
+    #[cfg(unix)]
     fn is_locked_returns_false_after_drop() {
         let dir = tempdir().unwrap();
         let _g = EnvGuard::save_and_set("MESH_LLM_RUNTIME_ROOT", dir.path().to_str().unwrap());
@@ -2014,6 +2019,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn validate_pid_matches_rejects_wrong_comm() {
         let pid = std::process::id();
         assert!(
@@ -2023,6 +2029,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn validate_pid_matches_rejects_wrong_start_time() {
         let pid = std::process::id();
         let comm = match validate::process_comm(pid).ok().flatten() {
@@ -2053,6 +2060,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn validate_pid_matches_accepts_within_tolerance() {
         let pid = std::process::id();
         let comm = match validate::process_comm(pid).ok().flatten() {
@@ -2071,6 +2079,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn validate_pid_matches_rejects_outside_tolerance() {
         let pid = std::process::id();
         let comm = match validate::process_comm(pid).ok().flatten() {
@@ -2170,6 +2179,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn reap_skips_own_dir() {
         let root = tempdir().unwrap();
         let dir_a = root.path().join("1001");
@@ -2190,6 +2200,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn reap_skips_alive_owner() {
         let root = tempdir().unwrap();
         let _g = EnvGuard::save_and_set("MESH_LLM_RUNTIME_ROOT", root.path().to_str().unwrap());
@@ -2212,6 +2223,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn reap_removes_dead_child_pidfile() {
         let root = tempdir().unwrap();
         let peer_dir = root.path().join("50001");
@@ -2245,6 +2257,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn reap_preserves_external_pid_via_comm_mismatch() {
         let root = tempdir().unwrap();
         let peer_dir = root.path().join("60001");
@@ -2309,6 +2322,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(unix)]
     async fn cross_runtime_reaper_ignores_non_directories() {
         let root = tempdir().unwrap();
         let my_dir = root.path().join("self");

--- a/mesh-llm/ui/src/App.tsx
+++ b/mesh-llm/ui/src/App.tsx
@@ -22,6 +22,7 @@ import type {
 import { type TopSection } from "./features/app-shell/lib/routes";
 import {
   applyThemeMode,
+  displayVramGb,
   formatLiveNodeState,
   localRoutableModels,
   modelDisplayName,
@@ -518,7 +519,7 @@ export function App() {
       )?.started_at_unix;
       nodes.push({
         id: status.node_id,
-        vram: overviewVramGb(status.node_state === "client", status.my_vram_gb),
+        vram: displayVramGb(status.node_state === "client", status.my_vram_gb, status.gpus),
         state: status.node_state,
         self: true,
         host: status.is_host,
@@ -552,7 +553,7 @@ export function App() {
           : peerAssignedModels(p);
       nodes.push({
         id: p.id,
-        vram: overviewVramGb(p.state === "client", p.vram_gb),
+        vram: displayVramGb(p.state === "client", p.vram_gb, p.gpus),
         state: p.state,
         self: false,
         host: /^Host/.test(p.role),

--- a/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  displayVramGb,
   formatLiveNodeState,
+  gpuInventoryVramGb,
   localRoutableModels,
+  meshGpuVram,
   topologyStatusTone,
   topologyStatusTooltip,
 } from "./status-helpers";
@@ -88,5 +91,66 @@ describe("live node state helpers", () => {
     expect(localRoutableModels({ ...baseStatus, node_state: "client", is_client: false })).toEqual(
       [],
     );
+  });
+
+  it("prefers physical GPU inventory over effective capacity for VRAM display", () => {
+    const physicalVramBytes = 17_094_934_528;
+
+    expect(gpuInventoryVramGb([{ vram_bytes: physicalVramBytes }])).toBeCloseTo(15.92, 2);
+    expect(displayVramGb(false, 29.4, [{ vram_bytes: physicalVramBytes }])).toBeCloseTo(
+      15.92,
+      2,
+    );
+  });
+
+  it("falls back to capacity VRAM when GPU inventory is absent", () => {
+    expect(displayVramGb(false, 29.4, [])).toBe(29.4);
+    expect(displayVramGb(false, 29.4, undefined)).toBe(29.4);
+    expect(displayVramGb(true, 29.4, [{ vram_bytes: 17_094_934_528 }])).toBe(0);
+  });
+
+  it("uses physical GPU inventory for mesh VRAM totals when available", () => {
+    const status: StatusPayload = {
+      node_id: "local-node",
+      node_status: "Serving",
+      node_state: "serving",
+      token: "token",
+      is_host: true,
+      is_client: false,
+      llama_ready: true,
+      peers: [
+        {
+          id: "peer-with-inventory",
+          role: "Host",
+          state: "serving",
+          models: [],
+          vram_gb: 48,
+          gpus: [{ name: "GPU", vram_bytes: 12 * 1024 ** 3 }],
+        },
+        {
+          id: "legacy-peer",
+          role: "Host",
+          state: "serving",
+          models: [],
+          vram_gb: 8,
+          gpus: [],
+        },
+      ],
+      model_name: "model",
+      requested_models: [],
+      available_models: [],
+      serving_models: ["model"],
+      hosted_models: ["model"],
+      my_vram_gb: 29.4,
+      gpus: [{ name: "RTX 5080", vram_bytes: 16 * 1024 ** 3 }],
+      api_port: 3131,
+      model_size_gb: 0,
+      inflight_requests: 0,
+      version: "test",
+      latest_version: null,
+      wakeable_nodes: [],
+    };
+
+    expect(meshGpuVram(status)).toBe(36);
   });
 });

--- a/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
+++ b/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
@@ -9,6 +9,8 @@ import type {
 } from "./status-types";
 import type { TopologyNode } from "./topology-types";
 
+type GpuInventory = Array<{ vram_bytes: number }>;
+
 export function modelDisplayName(model?: MeshModel | null) {
   if (!model) return "";
   return model.display_name || model.name;
@@ -48,6 +50,24 @@ export function overviewVramGb(isClient: boolean, vramGb?: number | null) {
   return Math.max(0, vramGb || 0);
 }
 
+export function gpuInventoryVramGb(gpus?: GpuInventory | null) {
+  const bytes =
+    gpus?.reduce((sum, gpu) => {
+      const vramBytes = Number(gpu.vram_bytes);
+      return sum + (Number.isFinite(vramBytes) && vramBytes > 0 ? vramBytes : 0);
+    }, 0) ?? 0;
+  return bytes > 0 ? bytes / 1024 ** 3 : null;
+}
+
+export function displayVramGb(
+  isClient: boolean,
+  capacityVramGb?: number | null,
+  gpus?: GpuInventory | null,
+) {
+  if (isClient) return 0;
+  return gpuInventoryVramGb(gpus) ?? overviewVramGb(false, capacityVramGb);
+}
+
 function assertLiveNodeState(state: LiveNodeState | undefined | null): LiveNodeState | null {
   if (!state || !(state in LIVE_NODE_STATE_LABELS)) {
     console.warn("Invalid or missing live node state:", state);
@@ -65,9 +85,9 @@ export function formatLiveNodeState(state: LiveNodeState | undefined | null): st
 export function meshGpuVram(status: StatusPayload | null) {
   if (!status) return 0;
   return (
-    overviewVramGb(status.node_state === "client", status.my_vram_gb) +
+    displayVramGb(status.node_state === "client", status.my_vram_gb, status.gpus) +
     (status.peers || []).reduce(
-      (sum, peer) => sum + overviewVramGb(peer.state === "client", peer.vram_gb),
+      (sum, peer) => sum + displayVramGb(peer.state === "client", peer.vram_gb, peer.gpus),
       0,
     )
   );

--- a/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
+++ b/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
@@ -54,10 +54,10 @@ import { cn } from "../../../lib/utils";
 import {
   formatLiveNodeState,
   formatLatency,
+  displayVramGb,
   localRoutableModels,
   meshGpuVram,
   modelDisplayName,
-  overviewVramGb,
   ownershipPrimaryLabel,
   ownershipStatusLabel,
   ownershipTone,
@@ -190,8 +190,8 @@ export function DashboardPage({
   }, [status]);
   const sortedPeers = useMemo(() => {
     return [...(status?.peers ?? [])].sort((a, b) => {
-      const bOverviewVramGb = overviewVramGb(b.state === "client", b.vram_gb);
-      const aOverviewVramGb = overviewVramGb(a.state === "client", a.vram_gb);
+      const bOverviewVramGb = displayVramGb(b.state === "client", b.vram_gb, b.gpus);
+      const aOverviewVramGb = displayVramGb(a.state === "client", a.vram_gb, a.gpus);
       return bOverviewVramGb - aOverviewVramGb || a.id.localeCompare(b.id);
     });
   }, [status?.peers]);
@@ -201,14 +201,14 @@ export function DashboardPage({
       const modelLabel =
         primaryModel && primaryModel !== "(idle)" ? shortName(primaryModel) : "idle";
       const latencyLabel = formatLatency(peer.rtt_ms);
-      const displayVramGb = overviewVramGb(peer.state === "client", peer.vram_gb);
+      const peerDisplayVramGb = displayVramGb(peer.state === "client", peer.vram_gb, peer.gpus);
       const sharePct =
         peer.state !== "client" && totalMeshVramGb > 0
-          ? Math.round((displayVramGb / totalMeshVramGb) * 100)
+          ? Math.round((peerDisplayVramGb / totalMeshVramGb) * 100)
           : null;
       return {
         ...peer,
-        displayVramGb,
+        displayVramGb: peerDisplayVramGb,
         modelLabel,
         latencyLabel,
         shareLabel: sharePct == null ? "n/a" : `${sharePct}%`,
@@ -227,15 +227,19 @@ export function DashboardPage({
     const totalModelVram = selectedCatalogModel.mesh_vram_gb ?? 0;
     const rows: ActivePeerRow[] = [];
     const localServing = localRoutableModels(status).includes(targetModel);
-    const localClientVram = overviewVramGb(status.node_state === "client", status.my_vram_gb);
+    const localDisplayVramGb = displayVramGb(
+      status.node_state === "client",
+      status.my_vram_gb,
+      status.gpus,
+    );
     if (localServing && status.node_state !== "client") {
       rows.push({
         id: status.node_id,
         latencyLabel: "local",
-        vramLabel: `${localClientVram.toFixed(1)} GB`,
+        vramLabel: `${localDisplayVramGb.toFixed(1)} GB`,
         shareLabel:
           totalModelVram > 0
-            ? `${Math.round((localClientVram / totalModelVram) * 100)}%`
+            ? `${Math.round((localDisplayVramGb / totalModelVram) * 100)}%`
             : "n/a",
       });
     }

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -590,19 +590,61 @@ switch ($backendName) {
 }
 
 Invoke-InRepo {
+    $llamaRepo = "https://github.com/Mesh-LLM/llama.cpp.git"
+    $llamaPinSha = $env:MESH_LLM_LLAMA_PIN_SHA
+    $llamaPinFile = Join-Path $repoRoot "LLAMA_CPP_SHA"
+    if (-not $llamaPinSha -and (Test-Path $llamaPinFile)) {
+        $llamaPinSha = (Get-Content -Path $llamaPinFile -Raw).Trim()
+    }
+
     if (-not (Test-Path $llamaDir)) {
-        Write-Host "Cloning michaelneale/llama.cpp (upstream-latest branch)..."
-        Invoke-NativeCommand "git" @("clone", "-b", "upstream-latest", "https://github.com/michaelneale/llama.cpp.git", $llamaDir)
+        if ($llamaPinSha) {
+            Write-Host "Cloning Mesh-LLM/llama.cpp pinned to $llamaPinSha..."
+            Invoke-NativeCommand "git" @("clone", "-b", "master", "--depth", "1", $llamaRepo, $llamaDir)
+            Push-Location $llamaDir
+            try {
+                if (-not (Test-CommandSuccess "git" @("cat-file", "-e", "${llamaPinSha}^{commit}"))) {
+                    Write-Host "Pinned SHA not on master tip, fetching explicitly..."
+                    Invoke-NativeCommand "git" @("fetch", "--depth", "1", "origin", $llamaPinSha)
+                }
+                Invoke-NativeCommand "git" @("checkout", "--detach", $llamaPinSha)
+            } finally {
+                Pop-Location
+            }
+        } else {
+            Write-Host "Cloning Mesh-LLM/llama.cpp (master)..."
+            Invoke-NativeCommand "git" @("clone", "-b", "master", $llamaRepo, $llamaDir)
+        }
     } else {
         Push-Location $llamaDir
         try {
-            $currentBranch = (& git branch --show-current).Trim()
-            if ($currentBranch -ne "upstream-latest") {
-                Write-Host "Switching llama.cpp from '$currentBranch' to upstream-latest..."
-                Invoke-NativeCommand "git" @("checkout", "upstream-latest")
+            if (Test-CommandSuccess "git" @("remote", "get-url", "origin")) {
+                Invoke-NativeCommand "git" @("remote", "set-url", "origin", $llamaRepo)
+            } else {
+                Invoke-NativeCommand "git" @("remote", "add", "origin", $llamaRepo)
             }
-            Write-Host "Pulling latest upstream-latest from origin..."
-            Invoke-NativeCommand "git" @("pull", "--ff-only", "origin", "upstream-latest")
+
+            if ($llamaPinSha) {
+                if (-not (Test-CommandSuccess "git" @("cat-file", "-e", "${llamaPinSha}^{commit}"))) {
+                    Write-Host "Fetching pinned llama.cpp SHA $llamaPinSha..."
+                    Invoke-NativeCommand "git" @("fetch", "--depth", "1", "origin", $llamaPinSha)
+                }
+                $currentSha = (& git rev-parse HEAD).Trim()
+                if ($currentSha -ne $llamaPinSha) {
+                    Write-Host "Checking out pinned llama.cpp SHA $llamaPinSha (was $currentSha)..."
+                    Invoke-NativeCommand "git" @("checkout", "--detach", $llamaPinSha)
+                } else {
+                    Write-Host "llama.cpp already at pinned SHA $llamaPinSha, no checkout needed"
+                }
+            } else {
+                $currentBranch = (& git branch --show-current).Trim()
+                if ($currentBranch -ne "master") {
+                    Write-Host "Switching llama.cpp from '$currentBranch' to master..."
+                    Invoke-NativeCommand "git" @("checkout", "master")
+                }
+                Write-Host "Pulling latest master from origin..."
+                Invoke-NativeCommand "git" @("pull", "--ff-only", "origin", "master")
+            }
         } finally {
             Pop-Location
         }
@@ -612,6 +654,7 @@ Invoke-InRepo {
         "-B", $buildDir,
         "-S", $llamaDir,
         "-DCMAKE_BUILD_TYPE=Release",
+        "-DCMAKE_CXX_FLAGS=/DPATH_MAX=4096",
         "-DGGML_RPC=ON",
         "-DGGML_METAL=OFF",
         "-DGGML_CUDA=OFF",


### PR DESCRIPTION
Windows users can now build the CUDA backend from the pinned Mesh-LLM llama.cpp fork, launch the bundled child servers without hand-editing PATH, and see dashboard VRAM values that match physical GPU inventory instead of effective serving capacity.

## What changed
- Updated the Windows build script to clone/fetch `Mesh-LLM/llama.cpp` and honor `MESH_LLM_LLAMA_PIN_SHA` or the repo-root `LLAMA_CPP_SHA` instead of tracking `michaelneale/upstream-latest`.
- Added an MSVC `PATH_MAX` define so the pinned `llama-moe-split` target builds on Windows while keeping the llama.cpp checkout at the pinned SHA.
- Added Windows CUDA runtime search paths for child `rpc-server` and `llama-server` processes, including CUDA 13.x `bin\x64` installs.
- Fixed Windows runtime-root fallback when PowerShell has `USERPROFILE` but not `HOME`.
- Fixed Windows plugin transport compilation and cleaned Windows-only Rust cfg warnings in process signaling/runtime reaper code.
- Dashboard VRAM display now prefers structured `gpus[].vram_bytes` for physical GPU VRAM, falling back to legacy capacity values only when inventory is absent.

## Validation
- `npm.cmd test -- status-helpers.test.ts`
- `just --shell powershell.exe --shell-arg -NoProfile --shell-arg -ExecutionPolicy --shell-arg Bypass --shell-arg -Command build backend=cuda cuda_arch=120 rocm_arch=unused` reached and passed the llama.cpp CUDA build plus UI typecheck/Vite build, then failed only at replacing the running `target\release\mesh-llm.exe` because the live node had the executable locked (`Access is denied`).
- Earlier full CUDA build on this branch completed successfully before the dashboard-only change.
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm` (passes with one pre-existing warning in `mesh-llm/src/system/hardware.rs`)
- `llama-server.exe --help` shows `--mesh-port` / `--mesh-hook-debug`
- `rpc-server.exe --help` starts with CUDA runtime DLL path available