### PR TITLE
fix(vram-share): correct a calculation bug for VRAM share

### DIFF
--- a/crates/mesh-llm/ui/src/App.test.tsx
+++ b/crates/mesh-llm/ui/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 vi.mock("./components/ui/select", async () => {
   const React = await import("react");
@@ -589,6 +589,66 @@ describe("App routing and status", () => {
     expect((await screen.findAllByText("Standby")).length).toBeGreaterThan(0);
     expect(screen.getByText("Host")).toBeInTheDocument();
     expect(screen.queryAllByText("Serving")).toHaveLength(0);
+  });
+
+  it("shows model peer shares from model-serving VRAM instead of physical inventory", async () => {
+    statusPayload = {
+      ...createStatusPayload(),
+      node_id: "6566c0f64b",
+      model_name: "Hermes-2-Pro-Mistral-7B-Q4_K_M",
+      models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+      available_models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+      serving_models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+      hosted_models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+      my_vram_gb: 15,
+      gpus: [{ name: "RTX 6000 Ada", vram_bytes: 64 * 1024 ** 3 }],
+      peers: [
+        {
+          id: "d0aa73bd0e",
+          role: "Worker",
+          state: "serving",
+          models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+          available_models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+          requested_models: [],
+          serving_models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+          hosted_models: ["Hermes-2-Pro-Mistral-7B-Q4_K_M"],
+          hosted_models_known: true,
+          vram_gb: 8,
+          rtt_ms: null,
+          gpus: [],
+        },
+      ],
+    };
+    modelsPayload = {
+      mesh_models: [
+        {
+          name: "Hermes-2-Pro-Mistral-7B-Q4_K_M",
+          status: "warm",
+          node_count: 2,
+          mesh_vram_gb: 23,
+          size_gb: 4.1,
+          source_file:
+            "bartowski/Hermes-2-Pro-Mistral-7B-GGUF/Hermes-2-Pro-Mistral-7B-Q4_K_M.gguf",
+        },
+      ],
+    };
+
+    setPath("/dashboard");
+    render(<App />);
+
+    const modelButton = await screen.findByRole("button", {
+      name: /Hermes-2-Pro-Mistral-7B/i,
+    });
+    fireEvent.click(modelButton);
+
+    await screen.findByText("Active Peers");
+    expect(screen.getAllByText("6566c0f64b").length).toBeGreaterThan(0);
+    expect(screen.getByText("15.0 GB")).toBeInTheDocument();
+    expect(screen.getByText("65%")).toBeInTheDocument();
+    expect(screen.getAllByText("d0aa73bd0e").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("8.0 GB").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("35%").length).toBeGreaterThan(0);
+    expect(screen.queryByText("278%")).not.toBeInTheDocument();
   });
 
   it("keeps client chat disabled until /api/models reports a warm model", async () => {

--- a/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
+++ b/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
@@ -6,6 +6,8 @@ import {
   gpuInventoryVramGb,
   localRoutableModels,
   meshGpuVram,
+  normalizeVramGb,
+  overviewVramGb,
   topologyStatusTone,
   topologyStatusTooltip,
 } from "./status-helpers";
@@ -107,6 +109,17 @@ describe("live node state helpers", () => {
     expect(displayVramGb(false, 29.4, [])).toBe(29.4);
     expect(displayVramGb(false, 29.4, undefined)).toBe(29.4);
     expect(displayVramGb(true, 29.4, [{ vram_bytes: 17_094_934_528 }])).toBe(0);
+  });
+
+  it("normalizes overview VRAM through the shared clamp helper", () => {
+    expect(normalizeVramGb(null)).toBe(0);
+    expect(normalizeVramGb(undefined)).toBe(0);
+    expect(normalizeVramGb(-4)).toBe(0);
+    expect(normalizeVramGb(12.5)).toBe(12.5);
+
+    expect(overviewVramGb(false, -4)).toBe(normalizeVramGb(-4));
+    expect(overviewVramGb(false, 12.5)).toBe(normalizeVramGb(12.5));
+    expect(overviewVramGb(true, 12.5)).toBe(0);
   });
 
   it("uses physical GPU inventory for mesh VRAM totals when available", () => {

--- a/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
+++ b/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
@@ -45,9 +45,13 @@ export function peerPrimaryModel(peer: Peer): string {
   return peerRoutableModels(peer)[0] ?? peerAssignedModels(peer)[0] ?? "";
 }
 
+export function normalizeVramGb(vramGb?: number | null) {
+  return Math.max(0, vramGb ?? 0);
+}
+
 export function overviewVramGb(isClient: boolean, vramGb?: number | null) {
   if (isClient) return 0;
-  return Math.max(0, vramGb || 0);
+  return normalizeVramGb(vramGb);
 }
 
 export function gpuInventoryVramGb(gpus?: GpuInventory | null) {

--- a/crates/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
+++ b/crates/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
@@ -58,6 +58,7 @@ import {
   localRoutableModels,
   meshGpuVram,
   modelDisplayName,
+  normalizeVramGb,
   ownershipPrimaryLabel,
   ownershipStatusLabel,
   ownershipTone,
@@ -97,10 +98,6 @@ type ActivePeerRow = {
   vramLabel: string;
   shareLabel: string;
 };
-
-function servingVramGb(vramGb?: number | null) {
-  return Math.max(0, vramGb ?? 0);
-}
 
 type NodeSidebarRecord = {
   id: string;
@@ -232,7 +229,7 @@ export function DashboardPage({
     const totalModelVram = selectedCatalogModel.mesh_vram_gb ?? 0;
     const rows: ActivePeerRow[] = [];
     const localServing = localRoutableModels(status).includes(targetModel);
-    const localServingVramGb = servingVramGb(status.my_vram_gb);
+    const localServingVramGb = normalizeVramGb(status.my_vram_gb);
     if (localServing && status.node_state !== "client") {
       rows.push({
         id: status.node_id,
@@ -249,7 +246,7 @@ export function DashboardPage({
         peerRoutableModels(peer).includes(targetModel) ||
         peerAssignedModels(peer).includes(targetModel);
       if (!servesTarget || peer.state === "client") continue;
-      const peerServingVramGb = servingVramGb(peer.vram_gb);
+      const peerServingVramGb = normalizeVramGb(peer.vram_gb);
       rows.push({
         id: peer.id,
         latencyLabel: peer.latencyLabel,

--- a/crates/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
+++ b/crates/mesh-llm/ui/src/features/dashboard/components/DashboardPage.tsx
@@ -98,6 +98,10 @@ type ActivePeerRow = {
   shareLabel: string;
 };
 
+function servingVramGb(vramGb?: number | null) {
+  return Math.max(0, vramGb ?? 0);
+}
+
 type NodeSidebarRecord = {
   id: string;
   title: string;
@@ -228,19 +232,15 @@ export function DashboardPage({
     const totalModelVram = selectedCatalogModel.mesh_vram_gb ?? 0;
     const rows: ActivePeerRow[] = [];
     const localServing = localRoutableModels(status).includes(targetModel);
-    const localDisplayVramGb = displayVramGb(
-      status.node_state === "client",
-      status.my_vram_gb,
-      status.gpus,
-    );
+    const localServingVramGb = servingVramGb(status.my_vram_gb);
     if (localServing && status.node_state !== "client") {
       rows.push({
         id: status.node_id,
         latencyLabel: "local",
-        vramLabel: `${localDisplayVramGb.toFixed(1)} GB`,
+        vramLabel: `${localServingVramGb.toFixed(1)} GB`,
         shareLabel:
           totalModelVram > 0
-            ? `${Math.round((localDisplayVramGb / totalModelVram) * 100)}%`
+            ? `${Math.round((localServingVramGb / totalModelVram) * 100)}%`
             : "n/a",
       });
     }
@@ -249,13 +249,14 @@ export function DashboardPage({
         peerRoutableModels(peer).includes(targetModel) ||
         peerAssignedModels(peer).includes(targetModel);
       if (!servesTarget || peer.state === "client") continue;
+      const peerServingVramGb = servingVramGb(peer.vram_gb);
       rows.push({
         id: peer.id,
         latencyLabel: peer.latencyLabel,
-        vramLabel: `${peer.displayVramGb.toFixed(1)} GB`,
+        vramLabel: `${peerServingVramGb.toFixed(1)} GB`,
         shareLabel:
           totalModelVram > 0
-            ? `${Math.round((peer.displayVramGb / totalModelVram) * 100)}%`
+            ? `${Math.round((peerServingVramGb / totalModelVram) * 100)}%`
             : "n/a",
       });
     }


### PR DESCRIPTION
## Summary
Fixes model share percentages in the dashboard model detail panel so they reflect model-serving VRAM allocation instead of physical GPU inventory.

## What Changed
- Updated the Active Peers calculation for selected models to use:
  - local `my_vram_gb`
  - peer `vram_gb`
- Preserved existing physical GPU inventory behavior for topology/node overview displays.
- Added a regression test for the reported Hermes scenario:
  - local node: 15 GB serving allocation on a 64 GB GPU
  - peer node: 8 GB serving allocation
  - total model VRAM: 23 GB
  - expected shares: 65% and 35%, not 278%

## Validation
- `npm run test:run -- App.test.tsx`
- `npm run test:run`
- `npm run typecheck`
- `just build`

Fixes #398 