### PR TITLE
chore: add JSONL formatter for piped log output

### DIFF
--- a/mesh-llm/src/cli/output/mod.rs
+++ b/mesh-llm/src/cli/output/mod.rs
@@ -746,14 +746,38 @@ impl OutputEvent {
                 Some(role) => format!("{model} elected {host} as {role}"),
                 None => format!("{model} elected {host} as host"),
             },
-            OutputEvent::RpcServerStarting { port, .. } => {
-                format!("rpc-server starting on port {port}")
+            OutputEvent::RpcServerStarting { port, log_path, .. } => {
+                let msg = format!("rpc-server starting on port {port}");
+                if let Some(path) = log_path {
+                    format!("{msg}\n  ↳ log={path}")
+                } else {
+                    msg
+                }
             }
-            OutputEvent::RpcReady { port, .. } => format!("rpc-server ready on port {port}"),
-            OutputEvent::LlamaStarting { http_port, .. } => {
-                format!("llama-server starting on port {http_port}")
+            OutputEvent::RpcReady { port, log_path, .. } => {
+                let msg = format!("rpc-server ready on port {port}");
+                if let Some(path) = log_path {
+                    format!("{msg}\n  ↳ log={path}")
+                } else {
+                    msg
+                }
             }
-            OutputEvent::LlamaReady { port, .. } => format!("llama-server ready on port {port}"),
+            OutputEvent::LlamaStarting { http_port, log_path, .. } => {
+                let msg = format!("llama-server starting on port {http_port}");
+                if let Some(path) = log_path {
+                    format!("{msg}\n  ↳ log={path}")
+                } else {
+                    msg
+                }
+            }
+            OutputEvent::LlamaReady { port, log_path, .. } => {
+                let msg = format!("llama-server ready on port {port}");
+                if let Some(path) = log_path {
+                    format!("{msg}\n  ↳ log={path}")
+                } else {
+                    msg
+                }
+            }
             OutputEvent::ModelReady {
                 model,
                 internal_port,

--- a/mesh-llm/src/inference/election.rs
+++ b/mesh-llm/src/inference/election.rs
@@ -274,12 +274,18 @@ fn stop_requested(stop_rx: &watch::Receiver<bool>) -> bool {
     *stop_rx.borrow()
 }
 
-fn emit_ready_events(model_name: &str, llama_port: u16, model_port: u16, ctx_size: u32) {
+fn emit_ready_events(
+    model_name: &str,
+    llama_port: u16,
+    model_port: u16,
+    ctx_size: u32,
+    log_path: Option<String>,
+) {
     let _ = emit_event(OutputEvent::LlamaReady {
         model: Some(model_name.to_string()),
         port: llama_port,
         ctx_size: Some(ctx_size),
-        log_path: None,
+        log_path,
     });
     let _ = emit_event(OutputEvent::ModelReady {
         model: model_name.to_string(),
@@ -2037,7 +2043,14 @@ pub async fn election_loop(
                     context_length: process.context_length,
                 }));
             }
-            emit_ready_events(&model_name, llama_port, local_proxy_port, ctx_size);
+            let lp = runtime.log_path(&format!("llama-server-{}", llama_port));
+            emit_ready_events(
+                &model_name,
+                llama_port,
+                local_proxy_port,
+                ctx_size,
+                Some(lp.display().to_string()),
+            );
             on_change(true, true);
         } else {
             // We're a worker in split mode. Find who the host is.
@@ -2508,7 +2521,14 @@ async fn moe_election_loop(
                         &model_name,
                     );
                     target_tx.send_replace(targets);
-                    emit_ready_events(&model_name, llama_port, local_proxy_port, ctx_size);
+                    let lp = runtime.log_path(&format!("llama-server-{}", llama_port));
+                    emit_ready_events(
+                        &model_name,
+                        llama_port,
+                        local_proxy_port,
+                        ctx_size,
+                        Some(lp.display().to_string()),
+                    );
                     on_change(true, true);
                 }
                 Err(e) => {
@@ -2625,7 +2645,14 @@ async fn moe_election_loop(
                             &target_tx,
                         )
                         .await;
-                        emit_ready_events(&model_name, llama_port, local_proxy_port, ctx_size);
+                        let lp = runtime.log_path(&format!("llama-server-{}", llama_port));
+                        emit_ready_events(
+                            &model_name,
+                            llama_port,
+                            local_proxy_port,
+                            ctx_size,
+                            Some(lp.display().to_string()),
+                        );
                         on_change(true, true);
                     }
                     Err(e) => {
@@ -2830,7 +2857,14 @@ async fn moe_election_loop(
                     );
                     target_tx.send_replace(targets);
 
-                    emit_ready_events(&model_name, llama_port, local_proxy_port, ctx_size);
+                    let lp = runtime.log_path(&format!("llama-server-{}", llama_port));
+                    emit_ready_events(
+                        &model_name,
+                        llama_port,
+                        local_proxy_port,
+                        ctx_size,
+                        Some(lp.display().to_string()),
+                    );
                     on_change(true, true);
                 }
                 Err(e) => {

--- a/mesh-llm/src/inference/launch.rs
+++ b/mesh-llm/src/inference/launch.rs
@@ -979,15 +979,21 @@ pub async fn start_rpc_server(
     for _ in 0..startup_polls {
         if is_port_open(port).await {
             let pidfile_path = runtime.pidfile_path(&format!("rpc-server-{port}"));
+            let device_for_spawn = device.clone();
             tokio::spawn(async move {
                 let _ = child.wait().await;
                 let _ = std::fs::remove_file(&pidfile_path);
                 if !expected_exit_clone.load(Ordering::Relaxed) && !runtime_shutting_down() {
                     let _ = emit_event(OutputEvent::Warning {
                         message: "rpc-server process exited unexpectedly".to_string(),
-                        context: Some(format!("port={port} device={device}")),
+                        context: Some(format!("port={port} device={device_for_spawn}")),
                     });
                 }
+            });
+            let _ = emit_event(OutputEvent::RpcReady {
+                port,
+                device: device.clone(),
+                log_path: Some(rpc_log.display().to_string()),
             });
             return Ok(RpcServerHandle {
                 pid,

--- a/mesh-llm/src/models/catalog.rs
+++ b/mesh-llm/src/models/catalog.rs
@@ -638,13 +638,9 @@ fn emit_or_print_model_progress(
     downloaded_bytes: Option<u64>,
     total_bytes: Option<u64>,
     status: ModelProgressStatus,
-    fallback: impl FnOnce(),
+    _fallback: impl FnOnce(),
 ) {
-    if interactive_tui_active() {
-        emit_model_progress(label, file, downloaded_bytes, total_bytes, status);
-    } else {
-        fallback();
-    }
+    emit_model_progress(label, file, downloaded_bytes, total_bytes, status);
 }
 
 fn download_hf_assets_blocking(

--- a/scripts/console-format.js
+++ b/scripts/console-format.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+const readline = require("readline");
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  terminal: false,
+});
+
+// ANSI colors
+const c = {
+  reset: "\x1b[0m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  yellow: "\x1b[33m",
+  green: "\x1b[32m",
+  blue: "\x1b[34m",
+  cyan: "\x1b[36m",
+};
+
+function levelColor(level) {
+  switch ((level || "").toLowerCase()) {
+    case "error": return c.red;
+    case "warn": return c.yellow;
+    case "info": return c.green;
+    case "debug": return c.cyan;
+    default: return c.dim;
+  }
+}
+
+function fmtTime(ts) {
+  if (!ts) return "";
+  try {
+    return new Date(ts).toISOString().replace("T", " ").replace("Z", "");
+  } catch {
+    return ts;
+  }
+}
+
+function format(obj) {
+  const ts = fmtTime(obj.timestamp);
+  const level = (obj.level || "info").toUpperCase();
+  const msg = obj.message || obj.event || "—";
+
+  const color = levelColor(level);
+
+  let out = `${c.dim}${ts}${c.reset} - ${color}${level}${c.reset}: ${msg}`;
+
+  // ---- DETAIL EXTRACTION ----
+  const details = [];
+
+  if (obj.event === "invite_token" && obj.token) {
+    details.push(`token=${obj.token}`);
+    if (obj.mesh_id) details.push(`mesh=${obj.mesh_id}`);
+  }
+
+  if (obj.port) details.push(`port=${obj.port}`);
+  if (obj.http_port) details.push(`http_port=${obj.http_port}`);
+  if (obj.internal_port) details.push(`internal_port=${obj.internal_port}`);
+  if (obj.model) details.push(`model=${obj.model}`);
+  if (obj.api_url) details.push(`api=${obj.api_url}`);
+  if (obj.context) details.push(obj.context);
+
+  if (details.length) {
+    out += `\n  ${c.blue}↳ ${details.join(" | ")}${c.reset}`;
+  }
+
+  return out;
+}
+
+rl.on("line", (line) => {
+  if (!line.trim()) return;
+
+  try {
+    const obj = JSON.parse(line);
+    console.log(format(obj));
+  } catch {
+    console.log(line);
+  }
+});
+


### PR DESCRIPTION
If you didn't want to use the TUI, it was hard to see what was going on when you started the `mesh-llm` binary, so I've added a quick node script that you can pipe output through that cleans it all up:

```rust
./target/release/mesh-llm serve --model Qwen2.5-0.5B-Instruct-Q4_K_M --log-format json | npx node scripts/console-format.js
2026-04-30 00:46:25.937 - INFO: ensuring model Qwen2.5-0.5B-Instruct-Q4_K_M
2026-04-30 00:46:25.984 - INFO: ensuring model qwen2.5-0.5b-instruct-q4_k_m.gguf
2026-04-30 00:46:26.023 - INFO: model qwen2.5-0.5b-instruct-q4_k_m.gguf ready (491MB)
2026-04-30 00:46:29.334 - INFO: invite token ready for mesh 0166238efbf931ba6bbd6bf7e0134189
  ↳ token=eyJpZCI6Ijg4YTM4NzZhN2NiNmZjYmYxY2I1NDgyNjg3ZGY4MDg2ODVmYTEwYjZlMzEyNWM3NjkwYzdhOWJkMzRjMWNjNjkiLCJhZGRycyI6W3siUmVsYXkiOiJodHRwczovL3VzdzEtMi5yZWxheS5taWNoYWVsbmVhbGUubWVzaC1sbG0uaXJvaC5saW5rLi8ifSx7IklwIjoiMTAuNC4wLjE1NDo1MTA4OCJ9LHsiSXAiOiIxMC40LjAuMTk4OjUxMDg4In0seyJJcCI6IjY0LjEzNy4xNTcuMTM5OjAifV19 | mesh=0166238efbf931ba6bbd6bf7e0134189
2026-04-30 00:46:29.334 - INFO: waiting for peers
2026-04-30 00:46:29.351 - INFO: rpc-server starting on port 51400
  ↳ log=/Users/ndizazzo/.mesh-llm/runtime/23248/logs/rpc-server-51400.log
  ↳ port=51400
2026-04-30 00:46:29.864 - INFO: rpc-server ready on port 51400
  ↳ log=/Users/ndizazzo/.mesh-llm/runtime/23248/logs/rpc-server-51400.log
  ↳ port=51400
2026-04-30 00:46:32.184 - INFO: qwen2.5-0.5b-instruct-q4_k_m elected 88a3876a7c as host
  ↳ model=qwen2.5-0.5b-instruct-q4_k_m
2026-04-30 00:46:32.184 - INFO: API: http://localhost:9337 (proxied to host)
2026-04-30 00:46:32.185 - INFO: llama-server starting on port 51407
  ↳ log=/Users/ndizazzo/.mesh-llm/runtime/23248/logs/llama-server-51407.log
  ↳ http_port=51407 | model=qwen2.5-0.5b-instruct-q4_k_m
2026-04-30 00:46:33.747 - INFO: llama-server ready on port 51407
  ↳ log=/Users/ndizazzo/.mesh-llm/runtime/23248/logs/llama-server-51407.log
  ↳ port=51407 | model=qwen2.5-0.5b-instruct-q4_k_m
2026-04-30 00:46:33.747 - INFO: model qwen2.5-0.5b-instruct-q4_k_m ready on port 51411
  ↳ port=51411 | internal_port=51411 | model=qwen2.5-0.5b-instruct-q4_k_m
2026-04-30 00:46:33.748 - INFO: mesh-llm runtime ready
  ↳ api=http://localhost:9337
  ```

Usage:

`mesh-llm serve --model <model> --log-format json | npx node scripts/console-format.js`