### PR TITLE
feat: add built-in pi launcher (mesh-llm pi)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,26 @@ jobs:
 
       # ── System dependencies ──
       - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          apt_retry() {
+            local attempt=1
+            local max_attempts=5
+            until "$@"; do
+              if (( attempt >= max_attempts )); then
+                return 1
+              fi
+              local delay=$((attempt * 15))
+              echo "::warning::apt command failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s: $*"
+              sleep "${delay}"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          apt_retry sudo apt-get -o Acquire::Retries=5 update
+          apt_retry sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y libdbus-1-dev
 
       # ── Rust ──
       - uses: dtolnay/rust-toolchain@stable
@@ -626,8 +645,24 @@ jobs:
       - name: Install base packages
         shell: bash
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          set -euo pipefail
+
+          apt_retry() {
+            local attempt=1
+            local max_attempts=5
+            until "$@"; do
+              if (( attempt >= max_attempts )); then
+                return 1
+              fi
+              local delay=$((attempt * 15))
+              echo "::warning::apt command failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s: $*"
+              sleep "${delay}"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          apt_retry apt-get -o Acquire::Retries=5 update
+          apt_retry env DEBIAN_FRONTEND=noninteractive apt-get install -y \
             ca-certificates \
             curl \
             git \
@@ -826,8 +861,24 @@ jobs:
       - name: Install base packages
         shell: bash
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          set -euo pipefail
+
+          apt_retry() {
+            local attempt=1
+            local max_attempts=5
+            until "$@"; do
+              if (( attempt >= max_attempts )); then
+                return 1
+              fi
+              local delay=$((attempt * 15))
+              echo "::warning::apt command failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s: $*"
+              sleep "${delay}"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          apt_retry apt-get -o Acquire::Retries=5 update
+          apt_retry env DEBIAN_FRONTEND=noninteractive apt-get install -y \
             ca-certificates \
             curl \
             git \
@@ -997,8 +1048,24 @@ jobs:
       - name: Install Vulkan build packages
         shell: bash
         run: |
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          set -euo pipefail
+
+          apt_retry() {
+            local attempt=1
+            local max_attempts=5
+            until "$@"; do
+              if (( attempt >= max_attempts )); then
+                return 1
+              fi
+              local delay=$((attempt * 15))
+              echo "::warning::apt command failed (attempt ${attempt}/${max_attempts}); retrying in ${delay}s: $*"
+              sleep "${delay}"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          apt_retry sudo apt-get -o Acquire::Retries=5 update
+          apt_retry sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y \
             ca-certificates \
             curl \
             git \

--- a/README.md
+++ b/README.md
@@ -387,8 +387,8 @@ mesh-llm exposes an OpenAI-compatible API on `localhost:9337`. Any tool that sup
 
 For built-in launcher integrations (`goose`, `claude`, `opencode`, `pi`):
 
-- Goose, Claude, and pi reuse a local mesh on `--port` and auto-start a local client if needed.
-- OpenCode targets `--host` (default `127.0.0.1:9337`) and only auto-starts a local client for loopback/localhost targets.
+- Goose and Claude reuse a local mesh on `--port` and auto-start a local client if needed.
+- OpenCode and pi target `--host` (default `127.0.0.1:9337`) and only auto-start a local client for loopback/localhost targets.
 - If `--model` is omitted, the launcher picks the strongest tool-capable model available on the mesh.
 - When the harness exits (e.g. `claude` quits), the auto-started node is cleaned up automatically.
 
@@ -446,7 +446,19 @@ Use a specific model:
 mesh-llm pi --model MiniMax-M2.5-Q4_K_M
 ```
 
-This writes a mesh provider into `~/.pi/agent/models.json` and launches pi.
+This writes every model from the mesh into `~/.pi/agent/models.json` with model context sizes when available, then launches pi.
+
+Write or update the Pi provider config without launching pi:
+
+```bash
+mesh-llm pi --write
+```
+
+Target a remote mesh host or URL, including a custom port:
+
+```bash
+mesh-llm pi --write --host carrack.patio51.com:9337
+```
 
 ### External OpenAI-compatible backends (vLLM, TGI, Ollama, Lemonade, etc.)
 

--- a/README.md
+++ b/README.md
@@ -385,9 +385,9 @@ Build-from-source and UI development instructions are in [CONTRIBUTING.md](CONTR
 
 mesh-llm exposes an OpenAI-compatible API on `localhost:9337`. Any tool that supports custom OpenAI endpoints works. `/v1/models` lists available models; the `model` field in requests routes to the right node.
 
-For built-in launcher integrations (`goose`, `claude`, `opencode`):
+For built-in launcher integrations (`goose`, `claude`, `opencode`, `pi`):
 
-- Goose and Claude reuse a local mesh on `--port` and auto-start a local client if needed.
+- Goose, Claude, and pi reuse a local mesh on `--port` and auto-start a local client if needed.
 - OpenCode targets `--host` (default `127.0.0.1:9337`) and only auto-starts a local client for loopback/localhost targets.
 - If `--model` is omitted, the launcher picks the strongest tool-capable model available on the mesh.
 - When the harness exits (e.g. `claude` quits), the auto-started node is cleaned up automatically.
@@ -436,15 +436,17 @@ mesh-llm opencode --write --host 127.0.0.1:9337
 
 ### pi
 
-1. Start a mesh client:
 ```bash
-mesh-llm client --auto --port 9337
+mesh-llm pi
 ```
 
-2. Check what models are available:
+Use a specific model:
+
 ```bash
-curl -s http://localhost:9337/v1/models | jq '.data[].id'
+mesh-llm pi --model MiniMax-M2.5-Q4_K_M
 ```
+
+This writes a mesh provider into `~/.pi/agent/models.json` and launches pi.
 
 ### External OpenAI-compatible backends (vLLM, TGI, Ollama, Lemonade, etc.)
 

--- a/crates/mesh-llm/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm/src/cli/commands/integrations.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 
-use crate::runtime;
+use crate::{cli::shell, runtime};
 use url::Url;
 
 const OPENCODE_PROVIDER_ID: &str = "mesh";
@@ -69,7 +69,10 @@ fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
         .ok_or_else(|| anyhow::anyhow!("mesh host '{trimmed}' is missing a hostname"))?
         .to_string();
 
-    if !has_scheme && parsed.port().is_none() {
+    let is_local_host = is_loopback_or_localhost(&host_name);
+    let should_default_api_port =
+        parsed.port().is_none() && (!has_scheme || (is_local_host && parsed.scheme() == "http"));
+    if should_default_api_port {
         parsed
             .set_port(Some(DEFAULT_API_PORT))
             .map_err(|_| anyhow::anyhow!("Invalid mesh host '{trimmed}'"))?;
@@ -85,14 +88,14 @@ fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
     api_models.set_path("/v1/models");
 
     let mut management = parsed.clone();
-    if !has_scheme {
+    if !has_scheme || should_default_api_port {
         management
             .set_port(Some(DEFAULT_MANAGEMENT_PORT))
             .map_err(|_| anyhow::anyhow!("Invalid mesh host '{trimmed}'"))?;
     }
     management.set_path("/api/models");
 
-    let auto_start_local_mesh = is_loopback_or_localhost(&host_name);
+    let auto_start_local_mesh = is_local_host && parsed.scheme() == "http";
 
     Ok(OpenCodeTarget {
         input: trimmed.to_string(),
@@ -175,10 +178,6 @@ fn build_opencode_launch_spec_with_limits(
     }
 }
 
-fn shell_single_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
 fn opencode_missing_binary_guidance(
     chosen: &str,
     host: &str,
@@ -199,7 +198,7 @@ fn pi_missing_binary_guidance(model_arg: &str) -> Vec<String> {
         "pi not found in PATH.".to_string(),
         "Install: npm install -g @mariozechner/pi-coding-agent".to_string(),
         "Or run manually:".to_string(),
-        format!("  pi --model {}", shell_single_quote(model_arg)),
+        format!("  pi --model {}", shell::single_quote(model_arg)),
     ]
 }
 
@@ -1534,6 +1533,42 @@ mod tests {
         );
         assert!(target.auto_start_local_mesh);
         assert_eq!(target.local_port, Some(9443));
+    }
+
+    #[test]
+    fn opencode_host_normalization_defaults_scheme_loopback_to_mesh_ports() {
+        let localhost = normalize_opencode_host("http://localhost").expect("valid localhost URL");
+        let loopback = normalize_opencode_host("http://127.0.0.1").expect("valid loopback URL");
+
+        assert_eq!(localhost.api_base_url, "http://localhost:9337/v1");
+        assert_eq!(localhost.api_models_url, "http://localhost:9337/v1/models");
+        assert_eq!(
+            localhost.management_models_url,
+            "http://localhost:3131/api/models"
+        );
+        assert!(localhost.auto_start_local_mesh);
+        assert_eq!(localhost.local_port, Some(9337));
+
+        assert_eq!(loopback.api_base_url, "http://127.0.0.1:9337/v1");
+        assert_eq!(
+            loopback.management_models_url,
+            "http://127.0.0.1:3131/api/models"
+        );
+        assert!(loopback.auto_start_local_mesh);
+        assert_eq!(loopback.local_port, Some(9337));
+    }
+
+    #[test]
+    fn opencode_host_normalization_does_not_auto_start_https_loopback() {
+        let target = normalize_opencode_host("https://localhost:9337").expect("valid HTTPS URL");
+
+        assert_eq!(target.api_base_url, "https://localhost:9337/v1");
+        assert_eq!(
+            target.management_models_url,
+            "https://localhost:9337/api/models"
+        );
+        assert!(!target.auto_start_local_mesh);
+        assert_eq!(target.local_port, Some(9337));
     }
 
     #[test]

--- a/crates/mesh-llm/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm/src/cli/commands/integrations.rs
@@ -456,6 +456,42 @@ pub(crate) async fn run_pi(model: Option<String>, port: u16) -> Result<()> {
     Ok(())
 }
 
+pub(crate) async fn run_hermes(model: Option<String>, port: u16) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    let (_models, chosen, mut mesh_child) = runtime::check_mesh(&client, port, &model).await?;
+
+    let base_url = format!("http://localhost:{port}/v1");
+
+    // Hermes is OpenAI-compatible — just pass provider, base URL, and model as CLI flags.
+    // No config file writing needed.
+    eprintln!("🚀 Launching Hermes Agent with {chosen} → {base_url}\n");
+    let status = std::process::Command::new("hermes")
+        .args([
+            "--provider",
+            "custom",
+            "--base-url",
+            &base_url,
+            "--model",
+            &chosen,
+        ])
+        .env("OPENAI_API_KEY", "mesh-llm")
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => eprintln!("hermes exited with {s}"),
+        Err(_) => {
+            eprintln!("hermes not found in PATH.");
+            eprintln!("Install: pip install hermes-agent");
+            eprintln!("Or run manually:");
+            eprintln!("  hermes --provider custom --base-url {base_url} --model {chosen}");
+        }
+    }
+    cleanup_mesh_child(&mut mesh_child);
+    Ok(())
+}
+
 pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))

--- a/crates/mesh-llm/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm/src/cli/commands/integrations.rs
@@ -40,12 +40,16 @@ fn is_loopback_or_localhost(host: &str) -> bool {
 }
 
 fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
+    normalize_mesh_host_with_label(host, "mesh host")
+}
+
+fn normalize_mesh_host_with_label(host: &str, label: &str) -> Result<OpenCodeTarget> {
     const DEFAULT_API_PORT: u16 = 9337;
     const DEFAULT_MANAGEMENT_PORT: u16 = 3131;
 
     let trimmed = host.trim();
     if trimmed.is_empty() {
-        anyhow::bail!("mesh host cannot be empty");
+        anyhow::bail!("{label} cannot be empty");
     }
 
     let has_scheme = trimmed.contains("://");
@@ -57,16 +61,15 @@ fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
         trimmed.to_string()
     };
     let mut parsed = if has_scheme {
-        Url::parse(&normalized_host)
-            .with_context(|| format!("Invalid mesh host URL '{trimmed}'"))?
+        Url::parse(&normalized_host).with_context(|| format!("Invalid {label} URL '{trimmed}'"))?
     } else {
         Url::parse(&format!("http://{normalized_host}"))
-            .with_context(|| format!("Invalid mesh host '{trimmed}'"))?
+            .with_context(|| format!("Invalid {label} '{trimmed}'"))?
     };
 
     let host_name = parsed
         .host_str()
-        .ok_or_else(|| anyhow::anyhow!("mesh host '{trimmed}' is missing a hostname"))?
+        .ok_or_else(|| anyhow::anyhow!("{label} '{trimmed}' is missing a hostname"))?
         .to_string();
 
     let is_local_host = is_loopback_or_localhost(&host_name);
@@ -75,7 +78,7 @@ fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
     if should_default_api_port {
         parsed
             .set_port(Some(DEFAULT_API_PORT))
-            .map_err(|_| anyhow::anyhow!("Invalid mesh host '{trimmed}'"))?;
+            .map_err(|_| anyhow::anyhow!("Invalid {label} '{trimmed}'"))?;
     }
 
     parsed.set_query(None);
@@ -88,10 +91,10 @@ fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
     api_models.set_path("/v1/models");
 
     let mut management = parsed.clone();
-    if !has_scheme || should_default_api_port {
+    if !has_scheme || should_default_api_port || (is_local_host && parsed.scheme() == "http") {
         management
             .set_port(Some(DEFAULT_MANAGEMENT_PORT))
-            .map_err(|_| anyhow::anyhow!("Invalid mesh host '{trimmed}'"))?;
+            .map_err(|_| anyhow::anyhow!("Invalid {label} '{trimmed}'"))?;
     }
     management.set_path("/api/models");
 
@@ -108,7 +111,7 @@ fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
 }
 
 fn normalize_opencode_host(host: &str) -> Result<OpenCodeTarget> {
-    normalize_mesh_host(host)
+    normalize_mesh_host_with_label(host, "OpenCode host")
 }
 
 fn build_opencode_launch_spec(
@@ -574,16 +577,14 @@ pub(crate) async fn run_pi(model: Option<String>, host: &str, write: bool) -> Re
         (models, chosen, None)
     };
 
-    let result = match fetch_model_context_lengths(&client, &target.management_models_url).await {
-        Ok(context_lengths) => run_pi_with_mesh(
-            &models,
-            &chosen,
-            &target.api_base_url,
-            &context_lengths,
-            write,
-        ),
-        Err(err) => Err(err),
-    };
+    let context_lengths = fetch_model_context_lengths(&client, &target.management_models_url).await;
+    let result = run_pi_with_mesh(
+        &models,
+        &chosen,
+        &target.api_base_url,
+        &context_lengths,
+        write,
+    );
 
     cleanup_mesh_child(&mut mesh_child);
 
@@ -711,7 +712,7 @@ fn merge_mesh_provider(
 async fn fetch_model_context_lengths(
     client: &reqwest::Client,
     management_models_url: &str,
-) -> Result<std::collections::HashMap<String, Option<u32>>> {
+) -> std::collections::HashMap<String, Option<u32>> {
     let mut context_map = std::collections::HashMap::new();
 
     if let Ok(resp) = client.get(management_models_url).send().await {
@@ -726,7 +727,7 @@ async fn fetch_model_context_lengths(
         }
     }
 
-    Ok(context_map)
+    context_map
 }
 
 async fn write_opencode_config(
@@ -750,8 +751,7 @@ async fn write_opencode_config_to_path(
 
     let existing_config = load_existing_config(config_path)?;
 
-    let context_lengths =
-        fetch_model_context_lengths(client, &target.management_models_url).await?;
+    let context_lengths = fetch_model_context_lengths(client, &target.management_models_url).await;
 
     let spec = build_opencode_launch_spec_with_limits(
         model_names,
@@ -1559,6 +1559,38 @@ mod tests {
     }
 
     #[test]
+    fn opencode_host_normalization_uses_management_port_for_explicit_loopback_api_urls() {
+        let localhost =
+            normalize_opencode_host("http://localhost:9337").expect("valid localhost URL");
+        let loopback =
+            normalize_opencode_host("http://127.0.0.1:9443").expect("valid loopback URL");
+
+        assert_eq!(localhost.api_base_url, "http://localhost:9337/v1");
+        assert_eq!(
+            localhost.management_models_url,
+            "http://localhost:3131/api/models"
+        );
+        assert!(localhost.auto_start_local_mesh);
+        assert_eq!(localhost.local_port, Some(9337));
+
+        assert_eq!(loopback.api_base_url, "http://127.0.0.1:9443/v1");
+        assert_eq!(
+            loopback.management_models_url,
+            "http://127.0.0.1:3131/api/models"
+        );
+        assert!(loopback.auto_start_local_mesh);
+        assert_eq!(loopback.local_port, Some(9443));
+    }
+
+    #[test]
+    fn opencode_host_validation_mentions_opencode_host() {
+        let err = normalize_opencode_host("   ").expect_err("empty host should fail");
+
+        assert!(err.to_string().contains("OpenCode host"));
+        assert!(!err.to_string().contains("mesh host"));
+    }
+
+    #[test]
     fn opencode_host_normalization_does_not_auto_start_https_loopback() {
         let target = normalize_opencode_host("https://localhost:9337").expect("valid HTTPS URL");
 
@@ -1569,6 +1601,23 @@ mod tests {
         );
         assert!(!target.auto_start_local_mesh);
         assert_eq!(target.local_port, Some(9337));
+    }
+
+    #[test]
+    fn context_length_lookup_is_best_effort_and_returns_empty_map_on_failure() {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_millis(50))
+            .build()
+            .expect("client should build");
+
+        let context_lengths = tokio::runtime::Runtime::new()
+            .expect("test runtime")
+            .block_on(super::fetch_model_context_lengths(
+                &client,
+                "http://127.0.0.1:9/api/models",
+            ));
+
+        assert!(context_lengths.is_empty());
     }
 
     #[test]

--- a/crates/mesh-llm/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm/src/cli/commands/integrations.rs
@@ -382,6 +382,76 @@ pub(crate) async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
     Ok(())
 }
 
+pub(crate) async fn run_pi(model: Option<String>, port: u16) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()?;
+    let (_models, chosen, mut mesh_child) = runtime::check_mesh(&client, port, &model).await?;
+
+    let base_url = format!("http://localhost:{port}/v1");
+
+    // Write/merge mesh provider into ~/.pi/agent/models.json
+    let pi_agent_dir = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".pi")
+        .join("agent");
+    std::fs::create_dir_all(&pi_agent_dir)?;
+
+    let models_path = pi_agent_dir.join("models.json");
+    let mut config = if models_path.exists() {
+        let content = std::fs::read_to_string(&models_path)?;
+        serde_json::from_str::<serde_json::Value>(&content).unwrap_or_else(|_| serde_json::json!({}))
+    } else {
+        serde_json::json!({})
+    };
+
+    let providers = config
+        .as_object_mut()
+        .expect("config must be an object")
+        .entry("providers".to_string())
+        .or_insert_with(|| serde_json::json!({}));
+
+    let mut model_entries = vec![serde_json::json!({ "id": "auto" })];
+    if model.is_some() && chosen != "auto" {
+        model_entries.push(serde_json::json!({ "id": &chosen }));
+    }
+
+    providers.as_object_mut().expect("providers must be an object").insert(
+        "mesh".to_string(),
+        serde_json::json!({
+            "api": "openai-completions",
+            "apiKey": "mesh",
+            "baseUrl": &base_url,
+            "models": model_entries
+        }),
+    );
+
+    std::fs::write(&models_path, serde_json::to_string_pretty(&config)?)?;
+    eprintln!("✅ Wrote mesh provider to {}", models_path.display());
+
+    let model_arg = if model.is_some() {
+        format!("mesh/{chosen}")
+    } else {
+        "mesh/auto".to_string()
+    };
+    eprintln!("🚀 Launching pi with {chosen} → {base_url}\n");
+    let status = std::process::Command::new("pi")
+        .args(["--model", &model_arg])
+        .status();
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => eprintln!("pi exited with {s}"),
+        Err(_) => {
+            eprintln!("pi not found in PATH.");
+            eprintln!("Install: npm install -g @mariozechner/pi-coding-agent");
+            eprintln!("Or run manually:");
+            eprintln!("  pi --model {model_arg}");
+        }
+    }
+    cleanup_mesh_child(&mut mesh_child);
+    Ok(())
+}
+
 pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))

--- a/crates/mesh-llm/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm/src/cli/commands/integrations.rs
@@ -400,7 +400,8 @@ pub(crate) async fn run_pi(model: Option<String>, port: u16) -> Result<()> {
     let models_path = pi_agent_dir.join("models.json");
     let mut config = if models_path.exists() {
         let content = std::fs::read_to_string(&models_path)?;
-        serde_json::from_str::<serde_json::Value>(&content).unwrap_or_else(|_| serde_json::json!({}))
+        serde_json::from_str::<serde_json::Value>(&content)
+            .unwrap_or_else(|_| serde_json::json!({}))
     } else {
         serde_json::json!({})
     };
@@ -416,15 +417,18 @@ pub(crate) async fn run_pi(model: Option<String>, port: u16) -> Result<()> {
         model_entries.push(serde_json::json!({ "id": &chosen }));
     }
 
-    providers.as_object_mut().expect("providers must be an object").insert(
-        "mesh".to_string(),
-        serde_json::json!({
-            "api": "openai-completions",
-            "apiKey": "mesh",
-            "baseUrl": &base_url,
-            "models": model_entries
-        }),
-    );
+    providers
+        .as_object_mut()
+        .expect("providers must be an object")
+        .insert(
+            "mesh".to_string(),
+            serde_json::json!({
+                "api": "openai-completions",
+                "apiKey": "mesh",
+                "baseUrl": &base_url,
+                "models": model_entries
+            }),
+        );
 
     std::fs::write(&models_path, serde_json::to_string_pretty(&config)?)?;
     eprintln!("✅ Wrote mesh provider to {}", models_path.display());

--- a/crates/mesh-llm/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm/src/cli/commands/integrations.rs
@@ -39,32 +39,40 @@ fn is_loopback_or_localhost(host: &str) -> bool {
         .unwrap_or(false)
 }
 
-fn normalize_opencode_host(host: &str) -> Result<OpenCodeTarget> {
+fn normalize_mesh_host(host: &str) -> Result<OpenCodeTarget> {
     const DEFAULT_API_PORT: u16 = 9337;
     const DEFAULT_MANAGEMENT_PORT: u16 = 3131;
 
     let trimmed = host.trim();
     if trimmed.is_empty() {
-        anyhow::bail!("OpenCode host cannot be empty");
+        anyhow::bail!("mesh host cannot be empty");
     }
 
     let has_scheme = trimmed.contains("://");
-    let mut parsed = if has_scheme {
-        Url::parse(trimmed).with_context(|| format!("Invalid OpenCode host URL '{trimmed}'"))?
+    let normalized_host = if has_scheme {
+        trimmed.to_string()
+    } else if trimmed.parse::<u16>().is_ok() {
+        format!("127.0.0.1:{trimmed}")
     } else {
-        Url::parse(&format!("http://{trimmed}"))
-            .with_context(|| format!("Invalid OpenCode host '{trimmed}'"))?
+        trimmed.to_string()
+    };
+    let mut parsed = if has_scheme {
+        Url::parse(&normalized_host)
+            .with_context(|| format!("Invalid mesh host URL '{trimmed}'"))?
+    } else {
+        Url::parse(&format!("http://{normalized_host}"))
+            .with_context(|| format!("Invalid mesh host '{trimmed}'"))?
     };
 
     let host_name = parsed
         .host_str()
-        .ok_or_else(|| anyhow::anyhow!("OpenCode host '{trimmed}' is missing a hostname"))?
+        .ok_or_else(|| anyhow::anyhow!("mesh host '{trimmed}' is missing a hostname"))?
         .to_string();
 
     if !has_scheme && parsed.port().is_none() {
         parsed
             .set_port(Some(DEFAULT_API_PORT))
-            .map_err(|_| anyhow::anyhow!("Invalid OpenCode host '{trimmed}'"))?;
+            .map_err(|_| anyhow::anyhow!("Invalid mesh host '{trimmed}'"))?;
     }
 
     parsed.set_query(None);
@@ -80,7 +88,7 @@ fn normalize_opencode_host(host: &str) -> Result<OpenCodeTarget> {
     if !has_scheme {
         management
             .set_port(Some(DEFAULT_MANAGEMENT_PORT))
-            .map_err(|_| anyhow::anyhow!("Invalid OpenCode host '{trimmed}'"))?;
+            .map_err(|_| anyhow::anyhow!("Invalid mesh host '{trimmed}'"))?;
     }
     management.set_path("/api/models");
 
@@ -94,6 +102,10 @@ fn normalize_opencode_host(host: &str) -> Result<OpenCodeTarget> {
         auto_start_local_mesh,
         local_port: api_base.port_or_known_default(),
     })
+}
+
+fn normalize_opencode_host(host: &str) -> Result<OpenCodeTarget> {
+    normalize_mesh_host(host)
 }
 
 fn build_opencode_launch_spec(
@@ -163,6 +175,10 @@ fn build_opencode_launch_spec_with_limits(
     }
 }
 
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
 fn opencode_missing_binary_guidance(
     chosen: &str,
     host: &str,
@@ -178,6 +194,15 @@ fn opencode_missing_binary_guidance(
     ]
 }
 
+fn pi_missing_binary_guidance(model_arg: &str) -> Vec<String> {
+    vec![
+        "pi not found in PATH.".to_string(),
+        "Install: npm install -g @mariozechner/pi-coding-agent".to_string(),
+        "Or run manually:".to_string(),
+        format!("  pi --model {}", shell_single_quote(model_arg)),
+    ]
+}
+
 fn cleanup_mesh_child(mesh_child: &mut Option<std::process::Child>) {
     if let Some(ref mut child) = mesh_child {
         eprintln!("🧹 Stopping mesh-llm node we started...");
@@ -186,7 +211,7 @@ fn cleanup_mesh_child(mesh_child: &mut Option<std::process::Child>) {
     }
 }
 
-async fn fetch_opencode_models(
+async fn fetch_mesh_models(
     client: &reqwest::Client,
     models_url: &str,
     requested_model: &Option<String>,
@@ -195,11 +220,11 @@ async fn fetch_opencode_models(
         .get(models_url)
         .send()
         .await
-        .with_context(|| format!("Failed to reach OpenCode target at {models_url}"))?;
+        .with_context(|| format!("Failed to reach mesh target at {models_url}"))?;
 
     let body = resp
         .error_for_status()
-        .with_context(|| format!("OpenCode target returned an error for {models_url}"))?
+        .with_context(|| format!("mesh target returned an error for {models_url}"))?
         .json::<serde_json::Value>()
         .await
         .with_context(|| format!("Failed to parse model list from {models_url}"))?;
@@ -213,7 +238,7 @@ async fn fetch_opencode_models(
 
     if models.is_empty() {
         anyhow::bail!(
-            "OpenCode target at {models_url} has no models yet (or could not be reached).\n\
+            "mesh target at {models_url} has no models yet (or could not be reached).\n\
              Ensure at least one serving peer is available on the mesh."
         );
     }
@@ -382,62 +407,204 @@ pub(crate) async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
     Ok(())
 }
 
-pub(crate) async fn run_pi(model: Option<String>, port: u16) -> Result<()> {
+fn resolve_pi_models_path() -> std::path::PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".pi")
+        .join("agent")
+        .join("models.json")
+}
+
+#[cfg(test)]
+fn build_pi_provider_config(model_names: &[String], api_base_url: &str) -> serde_json::Value {
+    build_pi_provider_config_with_limits(
+        model_names,
+        api_base_url,
+        &std::collections::HashMap::new(),
+    )
+}
+
+fn build_pi_provider_config_with_limits(
+    model_names: &[String],
+    api_base_url: &str,
+    context_lengths: &std::collections::HashMap<String, Option<u32>>,
+) -> serde_json::Value {
+    let models: Vec<serde_json::Value> = model_names
+        .iter()
+        .map(|name| {
+            let mut model = serde_json::Map::new();
+            model.insert("id".to_string(), serde_json::json!(name));
+            model.insert("name".to_string(), serde_json::json!(name));
+
+            if let Some(&Some(ctx_len)) = context_lengths.get(name) {
+                model.insert("contextWindow".to_string(), serde_json::json!(ctx_len));
+                model.insert("maxTokens".to_string(), serde_json::json!(ctx_len));
+            }
+
+            serde_json::Value::Object(model)
+        })
+        .collect();
+
+    let mut provider = serde_json::Map::new();
+    provider.insert("api".to_string(), serde_json::json!("openai-completions"));
+    provider.insert("apiKey".to_string(), serde_json::json!("mesh"));
+    provider.insert("baseUrl".to_string(), serde_json::json!(api_base_url));
+    provider.insert("models".to_string(), serde_json::Value::Array(models));
+
+    serde_json::Value::Object(provider)
+}
+
+fn load_existing_config(path: &std::path::Path) -> Result<serde_json::Value> {
+    if !path.exists() {
+        return Ok(serde_json::json!({}));
+    }
+
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let config: serde_json::Value = serde_json::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as JSON", path.display()))?;
+
+    if !config.is_object() {
+        anyhow::bail!("Expected {} to contain a JSON object", path.display());
+    }
+
+    Ok(config)
+}
+
+fn provider_map_mut<'a>(
+    config: &'a mut serde_json::Value,
+    field_name: &str,
+    path: &std::path::Path,
+) -> Result<&'a mut serde_json::Map<String, serde_json::Value>> {
+    let config_object = config
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("Expected {} to contain a JSON object", path.display()))?;
+    let providers = config_object
+        .entry(field_name.to_string())
+        .or_insert_with(|| serde_json::Value::Object(serde_json::Map::new()));
+
+    providers.as_object_mut().ok_or_else(|| {
+        anyhow::anyhow!(
+            "Expected '{}' in {} to be a JSON object",
+            field_name,
+            path.display()
+        )
+    })
+}
+
+fn merge_provider(
+    config: &mut serde_json::Value,
+    field_name: &str,
+    provider_id: &str,
+    provider: serde_json::Value,
+    path: &std::path::Path,
+) -> Result<()> {
+    provider_map_mut(config, field_name, path)?.insert(provider_id.to_string(), provider);
+    Ok(())
+}
+
+fn write_pi_config_with_limits(
+    model_names: &[String],
+    api_base_url: &str,
+    context_lengths: &std::collections::HashMap<String, Option<u32>>,
+) -> Result<()> {
+    let models_path = resolve_pi_models_path();
+    write_pi_config_to_path_with_limits(&models_path, model_names, api_base_url, context_lengths)
+}
+
+#[cfg(test)]
+fn write_pi_config_to_path(
+    models_path: &std::path::Path,
+    model_names: &[String],
+    api_base_url: &str,
+) -> Result<()> {
+    write_pi_config_to_path_with_limits(
+        models_path,
+        model_names,
+        api_base_url,
+        &std::collections::HashMap::new(),
+    )
+}
+
+fn write_pi_config_to_path_with_limits(
+    models_path: &std::path::Path,
+    model_names: &[String],
+    api_base_url: &str,
+    context_lengths: &std::collections::HashMap<String, Option<u32>>,
+) -> Result<()> {
+    std::fs::create_dir_all(models_path.parent().expect("models path must have parent"))?;
+
+    let mut config = load_existing_config(models_path)?;
+    let provider = build_pi_provider_config_with_limits(model_names, api_base_url, context_lengths);
+    merge_provider(&mut config, "providers", "mesh", provider, models_path)?;
+
+    std::fs::write(models_path, serde_json::to_string_pretty(&config)?)?;
+    eprintln!(
+        "✅ Wrote mesh provider to {} ({} models)",
+        models_path.display(),
+        model_names.len()
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+fn write_pi_config_for_test(
+    models_path: &std::path::Path,
+    model_names: &[String],
+    host: &str,
+) -> Result<()> {
+    let target = normalize_mesh_host(host)?;
+    write_pi_config_to_path(models_path, model_names, &target.api_base_url)
+}
+
+pub(crate) async fn run_pi(model: Option<String>, host: &str, write: bool) -> Result<()> {
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()?;
-    let (_models, chosen, mut mesh_child) = runtime::check_mesh(&client, port, &model).await?;
+    let target = normalize_mesh_host(host)?;
 
-    let base_url = format!("http://localhost:{port}/v1");
-
-    // Write/merge mesh provider into ~/.pi/agent/models.json
-    let pi_agent_dir = dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".pi")
-        .join("agent");
-    std::fs::create_dir_all(&pi_agent_dir)?;
-
-    let models_path = pi_agent_dir.join("models.json");
-    let mut config = if models_path.exists() {
-        let content = std::fs::read_to_string(&models_path)?;
-        serde_json::from_str::<serde_json::Value>(&content)
-            .unwrap_or_else(|_| serde_json::json!({}))
+    let (models, chosen, mut mesh_child) = if target.auto_start_local_mesh {
+        let port = target
+            .local_port
+            .ok_or_else(|| anyhow::anyhow!("Pi host '{}' is missing a usable port", host))?;
+        let (models, chosen, child) = runtime::check_mesh(&client, port, &model).await?;
+        (models, chosen, child)
     } else {
-        serde_json::json!({})
+        let (models, chosen) = fetch_mesh_models(&client, &target.api_models_url, &model).await?;
+        (models, chosen, None)
     };
 
-    let providers = config
-        .as_object_mut()
-        .expect("config must be an object")
-        .entry("providers".to_string())
-        .or_insert_with(|| serde_json::json!({}));
+    let result = match fetch_model_context_lengths(&client, &target.management_models_url).await {
+        Ok(context_lengths) => run_pi_with_mesh(
+            &models,
+            &chosen,
+            &target.api_base_url,
+            &context_lengths,
+            write,
+        ),
+        Err(err) => Err(err),
+    };
 
-    let mut model_entries = vec![serde_json::json!({ "id": "auto" })];
-    if model.is_some() && chosen != "auto" {
-        model_entries.push(serde_json::json!({ "id": &chosen }));
+    cleanup_mesh_child(&mut mesh_child);
+
+    result
+}
+
+fn run_pi_with_mesh(
+    model_names: &[String],
+    chosen: &str,
+    base_url: &str,
+    context_lengths: &std::collections::HashMap<String, Option<u32>>,
+    write: bool,
+) -> Result<()> {
+    write_pi_config_with_limits(model_names, base_url, context_lengths)?;
+
+    if write {
+        return Ok(());
     }
 
-    providers
-        .as_object_mut()
-        .expect("providers must be an object")
-        .insert(
-            "mesh".to_string(),
-            serde_json::json!({
-                "api": "openai-completions",
-                "apiKey": "mesh",
-                "baseUrl": &base_url,
-                "models": model_entries
-            }),
-        );
-
-    std::fs::write(&models_path, serde_json::to_string_pretty(&config)?)?;
-    eprintln!("✅ Wrote mesh provider to {}", models_path.display());
-
-    let model_arg = if model.is_some() {
-        format!("mesh/{chosen}")
-    } else {
-        "mesh/auto".to_string()
-    };
+    let model_arg = format!("mesh/{chosen}");
     eprintln!("🚀 Launching pi with {chosen} → {base_url}\n");
     let status = std::process::Command::new("pi")
         .args(["--model", &model_arg])
@@ -446,49 +613,12 @@ pub(crate) async fn run_pi(model: Option<String>, port: u16) -> Result<()> {
         Ok(s) if s.success() => {}
         Ok(s) => eprintln!("pi exited with {s}"),
         Err(_) => {
-            eprintln!("pi not found in PATH.");
-            eprintln!("Install: npm install -g @mariozechner/pi-coding-agent");
-            eprintln!("Or run manually:");
-            eprintln!("  pi --model {model_arg}");
+            for line in pi_missing_binary_guidance(&model_arg) {
+                eprintln!("{line}");
+            }
         }
     }
-    cleanup_mesh_child(&mut mesh_child);
-    Ok(())
-}
 
-pub(crate) async fn run_hermes(model: Option<String>, port: u16) -> Result<()> {
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(5))
-        .build()?;
-    let (_models, chosen, mut mesh_child) = runtime::check_mesh(&client, port, &model).await?;
-
-    let base_url = format!("http://localhost:{port}/v1");
-
-    // Hermes is OpenAI-compatible — just pass provider, base URL, and model as CLI flags.
-    // No config file writing needed.
-    eprintln!("🚀 Launching Hermes Agent with {chosen} → {base_url}\n");
-    let status = std::process::Command::new("hermes")
-        .args([
-            "--provider",
-            "custom",
-            "--base-url",
-            &base_url,
-            "--model",
-            &chosen,
-        ])
-        .env("OPENAI_API_KEY", "mesh-llm")
-        .status();
-    match status {
-        Ok(s) if s.success() => {}
-        Ok(s) => eprintln!("hermes exited with {s}"),
-        Err(_) => {
-            eprintln!("hermes not found in PATH.");
-            eprintln!("Install: pip install hermes-agent");
-            eprintln!("Or run manually:");
-            eprintln!("  hermes --provider custom --base-url {base_url} --model {chosen}");
-        }
-    }
-    cleanup_mesh_child(&mut mesh_child);
     Ok(())
 }
 
@@ -505,8 +635,7 @@ pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool)
         let (models, chosen, child) = runtime::check_mesh(&client, port, &model).await?;
         (models, chosen, child)
     } else {
-        let (models, chosen) =
-            fetch_opencode_models(&client, &target.api_models_url, &model).await?;
+        let (models, chosen) = fetch_mesh_models(&client, &target.api_models_url, &model).await?;
         (models, chosen, None)
     };
 
@@ -572,27 +701,12 @@ fn resolve_opencode_config_path_from_home(
     Ok(json_path)
 }
 
-fn load_existing_config(path: &std::path::Path) -> Result<serde_json::Value> {
-    if !path.exists() {
-        return Ok(serde_json::json!({}));
-    }
-
-    let content = std::fs::read_to_string(path)?;
-
-    serde_json::from_str(&content)
-        .map_err(|e| anyhow::anyhow!("Failed to parse {}: {}", path.display(), e))
-}
-
-fn merge_mesh_provider(config: &mut serde_json::Value, mesh_provider: serde_json::Value) {
-    let provider = config
-        .as_object_mut()
-        .expect("config must be an object")
-        .entry("provider".to_string())
-        .or_insert_with(|| serde_json::Map::new().into())
-        .as_object_mut()
-        .expect("provider must be an object");
-
-    provider.insert("mesh".to_string(), mesh_provider);
+fn merge_mesh_provider(
+    config: &mut serde_json::Value,
+    mesh_provider: serde_json::Value,
+    config_path: &std::path::Path,
+) -> Result<()> {
+    merge_provider(config, "provider", "mesh", mesh_provider, config_path)
 }
 
 async fn fetch_model_context_lengths(
@@ -655,12 +769,17 @@ async fn write_opencode_config_to_path(
         if let Some(schema) = config_value.get("$schema") {
             merged_config
                 .as_object_mut()
-                .expect("config is object")
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Expected {} to contain a JSON object",
+                        config_path.display()
+                    )
+                })?
                 .insert("$schema".to_string(), schema.clone());
         }
     }
 
-    merge_mesh_provider(&mut merged_config, mesh_provider.clone());
+    merge_mesh_provider(&mut merged_config, mesh_provider.clone(), config_path)?;
 
     let formatted_json = serde_json::to_string_pretty(&merged_config)?;
     std::fs::write(config_path, &formatted_json)?;
@@ -714,9 +833,11 @@ pub(crate) fn build_mesh_provider_spec_for_test(
 mod tests {
     use super::{
         build_mesh_provider_spec_for_test, build_opencode_launch_spec,
-        build_opencode_launch_spec_with_limits, cleanup_mesh_child, normalize_opencode_host,
-        opencode_missing_binary_guidance, resolve_opencode_config_path_from_home,
-        write_opencode_config_for_test, OPENCODE_INSTALL_HINT,
+        build_opencode_launch_spec_with_limits, build_pi_provider_config,
+        build_pi_provider_config_with_limits, cleanup_mesh_child, normalize_opencode_host,
+        opencode_missing_binary_guidance, pi_missing_binary_guidance,
+        resolve_opencode_config_path_from_home, write_opencode_config_for_test,
+        write_pi_config_for_test, write_pi_config_to_path, OPENCODE_INSTALL_HINT,
     };
 
     const LOCAL_OPENCODE_HOST: &str = "127.0.0.1:9337";
@@ -828,6 +949,19 @@ mod tests {
             lines[4],
             "mesh-llm injects OPENCODE_CONFIG_CONTENT automatically when launching OpenCode."
         );
+    }
+
+    #[test]
+    fn pi_missing_binary_guidance_quotes_model_argument() {
+        let lines = pi_missing_binary_guidance("mesh/Qwen's 3.6 27B");
+
+        assert_eq!(lines[0], "pi not found in PATH.");
+        assert_eq!(
+            lines[1],
+            "Install: npm install -g @mariozechner/pi-coding-agent"
+        );
+        assert_eq!(lines[2], "Or run manually:");
+        assert_eq!(lines[3], "  pi --model 'mesh/Qwen'\"'\"'s 3.6 27B'");
     }
 
     #[test]
@@ -1117,6 +1251,204 @@ mod tests {
     }
 
     #[test]
+    fn pi_provider_config_lists_all_mesh_models_with_models_key_last() {
+        let models = vec!["Qwen 3.6 27B".to_string(), "Qwen 3.5 4B".to_string()];
+        let provider = build_pi_provider_config(&models, "http://localhost:9337/v1");
+
+        assert_eq!(provider["api"], "openai-completions");
+        assert_eq!(provider["apiKey"], "mesh");
+        assert_eq!(provider["baseUrl"], "http://localhost:9337/v1");
+        assert_eq!(provider["models"].as_array().map(Vec::len), Some(2));
+        assert_eq!(provider["models"][0]["id"], "Qwen 3.6 27B");
+        assert_eq!(provider["models"][0]["name"], "Qwen 3.6 27B");
+        assert_eq!(provider["models"][1]["id"], "Qwen 3.5 4B");
+        assert_eq!(provider["models"][1]["name"], "Qwen 3.5 4B");
+
+        let key_order: Vec<&str> = provider
+            .as_object()
+            .expect("provider is object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(key_order.last(), Some(&"models"));
+    }
+
+    #[test]
+    fn pi_provider_config_includes_context_window_and_max_tokens_when_known() {
+        let models = vec![
+            "Qwen3.6-27B-UD-Q4_K_XL".to_string(),
+            "Qwen3.5-4B-UD-Q4_K_XL".to_string(),
+            "Unknown-Model".to_string(),
+        ];
+        let mut context_lengths = std::collections::HashMap::new();
+        context_lengths.insert("Qwen3.6-27B-UD-Q4_K_XL".to_string(), Some(262144));
+        context_lengths.insert("Qwen3.5-4B-UD-Q4_K_XL".to_string(), Some(65536));
+        context_lengths.insert("Unknown-Model".to_string(), None);
+
+        let provider = build_pi_provider_config_with_limits(
+            &models,
+            "http://carrack.patio51.com:9337/v1",
+            &context_lengths,
+        );
+
+        assert_eq!(provider["models"][0]["contextWindow"], 262144);
+        assert_eq!(provider["models"][0]["maxTokens"], 262144);
+        assert_eq!(provider["models"][1]["contextWindow"], 65536);
+        assert_eq!(provider["models"][1]["maxTokens"], 65536);
+        assert!(
+            provider["models"][2]["contextWindow"].is_null(),
+            "model with unknown context_length should omit contextWindow"
+        );
+        assert!(
+            provider["models"][2]["maxTokens"].is_null(),
+            "model with unknown context_length should omit maxTokens"
+        );
+
+        let key_order: Vec<&str> = provider
+            .as_object()
+            .expect("provider is object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(key_order.last(), Some(&"models"));
+    }
+
+    #[test]
+    fn pi_write_creates_provider_and_preserves_other_providers() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("models.json");
+        let existing_config = serde_json::json!({
+            "providers": {
+                "anthropic": {
+                    "api": "anthropic",
+                    "apiKey": "preserve-me",
+                    "models": [{ "id": "claude" }]
+                }
+            }
+        });
+        std::fs::write(
+            &config_path,
+            serde_json::to_string_pretty(&existing_config).unwrap(),
+        )
+        .expect("failed to write initial config");
+
+        let models = vec!["Qwen 3.6 27B".to_string(), "Qwen 3.5 4B".to_string()];
+        write_pi_config_to_path(&config_path, &models, "http://localhost:9337/v1")
+            .expect("pi write should succeed");
+
+        let content = std::fs::read_to_string(&config_path).expect("failed to read config");
+        let parsed: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+
+        assert_eq!(parsed["providers"]["anthropic"]["apiKey"], "preserve-me");
+        assert_eq!(parsed["providers"]["mesh"]["api"], "openai-completions");
+        assert_eq!(
+            parsed["providers"]["mesh"]["baseUrl"],
+            "http://localhost:9337/v1"
+        );
+        assert_eq!(
+            parsed["providers"]["mesh"]["models"]
+                .as_array()
+                .map(Vec::len),
+            Some(2)
+        );
+        assert!(
+            !parsed["providers"]["mesh"]["models"]
+                .as_array()
+                .expect("models is array")
+                .iter()
+                .any(|model| model["id"] == "auto"),
+            "pi --write should list mesh models, not add a synthetic auto model"
+        );
+    }
+
+    #[test]
+    fn pi_write_uses_normalized_remote_host_as_base_url() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("models.json");
+        let models = vec![
+            "Qwen3.5-4B-UD-Q4_K_XL".to_string(),
+            "Qwen3.6-27B-UD-Q4_K_XL".to_string(),
+        ];
+
+        write_pi_config_for_test(
+            &config_path,
+            &models,
+            "https://carrack.patio51.com:9443/custom/path",
+        )
+        .expect("pi write should succeed with a full remote URL");
+
+        let content = std::fs::read_to_string(&config_path).expect("failed to read config");
+        let parsed: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+
+        assert_eq!(
+            parsed["providers"]["mesh"]["baseUrl"],
+            "https://carrack.patio51.com:9443/v1"
+        );
+        assert_eq!(parsed["providers"]["mesh"]["models"][0]["id"], models[0]);
+        assert_eq!(parsed["providers"]["mesh"]["models"][1]["id"], models[1]);
+
+        let key_order: Vec<&str> = parsed["providers"]["mesh"]
+            .as_object()
+            .expect("provider is object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(key_order.last(), Some(&"models"));
+    }
+
+    #[test]
+    fn pi_write_rejects_invalid_json_without_clobbering_config() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("models.json");
+        std::fs::write(&config_path, "not-json").expect("failed to write invalid config");
+
+        let err = write_pi_config_to_path(
+            &config_path,
+            &["Qwen 3.6 27B".to_string()],
+            "http://localhost:9337/v1",
+        )
+        .expect_err("invalid JSON should fail");
+
+        assert!(err.to_string().contains("Failed to parse"));
+        assert_eq!(
+            std::fs::read_to_string(&config_path).expect("failed to reread config"),
+            "not-json"
+        );
+    }
+
+    #[test]
+    fn pi_write_rejects_non_object_providers() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("models.json");
+        std::fs::write(&config_path, r#"{"providers": []}"#)
+            .expect("failed to write invalid providers config");
+
+        let err = write_pi_config_to_path(
+            &config_path,
+            &["Qwen 3.6 27B".to_string()],
+            "http://localhost:9337/v1",
+        )
+        .expect_err("array providers should fail");
+
+        assert!(err.to_string().contains("providers"));
+        assert!(err.to_string().contains("object"));
+    }
+
+    #[test]
+    fn opencode_write_rejects_non_object_provider() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let config_path = temp_dir.path().join("config.json");
+        std::fs::write(&config_path, r#"{"provider": []}"#)
+            .expect("failed to write invalid provider config");
+
+        let result = write_config(&config_path, &["qwen".to_string()], LOCAL_OPENCODE_HOST);
+
+        let err = result.expect_err("array provider should fail");
+        assert!(err.to_string().contains("provider"));
+        assert!(err.to_string().contains("object"));
+    }
+
+    #[test]
     fn test_build_opencode_launch_spec_with_limits_includes_context_length() {
         let mut context_lengths = std::collections::HashMap::new();
         context_lengths.insert("Qwen3.5-27B".to_string(), Some(262144));
@@ -1188,6 +1520,20 @@ mod tests {
             "http://mesh.example.com:3131/api/models"
         );
         assert!(!target.auto_start_local_mesh);
+    }
+
+    #[test]
+    fn opencode_host_normalization_treats_bare_port_as_loopback_api_port() {
+        let target = normalize_opencode_host("9443").expect("valid port-only host");
+
+        assert_eq!(target.api_base_url, "http://127.0.0.1:9443/v1");
+        assert_eq!(target.api_models_url, "http://127.0.0.1:9443/v1/models");
+        assert_eq!(
+            target.management_models_url,
+            "http://127.0.0.1:3131/api/models"
+        );
+        assert!(target.auto_start_local_mesh);
+        assert_eq!(target.local_port, Some(9443));
     }
 
     #[test]

--- a/crates/mesh-llm/src/cli/commands/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::cli::commands::blackboard::{install_skill, run_blackboard};
 use crate::cli::commands::discover::{run_discover, run_stop};
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
-use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode, run_pi};
+use crate::cli::commands::integrations::{run_claude, run_goose, run_hermes, run_opencode, run_pi};
 use crate::cli::commands::models::dispatch_models_command;
 use crate::cli::commands::moe::dispatch_moe_command;
 use crate::cli::commands::plugin::run_plugin_command;
@@ -70,6 +70,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::Goose { model, port } => run_goose(model.clone(), *port).await,
         Command::Claude { model, port } => run_claude(model.clone(), *port).await,
         Command::Pi { model, port } => run_pi(model.clone(), *port).await,
+        Command::Hermes { model, port } => run_hermes(model.clone(), *port).await,
         Command::Opencode { model, host, write } => run_opencode(model.clone(), host, *write).await,
         Command::Blackboard {
             text,

--- a/crates/mesh-llm/src/cli/commands/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::cli::commands::blackboard::{install_skill, run_blackboard};
 use crate::cli::commands::discover::{run_discover, run_stop};
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
-use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode};
+use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode, run_pi};
 use crate::cli::commands::models::dispatch_models_command;
 use crate::cli::commands::moe::dispatch_moe_command;
 use crate::cli::commands::plugin::run_plugin_command;
@@ -69,6 +69,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::RotateKey => nostr::rotate_keys(),
         Command::Goose { model, port } => run_goose(model.clone(), *port).await,
         Command::Claude { model, port } => run_claude(model.clone(), *port).await,
+        Command::Pi { model, port } => run_pi(model.clone(), *port).await,
         Command::Opencode { model, host, write } => run_opencode(model.clone(), host, *write).await,
         Command::Blackboard {
             text,

--- a/crates/mesh-llm/src/cli/commands/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/mod.rs
@@ -18,7 +18,7 @@ use crate::cli::commands::blackboard::{install_skill, run_blackboard};
 use crate::cli::commands::discover::{run_discover, run_stop};
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
-use crate::cli::commands::integrations::{run_claude, run_goose, run_hermes, run_opencode, run_pi};
+use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode, run_pi};
 use crate::cli::commands::models::dispatch_models_command;
 use crate::cli::commands::moe::dispatch_moe_command;
 use crate::cli::commands::plugin::run_plugin_command;
@@ -69,8 +69,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::RotateKey => nostr::rotate_keys(),
         Command::Goose { model, port } => run_goose(model.clone(), *port).await,
         Command::Claude { model, port } => run_claude(model.clone(), *port).await,
-        Command::Pi { model, port } => run_pi(model.clone(), *port).await,
-        Command::Hermes { model, port } => run_hermes(model.clone(), *port).await,
+        Command::Pi { model, host, write } => run_pi(model.clone(), host, *write).await,
         Command::Opencode { model, host, write } => run_opencode(model.clone(), host, *write).await,
         Command::Blackboard {
             text,

--- a/crates/mesh-llm/src/cli/mod.rs
+++ b/crates/mesh-llm/src/cli/mod.rs
@@ -525,6 +525,19 @@ pub(crate) enum Command {
         #[arg(long, default_value = "9337")]
         port: u16,
     },
+    /// Launch pi with mesh-llm as the inference provider.
+    ///
+    /// If no mesh is running on --port, this auto-joins the mesh as a client.
+    /// Writes a mesh provider into ~/.pi/agent/models.json and launches pi.
+    #[command(name = "pi")]
+    Pi {
+        /// Model id to use from /v1/models (default: auto = mesh picks best)
+        #[arg(long)]
+        model: Option<String>,
+        /// API port for mesh-llm (default: 9337)
+        #[arg(long, default_value = "9337")]
+        port: u16,
+    },
     /// Launch OpenCode with mesh-llm as the inference provider.
     ///
     /// If no mesh is running on a loopback/localhost target, this auto-joins the mesh as a client.

--- a/crates/mesh-llm/src/cli/mod.rs
+++ b/crates/mesh-llm/src/cli/mod.rs
@@ -527,30 +527,19 @@ pub(crate) enum Command {
     },
     /// Launch pi with mesh-llm as the inference provider.
     ///
-    /// If no mesh is running on --port, this auto-joins the mesh as a client.
-    /// Writes a mesh provider into ~/.pi/agent/models.json and launches pi.
+    /// If no mesh is running on a loopback/localhost target, this auto-joins the mesh as a client.
+    /// Writes a mesh provider into ~/.pi/agent/models.json and launches pi unless --write is set.
     #[command(name = "pi")]
     Pi {
         /// Model id to use from /v1/models (default: auto = mesh picks best)
         #[arg(long)]
         model: Option<String>,
-        /// API port for mesh-llm (default: 9337)
-        #[arg(long, default_value = "9337")]
-        port: u16,
-    },
-    /// Launch Hermes Agent with mesh-llm as the inference provider.
-    ///
-    /// If no mesh is running on --port, this auto-joins the mesh as a client.
-    /// Hermes is OpenAI-compatible so this just passes --provider custom
-    /// with the mesh base URL and model.
-    #[command(name = "hermes")]
-    Hermes {
-        /// Model id to use from /v1/models (default: auto = mesh picks best)
+        /// mesh-llm host or URL for Pi (default: 127.0.0.1:9337)
+        #[arg(long, default_value = "127.0.0.1:9337")]
+        host: String,
+        /// Write the mesh provider config to Pi's models.json instead of launching.
         #[arg(long)]
-        model: Option<String>,
-        /// API port for mesh-llm (default: 9337)
-        #[arg(long, default_value = "9337")]
-        port: u16,
+        write: bool,
     },
     /// Launch OpenCode with mesh-llm as the inference provider.
     ///

--- a/crates/mesh-llm/src/cli/mod.rs
+++ b/crates/mesh-llm/src/cli/mod.rs
@@ -220,6 +220,7 @@ pub(crate) mod moe;
 pub mod output;
 pub(crate) mod pager;
 pub(crate) mod runtime;
+pub(crate) mod shell;
 pub(crate) mod terminal_progress;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]

--- a/crates/mesh-llm/src/cli/mod.rs
+++ b/crates/mesh-llm/src/cli/mod.rs
@@ -538,6 +538,20 @@ pub(crate) enum Command {
         #[arg(long, default_value = "9337")]
         port: u16,
     },
+    /// Launch Hermes Agent with mesh-llm as the inference provider.
+    ///
+    /// If no mesh is running on --port, this auto-joins the mesh as a client.
+    /// Hermes is OpenAI-compatible so this just passes --provider custom
+    /// with the mesh base URL and model.
+    #[command(name = "hermes")]
+    Hermes {
+        /// Model id to use from /v1/models (default: auto = mesh picks best)
+        #[arg(long)]
+        model: Option<String>,
+        /// API port for mesh-llm (default: 9337)
+        #[arg(long, default_value = "9337")]
+        port: u16,
+    },
     /// Launch OpenCode with mesh-llm as the inference provider.
     ///
     /// If no mesh is running on a loopback/localhost target, this auto-joins the mesh as a client.

--- a/crates/mesh-llm/src/cli/output/mod.rs
+++ b/crates/mesh-llm/src/cli/output/mod.rs
@@ -7270,7 +7270,7 @@ mod tests {
                 api_port: 9337,
                 console_port: Some(3131),
                 models_count: Some(2),
-                pi_command: Some("pi --provider mesh --model Qwen3-32B".to_string()),
+                pi_command: Some("mesh-llm pi --host 127.0.0.1:9337 --model 'Qwen3-32B'".to_string()),
                 goose_command: Some("GOOSE_PROVIDER=openai OPENAI_HOST=http://localhost:9337 OPENAI_API_KEY=mesh GOOSE_MODEL=Qwen3-32B goose session".to_string()),
             },
             OutputEvent::ModelDownloadProgress {
@@ -11284,7 +11284,7 @@ mod tests {
                 api_port: 9337,
                 console_port: Some(3131),
                 models_count: Some(1),
-                pi_command: Some("pi --provider mesh --model Qwen3.6-35B".to_string()),
+                pi_command: Some("mesh-llm pi --host 127.0.0.1:9337 --model 'Qwen3.6-35B'".to_string()),
                 goose_command: Some(
                     "GOOSE_PROVIDER=openai OPENAI_HOST=http://localhost:9337 OPENAI_API_KEY=mesh GOOSE_MODEL=Qwen3.6-35B goose session"
                         .to_string(),
@@ -11315,7 +11315,9 @@ mod tests {
         assert!(dashboard.contains("logs=/tmp/llama.log"));
         assert!(dashboard.contains("OpenAI-compatible API   ready   http://localhost:9337"));
         assert!(dashboard.contains("Console   ready   http://localhost:3131"));
-        assert!(dashboard.contains("pi:    pi --provider mesh --model Qwen3.6-35B"));
+        assert!(
+            dashboard.contains("pi:    mesh-llm pi --host 127.0.0.1:9337 --model 'Qwen3.6-35B'")
+        );
         assert!(dashboard.contains("goose: GOOSE_PROVIDER=openai OPENAI_HOST=http://localhost:9337 OPENAI_API_KEY=mesh GOOSE_MODEL=Qwen3.6-35B goose session"));
         assert!(dashboard.contains("peer-1"));
         assert!(dashboard.contains("peer-2"));
@@ -11438,7 +11440,9 @@ mod tests {
                     api_port: 9337,
                     console_port: Some(3131),
                     models_count: Some(2),
-                    pi_command: Some("pi --provider mesh --model Qwen3-32B".to_string()),
+                    pi_command: Some(
+                        "mesh-llm pi --host 127.0.0.1:9337 --model 'Qwen3-32B'".to_string(),
+                    ),
                     goose_command: Some("goose session".to_string()),
                 })
                 .expect("runtime ready render should succeed"),
@@ -11449,7 +11453,7 @@ mod tests {
         assert_eq!(runtime_ready["models_count"], 2);
         assert_eq!(
             runtime_ready["pi_command"],
-            "pi --provider mesh --model Qwen3-32B"
+            "mesh-llm pi --host 127.0.0.1:9337 --model 'Qwen3-32B'"
         );
         assert_eq!(runtime_ready["goose_command"], "goose session");
     }

--- a/crates/mesh-llm/src/cli/shell.rs
+++ b/crates/mesh-llm/src/cli/shell.rs
@@ -1,0 +1,14 @@
+pub(crate) fn single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_quote_wraps_and_escapes_embedded_quotes() {
+        assert_eq!(single_quote("Qwen 3.6 27B"), "'Qwen 3.6 27B'");
+        assert_eq!(single_quote("Qwen's model"), "'Qwen'\"'\"'s model'");
+    }
+}

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -608,7 +608,11 @@ impl StartupReadyReporter {
         let console_url = self
             .console_port
             .map(|port| format!("http://localhost:{port}"));
-        let pi_command = Some(format!("pi --provider mesh --model {}", self.primary_model));
+        let pi_command = Some(format!(
+            "mesh-llm pi --host 127.0.0.1:{} --model {}",
+            self.api_port,
+            shell_single_quote(&self.primary_model)
+        ));
         let goose_command = Some(format!(
             "GOOSE_PROVIDER=openai OPENAI_HOST={api_url} OPENAI_API_KEY=mesh GOOSE_MODEL={} goose session",
             self.primary_model
@@ -2916,8 +2920,9 @@ async fn run_auto(
                     });
                 }
                 if is_host && llama_ready {
-                    update_pi_models_json(&model_name_for_cb, api_port);
                     startup_ready_reporter.mark_ready_and_maybe_emit(&model_name_for_cb);
+                } else if is_host {
+                    eprintln!("⏳ Starting llama-server...");
                 } else {
                     let _ = emit_event(OutputEvent::Info {
                         message: format!("API: http://localhost:{api_port} (proxied to host)"),
@@ -3839,58 +3844,6 @@ fn detect_bin_dir() -> Result<PathBuf> {
     Ok(dir.to_path_buf())
 }
 
-/// Update ~/.pi/agent/models.json to include a "mesh" provider.
-fn update_pi_models_json(model_id: &str, port: u16) {
-    let Some(home) = dirs::home_dir() else { return };
-    let models_path = home.join(".pi/agent/models.json");
-
-    let mut root: serde_json::Value = if models_path.exists() {
-        match std::fs::read_to_string(&models_path) {
-            Ok(s) => serde_json::from_str(&s).unwrap_or_else(|_| serde_json::json!({})),
-            Err(_) => serde_json::json!({}),
-        }
-    } else {
-        serde_json::json!({})
-    };
-
-    let providers = root.as_object_mut().and_then(|r| {
-        r.entry("providers")
-            .or_insert_with(|| serde_json::json!({}));
-        r.get_mut("providers")?.as_object_mut()
-    });
-    let Some(providers) = providers else { return };
-
-    let mesh = serde_json::json!({
-        "baseUrl": format!("http://localhost:{port}/v1"),
-        "api": "openai-completions",
-        "apiKey": "mesh",
-        "models": [{
-            "id": model_id,
-            "name": model_id,
-            "reasoning": false,
-            "input": ["text"],
-            "contextWindow": 32768,
-            "maxTokens": 8192,
-            "compat": {
-                "supportsUsageInStreaming": false,
-                "maxTokensField": "max_tokens",
-                "supportsDeveloperRole": false
-            }
-        }]
-    });
-
-    providers.insert("mesh".to_string(), mesh);
-
-    if let Some(parent) = models_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(json) = serde_json::to_string_pretty(&root) {
-        if let Err(e) = std::fs::write(&models_path, json) {
-            tracing::warn!("Failed to update {}: {e}", models_path.display());
-        }
-    }
-}
-
 /// Resolve Nostr relay URLs from CLI or defaults.
 /// Build the list of models this node is serving for gossip announcement.
 /// `resolved_models` comes from explicit `--model` args (may be empty for `--auto`).
@@ -3923,6 +3876,10 @@ fn format_console_ready_line(headless: bool, console_port: u16) -> String {
     } else {
         format!("  Console: http://localhost:{console_port}")
     }
+}
+
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
 }
 
 #[cfg(test)]
@@ -4220,6 +4177,12 @@ mod tests {
         let resolved: Vec<PathBuf> = vec![];
         let result = build_serving_list(&resolved, "Qwen3-30B-A3B-Q4_K_M");
         assert_eq!(result, vec!["Qwen3-30B-A3B-Q4_K_M"]);
+    }
+
+    #[test]
+    fn shell_single_quote_handles_spaces_and_embedded_quotes() {
+        assert_eq!(shell_single_quote("Qwen 3.6 27B"), "'Qwen 3.6 27B'");
+        assert_eq!(shell_single_quote("Qwen's model"), "'Qwen'\"'\"'s model'");
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -611,7 +611,7 @@ impl StartupReadyReporter {
         let pi_command = Some(format!(
             "mesh-llm pi --host 127.0.0.1:{} --model {}",
             self.api_port,
-            shell_single_quote(&self.primary_model)
+            crate::cli::shell::single_quote(&self.primary_model)
         ));
         let goose_command = Some(format!(
             "GOOSE_PROVIDER=openai OPENAI_HOST={api_url} OPENAI_API_KEY=mesh GOOSE_MODEL={} goose session",
@@ -2862,6 +2862,7 @@ async fn run_auto(
         cb_console_port,
     );
     let primary_startup_ready_reporter = startup_ready_reporter.clone();
+    let primary_starting_llama_logged = Arc::new(AtomicBool::new(false));
     let moe_runtime_options = moe::MoeRuntimeOptions::default();
     let primary_mmproj = primary_startup_model
         .as_ref()
@@ -2905,6 +2906,7 @@ async fn run_auto(
                 let interactive_console_state = interactive_console_state.clone();
                 let interactive_control_tx = interactive_control_tx.clone();
                 let startup_ready_reporter = primary_startup_ready_reporter.clone();
+                let starting_llama_logged = primary_starting_llama_logged.clone();
                 tokio::spawn(async move {
                     if is_host && llama_ready {
                         advertise_model_ready(&advertise_node, &advertise_model, &advertise_model)
@@ -2919,10 +2921,17 @@ async fn run_auto(
                         n.set_llama_ready(true).await;
                     });
                 }
+                let should_log_starting_llama = should_emit_starting_llama_message(
+                    &starting_llama_logged,
+                    is_host,
+                    llama_ready,
+                );
                 if is_host && llama_ready {
                     startup_ready_reporter.mark_ready_and_maybe_emit(&model_name_for_cb);
                 } else if is_host {
-                    eprintln!("⏳ Starting llama-server...");
+                    if should_log_starting_llama {
+                        eprintln!("⏳ Starting llama-server...");
+                    }
                 } else {
                     let _ = emit_event(OutputEvent::Info {
                         message: format!("API: http://localhost:{api_port} (proxied to host)"),
@@ -3878,8 +3887,17 @@ fn format_console_ready_line(headless: bool, console_port: u16) -> String {
     }
 }
 
-fn shell_single_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
+fn should_emit_starting_llama_message(
+    logged: &AtomicBool,
+    is_host: bool,
+    llama_ready: bool,
+) -> bool {
+    if is_host && !llama_ready {
+        return !logged.swap(true, Ordering::SeqCst);
+    }
+
+    logged.store(false, Ordering::SeqCst);
+    false
 }
 
 #[cfg(test)]
@@ -4180,9 +4198,31 @@ mod tests {
     }
 
     #[test]
-    fn shell_single_quote_handles_spaces_and_embedded_quotes() {
-        assert_eq!(shell_single_quote("Qwen 3.6 27B"), "'Qwen 3.6 27B'");
-        assert_eq!(shell_single_quote("Qwen's model"), "'Qwen'\"'\"'s model'");
+    fn starting_llama_message_emits_once_per_host_not_ready_transition() {
+        let logged = AtomicBool::new(false);
+
+        assert!(should_emit_starting_llama_message(&logged, true, false));
+        assert!(!should_emit_starting_llama_message(&logged, true, false));
+        assert!(!should_emit_starting_llama_message(&logged, true, true));
+        assert!(should_emit_starting_llama_message(&logged, true, false));
+        assert!(!should_emit_starting_llama_message(&logged, false, false));
+        assert!(should_emit_starting_llama_message(&logged, true, false));
+    }
+
+    #[test]
+    fn starting_llama_message_gate_resets_when_callback_reports_ready_or_non_host() {
+        let logged = AtomicBool::new(false);
+
+        let callback_gate = |is_host, llama_ready| {
+            should_emit_starting_llama_message(&logged, is_host, llama_ready)
+        };
+
+        assert!(callback_gate(true, false));
+        assert!(!callback_gate(true, false));
+        assert!(!callback_gate(true, true));
+        assert!(callback_gate(true, false));
+        assert!(!callback_gate(false, false));
+        assert!(callback_gate(true, false));
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime_data/collector.rs
+++ b/crates/mesh-llm/src/runtime_data/collector.rs
@@ -715,10 +715,6 @@ struct RuntimeStatusDerivationInput<'a> {
     api_port: u16,
 }
 
-fn shell_single_quote(value: &str) -> String {
-    format!("'{}'", value.replace('\'', "'\"'\"'"))
-}
-
 fn derive_runtime_status(input: RuntimeStatusDerivationInput<'_>) -> RuntimeStatusDerivation {
     let has_local_processes = !input.local_processes.is_empty();
     let effective_llama_ready = input.llama_ready || has_local_processes;
@@ -742,7 +738,7 @@ fn derive_runtime_status(input: RuntimeStatusDerivationInput<'_>) -> RuntimeStat
         Some(format!(
             "mesh-llm pi --host 127.0.0.1:{} --model {}",
             input.api_port,
-            shell_single_quote(&display_model_name)
+            crate::cli::shell::single_quote(&display_model_name)
         ))
     } else {
         None

--- a/crates/mesh-llm/src/runtime_data/collector.rs
+++ b/crates/mesh-llm/src/runtime_data/collector.rs
@@ -715,6 +715,10 @@ struct RuntimeStatusDerivationInput<'a> {
     api_port: u16,
 }
 
+fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
 fn derive_runtime_status(input: RuntimeStatusDerivationInput<'_>) -> RuntimeStatusDerivation {
     let has_local_processes = !input.local_processes.is_empty();
     let effective_llama_ready = input.llama_ready || has_local_processes;
@@ -735,7 +739,11 @@ fn derive_runtime_status(input: RuntimeStatusDerivationInput<'_>) -> RuntimeStat
         &display_model_name,
     );
     let launch_pi = if effective_llama_ready {
-        Some(format!("pi --provider mesh --model {display_model_name}"))
+        Some(format!(
+            "mesh-llm pi --host 127.0.0.1:{} --model {}",
+            input.api_port,
+            shell_single_quote(&display_model_name)
+        ))
     } else {
         None
     };

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,8 +8,8 @@ Mesh LLM exposes an OpenAI-compatible API on `http://localhost:9337/v1`, so most
 
 For built-in launcher commands such as `goose`, `claude`, `opencode`, and `pi`:
 
-- goose, claude, and pi reuse a local mesh on the chosen `--port`
-- opencode targets `--host` (default `127.0.0.1:9337`) and only auto-starts a local client for loopback/localhost targets
+- goose and claude reuse a local mesh on the chosen `--port`
+- opencode and pi target `--host` (default `127.0.0.1:9337`) and only auto-start a local client for loopback/localhost targets
 - if `--model` is omitted, the launcher picks the strongest tool-capable model available
 - when the harness exits, the auto-started node is cleaned up
 
@@ -109,7 +109,18 @@ Use a specific model:
 mesh-llm pi --model MiniMax-M2.5-Q4_K_M
 ```
 
-This writes a mesh provider into `~/.pi/agent/models.json` and launches pi.
+This writes every model from the mesh into `~/.pi/agent/models.json` and launches pi.
+To update the Pi config without launching pi, run:
+
+```bash
+mesh-llm pi --write
+```
+
+Use `--host` to target a remote mesh host or URL, including a custom port:
+
+```bash
+mesh-llm pi --write --host carrack.patio51.com:9337
+```
 
 ### Manual setup
 
@@ -122,13 +133,26 @@ Alternatively, add a `mesh` provider to `~/.pi/agent/models.json` by hand:
       "api": "openai-completions",
       "apiKey": "mesh",
       "baseUrl": "http://localhost:9337/v1",
-      "models": [{ "id": "auto" }]
+      "models": [
+        {
+          "id": "Qwen 3.6 27B",
+          "name": "Qwen 3.6 27B",
+          "contextWindow": 262144,
+          "maxTokens": 262144
+        },
+        {
+          "id": "Qwen 3.5 4B",
+          "name": "Qwen 3.5 4B",
+          "contextWindow": 65536,
+          "maxTokens": 65536
+        }
+      ]
     }
   }
 }
 ```
 
-The `auto` model ID lets mesh-llm pick the strongest available model on the mesh. To target a specific model, replace `auto` with a model ID from the mesh:
+The `models` key belongs inside the provider block and is intentionally last. When mesh metadata includes a context length, `mesh-llm pi --write` also writes Pi's `contextWindow` and `maxTokens` model fields. To choose a model, use an ID from the mesh:
 
 ```bash
 curl -s http://localhost:9337/v1/models | jq '.data[].id'
@@ -137,7 +161,7 @@ curl -s http://localhost:9337/v1/models | jq '.data[].id'
 Run pi:
 
 ```bash
-pi --model mesh/auto
+pi --model "mesh/Qwen 3.6 27B"
 ```
 
 You can switch models interactively with `Ctrl+M` inside pi.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -6,9 +6,9 @@ Mesh LLM exposes an OpenAI-compatible API on `http://localhost:9337/v1`, so most
 
 ## Built-in launcher integrations
 
-For built-in launcher commands such as `goose`, `claude`, and `opencode`:
+For built-in launcher commands such as `goose`, `claude`, `opencode`, and `pi`:
 
-- goose and claude reuse a local mesh on the chosen `--port`
+- goose, claude, and pi reuse a local mesh on the chosen `--port`
 - opencode targets `--host` (default `127.0.0.1:9337`) and only auto-starts a local client for loopback/localhost targets
 - if `--model` is omitted, the launcher picks the strongest tool-capable model available
 - when the harness exits, the auto-started node is cleaned up
@@ -97,19 +97,23 @@ OPENCODE_CONFIG_CONTENT='{
 
 ## pi
 
-Start a mesh client:
+Launch pi directly through Mesh LLM:
 
 ```bash
-mesh-llm client --auto --port 9337
+mesh-llm pi
 ```
 
-Check available models:
+Use a specific model:
 
 ```bash
-curl -s http://localhost:9337/v1/models | jq '.data[].id'
+mesh-llm pi --model MiniMax-M2.5-Q4_K_M
 ```
 
-Add a `mesh` provider to `~/.pi/agent/models.json`:
+This writes a mesh provider into `~/.pi/agent/models.json` and launches pi.
+
+### Manual setup
+
+Alternatively, add a `mesh` provider to `~/.pi/agent/models.json` by hand:
 
 ```json
 {
@@ -118,30 +122,22 @@ Add a `mesh` provider to `~/.pi/agent/models.json`:
       "api": "openai-completions",
       "apiKey": "mesh",
       "baseUrl": "http://localhost:9337/v1",
-      "models": [
-        {
-          "id": "MiniMax-M2.5-Q4_K_M",
-          "name": "MiniMax M2.5 (Mesh)",
-          "contextWindow": 65536,
-          "maxTokens": 8192,
-          "reasoning": true,
-          "input": ["text"],
-          "compat": {
-            "maxTokensField": "max_tokens",
-            "supportsDeveloperRole": false,
-            "supportsUsageInStreaming": false
-          }
-        }
-      ]
+      "models": [{ "id": "auto" }]
     }
   }
 }
 ```
 
+The `auto` model ID lets mesh-llm pick the strongest available model on the mesh. To target a specific model, replace `auto` with a model ID from the mesh:
+
+```bash
+curl -s http://localhost:9337/v1/models | jq '.data[].id'
+```
+
 Run pi:
 
 ```bash
-pi --model mesh/MiniMax-M2.5-Q4_K_M
+pi --model mesh/auto
 ```
 
 You can switch models interactively with `Ctrl+M` inside pi.

--- a/docs/index.html
+++ b/docs/index.html
@@ -236,30 +236,13 @@
         </details>
 
         <details style="margin-bottom:1rem;">
-            <summary style="cursor:pointer; font-size:0.9rem; font-weight:600; color:#fff; padding:0.8rem 0;">▸ pi</summary>
-            <p style="font-size:0.8rem; color:var(--text2); margin:0.5rem 0;">Add to <code>~/.pi/agent/models.json</code>:</p>
-            <div class="code-block" style="margin-top:0.5rem; font-size:0.75rem;">
-<span class="val">{</span><br>
-&nbsp;&nbsp;<span class="flag">"providers"</span>: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"mesh"</span>: {<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"api"</span>: <span class="val">"openai-completions"</span>,<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"apiKey"</span>: <span class="val">"dummy"</span>,<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"baseUrl"</span>: <span class="val">"http://localhost:9337/v1"</span>,<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"models"</span>: [{<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"id"</span>: <span class="val">"GLM-4.7-Flash-Q4_K_M"</span>,<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"name"</span>: <span class="val">"GLM 4.7 Flash (mesh)"</span>,<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"contextWindow"</span>: 32768, <span class="flag">"maxTokens"</span>: 8192,<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"reasoning"</span>: false, <span class="flag">"input"</span>: [<span class="val">"text"</span>],<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"cost"</span>: { <span class="flag">"input"</span>: 0, <span class="flag">"output"</span>: 0, <span class="flag">"cacheRead"</span>: 0, <span class="flag">"cacheWrite"</span>: 0 },<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="flag">"compat"</span>: { <span class="flag">"maxTokensField"</span>: <span class="val">"max_tokens"</span>, <span class="flag">"supportsDeveloperRole"</span>: false, <span class="flag">"supportsUsageInStreaming"</span>: false }<br>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;}]<br>
-&nbsp;&nbsp;&nbsp;&nbsp;}<br>
-&nbsp;&nbsp;}<br>
-<span class="val">}</span>
-            </div>
+            <summary style="cursor:pointer; font-size:0.9rem; font-weight:600; color:#fff; padding:0.8rem 0;">▸ pi (built-in launcher)</summary>
             <div class="code-block" style="margin-top:0.5rem;">
-                <span class="cmd">pi</span> <span class="flag">--provider</span> <span class="val">mesh</span> <span class="flag">--model</span> <span class="val">GLM-4.7-Flash-Q4_K_M</span>
+                <span class="cmd">mesh-llm</span> pi<br><br>
+                <span class="comment"># Or pick a specific model</span><br>
+                <span class="cmd">mesh-llm</span> pi <span class="flag">--model</span> <span class="val">MiniMax-M2.5-Q4_K_M</span>
             </div>
+            <p style="font-size:0.8rem; color:var(--text2); margin:0.5rem 0;">Writes a mesh provider into <code>~/.pi/agent/models.json</code> and launches pi. Picks the strongest model automatically.</p>
         </details>
 
         <details style="margin-bottom:1rem;">

--- a/docs/index.html
+++ b/docs/index.html
@@ -240,9 +240,13 @@
             <div class="code-block" style="margin-top:0.5rem;">
                 <span class="cmd">mesh-llm</span> pi<br><br>
                 <span class="comment"># Or pick a specific model</span><br>
-                <span class="cmd">mesh-llm</span> pi <span class="flag">--model</span> <span class="val">MiniMax-M2.5-Q4_K_M</span>
+                <span class="cmd">mesh-llm</span> pi <span class="flag">--model</span> <span class="val">MiniMax-M2.5-Q4_K_M</span><br><br>
+                <span class="comment"># Only write ~/.pi/agent/models.json</span><br>
+                <span class="cmd">mesh-llm</span> pi <span class="flag">--write</span><br><br>
+                <span class="comment"># Target a remote mesh host or URL</span><br>
+                <span class="cmd">mesh-llm</span> pi <span class="flag">--write</span> <span class="flag">--host</span> <span class="val">carrack.patio51.com:9337</span>
             </div>
-            <p style="font-size:0.8rem; color:var(--text2); margin:0.5rem 0;">Writes a mesh provider into <code>~/.pi/agent/models.json</code> and launches pi. Picks the strongest model automatically.</p>
+            <p style="font-size:0.8rem; color:var(--text2); margin:0.5rem 0;">Writes every mesh model into <code>~/.pi/agent/models.json</code>, including Pi <code>contextWindow</code>/<code>maxTokens</code> when mesh metadata is available, and launches pi unless <code>--write</code> is set. Use <code>--host</code> for a remote mesh host or full URL.</p>
         </details>
 
         <details style="margin-bottom:1rem;">


### PR DESCRIPTION
Add a built-in `mesh-llm pi` launcher, matching the existing `mesh-llm goose`, `mesh-llm claude`, and `mesh-llm opencode` commands.

## What it does

```bash
mesh-llm pi                                # auto-picks strongest model
mesh-llm pi --model MiniMax-M2.5-Q4_K_M    # use a specific model
```

The launcher:
1. Ensures a mesh is running (auto-starts a client node if needed via `check_mesh`)
2. Writes/merges a `mesh` provider into `~/.pi/agent/models.json`
3. Launches `pi --model mesh/auto` (or `mesh/<model>` if `--model` was specified)
4. Cleans up the auto-started mesh child on exit

## Docs simplification

The pi `models.json` config was simplified — the `auto` model ID works without compat flags (`maxTokensField`, `supportsDeveloperRole`, `supportsUsageInStreaming`), so they were removed. Tested against a live mesh with pi 0.57.1.

## Changes

- `mesh-llm/src/cli/mod.rs` — `Pi` command variant
- `mesh-llm/src/cli/commands/mod.rs` — dispatch wiring
- `mesh-llm/src/cli/commands/integrations.rs` — `run_pi()` implementation
- `docs/AGENTS.md` — leads with `mesh-llm pi`, manual setup as subsection
- `docs/index.html` — replaced verbose JSON block with launcher example
- `README.md` — updated pi section and launcher integration lists
