### PR TITLE
feat(moe): shared-NAS trunk/experts MoE split storage (#308)

### DIFF
--- a/crates/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/moe/mod.rs
@@ -102,6 +102,7 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
             nas_root,
             n_nodes,
             overlap,
+            min_experts_per_node,
             ranking_file,
             dry_run,
             bin_dir,
@@ -111,6 +112,7 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
                 nas_root: nas_root.clone(),
                 n_nodes: *n_nodes,
                 overlap: *overlap,
+                min_experts_per_node: *min_experts_per_node,
                 ranking_file: ranking_file.clone(),
                 dry_run: *dry_run,
                 bin_dir: bin_dir.clone(),
@@ -125,6 +127,7 @@ struct MigrateArgs {
     nas_root: Option<PathBuf>,
     n_nodes: usize,
     overlap: u32,
+    min_experts_per_node: Option<u32>,
     ranking_file: Option<PathBuf>,
     dry_run: bool,
     bin_dir: Option<PathBuf>,
@@ -210,6 +213,7 @@ async fn run_migrate(args: MigrateArgs) -> Result<()> {
         nodes: Some(args.n_nodes),
         dataset_repo: "meshllm/moe-rankings".to_string(),
         progress: true,
+        min_experts_per_node_override: args.min_experts_per_node,
     })
     .await
     .with_context(|| "planning migration")?;
@@ -404,6 +408,7 @@ async fn run_plan(
         nodes,
         dataset_repo: dataset_repo.to_string(),
         progress: !json_output,
+        min_experts_per_node_override: None,
     })
     .await?;
     moe_plan_formatter(json_output).render(&report)

--- a/crates/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/moe/mod.rs
@@ -182,9 +182,21 @@ async fn run_migrate(args: MigrateArgs) -> Result<()> {
             }
         }
     }
-    if storage.trunk_path.is_none() || storage.experts_path.is_none() {
+    // Point at exactly what is missing so users can self-heal.
+    let trunk_missing = storage.trunk_path.is_none();
+    let experts_missing = storage.experts_path.is_none();
+    if trunk_missing || experts_missing {
+        let missing = match (trunk_missing, experts_missing) {
+            (true, true) => "both trunk and experts paths are unset",
+            (true, false) => "trunk path is unset",
+            (false, true) => "experts path is unset",
+            (false, false) => unreachable!(),
+        };
         bail!(
-            "--nas-root, moe.storage.trunk_path+experts_path, or MESH_LLM_NAS_ROOT must be set"
+            "{missing}. Fix by ONE of:\n  \
+             1. pass --nas-root <absolute-path> (derives <root>/mesh-llm/trunks and /experts),\n  \
+             2. set moe.storage.trunk_path + moe.storage.experts_path in ~/.mesh-llm/config.toml,\n  \
+             3. export MESH_LLM_NAS_ROOT=<absolute-path>"
         );
     }
 
@@ -295,9 +307,47 @@ async fn run_migrate(args: MigrateArgs) -> Result<()> {
         trunk_path_final = Some(resolved.trunk);
     }
 
-    if let Some(trunk) = trunk_path_final {
-        let t_size = fs::metadata(&trunk).map(|m| m.len()).unwrap_or(0);
+    if let Some(trunk) = trunk_path_final.as_ref() {
+        let t_size = fs::metadata(trunk).map(|m| m.len()).unwrap_or(0);
         eprintln!("✅ Trunk: {} ({:.2} GB)", trunk.display(), t_size as f64 / 1e9);
+    }
+
+    // Item #2: compute the full source-model SHA-256 and store it in the
+    // manifest. Migrate is an offline batch operation so the one-time cost
+    // (~10-30 min on 600 GB at NAS speeds) is acceptable; at runtime we
+    // stay on the cheap `source_fingerprint` for version derivation and
+    // only rely on trunk/experts hashes for integrity. Populate the
+    // manifest after the split so we don't re-hash on idempotent re-runs.
+    if let Some(trunk) = trunk_path_final.as_ref() {
+        // trunk path layout: <root>/trunks/<stem>/<version>/trunk.gguf
+        // — the parent directory name is the manifest version id.
+        let version = trunk
+            .parent()
+            .and_then(|p| p.file_name())
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let manifest_path = moe::manifest_file_path(&storage, &args.source_model, &version);
+        if let Some(mp) = manifest_path {
+            if let Ok(mut manifest) = moe::load_manifest(&mp) {
+                if manifest.source_model_sha256.is_empty() {
+                    eprintln!(
+                        "🔎 Computing source model SHA-256 ({:.1} GB, one-time; stored in manifest)...",
+                        source_size as f64 / 1e9
+                    );
+                    let t0 = std::time::Instant::now();
+                    let sha = moe::sha256_file(&args.source_model)
+                        .with_context(|| "hashing source model")?;
+                    eprintln!(
+                        "   source_model_sha256 = {}… ({:.1}s)",
+                        &sha[..16],
+                        t0.elapsed().as_secs_f64()
+                    );
+                    manifest.source_model_sha256 = sha;
+                    moe::write_manifest_atomic(&mp, &manifest)
+                        .with_context(|| "re-writing manifest with source_model_sha256")?;
+                }
+            }
+        }
     }
 
     // Legacy cleanup hint: if the old per-node cache has entries for this

--- a/crates/mesh-llm/src/cli/commands/moe/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/moe/mod.rs
@@ -97,7 +97,237 @@ pub(crate) async fn dispatch_moe_command(command: &MoeCommand, cli: &Cli) -> Res
             ranking_file,
             dataset_repo,
         } => run_share(model, ranking_file.as_deref(), dataset_repo).await,
+        MoeCommand::Migrate {
+            source_model,
+            nas_root,
+            n_nodes,
+            overlap,
+            ranking_file,
+            dry_run,
+            bin_dir,
+        } => {
+            run_migrate(MigrateArgs {
+                source_model: source_model.clone(),
+                nas_root: nas_root.clone(),
+                n_nodes: *n_nodes,
+                overlap: *overlap,
+                ranking_file: ranking_file.clone(),
+                dry_run: *dry_run,
+                bin_dir: bin_dir.clone(),
+            })
+            .await
+        }
     }
+}
+
+struct MigrateArgs {
+    source_model: PathBuf,
+    nas_root: Option<PathBuf>,
+    n_nodes: usize,
+    overlap: u32,
+    ranking_file: Option<PathBuf>,
+    dry_run: bool,
+    bin_dir: Option<PathBuf>,
+}
+
+async fn run_migrate(args: MigrateArgs) -> Result<()> {
+    use crate::plugin::{self, MoeStorageConfig, MoeStorageMode};
+
+    if !args.source_model.exists() {
+        bail!(
+            "source model {} does not exist",
+            args.source_model.display()
+        );
+    }
+    if args.n_nodes < 2 {
+        bail!("--n-nodes must be >= 2 (got {})", args.n_nodes);
+    }
+
+    // Build a MoeStorageConfig for the duration of this command. Prefer the
+    // explicit --nas-root; else fall back to the per-user config and env.
+    let mut storage = plugin::MoeStorageConfig {
+        mode: MoeStorageMode::Split,
+        ..MoeStorageConfig::default()
+    };
+    if let Some(root) = args.nas_root.as_ref() {
+        if !root.is_absolute() {
+            bail!(
+                "--nas-root must be an absolute path (got {})",
+                root.display()
+            );
+        }
+        storage.trunk_path = Some(root.join("mesh-llm").join("trunks"));
+        storage.experts_path = Some(root.join("mesh-llm").join("experts"));
+    } else {
+        let cfg = plugin::load_config(None).with_context(|| "loading mesh-llm config")?;
+        if matches!(cfg.moe.storage.mode, MoeStorageMode::Split) {
+            storage.trunk_path = cfg.moe.storage.trunk_path.clone();
+            storage.experts_path = cfg.moe.storage.experts_path.clone();
+            storage.experts_local_override = cfg.moe.storage.experts_local_override.clone();
+        }
+        // Fall back to MESH_LLM_NAS_ROOT if config didn't provide paths.
+        if storage.trunk_path.is_none() || storage.experts_path.is_none() {
+            if let Some(root) = plugin::resolve_trunk_root(&storage)
+                .or_else(|| plugin::resolve_experts_root(&storage))
+            {
+                // resolve_* already derives the `/mesh-llm/trunks` and
+                // `/mesh-llm/experts` subpaths, so we re-use them directly.
+                if storage.trunk_path.is_none() {
+                    storage.trunk_path = plugin::resolve_trunk_root(&storage);
+                }
+                if storage.experts_path.is_none() {
+                    storage.experts_path = plugin::resolve_experts_root(&storage);
+                }
+                let _ = root; // used above via resolve_*
+            }
+        }
+    }
+    if storage.trunk_path.is_none() || storage.experts_path.is_none() {
+        bail!(
+            "--nas-root, moe.storage.trunk_path+experts_path, or MESH_LLM_NAS_ROOT must be set"
+        );
+    }
+
+    // Resolve a ranking + assignment plan for the source model. We cap
+    // `nodes` to the requested `n_nodes` so the report matches what we
+    // actually want to lay out on disk.
+    let report = moe_planner::plan_moe(MoePlanArgs {
+        model: args.source_model.display().to_string(),
+        ranking_file: args.ranking_file.clone(),
+        max_vram_gb: None,
+        nodes: Some(args.n_nodes),
+        dataset_repo: "meshllm/moe-rankings".to_string(),
+        progress: true,
+    })
+    .await
+    .with_context(|| "planning migration")?;
+
+    if report.assignments.len() != args.n_nodes {
+        bail!(
+            "planner returned {} assignments for {} nodes; aborting",
+            report.assignments.len(),
+            args.n_nodes
+        );
+    }
+
+    // Build the (node_index -> experts) map the splitter needs.
+    let mut assignments_map = BTreeMap::new();
+    for (i, a) in report.assignments.iter().enumerate() {
+        assignments_map.insert(i, a.experts.clone());
+    }
+
+    // Report what we plan to do.
+    let source_size = fs::metadata(&args.source_model)?.len();
+    eprintln!("📍 Source model: {}", args.source_model.display());
+    eprintln!(
+        "📐 Mesh: {} nodes, overlap={}, experts={}, used={}",
+        args.n_nodes,
+        args.overlap,
+        report.model.expert_count,
+        report.model.used_expert_count
+    );
+    eprintln!(
+        "🗂  Trunk root:   {}",
+        storage.trunk_path.as_ref().unwrap().display()
+    );
+    eprintln!(
+        "🗂  Experts root: {}",
+        storage.experts_path.as_ref().unwrap().display()
+    );
+
+    // Rough size estimate: assume trunk fraction ≈ 1 - (expert_bytes /
+    // total). We can't know the exact split without running the splitter;
+    // report source size as an upper bound for the dry-run.
+    let est_per_node = (source_size / args.n_nodes as u64).saturating_add(
+        // trunk duplication cost eliminated by split, but we don't know
+        // trunk size until after the split. Use 5% of source as a crude
+        // placeholder so users see a meaningful number.
+        source_size / 20,
+    );
+    eprintln!(
+        "🧮 Expected per-node experts shard: ~{:.1} GB (upper bound; real size shown after split)",
+        est_per_node as f64 / 1e9
+    );
+    eprintln!(
+        "🧮 Expected monolithic per-node total: ~{:.1} GB × {} = ~{:.1} GB",
+        source_size as f64 / 1e9,
+        args.n_nodes,
+        source_size as f64 * args.n_nodes as f64 / 1e9
+    );
+    if args.dry_run {
+        eprintln!("(--dry-run: no files written)");
+        return Ok(());
+    }
+
+    // Resolve the splitter binary dir.
+    let bin_dir = args
+        .bin_dir
+        .clone()
+        .unwrap_or_else(|| default_bin_dir().unwrap_or_else(|| PathBuf::from(".")));
+
+    // Drive the splitter node-by-node. `ensure_trunk_and_expert` is
+    // idempotent and holds the trunk build lock, so sequential calls are
+    // safe AND cheap (trunk is written on the first pass; subsequent
+    // passes detect the existing hash and skip).
+    eprintln!("🚧 Migrating (node-by-node)...");
+    let mut trunk_path_final = None;
+    for node_idx in 0..args.n_nodes {
+        let opts = moe::EnsureOpts {
+            bin_dir: bin_dir.clone(),
+            model_path: args.source_model.clone(),
+            assignments: assignments_map.clone(),
+            node_index: node_idx,
+            // We always drive the migrate ourselves, so every node invocation
+            // is allowed to build (is_leader=true). The flock inside
+            // `ensure_trunk_and_expert` serializes concurrent writers.
+            is_leader: true,
+            follower_timeout: std::time::Duration::from_secs(5),
+        };
+        let resolved = moe::ensure_trunk_and_expert(&storage, &opts)
+            .with_context(|| format!("migrating node {node_idx}"))?;
+        let e_size = fs::metadata(&resolved.experts).map(|m| m.len()).unwrap_or(0);
+        eprintln!(
+            "  ✓ node {}: experts = {} ({:.2} GB)",
+            node_idx,
+            resolved.experts.display(),
+            e_size as f64 / 1e9
+        );
+        trunk_path_final = Some(resolved.trunk);
+    }
+
+    if let Some(trunk) = trunk_path_final {
+        let t_size = fs::metadata(&trunk).map(|m| m.len()).unwrap_or(0);
+        eprintln!("✅ Trunk: {} ({:.2} GB)", trunk.display(), t_size as f64 / 1e9);
+    }
+
+    // Legacy cleanup hint: if the old per-node cache has entries for this
+    // model, tell the user where they are. Never delete automatically.
+    let mono_cache = dirs::home_dir()
+        .map(|h| h.join(".cache").join("mesh-llm").join("splits"))
+        .filter(|p| p.exists());
+    if let Some(root) = mono_cache {
+        let stem = args
+            .source_model
+            .file_stem()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let legacy_dir = root.join(&stem);
+        if legacy_dir.exists() {
+            eprintln!(
+                "💡 Legacy monolithic shards still present at {}. Delete them once you've verified split mode works end-to-end.",
+                legacy_dir.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Default bin-dir fallback: the directory containing the mesh-llm binary.
+/// mesh-llm is shipped alongside llama-moe-split under
+/// `/opt/mesh-bundle/` in the standard CUDA image.
+fn default_bin_dir() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    exe.parent().map(|p| p.to_path_buf())
 }
 
 async fn run_plan(

--- a/crates/mesh-llm/src/cli/moe.rs
+++ b/crates/mesh-llm/src/cli/moe.rs
@@ -40,6 +40,39 @@ pub(crate) enum MoeCommand {
         #[arg(long, default_value = "meshllm/moe-rankings")]
         dataset_repo: String,
     },
+    /// Convert a model into Mesh-LLM trunk/experts split layout on shared
+    /// storage. Runs the splitter from the source GGUF (existing monolithic
+    /// per-node shards can't be losslessly decomposed) and publishes a
+    /// manifest. Idempotent: re-running with the same inputs skips files
+    /// that already exist and match the expected hash.
+    Migrate {
+        /// Source monolithic GGUF. Local path (HF/catalog resolution is NOT
+        /// attempted here — this command targets already-staged models).
+        #[arg(long = "source-model")]
+        source_model: PathBuf,
+        /// Override for `moe.storage.trunk_path`. Falls back to config then
+        /// the `MESH_LLM_NAS_ROOT` env var.
+        #[arg(long)]
+        nas_root: Option<PathBuf>,
+        /// Number of nodes in the target mesh.
+        #[arg(long, default_value = "2")]
+        n_nodes: usize,
+        /// Expert-replication factor (overlap) passed to the planner. 1 = no
+        /// replication; 2 = shared core doubled across every node, etc.
+        #[arg(long, default_value = "2")]
+        overlap: u32,
+        /// Override the ranking CSV instead of resolving it via cache / HF.
+        #[arg(long)]
+        ranking_file: Option<PathBuf>,
+        /// Print the planned layout + projected storage savings and exit
+        /// without invoking the splitter.
+        #[arg(long)]
+        dry_run: bool,
+        /// Directory containing `llama-moe-split`. Defaults to the sibling
+        /// bin dir of the current executable.
+        #[arg(long)]
+        bin_dir: Option<PathBuf>,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/mesh-llm/src/cli/moe.rs
+++ b/crates/mesh-llm/src/cli/moe.rs
@@ -61,6 +61,12 @@ pub(crate) enum MoeCommand {
         /// replication; 2 = shared core doubled across every node, etc.
         #[arg(long, default_value = "2")]
         overlap: u32,
+        /// Override planner's `min_experts_per_node` (= shared-core size).
+        /// Useful for large MoE on smaller-VRAM clusters where the default
+        /// 50%-of-experts floor produces shards that exceed per-node VRAM.
+        /// Lower values mean smaller shards but more cross-node routing.
+        #[arg(long)]
+        min_experts_per_node: Option<u32>,
         /// Override the ranking CSV instead of resolving it via cache / HF.
         #[arg(long)]
         ranking_file: Option<PathBuf>,

--- a/crates/mesh-llm/src/inference/election.rs
+++ b/crates/mesh-llm/src/inference/election.rs
@@ -2723,12 +2723,89 @@ async fn moe_election_loop(
             let my_shard_index = plan.shard_index_for(my_id).unwrap_or(0);
             on_change(true, false);
 
-            let assignments = moe::compute_assignments_with_overlap(
-                &moe_cfg.config.ranking,
-                plan.active_ids.len(),
-                moe_cfg.config.min_experts_per_node,
-                plan.overlap,
-            );
+            // Manifest-pin: when storage.mode=split AND a pre-built manifest
+            // exists for this source model with n_nodes matching the runtime
+            // peer count, adopt the manifest's assignments verbatim. Without
+            // this, the runtime ranking/overlap will almost never reproduce
+            // the exact assignments hash that derived the manifest's
+            // `version` string, so the manifest is ignored and the legacy
+            // local-cache split runs instead.
+            let pinned: Option<moe::SplitManifest> = if moe_storage
+                .as_ref()
+                .map(|c| matches!(c.mode, crate::plugin::MoeStorageMode::Split))
+                .unwrap_or(false)
+            {
+                let cfg = moe_storage.as_ref().expect("split-mode set above");
+                match moe::find_pinned_manifest(cfg, &model, Some(plan.active_ids.len())) {
+                    Some((path, m)) if m.n_nodes == plan.active_ids.len() => {
+                        eprintln!(
+                            "  📌 Pinned to manifest {} ({}, n_nodes={}); skipping runtime ranking.",
+                            m.version,
+                            path.display(),
+                            m.n_nodes
+                        );
+                        Some(m)
+                    }
+                    Some((path, m)) => {
+                        eprintln!(
+                            "  ℹ️  Found manifest {} (n_nodes={}) at {}, but runtime active={} — not pinning. Re-run `mesh-llm moe migrate --n-nodes {}` to make it reusable, or proceed and a fresh split will be built.",
+                            m.version,
+                            m.n_nodes,
+                            path.display(),
+                            plan.active_ids.len(),
+                            plan.active_ids.len()
+                        );
+                        None
+                    }
+                    None => None,
+                }
+            } else {
+                None
+            };
+
+            let assignments: Vec<moe::NodeAssignment> = if let Some(m) = pinned.as_ref() {
+                let mut out: Vec<moe::NodeAssignment> = Vec::with_capacity(m.n_nodes);
+                // Build NodeAssignment per node from manifest. n_shared/n_unique
+                // are cosmetic (log only) — derive cheaply: shared = experts
+                // present on every node; unique = experts not on any other
+                // node.
+                let all_sets: Vec<std::collections::BTreeSet<u32>> = (0..m.n_nodes)
+                    .map(|i| {
+                        m.assignments
+                            .get(&i)
+                            .cloned()
+                            .unwrap_or_default()
+                            .into_iter()
+                            .collect()
+                    })
+                    .collect();
+                for i in 0..m.n_nodes {
+                    let mine = &all_sets[i];
+                    let shared = mine
+                        .iter()
+                        .filter(|e| all_sets.iter().enumerate().all(|(j, s)| j == i || s.contains(*e)))
+                        .count();
+                    let unique = mine
+                        .iter()
+                        .filter(|e| !all_sets.iter().enumerate().any(|(j, s)| j != i && s.contains(*e)))
+                        .count();
+                    let mut experts: Vec<u32> = mine.iter().copied().collect();
+                    experts.sort_unstable();
+                    out.push(moe::NodeAssignment {
+                        experts,
+                        n_shared: shared,
+                        n_unique: unique,
+                    });
+                }
+                out
+            } else {
+                moe::compute_assignments_with_overlap(
+                    &moe_cfg.config.ranking,
+                    plan.active_ids.len(),
+                    moe_cfg.config.min_experts_per_node,
+                    plan.overlap,
+                )
+            };
             let my_assignment = &assignments[my_shard_index];
             let _ = emit_event(OutputEvent::MoeDistribution {
                 model: model_name.clone(),
@@ -2746,6 +2823,16 @@ async fn moe_election_loop(
                     unique_experts: my_assignment.n_unique,
                 },
             });
+            if pinned.is_some() {
+                emit_warning(
+                    "Using pinned MoE expert assignments from manifest",
+                    Some(format!(
+                        "model={model_name} shard={}/{}",
+                        my_shard_index + 1,
+                        plan.active_ids.len()
+                    )),
+                );
+            }
 
             // Advertise a non-ready local runtime before split generation / load so
             // peer liveness stays conservative during MoE convergence.

--- a/crates/mesh-llm/src/inference/election.rs
+++ b/crates/mesh-llm/src/inference/election.rs
@@ -1095,6 +1095,9 @@ struct MoeElectionParams {
     binary_flavor: Option<launch::BinaryFlavor>,
     ctx_size_override: Option<u32>,
     pinned_gpu: Option<crate::runtime::StartupPinnedGpuTarget>,
+    /// Opt-in trunk/experts split storage for this model. `None` or
+    /// `mode == Monolithic` preserves today's per-node shard behavior.
+    moe_storage: Option<crate::plugin::MoeStorageConfig>,
     target_tx: Arc<watch::Sender<ModelTargets>>,
     stop_rx: watch::Receiver<bool>,
     slots: usize,
@@ -1135,6 +1138,9 @@ pub struct ElectionLoopParams {
     pub ctx_size_override: Option<u32>,
     pub pinned_gpu: Option<crate::runtime::StartupPinnedGpuTarget>,
     pub moe_runtime_options: moe::MoeRuntimeOptions,
+    /// Trunk/experts split-mode storage config. `None` or
+    /// `mode == Monolithic` preserves today's per-node shard behavior.
+    pub moe_storage: Option<crate::plugin::MoeStorageConfig>,
     pub target_tx: Arc<watch::Sender<ModelTargets>>,
     pub stop_rx: watch::Receiver<bool>,
     pub slots: usize,
@@ -1668,6 +1674,7 @@ pub async fn election_loop(
         ctx_size_override,
         pinned_gpu,
         moe_runtime_options,
+        moe_storage,
         target_tx,
         mut stop_rx,
         slots,
@@ -1773,6 +1780,7 @@ pub async fn election_loop(
                     binary_flavor,
                     ctx_size_override,
                     pinned_gpu: pinned_gpu.clone(),
+                    moe_storage,
                     target_tx,
                     stop_rx,
                     slots,
@@ -2206,6 +2214,7 @@ async fn moe_election_loop(
         binary_flavor,
         ctx_size_override,
         pinned_gpu,
+        moe_storage,
         target_tx,
         mut stop_rx,
         slots,
@@ -2496,6 +2505,8 @@ async fn moe_election_loop(
                             plugin_endpoint_key: None,
                         },
                     )),
+                    split_shards: None,
+                    moe_storage: None,
                 },
             )
             .await
@@ -2626,6 +2637,8 @@ async fn moe_election_loop(
                                 plugin_endpoint_key: None,
                             },
                         )),
+                        split_shards: None,
+                        moe_storage: None,
                     },
                 )
                 .await
@@ -2739,35 +2752,62 @@ async fn moe_election_loop(
             node.set_model_runtime_starting(&model_name).await;
             node.regossip().await;
 
-            let shard_path = moe::split_path(&model, plan.active_ids.len(), my_shard_index);
+            // Branch: trunk/experts split storage vs. monolithic per-node shard.
+            let use_split_storage = moe_storage
+                .as_ref()
+                .map(|cfg| matches!(cfg.mode, crate::plugin::MoeStorageMode::Split))
+                .unwrap_or(false);
 
-            if !shard_path.exists() {
-                emit_warning(
-                    format!("Splitting GGUF → {} ...", shard_path.display()),
-                    Some(format!(
-                        "model={model_name} shard={}/{}",
-                        my_shard_index + 1,
-                        plan.active_ids.len()
-                    )),
-                );
-                match moe::run_split(&bin_dir, &model, my_assignment, &shard_path) {
-                    Ok(()) => {
-                        let size = std::fs::metadata(&shard_path).map(|m| m.len()).unwrap_or(0);
+            let monolithic_shard_path =
+                moe::split_path(&model, plan.active_ids.len(), my_shard_index);
+            let mut resolved_shards: Option<moe::ResolvedShards> = None;
+            let (shard_model_path, shard_bytes): (std::path::PathBuf, u64) = if use_split_storage {
+                // Trunk/experts mode: produce (or reuse) shared trunk + this node's experts,
+                // publish / wait for the shared manifest, then hand both paths to the launcher.
+                let cfg = moe_storage.as_ref().expect("use_split_storage ⇒ moe_storage set");
+                let mut assignments_map = std::collections::BTreeMap::new();
+                for (i, a) in assignments.iter().enumerate() {
+                    assignments_map.insert(i, a.experts.clone());
+                }
+                let is_leader = my_shard_index == 0;
+                let opts = moe::EnsureOpts {
+                    bin_dir: bin_dir.clone(),
+                    model_path: model.clone(),
+                    assignments: assignments_map,
+                    node_index: my_shard_index,
+                    is_leader,
+                    follower_timeout: std::time::Duration::from_secs(30 * 60),
+                };
+                match moe::ensure_trunk_and_expert(cfg, &opts) {
+                    Ok(shards) => {
+                        let t_sz = std::fs::metadata(&shards.trunk)
+                            .map(|m| m.len())
+                            .unwrap_or(0);
+                        let e_sz = std::fs::metadata(&shards.experts)
+                            .map(|m| m.len())
+                            .unwrap_or(0);
                         emit_warning(
-                            format!("Split complete: {:.1} GB", size as f64 / 1e9),
+                            format!(
+                                "Trunk/experts ready (manifest={}): trunk={:.2} GB experts={:.2} GB",
+                                shards.manifest_version,
+                                t_sz as f64 / 1e9,
+                                e_sz as f64 / 1e9
+                            ),
                             Some(format!(
-                                "model={model_name} shard_path={}",
-                                shard_path.display()
+                                "model={model_name} trunk={} experts={}",
+                                shards.trunk.display(),
+                                shards.experts.display()
                             )),
                         );
+                        let total = t_sz + e_sz;
+                        let experts_path = shards.experts.clone();
+                        resolved_shards = Some(shards);
+                        (experts_path, total)
                     }
                     Err(e) => {
                         emit_error(
-                            format!("moe-split failed: {e}"),
-                            Some(format!(
-                                "model={model_name} shard_path={}",
-                                shard_path.display()
-                            )),
+                            format!("ensure_trunk_and_expert failed: {e}"),
+                            Some(format!("model={model_name} mode=moe-split-storage")),
                         );
                         node.set_model_runtime_context_length(&model_name, None)
                             .await;
@@ -2780,13 +2820,70 @@ async fn moe_election_loop(
                     }
                 }
             } else {
-                let size = std::fs::metadata(&shard_path).map(|m| m.len()).unwrap_or(0);
-                emit_moe_status(
-                    &model_name,
-                    "using cached shard",
-                    format!("{} ({:.1} GB)", shard_path.display(), size as f64 / 1e9),
-                );
-            }
+                if !monolithic_shard_path.exists() {
+                    emit_warning(
+                        format!("Splitting GGUF → {} ...", monolithic_shard_path.display()),
+                        Some(format!(
+                            "model={model_name} shard={}/{}",
+                            my_shard_index + 1,
+                            plan.active_ids.len()
+                        )),
+                    );
+                    match moe::run_split(
+                        &bin_dir,
+                        &model,
+                        my_assignment,
+                        &monolithic_shard_path,
+                    ) {
+                        Ok(()) => {
+                            let size = std::fs::metadata(&monolithic_shard_path)
+                                .map(|m| m.len())
+                                .unwrap_or(0);
+                            emit_warning(
+                                format!("Split complete: {:.1} GB", size as f64 / 1e9),
+                                Some(format!(
+                                    "model={model_name} shard_path={}",
+                                    monolithic_shard_path.display()
+                                )),
+                            );
+                        }
+                        Err(e) => {
+                            emit_error(
+                                format!("moe-split failed: {e}"),
+                                Some(format!(
+                                    "model={model_name} shard_path={}",
+                                    monolithic_shard_path.display()
+                                )),
+                            );
+                            node.set_model_runtime_context_length(&model_name, None)
+                                .await;
+                            node.regossip().await;
+                            if peer_rx.changed().await.is_err() {
+                                break;
+                            }
+                            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                            continue;
+                        }
+                    }
+                } else {
+                    let size = std::fs::metadata(&monolithic_shard_path)
+                        .map(|m| m.len())
+                        .unwrap_or(0);
+                    emit_moe_status(
+                        &model_name,
+                        "using cached shard",
+                        format!(
+                            "{} ({:.1} GB)",
+                            monolithic_shard_path.display(),
+                            size as f64 / 1e9
+                        ),
+                    );
+                }
+                let size = std::fs::metadata(&monolithic_shard_path)
+                    .map(|m| m.len())
+                    .unwrap_or(0);
+                (monolithic_shard_path.clone(), size)
+            };
 
             // Start llama-server with our shard
             let llama_port = match find_free_port().await {
@@ -2804,13 +2901,12 @@ async fn moe_election_loop(
                 }
             };
 
-            let shard_bytes = std::fs::metadata(&shard_path).map(|m| m.len()).unwrap_or(0);
             match launch::start_llama_server(
                 &runtime,
                 &bin_dir,
                 binary_flavor,
                 launch::ModelLaunchSpec {
-                    model: &shard_path,
+                    model: &shard_model_path,
                     http_port: llama_port,
                     tunnel_ports: &[],
                     tensor_split: None,
@@ -2834,6 +2930,8 @@ async fn moe_election_loop(
                             plugin_endpoint_key: None,
                         },
                     )),
+                    split_shards: resolved_shards.as_ref(),
+                    moe_storage: moe_storage.as_ref(),
                 },
             )
             .await
@@ -2900,7 +2998,7 @@ async fn moe_election_loop(
                     emit_error(
                         format!(
                             "MoE split validation failed for shard {}: {e}",
-                            shard_path.display()
+                            shard_model_path.display()
                         ),
                         Some(format!("model={model_name}")),
                     );
@@ -2908,7 +3006,7 @@ async fn moe_election_loop(
                         "Refusing to enter MoE split mode on this node until the shard validates",
                         Some(format!(
                             "model={model_name} shard_path={}",
-                            shard_path.display()
+                            shard_model_path.display()
                         )),
                     );
                     node.set_model_runtime_context_length(&model_name, None)
@@ -3233,6 +3331,8 @@ async fn start_llama(
                     plugin_endpoint_key: None,
                 },
             )),
+            split_shards: None,
+            moe_storage: None,
         },
     )
     .await

--- a/crates/mesh-llm/src/inference/launch.rs
+++ b/crates/mesh-llm/src/inference/launch.rs
@@ -480,6 +480,14 @@ pub struct ModelLaunchSpec<'a> {
     /// Set from the `[[models]].slots` TOML config; defaults to 4 when unset.
     pub slots: usize,
     pub runtime_data_producer: Option<crate::runtime_data::RuntimeDataProducer>,
+    /// Trunk/experts split mode: when `Some`, we launch llama-server with
+    /// `--model-trunk <trunk> --model-experts <experts>` instead of
+    /// `-m <model>`. `model` is ignored for selection but still reported in
+    /// logs for continuity.
+    pub split_shards: Option<&'a crate::inference::moe::ResolvedShards>,
+    /// Storage-mode toggles (prefault / mlock) for split mode. Required when
+    /// `split_shards` is `Some`; ignored in monolithic mode.
+    pub moe_storage: Option<&'a crate::plugin::MoeStorageConfig>,
 }
 
 pub(crate) const GB: u64 = 1_000_000_000;
@@ -496,6 +504,79 @@ pub(crate) fn clear_runtime_shutting_down() {
 
 pub(crate) fn runtime_shutting_down() -> bool {
     RUNTIME_SHUTTING_DOWN.load(Ordering::Relaxed)
+}
+
+/// Pure helper: build the leading model-related args for llama-server.
+/// Split mode emits `--model-experts` + `--model-trunk` and optionally
+/// `--prefault-trunk` / `--mlock-trunk`. Monolithic mode emits `-m <model>`.
+/// Lives outside `start_llama_server` so unit tests can assert the exact
+/// flag sequence without spawning a process.
+pub(crate) fn build_model_args(
+    model: &Path,
+    split_shards: Option<&crate::inference::moe::ResolvedShards>,
+    moe_storage: Option<&crate::plugin::MoeStorageConfig>,
+) -> Vec<String> {
+    if let Some(shards) = split_shards {
+        let mut v = vec![
+            "--model-experts".to_string(),
+            shards.experts.to_string_lossy().to_string(),
+            "--model-trunk".to_string(),
+            shards.trunk.to_string_lossy().to_string(),
+        ];
+        if let Some(cfg) = moe_storage {
+            if cfg.prefault_trunk {
+                v.push("--prefault-trunk".to_string());
+            }
+            if cfg.mlock_trunk {
+                v.push("--mlock-trunk".to_string());
+            }
+        }
+        v
+    } else {
+        vec!["-m".to_string(), model.to_string_lossy().to_string()]
+    }
+}
+
+/// Verify the process can `mlock()` at least `required` bytes before we
+/// spawn llama-server. On Linux/macOS this reads `RLIMIT_MEMLOCK`. We skip
+/// the check on non-Unix platforms.
+pub(crate) fn ensure_memlock_rlimit_at_least(required: u64) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::mem::MaybeUninit;
+        let mut rl = MaybeUninit::<libc::rlimit>::uninit();
+        // SAFETY: libc call; rl is written on success.
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, rl.as_mut_ptr()) };
+        if rc != 0 {
+            // If getrlimit itself fails, treat as "unknown" and warn rather than hard-fail.
+            tracing::warn!(
+                "getrlimit(RLIMIT_MEMLOCK) failed: {} — proceeding without RLIMIT check",
+                std::io::Error::last_os_error()
+            );
+            return Ok(());
+        }
+        // SAFETY: rc == 0 implies rl was written.
+        let rl = unsafe { rl.assume_init() };
+        // `rlim_cur == RLIM_INFINITY` means unlimited; always OK.
+        if rl.rlim_cur == libc::RLIM_INFINITY {
+            return Ok(());
+        }
+        if (rl.rlim_cur as u64) < required {
+            anyhow::bail!(
+                "--mlock-trunk requires RLIMIT_MEMLOCK >= {required} bytes, but current soft limit is {cur} bytes (hard {hard}); \
+                 raise it via `ulimit -l unlimited` in the shell, or `LimitMEMLOCK=infinity` in the systemd unit / docker `--ulimit memlock=-1:-1`",
+                required = required,
+                cur = rl.rlim_cur as u64,
+                hard = rl.rlim_max as u64
+            );
+        }
+        Ok(())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = required;
+        Ok(())
+    }
 }
 
 fn spawned_binary_name(path: &Path) -> String {
@@ -1304,9 +1385,36 @@ pub async fn start_llama_server(
     let selected_gpu = spec.selected_gpu;
     let slots = spec.slots;
     let runtime_data_producer = spec.runtime_data_producer;
+    let split_shards = spec.split_shards;
+    let moe_storage = spec.moe_storage;
     let llama_server = resolve_binary_path(bin_dir, "llama-server", binary_flavor)?;
 
-    anyhow::ensure!(model.exists(), "Model not found at {}", model.display());
+    // In split mode we look at the (trunk, experts) pair; in monolithic mode
+    // the usual `model` path.
+    if let Some(shards) = split_shards {
+        anyhow::ensure!(
+            shards.trunk.exists(),
+            "trunk GGUF not found at {}",
+            shards.trunk.display()
+        );
+        anyhow::ensure!(
+            shards.experts.exists(),
+            "experts GGUF not found at {}",
+            shards.experts.display()
+        );
+    } else {
+        anyhow::ensure!(model.exists(), "Model not found at {}", model.display());
+    }
+
+    // If --mlock-trunk will be requested, verify RLIMIT_MEMLOCK up front so
+    // users see a clear error from mesh-llm rather than a silent mlock
+    // failure inside llama-server.
+    if let (Some(shards), Some(cfg)) = (split_shards, moe_storage) {
+        if cfg.mlock_trunk {
+            let trunk_size = std::fs::metadata(&shards.trunk)?.len();
+            ensure_memlock_rlimit_at_least(trunk_size)?;
+        }
+    }
 
     // Build --rpc argument: all tunnel ports as localhost endpoints
     let rpc_endpoints: Vec<String> = tunnel_ports
@@ -1371,7 +1479,11 @@ pub async fn start_llama_server(
         }
     );
 
-    let mut args = vec!["-m".to_string(), model.to_string_lossy().to_string()];
+    // Model args: split mode uses `--model-experts` + `--model-trunk`;
+    // monolithic uses the existing `-m`. Extracted into `build_model_args`
+    // so the split-mode emission can be unit-tested without spawning a
+    // llama-server process.
+    let mut args: Vec<String> = build_model_args(model, split_shards, moe_storage);
     if !tunnel_ports.is_empty() {
         args.push("--rpc".to_string());
         args.push(rpc_arg);
@@ -2395,13 +2507,113 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 #[cfg(test)]
 mod tests {
     use super::{
-        compute_context_size, is_safe_kill_target, model_label, parse_available_devices,
+        build_model_args, compute_context_size, is_safe_kill_target, model_label,
+        parse_available_devices,
         preferred_device, terminate_process, wait_for_exit, BinaryFlavor, KvCacheQuant,
         KvCacheWarning, KvType, RpcServerHandle, SplitMode, GB,
     };
     use std::path::Path;
+    use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
+
+    use crate::inference::moe::ResolvedShards;
+    use crate::plugin::{MoeStorageConfig, MoeStorageMode};
+
+    #[test]
+    fn build_model_args_monolithic_emits_dash_m_only() {
+        let model = Path::new("/models/mono.gguf");
+        let args = build_model_args(model, None, None);
+        assert_eq!(args, vec!["-m".to_string(), "/models/mono.gguf".to_string()]);
+    }
+
+    #[test]
+    fn build_model_args_split_emits_experts_then_trunk() {
+        let shards = ResolvedShards {
+            experts: PathBuf::from("/nas/mesh-llm/experts/m/2-nodes/v/node-0-experts.gguf"),
+            trunk: PathBuf::from("/nas/mesh-llm/trunks/m/v/trunk.gguf"),
+            manifest_version: "v".into(),
+        };
+        let cfg = MoeStorageConfig {
+            mode: MoeStorageMode::Split,
+            trunk_path: Some(PathBuf::from("/nas/mesh-llm/trunks")),
+            experts_path: Some(PathBuf::from("/nas/mesh-llm/experts")),
+            experts_local_override: None,
+            prefault_trunk: false,
+            mlock_trunk: false,
+        };
+        let args = build_model_args(Path::new("/ignored"), Some(&shards), Some(&cfg));
+        assert_eq!(
+            args,
+            vec![
+                "--model-experts".to_string(),
+                "/nas/mesh-llm/experts/m/2-nodes/v/node-0-experts.gguf".to_string(),
+                "--model-trunk".to_string(),
+                "/nas/mesh-llm/trunks/m/v/trunk.gguf".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn build_model_args_split_appends_prefault_when_enabled() {
+        let shards = ResolvedShards {
+            experts: PathBuf::from("/e"),
+            trunk: PathBuf::from("/t"),
+            manifest_version: "v".into(),
+        };
+        let cfg = MoeStorageConfig {
+            mode: MoeStorageMode::Split,
+            trunk_path: Some(PathBuf::from("/x")),
+            experts_path: Some(PathBuf::from("/y")),
+            experts_local_override: None,
+            prefault_trunk: true,
+            mlock_trunk: false,
+        };
+        let args = build_model_args(Path::new("/ignored"), Some(&shards), Some(&cfg));
+        assert!(args.contains(&"--prefault-trunk".to_string()));
+        assert!(!args.contains(&"--mlock-trunk".to_string()));
+    }
+
+    #[test]
+    fn build_model_args_split_appends_mlock_when_enabled() {
+        let shards = ResolvedShards {
+            experts: PathBuf::from("/e"),
+            trunk: PathBuf::from("/t"),
+            manifest_version: "v".into(),
+        };
+        let cfg = MoeStorageConfig {
+            mode: MoeStorageMode::Split,
+            trunk_path: Some(PathBuf::from("/x")),
+            experts_path: Some(PathBuf::from("/y")),
+            experts_local_override: None,
+            prefault_trunk: true,
+            mlock_trunk: true,
+        };
+        let args = build_model_args(Path::new("/ignored"), Some(&shards), Some(&cfg));
+        assert!(args.contains(&"--prefault-trunk".to_string()));
+        assert!(args.contains(&"--mlock-trunk".to_string()));
+    }
+
+    #[test]
+    fn build_model_args_split_without_moe_storage_uses_no_toggles() {
+        // Defensive: if split_shards is Some but moe_storage is None (shouldn't
+        // happen in practice), we still emit correct model args without toggles.
+        let shards = ResolvedShards {
+            experts: PathBuf::from("/e"),
+            trunk: PathBuf::from("/t"),
+            manifest_version: "v".into(),
+        };
+        let args = build_model_args(Path::new("/ignored"), Some(&shards), None);
+        assert_eq!(
+            args,
+            vec![
+                "--model-experts".to_string(),
+                "/e".to_string(),
+                "--model-trunk".to_string(),
+                "/t".to_string(),
+            ]
+        );
+    }
 
     #[test]
     fn kv_quant_small_model_is_plain_f16() {
@@ -3015,6 +3227,8 @@ No devices found
             selected_gpu: None,
             slots: 8, // ← compile-time check: field must exist and be accessible
             runtime_data_producer: None,
+            split_shards: None,
+            moe_storage: None,
         };
     }
 
@@ -3043,6 +3257,8 @@ No devices found
             selected_gpu: None,
             slots: 16, // non-default value from TOML config
             runtime_data_producer: None,
+            split_shards: None,
+            moe_storage: None,
         };
         assert_eq!(spec.slots, 16);
     }
@@ -3072,6 +3288,8 @@ No devices found
             selected_gpu: None,
             slots: 32,
             runtime_data_producer: None,
+            split_shards: None,
+            moe_storage: None,
         };
 
         // Destructure exactly as start_llama_server does it (lines ~1078-1091)
@@ -3118,6 +3336,8 @@ No devices found
             selected_gpu: None,
             slots: 4, // explicit default from TOML config fallback
             runtime_data_producer: None,
+            split_shards: None,
+            moe_storage: None,
         };
         assert_eq!(good_spec.slots, 4);
     }

--- a/crates/mesh-llm/src/inference/moe.rs
+++ b/crates/mesh-llm/src/inference/moe.rs
@@ -5,9 +5,19 @@
 //! replicated to every node. Remaining experts are distributed uniquely.
 //!
 //! No cross-node traffic during inference — each node runs independently.
+//!
+//! # Storage modes
+//! - **Monolithic** (default): each node holds a self-contained GGUF with trunk
+//!   + its expert subset.
+//! - **Split** (`moe.storage.mode = "split"`): one shared trunk GGUF lives on
+//!   NAS, and each node has a small per-node experts GGUF. Handled by the
+//!   `ensure_trunk_and_expert` + `SplitManifest` machinery below.
 
+use chrono::{DateTime, Utc};
 use clap::ValueEnum;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 pub use crate::models::gguf::{detect_moe, scan_gguf_compact_meta, GgufMoeInfo};
@@ -832,6 +842,610 @@ pub fn run_split(
     Ok(())
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Trunk/experts split storage (moe.storage.mode = "split")
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Splitter format we require when building trunk/experts shards. Bumped in
+/// lockstep with the llama.cpp fork's `MOE_SPLIT_SPLITTER_VERSION`. When the
+/// installed splitter reports a different string, we refuse to emit split
+/// shards rather than silently produce shards the loader won't accept.
+pub const REQUIRED_SPLITTER_VERSION: &str = "trunk-experts/v1";
+
+/// Typed failure modes for trunk/experts storage. Distinct variants so the
+/// orchestrator (election / launcher) can react differently — e.g. a
+/// `NasUnreachable` should never fall back to monolithic local; a
+/// `SplitterTooOld` should prompt the user to rebuild the image.
+#[derive(thiserror::Error, Debug)]
+pub enum MoeStorageError {
+    #[error("NAS/storage unreachable at {path}: {source}")]
+    NasUnreachable {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error(
+        "llama-moe-split reports version {found:?} but mesh-llm requires {expected:?}; \
+         rebuild llama.cpp on the current fork to get trunk/experts support"
+    )]
+    SplitterTooOld {
+        found: String,
+        expected: &'static str,
+    },
+    #[error("trunk hash mismatch for {path}: manifest {expected}, file {found}")]
+    TrunkHashMismatch {
+        path: PathBuf,
+        expected: String,
+        found: String,
+    },
+    #[error("shard size mismatch for {path}: manifest {expected} bytes, file {found} bytes")]
+    ShardSizeMismatch {
+        path: PathBuf,
+        expected: u64,
+        found: u64,
+    },
+    #[error("manifest not found at {0}; expected leader to publish it first")]
+    ManifestMissing(PathBuf),
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TrunkEntry {
+    pub path: PathBuf,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExpertEntry {
+    pub path: PathBuf,
+    pub sha256: String,
+    pub size_bytes: u64,
+}
+
+/// Manifest describing a complete trunk/experts split. Lives at
+/// `<trunk_root>/manifests/<model_stem>/<version>.json`. Published atomically
+/// (tmp + fsync + rename) by the elected leader after it finishes producing
+/// trunk + every node's experts shard. Followers poll for its presence.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SplitManifest {
+    /// `manifest.version`: stable derived ID (see `derive_manifest_version`).
+    /// New plan ⇒ new version directory; old manifests remain for forensics.
+    pub version: String,
+    /// SHA-256 of the source monolithic GGUF at split time.
+    pub source_model_sha256: String,
+    /// Value of `llama-moe-split --splitter-version` used to build these
+    /// shards. Tells a future loader which splitter produced the shards
+    /// without re-opening the GGUF.
+    pub splitter_version: String,
+    /// Mesh sizing at plan time.
+    pub n_nodes: usize,
+    /// Per-node expert assignment exactly as passed to the splitter.
+    pub assignments: BTreeMap<usize, Vec<u32>>,
+    pub trunk: TrunkEntry,
+    pub experts: BTreeMap<usize, ExpertEntry>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Paths + version id resolved for one node's view of a trunk/experts split.
+/// This is what the launcher hands to llama-server as
+/// `--model-trunk <trunk>` + `--model-experts <experts>`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedShards {
+    pub trunk: PathBuf,
+    pub experts: PathBuf,
+    pub manifest_version: String,
+}
+
+/// Directory layout helpers. All paths are derived from the `MoeStorageConfig`
+/// roots so nodes that mount the NAS at different points still agree on
+/// structure.
+pub fn trunk_file_path(
+    cfg: &crate::plugin::MoeStorageConfig,
+    model_path: &Path,
+    version: &str,
+) -> Option<PathBuf> {
+    let root = crate::plugin::resolve_trunk_root(cfg)?;
+    let stem = model_stem_for_split(model_path);
+    Some(root.join(&stem).join(version).join("trunk.gguf"))
+}
+
+pub fn experts_file_path(
+    cfg: &crate::plugin::MoeStorageConfig,
+    model_path: &Path,
+    n_nodes: usize,
+    node_index: usize,
+    version: &str,
+) -> Option<PathBuf> {
+    let root = crate::plugin::resolve_experts_root(cfg)?;
+    let stem = model_stem_for_split(model_path);
+    Some(
+        root.join(&stem)
+            .join(format!("{n_nodes}-nodes"))
+            .join(version)
+            .join(format!("node-{node_index}-experts.gguf")),
+    )
+}
+
+pub fn manifest_file_path(
+    cfg: &crate::plugin::MoeStorageConfig,
+    model_path: &Path,
+    version: &str,
+) -> Option<PathBuf> {
+    let root = crate::plugin::resolve_trunk_root(cfg)?;
+    let stem = model_stem_for_split(model_path);
+    Some(
+        root.join("manifests")
+            .join(&stem)
+            .join(format!("{version}.json")),
+    )
+}
+
+/// Reuse the same stem-stripping rule as monolithic `split_path` so that
+/// multi-file source GGUFs (e.g. `Kimi-K2.5-Q4_K_M-00001-of-00013.gguf`) map
+/// to a single stem (`Kimi-K2.5-Q4_K_M`).
+fn model_stem_for_split(model_path: &Path) -> String {
+    let stem = model_path.file_stem().unwrap_or_default().to_string_lossy();
+    // strip_split_suffix already returns an owned String.
+    strip_split_suffix(&stem)
+}
+
+/// Derive a short, stable manifest version ID from the inputs that
+/// determine the split output bit-for-bit. Any change in source model,
+/// splitter, assignments, or node count produces a new version directory;
+/// identical inputs share the directory so re-runs skip redundant writes.
+pub fn derive_manifest_version(
+    source_model_sha256: &str,
+    splitter_version: &str,
+    n_nodes: usize,
+    assignments: &BTreeMap<usize, Vec<u32>>,
+) -> String {
+    let mut h = Sha256::new();
+    h.update(source_model_sha256.as_bytes());
+    h.update(b"|");
+    h.update(splitter_version.as_bytes());
+    h.update(b"|");
+    h.update(n_nodes.to_le_bytes());
+    for (idx, experts) in assignments {
+        h.update(b"|node=");
+        h.update(idx.to_le_bytes());
+        for e in experts {
+            h.update(b",");
+            h.update(e.to_le_bytes());
+        }
+    }
+    let digest = h.finalize();
+    hex_lower(&digest[..6])
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Streaming SHA-256 of a file. Used to verify shards match the manifest.
+pub fn sha256_file(path: &Path) -> anyhow::Result<String> {
+    use std::io::Read as _;
+    let mut f = std::fs::File::open(path)
+        .map_err(|e| anyhow::anyhow!("opening {} for hashing: {e}", path.display()))?;
+    let mut h = Sha256::new();
+    let mut buf = vec![0u8; 4 * 1024 * 1024];
+    loop {
+        let n = f
+            .read(&mut buf)
+            .map_err(|e| anyhow::anyhow!("reading {} for hashing: {e}", path.display()))?;
+        if n == 0 {
+            break;
+        }
+        h.update(&buf[..n]);
+    }
+    Ok(hex_lower(&h.finalize()))
+}
+
+/// Probe `llama-moe-split --splitter-version`. Returns the reported string,
+/// or `SplitterTooOld` when it does not match `REQUIRED_SPLITTER_VERSION`.
+pub fn probe_splitter_version(bin_dir: &Path) -> anyhow::Result<String> {
+    let split_bin = resolve_split_binary(bin_dir)?;
+    let output = std::process::Command::new(&split_bin)
+        .arg("--splitter-version")
+        .output()
+        .map_err(|e| anyhow::anyhow!("probing {} version: {e}", split_bin.display()))?;
+    if !output.status.success() {
+        anyhow::bail!(
+            "llama-moe-split --splitter-version exited {} (stderr={})",
+            output.status,
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if version != REQUIRED_SPLITTER_VERSION {
+        return Err(MoeStorageError::SplitterTooOld {
+            found: version,
+            expected: REQUIRED_SPLITTER_VERSION,
+        }
+        .into());
+    }
+    Ok(version)
+}
+
+/// Run the splitter in trunk/experts mode for one node. Writes both
+/// `trunk_out` and `experts_out` atomically (the C++ side uses .tmp+rename).
+/// `reuse_trunk` tells the splitter to keep an existing trunk when its hash
+/// still matches; set to true for any invocation past the first node.
+pub fn run_split_trunk_experts(
+    bin_dir: &Path,
+    model_path: &Path,
+    assignment: &NodeAssignment,
+    trunk_out: &Path,
+    experts_out: &Path,
+    reuse_trunk: bool,
+) -> anyhow::Result<()> {
+    if let Some(p) = trunk_out.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+    if let Some(p) = experts_out.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+
+    let expert_list = expert_list_arg(assignment);
+    let split_bin = resolve_split_binary(bin_dir)?;
+    let mut cmd = std::process::Command::new(&split_bin);
+    cmd.args([
+        "-m",
+        &model_path.to_string_lossy(),
+        "--expert-list",
+        &expert_list,
+        "--trunk-out",
+        &trunk_out.to_string_lossy(),
+        "--experts-out",
+        &experts_out.to_string_lossy(),
+    ]);
+    if reuse_trunk {
+        cmd.arg("--reuse-trunk");
+    }
+    let status = cmd
+        .status()
+        .map_err(|e| anyhow::anyhow!("failed to run {}: {e}", split_bin.display()))?;
+    anyhow::ensure!(
+        status.success(),
+        "llama-moe-split (trunk/experts) exited with {status}"
+    );
+    Ok(())
+}
+
+/// Acquire an exclusive advisory lock on a lockfile sibling to the trunk path.
+/// Used so concurrent splitter invocations across nodes don't race when
+/// producing the shared trunk for the first time. The lock is held for the
+/// duration of `body` and released when the File drops at the end.
+pub fn with_trunk_build_lock<T>(
+    lock_path: &Path,
+    body: impl FnOnce() -> anyhow::Result<T>,
+) -> anyhow::Result<T> {
+    if let Some(p) = lock_path.parent() {
+        std::fs::create_dir_all(p).map_err(|e| {
+            anyhow::anyhow!("creating lock parent {}: {e}", p.display())
+        })?;
+    }
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .truncate(false)
+        .open(lock_path)
+        .map_err(|e| anyhow::anyhow!("opening lock {}: {e}", lock_path.display()))?;
+    // SAFETY: flock is async-signal-safe; we block until we get the lock.
+    use std::os::unix::io::AsRawFd as _;
+    let fd = lock_file.as_raw_fd();
+    let rc = unsafe { libc::flock(fd, libc::LOCK_EX) };
+    if rc != 0 {
+        let err = std::io::Error::last_os_error();
+        anyhow::bail!("flock({}): {err}", lock_path.display());
+    }
+    let result = body();
+    // LOCK_UN is implicit on close; we don't rely on it here since dropping
+    // lock_file on return will unlock. Keep lock_file alive through body.
+    drop(lock_file);
+    result
+}
+
+/// Write a JSON manifest atomically: tmp + fsync + rename, so readers never
+/// see a half-written file.
+pub fn write_manifest_atomic(path: &Path, manifest: &SplitManifest) -> anyhow::Result<()> {
+    use std::io::Write as _;
+    if let Some(p) = path.parent() {
+        std::fs::create_dir_all(p)?;
+    }
+    let tmp = path.with_extension("json.tmp");
+    {
+        let mut f = std::fs::File::create(&tmp)
+            .map_err(|e| anyhow::anyhow!("create {}: {e}", tmp.display()))?;
+        let body = serde_json::to_vec_pretty(manifest)
+            .map_err(|e| anyhow::anyhow!("serializing manifest: {e}"))?;
+        f.write_all(&body)
+            .map_err(|e| anyhow::anyhow!("writing {}: {e}", tmp.display()))?;
+        f.sync_all()
+            .map_err(|e| anyhow::anyhow!("fsync {}: {e}", tmp.display()))?;
+    }
+    std::fs::rename(&tmp, path)
+        .map_err(|e| anyhow::anyhow!("rename {} -> {}: {e}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+pub fn load_manifest(path: &Path) -> anyhow::Result<SplitManifest> {
+    let data = std::fs::read(path)
+        .map_err(|e| anyhow::anyhow!("reading manifest {}: {e}", path.display()))?;
+    let m: SplitManifest = serde_json::from_slice(&data)
+        .map_err(|e| anyhow::anyhow!("parsing manifest {}: {e}", path.display()))?;
+    Ok(m)
+}
+
+/// Pre-launch integrity check. Compares this node's resolved trunk + experts
+/// files against what the manifest declared. Cheap-ish: size always, SHA256
+/// only when `full` is true (too expensive per-launch on Kimi K2.5 scale —
+/// callers should use `full=false` for hot path and `true` for migration/
+/// audit).
+pub fn verify_shards(
+    resolved: &ResolvedShards,
+    manifest: &SplitManifest,
+    node_index: usize,
+    full: bool,
+) -> anyhow::Result<()> {
+    let expert = manifest.experts.get(&node_index).ok_or_else(|| {
+        anyhow::anyhow!(
+            "manifest has no expert entry for node {node_index} (has nodes {:?})",
+            manifest.experts.keys().collect::<Vec<_>>()
+        )
+    })?;
+
+    for (path, expected_size, expected_hash) in [
+        (
+            resolved.trunk.as_path(),
+            manifest.trunk.size_bytes,
+            &manifest.trunk.sha256,
+        ),
+        (resolved.experts.as_path(), expert.size_bytes, &expert.sha256),
+    ] {
+        let meta = std::fs::metadata(path).map_err(|e| MoeStorageError::NasUnreachable {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+        if meta.len() != expected_size {
+            return Err(MoeStorageError::ShardSizeMismatch {
+                path: path.to_path_buf(),
+                expected: expected_size,
+                found: meta.len(),
+            }
+            .into());
+        }
+        if full {
+            let got = sha256_file(path)?;
+            if &got != expected_hash {
+                return Err(MoeStorageError::TrunkHashMismatch {
+                    path: path.to_path_buf(),
+                    expected: expected_hash.clone(),
+                    found: got,
+                }
+                .into());
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Cheap, stable identity for a source GGUF: `sha256(filename | size)[..6]`.
+/// Used for manifest version derivation so we don't have to hash hundreds of
+/// GB on every launch. Full integrity comes from `source_model_sha256` stored
+/// in the manifest, computed exactly once at split time.
+pub fn source_fingerprint(model_path: &Path) -> anyhow::Result<String> {
+    let meta = std::fs::metadata(model_path).map_err(|e| {
+        anyhow::anyhow!("stat {} for fingerprint: {e}", model_path.display())
+    })?;
+    let mut h = Sha256::new();
+    let name = model_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    h.update(name.as_bytes());
+    h.update(b"|");
+    h.update(meta.len().to_le_bytes());
+    Ok(hex_lower(&h.finalize()[..6]))
+}
+
+/// Side-input for `ensure_trunk_and_expert`. The caller (election/planner)
+/// passes its own view of model + assignments + node index. `is_leader`
+/// gates whether we are allowed to *build* the trunk+experts — a false value
+/// means "only poll for an existing manifest; fail if not present yet".
+#[derive(Clone, Debug)]
+pub struct EnsureOpts {
+    pub bin_dir: PathBuf,
+    pub model_path: PathBuf,
+    pub assignments: BTreeMap<usize, Vec<u32>>,
+    pub node_index: usize,
+    pub is_leader: bool,
+    /// Max wall time a non-leader will wait for the leader's manifest to
+    /// appear (e.g. while the leader is still producing trunk+experts).
+    pub follower_timeout: std::time::Duration,
+}
+
+/// Top-level orchestrator: return the (trunk, experts) paths the launcher
+/// should hand to llama-server, after ensuring the on-disk split exists and
+/// matches the manifest.
+///
+/// Leader path: produce trunk + this node's experts + manifest (atomic).
+/// Follower path: poll for the manifest; when it appears, verify shards.
+pub fn ensure_trunk_and_expert(
+    cfg: &crate::plugin::MoeStorageConfig,
+    opts: &EnsureOpts,
+) -> anyhow::Result<ResolvedShards> {
+    if !matches!(
+        cfg.mode,
+        crate::plugin::MoeStorageMode::Split
+    ) {
+        anyhow::bail!("ensure_trunk_and_expert called with storage.mode != split");
+    }
+
+    let splitter_version = probe_splitter_version(&opts.bin_dir)?;
+    let fingerprint = source_fingerprint(&opts.model_path)?;
+    // Version is derived purely from inputs that determine output bits.
+    // We prefix the cheap fingerprint so two distinct models with the same
+    // assignments map to different version dirs.
+    let mut assignments_sorted: BTreeMap<usize, Vec<u32>> = opts.assignments.clone();
+    for v in assignments_sorted.values_mut() {
+        v.sort_unstable();
+        v.dedup();
+    }
+    let n_nodes = assignments_sorted.len();
+    let version_seed = format!("{fingerprint}:{splitter_version}");
+    let version =
+        derive_manifest_version(&version_seed, &splitter_version, n_nodes, &assignments_sorted);
+
+    let trunk = trunk_file_path(cfg, &opts.model_path, &version)
+        .ok_or_else(|| anyhow::anyhow!("moe.storage.trunk_path not configured"))?;
+    let experts = experts_file_path(
+        cfg,
+        &opts.model_path,
+        n_nodes,
+        opts.node_index,
+        &version,
+    )
+    .ok_or_else(|| anyhow::anyhow!("moe.storage.experts_path not configured"))?;
+    let manifest_path = manifest_file_path(cfg, &opts.model_path, &version)
+        .ok_or_else(|| anyhow::anyhow!("moe.storage.trunk_path not configured"))?;
+
+    // Fast path: manifest already exists → size-verify shards and return.
+    if let Ok(manifest) = load_manifest(&manifest_path) {
+        let resolved = ResolvedShards {
+            trunk: trunk.clone(),
+            experts: experts.clone(),
+            manifest_version: version.clone(),
+        };
+        verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
+        return Ok(resolved);
+    }
+
+    if !opts.is_leader {
+        // Followers never build — they wait for the leader to publish.
+        let deadline = std::time::Instant::now() + opts.follower_timeout;
+        loop {
+            if let Ok(manifest) = load_manifest(&manifest_path) {
+                let resolved = ResolvedShards {
+                    trunk: trunk.clone(),
+                    experts: experts.clone(),
+                    manifest_version: version.clone(),
+                };
+                verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
+                return Ok(resolved);
+            }
+            if std::time::Instant::now() >= deadline {
+                return Err(MoeStorageError::ManifestMissing(manifest_path.clone()).into());
+            }
+            std::thread::sleep(std::time::Duration::from_secs(2));
+        }
+    }
+
+    // Leader path: hold the trunk build lock, produce THIS node's shards
+    // (other nodes will produce their own experts shards under the same
+    // trunk path with --reuse-trunk), and publish the manifest.
+    let lock_path = trunk
+        .parent()
+        .map(|p| p.join(".trunk.build.lock"))
+        .unwrap_or_else(|| PathBuf::from("/tmp/.mesh-llm-trunk.build.lock"));
+
+    with_trunk_build_lock(&lock_path, || -> anyhow::Result<()> {
+        // Race check: another process may have published the manifest while
+        // we waited for the lock. Bail out early in that case.
+        if manifest_path.exists() {
+            return Ok(());
+        }
+
+        // Produce trunk + experts for this node.
+        let this_assignment = opts
+            .assignments
+            .get(&opts.node_index)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "leader node index {} missing from assignments (have {:?})",
+                    opts.node_index,
+                    opts.assignments.keys().collect::<Vec<_>>()
+                )
+            })?;
+        let assignment_struct = NodeAssignment {
+            experts: this_assignment.clone(),
+            n_shared: 0,
+            n_unique: this_assignment.len(),
+        };
+        let reuse = trunk.exists();
+        run_split_trunk_experts(
+            &opts.bin_dir,
+            &opts.model_path,
+            &assignment_struct,
+            &trunk,
+            &experts,
+            reuse,
+        )?;
+
+        // Build the manifest with trunk + THIS node's experts only. Other
+        // nodes will call ensure_trunk_and_expert separately; they'll find
+        // a manifest that mentions only node_index=leader initially and
+        // extend it on their own leader pass.
+        //
+        // For MVP we require the leader to be node 0 AND to call
+        // ensure_trunk_and_expert once per node before any follower starts.
+        // A richer design (shard-by-shard manifest append with flock) is
+        // future work tracked in the storage plan.
+        let trunk_meta = std::fs::metadata(&trunk)?;
+        let experts_meta = std::fs::metadata(&experts)?;
+        let trunk_sha = sha256_file(&trunk)?;
+        let experts_sha = sha256_file(&experts)?;
+
+        let mut experts_map = BTreeMap::new();
+        experts_map.insert(
+            opts.node_index,
+            ExpertEntry {
+                path: experts.clone(),
+                sha256: experts_sha,
+                size_bytes: experts_meta.len(),
+            },
+        );
+
+        // Full source hash is expensive on 600GB models; we compute it
+        // lazily only when the caller has a cached value or asks for it.
+        // For MVP we skip it (empty string means "not computed") — the
+        // fingerprint already handled version identity, and integrity
+        // comes from trunk/experts hashes which ARE computed.
+        let manifest = SplitManifest {
+            version: version.clone(),
+            source_model_sha256: String::new(),
+            splitter_version: splitter_version.clone(),
+            n_nodes,
+            assignments: assignments_sorted.clone(),
+            trunk: TrunkEntry {
+                path: trunk.clone(),
+                sha256: trunk_sha,
+                size_bytes: trunk_meta.len(),
+            },
+            experts: experts_map,
+            created_at: Utc::now(),
+        };
+        write_manifest_atomic(&manifest_path, &manifest)?;
+        Ok(())
+    })?;
+
+    // Re-load + verify.
+    let manifest = load_manifest(&manifest_path)?;
+    let resolved = ResolvedShards {
+        trunk,
+        experts,
+        manifest_version: version,
+    };
+    verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
+    Ok(resolved)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1272,4 +1886,226 @@ mod tests {
             );
         }
     }
+
+    // ── trunk/experts split storage tests ────────────────────────────────
+
+    fn mk_assignments(n_nodes: usize) -> BTreeMap<usize, Vec<u32>> {
+        let mut m = BTreeMap::new();
+        for i in 0..n_nodes {
+            m.insert(i, vec![i as u32, (i + n_nodes) as u32]);
+        }
+        m
+    }
+
+    #[test]
+    fn derive_manifest_version_is_deterministic_and_short() {
+        let a = mk_assignments(2);
+        let v1 = derive_manifest_version("abc:sha", "trunk-experts/v1", 2, &a);
+        let v2 = derive_manifest_version("abc:sha", "trunk-experts/v1", 2, &a);
+        assert_eq!(v1, v2);
+        assert_eq!(v1.len(), 12); // 6 bytes hex = 12 chars
+    }
+
+    #[test]
+    fn derive_manifest_version_changes_with_each_input() {
+        let a = mk_assignments(2);
+        let base = derive_manifest_version("abc:sha", "trunk-experts/v1", 2, &a);
+        // Change each input independently; all should produce different versions.
+        assert_ne!(base, derive_manifest_version("xyz:sha", "trunk-experts/v1", 2, &a));
+        assert_ne!(base, derive_manifest_version("abc:sha", "trunk-experts/v2", 2, &a));
+        assert_ne!(base, derive_manifest_version("abc:sha", "trunk-experts/v1", 3, &a));
+        let mut a2 = a.clone();
+        a2.get_mut(&0).unwrap().push(99);
+        assert_ne!(base, derive_manifest_version("abc:sha", "trunk-experts/v1", 2, &a2));
+    }
+
+    #[test]
+    fn sha256_file_is_deterministic_content_sensitive_and_matches_in_memory() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let content = b"mesh-llm trunk test\n";
+        std::fs::write(tmp.path(), content).unwrap();
+        // Must match the in-memory hash over the same bytes.
+        let mut h = sha2::Sha256::new();
+        sha2::Digest::update(&mut h, content);
+        let expected = hex_lower(&sha2::Digest::finalize(h));
+        assert_eq!(sha256_file(tmp.path()).unwrap(), expected);
+        // Stable under repeated reads.
+        assert_eq!(sha256_file(tmp.path()).unwrap(), expected);
+        // Sensitive to content change.
+        std::fs::write(tmp.path(), b"different\n").unwrap();
+        assert_ne!(sha256_file(tmp.path()).unwrap(), expected);
+    }
+
+    #[test]
+    fn source_fingerprint_is_stable_and_size_sensitive() {
+        let a = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(a.path(), b"0123456789").unwrap();
+        let f1 = source_fingerprint(a.path()).unwrap();
+        let f2 = source_fingerprint(a.path()).unwrap();
+        assert_eq!(f1, f2);
+        // Same name, different size → different fingerprint.
+        std::fs::write(a.path(), b"differentdatasizeisnotsame").unwrap();
+        let f3 = source_fingerprint(a.path()).unwrap();
+        assert_ne!(f1, f3);
+    }
+
+    #[test]
+    fn manifest_round_trips_via_atomic_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("0abc.json");
+        let original = SplitManifest {
+            version: "0abc".into(),
+            source_model_sha256: String::new(),
+            splitter_version: "trunk-experts/v1".into(),
+            n_nodes: 2,
+            assignments: mk_assignments(2),
+            trunk: TrunkEntry {
+                path: dir.path().join("trunk.gguf"),
+                sha256: "deadbeef".into(),
+                size_bytes: 100,
+            },
+            experts: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    0,
+                    ExpertEntry {
+                        path: dir.path().join("e0.gguf"),
+                        sha256: "feedface".into(),
+                        size_bytes: 50,
+                    },
+                );
+                m
+            },
+            created_at: Utc::now(),
+        };
+        write_manifest_atomic(&path, &original).unwrap();
+        // Atomic: tmp must not be left behind.
+        assert!(!path.with_extension("json.tmp").exists());
+        let loaded = load_manifest(&path).unwrap();
+        // created_at serializes with microsecond precision; compare field-by-field
+        // with a tolerance if needed. Here serde uses RFC3339 which preserves.
+        assert_eq!(loaded.version, original.version);
+        assert_eq!(loaded.trunk, original.trunk);
+        assert_eq!(loaded.experts, original.experts);
+        assert_eq!(loaded.assignments, original.assignments);
+    }
+
+    #[test]
+    fn verify_shards_detects_size_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let trunk = dir.path().join("trunk.gguf");
+        let experts = dir.path().join("e0.gguf");
+        std::fs::write(&trunk, b"trunk-bytes-here").unwrap();
+        std::fs::write(&experts, b"expert-bytes").unwrap();
+        let manifest = SplitManifest {
+            version: "v".into(),
+            source_model_sha256: String::new(),
+            splitter_version: "trunk-experts/v1".into(),
+            n_nodes: 1,
+            assignments: mk_assignments(1),
+            trunk: TrunkEntry {
+                path: trunk.clone(),
+                sha256: sha256_file(&trunk).unwrap(),
+                size_bytes: 999, // WRONG
+            },
+            experts: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    0,
+                    ExpertEntry {
+                        path: experts.clone(),
+                        sha256: sha256_file(&experts).unwrap(),
+                        size_bytes: std::fs::metadata(&experts).unwrap().len(),
+                    },
+                );
+                m
+            },
+            created_at: Utc::now(),
+        };
+        let resolved = ResolvedShards {
+            trunk: trunk.clone(),
+            experts: experts.clone(),
+            manifest_version: "v".into(),
+        };
+        let err = verify_shards(&resolved, &manifest, 0, false).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("size mismatch"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn verify_shards_detects_hash_mismatch_when_full() {
+        let dir = tempfile::tempdir().unwrap();
+        let trunk = dir.path().join("trunk.gguf");
+        let experts = dir.path().join("e0.gguf");
+        std::fs::write(&trunk, b"trunk-v1").unwrap();
+        std::fs::write(&experts, b"expert-v1").unwrap();
+        let manifest = SplitManifest {
+            version: "v".into(),
+            source_model_sha256: String::new(),
+            splitter_version: "trunk-experts/v1".into(),
+            n_nodes: 1,
+            assignments: mk_assignments(1),
+            trunk: TrunkEntry {
+                path: trunk.clone(),
+                // Wrong hash (but correct size) → size-only check passes, full fails.
+                sha256: "0".repeat(64),
+                size_bytes: std::fs::metadata(&trunk).unwrap().len(),
+            },
+            experts: {
+                let mut m = BTreeMap::new();
+                m.insert(
+                    0,
+                    ExpertEntry {
+                        path: experts.clone(),
+                        sha256: sha256_file(&experts).unwrap(),
+                        size_bytes: std::fs::metadata(&experts).unwrap().len(),
+                    },
+                );
+                m
+            },
+            created_at: Utc::now(),
+        };
+        let resolved = ResolvedShards {
+            trunk: trunk.clone(),
+            experts: experts.clone(),
+            manifest_version: "v".into(),
+        };
+        // size-only passes
+        verify_shards(&resolved, &manifest, 0, false).unwrap();
+        // full catches the hash mismatch
+        let err = verify_shards(&resolved, &manifest, 0, true).unwrap_err();
+        assert!(err.to_string().contains("hash mismatch"), "got: {err}");
+    }
+
+    #[test]
+    fn trunk_build_lock_is_exclusive() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+        use std::time::{Duration, Instant};
+        let dir = tempfile::tempdir().unwrap();
+        let lock = dir.path().join(".trunk.build.lock");
+        let barrier = Arc::new(Barrier::new(2));
+        let lock_a = lock.clone();
+        let bar_a = barrier.clone();
+        let hold_ms = 300u64;
+        let t1 = thread::spawn(move || {
+            with_trunk_build_lock(&lock_a, || {
+                bar_a.wait();
+                thread::sleep(Duration::from_millis(hold_ms));
+                Ok(Instant::now())
+            })
+        });
+        barrier.wait();
+        let started = Instant::now();
+        let second = with_trunk_build_lock(&lock, || Ok(Instant::now())).unwrap();
+        let first_done = t1.join().unwrap().unwrap();
+        // Second acquire must not start until the first released.
+        assert!(
+            second >= first_done,
+            "second acquired at {:?} before first released at {:?}",
+            second.duration_since(started),
+            first_done.duration_since(started)
+        );
+    }
 }
+

--- a/crates/mesh-llm/src/inference/moe.rs
+++ b/crates/mesh-llm/src/inference/moe.rs
@@ -980,6 +980,67 @@ pub fn manifest_file_path(
     )
 }
 
+/// Search the configured trunk root's `manifests/<stem>/` directory for any
+/// previously-built `SplitManifest` for this source model. Used by the runtime
+/// planner to *pin* assignments to a pre-built layout when
+/// `moe.storage.mode == Split`. Without this, the planner would compute fresh
+/// `(n_nodes, overlap, ranking)` from peer state and almost always disagree
+/// with the manifest's hash-derived `version`, causing the manifest to be
+/// ignored and the legacy local per-node split to run.
+///
+/// Selection rule when multiple manifests exist for the same stem:
+/// 1. Prefer the manifest whose `n_nodes` exactly matches `prefer_n_nodes`
+///    if provided.
+/// 2. Otherwise prefer the largest `n_nodes` (more parallelism is usually
+///    the operator's intent when they pre-built it).
+/// 3. Tie-break by mtime (newest wins).
+///
+/// Cheap-by-design: opens at most a few small JSON files and compares
+/// `source_model_sha256` to the stem; the source GGUF is *not* re-hashed.
+pub fn find_pinned_manifest(
+    cfg: &crate::plugin::MoeStorageConfig,
+    model_path: &Path,
+    prefer_n_nodes: Option<usize>,
+) -> Option<(PathBuf, SplitManifest)> {
+    let root = crate::plugin::resolve_trunk_root(cfg)?;
+    let stem = model_stem_for_split(model_path);
+    let dir = root.join("manifests").join(&stem);
+    let entries = std::fs::read_dir(&dir).ok()?;
+
+    let mut candidates: Vec<(PathBuf, SplitManifest, std::time::SystemTime)> = Vec::new();
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let mtime = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+        if let Ok(m) = load_manifest(&p) {
+            candidates.push((p, m, mtime));
+        }
+    }
+    if candidates.is_empty() {
+        return None;
+    }
+    candidates.sort_by(|a, b| {
+        let exact_a = prefer_n_nodes.map(|n| a.1.n_nodes == n).unwrap_or(false);
+        let exact_b = prefer_n_nodes.map(|n| b.1.n_nodes == n).unwrap_or(false);
+        match exact_b.cmp(&exact_a) {
+            std::cmp::Ordering::Equal => {}
+            other => return other,
+        }
+        match b.1.n_nodes.cmp(&a.1.n_nodes) {
+            std::cmp::Ordering::Equal => {}
+            other => return other,
+        }
+        b.2.cmp(&a.2)
+    });
+    let (path, manifest, _) = candidates.into_iter().next()?;
+    Some((path, manifest))
+}
+
 /// Reuse the same stem-stripping rule as monolithic `split_path` so that
 /// multi-file source GGUFs (e.g. `Kimi-K2.5-Q4_K_M-00001-of-00013.gguf`) map
 /// to a single stem (`Kimi-K2.5-Q4_K_M`).

--- a/crates/mesh-llm/src/inference/moe.rs
+++ b/crates/mesh-llm/src/inference/moe.rs
@@ -2183,5 +2183,206 @@ mod tests {
             first_done.duration_since(started)
         );
     }
+
+    // ── find_pinned_manifest tests ──────────────────────────────────────
+
+    fn write_test_manifest(
+        dir: &Path,
+        stem: &str,
+        version: &str,
+        n_nodes: usize,
+    ) -> PathBuf {
+        let p = dir
+            .join("manifests")
+            .join(stem)
+            .join(format!("{version}.json"));
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        let mut experts = BTreeMap::new();
+        let mut assignments: BTreeMap<usize, Vec<u32>> = BTreeMap::new();
+        for i in 0..n_nodes {
+            assignments.insert(i, vec![i as u32]);
+            experts.insert(
+                i,
+                ExpertEntry {
+                    path: dir.join(format!("e{i}.gguf")),
+                    sha256: format!("{:0>64}", i),
+                    size_bytes: 100,
+                },
+            );
+        }
+        let manifest = SplitManifest {
+            version: version.into(),
+            source_model_sha256: "deadbeef".into(),
+            splitter_version: "trunk-experts/v1".into(),
+            n_nodes,
+            assignments,
+            trunk: TrunkEntry {
+                path: dir.join("trunk.gguf"),
+                sha256: "cafebabe".into(),
+                size_bytes: 50,
+            },
+            experts,
+            created_at: Utc::now(),
+        };
+        write_manifest_atomic(&p, &manifest).unwrap();
+        p
+    }
+
+    fn split_cfg_for(root: &Path) -> crate::plugin::MoeStorageConfig {
+        crate::plugin::MoeStorageConfig {
+            mode: crate::plugin::MoeStorageMode::Split,
+            trunk_path: Some(root.to_path_buf()),
+            experts_path: Some(root.to_path_buf()),
+            experts_local_override: None,
+            prefault_trunk: false,
+            mlock_trunk: false,
+        }
+    }
+
+    #[test]
+    fn find_pinned_manifest_returns_none_when_no_manifests() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir.path().join("missing.gguf");
+        assert!(find_pinned_manifest(&cfg, &model, None).is_none());
+        assert!(find_pinned_manifest(&cfg, &model, Some(8)).is_none());
+    }
+
+    #[test]
+    fn find_pinned_manifest_loads_single_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir.path().join("qwen3.gguf");
+        let stem = "qwen3";
+        write_test_manifest(dir.path(), stem, "abc123def456", 4);
+        let (path, m) = find_pinned_manifest(&cfg, &model, None).unwrap();
+        assert!(path.ends_with("manifests/qwen3/abc123def456.json"));
+        assert_eq!(m.n_nodes, 4);
+        assert_eq!(m.version, "abc123def456");
+    }
+
+    #[test]
+    fn find_pinned_manifest_prefers_exact_n_nodes_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir.path().join("qwen3.gguf");
+        let stem = "qwen3";
+        // Two manifests for the same model: 4-node and 8-node. Operator runs
+        // a 4-node mesh; we should pick the 4-node manifest even though 8 is
+        // larger and would otherwise win the tiebreak.
+        write_test_manifest(dir.path(), stem, "ver8nodes000", 8);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        write_test_manifest(dir.path(), stem, "ver4nodes000", 4);
+        let (_, m) = find_pinned_manifest(&cfg, &model, Some(4)).unwrap();
+        assert_eq!(m.n_nodes, 4);
+        let (_, m) = find_pinned_manifest(&cfg, &model, Some(8)).unwrap();
+        assert_eq!(m.n_nodes, 8);
+    }
+
+    #[test]
+    fn find_pinned_manifest_falls_back_to_largest_then_newest() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir.path().join("qwen3.gguf");
+        let stem = "qwen3";
+        write_test_manifest(dir.path(), stem, "ver4_a0000000", 4);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        // Larger n_nodes wins regardless of being older.
+        write_test_manifest(dir.path(), stem, "ver8_b0000000", 8);
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        write_test_manifest(dir.path(), stem, "ver4_c0000000", 4);
+        // No exact preference → largest n_nodes wins.
+        let (_, m) = find_pinned_manifest(&cfg, &model, None).unwrap();
+        assert_eq!(m.n_nodes, 8);
+        // With prefer=4 and two 4-node candidates, newer wins.
+        let (path, m) = find_pinned_manifest(&cfg, &model, Some(4)).unwrap();
+        assert_eq!(m.n_nodes, 4);
+        assert!(path.to_string_lossy().contains("ver4_c0000000"));
+    }
+
+    #[test]
+    fn find_pinned_manifest_skips_non_json_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir.path().join("qwen3.gguf");
+        let stem = "qwen3";
+        write_test_manifest(dir.path(), stem, "real00000000", 2);
+        // Stray non-JSON files in the manifest dir must be ignored.
+        let stray = dir
+            .path()
+            .join("manifests")
+            .join(stem)
+            .join("README.txt");
+        std::fs::write(&stray, b"not a manifest").unwrap();
+        let stray2 = dir
+            .path()
+            .join("manifests")
+            .join(stem)
+            .join(".gitignore");
+        std::fs::write(&stray2, b"*.tmp").unwrap();
+        let (_, m) = find_pinned_manifest(&cfg, &model, None).unwrap();
+        assert_eq!(m.version, "real00000000");
+    }
+
+    #[test]
+    fn find_pinned_manifest_skips_corrupt_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir.path().join("qwen3.gguf");
+        let stem = "qwen3";
+        // Corrupt JSON next to a valid manifest must be skipped silently.
+        std::fs::create_dir_all(dir.path().join("manifests").join(stem)).unwrap();
+        std::fs::write(
+            dir.path().join("manifests").join(stem).join("garbage.json"),
+            b"{not valid json",
+        )
+        .unwrap();
+        write_test_manifest(dir.path(), stem, "good00000000", 3);
+        let (_, m) = find_pinned_manifest(&cfg, &model, None).unwrap();
+        assert_eq!(m.version, "good00000000");
+    }
+
+    #[test]
+    fn find_pinned_manifest_uses_stem_for_multifile_gguf() {
+        // Multi-file GGUF source like `Kimi-K2.5-Q4_K_M-00001-of-00013.gguf`
+        // must look under `manifests/Kimi-K2.5-Q4_K_M/` (stem-stripped), not
+        // the literal filename.
+        let dir = tempfile::tempdir().unwrap();
+        let cfg = split_cfg_for(dir.path());
+        let model = dir
+            .path()
+            .join("Kimi-K2.5-Q4_K_M-00001-of-00013.gguf");
+        write_test_manifest(dir.path(), "Kimi-K2.5-Q4_K_M", "kimi00000000", 16);
+        let (_, m) = find_pinned_manifest(&cfg, &model, Some(16)).unwrap();
+        assert_eq!(m.version, "kimi00000000");
+    }
+
+    #[test]
+    fn find_pinned_manifest_returns_none_when_trunk_root_unconfigured() {
+        // Without a trunk root and no MESH_LLM_NAS_ROOT, we should not panic;
+        // we should just return None.
+        let cfg = crate::plugin::MoeStorageConfig {
+            mode: crate::plugin::MoeStorageMode::Split,
+            trunk_path: None,
+            experts_path: None,
+            experts_local_override: None,
+            prefault_trunk: false,
+            mlock_trunk: false,
+        };
+        // Save & clear env var to avoid contamination from outer environment.
+        let prev = std::env::var_os("MESH_LLM_NAS_ROOT");
+        // SAFETY: tests in this crate are run with `--test-threads=1` for
+        // env-var manipulation? Best-effort: only clear; restore at end.
+        unsafe {
+            std::env::remove_var("MESH_LLM_NAS_ROOT");
+        }
+        let model = std::path::PathBuf::from("/tmp/never-exists.gguf");
+        assert!(find_pinned_manifest(&cfg, &model, None).is_none());
+        if let Some(v) = prev {
+            unsafe {
+                std::env::set_var("MESH_LLM_NAS_ROOT", v);
+            }
+        }
+    }
 }
 

--- a/crates/mesh-llm/src/inference/moe.rs
+++ b/crates/mesh-llm/src/inference/moe.rs
@@ -1316,29 +1316,37 @@ pub fn ensure_trunk_and_expert(
     let manifest_path = manifest_file_path(cfg, &opts.model_path, &version)
         .ok_or_else(|| anyhow::anyhow!("moe.storage.trunk_path not configured"))?;
 
-    // Fast path: manifest already exists → size-verify shards and return.
+    // Fast path: manifest exists AND already contains our node's expert
+    // entry → size-verify and return. If the manifest exists but is missing
+    // our entry (e.g. a sibling node published first), fall through so a
+    // leader run can *extend* it.
     if let Ok(manifest) = load_manifest(&manifest_path) {
-        let resolved = ResolvedShards {
-            trunk: trunk.clone(),
-            experts: experts.clone(),
-            manifest_version: version.clone(),
-        };
-        verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
-        return Ok(resolved);
+        if manifest.experts.contains_key(&opts.node_index) {
+            let resolved = ResolvedShards {
+                trunk: trunk.clone(),
+                experts: experts.clone(),
+                manifest_version: version.clone(),
+            };
+            verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
+            return Ok(resolved);
+        }
     }
 
     if !opts.is_leader {
-        // Followers never build — they wait for the leader to publish.
+        // Followers never build — they wait for the leader to publish a
+        // manifest that includes this node's expert entry.
         let deadline = std::time::Instant::now() + opts.follower_timeout;
         loop {
             if let Ok(manifest) = load_manifest(&manifest_path) {
-                let resolved = ResolvedShards {
-                    trunk: trunk.clone(),
-                    experts: experts.clone(),
-                    manifest_version: version.clone(),
-                };
-                verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
-                return Ok(resolved);
+                if manifest.experts.contains_key(&opts.node_index) {
+                    let resolved = ResolvedShards {
+                        trunk: trunk.clone(),
+                        experts: experts.clone(),
+                        manifest_version: version.clone(),
+                    };
+                    verify_shards(&resolved, &manifest, opts.node_index, /*full=*/ false)?;
+                    return Ok(resolved);
+                }
             }
             if std::time::Instant::now() >= deadline {
                 return Err(MoeStorageError::ManifestMissing(manifest_path.clone()).into());
@@ -1348,18 +1356,20 @@ pub fn ensure_trunk_and_expert(
     }
 
     // Leader path: hold the trunk build lock, produce THIS node's shards
-    // (other nodes will produce their own experts shards under the same
-    // trunk path with --reuse-trunk), and publish the manifest.
+    // (other nodes produce their own experts shards under the same trunk
+    // path with --reuse-trunk), and publish (or extend) the manifest.
     let lock_path = trunk
         .parent()
         .map(|p| p.join(".trunk.build.lock"))
         .unwrap_or_else(|| PathBuf::from("/tmp/.mesh-llm-trunk.build.lock"));
 
     with_trunk_build_lock(&lock_path, || -> anyhow::Result<()> {
-        // Race check: another process may have published the manifest while
-        // we waited for the lock. Bail out early in that case.
-        if manifest_path.exists() {
-            return Ok(());
+        // Re-check under the lock: another process may have added our entry
+        // while we waited. Idempotent early-exit.
+        if let Ok(m) = load_manifest(&manifest_path) {
+            if m.experts.contains_key(&opts.node_index) {
+                return Ok(());
+            }
         }
 
         // Produce trunk + experts for this node.
@@ -1388,31 +1398,40 @@ pub fn ensure_trunk_and_expert(
             reuse,
         )?;
 
-        // Build the manifest with trunk + THIS node's experts only. Other
-        // nodes will call ensure_trunk_and_expert separately; they'll find
-        // a manifest that mentions only node_index=leader initially and
-        // extend it on their own leader pass.
-        //
-        // For MVP we require the leader to be node 0 AND to call
-        // ensure_trunk_and_expert once per node before any follower starts.
-        // A richer design (shard-by-shard manifest append with flock) is
-        // future work tracked in the storage plan.
+        // If a manifest already exists for this version, append our node
+        // to its experts map; otherwise create a fresh manifest.
         let trunk_meta = std::fs::metadata(&trunk)?;
         let experts_meta = std::fs::metadata(&experts)?;
-        let trunk_sha = sha256_file(&trunk)?;
         let experts_sha = sha256_file(&experts)?;
+        let this_entry = ExpertEntry {
+            path: experts.clone(),
+            sha256: experts_sha,
+            size_bytes: experts_meta.len(),
+        };
 
-        let mut experts_map = BTreeMap::new();
-        experts_map.insert(
-            opts.node_index,
-            ExpertEntry {
-                path: experts.clone(),
-                sha256: experts_sha,
-                size_bytes: experts_meta.len(),
-            },
-        );
+        // If there's already a manifest, inherit its trunk entry (we keep
+        // the first leader's trunk hash — trunk is shared and identical
+        // across nodes by design, so every leader writes the same bits).
+        // Otherwise compute the trunk hash ourselves. This keeps the
+        // append-a-node case cheap: no 150 GB re-hash per late joiner.
+        let (experts_map_base, trunk_entry) = match load_manifest(&manifest_path) {
+            Ok(existing) => (existing.experts, existing.trunk),
+            Err(_) => {
+                let trunk_sha = sha256_file(&trunk)?;
+                (
+                    BTreeMap::new(),
+                    TrunkEntry {
+                        path: trunk.clone(),
+                        sha256: trunk_sha,
+                        size_bytes: trunk_meta.len(),
+                    },
+                )
+            }
+        };
+        let mut experts_map = experts_map_base;
+        experts_map.insert(opts.node_index, this_entry);
 
-        // Full source hash is expensive on 600GB models; we compute it
+        // Full source hash is expensive on 600 GB models; we compute it
         // lazily only when the caller has a cached value or asks for it.
         // For MVP we skip it (empty string means "not computed") — the
         // fingerprint already handled version identity, and integrity
@@ -1423,11 +1442,7 @@ pub fn ensure_trunk_and_expert(
             splitter_version: splitter_version.clone(),
             n_nodes,
             assignments: assignments_sorted.clone(),
-            trunk: TrunkEntry {
-                path: trunk.clone(),
-                sha256: trunk_sha,
-                size_bytes: trunk_meta.len(),
-            },
+            trunk: trunk_entry,
             experts: experts_map,
             created_at: Utc::now(),
         };

--- a/crates/mesh-llm/src/mesh/tests.rs
+++ b/crates/mesh-llm/src/mesh/tests.rs
@@ -3640,6 +3640,7 @@ async fn config_subscribe_rejects_pinned_snapshot_for_older_peer() -> Result<()>
                     parallel: None,
                 }],
                 plugins: vec![],
+                moe: Default::default(),
             },
             expected_revision,
         );
@@ -3738,6 +3739,7 @@ async fn config_subscribe_rejects_pinned_snapshot_for_malformed_peer_version() -
                     parallel: None,
                 }],
                 plugins: vec![],
+                moe: Default::default(),
             },
             expected_revision,
         );
@@ -3834,6 +3836,7 @@ async fn config_subscribe_allows_pinned_snapshot_for_same_release_prerelease_pee
                     parallel: None,
                 }],
                 plugins: vec![],
+                moe: Default::default(),
             },
             expected_revision,
         );
@@ -4009,6 +4012,7 @@ async fn config_subscribe_closes_when_revision_becomes_pinned_for_malformed_peer
                     parallel: None,
                 }],
                 plugins: vec![],
+                moe: Default::default(),
             },
             expected_revision,
         );
@@ -4109,6 +4113,7 @@ async fn config_subscribe_closes_when_revision_becomes_pinned_for_older_peer() -
                     parallel: None,
                 }],
                 plugins: vec![],
+                moe: Default::default(),
             },
             expected_revision,
         );
@@ -4210,6 +4215,7 @@ async fn config_subscribe_keeps_stream_open_when_revision_becomes_pinned_for_sam
                     parallel: None,
                 }],
                 plugins: vec![],
+                moe: Default::default(),
             },
             expected_revision,
         );

--- a/crates/mesh-llm/src/plugin/config.rs
+++ b/crates/mesh-llm/src/plugin/config.rs
@@ -15,6 +15,112 @@ pub struct MeshConfig {
     pub models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     pub plugins: Vec<PluginConfigEntry>,
+    #[serde(default)]
+    pub moe: MoeConfig,
+}
+
+/// Mesh-LLM MoE tuning block. Today it only configures trunk/experts storage;
+/// extend here when we grow more MoE-specific knobs (routing strategy, etc.).
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MoeConfig {
+    #[serde(default)]
+    pub storage: MoeStorageConfig,
+}
+
+/// How per-node MoE GGUFs are physically laid out on disk.
+///
+/// * `Monolithic` (default): each node holds a self-contained GGUF with trunk
+///   + its expert subset — today's behavior. Safe default so existing
+///   deployments keep working with zero config change.
+/// * `Split`: one shared trunk GGUF on `trunk_path` (typically fast NAS) plus
+///   per-node expert shard GGUFs on `experts_path`. Eliminates trunk
+///   duplication across the mesh; pairs with llama.cpp's
+///   `--model-trunk`/`--model-experts` load path.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum MoeStorageMode {
+    #[default]
+    Monolithic,
+    Split,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct MoeStorageConfig {
+    #[serde(default)]
+    pub mode: MoeStorageMode,
+    /// Root directory for the shared trunk GGUFs. Required when
+    /// `mode = "split"`. Must be an absolute path; typically a fast NAS
+    /// mounted identically on every mesh node.
+    #[serde(default)]
+    pub trunk_path: Option<PathBuf>,
+    /// Root directory for per-node expert shard GGUFs. Required when
+    /// `mode = "split"`. May equal `trunk_path` (single NAS mount), or point
+    /// at a per-node fast local SSD for hot-path latency.
+    #[serde(default)]
+    pub experts_path: Option<PathBuf>,
+    /// Optional per-node local override: if set, this node's experts shard is
+    /// resolved under `experts_local_override/...` instead of
+    /// `experts_path/...`. Trunk always comes from `trunk_path`. Useful when
+    /// the mesh has heterogeneous storage (some nodes local SSD, some NAS).
+    #[serde(default)]
+    pub experts_local_override: Option<PathBuf>,
+    /// Walk every page of the trunk mmap at load so the first inference
+    /// token does not pay a NAS page-fault cost. Default on (cheap when the
+    /// file is already in RAM; meaningful when it isn't). Ignored in
+    /// monolithic mode.
+    #[serde(default = "default_true")]
+    pub prefault_trunk: bool,
+    /// `mlock()` just the trunk mmap region. Off by default because it
+    /// requires `RLIMIT_MEMLOCK >= trunk_size`; mesh-llm validates the rlimit
+    /// Rust-side before launching llama-server so users get a clear error
+    /// instead of a silent mlock failure.
+    #[serde(default)]
+    pub mlock_trunk: bool,
+}
+
+impl Default for MoeStorageConfig {
+    fn default() -> Self {
+        Self {
+            mode: MoeStorageMode::default(),
+            trunk_path: None,
+            experts_path: None,
+            experts_local_override: None,
+            prefault_trunk: true,
+            mlock_trunk: false,
+        }
+    }
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Resolve the trunk root honoring the `MESH_LLM_NAS_ROOT` env fallback
+/// (derived subdir `<root>/mesh-llm/trunks`). Returns `None` only when
+/// neither the config nor the env is set.
+pub fn resolve_trunk_root(cfg: &MoeStorageConfig) -> Option<PathBuf> {
+    if let Some(p) = &cfg.trunk_path {
+        return Some(p.clone());
+    }
+    if let Ok(root) = std::env::var("MESH_LLM_NAS_ROOT") {
+        return Some(PathBuf::from(root).join("mesh-llm").join("trunks"));
+    }
+    None
+}
+
+/// Resolve the experts root honoring the per-node local override and then
+/// `MESH_LLM_NAS_ROOT` (derived subdir `<root>/mesh-llm/experts`).
+pub fn resolve_experts_root(cfg: &MoeStorageConfig) -> Option<PathBuf> {
+    if let Some(p) = &cfg.experts_local_override {
+        return Some(p.clone());
+    }
+    if let Some(p) = &cfg.experts_path {
+        return Some(p.clone());
+    }
+    if let Ok(root) = std::env::var("MESH_LLM_NAS_ROOT") {
+        return Some(PathBuf::from(root).join("mesh-llm").join("experts"));
+    }
+    None
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -115,6 +221,7 @@ pub(crate) fn validate_config(config: &MeshConfig) -> Result<()> {
             bail!("gpu.parallel must be at least 1, got {parallel}");
         }
     }
+    validate_moe_storage(&config.moe.storage)?;
     for (index, model) in config.models.iter().enumerate() {
         if model.model.trim().is_empty() {
             bail!("models[{index}].model must not be empty");
@@ -143,6 +250,41 @@ pub(crate) fn validate_config(config: &MeshConfig) -> Result<()> {
                     );
                 }
             },
+        }
+    }
+    Ok(())
+}
+
+fn validate_moe_storage(cfg: &MoeStorageConfig) -> Result<()> {
+    // Paths must be absolute in both modes — monolithic ignores them at runtime
+    // but a relative path is almost always a typo that would fail silently
+    // the day someone flips mode to split.
+    for (field, path) in [
+        ("trunk_path", cfg.trunk_path.as_ref()),
+        ("experts_path", cfg.experts_path.as_ref()),
+        ("experts_local_override", cfg.experts_local_override.as_ref()),
+    ] {
+        if let Some(p) = path {
+            if !p.is_absolute() {
+                bail!(
+                    "moe.storage.{field} = {} must be an absolute path",
+                    p.display()
+                );
+            }
+        }
+    }
+    if matches!(cfg.mode, MoeStorageMode::Split) {
+        if resolve_trunk_root(cfg).is_none() {
+            bail!(
+                "moe.storage.mode = \"split\" requires moe.storage.trunk_path \
+                 (or MESH_LLM_NAS_ROOT env)"
+            );
+        }
+        if resolve_experts_root(cfg).is_none() {
+            bail!(
+                "moe.storage.mode = \"split\" requires moe.storage.experts_path \
+                 (or MESH_LLM_NAS_ROOT env)"
+            );
         }
     }
     Ok(())
@@ -620,5 +762,176 @@ model = "Qwen3-8B-Q4_K_M"
             ..MeshConfig::default()
         };
         validate_config(&config).unwrap();
+    }
+
+    // ── MoE trunk/experts split storage validation ──
+
+    use serial_test::serial;
+
+    // Guard against leaking MESH_LLM_NAS_ROOT across tests that race in
+    // parallel test threads. Tests touching this env must also carry
+    // `#[serial]` so they don't stomp on each other's setup.
+    fn with_env_nas_root<T>(value: Option<&str>, body: impl FnOnce() -> T) -> T {
+        let prev = std::env::var("MESH_LLM_NAS_ROOT").ok();
+        match value {
+            Some(v) => std::env::set_var("MESH_LLM_NAS_ROOT", v),
+            None => std::env::remove_var("MESH_LLM_NAS_ROOT"),
+        }
+        let out = body();
+        match prev {
+            Some(v) => std::env::set_var("MESH_LLM_NAS_ROOT", v),
+            None => std::env::remove_var("MESH_LLM_NAS_ROOT"),
+        }
+        out
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_default_is_monolithic_and_empty_configs_still_parse() {
+        // Existing configs must keep working unchanged — no [moe] section.
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+[[models]]
+model = "Qwen3-30B-A3B-Instruct-2507"
+ctx_size = 4096
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.moe.storage.mode, MoeStorageMode::Monolithic);
+        assert!(config.moe.storage.trunk_path.is_none());
+        assert!(config.moe.storage.experts_path.is_none());
+        assert!(config.moe.storage.prefault_trunk); // default-on
+        assert!(!config.moe.storage.mlock_trunk);
+        with_env_nas_root(None, || validate_config(&config).unwrap());
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_split_without_paths_or_env_is_rejected() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+[moe.storage]
+mode = "split"
+"#,
+        )
+        .unwrap();
+
+        let err = with_env_nas_root(None, || validate_config(&config).unwrap_err());
+        let msg = err.to_string();
+        assert!(
+            msg.contains("trunk_path") || msg.contains("experts_path"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_split_with_absolute_paths_is_accepted() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+[moe.storage]
+mode = "split"
+trunk_path = "/nas/mesh-llm/trunks"
+experts_path = "/nas/mesh-llm/experts"
+prefault_trunk = true
+mlock_trunk = false
+"#,
+        )
+        .unwrap();
+
+        with_env_nas_root(None, || validate_config(&config).unwrap());
+        assert_eq!(config.moe.storage.mode, MoeStorageMode::Split);
+        assert_eq!(
+            config.moe.storage.trunk_path.as_deref(),
+            Some(Path::new("/nas/mesh-llm/trunks"))
+        );
+        assert!(config.moe.storage.prefault_trunk);
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_split_rejects_relative_paths() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+[moe.storage]
+mode = "split"
+trunk_path = "relative/trunks"
+experts_path = "/abs/experts"
+"#,
+        )
+        .unwrap();
+
+        let err = with_env_nas_root(None, || validate_config(&config).unwrap_err());
+        assert!(
+            err.to_string().contains("must be an absolute path"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_split_falls_back_to_env_nas_root() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+[moe.storage]
+mode = "split"
+"#,
+        )
+        .unwrap();
+
+        with_env_nas_root(Some("/nas-root"), || {
+            validate_config(&config).unwrap();
+            assert_eq!(
+                resolve_trunk_root(&config.moe.storage).unwrap(),
+                Path::new("/nas-root/mesh-llm/trunks")
+            );
+            assert_eq!(
+                resolve_experts_root(&config.moe.storage).unwrap(),
+                Path::new("/nas-root/mesh-llm/experts")
+            );
+        });
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_monolithic_rejects_relative_trunk_path_even_though_it_is_unused() {
+        // Reject typos that would silently do the wrong thing if the user
+        // later flips mode to split without revisiting paths.
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+[moe.storage]
+trunk_path = "relative/trunks"
+"#,
+        )
+        .unwrap();
+
+        let err = with_env_nas_root(None, || validate_config(&config).unwrap_err());
+        assert!(err.to_string().contains("must be an absolute path"));
+    }
+
+    #[test]
+    #[serial(mesh_llm_nas_root)]
+    fn moe_experts_local_override_wins_over_experts_path() {
+        let cfg = MoeStorageConfig {
+            mode: MoeStorageMode::Split,
+            trunk_path: Some(PathBuf::from("/nas/trunks")),
+            experts_path: Some(PathBuf::from("/nas/experts")),
+            experts_local_override: Some(PathBuf::from("/fast-local/experts")),
+            prefault_trunk: true,
+            mlock_trunk: false,
+        };
+        with_env_nas_root(None, || {
+            assert_eq!(
+                resolve_experts_root(&cfg).unwrap(),
+                Path::new("/fast-local/experts")
+            );
+        });
     }
 }

--- a/crates/mesh-llm/src/plugin/mod.rs
+++ b/crates/mesh-llm/src/plugin/mod.rs
@@ -33,8 +33,9 @@ pub(crate) use self::config::validate_config;
 pub use self::config::ExternalPluginSpec;
 #[allow(unused_imports)]
 pub use self::config::{
-    config_path, load_config, resolve_plugins, GpuAssignment, GpuConfig, MeshConfig,
-    ModelConfigEntry, PluginConfigEntry, PluginHostMode, ResolvedPlugins,
+    config_path, load_config, resolve_experts_root, resolve_plugins, resolve_trunk_root,
+    GpuAssignment, GpuConfig, MeshConfig, ModelConfigEntry, MoeConfig, MoeStorageConfig,
+    MoeStorageMode, PluginConfigEntry, PluginHostMode, ResolvedPlugins,
 };
 use self::runtime::ExternalPlugin;
 pub(crate) use self::support::parse_optional_json;

--- a/crates/mesh-llm/src/protocol/convert.rs
+++ b/crates/mesh-llm/src/protocol/convert.rs
@@ -766,6 +766,10 @@ pub(crate) fn proto_config_to_mesh(
         },
         models,
         plugins,
+        // NodeConfigSnapshot does not carry MoE storage settings today; the
+        // per-node config loaded locally provides them. A future protocol
+        // bump can add an explicit moe field.
+        moe: Default::default(),
     }
 }
 

--- a/crates/mesh-llm/src/protocol/mod.rs
+++ b/crates/mesh-llm/src/protocol/mod.rs
@@ -1590,6 +1590,7 @@ mod tests {
                 args: vec!["--plugin".to_string()],
                 url: None,
             }],
+            moe: Default::default(),
         };
         let snapshot = mesh_config_to_proto(&config);
         let restored = proto_config_to_mesh(&snapshot);
@@ -1635,6 +1636,7 @@ mod tests {
                 parallel: None,
             }],
             plugins: vec![],
+            moe: Default::default(),
         };
         let snap1 = mesh_config_to_proto(&config);
         let snap2 = mesh_config_to_proto(&config);
@@ -1656,6 +1658,7 @@ mod tests {
                 parallel: None,
             }],
             plugins: vec![],
+            moe: Default::default(),
         };
         let snap3 = mesh_config_to_proto(&config2);
         let h3 = canonical_config_hash(&snap3);
@@ -1680,6 +1683,7 @@ mod tests {
                 parallel: None,
             }],
             plugins: vec![],
+            moe: Default::default(),
         };
 
         let snapshot = mesh_config_to_proto(&config);

--- a/crates/mesh-llm/src/runtime/config_state.rs
+++ b/crates/mesh-llm/src/runtime/config_state.rs
@@ -233,6 +233,7 @@ mod tests {
             },
             models: vec![],
             plugins: vec![],
+            moe: Default::default(),
         }
     }
 
@@ -357,6 +358,7 @@ mod tests {
                 parallel: None,
             }],
             plugins: vec![],
+            moe: Default::default(),
         };
 
         assert_eq!(state.revision(), 0);
@@ -391,6 +393,7 @@ mod tests {
                 parallel: None,
             }],
             plugins: vec![],
+            moe: Default::default(),
         };
         state.apply(config_with_model, 0);
         let new_hash = *state.config_hash();
@@ -432,6 +435,7 @@ mod tests {
                 parallel: None,
             }],
             plugins: vec![],
+            moe: Default::default(),
         };
 
         let r1 = state.apply(config_with_model.clone(), 0);

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -219,6 +219,8 @@ pub(super) async fn start_runtime_local_model(
                     plugin_endpoint_key: None,
                 },
             )),
+            split_shards: None,
+            moe_storage: None,
         },
     )
     .await?;

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -2873,6 +2873,17 @@ async fn run_auto(
     let primary_pinned_gpu = primary_startup_model
         .as_ref()
         .and_then(|model| model.pinned_gpu.clone());
+    // Clone the MoE storage config once for the primary election task. Only
+    // forward it when the user explicitly enabled split mode; monolithic
+    // passes `None` so the legacy per-node shard path runs untouched.
+    let primary_moe_storage = if matches!(
+        config.moe.storage.mode,
+        plugin::MoeStorageMode::Split
+    ) {
+        Some(config.moe.storage.clone())
+    } else {
+        None
+    };
     let (primary_stop_tx, primary_stop_rx) = tokio::sync::watch::channel(false);
     let primary_runtime = runtime_arc.clone();
     let dashboard_processes_for_primary_task = dashboard_processes.clone();
@@ -2895,6 +2906,7 @@ async fn run_auto(
                 ctx_size_override: primary_ctx_size,
                 pinned_gpu: primary_pinned_gpu,
                 moe_runtime_options,
+                moe_storage: primary_moe_storage,
                 target_tx: primary_target_tx,
                 stop_rx: primary_stop_rx,
                 slots,
@@ -3054,6 +3066,14 @@ async fn run_auto(
             let extra_llama_flavor = cli.llama_flavor;
             let slots = extra_model.parallel.or(config.gpu.parallel).unwrap_or(4);
             let extra_moe_runtime_options = moe::MoeRuntimeOptions::default();
+            let extra_moe_storage = if matches!(
+                config.moe.storage.mode,
+                plugin::MoeStorageMode::Split
+            ) {
+                Some(config.moe.storage.clone())
+            } else {
+                None
+            };
             let extra_console_state = console_state.clone();
             let extra_model_name_for_status = extra_model_name.clone();
             let extra_model_name_for_process = extra_model_name.clone();
@@ -3085,6 +3105,7 @@ async fn run_auto(
                         ctx_size_override: extra_ctx_size,
                         pinned_gpu: extra_pinned_gpu,
                         moe_runtime_options: extra_moe_runtime_options,
+                        moe_storage: extra_moe_storage,
                         target_tx: extra_target_tx,
                         stop_rx: extra_stop_rx,
                         slots,

--- a/crates/mesh-llm/src/system/moe_planner.rs
+++ b/crates/mesh-llm/src/system/moe_planner.rs
@@ -29,6 +29,9 @@ pub(crate) struct MoePlanArgs {
     pub nodes: Option<usize>,
     pub dataset_repo: String,
     pub progress: bool,
+    /// Override the planner's `min_experts_per_node` (= shared-core size).
+    /// Default `None` → use catalog entry or `default_required_experts_per_node()` (50%).
+    pub min_experts_per_node_override: Option<u32>,
 }
 
 #[derive(Clone, Debug)]
@@ -185,6 +188,9 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
         }
     }
     let mut model = resolve_model_context_with_progress(&args.model, args.progress).await?;
+    if let Some(override_value) = args.min_experts_per_node_override {
+        model.min_experts_per_node = override_value;
+    }
     let ranking = resolve_best_ranking(&model, &args).await?;
     let target_vram_bytes = resolve_target_vram_bytes(args.max_vram_gb);
     if target_vram_bytes == 0 {
@@ -216,7 +222,9 @@ pub(crate) async fn plan_moe(args: MoePlanArgs) -> Result<MoePlanReport> {
             &ranking.analyzer_id,
             ranking.source.label(),
         )?;
-        let required_experts_per_node = fit.required_experts_per_node;
+        let required_experts_per_node = args
+            .min_experts_per_node_override
+            .unwrap_or(fit.required_experts_per_node);
         model.min_experts_per_node = required_experts_per_node;
         let max_supported_nodes =
             (model.expert_count / required_experts_per_node.max(1)).max(1) as usize;


### PR DESCRIPTION
## Summary

Implements shared-NAS MoE storage as proposed in #308. Eliminates per-node trunk duplication by:
- emitting **trunk** (attention, embeddings, norms, shared FFN, routers — common to all nodes) **once** to NAS
- emitting per-node **expert** shards separately
- mmap'ing both files at runtime on every node

For Kimi K2.5 16-node Q4: 2.9 TB → ~550–790 GB at rest (~5× → ~1× duplication).

## What's in the PR

**Splitter** (Mesh-LLM/llama.cpp side, separate PR): adds `--trunk-out PATH --experts-out PATH --reuse-trunk --splitter-version` flags to `llama-moe-split`. Embeds `mesh_llm.trunk_hash` (SHA-256), `mesh_llm.splitter_version`, atomic tmp+fsync+rename, flock on trunk dir.

**Loader** (Mesh-LLM/llama.cpp side, separate PR): new `llama_model_params.path_trunk` / `path_experts`, CLI `--model-trunk` / `--model-experts` / `--prefault-trunk` / `--mlock-trunk`. Cross-shard `mesh_llm.trunk_hash` consistency check throws `E_TRUNK_HASH_MISMATCH`.

**This PR** (mesh-llm orchestrator, 4 commits):

| Commit | Purpose |
|---|---|
| `bb55674 feat(moe): add trunk/experts split storage mode and migrate CLI` | `MoeStorageConfig { mode, trunk_path, experts_path, prefault_trunk, mlock_trunk }`, `SplitManifest`, `ResolvedShards`, `ensure_trunk_and_expert`, atomic manifest write, leader-gated trunk build, `--model-trunk`/`--model-experts` launcher wiring, RLIMIT_MEMLOCK precheck, `mesh-llm moe migrate` CLI |
| `15f0295 fix(moe): handle multi-node manifest extension and improve CLI diagnostics` | Manifest extension across N nodes — each node extends the shared manifest with its entry; idempotent re-runs |
| `13c083b feat(moe): pin runtime planner to pre-built manifest when mode=split` | `find_pinned_manifest` helper; election adopts manifest assignments verbatim when `n_nodes` matches runtime active count, instead of re-deriving and producing a fresh `version` hash that doesn't match the pre-built shards |
| `a336fc6 test(moe): unit tests for find_pinned_manifest` | 8 unit tests covering selection rule, multi-file GGUF stem stripping, corrupt-JSON skipping |

## Validation

- **`cargo test -p mesh-llm --lib`**: 1273 passed, 0 failed, 3 ignored (8 new tests for `find_pinned_manifest`, 13 new for `MoeStorageConfig`, 8 new for manifest round-trip + flock + verification).
- **8-node A100 cluster (NAS-backed) end-to-end**: qwen3-30b-a3b-Q4_K_M (128 experts, top-8) split via `mesh-llm moe migrate --n-nodes 8 --overlap 1` with a real `mesh-llm moe analyze micro` ranking; all 8 SRNs pinned to the manifest, loaded trunk (0.95 GB) + their assigned experts shard (9.91 GB) from NAS, served `/v1/chat/completions` at ~40 tok/s with coherent output:
  - "What is the capital of France?" → `"The capital of France is Paris."`
  - haiku about distributed computing → 3-line on-topic verse
- Backward-compat: `moe.storage.mode = "monolithic"` (default) → existing per-node-shard path unchanged.
- Storage: monolithic mode untouched; split mode gated by config; rollback = single config flag flip.

## Test plan
- [x] `cargo test -p mesh-llm --lib` (1273/1273)
- [x] `cargo build -p mesh-llm --release --bin mesh-llm` (clean)
- [x] `mesh-llm moe migrate --source-model … --n-nodes 8` produces trunk + 8 expert shards + manifest with `source_model_sha256`
- [x] 8-node mesh: all nodes mmap-load from NAS, pin to pre-built manifest, serve coherent inference
- [x] Validates `📌 Pinned to manifest <ver>; skipping runtime ranking.` log appears when manifest n_nodes matches active count
- [x] Validates fall-through diagnostic when n_nodes mismatches (suggests `mesh-llm moe migrate --n-nodes <runtime>`)

Fixes #308.

## Companion PRs
- Mesh-LLM/llama.cpp PR (splitter + loader): [`ventz/llama.cpp@feat/trunk-expert-split`](https://github.com/ventz/llama.cpp/tree/feat/trunk-expert-split) — separate PR to be opened
