### PR TITLE
Fix Vulkan device selection across startup and GPU reporting

### DIFF
--- a/mesh-llm/src/cli/commands/gpus.rs
+++ b/mesh-llm/src/cli/commands/gpus.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result};
 use serde_json::{json, Value};
 
 use crate::cli::GpuCommand;
+use crate::inference::launch;
 
 use crate::system::{
     benchmark::{self, SavedBenchmark},
@@ -17,6 +18,7 @@ pub(crate) fn dispatch_gpu_command(json_output: bool, command: Option<&GpuComman
 
 pub(crate) fn run_gpus(json_output: bool) -> Result<()> {
     let mut hw = hardware::survey();
+    apply_installed_backend_devices(&mut hw);
     attach_cached_bandwidth(&mut hw);
 
     if json_output {
@@ -36,6 +38,23 @@ pub(crate) fn run_gpus(json_output: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn apply_installed_backend_devices(hw: &mut HardwareSurvey) {
+    let Some(flavor) = installed_rpc_binary_flavor() else {
+        return;
+    };
+
+    for gpu in &mut hw.gpus {
+        gpu.backend_device = launch::backend_device_for_flavor(gpu.index, flavor);
+    }
+}
+
+fn installed_rpc_binary_flavor() -> Option<launch::BinaryFlavor> {
+    let bin_dir = std::env::current_exe().ok()?.parent()?.to_path_buf();
+    launch::resolve_binary_flavor(&bin_dir, "rpc-server", None)
+        .ok()
+        .flatten()
 }
 
 fn run_gpu_benchmark(json_output: bool) -> Result<()> {

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -211,6 +211,27 @@ fn resolve_binary_path(
     }
 }
 
+pub(crate) fn resolve_binary_flavor(
+    bin_dir: &Path,
+    name: &str,
+    requested_flavor: Option<BinaryFlavor>,
+) -> Result<Option<BinaryFlavor>> {
+    resolve_binary_path(bin_dir, name, requested_flavor).map(|binary| binary.flavor)
+}
+
+pub(crate) fn backend_device_for_flavor(
+    index: usize,
+    binary_flavor: BinaryFlavor,
+) -> Option<String> {
+    match binary_flavor {
+        BinaryFlavor::Cpu => None,
+        BinaryFlavor::Cuda => Some(format!("CUDA{index}")),
+        BinaryFlavor::Rocm => Some(format!("ROCm{index}")),
+        BinaryFlavor::Vulkan => Some(format!("Vulkan{index}")),
+        BinaryFlavor::Metal => Some(format!("MTL{index}")),
+    }
+}
+
 fn child_library_search_paths(binary_path: &Path) -> Vec<PathBuf> {
     let mut paths = Vec::new();
     if let Some(parent) = binary_path.parent() {
@@ -1950,6 +1971,19 @@ No devices found
             preferred_device(&available, Some(BinaryFlavor::Vulkan)),
             Some("Vulkan0".to_string())
         );
+    }
+
+    #[test]
+    fn backend_device_for_flavor_uses_backend_namespace() {
+        assert_eq!(
+            super::backend_device_for_flavor(0, BinaryFlavor::Vulkan),
+            Some("Vulkan0".to_string())
+        );
+        assert_eq!(
+            super::backend_device_for_flavor(1, BinaryFlavor::Cuda),
+            Some("CUDA1".to_string())
+        );
+        assert_eq!(super::backend_device_for_flavor(0, BinaryFlavor::Cpu), None);
     }
 
     #[test]

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -565,7 +565,21 @@ pub(crate) async fn run() -> Result<()> {
         return Ok(());
     }
     let mut startup_models = resolve_startup_models(&startup_specs, cli.max_vram).await?;
-    preflight_config_owned_startup_models(&config, &startup_specs, &mut startup_models)?;
+    let bin_dir = match &cli.bin_dir {
+        Some(d) => d.clone(),
+        None => detect_bin_dir()?,
+    };
+    let rpc_binary_flavor = if config.gpu.assignment == plugin::GpuAssignment::Pinned {
+        launch::resolve_binary_flavor(&bin_dir, "rpc-server", cli.llama_flavor)?
+    } else {
+        None
+    };
+    preflight_config_owned_startup_models(
+        &config,
+        &startup_specs,
+        &mut startup_models,
+        rpc_binary_flavor,
+    )?;
     let resolved_models: Vec<PathBuf> = startup_models
         .iter()
         .map(|model| model.resolved_path.clone())
@@ -594,11 +608,6 @@ pub(crate) async fn run() -> Result<()> {
                 .map(router::strip_split_suffix_owned)
         })
         .collect();
-
-    let bin_dir = match &cli.bin_dir {
-        Some(d) => d.clone(),
-        None => detect_bin_dir()?,
-    };
 
     run_auto(
         cli,
@@ -830,13 +839,28 @@ fn preflight_config_owned_startup_models(
     config: &plugin::MeshConfig,
     specs: &[StartupModelSpec],
     plans: &mut [StartupModelPlan],
+    binary_flavor: Option<launch::BinaryFlavor>,
 ) -> Result<()> {
     if config.gpu.assignment != plugin::GpuAssignment::Pinned {
         return Ok(());
     }
 
-    let survey = hardware::query(pinned_startup_preflight_metrics());
+    let mut survey = hardware::query(pinned_startup_preflight_metrics());
+    apply_backend_devices_for_flavor(&mut survey.gpus, binary_flavor);
     preflight_config_owned_startup_models_with_gpus(config, specs, plans, &survey.gpus)
+}
+
+fn apply_backend_devices_for_flavor(
+    gpus: &mut [hardware::GpuFacts],
+    binary_flavor: Option<launch::BinaryFlavor>,
+) {
+    let Some(binary_flavor) = binary_flavor else {
+        return;
+    };
+
+    for gpu in gpus {
+        gpu.backend_device = launch::backend_device_for_flavor(gpu.index, binary_flavor);
+    }
 }
 
 fn pinned_startup_preflight_metrics() -> &'static [hardware::Metric] {
@@ -3235,6 +3259,28 @@ mod tests {
                 vram_bytes: 24_000_000_000,
             })
         );
+    }
+
+    #[test]
+    fn pinned_gpu_startup_preflight_uses_backend_available_from_binary_flavor() {
+        let mut gpus = vec![
+            synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0")),
+            synthetic_gpu(1, Some("pci:0000:b3:00.0"), Some("ROCm1")),
+        ];
+
+        apply_backend_devices_for_flavor(&mut gpus, Some(launch::BinaryFlavor::Vulkan));
+
+        assert_eq!(gpus[0].backend_device.as_deref(), Some("Vulkan0"));
+        assert_eq!(gpus[1].backend_device.as_deref(), Some("Vulkan1"));
+    }
+
+    #[test]
+    fn pinned_gpu_startup_preflight_keeps_detected_backend_without_resolved_flavor() {
+        let mut gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
+
+        apply_backend_devices_for_flavor(&mut gpus, None);
+
+        assert_eq!(gpus[0].backend_device.as_deref(), Some("CUDA0"));
     }
 
     #[test]

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -540,6 +540,43 @@ function Ensure-VulkanToolchain {
     }
 }
 
+function Copy-DevRuntimeBinaries {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BackendName,
+        [Parameter(Mandatory = $true)]
+        [string]$BuildDir,
+        [Parameter(Mandatory = $true)]
+        [string]$RepoRoot
+    )
+
+    $sourceBinDir = Join-Path $BuildDir "bin"
+    $targetDir = Join-Path $RepoRoot "target\release"
+    New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+
+    $flavoredCopies = @(
+        @{ Source = "rpc-server.exe"; Target = "rpc-server-$BackendName.exe" },
+        @{ Source = "llama-server.exe"; Target = "llama-server-$BackendName.exe" }
+    )
+
+    foreach ($copy in $flavoredCopies) {
+        $source = Join-Path $sourceBinDir $copy.Source
+        if (-not (Test-Path $source)) {
+            throw "Expected llama.cpp binary not found: $source"
+        }
+        Copy-Item -LiteralPath $source -Destination (Join-Path $targetDir $copy.Target) -Force
+    }
+
+    foreach ($name in @("llama-moe-analyze.exe", "llama-moe-split.exe")) {
+        $source = Join-Path $sourceBinDir $name
+        if (Test-Path $source) {
+            Copy-Item -LiteralPath $source -Destination (Join-Path $targetDir $name) -Force
+        }
+    }
+
+    Write-Host "Staged llama.cpp runtime binaries in target\release with '$BackendName' flavor names."
+}
+
 function Invoke-InRepo {
     param(
         [scriptblock]$Script
@@ -734,5 +771,6 @@ Invoke-InRepo {
 
     Write-Host "Building mesh-llm..."
     Invoke-NativeCommand "cargo" @("build", "--release", "--locked", "-p", "mesh-llm")
+    Copy-DevRuntimeBinaries -BackendName $backendName -BuildDir $buildDir -RepoRoot $repoRoot
     Write-Host "Mesh binary: target\release\mesh-llm.exe"
 }


### PR DESCRIPTION
## Summary
- Resolve Vulkan `rpc-server` launches using Vulkan backend device names instead of CUDA labels
- Keep pinned startup preflight aligned with the selected llama.cpp backend flavor
- Update GPU/status reporting so device names reflect the active backend namespace more consistently
- Include Windows Vulkan build script support and related UI/status test updates

## Testing
- Added and ran focused unit tests for backend flavor/device resolution and pinned startup preflight behavior
- Ran local Rust validation with formatting and package checks passing
- Built the Windows Vulkan configuration successfully with `just build backend=vulkan`