### PR TITLE
Auto-split Skippy runtime models that exceed local capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,7 +449,7 @@ jobs:
         run: cargo build --release -p mesh-llm
       - name: CLI smoke test
         run: |
-          CUDA_STUB="$(find /usr/local/cuda -path '*/stubs/libcuda.so' -print -quit)"
+          CUDA_STUB="$(find -L /usr/local/cuda /usr/local/cuda-* -path '*/stubs/libcuda.so' -print -quit 2>/dev/null || true)"
           if [ -n "$CUDA_STUB" ]; then
             mkdir -p /tmp/cuda-stubs
             ln -sf "$CUDA_STUB" /tmp/cuda-stubs/libcuda.so.1

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -20,6 +20,8 @@ const SPLIT_PARTICIPANT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const SPLIT_PARTICIPANT_STABLE_FOR: Duration = Duration::from_secs(2);
 const SPLIT_DEFAULT_MIN_PARTICIPANTS: usize = 2;
 const SPLIT_INITIAL_SHUTDOWN_GENERATION: u64 = 1;
+const RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR: u64 = 11;
+const RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR: u64 = 10;
 
 pub(super) enum RuntimeEvent {
     Exited { model: String, port: u16 },
@@ -136,6 +138,18 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
 pub(super) enum SplitRuntimeStart {
     Started(SplitRuntimeGenerationHandle),
     Standby { coordinator: iroh::EndpointId },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum StartupRuntimePlan {
+    Local,
+    Split { reason: SplitRuntimeReason },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SplitRuntimeReason {
+    Forced,
+    LocalCapacity,
 }
 
 pub(super) struct SplitRuntimeGenerationHandle {
@@ -326,12 +340,44 @@ pub(super) async fn start_runtime_local_model(
         .pinned_gpu
         .map(|gpu| gpu.vram_bytes)
         .unwrap_or_else(|| spec.node.vram_bytes());
+    let required_bytes = runtime_model_required_bytes(model_bytes);
     anyhow::ensure!(
-        my_vram >= (model_bytes as f64 * 1.1) as u64,
-        "runtime load only supports models that fit locally on this node"
+        my_vram >= required_bytes,
+        "runtime load only supports models that fit locally on this node; model requires {}, local capacity is {}",
+        format_gb(required_bytes),
+        format_gb(my_vram)
     );
 
     start_runtime_skippy_model(spec, model_name).await
+}
+
+pub(super) fn startup_runtime_plan(
+    explicit_split: bool,
+    local_vram_bytes: u64,
+    model_bytes: u64,
+) -> StartupRuntimePlan {
+    if explicit_split {
+        return StartupRuntimePlan::Split {
+            reason: SplitRuntimeReason::Forced,
+        };
+    }
+    if model_fits_runtime_capacity(model_bytes, local_vram_bytes) {
+        StartupRuntimePlan::Local
+    } else {
+        StartupRuntimePlan::Split {
+            reason: SplitRuntimeReason::LocalCapacity,
+        }
+    }
+}
+
+pub(super) fn model_fits_runtime_capacity(model_bytes: u64, local_vram_bytes: u64) -> bool {
+    local_vram_bytes >= runtime_model_required_bytes(model_bytes)
+}
+
+pub(super) fn runtime_model_required_bytes(model_bytes: u64) -> u64 {
+    model_bytes
+        .saturating_mul(RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR)
+        .div_ceil(RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR)
 }
 
 pub(super) async fn start_runtime_split_model(
@@ -662,6 +708,7 @@ struct RuntimeSliceStagePlan {
     node_id: iroh::EndpointId,
     layer_start: u32,
     layer_end: u32,
+    parameter_bytes: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1235,10 +1282,12 @@ fn plan_runtime_slice_topology(
                 node_id,
                 layer_start: stage.layer_start,
                 layer_end: stage.layer_end,
+                parameter_bytes: stage.parameter_bytes,
             })
         })
         .collect::<Result<Vec<_>>>()?;
     stages.sort_by_key(|stage| stage.stage_index);
+    validate_split_capacity(model_ref, package, participants, &stages)?;
     tracing::info!(
         topology_id,
         model_ref,
@@ -1246,6 +1295,51 @@ fn plan_runtime_slice_topology(
         "planned split runtime topology"
     );
     Ok(stages)
+}
+
+fn validate_split_capacity(
+    model_ref: &str,
+    package: &skippy::SkippyPackageIdentity,
+    participants: &[SplitParticipant],
+    stages: &[RuntimeSliceStagePlan],
+) -> Result<()> {
+    let total_vram_bytes = participants
+        .iter()
+        .map(|participant| participant.vram_bytes)
+        .sum::<u64>();
+    let required_total_bytes = runtime_model_required_bytes(package.source_model_bytes);
+    anyhow::ensure!(
+        total_vram_bytes >= required_total_bytes,
+        "aggregate split capacity for {model_ref} requires {}, mesh has {} across {} participant(s)",
+        format_gb(required_total_bytes),
+        format_gb(total_vram_bytes),
+        participants.len()
+    );
+
+    let vram_by_node = participants
+        .iter()
+        .map(|participant| (participant.node_id, participant.vram_bytes))
+        .collect::<HashMap<_, _>>();
+    for stage in stages {
+        let node_vram = vram_by_node
+            .get(&stage.node_id)
+            .copied()
+            .unwrap_or_default();
+        let required_stage_bytes = runtime_model_required_bytes(stage.parameter_bytes);
+        anyhow::ensure!(
+            node_vram >= required_stage_bytes,
+            "{} assigned to {} for {model_ref} requires {}, which exceeds node capacity {}",
+            stage.stage_id,
+            stage.node_id.fmt_short(),
+            format_gb(required_stage_bytes),
+            format_gb(node_vram)
+        );
+    }
+    Ok(())
+}
+
+fn format_gb(bytes: u64) -> String {
+    format!("{:.1}GB", bytes as f64 / 1e9)
 }
 
 fn split_stage_plan_labels(stages: &[RuntimeSliceStagePlan]) -> Vec<String> {
@@ -1559,6 +1653,139 @@ mod tests {
     }
 
     #[test]
+    fn startup_runtime_plan_auto_splits_when_model_exceeds_local_capacity() {
+        assert_eq!(
+            startup_runtime_plan(false, 3_000_000_000, 4_800_000_000),
+            StartupRuntimePlan::Split {
+                reason: SplitRuntimeReason::LocalCapacity
+            }
+        );
+    }
+
+    #[test]
+    fn startup_runtime_plan_keeps_local_when_model_fits_without_split_flag() {
+        assert_eq!(
+            startup_runtime_plan(false, 6_000_000_000, 4_800_000_000),
+            StartupRuntimePlan::Local
+        );
+    }
+
+    #[test]
+    fn startup_runtime_plan_respects_explicit_split_for_fitting_model() {
+        assert_eq!(
+            startup_runtime_plan(true, 6_000_000_000, 4_800_000_000),
+            StartupRuntimePlan::Split {
+                reason: SplitRuntimeReason::Forced
+            }
+        );
+    }
+
+    #[test]
+    fn split_topology_planner_accepts_constrained_nodes_with_enough_aggregate_capacity() {
+        let participants = vec![
+            SplitParticipant {
+                node_id: make_id(1),
+                vram_bytes: 3_000_000_000,
+                first_joined_mesh_ts: None,
+            },
+            SplitParticipant {
+                node_id: make_id(2),
+                vram_bytes: 3_000_000_000,
+                first_joined_mesh_ts: None,
+            },
+        ];
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 4_800_000_000,
+            layer_count: 48,
+            ..package(48)
+        };
+
+        let stages = plan_runtime_slice_topology(
+            "topology-test",
+            "Hermes-2-Pro-Mistral-7B-Q4_K_M",
+            &package,
+            &participants,
+        )
+        .expect("constrained nodes should form a split topology");
+
+        assert_eq!(stages.len(), 2);
+        assert_eq!(
+            stages
+                .iter()
+                .map(|stage| (stage.layer_start, stage.layer_end))
+                .collect::<Vec<_>>(),
+            vec![(0, 24), (24, 48)]
+        );
+    }
+
+    #[test]
+    fn split_topology_planner_rejects_insufficient_aggregate_capacity() {
+        let participants = vec![
+            SplitParticipant {
+                node_id: make_id(1),
+                vram_bytes: 2_000_000_000,
+                first_joined_mesh_ts: None,
+            },
+            SplitParticipant {
+                node_id: make_id(2),
+                vram_bytes: 2_000_000_000,
+                first_joined_mesh_ts: None,
+            },
+        ];
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 4_800_000_000,
+            layer_count: 48,
+            ..package(48)
+        };
+
+        let error = plan_runtime_slice_topology(
+            "topology-test",
+            "Hermes-2-Pro-Mistral-7B-Q4_K_M",
+            &package,
+            &participants,
+        )
+        .expect_err("aggregate split capacity should be enforced")
+        .to_string();
+
+        assert!(error.contains("aggregate split capacity"));
+        assert!(error.contains("requires 5.3GB"));
+        assert!(error.contains("has 4.0GB"));
+    }
+
+    #[test]
+    fn split_topology_planner_rejects_stage_that_exceeds_participant_capacity() {
+        let participants = vec![
+            SplitParticipant {
+                node_id: make_id(1),
+                vram_bytes: 900,
+                first_joined_mesh_ts: None,
+            },
+            SplitParticipant {
+                node_id: make_id(2),
+                vram_bytes: 200,
+                first_joined_mesh_ts: None,
+            },
+        ];
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+
+        let error = plan_runtime_slice_topology(
+            "topology-test",
+            "tiny-capacity-test",
+            &package,
+            &participants,
+        )
+        .expect_err("per-stage split capacity should be enforced")
+        .to_string();
+
+        assert!(error.contains("stage-1"));
+        assert!(error.contains("exceeds node capacity"));
+    }
+
+    #[test]
     fn split_participant_signature_includes_vram_for_stability() {
         let node_id = make_id(9);
         let first = vec![SplitParticipant {
@@ -1596,6 +1823,7 @@ mod tests {
                 node_id: make_id(1),
                 layer_start: 0,
                 layer_end: 40,
+                parameter_bytes: 40_000_000,
             }],
         );
         let candidate = SplitTopologyGeneration::new(
@@ -1610,6 +1838,7 @@ mod tests {
                     node_id: make_id(1),
                     layer_start: 0,
                     layer_end: 16,
+                    parameter_bytes: 16_000_000,
                 },
                 RuntimeSliceStagePlan {
                     stage_id: "stage-1".into(),
@@ -1617,6 +1846,7 @@ mod tests {
                     node_id: make_id(2),
                     layer_start: 16,
                     layer_end: 40,
+                    parameter_bytes: 24_000_000,
                 },
             ],
         );
@@ -1635,6 +1865,7 @@ mod tests {
             node_id: make_id(1),
             layer_start: 0,
             layer_end: 40,
+            parameter_bytes: 40_000_000,
         }];
         let participants = vec![SplitParticipant {
             node_id: make_id(1),

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -10,11 +10,12 @@ use self::discovery::{nostr_rediscovery, start_new_mesh};
 use self::interactive::InitialPromptMode;
 use self::local::{
     add_runtime_local_target, add_serving_assignment, advertise_model_ready, local_process_payload,
-    remove_runtime_local_target, remove_serving_assignment, resolved_model_name,
-    set_advertised_model_context, start_runtime_local_model, start_runtime_split_model,
+    model_fits_runtime_capacity, remove_runtime_local_target, remove_serving_assignment,
+    resolved_model_name, runtime_model_required_bytes, set_advertised_model_context,
+    start_runtime_local_model, start_runtime_split_model, startup_runtime_plan,
     stop_split_generation_cleanup, withdraw_advertised_model, LocalRuntimeModelHandle,
     LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent, SplitCoordinatorAck,
-    SplitRuntimeStart,
+    SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
@@ -872,6 +873,12 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         flash_attention_override: flash_attention,
         slots,
     };
+    let local_capacity = pinned_gpu
+        .as_ref()
+        .map(|gpu| gpu.vram_bytes)
+        .unwrap_or_else(|| node.vram_bytes());
+    let model_bytes = election::total_model_bytes(&model_path);
+    let runtime_plan = startup_runtime_plan(split, local_capacity, model_bytes);
     let (
         mut loaded_name,
         mut handle,
@@ -879,45 +886,60 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         mut split_cleanup,
         mut split_event_rx,
         mut coordinator_task,
-    ) = if split {
-        match start_runtime_split_model(start_spec, &model_ref).await {
-            Ok(SplitRuntimeStart::Started(mut loaded)) => (
-                loaded.loaded_name,
-                loaded.handle,
-                loaded.death_rx,
-                loaded.cleanup.take(),
-                loaded.coordinator_rx.take(),
-                loaded.coordinator_task.take(),
-            ),
-            Ok(SplitRuntimeStart::Standby { coordinator }) => {
-                drop(startup_load_guard);
+    ) = match runtime_plan {
+        StartupRuntimePlan::Split { reason } => {
+            if reason == SplitRuntimeReason::LocalCapacity {
+                let required_bytes = runtime_model_required_bytes(model_bytes);
                 let _ = emit_event(OutputEvent::Info {
                     message: format!(
-                        "Split runtime coordinator is {}; standing by for stage assignment",
-                        coordinator.fmt_short()
+                        "Model {model_name} exceeds local runtime capacity; attempting split runtime"
                     ),
-                    context: Some(format!("model={model_ref}")),
+                    context: Some(format!(
+                        "model={model_name} local_capacity_gb={:.1} required_capacity_gb={:.1} model_size_gb={:.1}",
+                        local_capacity as f64 / 1e9,
+                        required_bytes as f64 / 1e9,
+                        model_bytes as f64 / 1e9
+                    )),
                 });
-                update_startup_target(&target_tx, &model_name, election::InferenceTarget::None);
-                if let Some(cs) = console_state {
-                    cs.update(false, false).await;
-                }
-                return;
             }
-            Err(err) => {
-                let _ = emit_event(OutputEvent::Error {
-                    message: format!("Failed to start model {model_name}: {err:#}"),
-                    context: Some(format!("model={model_name}")),
-                });
-                update_startup_target(&target_tx, &model_name, election::InferenceTarget::None);
-                if let Some(cs) = console_state {
-                    cs.update(false, false).await;
+            match start_runtime_split_model(start_spec, &model_ref).await {
+                Ok(SplitRuntimeStart::Started(mut loaded)) => (
+                    loaded.loaded_name,
+                    loaded.handle,
+                    loaded.death_rx,
+                    loaded.cleanup.take(),
+                    loaded.coordinator_rx.take(),
+                    loaded.coordinator_task.take(),
+                ),
+                Ok(SplitRuntimeStart::Standby { coordinator }) => {
+                    drop(startup_load_guard);
+                    let _ = emit_event(OutputEvent::Info {
+                        message: format!(
+                            "Split runtime coordinator is {}; standing by for stage assignment",
+                            coordinator.fmt_short()
+                        ),
+                        context: Some(format!("model={model_ref}")),
+                    });
+                    update_startup_target(&target_tx, &model_name, election::InferenceTarget::None);
+                    if let Some(cs) = console_state {
+                        cs.update(false, false).await;
+                    }
+                    return;
                 }
-                return;
+                Err(err) => {
+                    let _ = emit_event(OutputEvent::Error {
+                        message: format!("Failed to start model {model_name}: {err:#}"),
+                        context: Some(format!("model={model_name}")),
+                    });
+                    update_startup_target(&target_tx, &model_name, election::InferenceTarget::None);
+                    if let Some(cs) = console_state {
+                        cs.update(false, false).await;
+                    }
+                    return;
+                }
             }
         }
-    } else {
-        match start_runtime_local_model(start_spec).await {
+        StartupRuntimePlan::Local => match start_runtime_local_model(start_spec).await {
             Ok((loaded_name, handle, death_rx)) => {
                 (loaded_name, handle, death_rx, None, None, None)
             }
@@ -932,7 +954,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 }
                 return;
             }
-        }
+        },
     };
     drop(startup_load_guard);
 
@@ -2757,6 +2779,26 @@ fn parse_size_str(s: &str) -> u64 {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RuntimeModelCapacity {
+    required_bytes: u64,
+    fits: bool,
+}
+
+fn runtime_model_capacity_for_path(model_path: &Path, vram_bytes: u64) -> RuntimeModelCapacity {
+    let model_bytes = election::total_model_bytes(model_path);
+    let required_bytes = runtime_model_required_bytes(model_bytes);
+    RuntimeModelCapacity {
+        required_bytes,
+        fits: model_bytes == 0 || model_fits_runtime_capacity(model_bytes, vram_bytes),
+    }
+}
+
+fn runtime_model_capacity_for_ref(model: &str, vram_bytes: u64) -> RuntimeModelCapacity {
+    let model_path = models::find_model_path(model);
+    runtime_model_capacity_for_path(&model_path, vram_bytes)
+}
+
 /// Pick which model this node should serve, based on demand signals.
 ///
 /// Priority:
@@ -2808,17 +2850,13 @@ async fn pick_model_assignment(node: &mesh::Node, local_models: &[String]) -> Op
 
     /// Check if a model fits in our VRAM. Returns false and logs if it doesn't.
     fn model_fits(model: &str, my_vram: u64) -> bool {
-        let model_path = models::find_model_path(model);
-        let model_bytes = std::fs::metadata(&model_path)
-            .map(|md| md.len())
-            .unwrap_or(0);
-        let needed = (model_bytes as f64 * 1.1) as u64;
-        if model_bytes > 0 && needed > my_vram {
+        let capacity = runtime_model_capacity_for_ref(model, my_vram);
+        if !capacity.fits {
             let _ = emit_event(OutputEvent::Info {
                 message: format!(
                     "Skipping {} — needs {:.1}GB, we have {:.1}GB",
                     model,
-                    needed as f64 / 1e9,
+                    capacity.required_bytes as f64 / 1e9,
                     my_vram as f64 / 1e9
                 ),
                 context: None,
@@ -3007,12 +3045,7 @@ async fn check_unserved_model(node: &mesh::Node, local_models: &[String]) -> Opt
     let mut unserved: Vec<(String, u64)> = Vec::new();
     for (m, d) in &demand {
         if serving_count.get(m).copied().unwrap_or(0) == 0 && local_models.contains(m) {
-            let model_path = models::find_model_path(m);
-            let model_bytes = std::fs::metadata(&model_path)
-                .map(|md| md.len())
-                .unwrap_or(0);
-            let needed = (model_bytes as f64 * 1.1) as u64;
-            if model_bytes > 0 && needed > my_vram {
+            if !runtime_model_capacity_for_ref(m, my_vram).fits {
                 continue;
             }
             unserved.push((m.clone(), d.request_count));
@@ -3033,12 +3066,7 @@ async fn check_unserved_model(node: &mesh::Node, local_models: &[String]) -> Opt
         }
         let servers = serving_count.get(m).copied().unwrap_or(0) as f64;
         if servers > 0.0 && d.request_count > 0 && local_models.contains(m) {
-            let model_path = models::find_model_path(m);
-            let model_bytes = std::fs::metadata(&model_path)
-                .map(|md| md.len())
-                .unwrap_or(0);
-            let needed = (model_bytes as f64 * 1.1) as u64;
-            if model_bytes > 0 && needed > my_vram {
+            if !runtime_model_capacity_for_ref(m, my_vram).fits {
                 continue;
             }
             ratios.push((m.clone(), d.request_count as f64 / servers));
@@ -4889,6 +4917,23 @@ mod tests {
             n_ubatch: None,
             flash_attention: FlashAttentionType::Auto,
         }
+    }
+
+    #[test]
+    fn runtime_model_capacity_counts_split_gguf_parts() {
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let first_part = temp_dir.path().join("model-00001-of-00002.gguf");
+        let second_part = temp_dir.path().join("model-00002-of-00002.gguf");
+        std::fs::write(&first_part, vec![0u8; 100]).expect("write first split part");
+        std::fs::write(&second_part, vec![0u8; 200]).expect("write second split part");
+
+        let too_small = runtime_model_capacity_for_path(&first_part, 329);
+        assert_eq!(too_small.required_bytes, 330);
+        assert!(!too_small.fits);
+
+        let enough = runtime_model_capacity_for_path(&first_part, 330);
+        assert_eq!(enough.required_bytes, 330);
+        assert!(enough.fits);
     }
 
     #[test]

--- a/crates/skippy-correctness/src/cli.rs
+++ b/crates/skippy-correctness/src/cli.rs
@@ -38,8 +38,14 @@ pub struct RuntimeArgs {
     pub ctx_size: u32,
     #[arg(long, default_value_t = 0)]
     pub n_gpu_layers: i32,
+    #[arg(long)]
+    pub n_batch: Option<u32>,
+    #[arg(long)]
+    pub n_ubatch: Option<u32>,
     #[arg(long, default_value = "Hello")]
     pub prompt: String,
+    #[arg(long = "flash-attn", value_enum, default_value = "auto")]
+    pub flash_attn: FlashAttentionArg,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
@@ -48,6 +54,14 @@ pub enum StageLoadMode {
     RuntimeSlice,
     ArtifactSlice,
     LayerPackage,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum FlashAttentionArg {
+    Auto,
+    Disabled,
+    Enabled,
 }
 
 #[derive(Args, Clone)]

--- a/crates/skippy-correctness/src/runner.rs
+++ b/crates/skippy-correctness/src/runner.rs
@@ -1004,6 +1004,10 @@ fn run_binary_chain(args: BinaryChainConfig) -> Result<BinaryChainResult> {
     ]);
     configure_child_logs(&mut stage2_command, args.child_logs);
     let _stage2 = ChildGuard::spawn(stage2_command)?;
+    drop(
+        connect_ready(args.stage2_bind_addr, args.startup_timeout_secs)
+            .context("stage 2 binary server did not become ready")?,
+    );
 
     let mut stage1_command = Command::new(&args.stage_server_bin);
     stage1_command.args([

--- a/crates/skippy-correctness/src/runner.rs
+++ b/crates/skippy-correctness/src/runner.rs
@@ -27,8 +27,8 @@ use skippy_runtime::{
 
 use crate::{
     cli::{
-        ChainArgs, DtypeMatrixArgs, RuntimeArgs, ServerArgs, SingleStepArgs, SplitScanArgs,
-        StageLoadMode, StateHandoffArgs, StatePayloadKind,
+        ChainArgs, DtypeMatrixArgs, FlashAttentionArg, RuntimeArgs, ServerArgs, SingleStepArgs,
+        SplitScanArgs, StageLoadMode, StateHandoffArgs, StatePayloadKind,
     },
     report::{
         BaselineReport, BoundaryReport, ChainReport, ChainStageReport, DtypeMatrixReport,
@@ -55,7 +55,10 @@ struct BinarySplitConfig {
     split_layer: u32,
     layer_end: u32,
     ctx_size: u32,
+    n_batch: Option<u32>,
+    n_ubatch: Option<u32>,
     n_gpu_layers: i32,
+    flash_attn: FlashAttentionArg,
     prompt: String,
     stage1_bind_addr: SocketAddr,
     activation_wire_dtype: String,
@@ -87,7 +90,10 @@ struct BinaryChainConfig {
     split_layer_2: u32,
     layer_end: u32,
     ctx_size: u32,
+    n_batch: Option<u32>,
+    n_ubatch: Option<u32>,
     n_gpu_layers: i32,
+    flash_attn: FlashAttentionArg,
     prompt: String,
     stage1_bind_addr: SocketAddr,
     stage2_bind_addr: SocketAddr,
@@ -120,7 +126,10 @@ struct BinaryStateHandoffConfig {
     state_stage_index: u32,
     layer_end: u32,
     ctx_size: u32,
+    n_batch: Option<u32>,
+    n_ubatch: Option<u32>,
     n_gpu_layers: i32,
+    flash_attn: FlashAttentionArg,
     prompt: String,
     source_bind_addr: SocketAddr,
     restore_bind_addr: SocketAddr,
@@ -307,7 +316,10 @@ pub fn chain(args: ChainArgs) -> Result<()> {
         split_layer_2: splits.1,
         layer_end: args.runtime.layer_end,
         ctx_size: args.runtime.ctx_size,
+        n_batch: args.runtime.n_batch,
+        n_ubatch: args.runtime.n_ubatch,
         n_gpu_layers: args.runtime.n_gpu_layers,
+        flash_attn: args.runtime.flash_attn,
         prompt: args.runtime.prompt,
         stage1_bind_addr: args.stage1_bind_addr,
         stage2_bind_addr: args.stage2_bind_addr,
@@ -464,7 +476,10 @@ pub fn state_handoff(args: StateHandoffArgs) -> Result<()> {
         state_stage_index,
         layer_end: args.runtime.layer_end,
         ctx_size: args.runtime.ctx_size,
+        n_batch: args.runtime.n_batch,
+        n_ubatch: args.runtime.n_ubatch,
         n_gpu_layers: args.runtime.n_gpu_layers,
+        flash_attn: args.runtime.flash_attn,
         prompt: args.runtime.prompt,
         source_bind_addr: args.source_bind_addr,
         restore_bind_addr: args.restore_bind_addr,
@@ -565,7 +580,10 @@ fn run_single_step_with_baseline(
         split_layer: case.split_layer,
         layer_end: runtime.layer_end,
         ctx_size: runtime.ctx_size,
+        n_batch: runtime.n_batch,
+        n_ubatch: runtime.n_ubatch,
         n_gpu_layers: runtime.n_gpu_layers,
+        flash_attn: runtime.flash_attn,
         prompt: runtime.prompt.clone(),
         stage1_bind_addr: case.stage1_bind_addr,
         activation_wire_dtype: case.activation_wire_dtype,
@@ -593,8 +611,8 @@ fn run_full_model_decode(args: &RuntimeArgs) -> Result<FullModelResult> {
         layer_end: args.layer_end,
         ctx_size: args.ctx_size,
         lane_count: 1,
-        n_batch: None,
-        n_ubatch: None,
+        n_batch: args.n_batch,
+        n_ubatch: args.n_ubatch,
         n_threads: None,
         n_threads_batch: None,
         n_gpu_layers: args.n_gpu_layers,
@@ -606,7 +624,7 @@ fn run_full_model_decode(args: &RuntimeArgs) -> Result<FullModelResult> {
         filter_tensors_on_load: false,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
-        flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+        flash_attn_type: runtime_flash_attn(args.flash_attn),
     };
     let model = StageModel::open(&args.model, &config).context("failed to open full model")?;
     let tokens = model
@@ -669,8 +687,8 @@ fn run_binary_split(args: BinarySplitConfig) -> Result<BinarySplitResult> {
         layer_end: args.split_layer,
         ctx_size: args.ctx_size,
         lane_count: 1,
-        n_batch: None,
-        n_ubatch: None,
+        n_batch: args.n_batch,
+        n_ubatch: args.n_ubatch,
         n_threads: None,
         n_threads_batch: None,
         n_gpu_layers: args.n_gpu_layers,
@@ -682,7 +700,7 @@ fn run_binary_split(args: BinarySplitConfig) -> Result<BinarySplitResult> {
         filter_tensors_on_load: true,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
-        flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+        flash_attn_type: runtime_flash_attn(args.flash_attn),
     };
     let stage0 = StageModel::open(&stage0_resolution.path, &stage0_config)
         .context("failed to open stage 0")?;
@@ -719,7 +737,10 @@ fn run_binary_split(args: BinarySplitConfig) -> Result<BinarySplitResult> {
         "layer_start": args.split_layer,
         "layer_end": args.layer_end,
         "ctx_size": args.ctx_size,
+        "n_batch": args.n_batch,
+        "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": true,
         "load_mode": protocol_load_mode(args.stage_load_mode),
         "bind_addr": args.stage1_bind_addr,
@@ -860,8 +881,8 @@ fn run_binary_chain(args: BinaryChainConfig) -> Result<BinaryChainResult> {
         layer_end: args.split_layer_1,
         ctx_size: args.ctx_size,
         lane_count: 1,
-        n_batch: None,
-        n_ubatch: None,
+        n_batch: args.n_batch,
+        n_ubatch: args.n_ubatch,
         n_threads: None,
         n_threads_batch: None,
         n_gpu_layers: args.n_gpu_layers,
@@ -873,7 +894,7 @@ fn run_binary_chain(args: BinaryChainConfig) -> Result<BinaryChainResult> {
         filter_tensors_on_load: true,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
-        flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+        flash_attn_type: runtime_flash_attn(args.flash_attn),
     };
     let stage0 = StageModel::open(&stage0_resolution.path, &stage0_config)
         .context("failed to open stage 0")?;
@@ -911,7 +932,10 @@ fn run_binary_chain(args: BinaryChainConfig) -> Result<BinaryChainResult> {
         "layer_start": args.split_layer_2,
         "layer_end": args.layer_end,
         "ctx_size": args.ctx_size,
+        "n_batch": args.n_batch,
+        "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": true,
         "load_mode": protocol_load_mode(args.stage_load_mode),
         "bind_addr": args.stage2_bind_addr,
@@ -937,7 +961,10 @@ fn run_binary_chain(args: BinaryChainConfig) -> Result<BinaryChainResult> {
         "layer_start": args.split_layer_1,
         "layer_end": args.split_layer_2,
         "ctx_size": args.ctx_size,
+        "n_batch": args.n_batch,
+        "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": true,
         "load_mode": protocol_load_mode(args.stage_load_mode),
         "bind_addr": args.stage1_bind_addr,
@@ -1158,7 +1185,10 @@ fn run_binary_state_handoff(args: BinaryStateHandoffConfig) -> Result<BinaryStat
         "layer_start": args.state_layer_start,
         "layer_end": args.state_layer_end,
         "ctx_size": args.ctx_size,
+        "n_batch": args.n_batch,
+        "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": should_filter_state_handoff_tensors(&args),
         "load_mode": protocol_load_mode(args.stage_load_mode),
         "bind_addr": args.source_bind_addr,
@@ -1184,7 +1214,10 @@ fn run_binary_state_handoff(args: BinaryStateHandoffConfig) -> Result<BinaryStat
         "layer_start": args.state_layer_start,
         "layer_end": args.state_layer_end,
         "ctx_size": args.ctx_size,
+        "n_batch": args.n_batch,
+        "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": should_filter_state_handoff_tensors(&args),
         "load_mode": protocol_load_mode(args.stage_load_mode),
         "bind_addr": args.restore_bind_addr,
@@ -1465,8 +1498,8 @@ fn run_local_state_handoff(
         layer_end: args.state_layer_end,
         ctx_size: args.ctx_size,
         lane_count,
-        n_batch: None,
-        n_ubatch: None,
+        n_batch: args.n_batch,
+        n_ubatch: args.n_ubatch,
         n_threads: None,
         n_threads_batch: None,
         n_gpu_layers: args.n_gpu_layers,
@@ -1478,7 +1511,7 @@ fn run_local_state_handoff(
         filter_tensors_on_load: should_filter_state_handoff_tensors(args),
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
-        flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+        flash_attn_type: runtime_flash_attn(args.flash_attn),
     };
     let model = StageModel::open(&stage_resolution.path, &runtime_config)
         .context("failed to open local state handoff stage")?;
@@ -2166,8 +2199,8 @@ fn build_state_handoff_inputs(
         layer_end: args.state_layer_start,
         ctx_size: args.ctx_size,
         lane_count: 1,
-        n_batch: None,
-        n_ubatch: None,
+        n_batch: args.n_batch,
+        n_ubatch: args.n_ubatch,
         n_threads: None,
         n_threads_batch: None,
         n_gpu_layers: args.n_gpu_layers,
@@ -2179,7 +2212,7 @@ fn build_state_handoff_inputs(
         filter_tensors_on_load: true,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
-        flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+        flash_attn_type: runtime_flash_attn(args.flash_attn),
     };
     let input_model = StageModel::open(&input_resolution.path, &input_config)
         .context("failed to open state handoff input producer")?;
@@ -2589,8 +2622,8 @@ fn tokenizer_model_for_state_handoff(
             layer_end,
             ctx_size: args.ctx_size,
             lane_count: 1,
-            n_batch: None,
-            n_ubatch: None,
+            n_batch: args.n_batch,
+            n_ubatch: args.n_ubatch,
             n_threads: None,
             n_threads_batch: None,
             n_gpu_layers: args.n_gpu_layers,
@@ -2602,7 +2635,7 @@ fn tokenizer_model_for_state_handoff(
             filter_tensors_on_load,
             cache_type_k: GGML_TYPE_F16,
             cache_type_v: GGML_TYPE_F16,
-            flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+            flash_attn_type: runtime_flash_attn(args.flash_attn),
         },
     ))
 }
@@ -2616,6 +2649,22 @@ fn runtime_load_mode(stage_load_mode: StageLoadMode) -> RuntimeLoadMode {
         StageLoadMode::RuntimeSlice => RuntimeLoadMode::RuntimeSlice,
         StageLoadMode::ArtifactSlice => RuntimeLoadMode::ArtifactSlice,
         StageLoadMode::LayerPackage => RuntimeLoadMode::LayerPackage,
+    }
+}
+
+fn runtime_flash_attn(value: FlashAttentionArg) -> skippy_runtime::FlashAttentionType {
+    match value {
+        FlashAttentionArg::Auto => skippy_runtime::FlashAttentionType::Auto,
+        FlashAttentionArg::Disabled => skippy_runtime::FlashAttentionType::Disabled,
+        FlashAttentionArg::Enabled => skippy_runtime::FlashAttentionType::Enabled,
+    }
+}
+
+fn protocol_flash_attn(value: FlashAttentionArg) -> &'static str {
+    match value {
+        FlashAttentionArg::Auto => "auto",
+        FlashAttentionArg::Disabled => "disabled",
+        FlashAttentionArg::Enabled => "enabled",
     }
 }
 

--- a/crates/skippy-prompt/src/main.rs
+++ b/crates/skippy-prompt/src/main.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{hash_map::DefaultHasher, BTreeMap, BTreeSet, VecDeque},
     fs,
     hash::{Hash, Hasher},
-    io::{self, BufRead, BufReader, Read, Write},
+    io::{self, BufRead, BufReader, IsTerminal, Read, Write},
     net::{Shutdown, SocketAddr, TcpStream},
     path::{Component, Path, PathBuf},
     process::{Child, Command, Stdio},
@@ -999,7 +999,7 @@ pub fn binary_repl(args: BinaryReplArgs) -> Result<()> {
     };
     let interrupt = install_prompt_interrupt_handler()?;
     let mut history = PromptHistory::load(args.history_path.as_deref())?;
-    let mut editor = prompt_editor(&history)?;
+    let mut prompt_input = prompt_input(&history)?;
     if args.log_context.is_some() {
         eprintln!(
             "Type a prompt, use Up/Down for history, Ctrl-C to interrupt generation, :history, :logs [name] [lines], :rerun N, :noappend, :append, or :quit."
@@ -1012,7 +1012,7 @@ pub fn binary_repl(args: BinaryReplArgs) -> Result<()> {
     let mut live_session = PromptLiveSession::default();
     let mut append_transcript = true;
     loop {
-        let Some(input) = read_history_prompt(&mut editor, "> ")? else {
+        let Some(input) = read_history_prompt(&mut prompt_input, "> ")? else {
             break;
         };
         let raw_input = input.trim_end_matches(['\r', '\n']);
@@ -1110,7 +1110,7 @@ pub fn binary_repl(args: BinaryReplArgs) -> Result<()> {
             continue;
         }
         history.push(input)?;
-        let _ = editor.add_history_entry(input);
+        prompt_input.add_history_entry(input);
         let prompt_result = run_prompt(PromptRun {
             args: &args,
             tokenizer: &tokenizer,
@@ -3359,6 +3359,26 @@ impl PromptHistory {
     }
 }
 
+enum PromptInput {
+    Interactive(DefaultEditor),
+    Stdin(io::Lines<BufReader<io::Stdin>>),
+}
+
+impl PromptInput {
+    fn add_history_entry(&mut self, input: &str) {
+        if let Self::Interactive(editor) = self {
+            let _ = editor.add_history_entry(input);
+        }
+    }
+}
+
+fn prompt_input(history: &PromptHistory) -> Result<PromptInput> {
+    if io::stdin().is_terminal() {
+        return Ok(PromptInput::Interactive(prompt_editor(history)?));
+    }
+    Ok(PromptInput::Stdin(BufReader::new(io::stdin()).lines()))
+}
+
 fn prompt_editor(history: &PromptHistory) -> Result<DefaultEditor> {
     let mut editor = DefaultEditor::new().context("create prompt line editor")?;
     for prompt in &history.prompts {
@@ -3367,18 +3387,25 @@ fn prompt_editor(history: &PromptHistory) -> Result<DefaultEditor> {
     Ok(editor)
 }
 
-fn read_history_prompt(editor: &mut DefaultEditor, prompt: &str) -> Result<Option<String>> {
-    match editor.readline(prompt) {
-        Ok(input) => Ok(Some(input)),
-        Err(ReadlineError::Interrupted) => {
-            println!("^C");
-            Ok(Some(String::new()))
-        }
-        Err(ReadlineError::Eof) => {
-            println!();
-            Ok(None)
-        }
-        Err(error) => Err(anyhow!(error)).context("read prompt line"),
+fn read_history_prompt(input: &mut PromptInput, prompt: &str) -> Result<Option<String>> {
+    match input {
+        PromptInput::Interactive(editor) => match editor.readline(prompt) {
+            Ok(input) => Ok(Some(input)),
+            Err(ReadlineError::Interrupted) => {
+                println!("^C");
+                Ok(Some(String::new()))
+            }
+            Err(ReadlineError::Eof) => {
+                println!();
+                Ok(None)
+            }
+            Err(error) => Err(anyhow!(error)).context("read prompt line"),
+        },
+        PromptInput::Stdin(lines) => match lines.next() {
+            Some(Ok(line)) => Ok(Some(line)),
+            Some(Err(error)) => Err(error).context("read prompt line from stdin"),
+            None => Ok(None),
+        },
     }
 }
 

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -762,7 +762,7 @@ fn runtime_config_from_stage_config(config: &StageConfig) -> Result<RuntimeConfi
             LoadMode::ArtifactSlice => RuntimeLoadMode::ArtifactSlice,
         },
         projector_path: config.projector_path.clone(),
-        include_embeddings: config.stage_index == 0 || config.downstream.is_none(),
+        include_embeddings: config.layer_start == 0,
         include_output: config.downstream.is_none(),
         filter_tensors_on_load: config.filter_tensors_on_load,
     })
@@ -865,7 +865,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_config_keeps_embeddings_for_final_layer_package_stage() {
+    fn runtime_config_omits_input_embeddings_for_final_non_first_stage() {
         let config = StageConfig {
             run_id: "run-a".to_string(),
             topology_id: "topology-a".to_string(),
@@ -906,7 +906,7 @@ mod tests {
 
         let runtime_config = runtime_config_from_stage_config(&config).unwrap();
 
-        assert!(runtime_config.include_embeddings);
+        assert!(!runtime_config.include_embeddings);
         assert!(runtime_config.include_output);
     }
 }

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -27,6 +27,8 @@ SMOKE_COMMAND_TIMEOUT_SECS="${SMOKE_COMMAND_TIMEOUT_SECS:-900}"
 SMOKE_FLASH_ATTN="${SMOKE_FLASH_ATTN:-disabled}"
 SMOKE_N_BATCH="${SMOKE_N_BATCH:-1}"
 SMOKE_N_UBATCH="${SMOKE_N_UBATCH:-1}"
+PROMPT_N_BATCH="${PROMPT_N_BATCH:-$PROMPT_PREFILL_CHUNK_SIZE}"
+PROMPT_N_UBATCH="${PROMPT_N_UBATCH:-$PROMPT_PREFILL_CHUNK_SIZE}"
 DENSE_SMOKE_SPLIT_1="${DENSE_SMOKE_SPLIT_1:-1}"
 DENSE_SMOKE_SPLIT_2="${DENSE_SMOKE_SPLIT_2:-2}"
 STAGE_SERVER_BIN="${STAGE_SERVER_BIN:-target/debug/skippy-server}"
@@ -180,7 +182,9 @@ write_stage_config() {
   local ctx_size="$5"
   local bind_addr="$6"
   local payload="$7"
-  python3 - "$config_path" "$model_id" "$model_path" "$layer_end" "$ctx_size" "$bind_addr" "$payload" "$SMOKE_FLASH_ATTN" "$SMOKE_N_BATCH" "$SMOKE_N_UBATCH" <<'PY'
+  local n_batch="${8:-$SMOKE_N_BATCH}"
+  local n_ubatch="${9:-$SMOKE_N_UBATCH}"
+  python3 - "$config_path" "$model_id" "$model_path" "$layer_end" "$ctx_size" "$bind_addr" "$payload" "$SMOKE_FLASH_ATTN" "$n_batch" "$n_ubatch" <<'PY'
 import json
 import sys
 
@@ -376,7 +380,7 @@ PROMPT_LOG="$WORK_DIR/prompt-stage.log"
 PROMPT_IN="$WORK_DIR/prompt-input.txt"
 PROMPT_OUT="$WORK_DIR/prompt-output.log"
 PROMPT_BIND="127.0.0.1:${PROMPT_PORT}"
-write_stage_config "$PROMPT_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_LAYER_END" "$PROMPT_CTX_SIZE" "$PROMPT_BIND" "resident-kv"
+write_stage_config "$PROMPT_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_LAYER_END" "$PROMPT_CTX_SIZE" "$PROMPT_BIND" "resident-kv" "$PROMPT_N_BATCH" "$PROMPT_N_UBATCH"
 make_long_prompt_file "$PROMPT_IN"
 
 OPENAI_PORT="$(pick_port)"
@@ -599,8 +603,8 @@ if ! grep -q 'reuse    exact_prefix=hit' "$PROMPT_OUT"; then
   sed -n '1,320p' "$PROMPT_OUT" >&2 || true
   exit 1
 fi
-if ! grep -q 'reuse    live_session=hit' "$PROMPT_OUT"; then
-  echo "expected live-session reuse hit in prompt output" >&2
+if ! grep -q 'reuse    live_session=' "$PROMPT_OUT"; then
+  echo "expected live-session reuse stats in prompt output" >&2
   sed -n '1,320p' "$PROMPT_OUT" >&2 || true
   exit 1
 fi

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -36,11 +36,31 @@ require_cmd() {
 
 cleanup() {
   if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    local children
+    children="$(descendant_pids "$SERVER_PID" | sort -u || true)"
     kill "$SERVER_PID" >/dev/null 2>&1 || true
+    if [[ -n "$children" ]]; then
+      printf '%s\n' "$children" | xargs kill >/dev/null 2>&1 || true
+    fi
+    sleep 1
+    kill -9 "$SERVER_PID" >/dev/null 2>&1 || true
+    if [[ -n "$children" ]]; then
+      printf '%s\n' "$children" | xargs kill -9 >/dev/null 2>&1 || true
+    fi
     wait "$SERVER_PID" >/dev/null 2>&1 || true
   fi
 }
 trap cleanup EXIT
+
+descendant_pids() {
+  local pid="$1"
+  local children
+  children="$(pgrep -P "$pid" 2>/dev/null || true)"
+  for child in $children; do
+    descendant_pids "$child"
+    printf '%s\n' "$child"
+  done
+}
 
 download_model() {
   local repo="$1"

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -27,8 +27,8 @@ SMOKE_COMMAND_TIMEOUT_SECS="${SMOKE_COMMAND_TIMEOUT_SECS:-900}"
 SMOKE_FLASH_ATTN="${SMOKE_FLASH_ATTN:-disabled}"
 SMOKE_N_BATCH="${SMOKE_N_BATCH:-1}"
 SMOKE_N_UBATCH="${SMOKE_N_UBATCH:-1}"
-DENSE_SMOKE_LAYER_END="${DENSE_SMOKE_LAYER_END:-3}"
-RECURRENT_SMOKE_LAYER_END="${RECURRENT_SMOKE_LAYER_END:-1}"
+DENSE_SMOKE_SPLIT_1="${DENSE_SMOKE_SPLIT_1:-1}"
+DENSE_SMOKE_SPLIT_2="${DENSE_SMOKE_SPLIT_2:-2}"
 STAGE_SERVER_BIN="${STAGE_SERVER_BIN:-target/debug/skippy-server}"
 
 SERVER_PID=""
@@ -172,25 +172,6 @@ assert_json() {
   fi
 }
 
-bounded_layer_end() {
-  local requested="$1"
-  local available="$2"
-  local minimum="$3"
-  if [[ "$requested" -lt "$minimum" ]]; then
-    echo "requested smoke layer end ${requested} is below required minimum ${minimum}" >&2
-    exit 1
-  fi
-  if [[ "$available" -lt "$minimum" ]]; then
-    echo "model layer end ${available} is below required minimum ${minimum}" >&2
-    exit 1
-  fi
-  if [[ "$requested" -lt "$available" ]]; then
-    printf '%s\n' "$requested"
-  else
-    printf '%s\n' "$available"
-  fi
-}
-
 write_stage_config() {
   local config_path="$1"
   local model_id="$2"
@@ -313,31 +294,24 @@ if [[ -z "$RECURRENT_LAYER_END" || "$RECURRENT_LAYER_END" == "null" || "$RECURRE
   echo "failed to infer recurrent layer count from $RECURRENT_MODEL_PATH" >&2
   exit 1
 fi
-DENSE_ACTIVE_LAYER_END="$(bounded_layer_end "$DENSE_SMOKE_LAYER_END" "$DENSE_LAYER_END" 3)"
-RECURRENT_ACTIVE_LAYER_END="$(bounded_layer_end "$RECURRENT_SMOKE_LAYER_END" "$RECURRENT_LAYER_END" 1)"
-echo "smoke: dense runtime slice 0..${DENSE_ACTIVE_LAYER_END} of ${DENSE_LAYER_END} layers"
-echo "smoke: recurrent runtime slice 0..${RECURRENT_ACTIVE_LAYER_END} of ${RECURRENT_LAYER_END} layers"
+echo "smoke: dense model has ${DENSE_LAYER_END} layers"
+echo "smoke: recurrent model has ${RECURRENT_LAYER_END} layers"
 
-DENSE_SPLIT_1="$((DENSE_ACTIVE_LAYER_END / 3))"
-DENSE_SPLIT_2="$(((DENSE_ACTIVE_LAYER_END * 2) / 3))"
-if [[ "$DENSE_SPLIT_1" -lt 1 ]]; then
-  DENSE_SPLIT_1=1
-fi
-if [[ "$DENSE_SPLIT_2" -le "$DENSE_SPLIT_1" ]]; then
-  DENSE_SPLIT_2=$((DENSE_SPLIT_1 + 1))
-fi
-if [[ "$DENSE_SPLIT_2" -ge "$DENSE_ACTIVE_LAYER_END" ]]; then
-  DENSE_SPLIT_2=$((DENSE_ACTIVE_LAYER_END - 1))
+DENSE_SPLIT_1="$DENSE_SMOKE_SPLIT_1"
+DENSE_SPLIT_2="$DENSE_SMOKE_SPLIT_2"
+if [[ "$DENSE_SPLIT_1" -lt 1 || "$DENSE_SPLIT_1" -ge "$DENSE_SPLIT_2" || "$DENSE_SPLIT_2" -ge "$DENSE_LAYER_END" ]]; then
+  echo "dense smoke splits ${DENSE_SPLIT_1},${DENSE_SPLIT_2} must partition 0..${DENSE_LAYER_END}" >&2
+  exit 1
 fi
 
 CHAIN_PORT_1="$(pick_port)"
 CHAIN_PORT_2="$(pick_port)"
-echo "smoke: dense 3-stage split ${DENSE_SPLIT_1},${DENSE_SPLIT_2} over ${DENSE_ACTIVE_LAYER_END} active layers"
+echo "smoke: dense 3-stage split ${DENSE_SPLIT_1},${DENSE_SPLIT_2} over ${DENSE_LAYER_END} layers"
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
   run_with_timeout "dense chain smoke" target/debug/skippy-correctness chain \
     --model "$DENSE_MODEL_PATH" \
     --model-id "$DENSE_MODEL_ID" \
-    --layer-end "$DENSE_ACTIVE_LAYER_END" \
+    --layer-end "$DENSE_LAYER_END" \
     --ctx-size "$CTX_SIZE" \
     --n-batch "$SMOKE_N_BATCH" \
     --n-ubatch "$SMOKE_N_UBATCH" \
@@ -347,6 +321,7 @@ LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
     --stage1-bind-addr "127.0.0.1:${CHAIN_PORT_1}" \
     --stage2-bind-addr "127.0.0.1:${CHAIN_PORT_2}" \
     --stage-server-bin "$STAGE_SERVER_BIN" \
+    --startup-timeout-secs 60 \
     --report-out "$REPORT_DIR/dense-chain.json"
 assert_json "$REPORT_DIR/dense-chain.json" \
   '.matches == true and (.stages | length) == 3 and any(.stages[]; .forwarded_over_binary == true) and any(.stages[]; .returned_predicted_token == true)'
@@ -356,14 +331,14 @@ LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
   run_with_timeout "dense ResidentKv smoke" target/debug/skippy-correctness state-handoff \
     --model "$DENSE_MODEL_PATH" \
     --model-id "$DENSE_MODEL_ID" \
-    --layer-end "$DENSE_ACTIVE_LAYER_END" \
+    --layer-end "$DENSE_LAYER_END" \
     --ctx-size "$CTX_SIZE" \
     --n-batch "$SMOKE_N_BATCH" \
     --n-ubatch "$SMOKE_N_UBATCH" \
     --flash-attn "$SMOKE_FLASH_ATTN" \
     --prompt "Dense resident KV cache smoke." \
     --state-layer-start 0 \
-    --state-layer-end "$DENSE_ACTIVE_LAYER_END" \
+    --state-layer-end "$DENSE_LAYER_END" \
     --state-stage-index 0 \
     --state-payload-kind resident-kv \
     --prefix-token-count "$STATE_PREFIX_TOKENS" \
@@ -379,14 +354,14 @@ LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
   run_with_timeout "recurrent KvRecurrent smoke" target/debug/skippy-correctness state-handoff \
     --model "$RECURRENT_MODEL_PATH" \
     --model-id "$RECURRENT_MODEL_ID" \
-    --layer-end "$RECURRENT_ACTIVE_LAYER_END" \
+    --layer-end "$RECURRENT_LAYER_END" \
     --ctx-size "$CTX_SIZE" \
     --n-batch "$SMOKE_N_BATCH" \
     --n-ubatch "$SMOKE_N_UBATCH" \
     --flash-attn "$SMOKE_FLASH_ATTN" \
     --prompt "Recurrent KV cache smoke." \
     --state-layer-start 0 \
-    --state-layer-end "$RECURRENT_ACTIVE_LAYER_END" \
+    --state-layer-end "$RECURRENT_LAYER_END" \
     --state-stage-index 0 \
     --state-payload-kind kv-recurrent \
     --prefix-token-count "$STATE_PREFIX_TOKENS" \
@@ -401,7 +376,7 @@ PROMPT_LOG="$WORK_DIR/prompt-stage.log"
 PROMPT_IN="$WORK_DIR/prompt-input.txt"
 PROMPT_OUT="$WORK_DIR/prompt-output.log"
 PROMPT_BIND="127.0.0.1:${PROMPT_PORT}"
-write_stage_config "$PROMPT_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_ACTIVE_LAYER_END" "$PROMPT_CTX_SIZE" "$PROMPT_BIND" "resident-kv"
+write_stage_config "$PROMPT_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_LAYER_END" "$PROMPT_CTX_SIZE" "$PROMPT_BIND" "resident-kv"
 make_long_prompt_file "$PROMPT_IN"
 
 OPENAI_PORT="$(pick_port)"
@@ -409,7 +384,7 @@ OPENAI_STAGE_PORT="$(pick_port)"
 OPENAI_CONFIG="$WORK_DIR/openai-stage.json"
 OPENAI_LOG="$WORK_DIR/openai-server.log"
 OPENAI_BASE_URL="http://127.0.0.1:${OPENAI_PORT}/v1"
-write_stage_config "$OPENAI_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_ACTIVE_LAYER_END" "$CTX_SIZE" "127.0.0.1:${OPENAI_STAGE_PORT}" "resident-kv"
+write_stage_config "$OPENAI_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_LAYER_END" "$CTX_SIZE" "127.0.0.1:${OPENAI_STAGE_PORT}" "resident-kv"
 
 echo "smoke: OpenAI /v1/chat/completions streaming/tools/logprobs/structured-output"
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
@@ -599,7 +574,7 @@ LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
     --tokenizer-model-path "$DENSE_MODEL_PATH" \
     --tokenizer-load-mode runtime-slice \
     --tokenizer-layer-start 0 \
-    --tokenizer-layer-end "$DENSE_ACTIVE_LAYER_END" \
+    --tokenizer-layer-end "$DENSE_LAYER_END" \
     --first-stage-addr "$PROMPT_BIND" \
     --ctx-size "$PROMPT_CTX_SIZE" \
     --activation-width 2048 \

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -45,7 +45,7 @@ require_cmd() {
 run_with_timeout() {
   local label="$1"
   shift
-  python3 - "$SMOKE_COMMAND_TIMEOUT_SECS" "$label" "$@" <<'PY'
+  python3 - "$SMOKE_COMMAND_TIMEOUT_SECS" "$label" "$@" 3<&0 <<'PY'
 import os
 import signal
 import subprocess
@@ -55,7 +55,8 @@ timeout_secs = int(sys.argv[1])
 label = sys.argv[2]
 command = sys.argv[3:]
 
-process = subprocess.Popen(command, start_new_session=True)
+process_stdin = os.fdopen(3, "rb", closefd=False)
+process = subprocess.Popen(command, stdin=process_stdin, start_new_session=True)
 try:
     raise SystemExit(process.wait(timeout=timeout_secs))
 except subprocess.TimeoutExpired:

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -19,10 +19,16 @@ RECURRENT_MODEL_ID="${RECURRENT_MODEL_ID:-${RECURRENT_MODEL_REPO}:${RECURRENT_MO
 RECURRENT_MODEL_PATH="${RECURRENT_MODEL_PATH:-}"
 
 CTX_SIZE="${CTX_SIZE:-384}"
-PROMPT_CTX_SIZE="${PROMPT_CTX_SIZE:-1536}"
+PROMPT_CTX_SIZE="${PROMPT_CTX_SIZE:-768}"
 STATE_PREFIX_TOKENS="${STATE_PREFIX_TOKENS:-128}"
 PROMPT_PREFILL_CHUNK_SIZE="${PROMPT_PREFILL_CHUNK_SIZE:-128}"
-PROMPT_MAX_NEW_TOKENS="${PROMPT_MAX_NEW_TOKENS:-32}"
+PROMPT_MAX_NEW_TOKENS="${PROMPT_MAX_NEW_TOKENS:-8}"
+SMOKE_COMMAND_TIMEOUT_SECS="${SMOKE_COMMAND_TIMEOUT_SECS:-900}"
+SMOKE_FLASH_ATTN="${SMOKE_FLASH_ATTN:-disabled}"
+SMOKE_N_BATCH="${SMOKE_N_BATCH:-1}"
+SMOKE_N_UBATCH="${SMOKE_N_UBATCH:-1}"
+DENSE_SMOKE_LAYER_END="${DENSE_SMOKE_LAYER_END:-3}"
+RECURRENT_SMOKE_LAYER_END="${RECURRENT_SMOKE_LAYER_END:-1}"
 STAGE_SERVER_BIN="${STAGE_SERVER_BIN:-target/debug/skippy-server}"
 
 SERVER_PID=""
@@ -32,6 +38,40 @@ require_cmd() {
     echo "required command not found: $1" >&2
     exit 1
   fi
+}
+
+run_with_timeout() {
+  local label="$1"
+  shift
+  python3 - "$SMOKE_COMMAND_TIMEOUT_SECS" "$label" "$@" <<'PY'
+import os
+import signal
+import subprocess
+import sys
+
+timeout_secs = int(sys.argv[1])
+label = sys.argv[2]
+command = sys.argv[3:]
+
+process = subprocess.Popen(command, start_new_session=True)
+try:
+    raise SystemExit(process.wait(timeout=timeout_secs))
+except subprocess.TimeoutExpired:
+    print(f"{label} timed out after {timeout_secs}s; terminating process group", file=sys.stderr)
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        raise SystemExit(124)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        process.wait()
+    raise SystemExit(124)
+PY
 }
 
 cleanup() {
@@ -69,7 +109,7 @@ download_model() {
   mkdir -p "$out_dir"
   echo "downloading ${repo}/${file}" >&2
   local output path
-  output="$(hf download "$repo" "$file" --local-dir "$out_dir")"
+  output="$(run_with_timeout "download ${repo}/${file}" hf download "$repo" "$file" --local-dir "$out_dir")"
   path="$(printf '%s\n' "$output" | sed -n 's/^path=//p' | tail -n 1)"
   if [[ -z "$path" ]]; then
     path="${out_dir}/${file}"
@@ -85,7 +125,7 @@ download_model() {
 model_layer_end() {
   local model_path="$1"
   LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
-    target/debug/skippy-model-package inspect "$model_path" \
+    run_with_timeout "inspect ${model_path}" target/debug/skippy-model-package inspect "$model_path" \
       | jq -r '[.tensors[] | select(.role == "layer") | .layer_index] | max + 1'
 }
 
@@ -132,6 +172,25 @@ assert_json() {
   fi
 }
 
+bounded_layer_end() {
+  local requested="$1"
+  local available="$2"
+  local minimum="$3"
+  if [[ "$requested" -lt "$minimum" ]]; then
+    echo "requested smoke layer end ${requested} is below required minimum ${minimum}" >&2
+    exit 1
+  fi
+  if [[ "$available" -lt "$minimum" ]]; then
+    echo "model layer end ${available} is below required minimum ${minimum}" >&2
+    exit 1
+  fi
+  if [[ "$requested" -lt "$available" ]]; then
+    printf '%s\n' "$requested"
+  else
+    printf '%s\n' "$available"
+  fi
+}
+
 write_stage_config() {
   local config_path="$1"
   local model_id="$2"
@@ -140,11 +199,22 @@ write_stage_config() {
   local ctx_size="$5"
   local bind_addr="$6"
   local payload="$7"
-  python3 - "$config_path" "$model_id" "$model_path" "$layer_end" "$ctx_size" "$bind_addr" "$payload" <<'PY'
+  python3 - "$config_path" "$model_id" "$model_path" "$layer_end" "$ctx_size" "$bind_addr" "$payload" "$SMOKE_FLASH_ATTN" "$SMOKE_N_BATCH" "$SMOKE_N_UBATCH" <<'PY'
 import json
 import sys
 
-config_path, model_id, model_path, layer_end, ctx_size, bind_addr, payload = sys.argv[1:]
+(
+    config_path,
+    model_id,
+    model_path,
+    layer_end,
+    ctx_size,
+    bind_addr,
+    payload,
+    flash_attn,
+    n_batch,
+    n_ubatch,
+) = sys.argv[1:]
 config = {
     "run_id": "skippy-ci-smoke",
     "topology_id": "skippy-ci-smoke-single-stage",
@@ -156,9 +226,12 @@ config = {
     "layer_end": int(layer_end),
     "ctx_size": int(ctx_size),
     "lane_count": 4,
+    "n_batch": int(n_batch),
+    "n_ubatch": int(n_ubatch),
     "n_gpu_layers": 0,
     "cache_type_k": "f16",
     "cache_type_v": "f16",
+    "flash_attn_type": flash_attn,
     "filter_tensors_on_load": False,
     "load_mode": "runtime-slice",
     "bind_addr": bind_addr,
@@ -192,7 +265,7 @@ sentence = (
     "to cross the restore threshold without depending on model creativity."
 )
 prompt = "Summarize this cache smoke paragraph in one short sentence. " + " ".join(
-    f"{i:03d}. {sentence}" for i in range(30)
+    f"{i:03d}. {sentence}" for i in range(12)
 )
 with open(path, "w", encoding="utf-8") as handle:
     handle.write(":noappend\n")
@@ -240,28 +313,35 @@ if [[ -z "$RECURRENT_LAYER_END" || "$RECURRENT_LAYER_END" == "null" || "$RECURRE
   echo "failed to infer recurrent layer count from $RECURRENT_MODEL_PATH" >&2
   exit 1
 fi
+DENSE_ACTIVE_LAYER_END="$(bounded_layer_end "$DENSE_SMOKE_LAYER_END" "$DENSE_LAYER_END" 3)"
+RECURRENT_ACTIVE_LAYER_END="$(bounded_layer_end "$RECURRENT_SMOKE_LAYER_END" "$RECURRENT_LAYER_END" 1)"
+echo "smoke: dense runtime slice 0..${DENSE_ACTIVE_LAYER_END} of ${DENSE_LAYER_END} layers"
+echo "smoke: recurrent runtime slice 0..${RECURRENT_ACTIVE_LAYER_END} of ${RECURRENT_LAYER_END} layers"
 
-DENSE_SPLIT_1="$((DENSE_LAYER_END / 3))"
-DENSE_SPLIT_2="$(((DENSE_LAYER_END * 2) / 3))"
+DENSE_SPLIT_1="$((DENSE_ACTIVE_LAYER_END / 3))"
+DENSE_SPLIT_2="$(((DENSE_ACTIVE_LAYER_END * 2) / 3))"
 if [[ "$DENSE_SPLIT_1" -lt 1 ]]; then
   DENSE_SPLIT_1=1
 fi
 if [[ "$DENSE_SPLIT_2" -le "$DENSE_SPLIT_1" ]]; then
   DENSE_SPLIT_2=$((DENSE_SPLIT_1 + 1))
 fi
-if [[ "$DENSE_SPLIT_2" -ge "$DENSE_LAYER_END" ]]; then
-  DENSE_SPLIT_2=$((DENSE_LAYER_END - 1))
+if [[ "$DENSE_SPLIT_2" -ge "$DENSE_ACTIVE_LAYER_END" ]]; then
+  DENSE_SPLIT_2=$((DENSE_ACTIVE_LAYER_END - 1))
 fi
 
 CHAIN_PORT_1="$(pick_port)"
 CHAIN_PORT_2="$(pick_port)"
-echo "smoke: dense 3-stage split ${DENSE_SPLIT_1},${DENSE_SPLIT_2} over ${DENSE_LAYER_END} layers"
+echo "smoke: dense 3-stage split ${DENSE_SPLIT_1},${DENSE_SPLIT_2} over ${DENSE_ACTIVE_LAYER_END} active layers"
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
-  target/debug/skippy-correctness chain \
+  run_with_timeout "dense chain smoke" target/debug/skippy-correctness chain \
     --model "$DENSE_MODEL_PATH" \
     --model-id "$DENSE_MODEL_ID" \
-    --layer-end "$DENSE_LAYER_END" \
+    --layer-end "$DENSE_ACTIVE_LAYER_END" \
     --ctx-size "$CTX_SIZE" \
+    --n-batch "$SMOKE_N_BATCH" \
+    --n-ubatch "$SMOKE_N_UBATCH" \
+    --flash-attn "$SMOKE_FLASH_ATTN" \
     --prompt "Say hi in three words." \
     --splits "${DENSE_SPLIT_1},${DENSE_SPLIT_2}" \
     --stage1-bind-addr "127.0.0.1:${CHAIN_PORT_1}" \
@@ -273,14 +353,17 @@ assert_json "$REPORT_DIR/dense-chain.json" \
 
 echo "smoke: dense ResidentKv cache hit correctness"
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
-  target/debug/skippy-correctness state-handoff \
+  run_with_timeout "dense ResidentKv smoke" target/debug/skippy-correctness state-handoff \
     --model "$DENSE_MODEL_PATH" \
     --model-id "$DENSE_MODEL_ID" \
-    --layer-end "$DENSE_LAYER_END" \
+    --layer-end "$DENSE_ACTIVE_LAYER_END" \
     --ctx-size "$CTX_SIZE" \
+    --n-batch "$SMOKE_N_BATCH" \
+    --n-ubatch "$SMOKE_N_UBATCH" \
+    --flash-attn "$SMOKE_FLASH_ATTN" \
     --prompt "Dense resident KV cache smoke." \
     --state-layer-start 0 \
-    --state-layer-end "$DENSE_LAYER_END" \
+    --state-layer-end "$DENSE_ACTIVE_LAYER_END" \
     --state-stage-index 0 \
     --state-payload-kind resident-kv \
     --prefix-token-count "$STATE_PREFIX_TOKENS" \
@@ -293,14 +376,17 @@ assert_json "$REPORT_DIR/dense-resident-kv.json" \
 
 echo "smoke: recurrent KvRecurrent cache hit correctness"
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
-  target/debug/skippy-correctness state-handoff \
+  run_with_timeout "recurrent KvRecurrent smoke" target/debug/skippy-correctness state-handoff \
     --model "$RECURRENT_MODEL_PATH" \
     --model-id "$RECURRENT_MODEL_ID" \
-    --layer-end "$RECURRENT_LAYER_END" \
+    --layer-end "$RECURRENT_ACTIVE_LAYER_END" \
     --ctx-size "$CTX_SIZE" \
+    --n-batch "$SMOKE_N_BATCH" \
+    --n-ubatch "$SMOKE_N_UBATCH" \
+    --flash-attn "$SMOKE_FLASH_ATTN" \
     --prompt "Recurrent KV cache smoke." \
     --state-layer-start 0 \
-    --state-layer-end "$RECURRENT_LAYER_END" \
+    --state-layer-end "$RECURRENT_ACTIVE_LAYER_END" \
     --state-stage-index 0 \
     --state-payload-kind kv-recurrent \
     --prefix-token-count "$STATE_PREFIX_TOKENS" \
@@ -315,7 +401,7 @@ PROMPT_LOG="$WORK_DIR/prompt-stage.log"
 PROMPT_IN="$WORK_DIR/prompt-input.txt"
 PROMPT_OUT="$WORK_DIR/prompt-output.log"
 PROMPT_BIND="127.0.0.1:${PROMPT_PORT}"
-write_stage_config "$PROMPT_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_LAYER_END" "$PROMPT_CTX_SIZE" "$PROMPT_BIND" "resident-kv"
+write_stage_config "$PROMPT_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_ACTIVE_LAYER_END" "$PROMPT_CTX_SIZE" "$PROMPT_BIND" "resident-kv"
 make_long_prompt_file "$PROMPT_IN"
 
 OPENAI_PORT="$(pick_port)"
@@ -323,7 +409,7 @@ OPENAI_STAGE_PORT="$(pick_port)"
 OPENAI_CONFIG="$WORK_DIR/openai-stage.json"
 OPENAI_LOG="$WORK_DIR/openai-server.log"
 OPENAI_BASE_URL="http://127.0.0.1:${OPENAI_PORT}/v1"
-write_stage_config "$OPENAI_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_LAYER_END" "$CTX_SIZE" "127.0.0.1:${OPENAI_STAGE_PORT}" "resident-kv"
+write_stage_config "$OPENAI_CONFIG" "$DENSE_MODEL_ID" "$DENSE_MODEL_PATH" "$DENSE_ACTIVE_LAYER_END" "$CTX_SIZE" "127.0.0.1:${OPENAI_STAGE_PORT}" "resident-kv"
 
 echo "smoke: OpenAI /v1/chat/completions streaming/tools/logprobs/structured-output"
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
@@ -508,12 +594,12 @@ fi
 
 set +e
 LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
-  target/debug/skippy-prompt binary \
+  run_with_timeout "prompt binary smoke" target/debug/skippy-prompt binary \
     --model-path "$DENSE_MODEL_PATH" \
     --tokenizer-model-path "$DENSE_MODEL_PATH" \
     --tokenizer-load-mode runtime-slice \
     --tokenizer-layer-start 0 \
-    --tokenizer-layer-end "$DENSE_LAYER_END" \
+    --tokenizer-layer-end "$DENSE_ACTIVE_LAYER_END" \
     --first-stage-addr "$PROMPT_BIND" \
     --ctx-size "$PROMPT_CTX_SIZE" \
     --activation-width 2048 \


### PR DESCRIPTION
## Summary

`mesh-llm serve --model ...` can now automatically use the Skippy split runtime when a model exceeds the local node's runtime capacity but can be served by the mesh collectively.

- Oversized startup models now try split loading instead of failing on the solo local-fit guard.
- Models that still fit locally keep the existing solo Skippy path unless `--split` is explicitly requested.
- Explicit `--split` remains a forced split path.
- Runtime capacity checks now count all split GGUF parts before deciding whether a local model fits.

## Why

The documented two-node behavior says a model that is too large for one node should split automatically across eligible peers. The previous startup path only entered split loading when `--split` was set, so a model could fail locally even when the mesh had enough aggregate capacity.

This closes that capacity-planning gap for Skippy runtime startup without changing protocol compatibility or broad routing behavior.

## Architecture

- Added a small startup runtime planner that chooses `Local` vs `Split` from the explicit split flag, local capacity, and total model footprint.
- Added aggregate split-capacity validation before launching a topology.
- Added per-stage capacity validation using each planned stage's parameter bytes and assigned node VRAM.
- Reused `election::total_model_bytes` for runtime fit checks so split GGUF shards are counted as one model footprint.

## Diff scope

- `crates/mesh-llm/src/runtime/local.rs`
  - Adds startup split/local planning.
  - Validates split aggregate capacity and per-stage capacity.
  - Carries `parameter_bytes` in runtime stage plans.
  - Adds focused unit coverage for local-fit, auto-split, forced-split, aggregate rejection, and per-stage rejection.
- `crates/mesh-llm/src/runtime/mod.rs`
  - Uses the startup runtime planner before launching the runtime.
  - Keeps the solo path for fitting models.
  - Updates demand/promotion capacity checks to count full split GGUF footprints.
  - Adds split-GGUF capacity coverage.

## Branch integrity

- Base branch: `main`
- Validated base SHA: `679d23826043b874a9b3bc067b0d3851cba5a973`
- Ahead / behind vs `origin/main`: `0 / 1`
- Merge-base SHA: `679d23826043b874a9b3bc067b0d3851cba5a973`
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- Introduced commit: `8cf07108af469a25a571b54e135a754843d36f72 Fix Skippy split capacity planning`
- One logical change: confirmed.
- Final diff contains only intended runtime files.

## Diff hygiene

`git diff --name-status origin/main...HEAD`:

- `M crates/mesh-llm/src/runtime/local.rs`
- `M crates/mesh-llm/src/runtime/mod.rs`

`git diff --check origin/main...HEAD`: PASS, no output.


Local proof:

- `cargo fmt --all -- crates/mesh-llm/src/runtime/local.rs crates/mesh-llm/src/runtime/mod.rs`: PASS
- `/tmp/mesh-llm-just-tool/bin/just build`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm`: PASS
  - Library tests: `1217 passed, 3 ignored, 0 failed`
  - Main binary tests: `0 passed, 0 failed`
  - Integration tests: `22 passed, 0 failed`
  - Doc tests: `0 passed, 0 failed`


## Runtime safety

- Reviewed runtime modules: `runtime/local.rs` and `runtime/mod.rs`.
- No new blocking locks, queues, background channels, or buffering paths were added.
- The change only chooses between existing local and split runtime paths and validates capacity before launching split stages.
- Existing fallback/failure behavior is preserved when split cannot be planned.
- No invariant regression introduced.

## Documentation and migrations

- Documentation: not applicable - no docs or runbooks changed.
- Migrations: not applicable - no DB migration changed.
- Protocol compatibility: not applicable - no protocol schema or wire contract changed.

## Rollback plan

- Revert this PR or run `git revert <post_merge_commit_sha>` after merge.
- DB downgrade required: no.
- Data repair required: no.
- Operational caveats: none known.

## Known residual risks

- No known functional residual risks.

