### PR TITLE
Add Poolside Laguna XS.2 to model catalog

### DIFF
--- a/mesh-llm/src/models/catalog.json
+++ b/mesh-llm/src/models/catalog.json
@@ -258,6 +258,17 @@
     "mmproj": null
   },
   {
+    "name": "Laguna-XS.2-Q4_K_M",
+    "file": "Laguna-XS.2-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/laguna-xs.2/blobs/sha256:59885ff3cab3c264b315b4d3ebbd21190127c22283bd89e071932af0ddf2884e",
+    "size": "23.1GB",
+    "description": "Poolside Laguna XS.2 — 33B MoE coding model, 256 experts top-8, 131k context",
+    "draft": null,
+    "moe": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
     "name": "Gemma-3-27B-it-Q4_K_M",
     "file": "Gemma-3-27B-it-Q4_K_M.gguf",
     "url": "https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF/resolve/main/google_gemma-3-27b-it-Q4_K_M.gguf",


### PR DESCRIPTION
Adds Laguna XS.2 (33.4B MoE, Q4_K_M) to the built-in model catalog.

```
mesh-llm serve --model Laguna-XS.2-Q4_K_M
```

Laguna XS.2 is a coding-focused MoE from Poolside — 256 experts with 8 active per token, 131k context, Apache 2.0 licensed. At 23.1GB it runs on a single 24GB GPU without sharding.

GGUF sourced from the Ollama registry (public CDN, no auth).