### PR TITLE
Fix Windows mesh startup compatibility

### DIFF
--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -1,0 +1,24 @@
+# Windows helpers
+
+These optional PowerShell helpers wrap a local Windows build of `mesh-llm`.
+
+Build first from the repository root:
+
+```powershell
+just build backend=vulkan
+```
+
+Start a local server:
+
+```powershell
+.\contrib\windows\StartMeshServer.ps1 -Model Qwen2.5-3B-Instruct-Q4_K_M -Device Vulkan1
+```
+
+Chat with that server:
+
+```powershell
+.\contrib\windows\StartChat.ps1 -Model Qwen2.5-3B-Instruct-Q4_K_M
+```
+
+The scripts default to `target\release\mesh-llm.exe` when it exists, otherwise
+they fall back to `mesh-llm` on `PATH`.

--- a/contrib/windows/StartChat.ps1
+++ b/contrib/windows/StartChat.ps1
@@ -1,0 +1,58 @@
+param(
+    [string]$Model = "Qwen2.5-3B-Instruct-Q4_K_M",
+    [string]$BaseUrl = "http://localhost:9337/v1",
+    [string]$LogFile = "",
+    [int]$MaxTurns = 20
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $LogFile) {
+    $LogFile = Join-Path $env:TEMP "mesh-llm-chat.jsonl"
+}
+
+if (-not (Test-Path $LogFile)) {
+    New-Item -Path $LogFile -ItemType File -Force | Out-Null
+}
+
+$history = @()
+
+while ($true) {
+    $message = Read-Host "`nYou"
+    if ($message -in @("exit", "quit")) {
+        break
+    }
+
+    $messages = $history + @(@{ role = "user"; content = $message })
+    $body = @{
+        model = $Model
+        messages = $messages
+    } | ConvertTo-Json -Depth 16
+
+    try {
+        $response = Invoke-RestMethod `
+            -Uri "$BaseUrl/chat/completions" `
+            -Method Post `
+            -ContentType "application/json" `
+            -Body $body `
+            -ErrorAction Stop
+
+        $content = $response.choices[0].message.content
+        Write-Host "Assistant: $content" -ForegroundColor Green
+
+        $history += @{ role = "user"; content = $message }
+        $history += @{ role = "assistant"; content = $content }
+        if ($history.Count -gt ($MaxTurns * 2)) {
+            $history = $history[($history.Count - ($MaxTurns * 2))..($history.Count - 1)]
+        }
+
+        @{
+            user = $message
+            assistant = $content
+            timestamp = (Get-Date -Format "o")
+        } | ConvertTo-Json -Compress | Add-Content -Path $LogFile
+    } catch {
+        Write-Host "Could not reach Mesh-LLM at $BaseUrl" -ForegroundColor Red
+        Write-Host $_.Exception.Message -ForegroundColor DarkRed
+    }
+}

--- a/contrib/windows/StartMeshServer.ps1
+++ b/contrib/windows/StartMeshServer.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$Model = "Qwen2.5-3B-Instruct-Q4_K_M",
+    [string]$Device = "Vulkan1",
+    [int]$Port = 9337,
+    [int]$ConsolePort = 3131,
+    [string]$MeshLlm = "",
+    [string[]]$ExtraArgs = @()
+)
+
+$ErrorActionPreference = "Stop"
+
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $scriptDir "..\.."))
+
+if (-not $MeshLlm) {
+    $candidate = Join-Path $repoRoot "target\release\mesh-llm.exe"
+    if (Test-Path $candidate) {
+        $MeshLlm = $candidate
+    } else {
+        $MeshLlm = "mesh-llm"
+    }
+}
+
+& $MeshLlm serve `
+    --model $Model `
+    --device $Device `
+    --port $Port `
+    --console $ConsolePort `
+    @ExtraArgs

--- a/crates/mesh-llm/src/mesh/mod.rs
+++ b/crates/mesh-llm/src/mesh/mod.rs
@@ -64,6 +64,22 @@ const MIN_PINNED_GPU_CONFIG_PEER_VERSION: &str = "0.59.0";
 pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT: std::time::Duration =
     std::time::Duration::from_secs(15);
 
+fn quic_bind_addr(bind_port: Option<u16>) -> Option<std::net::SocketAddr> {
+    if let Some(port) = bind_port {
+        return Some(std::net::SocketAddr::from(([0, 0, 0, 0], port)));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        None
+    }
+}
+
 fn config_uses_pinned_gpu(config: &crate::plugin::MeshConfig) -> bool {
     config.gpu.assignment == crate::plugin::GpuAssignment::Pinned
 }
@@ -1911,9 +1927,9 @@ impl Node {
             tracing::info!("Relay: {:?}", urls);
             builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map));
         }
-        if let Some(port) = bind_port {
-            tracing::info!("Binding QUIC to UDP port {port}");
-            builder = builder.bind_addr(std::net::SocketAddr::from(([0, 0, 0, 0], port)))?;
+        if let Some(addr) = quic_bind_addr(bind_port) {
+            tracing::info!("Binding QUIC to {addr}");
+            builder = builder.bind_addr(addr)?;
         }
         let endpoint = builder.bind().await?;
         // Wait briefly for relay connection so the invite token includes the relay URL.
@@ -2149,6 +2165,7 @@ impl Node {
             .alpns(vec![ALPN.to_vec(), skippy_protocol::STAGE_ALPN_V1.to_vec()])
             .relay_mode(iroh::endpoint::RelayMode::Disabled)
             .transport_config(transport_config)
+            .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))?
             .bind()
             .await?;
 

--- a/crates/mesh-llm/src/mesh/tests.rs
+++ b/crates/mesh-llm/src/mesh/tests.rs
@@ -8,6 +8,29 @@ use crate::proto::node::{GossipFrame, NodeRole, PeerAnnouncement, RouteTableRequ
 use std::collections::HashSet;
 use tokio::sync::watch;
 
+#[test]
+fn quic_bind_addr_uses_explicit_port_on_all_platforms() {
+    assert_eq!(
+        quic_bind_addr(Some(7000)),
+        Some(std::net::SocketAddr::from(([0, 0, 0, 0], 7000)))
+    );
+}
+
+#[test]
+#[cfg(target_os = "windows")]
+fn quic_bind_addr_falls_back_to_localhost_ephemeral_on_windows() {
+    assert_eq!(
+        quic_bind_addr(None),
+        Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+    );
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
+    assert_eq!(quic_bind_addr(None), None);
+}
+
 async fn make_test_node(role: super::NodeRole) -> Result<Node> {
     use iroh::endpoint::QuicTransportConfig;
 

--- a/crates/mesh-llm/src/runtime/instance.rs
+++ b/crates/mesh-llm/src/runtime/instance.rs
@@ -160,9 +160,9 @@ impl InstanceRuntime {
     /// Creates the following directories (idempotent):
     /// - `{root}/{pid}/`
     ///
-    /// Then opens `{root}/{pid}/lock` and acquires a **non-blocking exclusive
-    /// flock**. Returns `Err` if the lock cannot be obtained (i.e. another live
-    /// process already holds it).
+    /// Then opens `{root}/{pid}/lock`. On Unix this also acquires a
+    /// **non-blocking exclusive flock** and returns `Err` if the lock cannot be
+    /// obtained (i.e. another live process already holds it).
     ///
     /// # Platform notes
     ///
@@ -1096,6 +1096,7 @@ mod tests {
 
     #[test]
     #[serial]
+    #[cfg(unix)]
     fn acquire_second_time_fails() {
         let dir = tempdir().unwrap();
         let _g = EnvGuard::save_and_set("MESH_LLM_RUNTIME_ROOT", dir.path().to_str().unwrap());
@@ -1106,6 +1107,18 @@ mod tests {
             result.is_err(),
             "second acquire of same pid slot must fail while first is held"
         );
+    }
+
+    #[test]
+    #[serial]
+    #[cfg(not(unix))]
+    fn acquire_second_time_is_best_effort_without_flock() {
+        let dir = tempdir().unwrap();
+        let _g = EnvGuard::save_and_set("MESH_LLM_RUNTIME_ROOT", dir.path().to_str().unwrap());
+
+        let _rt = InstanceRuntime::acquire(1003).expect("first acquire should succeed");
+        InstanceRuntime::acquire(1003)
+            .expect("non-Unix runtime acquisition is best-effort without flock");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This replaces the conflicted Windows compatibility PR in #382 with a clean branch on current `main`.

Windows nodes now bind the mesh QUIC endpoint to `127.0.0.1:0` when no explicit `--bind-port` is provided, avoiding the iroh default bind path that caused startup failures on the reported Windows/Vulkan setup. Test-only mesh nodes also bind to localhost explicitly.

The runtime instance tests now match the platform contract: Unix still enforces duplicate PID-slot exclusion through `flock`, while Windows/non-Unix keeps runtime acquisition best-effort. The PR also adds cleaned-up optional PowerShell helpers for starting a Windows server and chatting with it, without hardcoded local paths or personal dependencies.

Thanks @BiriBiri33 for the original Windows/Vulkan testing and PR. This keeps the useful pieces while avoiding the stale conflict and older runtime changes that no longer apply.

Supersedes #382.

## Validation

- Local macOS: `cargo fmt --all -- --check`
- Local macOS: `cargo check -p mesh-llm`
- Local macOS: `just build`
- Local macOS: `LLAMA_STAGE_BUILD_DIR=/Users/jdumay/code/mesh-llm-pr382/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib` (`1237 passed; 0 failed; 3 ignored`)
- `white.local`: `just build` (CUDA backend, SM 120)
- `white.local`: `LLAMA_STAGE_BUILD_DIR=/home/jdumay/code/mesh-llm-pr382-windows-fixes/.deps/llama-build/build-stage-abi-cuda-sm120 cargo test -p mesh-llm --lib` (`1238 passed; 0 failed; 3 ignored`)
