### PR TITLE
Use GGUF metadata for context and parallel defaults

### DIFF
--- a/crates/mesh-client/src/models/gguf.rs
+++ b/crates/mesh-client/src/models/gguf.rs
@@ -228,6 +228,7 @@ pub struct GgufCompactMeta {
     pub vocab_size: u32,
     pub embedding_size: u32,
     pub head_count: u32,
+    pub head_count_kv: Option<u32>,
     pub layer_count: u32,
     pub feed_forward_length: u32,
     pub key_length: u32,
@@ -237,6 +238,117 @@ pub struct GgufCompactMeta {
     pub rope_freq_base: f32,
     pub expert_count: u32,
     pub expert_used_count: u32,
+}
+
+impl GgufCompactMeta {
+    pub fn effective_kv_head_count(&self) -> Option<u32> {
+        if let Some(head_count_kv) = self.head_count_kv.filter(|value| *value > 0) {
+            Some(head_count_kv)
+        } else if self.head_count > 0 {
+            Some(self.head_count)
+        } else {
+            None
+        }
+    }
+
+    pub fn k_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        GgufKvCacheQuant::f16().k_cache_bytes_per_token(self)
+    }
+
+    pub fn v_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        GgufKvCacheQuant::f16().v_cache_bytes_per_token(self)
+    }
+
+    pub fn kv_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        GgufKvCacheQuant::f16().kv_cache_bytes_per_token(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GgufKvCacheType {
+    F16,
+    Q8_0,
+    Q4_0,
+}
+
+impl GgufKvCacheType {
+    pub fn from_llama_arg(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "f16" => Some(Self::F16),
+            "q8_0" => Some(Self::Q8_0),
+            "q4_0" => Some(Self::Q4_0),
+            _ => None,
+        }
+    }
+
+    fn block_shape(self) -> (u64, u64) {
+        match self {
+            Self::F16 => (1, 2),
+            Self::Q8_0 => (32, 34),
+            Self::Q4_0 => (32, 18),
+        }
+    }
+
+    fn bytes_for_elements(self, elements: u64) -> Option<u64> {
+        let (block_elements, block_bytes) = self.block_shape();
+        let blocks = elements
+            .checked_add(block_elements.checked_sub(1)?)?
+            .checked_div(block_elements)?;
+        blocks.checked_mul(block_bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GgufKvCacheQuant {
+    pub k: GgufKvCacheType,
+    pub v: GgufKvCacheType,
+}
+
+impl GgufKvCacheQuant {
+    pub const fn new(k: GgufKvCacheType, v: GgufKvCacheType) -> Self {
+        Self { k, v }
+    }
+
+    pub const fn f16() -> Self {
+        Self {
+            k: GgufKvCacheType::F16,
+            v: GgufKvCacheType::F16,
+        }
+    }
+
+    pub fn from_llama_args(cache_type_k: &str, cache_type_v: &str) -> Option<Self> {
+        Some(Self {
+            k: GgufKvCacheType::from_llama_arg(cache_type_k)?,
+            v: GgufKvCacheType::from_llama_arg(cache_type_v)?,
+        })
+    }
+
+    pub fn k_cache_bytes_per_token(self, meta: &GgufCompactMeta) -> Option<u64> {
+        cache_bytes_per_token(meta, meta.key_length, self.k)
+    }
+
+    pub fn v_cache_bytes_per_token(self, meta: &GgufCompactMeta) -> Option<u64> {
+        cache_bytes_per_token(meta, meta.value_length, self.v)
+    }
+
+    pub fn kv_cache_bytes_per_token(self, meta: &GgufCompactMeta) -> Option<u64> {
+        self.k_cache_bytes_per_token(meta)?
+            .checked_add(self.v_cache_bytes_per_token(meta)?)
+    }
+}
+
+fn cache_bytes_per_token(
+    meta: &GgufCompactMeta,
+    vector_length: u32,
+    cache_type: GgufKvCacheType,
+) -> Option<u64> {
+    let kv_heads = u64::from(meta.effective_kv_head_count()?);
+    let vector_length = u64::from((vector_length > 0).then_some(vector_length)?);
+    let layers = u64::from((meta.layer_count > 0).then_some(meta.layer_count)?);
+    let elements_per_layer = kv_heads.checked_mul(vector_length)?;
+    cache_type
+        .bytes_for_elements(elements_per_layer)?
+        .checked_mul(layers)
 }
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
@@ -273,8 +385,6 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
     let n_kv = read_gguf_header_count(&mut f, MAX_GGUF_HEADER_KV_COUNT, "KV count").ok()?;
 
     let mut meta = GgufCompactMeta::default();
-    let mut kv_head_count: u32 = 0;
-
     for _ in 0..n_kv {
         let key = read_gguf_string(&mut f).ok()?;
         let vtype = GgufType::from_u32(read_u32(&mut f).ok()?)?;
@@ -297,7 +407,7 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
             }
         } else if key.ends_with(".attention.head_count_kv") {
             if let Ok(Some(v)) = read_gguf_value_as_u32(&mut f, vtype) {
-                kv_head_count = v;
+                meta.head_count_kv = Some(v);
             }
         } else if key.ends_with(".block_count") {
             if let Ok(Some(v)) = read_gguf_value_as_u32(&mut f, vtype) {
@@ -340,18 +450,13 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
         }
     }
 
-    if meta.head_count > 0 {
-        if meta.key_length == 0 {
-            if let Some(key_length) = meta.embedding_size.checked_div(meta.head_count) {
-                meta.key_length = key_length;
-            }
+    if meta.key_length == 0 && meta.head_count > 0 {
+        if let Some(key_length) = meta.embedding_size.checked_div(meta.head_count) {
+            meta.key_length = key_length;
         }
-        if meta.value_length == 0 {
-            let effective_kv = if kv_head_count > 0 {
-                kv_head_count
-            } else {
-                meta.head_count
-            };
+    }
+    if meta.value_length == 0 {
+        if let Some(effective_kv) = meta.effective_kv_head_count() {
             if let Some(value_length) = meta.embedding_size.checked_div(effective_kv) {
                 meta.value_length = value_length;
             }
@@ -626,6 +731,64 @@ mod tests {
         assert_eq!(meta.key_length, 0);
         assert_eq!(meta.value_length, 512);
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scan_gguf_compact_meta_preserves_kv_head_count() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"GGUF");
+        bytes.extend_from_slice(&2u32.to_le_bytes());
+        bytes.extend_from_slice(&0i64.to_le_bytes());
+        bytes.extend_from_slice(&6i64.to_le_bytes());
+        push_u32_kv(&mut bytes, "llama.embedding_length", 4096);
+        push_u32_kv(&mut bytes, "llama.attention.head_count", 32);
+        push_u32_kv(&mut bytes, "llama.attention.head_count_kv", 8);
+        push_u32_kv(&mut bytes, "llama.block_count", 24);
+        push_u32_kv(&mut bytes, "llama.attention.key_length", 128);
+        push_u32_kv(&mut bytes, "llama.attention.value_length", 128);
+
+        let path = write_bytes("mesh-client-gguf-kv-head-count", &bytes);
+        let meta = scan_gguf_compact_meta(&path).expect("should parse GGUF");
+        assert_eq!(meta.head_count, 32);
+        assert_eq!(meta.head_count_kv, Some(8));
+        assert_eq!(meta.effective_kv_head_count(), Some(8));
+        assert_eq!(meta.k_cache_bytes_per_token_f16(), Some(49_152));
+        assert_eq!(meta.v_cache_bytes_per_token_f16(), Some(49_152));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn kv_cache_quant_prices_key_and_value_types_independently() {
+        let meta = GgufCompactMeta {
+            head_count: 32,
+            head_count_kv: Some(8),
+            layer_count: 24,
+            key_length: 128,
+            value_length: 128,
+            ..Default::default()
+        };
+        let quant = GgufKvCacheQuant::new(GgufKvCacheType::Q8_0, GgufKvCacheType::Q4_0);
+
+        assert_eq!(quant.k_cache_bytes_per_token(&meta), Some(26_112));
+        assert_eq!(quant.v_cache_bytes_per_token(&meta), Some(13_824));
+        assert_eq!(quant.kv_cache_bytes_per_token(&meta), Some(39_936));
+    }
+
+    #[test]
+    fn kv_cache_bytes_per_token_returns_none_when_required_fields_are_missing() {
+        let meta = GgufCompactMeta {
+            head_count: 32,
+            layer_count: 24,
+            key_length: 128,
+            ..Default::default()
+        };
+
+        assert_eq!(meta.k_cache_bytes_per_token_f16(), Some(196_608));
+        assert_eq!(meta.v_cache_bytes_per_token_f16(), None);
+        assert_eq!(
+            GgufKvCacheQuant::f16().kv_cache_bytes_per_token(&meta),
+            None
+        );
     }
 
     #[test]

--- a/crates/mesh-client/tests/models_extraction.rs
+++ b/crates/mesh-client/tests/models_extraction.rs
@@ -68,6 +68,7 @@ fn gguf_public_api_derives_value_length_from_kv_heads() {
         .unwrap();
     let meta = scan_gguf_compact_meta(&tmp).expect("should parse GGUF fixture");
     assert_eq!(meta.head_count, 0);
+    assert_eq!(meta.head_count_kv, Some(8));
     assert_eq!(meta.key_length, 0);
     assert_eq!(meta.value_length, 512);
     let _ = std::fs::remove_file(&tmp);

--- a/crates/mesh-llm/src/models/gguf.rs
+++ b/crates/mesh-llm/src/models/gguf.rs
@@ -1,3 +1,3 @@
-pub use mesh_client::models::gguf::scan_gguf_compact_meta;
+pub use mesh_client::models::gguf::{scan_gguf_compact_meta, GgufKvCacheQuant};
 
 pub type GgufCompactMeta = mesh_client::models::gguf::GgufCompactMeta;

--- a/crates/mesh-llm/src/runtime/context_planning.rs
+++ b/crates/mesh-llm/src/runtime/context_planning.rs
@@ -1,0 +1,251 @@
+use crate::models::gguf::{GgufCompactMeta, GgufKvCacheQuant};
+
+const DEFAULT_CONTEXT_LENGTH: u32 = 4096;
+const DEFAULT_PARALLEL_SLOTS: usize = 4;
+const MIN_AUTO_CONTEXT_LENGTH: u32 = 512;
+const MAX_AUTO_PARALLEL_SLOTS: usize = 16;
+const KV_CACHE_BUDGET_NUMERATOR: u64 = 85;
+const KV_CACHE_BUDGET_DENOMINATOR: u64 = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RuntimeResourcePlan {
+    pub(super) context_length: u32,
+    pub(super) slots: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct RuntimeResourcePlanInput<'a> {
+    pub(super) ctx_size_override: Option<u32>,
+    pub(super) parallel_override: Option<usize>,
+    pub(super) model_bytes: u64,
+    pub(super) vram_bytes: u64,
+    pub(super) metadata: Option<&'a GgufCompactMeta>,
+    pub(super) kv_cache_quant: GgufKvCacheQuant,
+}
+
+pub(super) fn plan_runtime_resources(input: RuntimeResourcePlanInput<'_>) -> RuntimeResourcePlan {
+    let context_length = input
+        .ctx_size_override
+        .unwrap_or_else(|| planned_context_length(input));
+    let slots = input
+        .parallel_override
+        .unwrap_or_else(|| planned_parallel_slots(input, context_length));
+
+    RuntimeResourcePlan {
+        context_length,
+        slots,
+    }
+}
+
+fn planned_context_length(input: RuntimeResourcePlanInput<'_>) -> u32 {
+    let Some(metadata) = input.metadata else {
+        return DEFAULT_CONTEXT_LENGTH;
+    };
+    let native_context = metadata.context_length;
+    if native_context == 0 {
+        return DEFAULT_CONTEXT_LENGTH;
+    }
+    let Some(kv_bytes_per_token) = input.kv_cache_quant.kv_cache_bytes_per_token(metadata) else {
+        return DEFAULT_CONTEXT_LENGTH.min(native_context);
+    };
+    let kv_budget = usable_kv_cache_budget(input.vram_bytes, input.model_bytes);
+    let max_affordable_context = kv_budget / kv_bytes_per_token;
+    if max_affordable_context == 0 {
+        return MIN_AUTO_CONTEXT_LENGTH.min(native_context);
+    }
+
+    let planned = max_affordable_context
+        .min(u64::from(native_context))
+        .min(u64::from(u32::MAX)) as u32;
+    let minimum = MIN_AUTO_CONTEXT_LENGTH.min(native_context);
+    if planned < minimum {
+        minimum
+    } else {
+        snap_context_length_down(planned).max(minimum)
+    }
+}
+
+fn planned_parallel_slots(input: RuntimeResourcePlanInput<'_>, context_length: u32) -> usize {
+    let Some(metadata) = input.metadata else {
+        return DEFAULT_PARALLEL_SLOTS;
+    };
+    let Some(kv_bytes_per_token) = input.kv_cache_quant.kv_cache_bytes_per_token(metadata) else {
+        return DEFAULT_PARALLEL_SLOTS;
+    };
+    let Some(bytes_per_slot) = u64::from(context_length).checked_mul(kv_bytes_per_token) else {
+        return DEFAULT_PARALLEL_SLOTS;
+    };
+    if bytes_per_slot == 0 {
+        return DEFAULT_PARALLEL_SLOTS;
+    }
+
+    let raw_slots = usable_kv_cache_budget(input.vram_bytes, input.model_bytes) / bytes_per_slot;
+    snap_parallel_slots_down(raw_slots)
+}
+
+fn usable_kv_cache_budget(vram_bytes: u64, model_bytes: u64) -> u64 {
+    let free_bytes = vram_bytes.saturating_sub(model_bytes);
+    let budget = u128::from(free_bytes) * u128::from(KV_CACHE_BUDGET_NUMERATOR)
+        / u128::from(KV_CACHE_BUDGET_DENOMINATOR);
+    budget.min(u128::from(u64::MAX)) as u64
+}
+
+fn snap_parallel_slots_down(raw_slots: u64) -> usize {
+    match raw_slots.min(MAX_AUTO_PARALLEL_SLOTS as u64) {
+        0 => 1,
+        1 => 1,
+        2 | 3 => 2,
+        4..=7 => 4,
+        8..=15 => 8,
+        _ => MAX_AUTO_PARALLEL_SLOTS,
+    }
+}
+
+fn snap_context_length_down(value: u32) -> u32 {
+    const CONTEXT_STEPS: &[u32] = &[512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536, 131_072];
+    CONTEXT_STEPS
+        .iter()
+        .rev()
+        .copied()
+        .find(|step| *step <= value)
+        .unwrap_or(MIN_AUTO_CONTEXT_LENGTH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gqa_metadata(context_length: u32) -> GgufCompactMeta {
+        GgufCompactMeta {
+            context_length,
+            head_count: 32,
+            head_count_kv: Some(8),
+            layer_count: 32,
+            key_length: 128,
+            value_length: 128,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn plan_runtime_resources_preserves_explicit_overrides() {
+        let metadata = gqa_metadata(32_768);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: Some(16_384),
+            parallel_override: Some(7),
+            model_bytes: 10_000_000_000,
+            vram_bytes: 24_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(
+            plan,
+            RuntimeResourcePlan {
+                context_length: 16_384,
+                slots: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_clamps_auto_context_to_native_metadata() {
+        let metadata = gqa_metadata(16_384);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(plan.context_length, 16_384);
+        assert!(
+            plan.slots > 4,
+            "expected metadata-based slots, got {plan:?}"
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_snaps_auto_context_down() {
+        let metadata = gqa_metadata(32_768);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: Some(1),
+            model_bytes: 5_000_000_000,
+            vram_bytes: 6_300_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(plan.context_length, 8192);
+        assert_eq!(plan.slots, 1);
+    }
+
+    #[test]
+    fn plan_runtime_resources_uses_effective_kv_quant_for_slot_budget() {
+        let metadata = gqa_metadata(131_072);
+        let f16_plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+        let q4_plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::new(
+                mesh_client::models::gguf::GgufKvCacheType::Q4_0,
+                mesh_client::models::gguf::GgufKvCacheType::Q4_0,
+            ),
+        });
+
+        assert_eq!(f16_plan.context_length, q4_plan.context_length);
+        assert!(
+            q4_plan.slots > f16_plan.slots,
+            "expected quantized KV cache to allow more slots: f16={f16_plan:?}, q4={q4_plan:?}"
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_falls_back_to_legacy_defaults_without_metadata() {
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 24_000_000_000,
+            metadata: None,
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(
+            plan,
+            RuntimeResourcePlan {
+                context_length: 4096,
+                slots: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_uses_explicit_parallel_with_metadata_context() {
+        let metadata = gqa_metadata(32_768);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: Some(2),
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(plan.context_length, 32_768);
+        assert_eq!(plan.slots, 2);
+    }
+}

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -1,3 +1,6 @@
+use super::context_planning::{
+    plan_runtime_resources, RuntimeResourcePlan, RuntimeResourcePlanInput,
+};
 use crate::api;
 use crate::inference::{election, skippy};
 use crate::mesh::{self, NodeRole};
@@ -72,6 +75,7 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
     pub(super) n_ubatch_override: Option<u32>,
     pub(super) flash_attention_override: FlashAttentionType,
     pub(super) slots: usize,
+    pub(super) parallel_override: Option<usize>,
 }
 
 pub(super) enum SplitRuntimeStart {
@@ -272,7 +276,29 @@ pub(super) async fn start_runtime_local_model(
         "runtime load only supports models that fit locally on this node"
     );
 
-    start_runtime_skippy_model(spec, model_name).await
+    let kv_cache = skippy::KvCachePolicy::for_model_size(model_bytes);
+    let effective_cache_type_k = spec
+        .cache_type_k_override
+        .unwrap_or(kv_cache.cache_type_k());
+    let effective_cache_type_v = spec
+        .cache_type_v_override
+        .unwrap_or(kv_cache.cache_type_v());
+    let kv_cache_quant = models::gguf::GgufKvCacheQuant::from_llama_args(
+        effective_cache_type_k,
+        effective_cache_type_v,
+    )
+    .unwrap_or_else(models::gguf::GgufKvCacheQuant::f16);
+    let compact_meta = models::gguf::scan_gguf_compact_meta(spec.model_path);
+    let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+        ctx_size_override: spec.ctx_size_override,
+        parallel_override: spec.parallel_override,
+        model_bytes,
+        vram_bytes: my_vram,
+        metadata: compact_meta.as_ref(),
+        kv_cache_quant,
+    });
+
+    start_runtime_skippy_model(spec, model_name, plan).await
 }
 
 pub(super) async fn start_runtime_split_model(
@@ -1319,13 +1345,14 @@ fn now_unix_nanos() -> i64 {
 async fn start_runtime_skippy_model(
     spec: LocalRuntimeModelStartSpec<'_>,
     model_name: String,
+    plan: RuntimeResourcePlan,
 ) -> Result<(
     String,
     LocalRuntimeModelHandle,
     tokio::sync::oneshot::Receiver<()>,
 )> {
     let port = alloc_local_port().await?;
-    let context_length = spec.ctx_size_override.unwrap_or(4096);
+    let context_length = plan.context_length;
     let model_bytes = election::total_model_bytes(spec.model_path);
     let kv_cache = skippy::KvCachePolicy::for_model_size(model_bytes);
     let effective_cache_type_k = spec
@@ -1348,7 +1375,7 @@ async fn start_runtime_skippy_model(
         .filter(|path| path.exists());
     let mut options = skippy::SkippyModelLoadOptions::for_direct_gguf(&model_name, spec.model_path)
         .with_ctx_size(context_length)
-        .with_generation_concurrency(spec.slots)
+        .with_generation_concurrency(plan.slots)
         .with_cache_types(effective_cache_type_k, effective_cache_type_v)
         .with_flash_attn_type(resolved_flash_attn_type);
     if spec.n_batch_override.is_some() || spec.n_ubatch_override.is_some() {
@@ -1378,7 +1405,7 @@ async fn start_runtime_skippy_model(
             port: http.port(),
             backend: "skippy".into(),
             context_length,
-            slots: spec.slots,
+            slots: plan.slots,
             inner: LocalRuntimeBackendHandle::Skippy {
                 model: skippy_model,
                 http,

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config_state;
+mod context_planning;
 mod discovery;
 pub mod instance;
 mod interactive;
@@ -542,6 +543,7 @@ struct StartupLocalModelTask {
     n_ubatch: Option<u32>,
     flash_attention: FlashAttentionType,
     slots: usize,
+    parallel_override: Option<usize>,
     split: bool,
     stop_rx: tokio::sync::watch::Receiver<bool>,
     dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
@@ -573,6 +575,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch,
         flash_attention,
         slots,
+        parallel_override,
         split,
         mut stop_rx,
         dashboard_processes,
@@ -599,6 +602,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch_override: n_ubatch,
         flash_attention_override: flash_attention,
         slots,
+        parallel_override,
     };
     let (
         mut loaded_name,
@@ -677,7 +681,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         &handle.backend,
         handle.port,
         handle.pid(),
-        slots,
+        handle.slots,
         handle.context_length,
     );
     upsert_dashboard_process(&dashboard_processes, payload.clone()).await;
@@ -2840,11 +2844,11 @@ async fn run_auto(
     let node2 = node.clone();
     let tunnel_mgr2 = tunnel_mgr.clone();
     let model2 = model.clone();
-    let slots = primary_startup_model
+    let primary_parallel_override = primary_startup_model
         .as_ref()
         .and_then(|m| m.parallel)
-        .or(config.gpu.parallel)
-        .unwrap_or(4);
+        .or(config.gpu.parallel);
+    let primary_slots = primary_parallel_override.unwrap_or(4);
     let cb_console_port = console_port;
     let model_name_for_election = model_name.clone();
     let primary_target_tx = target_tx.clone();
@@ -2915,7 +2919,8 @@ async fn run_auto(
             n_batch: primary_n_batch,
             n_ubatch: primary_n_ubatch,
             flash_attention: primary_flash_attention,
-            slots,
+            slots: primary_slots,
+            parallel_override: primary_parallel_override,
             split: startup_split,
             stop_rx: primary_stop_rx,
             dashboard_processes: dashboard_processes_for_primary_task,
@@ -2971,7 +2976,8 @@ async fn run_auto(
             let extra_target_tx = target_tx.clone();
             let extra_model_name = extra_name.clone();
             let api_port_extra = api_port;
-            let slots = extra_model.parallel.or(config.gpu.parallel).unwrap_or(4);
+            let extra_parallel_override = extra_model.parallel.or(config.gpu.parallel);
+            let extra_slots = extra_parallel_override.unwrap_or(4);
             let extra_console_state = console_state.clone();
             let extra_startup_ready_reporter = startup_ready_reporter.clone();
             let extra_startup_load_gate = startup_load_gate.clone();
@@ -2997,7 +3003,8 @@ async fn run_auto(
                     n_batch: extra_n_batch,
                     n_ubatch: extra_n_ubatch,
                     flash_attention: extra_flash_attention,
-                    slots,
+                    slots: extra_slots,
+                    parallel_override: extra_parallel_override,
                     split: startup_split,
                     stop_rx: extra_stop_rx,
                     dashboard_processes: dashboard_processes_for_extra_task,
@@ -3109,14 +3116,15 @@ async fn run_auto(
                                 "model '{runtime_model_name}' is already loaded"
                             );
 
-                            // Look up per-model parallel from TOML config by matching the
-                            // spec string against [[models]].model entries. Falls back to
-                            // gpu.parallel or default 4 when no entry matches.
+                            // Look up per-model overrides from TOML config by matching the
+                            // spec string against [[models]].model entries. Metadata-based
+                            // planning chooses direct-local defaults when no parallel
+                            // override matches.
                             let model_overrides = config.models.iter().find(|m| m.model == spec);
-                            let slots = model_overrides
+                            let parallel_override = model_overrides
                                 .and_then(|m| m.parallel)
-                                .or(config.gpu.parallel)
-                                .unwrap_or(4);
+                                .or(config.gpu.parallel);
+                            let slots = parallel_override.unwrap_or(4);
 
                             assigned_runtime_model = Some(runtime_model_name.clone());
                             add_serving_assignment(&node, &primary_model_name, &runtime_model_name)
@@ -3138,6 +3146,7 @@ async fn run_auto(
                                         .and_then(|m| m.flash_attention)
                                         .unwrap_or(FlashAttentionType::Auto),
                                     slots,
+                                    parallel_override,
                                 },
                             )
                             .await?;
@@ -3156,7 +3165,7 @@ async fn run_auto(
                                 &handle.backend,
                                 handle.port,
                                 handle.pid(),
-                                slots,
+                                handle.slots,
                                 handle.context_length,
                             );
                             upsert_dashboard_process(&dashboard_processes, payload.clone())


### PR DESCRIPTION
## 1. Summary
Direct local Skippy model startup now uses GGUF metadata to choose safer automatic context and parallel defaults. Explicit `ctx_size` and `parallel` overrides still win, and missing metadata preserves the existing `4096` context / `4` slot fallback.

## 2. Why
This addresses #359 by replacing fixed direct-local defaults with model-aware planning. GGUF native context, GQA KV heads, K/V dimensions, effective KV cache quantization, model size, and local VRAM now inform default planning so small-context models are not over-launched and high-headroom nodes are not capped at a fixed slot count.

## 3. Diff scope
- Narrow runtime/client change.
- `crates/mesh-client/src/models/gguf.rs`: stores `head_count_kv`, exposes GQA-aware K/V/KV bytes-per-token helpers, and adds exact GGUF KV cache quantization pricing.
- `crates/mesh-client/tests/models_extraction.rs`: covers the public GGUF metadata API.
- `crates/mesh-llm/src/models/gguf.rs`: reexports the GGUF scanner and KV quantization helper used by runtime planning.
- `crates/mesh-llm/src/runtime/context_planning.rs`: adds the direct-local context/slot planner and unit coverage.
- `crates/mesh-llm/src/runtime/local.rs`: computes effective cache K/V types from the current Skippy policy and config overrides, scans GGUF metadata, and applies the plan to direct local Skippy loads.
- `crates/mesh-llm/src/runtime/mod.rs`: carries optional parallel overrides beside the existing concrete slot count so split runtime lane behavior stays unchanged while direct local defaults can be metadata-planned.
- No protocol, CI, migration, release, or deployment files changed.
- This intentionally leaves split-runtime lane planning unchanged; split stage accounting has different semantics and should remain a separate change.

## 4. Branch integrity
- Base branch: `jd/feat/skippy` (#422 head)
- `git rev-parse origin/jd/feat/skippy`: `723c7a61d0e2b1d4aa7daa87a59f2fc89cb26951`
- `git rev-list --left-right --count origin/jd/feat/skippy...HEAD`: `0 1`
- Behind count: 0
- Ahead count: 1
- Merge-base SHA from `git merge-base origin/jd/feat/skippy HEAD`: `723c7a61d0e2b1d4aa7daa87a59f2fc89cb26951`
- Fast-forward safety: `git merge-base --is-ancestor origin/jd/feat/skippy HEAD` exited 0; `origin/jd/feat/skippy` is an ancestor of HEAD, no divergence.
- Stacked PR note: #422 is still open and mergeable. This PR targets `jd/feat/skippy` to keep the review diff focused; after #422 lands, retarget to `main`.

## 5. Commit integrity
- Commits introduced:
  - `ed6ff1e48ac295b7e447ab460cd74c65c3abf586 Use GGUF metadata for runtime defaults`
- One logical change per commit: confirmed.
- Ledger-Id trailers: Not applicable — `scripts/ledger/` does not exist in this repository.
- Unique Ledger-Id for squash merge: Not applicable — `scripts/ledger/` does not exist in this repository.

## 6. Ledger proof
Not applicable — `scripts/ledger/` does not exist in this repository.

## 7. Diff hygiene
- `git diff --name-status origin/jd/feat/skippy...HEAD`:
  - `M crates/mesh-client/src/models/gguf.rs`
  - `M crates/mesh-client/tests/models_extraction.rs`
  - `M crates/mesh-llm/src/models/gguf.rs`
  - `A crates/mesh-llm/src/runtime/context_planning.rs`
  - `M crates/mesh-llm/src/runtime/local.rs`
  - `M crates/mesh-llm/src/runtime/mod.rs`
- `git diff --check origin/jd/feat/skippy...HEAD`: PASS, no output.
- Forbidden-file confirmation: no .env files, local environment files, secrets, tokens, credentials, ops/reports artifacts, __pycache__, *.pyc, .DS_Store, coverage artifacts, build outputs, cache files, or unrelated generated files are included.
- Required metadata files: Not applicable — no version, ledger, changelog, release metadata, generated registry, or equivalent governance files changed.

## 8. Validation tier and test proof
- Validation tier: Tier 2 — Narrow runtime change.
- Reason: this changes GGUF metadata parsing and local Skippy runtime default planning, but does not change protocol compatibility, auth, permissions, migrations, CI, release tooling, deployment behavior, or external service contracts.
- `git fetch --no-tags origin main:refs/remotes/origin/main jd/feat/skippy:refs/remotes/origin/jd/feat/skippy pull/422/head:refs/remotes/origin/pr/422`: PASS.
- `cargo fmt --all -- --check`: PASS.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo check -p mesh-llm`: PASS.
- `cargo test -p mesh-llm-client --lib`: PASS, 94 passed, 0 failed, 0 ignored.
- `cargo test -p mesh-llm-client --test models_extraction`: PASS, 4 passed, 0 failed, 0 ignored.
- `LLAMA_STAGE_BUILD_DIR=/private/tmp/mesh-llm-gguf-pr-refresh/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm plan_runtime_resources`: PASS, 6 passed, 0 failed, 0 ignored.
- `LLAMA_STAGE_BUILD_DIR=/private/tmp/mesh-llm-gguf-pr-refresh/.deps/llama.cpp/build-stage-abi-metal cargo test -p skippy-server binary_transport`: PASS, 2 passed, 0 failed, 0 ignored.
- `LLAMA_STAGE_BUILD_DIR=/private/tmp/mesh-llm-gguf-pr-refresh/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib`: PASS, 1134 passed, 0 failed, 3 ignored.
- `/tmp/mesh-llm-just-tool/bin/just build`: PASS; built patched llama.cpp, UI, and release `mesh-llm` binary.
- First planner-test attempt with a relative `LLAMA_STAGE_BUILD_DIR` failed before rerun because the fresh worktree did not yet have a visible `llama-common` link path; `just build` produced the required stage ABI build, and the same planner tests passed with the absolute stage build path.
- Not run: `cargo test --workspace` — not required for Tier 2; targeted client/runtime/skippy tests plus full `mesh-llm --lib` and `just build` cover the changed paths.
- Not run: remote deploy, compatibility smoke, benchmark, release, and bundle checks — not required; no deployment, compatibility protocol, benchmark, release, or packaging logic changed.
- External gates: Pending — GitHub CI runs after PR creation/update.

## 9. Verification-pack proof
Not applicable — no infra/governance/replay/invariant/verification files changed.

## 10. Migration notes
Not applicable — no DB migration changed.

## 11. CI context confirmation
- Required contexts: Pending — GitHub CI has not completed for this new stacked PR yet.
- CI context names unchanged.
- Not applicable — no CI/workflow context changes.

## 12. Runtime safety
- Reviewed runtime files/modules: `crates/mesh-llm/src/runtime/context_planning.rs`, `crates/mesh-llm/src/runtime/local.rs`, and `crates/mesh-llm/src/runtime/mod.rs`.
- Explicit overrides remain authoritative: `ctx_size` and per-model/global `parallel` values still win over metadata planning.
- Missing or incomplete GGUF metadata falls back to the existing `4096` context / `4` slot defaults.
- Effective Skippy KV cache K/V types are resolved from current upstream policy plus config overrides before planning; this preserves #428/#429 behavior.
- Split runtime lane planning is intentionally unchanged. The concrete `slots` value is still passed to split stage lane count, avoiding a silent semantic change to distributed stage behavior.
- No new blocking locks: the change only scans local GGUF metadata and computes direct-local planning before model load.
- No new unbounded queues: no queues, channels, background tasks, or buffering paths were added.
- No invariant removal: local fit checks, cache policy application, flash-attention override handling, batch override handling, and Skippy load hooks remain in place.
- No invariant regression introduced.

## 13. Documentation integrity
Not applicable — no docs/runbooks/commands changed.
- README/runbook update: Not applicable — no command or operational procedure changed.
- Runbook mirror parity: Not applicable — no runbooks changed.
- Stale references: Not applicable — no docs changed.

## 14. Rollback plan
- Squash merge rollback: `git revert <post_merge_commit_sha>`.
- Replace `<post_merge_commit_sha>` with the final squash/merge commit SHA after merge.
- DB downgrade required: no.
- Data repair required: no.
- Operational caveats: none expected; rollback restores fixed direct-local context/slot defaults.

## 15. Known residual risks
- The PR is stacked on #422 and is not merge-ready until #422 lands or this PR is retargeted to `main`.
- GitHub CI is pending until the PR is opened/updated.
- #430 is a separate draft PR on the same base and may touch nearby runtime code later; refresh may be needed if #430 lands first.
- `/tmp/mesh-llm-just-tool/bin/just build` emitted existing environment/tooling warnings: missing compiler cache, OpenMP warning, llama.cpp compiler warnings, local Node version warning, npm audit output, and Vite chunk-size warnings. The command exited successfully and those warnings are unrelated to the changed Rust files.
