### PR TITLE
Keep Skippy and SDK crates covered by CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,23 +152,34 @@ jobs:
             exit 1
           fi
 
+      - name: SDK and API crate tests
+        run: |
+          cargo test -p mesh-llm-client
+          cargo test -p mesh-api
+          cargo test -p mesh-api-ffi
+
       - name: Prepare patched llama.cpp ABI checkout
         run: scripts/prepare-llama.sh pinned
 
       - name: Build patched llama.cpp ABI libraries
         run: scripts/build-llama.sh
 
+      - name: Skippy crate tests
+        run: |
+          cargo test -p skippy-protocol --lib
+          cargo test -p skippy-server --lib
+          cargo test -p openai-frontend --lib
+          cargo test -p skippy-runtime
+          cargo test -p skippy-topology
+          cargo test -p skippy-model-package
+          cargo test -p skippy-prompt
+          cargo test -p metrics-server
+
       - name: Build mesh-llm binary (debug)
         run: cargo build -p mesh-llm --bin mesh-llm
 
       - name: Unit tests
         run: cargo test -p mesh-llm --lib
-
-      - name: Skippy runtime crate tests
-        run: |
-          cargo test -p skippy-protocol --lib
-          cargo test -p skippy-server --lib
-          cargo test -p openai-frontend --lib
 
       - name: Protocol compatibility matrix
         run: |

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -561,6 +561,44 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
         "cargo run -p xtask -- repo-consistency release-targets",
         "CI xtask release-target check",
     )?;
+    check_ci_crate_test_coverage(&ci_workflow)?;
+
+    Ok(())
+}
+
+fn check_ci_crate_test_coverage(ci_workflow: &str) -> DynResult<()> {
+    const REQUIRED_TEST_COMMANDS: &[(&str, &str)] = &[
+        ("cargo test -p mesh-llm-client", "mesh client crate tests"),
+        ("cargo test -p mesh-api", "mesh API crate tests"),
+        ("cargo test -p mesh-api-ffi", "mesh API FFI crate tests"),
+        (
+            "cargo test -p skippy-protocol --lib",
+            "skippy protocol crate tests",
+        ),
+        (
+            "cargo test -p skippy-server --lib",
+            "skippy server crate tests",
+        ),
+        (
+            "cargo test -p openai-frontend --lib",
+            "OpenAI frontend crate tests",
+        ),
+        ("cargo test -p skippy-runtime", "skippy runtime crate tests"),
+        (
+            "cargo test -p skippy-topology",
+            "skippy topology crate tests",
+        ),
+        (
+            "cargo test -p skippy-model-package",
+            "skippy model-package crate tests",
+        ),
+        ("cargo test -p skippy-prompt", "skippy prompt crate tests"),
+        ("cargo test -p metrics-server", "metrics server crate tests"),
+    ];
+
+    for (command, context) in REQUIRED_TEST_COMMANDS {
+        ensure_contains(ci_workflow, command, &format!("CI {context}"))?;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

CI now exercises the Skippy runtime/support crates and public SDK crates that became part of the active repo surface after the Skippy runtime merge.

- Adds CI test coverage for `mesh-llm-client`, `mesh-api`, and `mesh-api-ffi`.
- Expands the Skippy CI test block to cover `skippy-runtime`, `skippy-topology`, `skippy-model-package`, `skippy-prompt`, and `metrics-server`, while preserving the existing `skippy-protocol`, `skippy-server`, and `openai-frontend` checks.
- Adds a repo-consistency invariant so the required CI crate-test commands cannot be removed from `.github/workflows/ci.yml` silently.

## Why

The Skippy merge moved important behavior into standalone workspace crates, but the main Linux CI job still tested only a subset of that surface. This closes that coverage gap with targeted crate checks instead of broad, expensive full-workspace testing.

## Diff scope

- `.github/workflows/ci.yml`
  - Adds `SDK and API crate tests` before the llama.cpp ABI build.
  - Expands `Skippy crate tests` after the patched llama.cpp ABI libraries are built.
- `tools/xtask/src/main.rs`
  - Extends `repo-consistency release-targets` with CI coverage invariants for the required SDK/API and Skippy crate-test commands.

## Branch integrity

- Base branch: `main`
- Validated base SHA: `679d23826043b874a9b3bc067b0d3851cba5a973`
- Head SHA: `dedcc2facc9311af4c7a7b2c0a32f5b08053536c`
- Ahead / behind: `0 1` for `origin/main...HEAD`
- Merge-base: `679d23826043b874a9b3bc067b0d3851cba5a973`
- Fast-forward safety: `origin/main` is an ancestor of `HEAD`; no divergence.

## Commit integrity

Introduced commit:

- `dedcc2facc9311af4c7a7b2c0a32f5b08053536c Expand CI coverage for Skippy and SDK crates`

One logical CI/tooling change. Final diff contains only intended files.

## Diff hygiene

`git diff --name-status origin/main...HEAD`:

- `M .github/workflows/ci.yml`
- `M tools/xtask/src/main.rs`

`git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Validation mode: Mode 4 / Tier 4 — CI workflow and repo-consistency tooling.

Local proof:

- Red check: `cargo run -p xtask -- repo-consistency release-targets` failed before the CI update because `cargo test -p mesh-llm-client` was missing from CI.
- `cargo fmt --all -- tools/xtask/src/main.rs`: PASS
- `cargo run -p xtask -- repo-consistency release-targets`: PASS
- `cargo test -p mesh-llm-client`: PASS
- `cargo test -p mesh-api`: PASS
- `cargo test -p mesh-api-ffi`: PASS
- `cargo test -p skippy-topology`: PASS
- `cargo test -p metrics-server`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static /tmp/mesh-llm-just-tool/bin/just llama-build`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p skippy-protocol --lib`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p skippy-server --lib`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p openai-frontend --lib`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p skippy-runtime`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p skippy-topology`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p skippy-model-package`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p skippy-prompt`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-static cargo test -p metrics-server`: PASS
- `cargo fmt --all -- --check`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS
- `git diff --check origin/main...HEAD`: PASS

Not run: full `just build` — not required for this targeted CI/tooling change; the affected CI commands and repo-consistency gate were run locally.


## CI context confirmation

CI context names unchanged. Required remote CI is pending until this PR is opened and GitHub runs checks on the final SHA.

## Runtime safety

Not applicable — no runtime path changed. This PR only changes CI workflow coverage and repo-consistency validation.

## Documentation integrity

Not applicable — no README, runbook, documented user command, or operational procedure changed.

## Rollback plan

Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

No known local blockers. GitHub CI remains the final proof for the remote Linux/macOS workflow environment after the PR is opened.