### PR TITLE
Support duplicate local runtime instances for the same model

### DIFF
--- a/crates/mesh-llm/src/api/mod.rs
+++ b/crates/mesh-llm/src/api/mod.rs
@@ -16,6 +16,7 @@
 //!   GET  /api/runtime/stages — backend-neutral staged-serving state (JSON)
 //!   POST /api/runtime/models — load a local model
 //!   DELETE /api/runtime/models/{model} — unload a local model
+//!   DELETE /api/runtime/instances/{instance_id} — unload one local runtime instance
 //!   GET  /api/events    — SSE stream of status updates
 //!   GET  /api/discover  — browse Nostr-published meshes
 //!   POST /api/chat      — proxy to chat completions API
@@ -45,8 +46,8 @@ pub(crate) use self::server::start_with_listener;
 #[cfg(test)]
 pub(crate) use self::server::{handle_request, is_ui_only_route};
 pub use self::state::{
-    LocalModelInterest, MeshApi, PublicationState, RuntimeControlRequest, RuntimeModelPayload,
-    RuntimeProcessPayload,
+    LocalModelInterest, MeshApi, PublicationState, RuntimeControlRequest, RuntimeLoadResponse,
+    RuntimeModelPayload, RuntimeProcessPayload, RuntimeUnloadResponse,
 };
 pub(crate) use self::status::classify_runtime_error;
 
@@ -388,7 +389,9 @@ impl MeshApi {
     pub async fn upsert_local_process(&self, process: RuntimeProcessPayload) {
         {
             let mut inner = self.inner.lock().await;
-            inner.local_processes.retain(|p| p.name != process.name);
+            inner.local_processes.retain(|p| {
+                runtime_process_payload_identity(p) != runtime_process_payload_identity(&process)
+            });
             inner.local_processes.push(process.clone());
             inner
                 .runtime_data_producer
@@ -401,14 +404,24 @@ impl MeshApi {
         }
     }
 
-    pub async fn remove_local_process(&self, model_name: &str) {
+    pub async fn remove_local_process(&self, target: &str) {
         {
             let mut inner = self.inner.lock().await;
-            inner.local_processes.retain(|p| p.name != model_name);
+            let has_instance_match = inner
+                .local_processes
+                .iter()
+                .any(|process| process.instance_id.as_deref() == Some(target));
+            inner.local_processes.retain(|process| {
+                if has_instance_match {
+                    process.instance_id.as_deref() != Some(target)
+                } else {
+                    process.name != target
+                }
+            });
             inner
                 .runtime_data_producer
                 .publish_local_processes(|local_processes| {
-                    runtime_data::remove_runtime_process_snapshot(local_processes, model_name)
+                    runtime_data::remove_runtime_process_snapshot(local_processes, target)
                 });
         }
     }
@@ -879,6 +892,10 @@ impl MeshApi {
         inner.runtime_data_producer.mark_status_dirty();
         inner.sse_clients.retain(|tx| !tx.is_closed());
     }
+}
+
+fn runtime_process_payload_identity(process: &RuntimeProcessPayload) -> &str {
+    process.instance_id.as_deref().unwrap_or(&process.name)
 }
 
 fn current_unix_secs() -> u64 {

--- a/crates/mesh-llm/src/api/mod.rs
+++ b/crates/mesh-llm/src/api/mod.rs
@@ -578,13 +578,16 @@ impl MeshApi {
     }
 
     async fn runtime_llama(&self) -> RuntimeLlamaPayload {
-        let runtime_llama = self
-            .inner
-            .lock()
-            .await
-            .runtime_data_collector
-            .runtime_llama_snapshot();
-        status::build_runtime_llama_payload(runtime_llama)
+        let (runtime_llama, runtime_llama_by_instance) = {
+            let inner = self.inner.lock().await;
+            (
+                inner.runtime_data_collector.runtime_llama_snapshot(),
+                inner
+                    .runtime_data_collector
+                    .runtime_llama_snapshots_by_instance(),
+            )
+        };
+        status::build_runtime_llama_payload(runtime_llama, runtime_llama_by_instance)
     }
 
     async fn runtime_endpoints(&self) -> anyhow::Result<Vec<plugin::PluginEndpointSummary>> {

--- a/crates/mesh-llm/src/api/routes/mod.rs
+++ b/crates/mesh-llm/src/api/routes/mod.rs
@@ -79,6 +79,10 @@ pub(super) const DISPATCH_REQUEST: DispatchRequestFn =
                     runtime::handle(stream, state, method, path_only, body).await?;
                     Ok(true)
                 }
+                ("DELETE", p) if p.starts_with("/api/runtime/instances/") => {
+                    runtime::handle(stream, state, method, path_only, body).await?;
+                    Ok(true)
+                }
                 ("DELETE", p) if p.starts_with("/api/runtime/models/") => {
                     runtime::handle(stream, state, method, path_only, body).await?;
                     Ok(true)

--- a/crates/mesh-llm/src/api/routes/runtime.rs
+++ b/crates/mesh-llm/src/api/routes/runtime.rs
@@ -23,6 +23,9 @@ pub(super) async fn handle(
         ("GET", "/api/runtime/processes") => handle_runtime_processes(stream, state).await,
         ("GET", "/api/runtime/stages") => handle_runtime_stages(stream, state).await,
         ("POST", "/api/runtime/models") => handle_load_model(stream, state, body).await,
+        ("DELETE", p) if p.starts_with("/api/runtime/instances/") => {
+            handle_unload_instance(stream, state, p).await
+        }
         ("DELETE", p) if p.starts_with("/api/runtime/models/") => {
             handle_unload_model(stream, state, p).await
         }
@@ -180,7 +183,15 @@ async fn handle_load_model(
                 });
                 match resp_rx.await {
                     Ok(Ok(loaded)) => {
-                        respond_json(stream, 201, &serde_json::json!({ "loaded": loaded })).await?;
+                        respond_json(
+                            stream,
+                            201,
+                            &serde_json::json!({
+                                "loaded": loaded.model,
+                                "instance_id": loaded.instance_id,
+                            }),
+                        )
+                        .await?;
                     }
                     Ok(Err(e)) => {
                         respond_runtime_error(stream, &e.to_string()).await?;
@@ -206,18 +217,65 @@ async fn handle_unload_model(
     let Some(control_tx) = state.inner.lock().await.runtime_control.clone() else {
         return respond_error(stream, 503, "Runtime control unavailable").await;
     };
-    let Some(model_name) = decode_runtime_model_path(path) else {
+    let Some(model_name) = decode_runtime_model_path(path, "/api/runtime/models/") else {
         return respond_error(stream, 400, "Missing model path").await;
     };
 
     let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
     let _ = control_tx.send(RuntimeControlRequest::Unload {
-        model: model_name.clone(),
+        target: model_name.clone(),
         resp: resp_tx,
     });
     match resp_rx.await {
-        Ok(Ok(())) => {
-            respond_json(stream, 200, &serde_json::json!({ "dropped": model_name })).await?;
+        Ok(Ok(dropped)) => {
+            respond_json(
+                stream,
+                200,
+                &serde_json::json!({
+                    "dropped": dropped.model,
+                    "instance_id": dropped.instance_id,
+                }),
+            )
+            .await?;
+        }
+        Ok(Err(e)) => {
+            respond_runtime_error(stream, &e.to_string()).await?;
+        }
+        Err(_) => {
+            respond_error(stream, 503, "Runtime control unavailable").await?;
+        }
+    }
+    Ok(())
+}
+
+async fn handle_unload_instance(
+    stream: &mut TcpStream,
+    state: &MeshApi,
+    path: &str,
+) -> anyhow::Result<()> {
+    let Some(control_tx) = state.inner.lock().await.runtime_control.clone() else {
+        return respond_error(stream, 503, "Runtime control unavailable").await;
+    };
+    let Some(instance_id) = decode_runtime_model_path(path, "/api/runtime/instances/") else {
+        return respond_error(stream, 400, "Missing runtime instance path").await;
+    };
+
+    let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+    let _ = control_tx.send(RuntimeControlRequest::Unload {
+        target: instance_id.clone(),
+        resp: resp_tx,
+    });
+    match resp_rx.await {
+        Ok(Ok(dropped)) => {
+            respond_json(
+                stream,
+                200,
+                &serde_json::json!({
+                    "dropped": dropped.model,
+                    "instance_id": dropped.instance_id,
+                }),
+            )
+            .await?;
         }
         Ok(Err(e)) => {
             respond_runtime_error(stream, &e.to_string()).await?;

--- a/crates/mesh-llm/src/api/state.rs
+++ b/crates/mesh-llm/src/api/state.rs
@@ -40,18 +40,32 @@ impl Serialize for PublicationState {
 pub enum RuntimeControlRequest {
     Load {
         spec: String,
-        resp: tokio::sync::oneshot::Sender<anyhow::Result<String>>,
+        resp: tokio::sync::oneshot::Sender<anyhow::Result<RuntimeLoadResponse>>,
     },
     Unload {
-        model: String,
-        resp: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+        target: String,
+        resp: tokio::sync::oneshot::Sender<anyhow::Result<RuntimeUnloadResponse>>,
     },
     Shutdown,
 }
 
 #[derive(Clone, Debug, Serialize)]
+pub struct RuntimeLoadResponse {
+    pub model: String,
+    pub instance_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct RuntimeUnloadResponse {
+    pub model: String,
+    pub instance_id: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
 pub struct RuntimeModelPayload {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
     pub backend: String,
     pub status: String,
     pub port: Option<u16>,
@@ -60,6 +74,8 @@ pub struct RuntimeModelPayload {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct RuntimeProcessPayload {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
     pub backend: String,
     pub status: String,
     pub port: u16,

--- a/crates/mesh-llm/src/api/status.rs
+++ b/crates/mesh-llm/src/api/status.rs
@@ -513,13 +513,25 @@ pub(crate) fn build_runtime_status_payload(
     llama_port: Option<u16>,
     mut local_processes: Vec<RuntimeProcessPayload>,
 ) -> RuntimeStatusPayload {
-    local_processes.sort_by_key(|process| process.name.to_lowercase());
+    local_processes.sort_by(|left, right| {
+        (
+            left.name.to_lowercase(),
+            left.instance_id.as_deref().unwrap_or(""),
+            left.port,
+        )
+            .cmp(&(
+                right.name.to_lowercase(),
+                right.instance_id.as_deref().unwrap_or(""),
+                right.port,
+            ))
+    });
     let backend = primary_backend.clone();
 
     let mut models: Vec<RuntimeModelPayload> = local_processes
         .into_iter()
         .map(|process| RuntimeModelPayload {
             name: process.name,
+            instance_id: process.instance_id,
             backend: process.backend,
             status: process.status,
             port: Some(process.port),
@@ -532,6 +544,7 @@ pub(crate) fn build_runtime_status_payload(
             0,
             RuntimeModelPayload {
                 name: model_name.to_string(),
+                instance_id: None,
                 backend: primary_backend.unwrap_or_else(|| "unknown".into()),
                 status: "starting".into(),
                 port: llama_port,
@@ -642,7 +655,18 @@ pub(crate) fn runtime_stage_wire_dtype_label(
 pub(super) fn build_runtime_processes_payload(
     mut local_processes: Vec<RuntimeProcessPayload>,
 ) -> RuntimeProcessesPayload {
-    local_processes.sort_by_key(|process| process.name.to_lowercase());
+    local_processes.sort_by(|left, right| {
+        (
+            left.name.to_lowercase(),
+            left.instance_id.as_deref().unwrap_or(""),
+            left.port,
+        )
+            .cmp(&(
+                right.name.to_lowercase(),
+                right.instance_id.as_deref().unwrap_or(""),
+                right.port,
+            ))
+    });
     RuntimeProcessesPayload {
         processes: local_processes,
     }
@@ -730,7 +754,7 @@ fn runtime_llama_endpoint_status(status: runtime_data::RuntimeLlamaEndpointStatu
 pub(crate) fn classify_runtime_error(msg: &str) -> u16 {
     if msg.contains("not loaded") {
         404
-    } else if msg.contains("already loaded") {
+    } else if msg.contains("already loaded") || msg.contains("multiple loaded instances") {
         409
     } else if msg.contains("fit locally") || msg.contains("runtime load only supports") {
         422
@@ -739,8 +763,8 @@ pub(crate) fn classify_runtime_error(msg: &str) -> u16 {
     }
 }
 
-pub(super) fn decode_runtime_model_path(path: &str) -> Option<String> {
-    let raw = path.strip_prefix("/api/runtime/models/")?;
+pub(super) fn decode_runtime_model_path(path: &str, prefix: &str) -> Option<String> {
+    let raw = path.strip_prefix(prefix)?;
     if raw.is_empty() {
         return None;
     }

--- a/crates/mesh-llm/src/api/status.rs
+++ b/crates/mesh-llm/src/api/status.rs
@@ -111,6 +111,18 @@ pub(crate) struct RuntimeLlamaPayload {
     pub(crate) metrics: RuntimeLlamaMetricsPayload,
     pub(crate) slots: RuntimeLlamaSlotsPayload,
     pub(crate) items: RuntimeLlamaItemsPayload,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub(crate) instances: Vec<RuntimeLlamaInstancePayload>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct RuntimeLlamaInstancePayload {
+    pub(crate) instance_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) model: Option<String>,
+    pub(crate) metrics: RuntimeLlamaMetricsPayload,
+    pub(crate) slots: RuntimeLlamaSlotsPayload,
+    pub(crate) items: RuntimeLlamaItemsPayload,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -141,6 +153,8 @@ pub(crate) struct RuntimeLlamaSlotsPayload {
     pub(crate) status: &'static str,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) instance_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) last_attempt_unix_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -674,9 +688,40 @@ pub(super) fn build_runtime_processes_payload(
 
 pub(crate) fn build_runtime_llama_payload(
     snapshot: runtime_data::RuntimeLlamaRuntimeSnapshot,
+    snapshots_by_instance: BTreeMap<String, runtime_data::RuntimeLlamaRuntimeSnapshot>,
 ) -> RuntimeLlamaPayload {
+    let instances = snapshots_by_instance
+        .into_iter()
+        .map(|(instance_id, snapshot)| {
+            let model = snapshot.slots.model.clone();
+            let (metrics, slots, items) = build_runtime_llama_snapshot_payload(snapshot);
+            RuntimeLlamaInstancePayload {
+                instance_id,
+                model,
+                metrics,
+                slots,
+                items,
+            }
+        })
+        .collect();
+    let (metrics, slots, items) = build_runtime_llama_snapshot_payload(snapshot);
     RuntimeLlamaPayload {
-        metrics: RuntimeLlamaMetricsPayload {
+        metrics,
+        slots,
+        items,
+        instances,
+    }
+}
+
+fn build_runtime_llama_snapshot_payload(
+    snapshot: runtime_data::RuntimeLlamaRuntimeSnapshot,
+) -> (
+    RuntimeLlamaMetricsPayload,
+    RuntimeLlamaSlotsPayload,
+    RuntimeLlamaItemsPayload,
+) {
+    (
+        RuntimeLlamaMetricsPayload {
             status: runtime_llama_endpoint_status(snapshot.metrics.status),
             last_attempt_unix_ms: snapshot.metrics.last_attempt_unix_ms,
             last_success_unix_ms: snapshot.metrics.last_success_unix_ms,
@@ -693,9 +738,10 @@ pub(crate) fn build_runtime_llama_payload(
                 })
                 .collect(),
         },
-        slots: RuntimeLlamaSlotsPayload {
+        RuntimeLlamaSlotsPayload {
             status: runtime_llama_endpoint_status(snapshot.slots.status),
             model: snapshot.slots.model,
+            instance_id: snapshot.slots.instance_id,
             last_attempt_unix_ms: snapshot.slots.last_attempt_unix_ms,
             last_success_unix_ms: snapshot.slots.last_success_unix_ms,
             error: snapshot.slots.error,
@@ -715,7 +761,7 @@ pub(crate) fn build_runtime_llama_payload(
                 })
                 .collect(),
         },
-        items: RuntimeLlamaItemsPayload {
+        RuntimeLlamaItemsPayload {
             metrics: snapshot
                 .items
                 .metrics
@@ -741,7 +787,7 @@ pub(crate) fn build_runtime_llama_payload(
             slots_total: snapshot.items.slots_total,
             slots_busy: snapshot.items.slots_busy,
         },
-    }
+    )
 }
 
 fn runtime_llama_endpoint_status(status: runtime_data::RuntimeLlamaEndpointStatus) -> &'static str {

--- a/crates/mesh-llm/src/api/tests.rs
+++ b/crates/mesh-llm/src/api/tests.rs
@@ -1407,7 +1407,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
                 local_processes.clear();
                 local_processes.push(runtime_data::RuntimeProcessSnapshot {
                     model: "collector-model".into(),
-                    instance_id: None,
+                    instance_id: Some("runtime-1".into()),
                     backend: "collector-backend".into(),
                     pid: 777,
                     port: 9337,
@@ -1438,6 +1438,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
             runtime_data::RuntimeLlamaSlotsSnapshot {
                 status: runtime_data::RuntimeLlamaEndpointStatus::Ready,
                 model: Some("collector-model".into()),
+                instance_id: Some("runtime-1".into()),
                 last_attempt_unix_ms: Some(1_700_000_001_500),
                 last_success_unix_ms: Some(1_700_000_001_500),
                 error: None,
@@ -1514,6 +1515,10 @@ async fn runtime_data_api_routes_remain_payload_stable() {
         json!("collector-model")
     );
     assert_eq!(
+        status_body["runtime"]["models"][0]["instance_id"],
+        json!("runtime-1")
+    );
+    assert_eq!(
         status_body["runtime"]["models"][0]["backend"],
         json!("collector-backend")
     );
@@ -1564,6 +1569,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
     assert!(runtime_response.starts_with("HTTP/1.1 200"));
     let runtime_body = json_body(&runtime_response);
     assert_eq!(runtime_body["models"][0]["name"], json!("collector-model"));
+    assert_eq!(runtime_body["models"][0]["instance_id"], json!("runtime-1"));
     assert_eq!(
         runtime_body["models"][0]["backend"],
         json!("collector-backend")
@@ -1582,6 +1588,10 @@ async fn runtime_data_api_routes_remain_payload_stable() {
     assert_eq!(
         processes_body["processes"][0]["name"],
         json!("collector-model")
+    );
+    assert_eq!(
+        processes_body["processes"][0]["instance_id"],
+        json!("runtime-1")
     );
     assert_eq!(
         processes_body["processes"][0]["backend"],
@@ -1609,6 +1619,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
         json!("llama_requests_processing")
     );
     assert_eq!(llama_body["slots"]["status"], json!("ready"));
+    assert_eq!(llama_body["slots"]["instance_id"], json!("runtime-1"));
     assert_eq!(llama_body["slots"]["slots"][0]["id_task"], json!(42));
     assert_eq!(
         llama_body["slots"]["slots"][0]["extra"]["state"],
@@ -1621,6 +1632,19 @@ async fn runtime_data_api_routes_remain_payload_stable() {
         llama_body["items"]["slots"][0]["is_processing"],
         json!(true)
     );
+    assert_eq!(
+        llama_body["instances"][0]["instance_id"],
+        json!("runtime-1")
+    );
+    assert_eq!(
+        llama_body["instances"][0]["model"],
+        json!("collector-model")
+    );
+    assert_eq!(
+        llama_body["instances"][0]["slots"]["status"],
+        json!("ready")
+    );
+    assert_eq!(llama_body["instances"][0]["items"]["slots_busy"], json!(1));
     llama_handle.abort();
 
     let (endpoints_addr, endpoints_handle) = spawn_management_test_server(state.clone()).await;

--- a/crates/mesh-llm/src/api/tests.rs
+++ b/crates/mesh-llm/src/api/tests.rs
@@ -325,6 +325,7 @@ fn test_build_runtime_status_payload_uses_local_processes() {
         vec![
             RuntimeProcessPayload {
                 name: "Qwen".into(),
+                instance_id: None,
                 backend: "llama".into(),
                 status: "ready".into(),
                 port: 9337,
@@ -334,6 +335,7 @@ fn test_build_runtime_status_payload_uses_local_processes() {
             },
             RuntimeProcessPayload {
                 name: "Llama".into(),
+                instance_id: None,
                 backend: "llama".into(),
                 status: "ready".into(),
                 port: 9444,
@@ -350,10 +352,52 @@ fn test_build_runtime_status_payload_uses_local_processes() {
 }
 
 #[test]
+fn test_build_runtime_status_payload_keeps_duplicate_model_instances() {
+    let result = build_runtime_status_payload(
+        "Qwen",
+        Some("skippy".into()),
+        true,
+        true,
+        Some(9337),
+        vec![
+            RuntimeProcessPayload {
+                name: "Qwen".into(),
+                instance_id: Some("runtime-1".into()),
+                backend: "skippy".into(),
+                status: "ready".into(),
+                port: 41001,
+                pid: 100,
+                slots: 4,
+                context_length: Some(8192),
+            },
+            RuntimeProcessPayload {
+                name: "Qwen".into(),
+                instance_id: Some("runtime-2".into()),
+                backend: "skippy".into(),
+                status: "ready".into(),
+                port: 41002,
+                pid: 100,
+                slots: 4,
+                context_length: Some(8192),
+            },
+        ],
+    );
+
+    assert_eq!(result.models.len(), 2);
+    assert_eq!(result.models[0].name, "Qwen");
+    assert_eq!(result.models[0].instance_id.as_deref(), Some("runtime-1"));
+    assert_eq!(result.models[0].port, Some(41001));
+    assert_eq!(result.models[1].name, "Qwen");
+    assert_eq!(result.models[1].instance_id.as_deref(), Some("runtime-2"));
+    assert_eq!(result.models[1].port, Some(41002));
+}
+
+#[test]
 fn test_build_runtime_processes_payload_sorts_processes() {
     let payload = build_runtime_processes_payload(vec![
         RuntimeProcessPayload {
             name: "Zulu".into(),
+            instance_id: None,
             backend: "llama".into(),
             status: "ready".into(),
             port: 9444,
@@ -363,6 +407,7 @@ fn test_build_runtime_processes_payload_sorts_processes() {
         },
         RuntimeProcessPayload {
             name: "Alpha".into(),
+            instance_id: None,
             backend: "llama".into(),
             status: "ready".into(),
             port: 9337,
@@ -382,6 +427,7 @@ fn test_runtime_processes_payload_includes_context_length() {
     let payload = build_runtime_processes_payload(vec![
         RuntimeProcessPayload {
             name: "model-a".into(),
+            instance_id: None,
             backend: "llama".into(),
             status: "ready".into(),
             port: 9337,
@@ -391,6 +437,7 @@ fn test_runtime_processes_payload_includes_context_length() {
         },
         RuntimeProcessPayload {
             name: "model-b".into(),
+            instance_id: None,
             backend: "llama".into(),
             status: "ready".into(),
             port: 9444,
@@ -641,7 +688,7 @@ fn legacy_peer_fixture_uses_backend_state_fallback() {
 fn test_decode_runtime_model_path_decodes_percent_not_plus() {
     // %20 is a space; + is a literal plus in URL paths (not a space)
     assert_eq!(
-        decode_runtime_model_path("/api/runtime/models/Llama%203.2+1B"),
+        decode_runtime_model_path("/api/runtime/models/Llama%203.2+1B", "/api/runtime/models/"),
         Some("Llama 3.2+1B".into())
     );
 }
@@ -650,11 +697,14 @@ fn test_decode_runtime_model_path_decodes_percent_not_plus() {
 fn test_decode_runtime_model_path_decodes_utf8_multibyte() {
     // é is U+00E9, encoded in UTF-8 as 0xC3 0xA9
     assert_eq!(
-        decode_runtime_model_path("/api/runtime/models/mod%C3%A9le"),
+        decode_runtime_model_path("/api/runtime/models/mod%C3%A9le", "/api/runtime/models/"),
         Some("modéle".into())
     );
     // invalid UTF-8 sequence should return None
-    assert_eq!(decode_runtime_model_path("/api/runtime/models/%80"), None);
+    assert_eq!(
+        decode_runtime_model_path("/api/runtime/models/%80", "/api/runtime/models/"),
+        None
+    );
 }
 
 async fn build_test_mesh_api_with_api_port(api_port: u16) -> MeshApi {
@@ -1333,6 +1383,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
         inner.llama_port = Some(9999);
         inner.local_processes = vec![RuntimeProcessPayload {
             name: "legacy-model".into(),
+            instance_id: None,
             backend: "legacy-backend".into(),
             status: "ready".into(),
             port: 9999,
@@ -1356,6 +1407,7 @@ async fn runtime_data_api_routes_remain_payload_stable() {
                 local_processes.clear();
                 local_processes.push(runtime_data::RuntimeProcessSnapshot {
                     model: "collector-model".into(),
+                    instance_id: None,
                     backend: "collector-backend".into(),
                     pid: 777,
                     port: 9337,
@@ -2975,6 +3027,7 @@ async fn api_runtime_reads_from_collector_snapshot() {
         inner.llama_port = Some(9999);
         inner.local_processes = vec![RuntimeProcessPayload {
             name: "legacy-model".into(),
+            instance_id: None,
             backend: "legacy-backend".into(),
             status: "ready".into(),
             port: 9999,
@@ -2999,6 +3052,7 @@ async fn api_runtime_reads_from_collector_snapshot() {
                 local_processes.clear();
                 local_processes.push(runtime_data::RuntimeProcessSnapshot {
                     model: "collector-model".into(),
+                    instance_id: None,
                     backend: "collector-backend".into(),
                     pid: 777,
                     port: 9337,

--- a/crates/mesh-llm/src/cli/commands/runtime.rs
+++ b/crates/mesh-llm/src/cli/commands/runtime.rs
@@ -45,24 +45,53 @@ async fn display_runtime_result(
     verb: &str,
 ) -> Result<()> {
     let action_inf = if verb == "Loaded" { "load" } else { "unload" };
-    if resp.status().is_success() {
-        eprintln!("✅ {verb} runtime model");
-        eprintln!();
-        eprintln!("Model: {model_name}");
-        eprintln!("Scope: Local node");
+    let is_success = resp.status().is_success();
+    let body = resp.json::<serde_json::Value>().await.ok();
+    if is_success {
+        for line in runtime_success_lines(model_name, verb, body.as_ref()) {
+            eprintln!("{line}");
+        }
     } else {
         eprintln!("❌ Failed to {action_inf} runtime model");
         eprintln!();
         eprintln!("Model: {model_name}");
-        let reason = resp
-            .json::<serde_json::Value>()
-            .await
-            .ok()
-            .and_then(|v| v["error"].as_str().map(str::to_owned))
+        let reason = body
+            .as_ref()
+            .and_then(|value| value["error"].as_str().map(str::to_owned))
             .unwrap_or_else(|| "unknown error".to_string());
         eprintln!("Reason: {reason}");
     }
     Ok(())
+}
+
+fn runtime_success_lines(
+    model_name: &str,
+    verb: &str,
+    body: Option<&serde_json::Value>,
+) -> Vec<String> {
+    let response_model_key = match verb {
+        "Loaded" => "loaded",
+        "Unloaded" => "dropped",
+        _ => "model",
+    };
+    let display_model = body
+        .and_then(|value| value[response_model_key].as_str())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(model_name);
+    let instance_id = body
+        .and_then(|value| value["instance_id"].as_str())
+        .filter(|value| !value.trim().is_empty());
+
+    let mut lines = vec![
+        format!("✅ {verb} runtime model"),
+        String::new(),
+        format!("Model: {display_model}"),
+    ];
+    if let Some(instance_id) = instance_id {
+        lines.push(format!("Instance: {instance_id}"));
+    }
+    lines.push("Scope: Local node".to_string());
+    lines
 }
 
 /// Percent-encode a string for use as a URL path segment.
@@ -196,4 +225,61 @@ fn find_pid(processes: &[serde_json::Value], model: &serde_json::Value) -> Optio
                     .unwrap_or(true)
         })
         .and_then(|process| process["pid"].as_u64())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::runtime_success_lines;
+    use serde_json::json;
+
+    #[test]
+    fn runtime_success_lines_print_loaded_instance_id() {
+        let body = json!({
+            "loaded": "Qwen3-8B",
+            "instance_id": "runtime-2",
+        });
+
+        assert_eq!(
+            runtime_success_lines("fallback", "Loaded", Some(&body)),
+            vec![
+                "✅ Loaded runtime model".to_string(),
+                String::new(),
+                "Model: Qwen3-8B".to_string(),
+                "Instance: runtime-2".to_string(),
+                "Scope: Local node".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_success_lines_print_unloaded_instance_id() {
+        let body = json!({
+            "dropped": "Qwen3-8B",
+            "instance_id": "runtime-2",
+        });
+
+        assert_eq!(
+            runtime_success_lines("fallback", "Unloaded", Some(&body)),
+            vec![
+                "✅ Unloaded runtime model".to_string(),
+                String::new(),
+                "Model: Qwen3-8B".to_string(),
+                "Instance: runtime-2".to_string(),
+                "Scope: Local node".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn runtime_success_lines_omit_missing_instance_id() {
+        assert_eq!(
+            runtime_success_lines("Qwen3-8B", "Loaded", None),
+            vec![
+                "✅ Loaded runtime model".to_string(),
+                String::new(),
+                "Model: Qwen3-8B".to_string(),
+                "Scope: Local node".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/mesh-llm/src/cli/commands/runtime.rs
+++ b/crates/mesh-llm/src/cli/commands/runtime.rs
@@ -121,11 +121,12 @@ pub(crate) async fn run_status(port: u16) -> Result<()> {
     println!();
 
     println!(
-        "{:<42} {:<8} {:<10} {:<8} {:<6}",
-        "Model", "Backend", "State", "Pid", "Port"
+        "{:<42} {:<12} {:<8} {:<10} {:<8} {:<6}",
+        "Model", "Instance", "Backend", "State", "Pid", "Port"
     );
     for model in models {
         let name = model["name"].as_str().unwrap_or("unknown");
+        let instance = model["instance_id"].as_str().unwrap_or("-");
         let backend = display_backend_label(model["backend"].as_str().unwrap_or("unknown"));
         let status = display_runtime_state(model["status"].as_str().unwrap_or("unknown"));
         let pid = find_pid(processes, model)
@@ -136,8 +137,8 @@ pub(crate) async fn run_status(port: u16) -> Result<()> {
             .map(|p| p.to_string())
             .unwrap_or_else(|| "-".into());
         println!(
-            "{:<42} {:<8} {:<10} {:<8} {:<6}",
-            name, backend, status, pid, port
+            "{:<42} {:<12} {:<8} {:<10} {:<8} {:<6}",
+            name, instance, backend, status, pid, port
         );
     }
 
@@ -181,8 +182,18 @@ async fn fetch_runtime_payload(
 
 fn find_pid(processes: &[serde_json::Value], model: &serde_json::Value) -> Option<u64> {
     let name = model["name"].as_str()?;
+    let instance_id = model["instance_id"].as_str();
+    let port = model["port"].as_u64();
     processes
         .iter()
-        .find(|process| process["name"].as_str() == Some(name))
+        .find(|process| {
+            if let Some(instance_id) = instance_id {
+                return process["instance_id"].as_str() == Some(instance_id);
+            }
+            process["name"].as_str() == Some(name)
+                && port
+                    .map(|port| process["port"].as_u64() == Some(port))
+                    .unwrap_or(true)
+        })
         .and_then(|process| process["pid"].as_u64())
 }

--- a/crates/mesh-llm/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm/src/inference/skippy/materialization.rs
@@ -538,15 +538,17 @@ mod tests {
             .join("model-package.json");
         fs::create_dir_all(source.parent().unwrap()).unwrap();
         fs::write(&source, b"{}").unwrap();
-        let artifact = root.join("stage-000.gguf");
+        let fixture_id = cache_key(&temp.path().to_string_lossy());
+        let artifact = root.join(format!("stage-{fixture_id}.gguf"));
         fs::write(&artifact, b"stage").unwrap();
         let index = SourceIndex {
             artifact_path: artifact.clone(),
             source_model_path: source.to_string_lossy().to_string(),
         };
-        let index_path = root.join("source-test.json");
+        let index_path = root.join(format!("source-{fixture_id}.json"));
         fs::write(&index_path, serde_json::to_vec_pretty(&index).unwrap()).unwrap();
-        fs::create_dir(root.join("source-unreadable.json")).unwrap();
+        let unreadable_index_path = root.join(format!("source-unreadable-{fixture_id}.json"));
+        fs::create_dir(&unreadable_index_path).unwrap();
 
         let preview = materialized_stages_for_sources(std::slice::from_ref(&source)).unwrap();
         assert_eq!(preview, vec![artifact.clone()]);
@@ -556,6 +558,7 @@ mod tests {
         assert_eq!(removed, 1);
         assert!(!artifact.exists());
         assert!(!index_path.exists());
+        fs::remove_dir(unreadable_index_path).unwrap();
 
         restore_env("XDG_CACHE_HOME", prev_xdg);
     }

--- a/crates/mesh-llm/src/network/openai/ingress.rs
+++ b/crates/mesh-llm/src/network/openai/ingress.rs
@@ -86,7 +86,10 @@ pub(crate) async fn api_proxy(
                                 Ok(Ok(loaded)) => {
                                     let _ = proxy::send_json_ok(
                                         tcp_stream,
-                                        &serde_json::json!({"loaded": loaded}),
+                                        &serde_json::json!({
+                                            "loaded": loaded.model,
+                                            "instance_id": loaded.instance_id,
+                                        }),
                                     )
                                     .await;
                                 }
@@ -121,14 +124,17 @@ pub(crate) async fn api_proxy(
                         if let Some(ref name) = request.model_name {
                             let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
                             let _ = control_tx.send(api::RuntimeControlRequest::Unload {
-                                model: name.clone(),
+                                target: name.clone(),
                                 resp: resp_tx,
                             });
                             match resp_rx.await {
-                                Ok(Ok(())) => {
+                                Ok(Ok(dropped)) => {
                                     let _ = proxy::send_json_ok(
                                         tcp_stream,
-                                        &serde_json::json!({"dropped": name}),
+                                        &serde_json::json!({
+                                            "dropped": dropped.model,
+                                            "instance_id": dropped.instance_id,
+                                        }),
                                     )
                                     .await;
                                 }

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -27,7 +27,11 @@ const RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR: u64 = 11;
 const RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR: u64 = 10;
 
 pub(super) enum RuntimeEvent {
-    Exited { model: String, port: u16 },
+    Exited {
+        instance_id: String,
+        model: String,
+        port: u16,
+    },
 }
 
 pub(super) enum LocalRuntimeBackendHandle {
@@ -119,6 +123,7 @@ fn current_time_unix_ms() -> u64 {
 }
 
 pub(super) struct ManagedModelController {
+    pub(super) model_name: String,
     pub(super) stop_tx: tokio::sync::watch::Sender<bool>,
     pub(super) task: tokio::task::JoinHandle<()>,
 }
@@ -231,7 +236,9 @@ pub(super) fn add_runtime_local_target(
 ) {
     let mut targets = target_tx.borrow().clone();
     let entry = targets.targets.entry(model_name.to_string()).or_default();
-    entry.retain(|target| !matches!(target, election::InferenceTarget::Local(_)));
+    entry.retain(
+        |target| !matches!(target, election::InferenceTarget::Local(local_port) if *local_port == port),
+    );
     entry.insert(0, election::InferenceTarget::Local(port));
     target_tx.send_replace(targets);
 }
@@ -1731,17 +1738,28 @@ async fn start_runtime_skippy_model(
 
 pub(super) fn local_process_payload(
     model_name: &str,
+    instance_id: Option<&str>,
     backend: &str,
     port: u16,
     pid: u32,
     slots: usize,
     context_length: u32,
 ) -> api::RuntimeProcessPayload {
-    local_process_snapshot(model_name, backend, port, pid, slots, context_length).to_payload()
+    local_process_snapshot(
+        model_name,
+        instance_id,
+        backend,
+        port,
+        pid,
+        slots,
+        context_length,
+    )
+    .to_payload()
 }
 
 pub(super) fn local_process_snapshot(
     model_name: &str,
+    instance_id: Option<&str>,
     backend: &str,
     port: u16,
     pid: u32,
@@ -1750,6 +1768,7 @@ pub(super) fn local_process_snapshot(
 ) -> crate::runtime_data::RuntimeProcessSnapshot {
     crate::runtime_data::RuntimeProcessSnapshot {
         model: model_name.to_string(),
+        instance_id: instance_id.map(str::to_string),
         backend: backend.into(),
         pid,
         slots,
@@ -1785,6 +1804,26 @@ mod tests {
             activation_width: 2048,
             tensor_count: 100,
         }
+    }
+
+    #[test]
+    fn runtime_local_targets_keep_duplicate_same_model_ports() {
+        let (target_tx, _target_rx) =
+            tokio::sync::watch::channel(election::ModelTargets::default());
+        let target_tx = std::sync::Arc::new(target_tx);
+
+        add_runtime_local_target(&target_tx, "Qwen", 41001);
+        add_runtime_local_target(&target_tx, "Qwen", 41002);
+        add_runtime_local_target(&target_tx, "Qwen", 41002);
+
+        let targets = target_tx.borrow().candidates("Qwen");
+        assert_eq!(
+            targets,
+            vec![
+                election::InferenceTarget::Local(41002),
+                election::InferenceTarget::Local(41001),
+            ]
+        );
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -68,6 +68,7 @@ impl LocalRuntimeModelHandle {
     pub(super) fn llama_slots_snapshot(
         &self,
         model_name: &str,
+        instance_id: Option<&str>,
     ) -> Option<RuntimeLlamaSlotsSnapshot> {
         match &self.inner {
             LocalRuntimeBackendHandle::Skippy { model, .. } => {
@@ -77,6 +78,7 @@ impl LocalRuntimeModelHandle {
                 Some(RuntimeLlamaSlotsSnapshot {
                     status: RuntimeLlamaEndpointStatus::Ready,
                     model: Some(model_name.to_string()),
+                    instance_id: instance_id.map(str::to_string),
                     last_attempt_unix_ms: Some(now),
                     last_success_unix_ms: Some(now),
                     error: None,

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -409,11 +409,16 @@ fn dashboard_context_usage_for_process(
         .or_else(|| dashboard_context_usage_for_model(values_by_name, &process.name))
 }
 
-fn dashboard_lanes_for_model(
+fn dashboard_lanes_for_process(
+    snapshots_by_instance: &BTreeMap<String, crate::runtime_data::RuntimeLlamaRuntimeSnapshot>,
     snapshots_by_model: &BTreeMap<String, crate::runtime_data::RuntimeLlamaRuntimeSnapshot>,
-    model_name: &str,
+    process: &api::RuntimeProcessPayload,
 ) -> Option<Vec<DashboardModelLane>> {
-    let snapshot = snapshots_by_model.get(model_name)?;
+    let snapshot = process
+        .instance_id
+        .as_ref()
+        .and_then(|instance_id| snapshots_by_instance.get(instance_id))
+        .or_else(|| snapshots_by_model.get(&process.name))?;
 
     let mut lanes = snapshot
         .items
@@ -500,6 +505,8 @@ impl DashboardSnapshotProvider for RuntimeDashboardSnapshotProvider {
             let process_rows = local_processes.lock().await.clone();
             let context_usage_by_name = local_context_usage.lock().await.clone();
             let llama_runtime_by_model = runtime_data_collector.runtime_llama_snapshots_by_model();
+            let llama_runtime_by_instance =
+                runtime_data_collector.runtime_llama_snapshots_by_instance();
             let request_metrics = node.local_request_metrics_snapshot();
             let accepted_request_counts_len = request_metrics.accepted_request_counts.len();
             let inventory_snapshot = provider.inventory_snapshot().await;
@@ -538,7 +545,11 @@ impl DashboardSnapshotProvider for RuntimeDashboardSnapshotProvider {
                         &context_usage_by_name,
                         process,
                     ),
-                    lanes: dashboard_lanes_for_model(&llama_runtime_by_model, &process.name),
+                    lanes: dashboard_lanes_for_process(
+                        &llama_runtime_by_instance,
+                        &llama_runtime_by_model,
+                        process,
+                    ),
                     file_size_gb: dashboard_inventory_value_for_model(&size_by_name, &process.name)
                         .map(|size| *size as f64 / 1e9),
                 });
@@ -899,12 +910,13 @@ async fn refresh_dashboard_context_usage(
 fn publish_runtime_llama_slots(
     producer: Option<&crate::runtime_data::RuntimeDataProducer>,
     model_name: &str,
+    instance_id: Option<&str>,
     handle: &LocalRuntimeModelHandle,
 ) {
     let Some(producer) = producer else {
         return;
     };
-    if let Some(snapshot) = handle.llama_slots_snapshot(model_name) {
+    if let Some(snapshot) = handle.llama_slots_snapshot(model_name, instance_id) {
         producer.publish_llama_slots_snapshot(snapshot);
     }
 }
@@ -912,6 +924,7 @@ fn publish_runtime_llama_slots(
 fn publish_runtime_llama_unavailable(
     producer: Option<&crate::runtime_data::RuntimeDataProducer>,
     model_name: &str,
+    instance_id: Option<&str>,
 ) {
     let Some(producer) = producer else {
         return;
@@ -919,6 +932,7 @@ fn publish_runtime_llama_unavailable(
     producer.publish_llama_slots_snapshot(crate::runtime_data::RuntimeLlamaSlotsSnapshot {
         status: crate::runtime_data::RuntimeLlamaEndpointStatus::Unavailable,
         model: Some(model_name.to_string()),
+        instance_id: instance_id.map(str::to_string),
         last_attempt_unix_ms: Some(current_time_unix_ms()),
         last_success_unix_ms: None,
         error: None,
@@ -1197,7 +1211,12 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     );
     upsert_dashboard_process(&dashboard_processes, payload.clone()).await;
     refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
-    publish_runtime_llama_slots(runtime_data_producer.as_ref(), &loaded_name, &handle);
+    publish_runtime_llama_slots(
+        runtime_data_producer.as_ref(),
+        &loaded_name,
+        Some(&instance_id),
+        &handle,
+    );
     if let Some(ref cs) = console_state {
         cs.upsert_local_process(payload).await;
         cs.update(true, true).await;
@@ -1236,7 +1255,12 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         tokio::select! {
             _ = context_usage_tick.tick() => {
                 refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
-                publish_runtime_llama_slots(runtime_data_producer.as_ref(), &loaded_name, &handle);
+                publish_runtime_llama_slots(
+                    runtime_data_producer.as_ref(),
+                    &loaded_name,
+                    Some(&instance_id),
+                    &handle,
+                );
             }
             _ = &mut death_rx => {
                 let _ = emit_event(OutputEvent::Warning {
@@ -1272,7 +1296,11 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     )
                     .await
                 {
-                    publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &old_loaded_name);
+                    publish_runtime_llama_unavailable(
+                        runtime_data_producer.as_ref(),
+                        &old_loaded_name,
+                        Some(&instance_id),
+                    );
                 }
                 register_runtime_instance(
                     &runtime_instance_registry,
@@ -1307,7 +1335,12 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 loaded_name = next.loaded_name;
                 refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle)
                     .await;
-                publish_runtime_llama_slots(runtime_data_producer.as_ref(), &loaded_name, &handle);
+                publish_runtime_llama_slots(
+                    runtime_data_producer.as_ref(),
+                    &loaded_name,
+                    Some(&instance_id),
+                    &handle,
+                );
                 death_rx = next.death_rx;
                 split_cleanup = next.cleanup.take();
                 let _ = event.ack.send(SplitCoordinatorAck::Accepted);
@@ -1345,7 +1378,11 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     )
     .await
     {
-        publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &loaded_name);
+        publish_runtime_llama_unavailable(
+            runtime_data_producer.as_ref(),
+            &loaded_name,
+            Some(&instance_id),
+        );
     }
     upsert_dashboard_process(
         &dashboard_processes,
@@ -2933,7 +2970,8 @@ async fn startup_ready_reporter_uses_bound_urls_for_runtime_ready() {
 #[cfg(test)]
 #[test]
 fn dashboard_lanes_prefer_sparse_slot_ids() {
-    let mut snapshots = BTreeMap::new();
+    let snapshots_by_instance = BTreeMap::new();
+    let mut snapshots_by_model = BTreeMap::new();
     let mut snapshot = crate::runtime_data::RuntimeLlamaRuntimeSnapshot::default();
     snapshot.items.slots = vec![
         crate::runtime_data::RuntimeLlamaSlotItem {
@@ -2951,9 +2989,19 @@ fn dashboard_lanes_prefer_sparse_slot_ids() {
             is_processing: true,
         },
     ];
-    snapshots.insert("model-a".to_string(), snapshot);
+    snapshots_by_model.insert("model-a".to_string(), snapshot);
+    let process = api::RuntimeProcessPayload {
+        name: "model-a".to_string(),
+        instance_id: None,
+        backend: "skippy".to_string(),
+        status: "ready".to_string(),
+        port: 4001,
+        pid: 1234,
+        slots: 2,
+        context_length: Some(8192),
+    };
 
-    let lanes = dashboard_lanes_for_model(&snapshots, "model-a")
+    let lanes = dashboard_lanes_for_process(&snapshots_by_instance, &snapshots_by_model, &process)
         .expect("snapshot with slots should produce dashboard lanes");
 
     assert_eq!(lanes.len(), 2);
@@ -2966,7 +3014,8 @@ fn dashboard_lanes_prefer_sparse_slot_ids() {
 #[cfg(test)]
 #[test]
 fn dashboard_lanes_fall_back_to_slot_index_when_id_is_missing() {
-    let mut snapshots = BTreeMap::new();
+    let snapshots_by_instance = BTreeMap::new();
+    let mut snapshots_by_model = BTreeMap::new();
     let mut snapshot = crate::runtime_data::RuntimeLlamaRuntimeSnapshot::default();
     snapshot.items.slots = vec![crate::runtime_data::RuntimeLlamaSlotItem {
         index: 7,
@@ -2975,13 +3024,66 @@ fn dashboard_lanes_fall_back_to_slot_index_when_id_is_missing() {
         n_ctx: None,
         is_processing: true,
     }];
-    snapshots.insert("model-a".to_string(), snapshot);
+    snapshots_by_model.insert("model-a".to_string(), snapshot);
+    let process = api::RuntimeProcessPayload {
+        name: "model-a".to_string(),
+        instance_id: None,
+        backend: "skippy".to_string(),
+        status: "ready".to_string(),
+        port: 4001,
+        pid: 1234,
+        slots: 1,
+        context_length: Some(8192),
+    };
 
-    let lanes = dashboard_lanes_for_model(&snapshots, "model-a")
+    let lanes = dashboard_lanes_for_process(&snapshots_by_instance, &snapshots_by_model, &process)
         .expect("snapshot with slots should produce dashboard lanes");
 
     assert_eq!(lanes.len(), 1);
     assert_eq!(lanes[0].index, 7);
+    assert!(lanes[0].active);
+}
+
+#[cfg(test)]
+#[test]
+fn dashboard_lanes_prefer_instance_snapshot_for_duplicate_models() {
+    let mut snapshots_by_instance = BTreeMap::new();
+    let snapshots_by_model = BTreeMap::new();
+    let mut first_snapshot = crate::runtime_data::RuntimeLlamaRuntimeSnapshot::default();
+    first_snapshot.items.slots = vec![crate::runtime_data::RuntimeLlamaSlotItem {
+        index: 0,
+        id: Some(1),
+        id_task: None,
+        n_ctx: None,
+        is_processing: false,
+    }];
+    let mut second_snapshot = crate::runtime_data::RuntimeLlamaRuntimeSnapshot::default();
+    second_snapshot.items.slots = vec![crate::runtime_data::RuntimeLlamaSlotItem {
+        index: 0,
+        id: Some(2),
+        id_task: None,
+        n_ctx: None,
+        is_processing: true,
+    }];
+    snapshots_by_instance.insert("runtime-1".to_string(), first_snapshot);
+    snapshots_by_instance.insert("runtime-2".to_string(), second_snapshot);
+
+    let process = api::RuntimeProcessPayload {
+        name: "model-a".to_string(),
+        instance_id: Some("runtime-2".to_string()),
+        backend: "skippy".to_string(),
+        status: "ready".to_string(),
+        port: 4002,
+        pid: 1235,
+        slots: 1,
+        context_length: Some(8192),
+    };
+
+    let lanes = dashboard_lanes_for_process(&snapshots_by_instance, &snapshots_by_model, &process)
+        .expect("instance snapshot should produce dashboard lanes");
+
+    assert_eq!(lanes.len(), 1);
+    assert_eq!(lanes[0].index, 2);
     assert!(lanes[0].active);
 }
 
@@ -4441,11 +4543,12 @@ async fn run_auto(
         tokio::select! {
             _ = dashboard_context_usage_tick.tick() => {
                 let updates = runtime_models
-                    .values()
-                    .map(|entry| {
+                    .iter()
+                    .map(|(instance_id, entry)| {
                         publish_runtime_llama_slots(
                             runtime_data_producer.as_ref(),
                             &entry.model_name,
+                            Some(instance_id.as_str()),
                             &entry.handle,
                         );
                         (
@@ -4559,6 +4662,7 @@ async fn run_auto(
                             publish_runtime_llama_slots(
                                 runtime_data_producer.as_ref(),
                                 &loaded_name,
+                                Some(&instance_id),
                                 &handle,
                             );
                             runtime_models.insert(
@@ -4606,6 +4710,7 @@ async fn run_auto(
                                         publish_runtime_llama_unavailable(
                                             runtime_data_producer.as_ref(),
                                             &model,
+                                            Some(&unload.instance_id),
                                         );
                                     }
                                     upsert_dashboard_process(
@@ -4670,6 +4775,7 @@ async fn run_auto(
                                         publish_runtime_llama_unavailable(
                                             runtime_data_producer.as_ref(),
                                             &model,
+                                            Some(&unload.instance_id),
                                         );
                                         withdraw_advertised_model(&node, &model).await;
                                         set_advertised_model_context(&node, &model, None).await;
@@ -4721,6 +4827,7 @@ async fn run_auto(
                                     publish_runtime_llama_unavailable(
                                         runtime_data_producer.as_ref(),
                                         &model,
+                                        Some(&instance_id),
                                     );
                                 }
                                 upsert_dashboard_process(
@@ -4806,7 +4913,11 @@ async fn run_auto(
         remove_runtime_local_target(&target_tx, &name, handle.port);
         if unregister_runtime_instance(&runtime_instance_registry, &node, &name, &instance_id).await
         {
-            publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &name);
+            publish_runtime_llama_unavailable(
+                runtime_data_producer.as_ref(),
+                &name,
+                Some(&instance_id),
+            );
         }
         remove_dashboard_context_usage(&dashboard_context_usage, &name, &handle).await;
         let stopped_payload =
@@ -5561,6 +5672,7 @@ mod tests {
         producer.publish_llama_slots_snapshot(crate::runtime_data::RuntimeLlamaSlotsSnapshot {
             status: crate::runtime_data::RuntimeLlamaEndpointStatus::Ready,
             model: Some("model-a".to_string()),
+            instance_id: None,
             last_attempt_unix_ms: Some(1),
             last_success_unix_ms: Some(1),
             error: None,
@@ -5580,6 +5692,7 @@ mod tests {
         producer.publish_llama_slots_snapshot(crate::runtime_data::RuntimeLlamaSlotsSnapshot {
             status: crate::runtime_data::RuntimeLlamaEndpointStatus::Ready,
             model: Some("model-b".to_string()),
+            instance_id: None,
             last_attempt_unix_ms: Some(2),
             last_success_unix_ms: Some(2),
             error: None,

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -60,11 +60,31 @@ const DASHBOARD_FIRST_PAINT_TIMEOUT: Duration = Duration::from_secs(2);
 
 type DashboardContextUsage =
     Arc<tokio::sync::Mutex<HashMap<String, HashMap<DashboardContextUsageSource, u64>>>>;
+type RuntimeInstanceRegistry =
+    Arc<tokio::sync::Mutex<HashMap<String, BTreeMap<String, Option<u32>>>>>;
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct DashboardContextUsageSource {
     port: u16,
     pid: u32,
+}
+
+struct RuntimeModelHandleEntry {
+    model_name: String,
+    handle: LocalRuntimeModelHandle,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RuntimeUnloadOwner {
+    Runtime,
+    Managed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RuntimeUnloadCandidate {
+    owner: RuntimeUnloadOwner,
+    instance_id: String,
+    model_name: String,
 }
 
 thread_local! {
@@ -374,6 +394,21 @@ fn dashboard_context_usage_for_model(
         .max()
 }
 
+fn dashboard_context_usage_for_process(
+    values_by_name: &HashMap<String, HashMap<DashboardContextUsageSource, u64>>,
+    process: &api::RuntimeProcessPayload,
+) -> Option<u64> {
+    let source = DashboardContextUsageSource {
+        port: process.port,
+        pid: process.pid,
+    };
+    dashboard_inventory_model_keys(&process.name)
+        .into_iter()
+        .filter_map(|key| values_by_name.get(&key))
+        .find_map(|source_values| source_values.get(&source).copied())
+        .or_else(|| dashboard_context_usage_for_model(values_by_name, &process.name))
+}
+
 fn dashboard_lanes_for_model(
     snapshots_by_model: &BTreeMap<String, crate::runtime_data::RuntimeLlamaRuntimeSnapshot>,
     model_name: &str,
@@ -499,9 +534,9 @@ impl DashboardSnapshotProvider for RuntimeDashboardSnapshotProvider {
                     slots: Some(process.slots),
                     quantization,
                     ctx_size,
-                    ctx_used_tokens: dashboard_context_usage_for_model(
+                    ctx_used_tokens: dashboard_context_usage_for_process(
                         &context_usage_by_name,
-                        &process.name,
+                        process,
                     ),
                     lanes: dashboard_lanes_for_model(&llama_runtime_by_model, &process.name),
                     file_size_gb: dashboard_inventory_value_for_model(&size_by_name, &process.name)
@@ -643,11 +678,13 @@ fn plugin_dashboard_command_name(summary: &plugin::PluginSummary) -> String {
 
 fn runtime_process_payload_with_status(
     name: &str,
+    instance_id: Option<&str>,
     handle: &LocalRuntimeModelHandle,
     status: &str,
 ) -> api::RuntimeProcessPayload {
     api::RuntimeProcessPayload {
         name: name.to_string(),
+        instance_id: instance_id.map(str::to_string),
         backend: handle.backend.clone(),
         status: status.to_string(),
         port: handle.port,
@@ -662,19 +699,187 @@ async fn upsert_dashboard_process(
     process: api::RuntimeProcessPayload,
 ) {
     let mut guard = shared.lock().await;
-    guard.retain(|existing| existing.name != process.name);
+    guard.retain(|existing| {
+        runtime_process_payload_identity(existing) != runtime_process_payload_identity(&process)
+    });
     guard.push(process);
-    guard.sort_by_key(|process| process.name.to_lowercase());
+    guard.sort_by(|left, right| {
+        (
+            left.name.to_lowercase(),
+            left.instance_id.as_deref().unwrap_or(""),
+            left.port,
+        )
+            .cmp(&(
+                right.name.to_lowercase(),
+                right.instance_id.as_deref().unwrap_or(""),
+                right.port,
+            ))
+    });
 }
 
 async fn remove_dashboard_process(
     shared: &Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
-    model_name: &str,
+    target: &str,
 ) {
-    shared
+    let mut guard = shared.lock().await;
+    let has_instance_match = guard
+        .iter()
+        .any(|process| process.instance_id.as_deref() == Some(target));
+    guard.retain(|process| {
+        if has_instance_match {
+            process.instance_id.as_deref() != Some(target)
+        } else {
+            process.name != target
+        }
+    });
+}
+
+fn runtime_process_payload_identity(process: &api::RuntimeProcessPayload) -> &str {
+    process.instance_id.as_deref().unwrap_or(&process.name)
+}
+
+fn next_runtime_instance_id(next_sequence: &mut u64) -> String {
+    let instance_id = format!("runtime-{}", *next_sequence);
+    *next_sequence = next_sequence.saturating_add(1);
+    instance_id
+}
+
+async fn register_runtime_instance(
+    registry: &RuntimeInstanceRegistry,
+    node: &mesh::Node,
+    primary_model_name: &str,
+    model_name: &str,
+    instance_id: &str,
+    context_length: Option<u32>,
+) {
+    let (was_empty, context_changed, next_context) = {
+        let mut guard = registry.lock().await;
+        let instances = guard.entry(model_name.to_string()).or_default();
+        let previous_context = runtime_registry_model_context(instances);
+        let was_empty = instances.is_empty();
+        instances.insert(instance_id.to_string(), context_length);
+        let next_context = runtime_registry_model_context(instances);
+        (was_empty, previous_context != next_context, next_context)
+    };
+
+    if context_changed {
+        set_advertised_model_context(node, model_name, next_context).await;
+    }
+    if was_empty {
+        add_serving_assignment(node, primary_model_name, model_name).await;
+        advertise_model_ready(node, primary_model_name, model_name).await;
+    }
+}
+
+async fn unregister_runtime_instance(
+    registry: &RuntimeInstanceRegistry,
+    node: &mesh::Node,
+    model_name: &str,
+    instance_id: &str,
+) -> bool {
+    let (removed, became_empty, context_changed, next_context) = {
+        let mut guard = registry.lock().await;
+        let Some(instances) = guard.get_mut(model_name) else {
+            return false;
+        };
+        let previous_context = runtime_registry_model_context(instances);
+        let removed = instances.remove(instance_id).is_some();
+        let next_context = runtime_registry_model_context(instances);
+        let became_empty = instances.is_empty();
+        if became_empty {
+            guard.remove(model_name);
+        }
+        (
+            removed,
+            became_empty,
+            previous_context != next_context,
+            next_context,
+        )
+    };
+
+    if !removed {
+        return false;
+    }
+    if became_empty {
+        set_advertised_model_context(node, model_name, None).await;
+        withdraw_advertised_model(node, model_name).await;
+        remove_serving_assignment(node, model_name).await;
+        true
+    } else {
+        if context_changed {
+            set_advertised_model_context(node, model_name, next_context).await;
+        }
+        false
+    }
+}
+
+async fn runtime_registry_has_model(registry: &RuntimeInstanceRegistry, model_name: &str) -> bool {
+    registry
         .lock()
         .await
-        .retain(|process| process.name != model_name);
+        .get(model_name)
+        .map(|instances| !instances.is_empty())
+        .unwrap_or(false)
+}
+
+fn runtime_registry_model_context(instances: &BTreeMap<String, Option<u32>>) -> Option<u32> {
+    instances.values().filter_map(|context| *context).max()
+}
+
+fn runtime_unload_candidates(
+    runtime_models: &HashMap<String, RuntimeModelHandleEntry>,
+    managed_models: &HashMap<String, ManagedModelController>,
+) -> Vec<RuntimeUnloadCandidate> {
+    runtime_models
+        .iter()
+        .map(|(instance_id, entry)| RuntimeUnloadCandidate {
+            owner: RuntimeUnloadOwner::Runtime,
+            instance_id: instance_id.clone(),
+            model_name: entry.model_name.clone(),
+        })
+        .chain(
+            managed_models
+                .iter()
+                .map(|(instance_id, controller)| RuntimeUnloadCandidate {
+                    owner: RuntimeUnloadOwner::Managed,
+                    instance_id: instance_id.clone(),
+                    model_name: controller.model_name.clone(),
+                }),
+        )
+        .collect()
+}
+
+fn resolve_runtime_unload_target(
+    target: &str,
+    candidates: Vec<RuntimeUnloadCandidate>,
+) -> Result<RuntimeUnloadCandidate> {
+    let mut instance_matches = candidates
+        .iter()
+        .filter(|candidate| candidate.instance_id == target);
+    if let Some(candidate) = instance_matches.next() {
+        return Ok(candidate.clone());
+    }
+
+    let model_matches: Vec<_> = candidates
+        .into_iter()
+        .filter(|candidate| candidate.model_name == target)
+        .collect();
+    match model_matches.len() {
+        0 => Err(anyhow::anyhow!(
+            "model or runtime instance '{target}' is not loaded"
+        )),
+        1 => Ok(model_matches.into_iter().next().expect("one model match")),
+        _ => {
+            let ids = model_matches
+                .iter()
+                .map(|candidate| candidate.instance_id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(anyhow::anyhow!(
+                "model '{target}' has multiple loaded instances ({ids}); unload by runtime instance id"
+            ))
+        }
+    }
 }
 
 async fn refresh_dashboard_context_usage(
@@ -798,6 +1003,7 @@ struct StartupLocalModelTask {
     model_path: PathBuf,
     model_ref: String,
     model_name: String,
+    instance_id: String,
     primary_model_name: String,
     mmproj_path: Option<PathBuf>,
     ctx_size: Option<u32>,
@@ -813,6 +1019,7 @@ struct StartupLocalModelTask {
     stop_rx: tokio::sync::watch::Receiver<bool>,
     dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
     dashboard_context_usage: DashboardContextUsage,
+    runtime_instance_registry: RuntimeInstanceRegistry,
     console_state: Option<api::MeshApi>,
     api_port: u16,
     startup_ready_reporter: StartupReadyReporter,
@@ -831,6 +1038,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         model_path,
         model_ref,
         model_name,
+        instance_id,
         primary_model_name,
         mmproj_path,
         ctx_size,
@@ -846,6 +1054,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         mut stop_rx,
         dashboard_processes,
         dashboard_context_usage,
+        runtime_instance_registry,
         console_state,
         api_port,
         startup_ready_reporter,
@@ -968,10 +1177,18 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         http_port: api_port,
     })
     .await;
-    set_advertised_model_context(&node, &loaded_name, Some(handle.context_length)).await;
-    advertise_model_ready(&node, &primary_model_name, &loaded_name).await;
+    register_runtime_instance(
+        &runtime_instance_registry,
+        &node,
+        &primary_model_name,
+        &loaded_name,
+        &instance_id,
+        Some(handle.context_length),
+    )
+    .await;
     let payload = local_process_payload(
         &loaded_name,
+        Some(&instance_id),
         &handle.backend,
         handle.port,
         handle.pid(),
@@ -1046,19 +1263,29 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 remove_runtime_local_target(&target_tx, &old_loaded_name, old_port);
                 add_runtime_local_target(&target_tx, &next.loaded_name, next.handle.port);
                 tunnel_mgr.set_http_port(api_port);
-                if old_loaded_name != next.loaded_name {
-                    withdraw_advertised_model(&node, &old_loaded_name).await;
-                    set_advertised_model_context(&node, &old_loaded_name, None).await;
-                    advertise_model_ready(&node, &primary_model_name, &next.loaded_name).await;
+                if old_loaded_name != next.loaded_name
+                    && unregister_runtime_instance(
+                        &runtime_instance_registry,
+                        &node,
+                        &old_loaded_name,
+                        &instance_id,
+                    )
+                    .await
+                {
+                    publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &old_loaded_name);
                 }
-                set_advertised_model_context(
+                register_runtime_instance(
+                    &runtime_instance_registry,
                     &node,
+                    &primary_model_name,
                     &next.loaded_name,
+                    &instance_id,
                     Some(next.handle.context_length),
                 )
                 .await;
                 let payload = local_process_payload(
                     &next.loaded_name,
+                    Some(&instance_id),
                     &next.handle.backend,
                     next.handle.port,
                     next.handle.pid(),
@@ -1077,9 +1304,6 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     &old_handle,
                 )
                 .await;
-                if old_loaded_name != next.loaded_name {
-                    publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &old_loaded_name);
-                }
                 loaded_name = next.loaded_name;
                 refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle)
                     .await;
@@ -1113,30 +1337,43 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     let port = handle.port;
     remove_runtime_local_target(&target_tx, &loaded_name, port);
     tunnel_mgr.set_http_port(api_port);
-    withdraw_advertised_model(&node, &loaded_name).await;
-    set_advertised_model_context(&node, &loaded_name, None).await;
+    if unregister_runtime_instance(
+        &runtime_instance_registry,
+        &node,
+        &loaded_name,
+        &instance_id,
+    )
+    .await
+    {
+        publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &loaded_name);
+    }
     upsert_dashboard_process(
         &dashboard_processes,
-        runtime_process_payload_with_status(&loaded_name, &handle, "shutting down"),
+        runtime_process_payload_with_status(
+            &loaded_name,
+            Some(&instance_id),
+            &handle,
+            "shutting down",
+        ),
     )
     .await;
     if let Some(ref cs) = console_state {
         cs.upsert_local_process(runtime_process_payload_with_status(
             &loaded_name,
+            Some(&instance_id),
             &handle,
             "shutting down",
         ))
         .await;
     }
     remove_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
-    publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &loaded_name);
     handle.shutdown().await;
     if let Some(cleanup) = split_cleanup.take() {
         stop_split_generation_cleanup(&node, cleanup, u64::MAX).await;
     }
-    remove_dashboard_process(&dashboard_processes, &loaded_name).await;
+    remove_dashboard_process(&dashboard_processes, &instance_id).await;
     if let Some(cs) = console_state {
-        cs.remove_local_process(&loaded_name).await;
+        cs.remove_local_process(&instance_id).await;
         cs.update(false, false).await;
     }
     let _ = emit_event(OutputEvent::Info {
@@ -3709,8 +3946,11 @@ async fn run_auto(
         tokio::sync::mpsc::unbounded_channel::<api::RuntimeControlRequest>();
     let (runtime_event_tx, mut runtime_event_rx) =
         tokio::sync::mpsc::unbounded_channel::<RuntimeEvent>();
-    let mut runtime_models: HashMap<String, LocalRuntimeModelHandle> = HashMap::new();
+    let mut runtime_models: HashMap<String, RuntimeModelHandleEntry> = HashMap::new();
     let mut managed_models: HashMap<String, ManagedModelController> = HashMap::new();
+    let runtime_instance_registry: RuntimeInstanceRegistry =
+        Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let mut next_runtime_instance_sequence = 1_u64;
     let dashboard_processes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
     let dashboard_context_usage = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
     let input_handler_enabled = crate::cli::output::OutputManager::global()
@@ -3978,8 +4218,11 @@ async fn run_auto(
         .unwrap_or_else(|| model_name.clone());
     let startup_split = cli.split;
     let (primary_stop_tx, primary_stop_rx) = tokio::sync::watch::channel(false);
+    let primary_instance_id = next_runtime_instance_id(&mut next_runtime_instance_sequence);
+    let primary_task_instance_id = primary_instance_id.clone();
     let dashboard_processes_for_primary_task = dashboard_processes.clone();
     let dashboard_context_usage_for_primary_task = dashboard_context_usage.clone();
+    let runtime_instance_registry_for_primary_task = runtime_instance_registry.clone();
     let primary_startup_load_gate = startup_load_gate.clone();
     let primary_task = tokio::spawn(async move {
         startup_local_model_loop(StartupLocalModelTask {
@@ -3989,6 +4232,7 @@ async fn run_auto(
             model_path: model2,
             model_ref: primary_model_ref,
             model_name: model_name_for_election,
+            instance_id: primary_task_instance_id,
             primary_model_name: primary_model_name_for_advertise,
             mmproj_path: primary_mmproj,
             ctx_size: primary_ctx_size,
@@ -4004,6 +4248,7 @@ async fn run_auto(
             stop_rx: primary_stop_rx,
             dashboard_processes: dashboard_processes_for_primary_task,
             dashboard_context_usage: dashboard_context_usage_for_primary_task,
+            runtime_instance_registry: runtime_instance_registry_for_primary_task,
             console_state: console_state_for_election,
             api_port,
             startup_ready_reporter: primary_startup_ready_reporter,
@@ -4016,8 +4261,9 @@ async fn run_auto(
         .await;
     });
     managed_models.insert(
-        model_name.clone(),
+        primary_instance_id,
         ManagedModelController {
+            model_name: model_name.clone(),
             stop_tx: primary_stop_tx,
             task: primary_task,
         },
@@ -4064,8 +4310,11 @@ async fn run_auto(
             let primary_model_name_for_extra = model_name.clone();
             let managed_model_name = extra_name.clone();
             let (extra_stop_tx, extra_stop_rx) = tokio::sync::watch::channel(false);
+            let extra_instance_id = next_runtime_instance_id(&mut next_runtime_instance_sequence);
+            let extra_task_instance_id = extra_instance_id.clone();
             let dashboard_processes_for_extra_task = dashboard_processes.clone();
             let dashboard_context_usage_for_extra_task = dashboard_context_usage.clone();
+            let runtime_instance_registry_for_extra_task = runtime_instance_registry.clone();
             let extra_control_tx = control_tx.clone();
             let extra_task = tokio::spawn(async move {
                 startup_local_model_loop(StartupLocalModelTask {
@@ -4075,6 +4324,7 @@ async fn run_auto(
                     model_path: extra_path,
                     model_ref: extra_ref,
                     model_name: extra_model_name,
+                    instance_id: extra_task_instance_id,
                     primary_model_name: primary_model_name_for_extra,
                     mmproj_path: extra_mmproj,
                     ctx_size: extra_ctx_size,
@@ -4090,6 +4340,7 @@ async fn run_auto(
                     stop_rx: extra_stop_rx,
                     dashboard_processes: dashboard_processes_for_extra_task,
                     dashboard_context_usage: dashboard_context_usage_for_extra_task,
+                    runtime_instance_registry: runtime_instance_registry_for_extra_task,
                     console_state: extra_console_state,
                     api_port: api_port_extra,
                     startup_ready_reporter: extra_startup_ready_reporter,
@@ -4102,8 +4353,9 @@ async fn run_auto(
                 .await;
             });
             managed_models.insert(
-                managed_model_name,
+                extra_instance_id,
                 ManagedModelController {
+                    model_name: managed_model_name,
                     stop_tx: extra_stop_tx,
                     task: extra_task,
                 },
@@ -4189,13 +4441,17 @@ async fn run_auto(
         tokio::select! {
             _ = dashboard_context_usage_tick.tick() => {
                 let updates = runtime_models
-                    .iter()
-                    .map(|(name, handle)| {
-                        publish_runtime_llama_slots(runtime_data_producer.as_ref(), name, handle);
+                    .values()
+                    .map(|entry| {
+                        publish_runtime_llama_slots(
+                            runtime_data_producer.as_ref(),
+                            &entry.model_name,
+                            &entry.handle,
+                        );
                         (
-                            name.clone(),
-                            dashboard_context_usage_source(handle),
-                            handle.ctx_used_tokens(),
+                            entry.model_name.clone(),
+                            dashboard_context_usage_source(&entry.handle),
+                            entry.handle.ctx_used_tokens(),
                         )
                     })
                     .collect();
@@ -4209,18 +4465,8 @@ async fn run_auto(
             Some(cmd) = control_rx.recv() => {
                 match cmd {
                     api::RuntimeControlRequest::Load { spec, resp } => {
-                        let mut assigned_runtime_model: Option<String> = None;
                         let result = async {
                             let model_path = resolve_model(&PathBuf::from(&spec)).await?;
-                            let runtime_model_name = models::find_catalog_model_exact(&spec)
-                                .map(models::catalog_model_ref)
-                                .unwrap_or_else(|| models::model_ref_for_path(&model_path));
-                            let already_loaded = managed_models.contains_key(&runtime_model_name)
-                                || runtime_models.contains_key(&runtime_model_name);
-                            anyhow::ensure!(
-                                !already_loaded,
-                                "model '{runtime_model_name}' is already loaded"
-                            );
 
                             // Look up per-model overrides from TOML config by matching the
                             // spec string against [[models]].model entries. Metadata-based
@@ -4232,9 +4478,8 @@ async fn run_auto(
                                 .or(config.gpu.parallel);
                             let slots = parallel_override.unwrap_or(4);
 
-                            assigned_runtime_model = Some(runtime_model_name.clone());
-                            add_serving_assignment(&node, &primary_model_name, &runtime_model_name)
-                                .await;
+                            let instance_id =
+                                next_runtime_instance_id(&mut next_runtime_instance_sequence);
                             let (loaded_name, handle, death_rx) = start_runtime_local_model(
                                 LocalRuntimeModelStartSpec {
                                     node: &node,
@@ -4258,16 +4503,19 @@ async fn run_auto(
                             .await?;
 
                             add_runtime_local_target(&target_tx, &loaded_name, handle.port);
-                            set_advertised_model_context(
+                            register_runtime_instance(
+                                &runtime_instance_registry,
                                 &node,
+                                &primary_model_name,
                                 &loaded_name,
+                                &instance_id,
                                 Some(handle.context_length),
                             )
                             .await;
-                            advertise_model_ready(&node, &primary_model_name, &loaded_name).await;
                             node.set_available_models(models::scan_local_models()).await;
                             let payload = local_process_payload(
                                 &loaded_name,
+                                Some(&instance_id),
                                 &handle.backend,
                                 handle.port,
                                 handle.pid(),
@@ -4281,11 +4529,13 @@ async fn run_auto(
                             }
 
                             let event_tx = runtime_event_tx.clone();
+                            let event_instance_id = instance_id.clone();
                             let event_name = loaded_name.clone();
                             let event_port = handle.port;
                             tokio::spawn(async move {
                                 let _ = death_rx.await;
                                 let _ = event_tx.send(RuntimeEvent::Exited {
+                                    instance_id: event_instance_id,
                                     model: event_name,
                                     port: event_port,
                                 });
@@ -4311,75 +4561,136 @@ async fn run_auto(
                                 &loaded_name,
                                 &handle,
                             );
-                            runtime_models.insert(loaded_name.clone(), handle);
-                            Ok(loaded_name)
+                            runtime_models.insert(
+                                instance_id.clone(),
+                                RuntimeModelHandleEntry {
+                                    model_name: loaded_name.clone(),
+                                    handle,
+                                },
+                            );
+                            Ok(api::RuntimeLoadResponse {
+                                model: loaded_name,
+                                instance_id,
+                            })
                         }
                         .await;
-                        if let Err(err) = &result {
-                            let _ = err;
-                            if let Some(name) = assigned_runtime_model.as_deref() {
-                                remove_serving_assignment(&node, name).await;
-                            }
-                        }
                         let _ = resp.send(result);
                     }
-                    api::RuntimeControlRequest::Unload { model, resp } => {
-                        let result = if let Some(handle) = runtime_models.remove(&model) {
-                            let port = handle.port;
-                            publish_runtime_llama_unavailable(
-                                runtime_data_producer.as_ref(),
-                                &model,
-                            );
-                            remove_runtime_local_target(&target_tx, &model, port);
-                            withdraw_advertised_model(&node, &model).await;
-                            upsert_dashboard_process(
-                                &dashboard_processes,
-                                runtime_process_payload_with_status(&model, &handle, "shutting down"),
-                            )
-                            .await;
-                            if let Some(ref cs) = console_state {
-                                cs.upsert_local_process(runtime_process_payload_with_status(
-                                    &model,
-                                    &handle,
-                                    "shutting down",
-                                ))
-                                .await;
+                    api::RuntimeControlRequest::Unload { target, resp } => {
+                        let result = async {
+                            let unload = resolve_runtime_unload_target(
+                                &target,
+                                runtime_unload_candidates(&runtime_models, &managed_models),
+                            )?;
+                            match unload.owner {
+                                RuntimeUnloadOwner::Runtime => {
+                                    let Some(entry) = runtime_models.remove(&unload.instance_id)
+                                    else {
+                                        anyhow::bail!(
+                                            "model or runtime instance '{}' is not loaded",
+                                            unload.instance_id
+                                        );
+                                    };
+                                    let model = entry.model_name;
+                                    let handle = entry.handle;
+                                    let port = handle.port;
+                                    remove_runtime_local_target(&target_tx, &model, port);
+                                    if unregister_runtime_instance(
+                                        &runtime_instance_registry,
+                                        &node,
+                                        &model,
+                                        &unload.instance_id,
+                                    )
+                                    .await
+                                    {
+                                        publish_runtime_llama_unavailable(
+                                            runtime_data_producer.as_ref(),
+                                            &model,
+                                        );
+                                    }
+                                    upsert_dashboard_process(
+                                        &dashboard_processes,
+                                        runtime_process_payload_with_status(
+                                            &model,
+                                            Some(&unload.instance_id),
+                                            &handle,
+                                            "shutting down",
+                                        ),
+                                    )
+                                    .await;
+                                    if let Some(ref cs) = console_state {
+                                        cs.upsert_local_process(runtime_process_payload_with_status(
+                                            &model,
+                                            Some(&unload.instance_id),
+                                            &handle,
+                                            "shutting down",
+                                        ))
+                                        .await;
+                                    }
+                                    tokio::time::sleep(std::time::Duration::from_millis(300))
+                                        .await;
+                                    remove_dashboard_context_usage(
+                                        &dashboard_context_usage,
+                                        &model,
+                                        &handle,
+                                    )
+                                    .await;
+                                    handle.shutdown().await;
+                                    remove_dashboard_process(
+                                        &dashboard_processes,
+                                        &unload.instance_id,
+                                    )
+                                    .await;
+                                    if let Some(ref cs) = console_state {
+                                        cs.remove_local_process(&unload.instance_id).await;
+                                    }
+                                    let _ = emit_event(OutputEvent::Info {
+                                        message: format!(
+                                            "Unloaded local model '{}' from :{}",
+                                            model, port
+                                        ),
+                                        context: None,
+                                    });
+                                    Ok(api::RuntimeUnloadResponse {
+                                        model,
+                                        instance_id: unload.instance_id,
+                                    })
+                                }
+                                RuntimeUnloadOwner::Managed => {
+                                    let Some(controller) = managed_models.remove(&unload.instance_id) else {
+                                        anyhow::bail!(
+                                            "model or runtime instance '{}' is not loaded",
+                                            unload.instance_id
+                                        );
+                                    };
+                                    let model = controller.model_name.clone();
+                                    let _ = controller.stop_tx.send(true);
+                                    let _ = controller.task.await;
+                                    if !runtime_registry_has_model(&runtime_instance_registry, &model).await {
+                                        publish_runtime_llama_unavailable(
+                                            runtime_data_producer.as_ref(),
+                                            &model,
+                                        );
+                                        withdraw_advertised_model(&node, &model).await;
+                                        set_advertised_model_context(&node, &model, None).await;
+                                        remove_serving_assignment(&node, &model).await;
+                                    }
+                                    remove_dashboard_process(&dashboard_processes, &unload.instance_id).await;
+                                    if let Some(ref cs) = console_state {
+                                        cs.remove_local_process(&unload.instance_id).await;
+                                    }
+                                    let _ = emit_event(OutputEvent::Info {
+                                        message: format!("Unloaded managed model '{}'", model),
+                                        context: None,
+                                    });
+                                    Ok(api::RuntimeUnloadResponse {
+                                        model,
+                                        instance_id: unload.instance_id,
+                                    })
+                                }
                             }
-                            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
-                            remove_dashboard_context_usage(&dashboard_context_usage, &model, &handle)
-                                .await;
-                            handle.shutdown().await;
-                            remove_serving_assignment(&node, &model).await;
-                            remove_dashboard_process(&dashboard_processes, &model).await;
-                            if let Some(ref cs) = console_state {
-                                cs.remove_local_process(&model).await;
-                            }
-                            let _ = emit_event(OutputEvent::Info {
-                                message: format!("Unloaded local model '{}' from :{}", model, port),
-                                context: None,
-                            });
-                            Ok(())
-                        } else if let Some(controller) = managed_models.remove(&model) {
-                            let _ = controller.stop_tx.send(true);
-                            let _ = controller.task.await;
-                            publish_runtime_llama_unavailable(
-                                runtime_data_producer.as_ref(),
-                                &model,
-                            );
-                            withdraw_advertised_model(&node, &model).await;
-                            remove_serving_assignment(&node, &model).await;
-                            remove_dashboard_process(&dashboard_processes, &model).await;
-                            if let Some(ref cs) = console_state {
-                                cs.remove_local_process(&model).await;
-                            }
-                            let _ = emit_event(OutputEvent::Info {
-                                message: format!("Unloaded managed model '{}'", model),
-                                context: None,
-                            });
-                            Ok(())
-                        } else {
-                            Err(anyhow::anyhow!("model '{model}' is not loaded"))
-                        };
+                        }
+                        .await;
                         let _ = resp.send(result);
                     }
                     api::RuntimeControlRequest::Shutdown => {
@@ -4391,25 +4702,43 @@ async fn run_auto(
             }
             Some(event) = runtime_event_rx.recv() => {
                 match event {
-                    RuntimeEvent::Exited { model, port } => {
+                    RuntimeEvent::Exited { instance_id, model, port } => {
                         let matches = runtime_models
-                            .get(&model)
-                            .map(|handle| handle.port == port)
+                            .get(&instance_id)
+                            .map(|entry| entry.model_name == model && entry.handle.port == port)
                             .unwrap_or(false);
                         if matches {
-                            if let Some(handle) = runtime_models.remove(&model) {
-                                publish_runtime_llama_unavailable(
-                                    runtime_data_producer.as_ref(),
+                            if let Some(entry) = runtime_models.remove(&instance_id) {
+                                let handle = entry.handle;
+                                if unregister_runtime_instance(
+                                    &runtime_instance_registry,
+                                    &node,
                                     &model,
-                                );
+                                    &instance_id,
+                                )
+                                .await
+                                {
+                                    publish_runtime_llama_unavailable(
+                                        runtime_data_producer.as_ref(),
+                                        &model,
+                                    );
+                                }
                                 upsert_dashboard_process(
                                     &dashboard_processes,
-                                    runtime_process_payload_with_status(&model, &handle, "exited"),
+                                    runtime_process_payload_with_status(
+                                        &model,
+                                        Some(&instance_id),
+                                        &handle,
+                                        "exited",
+                                    ),
                                 )
                                 .await;
                                 if let Some(ref cs) = console_state {
                                     cs.upsert_local_process(runtime_process_payload_with_status(
-                                        &model, &handle, "exited",
+                                        &model,
+                                        Some(&instance_id),
+                                        &handle,
+                                        "exited",
                                     ))
                                     .await;
                                 }
@@ -4422,8 +4751,6 @@ async fn run_auto(
                                 handle.shutdown().await;
                             }
                             remove_runtime_local_target(&target_tx, &model, port);
-                            withdraw_advertised_model(&node, &model).await;
-                            remove_serving_assignment(&node, &model).await;
                             let _ = emit_event(OutputEvent::Warning {
                                 message: format!("Runtime model '{model}' exited unexpectedly"),
                                 context: Some(format!("model={model} port={port}")),
@@ -4463,19 +4790,27 @@ async fn run_auto(
         let _ = handle.await;
     }
 
-    for (name, handle) in runtime_models.drain() {
-        let shutting_down_payload =
-            runtime_process_payload_with_status(&name, &handle, "shutting down");
+    for (instance_id, entry) in runtime_models.drain() {
+        let name = entry.model_name;
+        let handle = entry.handle;
+        let shutting_down_payload = runtime_process_payload_with_status(
+            &name,
+            Some(&instance_id),
+            &handle,
+            "shutting down",
+        );
         upsert_dashboard_process(&dashboard_processes, shutting_down_payload.clone()).await;
         if let Some(ref cs) = console_state {
             cs.upsert_local_process(shutting_down_payload).await;
         }
         remove_runtime_local_target(&target_tx, &name, handle.port);
-        publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &name);
-        withdraw_advertised_model(&node, &name).await;
-        remove_serving_assignment(&node, &name).await;
+        if unregister_runtime_instance(&runtime_instance_registry, &node, &name, &instance_id).await
+        {
+            publish_runtime_llama_unavailable(runtime_data_producer.as_ref(), &name);
+        }
         remove_dashboard_context_usage(&dashboard_context_usage, &name, &handle).await;
-        let stopped_payload = runtime_process_payload_with_status(&name, &handle, "stopped");
+        let stopped_payload =
+            runtime_process_payload_with_status(&name, Some(&instance_id), &handle, "stopped");
         handle.shutdown().await;
         upsert_dashboard_process(&dashboard_processes, stopped_payload.clone()).await;
         if let Some(ref cs) = console_state {
@@ -5042,6 +5377,52 @@ mod tests {
         assert_eq!(plugin_dashboard_command_name(&summary), "browser-tools");
     }
 
+    #[test]
+    fn runtime_unload_target_requires_instance_id_for_duplicate_models() {
+        let err = resolve_runtime_unload_target(
+            "Qwen",
+            vec![
+                RuntimeUnloadCandidate {
+                    owner: RuntimeUnloadOwner::Runtime,
+                    instance_id: "runtime-1".to_string(),
+                    model_name: "Qwen".to_string(),
+                },
+                RuntimeUnloadCandidate {
+                    owner: RuntimeUnloadOwner::Managed,
+                    instance_id: "runtime-2".to_string(),
+                    model_name: "Qwen".to_string(),
+                },
+            ],
+        )
+        .expect_err("duplicate model-name unload should be ambiguous");
+
+        assert!(err.to_string().contains("multiple loaded instances"));
+    }
+
+    #[test]
+    fn runtime_unload_target_resolves_exact_instance_before_model_name() {
+        let target = resolve_runtime_unload_target(
+            "runtime-2",
+            vec![
+                RuntimeUnloadCandidate {
+                    owner: RuntimeUnloadOwner::Runtime,
+                    instance_id: "runtime-1".to_string(),
+                    model_name: "runtime-2".to_string(),
+                },
+                RuntimeUnloadCandidate {
+                    owner: RuntimeUnloadOwner::Managed,
+                    instance_id: "runtime-2".to_string(),
+                    model_name: "Qwen".to_string(),
+                },
+            ],
+        )
+        .expect("exact instance id should resolve");
+
+        assert_eq!(target.instance_id, "runtime-2");
+        assert_eq!(target.model_name, "Qwen");
+        assert_eq!(target.owner, RuntimeUnloadOwner::Managed);
+    }
+
     #[tokio::test]
     async fn dashboard_snapshot_provider_reuses_cached_inventory_within_ttl() {
         let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
@@ -5081,6 +5462,7 @@ mod tests {
         set_advertised_model_context(&node, &model_name, Some(8192)).await;
         let local_processes = Arc::new(tokio::sync::Mutex::new(vec![api::RuntimeProcessPayload {
             name: model_name.clone(),
+            instance_id: None,
             backend: "CUDA0".to_string(),
             status: "ready".to_string(),
             port: 4001,
@@ -5157,6 +5539,7 @@ mod tests {
         let local_processes = Arc::new(tokio::sync::Mutex::new(vec![
             api::RuntimeProcessPayload {
                 name: "model-a".to_string(),
+                instance_id: None,
                 backend: "skippy".to_string(),
                 status: "ready".to_string(),
                 port: 4001,
@@ -5166,6 +5549,7 @@ mod tests {
             },
             api::RuntimeProcessPayload {
                 name: "model-b".to_string(),
+                instance_id: None,
                 backend: "skippy".to_string(),
                 status: "ready".to_string(),
                 port: 4002,
@@ -5268,6 +5652,7 @@ mod tests {
         let inventory_model_name = "Qwen3.5-4B-UD-Q4_K_XL".to_string();
         let local_processes = Arc::new(tokio::sync::Mutex::new(vec![api::RuntimeProcessPayload {
             name: runtime_model_name.clone(),
+            instance_id: None,
             backend: "skippy".to_string(),
             status: "ready".to_string(),
             port: 37615,
@@ -5323,6 +5708,7 @@ mod tests {
         set_advertised_model_context(&node, &model_name, Some(131_072)).await;
         let local_processes = Arc::new(tokio::sync::Mutex::new(vec![api::RuntimeProcessPayload {
             name: model_name.clone(),
+            instance_id: None,
             backend: "skippy".to_string(),
             status: "ready".to_string(),
             port: 34097,

--- a/crates/mesh-llm/src/runtime_data/collector.rs
+++ b/crates/mesh-llm/src/runtime_data/collector.rs
@@ -108,6 +108,12 @@ impl RuntimeDataCollector {
         self.runtime_status_snapshot().llama_runtime_by_model
     }
 
+    pub(crate) fn runtime_llama_snapshots_by_instance(
+        &self,
+    ) -> BTreeMap<String, RuntimeLlamaRuntimeSnapshot> {
+        self.runtime_status_snapshot().llama_runtime_by_instance
+    }
+
     pub(crate) fn routing_snapshot(&self) -> RoutingCollectorSnapshot {
         self.snapshots().routing
     }
@@ -154,6 +160,14 @@ impl RuntimeDataCollector {
                     changed = true;
                 }
             }
+            for runtime in runtime_status.llama_runtime_by_instance.values_mut() {
+                let next_items = build_llama_runtime_items(&snapshot, &runtime.slots);
+                if runtime.metrics != snapshot || runtime.items != next_items {
+                    runtime.metrics = snapshot.clone();
+                    runtime.items = next_items;
+                    changed = true;
+                }
+            }
 
             let selected = select_runtime_llama_projection(runtime_status);
             if runtime_status.llama_runtime != selected {
@@ -170,11 +184,24 @@ impl RuntimeDataCollector {
                 build_llama_runtime_snapshot(&runtime_status.llama_runtime.metrics, snapshot);
             let mut changed = false;
 
+            if let Some(instance_id) = next_runtime.slots.instance_id.clone() {
+                if runtime_status.llama_runtime_by_instance.get(&instance_id) != Some(&next_runtime)
+                {
+                    runtime_status
+                        .llama_runtime_by_instance
+                        .insert(instance_id, next_runtime.clone());
+                    changed = true;
+                }
+            }
+
             if let Some(model) = next_runtime.slots.model.clone() {
-                if runtime_status.llama_runtime_by_model.get(&model) != Some(&next_runtime) {
+                if should_replace_model_runtime_projection(
+                    runtime_status.llama_runtime_by_model.get(&model),
+                    &next_runtime,
+                ) {
                     runtime_status
                         .llama_runtime_by_model
-                        .insert(model, next_runtime);
+                        .insert(model, next_runtime.clone());
                     changed = true;
                 }
 
@@ -725,9 +752,43 @@ fn build_llama_runtime_snapshot(
     }
 }
 
+fn should_replace_model_runtime_projection(
+    current: Option<&RuntimeLlamaRuntimeSnapshot>,
+    next: &RuntimeLlamaRuntimeSnapshot,
+) -> bool {
+    let Some(current) = current else {
+        return true;
+    };
+    if current == next {
+        return false;
+    }
+    if current.slots.instance_id == next.slots.instance_id {
+        return true;
+    }
+    matches!(
+        (current.slots.status, next.slots.status),
+        (
+            super::RuntimeLlamaEndpointStatus::Unavailable,
+            super::RuntimeLlamaEndpointStatus::Ready
+        )
+    )
+}
+
 fn select_runtime_llama_projection(
     runtime_status: &RuntimeStatusSnapshot,
 ) -> RuntimeLlamaRuntimeSnapshot {
+    if let Some(primary_ready) = runtime_status.primary_model.as_ref().and_then(|model| {
+        runtime_status
+            .llama_runtime_by_instance
+            .values()
+            .find(|snapshot| {
+                snapshot.slots.model.as_deref() == Some(model.as_str())
+                    && snapshot.slots.status == super::RuntimeLlamaEndpointStatus::Ready
+            })
+    }) {
+        return primary_ready.clone();
+    }
+
     if let Some(primary_ready) = runtime_status
         .primary_model
         .as_ref()
@@ -735,6 +796,14 @@ fn select_runtime_llama_projection(
         .filter(|snapshot| snapshot.slots.status == super::RuntimeLlamaEndpointStatus::Ready)
     {
         return primary_ready.clone();
+    }
+
+    if let Some((_, ready)) = runtime_status
+        .llama_runtime_by_instance
+        .iter()
+        .find(|(_, snapshot)| snapshot.slots.status == super::RuntimeLlamaEndpointStatus::Ready)
+    {
+        return ready.clone();
     }
 
     if let Some((_, ready)) = runtime_status
@@ -751,6 +820,19 @@ fn select_runtime_llama_projection(
         .and_then(|model| runtime_status.llama_runtime_by_model.get(model))
     {
         return primary.clone();
+    }
+
+    if let Some(primary) = runtime_status.primary_model.as_ref().and_then(|model| {
+        runtime_status
+            .llama_runtime_by_instance
+            .values()
+            .find(|snapshot| snapshot.slots.model.as_deref() == Some(model.as_str()))
+    }) {
+        return primary.clone();
+    }
+
+    if let Some((_, snapshot)) = runtime_status.llama_runtime_by_instance.iter().next() {
+        return snapshot.clone();
     }
 
     runtime_status

--- a/crates/mesh-llm/src/runtime_data/metrics.rs
+++ b/crates/mesh-llm/src/runtime_data/metrics.rs
@@ -41,6 +41,7 @@ pub(crate) struct RuntimeLlamaSlotSnapshot {
 pub(crate) struct RuntimeLlamaSlotsSnapshot {
     pub status: RuntimeLlamaEndpointStatus,
     pub model: Option<String>,
+    pub instance_id: Option<String>,
     pub last_attempt_unix_ms: Option<u64>,
     pub last_success_unix_ms: Option<u64>,
     pub error: Option<String>,

--- a/crates/mesh-llm/src/runtime_data/mod.rs
+++ b/crates/mesh-llm/src/runtime_data/mod.rs
@@ -164,6 +164,7 @@ mod tests {
         let processes_changed = producer.publish_local_processes(|local_processes| {
             local_processes.push(RuntimeProcessSnapshot {
                 model: "Qwen3-8B".into(),
+                instance_id: None,
                 backend: "metal".into(),
                 pid: 4242,
                 port: 9337,
@@ -263,6 +264,7 @@ mod tests {
         let legacy_processes = vec![
             RuntimeProcessPayload {
                 name: "Zulu".into(),
+                instance_id: None,
                 backend: "llama".into(),
                 status: "ready".into(),
                 port: 9444,
@@ -272,6 +274,7 @@ mod tests {
             },
             RuntimeProcessPayload {
                 name: "Alpha".into(),
+                instance_id: None,
                 backend: "llama".into(),
                 status: "starting".into(),
                 port: 9337,

--- a/crates/mesh-llm/src/runtime_data/mod.rs
+++ b/crates/mesh-llm/src/runtime_data/mod.rs
@@ -557,6 +557,7 @@ mod tests {
         producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
             status: RuntimeLlamaEndpointStatus::Ready,
             model: Some("Qwen3-8B".to_string()),
+            instance_id: None,
             last_attempt_unix_ms: Some(1),
             last_success_unix_ms: Some(1),
             error: None,
@@ -599,6 +600,7 @@ mod tests {
         producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
             status: RuntimeLlamaEndpointStatus::Ready,
             model: Some("model-b".to_string()),
+            instance_id: None,
             last_attempt_unix_ms: Some(1),
             last_success_unix_ms: Some(1),
             error: None,
@@ -611,6 +613,7 @@ mod tests {
         producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
             status: RuntimeLlamaEndpointStatus::Ready,
             model: Some("model-a".to_string()),
+            instance_id: None,
             last_attempt_unix_ms: Some(2),
             last_success_unix_ms: Some(2),
             error: None,
@@ -633,6 +636,7 @@ mod tests {
         producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
             status: RuntimeLlamaEndpointStatus::Unavailable,
             model: Some("model-a".to_string()),
+            instance_id: None,
             last_attempt_unix_ms: Some(3),
             last_success_unix_ms: None,
             error: None,
@@ -653,6 +657,77 @@ mod tests {
             Some("model-b")
         );
         assert_eq!(collector.runtime_llama_snapshot().items.slots_total, 1);
+    }
+
+    #[test]
+    fn runtime_data_llama_slots_keep_per_instance_snapshots_for_same_model() {
+        let collector = RuntimeDataCollector::new();
+        let producer = collector.producer(RuntimeDataSource {
+            scope: "runtime",
+            plugin_data_key: None,
+            plugin_endpoint_key: None,
+        });
+
+        producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
+            status: RuntimeLlamaEndpointStatus::Ready,
+            model: Some("model-a".to_string()),
+            instance_id: Some("runtime-1".to_string()),
+            last_attempt_unix_ms: Some(1),
+            last_success_unix_ms: Some(1),
+            error: None,
+            slots: vec![RuntimeLlamaSlotSnapshot {
+                id: Some(1),
+                is_processing: Some(false),
+                ..RuntimeLlamaSlotSnapshot::default()
+            }],
+        });
+        producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
+            status: RuntimeLlamaEndpointStatus::Ready,
+            model: Some("model-a".to_string()),
+            instance_id: Some("runtime-2".to_string()),
+            last_attempt_unix_ms: Some(2),
+            last_success_unix_ms: Some(2),
+            error: None,
+            slots: vec![RuntimeLlamaSlotSnapshot {
+                id: Some(2),
+                is_processing: Some(true),
+                ..RuntimeLlamaSlotSnapshot::default()
+            }],
+        });
+
+        let by_instance = collector.runtime_llama_snapshots_by_instance();
+        assert_eq!(by_instance.len(), 2);
+        assert_eq!(by_instance["runtime-1"].items.slots_busy, 0);
+        assert_eq!(by_instance["runtime-2"].items.slots_busy, 1);
+
+        producer.publish_llama_slots_snapshot(RuntimeLlamaSlotsSnapshot {
+            status: RuntimeLlamaEndpointStatus::Unavailable,
+            model: Some("model-a".to_string()),
+            instance_id: Some("runtime-1".to_string()),
+            last_attempt_unix_ms: Some(3),
+            last_success_unix_ms: None,
+            error: None,
+            slots: Vec::new(),
+        });
+
+        let by_instance = collector.runtime_llama_snapshots_by_instance();
+        assert_eq!(
+            by_instance["runtime-1"].slots.status,
+            RuntimeLlamaEndpointStatus::Unavailable
+        );
+        assert_eq!(
+            by_instance["runtime-2"].slots.status,
+            RuntimeLlamaEndpointStatus::Ready
+        );
+        assert_eq!(collector.runtime_llama_snapshot().items.slots_busy, 1);
+        assert_eq!(
+            collector
+                .runtime_llama_snapshot()
+                .slots
+                .instance_id
+                .as_deref(),
+            Some("runtime-2")
+        );
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime_data/processes.rs
+++ b/crates/mesh-llm/src/runtime_data/processes.rs
@@ -3,6 +3,7 @@ use crate::api::RuntimeProcessPayload;
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(crate) struct RuntimeProcessSnapshot {
     pub model: String,
+    pub instance_id: Option<String>,
     pub backend: String,
     pub pid: u32,
     pub port: u16,
@@ -18,6 +19,7 @@ impl RuntimeProcessSnapshot {
     pub(crate) fn from_payload(payload: &RuntimeProcessPayload) -> Self {
         Self {
             model: payload.name.clone(),
+            instance_id: payload.instance_id.clone(),
             backend: payload.backend.clone(),
             pid: payload.pid,
             port: payload.port,
@@ -33,6 +35,7 @@ impl RuntimeProcessSnapshot {
     pub(crate) fn to_payload(&self) -> RuntimeProcessPayload {
         RuntimeProcessPayload {
             name: self.model.clone(),
+            instance_id: self.instance_id.clone(),
             backend: self.backend.clone(),
             status: self.state.clone(),
             port: self.port,
@@ -55,10 +58,9 @@ pub(crate) fn upsert_runtime_process_snapshot(
     rows: &mut Vec<RuntimeProcessSnapshot>,
     snapshot: RuntimeProcessSnapshot,
 ) -> bool {
-    if let Some(existing) = rows
-        .iter_mut()
-        .find(|existing| existing.model == snapshot.model)
-    {
+    if let Some(existing) = rows.iter_mut().find(|existing| {
+        runtime_process_snapshot_identity(existing) == runtime_process_snapshot_identity(&snapshot)
+    }) {
         if *existing == snapshot {
             return false;
         }
@@ -72,9 +74,83 @@ pub(crate) fn upsert_runtime_process_snapshot(
 
 pub(crate) fn remove_runtime_process_snapshot(
     rows: &mut Vec<RuntimeProcessSnapshot>,
-    model_name: &str,
+    target: &str,
 ) -> bool {
     let before = rows.len();
-    rows.retain(|existing| existing.model != model_name);
+    let has_instance_match = rows
+        .iter()
+        .any(|existing| existing.instance_id.as_deref() == Some(target));
+    rows.retain(|existing| {
+        if has_instance_match {
+            existing.instance_id.as_deref() != Some(target)
+        } else {
+            existing.model != target
+        }
+    });
     rows.len() != before
+}
+
+fn runtime_process_snapshot_identity(snapshot: &RuntimeProcessSnapshot) -> &str {
+    snapshot.instance_id.as_deref().unwrap_or(&snapshot.model)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(model: &str, instance_id: Option<&str>, port: u16) -> RuntimeProcessSnapshot {
+        RuntimeProcessSnapshot {
+            model: model.to_string(),
+            instance_id: instance_id.map(str::to_string),
+            backend: "skippy".to_string(),
+            pid: 100,
+            port,
+            slots: 4,
+            context_length: Some(8192),
+            command: None,
+            state: "ready".to_string(),
+            start: None,
+            health: Some("ready".to_string()),
+        }
+    }
+
+    #[test]
+    fn process_snapshots_keep_distinct_same_model_instances() {
+        let mut rows = Vec::new();
+
+        assert!(upsert_runtime_process_snapshot(
+            &mut rows,
+            snapshot("Qwen", Some("runtime-1"), 41001)
+        ));
+        assert!(upsert_runtime_process_snapshot(
+            &mut rows,
+            snapshot("Qwen", Some("runtime-2"), 41002)
+        ));
+        assert_eq!(rows.len(), 2);
+
+        assert!(upsert_runtime_process_snapshot(
+            &mut rows,
+            snapshot("Qwen", Some("runtime-2"), 41003)
+        ));
+        assert_eq!(rows.len(), 2);
+        assert_eq!(
+            rows.iter()
+                .find(|row| row.instance_id.as_deref() == Some("runtime-2"))
+                .map(|row| row.port),
+            Some(41003)
+        );
+    }
+
+    #[test]
+    fn remove_process_snapshot_accepts_instance_id_without_dropping_siblings() {
+        let mut rows = vec![
+            snapshot("Qwen", Some("runtime-1"), 41001),
+            snapshot("Qwen", Some("runtime-2"), 41002),
+        ];
+
+        assert!(remove_runtime_process_snapshot(&mut rows, "runtime-1"));
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].instance_id.as_deref(), Some("runtime-2"));
+    }
 }

--- a/crates/mesh-llm/src/runtime_data/snapshots.rs
+++ b/crates/mesh-llm/src/runtime_data/snapshots.rs
@@ -40,6 +40,7 @@ pub(crate) struct RuntimeStatusSnapshot {
     pub local_processes: Vec<RuntimeProcessSnapshot>,
     pub llama_runtime: RuntimeLlamaRuntimeSnapshot,
     pub llama_runtime_by_model: BTreeMap<String, RuntimeLlamaRuntimeSnapshot>,
+    pub llama_runtime_by_instance: BTreeMap<String, RuntimeLlamaRuntimeSnapshot>,
 }
 
 #[derive(Clone, Debug, Default)]


### PR DESCRIPTION
## Summary
Operators can now load and manage multiple local runtime instances for the same model without one instance replacing the other. Runtime status, process views, and load/unload responses include a stable `instance_id`, so duplicate same-model processes can be inspected and unloaded precisely.

## Why
Local serving was still keyed by model name in several runtime management paths. That made duplicate same-model serving collapse into a single entry, removed sibling local targets, and made unload ambiguous. This keeps public model routing model-centric while adding node-local runtime identity for management surfaces.

## What Changed
- Key local runtime handles, dashboard/process snapshots, and runtime data snapshots by `instance_id` when present.
- Preserve multiple local runtime target ports for the same model.
- Return `instance_id` from runtime load paths, including `/api/runtime/models` and `/mesh/load`.
- Add `DELETE /api/runtime/instances/{instance_id}` for precise unload.
- Keep `DELETE /api/runtime/models/{model}` backwards-compatible when only one instance matches; return `409` when multiple loaded instances make model-name unload ambiguous.
- Add an `Instance` column to `mesh-llm runtime status`.
- Fix Skippy materialization test fixture isolation so repeated lib test runs do not fail on reused fixture paths.

## Compatibility
- No protobuf or mesh protocol schema changes.
- `/v1/models` remains model-centric; duplicate runtime instances are not exposed as duplicate OpenAI models.
- `instance_id` is additive and optional in management payloads, so older payload consumers can ignore it.
- Existing model-name unload still works for unambiguous single-instance cases.

## Validation
Local validation from final HEAD `6e05519a09ab6cfe9c29043982da9ac6048ea2d7` against `origin/main` `20375f4fd6eaba6e5a39e22849584549a677a495`:

- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm materialized_stage_preview_matches_source_removal_candidates`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib`: PASS (1253 passed, 3 ignored)
- `git diff --check origin/main...HEAD`: PASS

## Branch Integrity
- Base branch: `main`
- `origin/main`: `20375f4fd6eaba6e5a39e22849584549a677a495`
- Ahead/behind: `0 1`
- Merge-base: `20375f4fd6eaba6e5a39e22849584549a677a495`
- Fast-forward safety: `origin/main` is an ancestor of HEAD.
- Introduced commit: `6e05519a09ab6cfe9c29043982da9ac6048ea2d7 Add runtime instance identity for duplicate local models`

## Rollback
Revert this PR.

DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveats: none known.

## Residual Notes
- `just build` was not run locally because this is a Rust-only change and UI assets were not touched.

