### PR TITLE
Use GGUF metadata for context and parallel defaults

### DIFF
--- a/crates/mesh-client/src/models/gguf.rs
+++ b/crates/mesh-client/src/models/gguf.rs
@@ -240,6 +240,117 @@ pub struct GgufCompactMeta {
     pub expert_used_count: u32,
 }
 
+impl GgufCompactMeta {
+    pub fn effective_kv_head_count(&self) -> Option<u32> {
+        if self.kv_head_count > 0 {
+            Some(self.kv_head_count)
+        } else if self.head_count > 0 {
+            Some(self.head_count)
+        } else {
+            None
+        }
+    }
+
+    pub fn k_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        GgufKvCacheQuant::f16().k_cache_bytes_per_token(self)
+    }
+
+    pub fn v_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        GgufKvCacheQuant::f16().v_cache_bytes_per_token(self)
+    }
+
+    pub fn kv_cache_bytes_per_token_f16(&self) -> Option<u64> {
+        GgufKvCacheQuant::f16().kv_cache_bytes_per_token(self)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GgufKvCacheType {
+    F16,
+    Q8_0,
+    Q4_0,
+}
+
+impl GgufKvCacheType {
+    pub fn from_llama_arg(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "f16" => Some(Self::F16),
+            "q8_0" => Some(Self::Q8_0),
+            "q4_0" => Some(Self::Q4_0),
+            _ => None,
+        }
+    }
+
+    fn block_shape(self) -> (u64, u64) {
+        match self {
+            Self::F16 => (1, 2),
+            Self::Q8_0 => (32, 34),
+            Self::Q4_0 => (32, 18),
+        }
+    }
+
+    fn bytes_for_elements(self, elements: u64) -> Option<u64> {
+        let (block_elements, block_bytes) = self.block_shape();
+        let blocks = elements
+            .checked_add(block_elements.checked_sub(1)?)?
+            .checked_div(block_elements)?;
+        blocks.checked_mul(block_bytes)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GgufKvCacheQuant {
+    pub k: GgufKvCacheType,
+    pub v: GgufKvCacheType,
+}
+
+impl GgufKvCacheQuant {
+    pub const fn new(k: GgufKvCacheType, v: GgufKvCacheType) -> Self {
+        Self { k, v }
+    }
+
+    pub const fn f16() -> Self {
+        Self {
+            k: GgufKvCacheType::F16,
+            v: GgufKvCacheType::F16,
+        }
+    }
+
+    pub fn from_llama_args(cache_type_k: &str, cache_type_v: &str) -> Option<Self> {
+        Some(Self {
+            k: GgufKvCacheType::from_llama_arg(cache_type_k)?,
+            v: GgufKvCacheType::from_llama_arg(cache_type_v)?,
+        })
+    }
+
+    pub fn k_cache_bytes_per_token(self, meta: &GgufCompactMeta) -> Option<u64> {
+        cache_bytes_per_token(meta, meta.key_length, self.k)
+    }
+
+    pub fn v_cache_bytes_per_token(self, meta: &GgufCompactMeta) -> Option<u64> {
+        cache_bytes_per_token(meta, meta.value_length, self.v)
+    }
+
+    pub fn kv_cache_bytes_per_token(self, meta: &GgufCompactMeta) -> Option<u64> {
+        self.k_cache_bytes_per_token(meta)?
+            .checked_add(self.v_cache_bytes_per_token(meta)?)
+    }
+}
+
+fn cache_bytes_per_token(
+    meta: &GgufCompactMeta,
+    vector_length: u32,
+    cache_type: GgufKvCacheType,
+) -> Option<u64> {
+    let kv_heads = u64::from(meta.effective_kv_head_count()?);
+    let vector_length = u64::from((vector_length > 0).then_some(vector_length)?);
+    let layers = u64::from((meta.layer_count > 0).then_some(meta.layer_count)?);
+    let elements_per_layer = kv_heads.checked_mul(vector_length)?;
+    cache_type
+        .bytes_for_elements(elements_per_layer)?
+        .checked_mul(layers)
+}
+
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct GgufTensorByteProfile {
     pub expert_count: u32,
@@ -274,8 +385,6 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
     let n_kv = read_gguf_header_count(&mut f, MAX_GGUF_HEADER_KV_COUNT, "KV count").ok()?;
 
     let mut meta = GgufCompactMeta::default();
-    let mut kv_head_count: u32 = 0;
-
     for _ in 0..n_kv {
         let key = read_gguf_string(&mut f).ok()?;
         let vtype = GgufType::from_u32(read_u32(&mut f).ok()?)?;
@@ -298,7 +407,6 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
             }
         } else if key.ends_with(".attention.head_count_kv") {
             if let Ok(Some(v)) = read_gguf_value_as_u32(&mut f, vtype) {
-                kv_head_count = v;
                 meta.kv_head_count = v;
             }
         } else if key.ends_with(".block_count") {
@@ -348,12 +456,7 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
         }
     }
     if meta.value_length == 0 {
-        let effective_kv = if kv_head_count > 0 {
-            kv_head_count
-        } else {
-            meta.head_count
-        };
-        if effective_kv > 0 {
+        if let Some(effective_kv) = meta.effective_kv_head_count() {
             if let Some(value_length) = meta.embedding_size.checked_div(effective_kv) {
                 meta.value_length = value_length;
             }
@@ -629,6 +732,64 @@ mod tests {
         assert_eq!(meta.key_length, 0);
         assert_eq!(meta.value_length, 512);
         let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn scan_gguf_compact_meta_preserves_kv_head_count() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"GGUF");
+        bytes.extend_from_slice(&2u32.to_le_bytes());
+        bytes.extend_from_slice(&0i64.to_le_bytes());
+        bytes.extend_from_slice(&6i64.to_le_bytes());
+        push_u32_kv(&mut bytes, "llama.embedding_length", 4096);
+        push_u32_kv(&mut bytes, "llama.attention.head_count", 32);
+        push_u32_kv(&mut bytes, "llama.attention.head_count_kv", 8);
+        push_u32_kv(&mut bytes, "llama.block_count", 24);
+        push_u32_kv(&mut bytes, "llama.attention.key_length", 128);
+        push_u32_kv(&mut bytes, "llama.attention.value_length", 128);
+
+        let path = write_bytes("mesh-client-gguf-kv-head-count", &bytes);
+        let meta = scan_gguf_compact_meta(&path).expect("should parse GGUF");
+        assert_eq!(meta.head_count, 32);
+        assert_eq!(meta.kv_head_count, 8);
+        assert_eq!(meta.effective_kv_head_count(), Some(8));
+        assert_eq!(meta.k_cache_bytes_per_token_f16(), Some(49_152));
+        assert_eq!(meta.v_cache_bytes_per_token_f16(), Some(49_152));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn kv_cache_quant_prices_key_and_value_types_independently() {
+        let meta = GgufCompactMeta {
+            head_count: 32,
+            kv_head_count: 8,
+            layer_count: 24,
+            key_length: 128,
+            value_length: 128,
+            ..Default::default()
+        };
+        let quant = GgufKvCacheQuant::new(GgufKvCacheType::Q8_0, GgufKvCacheType::Q4_0);
+
+        assert_eq!(quant.k_cache_bytes_per_token(&meta), Some(26_112));
+        assert_eq!(quant.v_cache_bytes_per_token(&meta), Some(13_824));
+        assert_eq!(quant.kv_cache_bytes_per_token(&meta), Some(39_936));
+    }
+
+    #[test]
+    fn kv_cache_bytes_per_token_returns_none_when_required_fields_are_missing() {
+        let meta = GgufCompactMeta {
+            head_count: 32,
+            layer_count: 24,
+            key_length: 128,
+            ..Default::default()
+        };
+
+        assert_eq!(meta.k_cache_bytes_per_token_f16(), Some(196_608));
+        assert_eq!(meta.v_cache_bytes_per_token_f16(), None);
+        assert_eq!(
+            GgufKvCacheQuant::f16().kv_cache_bytes_per_token(&meta),
+            None
+        );
     }
 
     #[test]

--- a/crates/mesh-llm/src/models/gguf.rs
+++ b/crates/mesh-llm/src/models/gguf.rs
@@ -1,3 +1,3 @@
-pub use mesh_client::models::gguf::scan_gguf_compact_meta;
+pub use mesh_client::models::gguf::{scan_gguf_compact_meta, GgufKvCacheQuant};
 
 pub type GgufCompactMeta = mesh_client::models::gguf::GgufCompactMeta;

--- a/crates/mesh-llm/src/runtime/context_planning.rs
+++ b/crates/mesh-llm/src/runtime/context_planning.rs
@@ -1,0 +1,251 @@
+use crate::models::gguf::{GgufCompactMeta, GgufKvCacheQuant};
+
+const DEFAULT_CONTEXT_LENGTH: u32 = 4096;
+const DEFAULT_PARALLEL_SLOTS: usize = 4;
+const MIN_AUTO_CONTEXT_LENGTH: u32 = 512;
+const MAX_AUTO_PARALLEL_SLOTS: usize = 16;
+const KV_CACHE_BUDGET_NUMERATOR: u64 = 85;
+const KV_CACHE_BUDGET_DENOMINATOR: u64 = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RuntimeResourcePlan {
+    pub(super) context_length: u32,
+    pub(super) slots: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct RuntimeResourcePlanInput<'a> {
+    pub(super) ctx_size_override: Option<u32>,
+    pub(super) parallel_override: Option<usize>,
+    pub(super) model_bytes: u64,
+    pub(super) vram_bytes: u64,
+    pub(super) metadata: Option<&'a GgufCompactMeta>,
+    pub(super) kv_cache_quant: GgufKvCacheQuant,
+}
+
+pub(super) fn plan_runtime_resources(input: RuntimeResourcePlanInput<'_>) -> RuntimeResourcePlan {
+    let context_length = input
+        .ctx_size_override
+        .unwrap_or_else(|| planned_context_length(input));
+    let slots = input
+        .parallel_override
+        .unwrap_or_else(|| planned_parallel_slots(input, context_length));
+
+    RuntimeResourcePlan {
+        context_length,
+        slots,
+    }
+}
+
+fn planned_context_length(input: RuntimeResourcePlanInput<'_>) -> u32 {
+    let Some(metadata) = input.metadata else {
+        return DEFAULT_CONTEXT_LENGTH;
+    };
+    let native_context = metadata.context_length;
+    if native_context == 0 {
+        return DEFAULT_CONTEXT_LENGTH;
+    }
+    let Some(kv_bytes_per_token) = input.kv_cache_quant.kv_cache_bytes_per_token(metadata) else {
+        return DEFAULT_CONTEXT_LENGTH.min(native_context);
+    };
+    let kv_budget = usable_kv_cache_budget(input.vram_bytes, input.model_bytes);
+    let max_affordable_context = kv_budget / kv_bytes_per_token;
+    if max_affordable_context == 0 {
+        return MIN_AUTO_CONTEXT_LENGTH.min(native_context);
+    }
+
+    let planned = max_affordable_context
+        .min(u64::from(native_context))
+        .min(u64::from(u32::MAX)) as u32;
+    let minimum = MIN_AUTO_CONTEXT_LENGTH.min(native_context);
+    if planned < minimum {
+        minimum
+    } else {
+        snap_context_length_down(planned).max(minimum)
+    }
+}
+
+fn planned_parallel_slots(input: RuntimeResourcePlanInput<'_>, context_length: u32) -> usize {
+    let Some(metadata) = input.metadata else {
+        return DEFAULT_PARALLEL_SLOTS;
+    };
+    let Some(kv_bytes_per_token) = input.kv_cache_quant.kv_cache_bytes_per_token(metadata) else {
+        return DEFAULT_PARALLEL_SLOTS;
+    };
+    let Some(bytes_per_slot) = u64::from(context_length).checked_mul(kv_bytes_per_token) else {
+        return DEFAULT_PARALLEL_SLOTS;
+    };
+    if bytes_per_slot == 0 {
+        return DEFAULT_PARALLEL_SLOTS;
+    }
+
+    let raw_slots = usable_kv_cache_budget(input.vram_bytes, input.model_bytes) / bytes_per_slot;
+    snap_parallel_slots_down(raw_slots)
+}
+
+fn usable_kv_cache_budget(vram_bytes: u64, model_bytes: u64) -> u64 {
+    let free_bytes = vram_bytes.saturating_sub(model_bytes);
+    let budget = u128::from(free_bytes) * u128::from(KV_CACHE_BUDGET_NUMERATOR)
+        / u128::from(KV_CACHE_BUDGET_DENOMINATOR);
+    budget.min(u128::from(u64::MAX)) as u64
+}
+
+fn snap_parallel_slots_down(raw_slots: u64) -> usize {
+    match raw_slots.min(MAX_AUTO_PARALLEL_SLOTS as u64) {
+        0 => 1,
+        1 => 1,
+        2 | 3 => 2,
+        4..=7 => 4,
+        8..=15 => 8,
+        _ => MAX_AUTO_PARALLEL_SLOTS,
+    }
+}
+
+fn snap_context_length_down(value: u32) -> u32 {
+    const CONTEXT_STEPS: &[u32] = &[512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536, 131_072];
+    CONTEXT_STEPS
+        .iter()
+        .rev()
+        .copied()
+        .find(|step| *step <= value)
+        .unwrap_or(MIN_AUTO_CONTEXT_LENGTH)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn gqa_metadata(context_length: u32) -> GgufCompactMeta {
+        GgufCompactMeta {
+            context_length,
+            head_count: 32,
+            kv_head_count: 8,
+            layer_count: 32,
+            key_length: 128,
+            value_length: 128,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn plan_runtime_resources_preserves_explicit_overrides() {
+        let metadata = gqa_metadata(32_768);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: Some(16_384),
+            parallel_override: Some(7),
+            model_bytes: 10_000_000_000,
+            vram_bytes: 24_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(
+            plan,
+            RuntimeResourcePlan {
+                context_length: 16_384,
+                slots: 7,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_clamps_auto_context_to_native_metadata() {
+        let metadata = gqa_metadata(16_384);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(plan.context_length, 16_384);
+        assert!(
+            plan.slots > 4,
+            "expected metadata-based slots, got {plan:?}"
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_snaps_auto_context_down() {
+        let metadata = gqa_metadata(32_768);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: Some(1),
+            model_bytes: 5_000_000_000,
+            vram_bytes: 6_300_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(plan.context_length, 8192);
+        assert_eq!(plan.slots, 1);
+    }
+
+    #[test]
+    fn plan_runtime_resources_uses_effective_kv_quant_for_slot_budget() {
+        let metadata = gqa_metadata(131_072);
+        let f16_plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+        let q4_plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::new(
+                mesh_client::models::gguf::GgufKvCacheType::Q4_0,
+                mesh_client::models::gguf::GgufKvCacheType::Q4_0,
+            ),
+        });
+
+        assert_eq!(f16_plan.context_length, q4_plan.context_length);
+        assert!(
+            q4_plan.slots > f16_plan.slots,
+            "expected quantized KV cache to allow more slots: f16={f16_plan:?}, q4={q4_plan:?}"
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_falls_back_to_legacy_defaults_without_metadata() {
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 24_000_000_000,
+            metadata: None,
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(
+            plan,
+            RuntimeResourcePlan {
+                context_length: 4096,
+                slots: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_runtime_resources_uses_explicit_parallel_with_metadata_context() {
+        let metadata = gqa_metadata(32_768);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: Some(2),
+            model_bytes: 5_000_000_000,
+            vram_bytes: 80_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::f16(),
+        });
+
+        assert_eq!(plan.context_length, 32_768);
+        assert_eq!(plan.slots, 2);
+    }
+}

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -1,3 +1,6 @@
+use super::context_planning::{
+    plan_runtime_resources, RuntimeResourcePlan, RuntimeResourcePlanInput,
+};
 use crate::api;
 use crate::inference::{election, skippy};
 use crate::mesh::{self, NodeRole};
@@ -132,6 +135,7 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
     pub(super) n_ubatch_override: Option<u32>,
     pub(super) flash_attention_override: FlashAttentionType,
     pub(super) slots: usize,
+    pub(super) parallel_override: Option<usize>,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -348,7 +352,29 @@ pub(super) async fn start_runtime_local_model(
         format_gb(my_vram)
     );
 
-    start_runtime_skippy_model(spec, model_name).await
+    let kv_cache = skippy::KvCachePolicy::for_model_size(model_bytes);
+    let effective_cache_type_k = spec
+        .cache_type_k_override
+        .unwrap_or(kv_cache.cache_type_k());
+    let effective_cache_type_v = spec
+        .cache_type_v_override
+        .unwrap_or(kv_cache.cache_type_v());
+    let kv_cache_quant = models::gguf::GgufKvCacheQuant::from_llama_args(
+        effective_cache_type_k,
+        effective_cache_type_v,
+    )
+    .unwrap_or_else(models::gguf::GgufKvCacheQuant::f16);
+    let compact_meta = models::gguf::scan_gguf_compact_meta(spec.model_path);
+    let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+        ctx_size_override: spec.ctx_size_override,
+        parallel_override: spec.parallel_override,
+        model_bytes,
+        vram_bytes: my_vram,
+        metadata: compact_meta.as_ref(),
+        kv_cache_quant,
+    });
+
+    start_runtime_skippy_model(spec, model_name, plan).await
 }
 
 pub(super) fn startup_runtime_plan(
@@ -1632,13 +1658,14 @@ fn now_unix_nanos() -> i64 {
 async fn start_runtime_skippy_model(
     spec: LocalRuntimeModelStartSpec<'_>,
     model_name: String,
+    plan: RuntimeResourcePlan,
 ) -> Result<(
     String,
     LocalRuntimeModelHandle,
     tokio::sync::oneshot::Receiver<()>,
 )> {
     let port = alloc_local_port().await?;
-    let context_length = spec.ctx_size_override.unwrap_or(4096);
+    let context_length = plan.context_length;
     let model_bytes = election::total_model_bytes(spec.model_path);
     let kv_cache = skippy::KvCachePolicy::for_model_size(model_bytes);
     let effective_cache_type_k = spec
@@ -1661,7 +1688,7 @@ async fn start_runtime_skippy_model(
         .filter(|path| path.exists());
     let mut options = skippy::SkippyModelLoadOptions::for_direct_gguf(&model_name, spec.model_path)
         .with_ctx_size(context_length)
-        .with_generation_concurrency(spec.slots)
+        .with_generation_concurrency(plan.slots)
         .with_cache_types(effective_cache_type_k, effective_cache_type_v)
         .with_flash_attn_type(resolved_flash_attn_type);
     if spec.n_batch_override.is_some() || spec.n_ubatch_override.is_some() {
@@ -1691,7 +1718,7 @@ async fn start_runtime_skippy_model(
             port: http.port(),
             backend: "skippy".into(),
             context_length,
-            slots: spec.slots,
+            slots: plan.slots,
             inner: LocalRuntimeBackendHandle::Skippy {
                 model: skippy_model,
                 http,

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod config_state;
+mod context_planning;
 mod discovery;
 pub mod instance;
 mod interactive;
@@ -807,6 +808,7 @@ struct StartupLocalModelTask {
     n_ubatch: Option<u32>,
     flash_attention: FlashAttentionType,
     slots: usize,
+    parallel_override: Option<usize>,
     split: bool,
     stop_rx: tokio::sync::watch::Receiver<bool>,
     dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
@@ -839,6 +841,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch,
         flash_attention,
         slots,
+        parallel_override,
         split,
         mut stop_rx,
         dashboard_processes,
@@ -872,6 +875,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch_override: n_ubatch,
         flash_attention_override: flash_attention,
         slots,
+        parallel_override,
     };
     let local_capacity = pinned_gpu
         .as_ref()
@@ -971,7 +975,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         &handle.backend,
         handle.port,
         handle.pid(),
-        slots,
+        handle.slots,
         handle.context_length,
     );
     upsert_dashboard_process(&dashboard_processes, payload.clone()).await;
@@ -3917,11 +3921,11 @@ async fn run_auto(
     let node2 = node.clone();
     let tunnel_mgr2 = tunnel_mgr.clone();
     let model2 = model.clone();
-    let slots = primary_startup_model
+    let primary_parallel_override = primary_startup_model
         .as_ref()
         .and_then(|m| m.parallel)
-        .or(config.gpu.parallel)
-        .unwrap_or(4);
+        .or(config.gpu.parallel);
+    let primary_slots = primary_parallel_override.unwrap_or(4);
     let model_name_for_election = model_name.clone();
     let primary_target_tx = target_tx.clone();
     let console_state_for_election = console_state.clone();
@@ -3994,7 +3998,8 @@ async fn run_auto(
             n_batch: primary_n_batch,
             n_ubatch: primary_n_ubatch,
             flash_attention: primary_flash_attention,
-            slots,
+            slots: primary_slots,
+            parallel_override: primary_parallel_override,
             split: startup_split,
             stop_rx: primary_stop_rx,
             dashboard_processes: dashboard_processes_for_primary_task,
@@ -4051,7 +4056,8 @@ async fn run_auto(
             let extra_target_tx = target_tx.clone();
             let extra_model_name = extra_name.clone();
             let api_port_extra = api_port;
-            let slots = extra_model.parallel.or(config.gpu.parallel).unwrap_or(4);
+            let extra_parallel_override = extra_model.parallel.or(config.gpu.parallel);
+            let extra_slots = extra_parallel_override.unwrap_or(4);
             let extra_console_state = console_state.clone();
             let extra_startup_ready_reporter = startup_ready_reporter.clone();
             let extra_startup_load_gate = startup_load_gate.clone();
@@ -4078,7 +4084,8 @@ async fn run_auto(
                     n_batch: extra_n_batch,
                     n_ubatch: extra_n_ubatch,
                     flash_attention: extra_flash_attention,
-                    slots,
+                    slots: extra_slots,
+                    parallel_override: extra_parallel_override,
                     split: startup_split,
                     stop_rx: extra_stop_rx,
                     dashboard_processes: dashboard_processes_for_extra_task,
@@ -4215,14 +4222,15 @@ async fn run_auto(
                                 "model '{runtime_model_name}' is already loaded"
                             );
 
-                            // Look up per-model parallel from TOML config by matching the
-                            // spec string against [[models]].model entries. Falls back to
-                            // gpu.parallel or default 4 when no entry matches.
+                            // Look up per-model overrides from TOML config by matching the
+                            // spec string against [[models]].model entries. Metadata-based
+                            // planning chooses direct-local defaults when no parallel
+                            // override matches.
                             let model_overrides = config.models.iter().find(|m| m.model == spec);
-                            let slots = model_overrides
+                            let parallel_override = model_overrides
                                 .and_then(|m| m.parallel)
-                                .or(config.gpu.parallel)
-                                .unwrap_or(4);
+                                .or(config.gpu.parallel);
+                            let slots = parallel_override.unwrap_or(4);
 
                             assigned_runtime_model = Some(runtime_model_name.clone());
                             add_serving_assignment(&node, &primary_model_name, &runtime_model_name)
@@ -4244,6 +4252,7 @@ async fn run_auto(
                                         .and_then(|m| m.flash_attention)
                                         .unwrap_or(FlashAttentionType::Auto),
                                     slots,
+                                    parallel_override,
                                 },
                             )
                             .await?;
@@ -4262,7 +4271,7 @@ async fn run_auto(
                                 &handle.backend,
                                 handle.port,
                                 handle.pid(),
-                                slots,
+                                handle.slots,
                                 handle.context_length,
                             );
                             upsert_dashboard_process(&dashboard_processes, payload.clone())

--- a/scripts/ci-swift-sdk-smoke.sh
+++ b/scripts/ci-swift-sdk-smoke.sh
@@ -9,7 +9,11 @@ fi
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-./sdk/swift/scripts/build-xcframework.sh
+if [[ "${MESH_SWIFT_FULL_XCFRAMEWORK_SMOKE:-0}" == "1" ]]; then
+    ./sdk/swift/scripts/build-xcframework.sh
+else
+    ./sdk/swift/scripts/build-host-macos-xcframework.sh
+fi
 
 scripts/ci-sdk-fixture.sh "$1" "$2" "$3" -- \
     bash -lc '

--- a/sdk/swift/example/MeshExampleApp/Package.swift
+++ b/sdk/swift/example/MeshExampleApp/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .macOS(.v13),
     ],
     dependencies: [
-        .package(path: "../../../.."),
+        .package(name: "mesh-llm", path: "../../../.."),
     ],
     targets: [
         .executableTarget(

--- a/sdk/swift/example/MeshExampleApp/Sources/MeshExampleApp/main.swift
+++ b/sdk/swift/example/MeshExampleApp/Sources/MeshExampleApp/main.swift
@@ -41,7 +41,7 @@ Task {
         var firstToken = true
         var sawToken = false
         var completed = false
-        for try await event in client.chatStream(request) {
+        chatLoop: for try await event in client.chatStream(request) {
             switch event {
             case .tokenDelta(_, let delta):
                 if firstToken {
@@ -54,6 +54,7 @@ Task {
             case .completed:
                 completed = true
                 print("\n[chat] done")
+                break chatLoop
             case .failed(_, let error):
                 throw ExampleError.chatFailed(error)
             default:

--- a/sdk/swift/scripts/build-host-macos-xcframework.sh
+++ b/sdk/swift/scripts/build-host-macos-xcframework.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SWIFT_DIR="$REPO_ROOT/sdk/swift"
+FFI_DIR="$SWIFT_DIR/Generated/FFI"
+TARGET_DIR="$REPO_ROOT/target"
+XCFRAMEWORK_DIR="$SWIFT_DIR/Generated"
+FRAMEWORK_NAME="MeshLLMFFI"
+GENERATED_SWIFT="$SWIFT_DIR/Sources/MeshLLM/Generated/mesh_ffi.swift"
+
+echo "Building host macOS $FRAMEWORK_NAME XCFramework..."
+echo "Repo root: $REPO_ROOT"
+
+if ! cargo metadata --no-deps --format-version 1 2>/dev/null | grep -q '"name":"mesh-api-ffi"'; then
+  echo "ERROR: mesh-api-ffi crate not found. Ensure the workspace is configured."
+  exit 1
+fi
+
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+  arm64|aarch64)
+    RUST_TARGET="aarch64-apple-darwin"
+    XCFRAMEWORK_ID="macos-arm64"
+    SUPPORTED_ARCH="arm64"
+    ;;
+  x86_64)
+    RUST_TARGET="x86_64-apple-darwin"
+    XCFRAMEWORK_ID="macos-x86_64"
+    SUPPORTED_ARCH="x86_64"
+    ;;
+  *)
+    echo "Unsupported macOS host architecture: $HOST_ARCH" >&2
+    exit 1
+    ;;
+esac
+
+rustup target add "$RUST_TARGET" 2>/dev/null || true
+
+"$SWIFT_DIR/scripts/generate-swift-bindings.sh"
+
+RUSTUP_RUSTC="$(rustup run stable which rustc)"
+echo "Using rustc: $RUSTUP_RUSTC"
+echo "Building for $RUST_TARGET..."
+RUSTC="$RUSTUP_RUSTC" \
+  cargo build --release -p mesh-api-ffi --target "$RUST_TARGET" --no-default-features
+
+LIB_PATH="$TARGET_DIR/$RUST_TARGET/release/libmesh_ffi.a"
+
+echo "Syncing UniFFI API checksums into generated Swift bindings..."
+python3 - "$LIB_PATH" "$GENERATED_SWIFT" <<'PY'
+import pathlib
+import re
+import subprocess
+import sys
+
+lib_path = pathlib.Path(sys.argv[1])
+swift_path = pathlib.Path(sys.argv[2])
+
+disassembly = subprocess.run(
+    ["otool", "-tvV", str(lib_path)],
+    check=True,
+    capture_output=True,
+    text=True,
+).stdout
+
+pattern = re.compile(
+    r"_uniffi_mesh_ffi_(checksum_[A-Za-z0-9_]+):\n[0-9a-f]+\s+mov\s+w0, #0x([0-9a-f]+)\n[0-9a-f]+\s+ret",
+    re.MULTILINE,
+)
+checksums = {name: int(value, 16) for name, value in pattern.findall(disassembly)}
+
+swift = swift_path.read_text()
+
+for name, value in checksums.items():
+    call = f"{name}()"
+    swift = re.sub(
+        rf"({re.escape(call)} != )\d+",
+        rf"\g<1>{value}",
+        swift,
+    )
+
+swift_path.write_text(swift)
+PY
+
+FRAMEWORK_DIR="$TARGET_DIR/frameworks/macos-host/$FRAMEWORK_NAME.framework"
+rm -rf "$FRAMEWORK_DIR"
+mkdir -p "$FRAMEWORK_DIR/Headers"
+mkdir -p "$FRAMEWORK_DIR/Modules"
+
+cp "$LIB_PATH" "$FRAMEWORK_DIR/$FRAMEWORK_NAME"
+cp "$FFI_DIR/MeshLLMFFI.h" "$FRAMEWORK_DIR/Headers/MeshLLMFFI.h"
+cp "$FFI_DIR/MeshLLMFFI.modulemap" "$FRAMEWORK_DIR/Modules/module.modulemap"
+
+if [ -f "$SWIFT_DIR/PrivacyInfo.xcprivacy" ]; then
+  cp "$SWIFT_DIR/PrivacyInfo.xcprivacy" "$FRAMEWORK_DIR/PrivacyInfo.xcprivacy"
+  echo "  Embedded PrivacyInfo.xcprivacy in host macOS framework"
+else
+  echo "WARNING: PrivacyInfo.xcprivacy not found at $SWIFT_DIR/PrivacyInfo.xcprivacy"
+fi
+
+cat > "$FRAMEWORK_DIR/Info.plist" << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>ai.meshllm.MeshLLMFFI</string>
+    <key>CFBundleName</key>
+    <string>MeshLLMFFI</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>13.0</string>
+</dict>
+</plist>
+PLIST
+
+echo "Creating host macOS XCFramework..."
+XCFW_OUT="$XCFRAMEWORK_DIR/$FRAMEWORK_NAME.xcframework"
+rm -rf "$XCFW_OUT"
+mkdir -p "$XCFW_OUT/$XCFRAMEWORK_ID/$FRAMEWORK_NAME.framework"
+cp -R "$FRAMEWORK_DIR/" "$XCFW_OUT/$XCFRAMEWORK_ID/$FRAMEWORK_NAME.framework/"
+
+cat > "$XCFW_OUT/Info.plist" << XCINFO
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>AvailableLibraries</key>
+    <array>
+        <dict>
+            <key>BinaryPath</key>
+            <string>MeshLLMFFI.framework/MeshLLMFFI</string>
+            <key>LibraryIdentifier</key>
+            <string>$XCFRAMEWORK_ID</string>
+            <key>LibraryPath</key>
+            <string>MeshLLMFFI.framework</string>
+            <key>SupportedArchitectures</key>
+            <array><string>$SUPPORTED_ARCH</string></array>
+            <key>SupportedPlatform</key>
+            <string>macos</string>
+        </dict>
+    </array>
+    <key>CFBundlePackageType</key>
+    <string>XFWK</string>
+    <key>XCFrameworkFormatVersion</key>
+    <string>1.0</string>
+</dict>
+</plist>
+XCINFO
+
+echo "XCFramework created at: $XCFW_OUT"
+
+PRIVACY_COUNT=$(find "$XCFW_OUT" -name "PrivacyInfo.xcprivacy" | wc -l | tr -d ' ')
+echo "Found $PRIVACY_COUNT PrivacyInfo.xcprivacy file(s) inside XCFramework"
+if [ "$PRIVACY_COUNT" -lt 1 ]; then
+  echo "ERROR: PrivacyInfo.xcprivacy not embedded in XCFramework!"
+  exit 1
+fi
+
+echo "Host macOS XCFramework build complete!"


### PR DESCRIPTION
Supersedes #432.

## Summary
Direct local Skippy model startup now uses GGUF metadata to choose safer automatic context and parallel defaults. Explicit `ctx_size` and `parallel` overrides still win; missing or incomplete metadata keeps the legacy `4096` context / `4` slots fallback.

This rebases the original PR 432 change onto current `main`, which includes the CUDA CI stub-path fix from #355/#448, so the superseding branch avoids the `libcuda.so.1` failure seen on PR 432.

## What changed
- Added GGUF metadata support for `head_count_kv` and exact KV-cache byte accounting in `mesh-llm-client`.
- Added direct-local runtime planning for context length and parallelism.
- Wired the planner into direct local Skippy startup while preserving explicit overrides and split-runtime lane semantics.
- Added focused tests for GGUF KV metadata, KV quantization pricing, and runtime planning.
- Fixed the Swift example smoke app to exit as soon as chat completion is observed.
- Made the Swift example package dependency stable across checkout directory names.
- Added a host-macOS-only FFI XCFramework builder for the Swift CI smoke test so it validates the real Swift FFI path without building unrelated iOS/Catalyst slices.

## Validation
- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo check -p mesh-llm`
- `cargo test -p mesh-llm-client --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib`
- `cargo test -p mesh-llm-client --test models_extraction`
- `sdk/swift/scripts/build-host-macos-xcframework.sh`
- `scripts/ci-swift-sdk-smoke.sh target/debug/mesh-llm target/debug "$HOME/.models/SmolLM2-135M-Instruct-Q8_0.gguf"`

## CI
All required PR checks are passing on `ed361a53`, including Linux CUDA slim, Linux ROCm slim, Linux Vulkan, docker-client, inference smoke tests, native SDK smoke, Kotlin SDK smoke, and Swift SDK smoke.
