### PR TITLE
feature(cli): --private-only flag for single-tenant deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,15 @@ mesh-llm serve --model Qwen2.5-32B
 
 This starts serving a model, opens the local API and console, and prints an invite token for other machines.
 
-### 3. Build from source
+### 3. Lock to private-only (single-tenant / company fleet)
+
+```bash
+mesh-llm serve --private-only --model Qwen2.5-32B
+```
+
+`--private-only` is a hard lock for deployments that must never accidentally publish to or auto-join a public mesh — internal company fleets, on-prem clusters, regulated environments. It conflicts at parse time with `--auto`, `--publish`, `--discover`, `--mesh-name`, and `--region`, so a misconfigured invocation fails fast instead of silently joining the wrong mesh. Joining via an explicit invite token (`--join <token>`) still works; only Nostr-based discovery and publishing are disabled.
+
+### 4. Build from source
 
 ```bash
 git clone https://github.com/Mesh-LLM/mesh-llm

--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -260,6 +260,21 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) auto: bool,
 
+    /// Refuse to publish or discover this mesh on any public network.
+    ///
+    /// Intended for single-tenant / company-fleet deployments where the
+    /// operator wants to assert "this binary will never publish to Nostr
+    /// or auto-join a public mesh by accident." Hard-conflicts with
+    /// `--auto`, `--publish`, `--discover`, `--mesh-name`, and `--region`
+    /// at parse time, so a misconfigured invocation fails fast with a
+    /// clear error instead of silently joining the wrong mesh.
+    /// Joining via an explicit `--join <token>` is unaffected.
+    #[arg(
+        long,
+        conflicts_with_all = ["auto", "publish", "discover", "mesh_name", "region"]
+    )]
+    pub(crate) private_only: bool,
+
     /// Model to serve (path, catalog name, HF exact ref, or HuggingFace URL).
     #[arg(long)]
     pub(crate) model: Vec<PathBuf>,
@@ -630,9 +645,9 @@ where
     // Skip leading global flags to find the pseudo-subcommand position.
     // Recognized value-taking flags: --log-format, --max-vram, --llama-flavor, --device,
     // --tensor-split, --bind-port, --max-clients, --port, --console, --draft-max, --ctx-size.
-    // Boolean flags: --help-advanced, --auto, --client, --headless, --publish, --blackboard,
-    // --plugin, --auto-update, --no-draft, --split, --no-enumerate-host, --listen-all,
-    // --no-console, --owner-required.
+    // Boolean flags: --help-advanced, --auto, --private-only, --client, --headless,
+    // --publish, --blackboard, --plugin, --auto-update, --no-draft, --split,
+    // --no-enumerate-host, --listen-all, --no-console, --owner-required.
     let value_taking_flags = [
         "--log-format",
         "--max-vram",
@@ -1275,5 +1290,102 @@ mod tests {
             } => {}
             other => panic!("unexpected command: {other:?}"),
         }
+    }
+
+    #[test]
+    fn cli_accepts_private_only_flag() {
+        let normalized = normalize_runtime_surface_args(["mesh-llm", "serve", "--private-only"]);
+        let cli = Cli::parse_from(normalized.normalized);
+        assert!(cli.private_only);
+        assert!(!cli.auto);
+        assert!(!cli.publish);
+        assert!(cli.discover.is_none());
+        assert!(cli.mesh_name.is_none());
+        assert!(cli.region.is_none());
+    }
+
+    #[test]
+    fn cli_private_only_allows_explicit_invite_join() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "serve",
+            "--private-only",
+            "--join",
+            "TOKEN",
+        ]);
+        let cli = Cli::parse_from(normalized.normalized);
+        assert!(cli.private_only);
+        assert_eq!(cli.join, vec!["TOKEN".to_string()]);
+    }
+
+    #[test]
+    fn cli_private_only_conflicts_with_auto() {
+        let normalized =
+            normalize_runtime_surface_args(["mesh-llm", "serve", "--private-only", "--auto"]);
+        let err =
+            Cli::try_parse_from(normalized.normalized).expect_err("--private-only --auto must err");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+        let rendered = err.to_string();
+        assert!(rendered.contains("--private-only"));
+        assert!(rendered.contains("--auto"));
+    }
+
+    #[test]
+    fn cli_private_only_conflicts_with_publish() {
+        let normalized =
+            normalize_runtime_surface_args(["mesh-llm", "serve", "--private-only", "--publish"]);
+        let err = Cli::try_parse_from(normalized.normalized)
+            .expect_err("--private-only --publish must err");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn cli_private_only_conflicts_with_discover() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "serve",
+            "--private-only",
+            "--discover",
+            "poker-night",
+        ]);
+        let err = Cli::try_parse_from(normalized.normalized)
+            .expect_err("--private-only --discover must err");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn cli_private_only_conflicts_with_mesh_name() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "serve",
+            "--private-only",
+            "--mesh-name",
+            "office",
+        ]);
+        let err = Cli::try_parse_from(normalized.normalized)
+            .expect_err("--private-only --mesh-name must err");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn cli_private_only_conflicts_with_region() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "serve",
+            "--private-only",
+            "--region",
+            "EU",
+        ]);
+        let err = Cli::try_parse_from(normalized.normalized)
+            .expect_err("--private-only --region must err");
+        assert_eq!(err.kind(), ErrorKind::ArgumentConflict);
+    }
+
+    #[test]
+    fn cli_help_documents_private_only_flag() {
+        let mut command = Cli::command();
+        let help = command.render_long_help().to_string();
+        assert!(help.contains("--private-only"));
+        assert!(help.contains("Refuse to publish or discover"));
     }
 }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -824,6 +824,13 @@ pub(crate) async fn run() -> Result<()> {
         initial_console_session_mode(normalized_args.explicit_surface),
     );
 
+    if cli.private_only {
+        let _ = emit_event(OutputEvent::Info {
+            message: "private-only mode: Nostr publish and public-mesh discovery are disabled for this process".to_string(),
+            context: Some("private-only".to_string()),
+        });
+    }
+
     if let Some(warning) = crate::cli::legacy_runtime_surface_warning(
         &cli,
         &normalized_args.original,


### PR DESCRIPTION
## Summary

Adds a top-level `--private-only` boolean flag to `mesh-llm serve` (and
`mesh-llm client`) that hard-disables Nostr publish and public-mesh
discovery for the lifetime of a process.

`--private-only` is a parse-time hard conflict (via clap
`conflicts_with_all`) with:

- `--auto` — Nostr auto-discovery
- `--publish` — Nostr publishing for public discovery
- `--discover` — Nostr-discovered mesh joining
- `--mesh-name` — display name on Nostr
- `--region` — region tag on Nostr

Joining a private mesh via an explicit invite token (`--join <token>`)
is unaffected; only the Nostr-touching code paths are blocked.

## Why

Single-tenant / company-fleet deployments — internal Mac fleets, on-prem
GPU clusters, regulated environments — want an audit-friendly assertion
that the binary cannot accidentally publish to or auto-join a public
mesh, even if a user mistypes a flag.

Today that is true if you simply do not pass `--auto` or `--publish`.
But there is no way for an operator to assert this from outside the
running process. A flag the binary refuses to accept in conjunction
with the public-mesh flags makes the lock posture explicit and visible.

When `--private-only` is set, the runtime also emits an info banner at
startup so the lock is observable in the JSONL/pretty output.

## Alternatives considered

- **Doing nothing** — users can already reach a private mesh by omitting
  `--auto` / `--publish`. But proving the binary will not publish
  requires either source inspection or runtime tracing today.
- **Compile-time feature flag** — heavier, forces a fork. The CLI flag
  approach is lighter and discoverable via `--help`.
- **Force-override (warn + silently disable)** — also considered emitting
  a warning and forcing `auto = publish = false`. Failing fast at parse
  time with a clear conflict error is louder and harder to miss.

## Follow-ups (not in this PR)

- Mirror as a `private_only = true` field in `~/.mesh-llm/config.toml`
  so fleet admins can lock a box once via config rather than wrapping
  systemd / launchd ExecStart with the flag.
- Defense-in-depth `debug_assert!(!cli.private_only)` at every Nostr
  call site.

## Tests

Eight new cases under `mesh-llm::cli::tests`, all green:

- `cli_accepts_private_only_flag`
- `cli_private_only_allows_explicit_invite_join`
- `cli_private_only_conflicts_with_auto`
- `cli_private_only_conflicts_with_publish`
- `cli_private_only_conflicts_with_discover`
- `cli_private_only_conflicts_with_mesh_name`
- `cli_private_only_conflicts_with_region`
- `cli_help_documents_private_only_flag`

`cargo test -p mesh-llm --lib cli::tests::cli_` — 19 passed; 0 failed.
