### PR TITLE
fix(tui): fix TUI interrupting error output for 'mesh-llm model show'

### DIFF
--- a/mesh-llm/src/cli/output/mod.rs
+++ b/mesh-llm/src/cli/output/mod.rs
@@ -66,6 +66,7 @@ impl RuntimeStatus {
 pub enum ConsoleSessionMode {
     InteractiveDashboard,
     Fallback,
+    None,
 }
 
 #[allow(dead_code)]
@@ -6381,9 +6382,18 @@ impl Formatter for JsonFormatter {
     }
 }
 
+pub struct PrettyFormatter;
+
+impl Formatter for PrettyFormatter {
+    fn format(&mut self, event: &OutputEvent) -> io::Result<String> {
+        Ok(format!("{}\n", event.summary_line()))
+    }
+}
+
 enum FormatterSelection {
     InteractiveDashboard(InteractiveDashboardFormatter),
     DashboardFallback(DashboardFormatter),
+    Plain(PrettyFormatter),
     Json(JsonFormatter),
 }
 
@@ -6393,13 +6403,16 @@ impl FormatterSelection {
         match self {
             Self::InteractiveDashboard(_) => "interactive_dashboard",
             Self::DashboardFallback(_) => "pretty_fallback",
+            Self::Plain(_) => "plain",
             Self::Json(_) => "json",
         }
     }
 
     fn mode(&self) -> LogFormat {
         match self {
-            Self::InteractiveDashboard(_) | Self::DashboardFallback(_) => LogFormat::Pretty,
+            Self::InteractiveDashboard(_) | Self::DashboardFallback(_) | Self::Plain(_) => {
+                LogFormat::Pretty
+            }
             Self::Json(_) => LogFormat::Json,
         }
     }
@@ -6467,6 +6480,7 @@ impl Formatter for FormatterSelection {
         match self {
             Self::InteractiveDashboard(formatter) => formatter.format(event),
             Self::DashboardFallback(formatter) => formatter.format(event),
+            Self::Plain(formatter) => formatter.format(event),
             Self::Json(formatter) => formatter.format(event),
         }
     }
@@ -6484,6 +6498,7 @@ fn select_formatter(
             ConsoleSessionMode::Fallback => {
                 FormatterSelection::DashboardFallback(DashboardFormatter::default())
             }
+            ConsoleSessionMode::None => FormatterSelection::Plain(PrettyFormatter),
         },
         LogFormat::Json => FormatterSelection::Json(JsonFormatter),
     }
@@ -11540,5 +11555,47 @@ mod tests {
         assert!(dashboard
             .lines()
             .any(|line| line.starts_with("┌ Mesh events (latest 8) ")));
+    }
+
+    #[test]
+    fn test_select_formatter_for_console_session_mode_none() {
+        let formatter = select_formatter(LogFormat::Pretty, ConsoleSessionMode::None);
+        assert!(matches!(formatter, FormatterSelection::Plain(_)));
+    }
+
+    #[test]
+    fn test_select_formatter_for_console_session_mode_interactive_dashboard() {
+        let formatter =
+            select_formatter(LogFormat::Pretty, ConsoleSessionMode::InteractiveDashboard);
+        assert!(matches!(
+            formatter,
+            FormatterSelection::InteractiveDashboard(_)
+        ));
+    }
+
+    #[test]
+    fn test_select_formatter_for_console_session_mode_fallback() {
+        let formatter = select_formatter(LogFormat::Pretty, ConsoleSessionMode::Fallback);
+        assert!(matches!(
+            formatter,
+            FormatterSelection::DashboardFallback(_)
+        ));
+    }
+
+    #[test]
+    fn test_select_formatter_for_json_mode() {
+        let formatter = select_formatter(LogFormat::Json, ConsoleSessionMode::InteractiveDashboard);
+        assert!(matches!(formatter, FormatterSelection::Json(_)));
+    }
+
+    #[test]
+    fn test_pretty_formatter_outputs_simple_line() {
+        let mut formatter = PrettyFormatter;
+        let event = OutputEvent::Info {
+            message: "test message".to_string(),
+            context: None,
+        };
+        let result = formatter.format(&event).unwrap();
+        assert_eq!(result, "test message\n");
     }
 }

--- a/mesh-llm/src/runtime/mod.rs
+++ b/mesh-llm/src/runtime/mod.rs
@@ -1573,7 +1573,7 @@ fn initial_console_session_mode_for_surface(
 ) -> ConsoleSessionMode {
     match explicit_surface {
         Some(RuntimeSurface::Serve) => current_mode,
-        _ => ConsoleSessionMode::Fallback,
+        _ => ConsoleSessionMode::None,
     }
 }
 
@@ -4769,7 +4769,7 @@ mod tests {
                 Some(RuntimeSurface::Client),
                 ConsoleSessionMode::InteractiveDashboard
             ),
-            ConsoleSessionMode::Fallback
+            ConsoleSessionMode::None
         );
 
         assert_eq!(
@@ -4777,7 +4777,7 @@ mod tests {
                 None,
                 ConsoleSessionMode::InteractiveDashboard
             ),
-            ConsoleSessionMode::Fallback
+            ConsoleSessionMode::None
         );
     }
 
@@ -5289,5 +5289,39 @@ mod tests {
             async move { state.publication_state().await.as_str() == "publish_failed" }
         })
         .await;
+    }
+
+    #[test]
+    fn test_console_session_mode_serve_uses_interactive_mode() {
+        use crate::cli::RuntimeSurface;
+
+        // When explicit_surface is Some(RuntimeSurface::Serve), should preserve current mode
+        let result = initial_console_session_mode_for_surface(
+            Some(RuntimeSurface::Serve),
+            ConsoleSessionMode::InteractiveDashboard,
+        );
+        assert_eq!(result, ConsoleSessionMode::InteractiveDashboard);
+    }
+
+    #[test]
+    fn test_console_session_mode_non_serve_uses_none() {
+        use crate::cli::RuntimeSurface;
+
+        // When explicit_surface is Some(RuntimeSurface::Client), should use None mode
+        let result = initial_console_session_mode_for_surface(
+            Some(RuntimeSurface::Client),
+            ConsoleSessionMode::InteractiveDashboard,
+        );
+        assert_eq!(result, ConsoleSessionMode::None);
+    }
+
+    #[test]
+    fn test_console_session_mode_no_explicit_surface_uses_none() {
+        // When explicit_surface is None, should use None mode
+        let result = initial_console_session_mode_for_surface(
+            None,
+            ConsoleSessionMode::InteractiveDashboard,
+        );
+        assert_eq!(result, ConsoleSessionMode::None);
     }
 }


### PR DESCRIPTION
Before:

```
> ./target/release/mesh-llm models show Qwen2.5-0.5B-Instruct-Q4_K_MA
🔎 Resolving model details from Hugging Face...
mesh-llm

┌ Running llama.cpp instances ────────────────────────────────────────────────────────────
│ (none)
└────────────────────────────────────────────────────────────────────

┌ Running models ────────────────────────────────────────────────────────────
│ (none)
└────────────────────────────────────────────────────────────────────

┌ Running webserver ────────────────────────────────────────────────────────────
│ (none)
└────────────────────────────────────────────────────────────────────

┌ Running API ────────────────────────────────────────────────────────────
│ (none)
└────────────────────────────────────────────────────────────────────

┌ Mesh events (latest 1000) ────────────────────────────────────────────────────────────
│ 21:32:20 ERR  Expected an exact model ref. Use a catalog id, a Hugging Face ref like org/repo, org/repo@rev:QUANT, org/repo/file.gguf, org/repo/file-stem for split GGUFs, org/repo/model.safetensors, or org/repo/model-00001-of-00048.safetensors, or a direct URL.
└────────────────────────────────────────────────────────────────────
```

after

```
> ./target/release/mesh-llm models show Qwen2.5-0.5B-Instruct-Q4_K_MA
🔎 Resolving model details from Hugging Face...
Expected an exact model ref. Use a catalog id, a Hugging Face ref like org/repo, org/repo@rev:QUANT, org/repo/file.gguf, org/repo/file-stem for split GGUFs, org/repo/model.safetensors, or org/repo/model-00001-of-00048.safetensors, or a direct URL.
```