### PR TITLE
fix: wire --discover into serve path, add --name to discover subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,19 @@ mesh-llm serve --auto --model GLM-4.7-Flash-Q4_K_M --mesh-name "poker-night" --p
 ```
 Everyone runs the same command. First person creates it, everyone else discovers "poker-night" and joins automatically. Use `--publish` to make your named mesh discoverable on Nostr; without it the mesh is private but still joinable via invite token.
 
+You can also join a named mesh explicitly:
+```bash
+mesh-llm serve --discover "poker-night"    # discover by name, join, and serve
+mesh-llm client --discover "poker-night"   # discover by name, join as client
+```
+
 ### Auto-discover
 ```bash
 mesh-llm serve --auto                      # discover, join, and serve a model
 mesh-llm client --auto                     # join as API-only client (no GPU)
+mesh-llm serve --discover "my-mesh"        # discover a named mesh and join it
 mesh-llm discover                          # browse available meshes
+mesh-llm discover --name "poker-night"     # search for a specific mesh by name
 mesh-llm gpus                              # inspect local GPUs and stable IDs
 ```
 

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ mesh-llm client --join <token>
 mesh-llm serve --auto --model GLM-4.7-Flash-Q4_K_M --mesh-name "poker-night" --publish
 ```
 
-Everyone runs the same command. The first node creates the mesh, the rest discover and join it automatically. Use `--publish` so your named mesh appears in Nostr discovery; without it you must share the invite token manually.
+Everyone runs the same command. The first node creates the mesh, the rest discover and join it automatically. Others can also join with `mesh-llm serve --discover "poker-night"` or `mesh-llm client --discover "poker-night"`. Use `--publish` so your named mesh appears in Nostr discovery; without it you must share the invite token manually.
 
 ### 5. Serve more than one model
 

--- a/crates/mesh-llm/src/cli/commands/discover.rs
+++ b/crates/mesh-llm/src/cli/commands/discover.rs
@@ -6,6 +6,7 @@ use crate::runtime;
 use crate::system::backend;
 
 pub(crate) async fn run_discover(
+    name: Option<String>,
     model: Option<String>,
     min_vram: Option<f64>,
     region: Option<String>,
@@ -15,6 +16,7 @@ pub(crate) async fn run_discover(
     let relays = runtime::nostr_relays(&relays);
 
     let filter = nostr::MeshFilter {
+        name,
         model,
         min_vram_gb: min_vram,
         region,
@@ -25,7 +27,11 @@ pub(crate) async fn run_discover(
 
     if meshes.is_empty() {
         eprintln!("No meshes found.");
-        if filter.model.is_some() || filter.min_vram_gb.is_some() || filter.region.is_some() {
+        if filter.name.is_some()
+            || filter.model.is_some()
+            || filter.min_vram_gb.is_some()
+            || filter.region.is_some()
+        {
             eprintln!("Try broader filters or check relays.");
         }
         return Ok(());
@@ -86,7 +92,8 @@ pub(crate) async fn run_discover(
     } else {
         eprintln!("To join a mesh:");
         eprintln!("  mesh-llm --join <token>");
-        eprintln!("\nOr use `mesh-llm discover --join` to auto-join the best match.");
+        eprintln!("  mesh-llm --discover <name>       # join by mesh name");
+        eprintln!("  mesh-llm client --discover <name> # join as client by mesh name");
     }
 
     Ok(())

--- a/crates/mesh-llm/src/cli/commands/mod.rs
+++ b/crates/mesh-llm/src/cli/commands/mod.rs
@@ -48,6 +48,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::Status { port } => run_status(*port).await,
         Command::Stop => run_stop(),
         Command::Discover {
+            name,
             model,
             min_vram,
             region,
@@ -55,6 +56,7 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
             relay,
         } => {
             run_discover(
+                name.clone(),
                 model.clone(),
                 *min_vram,
                 region.clone(),

--- a/crates/mesh-llm/src/cli/mod.rs
+++ b/crates/mesh-llm/src/cli/mod.rs
@@ -476,6 +476,9 @@ pub(crate) enum Command {
     },
     /// Discover meshes on Nostr and optionally auto-join one.
     Discover {
+        /// Filter by mesh name (case-insensitive exact match)
+        #[arg(long)]
+        name: Option<String>,
         /// Filter by model name (substring match)
         #[arg(long)]
         model: Option<String>,

--- a/crates/mesh-llm/src/mesh/mod.rs
+++ b/crates/mesh-llm/src/mesh/mod.rs
@@ -2334,6 +2334,28 @@ impl Node {
         self.connect_to_peer(addr).await
     }
 
+    /// Like [`join`], but retries once after a delay on transient (connect/timeout)
+    /// errors.  Decode errors (invalid base64/JSON) fail immediately.
+    pub async fn join_with_retry(&self, invite_token: &str) -> Result<()> {
+        // Decode first — bail immediately on bad tokens.
+        let json = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(invite_token)
+            .context("invalid invite token encoding")?;
+        let addr: EndpointAddr =
+            serde_json::from_slice(&json).context("invalid invite token JSON")?;
+
+        self.state.lock().await.dead_peers.remove(&addr.id);
+        match self.connect_to_peer(addr.clone()).await {
+            Ok(()) => Ok(()),
+            Err(first_err) => {
+                tracing::info!("First join attempt failed ({first_err:#}), retrying in 5s...");
+                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                self.state.lock().await.dead_peers.remove(&addr.id);
+                self.connect_to_peer(addr).await
+            }
+        }
+    }
+
     /// Connect to a peer without gossip exchange — for passive nodes (clients/standby).
     pub fn id(&self) -> EndpointId {
         self.endpoint.id()

--- a/crates/mesh-llm/src/network/nostr.rs
+++ b/crates/mesh-llm/src/network/nostr.rs
@@ -1477,6 +1477,17 @@ mod filter_tests {
         vram: u64,
         region: Option<&str>,
     ) -> DiscoveredMesh {
+        make_mesh_for_filter_named(serving, wanted, on_disk, vram, region, None)
+    }
+
+    fn make_mesh_for_filter_named(
+        serving: &[&str],
+        wanted: &[&str],
+        on_disk: &[&str],
+        vram: u64,
+        region: Option<&str>,
+        name: Option<&str>,
+    ) -> DiscoveredMesh {
         DiscoveredMesh {
             listing: MeshListing {
                 invite_token: "tok".into(),
@@ -1487,7 +1498,7 @@ mod filter_tests {
                 node_count: 1,
                 client_count: 0,
                 max_clients: 0,
-                name: None,
+                name: name.map(|s| s.to_string()),
                 region: region.map(|s| s.to_string()),
                 mesh_id: None,
             },
@@ -1606,6 +1617,58 @@ mod filter_tests {
         };
         assert!(pass.matches(&m));
         assert!(!fail_model.matches(&m));
+    }
+
+    #[test]
+    fn filter_name_exact() {
+        let m = make_mesh_for_filter_named(&[], &[], &[], 8_000_000_000, None, Some("poker-night"));
+        let f = MeshFilter {
+            name: Some("poker-night".into()),
+            ..Default::default()
+        };
+        assert!(f.matches(&m));
+    }
+
+    #[test]
+    fn filter_name_case_insensitive() {
+        let m = make_mesh_for_filter_named(&[], &[], &[], 8_000_000_000, None, Some("Poker-Night"));
+        let f = MeshFilter {
+            name: Some("poker-night".into()),
+            ..Default::default()
+        };
+        assert!(f.matches(&m));
+    }
+
+    #[test]
+    fn filter_name_no_match() {
+        let m = make_mesh_for_filter_named(&[], &[], &[], 8_000_000_000, None, Some("other-mesh"));
+        let f = MeshFilter {
+            name: Some("poker-night".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&m));
+    }
+
+    #[test]
+    fn filter_name_mesh_unnamed() {
+        // Mesh has no name — filter by name should not match.
+        let m = make_mesh_for_filter_named(&[], &[], &[], 8_000_000_000, None, None);
+        let f = MeshFilter {
+            name: Some("poker-night".into()),
+            ..Default::default()
+        };
+        assert!(!f.matches(&m));
+    }
+
+    #[test]
+    fn filter_name_none_matches_all() {
+        // No name filter — matches meshes with and without names.
+        let named =
+            make_mesh_for_filter_named(&[], &[], &[], 8_000_000_000, None, Some("poker-night"));
+        let unnamed = make_mesh_for_filter_named(&[], &[], &[], 8_000_000_000, None, None);
+        let f = MeshFilter::default();
+        assert!(f.matches(&named));
+        assert!(f.matches(&unnamed));
     }
 }
 

--- a/crates/mesh-llm/src/network/nostr.rs
+++ b/crates/mesh-llm/src/network/nostr.rs
@@ -1596,11 +1596,13 @@ mod filter_tests {
             model: Some("qwen3".into()),
             min_vram_gb: Some(10.0),
             region: Some("us-east".into()),
+            ..Default::default()
         };
         let fail_model = MeshFilter {
             model: Some("llama".into()),
             min_vram_gb: Some(10.0),
             region: Some("us-east".into()),
+            ..Default::default()
         };
         assert!(pass.matches(&m));
         assert!(!fail_model.matches(&m));

--- a/crates/mesh-llm/src/network/nostr.rs
+++ b/crates/mesh-llm/src/network/nostr.rs
@@ -658,6 +658,8 @@ pub async fn publish_watchdog(
 /// Criteria for filtering discovered meshes.
 #[derive(Debug, Clone, Default)]
 pub struct MeshFilter {
+    /// Match meshes by name (case-insensitive exact match)
+    pub name: Option<String>,
     /// Match meshes serving (or wanting) this model name (substring match)
     pub model: Option<String>,
     /// Minimum total VRAM in GB
@@ -668,6 +670,12 @@ pub struct MeshFilter {
 
 impl MeshFilter {
     pub fn matches(&self, mesh: &DiscoveredMesh) -> bool {
+        if let Some(ref name) = self.name {
+            match &mesh.listing.name {
+                Some(n) if n.eq_ignore_ascii_case(name) => {}
+                _ => return false,
+            }
+        }
         if let Some(ref model) = self.model {
             let model_lower = model.to_lowercase();
             let has_model = mesh

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -1527,8 +1527,14 @@ pub(crate) async fn run() -> Result<()> {
     // Publication intent is now explicit only: --publish gates Nostr discovery.
     // --mesh-name alone never implies publication (Issue #240).
 
-    // Warn users who used to rely on --mesh-name auto-publishing
-    if let Some(mesh_name) = cli.mesh_name.as_ref().filter(|_| !cli.publish) {
+    // Warn users who set --mesh-name without --publish — but only when they
+    // are creating a new mesh, not when they are joining one via --discover
+    // or --auto (where --mesh-name is just a filter for which mesh to join).
+    if let Some(mesh_name) = cli
+        .mesh_name
+        .as_ref()
+        .filter(|_| !cli.publish && !cli.auto && cli.discover.is_none())
+    {
         let _ = emit_event(OutputEvent::Info {
             message: format!(
                 "Mesh named '{}' — private by default. Add --publish to make it publicly discoverable.",
@@ -1542,7 +1548,7 @@ pub(crate) async fn run() -> Result<()> {
     // If the previous run was public (--auto or --publish) but this run is
     // private, clear the stored identity so the private mesh gets a fresh key
     // that isn't associated with the old public listing.
-    let is_public = cli.auto || cli.publish;
+    let is_public = cli.auto || cli.publish || cli.discover.is_some();
     if is_public {
         mesh::mark_was_public();
     } else if mesh::was_previously_public() {
@@ -1556,18 +1562,26 @@ pub(crate) async fn run() -> Result<()> {
     let mut auto_join_candidates: Vec<(String, Option<String>)> = Vec::new();
 
     // --- Auto-discover ---
-    if cli.auto && cli.join.is_empty() {
+    // --auto: join the community mesh (unnamed / "mesh-llm"), optionally
+    //         scoped to --mesh-name.
+    // --discover [name]: discover a mesh by name on Nostr and join it.
+    //         Without a name, behaves like --auto.
+    let discover_active = cli.auto || cli.discover.is_some();
+    if discover_active && cli.join.is_empty() {
+        // When --discover provides a name, use it as the target mesh name
+        // so smart_auto filters by that name on Nostr.
+        if let Some(ref name) = cli.discover {
+            if !name.is_empty() && cli.mesh_name.is_none() {
+                cli.mesh_name = Some(name.clone());
+            }
+        }
         cli.nostr_discovery = true;
         let _ = emit_event(OutputEvent::DiscoveryStarting {
             source: "Nostr auto-discovery".to_string(),
         });
 
         let relays = nostr_relays(&cli.nostr_relay);
-        let filter = nostr::MeshFilter {
-            model: None,
-            min_vram_gb: None,
-            region: None,
-        };
+        let filter = nostr::MeshFilter::default();
         let meshes = match nostr::discover(&relays, &filter, None).await {
             Ok(meshes) => meshes,
             Err(err) => {
@@ -3127,9 +3141,8 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
     if cli.auto || cli.discover.is_some() {
         let relays = nostr_relays(&cli.nostr_relay);
         let filter = nostr::MeshFilter {
-            model: None,
-            min_vram_gb: None,
             region: cli.region.clone(),
+            ..Default::default()
         };
         let target_name = cli.discover.as_deref().or(cli.mesh_name.as_deref());
         let _ = emit_event(OutputEvent::DiscoveryStarting {

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -3121,7 +3121,15 @@ fn node_display_name(cli: &Cli, node: &mesh::Node) -> String {
 async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
     if !cli.join.is_empty() {
         for token in &cli.join {
-            match node.join(token).await {
+            let result = match node.join(token).await {
+                Ok(()) => Ok(()),
+                Err(first_err) => {
+                    tracing::info!("First join attempt failed ({first_err:#}), retrying in 5s...");
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    node.join(token).await
+                }
+            };
+            match result {
                 Ok(()) => {
                     if node.mesh_id().await.is_some() {
                         record_first_joined_mesh_ts(node).await;
@@ -3422,7 +3430,18 @@ async fn run_auto(
         let mut successful_join: Option<(String, Option<String>)> = None;
 
         for (t, mesh_name) in &join_attempts {
-            match node.join(t).await {
+            // Try joining, and if the first attempt fails (e.g. relay not yet
+            // connected), wait briefly and retry once. Relay-only connections
+            // can take longer to establish than the initial connect timeout.
+            let result = match node.join(t).await {
+                Ok(()) => Ok(()),
+                Err(first_err) => {
+                    tracing::info!("First join attempt failed ({first_err:#}), retrying in 5s...");
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                    node.join(t).await
+                }
+            };
+            match result {
                 Ok(()) => {
                     if node.mesh_id().await.is_some() {
                         record_first_joined_mesh_ts(&node).await;

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -3121,15 +3121,7 @@ fn node_display_name(cli: &Cli, node: &mesh::Node) -> String {
 async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
     if !cli.join.is_empty() {
         for token in &cli.join {
-            let result = match node.join(token).await {
-                Ok(()) => Ok(()),
-                Err(first_err) => {
-                    tracing::info!("First join attempt failed ({first_err:#}), retrying in 5s...");
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    node.join(token).await
-                }
-            };
-            match result {
+            match node.join_with_retry(token).await {
                 Ok(()) => {
                     if node.mesh_id().await.is_some() {
                         record_first_joined_mesh_ts(node).await;
@@ -3430,18 +3422,7 @@ async fn run_auto(
         let mut successful_join: Option<(String, Option<String>)> = None;
 
         for (t, mesh_name) in &join_attempts {
-            // Try joining, and if the first attempt fails (e.g. relay not yet
-            // connected), wait briefly and retry once. Relay-only connections
-            // can take longer to establish than the initial connect timeout.
-            let result = match node.join(t).await {
-                Ok(()) => Ok(()),
-                Err(first_err) => {
-                    tracing::info!("First join attempt failed ({first_err:#}), retrying in 5s...");
-                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    node.join(t).await
-                }
-            };
-            match result {
+            match node.join_with_retry(t).await {
                 Ok(()) => {
                     if node.mesh_id().await.is_some() {
                         record_first_joined_mesh_ts(&node).await;

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -3144,7 +3144,13 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
             region: cli.region.clone(),
             ..Default::default()
         };
-        let target_name = cli.discover.as_deref().or(cli.mesh_name.as_deref());
+        // Bare --discover (no name) parses as Some(""); treat that as None
+        // so smart_auto uses the normal --auto eligibility path.
+        let target_name = cli
+            .discover
+            .as_deref()
+            .filter(|s| !s.is_empty())
+            .or(cli.mesh_name.as_deref());
         let _ = emit_event(OutputEvent::DiscoveryStarting {
             source: "Nostr discovery".to_string(),
         });
@@ -3172,7 +3178,7 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
                         peers: mesh.listing.node_count,
                         region: mesh.listing.region.clone(),
                     });
-                    match node.join(token).await {
+                    match node.join_with_retry(token).await {
                         Ok(()) => {
                             if node.mesh_id().await.is_some() {
                                 record_first_joined_mesh_ts(node).await;
@@ -3498,10 +3504,10 @@ async fn run_auto(
             }
         });
 
-        // Nostr re-discovery: if we joined via --auto (Nostr discovery) and lose
+        // Nostr re-discovery: if we joined via --auto or --discover and lose
         // all peers, re-discover and join a new mesh. This handles the case where
         // the original mesh publisher restarts with a new identity.
-        if cli.auto {
+        if cli.auto || cli.discover.is_some() {
             let rediscover_node = node.clone();
             let rediscover_relays = nostr_relays(&cli.nostr_relay);
             let rediscover_relay_urls = cli.relay.clone();
@@ -3539,7 +3545,7 @@ async fn run_auto(
 
         // Originator also re-discovers: if we started solo and a matching mesh
         // already exists on Nostr, we should join it instead of staying alone.
-        if cli.auto {
+        if cli.auto || cli.discover.is_some() {
             let rediscover_node = node.clone();
             let rediscover_relays = nostr_relays(&cli.nostr_relay);
             let rediscover_relay_urls = cli.relay.clone();
@@ -3591,16 +3597,17 @@ async fn run_auto(
 
         let assignment = pick_model_assignment(&node, &local_models).await;
         // If no demand-based assignment but we have VRAM, use auto pack's primary model
-        let assignment = if assignment.is_none() && cli.auto && !is_client {
-            let pack = nostr::auto_model_pack(node.vram_bytes() as f64 / 1e9);
-            if !pack.is_empty() {
-                Some(pack[0].clone())
+        let assignment =
+            if assignment.is_none() && (cli.auto || cli.discover.is_some()) && !is_client {
+                let pack = nostr::auto_model_pack(node.vram_bytes() as f64 / 1e9);
+                if !pack.is_empty() {
+                    Some(pack[0].clone())
+                } else {
+                    assignment
+                }
             } else {
                 assignment
-            }
-        } else {
-            assignment
-        };
+            };
         if let Some(model_name) = assignment {
             let _ = emit_event(OutputEvent::HostElected {
                 model: model_name.clone(),
@@ -4133,8 +4140,8 @@ async fn run_auto(
                 None
             }
         }
-    } else if cli.auto {
-        // Watchdog: if we joined via --auto, watch for the publisher to die and take over
+    } else if cli.auto || cli.discover.is_some() {
+        // Watchdog: if we joined via --auto/--discover, watch for the publisher to die and take over
         let relays = nostr_relays(&cli.nostr_relay);
         let wd_node = node.clone();
         let wd_name = cli.mesh_name.clone();
@@ -4549,7 +4556,7 @@ async fn run_passive(
                 passive_publication_state = Some(api::PublicationState::PublishFailed);
             }
         }
-    } else if cli.auto && !is_client {
+    } else if (cli.auto || cli.discover.is_some()) && !is_client {
         // Watchdog: take over publishing if the original publisher dies
         let relays = nostr_relays(&cli.nostr_relay);
         let wd_node = node.clone();

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -64,7 +64,7 @@ mesh-llm client --auto
 Runtime switches:
 
 - `--join <TOKEN>`: join a specific mesh using an invite token (repeatable).
-- `--discover [QUERY]`: discover a mesh via Nostr and join.
+- `--discover [NAME]`: discover a mesh via Nostr and join it. With a name, joins the mesh matching that name. Without a name, behaves like `--auto`.
 - `--auto`: auto-join the best discovered mesh.
 - `--model <MODEL>`: model to serve (catalog id from `models recommended`, HF ref/URL, or path).
 - `--gguf <GGUF>`: serve a specific local GGUF file directly (repeatable).
@@ -251,6 +251,7 @@ Use this to discover meshes via Nostr and optionally select one automatically.
 
 Switches:
 
+- `--name <NAME>`: filter by mesh name (case-insensitive exact match).
 - `--model <MODEL>`: filter discovered meshes by model name substring.
 - `--min-vram <MIN_VRAM>`: filter by minimum VRAM (GB).
 - `--region <REGION>`: filter by region.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -70,9 +70,11 @@ For full build details, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 mesh-llm serve --auto
 mesh-llm serve --model Qwen2.5-32B
 mesh-llm serve --join <token>
+mesh-llm serve --discover "my-mesh"
 mesh-llm client --auto
 mesh-llm gpus
 mesh-llm discover
+mesh-llm discover --name "my-mesh"
 ```
 
 If you run `mesh-llm` with no arguments, it prints `--help` and exits. It does not start the console or bind ports until you choose a mode.

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@
             <div class="feature">
                 <div class="feature-icon">📡</div>
                 <h3>Nostr discovery</h3>
-                <p>Publish your mesh to Nostr relays. Others find it with <code>--auto</code>. Smart scoring: region match, VRAM, health probe before joining.</p>
+                <p>Publish your mesh to Nostr relays. Others find it with <code>--auto</code> or join by name with <code>--discover "my-mesh"</code>. Smart scoring: region match, VRAM, health probe before joining.</p>
             </div>
             <div class="feature">
                 <div class="feature-icon">🚀</div>


### PR DESCRIPTION
--discover <name> was completely ignored on the serve/client startup path — only worked for the MCP path. Users running 'mesh-llm --discover mic22' would silently create a new standalone mesh instead of joining mic22.

Changes:
- --discover triggers Nostr discovery on serve path (same as --auto)
- --discover name is used as target mesh name filter
- discover subcommand gains --name flag for filtering by mesh name
- Suppress misleading 'private by default' warning when joining
- Fix discover subcommand help text (was suggesting nonexistent 'discover --join')
- MeshFilter gains name field for case-insensitive exact mesh name matching

Tested: --join token, --discover name (serve), client --discover name, discover --name, relay-only join

Next: want to diagnose joining when only relay endpoint is accessible