### PR TITLE
Add opt-in survey OTLP metrics exporter

### DIFF
--- a/.agents/skills/telemetry-privacy-review/SKILL.md
+++ b/.agents/skills/telemetry-privacy-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: telemetry-privacy-review
+description: Use this skill when adding, renaming, removing, or reviewing mesh-llm OTLP metrics, telemetry attributes, metrics exporter settings, or telemetry documentation.
+metadata:
+  short-description: Review mesh-llm telemetry privacy
+---
+
+# telemetry-privacy-review
+
+Use this skill before changing mesh-llm OTLP metrics, exporter activation, or
+telemetry attribute names.
+
+## Review Contract
+
+- Keep telemetry metrics-only. Do not export prompts, completions, logs, traces,
+  hostnames, mesh gossip, relay messages, raw node IDs, raw GPU stable IDs,
+  endpoint URLs, local absolute paths, or prompt hashes.
+- Keep egress explicit. There must be no hard-coded collector. Generic OTel env
+  endpoints may only be consumed after `telemetry.enabled = true`; mesh config
+  endpoints are explicit operator configuration.
+- Treat hashed IDs as stable pseudonymous identifiers, not anonymous data.
+- Keep request-path telemetry non-blocking and bounded.
+- Keep model labels sanitized with the runtime telemetry model-label helper.
+- Prefer bounded enums, buckets, counts, and hashes over high-cardinality raw
+  values.
+
+## Required Updates
+
+- Update `TELEMETRY_ATTRIBUTE_ALLOWLIST` in
+  `crates/mesh-llm/src/runtime/survey.rs` for every new exported attribute.
+- Update `docs/plugins/telemetry.md` with the metric or attribute inventory and
+  privacy handling.
+- Add focused tests for private-path, raw-ID, endpoint-URL, prompt, and
+  completion exclusion when the change touches those surfaces.
+
+## Validation
+
+Run the narrowest relevant checks for the touched area. For telemetry runtime
+changes, start with:
+
+```bash
+cargo test -p mesh-llm runtime::survey::tests --lib
+cargo test -p mesh-llm telemetry_config --lib
+```
+
+If routing telemetry changed, also run the focused mesh routing telemetry test:
+
+```bash
+cargo test -p mesh-llm routing_telemetry_sink_receives_request_pressure_and_attempt_events --lib
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,9 @@ dependencies = [
  "model-ref",
  "nostr-sdk",
  "openai-frontend",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "prost",
  "prost-build",
  "protoc-bin-vendored",
@@ -5000,6 +5003,35 @@ dependencies = [
  "pin-project-lite",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Precedence rules:
 - Explicit `--ctx-size` overrides configured `ctx_size` for the selected startup models.
 - Plugin entries still live in the same file.
 
-Telemetry metrics export is available through the built-in `telemetry` plugin. Configure `[telemetry]` to export metrics, or opt out with `[[plugin]] name = "telemetry" enabled = false`; see [docs/plugins/telemetry.md](docs/plugins/telemetry.md).
+Telemetry metrics export is available through the built-in `telemetry` plugin. Configure a `[telemetry]` endpoint to export metrics; no collector is hard-coded, and the plugin can be opted out with `[[plugin]] name = "telemetry" enabled = false`. See [docs/plugins/telemetry.md](docs/plugins/telemetry.md).
 
 Pinned startup notes:
 

--- a/README.md
+++ b/README.md
@@ -277,6 +277,27 @@ Precedence rules:
 - Explicit `--ctx-size` overrides configured `ctx_size` for the selected startup models.
 - Plugin entries still live in the same file.
 
+Survey metrics export is opt-in. Enable the built-in `survey` plugin and configure an OTLP/HTTP metrics endpoint:
+
+```toml
+[telemetry]
+enabled = true
+service_name = "mesh-llm"
+endpoint = "https://otel.example.com"
+headers = { "authorization" = "Bearer TOKEN" }
+export_interval_secs = 15
+queue_size = 2048
+
+[telemetry.metrics]
+endpoint = "https://otel.example.com/v1/metrics"
+
+[[plugin]]
+name = "survey"
+enabled = true
+```
+
+`telemetry.metrics.endpoint` wins over `telemetry.endpoint`; when config endpoints are absent, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and then `OTEL_EXPORTER_OTLP_ENDPOINT` are used. The survey path exports local model lifecycle metrics only; it does not export prompts, completions, logs, traces, hostnames, mesh gossip, or raw GPU stable IDs.
+
 Pinned startup notes:
 
 - `assignment = "pinned"` requires every configured `[[models]]` entry to include a `gpu_id`.

--- a/README.md
+++ b/README.md
@@ -277,26 +277,7 @@ Precedence rules:
 - Explicit `--ctx-size` overrides configured `ctx_size` for the selected startup models.
 - Plugin entries still live in the same file.
 
-Survey metrics export is opt-in. Enable the built-in `survey` plugin and configure an OTLP/HTTP metrics endpoint:
-
-```toml
-[telemetry]
-enabled = true
-service_name = "mesh-llm"
-endpoint = "https://otel.example.com"
-headers = { "authorization" = "Bearer TOKEN" }
-export_interval_secs = 15
-queue_size = 2048
-
-[telemetry.metrics]
-endpoint = "https://otel.example.com/v1/metrics"
-
-[[plugin]]
-name = "survey"
-enabled = true
-```
-
-`telemetry.metrics.endpoint` wins over `telemetry.endpoint`; when config endpoints are absent, `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and then `OTEL_EXPORTER_OTLP_ENDPOINT` are used. The survey path exports local model lifecycle metrics only; it does not export prompts, completions, logs, traces, hostnames, mesh gossip, or raw GPU stable IDs.
+Telemetry metrics export is opt-in. Enable the built-in `telemetry` plugin and configure `[telemetry]`; see [docs/plugins/telemetry.md](docs/plugins/telemetry.md).
 
 Pinned startup notes:
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Precedence rules:
 - Explicit `--ctx-size` overrides configured `ctx_size` for the selected startup models.
 - Plugin entries still live in the same file.
 
-Telemetry metrics export is opt-in. Enable the built-in `telemetry` plugin and configure `[telemetry]`; see [docs/plugins/telemetry.md](docs/plugins/telemetry.md).
+Telemetry metrics export is available through the built-in `telemetry` plugin. Configure `[telemetry]` to export metrics, or opt out with `[[plugin]] name = "telemetry" enabled = false`; see [docs/plugins/telemetry.md](docs/plugins/telemetry.md).
 
 Pinned startup notes:
 

--- a/crates/mesh-llm/Cargo.toml
+++ b/crates/mesh-llm/Cargo.toml
@@ -31,6 +31,9 @@ dirs = "6.0.0"
 hex = "0.4.3"
 include_dir = "0.7"
 nostr-sdk = { version = "0.44.1", default-features = false }
+opentelemetry = { version = "0.31.0", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["metrics", "http-proto", "reqwest-blocking-client"] }
 rustls = "0.23.36"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 semver = "1"

--- a/crates/mesh-llm/README.md
+++ b/crates/mesh-llm/README.md
@@ -32,7 +32,9 @@ Notable built-ins under `src/plugins/` today:
 ```text
 plugins/
 ├── blackboard/            shared mesh message feed + MCP surface
-└── lemonade/              external OpenAI-compatible inference endpoint bridge
+├── blobstore/             request-scoped media object storage for multimodal
+├── openai_endpoint/       external OpenAI-compatible inference endpoint bridge
+└── survey/                opt-in OTLP metrics-only local runtime survey
 ```
 
 ## Runtime model

--- a/crates/mesh-llm/README.md
+++ b/crates/mesh-llm/README.md
@@ -34,7 +34,7 @@ plugins/
 ├── blackboard/            shared mesh message feed + MCP surface
 ├── blobstore/             request-scoped media object storage for multimodal
 ├── openai_endpoint/       external OpenAI-compatible inference endpoint bridge
-└── survey/                opt-in OTLP metrics-only local runtime survey
+└── telemetry/             opt-in OTLP metrics-only local runtime telemetry
 ```
 
 ## Runtime model

--- a/crates/mesh-llm/src/cli/commands/plugin.rs
+++ b/crates/mesh-llm/src/cli/commands/plugin.rs
@@ -14,6 +14,12 @@ pub(crate) async fn run_plugin_command(command: &PluginCommand, cli: &Cli) -> Re
             eprintln!("Blobstore is auto-registered by mesh-llm. Nothing to install.");
             eprintln!("Disable it with [[plugin]] name = \"blobstore\" enabled = false in the config if needed.");
         }
+        PluginCommand::Install { name } if name == plugin::SURVEY_PLUGIN_ID => {
+            eprintln!("Survey is built into mesh-llm. Nothing to install.");
+            eprintln!(
+                "Enable it with [[plugin]] name = \"survey\" enabled = true and configure [telemetry]."
+            );
+        }
         PluginCommand::Install { name } => {
             let config = plugin::config_path(cli.config.as_deref())?;
             anyhow::bail!(

--- a/crates/mesh-llm/src/cli/commands/plugin.rs
+++ b/crates/mesh-llm/src/cli/commands/plugin.rs
@@ -17,7 +17,7 @@ pub(crate) async fn run_plugin_command(command: &PluginCommand, cli: &Cli) -> Re
         PluginCommand::Install { name } if name == plugin::TELEMETRY_PLUGIN_ID => {
             eprintln!("Telemetry is built into mesh-llm. Nothing to install.");
             eprintln!(
-                "Enable it with [[plugin]] name = \"telemetry\" enabled = true and configure [telemetry]."
+                "Configure [telemetry] to export metrics, or disable it with [[plugin]] name = \"telemetry\" enabled = false."
             );
         }
         PluginCommand::Install { name } => {

--- a/crates/mesh-llm/src/cli/commands/plugin.rs
+++ b/crates/mesh-llm/src/cli/commands/plugin.rs
@@ -14,10 +14,10 @@ pub(crate) async fn run_plugin_command(command: &PluginCommand, cli: &Cli) -> Re
             eprintln!("Blobstore is auto-registered by mesh-llm. Nothing to install.");
             eprintln!("Disable it with [[plugin]] name = \"blobstore\" enabled = false in the config if needed.");
         }
-        PluginCommand::Install { name } if name == plugin::SURVEY_PLUGIN_ID => {
-            eprintln!("Survey is built into mesh-llm. Nothing to install.");
+        PluginCommand::Install { name } if name == plugin::TELEMETRY_PLUGIN_ID => {
+            eprintln!("Telemetry is built into mesh-llm. Nothing to install.");
             eprintln!(
-                "Enable it with [[plugin]] name = \"survey\" enabled = true and configure [telemetry]."
+                "Enable it with [[plugin]] name = \"telemetry\" enabled = true and configure [telemetry]."
             );
         }
         PluginCommand::Install { name } => {

--- a/crates/mesh-llm/src/mesh/mod.rs
+++ b/crates/mesh-llm/src/mesh/mod.rs
@@ -976,6 +976,8 @@ pub struct Node {
     inflight_requests: Arc<std::sync::atomic::AtomicUsize>,
     inflight_change_tx: watch::Sender<u64>,
     routing_metrics: crate::network::metrics::RoutingMetrics,
+    routing_telemetry:
+        Arc<std::sync::Mutex<Option<Arc<dyn crate::network::metrics::RoutingTelemetrySink>>>>,
     local_request_metrics: Arc<LocalRequestMetricsSampler>,
     runtime_data_producer: crate::runtime_data::RuntimeDataProducer,
     tunnel_tx: tokio::sync::mpsc::Sender<(iroh::endpoint::SendStream, iroh::endpoint::RecvStream)>,
@@ -1395,6 +1397,7 @@ pub struct InflightRequestGuard {
     local_request_metrics: Arc<LocalRequestMetricsSampler>,
     started_at: std::time::Instant,
     routing_metrics: crate::network::metrics::RoutingMetrics,
+    routing_telemetry: Option<Arc<dyn crate::network::metrics::RoutingTelemetrySink>>,
     runtime_data_producer: crate::runtime_data::RuntimeDataProducer,
 }
 
@@ -1414,6 +1417,9 @@ impl Drop for InflightRequestGuard {
         let current_inflight_requests =
             self.inflight_requests
                 .load(std::sync::atomic::Ordering::Relaxed) as u64;
+        if let Some(routing_telemetry) = &self.routing_telemetry {
+            routing_telemetry.observe_inflight_requests(current_inflight_requests);
+        }
         self.runtime_data_producer.publish_routing_snapshot(
             self.routing_metrics
                 .collector_snapshot(current_inflight_requests),
@@ -1422,6 +1428,25 @@ impl Drop for InflightRequestGuard {
 }
 
 impl Node {
+    pub(crate) fn set_routing_telemetry_sink(
+        &self,
+        sink: Option<Arc<dyn crate::network::metrics::RoutingTelemetrySink>>,
+    ) {
+        *self
+            .routing_telemetry
+            .lock()
+            .expect("routing telemetry sink lock poisoned") = sink;
+    }
+
+    fn routing_telemetry_sink(
+        &self,
+    ) -> Option<Arc<dyn crate::network::metrics::RoutingTelemetrySink>> {
+        self.routing_telemetry
+            .lock()
+            .expect("routing telemetry sink lock poisoned")
+            .clone()
+    }
+
     fn publish_routing_runtime_snapshot(&self) {
         self.runtime_data_producer.publish_routing_snapshot(
             self.routing_metrics
@@ -1438,6 +1463,10 @@ impl Node {
             .load(std::sync::atomic::Ordering::Relaxed) as u64;
         let _ = self.inflight_change_tx.send(current);
         self.routing_metrics.observe_inflight(current);
+        let routing_telemetry = self.routing_telemetry_sink();
+        if let Some(sink) = &routing_telemetry {
+            sink.observe_inflight_requests(current);
+        }
         self.publish_routing_runtime_snapshot();
         InflightRequestGuard {
             inflight_requests: self.inflight_requests.clone(),
@@ -1445,6 +1474,7 @@ impl Node {
             local_request_metrics: self.local_request_metrics.clone(),
             started_at: std::time::Instant::now(),
             routing_metrics: self.routing_metrics.clone(),
+            routing_telemetry,
             runtime_data_producer: self.runtime_data_producer.clone(),
         }
     }
@@ -1819,12 +1849,15 @@ impl Node {
         };
         self.routing_metrics.record_attempt(
             model,
-            attempt_target,
+            attempt_target.clone(),
             queue_wait,
             attempt_time,
             outcome,
             completion_tokens,
         );
+        if let Some(sink) = self.routing_telemetry_sink() {
+            sink.record_route_attempt(model, &attempt_target, outcome);
+        }
         self.publish_routing_runtime_snapshot();
     }
 
@@ -1838,14 +1871,18 @@ impl Node {
         completion_tokens: Option<u64>,
     ) {
         let model_ref = model.map(canonical_demand_model_ref);
+        let attempt_target = crate::network::metrics::AttemptTarget::Endpoint(endpoint.to_string());
         self.routing_metrics.record_attempt(
             model_ref.as_deref(),
-            crate::network::metrics::AttemptTarget::Endpoint(endpoint.to_string()),
+            attempt_target.clone(),
             queue_wait,
             attempt_time,
             outcome,
             completion_tokens,
         );
+        if let Some(sink) = self.routing_telemetry_sink() {
+            sink.record_route_attempt(model_ref.as_deref(), &attempt_target, outcome);
+        }
         self.publish_routing_runtime_snapshot();
     }
 
@@ -1858,6 +1895,9 @@ impl Node {
         let model_ref = model.map(canonical_demand_model_ref);
         self.routing_metrics
             .record_request(model_ref.as_deref(), attempts, outcome);
+        if let Some(sink) = self.routing_telemetry_sink() {
+            sink.record_model_request(model_ref.as_deref(), attempts, outcome);
+        }
         self.publish_routing_runtime_snapshot();
     }
 
@@ -2106,6 +2146,7 @@ impl Node {
             inflight_requests: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             inflight_change_tx,
             routing_metrics: crate::network::metrics::RoutingMetrics::default(),
+            routing_telemetry: Arc::new(std::sync::Mutex::new(None)),
             local_request_metrics: Arc::new(LocalRequestMetricsSampler::default()),
             runtime_data_producer,
             tunnel_tx,
@@ -2225,6 +2266,7 @@ impl Node {
             inflight_requests: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             inflight_change_tx,
             routing_metrics: crate::network::metrics::RoutingMetrics::default(),
+            routing_telemetry: Arc::new(std::sync::Mutex::new(None)),
             local_request_metrics: Arc::new(LocalRequestMetricsSampler::default()),
             runtime_data_producer,
             tunnel_tx,

--- a/crates/mesh-llm/src/mesh/tests.rs
+++ b/crates/mesh-llm/src/mesh/tests.rs
@@ -3570,6 +3570,7 @@ async fn config_subscribe_rejects_pinned_snapshot_for_older_peer() -> Result<()>
                     assignment: crate::plugin::GpuAssignment::Pinned,
                     ..Default::default()
                 },
+                telemetry: Default::default(),
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
@@ -3673,6 +3674,7 @@ async fn config_subscribe_rejects_pinned_snapshot_for_malformed_peer_version() -
                     assignment: crate::plugin::GpuAssignment::Pinned,
                     ..Default::default()
                 },
+                telemetry: Default::default(),
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
@@ -3774,6 +3776,7 @@ async fn config_subscribe_allows_pinned_snapshot_for_same_release_prerelease_pee
                     assignment: crate::plugin::GpuAssignment::Pinned,
                     ..Default::default()
                 },
+                telemetry: Default::default(),
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
@@ -3954,6 +3957,7 @@ async fn config_subscribe_closes_when_revision_becomes_pinned_for_malformed_peer
                     assignment: crate::plugin::GpuAssignment::Pinned,
                     ..Default::default()
                 },
+                telemetry: Default::default(),
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
@@ -4059,6 +4063,7 @@ async fn config_subscribe_closes_when_revision_becomes_pinned_for_older_peer() -
                     assignment: crate::plugin::GpuAssignment::Pinned,
                     ..Default::default()
                 },
+                telemetry: Default::default(),
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,
@@ -4165,6 +4170,7 @@ async fn config_subscribe_keeps_stream_open_when_revision_becomes_pinned_for_sam
                     assignment: crate::plugin::GpuAssignment::Pinned,
                     ..Default::default()
                 },
+                telemetry: Default::default(),
                 models: vec![crate::plugin::ModelConfigEntry {
                     model: "Qwen3-8B-Q4_K_M".into(),
                     mmproj: None,

--- a/crates/mesh-llm/src/mesh/tests.rs
+++ b/crates/mesh-llm/src/mesh/tests.rs
@@ -95,6 +95,7 @@ async fn make_test_node(role: super::NodeRole) -> Result<Node> {
         inflight_requests: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         inflight_change_tx,
         routing_metrics: crate::network::metrics::RoutingMetrics::default(),
+        routing_telemetry: Arc::new(std::sync::Mutex::new(None)),
         local_request_metrics: Arc::new(LocalRequestMetricsSampler::default()),
         runtime_data_producer,
         tunnel_tx,
@@ -150,6 +151,118 @@ async fn local_request_metrics_snapshot_tracks_accepted_and_completed_requests()
     assert_eq!(snapshot.accepted_request_counts.len(), 24 * 60 * 60);
     assert_eq!(snapshot.accepted_request_counts.iter().sum::<u64>(), 1);
     assert_eq!(snapshot.latency_samples_ms.len(), 1);
+}
+
+#[derive(Default)]
+struct TestRoutingTelemetrySink {
+    inflight: std::sync::Mutex<Vec<u64>>,
+    requests: std::sync::Mutex<
+        Vec<(
+            Option<String>,
+            usize,
+            crate::network::metrics::RequestOutcome,
+        )>,
+    >,
+    attempts: std::sync::Mutex<
+        Vec<(
+            Option<String>,
+            String,
+            crate::network::metrics::AttemptOutcome,
+        )>,
+    >,
+}
+
+impl crate::network::metrics::RoutingTelemetrySink for TestRoutingTelemetrySink {
+    fn observe_inflight_requests(&self, current: u64) {
+        self.inflight.lock().unwrap().push(current);
+    }
+
+    fn record_model_request(
+        &self,
+        model: Option<&str>,
+        attempts: usize,
+        outcome: crate::network::metrics::RequestOutcome,
+    ) {
+        self.requests
+            .lock()
+            .unwrap()
+            .push((model.map(str::to_string), attempts, outcome));
+    }
+
+    fn record_route_attempt(
+        &self,
+        model: Option<&str>,
+        target: &crate::network::metrics::AttemptTarget,
+        outcome: crate::network::metrics::AttemptOutcome,
+    ) {
+        let target_kind = match target {
+            crate::network::metrics::AttemptTarget::Local(_) => "local",
+            crate::network::metrics::AttemptTarget::Remote(_) => "remote",
+            crate::network::metrics::AttemptTarget::Endpoint(_) => "endpoint",
+        };
+        self.attempts.lock().unwrap().push((
+            model.map(str::to_string),
+            target_kind.into(),
+            outcome,
+        ));
+    }
+}
+
+#[tokio::test]
+async fn routing_telemetry_sink_receives_request_pressure_and_attempt_events() {
+    let node = make_test_node(super::NodeRole::Client)
+        .await
+        .expect("test node should initialize");
+    let sink = Arc::new(TestRoutingTelemetrySink::default());
+    node.set_routing_telemetry_sink(Some(sink.clone()));
+
+    {
+        let _request = node.begin_inflight_request();
+        assert_eq!(sink.inflight.lock().unwrap().as_slice(), &[1]);
+    }
+    assert_eq!(sink.inflight.lock().unwrap().as_slice(), &[1, 0]);
+
+    node.record_routed_request(
+        Some("Qwen/Qwen3-8B-GGUF:Q4_K_M"),
+        2,
+        crate::network::metrics::RequestOutcome::Success(
+            crate::network::metrics::RequestService::Remote,
+        ),
+    );
+    node.record_inference_attempt(
+        Some("Qwen/Qwen3-8B-GGUF:Q4_K_M"),
+        &crate::inference::election::InferenceTarget::Remote(iroh::EndpointId::from(
+            SecretKey::from_bytes(&[0x45; 32]).public(),
+        )),
+        std::time::Duration::from_millis(3),
+        std::time::Duration::from_millis(5),
+        crate::network::metrics::AttemptOutcome::Success,
+        Some(16),
+    );
+
+    let requests = sink.requests.lock().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(
+        requests[0],
+        (
+            Some("Qwen/Qwen3-8B-GGUF:Q4_K_M".into()),
+            2,
+            crate::network::metrics::RequestOutcome::Success(
+                crate::network::metrics::RequestService::Remote
+            )
+        )
+    );
+    drop(requests);
+
+    let attempts = sink.attempts.lock().unwrap();
+    assert_eq!(
+        attempts.as_slice(),
+        &[(
+            Some("Qwen/Qwen3-8B-GGUF:Q4_K_M".into()),
+            "remote".into(),
+            crate::network::metrics::AttemptOutcome::Success,
+        )]
+    );
 }
 
 #[test]
@@ -3248,6 +3361,7 @@ async fn make_test_node_with_owner(
         inflight_requests: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
         inflight_change_tx,
         routing_metrics: crate::network::metrics::RoutingMetrics::default(),
+        routing_telemetry: Arc::new(std::sync::Mutex::new(None)),
         local_request_metrics: Arc::new(LocalRequestMetricsSampler::default()),
         runtime_data_producer,
         tunnel_tx,

--- a/crates/mesh-llm/src/network/metrics.rs
+++ b/crates/mesh-llm/src/network/metrics.rs
@@ -282,6 +282,19 @@ pub(crate) enum RequestOutcome {
     Unavailable,
 }
 
+pub(crate) trait RoutingTelemetrySink: Send + Sync {
+    fn observe_inflight_requests(&self, current: u64);
+
+    fn record_model_request(&self, model: Option<&str>, attempts: usize, outcome: RequestOutcome);
+
+    fn record_route_attempt(
+        &self,
+        model: Option<&str>,
+        target: &AttemptTarget,
+        outcome: AttemptOutcome,
+    );
+}
+
 #[derive(Clone)]
 pub struct RoutingMetrics {
     globals: Arc<GlobalMetrics>,

--- a/crates/mesh-llm/src/plugin/config.rs
+++ b/crates/mesh-llm/src/plugin/config.rs
@@ -1,6 +1,6 @@
 use super::{
     PluginSummary, BLACKBOARD_PLUGIN_ID, BLOBSTORE_PLUGIN_ID, OPENAI_ENDPOINT_PLUGIN_ID,
-    SURVEY_PLUGIN_ID,
+    TELEMETRY_PLUGIN_ID,
 };
 use anyhow::{bail, Context, Result};
 use mesh_llm_plugin::MeshVisibility;
@@ -244,11 +244,11 @@ fn validate_telemetry_config(config: &TelemetryConfig) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn survey_plugin_enabled(config: &MeshConfig) -> bool {
+pub(crate) fn telemetry_plugin_enabled(config: &MeshConfig) -> bool {
     config
         .plugins
         .iter()
-        .find(|entry| entry.name == SURVEY_PLUGIN_ID)
+        .find(|entry| entry.name == TELEMETRY_PLUGIN_ID)
         .map(|entry| entry.enabled.unwrap_or(true))
         .unwrap_or(false)
 }
@@ -261,7 +261,7 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
     let mut blobstore_enabled = true;
     let mut openai_endpoint_enabled = false;
     let mut openai_endpoint_url: Option<String> = None;
-    let mut survey_enabled = false;
+    let mut telemetry_enabled = false;
     for entry in &config.plugins {
         if names.insert(entry.name.clone(), ()).is_some() {
             bail!("Duplicate plugin entry '{}'", entry.name);
@@ -300,14 +300,14 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
             }
             continue;
         }
-        if entry.name == SURVEY_PLUGIN_ID {
+        if entry.name == TELEMETRY_PLUGIN_ID {
             if entry.command.is_some() || !entry.args.is_empty() || entry.url.is_some() {
                 bail!(
                     "Plugin '{}' is served by mesh-llm itself; only `enabled` may be set",
-                    SURVEY_PLUGIN_ID
+                    TELEMETRY_PLUGIN_ID
                 );
             }
-            survey_enabled = enabled;
+            telemetry_enabled = enabled;
             continue;
         }
         if !enabled {
@@ -328,9 +328,9 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
     if blackboard_enabled {
         externals.insert(0, blackboard_plugin_spec()?);
     }
-    if survey_enabled {
+    if telemetry_enabled {
         let insert_at = usize::from(blackboard_enabled).min(externals.len());
-        externals.insert(insert_at, survey_plugin_spec()?);
+        externals.insert(insert_at, telemetry_plugin_spec()?);
     }
     if openai_endpoint_enabled {
         let mut spec = openai_endpoint_plugin_spec()?;
@@ -401,19 +401,19 @@ pub fn openai_endpoint_plugin_spec() -> Result<ExternalPluginSpec> {
     })
 }
 
-pub fn survey_plugin_spec() -> Result<ExternalPluginSpec> {
+pub fn telemetry_plugin_spec() -> Result<ExternalPluginSpec> {
     let command = std::env::current_exe()
         .context("Cannot determine mesh-llm executable path")?
         .display()
         .to_string();
     Ok(ExternalPluginSpec {
-        name: SURVEY_PLUGIN_ID.to_string(),
+        name: TELEMETRY_PLUGIN_ID.to_string(),
         command,
         args: vec![
             "--log-format".into(),
             "json".into(),
             "--plugin".into(),
-            SURVEY_PLUGIN_ID.into(),
+            TELEMETRY_PLUGIN_ID.into(),
         ],
         url: None,
     })
@@ -486,7 +486,7 @@ prompt_shape_metrics = false
 endpoint = "https://otel.example.com/v1/metrics"
 
 [[plugin]]
-name = "survey"
+name = "telemetry"
 enabled = true
 "#,
         )

--- a/crates/mesh-llm/src/plugin/config.rs
+++ b/crates/mesh-llm/src/plugin/config.rs
@@ -534,6 +534,24 @@ queue_size = 0
     }
 
     #[test]
+    fn telemetry_config_rejects_prompt_shape_metrics_until_reviewed() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+[telemetry]
+prompt_shape_metrics = true
+"#,
+        )
+        .unwrap();
+
+        let err = validate_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("telemetry.prompt_shape_metrics is not supported yet"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn pinned_gpu_config_accepted_pinned_config() {
         let config: MeshConfig = toml::from_str(
             r#"

--- a/crates/mesh-llm/src/plugin/config.rs
+++ b/crates/mesh-llm/src/plugin/config.rs
@@ -1,4 +1,7 @@
-use super::{PluginSummary, BLACKBOARD_PLUGIN_ID, BLOBSTORE_PLUGIN_ID, OPENAI_ENDPOINT_PLUGIN_ID};
+use super::{
+    PluginSummary, BLACKBOARD_PLUGIN_ID, BLOBSTORE_PLUGIN_ID, OPENAI_ENDPOINT_PLUGIN_ID,
+    SURVEY_PLUGIN_ID,
+};
 use anyhow::{bail, Context, Result};
 use mesh_llm_plugin::MeshVisibility;
 use serde::{Deserialize, Serialize};
@@ -12,6 +15,8 @@ pub struct MeshConfig {
     pub version: Option<u32>,
     #[serde(default)]
     pub gpu: GpuConfig,
+    #[serde(default)]
+    pub telemetry: TelemetryConfig,
     #[serde(default)]
     pub models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
@@ -55,6 +60,32 @@ pub struct ModelConfigEntry {
     pub ubatch: Option<u32>,
     #[serde(default)]
     pub flash_attention: Option<FlashAttentionType>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TelemetryConfig {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub service_name: Option<String>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    #[serde(default)]
+    pub export_interval_secs: Option<u64>,
+    #[serde(default)]
+    pub queue_size: Option<usize>,
+    #[serde(default)]
+    pub prompt_shape_metrics: bool,
+    #[serde(default)]
+    pub metrics: TelemetryMetricsConfig,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TelemetryMetricsConfig {
+    #[serde(default)]
+    pub endpoint: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -126,6 +157,7 @@ pub(crate) fn validate_config(config: &MeshConfig) -> Result<()> {
             bail!("gpu.parallel must be at least 1, got {parallel}");
         }
     }
+    validate_telemetry_config(&config.telemetry)?;
     for (index, model) in config.models.iter().enumerate() {
         if model.model.trim().is_empty() {
             bail!("models[{index}].model must not be empty");
@@ -175,6 +207,52 @@ pub(crate) fn validate_config(config: &MeshConfig) -> Result<()> {
     Ok(())
 }
 
+fn validate_telemetry_config(config: &TelemetryConfig) -> Result<()> {
+    if let Some(service_name) = &config.service_name {
+        if service_name.trim().is_empty() {
+            bail!("telemetry.service_name must not be empty when set");
+        }
+    }
+    if let Some(endpoint) = &config.endpoint {
+        if endpoint.trim().is_empty() {
+            bail!("telemetry.endpoint must not be empty when set");
+        }
+    }
+    if let Some(endpoint) = &config.metrics.endpoint {
+        if endpoint.trim().is_empty() {
+            bail!("telemetry.metrics.endpoint must not be empty when set");
+        }
+    }
+    for key in config.headers.keys() {
+        if key.trim().is_empty() {
+            bail!("telemetry.headers keys must not be empty");
+        }
+    }
+    if let Some(export_interval_secs) = config.export_interval_secs {
+        if export_interval_secs < 1 {
+            bail!("telemetry.export_interval_secs must be at least 1");
+        }
+    }
+    if let Some(queue_size) = config.queue_size {
+        if queue_size < 1 {
+            bail!("telemetry.queue_size must be at least 1");
+        }
+    }
+    if config.prompt_shape_metrics {
+        bail!("telemetry.prompt_shape_metrics is not supported yet and must remain false");
+    }
+    Ok(())
+}
+
+pub(crate) fn survey_plugin_enabled(config: &MeshConfig) -> bool {
+    config
+        .plugins
+        .iter()
+        .find(|entry| entry.name == SURVEY_PLUGIN_ID)
+        .map(|entry| entry.enabled.unwrap_or(true))
+        .unwrap_or(false)
+}
+
 pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Result<ResolvedPlugins> {
     let mut externals = Vec::new();
     let inactive = Vec::new();
@@ -183,6 +261,7 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
     let mut blobstore_enabled = true;
     let mut openai_endpoint_enabled = false;
     let mut openai_endpoint_url: Option<String> = None;
+    let mut survey_enabled = false;
     for entry in &config.plugins {
         if names.insert(entry.name.clone(), ()).is_some() {
             bail!("Duplicate plugin entry '{}'", entry.name);
@@ -221,6 +300,16 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
             }
             continue;
         }
+        if entry.name == SURVEY_PLUGIN_ID {
+            if entry.command.is_some() || !entry.args.is_empty() || entry.url.is_some() {
+                bail!(
+                    "Plugin '{}' is served by mesh-llm itself; only `enabled` may be set",
+                    SURVEY_PLUGIN_ID
+                );
+            }
+            survey_enabled = enabled;
+            continue;
+        }
         if !enabled {
             continue;
         }
@@ -238,6 +327,10 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
 
     if blackboard_enabled {
         externals.insert(0, blackboard_plugin_spec()?);
+    }
+    if survey_enabled {
+        let insert_at = usize::from(blackboard_enabled).min(externals.len());
+        externals.insert(insert_at, survey_plugin_spec()?);
     }
     if openai_endpoint_enabled {
         let mut spec = openai_endpoint_plugin_spec()?;
@@ -308,6 +401,24 @@ pub fn openai_endpoint_plugin_spec() -> Result<ExternalPluginSpec> {
     })
 }
 
+pub fn survey_plugin_spec() -> Result<ExternalPluginSpec> {
+    let command = std::env::current_exe()
+        .context("Cannot determine mesh-llm executable path")?
+        .display()
+        .to_string();
+    Ok(ExternalPluginSpec {
+        name: SURVEY_PLUGIN_ID.to_string(),
+        command,
+        args: vec![
+            "--log-format".into(),
+            "json".into(),
+            "--plugin".into(),
+            SURVEY_PLUGIN_ID.into(),
+        ],
+        url: None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -354,6 +465,72 @@ command = "/tmp/demo"
         assert_eq!(config.models[1].gpu_id, None);
         assert_eq!(config.plugins.len(), 1);
         assert_eq!(config.plugins[0].name, "demo");
+    }
+
+    #[test]
+    fn telemetry_config_deserializes_standard_metrics_settings() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+
+[telemetry]
+enabled = true
+service_name = "mesh-llm"
+endpoint = "https://otel.example.com"
+headers = { "authorization" = "Bearer TOKEN" }
+export_interval_secs = 15
+queue_size = 2048
+prompt_shape_metrics = false
+
+[telemetry.metrics]
+endpoint = "https://otel.example.com/v1/metrics"
+
+[[plugin]]
+name = "survey"
+enabled = true
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.telemetry.enabled, Some(true));
+        assert_eq!(config.telemetry.service_name.as_deref(), Some("mesh-llm"));
+        assert_eq!(
+            config.telemetry.endpoint.as_deref(),
+            Some("https://otel.example.com")
+        );
+        assert_eq!(
+            config.telemetry.metrics.endpoint.as_deref(),
+            Some("https://otel.example.com/v1/metrics")
+        );
+        assert_eq!(
+            config
+                .telemetry
+                .headers
+                .get("authorization")
+                .map(String::as_str),
+            Some("Bearer TOKEN")
+        );
+        assert_eq!(config.telemetry.export_interval_secs, Some(15));
+        assert_eq!(config.telemetry.queue_size, Some(2048));
+        assert!(!config.telemetry.prompt_shape_metrics);
+    }
+
+    #[test]
+    fn telemetry_config_rejects_zero_queue_size() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+[telemetry]
+queue_size = 0
+"#,
+        )
+        .unwrap();
+
+        let err = validate_config(&config).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("telemetry.queue_size must be at least 1"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/mesh-llm/src/plugin/config.rs
+++ b/crates/mesh-llm/src/plugin/config.rs
@@ -250,7 +250,7 @@ pub(crate) fn telemetry_plugin_enabled(config: &MeshConfig) -> bool {
         .iter()
         .find(|entry| entry.name == TELEMETRY_PLUGIN_ID)
         .map(|entry| entry.enabled.unwrap_or(true))
-        .unwrap_or(false)
+        .unwrap_or(true)
 }
 
 pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Result<ResolvedPlugins> {
@@ -261,7 +261,7 @@ pub fn resolve_plugins(config: &MeshConfig, _host_mode: PluginHostMode) -> Resul
     let mut blobstore_enabled = true;
     let mut openai_endpoint_enabled = false;
     let mut openai_endpoint_url: Option<String> = None;
-    let mut telemetry_enabled = false;
+    let mut telemetry_enabled = true;
     for entry in &config.plugins {
         if names.insert(entry.name.clone(), ()).is_some() {
             bail!("Duplicate plugin entry '{}'", entry.name);

--- a/crates/mesh-llm/src/plugin/mod.rs
+++ b/crates/mesh-llm/src/plugin/mod.rs
@@ -28,14 +28,15 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, Mutex};
 use url::Url;
 
-pub(crate) use self::config::validate_config;
 #[allow(unused_imports)]
 pub use self::config::ExternalPluginSpec;
 #[allow(unused_imports)]
 pub use self::config::{
     config_path, load_config, resolve_plugins, GpuAssignment, GpuConfig, MeshConfig,
-    ModelConfigEntry, PluginConfigEntry, PluginHostMode, ResolvedPlugins,
+    ModelConfigEntry, PluginConfigEntry, PluginHostMode, ResolvedPlugins, TelemetryConfig,
+    TelemetryMetricsConfig,
 };
+pub(crate) use self::config::{survey_plugin_enabled, validate_config};
 use self::runtime::ExternalPlugin;
 pub(crate) use self::support::parse_optional_json;
 use self::support::{format_args_for_log, format_slice_for_log, format_tool_names_for_log};
@@ -50,6 +51,8 @@ use mesh_llm_plugin::MeshVisibility;
 pub const BLACKBOARD_PLUGIN_ID: &str = "blackboard";
 pub const BLOBSTORE_PLUGIN_ID: &str = "blobstore";
 pub const OPENAI_ENDPOINT_PLUGIN_ID: &str = "openai-endpoint";
+pub const SURVEY_PLUGIN_ID: &str = "survey";
+pub const SURVEY_CAPABILITY: &str = "survey.metrics.v1";
 #[allow(dead_code)]
 pub const BLACKBOARD_CAPABILITY: &str = "blackboard.v1";
 pub(crate) const PROTOCOL_VERSION: u32 = mesh_llm_plugin::PROTOCOL_VERSION;
@@ -1716,6 +1719,7 @@ pub async fn run_plugin_process(name: String) -> Result<()> {
         BLACKBOARD_PLUGIN_ID => crate::plugins::blackboard::run_plugin(name).await,
         BLOBSTORE_PLUGIN_ID => crate::plugins::blobstore::run_plugin(name).await,
         OPENAI_ENDPOINT_PLUGIN_ID => crate::plugins::openai_endpoint::run_plugin(name).await,
+        SURVEY_PLUGIN_ID => crate::plugins::survey::run_plugin(name).await,
         _ => bail!("Unknown built-in plugin '{}'", name),
     }
 }
@@ -1804,6 +1808,53 @@ mod tests {
         assert_eq!(resolved.externals.len(), 1);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
         assert!(resolved.inactive.is_empty());
+    }
+
+    #[test]
+    fn survey_plugin_is_opt_in_builtin() {
+        let resolved = resolve_plugins(&MeshConfig::default(), private_host_mode()).unwrap();
+        assert!(!resolved
+            .externals
+            .iter()
+            .any(|spec| spec.name == SURVEY_PLUGIN_ID));
+
+        let config = MeshConfig {
+            plugins: vec![PluginConfigEntry {
+                name: SURVEY_PLUGIN_ID.into(),
+                enabled: Some(true),
+                command: None,
+                args: Vec::new(),
+                url: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
+        assert_eq!(resolved.externals.len(), 3);
+        assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, SURVEY_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
+        assert!(resolved.externals[1].args.contains(&"--plugin".to_string()));
+        assert!(resolved.externals[1]
+            .args
+            .contains(&SURVEY_PLUGIN_ID.to_string()));
+    }
+
+    #[test]
+    fn survey_plugin_rejects_custom_runtime_fields() {
+        let config = MeshConfig {
+            plugins: vec![PluginConfigEntry {
+                name: SURVEY_PLUGIN_ID.into(),
+                enabled: Some(true),
+                command: Some("/tmp/survey".into()),
+                args: Vec::new(),
+                url: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        let result = resolve_plugins(&config, private_host_mode());
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/mesh-llm/src/plugin/mod.rs
+++ b/crates/mesh-llm/src/plugin/mod.rs
@@ -36,7 +36,7 @@ pub use self::config::{
     ModelConfigEntry, PluginConfigEntry, PluginHostMode, ResolvedPlugins, TelemetryConfig,
     TelemetryMetricsConfig,
 };
-pub(crate) use self::config::{survey_plugin_enabled, validate_config};
+pub(crate) use self::config::{telemetry_plugin_enabled, validate_config};
 use self::runtime::ExternalPlugin;
 pub(crate) use self::support::parse_optional_json;
 use self::support::{format_args_for_log, format_slice_for_log, format_tool_names_for_log};
@@ -51,8 +51,8 @@ use mesh_llm_plugin::MeshVisibility;
 pub const BLACKBOARD_PLUGIN_ID: &str = "blackboard";
 pub const BLOBSTORE_PLUGIN_ID: &str = "blobstore";
 pub const OPENAI_ENDPOINT_PLUGIN_ID: &str = "openai-endpoint";
-pub const SURVEY_PLUGIN_ID: &str = "survey";
-pub const SURVEY_CAPABILITY: &str = "survey.metrics.v1";
+pub const TELEMETRY_PLUGIN_ID: &str = "telemetry";
+pub const TELEMETRY_CAPABILITY: &str = "telemetry.metrics.v1";
 #[allow(dead_code)]
 pub const BLACKBOARD_CAPABILITY: &str = "blackboard.v1";
 pub(crate) const PROTOCOL_VERSION: u32 = mesh_llm_plugin::PROTOCOL_VERSION;
@@ -1719,7 +1719,7 @@ pub async fn run_plugin_process(name: String) -> Result<()> {
         BLACKBOARD_PLUGIN_ID => crate::plugins::blackboard::run_plugin(name).await,
         BLOBSTORE_PLUGIN_ID => crate::plugins::blobstore::run_plugin(name).await,
         OPENAI_ENDPOINT_PLUGIN_ID => crate::plugins::openai_endpoint::run_plugin(name).await,
-        SURVEY_PLUGIN_ID => crate::plugins::survey::run_plugin(name).await,
+        TELEMETRY_PLUGIN_ID => crate::plugins::telemetry::run_plugin(name).await,
         _ => bail!("Unknown built-in plugin '{}'", name),
     }
 }
@@ -1811,16 +1811,16 @@ mod tests {
     }
 
     #[test]
-    fn survey_plugin_is_opt_in_builtin() {
+    fn telemetry_plugin_is_opt_in_builtin() {
         let resolved = resolve_plugins(&MeshConfig::default(), private_host_mode()).unwrap();
         assert!(!resolved
             .externals
             .iter()
-            .any(|spec| spec.name == SURVEY_PLUGIN_ID));
+            .any(|spec| spec.name == TELEMETRY_PLUGIN_ID));
 
         let config = MeshConfig {
             plugins: vec![PluginConfigEntry {
-                name: SURVEY_PLUGIN_ID.into(),
+                name: TELEMETRY_PLUGIN_ID.into(),
                 enabled: Some(true),
                 command: None,
                 args: Vec::new(),
@@ -1832,21 +1832,21 @@ mod tests {
         let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
         assert_eq!(resolved.externals.len(), 3);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
-        assert_eq!(resolved.externals[1].name, SURVEY_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
         assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
         assert!(resolved.externals[1].args.contains(&"--plugin".to_string()));
         assert!(resolved.externals[1]
             .args
-            .contains(&SURVEY_PLUGIN_ID.to_string()));
+            .contains(&TELEMETRY_PLUGIN_ID.to_string()));
     }
 
     #[test]
-    fn survey_plugin_rejects_custom_runtime_fields() {
+    fn telemetry_plugin_rejects_custom_runtime_fields() {
         let config = MeshConfig {
             plugins: vec![PluginConfigEntry {
-                name: SURVEY_PLUGIN_ID.into(),
+                name: TELEMETRY_PLUGIN_ID.into(),
                 enabled: Some(true),
-                command: Some("/tmp/survey".into()),
+                command: Some("/tmp/telemetry".into()),
                 args: Vec::new(),
                 url: None,
             }],

--- a/crates/mesh-llm/src/plugin/mod.rs
+++ b/crates/mesh-llm/src/plugin/mod.rs
@@ -1768,9 +1768,10 @@ mod tests {
     #[test]
     fn resolves_default_blackboard_plugin() {
         let resolved = resolve_plugins(&MeshConfig::default(), private_host_mode()).unwrap();
-        assert_eq!(resolved.externals.len(), 2);
+        assert_eq!(resolved.externals.len(), 3);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
-        assert_eq!(resolved.externals[1].name, BLOBSTORE_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
         assert!(resolved.inactive.is_empty());
     }
 
@@ -1787,8 +1788,9 @@ mod tests {
             ..MeshConfig::default()
         };
         let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
-        assert_eq!(resolved.externals.len(), 1);
-        assert_eq!(resolved.externals[0].name, BLOBSTORE_PLUGIN_ID);
+        assert_eq!(resolved.externals.len(), 2);
+        assert_eq!(resolved.externals[0].name, TELEMETRY_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, BLOBSTORE_PLUGIN_ID);
         assert!(resolved.inactive.is_empty());
     }
 
@@ -1805,31 +1807,15 @@ mod tests {
             ..MeshConfig::default()
         };
         let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
-        assert_eq!(resolved.externals.len(), 1);
+        assert_eq!(resolved.externals.len(), 2);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
         assert!(resolved.inactive.is_empty());
     }
 
     #[test]
-    fn telemetry_plugin_is_opt_in_builtin() {
+    fn telemetry_plugin_is_opt_out_builtin() {
         let resolved = resolve_plugins(&MeshConfig::default(), private_host_mode()).unwrap();
-        assert!(!resolved
-            .externals
-            .iter()
-            .any(|spec| spec.name == TELEMETRY_PLUGIN_ID));
-
-        let config = MeshConfig {
-            plugins: vec![PluginConfigEntry {
-                name: TELEMETRY_PLUGIN_ID.into(),
-                enabled: Some(true),
-                command: None,
-                args: Vec::new(),
-                url: None,
-            }],
-            ..MeshConfig::default()
-        };
-
-        let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
         assert_eq!(resolved.externals.len(), 3);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
         assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
@@ -1838,6 +1824,22 @@ mod tests {
         assert!(resolved.externals[1]
             .args
             .contains(&TELEMETRY_PLUGIN_ID.to_string()));
+
+        let config = MeshConfig {
+            plugins: vec![PluginConfigEntry {
+                name: TELEMETRY_PLUGIN_ID.into(),
+                enabled: Some(false),
+                command: None,
+                args: Vec::new(),
+                url: None,
+            }],
+            ..MeshConfig::default()
+        };
+
+        let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
+        assert_eq!(resolved.externals.len(), 2);
+        assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, BLOBSTORE_PLUGIN_ID);
     }
 
     #[test]
@@ -1870,11 +1872,12 @@ mod tests {
             ..MeshConfig::default()
         };
         let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
-        assert_eq!(resolved.externals.len(), 3);
+        assert_eq!(resolved.externals.len(), 4);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
-        assert_eq!(resolved.externals[1].name, OPENAI_ENDPOINT_PLUGIN_ID);
-        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
-        let spec = &resolved.externals[1];
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, OPENAI_ENDPOINT_PLUGIN_ID);
+        assert_eq!(resolved.externals[3].name, BLOBSTORE_PLUGIN_ID);
+        let spec = &resolved.externals[2];
         assert!(spec.args.contains(&"openai-endpoint".to_string()));
         assert_eq!(spec.url.as_deref(), Some("http://gpu-box:8000/v1"));
     }
@@ -1892,12 +1895,13 @@ mod tests {
             ..MeshConfig::default()
         };
         let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
-        assert_eq!(resolved.externals.len(), 3);
+        assert_eq!(resolved.externals.len(), 4);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
-        assert_eq!(resolved.externals[1].name, OPENAI_ENDPOINT_PLUGIN_ID);
-        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, OPENAI_ENDPOINT_PLUGIN_ID);
+        assert_eq!(resolved.externals[3].name, BLOBSTORE_PLUGIN_ID);
         // Verify the spec args dispatch to the right plugin binary
-        let spec = &resolved.externals[1];
+        let spec = &resolved.externals[2];
         assert!(spec.args.contains(&"--plugin".to_string()));
         assert!(spec.args.contains(&"openai-endpoint".to_string()));
     }
@@ -1927,9 +1931,10 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(resolved.externals.len(), 2);
+        assert_eq!(resolved.externals.len(), 3);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
-        assert_eq!(resolved.externals[1].name, BLOBSTORE_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
         assert!(resolved.inactive.is_empty());
     }
 
@@ -1946,10 +1951,11 @@ mod tests {
             ..MeshConfig::default()
         };
         let resolved = resolve_plugins(&config, private_host_mode()).unwrap();
-        assert_eq!(resolved.externals.len(), 3);
+        assert_eq!(resolved.externals.len(), 4);
         assert_eq!(resolved.externals[0].name, BLACKBOARD_PLUGIN_ID);
-        assert_eq!(resolved.externals[1].name, "demo");
-        assert_eq!(resolved.externals[2].name, BLOBSTORE_PLUGIN_ID);
+        assert_eq!(resolved.externals[1].name, TELEMETRY_PLUGIN_ID);
+        assert_eq!(resolved.externals[2].name, "demo");
+        assert_eq!(resolved.externals[3].name, BLOBSTORE_PLUGIN_ID);
         assert!(resolved.inactive.is_empty());
     }
 

--- a/crates/mesh-llm/src/plugins/mod.rs
+++ b/crates/mesh-llm/src/plugins/mod.rs
@@ -1,4 +1,4 @@
 pub mod blackboard;
 pub mod blobstore;
 pub mod openai_endpoint;
-pub mod survey;
+pub mod telemetry;

--- a/crates/mesh-llm/src/plugins/mod.rs
+++ b/crates/mesh-llm/src/plugins/mod.rs
@@ -1,3 +1,4 @@
 pub mod blackboard;
 pub mod blobstore;
 pub mod openai_endpoint;
+pub mod survey;

--- a/crates/mesh-llm/src/plugins/survey/mod.rs
+++ b/crates/mesh-llm/src/plugins/survey/mod.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use mesh_llm_plugin::{
+    capability, plugin_server_info, PluginMetadata, PluginRuntime, PluginStartupPolicy,
+};
+
+fn build_plugin(name: String) -> mesh_llm_plugin::SimplePlugin {
+    mesh_llm_plugin::plugin! {
+        metadata: PluginMetadata::new(
+            name,
+            crate::VERSION,
+            plugin_server_info(
+                "mesh-survey",
+                crate::VERSION,
+                "Survey Metrics Plugin",
+                "Enables host-owned OTLP metrics export for local model lifecycle telemetry.",
+                Some(
+                    "Configure [telemetry] and enable [[plugin]] name = \"survey\" \
+                     to export metrics-only OTLP survey telemetry.",
+                ),
+            ),
+        ),
+        startup_policy: PluginStartupPolicy::Any,
+        provides: [
+            capability(crate::plugin::SURVEY_CAPABILITY),
+        ],
+        health: |_context| {
+            Box::pin(async move { Ok("metrics=host-owned".to_string()) })
+        },
+    }
+}
+
+pub(crate) async fn run_plugin(name: String) -> Result<()> {
+    PluginRuntime::run(build_plugin(name)).await
+}

--- a/crates/mesh-llm/src/plugins/telemetry/mod.rs
+++ b/crates/mesh-llm/src/plugins/telemetry/mod.rs
@@ -12,10 +12,10 @@ fn build_plugin(name: String) -> mesh_llm_plugin::SimplePlugin {
                 "mesh-telemetry",
                 crate::VERSION,
                 "Telemetry Metrics Plugin",
-                "Enables host-owned OTLP metrics export for local model lifecycle telemetry.",
+                "Enables host-owned OTLP metrics export for model lifecycle and routing telemetry.",
                 Some(
-                    "Configure [telemetry] and enable [[plugin]] name = \"telemetry\" \
-                     to export metrics-only OTLP telemetry.",
+                    "Configure [telemetry] to export metrics-only OTLP telemetry, \
+                     or set [[plugin]] name = \"telemetry\" enabled = false to opt out.",
                 ),
             ),
         ),

--- a/crates/mesh-llm/src/plugins/telemetry/mod.rs
+++ b/crates/mesh-llm/src/plugins/telemetry/mod.rs
@@ -9,19 +9,19 @@ fn build_plugin(name: String) -> mesh_llm_plugin::SimplePlugin {
             name,
             crate::VERSION,
             plugin_server_info(
-                "mesh-survey",
+                "mesh-telemetry",
                 crate::VERSION,
-                "Survey Metrics Plugin",
+                "Telemetry Metrics Plugin",
                 "Enables host-owned OTLP metrics export for local model lifecycle telemetry.",
                 Some(
-                    "Configure [telemetry] and enable [[plugin]] name = \"survey\" \
-                     to export metrics-only OTLP survey telemetry.",
+                    "Configure [telemetry] and enable [[plugin]] name = \"telemetry\" \
+                     to export metrics-only OTLP telemetry.",
                 ),
             ),
         ),
         startup_policy: PluginStartupPolicy::Any,
         provides: [
-            capability(crate::plugin::SURVEY_CAPABILITY),
+            capability(crate::plugin::TELEMETRY_CAPABILITY),
         ],
         health: |_context| {
             Box::pin(async move { Ok("metrics=host-owned".to_string()) })

--- a/crates/mesh-llm/src/protocol/convert.rs
+++ b/crates/mesh-llm/src/protocol/convert.rs
@@ -769,6 +769,7 @@ pub(crate) fn proto_config_to_mesh(
             assignment,
             parallel: None,
         },
+        telemetry: Default::default(),
         models,
         plugins,
     }

--- a/crates/mesh-llm/src/protocol/mod.rs
+++ b/crates/mesh-llm/src/protocol/mod.rs
@@ -1575,6 +1575,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B.gguf".to_string(),
                 mmproj: Some("mm.gguf".to_string()),
@@ -1631,6 +1632,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "test.gguf".to_string(),
                 mmproj: None,
@@ -1657,6 +1659,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "other.gguf".to_string(),
                 mmproj: None,
@@ -1686,6 +1689,7 @@ mod tests {
                 assignment: GpuAssignment::Pinned,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".to_string(),
                 mmproj: Some("mmproj-f16.gguf".to_string()),

--- a/crates/mesh-llm/src/runtime/config_state.rs
+++ b/crates/mesh-llm/src/runtime/config_state.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 use crate::plugin::{load_config, validate_config, MeshConfig};
@@ -38,7 +39,7 @@ pub(crate) struct ConfigState {
     config_hash: [u8; 32],
     config: MeshConfig,
     config_path: PathBuf,
-    last_write_hash: [u8; 32],
+    last_write_config_hash: [u8; 32],
 }
 
 fn revision_sidecar_path(config_path: &Path) -> PathBuf {
@@ -106,6 +107,16 @@ fn atomic_write(target: &Path, contents: &[u8]) -> std::io::Result<()> {
     Ok(())
 }
 
+fn local_config_write_hash(config: &MeshConfig) -> [u8; 32] {
+    let bytes = serde_json::to_vec(config)
+        .or_else(|_| toml::to_string(config).map(String::into_bytes))
+        .unwrap_or_default();
+    let digest = Sha256::digest(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&digest);
+    out
+}
+
 impl Default for ConfigState {
     fn default() -> Self {
         let config = crate::plugin::MeshConfig::default();
@@ -116,7 +127,7 @@ impl Default for ConfigState {
             config_hash,
             config,
             config_path: std::path::PathBuf::from("config.toml"),
-            last_write_hash: [0xFF; 32],
+            last_write_config_hash: [0xFF; 32],
         }
     }
 }
@@ -127,8 +138,8 @@ impl ConfigState {
         let revision = read_revision(&revision_sidecar_path(path));
         let proto = mesh_config_to_proto(&config);
         let config_hash = canonical_config_hash(&proto);
-        let last_write_hash = if path.exists() {
-            config_hash
+        let last_write_config_hash = if path.exists() {
+            local_config_write_hash(&config)
         } else {
             [0xFF; 32]
         };
@@ -137,7 +148,7 @@ impl ConfigState {
             config_hash,
             config,
             config_path: path.to_path_buf(),
-            last_write_hash,
+            last_write_config_hash,
         })
     }
 
@@ -166,8 +177,9 @@ impl ConfigState {
 
         let proto = mesh_config_to_proto(&new_config);
         let new_hash = canonical_config_hash(&proto);
+        let new_write_hash = local_config_write_hash(&new_config);
 
-        if new_hash == self.last_write_hash {
+        if new_write_hash == self.last_write_config_hash {
             return ApplyResult::Applied {
                 revision: self.revision,
                 hash: self.config_hash,
@@ -189,6 +201,7 @@ impl ConfigState {
         if let Err(e) = atomic_write(&sidecar, new_revision.to_string().as_bytes()) {
             self.config = new_config;
             self.config_hash = new_hash;
+            self.last_write_config_hash = new_write_hash;
             self.revision = new_revision;
             return ApplyResult::PersistedWithRevisionTrackingError {
                 revision: self.revision,
@@ -201,7 +214,7 @@ impl ConfigState {
 
         self.config = new_config;
         self.config_hash = new_hash;
-        self.last_write_hash = new_hash;
+        self.last_write_config_hash = new_write_hash;
         self.revision = new_revision;
 
         ApplyResult::Applied {
@@ -231,6 +244,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![],
             plugins: vec![],
         }
@@ -349,6 +363,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![crate::plugin::ModelConfigEntry {
                 model: model.to_string(),
                 mmproj: None,
@@ -388,6 +403,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![crate::plugin::ModelConfigEntry {
                 model: "test.gguf".to_string(),
                 mmproj: None,
@@ -434,6 +450,7 @@ mod tests {
                 assignment: GpuAssignment::Auto,
                 parallel: None,
             },
+            telemetry: Default::default(),
             models: vec![crate::plugin::ModelConfigEntry {
                 model: "noop-test.gguf".to_string(),
                 mmproj: None,
@@ -485,6 +502,53 @@ mod tests {
             }
             other => panic!("expected Applied with Noop apply_mode, got {other:?}"),
         }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn config_sync_telemetry_only_change_is_persisted_locally() {
+        let dir = test_dir();
+        let config_path = dir.join("config.toml");
+        let mut state = ConfigState::load(&config_path).expect("load");
+
+        let base = minimal_valid_config();
+        let r1 = state.apply(base.clone(), 0);
+        let rev_after_first = match r1 {
+            ApplyResult::Applied {
+                revision,
+                apply_mode,
+                ..
+            } => {
+                assert_eq!(apply_mode, ConfigApplyMode::Staged);
+                revision
+            }
+            other => panic!("expected Applied, got {other:?}"),
+        };
+
+        let mut telemetry_only = base;
+        telemetry_only.telemetry.enabled = Some(true);
+        telemetry_only.telemetry.endpoint = Some("https://otel.example.com".to_string());
+
+        let r2 = state.apply(telemetry_only, rev_after_first);
+        match r2 {
+            ApplyResult::Applied {
+                revision,
+                apply_mode,
+                ..
+            } => {
+                assert_eq!(
+                    apply_mode,
+                    ConfigApplyMode::Staged,
+                    "local-only telemetry changes must still be written to config.toml"
+                );
+                assert_eq!(revision, rev_after_first + 1);
+            }
+            other => panic!("expected Applied with Staged apply_mode, got {other:?}"),
+        }
+
+        let persisted = std::fs::read_to_string(&config_path).expect("persisted config");
+        assert!(persisted.contains("https://otel.example.com"));
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -3759,7 +3759,15 @@ async fn run_auto(
             hardware::Metric::GpuFacts,
         ])
     };
-    let survey_telemetry = survey::SurveyTelemetry::start(&config, survey_hardware);
+    let survey_telemetry = survey::SurveyTelemetry::start(
+        &config,
+        survey_hardware,
+        survey::SurveyTelemetrySource {
+            node_id: node.id().fmt_short().to_string(),
+            node_role: if is_client { "client" } else { "worker" }.into(),
+        },
+    );
+    node.set_routing_telemetry_sink(survey_telemetry.routing_sink());
 
     // Advertise what we have on disk and what we want the mesh to serve
     node.set_available_models(local_models.clone()).await;

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -5,6 +5,7 @@ pub mod instance;
 mod interactive;
 mod local;
 mod proxy;
+mod survey;
 pub(crate) mod wakeable;
 
 use self::discovery::{nostr_rediscovery, start_new_mesh};
@@ -1030,6 +1031,8 @@ struct StartupLocalModelTask {
     slots: usize,
     parallel_override: Option<usize>,
     split: bool,
+    survey_telemetry: survey::SurveyTelemetry,
+    survey_launch_kind: survey::SurveyLaunchKind,
     stop_rx: tokio::sync::watch::Receiver<bool>,
     dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
     dashboard_context_usage: DashboardContextUsage,
@@ -1065,6 +1068,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         slots,
         parallel_override,
         split,
+        survey_telemetry,
+        survey_launch_kind,
         mut stop_rx,
         dashboard_processes,
         dashboard_context_usage,
@@ -1106,6 +1111,16 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         .unwrap_or_else(|| node.vram_bytes());
     let model_bytes = election::total_model_bytes(&model_path);
     let runtime_plan = startup_runtime_plan(split, local_capacity, model_bytes);
+    let launch_kind = match runtime_plan {
+        StartupRuntimePlan::Local => survey_launch_kind,
+        StartupRuntimePlan::Split {
+            reason: SplitRuntimeReason::Forced,
+        } => survey::SurveyLaunchKind::MoeShard,
+        StartupRuntimePlan::Split {
+            reason: SplitRuntimeReason::LocalCapacity,
+        } => survey::SurveyLaunchKind::MoeFallback,
+    };
+    let launch_started = Instant::now();
     let (
         mut loaded_name,
         mut handle,
@@ -1154,6 +1169,18 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     return;
                 }
                 Err(err) => {
+                    survey_telemetry.record_launch_failure(
+                        survey::SurveyModelSpec {
+                            model: &model_name,
+                            model_path: Some(&model_path),
+                            launch_kind,
+                            pinned_gpu: pinned_gpu.as_ref(),
+                            backend: None,
+                            context_length: ctx_size.map(u64::from),
+                        },
+                        launch_started.elapsed(),
+                        survey::classify_launch_failure(&err),
+                    );
                     let _ = emit_event(OutputEvent::Error {
                         message: format!("Failed to start model {model_name}: {err:#}"),
                         context: Some(format!("model={model_name}")),
@@ -1171,6 +1198,18 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 (loaded_name, handle, death_rx, None, None, None)
             }
             Err(err) => {
+                survey_telemetry.record_launch_failure(
+                    survey::SurveyModelSpec {
+                        model: &model_name,
+                        model_path: Some(&model_path),
+                        launch_kind,
+                        pinned_gpu: pinned_gpu.as_ref(),
+                        backend: None,
+                        context_length: ctx_size.map(u64::from),
+                    },
+                    launch_started.elapsed(),
+                    survey::classify_launch_failure(&err),
+                );
                 let _ = emit_event(OutputEvent::Error {
                     message: format!("Failed to start model {model_name}: {err:#}"),
                     context: Some(format!("model={model_name}")),
@@ -1184,6 +1223,16 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         },
     };
     drop(startup_load_guard);
+
+    let mut survey_loaded_model = survey_telemetry.model(survey::SurveyModelSpec {
+        model: &loaded_name,
+        model_path: Some(&model_path),
+        launch_kind,
+        pinned_gpu: pinned_gpu.as_ref(),
+        backend: Some(&handle.backend),
+        context_length: Some(u64::from(handle.context_length)),
+    });
+    survey_telemetry.record_launch_success(&survey_loaded_model, launch_started.elapsed());
 
     add_runtime_local_target(&target_tx, &loaded_name, handle.port);
     tunnel_mgr.set_http_port(api_port);
@@ -1250,6 +1299,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
 
     let mut context_usage_tick = tokio::time::interval(DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL);
     context_usage_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut survey_exited_unexpectedly = false;
 
     loop {
         tokio::select! {
@@ -1263,6 +1313,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 );
             }
             _ = &mut death_rx => {
+                survey_exited_unexpectedly = true;
+                survey_telemetry.record_unexpected_exit(&survey_loaded_model);
                 let _ = emit_event(OutputEvent::Warning {
                     message: format!("Startup model '{loaded_name}' exited unexpectedly"),
                     context: Some(format!("model={loaded_name} port={}", handle.port)),
@@ -1332,7 +1384,20 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     &old_handle,
                 )
                 .await;
+                survey_telemetry.record_unload(&survey_loaded_model);
                 loaded_name = next.loaded_name;
+                survey_loaded_model = survey_telemetry.model(survey::SurveyModelSpec {
+                    model: &loaded_name,
+                    model_path: Some(&model_path),
+                    launch_kind,
+                    pinned_gpu: pinned_gpu.as_ref(),
+                    backend: Some(&handle.backend),
+                    context_length: Some(u64::from(handle.context_length)),
+                });
+                survey_telemetry.record_launch_success(
+                    &survey_loaded_model,
+                    Duration::from_secs(0),
+                );
                 refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle)
                     .await;
                 publish_runtime_llama_slots(
@@ -1366,6 +1431,9 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     if let Some(task) = coordinator_task.take() {
         task.abort();
         let _ = task.await;
+    }
+    if !survey_exited_unexpectedly {
+        survey_telemetry.record_unload(&survey_loaded_model);
     }
     let port = handle.port;
     remove_runtime_local_target(&target_tx, &loaded_name, port);
@@ -3681,6 +3749,17 @@ async fn run_auto(
             .await?;
     node.set_plugin_manager(plugin_manager.clone()).await;
     node.start_plugin_channel_forwarder(plugin_mesh_rx);
+    let survey_hardware = if is_client {
+        hardware::HardwareSurvey::default()
+    } else {
+        hardware::query(&[
+            hardware::Metric::GpuName,
+            hardware::Metric::GpuCount,
+            hardware::Metric::IsSoc,
+            hardware::Metric::GpuFacts,
+        ])
+    };
+    let survey_telemetry = survey::SurveyTelemetry::start(&config, survey_hardware);
 
     // Advertise what we have on disk and what we want the mesh to serve
     node.set_available_models(local_models.clone()).await;
@@ -4049,6 +4128,7 @@ async fn run_auto(
     let (runtime_event_tx, mut runtime_event_rx) =
         tokio::sync::mpsc::unbounded_channel::<RuntimeEvent>();
     let mut runtime_models: HashMap<String, RuntimeModelHandleEntry> = HashMap::new();
+    let mut runtime_survey_models: HashMap<String, survey::SurveyLoadedModel> = HashMap::new();
     let mut managed_models: HashMap<String, ManagedModelController> = HashMap::new();
     let runtime_instance_registry: RuntimeInstanceRegistry =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
@@ -4273,6 +4353,7 @@ async fn run_auto(
     let console_state_for_election = console_state.clone();
     let interactive_console_state = console_state.clone();
     let interactive_control_tx = control_tx.clone();
+    let survey_telemetry_for_primary = survey_telemetry.clone();
 
     let primary_model_name_for_advertise = model_name.clone();
     let startup_model_names: Vec<String> = startup_models
@@ -4347,6 +4428,8 @@ async fn run_auto(
             slots: primary_slots,
             parallel_override: primary_parallel_override,
             split: startup_split,
+            survey_telemetry: survey_telemetry_for_primary,
+            survey_launch_kind: survey::SurveyLaunchKind::Startup,
             stop_rx: primary_stop_rx,
             dashboard_processes: dashboard_processes_for_primary_task,
             dashboard_context_usage: dashboard_context_usage_for_primary_task,
@@ -4418,6 +4501,7 @@ async fn run_auto(
             let dashboard_context_usage_for_extra_task = dashboard_context_usage.clone();
             let runtime_instance_registry_for_extra_task = runtime_instance_registry.clone();
             let extra_control_tx = control_tx.clone();
+            let extra_survey_telemetry = survey_telemetry.clone();
             let extra_task = tokio::spawn(async move {
                 startup_local_model_loop(StartupLocalModelTask {
                     node: extra_node,
@@ -4439,6 +4523,8 @@ async fn run_auto(
                     slots: extra_slots,
                     parallel_override: extra_parallel_override,
                     split: startup_split,
+                    survey_telemetry: extra_survey_telemetry,
+                    survey_launch_kind: survey::SurveyLaunchKind::MultiModel,
                     stop_rx: extra_stop_rx,
                     dashboard_processes: dashboard_processes_for_extra_task,
                     dashboard_context_usage: dashboard_context_usage_for_extra_task,
@@ -4583,7 +4669,11 @@ async fn run_auto(
 
                             let instance_id =
                                 next_runtime_instance_id(&mut next_runtime_instance_sequence);
-                            let (loaded_name, handle, death_rx) = start_runtime_local_model(
+                            let requested_model = spec.clone();
+                            add_serving_assignment(&node, &primary_model_name, &requested_model)
+                                .await;
+                            let launch_started = Instant::now();
+                            let (loaded_name, handle, death_rx) = match start_runtime_local_model(
                                 LocalRuntimeModelStartSpec {
                                     node: &node,
                                     model_path: &model_path,
@@ -4603,7 +4693,37 @@ async fn run_auto(
                                     parallel_override,
                                 },
                             )
-                            .await?;
+                            .await
+                            {
+                                Ok(result) => result,
+                                Err(err) => {
+                                    remove_serving_assignment(&node, &requested_model).await;
+                                    survey_telemetry.record_launch_failure(
+                                        survey::SurveyModelSpec {
+                                            model: &requested_model,
+                                            model_path: Some(&model_path),
+                                            launch_kind: survey::SurveyLaunchKind::RuntimeLoad,
+                                            pinned_gpu: None,
+                                            backend: None,
+                                            context_length: cli.ctx_size.map(u64::from),
+                                        },
+                                        launch_started.elapsed(),
+                                        survey::classify_launch_failure(&err),
+                                    );
+                                    return Err(err);
+                                }
+                            };
+                            let survey_loaded_model =
+                                survey_telemetry.model(survey::SurveyModelSpec {
+                                    model: &loaded_name,
+                                    model_path: Some(&model_path),
+                                    launch_kind: survey::SurveyLaunchKind::RuntimeLoad,
+                                    pinned_gpu: None,
+                                    backend: Some(&handle.backend),
+                                    context_length: Some(u64::from(handle.context_length)),
+                                });
+                            survey_telemetry
+                                .record_launch_success(&survey_loaded_model, launch_started.elapsed());
 
                             add_runtime_local_target(&target_tx, &loaded_name, handle.port);
                             register_runtime_instance(
@@ -4665,6 +4785,8 @@ async fn run_auto(
                                 Some(&instance_id),
                                 &handle,
                             );
+                            runtime_survey_models
+                                .insert(instance_id.clone(), survey_loaded_model);
                             runtime_models.insert(
                                 instance_id.clone(),
                                 RuntimeModelHandleEntry {
@@ -4698,6 +4820,11 @@ async fn run_auto(
                                     let model = entry.model_name;
                                     let handle = entry.handle;
                                     let port = handle.port;
+                                    if let Some(survey_model) =
+                                        runtime_survey_models.remove(&unload.instance_id)
+                                    {
+                                        survey_telemetry.record_unload(&survey_model);
+                                    }
                                     remove_runtime_local_target(&target_tx, &model, port);
                                     if unregister_runtime_instance(
                                         &runtime_instance_registry,
@@ -4816,6 +4943,11 @@ async fn run_auto(
                         if matches {
                             if let Some(entry) = runtime_models.remove(&instance_id) {
                                 let handle = entry.handle;
+                                if let Some(survey_model) =
+                                    runtime_survey_models.remove(&instance_id)
+                                {
+                                    survey_telemetry.record_unexpected_exit(&survey_model);
+                                }
                                 if unregister_runtime_instance(
                                     &runtime_instance_registry,
                                     &node,
@@ -4900,6 +5032,9 @@ async fn run_auto(
     for (instance_id, entry) in runtime_models.drain() {
         let name = entry.model_name;
         let handle = entry.handle;
+        if let Some(survey_model) = runtime_survey_models.remove(&instance_id) {
+            survey_telemetry.record_unload(&survey_model);
+        }
         let shutting_down_payload = runtime_process_payload_with_status(
             &name,
             Some(&instance_id),

--- a/crates/mesh-llm/src/runtime/survey.rs
+++ b/crates/mesh-llm/src/runtime/survey.rs
@@ -21,6 +21,30 @@ const DEFAULT_EXPORT_INTERVAL_SECS: u64 = 15;
 const DEFAULT_QUEUE_SIZE: usize = 2048;
 const OTLP_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 const OTLP_METRICS_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+#[cfg(any(debug_assertions, test))]
+const TELEMETRY_ATTRIBUTE_ALLOWLIST: &[&str] = &[
+    "mesh_llm.architecture",
+    "mesh_llm.attempt_outcome",
+    "mesh_llm.backend",
+    "mesh_llm.backend_device",
+    "mesh_llm.context_bucket",
+    "mesh_llm.failure_reason",
+    "mesh_llm.gpu_count",
+    "mesh_llm.gpu_name",
+    "mesh_llm.gpu_stable_id",
+    "mesh_llm.is_soc",
+    "mesh_llm.launch_kind",
+    "mesh_llm.model",
+    "mesh_llm.quantization",
+    "mesh_llm.request_outcome",
+    "mesh_llm.route_attempt_bucket",
+    "mesh_llm.route_service",
+    "mesh_llm.service_version",
+    "mesh_llm.source_node_id",
+    "mesh_llm.source_node_role",
+    "mesh_llm.target_kind",
+    "mesh_llm.target_node_id",
+];
 
 #[derive(Clone)]
 pub(super) struct SurveyTelemetry {
@@ -48,6 +72,7 @@ impl SurveyTelemetrySource {
         if let Some(node_id) = redact_stable_id(&self.node_id) {
             attrs.push(KeyValue::new("mesh_llm.source_node_id", node_id));
         }
+        debug_assert_telemetry_attrs_allowlisted(&attrs);
         attrs
     }
 }
@@ -113,7 +138,11 @@ impl SurveySettings {
         if config.telemetry.enabled == Some(false) {
             return None;
         }
-        let endpoint = resolve_metrics_endpoint(&config.telemetry, env)?;
+        let endpoint = resolve_metrics_endpoint(
+            &config.telemetry,
+            env,
+            config.telemetry.enabled == Some(true),
+        )?;
         let service_name = config
             .telemetry
             .service_name
@@ -316,16 +345,22 @@ fn spawn_survey_worker(queue: Arc<SurveyEventQueue>, mut recorder: SurveyRecorde
     });
 }
 
-fn resolve_metrics_endpoint<F>(config: &plugin::TelemetryConfig, env: F) -> Option<String>
+fn resolve_metrics_endpoint<F>(
+    config: &plugin::TelemetryConfig,
+    env: F,
+    allow_env_endpoint: bool,
+) -> Option<String>
 where
     F: Fn(&str) -> Option<String>,
 {
-    trimmed_nonempty(config.metrics.endpoint.as_deref())
+    let configured = trimmed_nonempty(config.metrics.endpoint.as_deref())
         .map(ToOwned::to_owned)
-        .or_else(|| trimmed_nonempty(config.endpoint.as_deref()).map(metrics_endpoint_from_base))
-        .or_else(|| {
-            trimmed_nonempty(env(OTLP_METRICS_ENDPOINT_ENV).as_deref()).map(ToOwned::to_owned)
-        })
+        .or_else(|| trimmed_nonempty(config.endpoint.as_deref()).map(metrics_endpoint_from_base));
+    if configured.is_some() || !allow_env_endpoint {
+        return configured;
+    }
+    trimmed_nonempty(env(OTLP_METRICS_ENDPOINT_ENV).as_deref())
+        .map(ToOwned::to_owned)
         .or_else(|| {
             trimmed_nonempty(env(OTLP_ENDPOINT_ENV).as_deref()).map(metrics_endpoint_from_base)
         })
@@ -465,6 +500,7 @@ impl SurveyAttributes {
         if let Some(reason) = failure_reason {
             attrs.push(KeyValue::new("mesh_llm.failure_reason", reason.as_str()));
         }
+        debug_assert_telemetry_attrs_allowlisted(&attrs);
         attrs
     }
 }
@@ -501,6 +537,25 @@ fn context_bucket(context_length: u64) -> &'static str {
         _ => ">128k",
     }
 }
+
+#[cfg(any(debug_assertions, test))]
+fn telemetry_attribute_allowed(key: &str) -> bool {
+    TELEMETRY_ATTRIBUTE_ALLOWLIST.contains(&key)
+}
+
+#[cfg(debug_assertions)]
+fn debug_assert_telemetry_attrs_allowlisted(attrs: &[KeyValue]) {
+    for attr in attrs {
+        let key = attr.key.to_string();
+        debug_assert!(
+            telemetry_attribute_allowed(&key),
+            "OTLP telemetry attribute '{key}' must be added to the privacy-reviewed allowlist"
+        );
+    }
+}
+
+#[cfg(not(debug_assertions))]
+fn debug_assert_telemetry_attrs_allowlisted(_attrs: &[KeyValue]) {}
 
 impl SurveyLaunchKind {
     fn as_str(self) -> &'static str {
@@ -570,9 +625,10 @@ impl RequestAttributes {
             self.request_outcome,
         ));
         attrs.push(KeyValue::new(
-            "mesh_llm.route_attempt_count",
-            i64::try_from(self.attempts).unwrap_or(i64::MAX),
+            "mesh_llm.route_attempt_bucket",
+            request_attempt_bucket(self.attempts),
         ));
+        debug_assert_telemetry_attrs_allowlisted(&attrs);
         attrs
     }
 }
@@ -620,6 +676,7 @@ impl RouteAttemptAttributes {
             "mesh_llm.attempt_outcome",
             self.attempt_outcome,
         ));
+        debug_assert_telemetry_attrs_allowlisted(&attrs);
         attrs
     }
 }
@@ -629,6 +686,15 @@ fn request_service_label(service: RequestService) -> &'static str {
         RequestService::Local => "local",
         RequestService::Remote => "remote",
         RequestService::Endpoint => "endpoint",
+    }
+}
+
+fn request_attempt_bucket(attempts: u64) -> &'static str {
+    match attempts {
+        0 | 1 => "1",
+        2 => "2",
+        3 | 4 => "3_4",
+        _ => "5_plus",
     }
 }
 
@@ -882,19 +948,31 @@ impl SurveyRecorder {
 }
 
 fn service_version_attrs() -> Vec<KeyValue> {
-    vec![KeyValue::new("mesh_llm.service_version", crate::VERSION)]
+    let attrs = vec![KeyValue::new("mesh_llm.service_version", crate::VERSION)];
+    debug_assert_telemetry_attrs_allowlisted(&attrs);
+    attrs
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::plugin::{MeshConfig, PluginConfigEntry, TelemetryConfig, TelemetryMetricsConfig};
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
 
     fn test_source() -> SurveyTelemetrySource {
         SurveyTelemetrySource {
             node_id: "source-node-raw".into(),
             node_role: "client".into(),
+        }
+    }
+
+    fn assert_attrs_allowlisted(attrs: Vec<KeyValue>) {
+        for attr in attrs {
+            let key = attr.key.to_string();
+            assert!(
+                telemetry_attribute_allowed(&key),
+                "unexpected telemetry attribute key: {key}"
+            );
         }
     }
 
@@ -988,6 +1066,43 @@ mod tests {
     }
 
     #[test]
+    fn ambient_otel_env_does_not_enable_export_without_explicit_telemetry_enable() {
+        let mut config = survey_config();
+        config.telemetry.enabled = None;
+        config.telemetry.endpoint = None;
+        config.telemetry.metrics.endpoint = None;
+
+        let settings = SurveySettings::from_config_with_env(&config, |key| match key {
+            OTLP_ENDPOINT_ENV => Some("https://ambient.example.com".into()),
+            _ => None,
+        });
+        assert!(settings.is_none());
+
+        config.telemetry.enabled = Some(true);
+        let settings = SurveySettings::from_config_with_env(&config, |key| match key {
+            OTLP_ENDPOINT_ENV => Some("https://ambient.example.com".into()),
+            _ => None,
+        })
+        .expect("explicit telemetry enable should allow OTel env endpoint");
+        assert_eq!(settings.endpoint, "https://ambient.example.com/v1/metrics");
+    }
+
+    #[test]
+    fn config_endpoint_enables_export_without_boolean_flag() {
+        let mut config = survey_config();
+        config.telemetry.enabled = None;
+        config.telemetry.endpoint = Some("https://config-owned.example.com".into());
+        config.telemetry.metrics.endpoint = None;
+
+        let settings =
+            SurveySettings::from_config_with_env(&config, |_| None).expect("config endpoint");
+        assert_eq!(
+            settings.endpoint,
+            "https://config-owned.example.com/v1/metrics"
+        );
+    }
+
+    #[test]
     fn event_queue_drops_oldest_when_full() {
         let queue = SurveyEventQueue::new(2);
         for model in ["first", "second", "third"] {
@@ -1068,6 +1183,78 @@ mod tests {
             Some("skippy")
         );
         assert_eq!(kv.get("mesh_llm.is_soc").map(String::as_str), Some("true"));
+        assert!(!kv.values().any(|value| value.contains("/private/models")));
+    }
+
+    #[test]
+    fn telemetry_attribute_allowlist_has_unique_reviewed_keys() {
+        let keys: BTreeSet<_> = TELEMETRY_ATTRIBUTE_ALLOWLIST.iter().copied().collect();
+        assert_eq!(keys.len(), TELEMETRY_ATTRIBUTE_ALLOWLIST.len());
+        assert_eq!(
+            keys,
+            BTreeSet::from([
+                "mesh_llm.architecture",
+                "mesh_llm.attempt_outcome",
+                "mesh_llm.backend",
+                "mesh_llm.backend_device",
+                "mesh_llm.context_bucket",
+                "mesh_llm.failure_reason",
+                "mesh_llm.gpu_count",
+                "mesh_llm.gpu_name",
+                "mesh_llm.gpu_stable_id",
+                "mesh_llm.is_soc",
+                "mesh_llm.launch_kind",
+                "mesh_llm.model",
+                "mesh_llm.quantization",
+                "mesh_llm.request_outcome",
+                "mesh_llm.route_attempt_bucket",
+                "mesh_llm.route_service",
+                "mesh_llm.service_version",
+                "mesh_llm.source_node_id",
+                "mesh_llm.source_node_role",
+                "mesh_llm.target_kind",
+                "mesh_llm.target_node_id",
+            ])
+        );
+    }
+
+    #[test]
+    fn generated_telemetry_attributes_are_allowlisted() {
+        let lifecycle_attrs = SurveyAttributes {
+            model: "Qwen3-8B-Q4_K_M.gguf".into(),
+            architecture: Some("qwen3".into()),
+            quantization: Some("Q4_K_M".into()),
+            launch_kind: SurveyLaunchKind::Startup,
+            gpu_name: Some("NVIDIA Test".into()),
+            gpu_stable_id: Some("sha256:abcdef1234567890".into()),
+            backend_device: Some("CUDA0".into()),
+            gpu_count: 1,
+            is_soc: false,
+            backend: Some("skippy".into()),
+            context_length: Some(131_072),
+        };
+        assert_attrs_allowlisted(lifecycle_attrs.key_values(Some(SurveyFailureReason::Other)));
+
+        assert_attrs_allowlisted(
+            RequestAttributes::from_request(
+                Some("Qwen/Qwen3-8B-GGUF:Q4_K_M"),
+                2,
+                RequestOutcome::Rejected(RequestService::Endpoint),
+                test_source(),
+            )
+            .key_values(),
+        );
+        assert_attrs_allowlisted(
+            RouteAttemptAttributes::from_attempt(
+                Some("Qwen/Qwen3-8B-GGUF:Q4_K_M"),
+                &AttemptTarget::Remote("remote-node-raw".into()),
+                AttemptOutcome::Success,
+                test_source(),
+            )
+            .key_values(),
+        );
+        assert_attrs_allowlisted(test_source().key_values());
+        assert_attrs_allowlisted(service_version_attrs());
     }
 
     #[test]
@@ -1097,13 +1284,24 @@ mod tests {
             Some("success")
         );
         assert_eq!(
-            kv.get("mesh_llm.route_attempt_count").map(String::as_str),
+            kv.get("mesh_llm.route_attempt_bucket").map(String::as_str),
             Some("2")
         );
         assert_eq!(
             kv.get("mesh_llm.source_node_role").map(String::as_str),
             Some("client")
         );
+    }
+
+    #[test]
+    fn request_attempt_count_is_exported_as_bounded_bucket() {
+        assert_eq!(request_attempt_bucket(0), "1");
+        assert_eq!(request_attempt_bucket(1), "1");
+        assert_eq!(request_attempt_bucket(2), "2");
+        assert_eq!(request_attempt_bucket(3), "3_4");
+        assert_eq!(request_attempt_bucket(4), "3_4");
+        assert_eq!(request_attempt_bucket(5), "5_plus");
+        assert_eq!(request_attempt_bucket(100), "5_plus");
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime/survey.rs
+++ b/crates/mesh-llm/src/runtime/survey.rs
@@ -1,0 +1,847 @@
+use crate::plugin;
+use crate::system::hardware;
+use anyhow::{Context, Result};
+use opentelemetry::metrics::{Counter, Gauge, Histogram, MeterProvider as _};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{Protocol, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::metrics::{PeriodicReader, SdkMeterProvider};
+use opentelemetry_sdk::Resource;
+use sha2::{Digest, Sha256};
+use std::collections::VecDeque;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::Notify;
+
+const DEFAULT_SERVICE_NAME: &str = "mesh-llm";
+const DEFAULT_EXPORT_INTERVAL_SECS: u64 = 15;
+const DEFAULT_QUEUE_SIZE: usize = 2048;
+const OTLP_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
+const OTLP_METRICS_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
+
+#[derive(Clone)]
+pub(super) struct SurveyTelemetry {
+    inner: Option<Arc<SurveyTelemetryInner>>,
+}
+
+struct SurveyTelemetryInner {
+    queue: Arc<SurveyEventQueue>,
+    hardware: hardware::HardwareSurvey,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SurveyLoadedModel {
+    attrs: SurveyAttributes,
+    loaded_at: Instant,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SurveyLaunchKind {
+    Startup,
+    RuntimeLoad,
+    MultiModel,
+    MoeFallback,
+    MoeShard,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SurveyFailureReason {
+    SpawnFailed,
+    HealthTimeout,
+    ExitedBeforeHealthy,
+    BackendProxyFailed,
+    CapacityRejected,
+    KnownKvCacheCrash,
+    MmprojMissing,
+    Other,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct SurveyModelSpec<'a> {
+    pub(super) model: &'a str,
+    pub(super) model_path: Option<&'a Path>,
+    pub(super) launch_kind: SurveyLaunchKind,
+    pub(super) pinned_gpu: Option<&'a super::StartupPinnedGpuTarget>,
+    pub(super) backend: Option<&'a str>,
+    pub(super) context_length: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+struct SurveySettings {
+    service_name: String,
+    endpoint: String,
+    headers: std::collections::HashMap<String, String>,
+    export_interval: Duration,
+    queue_size: usize,
+}
+
+impl SurveySettings {
+    fn from_config(config: &plugin::MeshConfig) -> Option<Self> {
+        Self::from_config_with_env(config, |key| std::env::var(key).ok())
+    }
+
+    fn from_config_with_env<F>(config: &plugin::MeshConfig, env: F) -> Option<Self>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        if !plugin::survey_plugin_enabled(config) {
+            return None;
+        }
+        if config.telemetry.enabled == Some(false) {
+            return None;
+        }
+        let endpoint = resolve_metrics_endpoint(&config.telemetry, env)?;
+        let service_name = config
+            .telemetry
+            .service_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(DEFAULT_SERVICE_NAME)
+            .to_string();
+        let headers = config
+            .telemetry
+            .headers
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+        let export_interval = Duration::from_secs(
+            config
+                .telemetry
+                .export_interval_secs
+                .unwrap_or(DEFAULT_EXPORT_INTERVAL_SECS),
+        );
+        let queue_size = config.telemetry.queue_size.unwrap_or(DEFAULT_QUEUE_SIZE);
+        Some(Self {
+            service_name,
+            endpoint,
+            headers,
+            export_interval,
+            queue_size,
+        })
+    }
+}
+
+impl SurveyTelemetry {
+    pub(super) fn disabled() -> Self {
+        Self { inner: None }
+    }
+
+    pub(super) fn start(config: &plugin::MeshConfig, hardware: hardware::HardwareSurvey) -> Self {
+        let Some(settings) = SurveySettings::from_config(config) else {
+            return Self::disabled();
+        };
+        let queue = Arc::new(SurveyEventQueue::new(settings.queue_size));
+        let recorder = match SurveyRecorder::otlp(&settings) {
+            Ok(recorder) => recorder,
+            Err(err) => {
+                tracing::warn!("disabling survey OTLP metrics exporter: {err:#}");
+                return Self::disabled();
+            }
+        };
+        spawn_survey_worker(queue.clone(), recorder);
+        Self {
+            inner: Some(Arc::new(SurveyTelemetryInner { queue, hardware })),
+        }
+    }
+
+    pub(super) fn model(&self, spec: SurveyModelSpec<'_>) -> SurveyLoadedModel {
+        let attrs = if let Some(inner) = self.inner.as_ref() {
+            SurveyAttributes::from_spec(spec, &inner.hardware)
+        } else {
+            SurveyAttributes::from_disabled_spec(spec)
+        };
+        SurveyLoadedModel {
+            attrs,
+            loaded_at: Instant::now(),
+        }
+    }
+
+    pub(super) fn record_launch_success(&self, model: &SurveyLoadedModel, duration: Duration) {
+        self.emit(SurveyEvent::LaunchSuccess {
+            attrs: model.attrs.clone(),
+            duration_ms: duration.as_secs_f64() * 1000.0,
+        });
+    }
+
+    pub(super) fn record_launch_failure(
+        &self,
+        spec: SurveyModelSpec<'_>,
+        duration: Duration,
+        reason: SurveyFailureReason,
+    ) {
+        let Some(inner) = self.inner.as_ref() else {
+            return;
+        };
+        self.emit(SurveyEvent::LaunchFailure {
+            attrs: SurveyAttributes::from_spec(spec, &inner.hardware),
+            duration_ms: duration.as_secs_f64() * 1000.0,
+            reason,
+        });
+    }
+
+    pub(super) fn record_unload(&self, model: &SurveyLoadedModel) {
+        self.emit(SurveyEvent::Unload {
+            attrs: model.attrs.clone(),
+            uptime_s: model.loaded_at.elapsed().as_secs_f64(),
+        });
+    }
+
+    pub(super) fn record_unexpected_exit(&self, model: &SurveyLoadedModel) {
+        self.emit(SurveyEvent::UnexpectedExit {
+            attrs: model.attrs.clone(),
+            uptime_s: model.loaded_at.elapsed().as_secs_f64(),
+        });
+    }
+
+    fn emit(&self, event: SurveyEvent) {
+        if let Some(inner) = self.inner.as_ref() {
+            inner.queue.push(event);
+        }
+    }
+}
+
+pub(super) fn classify_launch_failure(err: &anyhow::Error) -> SurveyFailureReason {
+    let message = format!("{err:#}").to_ascii_lowercase();
+    if message.contains("capacity")
+        || message.contains("fit locally")
+        || message.contains("requires")
+    {
+        SurveyFailureReason::CapacityRejected
+    } else if message.contains("mmproj") {
+        SurveyFailureReason::MmprojMissing
+    } else if message.contains("health") || message.contains("timeout") {
+        SurveyFailureReason::HealthTimeout
+    } else if message.contains("kv cache") {
+        SurveyFailureReason::KnownKvCacheCrash
+    } else if message.contains("proxy") {
+        SurveyFailureReason::BackendProxyFailed
+    } else if message.contains("exit") || message.contains("exited") {
+        SurveyFailureReason::ExitedBeforeHealthy
+    } else if message.contains("spawn") || message.contains("start") || message.contains("launch") {
+        SurveyFailureReason::SpawnFailed
+    } else {
+        SurveyFailureReason::Other
+    }
+}
+
+fn spawn_survey_worker(queue: Arc<SurveyEventQueue>, mut recorder: SurveyRecorder) {
+    tokio::spawn(async move {
+        loop {
+            let events = queue.drain();
+            if events.is_empty() {
+                queue.notified().await;
+                continue;
+            }
+            for event in events {
+                recorder.record(event);
+            }
+        }
+    });
+}
+
+fn resolve_metrics_endpoint<F>(config: &plugin::TelemetryConfig, env: F) -> Option<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    trimmed_nonempty(config.metrics.endpoint.as_deref())
+        .map(ToOwned::to_owned)
+        .or_else(|| trimmed_nonempty(config.endpoint.as_deref()).map(metrics_endpoint_from_base))
+        .or_else(|| {
+            trimmed_nonempty(env(OTLP_METRICS_ENDPOINT_ENV).as_deref()).map(ToOwned::to_owned)
+        })
+        .or_else(|| {
+            trimmed_nonempty(env(OTLP_ENDPOINT_ENV).as_deref()).map(metrics_endpoint_from_base)
+        })
+}
+
+fn metrics_endpoint_from_base(endpoint: &str) -> String {
+    let endpoint = endpoint.trim().trim_end_matches('/');
+    if endpoint.ends_with("/v1/metrics") {
+        endpoint.to_string()
+    } else {
+        format!("{endpoint}/v1/metrics")
+    }
+}
+
+fn trimmed_nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+#[derive(Clone, Debug)]
+struct SurveyAttributes {
+    model: String,
+    architecture: Option<String>,
+    quantization: Option<String>,
+    launch_kind: SurveyLaunchKind,
+    gpu_name: Option<String>,
+    gpu_stable_id: Option<String>,
+    backend_device: Option<String>,
+    gpu_count: u64,
+    is_soc: bool,
+    backend: Option<String>,
+    context_length: Option<u64>,
+}
+
+impl SurveyAttributes {
+    fn from_disabled_spec(spec: SurveyModelSpec<'_>) -> Self {
+        Self {
+            model: model_metric_value(spec.model),
+            architecture: None,
+            quantization: None,
+            launch_kind: spec.launch_kind,
+            gpu_name: None,
+            gpu_stable_id: None,
+            backend_device: None,
+            gpu_count: 0,
+            is_soc: false,
+            backend: spec
+                .backend
+                .and_then(|value| trimmed_nonempty(Some(value)))
+                .map(ToOwned::to_owned),
+            context_length: spec.context_length,
+        }
+    }
+
+    fn from_spec(spec: SurveyModelSpec<'_>, hardware: &hardware::HardwareSurvey) -> Self {
+        let gpu = spec
+            .pinned_gpu
+            .and_then(|pinned| hardware.gpus.iter().find(|gpu| gpu.index == pinned.index))
+            .or_else(|| hardware.gpus.first());
+        let gpu_name = gpu
+            .map(|gpu| gpu.display_name.as_str())
+            .or(hardware.gpu_name.as_deref())
+            .and_then(|value| trimmed_nonempty(Some(value)))
+            .map(ToOwned::to_owned);
+        let stable_id = spec
+            .pinned_gpu
+            .map(|gpu| gpu.stable_id.as_str())
+            .or_else(|| gpu.and_then(|gpu| gpu.stable_id.as_deref()));
+        let backend_device = spec
+            .pinned_gpu
+            .map(|gpu| gpu.backend_device.as_str())
+            .or_else(|| gpu.and_then(|gpu| gpu.backend_device.as_deref()))
+            .and_then(|value| trimmed_nonempty(Some(value)))
+            .map(ToOwned::to_owned);
+        let architecture = spec
+            .model_path
+            .and_then(crate::models::gguf::scan_gguf_compact_meta)
+            .and_then(|meta| {
+                trimmed_nonempty(Some(meta.architecture.as_str())).map(ToOwned::to_owned)
+            });
+        let quantization = spec
+            .model_path
+            .and_then(|path| path.file_stem())
+            .and_then(|stem| stem.to_str())
+            .map(crate::models::inventory::derive_quantization_type)
+            .and_then(|value| trimmed_nonempty(Some(value.as_str())).map(ToOwned::to_owned))
+            .or_else(|| super::dashboard_quantization_from_model_name(spec.model));
+        Self {
+            model: model_metric_value(spec.model),
+            architecture,
+            quantization,
+            launch_kind: spec.launch_kind,
+            gpu_name,
+            gpu_stable_id: stable_id.and_then(redact_stable_id),
+            backend_device,
+            gpu_count: u64::from(hardware.gpu_count).max(hardware.gpus.len() as u64),
+            is_soc: hardware.is_soc,
+            backend: spec
+                .backend
+                .and_then(|value| trimmed_nonempty(Some(value)))
+                .map(ToOwned::to_owned),
+            context_length: spec.context_length,
+        }
+    }
+
+    fn key_values(&self, failure_reason: Option<SurveyFailureReason>) -> Vec<KeyValue> {
+        let mut attrs = vec![
+            KeyValue::new("mesh_llm.model", self.model.clone()),
+            KeyValue::new("mesh_llm.launch_kind", self.launch_kind.as_str()),
+            KeyValue::new("mesh_llm.gpu_count", self.gpu_count as i64),
+            KeyValue::new("mesh_llm.is_soc", self.is_soc),
+            KeyValue::new("mesh_llm.service_version", crate::VERSION),
+        ];
+        if let Some(value) = &self.architecture {
+            attrs.push(KeyValue::new("mesh_llm.architecture", value.clone()));
+        }
+        if let Some(value) = &self.quantization {
+            attrs.push(KeyValue::new("mesh_llm.quantization", value.clone()));
+        }
+        if let Some(value) = &self.gpu_name {
+            attrs.push(KeyValue::new("mesh_llm.gpu_name", value.clone()));
+        }
+        if let Some(value) = &self.gpu_stable_id {
+            attrs.push(KeyValue::new("mesh_llm.gpu_stable_id", value.clone()));
+        }
+        if let Some(value) = &self.backend_device {
+            attrs.push(KeyValue::new("mesh_llm.backend_device", value.clone()));
+        }
+        if let Some(value) = &self.backend {
+            attrs.push(KeyValue::new("mesh_llm.backend", value.clone()));
+        }
+        if let Some(context_length) = self.context_length {
+            attrs.push(KeyValue::new(
+                "mesh_llm.context_bucket",
+                context_bucket(context_length),
+            ));
+        }
+        if let Some(reason) = failure_reason {
+            attrs.push(KeyValue::new("mesh_llm.failure_reason", reason.as_str()));
+        }
+        attrs
+    }
+}
+
+fn model_metric_value(model: &str) -> String {
+    let path = Path::new(model);
+    if path.is_absolute() || (path.components().count() > 1 && path.extension().is_some()) {
+        return path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.is_empty())
+            .unwrap_or(model)
+            .to_string();
+    }
+    model.to_string()
+}
+
+fn redact_stable_id(stable_id: &str) -> Option<String> {
+    let stable_id = stable_id.trim();
+    if stable_id.is_empty() {
+        return None;
+    }
+    let digest = Sha256::digest(stable_id.as_bytes());
+    Some(format!("sha256:{}", hex::encode(&digest[..8])))
+}
+
+fn context_bucket(context_length: u64) -> &'static str {
+    match context_length {
+        0..=8192 => "<=8k",
+        8193..=16_384 => "8k_16k",
+        16_385..=32_768 => "16k_32k",
+        32_769..=65_536 => "32k_64k",
+        65_537..=131_072 => "64k_128k",
+        _ => ">128k",
+    }
+}
+
+impl SurveyLaunchKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Startup => "startup",
+            Self::RuntimeLoad => "runtime_load",
+            Self::MultiModel => "multi_model",
+            Self::MoeFallback => "moe_fallback",
+            Self::MoeShard => "moe_shard",
+        }
+    }
+}
+
+impl SurveyFailureReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::SpawnFailed => "spawn_failed",
+            Self::HealthTimeout => "health_timeout",
+            Self::ExitedBeforeHealthy => "exited_before_healthy",
+            Self::BackendProxyFailed => "backend_proxy_failed",
+            Self::CapacityRejected => "capacity_rejected",
+            Self::KnownKvCacheCrash => "known_kv_cache_crash",
+            Self::MmprojMissing => "mmproj_missing",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum SurveyEvent {
+    LaunchSuccess {
+        attrs: SurveyAttributes,
+        duration_ms: f64,
+    },
+    LaunchFailure {
+        attrs: SurveyAttributes,
+        duration_ms: f64,
+        reason: SurveyFailureReason,
+    },
+    Unload {
+        attrs: SurveyAttributes,
+        uptime_s: f64,
+    },
+    UnexpectedExit {
+        attrs: SurveyAttributes,
+        uptime_s: f64,
+    },
+}
+
+#[derive(Debug)]
+struct SurveyEventQueue {
+    capacity: usize,
+    events: Mutex<VecDeque<SurveyEvent>>,
+    notify: Notify,
+}
+
+impl SurveyEventQueue {
+    fn new(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            events: Mutex::new(VecDeque::with_capacity(capacity.max(1))),
+            notify: Notify::new(),
+        }
+    }
+
+    fn push(&self, event: SurveyEvent) {
+        let mut events = self
+            .events
+            .lock()
+            .expect("survey event queue lock poisoned");
+        if events.len() == self.capacity {
+            events.pop_front();
+        }
+        events.push_back(event);
+        drop(events);
+        self.notify.notify_one();
+    }
+
+    fn drain(&self) -> Vec<SurveyEvent> {
+        let mut events = self
+            .events
+            .lock()
+            .expect("survey event queue lock poisoned");
+        events.drain(..).collect()
+    }
+
+    async fn notified(&self) {
+        self.notify.notified().await;
+    }
+}
+
+struct SurveyRecorder {
+    _provider: SdkMeterProvider,
+    launch_total: Counter<u64>,
+    launch_success_total: Counter<u64>,
+    launch_failure_total: Counter<u64>,
+    unload_total: Counter<u64>,
+    unexpected_exit_total: Counter<u64>,
+    loaded_models: Gauge<u64>,
+    model_loaded: Gauge<u64>,
+    model_context_length: Gauge<u64>,
+    launch_duration_ms: Histogram<f64>,
+    uptime_s: Histogram<f64>,
+    loaded_count: u64,
+}
+
+impl SurveyRecorder {
+    fn otlp(settings: &SurveySettings) -> Result<Self> {
+        let exporter = opentelemetry_otlp::MetricExporter::builder()
+            .with_http()
+            .with_protocol(Protocol::HttpBinary)
+            .with_endpoint(settings.endpoint.clone())
+            .with_timeout(Duration::from_secs(10))
+            .with_headers(settings.headers.clone())
+            .build()
+            .context("build OTLP metrics exporter")?;
+        let reader = PeriodicReader::builder(exporter)
+            .with_interval(settings.export_interval)
+            .build();
+        let provider = SdkMeterProvider::builder()
+            .with_resource(
+                Resource::builder()
+                    .with_service_name(settings.service_name.clone())
+                    .with_attribute(KeyValue::new("service.version", crate::VERSION))
+                    .build(),
+            )
+            .with_reader(reader)
+            .build();
+        Ok(Self::new(provider))
+    }
+
+    fn new(provider: SdkMeterProvider) -> Self {
+        let meter = provider.meter("mesh-llm.survey");
+        Self {
+            _provider: provider,
+            launch_total: meter
+                .u64_counter("mesh_llm_model_launch_total")
+                .with_description("Total local model launch attempts.")
+                .build(),
+            launch_success_total: meter
+                .u64_counter("mesh_llm_model_launch_success_total")
+                .with_description("Successful local model launches.")
+                .build(),
+            launch_failure_total: meter
+                .u64_counter("mesh_llm_model_launch_failure_total")
+                .with_description("Failed local model launches.")
+                .build(),
+            unload_total: meter
+                .u64_counter("mesh_llm_model_unload_total")
+                .with_description("Intentional local model unloads.")
+                .build(),
+            unexpected_exit_total: meter
+                .u64_counter("mesh_llm_model_exit_unexpected_total")
+                .with_description("Unexpected local model exits.")
+                .build(),
+            loaded_models: meter
+                .u64_gauge("mesh_llm_loaded_models")
+                .with_description("Current number of locally loaded models.")
+                .build(),
+            model_loaded: meter
+                .u64_gauge("mesh_llm_model_loaded")
+                .with_description("Whether a local model is currently loaded.")
+                .build(),
+            model_context_length: meter
+                .u64_gauge("mesh_llm_model_context_length")
+                .with_description("Effective context length for a loaded local model.")
+                .with_unit("{token}")
+                .build(),
+            launch_duration_ms: meter
+                .f64_histogram("mesh_llm_model_launch_duration_ms")
+                .with_description("Local model launch duration.")
+                .with_unit("ms")
+                .build(),
+            uptime_s: meter
+                .f64_histogram("mesh_llm_model_uptime_s")
+                .with_description("Local model uptime before unload or unexpected exit.")
+                .with_unit("s")
+                .build(),
+            loaded_count: 0,
+        }
+    }
+
+    fn record(&mut self, event: SurveyEvent) {
+        match event {
+            SurveyEvent::LaunchSuccess { attrs, duration_ms } => {
+                let kv = attrs.key_values(None);
+                self.launch_total.add(1, &kv);
+                self.launch_success_total.add(1, &kv);
+                self.launch_duration_ms.record(duration_ms, &kv);
+                self.loaded_count = self.loaded_count.saturating_add(1);
+                self.loaded_models
+                    .record(self.loaded_count, &service_version_attrs());
+                self.model_loaded.record(1, &kv);
+                if let Some(context_length) = attrs.context_length {
+                    self.model_context_length.record(context_length, &kv);
+                }
+            }
+            SurveyEvent::LaunchFailure {
+                attrs,
+                duration_ms,
+                reason,
+            } => {
+                let kv = attrs.key_values(Some(reason));
+                self.launch_total.add(1, &kv);
+                self.launch_failure_total.add(1, &kv);
+                self.launch_duration_ms.record(duration_ms, &kv);
+            }
+            SurveyEvent::Unload { attrs, uptime_s } => {
+                let kv = attrs.key_values(None);
+                self.unload_total.add(1, &kv);
+                self.uptime_s.record(uptime_s, &kv);
+                self.loaded_count = self.loaded_count.saturating_sub(1);
+                self.loaded_models
+                    .record(self.loaded_count, &service_version_attrs());
+                self.model_loaded.record(0, &kv);
+            }
+            SurveyEvent::UnexpectedExit { attrs, uptime_s } => {
+                let kv = attrs.key_values(None);
+                self.unexpected_exit_total.add(1, &kv);
+                self.uptime_s.record(uptime_s, &kv);
+                self.loaded_count = self.loaded_count.saturating_sub(1);
+                self.loaded_models
+                    .record(self.loaded_count, &service_version_attrs());
+                self.model_loaded.record(0, &kv);
+            }
+        }
+    }
+}
+
+fn service_version_attrs() -> Vec<KeyValue> {
+    vec![KeyValue::new("mesh_llm.service_version", crate::VERSION)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::plugin::{MeshConfig, PluginConfigEntry, TelemetryConfig, TelemetryMetricsConfig};
+    use std::collections::{BTreeMap, HashMap};
+
+    fn survey_config() -> MeshConfig {
+        MeshConfig {
+            telemetry: TelemetryConfig {
+                enabled: Some(true),
+                service_name: Some("mesh-llm-test".into()),
+                endpoint: Some("https://config.example.com".into()),
+                export_interval_secs: Some(5),
+                queue_size: Some(2),
+                ..Default::default()
+            },
+            plugins: vec![PluginConfigEntry {
+                name: plugin::SURVEY_PLUGIN_ID.into(),
+                enabled: Some(true),
+                command: None,
+                args: Vec::new(),
+                url: None,
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn settings_require_survey_plugin_opt_in() {
+        let mut config = survey_config();
+        config.plugins.clear();
+        assert!(SurveySettings::from_config_with_env(&config, |_| {
+            Some("https://env.example.com".into())
+        })
+        .is_none());
+    }
+
+    #[test]
+    fn metrics_endpoint_prefers_config_metrics_endpoint_over_base_and_env() {
+        let mut config = survey_config();
+        config.telemetry.endpoint = Some("https://base.example.com".into());
+        config.telemetry.metrics = TelemetryMetricsConfig {
+            endpoint: Some("https://metrics.example.com/custom".into()),
+        };
+
+        let settings = SurveySettings::from_config_with_env(&config, |key| match key {
+            OTLP_METRICS_ENDPOINT_ENV => Some("https://env-metrics.example.com/v1/metrics".into()),
+            OTLP_ENDPOINT_ENV => Some("https://env-base.example.com".into()),
+            _ => None,
+        })
+        .expect("settings");
+
+        assert_eq!(settings.endpoint, "https://metrics.example.com/custom");
+        assert_eq!(settings.queue_size, 2);
+        assert_eq!(settings.export_interval, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn metrics_endpoint_normalizes_base_endpoint_from_env() {
+        let mut config = survey_config();
+        config.telemetry.endpoint = None;
+        config.telemetry.metrics.endpoint = None;
+
+        let settings = SurveySettings::from_config_with_env(&config, |key| match key {
+            OTLP_ENDPOINT_ENV => Some("https://collector.example.com/".into()),
+            _ => None,
+        })
+        .expect("settings");
+
+        assert_eq!(
+            settings.endpoint,
+            "https://collector.example.com/v1/metrics"
+        );
+    }
+
+    #[test]
+    fn event_queue_drops_oldest_when_full() {
+        let queue = SurveyEventQueue::new(2);
+        for model in ["first", "second", "third"] {
+            let attrs = SurveyAttributes {
+                model: model.into(),
+                architecture: None,
+                quantization: None,
+                launch_kind: SurveyLaunchKind::Startup,
+                gpu_name: None,
+                gpu_stable_id: None,
+                backend_device: None,
+                gpu_count: 0,
+                is_soc: false,
+                backend: None,
+                context_length: None,
+            };
+            queue.push(SurveyEvent::LaunchSuccess {
+                attrs,
+                duration_ms: 1.0,
+            });
+        }
+
+        let drained = queue.drain();
+        let models: Vec<_> = drained
+            .iter()
+            .filter_map(|event| match event {
+                SurveyEvent::LaunchSuccess { attrs, .. } => Some(attrs.model.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(models, vec!["second", "third"]);
+    }
+
+    #[test]
+    fn attributes_hash_gpu_stable_id_and_bucket_context() {
+        let hardware = hardware::HardwareSurvey {
+            gpu_count: 1,
+            is_soc: true,
+            gpus: vec![hardware::GpuFacts {
+                index: 0,
+                display_name: "NVIDIA Test".into(),
+                backend_device: Some("CUDA0".into()),
+                stable_id: Some("uuid:SECRET-GPU".into()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let attrs = SurveyAttributes::from_spec(
+            SurveyModelSpec {
+                model: "/private/models/Qwen3-8B-Q4_K_M.gguf",
+                model_path: None,
+                launch_kind: SurveyLaunchKind::RuntimeLoad,
+                pinned_gpu: None,
+                backend: Some("skippy"),
+                context_length: Some(32_768),
+            },
+            &hardware,
+        );
+        let kv: HashMap<_, _> = attrs
+            .key_values(None)
+            .into_iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect();
+
+        assert_eq!(
+            kv.get("mesh_llm.model").map(String::as_str),
+            Some("Qwen3-8B-Q4_K_M.gguf")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.context_bucket").map(String::as_str),
+            Some("16k_32k")
+        );
+        let stable_id = kv.get("mesh_llm.gpu_stable_id").expect("stable id");
+        assert!(stable_id.starts_with("sha256:"));
+        assert!(!stable_id.contains("SECRET-GPU"));
+        assert_eq!(
+            kv.get("mesh_llm.backend").map(String::as_str),
+            Some("skippy")
+        );
+        assert_eq!(kv.get("mesh_llm.is_soc").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn model_metric_keeps_huggingface_refs_but_strips_absolute_paths() {
+        assert_eq!(
+            model_metric_value("Qwen/Qwen3-8B-GGUF:Q4_K_M"),
+            "Qwen/Qwen3-8B-GGUF:Q4_K_M"
+        );
+        assert_eq!(
+            model_metric_value("/private/models/Qwen3-8B-Q4_K_M.gguf"),
+            "Qwen3-8B-Q4_K_M.gguf"
+        );
+        assert_eq!(
+            model_metric_value("models/Qwen3-8B-Q4_K_M.gguf"),
+            "Qwen3-8B-Q4_K_M.gguf"
+        );
+    }
+
+    #[test]
+    fn telemetry_headers_are_copied_from_config() {
+        let mut config = survey_config();
+        config.telemetry.headers = BTreeMap::from([("authorization".into(), "Bearer abc".into())]);
+
+        let settings = SurveySettings::from_config_with_env(&config, |_| None).expect("settings");
+
+        assert_eq!(
+            settings.headers.get("authorization").map(String::as_str),
+            Some("Bearer abc")
+        );
+    }
+}

--- a/crates/mesh-llm/src/runtime/survey.rs
+++ b/crates/mesh-llm/src/runtime/survey.rs
@@ -1,3 +1,6 @@
+use crate::network::metrics::{
+    AttemptOutcome, AttemptTarget, RequestOutcome, RequestService, RoutingTelemetrySink,
+};
 use crate::plugin;
 use crate::system::hardware;
 use anyhow::{Context, Result};
@@ -27,6 +30,26 @@ pub(super) struct SurveyTelemetry {
 struct SurveyTelemetryInner {
     queue: Arc<SurveyEventQueue>,
     hardware: hardware::HardwareSurvey,
+    source: SurveyTelemetrySource,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct SurveyTelemetrySource {
+    pub(super) node_id: String,
+    pub(super) node_role: String,
+}
+
+impl SurveyTelemetrySource {
+    fn key_values(&self) -> Vec<KeyValue> {
+        let mut attrs = vec![
+            KeyValue::new("mesh_llm.source_node_role", self.node_role.clone()),
+            KeyValue::new("mesh_llm.service_version", crate::VERSION),
+        ];
+        if let Some(node_id) = redact_stable_id(&self.node_id) {
+            attrs.push(KeyValue::new("mesh_llm.source_node_id", node_id));
+        }
+        attrs
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -127,7 +150,11 @@ impl SurveyTelemetry {
         Self { inner: None }
     }
 
-    pub(super) fn start(config: &plugin::MeshConfig, hardware: hardware::HardwareSurvey) -> Self {
+    pub(super) fn start(
+        config: &plugin::MeshConfig,
+        hardware: hardware::HardwareSurvey,
+        source: SurveyTelemetrySource,
+    ) -> Self {
         let Some(settings) = SurveySettings::from_config(config) else {
             return Self::disabled();
         };
@@ -141,8 +168,17 @@ impl SurveyTelemetry {
         };
         spawn_survey_worker(queue.clone(), recorder);
         Self {
-            inner: Some(Arc::new(SurveyTelemetryInner { queue, hardware })),
+            inner: Some(Arc::new(SurveyTelemetryInner {
+                queue,
+                hardware,
+                source,
+            })),
         }
+    }
+
+    pub(super) fn routing_sink(&self) -> Option<Arc<dyn RoutingTelemetrySink>> {
+        self.inner.as_ref()?;
+        Some(Arc::new(self.clone()))
     }
 
     pub(super) fn model(&self, spec: SurveyModelSpec<'_>) -> SurveyLoadedModel {
@@ -198,6 +234,46 @@ impl SurveyTelemetry {
         if let Some(inner) = self.inner.as_ref() {
             inner.queue.push(event);
         }
+    }
+}
+
+impl RoutingTelemetrySink for SurveyTelemetry {
+    fn observe_inflight_requests(&self, current: u64) {
+        let Some(inner) = self.inner.as_ref() else {
+            return;
+        };
+        self.emit(SurveyEvent::InflightRequests {
+            source: inner.source.clone(),
+            current,
+        });
+    }
+
+    fn record_model_request(&self, model: Option<&str>, attempts: usize, outcome: RequestOutcome) {
+        let Some(inner) = self.inner.as_ref() else {
+            return;
+        };
+        self.emit(SurveyEvent::ModelRequest {
+            attrs: RequestAttributes::from_request(model, attempts, outcome, inner.source.clone()),
+        });
+    }
+
+    fn record_route_attempt(
+        &self,
+        model: Option<&str>,
+        target: &AttemptTarget,
+        outcome: AttemptOutcome,
+    ) {
+        let Some(inner) = self.inner.as_ref() else {
+            return;
+        };
+        self.emit(SurveyEvent::RouteAttempt {
+            attrs: RouteAttemptAttributes::from_attempt(
+                model,
+                target,
+                outcome,
+                inner.source.clone(),
+            ),
+        });
     }
 }
 
@@ -454,6 +530,119 @@ impl SurveyFailureReason {
 }
 
 #[derive(Clone, Debug)]
+struct RequestAttributes {
+    model: Option<String>,
+    source: SurveyTelemetrySource,
+    route_service: &'static str,
+    request_outcome: &'static str,
+    attempts: u64,
+}
+
+impl RequestAttributes {
+    fn from_request(
+        model: Option<&str>,
+        attempts: usize,
+        outcome: RequestOutcome,
+        source: SurveyTelemetrySource,
+    ) -> Self {
+        let (request_outcome, route_service) = match outcome {
+            RequestOutcome::Success(service) => ("success", request_service_label(service)),
+            RequestOutcome::Rejected(service) => ("rejected", request_service_label(service)),
+            RequestOutcome::Unavailable => ("unavailable", "unavailable"),
+        };
+        Self {
+            model: model.map(model_metric_value),
+            source,
+            route_service,
+            request_outcome,
+            attempts: attempts as u64,
+        }
+    }
+
+    fn key_values(&self) -> Vec<KeyValue> {
+        let mut attrs = self.source.key_values();
+        if let Some(model) = &self.model {
+            attrs.push(KeyValue::new("mesh_llm.model", model.clone()));
+        }
+        attrs.push(KeyValue::new("mesh_llm.route_service", self.route_service));
+        attrs.push(KeyValue::new(
+            "mesh_llm.request_outcome",
+            self.request_outcome,
+        ));
+        attrs.push(KeyValue::new(
+            "mesh_llm.route_attempt_count",
+            i64::try_from(self.attempts).unwrap_or(i64::MAX),
+        ));
+        attrs
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RouteAttemptAttributes {
+    model: Option<String>,
+    source: SurveyTelemetrySource,
+    target_kind: &'static str,
+    target_node_id: Option<String>,
+    attempt_outcome: &'static str,
+}
+
+impl RouteAttemptAttributes {
+    fn from_attempt(
+        model: Option<&str>,
+        target: &AttemptTarget,
+        outcome: AttemptOutcome,
+        source: SurveyTelemetrySource,
+    ) -> Self {
+        let (target_kind, target_node_id) = match target {
+            AttemptTarget::Local(_) => ("local", redact_stable_id(&source.node_id)),
+            AttemptTarget::Remote(node_id) => ("remote", redact_stable_id(node_id)),
+            AttemptTarget::Endpoint(_) => ("endpoint", None),
+        };
+        Self {
+            model: model.map(model_metric_value),
+            source,
+            target_kind,
+            target_node_id,
+            attempt_outcome: attempt_outcome_label(outcome),
+        }
+    }
+
+    fn key_values(&self) -> Vec<KeyValue> {
+        let mut attrs = self.source.key_values();
+        if let Some(model) = &self.model {
+            attrs.push(KeyValue::new("mesh_llm.model", model.clone()));
+        }
+        attrs.push(KeyValue::new("mesh_llm.target_kind", self.target_kind));
+        if let Some(node_id) = &self.target_node_id {
+            attrs.push(KeyValue::new("mesh_llm.target_node_id", node_id.clone()));
+        }
+        attrs.push(KeyValue::new(
+            "mesh_llm.attempt_outcome",
+            self.attempt_outcome,
+        ));
+        attrs
+    }
+}
+
+fn request_service_label(service: RequestService) -> &'static str {
+    match service {
+        RequestService::Local => "local",
+        RequestService::Remote => "remote",
+        RequestService::Endpoint => "endpoint",
+    }
+}
+
+fn attempt_outcome_label(outcome: AttemptOutcome) -> &'static str {
+    match outcome {
+        AttemptOutcome::Success => "success",
+        AttemptOutcome::Timeout => "timeout",
+        AttemptOutcome::Unavailable => "unavailable",
+        AttemptOutcome::ContextOverflow => "context_overflow",
+        AttemptOutcome::Rejected => "rejected",
+    }
+}
+
+#[derive(Clone, Debug)]
 enum SurveyEvent {
     LaunchSuccess {
         attrs: SurveyAttributes,
@@ -471,6 +660,16 @@ enum SurveyEvent {
     UnexpectedExit {
         attrs: SurveyAttributes,
         uptime_s: f64,
+    },
+    ModelRequest {
+        attrs: RequestAttributes,
+    },
+    RouteAttempt {
+        attrs: RouteAttemptAttributes,
+    },
+    InflightRequests {
+        source: SurveyTelemetrySource,
+        current: u64,
     },
 }
 
@@ -526,6 +725,9 @@ struct SurveyRecorder {
     loaded_models: Gauge<u64>,
     model_loaded: Gauge<u64>,
     model_context_length: Gauge<u64>,
+    model_request_total: Counter<u64>,
+    route_attempt_total: Counter<u64>,
+    requests_inflight: Gauge<u64>,
     launch_duration_ms: Histogram<f64>,
     uptime_s: Histogram<f64>,
     loaded_count: u64,
@@ -593,6 +795,20 @@ impl SurveyRecorder {
                 .with_description("Effective context length for a loaded local model.")
                 .with_unit("{token}")
                 .build(),
+            model_request_total: meter
+                .u64_counter("mesh_llm_model_request_total")
+                .with_description("Requests fronted by this node for a model.")
+                .build(),
+            route_attempt_total: meter
+                .u64_counter("mesh_llm_route_attempt_total")
+                .with_description(
+                    "Routing attempts from this node to local, remote, or endpoint targets.",
+                )
+                .build(),
+            requests_inflight: meter
+                .u64_gauge("mesh_llm_requests_inflight")
+                .with_description("Current in-flight requests fronted by this node.")
+                .build(),
             launch_duration_ms: meter
                 .f64_histogram("mesh_llm_model_launch_duration_ms")
                 .with_description("Local model launch duration.")
@@ -650,6 +866,17 @@ impl SurveyRecorder {
                     .record(self.loaded_count, &service_version_attrs());
                 self.model_loaded.record(0, &kv);
             }
+            SurveyEvent::ModelRequest { attrs } => {
+                let kv = attrs.key_values();
+                self.model_request_total.add(1, &kv);
+            }
+            SurveyEvent::RouteAttempt { attrs } => {
+                let kv = attrs.key_values();
+                self.route_attempt_total.add(1, &kv);
+            }
+            SurveyEvent::InflightRequests { source, current } => {
+                self.requests_inflight.record(current, &source.key_values());
+            }
         }
     }
 }
@@ -663,6 +890,13 @@ mod tests {
     use super::*;
     use crate::plugin::{MeshConfig, PluginConfigEntry, TelemetryConfig, TelemetryMetricsConfig};
     use std::collections::{BTreeMap, HashMap};
+
+    fn test_source() -> SurveyTelemetrySource {
+        SurveyTelemetrySource {
+            node_id: "source-node-raw".into(),
+            node_role: "client".into(),
+        }
+    }
 
     fn survey_config() -> MeshConfig {
         MeshConfig {
@@ -686,13 +920,33 @@ mod tests {
     }
 
     #[test]
-    fn settings_require_survey_plugin_opt_in() {
+    fn settings_default_to_enabled_with_endpoint() {
         let mut config = survey_config();
         config.plugins.clear();
+        assert!(SurveySettings::from_config_with_env(&config, |_| None).is_some());
+    }
+
+    #[test]
+    fn settings_disable_when_plugin_opted_out() {
+        let mut config = survey_config();
+        config.plugins = vec![PluginConfigEntry {
+            name: plugin::TELEMETRY_PLUGIN_ID.into(),
+            enabled: Some(false),
+            command: None,
+            args: Vec::new(),
+            url: None,
+        }];
         assert!(SurveySettings::from_config_with_env(&config, |_| {
             Some("https://env.example.com".into())
         })
         .is_none());
+    }
+
+    #[test]
+    fn settings_disable_when_telemetry_config_opted_out() {
+        let mut config = survey_config();
+        config.telemetry.enabled = Some(false);
+        assert!(SurveySettings::from_config_with_env(&config, |_| None).is_none());
     }
 
     #[test]
@@ -814,6 +1068,98 @@ mod tests {
             Some("skippy")
         );
         assert_eq!(kv.get("mesh_llm.is_soc").map(String::as_str), Some("true"));
+    }
+
+    #[test]
+    fn request_attributes_capture_model_service_and_attempt_count() {
+        let attrs = RequestAttributes::from_request(
+            Some("/private/models/Qwen3-8B-Q4_K_M.gguf"),
+            2,
+            RequestOutcome::Success(RequestService::Remote),
+            test_source(),
+        );
+        let kv: HashMap<_, _> = attrs
+            .key_values()
+            .into_iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect();
+
+        assert_eq!(
+            kv.get("mesh_llm.model").map(String::as_str),
+            Some("Qwen3-8B-Q4_K_M.gguf")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.route_service").map(String::as_str),
+            Some("remote")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.request_outcome").map(String::as_str),
+            Some("success")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.route_attempt_count").map(String::as_str),
+            Some("2")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.source_node_role").map(String::as_str),
+            Some("client")
+        );
+    }
+
+    #[test]
+    fn route_attempt_attributes_hash_source_and_remote_node_ids() {
+        let attrs = RouteAttemptAttributes::from_attempt(
+            Some("Qwen/Qwen3-8B-GGUF:Q4_K_M"),
+            &AttemptTarget::Remote("remote-node-raw".into()),
+            AttemptOutcome::Timeout,
+            test_source(),
+        );
+        let kv: HashMap<_, _> = attrs
+            .key_values()
+            .into_iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect();
+
+        assert_eq!(
+            kv.get("mesh_llm.model").map(String::as_str),
+            Some("Qwen/Qwen3-8B-GGUF:Q4_K_M")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.target_kind").map(String::as_str),
+            Some("remote")
+        );
+        assert_eq!(
+            kv.get("mesh_llm.attempt_outcome").map(String::as_str),
+            Some("timeout")
+        );
+        let source_node_id = kv.get("mesh_llm.source_node_id").expect("source node id");
+        assert!(source_node_id.starts_with("sha256:"));
+        assert!(!source_node_id.contains("source-node-raw"));
+        let target_node_id = kv.get("mesh_llm.target_node_id").expect("target node id");
+        assert!(target_node_id.starts_with("sha256:"));
+        assert!(!target_node_id.contains("remote-node-raw"));
+    }
+
+    #[test]
+    fn route_attempt_attributes_do_not_export_endpoint_urls() {
+        let attrs = RouteAttemptAttributes::from_attempt(
+            None,
+            &AttemptTarget::Endpoint("https://private-endpoint.example.com/v1".into()),
+            AttemptOutcome::Rejected,
+            test_source(),
+        );
+        let kv: HashMap<_, _> = attrs
+            .key_values()
+            .into_iter()
+            .map(|kv| (kv.key.to_string(), kv.value.to_string()))
+            .collect();
+
+        assert_eq!(
+            kv.get("mesh_llm.target_kind").map(String::as_str),
+            Some("endpoint")
+        );
+        assert!(!kv.contains_key("mesh_llm.target_node_id"));
+        assert!(!kv.values().any(|value| value.contains("private-endpoint")));
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime/survey.rs
+++ b/crates/mesh-llm/src/runtime/survey.rs
@@ -84,7 +84,7 @@ impl SurveySettings {
     where
         F: Fn(&str) -> Option<String>,
     {
-        if !plugin::survey_plugin_enabled(config) {
+        if !plugin::telemetry_plugin_enabled(config) {
             return None;
         }
         if config.telemetry.enabled == Some(false) {
@@ -135,7 +135,7 @@ impl SurveyTelemetry {
         let recorder = match SurveyRecorder::otlp(&settings) {
             Ok(recorder) => recorder,
             Err(err) => {
-                tracing::warn!("disabling survey OTLP metrics exporter: {err:#}");
+                tracing::warn!("disabling telemetry OTLP metrics exporter: {err:#}");
                 return Self::disabled();
             }
         };
@@ -494,7 +494,7 @@ impl SurveyEventQueue {
         let mut events = self
             .events
             .lock()
-            .expect("survey event queue lock poisoned");
+            .expect("telemetry event queue lock poisoned");
         if events.len() == self.capacity {
             events.pop_front();
         }
@@ -507,7 +507,7 @@ impl SurveyEventQueue {
         let mut events = self
             .events
             .lock()
-            .expect("survey event queue lock poisoned");
+            .expect("telemetry event queue lock poisoned");
         events.drain(..).collect()
     }
 
@@ -557,7 +557,7 @@ impl SurveyRecorder {
     }
 
     fn new(provider: SdkMeterProvider) -> Self {
-        let meter = provider.meter("mesh-llm.survey");
+        let meter = provider.meter("mesh-llm.telemetry");
         Self {
             _provider: provider,
             launch_total: meter
@@ -675,7 +675,7 @@ mod tests {
                 ..Default::default()
             },
             plugins: vec![PluginConfigEntry {
-                name: plugin::SURVEY_PLUGIN_ID.into(),
+                name: plugin::TELEMETRY_PLUGIN_ID.into(),
                 enabled: Some(true),
                 command: None,
                 args: Vec::new(),

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -6,6 +6,10 @@ It describes the target architecture, not just the code as it exists today.
 
 As implementation lands, this document should be updated to match the intended end state and the concrete protocol and runtime decisions that have been made.
 
+Plugin-specific documentation:
+
+- [Telemetry](telemetry.md) - opt-in OTLP metrics-only local runtime telemetry
+
 The main goals are:
 
 - keep `mesh-llm` decoupled from specific plugins

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -8,7 +8,7 @@ As implementation lands, this document should be updated to match the intended e
 
 Plugin-specific documentation:
 
-- [Telemetry](telemetry.md) - opt-in OTLP metrics-only local runtime telemetry
+- [Telemetry](telemetry.md) - built-in OTLP metrics-only runtime and routing telemetry
 
 The main goals are:
 

--- a/docs/plugins/telemetry.md
+++ b/docs/plugins/telemetry.md
@@ -1,13 +1,12 @@
 # Telemetry Plugin
 
 The built-in `telemetry` plugin enables metrics-only OTLP/HTTP export for local
-model lifecycle telemetry. It is opt-in and records from the runtime load,
-unload, and exit paths instead of polling local APIs.
+model lifecycle and routing telemetry. The plugin is enabled by default, while
+export still requires a configured OTLP metrics endpoint.
 
 ## Configuration
 
-Enable the plugin with `[[plugin]] name = "telemetry"` and configure an OTLP
-metrics endpoint:
+Configure an OTLP metrics endpoint:
 
 ```toml
 [telemetry]
@@ -26,6 +25,15 @@ name = "telemetry"
 enabled = true
 ```
 
+The `[[plugin]]` entry is optional when telemetry should stay enabled. To opt
+out of the built-in plugin entirely, set:
+
+```toml
+[[plugin]]
+name = "telemetry"
+enabled = false
+```
+
 Endpoint precedence is:
 
 1. `telemetry.metrics.endpoint`
@@ -37,6 +45,10 @@ If no endpoint is configured, telemetry export stays disabled.
 
 ## Exported Metrics
 
+Request and route metrics are emitted per fronting node. A collector or
+dashboard can aggregate `mesh_llm_requests_inflight` across nodes for a
+mesh-wide in-flight request view.
+
 Counters:
 
 - `mesh_llm_model_launch_total`
@@ -44,12 +56,15 @@ Counters:
 - `mesh_llm_model_launch_failure_total`
 - `mesh_llm_model_unload_total`
 - `mesh_llm_model_exit_unexpected_total`
+- `mesh_llm_model_request_total`
+- `mesh_llm_route_attempt_total`
 
 Gauges:
 
 - `mesh_llm_loaded_models`
 - `mesh_llm_model_loaded`
 - `mesh_llm_model_context_length`
+- `mesh_llm_requests_inflight`
 
 Histograms:
 
@@ -58,12 +73,15 @@ Histograms:
 
 ## Privacy Boundary
 
-The telemetry plugin exports lifecycle metrics only. It does not export prompts,
-completions, logs, traces, hostnames, mesh gossip, relay messages, raw GPU stable
-IDs, or prompt hashes.
+The telemetry plugin exports metrics only. It does not export prompts,
+completions, logs, traces, hostnames, mesh gossip, relay messages, raw node IDs,
+raw GPU stable IDs, endpoint URLs, or prompt hashes.
 
 Local absolute and path-like model labels are reduced to filenames before export.
-Hugging Face refs are preserved. GPU stable IDs are hashed before export.
+Hugging Face refs are preserved. GPU stable IDs and node IDs are hashed before
+export. Route-attempt metrics label local, remote, and endpoint target kinds;
+remote target IDs are exported only as stable hashes so collectors can aggregate
+node-to-node traffic without exposing raw peer IDs.
 
 ## Runtime Safety
 

--- a/docs/plugins/telemetry.md
+++ b/docs/plugins/telemetry.md
@@ -1,0 +1,72 @@
+# Telemetry Plugin
+
+The built-in `telemetry` plugin enables metrics-only OTLP/HTTP export for local
+model lifecycle telemetry. It is opt-in and records from the runtime load,
+unload, and exit paths instead of polling local APIs.
+
+## Configuration
+
+Enable the plugin with `[[plugin]] name = "telemetry"` and configure an OTLP
+metrics endpoint:
+
+```toml
+[telemetry]
+enabled = true
+service_name = "mesh-llm"
+endpoint = "https://otel.example.com"
+headers = { "authorization" = "Bearer TOKEN" }
+export_interval_secs = 15
+queue_size = 2048
+
+[telemetry.metrics]
+endpoint = "https://otel.example.com/v1/metrics"
+
+[[plugin]]
+name = "telemetry"
+enabled = true
+```
+
+Endpoint precedence is:
+
+1. `telemetry.metrics.endpoint`
+2. `telemetry.endpoint` normalized to `/v1/metrics`
+3. `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
+4. `OTEL_EXPORTER_OTLP_ENDPOINT` normalized to `/v1/metrics`
+
+If no endpoint is configured, telemetry export stays disabled.
+
+## Exported Metrics
+
+Counters:
+
+- `mesh_llm_model_launch_total`
+- `mesh_llm_model_launch_success_total`
+- `mesh_llm_model_launch_failure_total`
+- `mesh_llm_model_unload_total`
+- `mesh_llm_model_exit_unexpected_total`
+
+Gauges:
+
+- `mesh_llm_loaded_models`
+- `mesh_llm_model_loaded`
+- `mesh_llm_model_context_length`
+
+Histograms:
+
+- `mesh_llm_model_launch_duration_ms`
+- `mesh_llm_model_uptime_s`
+
+## Privacy Boundary
+
+The telemetry plugin exports lifecycle metrics only. It does not export prompts,
+completions, logs, traces, hostnames, mesh gossip, relay messages, raw GPU stable
+IDs, or prompt hashes.
+
+Local absolute and path-like model labels are reduced to filenames before export.
+Hugging Face refs are preserved. GPU stable IDs are hashed before export.
+
+## Runtime Safety
+
+Telemetry exporter setup failures disable telemetry without failing inference
+startup. Runtime events are buffered through a bounded queue; when the queue is
+full, the oldest event is dropped instead of blocking inference.

--- a/docs/plugins/telemetry.md
+++ b/docs/plugins/telemetry.md
@@ -2,7 +2,8 @@
 
 The built-in `telemetry` plugin enables metrics-only OTLP/HTTP export for local
 model lifecycle and routing telemetry. The plugin is enabled by default, while
-export still requires a configured OTLP metrics endpoint.
+export still requires a configured OTLP metrics endpoint. No collector or
+project-owned destination is hard-coded.
 
 ## Configuration
 
@@ -38,10 +39,13 @@ Endpoint precedence is:
 
 1. `telemetry.metrics.endpoint`
 2. `telemetry.endpoint` normalized to `/v1/metrics`
-3. `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`
-4. `OTEL_EXPORTER_OTLP_ENDPOINT` normalized to `/v1/metrics`
+3. `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, only when `telemetry.enabled = true`
+4. `OTEL_EXPORTER_OTLP_ENDPOINT` normalized to `/v1/metrics`, only when
+   `telemetry.enabled = true`
 
-If no endpoint is configured, telemetry export stays disabled.
+If no endpoint is configured, telemetry export stays disabled. Ambient OTel
+environment variables are not consumed unless telemetry is explicitly enabled in
+mesh-llm config.
 
 ## Exported Metrics
 
@@ -78,10 +82,53 @@ completions, logs, traces, hostnames, mesh gossip, relay messages, raw node IDs,
 raw GPU stable IDs, endpoint URLs, or prompt hashes.
 
 Local absolute and path-like model labels are reduced to filenames before export.
-Hugging Face refs are preserved. GPU stable IDs and node IDs are hashed before
-export. Route-attempt metrics label local, remote, and endpoint target kinds;
-remote target IDs are exported only as stable hashes so collectors can aggregate
-node-to-node traffic without exposing raw peer IDs.
+Hugging Face refs are preserved. GPU stable IDs and node IDs are exported as
+stable pseudonymous hashes, not raw identifiers. Route-attempt metrics label
+local, remote, and endpoint target kinds; remote target IDs are exported only as
+stable hashes so collectors can aggregate node-to-node traffic without exposing
+raw peer IDs.
+
+Telemetry attributes are intentionally allowlisted in code. Any new exported
+attribute must update the allowlist, tests, and this document before it is added
+to an OTLP record.
+
+| Attribute | Used by | Privacy handling |
+|---|---|---|
+| `mesh_llm.model` | lifecycle, request, route | Local/path-like labels are reduced to filenames; Hugging Face refs are preserved. |
+| `mesh_llm.launch_kind` | lifecycle | Bounded enum. |
+| `mesh_llm.gpu_count` | lifecycle | Count only. |
+| `mesh_llm.is_soc` | lifecycle | Boolean only. |
+| `mesh_llm.service_version` | lifecycle, request, route, in-flight | Build version only. |
+| `mesh_llm.architecture` | lifecycle | GGUF architecture string when available. |
+| `mesh_llm.quantization` | lifecycle | Derived quantization label. |
+| `mesh_llm.gpu_name` | lifecycle | Hardware product label; no hostname or stable device ID. |
+| `mesh_llm.gpu_stable_id` | lifecycle | Stable pseudonymous hash of the GPU ID. |
+| `mesh_llm.backend_device` | lifecycle | Backend-local slot label such as `CUDA0`, `ROCm0`, `Vulkan0`, or `MTL0`. |
+| `mesh_llm.backend` | lifecycle | Runtime/backend label. |
+| `mesh_llm.context_bucket` | lifecycle | Bucketed context length, not the exact configured value. |
+| `mesh_llm.failure_reason` | lifecycle | Bounded enum. |
+| `mesh_llm.source_node_role` | request, route, in-flight | Bounded node role label such as `client` or `worker`. |
+| `mesh_llm.source_node_id` | request, route, in-flight | Stable pseudonymous hash of the source node ID. |
+| `mesh_llm.route_service` | request | Bounded service label: `local`, `remote`, `endpoint`, or `unavailable`. |
+| `mesh_llm.request_outcome` | request | Bounded enum. |
+| `mesh_llm.route_attempt_bucket` | request | Bounded retry bucket: `1`, `2`, `3_4`, or `5_plus`. |
+| `mesh_llm.target_kind` | route | Bounded target kind: `local`, `remote`, or `endpoint`. |
+| `mesh_llm.target_node_id` | route | Stable pseudonymous hash for local/remote node targets; omitted for endpoint targets. |
+| `mesh_llm.attempt_outcome` | route | Bounded enum. |
+
+## Review Checklist
+
+Before adding, renaming, or removing OTLP metrics or attributes:
+
+1. Run the repo-local telemetry privacy review skill:
+   `.agents/skills/telemetry-privacy-review/SKILL.md`.
+2. Keep export destination behavior explicit: no default collector and no ambient
+   OTel env export unless `telemetry.enabled = true`.
+3. Update `TELEMETRY_ATTRIBUTE_ALLOWLIST` in
+   `crates/mesh-llm/src/runtime/survey.rs`.
+4. Update the attribute inventory above.
+5. Add or update focused tests proving private paths, raw node IDs, raw GPU
+   stable IDs, endpoint URLs, prompts, and completions are not exported.
 
 ## Runtime Safety
 


### PR DESCRIPTION
## Summary

Hosts can now opt in to a built-in `survey` plugin that exports local model lifecycle metrics to an OTLP/HTTP collector. The exporter is metrics-only and records from the runtime load/unload paths instead of scraping local APIs.

## Why

Operators need a standard, low-friction way to understand model launch reliability, loaded-model count, context buckets, backend/hardware mix, unloads, and unexpected exits across real nodes. This keeps that visibility in the existing runtime path while avoiding custom telemetry protocols or privacy-sensitive payloads.

## What Changed

- Added standard OpenTelemetry metrics dependencies: `opentelemetry`, `opentelemetry_sdk`, and `opentelemetry-otlp`.
- Added `[telemetry]` and `[telemetry.metrics]` config, with config endpoints taking precedence over `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` and `OTEL_EXPORTER_OTLP_ENDPOINT`.
- Added the opt-in built-in `survey` plugin surface and CLI install guidance.
- Added runtime-owned lifecycle hooks for startup, multi-model, split/fallback, runtime load, unload, and unexpected-exit paths.
- Added bounded async event buffering with oldest-event drop behavior so exporter backpressure does not block inference.
- Preserved local telemetry-only config updates without changing protocol/gossip hash semantics.

## Metrics

Counters:

- `mesh_llm_model_launch_total`
- `mesh_llm_model_launch_success_total`
- `mesh_llm_model_launch_failure_total`
- `mesh_llm_model_unload_total`
- `mesh_llm_model_exit_unexpected_total`

Gauges:

- `mesh_llm_loaded_models`
- `mesh_llm_model_loaded`
- `mesh_llm_model_context_length`

Histograms:

- `mesh_llm_model_launch_duration_ms`
- `mesh_llm_model_uptime_s`

## Privacy and Protocol

- Metrics only: no logs, traces, prompts, completions, prompt hashes, mesh gossip, relay channels, or hostnames.
- Local absolute/path-like model labels are reduced to filenames; Hugging Face refs are preserved.
- GPU stable IDs are SHA-256 redacted before export.
- No new gossip fields or wire-format changes were introduced; mixed-version peers are unaffected.

## Configuration

```toml
[telemetry]
enabled = true
service_name = "mesh-llm"
endpoint = "https://otel.example.com"
headers = { "authorization" = "Bearer TOKEN" }
export_interval_secs = 15
queue_size = 2048

[telemetry.metrics]
endpoint = "https://otel.example.com/v1/metrics"

[[plugin]]
name = "survey"
enabled = true
```

## Branch Integrity

- Base branch: `main`
- Validated base SHA: `20375f4fd6eaba6e5a39e22849584549a677a495`
- Head SHA: `93ddbc97ee99f11d432e941bad12d80812a55817`
- Ahead/behind: `0 1`
- Merge-base SHA: `20375f4fd6eaba6e5a39e22849584549a677a495`
- Fast-forward safety: `origin/main` is an ancestor of `HEAD`; no divergence.
- Remote branch: `IvGolovach/codex/survey-otlp-metrics-plugin` matches local `HEAD`.

## Commit Integrity

- Introduced commit: `93ddbc97ee99f11d432e941bad12d80812a55817 Add survey OTLP metrics plugin`
- One logical change: confirmed.
- Ledger: not applicable — `scripts/ledger/` does not exist in this repository.
- Version: not applicable — no repository-required version bump for this PR branch.

## Diff Scope

- `Cargo.lock`
- `README.md`
- `crates/mesh-llm/Cargo.toml`
- `crates/mesh-llm/README.md`
- `crates/mesh-llm/src/cli/commands/plugin.rs`
- `crates/mesh-llm/src/mesh/tests.rs`
- `crates/mesh-llm/src/plugin/config.rs`
- `crates/mesh-llm/src/plugin/mod.rs`
- `crates/mesh-llm/src/plugins/mod.rs`
- `crates/mesh-llm/src/plugins/survey/mod.rs`
- `crates/mesh-llm/src/protocol/convert.rs`
- `crates/mesh-llm/src/protocol/mod.rs`
- `crates/mesh-llm/src/runtime/config_state.rs`
- `crates/mesh-llm/src/runtime/mod.rs`
- `crates/mesh-llm/src/runtime/survey.rs`

## Validation

- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm runtime::survey::tests --lib`: PASS, 7 passed
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib`: PASS, 1259 passed, 3 ignored
- `git diff --check origin/main...HEAD`: PASS, no output

Not run:

- `just build` — not required for this Rust/runtime plus docs change; no UI files changed.
- Multi-node deploy checklist — no deployment requested and no gossip field or wire-format change was introduced.



## Runtime Safety

- The exporter is opt-in and disabled unless the `survey` plugin is enabled and an OTLP metrics endpoint is configured.
- Exporter setup failures disable survey metrics without failing inference startup.
- Event buffering is bounded and drops the oldest event when full.
- No blocking locks or unbounded queues are added to inference request handling.
- No runtime invariant was removed; lifecycle metrics are emitted from existing model load/unload/exit paths.

## Rollback

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none expected; rollback removes the opt-in survey exporter and restores the previous config/runtime behavior.

## Known Residual Risks

- Local validation does not prove collector-specific auth/header behavior against every OTLP backend. The implementation uses the standard OTel HTTP/protobuf exporter and keeps exporter failures isolated from inference.
