### PR TITLE
task(improve-tui): improve TUI startup sequence while preserving raw console commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,13 @@ pkill -f mesh-llm
 
 If the embedded runtime fails to load, check mesh-llm stderr/log output and
 `~/.mesh-llm/runtime/` for the active instance metadata. The old external
-`llama-server` and `rpc-server` log files are no longer produced.
+`llama-server` and `rpc-server` log files are no longer produced. Embedded
+skippy/llama.cpp native logs are redirected away from the TUI into the active
+instance runtime directory:
+
+```text
+<runtime-root>/<pid>/logs/skippy-native.log
+```
 
 To override the runtime root (e.g., for tests or systemd):
 - `MESH_LLM_RUNTIME_ROOT=/path/to/custom/root` — highest priority

--- a/crates/mesh-client/src/models/gguf.rs
+++ b/crates/mesh-client/src/models/gguf.rs
@@ -340,18 +340,18 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
         }
     }
 
-    if meta.head_count > 0 {
-        if meta.key_length == 0 {
-            if let Some(key_length) = meta.embedding_size.checked_div(meta.head_count) {
-                meta.key_length = key_length;
-            }
+    if meta.head_count > 0 && meta.key_length == 0 {
+        if let Some(key_length) = meta.embedding_size.checked_div(meta.head_count) {
+            meta.key_length = key_length;
         }
-        if meta.value_length == 0 {
-            let effective_kv = if kv_head_count > 0 {
-                kv_head_count
-            } else {
-                meta.head_count
-            };
+    }
+    if meta.value_length == 0 {
+        let effective_kv = if kv_head_count > 0 {
+            kv_head_count
+        } else {
+            meta.head_count
+        };
+        if effective_kv > 0 {
             if let Some(value_length) = meta.embedding_size.checked_div(effective_kv) {
                 meta.value_length = value_length;
             }

--- a/crates/mesh-llm/src/api/mod.rs
+++ b/crates/mesh-llm/src/api/mod.rs
@@ -41,7 +41,7 @@ mod server;
 mod state;
 pub(crate) mod status;
 
-pub use self::server::start;
+pub(crate) use self::server::start_with_listener;
 #[cfg(test)]
 pub(crate) use self::server::{handle_request, is_ui_only_route};
 pub use self::state::{

--- a/crates/mesh-llm/src/api/server.rs
+++ b/crates/mesh-llm/src/api/server.rs
@@ -12,12 +12,13 @@ use tokio::{
 
 // ── Server ──
 
-pub async fn start(
+pub(crate) async fn start_with_listener(
     port: u16,
     state: MeshApi,
     mut target_rx: watch::Receiver<election::InferenceTarget>,
     listen_all: bool,
     headless: bool,
+    existing_listener: Option<TcpListener>,
 ) {
     state.set_headless(headless).await;
     // Watch election target changes
@@ -105,14 +106,24 @@ pub async fn start(
     });
 
     let addr = if listen_all { "0.0.0.0" } else { "127.0.0.1" };
-    let listener = match TcpListener::bind(format!("{addr}:{port}")).await {
-        Ok(l) => l,
-        Err(e) => {
-            tracing::error!("Management API: failed to bind :{port}: {e}");
-            return;
-        }
+    let listener = match existing_listener {
+        Some(listener) => listener,
+        None => match TcpListener::bind(format!("{addr}:{port}")).await {
+            Ok(l) => l,
+            Err(e) => {
+                tracing::error!("Management API: failed to bind :{port}: {e}");
+                return;
+            }
+        },
     };
-    tracing::info!("Management API on http://localhost:{port}");
+    let management_url = listener
+        .local_addr()
+        .map(|addr| format!("http://{addr}"))
+        .unwrap_or_else(|err| {
+            tracing::warn!("Management API: failed to read listener address: {err}");
+            format!("http://localhost:{port}")
+        });
+    tracing::info!("Management API on {management_url}");
 
     loop {
         let Ok((stream, _)) = listener.accept().await else {

--- a/crates/mesh-llm/src/api/status.rs
+++ b/crates/mesh-llm/src/api/status.rs
@@ -140,6 +140,8 @@ pub(crate) struct RuntimeLlamaMetricSamplePayload {
 pub(crate) struct RuntimeLlamaSlotsPayload {
     pub(crate) status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) last_attempt_unix_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) last_success_unix_ms: Option<u64>,
@@ -669,6 +671,7 @@ pub(crate) fn build_runtime_llama_payload(
         },
         slots: RuntimeLlamaSlotsPayload {
             status: runtime_llama_endpoint_status(snapshot.slots.status),
+            model: snapshot.slots.model,
             last_attempt_unix_ms: snapshot.slots.last_attempt_unix_ms,
             last_success_unix_ms: snapshot.slots.last_success_unix_ms,
             error: snapshot.slots.error,
@@ -719,7 +722,6 @@ pub(crate) fn build_runtime_llama_payload(
 
 fn runtime_llama_endpoint_status(status: runtime_data::RuntimeLlamaEndpointStatus) -> &'static str {
     match status {
-        #[cfg(test)]
         runtime_data::RuntimeLlamaEndpointStatus::Ready => "ready",
         runtime_data::RuntimeLlamaEndpointStatus::Unavailable => "unavailable",
     }

--- a/crates/mesh-llm/src/api/tests.rs
+++ b/crates/mesh-llm/src/api/tests.rs
@@ -1385,6 +1385,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
         inner.runtime_data_producer.publish_llama_slots_snapshot(
             runtime_data::RuntimeLlamaSlotsSnapshot {
                 status: runtime_data::RuntimeLlamaEndpointStatus::Ready,
+                model: Some("collector-model".into()),
                 last_attempt_unix_ms: Some(1_700_000_001_500),
                 last_success_unix_ms: Some(1_700_000_001_500),
                 error: None,

--- a/crates/mesh-llm/src/cli/mod.rs
+++ b/crates/mesh-llm/src/cli/mod.rs
@@ -720,7 +720,7 @@ where
                 explicit_surface = Some(RuntimeSurface::Serve);
             }
             None => {
-                normalized[pos] = OsString::from("--help");
+                normalized.remove(pos);
                 explicit_surface = Some(RuntimeSurface::Serve);
             }
             _ => {}
@@ -842,13 +842,13 @@ mod tests {
     }
 
     #[test]
-    fn normalize_runtime_surface_args_bare_serve_rewrites_to_help() {
+    fn normalize_runtime_surface_args_bare_serve_loads_default_config() {
         let normalized = normalize_runtime_surface_args(["mesh-llm", "serve"]);
 
         assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Serve));
         assert_eq!(
             normalized.normalized,
-            vec!["mesh-llm", "--help"]
+            vec!["mesh-llm"]
                 .into_iter()
                 .map(OsString::from)
                 .collect::<Vec<_>>()

--- a/crates/mesh-llm/src/cli/output/EVENTS.md
+++ b/crates/mesh-llm/src/cli/output/EVENTS.md
@@ -18,6 +18,7 @@ Keep these details current when changing `OutputEvent` or dashboard state:
 - `model_download_progress` is emitted during catalog preparation when the interactive TUI is active and drives the model-progress panel.
 - `ready` may include `pi_command` and `goose_command`; these are operational hints shown after startup.
 - Some variants are schema/dashboard-supported before all of them have production emitters. Mark that explicitly rather than leaving stale source-search notes.
+- Embedded skippy/llama.cpp native logs are process-global and are redirected before model load into `<runtime-root>/<pid>/logs/skippy-native.log`; do not stream those native logs through `OutputEvent` or the TUI.
 
 ## Events
 
@@ -41,11 +42,11 @@ Keep these details current when changing `OutputEvent` or dashboard state:
 | `model_loading` | `model`, `source?` | Dashboard-supported model lifecycle state; no production emitter was found in this pass. |
 | `model_loaded` | `model`, `bytes?` | Dashboard-supported model lifecycle state; no production emitter was found in this pass. |
 | `host_elected` | `model`, `host`, `role?`, `capacity_gb?` | Model host election, including demand-based rebalancing. |
-| `rpc_server_starting` | `port`, `device`, `log_path?` | `rpc-server` launch started in `inference/launch.rs`. |
-| `rpc_ready` | `port`, `device`, `log_path?` | Formatter/dashboard-supported ready transition; no production emitter was found in this pass. |
-| `llama_starting` | `model?`, `http_port`, `ctx_size?`, `log_path?` | `llama-server` launch started in `inference/launch.rs`. |
-| `llama_ready` | `model?`, `port`, `ctx_size?`, `log_path?` | `llama-server` is ready, before aggregate `ready`. |
-| `model_ready` | `model`, `internal_port?`, `role?` | Model-serving readiness. JSON includes both `port` and `internal_port` for compatibility when a port exists. |
+| `rpc_server_starting` | `port`, `device`, `log_path?` | Legacy/dashboard-supported external `rpc-server` transition; embedded skippy does not emit this. |
+| `rpc_ready` | `port`, `device`, `log_path?` | Legacy/dashboard-supported external `rpc-server` ready transition; embedded skippy does not emit this. |
+| `llama_starting` | `model?`, `http_port`, `ctx_size?`, `log_path?` | Legacy/dashboard-supported external `llama-server` transition; embedded skippy native logs use the process-level runtime log instead. |
+| `llama_ready` | `model?`, `port`, `ctx_size?`, `log_path?` | Legacy/dashboard-supported external `llama-server` ready transition; embedded skippy readiness is represented by `model_ready`. |
+| `model_ready` | `model`, `internal_port?`, `role?` | Embedded model-serving readiness. JSON includes both `port` and `internal_port` for compatibility when a port exists. |
 | `multi_model_mode` | `count`, `models` | Startup declared more than one model. |
 | `webserver_starting` | `url` | Formatter/dashboard-supported console startup state; no production emitter was found in this pass. |
 | `webserver_ready` | `url` | Web console ready. |

--- a/crates/mesh-llm/src/cli/output/mod.rs
+++ b/crates/mesh-llm/src/cli/output/mod.rs
@@ -8,9 +8,10 @@ use crossterm::{
     execute,
     terminal::{Clear, ClearType, EnterAlternateScreen, LeaveAlternateScreen},
 };
+#[cfg(test)]
+use ratatui::backend::TestBackend;
 use ratatui::{
     backend::CrosstermBackend,
-    backend::TestBackend,
     buffer::Buffer,
     layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -38,7 +39,9 @@ use tokio::time::{self, Duration, Instant, MissedTickBehavior};
 #[allow(dead_code)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RuntimeStatus {
+    NotReady,
     Starting,
+    Loading,
     Ready,
     ShuttingDown,
     Stopped,
@@ -50,7 +53,9 @@ pub enum RuntimeStatus {
 impl RuntimeStatus {
     fn as_str(&self) -> &'static str {
         match self {
+            RuntimeStatus::NotReady => "NOT READY",
             RuntimeStatus::Starting => "starting",
+            RuntimeStatus::Loading => "loading",
             RuntimeStatus::Ready => "ready",
             RuntimeStatus::ShuttingDown => "shutting down",
             RuntimeStatus::Stopped => "stopped",
@@ -100,7 +105,16 @@ pub struct DashboardModelRow {
     pub slots: Option<usize>,
     pub quantization: Option<String>,
     pub ctx_size: Option<u32>,
+    pub ctx_used_tokens: Option<u64>,
+    pub lanes: Option<Vec<DashboardModelLane>>,
     pub file_size_gb: Option<f64>,
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DashboardModelLane {
+    pub index: usize,
+    pub active: bool,
 }
 
 #[allow(dead_code)]
@@ -143,6 +157,234 @@ struct StartupProgressState {
     detail: String,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StartupLifecyclePhase {
+    Pending,
+    Starting,
+    Partial,
+    Ready,
+    Failed,
+    ShuttingDown,
+}
+
+impl StartupLifecyclePhase {
+    fn as_str(&self) -> &'static str {
+        match self {
+            StartupLifecyclePhase::Pending => "pending",
+            StartupLifecyclePhase::Starting => "starting",
+            StartupLifecyclePhase::Partial => "partial",
+            StartupLifecyclePhase::Ready => "ready",
+            StartupLifecyclePhase::Failed => "failed",
+            StartupLifecyclePhase::ShuttingDown => "shutting down",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StartupComponentState {
+    pub phase: StartupLifecyclePhase,
+    pub detail: Option<String>,
+}
+
+impl Default for StartupComponentState {
+    fn default() -> Self {
+        Self {
+            phase: StartupLifecyclePhase::Pending,
+            detail: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StartupLifecycleState {
+    pub phase: StartupLifecyclePhase,
+    pub mesh: StartupComponentState,
+    pub api: StartupComponentState,
+    pub console: StartupComponentState,
+    pub llama_server: StartupComponentState,
+    pub model_readiness: StartupComponentState,
+    boot_started: bool,
+    failure: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TruthfulStartupStatusKey {
+    Console,
+    Api,
+    LlamaServer,
+}
+
+impl Default for StartupLifecycleState {
+    fn default() -> Self {
+        Self {
+            phase: StartupLifecyclePhase::Pending,
+            mesh: StartupComponentState::default(),
+            api: StartupComponentState::default(),
+            console: StartupComponentState::default(),
+            llama_server: StartupComponentState::default(),
+            model_readiness: StartupComponentState::default(),
+            boot_started: false,
+            failure: None,
+        }
+    }
+}
+
+impl StartupLifecycleState {
+    fn mark_boot_started(&mut self, detail: Option<String>) {
+        self.boot_started = true;
+        if self.mesh.detail.is_none() {
+            self.mesh.detail = detail;
+        }
+        self.recompute_phase(false, false);
+    }
+
+    fn update_component_starting(component: &mut StartupComponentState, detail: Option<String>) {
+        component.phase = match component.phase {
+            StartupLifecyclePhase::Ready => StartupLifecyclePhase::Partial,
+            StartupLifecyclePhase::Failed => StartupLifecyclePhase::Failed,
+            StartupLifecyclePhase::ShuttingDown => StartupLifecyclePhase::ShuttingDown,
+            _ => StartupLifecyclePhase::Starting,
+        };
+        component.detail = detail.or_else(|| component.detail.clone());
+    }
+
+    fn update_component_ready(component: &mut StartupComponentState, detail: Option<String>) {
+        if !matches!(component.phase, StartupLifecyclePhase::Failed) {
+            component.phase = StartupLifecyclePhase::Ready;
+            component.detail = detail.or_else(|| component.detail.clone());
+        }
+    }
+
+    fn update_component_failed(component: &mut StartupComponentState, detail: Option<String>) {
+        component.phase = StartupLifecyclePhase::Failed;
+        component.detail = detail;
+    }
+
+    fn update_component_shutting_down(component: &mut StartupComponentState) {
+        if !matches!(component.phase, StartupLifecyclePhase::Pending) {
+            component.phase = StartupLifecyclePhase::ShuttingDown;
+        }
+    }
+
+    fn finalize_for_runtime_ready(&mut self, api_url: &str, console_url: Option<&str>) {
+        self.boot_started = true;
+        let mesh_detail = self.mesh.detail.clone();
+        let llama_detail = self.llama_server.detail.clone();
+        let model_detail = self.model_readiness.detail.clone();
+        Self::update_component_ready(&mut self.mesh, mesh_detail);
+        Self::update_component_ready(&mut self.api, Some(format!("API ready at {api_url}")));
+        if let Some(url) = console_url {
+            Self::update_component_ready(
+                &mut self.console,
+                Some(format!("console ready at {url}")),
+            );
+        }
+        if !matches!(
+            self.llama_server.phase,
+            StartupLifecyclePhase::Failed | StartupLifecyclePhase::ShuttingDown
+        ) {
+            Self::update_component_ready(
+                &mut self.llama_server,
+                llama_detail.or_else(|| Some("embedded runtime ready".to_string())),
+            );
+        }
+        if matches!(
+            self.model_readiness.phase,
+            StartupLifecyclePhase::Starting | StartupLifecyclePhase::Partial
+        ) {
+            Self::update_component_ready(&mut self.model_readiness, model_detail);
+        }
+        self.recompute_phase(true, false);
+    }
+
+    fn mark_failure(&mut self, detail: String) {
+        self.boot_started = true;
+        self.failure = Some(detail.clone());
+        let target = if matches!(
+            self.model_readiness.phase,
+            StartupLifecyclePhase::Starting | StartupLifecyclePhase::Partial
+        ) {
+            &mut self.model_readiness
+        } else if matches!(
+            self.llama_server.phase,
+            StartupLifecyclePhase::Starting | StartupLifecyclePhase::Partial
+        ) {
+            &mut self.llama_server
+        } else if matches!(
+            self.api.phase,
+            StartupLifecyclePhase::Starting | StartupLifecyclePhase::Partial
+        ) {
+            &mut self.api
+        } else if matches!(
+            self.console.phase,
+            StartupLifecyclePhase::Starting | StartupLifecyclePhase::Partial
+        ) {
+            &mut self.console
+        } else {
+            &mut self.mesh
+        };
+        Self::update_component_failed(target, Some(detail));
+        self.recompute_phase(false, false);
+    }
+
+    fn mark_shutting_down(&mut self) {
+        self.boot_started = true;
+        Self::update_component_shutting_down(&mut self.mesh);
+        Self::update_component_shutting_down(&mut self.api);
+        Self::update_component_shutting_down(&mut self.console);
+        Self::update_component_shutting_down(&mut self.llama_server);
+        Self::update_component_shutting_down(&mut self.model_readiness);
+        self.recompute_phase(false, true);
+    }
+
+    fn recompute_phase(&mut self, runtime_ready: bool, shutdown_in_progress: bool) {
+        if shutdown_in_progress {
+            self.phase = StartupLifecyclePhase::ShuttingDown;
+            return;
+        }
+        if self.failure.is_some()
+            || [
+                &self.mesh,
+                &self.api,
+                &self.console,
+                &self.llama_server,
+                &self.model_readiness,
+            ]
+            .iter()
+            .any(|component| matches!(component.phase, StartupLifecyclePhase::Failed))
+        {
+            self.phase = StartupLifecyclePhase::Failed;
+            return;
+        }
+        if runtime_ready {
+            self.phase = StartupLifecyclePhase::Ready;
+            return;
+        }
+        if !self.boot_started {
+            self.phase = StartupLifecyclePhase::Pending;
+            return;
+        }
+        if [
+            &self.mesh,
+            &self.api,
+            &self.console,
+            &self.llama_server,
+            &self.model_readiness,
+        ]
+        .iter()
+        .any(|component| {
+            matches!(
+                component.phase,
+                StartupLifecyclePhase::Ready | StartupLifecyclePhase::Partial
+            )
+        }) {
+            self.phase = StartupLifecyclePhase::Partial;
+        } else {
+            self.phase = StartupLifecyclePhase::Starting;
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 struct LoadingProgressState {
     ratio: f64,
@@ -179,6 +421,14 @@ impl Default for DashboardSnapshot {
 }
 
 #[allow(dead_code)]
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct DashboardLaunchPlan {
+    pub llama_process_rows: Vec<DashboardProcessRow>,
+    pub webserver_rows: Vec<DashboardEndpointRow>,
+    pub loaded_model_rows: Vec<DashboardModelRow>,
+}
+
+#[allow(dead_code)]
 pub type DashboardSnapshotFuture<'a> = Pin<Box<dyn Future<Output = DashboardSnapshot> + Send + 'a>>;
 
 #[allow(dead_code)]
@@ -187,12 +437,14 @@ pub trait DashboardSnapshotProvider: Send + Sync {
 }
 
 const DEFAULT_PRETTY_DASHBOARD_EVENT_HISTORY_LIMIT: usize = 1000;
+const PRETTY_TUI_STARTUP_HISTORY_LIMIT: usize = 32;
 const PRETTY_DASHBOARD_REQUEST_WINDOW_BUCKETS: usize = 30;
 const PRETTY_DASHBOARD_REQUEST_MAX_WINDOW_SECS: u32 = 24 * 60 * 60;
 const PRETTY_DASHBOARD_PANEL_COUNT: usize = 6;
 const PRETTY_TUI_REDRAW_INTERVAL: Duration = Duration::from_millis(33);
 const PRETTY_TUI_SNAPSHOT_INTERVAL: Duration = Duration::from_millis(250);
-const PRETTY_TUI_MODEL_CARD_HEIGHT: usize = 7;
+const PRETTY_TUI_MODEL_CARD_HEIGHT: usize = 8;
+const PRETTY_TUI_MODEL_CARD_STRIDE: usize = PRETTY_TUI_MODEL_CARD_HEIGHT;
 const PRETTY_TUI_LIST_HIGHLIGHT_SYMBOL_WIDTH: u16 = 2;
 const PRETTY_TUI_REQUEST_GRAPH_GUIDE_SYMBOL: &str = "·";
 const PRETTY_TUI_REQUEST_GRAPH_BASELINE_SYMBOL: &str = "─";
@@ -307,22 +559,19 @@ impl OutputLevel {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum LlamaInstanceKind {
-    RpcServer,
     LlamaServer,
 }
 
 impl LlamaInstanceKind {
     fn as_str(&self) -> &'static str {
         match self {
-            LlamaInstanceKind::RpcServer => "rpc-server",
             LlamaInstanceKind::LlamaServer => "llama-server",
         }
     }
 
     fn sort_key(&self) -> u8 {
         match self {
-            LlamaInstanceKind::RpcServer => 0,
-            LlamaInstanceKind::LlamaServer => 1,
+            LlamaInstanceKind::LlamaServer => 0,
         }
     }
 }
@@ -352,6 +601,9 @@ pub enum OutputEvent {
     Startup {
         version: String,
         message: Option<String>,
+    },
+    LaunchPlan {
+        plan: DashboardLaunchPlan,
     },
     NodeIdentity {
         node_id: String,
@@ -422,6 +674,12 @@ pub enum OutputEvent {
         device: String,
         log_path: Option<String>,
     },
+    RpcStartupFailed {
+        port: u16,
+        device: String,
+        log_path: Option<String>,
+        detail: String,
+    },
     LlamaStarting {
         model: Option<String>,
         http_port: u16,
@@ -433,6 +691,13 @@ pub enum OutputEvent {
         port: u16,
         ctx_size: Option<u32>,
         log_path: Option<String>,
+    },
+    LlamaStartupFailed {
+        model: Option<String>,
+        http_port: u16,
+        ctx_size: Option<u32>,
+        log_path: Option<String>,
+        detail: String,
     },
     ModelReady {
         model: String,
@@ -493,6 +758,7 @@ impl OutputEvent {
         match self {
             OutputEvent::Info { .. } => "info",
             OutputEvent::Startup { .. } => "startup",
+            OutputEvent::LaunchPlan { .. } => "launch_plan",
             OutputEvent::NodeIdentity { .. } => "node_identity",
             OutputEvent::InviteToken { .. } => "invite_token",
             OutputEvent::DiscoveryStarting { .. } => "discovery_starting",
@@ -509,8 +775,10 @@ impl OutputEvent {
             OutputEvent::HostElected { .. } => "host_elected",
             OutputEvent::RpcServerStarting { .. } => "rpc_server_starting",
             OutputEvent::RpcReady { .. } => "rpc_ready",
+            OutputEvent::RpcStartupFailed { .. } => "rpc_startup_failed",
             OutputEvent::LlamaStarting { .. } => "llama_starting",
             OutputEvent::LlamaReady { .. } => "llama_ready",
+            OutputEvent::LlamaStartupFailed { .. } => "llama_startup_failed",
             OutputEvent::ModelReady { .. } => "model_ready",
             OutputEvent::MultiModelMode { .. } => "multi_model_mode",
             OutputEvent::WebserverStarting { .. } => "webserver_starting",
@@ -528,6 +796,9 @@ impl OutputEvent {
 
     fn level(&self) -> OutputLevel {
         match self {
+            OutputEvent::RpcStartupFailed { .. } | OutputEvent::LlamaStartupFailed { .. } => {
+                OutputLevel::Error
+            }
             OutputEvent::Warning { .. } => OutputLevel::Warn,
             OutputEvent::Error { .. } => OutputLevel::Error,
             _ => OutputLevel::Info,
@@ -540,6 +811,12 @@ impl OutputEvent {
             OutputEvent::Startup { message, .. } => message
                 .clone()
                 .unwrap_or_else(|| "mesh-llm starting".to_string()),
+            OutputEvent::LaunchPlan { plan } => format!(
+                "startup plan ready ({} process(es), {} endpoint(s), {} model(s))",
+                plan.llama_process_rows.len(),
+                plan.webserver_rows.len(),
+                plan.loaded_model_rows.len()
+            ),
             OutputEvent::NodeIdentity { node_id, mesh_id } => match mesh_id {
                 Some(mesh_id) => format!("node {node_id} joined mesh {mesh_id}"),
                 None => format!("node {node_id} initialized"),
@@ -609,6 +886,19 @@ impl OutputEvent {
                     msg
                 }
             }
+            OutputEvent::RpcStartupFailed {
+                port,
+                detail,
+                log_path,
+                ..
+            } => {
+                let msg = format!("rpc-server failed to start on port {port}: {detail}");
+                if let Some(path) = log_path {
+                    format!("{msg}\n  ↳ log={path}")
+                } else {
+                    msg
+                }
+            }
             OutputEvent::LlamaStarting {
                 http_port,
                 log_path,
@@ -623,6 +913,25 @@ impl OutputEvent {
             }
             OutputEvent::LlamaReady { port, log_path, .. } => {
                 let msg = format!("llama-server ready on port {port}");
+                if let Some(path) = log_path {
+                    format!("{msg}\n  ↳ log={path}")
+                } else {
+                    msg
+                }
+            }
+            OutputEvent::LlamaStartupFailed {
+                model,
+                http_port,
+                detail,
+                log_path,
+                ..
+            } => {
+                let msg = match model {
+                    Some(model) => {
+                        format!("llama-server failed to start for {model} on port {http_port}: {detail}")
+                    }
+                    None => format!("llama-server failed to start on port {http_port}: {detail}"),
+                };
                 if let Some(path) = log_path {
                     format!("{msg}\n  ↳ log={path}")
                 } else {
@@ -685,6 +994,12 @@ impl OutputEvent {
             OutputEvent::DiscoveryStarting { source } => {
                 format!("🔍 discovering mesh via {source}")
             }
+            OutputEvent::LaunchPlan { plan } => format!(
+                "📋 startup plan ready: {} process(es), {} endpoint(s), {} model(s)",
+                plan.llama_process_rows.len(),
+                plan.webserver_rows.len(),
+                plan.loaded_model_rows.len()
+            ),
             OutputEvent::MeshFound {
                 mesh,
                 peers,
@@ -781,6 +1096,14 @@ impl OutputEvent {
             OutputEvent::RpcServerStarting { port, device, .. } => {
                 format!("🧵 rpc-server starting: port={port} device={device}")
             }
+            OutputEvent::RpcStartupFailed {
+                port,
+                device,
+                detail,
+                ..
+            } => {
+                format!("❌ rpc-server failed: port={port} device={device} {detail}")
+            }
             OutputEvent::LlamaStarting {
                 model,
                 http_port,
@@ -799,6 +1122,17 @@ impl OutputEvent {
             OutputEvent::LlamaReady { model, port, .. } => match model {
                 Some(model) => format!("✅ {model} ready on internal port {port}"),
                 None => format!("✅ llama-server ready on port {port}"),
+            },
+            OutputEvent::LlamaStartupFailed {
+                model,
+                http_port,
+                detail,
+                ..
+            } => match model {
+                Some(model) => {
+                    format!("❌ {model} failed to start on port {http_port}: {detail}")
+                }
+                None => format!("❌ llama-server failed to start on port {http_port}: {detail}"),
             },
             OutputEvent::RuntimeReady { models_count, .. } => match models_count {
                 Some(count) => format!("✅ Mesh runtime ready ({count} model(s))"),
@@ -835,6 +1169,11 @@ impl OutputEvent {
                 json!({ "message": message, "context": context })
             }
             OutputEvent::Startup { version, .. } => json!({ "version": version }),
+            OutputEvent::LaunchPlan { plan } => json!({
+                "llama_process_count": plan.llama_process_rows.len(),
+                "webserver_count": plan.webserver_rows.len(),
+                "loaded_model_count": plan.loaded_model_rows.len(),
+            }),
             OutputEvent::NodeIdentity { node_id, mesh_id } => {
                 json!({ "node_id": node_id, "mesh_id": mesh_id })
             }
@@ -899,6 +1238,17 @@ impl OutputEvent {
                 device,
                 log_path,
             } => json!({ "port": port, "device": device, "log_path": log_path }),
+            OutputEvent::RpcStartupFailed {
+                port,
+                device,
+                log_path,
+                detail,
+            } => json!({
+                "port": port,
+                "device": device,
+                "log_path": log_path,
+                "detail": detail,
+            }),
             OutputEvent::LlamaStarting {
                 model,
                 http_port,
@@ -920,6 +1270,19 @@ impl OutputEvent {
                 "port": port,
                 "ctx_size": ctx_size,
                 "log_path": log_path,
+            }),
+            OutputEvent::LlamaStartupFailed {
+                model,
+                http_port,
+                ctx_size,
+                log_path,
+                detail,
+            } => json!({
+                "model": model,
+                "http_port": http_port,
+                "ctx_size": ctx_size,
+                "log_path": log_path,
+                "detail": detail,
             }),
             OutputEvent::ModelReady {
                 model,
@@ -1407,21 +1770,26 @@ pub struct DashboardState {
     api: Option<EndpointState>,
     mesh_events: VecDeque<MeshEventState>,
     mesh_event_limit: usize,
+    startup_history: VecDeque<MeshEventState>,
+    startup_history_limit: usize,
     panel_focus: DashboardPanel,
     panel_layout: DashboardLayoutState,
     panel_view_states: [DashboardPanelViewState; PRETTY_DASHBOARD_PANEL_COUNT],
     events_follow: bool,
     events_filter: DashboardEventsFilterState,
     llama_process_rows: Vec<DashboardProcessRow>,
+    ready_llama_process_rows: BTreeSet<String>,
     webserver_rows: Vec<DashboardEndpointRow>,
     loaded_model_rows: Vec<DashboardModelRow>,
     request_history: DashboardRequestHistoryState,
     request_window: DashboardRequestWindow,
     join_token: Option<DashboardJoinTokenState>,
     terminal_size: Option<(u16, u16)>,
+    launch_plan: Option<DashboardLaunchPlan>,
     model_progress: Option<ModelProgressState>,
     startup_progress: Option<StartupProgressState>,
     startup_milestones: BTreeSet<String>,
+    startup_lifecycle: StartupLifecycleState,
     shutdown_in_progress: bool,
 }
 
@@ -1443,21 +1811,26 @@ impl Default for DashboardState {
             api: None,
             mesh_events: VecDeque::new(),
             mesh_event_limit: DEFAULT_PRETTY_DASHBOARD_EVENT_HISTORY_LIMIT,
+            startup_history: VecDeque::new(),
+            startup_history_limit: PRETTY_TUI_STARTUP_HISTORY_LIMIT,
             panel_focus: DashboardPanel::Events,
             panel_layout,
             panel_view_states: [DashboardPanelViewState::default(); PRETTY_DASHBOARD_PANEL_COUNT],
             events_follow: true,
             events_filter: DashboardEventsFilterState::default(),
             llama_process_rows: Vec::new(),
+            ready_llama_process_rows: BTreeSet::new(),
             webserver_rows: Vec::new(),
             loaded_model_rows: Vec::new(),
             request_history: DashboardRequestHistoryState::default(),
             request_window: DashboardRequestWindow::default(),
             join_token: None,
             terminal_size: None,
+            launch_plan: None,
             model_progress: None,
             startup_progress: None,
             startup_milestones: BTreeSet::new(),
+            startup_lifecycle: StartupLifecycleState::default(),
             shutdown_in_progress: false,
         };
         state.apply_layout(panel_layout);
@@ -1466,6 +1839,201 @@ impl Default for DashboardState {
 }
 
 impl DashboardState {
+    #[cfg(test)]
+    fn startup_lifecycle(&self) -> &StartupLifecycleState {
+        &self.startup_lifecycle
+    }
+
+    fn startup_mesh_component_active(&self) -> bool {
+        !self.runtime_ready && !self.shutdown_in_progress
+    }
+
+    fn update_startup_mesh_component_starting(&mut self, detail: Option<String>) {
+        if !self.startup_mesh_component_active() {
+            return;
+        }
+        StartupLifecycleState::update_component_starting(&mut self.startup_lifecycle.mesh, detail);
+        self.startup_lifecycle
+            .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+    }
+
+    fn update_startup_mesh_component_ready(&mut self, detail: Option<String>) {
+        if !self.startup_mesh_component_active() {
+            return;
+        }
+        StartupLifecycleState::update_component_ready(&mut self.startup_lifecycle.mesh, detail);
+        self.startup_lifecycle
+            .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+    }
+
+    fn mark_startup_mesh_component_failed(&mut self, detail: String) {
+        if !self.startup_mesh_component_active() {
+            return;
+        }
+        self.startup_lifecycle.failure = Some(detail.clone());
+        StartupLifecycleState::update_component_failed(
+            &mut self.startup_lifecycle.mesh,
+            Some(detail),
+        );
+        self.startup_lifecycle
+            .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+    }
+
+    fn startup_component_for_truthful_status(
+        &self,
+        key: TruthfulStartupStatusKey,
+    ) -> StartupComponentState {
+        match key {
+            TruthfulStartupStatusKey::Console => self.startup_lifecycle.console.clone(),
+            TruthfulStartupStatusKey::Api => self.startup_lifecycle.api.clone(),
+            TruthfulStartupStatusKey::LlamaServer => self.startup_lifecycle.llama_server.clone(),
+        }
+    }
+
+    fn truthful_startup_key_for_process(name: &str) -> Option<TruthfulStartupStatusKey> {
+        let normalized = name.to_ascii_lowercase();
+        if normalized.contains("llama") {
+            Some(TruthfulStartupStatusKey::LlamaServer)
+        } else {
+            None
+        }
+    }
+
+    fn truthful_startup_key_for_endpoint(label: &str) -> Option<TruthfulStartupStatusKey> {
+        let normalized = label.to_ascii_lowercase();
+        if normalized.contains("console") {
+            Some(TruthfulStartupStatusKey::Console)
+        } else if normalized == "api" || normalized.contains("openai-compatible api") {
+            Some(TruthfulStartupStatusKey::Api)
+        } else {
+            None
+        }
+    }
+
+    fn truthful_runtime_status_for_component(
+        component: &StartupComponentState,
+        current: &RuntimeStatus,
+    ) -> RuntimeStatus {
+        match component.phase {
+            StartupLifecyclePhase::Failed => match current {
+                RuntimeStatus::Warning
+                | RuntimeStatus::Error
+                | RuntimeStatus::Exited
+                | RuntimeStatus::Stopped
+                | RuntimeStatus::ShuttingDown => current.clone(),
+                _ => RuntimeStatus::Error,
+            },
+            StartupLifecyclePhase::ShuttingDown => RuntimeStatus::ShuttingDown,
+            StartupLifecyclePhase::Ready => match current {
+                RuntimeStatus::Warning
+                | RuntimeStatus::Error
+                | RuntimeStatus::Exited
+                | RuntimeStatus::Stopped
+                | RuntimeStatus::ShuttingDown => current.clone(),
+                _ => RuntimeStatus::Ready,
+            },
+            StartupLifecyclePhase::Pending
+            | StartupLifecyclePhase::Starting
+            | StartupLifecyclePhase::Partial => match current {
+                RuntimeStatus::NotReady => RuntimeStatus::NotReady,
+                RuntimeStatus::Loading => RuntimeStatus::Loading,
+                RuntimeStatus::Warning
+                | RuntimeStatus::Error
+                | RuntimeStatus::Exited
+                | RuntimeStatus::Stopped
+                | RuntimeStatus::ShuttingDown => current.clone(),
+                _ => RuntimeStatus::Starting,
+            },
+        }
+    }
+
+    fn truthful_runtime_status_for_process_component(
+        component: &StartupComponentState,
+        current: &RuntimeStatus,
+        ready_event_seen: bool,
+    ) -> RuntimeStatus {
+        match component.phase {
+            StartupLifecyclePhase::Pending
+            | StartupLifecyclePhase::Starting
+            | StartupLifecyclePhase::Partial
+                if ready_event_seen
+                    && matches!(
+                        current,
+                        RuntimeStatus::NotReady
+                            | RuntimeStatus::Loading
+                            | RuntimeStatus::Starting
+                            | RuntimeStatus::Ready
+                    ) =>
+            {
+                RuntimeStatus::Ready
+            }
+            _ => Self::truthful_runtime_status_for_component(component, current),
+        }
+    }
+
+    fn sync_truthful_startup_statuses(&mut self) {
+        let console_component =
+            self.startup_component_for_truthful_status(TruthfulStartupStatusKey::Console);
+        let api_component =
+            self.startup_component_for_truthful_status(TruthfulStartupStatusKey::Api);
+        let llama_component =
+            self.startup_component_for_truthful_status(TruthfulStartupStatusKey::LlamaServer);
+
+        if let Some(webserver) = &mut self.webserver {
+            if let Some(key) = Self::truthful_startup_key_for_endpoint(&webserver.label) {
+                webserver.status = Self::truthful_runtime_status_for_component(
+                    match key {
+                        TruthfulStartupStatusKey::Console => &console_component,
+                        TruthfulStartupStatusKey::Api => &api_component,
+                        TruthfulStartupStatusKey::LlamaServer => &llama_component,
+                    },
+                    &webserver.status,
+                );
+            }
+        }
+        if let Some(api) = &mut self.api {
+            if let Some(key) = Self::truthful_startup_key_for_endpoint(&api.label) {
+                api.status = Self::truthful_runtime_status_for_component(
+                    match key {
+                        TruthfulStartupStatusKey::Console => &console_component,
+                        TruthfulStartupStatusKey::Api => &api_component,
+                        TruthfulStartupStatusKey::LlamaServer => &llama_component,
+                    },
+                    &api.status,
+                );
+            }
+        }
+        let ready_llama_process_rows = self.ready_llama_process_rows.clone();
+        for row in &mut self.llama_process_rows {
+            if let Some(key) = Self::truthful_startup_key_for_process(&row.name) {
+                let ready_event_seen = ready_llama_process_rows
+                    .iter()
+                    .any(|ready_name| process_row_names_match(ready_name, &row.name));
+                row.status = Self::truthful_runtime_status_for_process_component(
+                    match key {
+                        TruthfulStartupStatusKey::Console => &console_component,
+                        TruthfulStartupStatusKey::Api => &api_component,
+                        TruthfulStartupStatusKey::LlamaServer => &llama_component,
+                    },
+                    &row.status,
+                    ready_event_seen,
+                );
+            }
+        }
+        for row in &mut self.webserver_rows {
+            if let Some(key) = Self::truthful_startup_key_for_endpoint(&row.label) {
+                row.status = Self::truthful_runtime_status_for_component(
+                    match key {
+                        TruthfulStartupStatusKey::Console => &console_component,
+                        TruthfulStartupStatusKey::Api => &api_component,
+                        TruthfulStartupStatusKey::LlamaServer => &llama_component,
+                    },
+                    &row.status,
+                );
+            }
+        }
+    }
+
     fn reduce(&mut self, action: DashboardAction) {
         match action {
             DashboardAction::OutputEvent(event) => self.apply_output_event(&event),
@@ -1562,11 +2130,17 @@ impl DashboardState {
     fn apply_snapshot(&mut self, snapshot: &DashboardSnapshot) {
         if self.shutdown_in_progress {
             self.merge_shutdown_process_snapshot(snapshot);
+        } else if self.launch_plan_known() && !self.runtime_ready {
+            self.merge_startup_process_snapshot(snapshot);
         } else {
             self.llama_process_rows = snapshot.llama_process_rows.clone();
             self.webserver_rows = snapshot.webserver_rows.clone();
-            self.loaded_model_rows = snapshot.loaded_model_rows.clone();
+            self.loaded_model_rows = merged_loaded_model_snapshot_rows(
+                &self.loaded_model_rows,
+                &snapshot.loaded_model_rows,
+            );
         }
+        self.sync_truthful_startup_statuses();
         self.request_history = DashboardRequestHistoryState::from_snapshot(snapshot);
         self.clamp_all_panel_views();
         self.sync_events_panel();
@@ -1612,8 +2186,23 @@ impl DashboardState {
                 self.webserver_rows.push(snapshot_row.clone());
             }
         }
-        self.webserver_rows
-            .sort_by(|left, right| left.label.cmp(&right.label));
+        sort_dashboard_endpoint_rows(&mut self.webserver_rows);
+    }
+
+    fn merge_startup_process_snapshot(&mut self, snapshot: &DashboardSnapshot) {
+        for row in &snapshot.llama_process_rows {
+            self.upsert_process_row(row.clone());
+        }
+        for row in &snapshot.webserver_rows {
+            self.upsert_endpoint_row(row.clone());
+        }
+        for row in &snapshot.loaded_model_rows {
+            self.upsert_loaded_model_row(row.clone());
+        }
+
+        if let Some(plan) = self.launch_plan.clone() {
+            self.preseed_launch_plan_rows(&plan);
+        }
     }
 
     fn mark_runtime_shutting_down(&mut self) {
@@ -1642,8 +2231,12 @@ impl DashboardState {
         }
     }
 
+    fn launch_plan_known(&self) -> bool {
+        self.launch_plan.is_some()
+    }
+
     fn is_startup_loading(&self) -> bool {
-        !self.runtime_ready && self.active_loading_progress().is_some()
+        false
     }
 
     fn active_loading_progress(&self) -> Option<LoadingProgressState> {
@@ -1682,6 +2275,10 @@ impl DashboardState {
     }
 
     fn apply_startup_progress_event(&mut self, event: &OutputEvent) {
+        if self.shutdown_in_progress && is_shutdown_suppressed_ready_event(event) {
+            return;
+        }
+
         if matches!(event, OutputEvent::Startup { .. }) {
             self.startup_milestones.clear();
             self.startup_progress = None;
@@ -1709,22 +2306,264 @@ impl DashboardState {
         });
     }
 
+    fn apply_startup_lifecycle_event(&mut self, event: &OutputEvent) {
+        match event {
+            OutputEvent::Startup { version, .. } => {
+                self.startup_lifecycle = StartupLifecycleState::default();
+                self.startup_lifecycle
+                    .mark_boot_started(Some(format!("starting mesh-llm {version}")));
+            }
+            OutputEvent::NodeIdentity { node_id, mesh_id } => {
+                let detail = match mesh_id {
+                    Some(mesh_id) => Some(format!("node {node_id} joined mesh {mesh_id}")),
+                    None => Some(format!("node {node_id} initialized")),
+                };
+                self.update_startup_mesh_component_ready(detail);
+            }
+            OutputEvent::InviteToken {
+                mesh_id, mesh_name, ..
+            } => {
+                self.update_startup_mesh_component_ready(Some(format!(
+                    "invite ready for {}",
+                    format_invite_mesh_label(mesh_name.as_deref(), mesh_id)
+                )));
+            }
+            OutputEvent::DiscoveryStarting { source } => {
+                self.update_startup_mesh_component_starting(Some(format!(
+                    "discovering mesh via {source}"
+                )));
+            }
+            OutputEvent::MeshFound { mesh, peers, .. } => {
+                self.update_startup_mesh_component_starting(Some(format!(
+                    "found mesh {mesh} with {peers} peer(s)"
+                )));
+            }
+            OutputEvent::DiscoveryJoined { mesh } => {
+                self.update_startup_mesh_component_ready(Some(format!("joined mesh {mesh}")));
+            }
+            OutputEvent::DiscoveryFailed { message, detail } => {
+                let failure_detail = detail
+                    .as_ref()
+                    .map(|detail| format!("{message}: {detail}"))
+                    .unwrap_or_else(|| message.clone());
+                self.mark_startup_mesh_component_failed(failure_detail);
+            }
+            OutputEvent::WaitingForPeers { detail } => {
+                self.update_startup_mesh_component_starting(
+                    detail
+                        .clone()
+                        .or_else(|| Some("waiting for peers".to_string())),
+                );
+            }
+            OutputEvent::PassiveMode { detail, .. } => {
+                self.update_startup_mesh_component_ready(detail.clone());
+            }
+            OutputEvent::Info { message, .. } if message == "Joined mesh" => {
+                self.update_startup_mesh_component_ready(Some(message.clone()));
+            }
+            OutputEvent::Warning { message, .. }
+                if message == "Failed to join any peer — running standalone" =>
+            {
+                self.mark_startup_mesh_component_failed(message.clone());
+            }
+            OutputEvent::ModelQueued { model }
+            | OutputEvent::ModelLoading { model, .. }
+            | OutputEvent::ModelLoaded { model, .. }
+            | OutputEvent::HostElected { model, .. } => {
+                StartupLifecycleState::update_component_starting(
+                    &mut self.startup_lifecycle.model_readiness,
+                    Some(format!("preparing model {model}")),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::LlamaStarting {
+                model, http_port, ..
+            } => {
+                let detail = match model {
+                    Some(model) => Some(format!("starting llama-server for {model}")),
+                    None => Some(format!("starting llama-server on port {http_port}")),
+                };
+                StartupLifecycleState::update_component_starting(
+                    &mut self.startup_lifecycle.llama_server,
+                    detail,
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::LlamaReady { model, port, .. } => {
+                let detail = match model {
+                    Some(model) => Some(format!("llama-server ready for {model}")),
+                    None => Some(format!("llama-server ready on port {port}")),
+                };
+                StartupLifecycleState::update_component_ready(
+                    &mut self.startup_lifecycle.llama_server,
+                    detail,
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::LlamaStartupFailed {
+                model,
+                http_port,
+                detail,
+                ..
+            } => {
+                self.startup_lifecycle.failure = Some(detail.clone());
+                let llama_detail = match model {
+                    Some(model) => {
+                        format!("llama-server failed for {model} (port {http_port}): {detail}")
+                    }
+                    None => format!("llama-server failed on port {http_port}: {detail}"),
+                };
+                let model_detail = match model {
+                    Some(model) => format!("model {model} failed during llama startup: {detail}"),
+                    None => format!("model startup blocked by llama-server failure: {detail}"),
+                };
+                StartupLifecycleState::update_component_failed(
+                    &mut self.startup_lifecycle.llama_server,
+                    Some(llama_detail),
+                );
+                StartupLifecycleState::update_component_failed(
+                    &mut self.startup_lifecycle.model_readiness,
+                    Some(model_detail),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::ModelReady { model, .. } => {
+                StartupLifecycleState::update_component_ready(
+                    &mut self.startup_lifecycle.model_readiness,
+                    Some(format!("model {model} ready")),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::WebserverStarting { url } => {
+                StartupLifecycleState::update_component_starting(
+                    &mut self.startup_lifecycle.console,
+                    Some(format!("starting console at {url}")),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::WebserverReady { url } => {
+                StartupLifecycleState::update_component_ready(
+                    &mut self.startup_lifecycle.console,
+                    Some(format!("console ready at {url}")),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::ApiStarting { url } => {
+                StartupLifecycleState::update_component_starting(
+                    &mut self.startup_lifecycle.api,
+                    Some(format!("starting API at {url}")),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::ApiReady { url } => {
+                StartupLifecycleState::update_component_ready(
+                    &mut self.startup_lifecycle.api,
+                    Some(format!("API ready at {url}")),
+                );
+                self.startup_lifecycle
+                    .recompute_phase(self.runtime_ready, self.shutdown_in_progress);
+            }
+            OutputEvent::RuntimeReady {
+                api_url,
+                console_url,
+                ..
+            } => {
+                self.startup_lifecycle
+                    .finalize_for_runtime_ready(api_url, console_url.as_deref());
+            }
+            OutputEvent::Error { message, context } => {
+                if self.runtime_ready || self.shutdown_in_progress {
+                    return;
+                }
+                let detail = context
+                    .as_ref()
+                    .map(|context| format!("{context}: {message}"))
+                    .unwrap_or_else(|| message.clone());
+                self.startup_lifecycle.mark_failure(detail);
+            }
+            OutputEvent::Shutdown { .. } => {
+                self.startup_lifecycle.mark_shutting_down();
+            }
+            _ => {}
+        }
+    }
+
+    fn mark_llama_process_row_pending(&mut self, name: &str) {
+        self.ready_llama_process_rows
+            .retain(|ready_name| !process_row_names_match(ready_name, name));
+    }
+
+    fn mark_llama_process_row_ready(&mut self, name: String) {
+        self.ready_llama_process_rows.insert(name);
+    }
+
     fn apply_output_event(&mut self, event: &OutputEvent) {
+        self.record_startup_history_event(event);
+
+        if self.shutdown_in_progress && is_shutdown_suppressed_ready_event(event) {
+            return;
+        }
+
         match event {
             OutputEvent::Startup { version, .. } => {
                 self.version = Some(version.clone());
                 self.runtime_ready = false;
+                self.launch_plan = None;
+                self.ready_llama_process_rows.clear();
+            }
+            OutputEvent::LaunchPlan { plan } => {
+                self.launch_plan = Some(plan.clone());
+                self.preseed_launch_plan_rows(plan);
             }
             OutputEvent::NodeIdentity { node_id, mesh_id } => {
                 self.node_id = Some(node_id.clone());
                 self.mesh_id = mesh_id.clone();
             }
             OutputEvent::ModelQueued { model } | OutputEvent::ModelLoading { model, .. } => {
-                self.upsert_model(model, RuntimeStatus::Starting, None, None, None);
+                self.upsert_model(model, RuntimeStatus::Loading, None, None, None);
+                self.upsert_loading_model_row(model);
+                self.upsert_loading_process_row(model);
             }
             OutputEvent::ModelLoaded { model, .. } => {
-                self.upsert_model(model, RuntimeStatus::Starting, None, None, None);
+                self.upsert_model(model, RuntimeStatus::Loading, None, None, None);
+                self.upsert_loading_model_row(model);
+                self.upsert_loading_process_row(model);
             }
+            OutputEvent::ModelReady {
+                model,
+                internal_port,
+                role,
+            } => {
+                self.upsert_model(
+                    model,
+                    RuntimeStatus::Ready,
+                    *internal_port,
+                    role.clone(),
+                    None,
+                );
+                self.upsert_loaded_model_row(DashboardModelRow {
+                    name: model.clone(),
+                    role: role.clone(),
+                    status: RuntimeStatus::Ready,
+                    port: *internal_port,
+                    device: None,
+                    slots: None,
+                    quantization: None,
+                    ctx_size: None,
+                    ctx_used_tokens: None,
+                    lanes: None,
+                    file_size_gb: None,
+                });
+            }
+
             OutputEvent::HostElected {
                 model,
                 role,
@@ -1771,72 +2610,96 @@ impl DashboardState {
                     models: models.clone(),
                 });
             }
-            OutputEvent::RpcServerStarting {
-                port,
-                device,
-                log_path,
-            } => self.upsert_llama_instance(LlamaInstanceState {
-                kind: LlamaInstanceKind::RpcServer,
-                port: *port,
-                status: RuntimeStatus::Starting,
-                device: Some(device.clone()),
-                model: None,
-                ctx_size: None,
-                log_path: log_path.clone(),
-            }),
-            OutputEvent::RpcReady {
-                port,
-                device,
-                log_path,
-            } => self.upsert_llama_instance(LlamaInstanceState {
-                kind: LlamaInstanceKind::RpcServer,
-                port: *port,
-                status: RuntimeStatus::Ready,
-                device: Some(device.clone()),
-                model: None,
-                ctx_size: None,
-                log_path: log_path.clone(),
-            }),
             OutputEvent::LlamaStarting {
                 model,
                 http_port,
                 ctx_size,
                 log_path,
-            } => self.upsert_llama_instance(LlamaInstanceState {
-                kind: LlamaInstanceKind::LlamaServer,
-                port: *http_port,
-                status: RuntimeStatus::Starting,
-                device: None,
-                model: model.clone(),
-                ctx_size: *ctx_size,
-                log_path: log_path.clone(),
-            }),
+            } => {
+                let process_name = llama_process_row_name(model.as_deref());
+                self.mark_llama_process_row_pending(&process_name);
+                self.upsert_llama_instance(LlamaInstanceState {
+                    kind: LlamaInstanceKind::LlamaServer,
+                    port: *http_port,
+                    status: RuntimeStatus::Starting,
+                    device: None,
+                    model: model.clone(),
+                    ctx_size: *ctx_size,
+                    log_path: log_path.clone(),
+                });
+                self.upsert_process_row(DashboardProcessRow {
+                    name: process_name,
+                    backend: String::new(),
+                    status: RuntimeStatus::Starting,
+                    port: *http_port,
+                    pid: 0,
+                });
+            }
             OutputEvent::LlamaReady {
                 model,
                 port,
                 ctx_size,
                 log_path,
-            } => self.upsert_llama_instance(LlamaInstanceState {
-                kind: LlamaInstanceKind::LlamaServer,
-                port: *port,
-                status: RuntimeStatus::Ready,
-                device: None,
-                model: model.clone(),
-                ctx_size: *ctx_size,
-                log_path: log_path.clone(),
-            }),
-            OutputEvent::ModelReady {
-                model,
-                internal_port,
-                role,
             } => {
-                self.upsert_model(
-                    model,
-                    RuntimeStatus::Ready,
-                    *internal_port,
-                    role.clone(),
-                    None,
-                );
+                let process_name = llama_process_row_name(model.as_deref());
+                self.mark_llama_process_row_ready(process_name.clone());
+                self.upsert_llama_instance(LlamaInstanceState {
+                    kind: LlamaInstanceKind::LlamaServer,
+                    port: *port,
+                    status: RuntimeStatus::Ready,
+                    device: None,
+                    model: model.clone(),
+                    ctx_size: *ctx_size,
+                    log_path: log_path.clone(),
+                });
+                self.upsert_process_row(DashboardProcessRow {
+                    name: process_name,
+                    backend: String::new(),
+                    status: RuntimeStatus::Ready,
+                    port: *port,
+                    pid: 0,
+                });
+            }
+            OutputEvent::LlamaStartupFailed {
+                model,
+                http_port,
+                ctx_size,
+                log_path,
+                ..
+            } => {
+                self.mark_llama_process_row_pending(&llama_process_row_name(model.as_deref()));
+                self.upsert_llama_instance(LlamaInstanceState {
+                    kind: LlamaInstanceKind::LlamaServer,
+                    port: *http_port,
+                    status: RuntimeStatus::Error,
+                    device: None,
+                    model: model.clone(),
+                    ctx_size: *ctx_size,
+                    log_path: log_path.clone(),
+                });
+                self.upsert_process_row(DashboardProcessRow {
+                    name: llama_process_row_name(model.as_deref()),
+                    backend: String::new(),
+                    status: RuntimeStatus::Error,
+                    port: *http_port,
+                    pid: 0,
+                });
+                if let Some(model) = model {
+                    self.upsert_model(model, RuntimeStatus::Error, Some(*http_port), None, None);
+                    self.upsert_loaded_model_row(DashboardModelRow {
+                        name: model.clone(),
+                        role: None,
+                        status: RuntimeStatus::Error,
+                        port: Some(*http_port),
+                        device: None,
+                        slots: None,
+                        quantization: None,
+                        ctx_size: *ctx_size,
+                        ctx_used_tokens: None,
+                        lanes: None,
+                        file_size_gb: None,
+                    });
+                }
             }
             OutputEvent::WebserverStarting { url } => {
                 self.webserver = Some(EndpointState {
@@ -1844,6 +2707,13 @@ impl DashboardState {
                     status: RuntimeStatus::Starting,
                     url: url.clone(),
                     details: Vec::new(),
+                });
+                self.upsert_endpoint_row(DashboardEndpointRow {
+                    label: "Console".to_string(),
+                    status: RuntimeStatus::Starting,
+                    url: url.clone(),
+                    port: dashboard_port_from_url(url),
+                    pid: None,
                 });
             }
             OutputEvent::WebserverReady { url } => {
@@ -1853,6 +2723,13 @@ impl DashboardState {
                     url: url.clone(),
                     details: Vec::new(),
                 });
+                self.upsert_endpoint_row(DashboardEndpointRow {
+                    label: "Console".to_string(),
+                    status: RuntimeStatus::Ready,
+                    url: url.clone(),
+                    port: dashboard_port_from_url(url),
+                    pid: None,
+                });
             }
             OutputEvent::ApiStarting { url } => {
                 self.api = Some(EndpointState {
@@ -1861,6 +2738,13 @@ impl DashboardState {
                     url: url.clone(),
                     details: Vec::new(),
                 });
+                self.upsert_endpoint_row(DashboardEndpointRow {
+                    label: "API".to_string(),
+                    status: RuntimeStatus::Starting,
+                    url: url.clone(),
+                    port: dashboard_port_from_url(url),
+                    pid: None,
+                });
             }
             OutputEvent::ApiReady { url } => {
                 self.api = Some(EndpointState {
@@ -1868,6 +2752,13 @@ impl DashboardState {
                     status: RuntimeStatus::Ready,
                     url: url.clone(),
                     details: Vec::new(),
+                });
+                self.upsert_endpoint_row(DashboardEndpointRow {
+                    label: "API".to_string(),
+                    status: RuntimeStatus::Ready,
+                    url: url.clone(),
+                    port: dashboard_port_from_url(url),
+                    pid: None,
                 });
             }
             OutputEvent::RuntimeReady {
@@ -1942,6 +2833,9 @@ impl DashboardState {
             }
             OutputEvent::Info { .. }
             | OutputEvent::Warning { .. }
+            | OutputEvent::RpcServerStarting { .. }
+            | OutputEvent::RpcReady { .. }
+            | OutputEvent::RpcStartupFailed { .. }
             | OutputEvent::DiscoveryStarting { .. }
             | OutputEvent::MeshFound { .. }
             | OutputEvent::DiscoveryJoined { .. }
@@ -1956,6 +2850,8 @@ impl DashboardState {
             }
         }
 
+        self.apply_startup_lifecycle_event(event);
+        self.sync_truthful_startup_statuses();
         self.apply_startup_progress_event(event);
         self.record_mesh_event(event);
         self.clamp_all_panel_views();
@@ -2372,6 +3268,151 @@ impl DashboardState {
             .sort_by(|left, right| left.model.cmp(&right.model));
     }
 
+    fn preseed_launch_plan_rows(&mut self, plan: &DashboardLaunchPlan) {
+        for row in &plan.llama_process_rows {
+            self.seed_process_row(row);
+        }
+        for row in &plan.webserver_rows {
+            self.seed_endpoint_row(row);
+        }
+        for row in &plan.loaded_model_rows {
+            self.seed_loaded_model_row(row);
+        }
+    }
+
+    fn seed_process_row(&mut self, row: &DashboardProcessRow) {
+        if self
+            .llama_process_rows
+            .iter()
+            .any(|candidate| process_rows_match(candidate, row))
+        {
+            return;
+        }
+
+        let planned = row.clone();
+        self.llama_process_rows.push(planned);
+        self.llama_process_rows
+            .sort_by(|left, right| left.port.cmp(&right.port).then(left.name.cmp(&right.name)));
+    }
+
+    fn seed_endpoint_row(&mut self, row: &DashboardEndpointRow) {
+        if self
+            .webserver_rows
+            .iter()
+            .any(|candidate| endpoint_rows_match(candidate, row))
+        {
+            return;
+        }
+
+        let mut planned = row.clone();
+        planned.status = RuntimeStatus::NotReady;
+        self.webserver_rows.push(planned);
+        sort_dashboard_endpoint_rows(&mut self.webserver_rows);
+    }
+
+    fn seed_loaded_model_row(&mut self, row: &DashboardModelRow) {
+        if self
+            .loaded_model_rows
+            .iter()
+            .any(|candidate| model_rows_match(candidate, row))
+        {
+            return;
+        }
+
+        let planned = row.clone();
+        self.loaded_model_rows.push(planned);
+        self.loaded_model_rows
+            .sort_by(|left, right| left.name.cmp(&right.name));
+    }
+
+    fn upsert_process_row(&mut self, next: DashboardProcessRow) {
+        if let Some(existing) = self
+            .llama_process_rows
+            .iter_mut()
+            .find(|candidate| process_rows_match(candidate, &next))
+        {
+            existing.name = preferred_dashboard_row_name(&existing.name, &next.name);
+            existing.backend = if next.backend.is_empty() {
+                existing.backend.clone()
+            } else {
+                next.backend
+            };
+            existing.status = merged_runtime_status(&existing.status, &next.status);
+            if next.port != 0 {
+                existing.port = next.port;
+            }
+            if next.pid != 0 {
+                existing.pid = next.pid;
+            }
+        } else {
+            self.llama_process_rows.push(next);
+        }
+
+        self.llama_process_rows
+            .sort_by(|left, right| left.port.cmp(&right.port).then(left.name.cmp(&right.name)));
+    }
+
+    fn upsert_endpoint_row(&mut self, next: DashboardEndpointRow) {
+        if let Some(existing) = self
+            .webserver_rows
+            .iter_mut()
+            .find(|candidate| endpoint_rows_match(candidate, &next))
+        {
+            existing.label = next.label;
+            existing.status = next.status;
+            existing.url = next.url;
+            if next.port != 0 {
+                existing.port = next.port;
+            }
+            existing.pid = next.pid.or(existing.pid);
+        } else {
+            self.webserver_rows.push(next);
+        }
+
+        sort_dashboard_endpoint_rows(&mut self.webserver_rows);
+    }
+
+    fn upsert_loading_model_row(&mut self, model: &str) {
+        self.upsert_loaded_model_row(DashboardModelRow {
+            name: model.to_string(),
+            role: None,
+            status: RuntimeStatus::Loading,
+            port: None,
+            device: None,
+            slots: None,
+            quantization: None,
+            ctx_size: None,
+            ctx_used_tokens: None,
+            lanes: None,
+            file_size_gb: None,
+        });
+    }
+
+    fn upsert_loading_process_row(&mut self, model: &str) {
+        self.upsert_process_row(DashboardProcessRow {
+            name: llama_process_row_name(Some(model)),
+            backend: String::new(),
+            status: RuntimeStatus::Loading,
+            port: 0,
+            pid: 0,
+        });
+    }
+
+    fn upsert_loaded_model_row(&mut self, next: DashboardModelRow) {
+        if let Some(existing) = self
+            .loaded_model_rows
+            .iter_mut()
+            .find(|candidate| model_rows_match(candidate, &next))
+        {
+            *existing = merged_loaded_model_row(existing.clone(), next);
+        } else {
+            self.loaded_model_rows.push(next);
+        }
+
+        self.loaded_model_rows
+            .sort_by(|left, right| left.name.cmp(&right.name));
+    }
+
     fn record_mesh_event(&mut self, event: &OutputEvent) {
         self.mesh_events.push_back(MeshEventState {
             timestamp: Local::now().format("%H:%M:%S").to_string(),
@@ -2380,6 +3421,29 @@ impl DashboardState {
         });
         while self.mesh_events.len() > self.mesh_event_limit {
             self.mesh_events.pop_front();
+        }
+    }
+
+    fn record_startup_history_event(&mut self, event: &OutputEvent) {
+        if self.shutdown_in_progress && is_shutdown_suppressed_ready_event(event) {
+            return;
+        }
+
+        if matches!(event, OutputEvent::Startup { .. }) {
+            self.startup_history.clear();
+        }
+
+        let Some(summary) = startup_history_summary(event) else {
+            return;
+        };
+
+        self.startup_history.push_back(MeshEventState {
+            timestamp: Local::now().format("%H:%M:%S").to_string(),
+            level: event.level(),
+            summary,
+        });
+        while self.startup_history.len() > self.startup_history_limit {
+            self.startup_history.pop_front();
         }
     }
 
@@ -2634,6 +3698,246 @@ impl DashboardState {
     }
 }
 
+fn process_rows_match(existing: &DashboardProcessRow, next: &DashboardProcessRow) -> bool {
+    if existing.port == next.port {
+        return existing.port != 0 || process_row_names_match(&existing.name, &next.name);
+    }
+
+    (existing.port == 0 && next.port != 0 && process_row_names_match(&existing.name, &next.name))
+        || (next.port == 0
+            && existing.port != 0
+            && process_row_names_match(&existing.name, &next.name))
+}
+
+fn endpoint_rows_match(existing: &DashboardEndpointRow, next: &DashboardEndpointRow) -> bool {
+    existing.label == next.label || (existing.port != 0 && existing.port == next.port)
+}
+
+fn process_row_names_match(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+
+    if process_row_is_generic_llama(left) || process_row_is_generic_llama(right) {
+        return left.contains("llama-server") && right.contains("llama-server");
+    }
+
+    match (
+        process_row_model_identity(left),
+        process_row_model_identity(right),
+    ) {
+        (Some(left_model), Some(right_model)) => model_names_match(left_model, right_model),
+        _ => false,
+    }
+}
+
+fn process_row_is_generic_llama(name: &str) -> bool {
+    name == "llama-server"
+}
+
+fn process_row_model_identity(name: &str) -> Option<&str> {
+    if process_row_is_generic_llama(name) {
+        None
+    } else {
+        Some(llama_process_model_name(name).unwrap_or(name))
+    }
+}
+
+fn llama_process_model_name(name: &str) -> Option<&str> {
+    name.strip_prefix("llama-server ")
+}
+
+fn model_name_without_variant_suffix(name: &str) -> &str {
+    name.split_once(':')
+        .map(|(base_model, _variant)| base_model)
+        .unwrap_or(name)
+}
+
+fn llama_process_row_name(model: Option<&str>) -> String {
+    model
+        .map(|model| format!("llama-server {model}"))
+        .unwrap_or_else(|| "llama-server".to_string())
+}
+
+fn preferred_dashboard_row_name(existing: &str, next: &str) -> String {
+    if next == "llama-server" {
+        return existing.to_string();
+    }
+    if existing == "llama-server" {
+        return next.to_string();
+    }
+    match (name_looks_canonical(existing), name_looks_canonical(next)) {
+        (true, false) => existing.to_string(),
+        (false, true) => next.to_string(),
+        _ => next.to_string(),
+    }
+}
+
+fn name_looks_canonical(name: &str) -> bool {
+    let model_name = llama_process_model_name(name).unwrap_or(name);
+    model_name.contains('/') || model_name.contains(':')
+}
+
+fn merged_runtime_status(existing: &RuntimeStatus, next: &RuntimeStatus) -> RuntimeStatus {
+    if runtime_status_update_is_stale(existing, next) {
+        existing.clone()
+    } else {
+        next.clone()
+    }
+}
+
+fn runtime_status_update_is_stale(existing: &RuntimeStatus, next: &RuntimeStatus) -> bool {
+    matches!(
+        (existing, next),
+        (
+            RuntimeStatus::Ready,
+            RuntimeStatus::Loading | RuntimeStatus::Starting | RuntimeStatus::NotReady
+        ) | (
+            RuntimeStatus::Loading | RuntimeStatus::Starting,
+            RuntimeStatus::NotReady
+        )
+    )
+}
+
+fn merged_dashboard_device(existing: Option<String>, next: Option<String>) -> Option<String> {
+    match (existing, next) {
+        (Some(existing), Some(next)) if dashboard_device_update_is_backend_label(&next) => {
+            Some(existing)
+        }
+        (_, Some(next)) => Some(next),
+        (existing, None) => existing,
+    }
+}
+
+fn dashboard_device_update_is_backend_label(device: &str) -> bool {
+    matches!(
+        device.trim().to_ascii_lowercase().as_str(),
+        "skippy" | "llama" | "llama.cpp" | "llama-server"
+    )
+}
+
+fn merged_loaded_model_snapshot_rows(
+    existing_rows: &[DashboardModelRow],
+    snapshot_rows: &[DashboardModelRow],
+) -> Vec<DashboardModelRow> {
+    if snapshot_rows.is_empty() {
+        return existing_rows.to_vec();
+    }
+
+    snapshot_rows
+        .iter()
+        .cloned()
+        .map(|snapshot_row| {
+            existing_rows
+                .iter()
+                .find(|existing| model_rows_match(existing, &snapshot_row))
+                .cloned()
+                .map(|existing| merged_loaded_model_snapshot_row(existing, snapshot_row.clone()))
+                .unwrap_or(snapshot_row)
+        })
+        .collect()
+}
+
+fn merged_loaded_model_snapshot_row(
+    existing: DashboardModelRow,
+    next: DashboardModelRow,
+) -> DashboardModelRow {
+    let ctx_used_tokens = next.ctx_used_tokens;
+    let lanes = next.lanes.clone();
+    let mut merged = merged_loaded_model_row(existing, next);
+    // Dashboard snapshots are the authoritative source for live context usage;
+    // event/launch-plan rows may omit it and should not clear the latest reading.
+    merged.ctx_used_tokens = ctx_used_tokens;
+    merged.lanes = lanes;
+    merged
+}
+
+fn merged_loaded_model_row(
+    mut existing: DashboardModelRow,
+    next: DashboardModelRow,
+) -> DashboardModelRow {
+    existing.name = preferred_dashboard_row_name(&existing.name, &next.name);
+    existing.status = merged_runtime_status(&existing.status, &next.status);
+    existing.role = next.role.or(existing.role);
+    existing.port = next.port.or(existing.port);
+    existing.device = merged_dashboard_device(existing.device, next.device);
+    existing.slots = next.slots.or(existing.slots);
+    existing.quantization = next.quantization.or(existing.quantization);
+    existing.ctx_size = next.ctx_size.or(existing.ctx_size);
+    existing.ctx_used_tokens = next.ctx_used_tokens.or(existing.ctx_used_tokens);
+    existing.lanes = next.lanes.or(existing.lanes);
+    existing.file_size_gb = next.file_size_gb.or(existing.file_size_gb);
+    existing
+}
+
+fn model_rows_match(existing: &DashboardModelRow, next: &DashboardModelRow) -> bool {
+    model_names_match(&existing.name, &next.name)
+}
+
+fn model_names_match(left: &str, right: &str) -> bool {
+    let left_keys = model_identity_keys(left);
+    let right_keys = model_identity_keys(right);
+    left_keys
+        .iter()
+        .any(|left_key| right_keys.iter().any(|right_key| left_key == right_key))
+}
+
+fn model_identity_keys(name: &str) -> Vec<String> {
+    let normalized = name.trim().to_ascii_lowercase();
+    let basename = normalized
+        .rsplit('/')
+        .next()
+        .unwrap_or(normalized.as_str())
+        .to_string();
+    let candidates = [normalized, basename];
+    let mut keys = Vec::new();
+    for candidate in candidates {
+        push_model_identity_key(&mut keys, candidate.clone());
+        if let Some(variant_name) = candidate
+            .rsplit(':')
+            .next()
+            .filter(|part| *part != candidate && variant_name_looks_like_model_file(part))
+        {
+            push_model_identity_key(&mut keys, variant_name.to_string());
+            push_model_identity_key(&mut keys, variant_name.replace(".gguf", ""));
+        }
+        push_model_identity_key(&mut keys, candidate.replace("-gguf:", "-"));
+        push_model_identity_key(&mut keys, candidate.replace(":gguf:", "-"));
+        push_model_identity_key(&mut keys, candidate.replace(':', "-"));
+        push_model_identity_key(&mut keys, candidate.replace(".gguf", ""));
+    }
+    keys
+}
+
+fn push_model_identity_key(keys: &mut Vec<String>, key: String) {
+    if !key.is_empty() && !keys.iter().any(|existing| existing == &key) {
+        keys.push(key);
+    }
+}
+fn variant_name_looks_like_model_file(value: &str) -> bool {
+    value.matches('-').count() >= 2
+}
+
+pub(crate) fn sort_dashboard_endpoint_rows(rows: &mut [DashboardEndpointRow]) {
+    rows.sort_by(|left, right| {
+        dashboard_endpoint_sort_bucket(left)
+            .cmp(&dashboard_endpoint_sort_bucket(right))
+            .then_with(|| left.label.cmp(&right.label))
+    });
+}
+
+fn dashboard_endpoint_sort_bucket(row: &DashboardEndpointRow) -> u8 {
+    if row.label.starts_with("Plugin: ") {
+        1
+    } else {
+        0
+    }
+}
+
+fn single_line_status_text(message: &str) -> String {
+    message.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
 fn render_dashboard_text(state: &DashboardState) -> String {
     let mut output = String::new();
     let mut header = String::from("mesh-llm");
@@ -2650,6 +3954,12 @@ fn render_dashboard_text(state: &DashboardState) -> String {
     let _ = writeln!(&mut output, "{header}");
     let _ = writeln!(&mut output);
 
+    write_dashboard_section(
+        &mut output,
+        "Startup status",
+        &render_startup_summary(state),
+    );
+    let _ = writeln!(&mut output);
     write_dashboard_section(
         &mut output,
         "Running llama.cpp instances",
@@ -2686,6 +3996,37 @@ fn write_dashboard_section(output: &mut String, title: &str, lines: &[String]) {
         output,
         "└────────────────────────────────────────────────────────────────────"
     );
+}
+
+fn render_startup_summary(state: &DashboardState) -> Vec<String> {
+    let lifecycle = &state.startup_lifecycle;
+    let mut lines = vec![format!(
+        "startup={}{}",
+        lifecycle.phase.as_str(),
+        lifecycle
+            .failure
+            .as_ref()
+            .map(|failure| format!("  failure={}", single_line_status_text(failure)))
+            .unwrap_or_default()
+    )];
+    lines.extend(startup_component_summary_lines(lifecycle));
+    lines
+}
+
+fn startup_component_summary_lines(lifecycle: &StartupLifecycleState) -> Vec<String> {
+    vec![
+        format!(
+            "mesh={}  api={}  console={}",
+            lifecycle.mesh.phase.as_str(),
+            lifecycle.api.phase.as_str(),
+            lifecycle.console.phase.as_str(),
+        ),
+        format!(
+            "llama-server={}  model readiness={}",
+            lifecycle.llama_server.phase.as_str(),
+            lifecycle.model_readiness.phase.as_str(),
+        ),
+    ]
 }
 
 fn render_llama_instances(state: &DashboardState) -> Vec<String> {
@@ -2922,26 +4263,6 @@ fn draw_tui_dashboard_with_terminal(
         .draw(|frame| render_tui_frame(frame, state))
         .map(|_| ())
         .map_err(io::Error::other)
-}
-
-fn render_tui_text_snapshot(state: &DashboardState, width: u16, height: u16) -> io::Result<String> {
-    let width = width.max(1);
-    let height = height.max(1);
-    let backend = TestBackend::new(width, height);
-    let mut terminal = Terminal::new(backend).map_err(io::Error::other)?;
-    terminal
-        .draw(|frame| render_tui_frame(frame, state))
-        .map_err(io::Error::other)?;
-    let buffer = terminal.backend().buffer();
-    let mut lines = Vec::with_capacity(usize::from(height));
-    for y in 0..height {
-        let mut line = String::new();
-        for x in 0..width {
-            line.push_str(buffer[(x, y)].symbol());
-        }
-        lines.push(line.trim_end().to_string());
-    }
-    Ok(lines.join("\n"))
 }
 
 fn render_tui_frame(frame: &mut Frame, state: &DashboardState) {
@@ -3399,7 +4720,10 @@ fn render_join_token_title_status(frame: &mut Frame, state: &DashboardState, pan
 }
 
 fn join_token_panel_left_title(state: &DashboardState, focus_marker: char) -> String {
-    let mut title = format!("{focus_marker} Join Token");
+    let mut title = format!(
+        "{focus_marker} Join Token  startup={}",
+        state.startup_lifecycle.phase.as_str()
+    );
     if let Some(join_token) = &state.join_token {
         title.push_str("  mesh=");
         title.push_str(&join_token.mesh_label());
@@ -3408,6 +4732,12 @@ fn join_token_panel_left_title(state: &DashboardState, focus_marker: char) -> St
 }
 
 fn join_token_panel_right_title(state: &DashboardState) -> String {
+    if let Some(failure) = state.startup_lifecycle.failure.as_ref() {
+        return format!(
+            "startup failed: {}",
+            truncate_with_ellipsis(&single_line_status_text(failure), 40)
+        );
+    }
     let Some(join_token) = &state.join_token else {
         return "waiting for cluster invite".to_string();
     };
@@ -3580,11 +4910,6 @@ fn render_requests_panel(
     );
 }
 
-#[derive(Clone, Copy, Default)]
-struct TuiModelGaugeScale {
-    max_file_size_gb: f64,
-}
-
 fn render_models_panel(
     frame: &mut Frame,
     state: &DashboardState,
@@ -3610,8 +4935,8 @@ fn render_models_panel(
 
     let view = state.panel_view_state(DashboardPanel::Models);
     let is_focused = state.panel_focus == DashboardPanel::Models;
-    let viewport_rows =
-        tui_panel_viewport_rows(DashboardPanel::Models, usize::from(inner_area.height));
+    let visible_height = usize::from(inner_area.height);
+    let viewport_rows = tui_panel_viewport_rows(DashboardPanel::Models, visible_height);
     let row_count = state.row_count_for_panel(DashboardPanel::Models);
     let show_scrollbar = row_count > viewport_rows && inner_area.width > 1;
     let list_area = if show_scrollbar {
@@ -3623,7 +4948,6 @@ fn render_models_panel(
         inner_area
     };
     let content_width = usize::from(list_area.width.max(1));
-    let scale = tui_model_gauge_scale(&state.loaded_model_rows);
     for (local_index, (row_index, row)) in state
         .loaded_model_rows
         .iter()
@@ -3633,7 +4957,7 @@ fn render_models_panel(
         .enumerate()
     {
         let card_y = list_area.y.saturating_add(
-            u16::try_from(local_index.saturating_mul(PRETTY_TUI_MODEL_CARD_HEIGHT)).unwrap_or(0),
+            u16::try_from(local_index.saturating_mul(PRETTY_TUI_MODEL_CARD_STRIDE)).unwrap_or(0),
         );
         if card_y >= list_area.bottom() {
             break;
@@ -3650,7 +4974,6 @@ fn render_models_panel(
         frame.render_widget(
             TuiModelCardWidget {
                 row,
-                scale,
                 content_width,
                 is_selected,
                 is_focused,
@@ -3689,12 +5012,11 @@ fn tui_models_viewport_rows(visible_height: u16) -> usize {
     if visible_height == 0 {
         return 0;
     }
-    (visible_height / PRETTY_TUI_MODEL_CARD_HEIGHT).max(1)
+    (visible_height / PRETTY_TUI_MODEL_CARD_STRIDE).max(1)
 }
 
 struct TuiModelCardWidget<'a> {
     row: &'a DashboardModelRow,
-    scale: TuiModelGaugeScale,
     content_width: usize,
     is_selected: bool,
     is_focused: bool,
@@ -3720,55 +5042,44 @@ impl Widget for TuiModelCardWidget<'_> {
         let block = Block::bordered()
             .border_type(BorderType::Rounded)
             .style(Style::default().bg(card_bg))
-            .border_style(Style::default().fg(border_fg).bg(card_bg))
-            .title(Line::styled(
-                truncate_with_ellipsis(&self.row.name, self.content_width.saturating_sub(6).max(1)),
-                Style::default()
-                    .fg(theme.text)
-                    .bg(card_bg)
-                    .add_modifier(Modifier::BOLD),
-            ));
+            .border_style(Style::default().fg(border_fg).bg(card_bg));
         let inner = block.inner(area);
         block.render(area, buf);
         if inner.height == 0 || inner.width == 0 {
             return;
         }
+        let [name_row, summary_top, summary_bottom, divider, ctx_row, slots_row] =
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                    Constraint::Length(1),
+                ])
+                .areas(inner);
 
-        let [summary_top, summary_bottom, divider, ctx_row, file_row] = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Length(1),
-                Constraint::Length(1),
-            ])
-            .areas(inner);
+        render_tui_model_name_row(
+            buf,
+            name_row,
+            card_bg,
+            &self.row.name,
+            self.content_width.saturating_sub(2).max(1),
+        );
 
-        render_tui_model_summary_cells(
+        render_tui_model_identity_cells(
             buf,
             summary_top,
             card_bg,
-            vec![
-                (
-                    "PORT",
-                    self.row
-                        .port
-                        .map(|port| port.to_string())
-                        .unwrap_or_else(|| "n/a".to_string()),
-                    Style::default().fg(theme.text).bg(card_bg),
-                ),
-                (
-                    "DEVICE",
-                    "n/a".to_string(),
-                    Style::default().fg(theme.text).bg(card_bg),
-                ),
-                (
-                    "STATUS",
-                    self.row.status.as_str().to_string(),
-                    tui_model_status_style(&self.row.status).bg(card_bg),
-                ),
-            ],
+            self.row
+                .port
+                .map(|port| port.to_string())
+                .unwrap_or_else(|| "n/a".to_string()),
+            self.row.device.as_deref().unwrap_or("n/a").to_string(),
+            self.row.status.as_str().to_string(),
+            tui_model_status_style(&self.row.status).bg(card_bg),
         );
 
         render_tui_model_summary_cells(
@@ -3795,7 +5106,10 @@ impl Widget for TuiModelCardWidget<'_> {
                 ),
                 (
                     "CTX",
-                    "n/a".to_string(),
+                    self.row
+                        .ctx_size
+                        .map(|ctx_size| ctx_size.to_string())
+                        .unwrap_or_else(|| "n/a".to_string()),
                     Style::default().fg(theme.text).bg(card_bg),
                 ),
             ],
@@ -3805,36 +5119,54 @@ impl Widget for TuiModelCardWidget<'_> {
             .style(Style::default().fg(theme.dim).bg(card_bg))
             .render(divider, buf);
 
-        let ctx_value = "n/a".to_string();
-        let ctx_max = "n/a".to_string();
-        let file_value = self
+        let ctx_value = self
             .row
-            .file_size_gb
-            .map(|file_size_gb| format!("{file_size_gb:.1}"))
+            .ctx_used_tokens
+            .map(|ctx_used_tokens| ctx_used_tokens.to_string())
             .unwrap_or_else(|| "n/a".to_string());
-        let file_max = if self.scale.max_file_size_gb > 0.0 {
-            format!("{:.1} GB", self.scale.max_file_size_gb)
-        } else {
-            "n/a".to_string()
-        };
+        let ctx_max = self
+            .row
+            .ctx_size
+            .map(|ctx_size| ctx_size.to_string())
+            .unwrap_or_else(|| "n/a".to_string());
+        let ctx_label = format!("{ctx_value} / {ctx_max}");
+        let slots_label = tui_model_slots_value_label(self.row);
+        let metric_value_width =
+            tui_model_metric_value_width([ctx_label.as_str(), slots_label.as_str()]);
 
         render_tui_model_metric_row(
             buf,
             ctx_row,
             card_bg,
             "CTX",
-            format!("{ctx_value} / {ctx_max}"),
-            0.0,
+            ctx_label,
+            metric_value_width,
+            tui_model_gauge_ratio(
+                self.row
+                    .ctx_used_tokens
+                    .map(|ctx_used_tokens| ctx_used_tokens as f64),
+                self.row.ctx_size.map(f64::from).unwrap_or(0.0),
+            ),
         );
-        render_tui_model_metric_row(
+        render_tui_model_slots_row(
             buf,
-            file_row,
+            slots_row,
             card_bg,
-            "FILE",
-            format!("{file_value} / {file_max}"),
-            tui_model_gauge_ratio(self.row.file_size_gb, self.scale.max_file_size_gb),
+            slots_label,
+            metric_value_width,
+            self.row,
         );
     }
+}
+
+fn tui_model_metric_value_width<'a>(labels: impl IntoIterator<Item = &'a str>) -> u16 {
+    let width = labels
+        .into_iter()
+        .map(|label| label.chars().count())
+        .max()
+        .unwrap_or(8)
+        .clamp(8, 20);
+    u16::try_from(width).unwrap_or(20)
 }
 
 fn render_tui_model_metric_row(
@@ -3843,6 +5175,7 @@ fn render_tui_model_metric_row(
     card_bg: Color,
     label: &'static str,
     value_label: String,
+    value_width: u16,
     ratio: f64,
 ) {
     if area.width == 0 || area.height == 0 {
@@ -3850,12 +5183,12 @@ fn render_tui_model_metric_row(
     }
 
     let theme = tui_theme();
-    let value_width = u16::try_from(value_label.chars().count().clamp(8, 20)).unwrap_or(20);
-    let [label_area, bar_area, value_area] = Layout::default()
+    let [label_area, bar_area, _, value_area] = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
             Constraint::Length(5),
             Constraint::Min(1),
+            Constraint::Length(1),
             Constraint::Length(value_width),
         ])
         .areas(area);
@@ -3876,6 +5209,201 @@ fn render_tui_model_metric_row(
     .style(Style::default().fg(theme.text).bg(card_bg))
     .alignment(Alignment::Right)
     .render(value_area, buf);
+}
+
+fn render_tui_model_slots_row(
+    buf: &mut Buffer,
+    area: Rect,
+    card_bg: Color,
+    value_label: String,
+    value_width: u16,
+    row: &DashboardModelRow,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let theme = tui_theme();
+    let [label_area, _, bar_area, _, value_area] = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Length(5),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(value_width),
+        ])
+        .areas(area);
+
+    Paragraph::new("SLOTS")
+        .style(
+            Style::default()
+                .fg(theme.muted)
+                .bg(card_bg)
+                .add_modifier(Modifier::BOLD),
+        )
+        .render(label_area, buf);
+    render_tui_model_slot_blocks(buf, bar_area, card_bg, row);
+    Paragraph::new(truncate_with_ellipsis(
+        &value_label,
+        usize::from(value_area.width),
+    ))
+    .style(Style::default().fg(theme.text).bg(card_bg))
+    .alignment(Alignment::Right)
+    .render(value_area, buf);
+}
+
+fn render_tui_model_slot_blocks(
+    buf: &mut Buffer,
+    area: Rect,
+    card_bg: Color,
+    row: &DashboardModelRow,
+) {
+    let theme = tui_theme();
+    let lanes = tui_model_slot_lanes(row);
+    let max_width = usize::from(area.width);
+    if max_width == 0 {
+        return;
+    }
+
+    let spans = if lanes.is_empty() {
+        vec![Span::styled(
+            "n/a",
+            Style::default().fg(theme.dim).bg(card_bg),
+        )]
+    } else {
+        let visible_slots = lanes.len().min(max_width);
+        let mut spans = Vec::with_capacity(visible_slots);
+        for lane in lanes.into_iter().take(visible_slots) {
+            spans.push(Span::styled(
+                "◼",
+                Style::default()
+                    .fg(if lane.active {
+                        theme.warning
+                    } else {
+                        theme.dim
+                    })
+                    .bg(card_bg),
+            ));
+        }
+        spans
+    };
+    Paragraph::new(Line::from(spans))
+        .style(Style::default().bg(card_bg))
+        .render(area, buf);
+}
+
+fn tui_model_slot_lanes(row: &DashboardModelRow) -> Vec<DashboardModelLane> {
+    if let Some(lanes) = row.lanes.as_ref().filter(|lanes| !lanes.is_empty()) {
+        let mut lanes = lanes.clone();
+        lanes.sort_by_key(|lane| lane.index);
+        return lanes;
+    }
+
+    let slot_count = row.slots.unwrap_or(0).min(usize::from(u16::MAX));
+    (0..slot_count)
+        .map(|index| DashboardModelLane {
+            index,
+            active: false,
+        })
+        .collect()
+}
+
+fn tui_model_slots_value_label(row: &DashboardModelRow) -> String {
+    let lanes = tui_model_slot_lanes(row);
+    if lanes.is_empty() {
+        return "n/a".to_string();
+    }
+    let active = lanes.iter().filter(|lane| lane.active).count();
+    format!("{active} / {}", lanes.len())
+}
+
+fn render_tui_model_identity_cells(
+    buf: &mut Buffer,
+    area: Rect,
+    card_bg: Color,
+    port: String,
+    device: String,
+    status: String,
+    status_style: Style,
+) {
+    render_tui_model_summary_cells(
+        buf,
+        area,
+        card_bg,
+        vec![
+            (
+                "PORT",
+                port,
+                Style::default().fg(tui_theme().text).bg(card_bg),
+            ),
+            ("STATUS", status, status_style),
+            (
+                "DEVICE",
+                device,
+                Style::default().fg(tui_theme().text).bg(card_bg),
+            ),
+        ],
+    );
+}
+
+fn render_tui_model_name_row(
+    buf: &mut Buffer,
+    area: Rect,
+    card_bg: Color,
+    name: &str,
+    max_width: usize,
+) {
+    if area.width == 0 {
+        return;
+    }
+
+    Paragraph::new(truncate_with_ellipsis(
+        name,
+        usize::from(area.width).min(max_width),
+    ))
+    .style(
+        Style::default()
+            .fg(tui_theme().text)
+            .bg(card_bg)
+            .add_modifier(Modifier::BOLD),
+    )
+    .alignment(Alignment::Left)
+    .render(area, buf);
+}
+
+fn render_tui_model_summary_cell(
+    buf: &mut Buffer,
+    area: Rect,
+    card_bg: Color,
+    label: &'static str,
+    value: String,
+    value_style: Style,
+) {
+    if area.width == 0 {
+        return;
+    }
+
+    let label_text = format!("{label}: ");
+    let label_width = label_text.chars().count();
+    let value_width = usize::from(area.width).saturating_sub(label_width).max(1);
+    let line = Line::from(vec![
+        Span::styled(
+            label_text,
+            Style::default()
+                .fg(tui_theme().dim)
+                .bg(card_bg)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            truncate_with_ellipsis(&value, value_width),
+            value_style.bg(card_bg),
+        ),
+    ]);
+    Paragraph::new(line)
+        .style(Style::default().bg(card_bg))
+        .alignment(Alignment::Left)
+        .render(area, buf);
 }
 
 fn render_tui_model_summary_cells(
@@ -3911,26 +5439,7 @@ fn render_tui_model_summary_cells(
             continue;
         }
 
-        let label_text = format!("{label}: ");
-        let label_width = label_text.chars().count();
-        let value_width = usize::from(cell_area.width)
-            .saturating_sub(label_width)
-            .max(1);
-        let value = truncate_with_ellipsis(&value, value_width);
-        let line = Line::from(vec![
-            Span::styled(
-                label_text,
-                Style::default()
-                    .fg(tui_theme().dim)
-                    .bg(card_bg)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(value, value_style.bg(card_bg)),
-        ]);
-        Paragraph::new(line)
-            .style(Style::default().bg(card_bg))
-            .alignment(Alignment::Left)
-            .render(cell_area, buf);
+        render_tui_model_summary_cell(buf, cell_area, card_bg, label, value, value_style);
     }
 }
 
@@ -4406,15 +5915,6 @@ fn tui_p50_latency_ms(samples_ms: &[u64]) -> Option<u64> {
     }
 }
 
-fn tui_model_gauge_scale(rows: &[DashboardModelRow]) -> TuiModelGaugeScale {
-    TuiModelGaugeScale {
-        max_file_size_gb: rows
-            .iter()
-            .filter_map(|row| row.file_size_gb)
-            .fold(0.0, f64::max),
-    }
-}
-
 fn tui_model_card_divider(content_width: usize) -> Line<'static> {
     let theme = tui_theme();
     Line::from(Span::styled(
@@ -4443,14 +5943,16 @@ fn tui_model_gauge_ratio(value: Option<f64>, max_value: f64) -> f64 {
 }
 
 fn tui_model_status_style(status: &RuntimeStatus) -> Style {
+    let theme = tui_theme();
     match status {
-        RuntimeStatus::Starting => Style::default().fg(Color::Yellow),
-        RuntimeStatus::Ready => Style::default().fg(Color::Green),
-        RuntimeStatus::ShuttingDown => Style::default().fg(Color::Yellow),
-        RuntimeStatus::Stopped => Style::default().fg(Color::DarkGray),
-        RuntimeStatus::Exited => Style::default().fg(Color::DarkGray),
-        RuntimeStatus::Warning => Style::default().fg(Color::Yellow),
-        RuntimeStatus::Error => Style::default().fg(Color::Red),
+        RuntimeStatus::NotReady => Style::default().fg(theme.muted),
+        RuntimeStatus::Starting | RuntimeStatus::Loading => Style::default().fg(theme.warning),
+        RuntimeStatus::Ready => Style::default().fg(theme.success),
+        RuntimeStatus::ShuttingDown => Style::default().fg(theme.warning),
+        RuntimeStatus::Stopped => Style::default().fg(theme.dim),
+        RuntimeStatus::Exited => Style::default().fg(theme.dim),
+        RuntimeStatus::Warning => Style::default().fg(theme.warning),
+        RuntimeStatus::Error => Style::default().fg(theme.error),
     }
 }
 
@@ -4507,7 +6009,7 @@ fn render_process_table(
             }
 
             let [model_width, pid_width, port_width, status_width] =
-                llama_process_column_widths(inner_area.width);
+                llama_process_column_widths_for_rows(inner_area.width, &state.llama_process_rows);
             let available_rows = usize::from(inner_area.height.saturating_sub(1));
             let rows = state
                 .llama_process_rows
@@ -4517,14 +6019,18 @@ fn render_process_table(
                 .take(available_rows)
                 .map(|(_, row)| {
                     let model = llama_process_model_metadata(row, &state.loaded_model_rows);
+                    let model_name = model.map(|model| model.name.as_str()).unwrap_or(&row.name);
                     Row::new(vec![
                         Cell::from(truncate_with_ellipsis(
-                            model.map(|model| model.name.as_str()).unwrap_or(&row.name),
+                            model_name_without_variant_suffix(model_name),
                             model_width,
                         )),
-                        Cell::from(truncate_with_ellipsis(&row.pid.to_string(), pid_width)),
+                        Cell::from(truncate_with_ellipsis(
+                            &format_dashboard_pid((row.pid != 0).then_some(row.pid)),
+                            pid_width,
+                        )),
                         Cell::from(truncate_with_ellipsis(&row.port.to_string(), port_width)),
-                        process_status_cell(row.status.as_str(), status_width),
+                        process_status_cell(&row.status, status_width),
                     ])
                 })
                 .collect::<Vec<_>>();
@@ -4565,7 +6071,7 @@ fn render_process_table(
             }
 
             let [label_width, pid_width, port_width, status_width] =
-                webserver_process_column_widths(inner_area.width);
+                webserver_process_column_widths_for_rows(inner_area.width, &state.webserver_rows);
             let available_rows = usize::from(inner_area.height.saturating_sub(1));
             let rows = state
                 .webserver_rows
@@ -4584,7 +6090,7 @@ fn render_process_table(
                             &format_dashboard_port(row.port),
                             port_width,
                         )),
-                        process_status_cell(row.status.as_str(), status_width),
+                        process_status_cell(&row.status, status_width),
                     ])
                 })
                 .collect::<Vec<_>>();
@@ -4712,19 +6218,27 @@ fn format_dashboard_port(port: u16) -> String {
     }
 }
 
-fn process_status_cell(status: &str, width: usize) -> Cell<'static> {
+fn dashboard_port_from_url(url: &str) -> u16 {
+    url.rsplit(':')
+        .next()
+        .map(|tail| tail.trim_end_matches('/'))
+        .and_then(|tail| tail.parse().ok())
+        .unwrap_or(0)
+}
+
+fn process_status_cell(status: &RuntimeStatus, width: usize) -> Cell<'static> {
     let theme = tui_theme();
     let style = match status {
-        "ready" => Style::default().fg(theme.success),
-        "starting" => Style::default().fg(theme.warning),
-        "shutting down" => Style::default().fg(theme.warning),
-        "warning" => Style::default().fg(theme.warning),
-        "error" => Style::default().fg(theme.error),
-        "stopped" => Style::default().fg(theme.dim),
-        "exited" => Style::default().fg(theme.dim),
-        _ => Style::default().fg(theme.text),
+        RuntimeStatus::NotReady => Style::default().fg(theme.muted),
+        RuntimeStatus::Ready => Style::default().fg(theme.success),
+        RuntimeStatus::Starting
+        | RuntimeStatus::Loading
+        | RuntimeStatus::ShuttingDown
+        | RuntimeStatus::Warning => Style::default().fg(theme.warning),
+        RuntimeStatus::Error => Style::default().fg(theme.error),
+        RuntimeStatus::Stopped | RuntimeStatus::Exited => Style::default().fg(theme.dim),
     };
-    Cell::from(right_align_text(status, width)).style(style)
+    Cell::from(right_align_text(status.as_str(), width)).style(style)
 }
 
 fn llama_process_model_metadata<'a>(
@@ -4736,31 +6250,93 @@ fn llama_process_model_metadata<'a>(
         .find(|model| model.port == Some(process.port))
         .or_else(|| {
             models.iter().find(|model| {
-                process.name.contains(&model.name) || model.name.contains(&process.name)
+                llama_process_model_name(&process.name)
+                    .map(|process_model| model_names_match(process_model, &model.name))
+                    .unwrap_or(false)
             })
         })
 }
 
+#[cfg(test)]
 fn llama_process_column_widths(body_width: u16) -> [usize; 4] {
-    let status_width = 5usize;
-    let port_width = 5usize;
-    let pid_width = 5usize;
-    let reserved_width = status_width + port_width + pid_width + 3 + 2;
-    let model_width = usize::from(body_width)
-        .saturating_sub(reserved_width)
-        .max(8);
-    [model_width, pid_width, port_width, status_width]
+    process_column_widths(
+        body_width,
+        8,
+        process_pid_width(std::iter::empty()),
+        RuntimeStatus::NotReady.as_str().len(),
+    )
 }
 
+fn llama_process_column_widths_for_rows(
+    body_width: u16,
+    rows: &[DashboardProcessRow],
+) -> [usize; 4] {
+    process_column_widths(
+        body_width,
+        8,
+        process_pid_width(rows.iter().map(|row| (row.pid != 0).then_some(row.pid))),
+        process_status_width(rows.iter().map(|row| &row.status)),
+    )
+}
+
+#[cfg(test)]
 fn webserver_process_column_widths(body_width: u16) -> [usize; 4] {
-    let pid_width = 5usize;
+    process_column_widths(
+        body_width,
+        PRETTY_TUI_WEBSERVER_PROCESS_HEADER_LABEL.len(),
+        process_pid_width(std::iter::empty()),
+        RuntimeStatus::NotReady.as_str().len(),
+    )
+}
+
+fn webserver_process_column_widths_for_rows(
+    body_width: u16,
+    rows: &[DashboardEndpointRow],
+) -> [usize; 4] {
+    process_column_widths(
+        body_width,
+        PRETTY_TUI_WEBSERVER_PROCESS_HEADER_LABEL.len(),
+        process_pid_width(rows.iter().map(|row| row.pid)),
+        process_status_width(rows.iter().map(|row| &row.status)),
+    )
+}
+
+fn process_column_widths(
+    body_width: u16,
+    min_text_width: usize,
+    pid_width: usize,
+    status_width: usize,
+) -> [usize; 4] {
     let port_width = 5usize;
-    let status_width = 5usize;
     let reserved_width = pid_width + port_width + status_width + 3 + 2;
-    let label_width = usize::from(body_width)
+    let text_width = usize::from(body_width)
         .saturating_sub(reserved_width)
-        .max(PRETTY_TUI_WEBSERVER_PROCESS_HEADER_LABEL.len());
-    [label_width, pid_width, port_width, status_width]
+        .max(min_text_width);
+    [text_width, pid_width, port_width, status_width]
+}
+
+fn process_pid_width<I>(pids: I) -> usize
+where
+    I: IntoIterator<Item = Option<u32>>,
+{
+    pids.into_iter()
+        .map(format_dashboard_pid)
+        .map(|pid| pid.chars().count())
+        .max()
+        .unwrap_or(5)
+        .max(5)
+}
+
+fn process_status_width<'a, I>(statuses: I) -> usize
+where
+    I: IntoIterator<Item = &'a RuntimeStatus>,
+{
+    statuses
+        .into_iter()
+        .map(|status| status.as_str().chars().count())
+        .max()
+        .unwrap_or_else(|| RuntimeStatus::NotReady.as_str().len())
+        .max("STATE".len())
 }
 
 fn render_events_panel(
@@ -5003,21 +6579,34 @@ fn render_model_progress_loader(frame: &mut Frame, state: &DashboardState, area:
     }
     let progress = state.active_loading_progress();
     let logo_text = tui_logo_view(area, false);
-    let logo_height = logo_text
+    let raw_logo_height = logo_text
         .as_ref()
         .map(|text| u16::try_from(text.lines.len()).unwrap_or(u16::MAX))
         .unwrap_or(0)
         .min(area.height);
     let has_progress = progress.is_some();
-    let gap_height = u16::from(has_progress && logo_height > 0);
     let bar_height = u16::from(has_progress);
     let detail_height = u16::from(has_progress);
-    let loader_height = logo_height
+    let desired_context_rows =
+        u16::try_from((state.startup_history.len().saturating_add(1)).min(10)).unwrap_or(10);
+    let max_logo_height = area
+        .height
+        .saturating_sub(u16::from(has_progress))
+        .saturating_sub(bar_height)
+        .saturating_sub(detail_height)
+        .saturating_sub(desired_context_rows)
+        .max(1);
+    let logo_height = raw_logo_height.min(max_logo_height);
+    let gap_height = u16::from(has_progress && logo_height > 0);
+    let base_height = logo_height
         .saturating_add(gap_height)
         .saturating_add(bar_height)
         .saturating_add(detail_height)
-        .max(logo_height.max(1))
-        .min(area.height);
+        .max(logo_height.max(1));
+    let context_lines =
+        startup_loader_context_lines(state, area.width, area.height.saturating_sub(base_height));
+    let context_height = u16::try_from(context_lines.len()).unwrap_or(u16::MAX);
+    let loader_height = base_height.saturating_add(context_height).min(area.height);
     let loader_area = Rect {
         x: area.x,
         y: area.y + area.height.saturating_sub(loader_height) / 2,
@@ -5075,6 +6664,69 @@ fn render_model_progress_loader(frame: &mut Frame, state: &DashboardState, area:
             detail_area,
         );
     }
+
+    if context_height > 0 {
+        let context_y = loader_area.y + logo_height + gap_height + bar_height + detail_height;
+        let context_area = Rect {
+            x: loader_area.x,
+            y: context_y,
+            width: loader_area.width,
+            height: context_height.min(loader_area.bottom().saturating_sub(context_y)),
+        };
+        if context_area.height > 0 {
+            frame.render_widget(Paragraph::new(context_lines), context_area);
+        }
+    }
+}
+
+fn startup_loader_context_lines(
+    state: &DashboardState,
+    width: u16,
+    available_rows: u16,
+) -> Vec<Line<'static>> {
+    if available_rows == 0 {
+        return Vec::new();
+    }
+
+    let content_width = usize::from(width.max(1));
+    let mut lines = vec![startup_lifecycle_summary_line(
+        &state.startup_lifecycle,
+        content_width,
+    )];
+    lines.extend(
+        state
+            .startup_history
+            .iter()
+            .take(usize::from(available_rows).saturating_sub(lines.len()))
+            .map(|event| event_line(event, content_width)),
+    );
+    lines.truncate(usize::from(available_rows));
+    lines
+}
+
+fn startup_lifecycle_summary_line(
+    lifecycle: &StartupLifecycleState,
+    width: usize,
+) -> Line<'static> {
+    let theme = tui_theme();
+    let summary = format!(
+        "startup={}{}  mesh={}  api={}  console={}  llama-server={}  model readiness={}",
+        lifecycle.phase.as_str(),
+        lifecycle
+            .failure
+            .as_ref()
+            .map(|failure| format!("  failure={}", single_line_status_text(failure)))
+            .unwrap_or_default(),
+        lifecycle.mesh.phase.as_str(),
+        lifecycle.api.phase.as_str(),
+        lifecycle.console.phase.as_str(),
+        lifecycle.llama_server.phase.as_str(),
+        lifecycle.model_readiness.phase.as_str(),
+    );
+    Line::from(Span::styled(
+        truncate_with_ellipsis(&summary, width),
+        Style::default().fg(theme.dim),
+    ))
 }
 
 fn render_tui_logo(frame: &mut Frame, area: Rect, dimmed: bool) {
@@ -5417,14 +7069,6 @@ fn startup_progress_event(event: &OutputEvent) -> Option<(Option<String>, String
             Some(format!("host_elected:{model}")),
             format!("elected {host} for {model}"),
         )),
-        OutputEvent::RpcServerStarting { port, device, .. } => Some((
-            Some(format!("rpc_server_starting:{port}")),
-            format!("starting rpc-server on {device}"),
-        )),
-        OutputEvent::RpcReady { port, device, .. } => Some((
-            Some(format!("rpc_ready:{port}")),
-            format!("rpc-server ready on {device}"),
-        )),
         OutputEvent::LlamaStarting {
             model, http_port, ..
         } => Some((
@@ -5440,6 +7084,18 @@ fn startup_progress_event(event: &OutputEvent) -> Option<(Option<String>, String
                 .as_ref()
                 .map(|model| format!("llama-server ready for {model}"))
                 .unwrap_or_else(|| format!("llama-server ready on port {port}")),
+        )),
+        OutputEvent::LlamaStartupFailed {
+            model,
+            http_port,
+            detail,
+            ..
+        } => Some((
+            Some(format!("llama_failed:{}", model_key(model, *http_port))),
+            model
+                .as_ref()
+                .map(|model| format!("llama-server failed for {model}: {detail}"))
+                .unwrap_or_else(|| format!("llama-server failed on port {http_port}: {detail}")),
         )),
         OutputEvent::ModelReady { model, .. } => Some((
             Some(format!("model_ready:{model}")),
@@ -5466,6 +7122,55 @@ fn startup_progress_event(event: &OutputEvent) -> Option<(Option<String>, String
         )),
         _ => None,
     }
+}
+
+fn startup_history_summary(event: &OutputEvent) -> Option<String> {
+    match event {
+        OutputEvent::Startup { .. }
+        | OutputEvent::LaunchPlan { .. }
+        | OutputEvent::NodeIdentity { .. }
+        | OutputEvent::InviteToken { .. }
+        | OutputEvent::DiscoveryStarting { .. }
+        | OutputEvent::MeshFound { .. }
+        | OutputEvent::DiscoveryJoined { .. }
+        | OutputEvent::DiscoveryFailed { .. }
+        | OutputEvent::WaitingForPeers { .. }
+        | OutputEvent::PassiveMode { .. }
+        | OutputEvent::ModelQueued { .. }
+        | OutputEvent::ModelLoading { .. }
+        | OutputEvent::ModelLoaded { .. }
+        | OutputEvent::HostElected { .. }
+        | OutputEvent::LlamaStarting { .. }
+        | OutputEvent::LlamaReady { .. }
+        | OutputEvent::LlamaStartupFailed { .. }
+        | OutputEvent::ModelReady { .. }
+        | OutputEvent::WebserverStarting { .. }
+        | OutputEvent::WebserverReady { .. }
+        | OutputEvent::ApiStarting { .. }
+        | OutputEvent::ApiReady { .. }
+        | OutputEvent::RuntimeReady { .. }
+        | OutputEvent::Error { .. }
+        | OutputEvent::Warning { .. } => Some(event.summary_line()),
+        OutputEvent::ModelDownloadProgress { status, .. } => {
+            if matches!(status, ModelProgressStatus::Ready) {
+                Some(event.summary_line())
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_shutdown_suppressed_ready_event(event: &OutputEvent) -> bool {
+    matches!(
+        event,
+        OutputEvent::LlamaReady { .. }
+            | OutputEvent::ModelReady { .. }
+            | OutputEvent::WebserverReady { .. }
+            | OutputEvent::ApiReady { .. }
+            | OutputEvent::RuntimeReady { .. }
+    )
 }
 
 fn model_key(model: &Option<String>, port: u16) -> String {
@@ -5859,22 +7564,24 @@ fn readiness_label(state: &DashboardState) -> &'static str {
             .any(|row| matches!(row.status, RuntimeStatus::Error | RuntimeStatus::Warning))
     {
         "degraded"
-    } else if state
-        .llama_instances
+    } else if state.llama_instances.iter().any(|instance| {
+        matches!(
+            instance.status,
+            RuntimeStatus::Starting | RuntimeStatus::Loading
+        )
+    }) || state.running_models.iter().any(|model| {
+        matches!(
+            model.status,
+            RuntimeStatus::Starting | RuntimeStatus::Loading
+        )
+    }) || state
+        .loaded_model_rows
         .iter()
-        .any(|instance| matches!(instance.status, RuntimeStatus::Starting))
-        || state
-            .running_models
-            .iter()
-            .any(|model| matches!(model.status, RuntimeStatus::Starting))
-        || state
-            .loaded_model_rows
-            .iter()
-            .any(|row| matches!(row.status, RuntimeStatus::Starting))
+        .any(|row| matches!(row.status, RuntimeStatus::Starting | RuntimeStatus::Loading))
         || state
             .webserver_rows
             .iter()
-            .any(|row| matches!(row.status, RuntimeStatus::Starting))
+            .any(|row| matches!(row.status, RuntimeStatus::Starting | RuntimeStatus::Loading))
     {
         "starting"
     } else if state
@@ -5976,8 +7683,7 @@ impl InteractiveDashboardFormatter {
             self.dirty = true;
             Ok(None)
         } else {
-            let (columns, rows) = crossterm::terminal::size().unwrap_or((120, 24));
-            render_tui_text_snapshot(&self.state, columns, rows).map(Some)
+            Ok(Some(format!("{}\n", event.summary_line())))
         }
     }
 
@@ -6557,9 +8263,9 @@ fn dashboard_layout_for_terminal_size(columns: u16, rows: u16) -> DashboardLayou
     let join_token_rows = usize::from(PRETTY_TUI_JOIN_TOKEN_PANEL_HEIGHT);
     let requests_rows = 6usize;
     let requests_band_rows = requests_rows + 2;
-    // Cap the dashboard height so it stays compact (~32 rows) instead of
-    // stretching to fill the entire terminal.
-    let max_dashboard_rows = usize::from(rows).min(32);
+    // Cap the dashboard height so it stays compact while leaving enough
+    // room for two full-height loaded model cards.
+    let max_dashboard_rows = usize::from(rows).min(33);
     let narrow_width_penalty = usize::from(columns < PRETTY_TUI_MIN_DASHBOARD_WIDTH);
     let main_body_rows = max_dashboard_rows
         .saturating_sub(footer_rows + join_token_rows + requests_band_rows)
@@ -6670,6 +8376,126 @@ impl DashboardFormatter {
 }
 
 #[cfg(test)]
+pub(crate) fn assert_startup_lifecycle_transitions_pending_partial_ready_failed() {
+    tests::assert_startup_lifecycle_transitions_pending_partial_ready_failed();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_lifecycle_keeps_runtime_ready_as_final_edge() {
+    tests::assert_startup_lifecycle_keeps_runtime_ready_as_final_edge();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_failures_surface_in_tui_events_and_status() {
+    tests::assert_startup_failures_surface_in_tui_events_and_status();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_failure_summary_sanitizes_multiline_detail() {
+    tests::assert_startup_failure_summary_sanitizes_multiline_detail();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_rpc_and_llama_startup_failures_mark_components_failed() {
+    tests::assert_rpc_and_llama_startup_failures_mark_components_failed();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_discovery_and_join_failures_mark_startup_mesh_component_failed() {
+    tests::assert_discovery_and_join_failures_mark_startup_mesh_component_failed();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_post_ready_peer_churn_does_not_reopen_startup_failure() {
+    tests::assert_post_ready_peer_churn_does_not_reopen_startup_failure();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_history_is_visible_after_late_tui_attach() {
+    tests::assert_startup_history_is_visible_after_late_tui_attach();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_history_keeps_order_when_tui_attaches_late() {
+    tests::assert_startup_history_keeps_order_when_tui_attaches_late();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_endpoint_rows_remain_starting_until_ready_events() {
+    tests::assert_endpoint_rows_remain_starting_until_ready_events();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_launch_plan_renders_not_ready_rows_before_actions() {
+    tests::assert_startup_launch_plan_renders_not_ready_rows_before_actions();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_progress_after_launch_plan_shows_dashboard_not_loader() {
+    tests::assert_startup_progress_after_launch_plan_shows_dashboard_not_loader();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_tui_model_progress_renders_dashboard_without_loading_screen() {
+    tests::assert_tui_model_progress_renders_dashboard_without_loading_screen();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_tui_startup_progress_continues_in_dashboard_after_model_download_ready() {
+    tests::assert_tui_startup_progress_continues_in_dashboard_after_model_download_ready();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_planned_rows_transition_from_not_ready_to_ready_events() {
+    tests::assert_planned_rows_transition_from_not_ready_to_ready_events();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_launch_plan_rows_survive_empty_startup_snapshot() {
+    tests::assert_launch_plan_rows_survive_empty_startup_snapshot();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_launch_plan_preserves_distinct_port_zero_endpoint_rows() {
+    tests::assert_launch_plan_preserves_distinct_port_zero_endpoint_rows();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_snapshot_upsert_preserves_distinct_port_zero_endpoint_rows() {
+    tests::assert_snapshot_upsert_preserves_distinct_port_zero_endpoint_rows();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_planned_port_zero_process_rows_bind_to_concrete_startup_events() {
+    tests::assert_planned_port_zero_process_rows_bind_to_concrete_startup_events();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_fallback_mode_surfaces_startup_failures_without_tui() {
+    tests::assert_fallback_mode_surfaces_startup_failures_without_tui();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_shutdown_suppresses_late_ready_render() {
+    tests::assert_shutdown_suppresses_late_ready_render();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_interactive_preterminal_render_uses_plain_event_output() {
+    tests::assert_interactive_preterminal_render_uses_plain_event_output();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_interactive_post_terminal_exit_resumes_plain_event_output() {
+    tests::assert_interactive_post_terminal_exit_resumes_plain_event_output();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_tui_model_card_separates_name_from_metadata_columns() {
+    tests::assert_tui_model_card_separates_name_from_metadata_columns();
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
     struct StaticDashboardSnapshotProvider {
@@ -6740,7 +8566,97 @@ mod tests {
             slots: Some(4),
             quantization: Some("Q4_K_M".to_string()),
             ctx_size: Some(8192),
+            ctx_used_tokens: Some(8192),
+            lanes: Some(vec![
+                DashboardModelLane {
+                    index: 0,
+                    active: true,
+                },
+                DashboardModelLane {
+                    index: 1,
+                    active: true,
+                },
+                DashboardModelLane {
+                    index: 2,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 3,
+                    active: false,
+                },
+            ]),
             file_size_gb: Some(24.0),
+        }
+    }
+
+    fn sample_launch_plan() -> DashboardLaunchPlan {
+        DashboardLaunchPlan {
+            llama_process_rows: vec![DashboardProcessRow {
+                name: "llama-server".to_string(),
+                backend: String::new(),
+                status: RuntimeStatus::Loading,
+                port: 0,
+                pid: 0,
+            }],
+            webserver_rows: vec![
+                DashboardEndpointRow {
+                    label: "Console".to_string(),
+                    status: RuntimeStatus::NotReady,
+                    url: "http://localhost:3131".to_string(),
+                    port: 3131,
+                    pid: None,
+                },
+                DashboardEndpointRow {
+                    label: "API".to_string(),
+                    status: RuntimeStatus::NotReady,
+                    url: "http://localhost:9337".to_string(),
+                    port: 9337,
+                    pid: None,
+                },
+            ],
+            loaded_model_rows: vec![DashboardModelRow {
+                name: "Planned-Model".to_string(),
+                role: Some("host".to_string()),
+                status: RuntimeStatus::Loading,
+                port: None,
+                device: Some("GPU0".to_string()),
+                slots: Some(4),
+                quantization: Some("Q4_K_M".to_string()),
+                ctx_size: Some(8192),
+                ctx_used_tokens: None,
+                lanes: None,
+                file_size_gb: Some(7.5),
+            }],
+        }
+    }
+
+    fn port_zero_endpoint_launch_plan() -> DashboardLaunchPlan {
+        DashboardLaunchPlan {
+            llama_process_rows: Vec::new(),
+            webserver_rows: vec![
+                DashboardEndpointRow {
+                    label: "Plugin: alpha".to_string(),
+                    status: RuntimeStatus::Ready,
+                    url: "alpha-plugin".to_string(),
+                    port: 0,
+                    pid: Some(1000),
+                },
+                DashboardEndpointRow {
+                    label: "Plugin: beta".to_string(),
+                    status: RuntimeStatus::Ready,
+                    url: "beta-plugin".to_string(),
+                    port: 0,
+                    pid: Some(1002),
+                },
+                DashboardEndpointRow {
+                    label: "Plugin: zebra".to_string(),
+                    status: RuntimeStatus::Ready,
+                    url: "zebra-plugin".to_string(),
+                    port: 0,
+                    pid: Some(1001),
+                },
+            ],
+            loaded_model_rows: Vec::new(),
         }
     }
 
@@ -6781,6 +8697,9 @@ mod tests {
             OutputEvent::Startup {
                 version: "v0.64.0".to_string(),
                 message: Some("mesh-llm starting".to_string()),
+            },
+            OutputEvent::LaunchPlan {
+                plan: sample_launch_plan(),
             },
             OutputEvent::NodeIdentity {
                 node_id: "node-123".to_string(),
@@ -7997,6 +9916,19 @@ mod tests {
         (lines.join("\n"), buffer)
     }
 
+    fn buffer_to_rendered_string(buffer: &ratatui::buffer::Buffer) -> String {
+        let area = buffer.area;
+        let mut lines = Vec::with_capacity(usize::from(area.height));
+        for y in area.y..area.bottom() {
+            let mut line = String::new();
+            for x in area.x..area.right() {
+                line.push_str(buffer[(x, y)].symbol());
+            }
+            lines.push(line.trim_end().to_string());
+        }
+        lines.join("\n")
+    }
+
     fn find_rendered_line<'a>(rendered: &'a str, needle: &str) -> (usize, &'a str) {
         rendered
             .lines()
@@ -8577,13 +10509,39 @@ mod tests {
     }
 
     #[test]
+    fn tui_llama_process_table_omits_model_variant_suffix() {
+        let mut formatter = InteractiveDashboardFormatter::default();
+        let mut process_row = sample_process_row("llama-server", 8001);
+        process_row.name = "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string();
+        formatter.handle_snapshot(DashboardSnapshot {
+            llama_process_rows: vec![process_row],
+            ..snapshot_fixture(0, 30)
+        });
+        formatter.handle_tui_event(TuiEvent::Resize {
+            columns: 160,
+            rows: 30,
+        });
+
+        let rendered = render_tui_frame_snapshot(&formatter.state, 160, 30);
+
+        assert!(
+            rendered.contains("unsloth/Qwen3.5-4B-G"),
+            "expected truncated base model ref in llama.cpp process table: {rendered}"
+        );
+        assert!(
+            !rendered.contains(":UD-Q4_K_XL"),
+            "TUI should omit GGUF variant suffix from llama.cpp process model names: {rendered}"
+        );
+    }
+
+    #[test]
     fn tui_process_table_widths_give_text_columns_leftover_space() {
         let [model_width, pid_width, port_width, status_width] = llama_process_column_widths(52);
 
         assert_eq!(pid_width, 5);
         assert_eq!(port_width, 5);
-        assert_eq!(status_width, 5);
-        assert_eq!(model_width, 32);
+        assert_eq!(status_width, RuntimeStatus::NotReady.as_str().len());
+        assert_eq!(model_width, 28);
 
         let rows = [DashboardEndpointRow {
             label: "Plugin: browser-tools".to_string(),
@@ -8597,8 +10555,8 @@ mod tests {
 
         assert_eq!(web_pid_width, 5);
         assert_eq!(web_port_width, 5);
-        assert_eq!(web_status_width, 5);
-        assert_eq!(label_width, 32);
+        assert_eq!(web_status_width, RuntimeStatus::NotReady.as_str().len());
+        assert_eq!(label_width, 28);
         assert!(label_width >= rows[0].label.len());
         assert!(label_width >= PRETTY_TUI_WEBSERVER_PROCESS_HEADER_LABEL.len());
     }
@@ -8607,6 +10565,32 @@ mod tests {
     fn tui_dashboard_process_table_renders_missing_pid_as_dash() {
         assert_eq!(format_dashboard_pid(None), "-");
         assert_eq!(format_dashboard_pid(Some(4321)), "4321");
+    }
+
+    #[test]
+    fn tui_process_table_renders_six_digit_pid_without_truncation() {
+        let mut formatter = InteractiveDashboardFormatter::default();
+        formatter.handle_snapshot(DashboardSnapshot {
+            webserver_rows: vec![DashboardEndpointRow {
+                label: "Plugin: blobstore".to_string(),
+                status: RuntimeStatus::Ready,
+                url: "blobstore".to_string(),
+                port: 0,
+                pid: Some(132098),
+            }],
+            ..snapshot_fixture(0, 30)
+        });
+        formatter.handle_tui_event(TuiEvent::Resize {
+            columns: 120,
+            rows: 24,
+        });
+
+        let rendered = render_tui_frame_snapshot(&formatter.state, 120, 24);
+
+        assert!(
+            rendered.contains("132098"),
+            "expected full six-digit PID in process table: {rendered}"
+        );
     }
 
     #[test]
@@ -9336,7 +11320,7 @@ mod tests {
     }
 
     #[test]
-    fn tui_model_progress_renders_meshllm_wordmark_and_bar() {
+    fn tui_model_progress_renders_dashboard_without_loading_screen() {
         let mut state = DashboardState::default();
         state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
             120, 24,
@@ -9351,31 +11335,24 @@ mod tests {
             },
         ));
 
-        let (rendered, buffer) = render_tui_frame_snapshot_with_buffer(&state, 120, 48);
-        let (detail_y, _) = find_rendered_line(
-            &rendered,
-            "downloading model qwen2.5-0.5b-instruct-q4_k_m.gguf",
-        );
+        let rendered = render_tui_frame_snapshot(&state, 120, 48);
 
-        assert!(rendered.contains("downloading model qwen2.5-0.5b-instruct-q4_k_m.gguf"));
-        assert!(rendered.contains('█'));
         assert!(
-            !render_tui_frame_snapshot(&state, 120, 48).contains("Mesh Events"),
-            "loading splash should own the full frame"
+            rendered.contains("Mesh Events"),
+            "startup progress should render inside the dashboard, not a loading screen: {rendered}"
         );
         assert!(
-            (0..detail_y.saturating_sub(2)).any(|y| {
-                (0..120).any(|x| {
-                    let cell = &buffer[(x as u16, y as u16)];
-                    cell.symbol() != " " && cell.style().fg.is_some()
-                })
-            }),
-            "expected ANSI logo content above the progress detail\n{rendered}"
+            !rendered.contains('█'),
+            "startup progress should not render the old progress bar: {rendered}"
         );
     }
 
+    pub(crate) fn assert_tui_model_progress_renders_dashboard_without_loading_screen() {
+        tui_model_progress_renders_dashboard_without_loading_screen();
+    }
+
     #[test]
-    fn tui_startup_progress_continues_after_model_download_ready() {
+    fn tui_startup_progress_continues_in_dashboard_after_model_download_ready() {
         let mut state = DashboardState::default();
         state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
             120, 24,
@@ -9400,7 +11377,6 @@ mod tests {
             .active_loading_progress()
             .expect("startup loading progress should remain active before runtime ready");
         let rendered = render_tui_frame_snapshot(&state, 120, 48);
-        let bar = loading_progress_bar(progress.ratio, 40);
 
         assert!(
             progress.ratio < 1.0,
@@ -9409,12 +11385,15 @@ mod tests {
         assert!(progress
             .detail
             .contains("starting llama-server for Qwen2.5"));
-        assert!(rendered.contains("starting llama-server for Qwen2.5"));
         assert!(
-            bar.contains('░'),
-            "progress bar should still have remaining work"
+            rendered.contains("Mesh Events"),
+            "startup progress should stay in the dashboard instead of taking over the frame: {rendered}"
         );
-        assert!(!rendered.contains("Mesh Events"));
+        assert!(!rendered.contains('█'));
+    }
+
+    pub(crate) fn assert_tui_startup_progress_continues_in_dashboard_after_model_download_ready() {
+        tui_startup_progress_continues_in_dashboard_after_model_download_ready();
     }
 
     #[test]
@@ -9433,17 +11412,15 @@ mod tests {
             .active_loading_progress()
             .expect("download-ready progress should seed startup progress")
             .ratio;
-
-        state.reduce(DashboardAction::OutputEvent(
-            OutputEvent::RpcServerStarting {
-                port: 50052,
-                device: "CUDA0".to_string(),
-                log_path: None,
-            },
-        ));
-        let after_rpc = state
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Qwen2.5-0.5B-Instruct-Q4_K_M".to_string()),
+            http_port: 9338,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+        let after_llama_start = state
             .active_loading_progress()
-            .expect("rpc startup should advance startup progress")
+            .expect("llama startup should advance startup progress")
             .ratio;
 
         state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelReady {
@@ -9456,8 +11433,8 @@ mod tests {
             .expect("model ready should advance startup progress")
             .ratio;
 
-        assert!(after_rpc > after_download);
-        assert!(after_model_ready > after_rpc);
+        assert!(after_llama_start > after_download);
+        assert!(after_model_ready > after_llama_start);
     }
 
     #[test]
@@ -9538,10 +11515,1681 @@ mod tests {
     }
 
     #[test]
+    fn startup_lifecycle_transitions_pending_partial_ready_failed() {
+        let mut state = DashboardState::default();
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Pending
+        );
+        assert_eq!(
+            state.startup_lifecycle().api.phase,
+            StartupLifecyclePhase::Pending
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Starting
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiStarting {
+            url: "http://localhost:9337".to_string(),
+        }));
+        assert_eq!(
+            state.startup_lifecycle().api.phase,
+            StartupLifecyclePhase::Starting
+        );
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Starting
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiReady {
+            url: "http://localhost:9337".to_string(),
+        }));
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Partial
+        );
+        assert_eq!(
+            state.startup_lifecycle().api.phase,
+            StartupLifecyclePhase::Ready
+        );
+
+        let partial_rendered = render_tui_frame_snapshot(&state, 160, 32);
+        let partial_dashboard = render_dashboard_text(&state);
+        assert!(partial_rendered.contains("startup=partial"));
+        assert!(partial_dashboard.contains("mesh=pending  api=ready  console=pending"));
+        assert!(partial_dashboard.contains("llama-server=pending  model readiness=pending"));
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::RuntimeReady {
+            api_url: "http://localhost:9337".to_string(),
+            console_url: Some("http://localhost:3131".to_string()),
+            api_port: 9337,
+            console_port: Some(3131),
+            models_count: Some(1),
+            pi_command: None,
+            goose_command: None,
+        }));
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(
+            state.startup_lifecycle().llama_server.phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(
+            state.startup_lifecycle().llama_server.detail.as_deref(),
+            Some("embedded runtime ready")
+        );
+
+        let ready_rendered = render_tui_frame_snapshot(&state, 160, 32);
+        let ready_dashboard = render_dashboard_text(&state);
+        assert!(ready_rendered.contains("startup=ready"));
+        assert!(ready_dashboard.contains("mesh=ready  api=ready  console=ready"));
+        assert!(ready_dashboard.contains("llama-server=ready  model readiness=pending"));
+
+        let mut failed = DashboardState::default();
+        failed.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        failed.reduce(DashboardAction::OutputEvent(OutputEvent::Error {
+            message: "mesh startup failed".to_string(),
+            context: Some("startup".to_string()),
+        }));
+        assert_eq!(
+            failed.startup_lifecycle().phase,
+            StartupLifecyclePhase::Failed
+        );
+        let failed_rendered = render_tui_frame_snapshot(&failed, 160, 32);
+        let failed_dashboard = render_dashboard_text(&failed);
+        assert!(failed_rendered.contains("startup=failed"));
+        assert!(failed_dashboard.contains("mesh=failed"));
+    }
+
+    #[test]
+    fn startup_lifecycle_keeps_runtime_ready_as_final_edge() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::NodeIdentity {
+            node_id: "node-7".to_string(),
+            mesh_id: Some("poker-night".to_string()),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::WebserverReady {
+            url: "http://localhost:3131".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiReady {
+            url: "http://localhost:9337".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaReady {
+            model: Some("Qwen3-32B".to_string()),
+            port: 9338,
+            ctx_size: Some(8192),
+            log_path: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelReady {
+            model: "Qwen3-32B".to_string(),
+            internal_port: Some(9338),
+            role: Some("host".to_string()),
+        }));
+
+        assert!(
+            !state.runtime_ready,
+            "RuntimeReady must remain the final edge"
+        );
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Partial
+        );
+        assert_eq!(
+            state.startup_lifecycle().model_readiness.phase,
+            StartupLifecyclePhase::Ready
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::RuntimeReady {
+            api_url: "http://localhost:9337".to_string(),
+            console_url: Some("http://localhost:3131".to_string()),
+            api_port: 9337,
+            console_port: Some(3131),
+            models_count: Some(1),
+            pi_command: None,
+            goose_command: None,
+        }));
+
+        assert!(state.runtime_ready);
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Ready
+        );
+    }
+
+    #[test]
+    fn endpoint_rows_remain_starting_until_ready_events() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            llama_process_rows: vec![sample_process_row("llama-server", 9338)],
+            webserver_rows: vec![
+                sample_endpoint_row("Console", 3131),
+                sample_endpoint_row("API", 9337),
+            ],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(
+            state.webserver_rows,
+            vec![
+                DashboardEndpointRow {
+                    label: "Console".to_string(),
+                    status: RuntimeStatus::Starting,
+                    url: "http://127.0.0.1:3131".to_string(),
+                    port: 3131,
+                    pid: None,
+                },
+                DashboardEndpointRow {
+                    label: "API".to_string(),
+                    status: RuntimeStatus::Starting,
+                    url: "http://127.0.0.1:9337".to_string(),
+                    port: 9337,
+                    pid: None,
+                },
+            ]
+        );
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .map(|row| (&row.name, &row.status))
+                .collect::<Vec<_>>(),
+            vec![(&"llama-server".to_string(), &RuntimeStatus::Starting)]
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::WebserverReady {
+            url: "http://localhost:3131".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiReady {
+            url: "http://localhost:9337".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaReady {
+            model: Some("Qwen3-32B".to_string()),
+            port: 9338,
+            ctx_size: Some(8192),
+            log_path: None,
+        }));
+
+        assert!(state
+            .webserver_rows
+            .iter()
+            .all(|row| row.status == RuntimeStatus::Ready));
+        assert_eq!(state.llama_process_rows[0].status, RuntimeStatus::Ready);
+    }
+
+    #[test]
+    fn startup_history_is_visible_after_late_tui_attach() {
+        let mut formatter = InteractiveDashboardFormatter::default();
+        for event in [
+            OutputEvent::Startup {
+                version: "v0.65.0".to_string(),
+                message: None,
+            },
+            OutputEvent::NodeIdentity {
+                node_id: "node-7".to_string(),
+                mesh_id: Some("poker-night".to_string()),
+            },
+            OutputEvent::ApiStarting {
+                url: "http://localhost:9337".to_string(),
+            },
+            OutputEvent::LlamaStarting {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: None,
+            },
+        ] {
+            formatter
+                .handle_output_event(&event)
+                .expect("pre-attach startup events should reduce cleanly");
+        }
+
+        let rendered = render_tui_frame_snapshot(&formatter.state, 160, 32);
+
+        assert!(
+            rendered.contains("startup=partial"),
+            "expected lifecycle summary in {rendered}"
+        );
+        assert!(
+            rendered.contains("mesh-llm starting"),
+            "expected startup line in {rendered}"
+        );
+        assert!(
+            rendered.contains("node node-7 joined mesh poker-night"),
+            "expected node identity line in {rendered}"
+        );
+        assert!(
+            rendered.contains("api starting at http://localhost:9337"),
+            "expected API start line in {rendered}"
+        );
+        assert!(
+            rendered.contains("llama-server starting: port=9338 model=Qwen3-32B"),
+            "expected llama start line in {rendered}"
+        );
+        assert!(
+            rendered.contains("Mesh Events"),
+            "late attach should render the main dashboard now that the loading screen is gone"
+        );
+        assert!(formatter
+            .state
+            .startup_history
+            .iter()
+            .any(|event| event.summary.contains("llama-server starting: port=9338")));
+    }
+
+    #[test]
+    fn startup_history_keeps_order_when_tui_attaches_late() {
+        let mut formatter = InteractiveDashboardFormatter::default();
+        for event in [
+            OutputEvent::Startup {
+                version: "v0.65.0".to_string(),
+                message: None,
+            },
+            OutputEvent::NodeIdentity {
+                node_id: "node-7".to_string(),
+                mesh_id: Some("poker-night".to_string()),
+            },
+            OutputEvent::ApiStarting {
+                url: "http://localhost:9337".to_string(),
+            },
+            OutputEvent::ApiReady {
+                url: "http://localhost:9337".to_string(),
+            },
+            OutputEvent::LlamaStarting {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: None,
+            },
+        ] {
+            formatter
+                .handle_output_event(&event)
+                .expect("pre-attach startup events should reduce cleanly");
+        }
+
+        let rendered = render_tui_frame_snapshot(&formatter.state, 160, 32);
+        assert!(rendered.contains("Mesh Events"));
+        let history: Vec<&str> = formatter
+            .state
+            .startup_history
+            .iter()
+            .map(|event| event.summary.as_str())
+            .collect();
+        let startup_index = history
+            .iter()
+            .position(|summary| summary.contains("mesh-llm starting"))
+            .expect("expected startup line in retained history");
+        let node_index = history
+            .iter()
+            .position(|summary| summary.contains("node node-7 joined mesh poker-night"))
+            .expect("expected node identity line in retained history");
+        let api_start_index = history
+            .iter()
+            .position(|summary| summary.contains("api starting at http://localhost:9337"))
+            .expect("expected API start line in retained history");
+        let api_ready_index = history
+            .iter()
+            .position(|summary| summary.contains("api ready at http://localhost:9337"))
+            .expect("expected API ready line in retained history");
+
+        assert!(startup_index < node_index);
+        assert!(node_index < api_start_index);
+        assert!(api_start_index < api_ready_index);
+    }
+
+    #[test]
+    fn startup_failures_surface_in_tui_events_and_status() {
+        let mut formatter = InteractiveDashboardFormatter::default();
+        for event in [
+            OutputEvent::Startup {
+                version: "v0.65.0".to_string(),
+                message: None,
+            },
+            OutputEvent::LlamaStarting {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: Some("/tmp/llama.log".to_string()),
+            },
+            OutputEvent::LlamaStartupFailed {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: Some("/tmp/llama.log".to_string()),
+                detail: "llama-server exited before becoming healthy".to_string(),
+            },
+        ] {
+            formatter
+                .handle_output_event(&event)
+                .expect("startup failure events should reduce cleanly");
+        }
+
+        formatter
+            .handle_output_event(&OutputEvent::Info {
+                message: "background retry skipped after startup failure".to_string(),
+                context: None,
+            })
+            .expect("later info events should not clear startup failures");
+
+        let rendered = render_tui_frame_snapshot(&formatter.state, 160, 32);
+        let dashboard = render_dashboard_text(&formatter.state);
+        assert!(
+            rendered.contains("startup=failed"),
+            "expected failed lifecycle in {rendered}"
+        );
+        assert!(dashboard.contains("llama-server=failed  model readiness=failed"));
+        assert!(formatter.state.startup_history.iter().any(|event| event
+            .summary
+            .contains("llama-server exited before becoming healthy")));
+    }
+
+    #[test]
+    fn llama_startup_failures_mark_components_failed() {
+        let mut llama_failed = DashboardState::default();
+        llama_failed.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        llama_failed.reduce(DashboardAction::OutputEvent(OutputEvent::ModelQueued {
+            model: "Qwen3-32B".to_string(),
+        }));
+        llama_failed.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Qwen3-32B".to_string()),
+            http_port: 9338,
+            ctx_size: Some(8192),
+            log_path: None,
+        }));
+        llama_failed.reduce(DashboardAction::OutputEvent(
+            OutputEvent::LlamaStartupFailed {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: None,
+                detail: "llama-server exited before becoming healthy".to_string(),
+            },
+        ));
+
+        assert_eq!(
+            llama_failed.startup_lifecycle().phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert_eq!(
+            llama_failed.startup_lifecycle().llama_server.phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert_eq!(
+            llama_failed.startup_lifecycle().model_readiness.phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert!(matches!(
+            llama_failed
+                .llama_instances
+                .iter()
+                .find(|instance| instance.kind == LlamaInstanceKind::LlamaServer)
+                .map(|instance| &instance.status),
+            Some(RuntimeStatus::Error)
+        ));
+        assert!(matches!(
+            llama_failed
+                .running_models
+                .iter()
+                .find(|model| model.model == "Qwen3-32B")
+                .map(|model| &model.status),
+            Some(RuntimeStatus::Error)
+        ));
+    }
+
+    #[test]
+    fn discovery_and_join_failures_mark_startup_mesh_component_failed() {
+        let mut discovery_failed = DashboardState::default();
+        discovery_failed.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        discovery_failed.reduce(DashboardAction::OutputEvent(
+            OutputEvent::DiscoveryStarting {
+                source: "Nostr auto-discovery".to_string(),
+            },
+        ));
+        discovery_failed.reduce(DashboardAction::OutputEvent(OutputEvent::DiscoveryFailed {
+            message: "Nostr auto-discovery failed".to_string(),
+            detail: Some("relay timeout".to_string()),
+        }));
+
+        assert_eq!(
+            discovery_failed.startup_lifecycle().phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert_eq!(
+            discovery_failed.startup_lifecycle().mesh.phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert_eq!(
+            discovery_failed.startup_lifecycle().mesh.detail.as_deref(),
+            Some("Nostr auto-discovery failed: relay timeout")
+        );
+
+        let mut join_failed = DashboardState::default();
+        join_failed.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        join_failed.reduce(DashboardAction::OutputEvent(OutputEvent::WaitingForPeers {
+            detail: Some("waiting for peers while joining mesh".to_string()),
+        }));
+        join_failed.reduce(DashboardAction::OutputEvent(OutputEvent::Warning {
+            message: "Failed to join any peer — running standalone".to_string(),
+            context: None,
+        }));
+
+        assert_eq!(
+            join_failed.startup_lifecycle().phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert_eq!(
+            join_failed.startup_lifecycle().mesh.phase,
+            StartupLifecyclePhase::Failed
+        );
+        assert_eq!(
+            join_failed.startup_lifecycle().mesh.detail.as_deref(),
+            Some("Failed to join any peer — running standalone")
+        );
+    }
+
+    #[test]
+    fn post_ready_peer_churn_does_not_reopen_startup_failure() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::DiscoveryJoined {
+            mesh: "poker-night".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiReady {
+            url: "http://localhost:9337".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::RuntimeReady {
+            api_url: "http://localhost:9337".to_string(),
+            console_url: Some("http://localhost:3131".to_string()),
+            api_port: 9337,
+            console_port: Some(3131),
+            models_count: Some(1),
+            pi_command: None,
+            goose_command: None,
+        }));
+
+        assert!(state.runtime_ready);
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(
+            state.startup_lifecycle().mesh.phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(
+            state.startup_lifecycle().mesh.detail.as_deref(),
+            Some("joined mesh poker-night")
+        );
+
+        for event in [
+            OutputEvent::DiscoveryStarting {
+                source: "Nostr re-discovery".to_string(),
+            },
+            OutputEvent::WaitingForPeers {
+                detail: Some("waiting for peers after reconnect".to_string()),
+            },
+            OutputEvent::DiscoveryFailed {
+                message: "Nostr re-discovery failed".to_string(),
+                detail: Some("relay timeout".to_string()),
+            },
+            OutputEvent::Warning {
+                message: "Failed to join any peer — running standalone".to_string(),
+                context: None,
+            },
+        ] {
+            state.reduce(DashboardAction::OutputEvent(event));
+        }
+
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(
+            state.startup_lifecycle().mesh.phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(
+            state.startup_lifecycle().mesh.detail.as_deref(),
+            Some("joined mesh poker-night")
+        );
+    }
+
+    #[test]
+    fn generic_error_after_runtime_ready_does_not_reopen_startup_failure() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiReady {
+            url: "http://localhost:9337".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::RuntimeReady {
+            api_url: "http://localhost:9337".to_string(),
+            console_url: Some("http://localhost:3131".to_string()),
+            api_port: 9337,
+            console_port: Some(3131),
+            models_count: Some(1),
+            pi_command: None,
+            goose_command: None,
+        }));
+
+        assert!(state.runtime_ready);
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Ready
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Error {
+            message: "native stderr surfaced after startup".to_string(),
+            context: Some("stderr".to_string()),
+        }));
+
+        assert!(state.runtime_ready);
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::Ready
+        );
+        assert_eq!(state.startup_lifecycle().failure, None);
+        assert!(render_dashboard_text(&state).contains("startup=ready"));
+    }
+
+    #[test]
+    fn startup_launch_plan_renders_not_ready_rows_before_actions() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
+            160, 32,
+        )));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: sample_launch_plan(),
+        }));
+
+        let rendered = render_tui_frame_snapshot(&state, 160, 32);
+
+        assert!(
+            rendered.contains("Mesh Events"),
+            "expected dashboard in {rendered}"
+        );
+        assert!(
+            rendered.contains("NOT READY"),
+            "expected not-ready rows in {rendered}"
+        );
+        assert!(rendered.contains("Console"));
+        assert!(rendered.contains("Planned-Model"));
+        assert_eq!(state.llama_process_rows[0].status, RuntimeStatus::Loading);
+        assert_eq!(state.webserver_rows[0].status, RuntimeStatus::NotReady);
+        assert_eq!(state.loaded_model_rows[0].status, RuntimeStatus::Loading);
+    }
+
+    #[test]
+    fn startup_progress_after_launch_plan_shows_dashboard_not_loader() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
+            160, 32,
+        )));
+        state.reduce(DashboardAction::OutputEvent(
+            OutputEvent::ModelDownloadProgress {
+                label: "Planned-Model".to_string(),
+                file: Some("planned-model.gguf".to_string()),
+                downloaded_bytes: Some(100),
+                total_bytes: Some(100),
+                status: ModelProgressStatus::Ready,
+            },
+        ));
+
+        let loader_render = render_tui_frame_snapshot(&state, 160, 32);
+        assert!(state.active_loading_progress().is_some());
+        assert!(
+            loader_render.contains("Mesh Events"),
+            "startup progress should use the dashboard instead of a full-screen loader: {loader_render}"
+        );
+        assert!(!loader_render.contains('█'));
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: sample_launch_plan(),
+        }));
+
+        let dashboard_render = render_tui_frame_snapshot(&state, 160, 32);
+        assert!(state.active_loading_progress().is_some());
+        assert!(
+            dashboard_render.contains("Mesh Events"),
+            "expected dashboard after launch plan in {dashboard_render}"
+        );
+        assert!(dashboard_render.contains("NOT READY"));
+        assert!(dashboard_render.contains("Planned-Model"));
+    }
+
+    #[test]
+    fn planned_rows_transition_from_not_ready_to_ready_events() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: sample_launch_plan(),
+        }));
+
+        assert!(state
+            .llama_process_rows
+            .iter()
+            .all(|row| row.status == RuntimeStatus::Loading));
+        assert!(state
+            .webserver_rows
+            .iter()
+            .all(|row| row.status == RuntimeStatus::NotReady));
+        assert_eq!(state.loaded_model_rows[0].status, RuntimeStatus::Loading);
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Planned-Model".to_string()),
+            http_port: 9338,
+            ctx_size: Some(8192),
+            log_path: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(
+            OutputEvent::WebserverStarting {
+                url: "http://localhost:3131".to_string(),
+            },
+        ));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiStarting {
+            url: "http://localhost:9337".to_string(),
+        }));
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.port == 9338)
+                .expect("expected planned llama row")
+                .status,
+            RuntimeStatus::Starting
+        );
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "Console")
+                .expect("expected planned console row")
+                .status,
+            RuntimeStatus::Starting
+        );
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "API")
+                .expect("expected planned api row")
+                .status,
+            RuntimeStatus::Starting
+        );
+        assert_eq!(state.loaded_model_rows[0].status, RuntimeStatus::Loading);
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaReady {
+            model: Some("Planned-Model".to_string()),
+            port: 9338,
+            ctx_size: Some(8192),
+            log_path: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::WebserverReady {
+            url: "http://localhost:3131".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiReady {
+            url: "http://localhost:9337".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelReady {
+            model: "Planned-Model".to_string(),
+            internal_port: Some(9338),
+            role: Some("host".to_string()),
+        }));
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.port == 9338)
+                .expect("expected planned llama row")
+                .status,
+            RuntimeStatus::Ready
+        );
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "Console")
+                .expect("expected planned console row")
+                .status,
+            RuntimeStatus::Ready
+        );
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "API")
+                .expect("expected planned api row")
+                .status,
+            RuntimeStatus::Ready
+        );
+        assert_eq!(state.loaded_model_rows[0].status, RuntimeStatus::Ready);
+    }
+
+    #[test]
+    fn launch_plan_rows_survive_empty_startup_snapshot() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: sample_launch_plan(),
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(
+            DashboardSnapshot::default(),
+        ));
+
+        assert_eq!(state.llama_process_rows.len(), 1);
+        assert_eq!(state.webserver_rows.len(), 2);
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        assert!(state
+            .llama_process_rows
+            .iter()
+            .all(|row| row.status == RuntimeStatus::Loading));
+        assert!(state
+            .webserver_rows
+            .iter()
+            .all(|row| row.status == RuntimeStatus::NotReady));
+        assert_eq!(state.loaded_model_rows[0].status, RuntimeStatus::Loading);
+        state.reduce(DashboardAction::SnapshotUpdated(
+            DashboardSnapshot::default(),
+        ));
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server")
+                .expect("expected planned llama row")
+                .status,
+            RuntimeStatus::Loading
+        );
+    }
+
+    #[test]
+    fn launch_plan_preserves_distinct_port_zero_endpoint_rows() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: port_zero_endpoint_launch_plan(),
+        }));
+
+        let rows = state
+            .webserver_rows
+            .iter()
+            .map(|row| (row.label.clone(), row.port, row.status.clone()))
+            .collect::<Vec<_>>();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(
+            rows,
+            vec![
+                ("Plugin: alpha".to_string(), 0, RuntimeStatus::NotReady),
+                ("Plugin: beta".to_string(), 0, RuntimeStatus::NotReady),
+                ("Plugin: zebra".to_string(), 0, RuntimeStatus::NotReady),
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_upsert_preserves_distinct_port_zero_endpoint_rows() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: port_zero_endpoint_launch_plan(),
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            webserver_rows: vec![
+                DashboardEndpointRow {
+                    label: "Plugin: alpha".to_string(),
+                    status: RuntimeStatus::Ready,
+                    url: "alpha-plugin-live".to_string(),
+                    port: 0,
+                    pid: Some(2000),
+                },
+                DashboardEndpointRow {
+                    label: "Plugin: zebra".to_string(),
+                    status: RuntimeStatus::Warning,
+                    url: "zebra-plugin-live".to_string(),
+                    port: 0,
+                    pid: Some(2001),
+                },
+            ],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(state.webserver_rows.len(), 3);
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "Plugin: beta")
+                .expect("expected beta plugin placeholder row")
+                .status,
+            RuntimeStatus::NotReady
+        );
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "Plugin: alpha")
+                .expect("expected alpha plugin row"),
+            &DashboardEndpointRow {
+                label: "Plugin: alpha".to_string(),
+                status: RuntimeStatus::Ready,
+                url: "alpha-plugin-live".to_string(),
+                port: 0,
+                pid: Some(2000),
+            }
+        );
+        assert_eq!(
+            state
+                .webserver_rows
+                .iter()
+                .find(|row| row.label == "Plugin: zebra")
+                .expect("expected zebra plugin row"),
+            &DashboardEndpointRow {
+                label: "Plugin: zebra".to_string(),
+                status: RuntimeStatus::Warning,
+                url: "zebra-plugin-live".to_string(),
+                port: 0,
+                pid: Some(2001),
+            }
+        );
+    }
+
+    #[test]
+    fn planned_port_zero_process_rows_bind_to_concrete_startup_events() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: vec![
+                    DashboardProcessRow {
+                        name: "llama-server Model-A".to_string(),
+                        backend: String::new(),
+                        status: RuntimeStatus::Loading,
+                        port: 0,
+                        pid: 0,
+                    },
+                    DashboardProcessRow {
+                        name: "llama-server Model-B".to_string(),
+                        backend: String::new(),
+                        status: RuntimeStatus::Loading,
+                        port: 0,
+                        pid: 0,
+                    },
+                ],
+                webserver_rows: Vec::new(),
+                loaded_model_rows: Vec::new(),
+            },
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Model-B".to_string()),
+            http_port: 9339,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+
+        assert_eq!(state.llama_process_rows.len(), 2);
+        assert!(state.webserver_rows.is_empty());
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server Model-A")
+                .expect("unstarted planned llama row should remain visible")
+                .status,
+            RuntimeStatus::Loading
+        );
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server Model-B")
+                .expect("planned llama row should bind to concrete model startup event"),
+            &DashboardProcessRow {
+                name: "llama-server Model-B".to_string(),
+                backend: String::new(),
+                status: RuntimeStatus::Starting,
+                port: 9339,
+                pid: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn ready_llama_process_row_stays_ready_when_another_model_starts() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.1".to_string(),
+            message: Some("starting multi-model runtime".to_string()),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Model-A".to_string()),
+            http_port: 9338,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaReady {
+            model: Some("Model-A".to_string()),
+            port: 9338,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server Model-A")
+                .expect("Model-A row should be present after ready event")
+                .status,
+            RuntimeStatus::Ready
+        );
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Model-B".to_string()),
+            http_port: 9339,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+
+        assert_eq!(state.llama_process_rows.len(), 2);
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server Model-A")
+                .expect("ready Model-A row should remain present")
+                .status,
+            RuntimeStatus::Ready
+        );
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server Model-B")
+                .expect("starting Model-B row should be present")
+                .status,
+            RuntimeStatus::Starting
+        );
+    }
+
+    #[test]
+    fn ready_llama_process_row_survives_lagging_startup_snapshot() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.1".to_string(),
+            message: Some("starting multi-model runtime".to_string()),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Model-A".to_string()),
+            http_port: 9338,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaReady {
+            model: Some("Model-A".to_string()),
+            port: 9338,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaStarting {
+            model: Some("Model-B".to_string()),
+            http_port: 9339,
+            ctx_size: Some(4096),
+            log_path: None,
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            llama_process_rows: vec![DashboardProcessRow {
+                name: "llama-server Model-A".to_string(),
+                backend: String::new(),
+                status: RuntimeStatus::Starting,
+                port: 9338,
+                pid: 0,
+            }],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(
+            state
+                .llama_process_rows
+                .iter()
+                .find(|row| row.name == "llama-server Model-A")
+                .expect("ready Model-A row should survive lagging snapshot")
+                .status,
+            RuntimeStatus::Ready
+        );
+    }
+
+    #[test]
+    fn model_loading_row_reconciles_with_canonical_ready_name() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelLoading {
+            model: "Qwen3.5-4B-UD-Q4_K_XL".to_string(),
+            source: None,
+        }));
+
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        assert_eq!(state.loaded_model_rows[0].name, "Qwen3.5-4B-UD-Q4_K_XL");
+        assert_eq!(state.loaded_model_rows[0].status, RuntimeStatus::Loading);
+        assert_eq!(state.llama_process_rows.len(), 1);
+        assert_eq!(
+            state.llama_process_rows[0].name,
+            "llama-server Qwen3.5-4B-UD-Q4_K_XL"
+        );
+        assert_eq!(state.llama_process_rows[0].status, RuntimeStatus::Loading);
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelReady {
+            model: "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string(),
+            internal_port: Some(9338),
+            role: Some("host".to_string()),
+        }));
+
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        let row = &state.loaded_model_rows[0];
+        assert_eq!(row.name, "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL");
+        assert_eq!(row.status, RuntimeStatus::Ready);
+        assert_eq!(row.port, Some(9338));
+        assert_eq!(row.role.as_deref(), Some("host"));
+    }
+
+    #[test]
+    fn planned_process_row_reconciles_with_canonical_loading_name() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: vec![DashboardProcessRow {
+                    name: "llama-server Qwen3.5-4B-UD-Q4_K_XL".to_string(),
+                    backend: String::new(),
+                    status: RuntimeStatus::Loading,
+                    port: 0,
+                    pid: 0,
+                }],
+                webserver_rows: Vec::new(),
+                loaded_model_rows: Vec::new(),
+            },
+        }));
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelLoading {
+            model: "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string(),
+            source: None,
+        }));
+
+        assert_eq!(state.llama_process_rows.len(), 1);
+        let row = &state.llama_process_rows[0];
+        assert_eq!(row.name, "llama-server unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL");
+        assert_eq!(row.status, RuntimeStatus::Loading);
+        assert_eq!(row.port, 0);
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            llama_process_rows: vec![DashboardProcessRow {
+                name: "llama-server Qwen3.5-4B-UD-Q4_K_XL".to_string(),
+                backend: String::new(),
+                status: RuntimeStatus::NotReady,
+                port: 0,
+                pid: 0,
+            }],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(state.llama_process_rows.len(), 1);
+        let row = &state.llama_process_rows[0];
+        assert_eq!(row.name, "llama-server unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL");
+        assert_eq!(row.status, RuntimeStatus::Loading);
+        assert_eq!(row.port, 0);
+    }
+
+    #[test]
+    fn raw_snapshot_ready_row_reconciles_with_canonical_loading_row() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: [
+                    "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL",
+                    "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL",
+                ]
+                .into_iter()
+                .map(|model| DashboardProcessRow {
+                    name: llama_process_row_name(Some(model)),
+                    backend: String::new(),
+                    status: RuntimeStatus::Loading,
+                    port: 0,
+                    pid: 0,
+                })
+                .collect(),
+                webserver_rows: Vec::new(),
+                loaded_model_rows: [
+                    "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL",
+                    "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL",
+                ]
+                .into_iter()
+                .map(|model| DashboardModelRow {
+                    name: model.to_string(),
+                    role: None,
+                    status: RuntimeStatus::Loading,
+                    port: None,
+                    device: None,
+                    slots: None,
+                    quantization: None,
+                    ctx_size: None,
+                    ctx_used_tokens: None,
+                    lanes: None,
+                    file_size_gb: None,
+                })
+                .collect(),
+            },
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            llama_process_rows: vec![DashboardProcessRow {
+                name: "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL".to_string(),
+                backend: String::new(),
+                status: RuntimeStatus::Ready,
+                port: 36561,
+                pid: 1221,
+            }],
+            loaded_model_rows: vec![DashboardModelRow {
+                name: "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL".to_string(),
+                role: Some("host".to_string()),
+                status: RuntimeStatus::Ready,
+                port: Some(36561),
+                device: None,
+                slots: None,
+                quantization: None,
+                ctx_size: None,
+                ctx_used_tokens: None,
+                lanes: None,
+                file_size_gb: None,
+            }],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(state.llama_process_rows.len(), 2);
+        let qwen_35 = state
+            .llama_process_rows
+            .iter()
+            .find(|row| row.name.contains("Qwen3.5-4B"))
+            .expect("expected 4B loading row");
+        assert_eq!(qwen_35.status, RuntimeStatus::Loading);
+        assert_eq!(qwen_35.port, 0);
+
+        let qwen_36 = state
+            .llama_process_rows
+            .iter()
+            .find(|row| row.name.contains("Qwen3.6-27B"))
+            .expect("expected 27B ready row");
+        assert_eq!(qwen_36.name, "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL");
+        assert_eq!(qwen_36.status, RuntimeStatus::Ready);
+        assert_eq!(qwen_36.port, 36561);
+        assert_eq!(qwen_36.pid, 1221);
+    }
+
+    #[test]
+    fn single_model_local_path_loading_row_merges_with_ready_model_ref() {
+        let mut state = DashboardState::default();
+        let loading_name = "Qwen/Qwen2.5-0.5B-Instruct-GGUF/qwen2.5-0.5b-instruct-q4_k_m";
+        let ready_name = "Qwen/Qwen2.5-0.5B-Instruct-GGUF:qwen2.5-0.5b-instruct-q4_k_m";
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: Vec::new(),
+                webserver_rows: Vec::new(),
+                loaded_model_rows: vec![DashboardModelRow {
+                    name: loading_name.to_string(),
+                    role: Some("primary".to_string()),
+                    status: RuntimeStatus::Loading,
+                    port: None,
+                    device: None,
+                    slots: None,
+                    quantization: None,
+                    ctx_size: None,
+                    ctx_used_tokens: None,
+                    lanes: None,
+                    file_size_gb: None,
+                }],
+            },
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ModelReady {
+            model: ready_name.to_string(),
+            internal_port: Some(51744),
+            role: Some("host".to_string()),
+        }));
+
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        let row = &state.loaded_model_rows[0];
+        assert_eq!(row.name, ready_name);
+        assert_eq!(row.status, RuntimeStatus::Ready);
+        assert_eq!(row.port, Some(51744));
+        assert_eq!(row.role.as_deref(), Some("host"));
+    }
+
+    #[test]
+    fn loaded_model_row_preserves_launch_plan_device_when_ready_snapshot_reports_backend() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: Vec::new(),
+                webserver_rows: Vec::new(),
+                loaded_model_rows: vec![DashboardModelRow {
+                    name: "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string(),
+                    role: Some("primary".to_string()),
+                    status: RuntimeStatus::Loading,
+                    port: None,
+                    device: Some("CUDA0".to_string()),
+                    slots: Some(4),
+                    quantization: None,
+                    ctx_size: Some(65_536),
+                    ctx_used_tokens: None,
+                    lanes: None,
+                    file_size_gb: None,
+                }],
+            },
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            loaded_model_rows: vec![DashboardModelRow {
+                name: "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string(),
+                role: Some("host".to_string()),
+                status: RuntimeStatus::Ready,
+                port: Some(40511),
+                device: Some("skippy".to_string()),
+                slots: Some(4),
+                quantization: Some("Q4_K_XL".to_string()),
+                ctx_size: Some(65_536),
+                ctx_used_tokens: None,
+                lanes: None,
+                file_size_gb: Some(2.9),
+            }],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        let row = &state.loaded_model_rows[0];
+        assert_eq!(row.name, "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL");
+        assert_eq!(row.device.as_deref(), Some("CUDA0"));
+        assert_eq!(row.status, RuntimeStatus::Ready);
+        assert_eq!(row.port, Some(40511));
+        assert_eq!(row.quantization.as_deref(), Some("Q4_K_XL"));
+    }
+
+    #[test]
+    fn runtime_ready_snapshot_preserves_launch_plan_device_metadata() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: Vec::new(),
+                webserver_rows: Vec::new(),
+                loaded_model_rows: vec![DashboardModelRow {
+                    name: "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string(),
+                    role: Some("primary".to_string()),
+                    status: RuntimeStatus::Loading,
+                    port: None,
+                    device: Some("CUDA0".to_string()),
+                    slots: Some(4),
+                    quantization: None,
+                    ctx_size: Some(65_536),
+                    ctx_used_tokens: None,
+                    lanes: None,
+                    file_size_gb: None,
+                }],
+            },
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::RuntimeReady {
+            api_url: "http://localhost:40511".to_string(),
+            console_url: None,
+            api_port: 40511,
+            console_port: None,
+            models_count: Some(1),
+            pi_command: None,
+            goose_command: None,
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            loaded_model_rows: vec![DashboardModelRow {
+                name: "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string(),
+                role: Some("host".to_string()),
+                status: RuntimeStatus::Ready,
+                port: Some(40511),
+                device: None,
+                slots: Some(4),
+                quantization: Some("Q4_K_XL".to_string()),
+                ctx_size: None,
+                ctx_used_tokens: None,
+                lanes: None,
+                file_size_gb: Some(2.9),
+            }],
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        let row = &state.loaded_model_rows[0];
+        assert_eq!(row.device.as_deref(), Some("CUDA0"));
+        assert_eq!(row.status, RuntimeStatus::Ready);
+        assert_eq!(row.port, Some(40511));
+        assert_eq!(row.quantization.as_deref(), Some("Q4_K_XL"));
+        assert_eq!(row.file_size_gb, Some(2.9));
+    }
+
+    #[test]
+    fn runtime_ready_process_only_snapshot_preserves_loaded_model_device_metadata() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: Vec::new(),
+                webserver_rows: Vec::new(),
+                loaded_model_rows: vec![DashboardModelRow {
+                    name: "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL".to_string(),
+                    role: Some("model".to_string()),
+                    status: RuntimeStatus::Loading,
+                    port: None,
+                    device: Some("CUDA1".to_string()),
+                    slots: Some(4),
+                    quantization: None,
+                    ctx_size: Some(65_536),
+                    ctx_used_tokens: None,
+                    lanes: None,
+                    file_size_gb: None,
+                }],
+            },
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::RuntimeReady {
+            api_url: "http://localhost:40511".to_string(),
+            console_url: None,
+            api_port: 40511,
+            console_port: None,
+            models_count: Some(1),
+            pi_command: None,
+            goose_command: None,
+        }));
+
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            llama_process_rows: vec![DashboardProcessRow {
+                name: "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL".to_string(),
+                backend: String::new(),
+                status: RuntimeStatus::Ready,
+                port: 45145,
+                pid: 132098,
+            }],
+            loaded_model_rows: Vec::new(),
+            ..DashboardSnapshot::default()
+        }));
+
+        assert_eq!(state.loaded_model_rows.len(), 1);
+        let row = &state.loaded_model_rows[0];
+        assert_eq!(row.name, "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL");
+        assert_eq!(row.device.as_deref(), Some("CUDA1"));
+        assert_eq!(row.status, RuntimeStatus::Loading);
+    }
+
+    #[test]
+    fn planned_process_row_reconciles_with_canonical_ready_name() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LaunchPlan {
+            plan: DashboardLaunchPlan {
+                llama_process_rows: vec![DashboardProcessRow {
+                    name: "llama-server Qwen3.5-4B-UD-Q4_K_XL".to_string(),
+                    backend: String::new(),
+                    status: RuntimeStatus::Loading,
+                    port: 0,
+                    pid: 0,
+                }],
+                webserver_rows: Vec::new(),
+                loaded_model_rows: Vec::new(),
+            },
+        }));
+
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::LlamaReady {
+            model: Some("unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string()),
+            port: 9338,
+            ctx_size: Some(8192),
+            log_path: None,
+        }));
+
+        assert_eq!(state.llama_process_rows.len(), 1);
+        let row = &state.llama_process_rows[0];
+        assert_eq!(row.name, "llama-server unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL");
+        assert_eq!(row.status, RuntimeStatus::Ready);
+        assert_eq!(row.port, 9338);
+    }
+
+    #[test]
+    fn startup_failure_summary_sanitizes_multiline_detail() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(
+            OutputEvent::LlamaStartupFailed {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: Some("/tmp/skippy-native.log".to_string()),
+                detail: "llama-server exited
+See /tmp/skippy-native.log:
+tail line"
+                    .to_string(),
+            },
+        ));
+
+        let summary = render_startup_summary(&state);
+        assert_eq!(
+            summary[0],
+            "startup=failed  failure=llama-server exited See /tmp/skippy-native.log: tail line"
+        );
+        assert!(!summary[0].contains('\n'));
+
+        let tui_summary =
+            spans_plain_text(&startup_lifecycle_summary_line(&state.startup_lifecycle, 160).spans);
+        assert!(tui_summary
+            .contains("failure=llama-server exited See /tmp/skippy-native.log: tail line"));
+        assert!(!tui_summary.contains('\n'));
+
+        let title = join_token_panel_right_title(&state);
+        assert!(title.starts_with("startup failed: llama-server exited See"));
+        assert!(!title.contains('\n'));
+    }
+
+    pub(crate) fn assert_startup_lifecycle_transitions_pending_partial_ready_failed() {
+        startup_lifecycle_transitions_pending_partial_ready_failed();
+    }
+
+    pub(crate) fn assert_startup_lifecycle_keeps_runtime_ready_as_final_edge() {
+        startup_lifecycle_keeps_runtime_ready_as_final_edge();
+    }
+
+    pub(crate) fn assert_startup_failures_surface_in_tui_events_and_status() {
+        startup_failures_surface_in_tui_events_and_status();
+    }
+
+    pub(crate) fn assert_startup_failure_summary_sanitizes_multiline_detail() {
+        startup_failure_summary_sanitizes_multiline_detail();
+    }
+
+    pub(crate) fn assert_rpc_and_llama_startup_failures_mark_components_failed() {
+        llama_startup_failures_mark_components_failed();
+    }
+
+    pub(crate) fn assert_discovery_and_join_failures_mark_startup_mesh_component_failed() {
+        discovery_and_join_failures_mark_startup_mesh_component_failed();
+    }
+
+    pub(crate) fn assert_post_ready_peer_churn_does_not_reopen_startup_failure() {
+        post_ready_peer_churn_does_not_reopen_startup_failure();
+    }
+
+    pub(crate) fn assert_startup_history_is_visible_after_late_tui_attach() {
+        startup_history_is_visible_after_late_tui_attach();
+    }
+
+    pub(crate) fn assert_startup_history_keeps_order_when_tui_attaches_late() {
+        startup_history_keeps_order_when_tui_attaches_late();
+    }
+
+    pub(crate) fn assert_endpoint_rows_remain_starting_until_ready_events() {
+        endpoint_rows_remain_starting_until_ready_events();
+    }
+
+    pub(crate) fn assert_startup_launch_plan_renders_not_ready_rows_before_actions() {
+        startup_launch_plan_renders_not_ready_rows_before_actions();
+    }
+
+    pub(crate) fn assert_startup_progress_after_launch_plan_shows_dashboard_not_loader() {
+        startup_progress_after_launch_plan_shows_dashboard_not_loader();
+    }
+
+    pub(crate) fn assert_planned_rows_transition_from_not_ready_to_ready_events() {
+        planned_rows_transition_from_not_ready_to_ready_events();
+    }
+
+    pub(crate) fn assert_launch_plan_rows_survive_empty_startup_snapshot() {
+        launch_plan_rows_survive_empty_startup_snapshot();
+    }
+
+    pub(crate) fn assert_launch_plan_preserves_distinct_port_zero_endpoint_rows() {
+        launch_plan_preserves_distinct_port_zero_endpoint_rows();
+    }
+
+    pub(crate) fn assert_snapshot_upsert_preserves_distinct_port_zero_endpoint_rows() {
+        snapshot_upsert_preserves_distinct_port_zero_endpoint_rows();
+    }
+
+    pub(crate) fn assert_planned_port_zero_process_rows_bind_to_concrete_startup_events() {
+        planned_port_zero_process_rows_bind_to_concrete_startup_events();
+    }
+
+    pub(crate) fn assert_fallback_mode_surfaces_startup_failures_without_tui() {
+        fallback_mode_surfaces_startup_failures_without_tui();
+    }
+
+    pub(crate) fn assert_shutdown_suppresses_late_ready_render() {
+        shutdown_suppresses_late_ready_render();
+    }
+
+    pub(crate) fn assert_interactive_post_terminal_exit_resumes_plain_event_output() {
+        interactive_post_terminal_exit_resumes_plain_event_output();
+    }
+
+    #[test]
+    fn fallback_mode_surfaces_startup_failures_without_tui() {
+        let mut formatter = DashboardFormatter::default();
+        let mut rendered = String::new();
+
+        for event in [
+            OutputEvent::Startup {
+                version: "v0.65.0".to_string(),
+                message: None,
+            },
+            OutputEvent::LlamaStarting {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: None,
+            },
+            OutputEvent::LlamaStartupFailed {
+                model: Some("Qwen3-32B".to_string()),
+                http_port: 9338,
+                ctx_size: Some(8192),
+                log_path: None,
+                detail: "llama-server exited before listening".to_string(),
+            },
+        ] {
+            rendered = formatter
+                .format(&event)
+                .expect("fallback formatter should keep rendering durable startup failures");
+        }
+
+        assert!(rendered.contains("startup=failed"));
+        assert!(rendered.contains("llama-server=failed"));
+        assert!(rendered.contains("llama-server exited before listening"));
+    }
+
+    #[test]
+    fn shutdown_suppresses_late_ready_render() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
+            version: "v0.65.0".to_string(),
+            message: None,
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::ApiStarting {
+            url: "http://localhost:9337".to_string(),
+        }));
+        state.reduce(DashboardAction::OutputEvent(OutputEvent::Shutdown {
+            reason: None,
+        }));
+
+        for event in [
+            OutputEvent::ApiReady {
+                url: "http://localhost:9337".to_string(),
+            },
+            OutputEvent::RuntimeReady {
+                api_url: "http://localhost:9337".to_string(),
+                console_url: Some("http://localhost:3131".to_string()),
+                api_port: 9337,
+                console_port: Some(3131),
+                models_count: Some(1),
+                pi_command: None,
+                goose_command: None,
+            },
+        ] {
+            state.reduce(DashboardAction::OutputEvent(event));
+        }
+
+        let dashboard = render_dashboard_text(&state);
+        let rendered = render_tui_frame_snapshot(&state, 160, 32);
+
+        assert_eq!(
+            state.startup_lifecycle().phase,
+            StartupLifecyclePhase::ShuttingDown
+        );
+        assert!(dashboard.contains("startup=shutting down"));
+        assert!(rendered.contains("startup=shutting down"));
+        assert!(!dashboard.contains("mesh-llm runtime ready"));
+        assert!(!rendered.contains("mesh-llm runtime ready"));
+        assert!(matches!(
+            state.api.as_ref().map(|api| &api.status),
+            Some(RuntimeStatus::ShuttingDown)
+        ));
+    }
+
+    #[test]
     fn tui_snapshot_renders_full_dashboard_spec() {
         let mut state = DashboardState::default();
         state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
-            220, 24,
+            260, 32,
         )));
         state.reduce(DashboardAction::SnapshotUpdated(snapshot_fixture(2, 30)));
         state.reduce(DashboardAction::OutputEvent(OutputEvent::Startup {
@@ -9695,6 +13343,41 @@ mod tests {
                     slots: Some(8),
                     quantization: Some("Q5_K_M".to_string()),
                     ctx_size: Some(4096),
+                    ctx_used_tokens: Some(2048),
+                    lanes: Some(vec![
+                        DashboardModelLane {
+                            index: 0,
+                            active: true,
+                        },
+                        DashboardModelLane {
+                            index: 1,
+                            active: false,
+                        },
+                        DashboardModelLane {
+                            index: 2,
+                            active: false,
+                        },
+                        DashboardModelLane {
+                            index: 3,
+                            active: false,
+                        },
+                        DashboardModelLane {
+                            index: 4,
+                            active: false,
+                        },
+                        DashboardModelLane {
+                            index: 5,
+                            active: false,
+                        },
+                        DashboardModelLane {
+                            index: 6,
+                            active: false,
+                        },
+                        DashboardModelLane {
+                            index: 7,
+                            active: false,
+                        },
+                    ]),
                     file_size_gb: Some(12.0),
                 },
             ],
@@ -9704,39 +13387,77 @@ mod tests {
         let (rendered, buffer) = render_tui_frame_snapshot_with_buffer(&state, 260, 32);
         let theme = tui_theme();
         let (full_title_y, full_title_line) = find_rendered_line(&rendered, "Segmented-Model");
+        let full_border_line = rendered
+            .lines()
+            .nth(full_title_y.saturating_sub(1))
+            .expect("expected card border above model name");
         assert!(
-            full_title_line.contains('╭') && full_title_line.contains('╮'),
-            "expected bordered card title line in {full_title_line}"
+            full_border_line.contains("│╭"),
+            "expected model card to start flush against the panel content edge, without a highlight gutter, in {full_border_line}"
         );
         assert!(
-            full_title_line.contains("│╭"),
-            "expected model card to start flush against the panel content edge, without a highlight gutter, in {full_title_line}"
+            !full_title_line.contains("PORT:"),
+            "model name should have its own interior row before metadata: {full_title_line}"
         );
         let (full_ctx_y, full_ctx_line) =
-            find_rendered_line_after(&rendered, full_title_y, "n/a / n/a");
-        let (full_cap_y, full_cap_line) =
-            find_rendered_line_after(&rendered, full_ctx_y, "24.0 / 24.0 GB");
+            find_rendered_line_after(&rendered, full_title_y, "8192 / 8192");
+        let (full_slots_y, full_slots_line) =
+            find_rendered_line_after(&rendered, full_ctx_y, "2 / 4");
         let (_, divider_line) = find_rendered_line_after(&rendered, full_title_y, "──");
         assert!(
             !divider_line.contains('├') && !divider_line.contains('┤'),
             "expected subtle interior divider, not frame-joining divider, in {divider_line}"
         );
         assert!(
-            full_ctx_line.contains("CTX") && full_ctx_line.contains("n/a / n/a"),
+            full_ctx_line.contains("CTX") && full_ctx_line.contains("8192 / 8192"),
             "expected CTX row with right-aligned value label in {full_ctx_line}"
         );
         assert!(
-            full_cap_line.contains("FILE") && full_cap_line.contains("24.0 / 24.0 GB"),
-            "expected FILE row with right-aligned value label in {full_cap_line}"
+            full_slots_line.contains("SLOTS") && full_slots_line.contains("2 / 4"),
+            "expected SLOTS row with right-aligned value label in {full_slots_line}"
         );
-        let full_ctx_gauge_x = full_ctx_line
+        let full_ctx_gauge_byte = full_ctx_line
             .find('█')
+            .expect("expected CTX usage bar byte coordinate");
+        let full_slots_block_byte = full_slots_line
+            .find('◼')
+            .expect("expected SLOTS block byte coordinate");
+        let full_ctx_gauge_x = full_ctx_line[..full_ctx_gauge_byte].chars().count();
+        let full_slots_block_x = full_slots_line[..full_slots_block_byte].chars().count();
+        let full_ctx_bar_end_x = full_ctx_gauge_x
+            + full_ctx_line[full_ctx_gauge_byte..]
+                .chars()
+                .take_while(|ch| *ch == '█')
+                .count();
+        let full_ctx_value_x = full_ctx_line
+            .find("8192 / 8192")
             .map(|index| full_ctx_line[..index].chars().count())
-            .expect("expected CTX usage bar x coordinate");
-        let full_cap_gauge_x = full_cap_line
-            .find('█')
-            .map(|index| full_cap_line[..index].chars().count())
-            .expect("expected FILE usage bar x coordinate");
+            .expect("expected CTX value label x coordinate");
+        let full_slots_value_x = full_slots_line
+            .find("2 / 4")
+            .map(|index| full_slots_line[..index].chars().count())
+            .expect("expected SLOTS value label x coordinate");
+        let full_slots_label_x = full_slots_line
+            .find("SLOTS")
+            .map(|index| full_slots_line[..index].chars().count())
+            .expect("expected SLOTS label x coordinate");
+        assert!(
+            full_ctx_bar_end_x < full_ctx_value_x && full_slots_block_x < full_slots_value_x,
+            "expected a visible gap between metric visuals and value labels: {full_ctx_line} / {full_slots_line}"
+        );
+        assert!(
+            full_slots_block_x > full_slots_label_x + "SLOTS".chars().count(),
+            "expected visible gap between SLOTS label and slot blocks: {full_slots_line}"
+        );
+        assert_eq!(
+            buffer[(
+                u16::try_from(full_slots_block_x + 1).unwrap(),
+                u16::try_from(full_slots_y).unwrap()
+            )]
+                .symbol(),
+            "◼",
+            "expected adjacent visible slot blocks without separators"
+        );
         assert_eq!(
             buffer[(
                 u16::try_from(full_ctx_gauge_x).unwrap(),
@@ -9744,60 +13465,125 @@ mod tests {
             )]
                 .style()
                 .fg,
-            Some(theme.dim)
+            Some(tui_model_usage_color(1.0))
         );
         assert_eq!(
             buffer[(
-                u16::try_from(full_cap_gauge_x).unwrap(),
-                u16::try_from(full_cap_y).unwrap()
+                u16::try_from(full_slots_block_x).unwrap(),
+                u16::try_from(full_slots_y).unwrap()
             )]
                 .style()
                 .fg,
-            Some(tui_model_usage_color(1.0))
+            Some(theme.warning)
+        );
+        assert_eq!(
+            buffer[(
+                u16::try_from(full_slots_block_x + 2).unwrap(),
+                u16::try_from(full_slots_y).unwrap()
+            )]
+                .style()
+                .fg,
+            Some(theme.dim)
         );
 
-        let (half_title_y, _) = find_rendered_line(&rendered, "Half-Scale");
+        let half_row = DashboardModelRow {
+            name: "Half-Scale".to_string(),
+            role: Some("host".to_string()),
+            status: RuntimeStatus::Ready,
+            port: Some(4002),
+            device: Some("CUDA0".to_string()),
+            slots: Some(8),
+            quantization: Some("Q5_K_M".to_string()),
+            ctx_size: Some(4096),
+            ctx_used_tokens: Some(2048),
+            lanes: Some(vec![
+                DashboardModelLane {
+                    index: 0,
+                    active: true,
+                },
+                DashboardModelLane {
+                    index: 1,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 2,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 3,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 4,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 5,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 6,
+                    active: false,
+                },
+                DashboardModelLane {
+                    index: 7,
+                    active: false,
+                },
+            ]),
+            file_size_gb: Some(12.0),
+        };
+        let mut half_buffer =
+            Buffer::empty(Rect::new(0, 0, 80, PRETTY_TUI_MODEL_CARD_HEIGHT as u16));
+        TuiModelCardWidget {
+            row: &half_row,
+            content_width: 78,
+            is_selected: false,
+            is_focused: false,
+        }
+        .render(half_buffer.area, &mut half_buffer);
+        let half_rendered = buffer_to_rendered_string(&half_buffer);
+        let (half_title_y, _) = find_rendered_line(&half_rendered, "Half-Scale");
         let (half_ctx_y, half_ctx_line) =
-            find_rendered_line_after(&rendered, half_title_y, "n/a / n/a");
-        let (half_cap_y, half_cap_line) =
-            find_rendered_line_after(&rendered, half_ctx_y, "12.0 / 24.0 GB");
+            find_rendered_line_after(&half_rendered, half_title_y, "2048 / 4096");
+        let (half_slots_y, half_slots_line) =
+            find_rendered_line_after(&half_rendered, half_ctx_y, "1 / 8");
         let half_ctx_gauge_x = half_ctx_line
             .find('█')
             .map(|index| half_ctx_line[..index].chars().count())
             .expect("expected half-scale CTX usage bar x coordinate");
-        let half_cap_gauge_x = half_cap_line
-            .find('█')
-            .map(|index| half_cap_line[..index].chars().count())
-            .expect("expected half-scale FILE usage bar x coordinate");
+        let half_slots_block_x = half_slots_line
+            .find('◼')
+            .map(|index| half_slots_line[..index].chars().count())
+            .expect("expected half-scale SLOTS block x coordinate");
         assert_eq!(
-            buffer[(
+            half_buffer[(
                 u16::try_from(half_ctx_gauge_x).unwrap(),
                 u16::try_from(half_ctx_y).unwrap()
             )]
                 .style()
                 .fg,
-            Some(theme.dim)
+            Some(tui_model_usage_color(0.5))
         );
         assert_eq!(
-            buffer[(
-                u16::try_from(half_cap_gauge_x).unwrap(),
-                u16::try_from(half_cap_y).unwrap()
+            half_buffer[(
+                u16::try_from(half_slots_block_x).unwrap(),
+                u16::try_from(half_slots_y).unwrap()
             )]
                 .style()
                 .fg,
-            Some(tui_model_usage_color(0.5))
+            Some(theme.warning)
         );
         let ctx_value_x = half_ctx_line
-            .find("n/a / n/a")
+            .find("2048 / 4096")
             .map(|index| half_ctx_line[..index].chars().count())
             .expect("expected half CTX value label x coordinate");
-        let file_value_x = half_cap_line
-            .find("12.0 / 24.0 GB")
-            .map(|index| half_cap_line[..index].chars().count())
-            .expect("expected half FILE value label x coordinate");
+        let slots_value_x = half_slots_line
+            .find("1 / 8")
+            .map(|index| half_slots_line[..index].chars().count())
+            .expect("expected half SLOTS value label x coordinate");
         assert!(
             ((half_ctx_gauge_x + 1)..ctx_value_x).any(|x| {
-                buffer[(
+                half_buffer[(
                     u16::try_from(x).unwrap(),
                     u16::try_from(half_ctx_y).unwrap(),
                 )]
@@ -9808,16 +13594,52 @@ mod tests {
             "expected CTX usage bar to show grey empty track after the fill"
         );
         assert!(
-            ((half_cap_gauge_x + 1)..file_value_x).any(|x| {
-                buffer[(
+            ((half_slots_block_x + 1)..slots_value_x).any(|x| {
+                half_buffer[(
                     u16::try_from(x).unwrap(),
-                    u16::try_from(half_cap_y).unwrap(),
+                    u16::try_from(half_slots_y).unwrap(),
                 )]
                     .style()
                     .fg
                     == Some(theme.dim)
             }),
-            "expected FILE usage bar to show grey empty track after the fill"
+            "expected SLOTS row to show grey inactive blocks after the active lane"
+        );
+        assert!(
+            half_slots_line.contains("◼◼") && !half_slots_line.contains("◼ ◼"),
+            "expected slot blocks to render adjacently without separators: {half_slots_line}"
+        );
+    }
+
+    #[test]
+    fn tui_models_panel_renders_two_loaded_model_cards_in_compact_dashboard() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
+            260, 33,
+        )));
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            loaded_model_rows: vec![
+                sample_model_row("unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL", 37615),
+                sample_model_row("unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL", 34097),
+            ],
+            ..snapshot_fixture(0, 30)
+        }));
+
+        let rendered = render_tui_frame_snapshot(&state, 260, 33);
+
+        assert!(
+            rendered.contains("unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL"),
+            "expected first loaded model card in compact dashboard: {rendered}"
+        );
+        assert!(
+            rendered.contains("unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL"),
+            "expected second loaded model card in compact dashboard: {rendered}"
+        );
+        let (first_y, _) = find_rendered_line(&rendered, "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL");
+        let (second_y, _) = find_rendered_line(&rendered, "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL");
+        assert!(
+            second_y.saturating_sub(first_y) >= PRETTY_TUI_MODEL_CARD_HEIGHT,
+            "expected the first card to keep its full height before the second card: {rendered}"
         );
     }
 
@@ -9837,17 +13659,51 @@ mod tests {
                 slots: Some(8),
                 quantization: Some("Q8_0".to_string()),
                 ctx_size: Some(8192),
+                ctx_used_tokens: Some(8192),
+                lanes: Some(vec![
+                    DashboardModelLane {
+                        index: 0,
+                        active: true,
+                    },
+                    DashboardModelLane {
+                        index: 1,
+                        active: true,
+                    },
+                    DashboardModelLane {
+                        index: 2,
+                        active: true,
+                    },
+                    DashboardModelLane {
+                        index: 3,
+                        active: false,
+                    },
+                    DashboardModelLane {
+                        index: 4,
+                        active: false,
+                    },
+                    DashboardModelLane {
+                        index: 5,
+                        active: false,
+                    },
+                    DashboardModelLane {
+                        index: 6,
+                        active: false,
+                    },
+                    DashboardModelLane {
+                        index: 7,
+                        active: false,
+                    },
+                ]),
                 file_size_gb: Some(24.0),
             }],
             ..snapshot_fixture(0, 30)
         }));
 
         let (rendered, buffer) = render_tui_frame_snapshot_with_buffer(&state, 260, 24);
-        let theme = tui_theme();
         let (title_y, title_line) = find_rendered_line(&rendered, "Metadata-Model");
         assert!(
-            title_line.contains('╭') && title_line.contains('╮'),
-            "expected bordered card title line in {title_line}"
+            !title_line.contains("PORT:"),
+            "model name should be separated from metadata: {title_line}"
         );
         let (meta_y, meta_line) = find_rendered_line_after(&rendered, title_y, "STATUS");
         let (_, detail_line) = find_rendered_line_after(&rendered, title_y, "QUANT");
@@ -9860,8 +13716,8 @@ mod tests {
             "expected port in {meta_line}"
         );
         assert!(
-            meta_line.contains("DEVICE: n/a"),
-            "expected temporary device placeholder in {meta_line}"
+            meta_line.contains("DEVICE: CUDA0"),
+            "expected device in {meta_line}"
         );
         assert!(
             !meta_line.contains("DEV:"),
@@ -9875,18 +13731,18 @@ mod tests {
         let port_byte = models_meta_line
             .find("PORT:")
             .expect("expected PORT label x coordinate");
-        let device_byte = models_meta_line
-            .find("DEVICE:")
-            .expect("expected DEVICE label x coordinate");
         let status_byte = models_meta_line
             .find("STATUS:")
             .expect("expected STATUS label x coordinate");
+        let device_byte = models_meta_line
+            .find("DEVICE:")
+            .expect("expected DEVICE label x coordinate");
         let port_x = models_meta_line[..port_byte].chars().count();
-        let device_x = models_meta_line[..device_byte].chars().count();
         let status_x = models_meta_line[..status_byte].chars().count();
+        let device_x = models_meta_line[..device_byte].chars().count();
         assert!(
-            (device_x - port_x).abs_diff(status_x - device_x) <= 1,
-            "expected PORT, DEVICE, and STATUS to use equal three-column spacing in {models_meta_line}"
+            port_x < status_x && status_x < device_x,
+            "expected PORT, STATUS, and DEVICE to stay ordered in {models_meta_line}"
         );
         assert!(
             detail_line.contains("SLOTS: 8"),
@@ -9897,36 +13753,36 @@ mod tests {
             "expected quantization in {detail_line}"
         );
         assert!(
-            detail_line.contains("CTX: n/a"),
-            "expected temporary ctx placeholder in {detail_line}"
+            detail_line.contains("CTX: 8192"),
+            "expected runtime context size in {detail_line}"
         );
         assert!(
             !detail_line.contains("ROLE:"),
             "role should not render in model details: {detail_line}"
         );
-        let (ctx_y, ctx_line) = find_rendered_line_after(&rendered, title_y, "n/a / n/a");
+        let (ctx_y, ctx_line) = find_rendered_line_after(&rendered, title_y, "8192 / 8192");
         let (_, divider_line) = find_rendered_line_after(&rendered, title_y, "──");
-        let (file_y, file_line) = find_rendered_line_after(&rendered, title_y, "24.0 / 24.0 GB");
+        let (slots_y, slots_line) = find_rendered_line_after(&rendered, title_y, "3 / 8");
         assert!(
             !divider_line.contains('├') && !divider_line.contains('┤'),
             "expected subtle interior divider, not frame-joining divider, in {divider_line}"
         );
         assert!(
-            ctx_line.contains("CTX") && ctx_line.contains("n/a / n/a"),
+            ctx_line.contains("CTX") && ctx_line.contains("8192 / 8192"),
             "expected visible ctx stat with right label in {ctx_line}"
         );
         assert!(
-            file_line.contains("FILE") && file_line.contains("24.0 / 24.0 GB"),
-            "expected visible file size stat with right label in {file_line}"
+            slots_line.contains("SLOTS") && slots_line.contains("3 / 8"),
+            "expected visible slot stat with right label in {slots_line}"
         );
         let ctx_gauge_x = ctx_line
             .find('█')
             .map(|index| ctx_line[..index].chars().count())
             .expect("expected CTX usage bar x coordinate");
-        let file_gauge_x = file_line
-            .find('█')
-            .map(|index| file_line[..index].chars().count())
-            .expect("expected FILE usage bar x coordinate");
+        let slots_block_x = slots_line
+            .find('◼')
+            .map(|index| slots_line[..index].chars().count())
+            .expect("expected SLOTS block x coordinate");
         assert_eq!(
             buffer[(
                 u16::try_from(ctx_gauge_x).unwrap(),
@@ -9934,17 +13790,77 @@ mod tests {
             )]
                 .style()
                 .fg,
-            Some(theme.dim)
+            Some(tui_model_usage_color(1.0))
         );
         assert_eq!(
             buffer[(
-                u16::try_from(file_gauge_x).unwrap(),
-                u16::try_from(file_y).unwrap()
+                u16::try_from(slots_block_x).unwrap(),
+                u16::try_from(slots_y).unwrap()
             )]
                 .style()
                 .fg,
-            Some(tui_model_usage_color(1.0))
+            Some(tui_theme().warning)
         );
+    }
+
+    #[test]
+    fn tui_model_card_separates_name_from_metadata_columns() {
+        let mut state = DashboardState::default();
+        state.reduce(DashboardAction::Resize(dashboard_layout_for_terminal_size(
+            120, 24,
+        )));
+        state.reduce(DashboardAction::SnapshotUpdated(DashboardSnapshot {
+            loaded_model_rows: vec![DashboardModelRow {
+                name: "qwen2.5-0.5b-instruct-q4_k_m".to_string(),
+                role: Some("host".to_string()),
+                status: RuntimeStatus::Ready,
+                port: Some(49201),
+                device: Some("GPU0".to_string()),
+                slots: Some(4),
+                quantization: Some("Q4_K_M".to_string()),
+                ctx_size: Some(8192),
+                ctx_used_tokens: None,
+                lanes: None,
+                file_size_gb: Some(0.5),
+            }],
+            ..snapshot_fixture(0, 30)
+        }));
+
+        let rendered = render_tui_frame_snapshot(&state, 120, 24);
+        let (name_y, name_line) = find_rendered_line(&rendered, "qwen2.5-0.5b");
+        let (meta_y, meta_line) = find_rendered_line_after(&rendered, name_y, "STATUS:");
+        let (_, detail_line) = find_rendered_line_after(&rendered, name_y, "QUANT:");
+
+        assert!(
+            !name_line.contains("PORT:")
+                && !name_line.contains("DEVICE:")
+                && !name_line.contains("STATUS:"),
+            "model name row should not share space with metadata columns: {name_line}"
+        );
+        assert!(
+            meta_y > name_y,
+            "metadata should render on a row after the model name"
+        );
+        assert!(
+            !meta_line.contains("qwen2.5"),
+            "metadata row should not include the model name: {meta_line}"
+        );
+        assert!(
+            meta_line.contains("PORT:")
+                && meta_line.contains("STATUS:")
+                && meta_line.contains("DEVICE:"),
+            "top metadata row should expose PORT, STATUS, and DEVICE: {meta_line}"
+        );
+        assert!(
+            detail_line.contains("SLOTS:")
+                && detail_line.contains("QUANT:")
+                && detail_line.contains("CTX:"),
+            "bottom metadata row should expose SLOTS, QUANT, and CTX: {detail_line}"
+        );
+    }
+
+    pub(crate) fn assert_tui_model_card_separates_name_from_metadata_columns() {
+        tui_model_card_separates_name_from_metadata_columns();
     }
 
     #[test]
@@ -9964,6 +13880,8 @@ mod tests {
                 slots: Some(4),
                 quantization: Some("Q4_K_M".to_string()),
                 ctx_size: Some(8192),
+                ctx_used_tokens: None,
+                lanes: None,
                 file_size_gb: Some(24.0),
             }],
             ..snapshot_fixture(0, 30)
@@ -9973,8 +13891,8 @@ mod tests {
         let (title_y, title_line) = rendered
             .lines()
             .enumerate()
-            .find(|(_, line)| line.contains('╭') && line.contains('…'))
-            .expect("expected truncated card title line");
+            .find(|(_, line)| line.contains('…'))
+            .expect("expected truncated model name line");
         let (meta_y, meta_line) = find_rendered_line_after(&rendered, title_y, "DEVICE");
         let (_, detail_line) = find_rendered_line_after(&rendered, title_y, "Q4_K_M");
         assert!(
@@ -9986,12 +13904,12 @@ mod tests {
             "expected quantization to remain visible: {detail_line}"
         );
         assert!(
-            meta_line.contains("n/a"),
-            "expected device placeholder: {meta_line}"
+            meta_line.contains("DEVICE: GPU0"),
+            "expected readable device column: {meta_line}"
         );
         assert!(
-            !meta_line.contains("GPU0"),
-            "raw device should not render while placeholder data is used: {meta_line}"
+            meta_line.contains("PORT:") && meta_line.contains("STATUS:"),
+            "top metadata row should keep three columns visible: {meta_line}"
         );
         assert!(meta_y > title_y, "expected metadata on a later card row");
         assert!(
@@ -10280,7 +14198,7 @@ mod tests {
     }
 
     #[test]
-    fn interactive_preterminal_render_uses_tui_snapshot_only() {
+    fn interactive_preterminal_render_uses_plain_event_output() {
         let mut formatter = InteractiveDashboardFormatter::default();
 
         let rendered = formatter
@@ -10294,14 +14212,60 @@ mod tests {
                 goose_command: None,
             })
             .expect("interactive pre-terminal render should succeed")
-            .expect("interactive formatter should emit initial textual snapshot");
+            .expect("interactive formatter should emit a normal console line");
 
-        assert!(rendered.contains("Incoming Requests"));
-        assert!(rendered.contains("READY"));
-        assert!(rendered.contains('─'));
-        assert!(rendered.contains('│'));
+        assert_eq!(rendered, "✅ Mesh runtime ready (1 model(s))\n");
+        assert!(!rendered.contains("Incoming Requests"));
+        assert!(!rendered.contains('─'));
+        assert!(!rendered.contains('│'));
         assert!(!rendered.contains("Running llama.cpp instances"));
         assert!(!rendered.contains("Running models"));
+    }
+
+    pub(crate) fn assert_interactive_preterminal_render_uses_plain_event_output() {
+        interactive_preterminal_render_uses_plain_event_output();
+    }
+
+    #[test]
+    fn interactive_post_terminal_exit_resumes_plain_event_output() {
+        let mut formatter = InteractiveDashboardFormatter {
+            terminal_active: true,
+            ..Default::default()
+        };
+
+        let active_shutdown = formatter
+            .handle_output_event(&OutputEvent::Shutdown { reason: None })
+            .expect("active TUI event formatting should succeed");
+        assert!(
+            active_shutdown.is_none(),
+            "active TUI should not emit normal console output"
+        );
+
+        formatter.terminal_active = false;
+
+        let shutdown = formatter
+            .handle_output_event(&OutputEvent::Shutdown { reason: None })
+            .expect("inactive post-exit event formatting should succeed")
+            .expect("post-exit event should resume normal pretty output");
+        assert_eq!(shutdown, "mesh-llm shutting down\n");
+        assert!(!shutdown.contains("Mesh Events"));
+        assert!(!shutdown.contains('─'));
+
+        let ready = formatter
+            .handle_output_event(&OutputEvent::RuntimeReady {
+                api_url: "http://localhost:9337".to_string(),
+                console_url: Some("http://localhost:3131".to_string()),
+                api_port: 9337,
+                console_port: Some(3131),
+                models_count: Some(1),
+                pi_command: None,
+                goose_command: None,
+            })
+            .expect("post-exit runtime event formatting should succeed")
+            .expect("post-exit runtime event should remain visible as plain output");
+        assert_eq!(ready, "✅ Mesh runtime ready (1 model(s))\n");
+        assert!(!ready.contains("Incoming Requests"));
+        assert!(!ready.contains('│'));
     }
 
     #[test]
@@ -10768,10 +14732,13 @@ mod tests {
             .expect("peer render should succeed");
 
         assert!(dashboard.contains("Running llama.cpp instances"));
+        assert!(dashboard.contains("Startup status"));
         assert!(dashboard.contains("Running models"));
         assert!(dashboard.contains("Running webserver"));
         assert!(dashboard.contains("Running API"));
         assert!(dashboard.contains("Mesh events (latest 2)"));
+        assert!(dashboard.contains("startup=ready"));
+        assert!(dashboard.contains("mesh=ready  api=ready  console=ready"));
         assert!(dashboard.contains("llama-server   starting   port=43683"));
         assert!(dashboard.contains("model=Qwen3.6-35B"));
         assert!(dashboard.contains("ctx=8192"));
@@ -10799,6 +14766,7 @@ mod tests {
                 .expect("pretty formatter should render every event variant");
             assert!(
                 dashboard_rendered.contains("Running llama.cpp instances")
+                    && dashboard_rendered.contains("Startup status")
                     && dashboard_rendered.contains("Running models")
                     && dashboard_rendered.contains("Running webserver")
                     && dashboard_rendered.contains("Running API")
@@ -10986,7 +14954,6 @@ mod tests {
         let long_model = "Qwen3.6-35B-A3B-UD-Q4_K_XL-with-extra-routing-suffix";
         let long_token =
             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.super.long.mesh.invite.token.payload";
-        let long_rpc_log = "/Users/ndizazzo/.mesh-llm/runtime/3845607/logs/rpc-server-43683-with-a-very-long-name.log";
         let long_llama_log = "/Users/ndizazzo/.mesh-llm/runtime/3845607/logs/llama-server-8001-with-a-very-long-name.log";
         let mut formatter =
             DashboardFormatter::with_state(DashboardState::with_mesh_event_limit(8));
@@ -10998,13 +14965,6 @@ mod tests {
                 mesh_name: None,
             })
             .expect("invite render should succeed");
-        formatter
-            .format(&OutputEvent::RpcServerStarting {
-                port: 43683,
-                device: "CUDA0".to_string(),
-                log_path: Some(long_rpc_log.to_string()),
-            })
-            .expect("rpc render should succeed");
         formatter
             .format(&OutputEvent::LlamaStarting {
                 model: Some(long_model.to_string()),
@@ -11023,11 +14983,8 @@ mod tests {
 
         assert!(dashboard.contains(long_model));
         assert!(dashboard.contains(long_token));
-        assert!(dashboard.contains(long_rpc_log));
         assert!(dashboard.contains(long_llama_log));
         assert!(dashboard.contains("Mesh events (latest 8)"));
-        assert!(dashboard.contains("│ rpc-server   starting   port=43683   device=CUDA0"));
-        assert!(dashboard.contains("│              logs=/Users/ndizazzo/.mesh-llm/runtime/3845607/logs/rpc-server-43683-with-a-very-long-name.log"));
         assert!(dashboard.contains("│ llama-server   starting   port=8001"));
         assert!(dashboard.contains("model=Qwen3.6-35B-A3B-UD-Q4_K_XL-with-extra-routing-suffix"));
         assert!(dashboard.contains("ctx=8192"));

--- a/crates/mesh-llm/src/exact_test_wrappers.rs
+++ b/crates/mesh-llm/src/exact_test_wrappers.rs
@@ -1,0 +1,144 @@
+#[test]
+fn early_tui_spawns_before_llama_ready_in_active_flow() {
+    runtime::assert_active_serve_path_spawn_gate_behavior();
+}
+
+#[test]
+fn passive_path_tui_still_starts_immediately() {
+    runtime::assert_passive_path_immediate_spawn_behavior();
+}
+
+#[tokio::test]
+async fn non_serving_subcommands_retain_plain_output() {
+    runtime::assert_non_serving_dispatch_short_circuit_behavior().await;
+}
+
+#[test]
+fn startup_lifecycle_transitions_pending_partial_ready_failed() {
+    cli::output::assert_startup_lifecycle_transitions_pending_partial_ready_failed();
+}
+
+#[test]
+fn startup_lifecycle_keeps_runtime_ready_as_final_edge() {
+    cli::output::assert_startup_lifecycle_keeps_runtime_ready_as_final_edge();
+}
+
+#[test]
+fn startup_failures_surface_in_tui_events_and_status() {
+    cli::output::assert_startup_failures_surface_in_tui_events_and_status();
+}
+
+#[test]
+fn startup_failure_summary_sanitizes_multiline_detail() {
+    cli::output::assert_startup_failure_summary_sanitizes_multiline_detail();
+}
+
+#[test]
+fn rpc_and_llama_startup_failures_mark_components_failed() {
+    cli::output::assert_rpc_and_llama_startup_failures_mark_components_failed();
+}
+
+#[test]
+fn discovery_and_join_failures_mark_startup_mesh_component_failed() {
+    cli::output::assert_discovery_and_join_failures_mark_startup_mesh_component_failed();
+}
+
+#[test]
+fn post_ready_peer_churn_does_not_reopen_startup_failure() {
+    cli::output::assert_post_ready_peer_churn_does_not_reopen_startup_failure();
+}
+
+#[test]
+fn interactive_handler_spawns_once_across_startup_callbacks() {
+    runtime::assert_interactive_handler_spawns_once_across_startup_callbacks();
+}
+
+#[test]
+fn startup_history_is_visible_after_late_tui_attach() {
+    cli::output::assert_startup_history_is_visible_after_late_tui_attach();
+}
+
+#[test]
+fn startup_history_keeps_order_when_tui_attaches_late() {
+    cli::output::assert_startup_history_keeps_order_when_tui_attaches_late();
+}
+
+#[test]
+fn endpoint_rows_remain_starting_until_ready_events() {
+    cli::output::assert_endpoint_rows_remain_starting_until_ready_events();
+}
+
+#[test]
+fn startup_launch_plan_renders_not_ready_rows_before_actions() {
+    cli::output::assert_startup_launch_plan_renders_not_ready_rows_before_actions();
+}
+
+#[test]
+fn tui_model_progress_renders_dashboard_without_loading_screen() {
+    cli::output::assert_tui_model_progress_renders_dashboard_without_loading_screen();
+}
+
+#[test]
+fn tui_startup_progress_continues_in_dashboard_after_model_download_ready() {
+    cli::output::assert_tui_startup_progress_continues_in_dashboard_after_model_download_ready();
+}
+
+#[test]
+fn startup_progress_after_launch_plan_shows_dashboard_not_loader() {
+    cli::output::assert_startup_progress_after_launch_plan_shows_dashboard_not_loader();
+}
+
+#[test]
+fn planned_rows_transition_from_not_ready_to_ready_events() {
+    cli::output::assert_planned_rows_transition_from_not_ready_to_ready_events();
+}
+
+#[test]
+fn launch_plan_rows_survive_empty_startup_snapshot() {
+    cli::output::assert_launch_plan_rows_survive_empty_startup_snapshot();
+}
+
+#[test]
+fn launch_plan_preserves_distinct_port_zero_endpoint_rows() {
+    cli::output::assert_launch_plan_preserves_distinct_port_zero_endpoint_rows();
+}
+
+#[test]
+fn snapshot_upsert_preserves_distinct_port_zero_endpoint_rows() {
+    cli::output::assert_snapshot_upsert_preserves_distinct_port_zero_endpoint_rows();
+}
+
+#[test]
+fn planned_port_zero_process_rows_bind_to_concrete_startup_events() {
+    cli::output::assert_planned_port_zero_process_rows_bind_to_concrete_startup_events();
+}
+
+#[test]
+fn startup_launch_plan_describes_planned_runtime_before_process_start() {
+    runtime::assert_startup_launch_plan_describes_planned_runtime_before_process_start();
+}
+
+#[test]
+fn fallback_mode_surfaces_startup_failures_without_tui() {
+    cli::output::assert_fallback_mode_surfaces_startup_failures_without_tui();
+}
+
+#[test]
+fn quitting_during_startup_cancels_without_late_ready_render() {
+    runtime::assert_quitting_during_startup_cancels_without_late_ready_render();
+}
+
+#[test]
+fn interactive_preterminal_render_uses_plain_event_output() {
+    cli::output::assert_interactive_preterminal_render_uses_plain_event_output();
+}
+
+#[test]
+fn interactive_post_terminal_exit_resumes_plain_event_output() {
+    cli::output::assert_interactive_post_terminal_exit_resumes_plain_event_output();
+}
+
+#[test]
+fn tui_model_card_separates_name_from_metadata_columns() {
+    cli::output::assert_tui_model_card_separates_name_from_metadata_columns();
+}

--- a/crates/mesh-llm/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm/src/inference/skippy/mod.rs
@@ -68,6 +68,8 @@ pub(crate) struct SkippyModelStatus {
     pub(crate) projector_path: Option<String>,
     pub(crate) ctx_size: u32,
     pub(crate) lane_count: u32,
+    pub(crate) lanes: Vec<SkippySessionLaneStatus>,
+    pub(crate) max_session_tokens: u64,
     pub(crate) n_batch: Option<u32>,
     pub(crate) n_ubatch: Option<u32>,
     pub(crate) n_gpu_layers: i32,
@@ -81,6 +83,14 @@ pub(crate) struct SkippyModelStatus {
     pub(crate) started_at_unix_nanos: i64,
     pub(crate) stopped_at_unix_nanos: Option<i64>,
     pub(crate) last_error: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SkippySessionLaneStatus {
+    pub(crate) index: usize,
+    pub(crate) active: bool,
+    pub(crate) session_id: Option<String>,
+    pub(crate) token_count: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -514,11 +524,11 @@ impl From<StageDevice> for SkippyDeviceDescriptor {
 }
 
 pub(crate) fn infer_layer_count(path: &Path) -> Result<u32> {
-    let info = ModelInfo::open(path)
-        .with_context(|| format!("open skippy model metadata {}", path.display()))?;
+    let info =
+        ModelInfo::open(path).with_context(|| format!("open model metadata {}", path.display()))?;
     let layer_count = info
         .tensors()
-        .with_context(|| format!("read skippy model tensors {}", path.display()))?
+        .with_context(|| format!("read model tensors {}", path.display()))?
         .into_iter()
         .filter_map(|tensor| tensor.layer_index)
         .max()
@@ -554,6 +564,18 @@ fn status_from_parts(
         projector_path: config.projector_path.clone(),
         ctx_size: config.ctx_size,
         lane_count: config.lane_count,
+        lanes: embedded
+            .sessions
+            .lanes
+            .iter()
+            .map(|lane| SkippySessionLaneStatus {
+                index: lane.index,
+                active: lane.active,
+                session_id: lane.session_id.clone(),
+                token_count: lane.token_count,
+            })
+            .collect(),
+        max_session_tokens: embedded.sessions.max_session_tokens,
         n_batch: config.n_batch,
         n_ubatch: config.n_ubatch,
         n_gpu_layers: config.n_gpu_layers,

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -41,3 +41,6 @@ pub async fn run_main() -> i32 {
         }
     }
 }
+
+#[cfg(test)]
+include!("exact_test_wrappers.rs");

--- a/crates/mesh-llm/src/runtime/instance.rs
+++ b/crates/mesh-llm/src/runtime/instance.rs
@@ -10,6 +10,7 @@
 //! **ALLOWED** under `runtime_dir/`:
 //! - `lock` — `flock(2)` advisory lock file held by the owning mesh-llm
 //! - `owner.json` — metadata about the owning instance (pid, version, api_port, started_at)
+//! - `logs/` — process-local runtime logs, including embedded skippy/llama.cpp native logs
 //!
 //! **FORBIDDEN** under `runtime_dir/`:
 //! - Application state, configuration, or catalog caches (live elsewhere under `~/.mesh-llm/`)

--- a/crates/mesh-llm/src/runtime/interactive.rs
+++ b/crates/mesh-llm/src/runtime/interactive.rs
@@ -25,6 +25,12 @@ pub(crate) enum InitialPromptMode {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum InteractiveEntryKind {
+    Tui,
+    Line,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum InteractiveCommand {
     Help,
     Quit,
@@ -97,20 +103,62 @@ pub(crate) fn spawn_handler(
     output_manager: &'static OutputManager,
     initial_prompt_mode: InitialPromptMode,
 ) {
-    match output_manager.console_session_mode() {
-        Some(ConsoleSessionMode::InteractiveDashboard) => spawn_tui_handler(
+    spawn_handler_with_first_paint_ack(
+        control_tx,
+        console_state,
+        output_manager,
+        initial_prompt_mode,
+        None,
+    );
+}
+
+pub(crate) fn spawn_handler_with_first_paint_ack(
+    control_tx: tokio::sync::mpsc::UnboundedSender<RuntimeControlRequest>,
+    console_state: MeshApi,
+    output_manager: &'static OutputManager,
+    initial_prompt_mode: InitialPromptMode,
+    first_paint_ack: Option<tokio::sync::oneshot::Sender<std::io::Result<()>>>,
+) {
+    match interactive_entry_kind(output_manager.console_session_mode()) {
+        InteractiveEntryKind::Tui => spawn_tui_handler(
             control_tx,
             console_state,
             output_manager,
             initial_prompt_mode,
+            first_paint_ack,
         ),
-        _ => spawn_line_handler(
-            control_tx,
-            console_state,
-            output_manager,
-            initial_prompt_mode,
-        ),
+        InteractiveEntryKind::Line => {
+            if let Some(ack) = first_paint_ack {
+                let _ = ack.send(Ok(()));
+            }
+            spawn_line_handler(
+                control_tx,
+                console_state,
+                output_manager,
+                initial_prompt_mode,
+            );
+        }
     }
+}
+
+pub(crate) fn interactive_entry_kind(
+    console_session_mode: Option<ConsoleSessionMode>,
+) -> InteractiveEntryKind {
+    match console_session_mode {
+        Some(ConsoleSessionMode::InteractiveDashboard) => InteractiveEntryKind::Tui,
+        _ => InteractiveEntryKind::Line,
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn assert_deferred_initial_prompt_waits_for_runtime_ready() {
+    let mut output = Vec::new();
+    maybe_write_initial_prompt(&mut output, InitialPromptMode::Deferred)
+        .expect("deferred prompt should remain a no-op until RuntimeReady");
+    assert!(
+        output.is_empty(),
+        "deferred prompt mode must not write the ready prompt during early interactive startup"
+    );
 }
 
 fn spawn_line_handler(
@@ -205,13 +253,16 @@ fn spawn_tui_handler(
     console_state: MeshApi,
     output_manager: &'static OutputManager,
     initial_prompt_mode: InitialPromptMode,
+    first_paint_ack: Option<tokio::sync::oneshot::Sender<std::io::Result<()>>>,
 ) {
     let runtime_handle = tokio::runtime::Handle::current();
     if let Err(err) = std::thread::Builder::new()
         .name("mesh-llm-interactive-tui".to_string())
         .spawn(move || {
             let fallback_control_tx = control_tx.clone();
-            if let Err(err) = run_tui_loop(&runtime_handle, control_tx, output_manager) {
+            if let Err(err) =
+                run_tui_loop(&runtime_handle, control_tx, output_manager, first_paint_ack)
+            {
                 let should_fallback = err.should_fallback_to_line_handler();
                 tracing::warn!("interactive pretty loop failed: {err}");
                 if should_fallback {
@@ -237,6 +288,7 @@ fn run_tui_loop(
     runtime_handle: &tokio::runtime::Handle,
     control_tx: tokio::sync::mpsc::UnboundedSender<RuntimeControlRequest>,
     output_manager: &'static OutputManager,
+    mut first_paint_ack: Option<tokio::sync::oneshot::Sender<std::io::Result<()>>>,
 ) -> Result<(), TuiLoopError> {
     enable_raw_mode()
         .map_err(std::io::Error::other)
@@ -246,13 +298,22 @@ fn run_tui_loop(
     let mut shutdown_sent = false;
 
     let result = (|| -> Result<(), TuiLoopError> {
-        runtime_handle
-            .block_on(output_manager.enter_tui())
-            .map_err(TuiLoopError::startup)?;
+        if let Err(err) = runtime_handle.block_on(output_manager.enter_tui()) {
+            send_first_paint_ack(&mut first_paint_ack, Err(clone_io_error(&err)));
+            return Err(TuiLoopError::startup(err));
+        }
 
         if let Ok((columns, rows)) = size() {
             let _ = runtime_handle
                 .block_on(output_manager.dispatch_tui_event(TuiEvent::Resize { columns, rows }));
+        }
+
+        match runtime_handle.block_on(output_manager.render_tui_if_dirty()) {
+            Ok(_) => send_first_paint_ack(&mut first_paint_ack, Ok(())),
+            Err(err) => {
+                send_first_paint_ack(&mut first_paint_ack, Err(clone_io_error(&err)));
+                return Err(TuiLoopError::startup(err));
+            }
         }
 
         loop {
@@ -315,6 +376,19 @@ fn run_tui_loop(
     result?;
     exit_result.map_err(TuiLoopError::runtime)?;
     raw_result.map_err(TuiLoopError::runtime)
+}
+
+fn send_first_paint_ack(
+    first_paint_ack: &mut Option<tokio::sync::oneshot::Sender<std::io::Result<()>>>,
+    result: std::io::Result<()>,
+) {
+    if let Some(ack) = first_paint_ack.take() {
+        let _ = ack.send(result);
+    }
+}
+
+fn clone_io_error(err: &std::io::Error) -> std::io::Error {
+    std::io::Error::new(err.kind(), err.to_string())
 }
 
 #[derive(Debug)]
@@ -452,9 +526,10 @@ fn map_key_event(code: KeyCode, modifiers: KeyModifiers) -> Option<TuiEvent> {
 #[cfg(test)]
 mod tests {
     use super::{
-        console_session_mode_for_term, map_key_event, maybe_write_initial_prompt, parse_command,
-        read_tui_event, restore_tui_terminal_after_loop, write_ready_prompt, InitialPromptMode,
-        InteractiveCommand, TuiLoopError, HELP_TEXT, READY_PROMPT,
+        console_session_mode_for_term, interactive_entry_kind, map_key_event,
+        maybe_write_initial_prompt, parse_command, read_tui_event, restore_tui_terminal_after_loop,
+        write_ready_prompt, InitialPromptMode, InteractiveCommand, InteractiveEntryKind,
+        TuiLoopError, HELP_TEXT, READY_PROMPT,
     };
     use crate::cli::output::{ConsoleSessionMode, TuiEvent, TuiKeyEvent};
     use crossterm::event::{Event, KeyCode, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
@@ -527,6 +602,19 @@ mod tests {
             console_session_mode_for_term(false, false, Some("xterm-256color")),
             ConsoleSessionMode::Fallback
         );
+    }
+
+    #[test]
+    fn interactive_entry_kind_matches_console_session_mode() {
+        assert_eq!(
+            interactive_entry_kind(Some(ConsoleSessionMode::InteractiveDashboard)),
+            InteractiveEntryKind::Tui
+        );
+        assert_eq!(
+            interactive_entry_kind(Some(ConsoleSessionMode::Fallback)),
+            InteractiveEntryKind::Line
+        );
+        assert_eq!(interactive_entry_kind(None), InteractiveEntryKind::Line);
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -3,6 +3,9 @@ use crate::inference::{election, skippy};
 use crate::mesh::{self, NodeRole};
 use crate::models;
 use crate::network::router;
+use crate::runtime_data::{
+    RuntimeLlamaEndpointStatus, RuntimeLlamaSlotSnapshot, RuntimeLlamaSlotsSnapshot,
+};
 use anyhow::{Context, Result};
 use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig};
 use skippy_topology::{
@@ -45,6 +48,54 @@ impl LocalRuntimeModelHandle {
         }
     }
 
+    pub(super) fn ctx_used_tokens(&self) -> Option<u64> {
+        match &self.inner {
+            LocalRuntimeBackendHandle::Skippy { model, .. } => {
+                Some(model.status().max_session_tokens)
+            }
+        }
+    }
+
+    pub(super) fn llama_slots_snapshot(
+        &self,
+        model_name: &str,
+    ) -> Option<RuntimeLlamaSlotsSnapshot> {
+        match &self.inner {
+            LocalRuntimeBackendHandle::Skippy { model, .. } => {
+                let status = model.status();
+                let ctx_size = status.ctx_size as u64;
+                let now = current_time_unix_ms();
+                Some(RuntimeLlamaSlotsSnapshot {
+                    status: RuntimeLlamaEndpointStatus::Ready,
+                    model: Some(model_name.to_string()),
+                    last_attempt_unix_ms: Some(now),
+                    last_success_unix_ms: Some(now),
+                    error: None,
+                    slots: status
+                        .lanes
+                        .into_iter()
+                        .map(|lane| RuntimeLlamaSlotSnapshot {
+                            id: Some(lane.index as u64),
+                            id_task: None,
+                            n_ctx: Some(ctx_size),
+                            speculative: None,
+                            is_processing: Some(lane.active),
+                            next_token: None,
+                            params: None,
+                            extra: serde_json::json!({
+                                "model": model_name,
+                                "lane_index": lane.index,
+                                "active": lane.active,
+                                "session_id": lane.session_id,
+                                "token_count": lane.token_count,
+                            }),
+                        })
+                        .collect(),
+                })
+            }
+        }
+    }
+
     pub(super) async fn shutdown(self) {
         match self.inner {
             LocalRuntimeBackendHandle::Skippy { model, http, .. } => {
@@ -53,6 +104,13 @@ impl LocalRuntimeModelHandle {
             }
         }
     }
+}
+
+fn current_time_unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
 }
 
 pub(super) struct ManagedModelController {

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -10,17 +10,19 @@ use self::discovery::{nostr_rediscovery, start_new_mesh};
 use self::interactive::InitialPromptMode;
 use self::local::{
     add_runtime_local_target, add_serving_assignment, advertise_model_ready, local_process_payload,
-    remove_runtime_local_target, remove_serving_assignment, set_advertised_model_context,
-    start_runtime_local_model, start_runtime_split_model, stop_split_generation_cleanup,
-    withdraw_advertised_model, LocalRuntimeModelHandle, LocalRuntimeModelStartSpec,
-    ManagedModelController, RuntimeEvent, SplitCoordinatorAck, SplitRuntimeStart,
+    remove_runtime_local_target, remove_serving_assignment, resolved_model_name,
+    set_advertised_model_context, start_runtime_local_model, start_runtime_split_model,
+    stop_split_generation_cleanup, withdraw_advertised_model, LocalRuntimeModelHandle,
+    LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent, SplitCoordinatorAck,
+    SplitRuntimeStart,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
 use crate::cli::output::{
-    emit_event, ConsoleSessionMode, DashboardAcceptedRequestBucket, DashboardEndpointRow,
-    DashboardModelRow, DashboardProcessRow, DashboardSnapshot, DashboardSnapshotFuture,
-    DashboardSnapshotProvider, OutputEvent, RuntimeStatus,
+    emit_event, sort_dashboard_endpoint_rows, ConsoleSessionMode, DashboardAcceptedRequestBucket,
+    DashboardEndpointRow, DashboardLaunchPlan, DashboardModelLane, DashboardModelRow,
+    DashboardProcessRow, DashboardSnapshot, DashboardSnapshotFuture, DashboardSnapshotProvider,
+    OutputEvent, RuntimeStatus,
 };
 use crate::cli::{Cli, Command, RuntimeSurface};
 use crate::crypto::{
@@ -39,7 +41,7 @@ use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser};
 use skippy_protocol::FlashAttentionType;
 use std::cell::Cell;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -51,6 +53,17 @@ use tracing_subscriber::fmt::MakeWriter;
 use zeroize::Zeroizing;
 
 const PRETTY_DASHBOARD_INVENTORY_CACHE_TTL: Duration = Duration::from_secs(5);
+const DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL: Duration = Duration::from_millis(250);
+const DASHBOARD_FIRST_PAINT_TIMEOUT: Duration = Duration::from_secs(2);
+
+type DashboardContextUsage =
+    Arc<tokio::sync::Mutex<HashMap<String, HashMap<DashboardContextUsageSource, u64>>>>;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct DashboardContextUsageSource {
+    port: u16,
+    pid: u32,
+}
 
 thread_local! {
     static ROUTING_TRACING_STDERR: Cell<bool> = const { Cell::new(false) };
@@ -177,6 +190,42 @@ fn write_stderr_line(message: &str) -> io::Result<()> {
     stderr.flush()
 }
 
+fn configure_skippy_native_logging(runtime_dir: Option<&Path>) -> Option<PathBuf> {
+    let Some(runtime_dir) = runtime_dir else {
+        skippy_runtime::suppress_native_logs();
+        tracing::debug!("suppressing skippy native logs without an instance runtime directory");
+        return None;
+    };
+
+    let log_dir = runtime_dir.join("logs");
+    if let Err(err) = std::fs::create_dir_all(&log_dir) {
+        tracing::warn!(
+            path = %log_dir.display(),
+            error = %err,
+            "failed to create skippy native log directory; suppressing native logs"
+        );
+        skippy_runtime::suppress_native_logs();
+        return None;
+    }
+
+    let native_log_path = log_dir.join("skippy-native.log");
+    if let Err(err) = skippy_runtime::redirect_native_logs_to_file(&native_log_path) {
+        tracing::warn!(
+            path = %native_log_path.display(),
+            error = %err,
+            "failed to redirect skippy native logs; suppressing native logs"
+        );
+        skippy_runtime::suppress_native_logs();
+        return None;
+    }
+
+    tracing::info!(
+        path = %native_log_path.display(),
+        "redirecting skippy native logs away from stdout"
+    );
+    Some(native_log_path)
+}
+
 fn current_time_unix_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -195,6 +244,8 @@ fn publication_state_from_update(update: nostr::PublishStateUpdate) -> api::Publ
 struct RuntimeDashboardSnapshotProvider {
     node: mesh::Node,
     local_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
+    local_context_usage: DashboardContextUsage,
+    runtime_data_collector: crate::runtime_data::RuntimeDataCollector,
     plugin_manager: Option<plugin::PluginManager>,
     api_port: u16,
     console_port: Option<u16>,
@@ -225,14 +276,17 @@ impl RuntimeDashboardSnapshotProvider {
     fn new(
         node: mesh::Node,
         local_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
+        local_context_usage: DashboardContextUsage,
         plugin_manager: Option<plugin::PluginManager>,
         api_port: u16,
         console_port: Option<u16>,
         headless: bool,
     ) -> Self {
         Self {
+            runtime_data_collector: node.runtime_data_collector(),
             node,
             local_processes,
+            local_context_usage,
             plugin_manager,
             api_port,
             console_port,
@@ -255,8 +309,10 @@ impl RuntimeDashboardSnapshotProvider {
         options: RuntimeDashboardSnapshotProviderTestOptions,
     ) -> Self {
         Self {
+            runtime_data_collector: node.runtime_data_collector(),
             node,
             local_processes,
+            local_context_usage: Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             plugin_manager,
             api_port: options.api_port,
             console_port: options.console_port,
@@ -296,10 +352,107 @@ impl RuntimeDashboardSnapshotProvider {
     }
 }
 
+fn dashboard_inventory_value_for_model<'a, T>(
+    values_by_name: &'a HashMap<String, T>,
+    model_name: &str,
+) -> Option<&'a T> {
+    dashboard_inventory_model_keys(model_name)
+        .into_iter()
+        .find_map(|key| values_by_name.get(&key))
+}
+
+fn dashboard_context_usage_for_model(
+    values_by_name: &HashMap<String, HashMap<DashboardContextUsageSource, u64>>,
+    model_name: &str,
+) -> Option<u64> {
+    dashboard_inventory_model_keys(model_name)
+        .into_iter()
+        .filter_map(|key| values_by_name.get(&key))
+        .flat_map(|source_values| source_values.values().copied())
+        .max()
+}
+
+fn dashboard_lanes_for_model(
+    snapshots_by_model: &BTreeMap<String, crate::runtime_data::RuntimeLlamaRuntimeSnapshot>,
+    model_name: &str,
+) -> Option<Vec<DashboardModelLane>> {
+    let snapshot = snapshots_by_model.get(model_name)?;
+
+    let mut lanes = snapshot
+        .items
+        .slots
+        .iter()
+        .map(|slot| DashboardModelLane {
+            index: dashboard_lane_index_for_slot(slot),
+            active: slot.is_processing,
+        })
+        .collect::<Vec<_>>();
+    lanes.sort_by_key(|lane| lane.index);
+    (!lanes.is_empty()).then_some(lanes)
+}
+
+fn dashboard_lane_index_for_slot(slot: &crate::runtime_data::RuntimeLlamaSlotItem) -> usize {
+    slot.id
+        .and_then(|id| usize::try_from(id).ok())
+        .unwrap_or(slot.index)
+}
+
+fn dashboard_quantization_from_model_name(model_name: &str) -> Option<String> {
+    dashboard_inventory_model_keys(model_name)
+        .into_iter()
+        .map(|key| models::inventory::derive_quantization_type(&key))
+        .map(|quantization| quantization.trim().trim_end_matches(".gguf").to_string())
+        .find(|quantization| !quantization.is_empty())
+}
+
+fn dashboard_inventory_model_keys(model_name: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    push_dashboard_inventory_model_key(&mut keys, model_name.trim());
+    if let Some(base_name) = model_name.trim().rsplit('/').next() {
+        push_dashboard_inventory_model_key(&mut keys, base_name);
+    }
+
+    let seeds = keys.clone();
+    for key in seeds {
+        if let Some(without_gguf_variant) = strip_gguf_variant_marker(&key) {
+            push_dashboard_inventory_model_key(&mut keys, &without_gguf_variant);
+        }
+        push_dashboard_inventory_model_key(&mut keys, &key.replace(':', "-"));
+        if key.to_ascii_lowercase().ends_with(".gguf") {
+            push_dashboard_inventory_model_key(&mut keys, &key[..key.len().saturating_sub(5)]);
+        }
+    }
+    keys
+}
+
+fn strip_gguf_variant_marker(model_name: &str) -> Option<String> {
+    let lower = model_name.to_ascii_lowercase();
+    for marker in ["-gguf:", ":gguf:"] {
+        if let Some(index) = lower.find(marker) {
+            let variant_start = index + marker.len();
+            return Some(format!(
+                "{}-{}",
+                &model_name[..index],
+                &model_name[variant_start..]
+            ));
+        }
+    }
+    None
+}
+
+fn push_dashboard_inventory_model_key(keys: &mut Vec<String>, key: &str) {
+    let key = key.trim();
+    if !key.is_empty() && !keys.iter().any(|candidate| candidate == key) {
+        keys.push(key.to_string());
+    }
+}
+
 impl DashboardSnapshotProvider for RuntimeDashboardSnapshotProvider {
     fn snapshot(&self) -> DashboardSnapshotFuture<'_> {
         let node = self.node.clone();
         let local_processes = self.local_processes.clone();
+        let local_context_usage = self.local_context_usage.clone();
+        let runtime_data_collector = self.runtime_data_collector.clone();
         let api_port = self.api_port;
         let console_port = self.console_port;
         let headless = self.headless;
@@ -308,35 +461,48 @@ impl DashboardSnapshotProvider for RuntimeDashboardSnapshotProvider {
 
         Box::pin(async move {
             let process_rows = local_processes.lock().await.clone();
+            let context_usage_by_name = local_context_usage.lock().await.clone();
+            let llama_runtime_by_model = runtime_data_collector.runtime_llama_snapshots_by_model();
             let request_metrics = node.local_request_metrics_snapshot();
             let accepted_request_counts_len = request_metrics.accepted_request_counts.len();
             let inventory_snapshot = provider.inventory_snapshot().await;
             let metadata_by_name = inventory_snapshot.metadata_by_name;
+            let size_by_name = inventory_snapshot.size_by_name;
             let mut loaded_model_rows = Vec::with_capacity(process_rows.len());
             for process in &process_rows {
-                let metadata = metadata_by_name.get(&process.name);
-                loaded_model_rows.push(DashboardModelRow {
-                    name: process.name.clone(),
-                    role: dashboard_role_for_local_process(process),
-                    status: runtime_status_from_process_status(&process.status),
-                    port: Some(process.port),
-                    device: Some(process.backend.clone()),
-                    slots: Some(process.slots),
-                    quantization: metadata
-                        .map(|model| model.quantization_type.trim())
-                        .filter(|value| !value.is_empty())
-                        .map(str::to_string),
-                    ctx_size: node
-                        .local_model_context_length(&process.name)
+                let metadata =
+                    dashboard_inventory_value_for_model(&metadata_by_name, &process.name);
+                let quantization = metadata
+                    .map(|model| model.quantization_type.trim())
+                    .filter(|value| !value.is_empty())
+                    .map(str::to_string)
+                    .or_else(|| dashboard_quantization_from_model_name(&process.name));
+                let ctx_size = if let Some(context_length) = process.context_length {
+                    Some(context_length)
+                } else {
+                    node.local_model_context_length(&process.name)
                         .await
                         .or_else(|| {
                             metadata
                                 .map(|model| model.context_length)
                                 .filter(|value| *value > 0)
-                        }),
-                    file_size_gb: inventory_snapshot
-                        .size_by_name
-                        .get(&process.name)
+                        })
+                };
+                loaded_model_rows.push(DashboardModelRow {
+                    name: process.name.clone(),
+                    role: dashboard_role_for_local_process(process),
+                    status: runtime_status_from_process_status(&process.status),
+                    port: Some(process.port),
+                    device: None,
+                    slots: Some(process.slots),
+                    quantization,
+                    ctx_size,
+                    ctx_used_tokens: dashboard_context_usage_for_model(
+                        &context_usage_by_name,
+                        &process.name,
+                    ),
+                    lanes: dashboard_lanes_for_model(&llama_runtime_by_model, &process.name),
+                    file_size_gb: dashboard_inventory_value_for_model(&size_by_name, &process.name)
                         .map(|size| *size as f64 / 1e9),
                 });
             }
@@ -437,22 +603,6 @@ fn build_dashboard_endpoint_rows(
     rows
 }
 
-fn sort_dashboard_endpoint_rows(rows: &mut [DashboardEndpointRow]) {
-    rows.sort_by(|left, right| {
-        dashboard_endpoint_sort_bucket(left)
-            .cmp(&dashboard_endpoint_sort_bucket(right))
-            .then_with(|| left.label.cmp(&right.label))
-    });
-}
-
-fn dashboard_endpoint_sort_bucket(row: &DashboardEndpointRow) -> u8 {
-    if row.label.starts_with("Plugin: ") {
-        1
-    } else {
-        0
-    }
-}
-
 #[allow(dead_code)]
 async fn plugin_dashboard_endpoint_rows(
     plugin_manager: &plugin::PluginManager,
@@ -525,6 +675,120 @@ async fn remove_dashboard_process(
         .retain(|process| process.name != model_name);
 }
 
+async fn refresh_dashboard_context_usage(
+    shared: &DashboardContextUsage,
+    model_name: &str,
+    handle: &LocalRuntimeModelHandle,
+) {
+    upsert_dashboard_context_usage(
+        shared,
+        model_name,
+        dashboard_context_usage_source(handle),
+        handle.ctx_used_tokens(),
+    )
+    .await;
+}
+
+fn publish_runtime_llama_slots(
+    producer: Option<&crate::runtime_data::RuntimeDataProducer>,
+    model_name: &str,
+    handle: &LocalRuntimeModelHandle,
+) {
+    let Some(producer) = producer else {
+        return;
+    };
+    if let Some(snapshot) = handle.llama_slots_snapshot(model_name) {
+        producer.publish_llama_slots_snapshot(snapshot);
+    }
+}
+
+fn publish_runtime_llama_unavailable(
+    producer: Option<&crate::runtime_data::RuntimeDataProducer>,
+    model_name: &str,
+) {
+    let Some(producer) = producer else {
+        return;
+    };
+    producer.publish_llama_slots_snapshot(crate::runtime_data::RuntimeLlamaSlotsSnapshot {
+        status: crate::runtime_data::RuntimeLlamaEndpointStatus::Unavailable,
+        model: Some(model_name.to_string()),
+        last_attempt_unix_ms: Some(current_time_unix_ms()),
+        last_success_unix_ms: None,
+        error: None,
+        slots: Vec::new(),
+    });
+}
+
+async fn refresh_dashboard_context_usage_batch(
+    shared: &DashboardContextUsage,
+    updates: Vec<(String, DashboardContextUsageSource, Option<u64>)>,
+) {
+    let mut guard = shared.lock().await;
+    for (model_name, source, ctx_used_tokens) in updates {
+        if let Some(ctx_used_tokens) = ctx_used_tokens {
+            guard
+                .entry(model_name)
+                .or_default()
+                .insert(source, ctx_used_tokens);
+        } else {
+            remove_dashboard_context_usage_source_locked(&mut guard, &model_name, source);
+        }
+    }
+}
+
+async fn upsert_dashboard_context_usage(
+    shared: &DashboardContextUsage,
+    model_name: &str,
+    source: DashboardContextUsageSource,
+    ctx_used_tokens: Option<u64>,
+) {
+    let mut guard = shared.lock().await;
+    if let Some(ctx_used_tokens) = ctx_used_tokens {
+        guard
+            .entry(model_name.to_string())
+            .or_default()
+            .insert(source, ctx_used_tokens);
+    } else {
+        remove_dashboard_context_usage_source_locked(&mut guard, model_name, source);
+    }
+}
+
+async fn remove_dashboard_context_usage(
+    shared: &DashboardContextUsage,
+    model_name: &str,
+    handle: &LocalRuntimeModelHandle,
+) {
+    let mut guard = shared.lock().await;
+    remove_dashboard_context_usage_source_locked(
+        &mut guard,
+        model_name,
+        dashboard_context_usage_source(handle),
+    );
+}
+
+fn remove_dashboard_context_usage_source_locked(
+    guard: &mut HashMap<String, HashMap<DashboardContextUsageSource, u64>>,
+    model_name: &str,
+    source: DashboardContextUsageSource,
+) {
+    let should_remove_model = if let Some(source_values) = guard.get_mut(model_name) {
+        source_values.remove(&source);
+        source_values.is_empty()
+    } else {
+        false
+    };
+    if should_remove_model {
+        guard.remove(model_name);
+    }
+}
+
+fn dashboard_context_usage_source(handle: &LocalRuntimeModelHandle) -> DashboardContextUsageSource {
+    DashboardContextUsageSource {
+        port: handle.port,
+        pid: handle.pid(),
+    }
+}
+
 struct StartupLocalModelTask {
     node: mesh::Node,
     tunnel_mgr: tunnel::Manager,
@@ -545,6 +809,7 @@ struct StartupLocalModelTask {
     split: bool,
     stop_rx: tokio::sync::watch::Receiver<bool>,
     dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
+    dashboard_context_usage: DashboardContextUsage,
     console_state: Option<api::MeshApi>,
     api_port: u16,
     startup_ready_reporter: StartupReadyReporter,
@@ -576,6 +841,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         split,
         mut stop_rx,
         dashboard_processes,
+        dashboard_context_usage,
         console_state,
         api_port,
         startup_ready_reporter,
@@ -585,6 +851,12 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         interactive_control_tx,
         interactive_console_state,
     } = params;
+
+    let runtime_data_producer = if let Some(cs) = console_state.as_ref() {
+        Some(cs.runtime_data_producer().await)
+    } else {
+        None
+    };
 
     let startup_load_guard = startup_load_gate.lock().await;
     let start_spec = LocalRuntimeModelStartSpec {
@@ -681,6 +953,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         handle.context_length,
     );
     upsert_dashboard_process(&dashboard_processes, payload.clone()).await;
+    refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
+    publish_runtime_llama_slots(runtime_data_producer.as_ref(), &loaded_name, &handle);
     if let Some(ref cs) = console_state {
         cs.upsert_local_process(payload).await;
         cs.update(true, true).await;
@@ -693,10 +967,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         role: Some(handle.backend.clone()),
     });
     let _ = emit_event(OutputEvent::Info {
-        message: format!(
-            "Startup-loaded {} model '{}' on :{}",
-            handle.backend, loaded_name, handle.port
-        ),
+        message: format!("Startup-loaded model '{}' on :{}", loaded_name, handle.port),
         context: None,
     });
 
@@ -715,8 +986,15 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         }
     }
 
+    let mut context_usage_tick = tokio::time::interval(DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL);
+    context_usage_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     loop {
         tokio::select! {
+            _ = context_usage_tick.tick() => {
+                refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
+                publish_runtime_llama_slots(runtime_data_producer.as_ref(), &loaded_name, &handle);
+            }
             _ = &mut death_rx => {
                 let _ = emit_event(OutputEvent::Warning {
                     message: format!("Startup model '{loaded_name}' exited unexpectedly"),
@@ -767,7 +1045,19 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     cs.update(true, true).await;
                 }
                 let old_handle = std::mem::replace(&mut handle, next.handle);
+                remove_dashboard_context_usage(
+                    &dashboard_context_usage,
+                    &old_loaded_name,
+                    &old_handle,
+                )
+                .await;
+                if old_loaded_name != next.loaded_name {
+                    publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &old_loaded_name);
+                }
                 loaded_name = next.loaded_name;
+                refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle)
+                    .await;
+                publish_runtime_llama_slots(runtime_data_producer.as_ref(), &loaded_name, &handle);
                 death_rx = next.death_rx;
                 split_cleanup = next.cleanup.take();
                 let _ = event.ack.send(SplitCoordinatorAck::Accepted);
@@ -812,6 +1102,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         ))
         .await;
     }
+    remove_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
+    publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &loaded_name);
     handle.shutdown().await;
     if let Some(cleanup) = split_cleanup.take() {
         stop_split_generation_cleanup(&node, cleanup, u64::MAX).await;
@@ -871,7 +1163,10 @@ fn emit_shutdown(reason: Option<String>) {
 struct StartupReadyReporter {
     ready_by_model: Arc<Mutex<HashMap<String, bool>>>,
     emitted: Arc<AtomicBool>,
+    shutdown_requested: Arc<AtomicBool>,
     primary_model: String,
+    api_url: String,
+    console_url: Option<String>,
     api_port: u16,
     console_port: Option<u16>,
 }
@@ -880,6 +1175,8 @@ impl StartupReadyReporter {
     fn new(
         models: &[String],
         primary_model: String,
+        api_url: String,
+        console_url: Option<String>,
         api_port: u16,
         console_port: Option<u16>,
     ) -> Self {
@@ -887,13 +1184,20 @@ impl StartupReadyReporter {
         Self {
             ready_by_model: Arc::new(Mutex::new(ready_by_model)),
             emitted: Arc::new(AtomicBool::new(false)),
+            shutdown_requested: Arc::new(AtomicBool::new(false)),
             primary_model,
+            api_url,
+            console_url,
             api_port,
             console_port,
         }
     }
 
-    fn mark_ready_and_maybe_emit(&self, model_name: &str) {
+    fn mark_shutdown_requested(&self) {
+        self.shutdown_requested.store(true, Ordering::SeqCst);
+    }
+
+    fn mark_ready_and_build_event(&self, model_name: &str) -> Option<OutputEvent> {
         let models_count = {
             let mut ready_by_model = self
                 .ready_by_model
@@ -909,36 +1213,41 @@ impl StartupReadyReporter {
             }
         };
 
-        let Some(models_count) = models_count else {
-            return;
+        let models_count = models_count?;
+
+        if self.shutdown_requested.load(Ordering::SeqCst) {
+            return None;
         };
 
         if self.emitted.swap(true, Ordering::SeqCst) {
-            return;
+            return None;
         }
 
-        let api_url = format!("http://localhost:{}", self.api_port);
-        let console_url = self
-            .console_port
-            .map(|port| format!("http://localhost:{port}"));
         let pi_command = Some(format!(
             "mesh-llm pi --host 127.0.0.1:{} --model {}",
             self.api_port,
             crate::cli::shell::single_quote(&self.primary_model)
         ));
         let goose_command = Some(format!(
-            "GOOSE_PROVIDER=openai OPENAI_HOST={api_url} OPENAI_API_KEY=mesh GOOSE_MODEL={} goose session",
-            self.primary_model
+            "GOOSE_PROVIDER=openai OPENAI_HOST={} OPENAI_API_KEY=mesh GOOSE_MODEL={} goose session",
+            self.api_url, self.primary_model
         ));
-        let _ = emit_event(OutputEvent::RuntimeReady {
-            api_url,
-            console_url,
+        Some(OutputEvent::RuntimeReady {
+            api_url: self.api_url.clone(),
+            console_url: self.console_url.clone(),
             api_port: self.api_port,
             console_port: self.console_port,
             models_count: Some(models_count),
             pi_command,
             goose_command,
-        });
+        })
+    }
+
+    fn mark_ready_and_maybe_emit(&self, model_name: &str) {
+        let Some(event) = self.mark_ready_and_build_event(model_name) else {
+            return;
+        };
+        let _ = emit_event(event);
         let _ = crate::cli::output::OutputManager::global().schedule_ready_prompt();
     }
 }
@@ -1173,7 +1482,7 @@ pub(crate) async fn run() -> Result<()> {
         autoupdate::check_for_update().await;
     }
 
-    if crate::cli::commands::dispatch(&cli).await? {
+    if should_short_circuit_after_dispatch(crate::cli::commands::dispatch(&cli).await?) {
         return Ok(());
     }
 
@@ -1752,6 +2061,667 @@ fn should_show_serve_config_help(
         && cli.discover.is_none()
 }
 
+fn should_short_circuit_after_dispatch(dispatched: bool) -> bool {
+    dispatched
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct InteractiveSpawnRequest {
+    prompt_mode: InitialPromptMode,
+}
+
+fn serve_path_interactive_spawn_request(
+    input_handler_enabled: bool,
+    interactive_started: &AtomicBool,
+    stdin_is_tty: bool,
+) -> Option<InteractiveSpawnRequest> {
+    if !input_handler_enabled || !stdin_is_tty {
+        return None;
+    }
+    if interactive_started.swap(true, Ordering::AcqRel) {
+        return None;
+    }
+    Some(InteractiveSpawnRequest {
+        prompt_mode: InitialPromptMode::Deferred,
+    })
+}
+
+fn passive_path_interactive_spawn_request(
+    console_session_mode: Option<ConsoleSessionMode>,
+    stdin_is_tty: bool,
+) -> Option<InteractiveSpawnRequest> {
+    if console_session_mode.is_some() && stdin_is_tty {
+        Some(InteractiveSpawnRequest {
+            prompt_mode: InitialPromptMode::Immediate,
+        })
+    } else {
+        None
+    }
+}
+
+fn startup_launch_plan(
+    startup_models: &[StartupModelPlan],
+    primary_model_name: &str,
+    api_port: u16,
+    console_port: Option<u16>,
+    headless: bool,
+    default_parallel: Option<usize>,
+    default_backend_device: Option<String>,
+) -> DashboardLaunchPlan {
+    let mut llama_process_rows = Vec::new();
+
+    let mut model_rows: Vec<_> = startup_models
+        .iter()
+        .enumerate()
+        .map(|(index, model)| {
+            let model_name = startup_model_display_name(model);
+            llama_process_rows.push(DashboardProcessRow {
+                name: format!("llama-server {model_name}"),
+                backend: String::new(),
+                status: RuntimeStatus::Loading,
+                port: 0,
+                pid: 0,
+            });
+
+            DashboardModelRow {
+                name: model_name,
+                role: Some(if index == 0 { "primary" } else { "model" }.to_string()),
+                status: RuntimeStatus::Loading,
+                port: None,
+                device: model
+                    .pinned_gpu
+                    .as_ref()
+                    .map(|gpu| gpu.backend_device.clone())
+                    .or_else(|| model.gpu_id.clone())
+                    .or_else(|| default_backend_device.clone()),
+                slots: model.parallel.or(default_parallel),
+                quantization: None,
+                ctx_size: model.ctx_size,
+                ctx_used_tokens: None,
+                lanes: None,
+                file_size_gb: None,
+            }
+        })
+        .collect();
+
+    let mut webserver_rows = vec![DashboardEndpointRow {
+        label: "API".to_string(),
+        status: RuntimeStatus::NotReady,
+        url: format!("http://localhost:{api_port}"),
+        port: api_port,
+        pid: None,
+    }];
+    if !headless {
+        if let Some(console_port) = console_port {
+            webserver_rows.push(DashboardEndpointRow {
+                label: "Console".to_string(),
+                status: RuntimeStatus::NotReady,
+                url: format!("http://localhost:{console_port}"),
+                port: console_port,
+                pid: None,
+            });
+        }
+    }
+    sort_dashboard_endpoint_rows(&mut webserver_rows);
+
+    if startup_models.is_empty() {
+        llama_process_rows.push(DashboardProcessRow {
+            name: format!("llama-server {primary_model_name}"),
+            backend: String::new(),
+            status: RuntimeStatus::Loading,
+            port: 0,
+            pid: 0,
+        });
+        model_rows.push(DashboardModelRow {
+            name: primary_model_name.to_string(),
+            role: Some("primary".to_string()),
+            status: RuntimeStatus::Loading,
+            port: None,
+            device: default_backend_device,
+            slots: default_parallel,
+            quantization: None,
+            ctx_size: None,
+            ctx_used_tokens: None,
+            lanes: None,
+            file_size_gb: None,
+        });
+    }
+
+    DashboardLaunchPlan {
+        llama_process_rows,
+        webserver_rows,
+        loaded_model_rows: model_rows,
+    }
+}
+
+fn serve_path_builtin_endpoint_ready_events(
+    api_url: String,
+    console_url: Option<String>,
+    headless: bool,
+) -> Vec<OutputEvent> {
+    let mut events = vec![OutputEvent::ApiReady { url: api_url }];
+
+    if !headless {
+        if let Some(console_url) = console_url {
+            events.push(OutputEvent::WebserverReady { url: console_url });
+        }
+    }
+
+    events
+}
+
+fn socket_addr_http_url(addr: std::net::SocketAddr) -> String {
+    format!("http://{addr}")
+}
+
+fn listener_http_url(
+    listener: &tokio::net::TcpListener,
+    fallback_port: u16,
+    label: &str,
+) -> String {
+    listener_http_endpoint(listener, fallback_port, label).0
+}
+
+fn listener_http_endpoint(
+    listener: &tokio::net::TcpListener,
+    fallback_port: u16,
+    label: &str,
+) -> (String, u16) {
+    listener
+        .local_addr()
+        .map(|addr| (socket_addr_http_url(addr), addr.port()))
+        .unwrap_or_else(|err| {
+            tracing::warn!("{label}: failed to read listener address: {err}");
+            (format!("http://localhost:{fallback_port}"), fallback_port)
+        })
+}
+
+async fn bind_runtime_tcp_listener(
+    port: u16,
+    listen_all: bool,
+    label: &str,
+) -> Result<tokio::net::TcpListener> {
+    let addr = if listen_all { "0.0.0.0" } else { "127.0.0.1" };
+    tokio::net::TcpListener::bind(format!("{addr}:{port}"))
+        .await
+        .with_context(|| format!("Failed to bind {label} to port {port}"))
+}
+
+fn startup_default_backend_device(binary_flavor: Option<backend::BinaryFlavor>) -> Option<String> {
+    let flavor = binary_flavor.or_else(platform_default_backend_flavor);
+    if flavor == Some(backend::BinaryFlavor::Metal) {
+        backend::backend_device_for_flavor(0, backend::BinaryFlavor::Metal)
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn platform_default_backend_flavor() -> Option<backend::BinaryFlavor> {
+    Some(backend::BinaryFlavor::Metal)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_default_backend_flavor() -> Option<backend::BinaryFlavor> {
+    None
+}
+
+fn startup_model_display_name(model: &StartupModelPlan) -> String {
+    let declared_ref = model.declared_ref.trim();
+    if declared_ref.is_empty() {
+        resolved_model_name(&model.resolved_path)
+    } else {
+        declared_ref.to_string()
+    }
+}
+
+async fn wait_for_dashboard_first_paint(
+    first_paint_rx: tokio::sync::oneshot::Receiver<std::io::Result<()>>,
+) {
+    match tokio::time::timeout(DASHBOARD_FIRST_PAINT_TIMEOUT, first_paint_rx).await {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(err))) => {
+            tracing::warn!("interactive dashboard first paint failed: {err}");
+        }
+        Ok(Err(_)) => {
+            tracing::warn!(
+                "interactive dashboard first paint channel closed before acknowledgement"
+            );
+        }
+        Err(_) => {
+            tracing::warn!(
+                "interactive dashboard first paint did not acknowledge before startup continued"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn assert_active_serve_path_spawn_gate_behavior() {
+    let interactive_started = AtomicBool::new(false);
+
+    let request = serve_path_interactive_spawn_request(true, &interactive_started, true)
+        .expect("active serve path should request interactive startup before llama_ready");
+    assert_eq!(request.prompt_mode, InitialPromptMode::Deferred);
+    interactive::assert_deferred_initial_prompt_waits_for_runtime_ready();
+    assert_eq!(
+        interactive::interactive_entry_kind(Some(ConsoleSessionMode::InteractiveDashboard)),
+        interactive::InteractiveEntryKind::Tui
+    );
+    assert_eq!(
+        serve_path_interactive_spawn_request(true, &interactive_started, true),
+        None,
+        "the active serve path should only request interactive startup once"
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn assert_interactive_handler_spawns_once_across_startup_callbacks() {
+    let interactive_started = AtomicBool::new(false);
+
+    let request = serve_path_interactive_spawn_request(true, &interactive_started, true)
+        .expect("console bootstrap should claim the one-shot interactive spawn gate");
+    assert_eq!(request.prompt_mode, InitialPromptMode::Deferred);
+
+    assert_eq!(
+        serve_path_interactive_spawn_request(true, &interactive_started, true),
+        None,
+        "later startup or election callbacks must not spawn a second interactive handler"
+    );
+    assert_eq!(
+        serve_path_interactive_spawn_request(false, &interactive_started, true),
+        None,
+        "disabling the input handler later must not reopen the one-shot spawn gate"
+    );
+    assert!(
+        interactive_started.load(Ordering::Acquire),
+        "the console-bootstrap spawn should consume the one-shot gate permanently"
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn assert_passive_path_immediate_spawn_behavior() {
+    let request = passive_path_interactive_spawn_request(
+        Some(ConsoleSessionMode::InteractiveDashboard),
+        true,
+    )
+    .expect("passive/client pretty sessions should request interactive startup immediately");
+
+    assert_eq!(request.prompt_mode, InitialPromptMode::Immediate);
+    assert_eq!(
+        interactive::interactive_entry_kind(Some(ConsoleSessionMode::InteractiveDashboard)),
+        interactive::InteractiveEntryKind::Tui
+    );
+    assert_eq!(
+        passive_path_interactive_spawn_request(
+            Some(ConsoleSessionMode::InteractiveDashboard),
+            false
+        ),
+        None,
+        "stdin must still be a TTY before passive/client startup requests interactive input"
+    );
+}
+
+#[cfg(test)]
+pub(crate) async fn assert_non_serving_dispatch_short_circuit_behavior() {
+    let cli = Cli::parse_from(["mesh-llm", "models", "installed"]);
+
+    assert!(matches!(
+        cli.command.as_ref(),
+        Some(Command::Models {
+            command: crate::cli::models::ModelsCommand::Installed { json: false }
+        })
+    ));
+
+    let dispatched = crate::cli::commands::dispatch(&cli)
+        .await
+        .expect("models installed should stay on the plain dispatch path");
+    assert!(dispatched);
+    assert_eq!(
+        initial_console_session_mode_for_surface(None, ConsoleSessionMode::InteractiveDashboard,),
+        ConsoleSessionMode::None,
+        "non-serving commands must keep the plain output surface instead of interactive startup"
+    );
+    assert!(
+        should_short_circuit_after_dispatch(dispatched),
+        "non-serving commands must return before runtime startup can reach interactive setup"
+    );
+}
+
+#[cfg(test)]
+pub(crate) fn assert_quitting_during_startup_cancels_without_late_ready_render() {
+    let reporter = StartupReadyReporter::new(
+        &["Qwen3-8B-Q4_K_M".to_string()],
+        "Qwen3-8B-Q4_K_M".to_string(),
+        "http://127.0.0.1:9337".to_string(),
+        Some("http://127.0.0.1:3131".to_string()),
+        9337,
+        Some(3131),
+    );
+    reporter.mark_shutdown_requested();
+    assert!(
+        reporter
+            .mark_ready_and_build_event("Qwen3-8B-Q4_K_M")
+            .is_none(),
+        "startup shutdown should cancel any late RuntimeReady emission"
+    );
+    crate::cli::output::assert_shutdown_suppresses_late_ready_render();
+}
+
+#[cfg(test)]
+pub(crate) fn assert_startup_launch_plan_describes_planned_runtime_before_process_start() {
+    let startup_models = vec![
+        StartupModelPlan {
+            declared_ref: "unsloth/Model-A-GGUF:Q4_K_M".to_string(),
+            resolved_path: PathBuf::from("/tmp/Model-A-Q4_K_M.gguf"),
+            mmproj_path: None,
+            ctx_size: Some(8192),
+            gpu_id: Some("GPU0".to_string()),
+            pinned_gpu: None,
+            parallel: Some(2),
+            cache_type_k: None,
+            cache_type_v: None,
+            n_batch: None,
+            n_ubatch: None,
+            flash_attention: FlashAttentionType::Auto,
+        },
+        StartupModelPlan {
+            declared_ref: "Model-B".to_string(),
+            resolved_path: PathBuf::from("/tmp/Model-B.gguf"),
+            mmproj_path: None,
+            ctx_size: Some(4096),
+            gpu_id: None,
+            pinned_gpu: Some(StartupPinnedGpuTarget {
+                index: 1,
+                stable_id: "gpu-b".to_string(),
+                backend_device: "CUDA1".to_string(),
+                vram_bytes: 24 * 1024 * 1024 * 1024,
+            }),
+            parallel: None,
+            cache_type_k: None,
+            cache_type_v: None,
+            n_batch: None,
+            n_ubatch: None,
+            flash_attention: FlashAttentionType::Auto,
+        },
+    ];
+
+    let plan = startup_launch_plan(
+        &startup_models,
+        "Fallback-Model",
+        9337,
+        Some(3131),
+        false,
+        Some(4),
+        None,
+    );
+
+    assert!(plan.llama_process_rows.iter().any(|row| {
+        row.name == "llama-server unsloth/Model-A-GGUF:Q4_K_M"
+            && row.status == RuntimeStatus::Loading
+            && row.port == 0
+    }));
+    assert!(plan.llama_process_rows.iter().any(|row| {
+        row.name == "llama-server Model-B" && row.status == RuntimeStatus::Loading && row.port == 0
+    }));
+    assert_eq!(plan.llama_process_rows.len(), 2);
+
+    let api_row = plan
+        .webserver_rows
+        .iter()
+        .find(|row| row.label == "API")
+        .expect("launch plan should include planned API row");
+    assert_eq!(api_row.status, RuntimeStatus::NotReady);
+    assert_eq!(api_row.port, 9337);
+
+    let console_row = plan
+        .webserver_rows
+        .iter()
+        .find(|row| row.label == "Console")
+        .expect("launch plan should include planned Console row");
+    assert_eq!(console_row.status, RuntimeStatus::NotReady);
+    assert_eq!(console_row.port, 3131);
+
+    let headless_plan = startup_launch_plan(
+        &startup_models,
+        "Fallback-Model",
+        9337,
+        Some(3131),
+        true,
+        Some(4),
+        None,
+    );
+    assert!(
+        headless_plan
+            .webserver_rows
+            .iter()
+            .any(|row| row.label == "API"),
+        "headless launch plan should keep the API row"
+    );
+    assert!(
+        headless_plan
+            .webserver_rows
+            .iter()
+            .all(|row| row.label != "Console"),
+        "headless launch plan should not seed a stale Console row"
+    );
+
+    let model_a = plan
+        .loaded_model_rows
+        .iter()
+        .find(|row| row.name == "unsloth/Model-A-GGUF:Q4_K_M")
+        .expect("launch plan should include first startup model row");
+    assert_eq!(model_a.role.as_deref(), Some("primary"));
+    assert_eq!(model_a.status, RuntimeStatus::Loading);
+    assert_eq!(model_a.device.as_deref(), Some("GPU0"));
+    assert_eq!(model_a.slots, Some(2));
+    assert_eq!(model_a.file_size_gb, None);
+
+    let model_b = plan
+        .loaded_model_rows
+        .iter()
+        .find(|row| row.name == "Model-B")
+        .expect("launch plan should include second startup model row");
+    assert_eq!(model_b.role.as_deref(), Some("model"));
+    assert_eq!(model_b.status, RuntimeStatus::Loading);
+    assert_eq!(model_b.device.as_deref(), Some("CUDA1"));
+    assert_eq!(model_b.slots, Some(4));
+    assert_eq!(model_b.file_size_gb, None);
+
+    let fallback_plan =
+        startup_launch_plan(&[], "Auto-Assigned-Model", 9337, None, false, Some(8), None);
+    assert!(fallback_plan.llama_process_rows.iter().any(|row| {
+        row.name == "llama-server Auto-Assigned-Model"
+            && row.status == RuntimeStatus::Loading
+            && row.port == 0
+    }));
+    let fallback_model = fallback_plan
+        .loaded_model_rows
+        .iter()
+        .find(|row| row.name == "Auto-Assigned-Model")
+        .expect("fallback launch plan should include planned loaded-model row");
+    assert_eq!(fallback_model.role.as_deref(), Some("primary"));
+    assert_eq!(fallback_model.status, RuntimeStatus::Loading);
+    assert_eq!(fallback_model.slots, Some(8));
+}
+
+#[test]
+fn startup_launch_plan_uses_metal_device_fallback_for_unpinned_model() {
+    let startup_models = vec![StartupModelPlan {
+        declared_ref: "Qwen/Qwen2.5-0.5B-Instruct-GGUF:qwen2.5-0.5b-instruct-q4_k_m".to_string(),
+        resolved_path: PathBuf::from("/tmp/qwen2.5-0.5b-instruct-q4_k_m.gguf"),
+        mmproj_path: None,
+        ctx_size: Some(4096),
+        gpu_id: None,
+        pinned_gpu: None,
+        parallel: Some(4),
+        cache_type_k: None,
+        cache_type_v: None,
+        n_batch: None,
+        n_ubatch: None,
+        flash_attention: FlashAttentionType::Auto,
+    }];
+
+    let plan = startup_launch_plan(
+        &startup_models,
+        "Fallback-Model",
+        9337,
+        None,
+        false,
+        Some(4),
+        startup_default_backend_device(Some(backend::BinaryFlavor::Metal)),
+    );
+    let model = plan
+        .loaded_model_rows
+        .iter()
+        .find(|row| row.name == startup_models[0].declared_ref)
+        .expect("launch plan should include unpinned local model row");
+
+    assert_eq!(model.device.as_deref(), Some("MTL0"));
+}
+
+#[test]
+fn serve_path_builtin_endpoint_ready_events_cover_api_and_console() {
+    let events = serve_path_builtin_endpoint_ready_events(
+        "http://127.0.0.1:9337".to_string(),
+        Some("http://127.0.0.1:3131".to_string()),
+        false,
+    );
+    assert_eq!(events.len(), 2);
+    assert!(matches!(
+        &events[0],
+        OutputEvent::ApiReady { url } if url == "http://127.0.0.1:9337"
+    ));
+    assert!(matches!(
+        &events[1],
+        OutputEvent::WebserverReady { url } if url == "http://127.0.0.1:3131"
+    ));
+
+    let headless_events = serve_path_builtin_endpoint_ready_events(
+        "http://127.0.0.1:9444".to_string(),
+        Some("http://127.0.0.1:3222".to_string()),
+        true,
+    );
+    assert_eq!(headless_events.len(), 1);
+    assert!(matches!(
+        &headless_events[0],
+        OutputEvent::ApiReady { url } if url == "http://127.0.0.1:9444"
+    ));
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn listener_http_url_uses_bound_ephemeral_addr() {
+    let listener = bind_runtime_tcp_listener(0, false, "test listener")
+        .await
+        .expect("ephemeral listener should bind");
+    let addr = listener
+        .local_addr()
+        .expect("bound listener should expose local address");
+
+    let url = listener_http_url(&listener, 0, "test listener");
+
+    assert_eq!(url, socket_addr_http_url(addr));
+    assert_ne!(url, "http://localhost:0");
+    assert!(!url.ends_with(":0"));
+}
+
+#[cfg(test)]
+#[tokio::test]
+async fn startup_ready_reporter_uses_bound_urls_for_runtime_ready() {
+    let api_listener = bind_runtime_tcp_listener(0, false, "test API listener")
+        .await
+        .expect("ephemeral API listener should bind");
+    let console_listener = bind_runtime_tcp_listener(0, false, "test console listener")
+        .await
+        .expect("ephemeral console listener should bind");
+    let (api_url, api_port) = listener_http_endpoint(&api_listener, 0, "test API listener");
+    let (console_url, console_port) =
+        listener_http_endpoint(&console_listener, 0, "test console listener");
+    let models = vec!["model-a".to_string()];
+    let reporter = StartupReadyReporter::new(
+        &models,
+        "model-a".to_string(),
+        api_url.clone(),
+        Some(console_url.clone()),
+        api_port,
+        Some(console_port),
+    );
+
+    let Some(OutputEvent::RuntimeReady {
+        api_url: reported_api_url,
+        console_url: reported_console_url,
+        api_port: reported_api_port,
+        console_port: reported_console_port,
+        ..
+    }) = reporter.mark_ready_and_build_event("model-a")
+    else {
+        panic!("reporter should emit RuntimeReady when the model is ready");
+    };
+
+    assert_eq!(reported_api_url, api_url);
+    assert_eq!(reported_console_url.as_deref(), Some(console_url.as_str()));
+    assert_eq!(reported_api_port, api_port);
+    assert_eq!(reported_console_port, Some(console_port));
+    assert_ne!(reported_api_url, "http://localhost:0");
+    assert_ne!(reported_console_url.as_deref(), Some("http://localhost:0"));
+}
+
+#[cfg(test)]
+#[test]
+fn dashboard_lanes_prefer_sparse_slot_ids() {
+    let mut snapshots = BTreeMap::new();
+    let mut snapshot = crate::runtime_data::RuntimeLlamaRuntimeSnapshot::default();
+    snapshot.items.slots = vec![
+        crate::runtime_data::RuntimeLlamaSlotItem {
+            index: 0,
+            id: Some(20),
+            id_task: None,
+            n_ctx: None,
+            is_processing: false,
+        },
+        crate::runtime_data::RuntimeLlamaSlotItem {
+            index: 1,
+            id: Some(10),
+            id_task: None,
+            n_ctx: None,
+            is_processing: true,
+        },
+    ];
+    snapshots.insert("model-a".to_string(), snapshot);
+
+    let lanes = dashboard_lanes_for_model(&snapshots, "model-a")
+        .expect("snapshot with slots should produce dashboard lanes");
+
+    assert_eq!(lanes.len(), 2);
+    assert_eq!(lanes[0].index, 10);
+    assert!(lanes[0].active);
+    assert_eq!(lanes[1].index, 20);
+    assert!(!lanes[1].active);
+}
+
+#[cfg(test)]
+#[test]
+fn dashboard_lanes_fall_back_to_slot_index_when_id_is_missing() {
+    let mut snapshots = BTreeMap::new();
+    let mut snapshot = crate::runtime_data::RuntimeLlamaRuntimeSnapshot::default();
+    snapshot.items.slots = vec![crate::runtime_data::RuntimeLlamaSlotItem {
+        index: 7,
+        id: None,
+        id_task: None,
+        n_ctx: None,
+        is_processing: true,
+    }];
+    snapshots.insert("model-a".to_string(), snapshot);
+
+    let lanes = dashboard_lanes_for_model(&snapshots, "model-a")
+        .expect("snapshot with slots should produce dashboard lanes");
+
+    assert_eq!(lanes.len(), 1);
+    assert_eq!(lanes[0].index, 7);
+    assert!(lanes[0].active);
+}
+
 fn initial_console_session_mode(explicit_surface: Option<RuntimeSurface>) -> ConsoleSessionMode {
     initial_console_session_mode_for_surface(
         explicit_surface,
@@ -2298,6 +3268,7 @@ async fn run_auto(
     // (default 9337), so callbacks do not loop through the OpenAI surface.
     std::env::set_var("MESH_API_PORT", cli.console.to_string());
     skippy::configure_materialized_stage_cache();
+    configure_skippy_native_logging(runtime.as_ref().map(|runtime| runtime.dir()));
     let console_port = Some(cli.console);
     let is_client = cli.client;
 
@@ -2696,7 +3667,6 @@ async fn run_auto(
 
     let tunnel_mgr =
         tunnel::Manager::start(node.clone(), channels.rpc, channels.http, channels.stage).await?;
-    tunnel_mgr.set_http_port(api_port);
 
     // Election publishes per-model targets
     let (target_tx, target_rx) = tokio::sync::watch::channel(election::ModelTargets::default());
@@ -2710,42 +3680,13 @@ async fn run_auto(
     let mut runtime_models: HashMap<String, LocalRuntimeModelHandle> = HashMap::new();
     let mut managed_models: HashMap<String, ManagedModelController> = HashMap::new();
     let dashboard_processes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+    let dashboard_context_usage = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let input_handler_enabled = crate::cli::output::OutputManager::global()
         .console_session_mode()
         .is_some();
 
-    // Take over listener from bootstrap proxy (if running), or bind a new one
-    let existing_listener = if let Some(tx) = bootstrap_listener_tx {
-        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-        let _ = tx.send(resp_tx).await;
-        // Wait for bootstrap to hand back the TcpListener
-        resp_rx.await.ok()
-    } else {
-        None
-    };
-
-    // API proxy: model-aware routing
-    let proxy_node = node.clone();
-    let proxy_rx = target_rx.clone();
-    let proxy_affinity = affinity_router.clone();
-    let api_control_tx = control_tx.clone();
-    let api_proxy_handle = tokio::spawn(async move {
-        api_proxy(
-            proxy_node,
-            api_port,
-            proxy_rx,
-            api_control_tx,
-            existing_listener,
-            cli.listen_all,
-            proxy_affinity,
-        )
-        .await;
-    });
-
-    // Console (optional)
     let model_name_for_console = model_name.clone();
-    let mut console_server_handle = None;
-    let console_state = if let Some(cport) = console_port {
+    let console_state = if console_port.is_some() {
         let model_size_bytes = election::total_model_bytes(&model);
         let runtime_data_collector = node.runtime_data_collector();
         let runtime_data_producer =
@@ -2779,6 +3720,120 @@ async fn run_auto(
         if let Some(ref name) = cli.mesh_name {
             cs.set_mesh_name(name.clone()).await;
         }
+        Some(cs)
+    } else {
+        None
+    };
+
+    crate::cli::output::OutputManager::global().register_dashboard_snapshot_provider(Arc::new(
+        RuntimeDashboardSnapshotProvider::new(
+            node.clone(),
+            dashboard_processes.clone(),
+            dashboard_context_usage.clone(),
+            Some(plugin_manager.clone()),
+            api_port,
+            console_port,
+            cli.headless,
+        ),
+    ));
+
+    let _ = emit_event(OutputEvent::LaunchPlan {
+        plan: startup_launch_plan(
+            &startup_models,
+            &model_name,
+            api_port,
+            console_port,
+            cli.headless,
+            config.gpu.parallel,
+            startup_default_backend_device(cli.llama_flavor),
+        ),
+    });
+
+    let interactive_started = Arc::new(AtomicBool::new(false));
+    let first_paint_rx = if let Some(request) = serve_path_interactive_spawn_request(
+        input_handler_enabled,
+        interactive_started.as_ref(),
+        std::io::stdin().is_terminal(),
+    ) {
+        if let Some(cs) = console_state.clone() {
+            let (first_paint_tx, first_paint_rx) = tokio::sync::oneshot::channel();
+            interactive::spawn_handler_with_first_paint_ack(
+                control_tx.clone(),
+                cs,
+                crate::cli::output::OutputManager::global(),
+                request.prompt_mode,
+                Some(first_paint_tx),
+            );
+            Some(first_paint_rx)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    if let Some(first_paint_rx) = first_paint_rx {
+        wait_for_dashboard_first_paint(first_paint_rx).await;
+    }
+
+    // Take over listener from bootstrap proxy (if running), or bind a new one.
+    // The bind is completed before model startup so the dashboard can mark the
+    // built-in endpoints ready independently from model readiness.
+    let api_listener = if let Some(tx) = bootstrap_listener_tx {
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        let _ = tx.send(resp_tx).await;
+        // Wait for bootstrap to hand back the TcpListener
+        resp_rx
+            .await
+            .context("bootstrap API listener handoff was cancelled")?
+    } else {
+        bind_runtime_tcp_listener(api_port, cli.listen_all, "OpenAI-compatible API").await?
+    };
+
+    let console_listener = if let (Some(cport), Some(_)) = (console_port, console_state.as_ref()) {
+        Some((
+            cport,
+            bind_runtime_tcp_listener(cport, cli.listen_all, "Web console").await?,
+        ))
+    } else {
+        None
+    };
+    let (api_ready_url, ready_api_port) =
+        listener_http_endpoint(&api_listener, api_port, "OpenAI-compatible API");
+    let ready_console_endpoint = console_listener
+        .as_ref()
+        .map(|(port, listener)| listener_http_endpoint(listener, *port, "Web console"));
+    let ready_console_url = ready_console_endpoint.as_ref().map(|(url, _)| url.clone());
+    let ready_console_port = ready_console_endpoint.map(|(_, port)| port);
+    for event in serve_path_builtin_endpoint_ready_events(
+        api_ready_url.clone(),
+        ready_console_url.clone(),
+        cli.headless,
+    ) {
+        let _ = emit_event(event);
+    }
+
+    // API proxy: model-aware routing
+    let proxy_node = node.clone();
+    let proxy_rx = target_rx.clone();
+    let proxy_affinity = affinity_router.clone();
+    let api_control_tx = control_tx.clone();
+    let api_proxy_handle = tokio::spawn(async move {
+        api_proxy(
+            proxy_node,
+            api_port,
+            proxy_rx,
+            api_control_tx,
+            Some(api_listener),
+            cli.listen_all,
+            proxy_affinity,
+        )
+        .await;
+    });
+
+    // Console (optional)
+    let mut console_server_handle = None;
+    if let (Some((cport, listener)), Some(cs)) = (console_listener, console_state.clone()) {
         let cs2 = cs.clone();
         let console_rx = target_rx.clone();
         let mn = model_name_for_console.clone();
@@ -2797,23 +3852,17 @@ async fn run_auto(
                     }
                 }
             });
-            api::start(cport, cs2, adapted_rx, cli.listen_all, cli.headless).await;
+            api::start_with_listener(
+                cport,
+                cs2,
+                adapted_rx,
+                cli.listen_all,
+                cli.headless,
+                Some(listener),
+            )
+            .await;
         }));
-        Some(cs)
-    } else {
-        None
-    };
-
-    crate::cli::output::OutputManager::global().register_dashboard_snapshot_provider(Arc::new(
-        RuntimeDashboardSnapshotProvider::new(
-            node.clone(),
-            dashboard_processes.clone(),
-            Some(plugin_manager.clone()),
-            api_port,
-            console_port,
-            cli.headless,
-        ),
-    ));
+    }
 
     if !is_client {
         if let Some(ref cs) = console_state {
@@ -2845,13 +3894,12 @@ async fn run_auto(
         .and_then(|m| m.parallel)
         .or(config.gpu.parallel)
         .unwrap_or(4);
-    let cb_console_port = console_port;
     let model_name_for_election = model_name.clone();
     let primary_target_tx = target_tx.clone();
     let console_state_for_election = console_state.clone();
     let interactive_console_state = console_state.clone();
     let interactive_control_tx = control_tx.clone();
-    let interactive_started = Arc::new(AtomicBool::new(false));
+
     let primary_model_name_for_advertise = model_name.clone();
     let startup_model_names: Vec<String> = startup_models
         .iter()
@@ -2860,8 +3908,10 @@ async fn run_auto(
     let startup_ready_reporter = StartupReadyReporter::new(
         &startup_model_names,
         model_name.clone(),
-        api_port,
-        cb_console_port,
+        api_ready_url,
+        ready_console_url,
+        ready_api_port,
+        ready_console_port,
     );
     let startup_load_gate = Arc::new(tokio::sync::Mutex::new(()));
     let primary_startup_ready_reporter = startup_ready_reporter.clone();
@@ -2897,6 +3947,7 @@ async fn run_auto(
     let startup_split = cli.split;
     let (primary_stop_tx, primary_stop_rx) = tokio::sync::watch::channel(false);
     let dashboard_processes_for_primary_task = dashboard_processes.clone();
+    let dashboard_context_usage_for_primary_task = dashboard_context_usage.clone();
     let primary_startup_load_gate = startup_load_gate.clone();
     let primary_task = tokio::spawn(async move {
         startup_local_model_loop(StartupLocalModelTask {
@@ -2919,6 +3970,7 @@ async fn run_auto(
             split: startup_split,
             stop_rx: primary_stop_rx,
             dashboard_processes: dashboard_processes_for_primary_task,
+            dashboard_context_usage: dashboard_context_usage_for_primary_task,
             console_state: console_state_for_election,
             api_port,
             startup_ready_reporter: primary_startup_ready_reporter,
@@ -2979,6 +4031,7 @@ async fn run_auto(
             let managed_model_name = extra_name.clone();
             let (extra_stop_tx, extra_stop_rx) = tokio::sync::watch::channel(false);
             let dashboard_processes_for_extra_task = dashboard_processes.clone();
+            let dashboard_context_usage_for_extra_task = dashboard_context_usage.clone();
             let extra_control_tx = control_tx.clone();
             let extra_task = tokio::spawn(async move {
                 startup_local_model_loop(StartupLocalModelTask {
@@ -3001,6 +4054,7 @@ async fn run_auto(
                     split: startup_split,
                     stop_rx: extra_stop_rx,
                     dashboard_processes: dashboard_processes_for_extra_task,
+                    dashboard_context_usage: dashboard_context_usage_for_extra_task,
                     console_state: extra_console_state,
                     api_port: api_port_extra,
                     startup_ready_reporter: extra_startup_ready_reporter,
@@ -3085,11 +4139,35 @@ async fn run_auto(
         None
     };
 
+    let runtime_data_producer = if let Some(cs) = console_state.as_ref() {
+        Some(cs.runtime_data_producer().await)
+    } else {
+        None
+    };
+
     // Wait for SIGINT/SIGTERM or runtime model control commands.
     let primary_model_name = model_name.clone();
+    let mut dashboard_context_usage_tick =
+        tokio::time::interval(DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL);
+    dashboard_context_usage_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         tokio::select! {
+            _ = dashboard_context_usage_tick.tick() => {
+                let updates = runtime_models
+                    .iter()
+                    .map(|(name, handle)| {
+                        publish_runtime_llama_slots(runtime_data_producer.as_ref(), name, handle);
+                        (
+                            name.clone(),
+                            dashboard_context_usage_source(handle),
+                            handle.ctx_used_tokens(),
+                        )
+                    })
+                    .collect();
+                refresh_dashboard_context_usage_batch(&dashboard_context_usage, updates).await;
+            }
             _ = wait_shutdown_signal() => {
+                startup_ready_reporter.mark_shutdown_requested();
                 emit_shutdown(None);
                 break;
             }
@@ -3185,6 +4263,17 @@ async fn run_auto(
                                 ),
                                 context: None,
                             });
+                            refresh_dashboard_context_usage(
+                                &dashboard_context_usage,
+                                &loaded_name,
+                                &handle,
+                            )
+                            .await;
+                            publish_runtime_llama_slots(
+                                runtime_data_producer.as_ref(),
+                                &loaded_name,
+                                &handle,
+                            );
                             runtime_models.insert(loaded_name.clone(), handle);
                             Ok(loaded_name)
                         }
@@ -3200,6 +4289,10 @@ async fn run_auto(
                     api::RuntimeControlRequest::Unload { model, resp } => {
                         let result = if let Some(handle) = runtime_models.remove(&model) {
                             let port = handle.port;
+                            publish_runtime_llama_unavailable(
+                                runtime_data_producer.as_ref(),
+                                &model,
+                            );
                             remove_runtime_local_target(&target_tx, &model, port);
                             withdraw_advertised_model(&node, &model).await;
                             upsert_dashboard_process(
@@ -3216,6 +4309,8 @@ async fn run_auto(
                                 .await;
                             }
                             tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                            remove_dashboard_context_usage(&dashboard_context_usage, &model, &handle)
+                                .await;
                             handle.shutdown().await;
                             remove_serving_assignment(&node, &model).await;
                             remove_dashboard_process(&dashboard_processes, &model).await;
@@ -3230,6 +4325,10 @@ async fn run_auto(
                         } else if let Some(controller) = managed_models.remove(&model) {
                             let _ = controller.stop_tx.send(true);
                             let _ = controller.task.await;
+                            publish_runtime_llama_unavailable(
+                                runtime_data_producer.as_ref(),
+                                &model,
+                            );
                             withdraw_advertised_model(&node, &model).await;
                             remove_serving_assignment(&node, &model).await;
                             remove_dashboard_process(&dashboard_processes, &model).await;
@@ -3247,6 +4346,7 @@ async fn run_auto(
                         let _ = resp.send(result);
                     }
                     api::RuntimeControlRequest::Shutdown => {
+                        startup_ready_reporter.mark_shutdown_requested();
                         emit_shutdown(None);
                         break;
                     }
@@ -3261,6 +4361,10 @@ async fn run_auto(
                             .unwrap_or(false);
                         if matches {
                             if let Some(handle) = runtime_models.remove(&model) {
+                                publish_runtime_llama_unavailable(
+                                    runtime_data_producer.as_ref(),
+                                    &model,
+                                );
                                 upsert_dashboard_process(
                                     &dashboard_processes,
                                     runtime_process_payload_with_status(&model, &handle, "exited"),
@@ -3272,6 +4376,12 @@ async fn run_auto(
                                     ))
                                     .await;
                                 }
+                                remove_dashboard_context_usage(
+                                    &dashboard_context_usage,
+                                    &model,
+                                    &handle,
+                                )
+                                .await;
                                 handle.shutdown().await;
                             }
                             remove_runtime_local_target(&target_tx, &model, port);
@@ -3324,8 +4434,10 @@ async fn run_auto(
             cs.upsert_local_process(shutting_down_payload).await;
         }
         remove_runtime_local_target(&target_tx, &name, handle.port);
+        publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &name);
         withdraw_advertised_model(&node, &name).await;
         remove_serving_assignment(&node, &name).await;
+        remove_dashboard_context_usage(&dashboard_context_usage, &name, &handle).await;
         let stopped_payload = runtime_process_payload_with_status(&name, &handle, "stopped");
         handle.shutdown().await;
         upsert_dashboard_process(&dashboard_processes, stopped_payload.clone()).await;
@@ -3449,14 +4561,13 @@ async fn run_passive(
         });
     }
 
-    let addr = if cli.listen_all {
-        "0.0.0.0"
-    } else {
-        "127.0.0.1"
-    };
-    let listener = tokio::net::TcpListener::bind(format!("{addr}:{local_port}"))
+    let listener = bind_runtime_tcp_listener(local_port, cli.listen_all, "OpenAI-compatible API")
         .await
         .with_context(|| format!("Failed to bind to port {local_port}"))?;
+    let api_ready_url = listener_http_url(&listener, local_port, "OpenAI-compatible API");
+    let cport = cli.console;
+    let console_listener = bind_runtime_tcp_listener(cport, cli.listen_all, "Web console").await?;
+    let console_ready_url = listener_http_url(&console_listener, cport, "Web console");
     if is_client {
         let _ = emit_event(OutputEvent::PassiveMode {
             role: "client".to_string(),
@@ -3474,24 +4585,21 @@ async fn run_passive(
             detail: Some("Standby ready".to_string()),
         });
     }
-    let _ = emit_event(OutputEvent::ApiReady {
-        url: format!("http://localhost:{local_port}"),
-    });
+    let _ = emit_event(OutputEvent::ApiReady { url: api_ready_url });
     if cli.headless {
         let _ = emit_event(OutputEvent::Info {
-            message: format!("Management API: http://localhost:{}", cli.console),
+            message: format!("Management API: {console_ready_url}"),
             context: None,
         });
     } else {
         let _ = emit_event(OutputEvent::WebserverReady {
-            url: format!("http://localhost:{}", cli.console),
+            url: console_ready_url,
         });
     }
 
     // Console
     let (control_tx, mut control_rx) =
         tokio::sync::mpsc::unbounded_channel::<api::RuntimeControlRequest>();
-    let cport = cli.console;
     let dashboard_processes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
     let label = if is_client {
         "(client)".to_string()
@@ -3535,30 +4643,38 @@ async fn run_passive(
     let headless = cli.headless;
     let console_state_for_server = console_state.clone();
     let mut console_server_handle = Some(tokio::spawn(async move {
-        api::start(cport, console_state_for_server, rx, la, headless).await;
+        api::start_with_listener(
+            cport,
+            console_state_for_server,
+            rx,
+            la,
+            headless,
+            Some(console_listener),
+        )
+        .await;
     }));
     crate::cli::output::OutputManager::global().register_dashboard_snapshot_provider(Arc::new(
         RuntimeDashboardSnapshotProvider::new(
             node.clone(),
             dashboard_processes,
+            Arc::new(tokio::sync::Mutex::new(HashMap::new())),
             Some(plugin_manager.clone()),
             local_port,
             Some(cport),
             headless,
         ),
     ));
-    if crate::cli::output::OutputManager::global()
-        .console_session_mode()
-        .is_some()
-        && std::io::stdin().is_terminal()
-    {
+    if let Some(request) = passive_path_interactive_spawn_request(
+        crate::cli::output::OutputManager::global().console_session_mode(),
+        std::io::stdin().is_terminal(),
+    ) {
         // Spawn input handler for both Dashboard and line-oriented Fallback modes;
         // spawn_handler internally selects the variant.
         interactive::spawn_handler(
             control_tx.clone(),
             console_state.clone(),
             crate::cli::output::OutputManager::global(),
-            InitialPromptMode::Immediate,
+            request.prompt_mode,
         );
     }
 
@@ -3729,11 +4845,11 @@ fn build_serving_list(startup_models: &[StartupModelPlan], model_ref: &str) -> V
 }
 
 #[cfg(test)]
-fn format_console_ready_line(headless: bool, console_port: u16) -> String {
+fn format_console_ready_line(headless: bool, console_url: &str) -> String {
     if headless {
-        format!("  Management API: http://localhost:{console_port}")
+        format!("  Management API: {console_url}")
     } else {
-        format!("  Console: http://localhost:{console_port}")
+        format!("  Console: {console_url}")
     }
 }
 
@@ -3773,6 +4889,46 @@ mod tests {
             n_ubatch: None,
             flash_attention: FlashAttentionType::Auto,
         }
+    }
+
+    #[test]
+    #[serial]
+    fn skippy_native_logging_setup_is_nonfatal_when_log_dir_cannot_be_created() {
+        struct RestoreNativeLogs;
+
+        impl Drop for RestoreNativeLogs {
+            fn drop(&mut self) {
+                skippy_runtime::restore_native_logs();
+            }
+        }
+
+        let _restore = RestoreNativeLogs;
+        let path = std::env::temp_dir().join(format!(
+            "mesh-native-log-runtime-file-{}-{}",
+            std::process::id(),
+            current_time_unix_ms()
+        ));
+        std::fs::write(&path, b"not a directory").expect("create runtime path file");
+
+        let configured_path = configure_skippy_native_logging(Some(&path));
+
+        std::fs::remove_file(&path).expect("remove runtime path file");
+        assert_eq!(configured_path, None);
+    }
+
+    #[test]
+    #[serial]
+    fn skippy_native_logging_setup_suppresses_logs_without_runtime_dir() {
+        struct RestoreNativeLogs;
+
+        impl Drop for RestoreNativeLogs {
+            fn drop(&mut self) {
+                skippy_runtime::restore_native_logs();
+            }
+        }
+
+        let _restore = RestoreNativeLogs;
+        assert_eq!(configure_skippy_native_logging(None), None);
     }
 
     async fn build_test_mesh_api() -> api::MeshApi {
@@ -3906,14 +5062,256 @@ mod tests {
                 }),
             },
         );
+        provider
+            .local_context_usage
+            .lock()
+            .await
+            .entry(model_name.clone())
+            .or_default()
+            .insert(
+                DashboardContextUsageSource {
+                    port: 4001,
+                    pid: 1234,
+                },
+                2048,
+            );
 
         let snapshot = provider.snapshot().await;
         assert_eq!(snapshot.loaded_model_rows.len(), 1);
         assert_eq!(snapshot.loaded_model_rows[0].slots, Some(4));
         assert_eq!(snapshot.loaded_model_rows[0].ctx_size, Some(8192));
+        assert_eq!(snapshot.loaded_model_rows[0].ctx_used_tokens, Some(2048));
         assert_eq!(snapshot.loaded_model_rows[0].file_size_gb, Some(24.0));
         assert_eq!(
             snapshot.loaded_model_rows[0].quantization.as_deref(),
+            Some("Q4_K_M")
+        );
+    }
+
+    #[tokio::test]
+    async fn dashboard_snapshot_provider_uses_per_model_runtime_slot_snapshots() {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
+            .await
+            .expect("test node should initialize");
+        let producer =
+            node.runtime_data_collector()
+                .producer(crate::runtime_data::RuntimeDataSource {
+                    scope: "runtime",
+                    plugin_data_key: None,
+                    plugin_endpoint_key: None,
+                });
+        let local_processes = Arc::new(tokio::sync::Mutex::new(vec![
+            api::RuntimeProcessPayload {
+                name: "model-a".to_string(),
+                backend: "skippy".to_string(),
+                status: "ready".to_string(),
+                port: 4001,
+                pid: 1234,
+                slots: 2,
+                context_length: Some(8192),
+            },
+            api::RuntimeProcessPayload {
+                name: "model-b".to_string(),
+                backend: "skippy".to_string(),
+                status: "ready".to_string(),
+                port: 4002,
+                pid: 1235,
+                slots: 2,
+                context_length: Some(8192),
+            },
+        ]));
+        producer.publish_llama_slots_snapshot(crate::runtime_data::RuntimeLlamaSlotsSnapshot {
+            status: crate::runtime_data::RuntimeLlamaEndpointStatus::Ready,
+            model: Some("model-a".to_string()),
+            last_attempt_unix_ms: Some(1),
+            last_success_unix_ms: Some(1),
+            error: None,
+            slots: vec![
+                crate::runtime_data::RuntimeLlamaSlotSnapshot {
+                    id: Some(0),
+                    is_processing: Some(true),
+                    ..crate::runtime_data::RuntimeLlamaSlotSnapshot::default()
+                },
+                crate::runtime_data::RuntimeLlamaSlotSnapshot {
+                    id: Some(1),
+                    is_processing: Some(false),
+                    ..crate::runtime_data::RuntimeLlamaSlotSnapshot::default()
+                },
+            ],
+        });
+        producer.publish_llama_slots_snapshot(crate::runtime_data::RuntimeLlamaSlotsSnapshot {
+            status: crate::runtime_data::RuntimeLlamaEndpointStatus::Ready,
+            model: Some("model-b".to_string()),
+            last_attempt_unix_ms: Some(2),
+            last_success_unix_ms: Some(2),
+            error: None,
+            slots: vec![
+                crate::runtime_data::RuntimeLlamaSlotSnapshot {
+                    id: Some(0),
+                    is_processing: Some(false),
+                    ..crate::runtime_data::RuntimeLlamaSlotSnapshot::default()
+                },
+                crate::runtime_data::RuntimeLlamaSlotSnapshot {
+                    id: Some(1),
+                    is_processing: Some(true),
+                    ..crate::runtime_data::RuntimeLlamaSlotSnapshot::default()
+                },
+            ],
+        });
+
+        let provider = RuntimeDashboardSnapshotProvider::with_inventory_loader(
+            node,
+            local_processes,
+            None,
+            RuntimeDashboardSnapshotProviderTestOptions {
+                api_port: 9337,
+                console_port: Some(3131),
+                headless: false,
+                inventory_snapshot_ttl: Duration::from_secs(60),
+                inventory_snapshot_loader: Arc::new(
+                    crate::models::LocalModelInventorySnapshot::default,
+                ),
+            },
+        );
+
+        let snapshot = provider.snapshot().await;
+        let model_a = snapshot
+            .loaded_model_rows
+            .iter()
+            .find(|row| row.name == "model-a")
+            .expect("model-a row should be present");
+        let model_b = snapshot
+            .loaded_model_rows
+            .iter()
+            .find(|row| row.name == "model-b")
+            .expect("model-b row should be present");
+        assert_eq!(
+            model_a.lanes.as_ref().map(|lanes| {
+                lanes
+                    .iter()
+                    .map(|lane| (lane.index, lane.active))
+                    .collect::<Vec<_>>()
+            }),
+            Some(vec![(0, true), (1, false)])
+        );
+        assert_eq!(
+            model_b.lanes.as_ref().map(|lanes| {
+                lanes
+                    .iter()
+                    .map(|lane| (lane.index, lane.active))
+                    .collect::<Vec<_>>()
+            }),
+            Some(vec![(0, false), (1, true)])
+        );
+    }
+
+    #[tokio::test]
+    async fn dashboard_snapshot_provider_maps_canonical_model_refs_to_inventory_metadata() {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
+            .await
+            .expect("test node should initialize");
+        let runtime_model_name = "unsloth/Qwen3.5-4B-GGUF:UD-Q4_K_XL".to_string();
+        let inventory_model_name = "Qwen3.5-4B-UD-Q4_K_XL".to_string();
+        let local_processes = Arc::new(tokio::sync::Mutex::new(vec![api::RuntimeProcessPayload {
+            name: runtime_model_name.clone(),
+            backend: "skippy".to_string(),
+            status: "ready".to_string(),
+            port: 37615,
+            pid: 132098,
+            slots: 4,
+            context_length: Some(65_536),
+        }]));
+        let provider = RuntimeDashboardSnapshotProvider::with_inventory_loader(
+            node,
+            local_processes,
+            None,
+            RuntimeDashboardSnapshotProviderTestOptions {
+                api_port: 9337,
+                console_port: Some(3131),
+                headless: false,
+                inventory_snapshot_ttl: Duration::from_secs(60),
+                inventory_snapshot_loader: Arc::new(move || {
+                    let mut snapshot = crate::models::LocalModelInventorySnapshot::default();
+                    snapshot
+                        .size_by_name
+                        .insert(inventory_model_name.clone(), 9_876_000_000);
+                    snapshot.metadata_by_name.insert(
+                        inventory_model_name.clone(),
+                        crate::proto::node::CompactModelMetadata {
+                            model_key: inventory_model_name.clone(),
+                            context_length: 4096,
+                            quantization_type: "Q4_K_XL".to_string(),
+                            ..Default::default()
+                        },
+                    );
+                    snapshot
+                }),
+            },
+        );
+
+        let snapshot = provider.snapshot().await;
+        assert_eq!(snapshot.loaded_model_rows.len(), 1);
+        let row = &snapshot.loaded_model_rows[0];
+        assert_eq!(row.name, runtime_model_name);
+        assert_eq!(row.device, None);
+        assert_eq!(row.slots, Some(4));
+        assert_eq!(row.ctx_size, Some(65_536));
+        assert_eq!(row.quantization.as_deref(), Some("Q4_K_XL"));
+        assert_eq!(row.file_size_gb, Some(9.876));
+    }
+
+    #[tokio::test]
+    async fn dashboard_snapshot_provider_prefers_node_context_over_inventory_metadata() {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
+            .await
+            .expect("test node should initialize");
+        let model_name = "unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL".to_string();
+        set_advertised_model_context(&node, &model_name, Some(131_072)).await;
+        let local_processes = Arc::new(tokio::sync::Mutex::new(vec![api::RuntimeProcessPayload {
+            name: model_name.clone(),
+            backend: "skippy".to_string(),
+            status: "ready".to_string(),
+            port: 34097,
+            pid: 132099,
+            slots: 4,
+            context_length: None,
+        }]));
+        let provider = RuntimeDashboardSnapshotProvider::with_inventory_loader(
+            node,
+            local_processes,
+            None,
+            RuntimeDashboardSnapshotProviderTestOptions {
+                api_port: 9337,
+                console_port: Some(3131),
+                headless: false,
+                inventory_snapshot_ttl: Duration::from_secs(60),
+                inventory_snapshot_loader: Arc::new(move || {
+                    let mut snapshot = crate::models::LocalModelInventorySnapshot::default();
+                    snapshot.metadata_by_name.insert(
+                        "Qwen3.6-27B-UD-Q4_K_XL".to_string(),
+                        crate::proto::node::CompactModelMetadata {
+                            model_key: "Qwen3.6-27B-UD-Q4_K_XL".to_string(),
+                            context_length: 4096,
+                            quantization_type: "Q4_K_XL".to_string(),
+                            ..Default::default()
+                        },
+                    );
+                    snapshot
+                }),
+            },
+        );
+
+        let snapshot = provider.snapshot().await;
+        assert_eq!(snapshot.loaded_model_rows.len(), 1);
+        let row = &snapshot.loaded_model_rows[0];
+        assert_eq!(row.ctx_size, Some(131_072));
+        assert_eq!(row.quantization.as_deref(), Some("Q4_K_XL"));
+    }
+
+    #[test]
+    fn dashboard_quantization_fallback_strips_direct_gguf_extension() {
+        assert_eq!(
+            dashboard_quantization_from_model_name("/models/Qwen3.5-4B-Q4_K_M.gguf").as_deref(),
             Some("Q4_K_M")
         );
     }
@@ -4193,6 +5591,26 @@ mod tests {
 
         let specs = build_startup_model_specs(&cli, &config).unwrap();
         assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn early_tui_spawns_before_llama_ready_in_active_flow() {
+        assert_active_serve_path_spawn_gate_behavior();
+    }
+
+    #[test]
+    fn passive_path_tui_still_starts_immediately() {
+        assert_passive_path_immediate_spawn_behavior();
+    }
+
+    #[test]
+    fn interactive_handler_spawns_once_across_startup_callbacks() {
+        assert_interactive_handler_spawns_once_across_startup_callbacks();
+    }
+
+    #[tokio::test]
+    async fn non_serving_subcommands_retain_plain_output() {
+        assert_non_serving_dispatch_short_circuit_behavior().await;
     }
 
     #[test]
@@ -4762,6 +6180,13 @@ mod tests {
                 pid: Some(1000),
             },
             DashboardEndpointRow {
+                label: "Metrics".to_string(),
+                status: RuntimeStatus::Ready,
+                url: "metrics".to_string(),
+                port: 0,
+                pid: None,
+            },
+            DashboardEndpointRow {
                 label: "OpenAI-compatible API".to_string(),
                 status: RuntimeStatus::Ready,
                 url: "http://localhost:9337".to_string(),
@@ -4776,6 +6201,7 @@ mod tests {
         assert_eq!(
             labels,
             vec![
+                "Metrics".to_string(),
                 "OpenAI-compatible API".to_string(),
                 "Web console".to_string(),
                 "Plugin: alpha".to_string(),
@@ -4878,7 +6304,7 @@ mod tests {
 
     #[test]
     fn headless_host_logs_management_api_without_console_url() {
-        let line = format_console_ready_line(true, 3131);
+        let line = format_console_ready_line(true, "http://127.0.0.1:3131");
         assert!(
             line.contains("Management API"),
             "expected 'Management API' in headless output, got: {line}"
@@ -4891,7 +6317,7 @@ mod tests {
 
     #[test]
     fn default_host_mode_still_logs_console_url() {
-        let line = format_console_ready_line(false, 3131);
+        let line = format_console_ready_line(false, "http://127.0.0.1:3131");
         assert!(
             line.contains("Console:"),
             "expected 'Console:' in default output, got: {line}"
@@ -4904,8 +6330,8 @@ mod tests {
 
     #[test]
     fn active_startup_passes_headless_to_management_server() {
-        let headless_line = format_console_ready_line(true, 9090);
-        let normal_line = format_console_ready_line(false, 9090);
+        let headless_line = format_console_ready_line(true, "http://127.0.0.1:9090");
+        let normal_line = format_console_ready_line(false, "http://127.0.0.1:9090");
         assert_ne!(
             headless_line, normal_line,
             "headless and non-headless output must differ"
@@ -4916,7 +6342,7 @@ mod tests {
 
     #[test]
     fn headless_passive_mode_preserves_api_without_ui() {
-        let line = format_console_ready_line(true, 3131);
+        let line = format_console_ready_line(true, "http://127.0.0.1:3131");
         assert!(
             line.contains("Management API"),
             "passive headless output must contain 'Management API', got: {line}"
@@ -4929,7 +6355,7 @@ mod tests {
 
     #[test]
     fn passive_headless_promotion_keeps_ui_disabled() {
-        let promoted_line = format_console_ready_line(true, 3131);
+        let promoted_line = format_console_ready_line(true, "http://127.0.0.1:3131");
         assert!(
             promoted_line.contains("Management API"),
             "promoted headless node must still advertise Management API, got: {promoted_line}"
@@ -4942,7 +6368,7 @@ mod tests {
 
     #[test]
     fn default_passive_mode_still_serves_ui_when_not_headless() {
-        let line = format_console_ready_line(false, 3131);
+        let line = format_console_ready_line(false, "http://127.0.0.1:3131");
         assert!(
             line.contains("Console:"),
             "default passive output must contain 'Console:', got: {line}"

--- a/crates/mesh-llm/src/runtime_data/collector.rs
+++ b/crates/mesh-llm/src/runtime_data/collector.rs
@@ -23,11 +23,9 @@ use super::snapshots::{
 use super::subscriptions::{
     RuntimeDataDirty, RuntimeDataSubscriptionState, RuntimeDataSubscriptions,
 };
-use super::RuntimeLlamaRuntimeSnapshot;
-#[cfg(test)]
 use super::{
     RuntimeLlamaMetricItem, RuntimeLlamaMetricsSnapshot, RuntimeLlamaRuntimeItems,
-    RuntimeLlamaSlotItem, RuntimeLlamaSlotsSnapshot,
+    RuntimeLlamaRuntimeSnapshot, RuntimeLlamaSlotItem, RuntimeLlamaSlotsSnapshot,
 };
 use crate::api::status::{
     build_gpus, build_ownership_payload, LocalInstance, MeshModelPayload, NodeState, PeerPayload,
@@ -39,7 +37,7 @@ use crate::network::metrics::RoutingCollectorSnapshot;
 use crate::plugin::PluginEndpointSummary;
 use crate::runtime::instance::LocalInstanceSnapshot;
 use crate::runtime::wakeable::{WakeableInventoryEntry, WakeableState};
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
 use tokio::sync::watch;
 
@@ -104,6 +102,12 @@ impl RuntimeDataCollector {
         self.runtime_status_snapshot().llama_runtime
     }
 
+    pub(crate) fn runtime_llama_snapshots_by_model(
+        &self,
+    ) -> BTreeMap<String, RuntimeLlamaRuntimeSnapshot> {
+        self.runtime_status_snapshot().llama_runtime_by_model
+    }
+
     pub(crate) fn routing_snapshot(&self) -> RoutingCollectorSnapshot {
         self.snapshots().routing
     }
@@ -133,30 +137,58 @@ impl RuntimeDataCollector {
         self.update_runtime_status(RuntimeDataDirty::RUNTIME, |runtime_status| {
             let next_items =
                 build_llama_runtime_items(&snapshot, &runtime_status.llama_runtime.slots);
-            if runtime_status.llama_runtime.metrics == snapshot
-                && runtime_status.llama_runtime.items == next_items
+            let mut changed = false;
+            if runtime_status.llama_runtime.metrics != snapshot
+                || runtime_status.llama_runtime.items != next_items
             {
-                return false;
+                runtime_status.llama_runtime.metrics = snapshot.clone();
+                runtime_status.llama_runtime.items = next_items;
+                changed = true;
             }
-            runtime_status.llama_runtime.metrics = snapshot;
-            runtime_status.llama_runtime.items = next_items;
-            true
+
+            for runtime in runtime_status.llama_runtime_by_model.values_mut() {
+                let next_items = build_llama_runtime_items(&snapshot, &runtime.slots);
+                if runtime.metrics != snapshot || runtime.items != next_items {
+                    runtime.metrics = snapshot.clone();
+                    runtime.items = next_items;
+                    changed = true;
+                }
+            }
+
+            let selected = select_runtime_llama_projection(runtime_status);
+            if runtime_status.llama_runtime != selected {
+                runtime_status.llama_runtime = selected;
+                changed = true;
+            }
+            changed
         })
     }
 
-    #[cfg(test)]
     pub(crate) fn replace_llama_slots_snapshot(&self, snapshot: RuntimeLlamaSlotsSnapshot) -> bool {
         self.update_runtime_status(RuntimeDataDirty::RUNTIME, |runtime_status| {
-            let next_items =
-                build_llama_runtime_items(&runtime_status.llama_runtime.metrics, &snapshot);
-            if runtime_status.llama_runtime.slots == snapshot
-                && runtime_status.llama_runtime.items == next_items
-            {
-                return false;
+            let next_runtime =
+                build_llama_runtime_snapshot(&runtime_status.llama_runtime.metrics, snapshot);
+            let mut changed = false;
+
+            if let Some(model) = next_runtime.slots.model.clone() {
+                if runtime_status.llama_runtime_by_model.get(&model) != Some(&next_runtime) {
+                    runtime_status
+                        .llama_runtime_by_model
+                        .insert(model, next_runtime);
+                    changed = true;
+                }
+
+                let selected = select_runtime_llama_projection(runtime_status);
+                if runtime_status.llama_runtime != selected {
+                    runtime_status.llama_runtime = selected;
+                    changed = true;
+                }
+            } else if runtime_status.llama_runtime != next_runtime {
+                runtime_status.llama_runtime = next_runtime;
+                changed = true;
             }
-            runtime_status.llama_runtime.slots = snapshot;
-            runtime_status.llama_runtime.items = next_items;
-            true
+
+            changed
         })
     }
 
@@ -650,7 +682,6 @@ impl RuntimeDataCollector {
     }
 }
 
-#[cfg(test)]
 fn build_llama_runtime_items(
     metrics: &RuntimeLlamaMetricsSnapshot,
     slots: &RuntimeLlamaSlotsSnapshot,
@@ -681,6 +712,53 @@ fn build_llama_runtime_items(
         slots_busy: slot_items.iter().filter(|slot| slot.is_processing).count(),
         slots: slot_items,
     }
+}
+
+fn build_llama_runtime_snapshot(
+    metrics: &RuntimeLlamaMetricsSnapshot,
+    slots: RuntimeLlamaSlotsSnapshot,
+) -> RuntimeLlamaRuntimeSnapshot {
+    RuntimeLlamaRuntimeSnapshot {
+        items: build_llama_runtime_items(metrics, &slots),
+        metrics: metrics.clone(),
+        slots,
+    }
+}
+
+fn select_runtime_llama_projection(
+    runtime_status: &RuntimeStatusSnapshot,
+) -> RuntimeLlamaRuntimeSnapshot {
+    if let Some(primary_ready) = runtime_status
+        .primary_model
+        .as_ref()
+        .and_then(|model| runtime_status.llama_runtime_by_model.get(model))
+        .filter(|snapshot| snapshot.slots.status == super::RuntimeLlamaEndpointStatus::Ready)
+    {
+        return primary_ready.clone();
+    }
+
+    if let Some((_, ready)) = runtime_status
+        .llama_runtime_by_model
+        .iter()
+        .find(|(_, snapshot)| snapshot.slots.status == super::RuntimeLlamaEndpointStatus::Ready)
+    {
+        return ready.clone();
+    }
+
+    if let Some(primary) = runtime_status
+        .primary_model
+        .as_ref()
+        .and_then(|model| runtime_status.llama_runtime_by_model.get(model))
+    {
+        return primary.clone();
+    }
+
+    runtime_status
+        .llama_runtime_by_model
+        .iter()
+        .next()
+        .map(|(_, snapshot)| snapshot.clone())
+        .unwrap_or_else(|| runtime_status.llama_runtime.clone())
 }
 
 struct RuntimeStatusDerivationInput<'a> {

--- a/crates/mesh-llm/src/runtime_data/metrics.rs
+++ b/crates/mesh-llm/src/runtime_data/metrics.rs
@@ -3,7 +3,6 @@ use std::collections::BTreeMap;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum RuntimeLlamaEndpointStatus {
-    #[cfg(test)]
     Ready,
     #[default]
     Unavailable,
@@ -41,6 +40,7 @@ pub(crate) struct RuntimeLlamaSlotSnapshot {
 #[derive(Clone, Debug, Default, PartialEq)]
 pub(crate) struct RuntimeLlamaSlotsSnapshot {
     pub status: RuntimeLlamaEndpointStatus,
+    pub model: Option<String>,
     pub last_attempt_unix_ms: Option<u64>,
     pub last_success_unix_ms: Option<u64>,
     pub error: Option<String>,

--- a/crates/mesh-llm/src/runtime_data/mod.rs
+++ b/crates/mesh-llm/src/runtime_data/mod.rs
@@ -15,12 +15,12 @@ mod subscriptions;
 
 pub(crate) use self::api_views::{collect_views, mesh_models, status_payload};
 pub(crate) use self::collector::RuntimeDataCollector;
-pub(crate) use self::metrics::{RuntimeLlamaEndpointStatus, RuntimeLlamaRuntimeSnapshot};
 #[cfg(test)]
+pub(crate) use self::metrics::RuntimeLlamaMetricSample;
 pub(crate) use self::metrics::{
-    RuntimeLlamaMetricItem, RuntimeLlamaMetricSample, RuntimeLlamaMetricsSnapshot,
-    RuntimeLlamaRuntimeItems, RuntimeLlamaSlotItem, RuntimeLlamaSlotSnapshot,
-    RuntimeLlamaSlotsSnapshot,
+    RuntimeLlamaEndpointStatus, RuntimeLlamaMetricItem, RuntimeLlamaMetricsSnapshot,
+    RuntimeLlamaRuntimeItems, RuntimeLlamaRuntimeSnapshot, RuntimeLlamaSlotItem,
+    RuntimeLlamaSlotSnapshot, RuntimeLlamaSlotsSnapshot,
 };
 pub(crate) use self::processes::{
     remove_runtime_process_snapshot, runtime_process_payloads, upsert_runtime_process_snapshot,
@@ -553,6 +553,7 @@ mod tests {
 
         producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
             status: RuntimeLlamaEndpointStatus::Ready,
+            model: Some("Qwen3-8B".to_string()),
             last_attempt_unix_ms: Some(1),
             last_success_unix_ms: Some(1),
             error: None,
@@ -581,6 +582,74 @@ mod tests {
         assert_eq!(snapshot.items.slots[1].index, 1);
         assert_eq!(snapshot.items.slots[1].id, Some(20));
         assert!(snapshot.items.slots[1].is_processing);
+    }
+
+    #[test]
+    fn runtime_data_llama_slots_keep_per_model_snapshots() {
+        let collector = RuntimeDataCollector::new();
+        let producer = collector.producer(RuntimeDataSource {
+            scope: "runtime",
+            plugin_data_key: None,
+            plugin_endpoint_key: None,
+        });
+
+        producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
+            status: RuntimeLlamaEndpointStatus::Ready,
+            model: Some("model-b".to_string()),
+            last_attempt_unix_ms: Some(1),
+            last_success_unix_ms: Some(1),
+            error: None,
+            slots: vec![RuntimeLlamaSlotSnapshot {
+                id: Some(0),
+                is_processing: Some(false),
+                ..RuntimeLlamaSlotSnapshot::default()
+            }],
+        });
+        producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
+            status: RuntimeLlamaEndpointStatus::Ready,
+            model: Some("model-a".to_string()),
+            last_attempt_unix_ms: Some(2),
+            last_success_unix_ms: Some(2),
+            error: None,
+            slots: vec![RuntimeLlamaSlotSnapshot {
+                id: Some(0),
+                is_processing: Some(true),
+                ..RuntimeLlamaSlotSnapshot::default()
+            }],
+        });
+
+        let by_model = collector.runtime_llama_snapshots_by_model();
+        assert_eq!(by_model.len(), 2);
+        assert_eq!(by_model["model-a"].items.slots_busy, 1);
+        assert_eq!(by_model["model-b"].items.slots_busy, 0);
+        assert_eq!(
+            collector.runtime_llama_snapshot().slots.model.as_deref(),
+            Some("model-a")
+        );
+
+        producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
+            status: RuntimeLlamaEndpointStatus::Unavailable,
+            model: Some("model-a".to_string()),
+            last_attempt_unix_ms: Some(3),
+            last_success_unix_ms: None,
+            error: None,
+            slots: Vec::new(),
+        });
+
+        let by_model = collector.runtime_llama_snapshots_by_model();
+        assert_eq!(
+            by_model["model-a"].slots.status,
+            RuntimeLlamaEndpointStatus::Unavailable
+        );
+        assert_eq!(
+            by_model["model-b"].slots.status,
+            RuntimeLlamaEndpointStatus::Ready
+        );
+        assert_eq!(
+            collector.runtime_llama_snapshot().slots.model.as_deref(),
+            Some("model-b")
+        );
+        assert_eq!(collector.runtime_llama_snapshot().items.slots_total, 1);
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime_data/producers.rs
+++ b/crates/mesh-llm/src/runtime_data/producers.rs
@@ -8,7 +8,8 @@ use super::snapshots::RuntimeDataSnapshots;
 use super::snapshots::{PluginDataKey, PluginEndpointKey, RuntimeStatusSnapshot};
 use super::subscriptions::{RuntimeDataDirty, RuntimeDataSubscriptionState};
 #[cfg(test)]
-use super::{RuntimeLlamaMetricsSnapshot, RuntimeLlamaSlotsSnapshot};
+use super::RuntimeLlamaMetricsSnapshot;
+use super::RuntimeLlamaSlotsSnapshot;
 use crate::network::metrics::RoutingCollectorSnapshot;
 use crate::plugin::{
     PluginCapabilityProvider, PluginEndpointSummary, PluginManifestOverview, PluginSummary,
@@ -118,7 +119,6 @@ impl RuntimeDataProducer {
         self.collector.replace_llama_metrics_snapshot(snapshot)
     }
 
-    #[cfg(test)]
     pub(crate) fn publish_llama_slots_snapshot(&self, snapshot: RuntimeLlamaSlotsSnapshot) -> bool {
         self.collector.replace_llama_slots_snapshot(snapshot)
     }

--- a/crates/mesh-llm/src/runtime_data/snapshots.rs
+++ b/crates/mesh-llm/src/runtime_data/snapshots.rs
@@ -39,6 +39,7 @@ pub(crate) struct RuntimeStatusSnapshot {
     pub llama_port: Option<u16>,
     pub local_processes: Vec<RuntimeProcessSnapshot>,
     pub llama_runtime: RuntimeLlamaRuntimeSnapshot,
+    pub llama_runtime_by_model: BTreeMap<String, RuntimeLlamaRuntimeSnapshot>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
+++ b/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.test.ts
@@ -78,14 +78,14 @@ describe("live node state helpers", () => {
     expect(topologyStatusTooltip(null as any)).toBe("Node state unavailable");
   });
 
-  it("uses node_state as the local routable-model source of truth", () => {
+  it("excludes client nodes from local routable models", () => {
     const baseStatus: StatusPayload = {
       node_id: "local-node",
       node_status: "Serving",
       node_state: "serving",
       token: "token",
       is_host: false,
-      is_client: true,
+      is_client: false,
       llama_ready: true,
       peers: [],
       model_name: "fallback-model",
@@ -103,6 +103,7 @@ describe("live node state helpers", () => {
     };
 
     expect(localRoutableModels(baseStatus)).toEqual(["hosted-model"]);
+    expect(localRoutableModels({ ...baseStatus, is_client: true })).toEqual([]);
     expect(localRoutableModels({ ...baseStatus, node_state: "client", is_client: false })).toEqual(
       [],
     );

--- a/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
+++ b/crates/mesh-llm/ui/src/features/app-shell/lib/status-helpers.ts
@@ -33,7 +33,7 @@ export function peerRoutableModels(peer: Peer): string[] {
 }
 
 export function localRoutableModels(status: StatusPayload | null): string[] {
-  if (!status || status.node_state === "client") return [];
+  if (!status || status.is_client || status.node_state === "client") return [];
   const hosted = status.hosted_models?.filter(Boolean) ?? [];
   if (hosted.length > 0) return hosted;
   const serving = status.serving_models?.filter(Boolean) ?? [];

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -554,6 +554,8 @@ extern "C" {
 
     pub fn mtmd_default_marker() -> *const c_char;
 
+    pub fn mtmd_helper_log_set(log_callback: LlamaLogCallback, user_data: *mut c_void);
+
     pub fn mtmd_context_params_default() -> MtmdContextParams;
 
     pub fn mtmd_init_from_file(

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -1,6 +1,12 @@
 use std::ffi::{c_char, c_int, c_void, CStr, CString};
+use std::fs::{File, OpenOptions};
+use std::io::{LineWriter, Write};
 use std::path::Path;
 use std::ptr;
+use std::sync::{Mutex, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
 
 use anyhow::{anyhow, Context, Result};
 use skippy_ffi::{
@@ -33,15 +39,74 @@ pub use skippy_ffi::{
     ActivationDType as RuntimeActivationDType, ActivationLayout as RuntimeActivationLayout,
 };
 
-pub fn suppress_native_logs() {
-    unsafe {
-        skippy_ffi::llama_log_set(Some(discard_native_log), ptr::null_mut());
+static NATIVE_LOG_FILE: OnceLock<Mutex<Option<LineWriter<File>>>> = OnceLock::new();
+
+fn native_log_file() -> &'static Mutex<Option<LineWriter<File>>> {
+    NATIVE_LOG_FILE.get_or_init(|| Mutex::new(None))
+}
+
+fn flush_native_log_writer<W: Write>(writer: &mut Option<LineWriter<W>>) {
+    if let Some(writer) = writer.as_mut() {
+        let _ = writer.flush();
     }
 }
 
-pub fn restore_native_logs() {
+fn clear_native_log_file() {
+    if let Ok(mut guard) = native_log_file().lock() {
+        flush_native_log_writer(&mut guard);
+        *guard = None;
+    }
+}
+
+fn set_native_log_callback(callback: skippy_ffi::LlamaLogCallback) {
     unsafe {
-        skippy_ffi::llama_log_set(None, ptr::null_mut());
+        skippy_ffi::llama_log_set(callback, ptr::null_mut());
+        skippy_ffi::mtmd_helper_log_set(callback, ptr::null_mut());
+    }
+}
+
+pub fn redirect_native_logs_to_file(path: impl AsRef<Path>) -> Result<()> {
+    let path = path.as_ref();
+    let mut options = OpenOptions::new();
+    options.create(true).append(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+
+    let file = options
+        .open(path)
+        .with_context(|| format!("open skippy native log file {}", path.display()))?;
+    let mut guard = native_log_file()
+        .lock()
+        .map_err(|_| anyhow!("native log file mutex poisoned"))?;
+    flush_native_log_writer(&mut guard);
+    *guard = Some(LineWriter::new(file));
+    drop(guard);
+
+    set_native_log_callback(Some(write_native_log));
+
+    Ok(())
+}
+
+pub fn suppress_native_logs() {
+    clear_native_log_file();
+    set_native_log_callback(Some(discard_native_log));
+}
+
+pub fn restore_native_logs() {
+    clear_native_log_file();
+    set_native_log_callback(None);
+}
+
+unsafe extern "C" fn write_native_log(_level: c_int, text: *const c_char, _user_data: *mut c_void) {
+    if text.is_null() {
+        return;
+    }
+
+    let bytes = unsafe { CStr::from_ptr(text) }.to_bytes();
+    if let Ok(mut guard) = native_log_file().lock() {
+        if let Some(writer) = guard.as_mut() {
+            let _ = writer.write_all(bytes);
+        }
     }
 }
 
@@ -485,7 +550,7 @@ impl MediaProjector {
             .context("projector path contains an interior NUL byte")?;
         let raw_model = unsafe { skippy_ffi::skippy_model_llama_model(model) };
         if raw_model.is_null() {
-            return Err(anyhow!("skippy model did not expose a llama_model handle"));
+            return Err(anyhow!("model did not expose a llama_model handle"));
         }
         let mut params = unsafe { skippy_ffi::mtmd_context_params_default() };
         params.use_gpu = true;
@@ -1840,11 +1905,25 @@ fn free_error(error: *mut RawError) {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, path::PathBuf};
+    use std::{
+        env,
+        ffi::CString,
+        fs,
+        io::{LineWriter, Write},
+        path::PathBuf,
+        ptr,
+        sync::{
+            atomic::{AtomicUsize, Ordering},
+            Arc,
+        },
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use super::{
-        parse_cache_type, ChatTemplateMessage, ModelInfo, RuntimeConfig, RuntimeLoadMode,
-        StageModel, TensorRole, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
+        flush_native_log_writer, parse_cache_type, redirect_native_logs_to_file,
+        restore_native_logs, write_native_log, ChatTemplateMessage, FlashAttentionType, ModelInfo,
+        RuntimeConfig, RuntimeLoadMode, StageModel, TensorRole, GGML_TYPE_F16, GGML_TYPE_Q4_0,
+        GGML_TYPE_Q8_0,
     };
 
     fn correctness_model() -> Option<PathBuf> {
@@ -1882,6 +1961,88 @@ mod tests {
         assert_eq!(parse_cache_type("f16")?, GGML_TYPE_F16);
         assert_eq!(parse_cache_type("q8_0")?, GGML_TYPE_Q8_0);
         assert_eq!(parse_cache_type("q4_0")?, GGML_TYPE_Q4_0);
+        Ok(())
+    }
+
+    struct FlushCountingWriter {
+        flush_count: Arc<AtomicUsize>,
+    }
+
+    impl Write for FlushCountingWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            self.flush_count.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn native_log_writer_flush_helper_explicitly_flushes_line_writer() {
+        let flush_count = Arc::new(AtomicUsize::new(0));
+        let writer = FlushCountingWriter {
+            flush_count: flush_count.clone(),
+        };
+        let mut writer = Some(LineWriter::new(writer));
+        writer
+            .as_mut()
+            .expect("writer should exist")
+            .write_all(b"buffered native log line\n")
+            .expect("write to buffered test writer should succeed");
+
+        flush_native_log_writer(&mut writer);
+
+        assert_eq!(flush_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn native_log_writer_flushes_newline_and_partial_line() -> anyhow::Result<()> {
+        struct RestoreNativeLogs;
+
+        impl Drop for RestoreNativeLogs {
+            fn drop(&mut self) {
+                restore_native_logs();
+            }
+        }
+
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let path = env::temp_dir().join(format!(
+            "skippy-native-log-buffer-test-{}-{nanos}.log",
+            std::process::id()
+        ));
+        let _guard = RestoreNativeLogs;
+        redirect_native_logs_to_file(&path)?;
+
+        let message = CString::new("buffered native log line\n")?;
+        unsafe {
+            write_native_log(0, message.as_ptr(), ptr::null_mut());
+        }
+
+        let contents = fs::read_to_string(&path)?;
+        restore_native_logs();
+
+        fs::remove_file(&path)?;
+        assert_eq!(contents, "buffered native log line\n");
+
+        let nanos = SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos();
+        let path = env::temp_dir().join(format!(
+            "skippy-native-log-partial-line-test-{}-{nanos}.log",
+            std::process::id()
+        ));
+        let _guard = RestoreNativeLogs;
+        redirect_native_logs_to_file(&path)?;
+
+        let message = CString::new("partial native log line")?;
+        unsafe {
+            write_native_log(0, message.as_ptr(), ptr::null_mut());
+        }
+        restore_native_logs();
+
+        let contents = fs::read_to_string(&path)?;
+        fs::remove_file(&path)?;
+        assert_eq!(contents, "partial native log line");
         Ok(())
     }
 

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -468,7 +468,7 @@ fn handle_binary_connection(
             insert_runtime_session_stats(
                 &mut reset_attrs,
                 "llama_stage.runtime_sessions_after",
-                drop_stats.stats_after,
+                &drop_stats.stats_after,
             );
             telemetry.emit_debug_span(
                 "stage.binary_session_stop",
@@ -745,14 +745,14 @@ fn handle_binary_connection(
             "llama_stage.runtime_lock_acquires".to_string(),
             json!(runtime_lock_acquires),
         );
-        if let Some(stats) = runtime_sessions_before {
+        if let Some(stats) = runtime_sessions_before.as_ref() {
             insert_runtime_session_stats(
                 &mut decode_attrs,
                 "llama_stage.runtime_sessions_before",
                 stats,
             );
         }
-        if let Some(stats) = runtime_sessions_after {
+        if let Some(stats) = runtime_sessions_after.as_ref() {
             insert_runtime_session_stats(
                 &mut decode_attrs,
                 "llama_stage.runtime_sessions_after",
@@ -1096,14 +1096,14 @@ fn handle_binary_connection(
             "llama_stage.runtime_lock_acquires".to_string(),
             json!(runtime_lock_acquires),
         );
-        if let Some(stats) = runtime_sessions_before {
+        if let Some(stats) = runtime_sessions_before.as_ref() {
             insert_runtime_session_stats(
                 &mut timing_attrs,
                 "llama_stage.runtime_sessions_before",
                 stats,
             );
         }
-        if let Some(stats) = runtime_sessions_after {
+        if let Some(stats) = runtime_sessions_after.as_ref() {
             insert_runtime_session_stats(
                 &mut timing_attrs,
                 "llama_stage.runtime_sessions_after",
@@ -1216,7 +1216,7 @@ fn insert_optional_unix_nanos(attrs: &mut BTreeMap<String, Value>, key: &str, va
 fn insert_runtime_session_stats(
     attrs: &mut BTreeMap<String, Value>,
     prefix: &str,
-    stats: RuntimeSessionStats,
+    stats: &RuntimeSessionStats,
 ) {
     attrs.insert(
         format!("{prefix}.active_sessions"),

--- a/crates/skippy-server/src/openai.rs
+++ b/crates/skippy-server/src/openai.rs
@@ -1367,7 +1367,7 @@ impl StageOpenAiBackend {
     fn insert_runtime_session_stats(
         attrs: &mut BTreeMap<String, Value>,
         prefix: &str,
-        stats: RuntimeSessionStats,
+        stats: &RuntimeSessionStats,
     ) {
         attrs.insert(
             format!("{prefix}.active_sessions"),
@@ -1946,12 +1946,12 @@ impl StageOpenAiBackend {
             Self::insert_runtime_session_stats(
                 &mut attrs,
                 "llama_stage.runtime_sessions_before",
-                runtime_sessions_before,
+                &runtime_sessions_before,
             );
             Self::insert_runtime_session_stats(
                 &mut attrs,
                 "llama_stage.runtime_sessions_after",
-                runtime_sessions_after,
+                &runtime_sessions_after,
             );
             self.emit_openai_phase("stage.openai_media_prefill", prefill_timer, attrs);
             (prefill, token_signal, signal_window)
@@ -2078,14 +2078,14 @@ impl StageOpenAiBackend {
                 "llama_stage.runtime_lock_acquires".to_string(),
                 json!(runtime_lock_acquires),
             );
-            if let Some(stats) = runtime_sessions_before {
+            if let Some(stats) = runtime_sessions_before.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_before",
                     stats,
                 );
             }
-            if let Some(stats) = runtime_sessions_after {
+            if let Some(stats) = runtime_sessions_after.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
@@ -2115,7 +2115,7 @@ impl StageOpenAiBackend {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
-                    drop_stats.stats_after,
+                    &drop_stats.stats_after,
                 );
                 self.telemetry
                     .emit_debug("stage.openai_session_stop", attrs);
@@ -2190,12 +2190,12 @@ impl StageOpenAiBackend {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_before",
-                    runtime_sessions_before,
+                    &runtime_sessions_before,
                 );
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
-                    runtime_sessions_after,
+                    &runtime_sessions_after,
                 );
                 self.emit_openai_phase("stage.openai_media_prefill", prefill_timer, attrs);
                 prefill
@@ -2483,7 +2483,7 @@ impl StageOpenAiBackend {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
-                    drop_stats.stats_after,
+                    &drop_stats.stats_after,
                 );
                 self.telemetry
                     .emit_debug("stage.openai_session_stop", attrs);
@@ -2652,12 +2652,12 @@ impl StageOpenAiBackend {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_before",
-                    runtime_sessions_before,
+                    &runtime_sessions_before,
                 );
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
-                    runtime_sessions_after,
+                    &runtime_sessions_after,
                 );
                 self.emit_openai_phase("stage.openai_prefill", prefill_timer, attrs);
             }
@@ -2800,14 +2800,14 @@ impl StageOpenAiBackend {
                 "llama_stage.runtime_lock_acquires".to_string(),
                 json!(runtime_lock_acquires),
             );
-            if let Some(stats) = runtime_sessions_before {
+            if let Some(stats) = runtime_sessions_before.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_before",
                     stats,
                 );
             }
-            if let Some(stats) = runtime_sessions_after {
+            if let Some(stats) = runtime_sessions_after.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
@@ -2837,7 +2837,7 @@ impl StageOpenAiBackend {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
-                    drop_stats.stats_after,
+                    &drop_stats.stats_after,
                 );
                 self.telemetry
                     .emit_debug("stage.openai_session_stop", attrs);
@@ -3224,14 +3224,14 @@ impl StageOpenAiBackend {
                 "llama_stage.runtime_lock_acquires".to_string(),
                 json!(prefill_runtime_lock_acquires),
             );
-            if let Some(stats) = prefill_runtime_sessions_before {
+            if let Some(stats) = prefill_runtime_sessions_before.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut prefill_attrs,
                     "llama_stage.runtime_sessions_before",
                     stats,
                 );
             }
-            if let Some(stats) = prefill_runtime_sessions_after {
+            if let Some(stats) = prefill_runtime_sessions_after.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut prefill_attrs,
                     "llama_stage.runtime_sessions_after",
@@ -3834,14 +3834,14 @@ impl StageOpenAiBackend {
                 "llama_stage.runtime_lock_acquires".to_string(),
                 json!(decode_runtime_lock_acquires),
             );
-            if let Some(stats) = decode_runtime_sessions_before {
+            if let Some(stats) = decode_runtime_sessions_before.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut decode_attrs,
                     "llama_stage.runtime_sessions_before",
                     stats,
                 );
             }
-            if let Some(stats) = decode_runtime_sessions_after {
+            if let Some(stats) = decode_runtime_sessions_after.as_ref() {
                 Self::insert_runtime_session_stats(
                     &mut decode_attrs,
                     "llama_stage.runtime_sessions_after",
@@ -3909,7 +3909,7 @@ impl StageOpenAiBackend {
                 Self::insert_runtime_session_stats(
                     &mut attrs,
                     "llama_stage.runtime_sessions_after",
-                    drop_stats.stats_after,
+                    &drop_stats.stats_after,
                 );
                 self.telemetry
                     .emit_debug("stage.openai_session_stop", attrs);

--- a/crates/skippy-server/src/openai/tests.rs
+++ b/crates/skippy-server/src/openai/tests.rs
@@ -490,7 +490,7 @@ fn split_layer_for_fixture(fixture: &MultimodalSmokeFixture) -> Result<Option<u3
         eprintln!("skipping split multimodal smoke: model has fewer than two layers");
         return Ok(None);
     }
-    let split = env_u32(MM_SPLIT_LAYER_ENV)?.unwrap_or_else(|| fixture.layer_end / 2);
+    let split = env_u32(MM_SPLIT_LAYER_ENV)?.unwrap_or(fixture.layer_end / 2);
     if split == 0 || split >= fixture.layer_end {
         bail!(
             "{MM_SPLIT_LAYER_ENV} must be in 1..{} for this model",

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -17,22 +17,39 @@ use crate::package::materialize_layer_package;
 pub struct RuntimeState {
     pub model: StageModel,
     lane_count: u32,
-    sessions: BTreeMap<String, StageSession>,
-    idle_sessions: Vec<StageSession>,
+    next_lane_index: usize,
+    sessions: BTreeMap<String, RuntimeLaneSession>,
+    idle_sessions: Vec<RuntimeLaneSession>,
     session_token_counts: BTreeMap<String, u64>,
     session_checkpoints: BTreeMap<String, StageSessionCheckpoint>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct RuntimeLaneSession {
+    index: usize,
+    session: StageSession,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RuntimeSessionLaneStats {
+    pub index: usize,
+    pub active: bool,
+    pub session_id: Option<String>,
+    pub token_count: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RuntimeSessionStats {
     pub lane_count: usize,
     pub active_sessions: usize,
     pub idle_sessions: usize,
     pub tracked_token_counts: usize,
+    pub max_session_tokens: u64,
+    pub total_session_tokens: u64,
     pub checkpoints: usize,
+    pub lanes: Vec<RuntimeSessionLaneStats>,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct RuntimeSessionDropStats {
     pub reset_session: bool,
     pub reset_ms: f64,
@@ -222,18 +239,19 @@ impl RuntimeState {
 
     fn session(&mut self, session_id: &str) -> Result<&mut StageSession> {
         if !self.sessions.contains_key(session_id) {
-            let session = self.idle_sessions.pop().map(Ok).unwrap_or_else(|| {
+            let lane_session = self.idle_sessions.pop().map(Ok).unwrap_or_else(|| {
                 if self.sessions.len() >= self.lane_count as usize {
                     bail!("all execution lanes are busy");
                 }
-                self.model.create_session()
+                self.create_lane_session()
             })?;
-            self.sessions.insert(session_id.to_string(), session);
+            self.sessions.insert(session_id.to_string(), lane_session);
         }
-        Ok(self
+        Ok(&mut self
             .sessions
             .get_mut(session_id)
-            .expect("session inserted above"))
+            .expect("session inserted above")
+            .session)
     }
 
     pub fn prewarm_idle_sessions(
@@ -244,7 +262,8 @@ impl RuntimeState {
             if self.sessions.len() + self.idle_sessions.len() >= self.lane_count as usize {
                 break;
             }
-            self.idle_sessions.push(self.model.create_session()?);
+            let lane_session = self.create_lane_session()?;
+            self.idle_sessions.push(lane_session);
         }
         Ok(self.session_stats())
     }
@@ -252,10 +271,10 @@ impl RuntimeState {
     pub fn drop_session_timed(&mut self, session_id: &str) -> Result<RuntimeSessionDropStats> {
         let reset_started = Instant::now();
         let mut reset_session = false;
-        if let Some(mut session) = self.sessions.remove(session_id) {
+        if let Some(mut lane_session) = self.sessions.remove(session_id) {
             reset_session = true;
-            session.reset()?;
-            self.idle_sessions.push(session);
+            lane_session.session.reset()?;
+            self.idle_sessions.push(lane_session);
         }
         self.session_token_counts.remove(session_id);
         self.session_checkpoints.remove(session_id);
@@ -267,12 +286,38 @@ impl RuntimeState {
     }
 
     pub fn session_stats(&self) -> RuntimeSessionStats {
+        let mut max_session_tokens = 0u64;
+        let mut total_session_tokens = 0u64;
+        let mut lanes = (0..self.lane_count as usize)
+            .map(|index| RuntimeSessionLaneStats {
+                index,
+                active: false,
+                session_id: None,
+                token_count: None,
+            })
+            .collect::<Vec<_>>();
+
+        for (session_id, lane_session) in &self.sessions {
+            if let Some(token_count) = self.session_token_counts.get(session_id).copied() {
+                max_session_tokens = max_session_tokens.max(token_count);
+                total_session_tokens = total_session_tokens.saturating_add(token_count);
+            }
+            if let Some(lane) = lanes.get_mut(lane_session.index) {
+                lane.active = true;
+                lane.session_id = Some(session_id.clone());
+                lane.token_count = self.session_token_counts.get(session_id).copied();
+            }
+        }
+
         RuntimeSessionStats {
             lane_count: self.lane_count as usize,
             active_sessions: self.sessions.len(),
             idle_sessions: self.idle_sessions.len(),
             tracked_token_counts: self.session_token_counts.len(),
+            max_session_tokens,
+            total_session_tokens,
             checkpoints: self.session_checkpoints.len(),
+            lanes,
         }
     }
 
@@ -292,6 +337,28 @@ impl RuntimeState {
             .and_modify(|current| *current = current.saturating_add(count))
             .or_insert(count);
     }
+
+    fn create_lane_session(&mut self) -> Result<RuntimeLaneSession> {
+        let (index, session) =
+            create_indexed_lane_resource(&mut self.next_lane_index, self.lane_count, || {
+                self.model.create_session()
+            })?;
+        Ok(RuntimeLaneSession { index, session })
+    }
+}
+
+fn create_indexed_lane_resource<T>(
+    next_lane_index: &mut usize,
+    lane_count: u32,
+    create: impl FnOnce() -> Result<T>,
+) -> Result<(usize, T)> {
+    if *next_lane_index >= lane_count as usize {
+        bail!("all execution lanes are busy");
+    }
+    let index = *next_lane_index;
+    let resource = create()?;
+    *next_lane_index = index + 1;
+    Ok((index, resource))
 }
 
 impl Drop for RuntimeState {
@@ -321,6 +388,7 @@ pub fn load_runtime(config: &StageConfig) -> Result<Option<Arc<Mutex<RuntimeStat
     Ok(Some(Arc::new(Mutex::new(RuntimeState {
         model,
         lane_count: config.lane_count,
+        next_lane_index: 0,
         sessions: BTreeMap::new(),
         idle_sessions: Vec::new(),
         session_token_counts: BTreeMap::new(),
@@ -371,10 +439,32 @@ fn open_stage_model(path: &std::path::Path, runtime_config: &RuntimeConfig) -> R
 
 #[cfg(test)]
 mod tests {
+    use anyhow::{bail, Result};
     use skippy_protocol::{FlashAttentionType, LoadMode, StageConfig, StageDevice};
     use skippy_runtime::FlashAttentionType as RuntimeFlashAttentionType;
 
-    use super::runtime_config_from_stage_config;
+    use super::{create_indexed_lane_resource, runtime_config_from_stage_config};
+
+    #[test]
+    fn create_indexed_lane_resource_keeps_index_available_when_creation_fails() {
+        let mut next_lane_index = 0;
+
+        let error = create_indexed_lane_resource(&mut next_lane_index, 2, || -> Result<()> {
+            bail!("transient session creation failure")
+        })
+        .expect_err("failed creation should propagate the original error");
+
+        assert_eq!(error.to_string(), "transient session creation failure");
+        assert_eq!(next_lane_index, 0);
+
+        let (index, resource) =
+            create_indexed_lane_resource(&mut next_lane_index, 2, || Ok("lane"))
+                .expect("successful retry should reuse the unconsumed lane index");
+
+        assert_eq!(index, 0);
+        assert_eq!(resource, "lane");
+        assert_eq!(next_lane_index, 1);
+    }
 
     #[test]
     fn runtime_config_preserves_selected_backend_device() {

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -929,6 +929,11 @@ struct SkippyModelRuntime {
 }
 ```
 
+Current embedded skippy/llama.cpp native logs are process-global because
+`llama_log_set` installs one callback for the process. Mesh redirects those logs
+to `<runtime-root>/<pid>/logs/skippy-native.log`; per-stage `log_path` fields
+should only be populated when a backend has a stage-scoped log sink.
+
 This should be additive to existing gossip. Older nodes must continue to
 operate using the existing protocol.
 


### PR DESCRIPTION
## Summary

Users can now see the TUI earlier in the active serve path, while startup is still in flight, and the screen stays honest about what is pending, partial, ready, or failed. Startup history is retained, fatal rpc and llama launch failures stay visible, and fallback output now keeps the same durable failure story when the TUI cannot open.

## What changed

* The active serve path can open the TUI before full runtime readiness.
* Startup now has one canonical lifecycle state, instead of inferring meaning from missing events.
* Startup history is kept for late TUI attach, so earlier events still explain what happened.
* Fatal rpc and llama startup failures now surface durably in the TUI and fallback output.
* Mesh and discovery startup failures map into the startup lifecycle only before readiness completes.
* Endpoint and process rows stay truthful during bootstrap instead of looking ready too early.
* The dashboard now shows an explicit startup summary and failure state.
* Fallback mode and shutdown race handling were hardened.
* The final fix keeps post ready generic errors from reopening startup failure, and it reaps timed out startup children before returning.

## Before vs After

```mermaid
flowchart LR
  subgraph After
    A1[Console bootstrap completes] --> A2[Open TUI early on active serve path]
    A2 --> A3[Track one canonical startup lifecycle]
    A3 --> A4[Retain startup history for late attach]
    A4 --> A5[Show durable failures and truthful row states]
  end

  subgraph Before
    B1[Console boot starts] --> B2[Wait for llama_ready] --> B3[TUI appears late]
    B3 --> B4[Startup events can be missed on late attach]
    B4 --> B5[Failures may disappear into unwind or fallback output]
  end


```

## Validation

* Targeted exact name regressions passed.
* `cargo fmt --all -- --check` passed.
* `cargo check -p mesh-llm` passed.
* `cargo test -p mesh-llm --lib` passed, `1269 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out`.

## Scope

This stayed within TUI and runtime plumbing. It did not change `/api/status`, `NodeState`, `runtime_data::collector`, protocol behavior, or web console behavior.

Fixes #413
