### PR TITLE
Restore skippy CI workflow coverage

### DIFF
--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -45,6 +45,16 @@ jobs:
           TMP_STDERR=$(mktemp)
           trap 'rm -f "$TMP_OUTPUT" "$TMP_STDERR"' EXIT
           if ! "$BIN" --json >"$TMP_OUTPUT" 2>"$TMP_STDERR"; then
+            if grep -q '"error":"Metal device not available"' "$TMP_OUTPUT" "$TMP_STDERR"; then
+              if [ -s "$TMP_OUTPUT" ]; then
+                cat "$TMP_OUTPUT"
+              fi
+              if [ -s "$TMP_STDERR" ]; then
+                cat "$TMP_STDERR" >&2
+              fi
+              echo "::warning::Metal device not available on this runner; skipping benchmark smoke."
+              exit 0
+            fi
             if [ -s "$TMP_OUTPUT" ]; then
               cat "$TMP_OUTPUT"
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,156 @@
-name: ci
+name: CI
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+  MODEL_URL: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
+  MODEL_FILE: SmolLM2-135M-Instruct-Q8_0.gguf
+  SCCACHE_GHA_ENABLED: "true"
+  LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
 
 jobs:
-  rust:
+  changes:
     runs-on: ubuntu-latest
-    env:
-      LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      ui: ${{ steps.filter.outputs.ui }}
+      benchmarks: ${{ steps.filter.outputs.benchmarks }}
+      sdk: ${{ steps.filter.outputs.sdk }}
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'tools/xtask/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'Justfile'
+              - 'scripts/**'
+              - 'third_party/llama.cpp/**'
+              - '.github/cache-version.txt'
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/smoke.yml'
+              - '.github/workflows/warm-caches.yml'
+              - '.github/workflows/gpu-warm-cache-job.yml'
+              - '.github/workflows/llama-cache-keys.yml'
+            ui:
+              - 'crates/mesh-llm/ui/**'
+            benchmarks:
+              - 'crates/skippy-bench/**'
+              - 'crates/llama-spec-bench/**'
+              - 'crates/mesh-llm/benchmarks/**'
+              - '.github/workflows/benchmark-smoke.yml'
+              - '.github/workflows/ci.yml'
+            sdk:
+              - 'crates/mesh-api/**'
+              - 'crates/mesh-api-ffi/**'
+              - 'crates/mesh-client/**'
+              - 'sdk/**'
+              - 'Package.swift'
+              - 'scripts/ci-native-sdk-smoke.sh'
+              - 'scripts/ci-kotlin-sdk-smoke.sh'
+              - 'scripts/ci-swift-sdk-smoke.sh'
+              - 'scripts/ci-sdk-fixture.sh'
+              - '.github/workflows/ci.yml'
+            docker:
+              - '.dockerignore'
+              - 'docker/**'
+              - 'fly/Dockerfile'
+              - 'crates/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/docker.yml'
+
+  resolve_llama_cache_keys:
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.benchmarks == 'true' }}
+    uses: ./.github/workflows/llama-cache-keys.yml
+
+  linux:
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            .github/cache-version.txt
+            ci/requirements-ci-python.txt
+
+      - name: Build UI
+        if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.ui == 'true' }}
+        working-directory: crates/mesh-llm/ui
+        run: npm ci && npm run build
+
+      - name: Test UI
+        if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.ui == 'true' }}
+        working-directory: crates/mesh-llm/ui
+        run: npm test
+
+      - name: Install Python SDKs
+        run: python -m pip install --upgrade pip -r ci/requirements-ci-python.txt
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl jq lsof
+
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android
 
-      - uses: taiki-e/install-action@just
+      - uses: mozilla-actions/sccache-action@v0.0.9
 
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev curl glslc libvulkan-dev
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+          prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Check release-target repo consistency
+        run: cargo run -p xtask -- repo-consistency release-targets
+
+      - name: Check embedded client dependency purity
+        run: |
+          cargo tree -p mesh-llm-client --prefix=none --no-dedupe > /tmp/mesh-client-deps.txt
+          FORBIDDEN="keyring|rpassword|hf-hub|dirs|clap|include_dir|rmcp|keyring-core"
+          if grep -E "^[[:space:]│├└─-]*($FORBIDDEN)([[:space:]]|$)" /tmp/mesh-client-deps.txt; then
+            echo "ERROR: Forbidden dependency found in mesh-client"
+            grep -E "^[[:space:]│├└─-]*($FORBIDDEN)([[:space:]]|$)" /tmp/mesh-client-deps.txt
+            exit 1
+          fi
 
       - name: Prepare patched llama.cpp ABI checkout
         run: scripts/prepare-llama.sh pinned
@@ -31,11 +158,387 @@ jobs:
       - name: Build patched llama.cpp ABI libraries
         run: scripts/build-llama.sh
 
-      - name: Format check
-        run: cargo fmt --all -- --check
-
-      - name: Cargo check
-        run: cargo check -p mesh-llm
+      - name: Build mesh-llm binary (debug)
+        run: cargo build -p mesh-llm --bin mesh-llm
 
       - name: Unit tests
         run: cargo test -p mesh-llm --lib
+
+      - name: Skippy runtime crate tests
+        run: |
+          cargo test -p skippy-protocol --lib
+          cargo test -p skippy-server --lib
+          cargo test -p openai-frontend --lib
+
+      - name: Protocol compatibility matrix
+        run: |
+          cargo test -p mesh-llm --test protocol_compat_v0_client
+          cargo test -p mesh-llm --test protocol_convert_matrix
+
+      - name: Clippy
+        run: cargo clippy -p mesh-llm -- -D warnings
+
+      - name: CLI smoke test
+        run: |
+          target/debug/mesh-llm --version
+          target/debug/mesh-llm --help | head -5
+
+      - name: Client-auto boot test
+        run: scripts/ci-client-auto-test.sh target/debug/mesh-llm
+
+      - name: Upload Linux inference binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-linux-inference-binaries
+          path: target/debug/mesh-llm
+          if-no-files-found: error
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  inference_smoke_tests:
+    needs: [changes, linux]
+    if: ${{ needs.linux.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
+    uses: ./.github/workflows/smoke.yml
+    with:
+      artifact_name: ci-linux-inference-binaries
+      mesh_binary_target: target/debug/mesh-llm
+      cache_key_prefix: ''
+      workflow_cache_file: .github/workflows/ci.yml
+
+  native_sdk_smoke:
+    needs: [changes, linux, inference_smoke_tests]
+    if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev curl jq lsof
+      - uses: actions/download-artifact@v7
+        with:
+          name: ci-linux-inference-binaries
+          path: ci-artifacts/linux
+      - name: Stage binary
+        run: |
+          mkdir -p target/debug
+          cp ci-artifacts/linux/mesh-llm target/debug/mesh-llm
+          chmod +x target/debug/mesh-llm
+      - name: Cache integration model
+        id: cache-model
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+      - name: Download integration model
+        if: steps.cache-model.outputs.cache-hit != 'true'
+        run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
+      - name: Save integration model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ steps.cache-model.outputs.cache-primary-key }}
+      - name: Native SDK smoke test
+        run: scripts/ci-native-sdk-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MODEL_FILE"
+
+  kotlin_sdk_smoke:
+    needs: [changes, linux, inference_smoke_tests]
+    if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev curl jq lsof
+      - uses: actions/download-artifact@v7
+        with:
+          name: ci-linux-inference-binaries
+          path: ci-artifacts/linux
+      - name: Stage binary
+        run: |
+          mkdir -p target/debug
+          cp ci-artifacts/linux/mesh-llm target/debug/mesh-llm
+          chmod +x target/debug/mesh-llm
+      - name: Cache integration model
+        id: cache-model
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-kotlin-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+      - name: Download integration model
+        if: steps.cache-model.outputs.cache-hit != 'true'
+        run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
+      - name: Kotlin SDK smoke test
+        run: scripts/ci-kotlin-sdk-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MODEL_FILE"
+
+  swift_sdk_smoke:
+    needs: [changes, inference_smoke_tests]
+    if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') }}
+    runs-on: macos-14
+    env:
+      LLAMA_STAGE_BACKEND: metal
+      LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-metal
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install tools
+        run: brew install cmake ninja jq
+      - name: Build UI placeholder
+        run: mkdir -p crates/mesh-llm/ui/dist && printf '<html></html>' > crates/mesh-llm/ui/dist/index.html
+      - name: Prepare patched llama.cpp ABI checkout
+        run: scripts/prepare-llama.sh pinned
+      - name: Build patched llama.cpp ABI libraries
+        run: scripts/build-llama.sh
+      - name: Build mesh-llm binary (debug)
+        run: cargo build -p mesh-llm --bin mesh-llm
+      - name: Cache integration model
+        id: cache-model
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-swift-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+      - name: Download integration model
+        if: steps.cache-model.outputs.cache-hit != 'true'
+        run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
+      - name: Swift SDK smoke test
+        run: scripts/ci-swift-sdk-smoke.sh target/debug/mesh-llm target/debug "$HOME/.models/$MODEL_FILE"
+
+  macos:
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.benchmarks == 'true' }}
+    runs-on: macos-14
+    env:
+      LLAMA_STAGE_BACKEND: metal
+      LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-metal
+    outputs:
+      benchmark_artifact_ready: ${{ steps.benchmark_gate.outputs.ready }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Benchmark gate
+        id: benchmark_gate
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ needs.changes.outputs.benchmarks }}" == "true" ]]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+      - name: Build UI
+        if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.ui == 'true' }}
+        working-directory: crates/mesh-llm/ui
+        run: npm ci && npm run build
+      - name: Test UI
+        if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.ui == 'true' }}
+        working-directory: crates/mesh-llm/ui
+        run: npm test
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install build dependencies
+        run: brew install cmake ninja jq
+      - name: Format check
+        run: cargo fmt --all -- --check
+      - name: Prepare patched llama.cpp ABI checkout
+        run: scripts/prepare-llama.sh pinned
+      - name: Build patched llama.cpp ABI libraries
+        run: scripts/build-llama.sh
+      - name: Build mesh-llm binary (debug)
+        run: cargo build -p mesh-llm --bin mesh-llm
+      - name: Unit tests
+        run: cargo test -p mesh-llm --lib
+      - name: CLI smoke test
+        run: |
+          target/debug/mesh-llm --version
+          target/debug/mesh-llm --help | head -5
+      - name: Build Swift benchmark binary
+        if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
+        run: swiftc -O crates/mesh-llm/benchmarks/membench-fingerprint.swift -o target/release/membench-fingerprint
+      - name: Upload Swift benchmark artifact
+        if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-benchmark-swift
+          path: target/release/membench-fingerprint
+
+  linux_cuda:
+    needs: [changes, resolve_llama_cache_keys]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.benchmarks == 'true' }}
+    name: Linux CUDA slim
+    runs-on: ubuntu-latest
+    container:
+      image: nvidia/cuda:${{ needs.resolve_llama_cache_keys.outputs.cuda_version }}-devel-ubuntu22.04
+    env:
+      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-cuda-sm89
+      LLAMA_STAGE_BACKEND: cuda
+      LLAMA_STAGE_CUDA_ARCHITECTURES: "89"
+      MESH_LLM_SKIP_UI: "1"
+    outputs:
+      benchmark_artifact_ready: ${{ steps.benchmark_gate.outputs.ready }}
+    steps:
+      - name: Install base packages
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - name: Benchmark gate
+        id: benchmark_gate
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ needs.changes.outputs.benchmarks }}" == "true" ]]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare UI placeholder
+        run: mkdir -p crates/mesh-llm/ui/dist && printf '<html></html>' > crates/mesh-llm/ui/dist/index.html
+      - uses: actions/cache/restore@v5
+        id: llama_cache
+        with:
+          path: .deps/llama-build/build-stage-abi-cuda-sm89
+          key: ${{ needs.resolve_llama_cache_keys.outputs.cuda_slim_cache_key }}
+      - name: Build Linux CUDA backend
+        if: steps.llama_cache.outputs.cache-hit != 'true'
+        run: just --shell bash --shell-arg -lc release-build-cuda 89
+      - name: Build mesh-llm binary only
+        if: steps.llama_cache.outputs.cache-hit == 'true'
+        run: cargo build --release -p mesh-llm
+      - name: CLI smoke test
+        run: target/release/mesh-llm --version
+      - name: Build CUDA benchmark binary
+        if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
+        run: nvcc -O3 -o target/release/membench-fingerprint-cuda crates/mesh-llm/benchmarks/membench-fingerprint.cu
+      - name: Upload CUDA benchmark artifact
+        if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-benchmark-cuda
+          path: target/release/membench-fingerprint-cuda
+
+  linux_rocm:
+    needs: [changes, resolve_llama_cache_keys]
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.benchmarks == 'true' }}
+    name: Linux ROCm slim
+    runs-on: ubuntu-latest
+    container:
+      image: rocm/dev-ubuntu-24.04:7.0-complete
+    env:
+      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-rocm-gfx1100
+      LLAMA_STAGE_BACKEND: rocm
+      LLAMA_STAGE_AMDGPU_TARGETS: gfx1100
+      MESH_LLM_SKIP_UI: "1"
+    outputs:
+      benchmark_artifact_ready: ${{ steps.benchmark_gate.outputs.ready }}
+    steps:
+      - name: Install base packages
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - name: Benchmark gate
+        id: benchmark_gate
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ needs.changes.outputs.benchmarks }}" == "true" ]]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          fi
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare UI placeholder
+        run: mkdir -p crates/mesh-llm/ui/dist && printf '<html></html>' > crates/mesh-llm/ui/dist/index.html
+      - uses: actions/cache/restore@v5
+        id: llama_cache
+        with:
+          path: .deps/llama-build/build-stage-abi-rocm-gfx1100
+          key: ${{ needs.resolve_llama_cache_keys.outputs.rocm_slim_cache_key }}
+      - name: Build Linux ROCm backend
+        if: steps.llama_cache.outputs.cache-hit != 'true'
+        run: just --shell bash --shell-arg -lc release-build-rocm gfx1100
+      - name: Build mesh-llm binary only
+        if: steps.llama_cache.outputs.cache-hit == 'true'
+        run: cargo build --release -p mesh-llm
+      - name: CLI smoke test
+        run: target/release/mesh-llm --version
+      - name: Build ROCm benchmark binary
+        if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
+        run: hipcc -O3 -std=c++17 -o target/release/membench-fingerprint-hip crates/mesh-llm/benchmarks/membench-fingerprint.hip
+      - name: Upload ROCm benchmark artifact
+        if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-benchmark-hip
+          path: target/release/membench-fingerprint-hip
+
+  linux_vulkan:
+    needs: changes
+    if: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' }}
+    name: Linux Vulkan
+    runs-on: ubuntu-latest
+    env:
+      LLAMA_STAGE_BACKEND: vulkan
+      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-vulkan
+      MESH_LLM_SKIP_UI: "1"
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Vulkan build packages
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev glslc libvulkan-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare UI placeholder
+        run: mkdir -p crates/mesh-llm/ui/dist && printf '<html></html>' > crates/mesh-llm/ui/dist/index.html
+      - name: Build Linux Vulkan backend
+        run: just --shell bash --shell-arg -lc release-build-vulkan
+      - name: CLI smoke test
+        run: target/release/mesh-llm --version
+
+  macos_benchmark_smoke:
+    needs: macos
+    if: ${{ needs.macos.result == 'success' && needs.macos.outputs.benchmark_artifact_ready == 'true' }}
+    name: macOS benchmark smoke
+    uses: ./.github/workflows/benchmark-smoke.yml
+    with:
+      artifact_name: ci-benchmark-swift
+      artifact_path: ci-artifacts/swift-benchmark
+      benchmark_binary: membench-fingerprint
+      runs_on: '"macos-14"'
+
+  linux_cuda_benchmark_smoke:
+    needs: linux_cuda
+    if: ${{ needs.linux_cuda.result == 'success' && needs.linux_cuda.outputs.benchmark_artifact_ready == 'true' && vars.CUDA_BENCHMARK_RUNNER != '' }}
+    name: Linux CUDA benchmark smoke
+    uses: ./.github/workflows/benchmark-smoke.yml
+    with:
+      artifact_name: ci-benchmark-cuda
+      artifact_path: ci-artifacts/cuda-benchmark
+      benchmark_binary: membench-fingerprint-cuda
+      runs_on: ${{ vars.CUDA_BENCHMARK_RUNNER }}
+
+  linux_rocm_benchmark_smoke:
+    needs: linux_rocm
+    if: ${{ needs.linux_rocm.result == 'success' && needs.linux_rocm.outputs.benchmark_artifact_ready == 'true' && vars.ROCM_BENCHMARK_RUNNER != '' }}
+    name: Linux ROCm benchmark smoke
+    uses: ./.github/workflows/benchmark-smoke.yml
+    with:
+      artifact_name: ci-benchmark-hip
+      artifact_path: ci-artifacts/hip-benchmark
+      benchmark_binary: membench-fingerprint-hip
+      runs_on: ${{ vars.ROCM_BENCHMARK_RUNNER }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,8 +392,15 @@ jobs:
     steps:
       - name: Install base packages
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
       - name: Benchmark gate
@@ -449,8 +456,15 @@ jobs:
     steps:
       - name: Install base packages
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
       - name: Benchmark gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,9 @@ jobs:
           target/debug/mesh-llm --help | head -5
       - name: Build Swift benchmark binary
         if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
-        run: swiftc -O crates/mesh-llm/benchmarks/membench-fingerprint.swift -o target/release/membench-fingerprint
+        run: |
+          mkdir -p target/release
+          swiftc -O crates/mesh-llm/benchmarks/membench-fingerprint.swift -o target/release/membench-fingerprint
       - name: Upload Swift benchmark artifact
         if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
         uses: actions/upload-artifact@v6
@@ -499,7 +501,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install Vulkan build packages
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev glslc libvulkan-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev glslc libvulkan-dev spirv-headers
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: mozilla-actions/sccache-action@v0.0.9

--- a/.github/workflows/debug-slim-cache.yml
+++ b/.github/workflows/debug-slim-cache.yml
@@ -1,0 +1,70 @@
+name: Debug slim GPU caches
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend:
+        description: Slim cache backend to inspect
+        type: choice
+        required: true
+        default: cuda
+        options:
+          - cuda
+          - rocm
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  resolve_llama_cache_keys:
+    uses: ./.github/workflows/llama-cache-keys.yml
+
+  inspect:
+    name: Inspect ${{ inputs.backend }} slim cache
+    needs: resolve_llama_cache_keys
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Resolve cache metadata
+        id: cache
+        env:
+          BACKEND: ${{ inputs.backend }}
+          CUDA_KEY: ${{ needs.resolve_llama_cache_keys.outputs.cuda_slim_cache_key }}
+          ROCM_KEY: ${{ needs.resolve_llama_cache_keys.outputs.rocm_slim_cache_key }}
+        run: |
+          set -euo pipefail
+          case "$BACKEND" in
+            cuda)
+              echo "key=$CUDA_KEY" >> "$GITHUB_OUTPUT"
+              echo "path=.deps/llama-build/build-stage-abi-cuda-sm89" >> "$GITHUB_OUTPUT"
+              ;;
+            rocm)
+              echo "key=$ROCM_KEY" >> "$GITHUB_OUTPUT"
+              echo "path=.deps/llama-build/build-stage-abi-rocm-gfx1100" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "unsupported backend: $BACKEND" >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Restore slim cache
+        id: restore
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ steps.cache.outputs.path }}
+          key: ${{ steps.cache.outputs.key }}
+
+      - name: Report cache contents
+        run: |
+          set -euo pipefail
+          echo "cache key: ${{ steps.cache.outputs.key }}"
+          echo "cache hit: ${{ steps.restore.outputs.cache-hit }}"
+          if [[ -d "${{ steps.cache.outputs.path }}" ]]; then
+            du -sh "${{ steps.cache.outputs.path }}" || true
+            find "${{ steps.cache.outputs.path }}" -maxdepth 3 -type f | sort | sed -n '1,200p'
+          else
+            echo "cache path not restored: ${{ steps.cache.outputs.path }}"
+          fi

--- a/.github/workflows/docker-precheck.yml
+++ b/.github/workflows/docker-precheck.yml
@@ -115,10 +115,10 @@ jobs:
         if: ${{ inputs.validate_entrypoint_modes }}
         run: |
           set -euo pipefail
-          grep -qE '^\s*console\)' docker/entrypoint.sh
-          grep -qE '^\s*worker\)' docker/entrypoint.sh
-          grep -qE '^\s*\*\)' docker/entrypoint.sh
-          if grep -qE '^\s*api\)' docker/entrypoint.sh; then
+          grep -qE '^[[:space:]]*console([|)])' docker/entrypoint.sh
+          grep -qE '^[[:space:]]*worker\)' docker/entrypoint.sh
+          grep -qE '^[[:space:]]*\*\)' docker/entrypoint.sh
+          if grep -qE '^[[:space:]]*api\)' docker/entrypoint.sh; then
             echo "api mode should not be a separate entrypoint mode" >&2
             exit 1
           fi

--- a/.github/workflows/docker-precheck.yml
+++ b/.github/workflows/docker-precheck.yml
@@ -1,0 +1,133 @@
+name: Docker precheck
+
+on:
+  workflow_call:
+    inputs:
+      job_name:
+        required: true
+        type: string
+      dockerfile_path:
+        required: true
+        type: string
+      validate_shared_core:
+        required: false
+        type: boolean
+        default: false
+      validate_fly_ui_builder:
+        required: false
+        type: boolean
+        default: false
+      validate_entrypoint_modes:
+        required: false
+        type: boolean
+        default: false
+      validate_workflow_no_qemu:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  precheck:
+    name: ${{ inputs.job_name }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Validate target Dockerfile exists
+        run: test -f "${{ inputs.dockerfile_path }}"
+
+      - name: UI build precedes cargo build
+        if: ${{ inputs.validate_shared_core || inputs.validate_fly_ui_builder }}
+        run: |
+          set -euo pipefail
+          file="${{ inputs.dockerfile_path }}"
+          ui_line="$(grep -n "COPY --from=ui-builder" "$file" | head -1 | cut -d: -f1 || true)"
+          build_line="$(grep -n "cargo build" "$file" | head -1 | cut -d: -f1 || true)"
+          if [[ -z "$ui_line" || -z "$build_line" || "$ui_line" -ge "$build_line" ]]; then
+            echo "UI dist must be copied before cargo build in $file" >&2
+            exit 1
+          fi
+
+      - name: Explicit workspace copy pattern is preserved
+        if: ${{ inputs.validate_shared_core }}
+        run: |
+          set -euo pipefail
+          file="${{ inputs.dockerfile_path }}"
+          if grep -qE '^\s*COPY \. \.' "$file"; then
+            echo "Blanket COPY . . is not allowed in $file" >&2
+            exit 1
+          fi
+          grep -qE '^\s*COPY\s+Cargo\.toml\s+Cargo\.lock\s+\./?$' "$file"
+          for path in \
+            crates/mesh-llm/ \
+            crates/mesh-llm-plugin/ \
+            crates/mesh-client/ \
+            crates/mesh-api/ \
+            crates/mesh-host-core/ \
+            crates/mesh-api-ffi/ \
+            crates/mesh-llm-test-harness/ \
+            crates/model-ref/ \
+            crates/model-artifact/ \
+            crates/model-hf/ \
+            crates/skippy-protocol/ \
+            crates/skippy-topology/ \
+            crates/skippy-ffi/ \
+            crates/skippy-runtime/ \
+            crates/skippy-server/ \
+            crates/skippy-model-package/ \
+            crates/skippy-correctness/ \
+            crates/skippy-bench/ \
+            tools/xtask/
+          do
+            grep -q "COPY ${path} ${path}" "$file"
+          done
+
+      - name: Llama patch queue is used
+        if: ${{ inputs.validate_shared_core }}
+        run: |
+          set -euo pipefail
+          file="${{ inputs.dockerfile_path }}"
+          grep -q "scripts/prepare-llama.sh pinned" "$file"
+          grep -q "scripts/build-llama.sh" "$file"
+          grep -q "third_party/llama.cpp/patches" "$file"
+
+      - name: Runtime apt libraries are present
+        if: ${{ inputs.validate_shared_core }}
+        run: |
+          set -euo pipefail
+          file="${{ inputs.dockerfile_path }}"
+          grep -q "ca-certificates" "$file"
+          grep -q "libgomp1" "$file"
+          grep -q "libdbus-1-3" "$file"
+
+      - name: Fly Dockerfile includes UI builder stage
+        if: ${{ inputs.validate_fly_ui_builder }}
+        run: |
+          set -euo pipefail
+          file="${{ inputs.dockerfile_path }}"
+          grep -q "AS ui-builder" "$file"
+          grep -q "COPY --from=ui-builder" "$file"
+
+      - name: Entrypoint supports console worker and default modes only
+        if: ${{ inputs.validate_entrypoint_modes }}
+        run: |
+          set -euo pipefail
+          grep -qE '^\s*console\)' docker/entrypoint.sh
+          grep -qE '^\s*worker\)' docker/entrypoint.sh
+          grep -qE '^\s*\*\)' docker/entrypoint.sh
+          if grep -qE '^\s*api\)' docker/entrypoint.sh; then
+            echo "api mode should not be a separate entrypoint mode" >&2
+            exit 1
+          fi
+
+      - name: Docker workflow avoids QEMU-based runners
+        if: ${{ inputs.validate_workflow_no_qemu }}
+        run: |
+          set -euo pipefail
+          if grep -qiE '(^|[^[:alnum:]_])qemu([^[:alnum:]_]|$)' .github/workflows/docker.yml; then
+            echo "QEMU tooling reference found in docker.yml" >&2
+            exit 1
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: docker
+name: Docker
 
 on:
   push:
@@ -13,6 +13,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - '.github/workflows/docker.yml'
+      - '.github/workflows/docker-precheck.yml'
 
 concurrency:
   group: docker-${{ github.ref }}
@@ -27,7 +28,25 @@ permissions:
   packages: write
 
 jobs:
-  docker-client:
+  docker-validate-client:
+    uses: ./.github/workflows/docker-precheck.yml
+    with:
+      job_name: Validate client Dockerfile
+      dockerfile_path: docker/Dockerfile.client
+      validate_shared_core: true
+      validate_entrypoint_modes: true
+      validate_workflow_no_qemu: true
+
+  docker-validate-fly-console:
+    uses: ./.github/workflows/docker-precheck.yml
+    with:
+      job_name: Validate Fly Dockerfile
+      dockerfile_path: fly/Dockerfile
+      validate_shared_core: true
+      validate_fly_ui_builder: true
+
+  docker-client-amd64:
+    needs: [docker-validate-client, docker-validate-fly-console]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -43,17 +62,73 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' }}
             type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=client,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=client-amd64,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
       - uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile.client
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-client-arm64:
+    needs: [docker-validate-client, docker-validate-fly-console]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}-arm64
+            type=sha,prefix=sha-,suffix=-arm64,format=short
+            type=raw,value=client-arm64
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.client
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-fly-console:
+    needs: docker-validate-fly-console
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}-fly-console
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-,format=short
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: fly/Dockerfile
+          platforms: linux/amd64
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/gpu-warm-cache-job.yml
+++ b/.github/workflows/gpu-warm-cache-job.yml
@@ -1,0 +1,113 @@
+name: GPU warm cache job
+
+on:
+  workflow_call:
+    inputs:
+      job_name:
+        required: true
+        type: string
+      cache_label:
+        required: true
+        type: string
+      container_image:
+        required: true
+        type: string
+      llama_sha:
+        required: true
+        type: string
+      cache_key:
+        required: true
+        type: string
+      build_recipe:
+        required: true
+        type: string
+      build_args:
+        required: false
+        type: string
+        default: ''
+      cache_path:
+        required: true
+        type: string
+      backend:
+        required: true
+        type: string
+      runs_on:
+        required: false
+        type: string
+        default: '"ubuntu-latest"'
+
+permissions:
+  actions: read
+  contents: read
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+
+jobs:
+  warm_cache:
+    name: ${{ inputs.job_name }}
+    runs-on: ${{ fromJson(inputs.runs_on) }}
+    container:
+      image: ${{ inputs.container_image }}
+    env:
+      LLAMA_STAGE_BUILD_DIR: ${{ inputs.cache_path }}
+      LLAMA_STAGE_BACKEND: ${{ inputs.backend }}
+      MESH_LLM_SKIP_UI: "1"
+
+    steps:
+      - name: Install base packages
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          rm -rf /var/lib/apt/lists/*
+
+      - uses: actions/checkout@v5
+
+      - uses: taiki-e/install-action@just
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+          prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
+
+      - name: Prepare UI placeholder
+        run: mkdir -p crates/mesh-llm/ui/dist && printf '<html></html>' > crates/mesh-llm/ui/dist/index.html
+
+      - name: Restore skippy ABI ${{ inputs.cache_label }} build
+        id: llama_cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ inputs.cache_path }}
+          key: ${{ inputs.cache_key }}
+
+      - name: Build ${{ inputs.cache_label }} ABI cache
+        if: steps.llama_cache.outputs.cache-hit != 'true'
+        env:
+          MESH_LLM_LLAMA_PIN_SHA: ${{ inputs.llama_sha }}
+          BUILD_RECIPE: ${{ inputs.build_recipe }}
+          BUILD_ARGS: ${{ inputs.build_args }}
+        run: |
+          set -euo pipefail
+          if [[ -n "$BUILD_ARGS" ]]; then
+            read -r -a build_args <<< "$BUILD_ARGS"
+            just --shell bash --shell-arg -lc "$BUILD_RECIPE" "${build_args[@]}"
+          else
+            just --shell bash --shell-arg -lc "$BUILD_RECIPE"
+          fi
+
+      - name: Verify ${{ inputs.cache_label }} ABI build
+        run: |
+          set -euo pipefail
+          test -d "${{ inputs.cache_path }}"
+          find "${{ inputs.cache_path }}" -maxdepth 3 -type f \( -name '*.a' -o -name 'libllama*' \) | head -20
+
+      - name: Save skippy ABI ${{ inputs.cache_label }} build
+        if: steps.llama_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ inputs.cache_path }}
+          key: ${{ steps.llama_cache.outputs.cache-primary-key }}

--- a/.github/workflows/gpu-warm-cache-job.yml
+++ b/.github/workflows/gpu-warm-cache-job.yml
@@ -57,8 +57,19 @@ jobs:
     steps:
       - name: Install base packages
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if apt-get update -o Acquire::Retries=3 && \
+              DEBIAN_FRONTEND=noninteractive apt-get install -y -o Acquire::Retries=3 ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential; then
+              break
+            fi
+
+            if [[ "$attempt" -eq 3 ]]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
           rm -rf /var/lib/apt/lists/*
 
       - uses: actions/checkout@v5

--- a/.github/workflows/llama-cache-keys.yml
+++ b/.github/workflows/llama-cache-keys.yml
@@ -1,0 +1,99 @@
+name: Resolve llama.cpp cache keys
+
+on:
+  workflow_call:
+    outputs:
+      cache_namespace:
+        description: Shared cache namespace for llama.cpp artifacts
+        value: ${{ jobs.resolve.outputs.cache_namespace }}
+      cuda_version:
+        description: CUDA version fragment used in cache keys and image tags
+        value: ${{ jobs.resolve.outputs.cuda_version }}
+      sha:
+        description: Resolved llama.cpp upstream SHA
+        value: ${{ jobs.resolve.outputs.sha }}
+      cuda_cache_inputs_hash:
+        description: Hash of repo inputs that affect CUDA cache artifacts
+        value: ${{ jobs.resolve.outputs.cuda_cache_inputs_hash }}
+      rocm_cache_inputs_hash:
+        description: Hash of repo inputs that affect ROCm cache artifacts
+        value: ${{ jobs.resolve.outputs.rocm_cache_inputs_hash }}
+      cuda_slim_cache_key:
+        description: Exact slim CUDA cache key
+        value: ${{ jobs.resolve.outputs.cuda_slim_cache_key }}
+      cuda_fat_cache_key:
+        description: Exact fat CUDA cache key
+        value: ${{ jobs.resolve.outputs.cuda_fat_cache_key }}
+      rocm_slim_cache_key:
+        description: Exact slim ROCm cache key
+        value: ${{ jobs.resolve.outputs.rocm_slim_cache_key }}
+      rocm_fat_cache_key:
+        description: Exact fat ROCm cache key
+        value: ${{ jobs.resolve.outputs.rocm_fat_cache_key }}
+
+permissions:
+  contents: read
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+
+jobs:
+  resolve:
+    name: Resolve llama.cpp cache keys
+    runs-on: ubuntu-latest
+    outputs:
+      cache_namespace: ${{ steps.cache_namespace.outputs.value }}
+      cuda_version: ${{ steps.cuda_version.outputs.value }}
+      sha: ${{ steps.resolve.outputs.sha }}
+      cuda_cache_inputs_hash: ${{ steps.cache_inputs.outputs.cuda_hash }}
+      rocm_cache_inputs_hash: ${{ steps.cache_inputs.outputs.rocm_hash }}
+      cuda_slim_cache_key: ${{ steps.render.outputs.cuda_slim_cache_key }}
+      cuda_fat_cache_key: ${{ steps.render.outputs.cuda_fat_cache_key }}
+      rocm_slim_cache_key: ${{ steps.render.outputs.rocm_slim_cache_key }}
+      rocm_fat_cache_key: ${{ steps.render.outputs.rocm_fat_cache_key }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Expose cache namespace
+        id: cache_namespace
+        run: echo "value=${CACHE_NAMESPACE}" >> "$GITHUB_OUTPUT"
+
+      - name: Expose CUDA version
+        id: cuda_version
+        run: echo "value=${{ vars.CUDA_VERSION || '12.8.0' }}" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve llama.cpp SHA
+        id: resolve
+        run: |
+          set -euo pipefail
+          SHA="$(tr -d '[:space:]' < third_party/llama.cpp/upstream.txt)"
+          if [[ -z "$SHA" ]]; then
+            echo "Failed to resolve llama.cpp SHA" >&2
+            exit 1
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Hash cache-key inputs
+        id: cache_inputs
+        run: |
+          set -euo pipefail
+          echo "cuda_hash=${{ hashFiles('scripts/build-linux.sh', 'scripts/build-llama.sh', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', 'Justfile', '.github/workflows/ci.yml', '.github/workflows/warm-caches.yml', '.github/workflows/gpu-warm-cache-job.yml', '.github/workflows/llama-cache-keys.yml', '.github/cache-version.txt') }}" >> "$GITHUB_OUTPUT"
+          echo "rocm_hash=${{ hashFiles('scripts/build-linux.sh', 'scripts/build-linux-rocm.sh', 'scripts/build-llama.sh', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', 'Justfile', '.github/workflows/ci.yml', '.github/workflows/warm-caches.yml', '.github/workflows/gpu-warm-cache-job.yml', '.github/workflows/llama-cache-keys.yml', '.github/cache-version.txt') }}" >> "$GITHUB_OUTPUT"
+
+      - name: Render cache keys
+        id: render
+        env:
+          CACHE_NAMESPACE: ${{ steps.cache_namespace.outputs.value }}
+          CUDA_VERSION: ${{ steps.cuda_version.outputs.value }}
+          LLAMA_SHA: ${{ steps.resolve.outputs.sha }}
+          CUDA_HASH: ${{ steps.cache_inputs.outputs.cuda_hash }}
+          ROCM_HASH: ${{ steps.cache_inputs.outputs.rocm_hash }}
+        run: |
+          set -euo pipefail
+          {
+            echo "cuda_slim_cache_key=${CACHE_NAMESPACE}-skippy-abi-cuda-slim-${LLAMA_SHA}-${CUDA_HASH}-arch89-cuda${CUDA_VERSION}"
+            echo "cuda_fat_cache_key=${CACHE_NAMESPACE}-skippy-abi-cuda-fat-${LLAMA_SHA}-${CUDA_HASH}-arch75-80-86-87-89-90-100-120-cuda${CUDA_VERSION}"
+            echo "rocm_slim_cache_key=${CACHE_NAMESPACE}-skippy-abi-rocm-slim-${LLAMA_SHA}-${ROCM_HASH}-gfx1100-rocm7.0"
+            echo "rocm_fat_cache_key=${CACHE_NAMESPACE}-skippy-abi-rocm-fat-${LLAMA_SHA}-${ROCM_HASH}-gfx90a-gfx942-gfx1100-gfx1101-gfx1102-gfx1200-gfx1201-rocm7.0"
+          } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/llama-upstream-canary.yml
+++ b/.github/workflows/llama-upstream-canary.yml
@@ -12,23 +12,21 @@ on:
 permissions:
   contents: write
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+  LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
+
 jobs:
-  latest-upstream:
+  latest_upstream:
+    name: Resolve latest upstream
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
+    outputs:
+      old_sha: ${{ steps.sha.outputs.old_sha }}
+      new_sha: ${{ steps.sha.outputs.new_sha }}
+      changed: ${{ steps.sha.outputs.changed }}
     steps:
       - uses: actions/checkout@v5
-
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: taiki-e/install-action@just
-
-      - uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build build-essential libcurl4-openssl-dev
 
       - name: Prepare requested llama.cpp upstream
         env:
@@ -48,29 +46,82 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
+  linux_build:
+    name: Build upstream candidate
+    needs: latest_upstream
+    if: needs.latest_upstream.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@just
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake ninja-build build-essential pkg-config libssl-dev libdbus-1-dev curl jq lsof
+
+      - name: Prepare upstream candidate
+        run: scripts/prepare-llama.sh "${{ needs.latest_upstream.outputs.new_sha }}"
+
       - name: Build patched llama.cpp ABI
-        if: steps.sha.outputs.changed == 'true'
         run: scripts/build-llama.sh
 
+      - name: Prepare UI placeholder
+        run: mkdir -p crates/mesh-llm/ui/dist && printf '<html></html>' > crates/mesh-llm/ui/dist/index.html
+
       - name: Build stage runtime crates
-        if: steps.sha.outputs.changed == 'true'
-        run: cargo check -p skippy-ffi -p skippy-runtime -p skippy-server -p skippy-model-package -p skippy-correctness -p llama-spec-bench
+        run: cargo check -p skippy-ffi -p skippy-runtime -p skippy-server -p skippy-model-package -p skippy-correctness -p llama-spec-bench -p mesh-llm
+
+      - name: Build mesh-llm binary
+        run: cargo build -p mesh-llm --bin mesh-llm
+
+      - name: Upload canary inference binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: canary-linux-inference-binary
+          path: target/debug/mesh-llm
+          if-no-files-found: error
+
+      - name: Show sccache stats
+        if: always()
+        run: sccache --show-stats || true
+
+  inference_smoke_tests:
+    needs: [latest_upstream, linux_build]
+    if: needs.latest_upstream.outputs.changed == 'true' && needs.linux_build.result == 'success'
+    uses: ./.github/workflows/smoke.yml
+    with:
+      artifact_name: canary-linux-inference-binary
+      mesh_binary_target: target/debug/mesh-llm
+      cache_key_prefix: canary-
+      workflow_cache_file: .github/workflows/llama-upstream-canary.yml
+
+  update_main_pin:
+    name: Push upstream pin branch
+    needs: [latest_upstream, linux_build, inference_smoke_tests]
+    if: needs.latest_upstream.outputs.changed == 'true' && needs.linux_build.result == 'success' && needs.inference_smoke_tests.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Prepare upstream candidate
+        run: scripts/prepare-llama.sh "${{ needs.latest_upstream.outputs.new_sha }}"
 
       - name: Update llama.cpp upstream pin
-        if: steps.sha.outputs.changed == 'true'
         run: scripts/update-llama-pin.sh
 
       - name: Generate summary
-        if: steps.sha.outputs.changed == 'true'
         run: |
           scripts/summarize-llama-upstream.sh \
-            "${{ steps.sha.outputs.old_sha }}" \
-            "${{ steps.sha.outputs.new_sha }}" \
+            "${{ needs.latest_upstream.outputs.old_sha }}" \
+            "${{ needs.latest_upstream.outputs.new_sha }}" \
             .deps/llama.cpp \
             > /tmp/llama-upstream-pr.md
 
       - name: Push upstream pin branch
-        if: steps.sha.outputs.changed == 'true'
         env:
           BRANCH: automation/update-llama-upstream
         run: |
@@ -91,7 +142,6 @@ jobs:
           fi
 
       - name: Report upstream pin branch
-        if: steps.sha.outputs.changed == 'true'
         run: |
           {
             echo "## llama.cpp upstream pin update"
@@ -100,7 +150,3 @@ jobs:
             echo
             cat /tmp/llama-upstream-pr.md
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,7 +269,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl glslc libvulkan-dev
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl glslc libvulkan-dev spirv-headers
       - name: Build Vulkan release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -292,6 +292,8 @@ jobs:
       - build_linux_cuda
       - build_linux_rocm
       - build_linux_vulkan
+      # build_windows:
+      # - build_windows  # disabled until llama.cpp CUDA fix
     if: ${{ always() && needs.metadata.result == 'success' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,330 @@
-name: release
+name: Release
 
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version/tag to build, for example v0.31.0
+        required: true
+        type: string
+      skip_gpu_bundles:
+        description: Skip Linux CUDA, ROCm, and Vulkan release bundles
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: release-${{ github.repository }}-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
+  packages: write
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+  SCCACHE_GHA_ENABLED: "true"
 
 jobs:
-  linux:
+  metadata:
+    name: Resolve release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      version: ${{ steps.meta.outputs.version }}
+      prerelease: ${{ steps.meta.outputs.prerelease }}
+      skip_gpu_bundles: ${{ steps.meta.outputs.skip_gpu_bundles }}
+    steps:
+      - id: meta
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_SKIP_GPU_BUNDLES: ${{ inputs.skip_gpu_bundles || 'false' }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            tag="${INPUT_VERSION}"
+          fi
+          tag="v${tag#v}"
+          version="${tag#v}"
+          if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid release version: $tag" >&2
+            exit 1
+          fi
+          prerelease=false
+          if [[ "$version" == *-* ]]; then
+            prerelease=true
+          fi
+          {
+            echo "tag=$tag"
+            echo "version=$version"
+            echo "prerelease=$prerelease"
+            echo "skip_gpu_bundles=$INPUT_SKIP_GPU_BUNDLES"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: metadata
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS aarch64 Metal
+            os: macos-14
+            artifact_name: release-macos
+            build_recipe: release-build
+            bundle_recipe: release-bundle
+            backend: metal
+          - name: Linux x86_64 CPU
+            os: ubuntu-latest
+            artifact_name: release-linux
+            build_recipe: release-build
+            bundle_recipe: release-bundle
+            backend: cpu
+    env:
+      LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: taiki-e/install-action@just
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install cmake ninja
+
+      - name: Build release bundle
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: |
+          just --shell bash --shell-arg -lc ${{ matrix.build_recipe }}
+          just --shell bash --shell-arg -lc ${{ matrix.bundle_recipe }} "$RELEASE_TAG" dist
+
+      - name: Upload release bundle
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/*
+          if-no-files-found: error
+
+      - name: Upload Linux smoke binary
+        if: matrix.artifact_name == 'release-linux'
+        uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-inference-binary
+          path: target/release/mesh-llm
+          if-no-files-found: error
+
+  inference_smoke_tests:
+    needs: [metadata, build]
+    if: needs.build.result == 'success'
+    uses: ./.github/workflows/smoke.yml
+    with:
+      artifact_name: release-linux-inference-binary
+      mesh_binary_target: target/release/mesh-llm
+      cache_key_prefix: release-
+      workflow_cache_file: .github/workflows/release.yml
+
+  build_linux_arm64:
+    name: Build Linux ARM64 CPU
+    needs: metadata
+    runs-on: ubuntu-24.04-arm
+    env:
+      LLAMA_STAGE_BACKEND: cpu
+      MESH_RELEASE_ARCH: aarch64
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl
+      - name: Build ARM64 CPU release bundle
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: |
+          just --shell bash --shell-arg -lc release-build-arm64
+          just --shell bash --shell-arg -lc release-bundle-arm64 "$RELEASE_TAG" dist
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-arm64
+          path: dist/*
+          if-no-files-found: error
+
+  build_linux_cuda:
+    name: Build Linux CUDA
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.8.0' }}-devel-ubuntu22.04
+    env:
+      LLAMA_STAGE_BACKEND: cuda
+    steps:
+      - name: Install base packages
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - name: Build CUDA release bundle
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: |
+          just --shell bash --shell-arg -lc release-build-cuda
+          just --shell bash --shell-arg -lc release-bundle-cuda "$RELEASE_TAG" dist
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-cuda
+          path: dist/*
+          if-no-files-found: error
+
+  build_linux_rocm:
+    name: Build Linux ROCm
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-latest
+    container:
+      image: rocm/dev-ubuntu-24.04:7.0-complete
+    env:
+      LLAMA_STAGE_BACKEND: rocm
+    steps:
+      - name: Install base packages
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          rm -rf /var/lib/apt/lists/*
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - name: Build ROCm release bundle
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: |
+          just --shell bash --shell-arg -lc release-build-rocm
+          just --shell bash --shell-arg -lc release-bundle-rocm "$RELEASE_TAG" dist
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-rocm
+          path: dist/*
+          if-no-files-found: error
+
+  build_linux_vulkan:
+    name: Build Linux Vulkan
+    needs: metadata
+    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: ubuntu-latest
     env:
-      LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
+      LLAMA_STAGE_BACKEND: vulkan
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@just
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl glslc libvulkan-dev
+      - name: Build Vulkan release bundle
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: |
+          just --shell bash --shell-arg -lc release-build-vulkan
+          just --shell bash --shell-arg -lc release-bundle-vulkan "$RELEASE_TAG" dist
+      - uses: actions/upload-artifact@v6
+        with:
+          name: release-linux-vulkan
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish GitHub release
+    needs:
+      - metadata
+      - build
+      - inference_smoke_tests
+      - build_linux_arm64
+      - build_linux_cuda
+      - build_linux_rocm
+      - build_linux_vulkan
+    if: ${{ always() && needs.metadata.result == 'success' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v7
+        with:
+          path: release-artifacts
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Remove smoke-only binary
+        run: rm -f release-artifacts/mesh-llm
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.metadata.outputs.tag }}
+          prerelease: ${{ needs.metadata.outputs.prerelease }}
+          files: release-artifacts/*
+
+  publish_crates:
+    name: Publish crates.io packages
+    needs: [metadata, publish]
+    if: ${{ needs.metadata.outputs.prerelease != 'true' }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@just
-      - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev curl
-      - name: Build release
-        run: just release-build
-      - name: Package release
-        run: just release-bundle "${GITHUB_REF_NAME}"
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
+      - name: Publish mesh-llm-client
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked -p mesh-llm-client
+      - name: Publish mesh-api
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked -p mesh-api

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,8 +188,15 @@ jobs:
     steps:
       - name: Install base packages
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -225,8 +232,15 @@ jobs:
     steps:
       - name: Install base packages
         run: |
-          apt-get update
-          DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+          for attempt in 1 2 3; do
+            apt-get -o Acquire::Retries=5 update &&
+              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential &&
+              break
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
           rm -rf /var/lib/apt/lists/*
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,104 @@
+name: Reusable Smoke Tests
+
+on:
+  workflow_call:
+    inputs:
+      artifact_name:
+        required: true
+        type: string
+      mesh_binary_target:
+        required: true
+        type: string
+      cache_key_prefix:
+        required: true
+        type: string
+      workflow_cache_file:
+        required: true
+        type: string
+      runs_on:
+        required: false
+        default: '"ubuntu-latest"'
+        type: string
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+  MODEL_URL: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
+  MODEL_FILE: SmolLM2-135M-Instruct-Q8_0.gguf
+
+jobs:
+  smoke_tests:
+    name: Skippy Inference Smoke Tests
+    runs-on: ${{ fromJson(inputs.runs_on) }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            .github/cache-version.txt
+            ci/requirements-ci-python.txt
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: |
+            .github/cache-version.txt
+            crates/mesh-llm/ui/package-lock.json
+
+      - name: Install smoke dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y curl jq lsof
+          python -m pip install --upgrade pip -r ci/requirements-ci-python.txt
+          npm install --global openai
+
+      - name: Download Linux inference binary
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ci-artifacts/linux
+
+      - name: Stage binary for inference smokes
+        run: |
+          mkdir -p "$(dirname "${{ inputs.mesh_binary_target }}")"
+          cp ci-artifacts/linux/mesh-llm "${{ inputs.mesh_binary_target }}"
+          chmod +x "${{ inputs.mesh_binary_target }}"
+          test -x "${{ inputs.mesh_binary_target }}"
+
+      - name: Cache integration model
+        id: cache-model
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ inputs.cache_key_prefix }}${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/smoke.yml', inputs.workflow_cache_file) }}
+
+      - name: Download integration model
+        if: steps.cache-model.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.models
+          curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
+          ls -lh "$HOME/.models/$MODEL_FILE"
+
+      - name: Save integration model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ steps.cache-model.outputs.cache-primary-key }}
+
+      - name: Smoke test real skippy inference
+        run: |
+          scripts/ci-smoke-test.sh \
+            "${{ inputs.mesh_binary_target }}" \
+            ci-artifacts/linux \
+            "$HOME/.models/$MODEL_FILE"
+
+      - name: OpenAI client compatibility smoke
+        run: |
+          scripts/ci-compat-smoke.sh \
+            "${{ inputs.mesh_binary_target }}" \
+            ci-artifacts/linux \
+            "$HOME/.models/$MODEL_FILE"

--- a/.github/workflows/warm-caches.yml
+++ b/.github/workflows/warm-caches.yml
@@ -1,0 +1,158 @@
+name: Warm GPU CI caches
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/build-linux.sh'
+      - 'scripts/build-linux-rocm.sh'
+      - 'scripts/build-llama.sh'
+      - 'third_party/llama.cpp/**'
+      - 'Justfile'
+      - '.github/workflows/ci.yml'
+      - '.github/workflows/warm-caches.yml'
+      - '.github/workflows/gpu-warm-cache-job.yml'
+      - '.github/workflows/llama-cache-keys.yml'
+      - '.github/cache-version.txt'
+  workflow_dispatch:
+    inputs:
+      retention:
+        description: 'Number of warmed GPU cache versions to keep'
+        required: false
+        default: ''
+
+concurrency:
+  group: warm-caches-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+  LLAMA_GPU_CACHE_RETENTION: ${{ github.event.inputs.retention || vars.LLAMA_GPU_CACHE_RETENTION || '2' }}
+
+jobs:
+  resolve_llama_cache_keys:
+    uses: ./.github/workflows/llama-cache-keys.yml
+
+  warm_llama_cuda_slim:
+    needs: resolve_llama_cache_keys
+    uses: ./.github/workflows/gpu-warm-cache-job.yml
+    with:
+      job_name: Warm Linux CUDA slim ABI cache
+      cache_label: CUDA slim
+      container_image: nvidia/cuda:${{ needs.resolve_llama_cache_keys.outputs.cuda_version }}-devel-ubuntu22.04
+      llama_sha: ${{ needs.resolve_llama_cache_keys.outputs.sha }}
+      runs_on: ${{ vars.CACHE_USE_SELF_HOSTED_RUNNER == '1' && '["self-hosted","gpu-nvidia"]' || '"ubuntu-latest"' }}
+      cache_key: ${{ needs.resolve_llama_cache_keys.outputs.cuda_slim_cache_key }}
+      cache_path: .deps/llama-build/build-stage-abi-cuda-sm89
+      backend: cuda
+      build_recipe: release-build-cuda
+      build_args: 89
+
+  warm_llama_cuda_fat:
+    needs: resolve_llama_cache_keys
+    uses: ./.github/workflows/gpu-warm-cache-job.yml
+    with:
+      job_name: Warm Linux CUDA fat ABI cache
+      cache_label: CUDA fat
+      container_image: nvidia/cuda:${{ needs.resolve_llama_cache_keys.outputs.cuda_version }}-devel-ubuntu22.04
+      llama_sha: ${{ needs.resolve_llama_cache_keys.outputs.sha }}
+      runs_on: ${{ vars.CACHE_USE_SELF_HOSTED_RUNNER == '1' && '["self-hosted","gpu-nvidia"]' || '"ubuntu-latest"' }}
+      cache_key: ${{ needs.resolve_llama_cache_keys.outputs.cuda_fat_cache_key }}
+      cache_path: .deps/llama-build/build-stage-abi-cuda-sm75_80_86_87_89_90_100_120
+      backend: cuda
+      build_recipe: release-build-cuda
+
+  warm_llama_rocm_slim:
+    needs: resolve_llama_cache_keys
+    uses: ./.github/workflows/gpu-warm-cache-job.yml
+    with:
+      job_name: Warm Linux ROCm slim ABI cache
+      cache_label: ROCm slim
+      container_image: rocm/dev-ubuntu-24.04:7.0-complete
+      llama_sha: ${{ needs.resolve_llama_cache_keys.outputs.sha }}
+      runs_on: '"ubuntu-latest"'
+      cache_key: ${{ needs.resolve_llama_cache_keys.outputs.rocm_slim_cache_key }}
+      cache_path: .deps/llama-build/build-stage-abi-rocm-gfx1100
+      backend: rocm
+      build_recipe: release-build-rocm
+      build_args: gfx1100
+
+  warm_llama_rocm_fat:
+    needs: resolve_llama_cache_keys
+    uses: ./.github/workflows/gpu-warm-cache-job.yml
+    with:
+      job_name: Warm Linux ROCm fat ABI cache
+      cache_label: ROCm fat
+      container_image: rocm/dev-ubuntu-24.04:7.0-complete
+      llama_sha: ${{ needs.resolve_llama_cache_keys.outputs.sha }}
+      runs_on: '"ubuntu-latest"'
+      cache_key: ${{ needs.resolve_llama_cache_keys.outputs.rocm_fat_cache_key }}
+      cache_path: .deps/llama-build/build-stage-abi-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1200_gfx1201
+      backend: rocm
+      build_recipe: release-build-rocm
+
+  prune_llama_gpu_caches:
+    name: Prune old GPU caches
+    needs:
+      - warm_llama_cuda_slim
+      - warm_llama_cuda_fat
+      - warm_llama_rocm_slim
+      - warm_llama_rocm_fat
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune old GPU caches
+        uses: actions/github-script@v8
+        env:
+          CACHE_NAMESPACE: ${{ env.CACHE_NAMESPACE }}
+          RETENTION: ${{ env.LLAMA_GPU_CACHE_RETENTION }}
+          TARGET_REF: ${{ github.ref }}
+        with:
+          script: |
+            const retention = parseInt(process.env.RETENTION, 10);
+            const ref = process.env.TARGET_REF;
+            const prefixes = [
+              `${process.env.CACHE_NAMESPACE}-skippy-abi-cuda-slim-`,
+              `${process.env.CACHE_NAMESPACE}-skippy-abi-cuda-fat-`,
+              `${process.env.CACHE_NAMESPACE}-skippy-abi-rocm-slim-`,
+              `${process.env.CACHE_NAMESPACE}-skippy-abi-rocm-fat-`,
+            ];
+
+            if (!Number.isFinite(retention) || retention < 1) {
+              core.setFailed(`LLAMA_GPU_CACHE_RETENTION must be positive, got: "${process.env.RETENTION}"`);
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const allCaches = [];
+            for (let page = 1; page <= 10; page++) {
+              const { data } = await github.request('GET /repos/{owner}/{repo}/actions/caches', {
+                owner,
+                repo,
+                ref,
+                per_page: 100,
+                page,
+                sort: 'created_at',
+                direction: 'desc',
+              });
+              const pageCaches = data.actions_caches || [];
+              allCaches.push(...pageCaches);
+              if (pageCaches.length < 100) break;
+            }
+
+            for (const prefix of prefixes) {
+              const matching = allCaches.filter((c) => c.key.startsWith(prefix));
+              for (const cache of matching.slice(retention)) {
+                await github.request('DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}', {
+                  owner,
+                  repo,
+                  cache_id: cache.id,
+                });
+              }
+              core.notice(`Pruned ${Math.max(matching.length - retention, 0)} cache(s) for ${prefix}`);
+            }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,6 +36,14 @@ just release-build
 just release-bundle v0.X.Y
 ```
 
+The current GitHub Actions release workflow publishes CPU bundles for macOS
+aarch64, Linux x86_64, and Linux ARM64. The Linux ARM64 artifact is named
+`mesh-llm-aarch64-unknown-linux-gnu.tar.gz`.
+
+Windows release bundles are not expected from the current GitHub Actions workflow while the publish block stays commented out.
+
+On native Windows, `just check-release` still runs the Rust/docs/workflow invariant checks, but it skips the Bash-only `install.sh` and `scripts/package-release.sh` parity checks.
+
 ## Smoke Test
 
 ```bash

--- a/crates/mesh-llm/src/inference/skippy/hooks.rs
+++ b/crates/mesh-llm/src/inference/skippy/hooks.rs
@@ -183,7 +183,7 @@ struct HookDebugForce {
     mid_generation: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 struct HookDebugConfig {
     force: HookDebugForce,
     injected_text: Option<String>,
@@ -221,15 +221,6 @@ impl HookDebugConfig {
                 .clone()
                 .unwrap_or_else(|| format!("[Mesh hook debug: forced {}]\n\n", point.label())),
         ))
-    }
-}
-
-impl Default for HookDebugConfig {
-    fn default() -> Self {
-        Self {
-            force: HookDebugForce::default(),
-            injected_text: None,
-        }
     }
 }
 

--- a/crates/mesh-llm/src/inference/skippy/stage.rs
+++ b/crates/mesh-llm/src/inference/skippy/stage.rs
@@ -16,6 +16,7 @@ pub(crate) struct StageControlCommand {
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum StageControlRequest {
     Load(StageLoadRequest),
     Stop(StageStopRequest),
@@ -23,6 +24,7 @@ pub(crate) enum StageControlRequest {
 }
 
 #[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum StageControlResponse {
     Ready(StageReadyResponse),
     Status(Vec<StageStatusSnapshot>),

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -74,6 +74,7 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
     pub(super) slots: usize,
 }
 
+#[allow(clippy::large_enum_variant)]
 pub(super) enum SplitRuntimeStart {
     Started(SplitRuntimeGenerationHandle),
     Standby { coordinator: iroh::EndpointId },

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -218,7 +218,7 @@ async fn responses(
                             out.push(
                                 Event::default()
                                     .event("response.created")
-                                    .json_data(&responses_stream_created_event(
+                                    .json_data(responses_stream_created_event(
                                         &state_machine.model,
                                         state_machine.created_at,
                                     ))
@@ -235,7 +235,7 @@ async fn responses(
                             out.push(
                                 Event::default()
                                     .event("response.output_text.delta")
-                                    .json_data(&responses_stream_delta_event_with_logprobs(
+                                    .json_data(responses_stream_delta_event_with_logprobs(
                                         &state_machine.item_id,
                                         &delta,
                                         logprobs,
@@ -251,7 +251,7 @@ async fn responses(
                         out.push(
                             Event::default()
                                 .event("error")
-                                .json_data(&error.body())
+                                .json_data(error.body())
                                 .unwrap_or_else(|_| Event::default().data("{}")),
                         );
                     }
@@ -267,7 +267,7 @@ async fn responses(
                     out.push(
                         Event::default()
                             .event("response.created")
-                            .json_data(&responses_stream_created_event(
+                            .json_data(responses_stream_created_event(
                                 &state_machine.model,
                                 state_machine.created_at,
                             ))
@@ -278,7 +278,7 @@ async fn responses(
                 out.push(
                     Event::default()
                         .event("response.output_text.done")
-                        .json_data(&responses_stream_text_done_event(
+                        .json_data(responses_stream_text_done_event(
                             &state_machine.item_id,
                             &state_machine.output_text,
                         ))
@@ -287,7 +287,7 @@ async fn responses(
                 out.push(
                     Event::default()
                         .event("response.completed")
-                        .json_data(&responses_stream_completed_event(
+                        .json_data(responses_stream_completed_event(
                             &state_machine.response_id,
                             state_machine.created_at,
                             &state_machine.model,

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -34,10 +34,7 @@ fn main() {
                 workspace_root.join(path)
             }
         })
-        .unwrap_or_else(|_| {
-            let default_dir = workspace_root.join(".deps/llama.cpp/build-stage-abi-static");
-            default_dir
-        });
+        .unwrap_or_else(|_| workspace_root.join(".deps/llama.cpp/build-stage-abi-static"));
 
     let search_dirs = [
         build_dir.join("tools/mtmd"),

--- a/crates/skippy-protocol/src/lib.rs
+++ b/crates/skippy-protocol/src/lib.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 pub mod binary;
 pub mod proto {
     pub mod stage {
+        #![allow(clippy::large_enum_variant)]
         include!(concat!(env!("OUT_DIR"), "/skippy.stage.v1.rs"));
     }
 }

--- a/crates/skippy-server/src/binary_transport/socket.rs
+++ b/crates/skippy-server/src/binary_transport/socket.rs
@@ -70,7 +70,7 @@ pub(super) fn connect_downstream_socket(
         connect_route_selected_blocking_with_timeout(downstream_addr, source_ip, timeout)
     );
 
-    Err(io::Error::new(io::ErrorKind::Other, errors.join("; ")))
+    Err(io::Error::other(errors.join("; ")))
 }
 
 pub(super) fn connect_route_selected_with_timeout(

--- a/crates/skippy-server/src/openai.rs
+++ b/crates/skippy-server/src/openai.rs
@@ -469,6 +469,7 @@ async fn openai_http_telemetry(
     response
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone)]
 enum OpenAiBackendMode {
     LocalRuntime,
@@ -1471,6 +1472,7 @@ impl StageOpenAiBackend {
         .map_err(|error| OpenAiError::backend(format!("generation task failed: {error}")))?
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run_generation_stream(
         &self,
         prompt: PreparedGenerationPrompt,
@@ -1687,6 +1689,7 @@ impl StageOpenAiBackend {
         Ok(parsed_tool_calls_from_message_json(&parsed_json, request))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn generate_text(
         &self,
         prompt: PreparedGenerationPrompt,
@@ -2631,7 +2634,7 @@ impl StageOpenAiBackend {
                     .map_err(openai_backend_error)?;
                 let runtime_sessions_after = runtime.session_stats();
                 let runtime_lock_hold_ms = runtime_lock_hold_timer.elapsed_ms();
-                let mut attrs = self.openai_attrs(&request.ids);
+                let mut attrs = self.openai_attrs(request.ids);
                 attrs.insert(
                     "llama_stage.prefill_token_count".to_string(),
                     json!(request.prompt_token_ids.len() - 1),
@@ -2745,7 +2748,7 @@ impl StageOpenAiBackend {
                     continue;
                 }
                 decoded_tokens += 1;
-                let mut token_attrs = self.openai_attrs(&request.ids);
+                let mut token_attrs = self.openai_attrs(request.ids);
                 token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
                 token_attrs.insert(
                     "llama_stage.decode_token_phase".to_string(),
@@ -2772,7 +2775,7 @@ impl StageOpenAiBackend {
                     break;
                 }
             }
-            let mut attrs = self.openai_attrs(&request.ids);
+            let mut attrs = self.openai_attrs(request.ids);
             attrs.insert(
                 "llama_stage.decode_token_count".to_string(),
                 json!(decoded_tokens),
@@ -2818,7 +2821,7 @@ impl StageOpenAiBackend {
         if let Ok(mut runtime) = self.runtime.lock() {
             let runtime_lock_wait_ms = lock_timer.elapsed_ms();
             if let Ok(drop_stats) = runtime.drop_session_timed(&session_id) {
-                let mut attrs = self.openai_attrs(&request.ids);
+                let mut attrs = self.openai_attrs(request.ids);
                 attrs.insert(
                     "llama_stage.runtime_lock_wait_ms".to_string(),
                     json!(runtime_lock_wait_ms),
@@ -2855,7 +2858,7 @@ impl StageOpenAiBackend {
         let mut stream =
             connect_endpoint_ready(request.first_stage_addr, request.startup_timeout_secs)
                 .map_err(openai_backend_error)?;
-        let mut connect_attrs = self.openai_attrs(&request.ids);
+        let mut connect_attrs = self.openai_attrs(request.ids);
         connect_attrs.insert(
             "llama_stage.first_stage_addr".to_string(),
             json!(request.first_stage_addr),
@@ -2909,7 +2912,7 @@ impl StageOpenAiBackend {
                     chunk_index += 1;
                 }
             }
-            let mut prefill_attrs = self.openai_attrs(&request.ids);
+            let mut prefill_attrs = self.openai_attrs(request.ids);
             prefill_attrs.insert(
                 "llama_stage.prefill_token_count".to_string(),
                 json!(prefill_token_count),
@@ -2996,7 +2999,7 @@ impl StageOpenAiBackend {
                     break;
                 }
             }
-            let mut decode_attrs = self.openai_attrs(&request.ids);
+            let mut decode_attrs = self.openai_attrs(request.ids);
             decode_attrs.insert(
                 "llama_stage.decode_token_count".to_string(),
                 json!(decoded_tokens),
@@ -3055,7 +3058,7 @@ impl StageOpenAiBackend {
             .lane_pool
             .as_ref()
             .ok_or_else(|| OpenAiError::backend("embedded stage 0 has no downstream lane pool"))?;
-        let mut lane = lane_pool.checkout(&request.ids)?;
+        let mut lane = lane_pool.checkout(request.ids)?;
 
         let result = (|| {
             let downstream = &mut lane.stream;
@@ -3182,7 +3185,7 @@ impl StageOpenAiBackend {
                     chunk_index += 1;
                 }
             }
-            let mut prefill_attrs = self.openai_attrs(&request.ids);
+            let mut prefill_attrs = self.openai_attrs(request.ids);
             prefill_attrs.insert(
                 "llama_stage.prefill_token_count".to_string(),
                 json!(prefill_token_count),
@@ -3326,7 +3329,7 @@ impl StageOpenAiBackend {
                         .reset_to_context(&context_tokens)
                         .map_err(openai_backend_error)?;
                     speculative_stats.draft_reset_ms += draft_reset_timer.elapsed_ms();
-                    let mut attrs = self.openai_attrs(&request.ids);
+                    let mut attrs = self.openai_attrs(request.ids);
                     attrs.insert(
                         "llama_stage.draft_model_path".to_string(),
                         json!(draft.path.display().to_string()),
@@ -3586,7 +3589,7 @@ impl StageOpenAiBackend {
                                 speculative_stats.draft_reset_ms += draft_reset_timer.elapsed_ms();
                             }
                         }
-                        let mut token_attrs = self.openai_attrs(&request.ids);
+                        let mut token_attrs = self.openai_attrs(request.ids);
                         token_attrs
                             .insert("llama_stage.decode_step".to_string(), json!(decode_step));
                         token_attrs
@@ -3757,7 +3760,7 @@ impl StageOpenAiBackend {
                 current = reply.predicted;
                 decoded_tokens += 1;
                 context_tokens.push(current);
-                let mut token_attrs = self.openai_attrs(&request.ids);
+                let mut token_attrs = self.openai_attrs(request.ids);
                 token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
                 token_attrs.insert(
                     "llama_stage.decode_token_phase".to_string(),
@@ -3802,7 +3805,7 @@ impl StageOpenAiBackend {
                     break;
                 }
             }
-            let mut decode_attrs = self.openai_attrs(&request.ids);
+            let mut decode_attrs = self.openai_attrs(request.ids);
             decode_attrs.insert(
                 "llama_stage.decode_token_count".to_string(),
                 json!(decoded_tokens),
@@ -3890,7 +3893,7 @@ impl StageOpenAiBackend {
         if let Ok(mut runtime) = self.runtime.lock() {
             let runtime_lock_wait_ms = lock_timer.elapsed_ms();
             if let Ok(drop_stats) = runtime.drop_session_timed(&session_key) {
-                let mut attrs = self.openai_attrs(&request.ids);
+                let mut attrs = self.openai_attrs(request.ids);
                 attrs.insert(
                     "llama_stage.runtime_lock_wait_ms".to_string(),
                     json!(runtime_lock_wait_ms),

--- a/scripts/ci-compat-smoke.sh
+++ b/scripts/ci-compat-smoke.sh
@@ -25,6 +25,11 @@ if [[ ! -x "$MESH_LLM" ]]; then
     exit 1
 fi
 
+if [[ ! -f "$MODEL" ]]; then
+    echo "Missing model file: $MODEL" >&2
+    exit 1
+fi
+
 "$MESH_LLM" \
     serve \
     --model "$MODEL" \

--- a/scripts/ci-compat-smoke.sh
+++ b/scripts/ci-compat-smoke.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# ci-compat-smoke.sh - run OpenAI client compatibility probes against mesh-llm.
+#
+# Usage: scripts/ci-compat-smoke.sh <mesh-llm-binary> <bin-dir> <model-path>
+
+set -euo pipefail
+
+MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+MODEL="${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+API_PORT="${MESH_COMPAT_API_PORT:-9348}"
+CONSOLE_PORT="${MESH_COMPAT_CONSOLE_PORT:-3142}"
+MAX_WAIT="${MESH_COMPAT_MAX_WAIT:-180}"
+LOG="${MESH_COMPAT_LOG:-/tmp/mesh-llm-compat-ci.log}"
+
+echo "=== CI OpenAI Compatibility Smoke ==="
+echo "  mesh-llm:  $MESH_LLM"
+echo "  bin-dir:   $BIN_DIR (compatibility placeholder)"
+echo "  model:     $MODEL"
+echo "  api port:  $API_PORT"
+echo "  console:   $CONSOLE_PORT"
+
+if [[ ! -x "$MESH_LLM" ]]; then
+    echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
+    exit 1
+fi
+
+"$MESH_LLM" \
+    serve \
+    --model "$MODEL" \
+    --no-draft \
+    --device CPU \
+    --ctx-size "${MESH_COMPAT_CTX_SIZE:-256}" \
+    --port "$API_PORT" \
+    --console "$CONSOLE_PORT" \
+    --headless \
+    >"$LOG" 2>&1 &
+MESH_PID=$!
+
+cleanup() {
+    kill "$MESH_PID" 2>/dev/null || true
+    pkill -P "$MESH_PID" 2>/dev/null || true
+    sleep 1
+    kill -9 "$MESH_PID" 2>/dev/null || true
+    wait "$MESH_PID" 2>/dev/null || true
+    echo "--- compat mesh-llm log tail ---"
+    tail -100 "$LOG" 2>/dev/null || true
+    echo "--- end log ---"
+}
+trap cleanup EXIT
+
+BASE_URL="http://127.0.0.1:${API_PORT}/v1"
+MODEL_ID=""
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$MESH_PID" 2>/dev/null; then
+        echo "mesh-llm exited unexpectedly" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+
+    MODELS_JSON="$(curl -sf "${BASE_URL}/models" 2>/dev/null || true)"
+    MODEL_ID="$(
+        printf '%s' "$MODELS_JSON" |
+            python3 -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0].get("id", "") if data else "")' 2>/dev/null ||
+            echo ""
+    )"
+    if [[ -n "$MODEL_ID" ]]; then
+        echo "OpenAI endpoint ready with model: $MODEL_ID"
+        break
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "Timed out waiting for OpenAI endpoint" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+python3 scripts/ci-openai-python-smoke.py --base-url "$BASE_URL"
+python3 scripts/ci-litellm-smoke.py --base-url "$BASE_URL" --model "$MODEL_ID"
+python3 scripts/ci-langchain-openai-smoke.py --base-url "$BASE_URL" --model "$MODEL_ID"
+NODE_PATH="${NODE_PATH:-$(npm root -g 2>/dev/null || true)}" node scripts/ci-openai-node-smoke.cjs --base-url "$BASE_URL"
+
+echo "OpenAI compatibility smoke passed"

--- a/scripts/ci-sdk-fixture.sh
+++ b/scripts/ci-sdk-fixture.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Start a skippy-backed mesh-llm node and expose environment for SDK smoke tests.
+
+set -euo pipefail
+
+if [[ "$#" -lt 5 ]]; then
+    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> -- <command...>" >&2
+    exit 1
+fi
+
+MESH_LLM="$1"
+BIN_DIR="$2"
+MODEL="$3"
+shift 3
+
+if [[ "${1:-}" != "--" ]]; then
+    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> -- <command...>" >&2
+    exit 1
+fi
+shift
+
+API_PORT="${MESH_SDK_API_PORT:-9347}"
+CONSOLE_PORT="${MESH_SDK_CONSOLE_PORT:-3141}"
+MAX_WAIT="${MESH_SDK_MAX_WAIT:-180}"
+LOG="${MESH_SDK_LOG:-/tmp/mesh-llm-sdk-ci.log}"
+
+echo "=== SDK Fixture ==="
+echo "  mesh-llm:  $MESH_LLM"
+echo "  bin-dir:   $BIN_DIR (compatibility placeholder)"
+echo "  model:     $MODEL"
+echo "  api port:  $API_PORT"
+echo "  console:   $CONSOLE_PORT"
+
+if [[ ! -x "$MESH_LLM" ]]; then
+    echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
+    exit 1
+fi
+if [[ ! -f "$MODEL" ]]; then
+    echo "Missing model: $MODEL" >&2
+    exit 1
+fi
+
+"$MESH_LLM" \
+    serve \
+    --model "$MODEL" \
+    --no-draft \
+    --device CPU \
+    --ctx-size "${MESH_SDK_CTX_SIZE:-256}" \
+    --port "$API_PORT" \
+    --console "$CONSOLE_PORT" \
+    >"$LOG" 2>&1 &
+MESH_PID=$!
+
+descendant_pids() {
+    local pid="$1"
+    local children
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    for child in $children; do
+        descendant_pids "$child"
+        printf '%s\n' "$child"
+    done
+}
+
+cleanup() {
+    local children
+    children="$(descendant_pids "$MESH_PID" | sort -u || true)"
+    kill "$MESH_PID" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill 2>/dev/null || true
+    fi
+    sleep 1
+    kill -9 "$MESH_PID" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill -9 2>/dev/null || true
+    fi
+    wait "$MESH_PID" 2>/dev/null || true
+    echo "--- SDK fixture log tail ---"
+    tail -100 "$LOG" 2>/dev/null || true
+    echo "--- end log ---"
+}
+trap cleanup EXIT
+
+STATUS_JSON=""
+TOKEN=""
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$MESH_PID" 2>/dev/null; then
+        echo "mesh-llm exited unexpectedly" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+
+    STATUS_JSON="$(curl -sf "http://127.0.0.1:${CONSOLE_PORT}/api/status" 2>/dev/null || true)"
+    READY="$(
+        printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("llama_ready", False))
+except Exception:
+    print(False)' 2>/dev/null || echo "False"
+    )"
+    TOKEN="$(
+        printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("token", ""))
+except Exception:
+    print("")' 2>/dev/null || echo ""
+    )"
+
+    if [[ "$READY" == "True" && -n "$TOKEN" ]]; then
+        break
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "Timed out waiting for SDK fixture readiness" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+MODELS_JSON="$(curl -sf "http://127.0.0.1:${API_PORT}/v1/models")"
+MODEL_ID="$(
+    printf '%s' "$MODELS_JSON" | python3 -c 'import json,sys
+data = json.load(sys.stdin).get("data", [])
+print(data[0]["id"] if data else "")'
+)"
+
+if [[ -z "$MODEL_ID" ]]; then
+    echo "No models returned from /v1/models" >&2
+    printf '%s\n' "$MODELS_JSON" >&2
+    exit 1
+fi
+
+export MESH_SDK_INVITE_TOKEN="$TOKEN"
+export MESH_SDK_MODEL_ID="$MODEL_ID"
+export MESH_SDK_API_PORT="$API_PORT"
+export MESH_SDK_CONSOLE_PORT="$CONSOLE_PORT"
+export MESH_CLIENT_API_BASE="http://127.0.0.1:${API_PORT}"
+
+echo "SDK fixture ready:"
+echo "  model: $MODEL_ID"
+
+"$@"

--- a/scripts/ci-smoke-test.sh
+++ b/scripts/ci-smoke-test.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# ci-smoke-test.sh - start mesh-llm with a tiny GGUF, exercise OpenAI routes.
+#
+# Usage: scripts/ci-smoke-test.sh <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]
+#
+# <bin-dir> is retained for compatibility with older workflow call sites. The
+# skippy runtime is embedded in mesh-llm and does not require external
+# llama-server or rpc-server binaries.
+
+set -euo pipefail
+
+MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]}"
+BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]}"
+MODEL="${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]}"
+MMPROJ="${4:-}"
+API_PORT="${MESH_CI_API_PORT:-9337}"
+CONSOLE_PORT="${MESH_CI_CONSOLE_PORT:-3131}"
+MAX_WAIT="${MESH_CI_MAX_WAIT:-180}"
+LOG="${MESH_CI_LOG:-/tmp/mesh-llm-ci.log}"
+
+echo "=== CI Skippy Smoke Test ==="
+echo "  mesh-llm:  $MESH_LLM"
+echo "  bin-dir:   $BIN_DIR (compatibility placeholder)"
+echo "  model:     $MODEL"
+if [[ -n "$MMPROJ" ]]; then
+    echo "  mmproj:    $MMPROJ"
+fi
+echo "  api port:  $API_PORT"
+echo "  console:   $CONSOLE_PORT"
+echo "  os:        $(uname -s)"
+
+if [[ ! -x "$MESH_LLM" ]]; then
+    echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
+    exit 1
+fi
+if [[ ! -f "$MODEL" ]]; then
+    echo "Missing model: $MODEL" >&2
+    exit 1
+fi
+
+ARGS=(
+    serve
+    --model "$MODEL"
+    --no-draft
+    --device CPU
+    --ctx-size "${MESH_CI_CTX_SIZE:-256}"
+    --port "$API_PORT"
+    --console "$CONSOLE_PORT"
+)
+
+if [[ -n "$MMPROJ" ]]; then
+    ARGS+=(--mmproj "$MMPROJ")
+fi
+
+"$MESH_LLM" "${ARGS[@]}" >"$LOG" 2>&1 &
+MESH_PID=$!
+
+cleanup() {
+    echo "Shutting down mesh-llm (PID $MESH_PID)..."
+    kill "$MESH_PID" 2>/dev/null || true
+    pkill -P "$MESH_PID" 2>/dev/null || true
+    sleep 1
+    kill -9 "$MESH_PID" 2>/dev/null || true
+    wait "$MESH_PID" 2>/dev/null || true
+    echo "--- mesh-llm log tail ---"
+    tail -100 "$LOG" 2>/dev/null || true
+    echo "--- end log ---"
+}
+trap cleanup EXIT
+
+echo "Waiting for skippy runtime readiness (up to ${MAX_WAIT}s)..."
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$MESH_PID" 2>/dev/null; then
+        echo "mesh-llm exited unexpectedly" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+
+    READY="$(
+        curl -sf "http://127.0.0.1:${CONSOLE_PORT}/api/status" 2>/dev/null |
+            python3 -c 'import json,sys; print(json.load(sys.stdin).get("llama_ready", False))' 2>/dev/null ||
+            echo "False"
+    )"
+    if [[ "$READY" == "True" ]]; then
+        echo "Runtime ready after ${i}s"
+        break
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "Timed out waiting for runtime readiness" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+
+    if (( i % 15 == 0 )); then
+        echo "  Still waiting... (${i}s)"
+        tail -5 "$LOG" 2>/dev/null | sed 's/^/    /' || true
+    fi
+    sleep 1
+done
+
+echo "Waiting for /v1/models..."
+SMOKE_MODEL_ID=""
+for i in $(seq 1 60); do
+    MODELS_JSON="$(curl -sf "http://127.0.0.1:${API_PORT}/v1/models" 2>/dev/null || true)"
+    SMOKE_MODEL_ID="$(
+        printf '%s' "$MODELS_JSON" |
+            python3 -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0].get("id", "") if data else "")' 2>/dev/null ||
+            echo ""
+    )"
+    if [[ -n "$SMOKE_MODEL_ID" ]]; then
+        echo "OpenAI API ready with model: $SMOKE_MODEL_ID"
+        break
+    fi
+
+    if [[ "$i" -eq 60 ]]; then
+        echo "OpenAI API did not publish a model" >&2
+        tail -120 "$LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+BASE_URL="http://127.0.0.1:${API_PORT}/v1"
+
+echo "Testing non-stream chat completion..."
+CHAT_PAYLOAD="$(
+    jq -cn --arg model "$SMOKE_MODEL_ID" '{
+      model: $model,
+      messages: [{role: "user", content: "Say hello in exactly 3 words."}],
+      max_tokens: 4,
+      temperature: 0
+    }'
+)"
+RESPONSE="$(curl -fsS --max-time 60 "${BASE_URL}/chat/completions" -H 'content-type: application/json' -d "$CHAT_PAYLOAD")"
+printf '%s' "$RESPONSE" | jq -e '.object == "chat.completion" and (.choices[0].message.content | length > 0)' >/dev/null
+
+echo "Testing stream chat completion..."
+STREAM_PAYLOAD="$(
+    jq -cn --arg model "$SMOKE_MODEL_ID" '{
+      model: $model,
+      messages: [{role: "user", content: "Count from one to three."}],
+      stream: true,
+      stream_options: {include_usage: true},
+      max_tokens: 4,
+      temperature: 0
+    }'
+)"
+STREAM_OUT="$(mktemp)"
+curl -fsS --max-time 60 -N "${BASE_URL}/chat/completions" -H 'content-type: application/json' -d "$STREAM_PAYLOAD" >"$STREAM_OUT"
+grep -q 'data: \[DONE\]' "$STREAM_OUT"
+grep -q '"role":"assistant"' "$STREAM_OUT"
+
+echo "Testing model=auto routing..."
+AUTO_PAYLOAD="$(
+    jq -cn '{
+      model: "auto",
+      messages: [{role: "user", content: "Say hi."}],
+      max_tokens: 4,
+      temperature: 0
+    }'
+)"
+AUTO_RESPONSE="$(curl -fsS --max-time 60 "${BASE_URL}/chat/completions" -H 'content-type: application/json' -d "$AUTO_PAYLOAD")"
+printf '%s' "$AUTO_RESPONSE" | jq -e '(.choices[0].message.content | length > 0)' >/dev/null
+
+echo "Testing headless mode subcase..."
+HEADLESS_API_PORT="${MESH_CI_HEADLESS_API_PORT:-9338}"
+HEADLESS_CONSOLE_PORT="${MESH_CI_HEADLESS_CONSOLE_PORT:-3132}"
+HEADLESS_LOG="${MESH_CI_HEADLESS_LOG:-/tmp/mesh-llm-ci-headless.log}"
+HEADLESS_ARGS=(
+    serve
+    --model "$MODEL"
+    --no-draft
+    --device CPU
+    --ctx-size "${MESH_CI_CTX_SIZE:-256}"
+    --port "$HEADLESS_API_PORT"
+    --console "$HEADLESS_CONSOLE_PORT"
+    --headless
+)
+if [[ -n "$MMPROJ" ]]; then
+    HEADLESS_ARGS+=(--mmproj "$MMPROJ")
+fi
+
+"$MESH_LLM" "${HEADLESS_ARGS[@]}" >"$HEADLESS_LOG" 2>&1 &
+HEADLESS_PID=$!
+
+headless_cleanup() {
+    kill "$HEADLESS_PID" 2>/dev/null || true
+    pkill -P "$HEADLESS_PID" 2>/dev/null || true
+    sleep 1
+    kill -9 "$HEADLESS_PID" 2>/dev/null || true
+    wait "$HEADLESS_PID" 2>/dev/null || true
+}
+trap 'headless_cleanup; cleanup' EXIT
+
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$HEADLESS_PID" 2>/dev/null; then
+        echo "headless mesh-llm exited unexpectedly" >&2
+        tail -100 "$HEADLESS_LOG" >&2 || true
+        exit 1
+    fi
+
+    if curl -sf "http://127.0.0.1:${HEADLESS_API_PORT}/v1/models" >/dev/null 2>&1 &&
+       curl -sf "http://127.0.0.1:${HEADLESS_CONSOLE_PORT}/api/status" >/dev/null 2>&1; then
+        echo "Headless mode ready after ${i}s"
+        break
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "Timed out waiting for headless mode" >&2
+        tail -100 "$HEADLESS_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+echo "Skippy smoke passed"

--- a/scripts/ci-smoke-test.sh
+++ b/scripts/ci-smoke-test.sh
@@ -147,9 +147,19 @@ STREAM_PAYLOAD="$(
     }'
 )"
 STREAM_OUT="$(mktemp)"
-curl -fsS --max-time 60 -N "${BASE_URL}/chat/completions" -H 'content-type: application/json' -d "$STREAM_PAYLOAD" >"$STREAM_OUT"
-grep -q 'data: \[DONE\]' "$STREAM_OUT"
-grep -q '"role":"assistant"' "$STREAM_OUT"
+if ! curl -fsS --max-time 60 -N "${BASE_URL}/chat/completions" -H 'content-type: application/json' -d "$STREAM_PAYLOAD" >"$STREAM_OUT"; then
+    rm -f "$STREAM_OUT"
+    exit 1
+fi
+if ! grep -q 'data: \[DONE\]' "$STREAM_OUT"; then
+    rm -f "$STREAM_OUT"
+    exit 1
+fi
+if ! grep -q '"role":"assistant"' "$STREAM_OUT"; then
+    rm -f "$STREAM_OUT"
+    exit 1
+fi
+rm -f "$STREAM_OUT"
 
 echo "Testing model=auto routing..."
 AUTO_PAYLOAD="$(


### PR DESCRIPTION
## Summary

Restore the CI, release, Docker, upstream-canary, and GPU cache workflow structure that was accidentally collapsed during the skippy runtime merge.

This brings back the user-facing coverage we still need for skippy:

- multi-lane CI with change detection, Linux, macOS, CUDA, ROCm, Vulkan, SDK, and benchmark smoke jobs
- reusable skippy inference smoke tests and OpenAI client compatibility probes
- release matrix for macOS, Linux x64/arm64, CUDA, ROCm, and Vulkan bundles
- upstream llama.cpp canary staging with build, smoke, and pin-update gates
- reusable GPU ABI cache key/warm/debug workflows
- Docker prechecks and builds for the surviving skippy-era client/Fly targets

## Root Cause

PR #422 replaced the legacy llama-server runtime lane with skippy, but the workflow changes also removed the sophisticated CI/release/cache structure. This PR restores that structure without reintroducing the deleted external `llama-server` / `rpc-server` assumptions.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/docker.yml .github/workflows/docker-precheck.yml .github/workflows/gpu-warm-cache-job.yml .github/workflows/llama-cache-keys.yml .github/workflows/llama-upstream-canary.yml .github/workflows/release.yml .github/workflows/smoke.yml .github/workflows/warm-caches.yml .github/workflows/debug-slim-cache.yml`
- `shellcheck scripts/ci-smoke-test.sh scripts/ci-compat-smoke.sh scripts/ci-sdk-fixture.sh`
- `ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p) }' .github/workflows/*.yml`
- `git diff --check --cached`
- `bash -n scripts/ci-smoke-test.sh scripts/ci-compat-smoke.sh scripts/ci-sdk-fixture.sh`
