### PR TITLE
an attempt: Cap session n_batch, lazy prewarm, idle session eviction

### DIFF
--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -213,7 +213,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         let sessions = runtime
             .lock()
             .map_err(|_| anyhow!("runtime lock poisoned"))?
-            .prewarm_idle_sessions(max_inflight)
+            .prewarm_idle_sessions(1.min(max_inflight))
             .context("prewarm binary stage runtime sessions")?;
         let mut attrs = lifecycle_attrs(&config);
         attrs.insert("llama_stage.max_inflight".to_string(), json!(max_inflight));

--- a/crates/skippy-server/src/openai.rs
+++ b/crates/skippy-server/src/openai.rs
@@ -378,7 +378,7 @@ fn prewarm_generation_sessions(
     let sessions = runtime
         .lock()
         .map_err(|_| anyhow!("runtime lock poisoned"))?
-        .prewarm_idle_sessions(generation_concurrency)?;
+        .prewarm_idle_sessions(1.min(generation_concurrency))?;
     let mut attrs = lifecycle_attrs(config);
     attrs.insert(
         "llama_stage.generation_concurrency".to_string(),

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -248,11 +248,22 @@ impl RuntimeState {
         }
         self.session_token_counts.remove(session_id);
         self.session_checkpoints.remove(session_id);
+        // Evict excess idle sessions to free VRAM. Keep at most 1 idle
+        // session ready; the rest are created on demand by `session()`.
+        self.evict_idle_sessions(1);
         Ok(RuntimeSessionDropStats {
             reset_session,
             reset_ms: reset_started.elapsed().as_secs_f64() * 1000.0,
             stats_after: self.session_stats(),
         })
+    }
+
+    /// Drop idle sessions beyond `keep`, freeing their VRAM.
+    pub fn evict_idle_sessions(&mut self, keep: usize) {
+        while self.idle_sessions.len() > keep {
+            // pop drops the StageSession, which calls skippy_session_free → llama_free
+            self.idle_sessions.pop();
+        }
     }
 
     pub fn session_stats(&self) -> RuntimeSessionStats {

--- a/third_party/llama.cpp/patches/0034-Cap-session-batch-size-and-disable-unified-KV.patch
+++ b/third_party/llama.cpp/patches/0034-Cap-session-batch-size-and-disable-unified-KV.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sun, 4 May 2026 16:00:00 +1000
+Subject: [PATCH 34/34] Cap session batch size and disable unified KV
+
+Cap n_batch to 2048 instead of n_ctx to avoid excessive compute buffer
+allocation. Set kv_unified=false so each sequence gets a dedicated KV
+partition, matching llama-server non-unified behavior and preventing
+sequences from competing for cache cells.
+
+---
+ src/skippy.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index 5a1d7cfa9..000000001 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -1347,7 +1347,8 @@ enum skippy_status skippy_session_create(
+ 
+     llama_context_params params = llama_context_default_params();
+     params.n_ctx = model->config.ctx_size > 0 ? static_cast<uint32_t>(model->config.ctx_size) : 512;
+-    params.n_batch = params.n_ctx;
++    params.n_batch = std::min(params.n_ctx, 2048u);
++    params.kv_unified = false;
+     params.type_k = model->config.cache_type_k > 0 ? static_cast<ggml_type>(model->config.cache_type_k) : GGML_TYPE_F16;
+     params.type_v = model->config.cache_type_v > 0 ? static_cast<ggml_type>(model->config.cache_type_v) : GGML_TYPE_F16;
+     params.embeddings = model->config.filter_tensors_on_load && !model->config.include_output;
+-- 
+2.50.1 (Apple Git-155)


### PR DESCRIPTION
- C++ patch 0034: cap n_batch to min(n_ctx, 2048) instead of n_ctx, set kv_unified=false as defensive default for transformer models
- Prewarm only 1 session at startup instead of generation_concurrency; additional sessions created on demand via existing session() path
- Evict excess idle sessions (free VRAM) after generation completes, keeping at most 1 idle session in the pool