### PR TITLE
Recover Skippy split serving after stage peer loss

### DIFF
--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -621,6 +621,28 @@ struct SplitGenerationLoadSpec<'a> {
 async fn load_split_runtime_generation(
     spec: SplitGenerationLoadSpec<'_>,
 ) -> Result<SplitRuntimeGenerationHandle> {
+    let mut cleanup_on_error = false;
+    let result = load_split_runtime_generation_inner(&spec, &mut cleanup_on_error).await;
+    if let Err(error) = &result {
+        if cleanup_on_error {
+            tracing::warn!(
+                model_ref = spec.model_ref,
+                topology_id = %spec.generation.topology_id,
+                run_id = %spec.generation.run_id,
+                generation = spec.generation.generation,
+                error = %error,
+                "cleaning up split runtime generation after failed load"
+            );
+            stop_split_generation(spec.node, spec.generation, spec.generation.generation).await;
+        }
+    }
+    result
+}
+
+async fn load_split_runtime_generation_inner(
+    spec: &SplitGenerationLoadSpec<'_>,
+    cleanup_on_error: &mut bool,
+) -> Result<SplitRuntimeGenerationHandle> {
     let stage0 = spec
         .generation
         .stages
@@ -665,6 +687,7 @@ async fn load_split_runtime_generation(
         skippy_stage_activation_width(spec.package.activation_width, spec.model_ref)?;
 
     for stage in spec.generation.stages.iter().skip(1).rev() {
+        *cleanup_on_error = true;
         let load = skippy::StageLoadRequest {
             topology_id: spec.generation.topology_id.clone(),
             run_id: spec.generation.run_id.clone(),
@@ -777,7 +800,7 @@ async fn load_split_runtime_generation(
         downstream.stage_id,
         downstream.stage_index,
         downstream_endpoint,
-        spec.projector_path,
+        spec.projector_path.clone(),
         spec.ctx_size,
         spec.slots as u32,
         kv_cache,
@@ -2277,6 +2300,7 @@ mod tests {
     use iroh::SecretKey;
     use sha2::{Digest, Sha256};
     use std::fs;
+    use std::sync::{Arc, Mutex as StdMutex};
 
     fn make_id(seed: u8) -> iroh::EndpointId {
         let mut bytes = [0u8; 32];
@@ -2384,6 +2408,135 @@ mod tests {
             layer_start,
             layer_end,
             parameter_bytes: u64::from(layer_end.saturating_sub(layer_start)) * 1_000_000,
+        }
+    }
+
+    fn local_stage(
+        node_id: iroh::EndpointId,
+        stage_index: u32,
+        layer_start: u32,
+        layer_end: u32,
+    ) -> RuntimeSliceStagePlan {
+        RuntimeSliceStagePlan {
+            stage_id: format!("stage-{stage_index}"),
+            stage_index,
+            node_id,
+            layer_start,
+            layer_end,
+            parameter_bytes: u64::from(layer_end.saturating_sub(layer_start)) * 1_000_000,
+        }
+    }
+
+    fn test_stage_status_from_load(
+        load: &skippy::StageLoadRequest,
+        state: skippy::StageRuntimeState,
+    ) -> skippy::StageStatusSnapshot {
+        skippy::StageStatusSnapshot {
+            topology_id: load.topology_id.clone(),
+            run_id: load.run_id.clone(),
+            model_id: load.model_id.clone(),
+            backend: load.backend.clone(),
+            package_ref: Some(load.package_ref.clone()),
+            manifest_sha256: Some(load.manifest_sha256.clone()),
+            source_model_path: load.model_path.clone(),
+            source_model_sha256: None,
+            source_model_bytes: load.source_model_bytes,
+            materialized_path: None,
+            materialized_pinned: false,
+            projector_path: load.projector_path.clone(),
+            stage_id: load.stage_id.clone(),
+            stage_index: load.stage_index,
+            layer_start: load.layer_start,
+            layer_end: load.layer_end,
+            state,
+            bind_addr: "127.0.0.1:31000".to_string(),
+            activation_width: load.activation_width as u32,
+            wire_dtype: load.wire_dtype,
+            selected_device: load.selected_device.clone(),
+            ctx_size: load.ctx_size,
+            lane_count: load.lane_count,
+            n_batch: load.n_batch,
+            n_ubatch: load.n_ubatch,
+            flash_attn_type: load.flash_attn_type,
+            error: None,
+            shutdown_generation: load.shutdown_generation,
+        }
+    }
+
+    fn test_stage_status_from_stop(stop: &skippy::StageStopRequest) -> skippy::StageStatusSnapshot {
+        skippy::StageStatusSnapshot {
+            topology_id: stop.topology_id.clone(),
+            run_id: stop.run_id.clone(),
+            model_id: String::new(),
+            backend: "skippy".to_string(),
+            package_ref: None,
+            manifest_sha256: None,
+            source_model_path: None,
+            source_model_sha256: None,
+            source_model_bytes: None,
+            materialized_path: None,
+            materialized_pinned: false,
+            projector_path: None,
+            stage_id: stop.stage_id.clone(),
+            stage_index: 0,
+            layer_start: 0,
+            layer_end: 0,
+            state: skippy::StageRuntimeState::Stopped,
+            bind_addr: String::new(),
+            activation_width: 0,
+            wire_dtype: skippy::StageWireDType::F16,
+            selected_device: None,
+            ctx_size: 0,
+            lane_count: 0,
+            n_batch: None,
+            n_ubatch: None,
+            flash_attn_type: FlashAttentionType::Auto,
+            error: None,
+            shutdown_generation: stop.shutdown_generation,
+        }
+    }
+
+    fn test_preparation_status_from_load(
+        load: &skippy::StageLoadRequest,
+    ) -> skippy::StagePreparationStatus {
+        skippy::StagePreparationStatus {
+            topology_id: load.topology_id.clone(),
+            run_id: load.run_id.clone(),
+            model_id: load.model_id.clone(),
+            backend: load.backend.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+            stage_id: load.stage_id.clone(),
+            stage_index: load.stage_index,
+            layer_start: load.layer_start,
+            layer_end: load.layer_end,
+            state: skippy::StagePreparationState::Available,
+            bytes_done: load.source_model_bytes,
+            bytes_total: load.source_model_bytes,
+            bind_addr: None,
+            error: None,
+            shutdown_generation: load.shutdown_generation,
+        }
+    }
+
+    fn test_inventory_from_request(
+        request: &skippy::StageInventoryRequest,
+    ) -> skippy::StageLayerInventory {
+        skippy::StageLayerInventory {
+            model_id: request.model_id.clone(),
+            package_ref: request.package_ref.clone(),
+            manifest_sha256: request.manifest_sha256.clone(),
+            layer_count: 40,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 40,
+            }],
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: Some("/models/qwen.gguf".to_string()),
+            source_model_bytes: Some(40_000_000),
+            source_model_kind: skippy::SourceModelKind::LayerPackage,
         }
     }
 
@@ -2665,6 +2818,138 @@ mod tests {
             split_missing_active_stage_nodes(&active, &current_participants),
             vec![make_id(2)]
         );
+    }
+
+    #[tokio::test]
+    async fn load_split_runtime_generation_stops_candidate_stages_after_partial_load_failure() {
+        let node = mesh::Node::new_for_tests(NodeRole::Host { http_port: 9337 })
+            .await
+            .unwrap();
+        let (control_tx, mut control_rx) =
+            tokio::sync::mpsc::unbounded_channel::<skippy::StageControlCommand>();
+        node.set_stage_control_sender(control_tx).await;
+
+        let requests = Arc::new(StdMutex::new(Vec::new()));
+        let captured_requests = Arc::clone(&requests);
+        tokio::spawn(async move {
+            while let Some(command) = control_rx.recv().await {
+                captured_requests
+                    .lock()
+                    .unwrap()
+                    .push(command.request.clone());
+                let response = match &command.request {
+                    skippy::StageControlRequest::Prepare(prepare) => {
+                        Ok(skippy::StageControlResponse::PrepareAccepted(
+                            skippy::StagePrepareAcceptedResponse {
+                                accepted: true,
+                                status: test_preparation_status_from_load(&prepare.load),
+                                error: None,
+                            },
+                        ))
+                    }
+                    skippy::StageControlRequest::Inventory(inventory) => {
+                        Ok(skippy::StageControlResponse::Inventory(
+                            test_inventory_from_request(inventory),
+                        ))
+                    }
+                    skippy::StageControlRequest::Load(load) if load.stage_id == "stage-1" => {
+                        Err(anyhow::anyhow!("injected stage load failure"))
+                    }
+                    skippy::StageControlRequest::Load(load) => Ok(
+                        skippy::StageControlResponse::Ready(skippy::StageReadyResponse {
+                            accepted: true,
+                            status: test_stage_status_from_load(
+                                load,
+                                skippy::StageRuntimeState::Ready,
+                            ),
+                            error: None,
+                        }),
+                    ),
+                    skippy::StageControlRequest::Stop(stop) => Ok(
+                        skippy::StageControlResponse::Ready(skippy::StageReadyResponse {
+                            accepted: true,
+                            status: test_stage_status_from_stop(stop),
+                            error: None,
+                        }),
+                    ),
+                    other => panic!("unexpected stage control request: {other:?}"),
+                };
+                let _ = command.resp.send(response);
+            }
+        });
+
+        let mut package = package(40);
+        package.package_ref = "hf://Mesh-LLM/test-split-package".to_string();
+        let local_id = node.id();
+        let generation = SplitTopologyGeneration::new(
+            "candidate-topology".into(),
+            "candidate-run".into(),
+            2,
+            vec![SplitParticipant {
+                node_id: local_id,
+                vram_bytes: 24_000_000_000,
+                first_joined_mesh_ts: None,
+            }],
+            vec![
+                local_stage(local_id, 0, 0, 12),
+                local_stage(local_id, 1, 12, 24),
+                local_stage(local_id, 2, 24, 40),
+            ],
+        );
+
+        let error = match load_split_runtime_generation(SplitGenerationLoadSpec {
+            node: &node,
+            model_ref: "Qwen",
+            model_path: Path::new("/models/qwen.gguf"),
+            package: &package,
+            generation: &generation,
+            projector_path: None,
+            ctx_size: 4096,
+            pinned_gpu: None,
+            slots: 1,
+            cache_type_k_override: None,
+            cache_type_v_override: None,
+            n_batch_override: None,
+            n_ubatch_override: None,
+            flash_attention_override: FlashAttentionType::Auto,
+        })
+        .await
+        {
+            Ok(_) => panic!("candidate split generation load unexpectedly succeeded"),
+            Err(error) => error,
+        };
+
+        let error_chain = format!("{error:#}");
+        assert!(
+            error_chain.contains("injected stage load failure"),
+            "unexpected error: {error_chain}"
+        );
+
+        let requests = requests.lock().unwrap();
+        let load_stage_ids = requests
+            .iter()
+            .filter_map(|request| match request {
+                skippy::StageControlRequest::Load(load) => Some(load.stage_id.as_str()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(load_stage_ids, vec!["stage-2", "stage-1"]);
+
+        let stop_requests = requests
+            .iter()
+            .filter_map(|request| match request {
+                skippy::StageControlRequest::Stop(stop) => Some(stop),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(stop_requests.len(), 2);
+        assert_eq!(stop_requests[0].stage_id, "stage-1");
+        assert_eq!(stop_requests[1].stage_id, "stage-2");
+        assert!(stop_requests.iter().all(|stop| {
+            stop.topology_id == generation.topology_id
+                && stop.run_id == generation.run_id
+                && stop.shutdown_generation == generation.generation
+        }));
     }
 
     #[test]

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -172,7 +172,7 @@ pub(super) struct SplitRuntimeGenerationHandle {
 }
 
 pub(super) enum SplitCoordinatorEvent {
-    Replace(SplitCoordinatorReplaceEvent),
+    Replace(Box<SplitCoordinatorReplaceEvent>),
     Withdraw(SplitCoordinatorWithdrawEvent),
 }
 
@@ -1095,16 +1095,17 @@ impl SplitTopologyCoordinator {
         })
         .await?;
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        let event = SplitCoordinatorEvent::Replace(SplitCoordinatorReplaceEvent {
+        let event = SplitCoordinatorEvent::Replace(Box::new(SplitCoordinatorReplaceEvent {
             reason,
             generation: candidate.generation,
             loaded,
             ack: ack_tx,
-        });
+        }));
         if let Err(err) = self.event_tx.send(event).await {
             let SplitCoordinatorEvent::Replace(event) = err.0 else {
                 unreachable!("replace event send returned a non-replace event")
             };
+            let event = *event;
             event.loaded.handle.shutdown().await;
             stop_split_generation(&self.node, &candidate, candidate.generation).await;
             anyhow::bail!("publish split topology candidate to runtime loop: receiver closed");

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -173,6 +173,7 @@ pub(super) struct SplitRuntimeGenerationHandle {
 
 pub(super) enum SplitCoordinatorEvent {
     Replace(Box<SplitCoordinatorReplaceEvent>),
+    LocalFallback(SplitCoordinatorLocalFallbackEvent),
     Withdraw(SplitCoordinatorWithdrawEvent),
 }
 
@@ -180,6 +181,14 @@ pub(super) struct SplitCoordinatorReplaceEvent {
     pub(super) reason: &'static str,
     pub(super) generation: u64,
     pub(super) loaded: SplitRuntimeGenerationHandle,
+    pub(super) ack: tokio::sync::oneshot::Sender<SplitCoordinatorAck>,
+}
+
+pub(super) struct SplitCoordinatorLocalFallbackEvent {
+    pub(super) reason: &'static str,
+    pub(super) generation: u64,
+    pub(super) topology_id: String,
+    pub(super) missing_stage_nodes: Vec<iroh::EndpointId>,
     pub(super) ack: tokio::sync::oneshot::Sender<SplitCoordinatorAck>,
 }
 
@@ -487,7 +496,7 @@ pub(super) async fn start_runtime_split_model(
     let stages =
         plan_runtime_slice_topology(&topology_id, model_ref, &package, &planned_participants)?;
     anyhow::ensure!(
-        stages.len() > 1,
+        split_stages_meet_minimum(&stages),
         "split runtime needs at least two stage participants"
     );
     let stage0 = stages
@@ -900,6 +909,14 @@ enum SplitReplanDecision {
     Candidate,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SplitLossRecoveryDecision {
+    NoActiveStageLoss,
+    ReplacementSplit,
+    LocalFallback,
+    Withdraw,
+}
+
 fn spawn_split_topology_coordinator(
     coordinator: SplitTopologyCoordinator,
 ) -> tokio::task::JoinHandle<()> {
@@ -955,9 +972,41 @@ impl SplitTopologyCoordinator {
             self.pinned_gpu.as_ref().map(|gpu| gpu.vram_bytes),
         )
         .await;
-        if snapshot.participants.len() < SPLIT_DEFAULT_MIN_PARTICIPANTS {
-            let missing_stage_nodes =
-                split_missing_active_stage_nodes(&self.active, &snapshot.participants);
+        let missing_stage_nodes =
+            split_missing_active_stage_nodes(&self.active, &snapshot.participants);
+        let planned_participants = snapshot.participants.clone();
+        let candidate = if split_participants_meet_minimum(&planned_participants) {
+            match self.plan_replan_candidate(&planned_participants) {
+                Ok(candidate) => {
+                    if candidate
+                        .stages
+                        .first()
+                        .is_none_or(|stage0| stage0.node_id != self.node.id())
+                    {
+                        tracing::debug!(
+                            model_ref = self.model_ref,
+                            reason,
+                            candidate_stages = ?split_stage_plan_labels(&candidate.stages),
+                            "split topology replan skipped; stage 0 would move to another node"
+                        );
+                        None
+                    } else {
+                        Some(candidate)
+                    }
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        model_ref = self.model_ref,
+                        reason,
+                        error = %err,
+                        participants = ?split_participant_labels(&planned_participants),
+                        excluded = ?split_participant_exclusion_labels(&snapshot.excluded),
+                        "split topology replan candidate failed"
+                    );
+                    None
+                }
+            }
+        } else {
             tracing::debug!(
                 model_ref = self.model_ref,
                 reason,
@@ -965,17 +1014,106 @@ impl SplitTopologyCoordinator {
                 excluded = ?split_participant_exclusion_labels(&snapshot.excluded),
                 "split topology replan skipped; quorum not met"
             );
-            if !missing_stage_nodes.is_empty() {
+            None
+        };
+
+        match split_loss_recovery_decision(
+            &self.active,
+            &snapshot.participants,
+            candidate.as_ref(),
+            self.local_model_fits(),
+        ) {
+            SplitLossRecoveryDecision::NoActiveStageLoss => {}
+            SplitLossRecoveryDecision::ReplacementSplit => {
+                let candidate = candidate.expect("replacement split decision requires a candidate");
+                tracing::info!(
+                    model_ref = self.model_ref,
+                    reason,
+                    active_topology_id = self.active.topology_id,
+                    active_generation = self.active.generation,
+                    candidate_topology_id = candidate.topology_id,
+                    candidate_generation = candidate.generation,
+                    missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
+                    active_stages = ?split_stage_plan_labels(&self.active.stages),
+                    candidate_stages = ?split_stage_plan_labels(&candidate.stages),
+                    participants = ?split_participant_labels(&candidate.participants),
+                    "split topology lost an active stage peer; loading replacement split generation"
+                );
+                match self.load_and_publish_candidate(reason, candidate).await {
+                    Ok(()) => return true,
+                    Err(err) => {
+                        tracing::warn!(
+                            model_ref = self.model_ref,
+                            reason,
+                            error = %err,
+                            "split topology replacement failed during load-and-cutover"
+                        );
+                    }
+                }
+                if self.local_model_fits() {
+                    if let Err(err) = self
+                        .request_local_fallback(reason, missing_stage_nodes.clone())
+                        .await
+                    {
+                        tracing::warn!(
+                            model_ref = self.model_ref,
+                            reason,
+                            error = %err,
+                            "failed to publish split topology local fallback request"
+                        );
+                    } else {
+                        return false;
+                    }
+                }
+                if let Err(err) = self
+                    .withdraw_active_generation(reason, missing_stage_nodes.clone())
+                    .await
+                {
+                    tracing::warn!(
+                        model_ref = self.model_ref,
+                        reason,
+                        error = %err,
+                        "failed to publish split topology withdrawal"
+                    );
+                } else {
+                    return false;
+                }
+                return true;
+            }
+            SplitLossRecoveryDecision::LocalFallback => {
                 tracing::warn!(
                     model_ref = self.model_ref,
                     reason,
                     topology_id = self.active.topology_id,
                     generation = self.active.generation,
                     missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
-                    "split topology lost an active stage peer and cannot meet quorum; withdrawing active generation"
+                    "split topology lost an active stage peer; requesting local runtime fallback"
                 );
                 if let Err(err) = self
-                    .withdraw_active_generation(reason, missing_stage_nodes)
+                    .request_local_fallback(reason, missing_stage_nodes.clone())
+                    .await
+                {
+                    tracing::warn!(
+                        model_ref = self.model_ref,
+                        reason,
+                        error = %err,
+                        "failed to publish split topology local fallback request"
+                    );
+                } else {
+                    return false;
+                }
+            }
+            SplitLossRecoveryDecision::Withdraw => {
+                tracing::warn!(
+                    model_ref = self.model_ref,
+                    reason,
+                    topology_id = self.active.topology_id,
+                    generation = self.active.generation,
+                    missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
+                    "split topology lost an active stage peer and no replacement path is available; withdrawing active generation"
+                );
+                if let Err(err) = self
+                    .withdraw_active_generation(reason, missing_stage_nodes.clone())
                     .await
                 {
                     tracing::warn!(
@@ -988,51 +1126,15 @@ impl SplitTopologyCoordinator {
                     return false;
                 }
             }
+        }
+
+        if snapshot.participants.len() < SPLIT_DEFAULT_MIN_PARTICIPANTS {
             return true;
         }
 
-        let planned_participants = snapshot.participants.clone();
-        let generation = self.active.generation.saturating_add(1);
-        let run_id = format!("mesh-split-{}-g{}", now_unix_nanos(), generation);
-        let topology_id = format!("topology-{run_id}");
-        let candidate = match plan_runtime_slice_topology(
-            &topology_id,
-            &self.model_ref,
-            &self.package,
-            &planned_participants,
-        ) {
-            Ok(stages) => SplitTopologyGeneration::new(
-                topology_id,
-                run_id,
-                generation,
-                planned_participants,
-                stages,
-            ),
-            Err(err) => {
-                tracing::warn!(
-                    model_ref = self.model_ref,
-                    reason,
-                    error = %err,
-                    participants = ?split_participant_labels(&planned_participants),
-                    excluded = ?split_participant_exclusion_labels(&snapshot.excluded),
-                    "split topology replan candidate failed"
-                );
-                return true;
-            }
-        };
-        if candidate
-            .stages
-            .first()
-            .is_none_or(|stage0| stage0.node_id != self.node.id())
-        {
-            tracing::debug!(
-                model_ref = self.model_ref,
-                reason,
-                candidate_stages = ?split_stage_plan_labels(&candidate.stages),
-                "split topology replan skipped; stage 0 would move to another node"
-            );
+        let Some(candidate) = candidate else {
             return true;
-        }
+        };
 
         match split_replan_decision(&self.active, &candidate) {
             SplitReplanDecision::Keep => {
@@ -1069,6 +1171,44 @@ impl SplitTopologyCoordinator {
             }
         }
         true
+    }
+
+    fn plan_replan_candidate(
+        &self,
+        planned_participants: &[SplitParticipant],
+    ) -> Result<SplitTopologyGeneration> {
+        let generation = self.active.generation.saturating_add(1);
+        let run_id = format!("mesh-split-{}-g{}", now_unix_nanos(), generation);
+        let topology_id = format!("topology-{run_id}");
+        let stages = plan_runtime_slice_topology(
+            &topology_id,
+            &self.model_ref,
+            &self.package,
+            planned_participants,
+        )?;
+        anyhow::ensure!(
+            split_stages_meet_minimum(&stages),
+            "split runtime needs at least two stage participants"
+        );
+        Ok(SplitTopologyGeneration::new(
+            topology_id,
+            run_id,
+            generation,
+            planned_participants.to_vec(),
+            stages,
+        ))
+    }
+
+    fn local_model_fits(&self) -> bool {
+        let local_capacity = self
+            .pinned_gpu
+            .as_ref()
+            .map(|gpu| gpu.vram_bytes)
+            .unwrap_or_else(|| self.node.vram_bytes());
+        model_fits_runtime_capacity(
+            election::total_model_bytes(&self.model_path),
+            local_capacity,
+        )
     }
 
     async fn load_and_publish_candidate(
@@ -1130,6 +1270,28 @@ impl SplitTopologyCoordinator {
         }
     }
 
+    async fn request_local_fallback(
+        &mut self,
+        reason: &'static str,
+        missing_stage_nodes: Vec<iroh::EndpointId>,
+    ) -> Result<()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        let event = SplitCoordinatorEvent::LocalFallback(SplitCoordinatorLocalFallbackEvent {
+            reason,
+            generation: self.active.generation,
+            topology_id: self.active.topology_id.clone(),
+            missing_stage_nodes,
+            ack: ack_tx,
+        });
+        if self.event_tx.send(event).await.is_err() {
+            anyhow::bail!("publish split topology local fallback to runtime loop: receiver closed");
+        }
+        match ack_rx.await {
+            Ok(SplitCoordinatorAck::Accepted) => Ok(()),
+            Err(_) => anyhow::bail!("runtime loop dropped split topology local fallback ack"),
+        }
+    }
+
     async fn withdraw_active_generation(
         &mut self,
         reason: &'static str,
@@ -1174,6 +1336,37 @@ fn split_replan_decision(
         return SplitReplanDecision::Candidate;
     }
     SplitReplanDecision::Keep
+}
+
+fn split_loss_recovery_decision(
+    active: &SplitTopologyGeneration,
+    current_participants: &[SplitParticipant],
+    candidate: Option<&SplitTopologyGeneration>,
+    local_model_fits: bool,
+) -> SplitLossRecoveryDecision {
+    if !split_active_stage_participant_missing(active, current_participants) {
+        return SplitLossRecoveryDecision::NoActiveStageLoss;
+    }
+    if candidate.is_some_and(split_candidate_is_valid_replacement_split) {
+        return SplitLossRecoveryDecision::ReplacementSplit;
+    }
+    if local_model_fits {
+        return SplitLossRecoveryDecision::LocalFallback;
+    }
+    SplitLossRecoveryDecision::Withdraw
+}
+
+fn split_candidate_is_valid_replacement_split(candidate: &SplitTopologyGeneration) -> bool {
+    split_participants_meet_minimum(&candidate.participants)
+        && split_stages_meet_minimum(&candidate.stages)
+}
+
+fn split_participants_meet_minimum(participants: &[SplitParticipant]) -> bool {
+    participants.len() >= SPLIT_DEFAULT_MIN_PARTICIPANTS
+}
+
+fn split_stages_meet_minimum(stages: &[RuntimeSliceStagePlan]) -> bool {
+    stages.len() >= SPLIT_DEFAULT_MIN_PARTICIPANTS
 }
 
 fn split_active_stage_participant_missing(
@@ -2607,5 +2800,132 @@ mod tests {
             split_replan_decision(&active, &candidate),
             SplitReplanDecision::Keep
         );
+    }
+
+    #[test]
+    fn split_loss_recovery_uses_replacement_split_when_active_stage_peer_is_lost() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 10), stage(2, 1, 10, 20), stage(3, 2, 20, 30)],
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1), participant(3)],
+            vec![stage(1, 0, 0, 15), stage(3, 1, 15, 30)],
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(
+                &active,
+                &[participant(1), participant(3)],
+                Some(&candidate),
+                true,
+            ),
+            SplitLossRecoveryDecision::ReplacementSplit
+        );
+    }
+
+    #[test]
+    fn split_loss_recovery_falls_back_to_local_when_replacement_split_is_unavailable() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(&active, &[participant(1)], None, true),
+            SplitLossRecoveryDecision::LocalFallback
+        );
+    }
+
+    #[test]
+    fn split_loss_recovery_withdraws_when_split_and_local_paths_are_unavailable() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(&active, &[participant(1)], None, false),
+            SplitLossRecoveryDecision::Withdraw
+        );
+    }
+
+    #[test]
+    fn split_loss_recovery_rejects_single_participant_candidate_as_split_topology() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1)],
+            vec![stage(1, 0, 0, 40)],
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(&active, &[participant(1)], Some(&candidate), true),
+            SplitLossRecoveryDecision::LocalFallback
+        );
+        assert!(!split_candidate_is_valid_replacement_split(&candidate));
+    }
+
+    #[test]
+    fn split_loss_recovery_ignores_unused_participant_loss() {
+        let active_stages = vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)];
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            active_stages.clone(),
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1), participant(2)],
+            active_stages,
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(
+                &active,
+                &[participant(1), participant(2)],
+                Some(&candidate),
+                false,
+            ),
+            SplitLossRecoveryDecision::NoActiveStageLoss
+        );
+    }
+
+    #[test]
+    fn split_topology_minimum_rejects_single_stage_split_candidate() {
+        assert!(split_participants_meet_minimum(&[
+            participant(1),
+            participant(2)
+        ]));
+        assert!(!split_participants_meet_minimum(&[participant(1)]));
+        assert!(split_stages_meet_minimum(&[
+            stage(1, 0, 0, 20),
+            stage(2, 1, 20, 40)
+        ]));
+        assert!(!split_stages_meet_minimum(&[stage(1, 0, 0, 40)]));
     }
 }

--- a/crates/mesh-llm/src/runtime/local.rs
+++ b/crates/mesh-llm/src/runtime/local.rs
@@ -171,10 +171,23 @@ pub(super) struct SplitRuntimeGenerationHandle {
     pub(super) coordinator_task: Option<tokio::task::JoinHandle<()>>,
 }
 
-pub(super) struct SplitCoordinatorEvent {
+pub(super) enum SplitCoordinatorEvent {
+    Replace(SplitCoordinatorReplaceEvent),
+    Withdraw(SplitCoordinatorWithdrawEvent),
+}
+
+pub(super) struct SplitCoordinatorReplaceEvent {
     pub(super) reason: &'static str,
     pub(super) generation: u64,
     pub(super) loaded: SplitRuntimeGenerationHandle,
+    pub(super) ack: tokio::sync::oneshot::Sender<SplitCoordinatorAck>,
+}
+
+pub(super) struct SplitCoordinatorWithdrawEvent {
+    pub(super) reason: &'static str,
+    pub(super) generation: u64,
+    pub(super) topology_id: String,
+    pub(super) missing_stage_nodes: Vec<iroh::EndpointId>,
     pub(super) ack: tokio::sync::oneshot::Sender<SplitCoordinatorAck>,
 }
 
@@ -920,16 +933,20 @@ impl SplitTopologyCoordinator {
                     while peer_rx.has_changed().unwrap_or(false) {
                         let _ = peer_rx.borrow_and_update();
                     }
-                    self.evaluate_replan("membership_changed").await;
+                    if !self.evaluate_replan("membership_changed").await {
+                        break;
+                    }
                 }
                 _ = health_tick.tick() => {
-                    self.evaluate_replan("periodic_check").await;
+                    if !self.evaluate_replan("periodic_check").await {
+                        break;
+                    }
                 }
             }
         }
     }
 
-    async fn evaluate_replan(&mut self, reason: &'static str) {
+    async fn evaluate_replan(&mut self, reason: &'static str) -> bool {
         let snapshot = collect_split_participants(
             &self.node,
             &self.model_name,
@@ -939,6 +956,8 @@ impl SplitTopologyCoordinator {
         )
         .await;
         if snapshot.participants.len() < SPLIT_DEFAULT_MIN_PARTICIPANTS {
+            let missing_stage_nodes =
+                split_missing_active_stage_nodes(&self.active, &snapshot.participants);
             tracing::debug!(
                 model_ref = self.model_ref,
                 reason,
@@ -946,7 +965,30 @@ impl SplitTopologyCoordinator {
                 excluded = ?split_participant_exclusion_labels(&snapshot.excluded),
                 "split topology replan skipped; quorum not met"
             );
-            return;
+            if !missing_stage_nodes.is_empty() {
+                tracing::warn!(
+                    model_ref = self.model_ref,
+                    reason,
+                    topology_id = self.active.topology_id,
+                    generation = self.active.generation,
+                    missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
+                    "split topology lost an active stage peer and cannot meet quorum; withdrawing active generation"
+                );
+                if let Err(err) = self
+                    .withdraw_active_generation(reason, missing_stage_nodes)
+                    .await
+                {
+                    tracing::warn!(
+                        model_ref = self.model_ref,
+                        reason,
+                        error = %err,
+                        "failed to publish split topology withdrawal"
+                    );
+                } else {
+                    return false;
+                }
+            }
+            return true;
         }
 
         let planned_participants = snapshot.participants.clone();
@@ -975,7 +1017,7 @@ impl SplitTopologyCoordinator {
                     excluded = ?split_participant_exclusion_labels(&snapshot.excluded),
                     "split topology replan candidate failed"
                 );
-                return;
+                return true;
             }
         };
         if candidate
@@ -989,7 +1031,7 @@ impl SplitTopologyCoordinator {
                 candidate_stages = ?split_stage_plan_labels(&candidate.stages),
                 "split topology replan skipped; stage 0 would move to another node"
             );
-            return;
+            return true;
         }
 
         match split_replan_decision(&self.active, &candidate) {
@@ -1026,6 +1068,7 @@ impl SplitTopologyCoordinator {
                 }
             }
         }
+        true
     }
 
     async fn load_and_publish_candidate(
@@ -1052,14 +1095,16 @@ impl SplitTopologyCoordinator {
         })
         .await?;
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
-        let event = SplitCoordinatorEvent {
+        let event = SplitCoordinatorEvent::Replace(SplitCoordinatorReplaceEvent {
             reason,
             generation: candidate.generation,
             loaded,
             ack: ack_tx,
-        };
+        });
         if let Err(err) = self.event_tx.send(event).await {
-            let event = err.0;
+            let SplitCoordinatorEvent::Replace(event) = err.0 else {
+                unreachable!("replace event send returned a non-replace event")
+            };
             event.loaded.handle.shutdown().await;
             stop_split_generation(&self.node, &candidate, candidate.generation).await;
             anyhow::bail!("publish split topology candidate to runtime loop: receiver closed");
@@ -1083,12 +1128,37 @@ impl SplitTopologyCoordinator {
             }
         }
     }
+
+    async fn withdraw_active_generation(
+        &mut self,
+        reason: &'static str,
+        missing_stage_nodes: Vec<iroh::EndpointId>,
+    ) -> Result<()> {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        let event = SplitCoordinatorEvent::Withdraw(SplitCoordinatorWithdrawEvent {
+            reason,
+            generation: self.active.generation,
+            topology_id: self.active.topology_id.clone(),
+            missing_stage_nodes,
+            ack: ack_tx,
+        });
+        if self.event_tx.send(event).await.is_err() {
+            anyhow::bail!("publish split topology withdrawal to runtime loop: receiver closed");
+        }
+        match ack_rx.await {
+            Ok(SplitCoordinatorAck::Accepted) => Ok(()),
+            Err(_) => anyhow::bail!("runtime loop dropped split topology withdrawal ack"),
+        }
+    }
 }
 
 fn split_replan_decision(
     active: &SplitTopologyGeneration,
     candidate: &SplitTopologyGeneration,
 ) -> SplitReplanDecision {
+    if split_active_stage_participant_missing(active, &candidate.participants) {
+        return SplitReplanDecision::Candidate;
+    }
     if candidate.stages.len() > active.stages.len() {
         return SplitReplanDecision::Candidate;
     }
@@ -1103,6 +1173,31 @@ fn split_replan_decision(
         return SplitReplanDecision::Candidate;
     }
     SplitReplanDecision::Keep
+}
+
+fn split_active_stage_participant_missing(
+    active: &SplitTopologyGeneration,
+    current_participants: &[SplitParticipant],
+) -> bool {
+    !split_missing_active_stage_nodes(active, current_participants).is_empty()
+}
+
+fn split_missing_active_stage_nodes(
+    active: &SplitTopologyGeneration,
+    current_participants: &[SplitParticipant],
+) -> Vec<iroh::EndpointId> {
+    let mut missing = Vec::new();
+    for stage in &active.stages {
+        if current_participants
+            .iter()
+            .any(|participant| participant.node_id == stage.node_id)
+            || missing.contains(&stage.node_id)
+        {
+            continue;
+        }
+        missing.push(stage.node_id);
+    }
+    missing
 }
 
 async fn stop_split_generation(
@@ -1347,6 +1442,13 @@ fn split_participant_labels(participants: &[SplitParticipant]) -> Vec<String> {
                 participant.vram_bytes / 1_000_000_000
             )
         })
+        .collect()
+}
+
+fn split_node_labels(nodes: &[iroh::EndpointId]) -> Vec<String> {
+    nodes
+        .iter()
+        .map(|node| node.fmt_short().to_string())
         .collect()
 }
 
@@ -2067,6 +2169,30 @@ mod tests {
         .unwrap();
     }
 
+    fn participant(seed: u8) -> SplitParticipant {
+        SplitParticipant {
+            node_id: make_id(seed),
+            vram_bytes: 24_000_000_000,
+            first_joined_mesh_ts: None,
+        }
+    }
+
+    fn stage(
+        seed: u8,
+        stage_index: u32,
+        layer_start: u32,
+        layer_end: u32,
+    ) -> RuntimeSliceStagePlan {
+        RuntimeSliceStagePlan {
+            stage_id: format!("stage-{stage_index}"),
+            stage_index,
+            node_id: make_id(seed),
+            layer_start,
+            layer_end,
+            parameter_bytes: u64::from(layer_end.saturating_sub(layer_start)) * 1_000_000,
+        }
+    }
+
     #[test]
     fn runtime_local_targets_keep_duplicate_same_model_ports() {
         let (target_tx, _target_rx) =
@@ -2331,6 +2457,23 @@ mod tests {
     }
 
     #[test]
+    fn split_missing_active_stage_nodes_ignores_unused_lost_participants() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+        let current_participants = vec![participant(1)];
+
+        assert_eq!(
+            split_missing_active_stage_nodes(&active, &current_participants),
+            vec![make_id(2)]
+        );
+    }
+
+    #[test]
     fn split_replan_decision_accepts_more_stage_capacity() {
         let participants = vec![SplitParticipant {
             node_id: make_id(1),
@@ -2410,6 +2553,53 @@ mod tests {
             2,
             participants,
             stages,
+        );
+
+        assert_eq!(
+            split_replan_decision(&active, &candidate),
+            SplitReplanDecision::Keep
+        );
+    }
+
+    #[test]
+    fn split_replan_decision_accepts_degraded_topology_when_active_stage_peer_is_lost() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 10), stage(2, 1, 10, 20), stage(3, 2, 20, 30)],
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1), participant(3)],
+            vec![stage(1, 0, 0, 15), stage(3, 1, 15, 30)],
+        );
+
+        assert_eq!(
+            split_replan_decision(&active, &candidate),
+            SplitReplanDecision::Candidate
+        );
+    }
+
+    #[test]
+    fn split_replan_decision_keeps_topology_when_only_unused_participant_is_lost() {
+        let active_stages = vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)];
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            active_stages.clone(),
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1), participant(2)],
+            active_stages,
         );
 
         assert_eq!(

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -17,7 +17,8 @@ use self::local::{
     set_advertised_model_context, start_runtime_local_model, start_runtime_split_model,
     startup_runtime_plan, stop_split_generation_cleanup, withdraw_advertised_model,
     LocalRuntimeModelHandle, LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent,
-    SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
+    SplitCoordinatorAck, SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart,
+    StartupRuntimePlan,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
@@ -1142,7 +1143,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     let launch_started = Instant::now();
     let (
         mut loaded_name,
-        mut handle,
+        handle,
         mut death_rx,
         mut split_cleanup,
         mut split_event_rx,
@@ -1321,6 +1322,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         }
     }
 
+    let mut handle = Some(handle);
     let mut context_usage_tick = tokio::time::interval(DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL);
     context_usage_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     let mut survey_exited_unexpectedly = false;
@@ -1328,20 +1330,23 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     loop {
         tokio::select! {
             _ = context_usage_tick.tick() => {
-                refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
-                publish_runtime_llama_slots(
-                    runtime_data_producer.as_ref(),
-                    &loaded_name,
-                    Some(&instance_id),
-                    &handle,
-                );
+                if let Some(handle) = handle.as_ref() {
+                    refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, handle).await;
+                    publish_runtime_llama_slots(
+                        runtime_data_producer.as_ref(),
+                        &loaded_name,
+                        Some(&instance_id),
+                        handle,
+                    );
+                }
             }
             _ = &mut death_rx => {
                 survey_exited_unexpectedly = true;
                 survey_telemetry.record_unexpected_exit(&survey_loaded_model);
+                let port = handle.as_ref().map(|handle| handle.port).unwrap_or_default();
                 let _ = emit_event(OutputEvent::Warning {
                     message: format!("Startup model '{loaded_name}' exited unexpectedly"),
-                    context: Some(format!("model={loaded_name} port={}", handle.port)),
+                    context: Some(format!("model={loaded_name} port={port}")),
                 });
                 break;
             }
@@ -1358,6 +1363,174 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 };
                 let event = match event {
                     SplitCoordinatorEvent::Replace(event) => *event,
+                    SplitCoordinatorEvent::LocalFallback(event) => {
+                        let missing_stage_nodes = event
+                            .missing_stage_nodes
+                            .iter()
+                            .map(|node| node.fmt_short().to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        let old_loaded_name = loaded_name.clone();
+                        let Some(old_handle) = handle.take() else {
+                            let _ = event.ack.send(SplitCoordinatorAck::Accepted);
+                            break;
+                        };
+                        let old_port = old_handle.port;
+                        remove_runtime_local_target(&target_tx, &old_loaded_name, old_port);
+                        remove_dashboard_context_usage(
+                            &dashboard_context_usage,
+                            &old_loaded_name,
+                            &old_handle,
+                        )
+                        .await;
+                        old_handle.shutdown().await;
+                        survey_telemetry.record_unload(&survey_loaded_model);
+                        if let Some(cleanup) = split_cleanup.take() {
+                            stop_split_generation_cleanup(
+                                &node,
+                                cleanup,
+                                event.generation.saturating_add(1),
+                            )
+                            .await;
+                        }
+                        let launch_started = Instant::now();
+                        match start_runtime_local_model(LocalRuntimeModelStartSpec {
+                            node: &node,
+                            model_path: &model_path,
+                            mmproj_override: mmproj_path.as_deref(),
+                            ctx_size_override: ctx_size,
+                            pinned_gpu: pinned_gpu.as_ref(),
+                            cache_type_k_override: cache_type_k.as_deref(),
+                            cache_type_v_override: cache_type_v.as_deref(),
+                            n_batch_override: n_batch,
+                            n_ubatch_override: n_ubatch,
+                            flash_attention_override: flash_attention,
+                            slots,
+                            parallel_override,
+                        }, &model_ref)
+                        .await
+                        {
+                            Ok((next_loaded_name, next_handle, next_death_rx)) => {
+                                loaded_name = next_loaded_name;
+                                add_runtime_local_target(&target_tx, &loaded_name, next_handle.port);
+                                tunnel_mgr.set_http_port(api_port);
+                                register_runtime_instance(
+                                    &runtime_instance_registry,
+                                    &node,
+                                    &primary_model_name,
+                                    &loaded_name,
+                                    &instance_id,
+                                    Some(next_handle.context_length),
+                                )
+                                .await;
+                                let payload = local_process_payload(
+                                    &loaded_name,
+                                    Some(&instance_id),
+                                    &next_handle.backend,
+                                    next_handle.port,
+                                    next_handle.pid(),
+                                    next_handle.slots,
+                                    next_handle.context_length,
+                                );
+                                upsert_dashboard_process(&dashboard_processes, payload.clone()).await;
+                                if let Some(ref cs) = console_state {
+                                    cs.upsert_local_process(payload).await;
+                                    cs.update(true, true).await;
+                                }
+                                survey_loaded_model = survey_telemetry.model(survey::SurveyModelSpec {
+                                    model: &loaded_name,
+                                    model_path: Some(&model_path),
+                                    launch_kind: survey::SurveyLaunchKind::MoeFallback,
+                                    pinned_gpu: pinned_gpu.as_ref(),
+                                    backend: Some(&next_handle.backend),
+                                    context_length: Some(u64::from(next_handle.context_length)),
+                                });
+                                survey_telemetry.record_launch_success(
+                                    &survey_loaded_model,
+                                    launch_started.elapsed(),
+                                );
+                                refresh_dashboard_context_usage(
+                                    &dashboard_context_usage,
+                                    &loaded_name,
+                                    &next_handle,
+                                )
+                                .await;
+                                publish_runtime_llama_slots(
+                                    runtime_data_producer.as_ref(),
+                                    &loaded_name,
+                                    Some(&instance_id),
+                                    &next_handle,
+                                );
+                                let new_port = next_handle.port;
+                                let new_context_length = next_handle.context_length;
+                                handle = Some(next_handle);
+                                death_rx = next_death_rx;
+                                split_event_rx = None;
+                                let _ = event.ack.send(SplitCoordinatorAck::Accepted);
+                                let _ = emit_event(OutputEvent::Warning {
+                                    message: format!(
+                                        "Split runtime topology '{}' lost required stage peer(s); recovered model '{}' locally",
+                                        event.topology_id, loaded_name
+                                    ),
+                                    context: Some(format!(
+                                        "reason={} generation={} missing_stage_nodes=[{}] previous_port={} new_port={} new_ctx={}",
+                                        event.reason,
+                                        event.generation,
+                                        missing_stage_nodes,
+                                        old_port,
+                                        new_port,
+                                        new_context_length
+                                    )),
+                                });
+                                continue;
+                            }
+                            Err(err) => {
+                                survey_telemetry.record_launch_failure(
+                                    survey::SurveyModelSpec {
+                                        model: &old_loaded_name,
+                                        model_path: Some(&model_path),
+                                        launch_kind: survey::SurveyLaunchKind::MoeFallback,
+                                        pinned_gpu: pinned_gpu.as_ref(),
+                                        backend: None,
+                                        context_length: ctx_size.map(u64::from),
+                                    },
+                                    launch_started.elapsed(),
+                                    survey::classify_launch_failure(&err),
+                                );
+                                let _ = emit_event(OutputEvent::Warning {
+                                    message: format!(
+                                        "Split runtime topology '{}' lost required stage peer(s); local fallback failed, withdrawing model '{}'",
+                                        event.topology_id, old_loaded_name
+                                    ),
+                                    context: Some(format!(
+                                        "reason={} generation={} missing_stage_nodes=[{}] error={err:#}",
+                                        event.reason, event.generation, missing_stage_nodes
+                                    )),
+                                });
+                                let _ = event.ack.send(SplitCoordinatorAck::Accepted);
+                                if unregister_runtime_instance(
+                                    &runtime_instance_registry,
+                                    &node,
+                                    &old_loaded_name,
+                                    &instance_id,
+                                )
+                                .await
+                                {
+                                    publish_runtime_llama_unavailable(
+                                        runtime_data_producer.as_ref(),
+                                        &old_loaded_name,
+                                        Some(&instance_id),
+                                    );
+                                }
+                                remove_dashboard_process(&dashboard_processes, &instance_id).await;
+                                if let Some(cs) = console_state {
+                                    cs.remove_local_process(&instance_id).await;
+                                    cs.update(false, false).await;
+                                }
+                                return;
+                            }
+                        }
+                    }
                     SplitCoordinatorEvent::Withdraw(event) => {
                         let missing_stage_nodes = event
                             .missing_stage_nodes
@@ -1381,8 +1554,12 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 };
                 let mut next = event.loaded;
                 let old_loaded_name = loaded_name.clone();
-                let old_port = handle.port;
-                let old_context_length = handle.context_length;
+                let Some(old_handle) = handle.take() else {
+                    let _ = event.ack.send(SplitCoordinatorAck::Accepted);
+                    break;
+                };
+                let old_port = old_handle.port;
+                let old_context_length = old_handle.context_length;
                 remove_runtime_local_target(&target_tx, &old_loaded_name, old_port);
                 add_runtime_local_target(&target_tx, &next.loaded_name, next.handle.port);
                 tunnel_mgr.set_http_port(api_port);
@@ -1424,7 +1601,6 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     cs.upsert_local_process(payload).await;
                     cs.update(true, true).await;
                 }
-                let old_handle = std::mem::replace(&mut handle, next.handle);
                 remove_dashboard_context_usage(
                     &dashboard_context_usage,
                     &old_loaded_name,
@@ -1438,33 +1614,36 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     model_path: Some(&model_path),
                     launch_kind,
                     pinned_gpu: pinned_gpu.as_ref(),
-                    backend: Some(&handle.backend),
-                    context_length: Some(u64::from(handle.context_length)),
+                    backend: Some(&next.handle.backend),
+                    context_length: Some(u64::from(next.handle.context_length)),
                 });
                 survey_telemetry.record_launch_success(
                     &survey_loaded_model,
                     Duration::from_secs(0),
                 );
-                refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle)
+                refresh_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &next.handle)
                     .await;
                 publish_runtime_llama_slots(
                     runtime_data_producer.as_ref(),
                     &loaded_name,
                     Some(&instance_id),
-                    &handle,
+                    &next.handle,
                 );
+                let new_port = next.handle.port;
+                let new_context_length = next.handle.context_length;
                 death_rx = next.death_rx;
                 split_cleanup = next.cleanup.take();
+                handle = Some(next.handle);
                 let _ = event.ack.send(SplitCoordinatorAck::Accepted);
                 old_handle.shutdown().await;
                 let _ = emit_event(OutputEvent::Info {
                     message: format!(
                         "Split runtime cut over model '{}' from :{} to :{}",
-                        loaded_name, old_port, handle.port
+                        loaded_name, old_port, new_port
                     ),
                     context: Some(format!(
                         "reason={} generation={} previous_ctx={} new_ctx={}",
-                        event.reason, event.generation, old_context_length, handle.context_length
+                        event.reason, event.generation, old_context_length, new_context_length
                     )),
                 });
             }
@@ -1482,6 +1661,9 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     if !survey_exited_unexpectedly {
         survey_telemetry.record_unload(&survey_loaded_model);
     }
+    let Some(handle) = handle.take() else {
+        return;
+    };
     let port = handle.port;
     remove_runtime_local_target(&target_tx, &loaded_name, port);
     tunnel_mgr.set_http_port(api_port);

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -17,7 +17,7 @@ use self::local::{
     set_advertised_model_context, start_runtime_local_model, start_runtime_split_model,
     startup_runtime_plan, stop_split_generation_cleanup, withdraw_advertised_model,
     LocalRuntimeModelHandle, LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent,
-    SplitCoordinatorAck, SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
+    SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
@@ -1355,6 +1355,29 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 let Some(event) = event else {
                     split_event_rx = None;
                     continue;
+                };
+                let event = match event {
+                    SplitCoordinatorEvent::Replace(event) => event,
+                    SplitCoordinatorEvent::Withdraw(event) => {
+                        let missing_stage_nodes = event
+                            .missing_stage_nodes
+                            .iter()
+                            .map(|node| node.fmt_short().to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        let _ = emit_event(OutputEvent::Warning {
+                            message: format!(
+                                "Split runtime topology '{}' lost required stage peer(s); withdrawing model '{}'",
+                                event.topology_id, loaded_name
+                            ),
+                            context: Some(format!(
+                                "reason={} generation={} missing_stage_nodes=[{}]",
+                                event.reason, event.generation, missing_stage_nodes
+                            )),
+                        });
+                        let _ = event.ack.send(SplitCoordinatorAck::Accepted);
+                        break;
+                    }
                 };
                 let mut next = event.loaded;
                 let old_loaded_name = loaded_name.clone();

--- a/crates/mesh-llm/src/runtime/mod.rs
+++ b/crates/mesh-llm/src/runtime/mod.rs
@@ -1357,7 +1357,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     continue;
                 };
                 let event = match event {
-                    SplitCoordinatorEvent::Replace(event) => event,
+                    SplitCoordinatorEvent::Replace(event) => *event,
                     SplitCoordinatorEvent::Withdraw(event) => {
                         let missing_stage_nodes = event
                             .missing_stage_nodes


### PR DESCRIPTION
## Summary

Skippy split-serving now recovers when an active stage peer leaves the mesh instead of keeping a stale split topology alive.

When a replacement topology can still be formed, the coordinator accepts a degraded but valid topology even if it has fewer stages or participants. When quorum is no longer available, the coordinator asks the runtime loop to withdraw the active split generation so the model is no longer advertised through a broken topology.

## Why

The split topology coordinator already replanned on membership changes, but the acceptance gate only treated a candidate as useful when it had more stages, more participants, or a better balance score. That optimized for upgrades, but it missed a correctness case: after a stage owner disappears, the replacement topology may be smaller and less balanced while still being the only valid topology.

Keeping the old generation in that case leaves routing pointed at a stage peer that is no longer present. This change makes peer-loss recovery a separate correctness condition from normal topology improvement.

## Diff Scope

- `crates/mesh-llm/src/runtime/local.rs`
  - Adds loss-aware active-stage participant detection.
  - Accepts replacement candidates when the active topology references a missing stage owner.
  - Adds a fail-closed withdrawal event when a stage peer is lost and split quorum is no longer available.
  - Keeps existing planner validation, stage-0 locality checks, and load-before-cutover behavior.
  - Adds focused unit coverage for degraded recovery and unused-participant loss.

- `crates/mesh-llm/src/runtime/mod.rs`
  - Handles split coordinator withdrawal events in the startup runtime loop.
  - Emits a warning and lets the existing shutdown/cleanup path remove local routing, unregister the runtime instance, and stop the split generation.

## Branch Integrity

- Base branch: `main`
- Validated base: `origin/main`
- `git rev-parse origin/main`: `e2a0b5770a91ea4fddb2c2cae7f067a5c7f34d4b`
- `git rev-list --left-right --count origin/main...HEAD`: `0 1`
- Ahead count: `1`
- Behind count: `0`
- Merge base: `e2a0b5770a91ea4fddb2c2cae7f067a5c7f34d4b`
- Fast-forward safety: `git merge-base --is-ancestor origin/main HEAD` exited `0`; `origin/main` is an ancestor of `HEAD`.

## Commit Integrity

Introduced commit:

- `7697dcd977ea6c0903581224b71c888513c1d908 Recover Skippy split topology after stage peer loss`


## Diff Hygiene

`git diff --name-status origin/main...HEAD`:

```text
M	crates/mesh-llm/src/runtime/local.rs
M	crates/mesh-llm/src/runtime/mod.rs
```

`git diff --check origin/main...HEAD`: PASS, no output.



## Validation Mode And Proof

Validation mode: **Mode 3 - shared backend/runtime behavior**.

Reason: this changes Skippy split runtime coordination and failover behavior for distributed serving, while keeping the change scoped to runtime split topology recovery.

Local validation:

```text
cargo fmt --all -- --check
PASS

cargo check -p mesh-llm
PASS

LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm split_replan --lib
PASS - 4 passed

LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm split_missing_active_stage_nodes --lib
PASS - 1 passed

cargo test -p skippy-topology --lib
PASS - 16 passed

LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm runtime::proxy::tests::test_api_proxy_integration_streaming_response_arrives_incrementally --lib -- --exact
PASS - 1 passed

LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib
PASS - 1291 passed, 3 ignored
```

Note: one earlier full `mesh-llm --lib` run hit a timing-sensitive assertion in the unrelated proxy streaming integration test. The exact test passed on isolated rerun, and the final full library suite passed.

Not run: `just build` - not required for this Rust-only runtime change under the selected validation mode; the Rust crate check and full library suite passed locally.

## CI Context Confirmation

Required CI context names unchanged.


## Runtime Safety

Reviewed runtime modules:

- `crates/mesh-llm/src/runtime/local.rs`
- `crates/mesh-llm/src/runtime/mod.rs`

Runtime safety notes:

- No new protocol or public API schema fields.
- No new blocking locks.
- No new unbounded queues.
- No in-flight request resume is attempted; active generations fail naturally and later requests use a fresh topology.
- Existing stage-0 locality validation remains in place.
- Existing topology planner and capacity validation remain in place before replacement candidates can be accepted.
- Replacement generations are still loaded before cutover.
- When quorum is lost, the runtime fails closed by withdrawing the active split generation instead of keeping a stale route advertised.

No invariant regression introduced.

## Documentation Integrity

Not applicable - no documented command, runbook, protocol, or public API contract changed.

## Migration Notes

Not applicable - no DB migration changed.

## Rollback Plan

Rollback: `git revert <post_merge_commit_sha>`.

Replace `<post_merge_commit_sha>` with the final squash/merge commit SHA after merge.

DB downgrade required: no.

Data repair required: no.

Operational caveats: rollback restores the previous Skippy split replan acceptance behavior.

## Known Residual Risks

- No known functional residual risks after local validation.
- This PR does not implement in-flight split request resume; failed active generations are intentionally allowed to fail, and the next request uses the replacement topology once ready.