### PR TITLE
Fix SIGABRT crash on Mac Studio (iroh 0.98 double-free in Endpoint::online)

### DIFF
--- a/mesh-llm/src/mesh/mod.rs
+++ b/mesh-llm/src/mesh/mod.rs
@@ -1458,9 +1458,32 @@ impl Node {
         let endpoint = builder.bind().await?;
         // Wait briefly for relay connection so the invite token includes the relay URL.
         // On sinkholed networks this times out and we proceed without relay (direct UDP only).
-        match tokio::time::timeout(std::time::Duration::from_secs(5), endpoint.online()).await {
-            Ok(()) => tracing::info!("Relay connected"),
-            Err(_) => tracing::warn!("Relay connection timed out (5s) — proceeding without relay"),
+        //
+        // We avoid `endpoint.online()` because iroh 0.98's implementation has a
+        // double-free in the `Flatten<IntoIter<Option<(RelayUrl, HomeRelayStatus)>>>`
+        // drop path, causing SIGABRT on some hardware (deterministically on Apple
+        // M3 Ultra / macOS 26.3).  Fixed on iroh main by PR #4149 which changed the
+        // type, but not yet released.  Instead we poll `watch_addr()` and wait until
+        // it advertises at least one relay address.
+        {
+            let mut watcher = endpoint.watch_addr();
+            let wait_relay = async {
+                loop {
+                    let addr = iroh::Watcher::get(&mut watcher);
+                    if addr.relay_urls().next().is_some() {
+                        return;
+                    }
+                    if iroh::Watcher::updated(&mut watcher).await.is_err() {
+                        std::future::pending::<()>().await;
+                    }
+                }
+            };
+            match tokio::time::timeout(std::time::Duration::from_secs(5), wait_relay).await {
+                Ok(()) => tracing::info!("Relay connected"),
+                Err(_) => {
+                    tracing::warn!("Relay connection timed out (5s) — proceeding without relay")
+                }
+            }
         }
 
         // Discover public IP via STUN so the invite token includes it.


### PR DESCRIPTION
## What changed

mesh-llm now starts reliably on the Mac Studio (M3 Ultra 256GB) which was crashing with SIGABRT on every launch.

The crash was a double-free in iroh 0.98's `Endpoint::online()` — the function iterates `Vec<Option<(RelayUrl, HomeRelayStatus)>>` via `into_iter().flatten().any(...)`, and dropping the `Flatten` iterator triggers `POINTER_BEING_FREED_WAS_NOT_ALLOCATED`. This happened deterministically at ~7 seconds on the M3 Ultra / macOS 26.3, with 20+ identical crash reports confirming the same stack every time.

The fix replaces `endpoint.online()` with an equivalent poll of `endpoint.watch_addr()` that waits until the endpoint advertises at least one relay URL. Same behavior, no buggy iterator path.

## Verification

| Test | Result |
|------|--------|
| v0.64.0 (iroh 0.97) | ✅ no crash |
| v0.65.0-rc2 (iroh 0.98.1) | ❌ SIGABRT at ~7s, exit 134 |
| iroh 0.98.2 bump | ❌ still crashes |
| iroh main (post n0-computer/iroh#4149) | ✅ no crash (type changed, Flatten removed) |
| **This fix** (watch_addr workaround) | ✅ 45s+ stable, API up, 11 peers, model loading |
| Local M4 Max | ✅ no regression |
| `cargo test -p mesh-llm --lib` | ✅ 1220 passed |

## Notes

- The bug is fixed on iroh main by PR [n0-computer/iroh#4149](https://github.com/n0-computer/iroh/pull/4149) which changed the watcher value type from `Vec<Option<(RelayUrl, HomeRelayStatus)>>` to `Vec<RelayStatus>`, eliminating the `Flatten`. That fix isn't released yet (still 0.98.2 on crates.io).
- This workaround can be removed when we upgrade to the next iroh release that includes #4149.
- The `watch_addr()` approach checks for relay URL presence rather than relay connection status — slightly different semantics but sufficient for the "wait for relay before proceeding" use case.