### PR TITLE
Revalidate sticky auto routing for media requests

### DIFF
--- a/mesh-llm/src/network/openai/transport.rs
+++ b/mesh-llm/src/network/openai/transport.rs
@@ -1853,6 +1853,14 @@ fn should_learn_affinity(status_code: u16) -> bool {
     (200..400).contains(&status_code)
 }
 
+fn cached_auto_model_satisfies_media_requirements(
+    model: &str,
+    media: &router::MediaRequirements,
+) -> bool {
+    let caps = crate::models::installed_model_capabilities(model);
+    router::model_satisfies_media_requirements(&caps, media)
+}
+
 // ── Model-aware tunnel routing ──
 
 /// The common request-handling path used by idle proxy, passive proxy, and bootstrap proxy.
@@ -1898,104 +1906,111 @@ pub async fn handle_mesh_request(
     // we cache the classified model choice by session key, so every turn
     // in the same auto-routed chat reuses the first pick. Prefix affinity
     // then has a chance to keep those turns on the same peer too.
-    let auto_session_key =
-        if request.model_name.is_none() || request.model_name.as_deref() == Some("auto") {
-            request.ensure_body_json();
-            request
-                .body_json
-                .as_ref()
-                .and_then(|body| crate::network::affinity::auto_model_session_key(Some(body)))
-        } else {
-            None
-        };
-    let routed_model =
-        if request.model_name.is_none() || request.model_name.as_deref() == Some("auto") {
-            request.ensure_body_json();
-            if let Some(body_json) = request.body_json.as_ref() {
-                // Try the sticky-auto cache first. If we have a remembered
-                // model for this session AND the mesh still has a host
-                // serving it, use that pick and skip classification.
-                let cached = if let Some(key) = auto_session_key {
-                    if let Some(model) = affinity.lookup_auto_model(key) {
-                        if !node.hosts_for_model(&model).await.is_empty() {
+    let is_auto_request =
+        request.model_name.is_none() || request.model_name.as_deref() == Some("auto");
+    let auto_session_key = if is_auto_request {
+        request.ensure_body_json();
+        request
+            .body_json
+            .as_ref()
+            .and_then(|body| crate::network::affinity::auto_model_session_key(Some(body)))
+    } else {
+        None
+    };
+    let routed_model = if is_auto_request {
+        request.ensure_body_json();
+        if let Some(body_json) = request.body_json.as_ref() {
+            let media = router::media_requirements(body_json);
+            // Try the sticky-auto cache first. If we have a remembered
+            // model for this session AND the mesh still has a host
+            // serving it AND it can satisfy this request's media inputs,
+            // use that pick and skip classification.
+            let cached = if let Some(key) = auto_session_key {
+                if let Some(model) = affinity.lookup_auto_model(key) {
+                    if !node.hosts_for_model(&model).await.is_empty() {
+                        if cached_auto_model_satisfies_media_requirements(&model, &media) {
                             tracing::debug!(
                                 "auto: reusing cached model {model} for session {key:016x}"
                             );
                             Some(model)
                         } else {
-                            // The model we picked last time is no longer
-                            // served anywhere. Drop the entry so we
-                            // reclassify and cache a fresh choice.
                             tracing::debug!(
-                                "auto: cached model {model} no longer served, reclassifying"
+                                "auto: cached model {model} cannot satisfy media requirements, \
+                                 reclassifying"
                             );
                             affinity.forget_auto_model(key);
                             None
                         }
                     } else {
+                        // The model we picked last time is no longer
+                        // served anywhere. Drop the entry so we
+                        // reclassify and cache a fresh choice.
+                        tracing::debug!(
+                            "auto: cached model {model} no longer served, reclassifying"
+                        );
+                        affinity.forget_auto_model(key);
                         None
                     }
                 } else {
                     None
-                };
-
-                if let Some(name) = cached {
-                    Some(name)
-                } else {
-                    let cl = router::classify(body_json);
-                    let served = node.models_being_served().await;
-                    let media = router::media_requirements(body_json);
-                    let with_caps: Vec<(&str, f64, crate::models::ModelCapabilities)> = served
-                        .iter()
-                        .map(|name| {
-                            let caps = crate::models::installed_model_capabilities(name);
-                            (name.as_str(), 0.0, caps)
-                        })
-                        .collect();
-                    let available: Vec<(&str, f64, crate::models::ModelCapabilities)> = with_caps
-                        .iter()
-                        .filter(|(_, _, caps)| {
-                            (!media.needs_vision || caps.vision_label().is_some())
-                                && (!media.needs_audio || caps.audio_label().is_some())
-                        })
-                        .cloned()
-                        .collect();
-                    let available = if available.is_empty() {
-                        with_caps
-                    } else {
-                        available
-                    };
-                    let picked = router::pick_model_classified(&cl, &available);
-                    if let Some(name) = picked {
-                        tracing::info!(
-                            "router: {:?}/{:?} tools={} media={} → {name}",
-                            cl.category,
-                            cl.complexity,
-                            cl.needs_tools,
-                            cl.has_media_inputs
-                        );
-                        let chosen = name.to_string();
-                        if let Some(key) = auto_session_key {
-                            affinity.remember_auto_model(key, &chosen);
-                        }
-                        Some(chosen)
-                    } else {
-                        None
-                    }
                 }
             } else {
                 None
+            };
+
+            if let Some(name) = cached {
+                Some(name)
+            } else {
+                let cl = router::classify(body_json);
+                let served = node.models_being_served().await;
+                let with_caps: Vec<(&str, f64, crate::models::ModelCapabilities)> = served
+                    .iter()
+                    .map(|name| {
+                        let caps = crate::models::installed_model_capabilities(name);
+                        (name.as_str(), 0.0, caps)
+                    })
+                    .collect();
+                let available: Vec<(&str, f64, crate::models::ModelCapabilities)> = with_caps
+                    .iter()
+                    .filter(|(_, _, caps)| router::model_satisfies_media_requirements(caps, &media))
+                    .cloned()
+                    .collect();
+                let available = if available.is_empty() {
+                    with_caps
+                } else {
+                    available
+                };
+                let picked = router::pick_model_classified(&cl, &available);
+                if let Some(name) = picked {
+                    tracing::info!(
+                        "router: {:?}/{:?} tools={} media={} → {name}",
+                        cl.category,
+                        cl.complexity,
+                        cl.needs_tools,
+                        cl.has_media_inputs
+                    );
+                    let chosen = name.to_string();
+                    if let Some(key) = auto_session_key {
+                        affinity.remember_auto_model(key, &chosen);
+                    }
+                    Some(chosen)
+                } else {
+                    None
+                }
             }
         } else {
             None
-        };
+        }
+    } else {
+        None
+    };
     let effective_model = routed_model.or(request.model_name.clone());
 
     // Enable mesh hooks for auto-routed requests. When the smart router
     // picks the model, hooks allow the local model to consult peers during
     // inference (e.g. caption images via a vision peer, get a second opinion
     // on uncertain answers). Explicit model names pass through without hooks.
-    if request.model_name.is_none() || request.model_name.as_deref() == Some("auto") {
+    if is_auto_request {
         inject_mesh_hooks_flag(&mut request.raw, true);
     }
 
@@ -3337,6 +3352,29 @@ mod tests {
             route_attempt_result_label(&RouteAttemptResult::ClientDisconnected),
             "client_disconnected"
         );
+    }
+
+    #[test]
+    fn test_cached_auto_model_rejects_text_model_for_image_request() {
+        let body = serde_json::json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+                ]
+            }]
+        });
+        let media = router::media_requirements(&body);
+
+        assert!(!cached_auto_model_satisfies_media_requirements(
+            "Qwen3-8B-Q4_K_M",
+            &media
+        ));
+        assert!(cached_auto_model_satisfies_media_requirements(
+            "Qwen3.5-0.8B-Vision-Q4_K_M",
+            &media
+        ));
     }
 
     #[test]

--- a/mesh-llm/src/network/router.rs
+++ b/mesh-llm/src/network/router.rs
@@ -366,6 +366,14 @@ pub fn media_requirements(body: &Value) -> MediaRequirements {
     requirements
 }
 
+pub(crate) fn model_satisfies_media_requirements(
+    caps: &crate::models::ModelCapabilities,
+    media: &MediaRequirements,
+) -> bool {
+    (!media.needs_vision || caps.vision_label().is_some())
+        && (!media.needs_audio || caps.audio_label().is_some())
+}
+
 /// Length of last user message in characters (rough complexity proxy).
 fn last_user_message_len(body: &Value) -> usize {
     body.get("messages")
@@ -762,6 +770,57 @@ mod tests {
         assert!(media.needs_vision);
         assert!(!media.needs_audio);
         assert!(classify(&body).has_media_inputs);
+    }
+
+    #[test]
+    fn test_model_satisfies_media_requirements_matches_required_modalities() {
+        use crate::models::{CapabilityLevel, ModelCapabilities};
+
+        let text_caps = ModelCapabilities::default();
+        let vision_caps = ModelCapabilities {
+            vision: CapabilityLevel::Supported,
+            ..Default::default()
+        };
+        let audio_caps = ModelCapabilities {
+            audio: CapabilityLevel::Supported,
+            ..Default::default()
+        };
+        let vision_audio_caps = ModelCapabilities {
+            vision: CapabilityLevel::Supported,
+            audio: CapabilityLevel::Supported,
+            ..Default::default()
+        };
+
+        let text_only = MediaRequirements::default();
+        let image = MediaRequirements {
+            has_media: true,
+            needs_vision: true,
+            needs_audio: false,
+        };
+        let audio = MediaRequirements {
+            has_media: true,
+            needs_vision: false,
+            needs_audio: true,
+        };
+        let image_and_audio = MediaRequirements {
+            has_media: true,
+            needs_vision: true,
+            needs_audio: true,
+        };
+
+        assert!(model_satisfies_media_requirements(&text_caps, &text_only));
+        assert!(!model_satisfies_media_requirements(&text_caps, &image));
+        assert!(model_satisfies_media_requirements(&vision_caps, &image));
+        assert!(!model_satisfies_media_requirements(&vision_caps, &audio));
+        assert!(model_satisfies_media_requirements(&audio_caps, &audio));
+        assert!(!model_satisfies_media_requirements(
+            &vision_caps,
+            &image_and_audio
+        ));
+        assert!(model_satisfies_media_requirements(
+            &vision_audio_caps,
+            &image_and_audio
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## 1. Summary

Auto-routed chat sessions now reuse a sticky cached model only when that model can satisfy the current request's media requirements.

**Image or audio follow-up requests no longer stay pinned to a text-only cached auto pick.**

## 2. Why

Sticky auto routing improves latency for follow-up turns, but the cached model choice must not bypass per-request media capability checks.

This closes a concrete routing correctness gap where an image/audio request in the same auto session could be sent to a model that is still served but cannot handle the request modality.

## 3. Diff Scope

**Runtime routing**

- `mesh-llm/src/network/openai/transport.rs`: revalidates cached auto-routed models against media requirements before reuse, forgets incompatible cache entries, and keeps mesh-hook behavior tied to the auto-request decision.

**Router capability checks**

- `mesh-llm/src/network/router.rs`: adds a shared media capability predicate used by both cached routing and reclassification filtering.
- Added focused Rust tests for cached text-model rejection on image requests and modality predicate behavior.

## 4. Branch Integrity

**Base branch:** `main`  
**`origin/main`:** `2e465f8c1f6b40cd197db057c09a01970cf868a2`  
**Ahead / behind:** `1 ahead, 0 behind`  
**Merge base:** `2e465f8c1f6b40cd197db057c09a01970cf868a2`  
**Fast-forward safety:** PASS — `origin/main` is an ancestor of `HEAD`; no divergence.

## 5. Commit Integrity

**Introduced commit**

`1cfb1fcde643cbc6d91395973fbb61205c1ac484 Revalidate sticky auto models for media requests`

**One logical change per commit:** confirmed.

**Ledger-Id trailers:** Not applicable — `scripts/ledger/` does not exist in this repository.

**Unique Ledger-Id for squash merge:** Not applicable — `scripts/ledger/` does not exist in this repository.

## 6. Ledger Proof

**Not applicable** — `scripts/ledger/` does not exist in this repository.

## 7. Diff Hygiene

**Changed files**

- `M mesh-llm/src/network/openai/transport.rs`
- `M mesh-llm/src/network/router.rs`

**`git diff --check origin/main...HEAD`:** PASS, no output.

**Forbidden-file confirmation:** no `.env` files, local environment files, secrets, tokens, credentials, `ops/reports` artifacts, `__pycache__`, `*.pyc`, `.DS_Store`, coverage artifacts, build outputs, cache files, or unrelated generated files are included.

## 8. Test Proof

**`cargo test -p mesh-llm`: PASS**

- Unit tests: `1221 passed`, `3 ignored`, `0 failed`
- Integration tests:
  - `protocol_compat_v0_client`: `10 passed`
  - `protocol_convert_matrix`: `11 passed`
  - `virtual_llm_injection`: `1 passed`
- Doc tests: `0 passed`, `0 failed`

**`/tmp/mesh-llm-just-tool/bin/just build`: PASS**

Built llama.cpp, the UI, and the release `mesh-llm` binary.

**Pytest/coverage:** Not applicable — this is a Rust runtime change and this repository has no Python test-runner or coverage gate for this path.

## 9. Verification-Pack Proof

**Not applicable** — `scripts/ops/` does not exist in this repository and no infra/governance/replay/invariant/verification files changed.

## 10. Migration Notes

**Not applicable** — no DB migration changed.

## 11. CI Context Confirmation

**Required contexts:** unchanged for this repository.

**CI context names unchanged.**

**Workflow changes:** Not applicable — no CI/workflow context changes.

## 12. Runtime Safety

**Reviewed runtime files/modules**

- `mesh-llm/src/network/openai/transport.rs`
- `mesh-llm/src/network/router.rs`

**No new blocking locks:** the change only computes media requirements and checks model capabilities before reusing an existing cached auto pick.

**No new unbounded queues:** no queues, channels, background tasks, or buffering paths were added.

**No invariant removal:** the existing served-host check remains, incompatible cached picks are forgotten, and the existing fallback behavior is preserved when no media-capable model is available.

**No invariant regression introduced.**

## 13. Documentation Integrity

**Not applicable** — no README, runbook, documented command, or operational behavior changed.

**Runbook mirror parity:** Not applicable — no runbooks changed.

**Stale references:** Not applicable — no docs changed.

## 14. Rollback Plan

**Squash merge rollback:** `git revert <post_merge_commit_sha>`

Replace `<post_merge_commit_sha>` with the final squash/merge commit SHA after merge.

**DB downgrade required:** no  
**Data repair required:** no  
**Operational caveats:** none expected; rollback restores the previous sticky auto-cache behavior.

## 15. Known Residual Risks

**No known functional residual risks.**

The successful `just build` emitted existing environment/tooling warnings, including local Node version warning, npm audit output, Vite chunk-size warnings, and llama.cpp compiler warnings. The command exited successfully, and these warnings are unrelated to the changed Rust files.