### PR TITLE
Recovered peers can rejoin the mesh after dead_peers TTL expires

### DIFF
--- a/mesh-llm/src/cli/mod.rs
+++ b/mesh-llm/src/cli/mod.rs
@@ -1164,7 +1164,7 @@ mod tests {
         let cli = Cli::parse_from(normalized.normalized);
 
         assert_eq!(cli.log_format, LogFormat::Json);
-        assert_eq!(cli.model, vec!["Qwen3-8B-Q4_K_M".to_string()]);
+        assert_eq!(cli.model, vec![std::path::PathBuf::from("Qwen3-8B-Q4_K_M")]);
         assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Serve));
     }
 

--- a/mesh-llm/src/mesh/gossip.rs
+++ b/mesh-llm/src/mesh/gossip.rs
@@ -262,7 +262,7 @@ impl Node {
 
         {
             let mut state = self.state.lock().await;
-            if state.dead_peers.remove(&remote) {
+            if state.dead_peers.remove(&remote).is_some() {
                 super::emit_mesh_info(format!(
                     "🔄 Dead peer {} is gossiping — clearing dead status",
                     remote.fmt_short()
@@ -409,7 +409,7 @@ impl Node {
         let now = std::time::Instant::now();
         // If this peer was previously dead, clear it — add_peer is only called
         // after a successful gossip exchange, which is proof of life.
-        let recovered = state.dead_peers.remove(&id);
+        let recovered = state.dead_peers.remove(&id).is_some();
         if recovered {
             super::emit_mesh_info(format!(
                 "🔄 Peer {} back from the dead (successful gossip)",
@@ -571,7 +571,11 @@ impl Node {
         if id == self.endpoint.id() {
             return;
         }
-        if state.dead_peers.contains(&id) {
+        if state
+            .dead_peers
+            .get(&id)
+            .is_some_and(|t| t.elapsed() < DEAD_PEER_TTL)
+        {
             return;
         }
         if let Some(existing) = state.peers.get_mut(&id) {

--- a/mesh-llm/src/mesh/heartbeat.rs
+++ b/mesh-llm/src/mesh/heartbeat.rs
@@ -580,7 +580,11 @@ impl Node {
                                 // Generic peers require 2 misses so a single timeout doesn't
                                 // evict an otherwise-alive inbound-only peer. Shared MoE peers
                                 // are stricter: one missed heartbeat should trigger re-election.
-                                node.state.lock().await.dead_peers.insert(peer_id);
+                                node.state
+                                    .lock()
+                                    .await
+                                    .dead_peers
+                                    .insert(peer_id, std::time::Instant::now());
                                 super::emit_mesh_warning(format!(
                                     "💔 Heartbeat: {} unreachable ({} failure{}), removing + broadcasting death",
                                     peer_id.fmt_short(),
@@ -629,6 +633,15 @@ impl Node {
                     node.state.lock().await.connections.remove(&stale_id);
                 }
 
+                // GC expired dead_peers entries so recovered peers can be
+                // re-learned transitively through gossip.
+                {
+                    let mut state = node.state.lock().await;
+                    state
+                        .dead_peers
+                        .retain(|_, ts| ts.elapsed() < DEAD_PEER_TTL);
+                }
+
                 // GC expired demand entries to prevent unbounded map growth
                 node.gc_demand().await;
             }
@@ -647,7 +660,7 @@ impl Node {
             // gossip will arrive on the existing connection and trigger recovery
             // via handle_gossip_stream → add_peer → clear dead_peers.
             // Don't remove: state.connections.remove(&dead_id);
-            state.dead_peers.insert(dead_id);
+            state.dead_peers.insert(dead_id, std::time::Instant::now());
         }
         self.remove_peer(dead_id).await;
         self.broadcast_peer_down(dead_id).await;

--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -862,6 +862,12 @@ impl PeerInfo {
 /// Peers not directly verified within this window are considered stale
 /// and excluded from gossip propagation. After 2x this duration they're removed entirely.
 const PEER_STALE_SECS: u64 = 180; // 3 minutes
+
+/// How long a dead-peer entry blocks transitive re-learning and outbound
+/// reconnection. After this period the entry expires silently and the peer
+/// can be re-discovered through normal gossip propagation. If the peer is
+/// genuinely gone, no bridge peer will mention it and it stays forgotten.
+const DEAD_PEER_TTL: std::time::Duration = std::time::Duration::from_secs(300); // 5 minutes
 /// Detect available VRAM. On Apple Silicon, uses ~75% of system RAM
 /// (the rest is reserved for OS/apps on unified memory).
 /// Detect available memory for model loading, capped by max_vram_gb if set.
@@ -1140,7 +1146,9 @@ struct MeshState {
     remote_tunnel_maps: HashMap<EndpointId, HashMap<EndpointId, u16>>,
     /// Peers confirmed dead — don't reconnect from gossip discovery.
     /// Cleared when the peer successfully reconnects via rejoin/join.
-    dead_peers: std::collections::HashSet<EndpointId>,
+    /// Entries expire after [`DEAD_PEER_TTL`] so that peers recovered
+    /// on other paths can be re-learned transitively through gossip.
+    dead_peers: HashMap<EndpointId, std::time::Instant>,
     seen_plugin_messages: HashMap<String, std::time::Instant>,
     seen_plugin_message_order: VecDeque<(std::time::Instant, String)>,
     /// Last policy-rejection status per peer — used to suppress duplicate log lines.
@@ -1568,7 +1576,7 @@ impl Node {
                 peers: HashMap::new(),
                 connections: HashMap::new(),
                 remote_tunnel_maps: HashMap::new(),
-                dead_peers: std::collections::HashSet::new(),
+                dead_peers: HashMap::new(),
                 seen_plugin_messages: HashMap::new(),
                 seen_plugin_message_order: VecDeque::new(),
                 policy_rejected_peers: HashMap::new(),
@@ -1677,7 +1685,7 @@ impl Node {
                 peers: HashMap::new(),
                 connections: HashMap::new(),
                 remote_tunnel_maps: HashMap::new(),
-                dead_peers: std::collections::HashSet::new(),
+                dead_peers: HashMap::new(),
                 seen_plugin_messages: HashMap::new(),
                 seen_plugin_message_order: VecDeque::new(),
                 policy_rejected_peers: HashMap::new(),
@@ -3076,7 +3084,7 @@ impl Node {
         // Don't add to peer list yet — only gossip exchange promotes to peer.
         let was_dead = {
             let mut state = self.state.lock().await;
-            let was_dead = state.dead_peers.remove(&remote);
+            let was_dead = state.dead_peers.remove(&remote).is_some();
             if was_dead {
                 emit_mesh_info(format!(
                     "🔄 Previously dead peer {} reconnected",
@@ -4022,7 +4030,11 @@ impl Node {
             if state.peers.contains_key(&peer_id) {
                 return Ok(());
             }
-            if state.dead_peers.contains(&peer_id) {
+            if state
+                .dead_peers
+                .get(&peer_id)
+                .is_some_and(|t| t.elapsed() < DEAD_PEER_TTL)
+            {
                 tracing::debug!("Skipping connection to dead peer {}", peer_id.fmt_short());
                 return Ok(());
             }

--- a/mesh-llm/src/mesh/tests.rs
+++ b/mesh-llm/src/mesh/tests.rs
@@ -2535,10 +2535,10 @@ fn worker_only_legacy_models_are_excluded_from_http_routes() {
     assert!(!legacy_worker.routes_http_model("worker-only-model"));
 }
 
-/// Verifies that dead-peer cleanup prevents re-admission: after a peer is cleaned
-/// up and added to dead_peers, the map blocks any further connection attempts,
-/// and a subsequent PeerLeaving from the same peer is rejected as forged (peer_id
-/// no longer in peers set).
+/// Verifies that dead-peer cleanup prevents re-admission within the TTL window:
+/// after a peer is cleaned up and added to dead_peers, the entry blocks connection
+/// attempts until it expires (after [`DEAD_PEER_TTL`]). A subsequent PeerLeaving
+/// from the same peer is rejected as forged (peer_id no longer in peers set).
 #[test]
 fn dead_peer_cleanup_prevents_readmission() {
     use crate::proto::node::PeerLeaving;
@@ -2640,9 +2640,12 @@ fn dead_peer_ttl_expires() {
 
     let mut dead_peers: HashMap<EndpointId, std::time::Instant> = HashMap::new();
 
-    // Insert with a timestamp far enough in the past to be expired
-    let expired_at =
-        std::time::Instant::now() - super::DEAD_PEER_TTL - std::time::Duration::from_secs(1);
+    // Insert with a timestamp far enough in the past to be expired.
+    // Use checked_sub to avoid panic on very fresh monotonic clocks.
+    let expired_age = super::DEAD_PEER_TTL + std::time::Duration::from_secs(1);
+    let expired_at = std::time::Instant::now()
+        .checked_sub(expired_age)
+        .expect("monotonic clock too fresh to test TTL expiry");
     dead_peers.insert(peer_id, expired_at);
 
     // The TTL check used in connect_to_peer / update_transitive_peer should NOT block

--- a/mesh-llm/src/mesh/tests.rs
+++ b/mesh-llm/src/mesh/tests.rs
@@ -41,7 +41,7 @@ async fn make_test_node(role: super::NodeRole) -> Result<Node> {
             peers: HashMap::new(),
             connections: HashMap::new(),
             remote_tunnel_maps: HashMap::new(),
-            dead_peers: HashSet::new(),
+            dead_peers: HashMap::new(),
             seen_plugin_messages: HashMap::new(),
             seen_plugin_message_order: VecDeque::new(),
             policy_rejected_peers: HashMap::new(),
@@ -2536,7 +2536,7 @@ fn worker_only_legacy_models_are_excluded_from_http_routes() {
 }
 
 /// Verifies that dead-peer cleanup prevents re-admission: after a peer is cleaned
-/// up and added to dead_peers, the HashSet blocks any further connection attempts,
+/// up and added to dead_peers, the map blocks any further connection attempts,
 /// and a subsequent PeerLeaving from the same peer is rejected as forged (peer_id
 /// no longer in peers set).
 #[test]
@@ -2549,7 +2549,7 @@ fn dead_peer_cleanup_prevents_readmission() {
     // Simulate state: peer is admitted
     let mut peers: HashMap<EndpointId, PeerInfo> = HashMap::new();
     let mut connections: HashSet<EndpointId> = HashSet::new();
-    let mut dead_peers: HashSet<EndpointId> = HashSet::new();
+    let mut dead_peers: HashMap<EndpointId, std::time::Instant> = HashMap::new();
 
     peers.insert(peer_id, make_test_peer_info(peer_id));
     connections.insert(peer_id);
@@ -2574,7 +2574,7 @@ fn dead_peer_cleanup_prevents_readmission() {
     // Clean up — as the handler does
     peers.remove(&accepted_id);
     connections.remove(&accepted_id);
-    dead_peers.insert(accepted_id);
+    dead_peers.insert(accepted_id, std::time::Instant::now());
 
     // Peer is now gone and in dead_peers
     assert!(
@@ -2586,14 +2586,16 @@ fn dead_peer_cleanup_prevents_readmission() {
         "connection must be removed after PeerLeaving"
     );
     assert!(
-        dead_peers.contains(&peer_id),
+        dead_peers.contains_key(&peer_id),
         "peer must be in dead_peers after cleanup"
     );
 
     // Verify dead_peers blocks re-admission (simulates the check in connect_to_peer)
     assert!(
-        dead_peers.contains(&peer_id),
-        "dead_peers.contains check prevents re-connection to cleaned-up peer"
+        dead_peers
+            .get(&peer_id)
+            .is_some_and(|t| t.elapsed() < super::DEAD_PEER_TTL),
+        "dead_peers TTL check prevents re-connection to recently cleaned-up peer"
     );
 
     // A new gossip attempt from the same peer should be blocked by dead_peers
@@ -2624,8 +2626,47 @@ fn dead_peer_cleanup_prevents_readmission() {
         "idempotent remove must not re-insert peer"
     );
     assert!(
-        dead_peers.contains(&peer_id),
+        dead_peers.contains_key(&peer_id),
         "dead_peers must still contain peer after idempotent removal"
+    );
+}
+
+/// Verifies that dead_peers entries expire after DEAD_PEER_TTL and no longer
+/// block transitive re-learning or outbound reconnection.
+#[test]
+fn dead_peer_ttl_expires() {
+    let peer_key = SecretKey::from_bytes(&[0xF0; 32]);
+    let peer_id = EndpointId::from(peer_key.public());
+
+    let mut dead_peers: HashMap<EndpointId, std::time::Instant> = HashMap::new();
+
+    // Insert with a timestamp far enough in the past to be expired
+    let expired_at =
+        std::time::Instant::now() - super::DEAD_PEER_TTL - std::time::Duration::from_secs(1);
+    dead_peers.insert(peer_id, expired_at);
+
+    // The TTL check used in connect_to_peer / update_transitive_peer should NOT block
+    assert!(
+        !dead_peers
+            .get(&peer_id)
+            .is_some_and(|t| t.elapsed() < super::DEAD_PEER_TTL),
+        "expired dead_peers entry must not block reconnection"
+    );
+
+    // The GC retain used in the heartbeat loop should remove it
+    dead_peers.retain(|_, ts| ts.elapsed() < super::DEAD_PEER_TTL);
+    assert!(
+        dead_peers.is_empty(),
+        "expired dead_peers entry must be removed by GC"
+    );
+
+    // A fresh entry should still block
+    dead_peers.insert(peer_id, std::time::Instant::now());
+    assert!(
+        dead_peers
+            .get(&peer_id)
+            .is_some_and(|t| t.elapsed() < super::DEAD_PEER_TTL),
+        "fresh dead_peers entry must block reconnection"
     );
 }
 
@@ -3228,7 +3269,7 @@ async fn make_test_node_with_owner(
             peers: HashMap::new(),
             connections: HashMap::new(),
             remote_tunnel_maps: HashMap::new(),
-            dead_peers: HashSet::new(),
+            dead_peers: HashMap::new(),
             seen_plugin_messages: HashMap::new(),
             seen_plugin_message_order: VecDeque::new(),
             policy_rejected_peers: HashMap::new(),


### PR DESCRIPTION
Peers that temporarily lose connectivity (relay hiccups, cross-region timeouts) can now be re-discovered through gossip after 5 minutes instead of being permanently blocked.

Previously, if a host went unreachable for even a moment, it was added to `dead_peers` and could never come back through transitive gossip — only through a direct inbound reconnection. In relay-partitioned meshes (e.g. Fly console in Sydney, hosts on US relays), this caused stable divergence where different nodes saw different models.

Now: dead peer entries expire after 5 minutes. Once expired, the peer can be re-learned normally through gossip from bridge peers. If the peer is genuinely gone, no bridge peer mentions it and it stays forgotten. No reconnect storms — expiry just removes the block, the next gossip round does the rest.

Verified locally against the live mesh: previously-invisible hosts (GLM on `79af`) re-appeared after TTL expiry, inference routes correctly including `model: auto`.

## What changed

- `dead_peers`: `HashSet<EndpointId>` → `HashMap<EndpointId, Instant>` with 5-minute TTL
- TTL-aware checks in `connect_to_peer` and `update_transitive_peer`
- GC of expired entries in the heartbeat loop (every 60s)
- No wire protocol changes — fully compatible with all existing mesh nodes