### PR TITLE
Preflight Vulkan launches against primary GPU VRAM

### DIFF
--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -164,8 +164,32 @@ fn split_peer_vram_bytes(peer: &mesh::PeerInfo, my_vram: u64) -> u64 {
 fn effective_local_launch_vram(
     my_vram: u64,
     pinned_gpu: Option<&crate::runtime::StartupPinnedGpuTarget>,
+    binary_flavor: Option<launch::BinaryFlavor>,
+    gpu_vram: Option<&str>,
 ) -> u64 {
-    pinned_gpu.map(|gpu| gpu.vram_bytes).unwrap_or(my_vram)
+    if let Some(gpu) = pinned_gpu {
+        return gpu.vram_bytes;
+    }
+
+    match binary_flavor {
+        Some(launch::BinaryFlavor::Vulkan) | Some(launch::BinaryFlavor::Metal) => {
+            primary_gpu_vram_bytes(gpu_vram)
+                .map(|bytes| bytes.min(my_vram))
+                .unwrap_or(my_vram)
+        }
+        Some(launch::BinaryFlavor::Cpu)
+        | Some(launch::BinaryFlavor::Cuda)
+        | Some(launch::BinaryFlavor::Rocm)
+        | None => my_vram,
+    }
+}
+
+fn primary_gpu_vram_bytes(gpu_vram: Option<&str>) -> Option<u64> {
+    gpu_vram?
+        .split(',')
+        .next()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .filter(|bytes| *bytes > 0)
 }
 
 fn build_dense_launch_plan(
@@ -1662,7 +1686,12 @@ pub async fn election_loop(
 
     let model_bytes = total_model_bytes(&model);
     let my_vram = node.vram_bytes();
-    let local_launch_vram = effective_local_launch_vram(my_vram, pinned_gpu.as_ref());
+    let local_launch_vram = effective_local_launch_vram(
+        my_vram,
+        pinned_gpu.as_ref(),
+        binary_flavor,
+        node.gpu_vram.as_deref(),
+    );
     let model_fits_locally = local_launch_vram >= (model_bytes as f64 * 1.1) as u64;
 
     // Check if this is a MoE model with enough metadata to plan expert routing.
@@ -3033,7 +3062,8 @@ async fn start_llama(
         slots,
     } = params;
     let my_vram = node.vram_bytes();
-    let local_launch_vram = effective_local_launch_vram(my_vram, pinned_gpu);
+    let local_launch_vram =
+        effective_local_launch_vram(my_vram, pinned_gpu, binary_flavor, node.gpu_vram.as_deref());
     let model_bytes = total_model_bytes(model);
     let launch_plan = build_dense_launch_plan(
         local_launch_vram,
@@ -3335,7 +3365,7 @@ mod tests {
             vram_bytes: 30,
         };
 
-        let local_launch_vram = effective_local_launch_vram(80, Some(&pinned_gpu));
+        let local_launch_vram = effective_local_launch_vram(80, Some(&pinned_gpu), None, None);
         let plan = build_dense_launch_plan(
             local_launch_vram,
             60,
@@ -3361,6 +3391,30 @@ mod tests {
             local_launch_vram,
             &[peer]
         ));
+    }
+
+    #[test]
+    fn vulkan_local_launch_preflight_uses_primary_device_capacity() {
+        let local_launch_vram = effective_local_launch_vram(
+            29_400_000_000,
+            None,
+            Some(BinaryFlavor::Vulkan),
+            Some("15977000000,16212000000"),
+        );
+
+        assert_eq!(local_launch_vram, 15_977_000_000);
+    }
+
+    #[test]
+    fn cuda_local_launch_preflight_keeps_aggregate_capacity() {
+        let local_launch_vram = effective_local_launch_vram(
+            48_000_000_000,
+            None,
+            Some(BinaryFlavor::Cuda),
+            Some("24000000000,24000000000"),
+        );
+
+        assert_eq!(local_launch_vram, 48_000_000_000);
     }
 
     #[test]

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -87,6 +87,13 @@ struct ResolvedBinary {
     flavor: Option<BinaryFlavor>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BinaryBackendDeviceProbe {
+    pub(crate) path: PathBuf,
+    pub(crate) flavor: Option<BinaryFlavor>,
+    pub(crate) available_devices: Vec<String>,
+}
+
 pub(crate) fn platform_bin_name(name: &str) -> String {
     #[cfg(windows)]
     {
@@ -221,6 +228,53 @@ pub(crate) fn resolve_binary_flavor(
     requested_flavor: Option<BinaryFlavor>,
 ) -> Result<Option<BinaryFlavor>> {
     resolve_binary_path(bin_dir, name, requested_flavor).map(|binary| binary.flavor)
+}
+
+pub(crate) fn probe_backend_devices_for_binary(
+    bin_dir: &Path,
+    name: &str,
+    requested_flavor: Option<BinaryFlavor>,
+) -> Result<BinaryBackendDeviceProbe> {
+    let binary = resolve_binary_path(bin_dir, name, requested_flavor)?;
+    let available_devices = probe_available_devices(&binary.path);
+    Ok(BinaryBackendDeviceProbe {
+        path: binary.path,
+        flavor: binary.flavor,
+        available_devices,
+    })
+}
+
+pub(crate) fn resolve_requested_device_from_available(
+    available: &[String],
+    binary: &Path,
+    requested: &str,
+) -> Result<String> {
+    if !available.is_empty() {
+        if available.iter().any(|candidate| candidate == requested) {
+            return Ok(requested.to_string());
+        }
+
+        // Dual support for ROCm/HIP transition.
+        let is_amd_requested = requested.starts_with("ROCm") || requested.starts_with("HIP");
+        if is_amd_requested {
+            let alt_device = if requested.starts_with("ROCm") {
+                requested.replace("ROCm", "HIP")
+            } else {
+                requested.replace("HIP", "ROCm")
+            };
+            if available.iter().any(|candidate| candidate == &alt_device) {
+                return Ok(alt_device);
+            }
+        }
+
+        anyhow::bail!(
+            "requested device {requested} is not supported by {}. Available devices: {}",
+            binary.display(),
+            available.join(", ")
+        );
+    }
+
+    Ok(requested.to_string())
 }
 
 pub(crate) fn backend_device_for_flavor(
@@ -804,31 +858,7 @@ fn resolve_device_for_binary(
     let available = probe_available_devices(binary);
 
     if let Some(device) = requested {
-        if !available.is_empty() {
-            if available.iter().any(|candidate| candidate == device) {
-                return Ok(device.to_string());
-            }
-
-            // Dual support for ROCm/HIP transition
-            let is_amd_requested = device.starts_with("ROCm") || device.starts_with("HIP");
-            if is_amd_requested {
-                let alt_device = if device.starts_with("ROCm") {
-                    device.replace("ROCm", "HIP")
-                } else {
-                    device.replace("HIP", "ROCm")
-                };
-                if available.iter().any(|candidate| candidate == &alt_device) {
-                    return Ok(alt_device);
-                }
-            }
-
-            anyhow::bail!(
-                "requested device {device} is not supported by {}. Available devices: {}",
-                binary.display(),
-                available.join(", ")
-            );
-        }
-        return Ok(device.to_string());
+        return resolve_requested_device_from_available(&available, binary, device);
     }
 
     if let Some(selected) = preferred_device(&available, flavor) {
@@ -2621,6 +2651,47 @@ No devices found
             preferred_device(&available, Some(BinaryFlavor::Vulkan)),
             Some("Vulkan0".to_string())
         );
+    }
+
+    #[test]
+    fn resolve_requested_device_from_available_rejects_missing_device() {
+        let available = vec!["Vulkan0".to_string(), "CPU".to_string()];
+        let err = super::resolve_requested_device_from_available(
+            &available,
+            Path::new("/tmp/rpc-server-vulkan"),
+            "Vulkan1",
+        )
+        .unwrap_err();
+
+        let message = err.to_string();
+        assert!(message.contains("requested device Vulkan1 is not supported"));
+        assert!(message.contains("Available devices: Vulkan0, CPU"));
+    }
+
+    #[test]
+    fn resolve_requested_device_from_available_preserves_rocm_hip_alias() {
+        let available = vec!["HIP1".to_string(), "CPU".to_string()];
+        let resolved = super::resolve_requested_device_from_available(
+            &available,
+            Path::new("/tmp/rpc-server-rocm"),
+            "ROCm1",
+        )
+        .unwrap();
+
+        assert_eq!(resolved, "HIP1");
+    }
+
+    #[test]
+    fn resolve_requested_device_from_available_keeps_request_when_probe_empty() {
+        let available = Vec::new();
+        let resolved = super::resolve_requested_device_from_available(
+            &available,
+            Path::new("/tmp/rpc-server-vulkan"),
+            "Vulkan1",
+        )
+        .unwrap();
+
+        assert_eq!(resolved, "Vulkan1");
     }
 
     #[test]

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -1160,11 +1160,11 @@ pub(crate) async fn run() -> Result<()> {
         Some(d) => d.clone(),
         None => detect_bin_dir()?,
     };
-    let rpc_binary_flavor = if config.gpu.assignment == plugin::GpuAssignment::Pinned {
-        launch::resolve_binary_flavor(&bin_dir, "rpc-server", cli.llama_flavor)?
-    } else {
-        None
-    };
+    let rpc_binary_flavor =
+        launch::resolve_binary_flavor(&bin_dir, "rpc-server", cli.llama_flavor)?;
+    if cli.llama_flavor.is_none() {
+        cli.llama_flavor = rpc_binary_flavor;
+    }
     preflight_config_owned_startup_models(
         &config,
         &startup_specs,

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -1160,8 +1160,19 @@ pub(crate) async fn run() -> Result<()> {
         Some(d) => d.clone(),
         None => detect_bin_dir()?,
     };
-    let rpc_binary_flavor =
-        launch::resolve_binary_flavor(&bin_dir, "rpc-server", cli.llama_flavor)?;
+    let rpc_backend_probe = if config.gpu.assignment == plugin::GpuAssignment::Pinned {
+        Some(launch::probe_backend_devices_for_binary(
+            &bin_dir,
+            "rpc-server",
+            cli.llama_flavor,
+        )?)
+    } else {
+        None
+    };
+    let rpc_binary_flavor = match &rpc_backend_probe {
+        Some(probe) => probe.flavor,
+        None => launch::resolve_binary_flavor(&bin_dir, "rpc-server", cli.llama_flavor)?,
+    };
     if cli.llama_flavor.is_none() {
         cli.llama_flavor = rpc_binary_flavor;
     }
@@ -1169,7 +1180,7 @@ pub(crate) async fn run() -> Result<()> {
         &config,
         &startup_specs,
         &mut startup_models,
-        rpc_binary_flavor,
+        rpc_backend_probe.as_ref(),
     )?;
     let resolved_models: Vec<PathBuf> = startup_models
         .iter()
@@ -1449,15 +1460,24 @@ fn preflight_config_owned_startup_models(
     config: &plugin::MeshConfig,
     specs: &[StartupModelSpec],
     plans: &mut [StartupModelPlan],
-    binary_flavor: Option<launch::BinaryFlavor>,
+    backend_probe: Option<&launch::BinaryBackendDeviceProbe>,
 ) -> Result<()> {
     if config.gpu.assignment != plugin::GpuAssignment::Pinned {
         return Ok(());
     }
 
     let mut survey = hardware::query(pinned_startup_preflight_metrics());
-    apply_backend_devices_for_flavor(&mut survey.gpus, binary_flavor);
-    preflight_config_owned_startup_models_with_gpus(config, specs, plans, &survey.gpus)
+    apply_backend_devices_for_flavor(
+        &mut survey.gpus,
+        backend_probe.and_then(|probe| probe.flavor),
+    );
+    preflight_config_owned_startup_models_with_gpus(
+        config,
+        specs,
+        plans,
+        &survey.gpus,
+        backend_probe,
+    )
 }
 
 fn apply_backend_devices_for_flavor(
@@ -1487,6 +1507,7 @@ fn preflight_config_owned_startup_models_with_gpus(
     specs: &[StartupModelSpec],
     plans: &mut [StartupModelPlan],
     gpus: &[hardware::GpuFacts],
+    backend_probe: Option<&launch::BinaryBackendDeviceProbe>,
 ) -> Result<()> {
     if config.gpu.assignment != plugin::GpuAssignment::Pinned {
         return Ok(());
@@ -1536,6 +1557,21 @@ fn preflight_config_owned_startup_models_with_gpus(
                     plan.declared_ref
                 )
             })?;
+        let backend_device = if let Some(probe) = backend_probe {
+            launch::resolve_requested_device_from_available(
+                &probe.available_devices,
+                &probe.path,
+                &backend_device,
+            )
+            .with_context(|| {
+                format!(
+                    "startup model '{}' failed pinned GPU preflight",
+                    plan.declared_ref
+                )
+            })?
+        } else {
+            backend_device
+        };
 
         plan.pinned_gpu = Some(StartupPinnedGpuTarget {
             index: resolved_gpu.index,
@@ -4352,7 +4388,7 @@ mod tests {
             synthetic_gpu(1, Some("pci:0000:b3:00.0"), Some("CUDA1")),
         ];
 
-        preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus)
+        preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus, None)
             .unwrap();
 
         assert_eq!(plans[0].gpu_id.as_deref(), Some("pci:0000:65:00.0"));
@@ -4368,7 +4404,7 @@ mod tests {
     }
 
     #[test]
-    fn pinned_gpu_startup_preflight_uses_backend_available_from_binary_flavor() {
+    fn pinned_gpu_startup_preflight_synthesizes_backend_from_binary_flavor() {
         let mut gpus = vec![
             synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0")),
             synthetic_gpu(1, Some("pci:0000:b3:00.0"), Some("ROCm1")),
@@ -4378,6 +4414,99 @@ mod tests {
 
         assert_eq!(gpus[0].backend_device.as_deref(), Some("Vulkan0"));
         assert_eq!(gpus[1].backend_device.as_deref(), Some("Vulkan1"));
+    }
+
+    #[test]
+    fn pinned_gpu_startup_preflight_rejects_synthesized_backend_missing_from_probe() {
+        let config = plugin::MeshConfig {
+            gpu: plugin::GpuConfig {
+                assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
+            },
+            ..plugin::MeshConfig::default()
+        };
+        let specs = vec![StartupModelSpec {
+            model_ref: PathBuf::from("Qwen3-8B-Q4_K_M"),
+            mmproj_ref: None,
+            ctx_size: Some(4096),
+            gpu_id: Some("pci:0000:b3:00.0".into()),
+            config_owned: true,
+            parallel: None,
+        }];
+        let mut plans = vec![StartupModelPlan {
+            declared_ref: "Qwen3-8B-Q4_K_M".into(),
+            resolved_path: PathBuf::from("/tmp/Qwen3-8B-Q4_K_M.gguf"),
+            mmproj_path: None,
+            ctx_size: Some(4096),
+            gpu_id: Some("pci:0000:b3:00.0".into()),
+            pinned_gpu: None,
+            parallel: None,
+        }];
+        let gpus = vec![synthetic_gpu(1, Some("pci:0000:b3:00.0"), Some("Vulkan1"))];
+        let backend_probe = launch::BinaryBackendDeviceProbe {
+            path: PathBuf::from("/tmp/rpc-server-vulkan"),
+            flavor: Some(launch::BinaryFlavor::Vulkan),
+            available_devices: vec!["Vulkan0".into(), "CPU".into()],
+        };
+
+        let err = preflight_config_owned_startup_models_with_gpus(
+            &config,
+            &specs,
+            &mut plans,
+            &gpus,
+            Some(&backend_probe),
+        )
+        .unwrap_err();
+        let message = format!("{err:#}");
+
+        assert!(message.contains("failed pinned GPU preflight"));
+        assert!(message.contains("requested device Vulkan1 is not supported"));
+        assert!(message.contains("Available devices: Vulkan0, CPU"));
+    }
+
+    #[test]
+    fn pinned_gpu_startup_preflight_canonicalizes_rocm_hip_alias_from_probe() {
+        let config = plugin::MeshConfig {
+            gpu: plugin::GpuConfig {
+                assignment: plugin::GpuAssignment::Pinned,
+                parallel: None,
+            },
+            ..plugin::MeshConfig::default()
+        };
+        let specs = vec![StartupModelSpec {
+            model_ref: PathBuf::from("Qwen3-8B-Q4_K_M"),
+            mmproj_ref: None,
+            ctx_size: Some(4096),
+            gpu_id: Some("pci:0000:b3:00.0".into()),
+            config_owned: true,
+            parallel: None,
+        }];
+        let mut plans = vec![StartupModelPlan {
+            declared_ref: "Qwen3-8B-Q4_K_M".into(),
+            resolved_path: PathBuf::from("/tmp/Qwen3-8B-Q4_K_M.gguf"),
+            mmproj_path: None,
+            ctx_size: Some(4096),
+            gpu_id: Some("pci:0000:b3:00.0".into()),
+            pinned_gpu: None,
+            parallel: None,
+        }];
+        let gpus = vec![synthetic_gpu(1, Some("pci:0000:b3:00.0"), Some("ROCm1"))];
+        let backend_probe = launch::BinaryBackendDeviceProbe {
+            path: PathBuf::from("/tmp/rpc-server-rocm"),
+            flavor: Some(launch::BinaryFlavor::Rocm),
+            available_devices: vec!["HIP1".into(), "CPU".into()],
+        };
+
+        preflight_config_owned_startup_models_with_gpus(
+            &config,
+            &specs,
+            &mut plans,
+            &gpus,
+            Some(&backend_probe),
+        )
+        .unwrap();
+
+        assert_eq!(plans[0].pinned_gpu.as_ref().unwrap().backend_device, "HIP1");
     }
 
     #[test]
@@ -4429,7 +4558,7 @@ mod tests {
         }];
         let gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
 
-        preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus)
+        preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus, None)
             .unwrap();
 
         assert_eq!(specs[0].gpu_id, None);
@@ -4466,9 +4595,10 @@ mod tests {
         }];
         let gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
 
-        let err =
-            preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus)
-                .unwrap_err();
+        let err = preflight_config_owned_startup_models_with_gpus(
+            &config, &specs, &mut plans, &gpus, None,
+        )
+        .unwrap_err();
         let message = format!("{err:#}");
 
         assert!(message.contains("failed pinned GPU preflight"));
@@ -4503,7 +4633,7 @@ mod tests {
         }];
         let gpus = vec![synthetic_gpu(3, Some("uuid:GPU-123"), Some("CUDA3"))];
 
-        preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus)
+        preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus, None)
             .unwrap();
 
         let pinned_gpu = plans[0].pinned_gpu.as_ref().unwrap();
@@ -4541,9 +4671,10 @@ mod tests {
         }];
         let gpus = vec![synthetic_gpu(3, Some("uuid:GPU-123"), None)];
 
-        let err =
-            preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus)
-                .unwrap_err();
+        let err = preflight_config_owned_startup_models_with_gpus(
+            &config, &specs, &mut plans, &gpus, None,
+        )
+        .unwrap_err();
         let message = format!("{err:#}");
 
         assert!(message.contains("failed pinned GPU preflight"));
@@ -4578,9 +4709,10 @@ mod tests {
         }];
         let gpus = vec![synthetic_gpu(0, Some("pci:0000:65:00.0"), Some("CUDA0"))];
 
-        let err =
-            preflight_config_owned_startup_models_with_gpus(&config, &specs, &mut plans, &gpus)
-                .unwrap_err();
+        let err = preflight_config_owned_startup_models_with_gpus(
+            &config, &specs, &mut plans, &gpus, None,
+        )
+        .unwrap_err();
         let message = format!("{err:#}");
 
         assert!(message.contains("failed pinned GPU preflight"));

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -193,6 +193,34 @@ configure_compiler_cache() {
     esac
 }
 
+stage_dev_runtime_binaries() {
+    local backend="$1"
+    local target_dir="$2"
+    local source_bin_dir="$BUILD_DIR/bin"
+
+    mkdir -p "$target_dir"
+    rm -f "$target_dir/rpc-server" "$target_dir/llama-server"
+    rm -f "$target_dir"/rpc-server-* "$target_dir"/llama-server-*
+
+    for name in rpc-server llama-server; do
+        local source="$source_bin_dir/$name"
+        if [[ ! -f "$source" ]]; then
+            echo "Error: expected llama.cpp binary not found: $source" >&2
+            exit 1
+        fi
+        cp "$source" "$target_dir/$name-$backend"
+    done
+
+    for name in llama-moe-analyze llama-moe-split; do
+        local source="$source_bin_dir/$name"
+        if [[ -f "$source" ]]; then
+            cp "$source" "$target_dir/$name"
+        fi
+    done
+
+    echo "Staged llama.cpp runtime binaries in $target_dir with '$backend' flavor names."
+}
+
 if [[ -z "$BACKEND" ]]; then
     BACKEND="$(detect_backend)"
 fi
@@ -370,10 +398,12 @@ if [[ -d "$MESH_DIR" ]]; then
     if [[ "${MESH_LLM_BUILD_PROFILE:-release}" == "dev" || "${MESH_LLM_BUILD_PROFILE:-release}" == "debug" ]]; then
         echo "Building mesh-llm (profile: dev, bin only)..."
         (cd "$REPO_ROOT" && cargo build -p mesh-llm --bin mesh-llm)
+        stage_dev_runtime_binaries "$BACKEND" "$REPO_ROOT/target/debug"
         echo "Mesh binary: target/debug/mesh-llm"
     else
         echo "Building mesh-llm (profile: release)..."
         (cd "$MESH_DIR" && cargo build --release)
+        stage_dev_runtime_binaries "$BACKEND" "$REPO_ROOT/target/release"
         echo "Mesh binary: target/release/mesh-llm"
     fi
 fi

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -43,6 +43,34 @@ configure_compiler_cache() {
     fi
 }
 
+stage_dev_runtime_binaries() {
+    local backend="$1"
+    local target_dir="$2"
+    local source_bin_dir="$BUILD_DIR/bin"
+
+    mkdir -p "$target_dir"
+    rm -f "$target_dir/rpc-server" "$target_dir/llama-server"
+    rm -f "$target_dir"/rpc-server-* "$target_dir"/llama-server-*
+
+    for name in rpc-server llama-server; do
+        local source="$source_bin_dir/$name"
+        if [[ ! -f "$source" ]]; then
+            echo "Error: expected llama.cpp binary not found: $source" >&2
+            exit 1
+        fi
+        cp "$source" "$target_dir/$name-$backend"
+    done
+
+    for name in llama-moe-analyze llama-moe-split; do
+        local source="$source_bin_dir/$name"
+        if [[ -f "$source" ]]; then
+            cp "$source" "$target_dir/$name"
+        fi
+    done
+
+    echo "Staged llama.cpp runtime binaries in $target_dir with '$backend' flavor names."
+}
+
 LLAMA_WORKDIR="$LLAMA_DIR" "$SCRIPT_DIR/prepare-llama.sh" "${MESH_LLM_LLAMA_PIN_SHA:-pinned}"
 
 configure_compiler_cache
@@ -87,5 +115,6 @@ if [[ -d "$MESH_DIR" ]]; then
         )
     fi
 
+    stage_dev_runtime_binaries "metal" "$REPO_ROOT/target/release"
     echo "Mesh binary: target/release/mesh-llm"
 fi

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -50,7 +50,7 @@ stage_dev_runtime_binaries() {
 
     mkdir -p "$target_dir"
     rm -f "$target_dir/rpc-server" "$target_dir/llama-server"
-    rm -f "$target_dir"/rpc-server-* "$target_dir"/llama-server-*
+    rm -f "$target_dir"/rpc-server-*(N) "$target_dir"/llama-server-*(N)
 
     for name in rpc-server llama-server; do
         local source="$source_bin_dir/$name"

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -601,6 +601,12 @@ function Copy-DevRuntimeBinaries {
     $sourceBinDir = Join-Path $BuildDir "bin"
     $targetDir = Join-Path $RepoRoot "target\release"
     New-Item -ItemType Directory -Force -Path $targetDir | Out-Null
+    Remove-Item -LiteralPath (Join-Path $targetDir "rpc-server.exe") -Force -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath (Join-Path $targetDir "llama-server.exe") -Force -ErrorAction SilentlyContinue
+    foreach ($pattern in @("rpc-server-*.exe", "llama-server-*.exe")) {
+        Get-ChildItem -Path (Join-Path $targetDir $pattern) -File -ErrorAction SilentlyContinue |
+            Remove-Item -Force
+    }
 
     $flavoredCopies = @(
         @{ Source = "rpc-server.exe"; Target = "rpc-server-$BackendName.exe" },


### PR DESCRIPTION
﻿## Summary

This adds a local-launch preflight for Vulkan and Metal so mesh-llm does not treat aggregate local GPU capacity as if it were available to the primary backend device.

For Vulkan/Metal solo launches, the fit check now uses the first advertised GPU VRAM value. CUDA/ROCm keep aggregate capacity because local multi-GPU row split can be valid there.

The build scripts also stage flavored llama.cpp runtime binaries consistently on Linux, macOS, and Windows, and clear stale flavored server binaries before copying the current backend.

## Validation

- cargo test -p mesh-llm local_launch_preflight
- cargo test -p mesh-llm pinned_gpu_startup_preflight
- cargo test -p mesh-llm backend_device_for_flavor_uses_backend_namespace
- cargo check -p mesh-llm
- cargo fmt --all -- --check
- bash -n scripts/build-linux.sh
- PowerShell parser check for scripts/build-windows.ps1

Could not run zsh -n scripts/build-mac.sh in this Windows environment because zsh is not installed.
