### PR TITLE
Verify Skippy layer packages before stage load

### DIFF
--- a/crates/mesh-llm/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm/src/inference/skippy/materialization.rs
@@ -7,7 +7,9 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use skippy_protocol::{LoadMode, StageConfig};
-use skippy_runtime::package::{self, LayerPackageInfo, PackageStageRequest};
+use skippy_runtime::package::{
+    self, LayerPackageInfo, PackageIntegrityOptions, PackageStageRequest,
+};
 
 use super::StageLoadRequest;
 
@@ -97,6 +99,14 @@ pub(crate) struct StagePackageLayerInfo {
 pub(crate) struct MaterializedStageArtifact {
     pub(crate) path: PathBuf,
     pub(crate) manifest_sha256: String,
+    pub(crate) source_model_path: String,
+    pub(crate) source_model_sha256: String,
+    pub(crate) source_model_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ResolvedStagePackage {
+    pub(crate) local_ref: String,
     pub(crate) source_model_path: String,
     pub(crate) source_model_sha256: String,
     pub(crate) source_model_bytes: Option<u64>,
@@ -216,6 +226,49 @@ fn resolve_local_package_files(
     Ok(package_dir.to_string_lossy().to_string())
 }
 
+fn package_integrity_cache_dir() -> PathBuf {
+    crate::models::mesh_llm_cache_dir().join("skippy-package-integrity")
+}
+
+fn verify_resolved_hf_package_files(
+    package_dir: &Path,
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+) -> Result<String> {
+    let local_ref = resolve_local_package_files(
+        package_dir,
+        layer_start,
+        layer_end,
+        include_embeddings,
+        include_output,
+    )?;
+    let request = PackageStageRequest {
+        model_id: "hf-layer-package".to_string(),
+        topology_id: "hf-layer-package-resolver".to_string(),
+        package_ref: local_ref.clone(),
+        stage_id: format!("layers-{layer_start}-{layer_end}"),
+        layer_start,
+        layer_end,
+        include_embeddings,
+        include_output,
+    };
+    let report = package::verify_layer_package_integrity(
+        &request,
+        &PackageIntegrityOptions::verify_with_cache(package_integrity_cache_dir()),
+    )
+    .map_err(|error| anyhow::anyhow!("verify resolved HF layer package artifacts: {error:#}"))?;
+    tracing::debug!(
+        artifacts = report.artifacts,
+        verified_artifacts = report.verified_artifacts,
+        cached_artifacts = report.cached_artifacts,
+        manifest_sha256 = %report.manifest_sha256,
+        "verified resolved HF layer package artifacts"
+    );
+    Ok(local_ref)
+}
+
 pub(crate) fn resolve_hf_package_to_local(
     package_ref: &str,
     layer_start: u32,
@@ -257,7 +310,7 @@ pub(crate) fn resolve_hf_package_to_local(
         .join("snapshots")
         .join(&revision_cache_path);
     if direct_snapshot_dir.join("model-package.json").is_file() {
-        return resolve_local_package_files(
+        return verify_resolved_hf_package_files(
             &direct_snapshot_dir,
             layer_start,
             layer_end,
@@ -275,7 +328,7 @@ pub(crate) fn resolve_hf_package_to_local(
             .join("snapshots")
             .join(commit_hash_path);
         if snapshot_dir.join("model-package.json").is_file() {
-            return resolve_local_package_files(
+            return verify_resolved_hf_package_files(
                 &snapshot_dir,
                 layer_start,
                 layer_end,
@@ -368,7 +421,13 @@ pub(crate) fn resolve_hf_package_to_local(
             .with_context(|| format!("download layer package file: {file_name}"))?;
     }
 
-    Ok(package_dir.to_string_lossy().to_string())
+    verify_resolved_hf_package_files(
+        &package_dir,
+        layer_start,
+        layer_end,
+        include_embeddings,
+        include_output,
+    )
 }
 
 fn safe_manifest_file_path(path: &str) -> Result<PathBuf> {
@@ -399,7 +458,9 @@ pub(crate) fn inspect_stage_package(package_ref: &str) -> Result<StagePackageInf
 /// Resolve an `hf://` package ref in a stage load request to a local directory.
 /// Returns the resolved local path if the package ref needed resolution, or `None`
 /// if it was already local / not a layer package.
-pub(crate) fn resolve_stage_load_package(load: &StageLoadRequest) -> Result<Option<String>> {
+pub(crate) fn resolve_stage_load_package(
+    load: &StageLoadRequest,
+) -> Result<Option<ResolvedStagePackage>> {
     if load.load_mode != LoadMode::LayerPackage {
         return Ok(None);
     }
@@ -414,7 +475,14 @@ pub(crate) fn resolve_stage_load_package(load: &StageLoadRequest) -> Result<Opti
         is_first, // include_embeddings
         is_final, // include_output
     )?;
-    Ok(Some(local_ref))
+    let info = package::inspect_layer_package(&local_ref)
+        .with_context(|| format!("inspect resolved layer package {}", load.package_ref))?;
+    Ok(Some(ResolvedStagePackage {
+        local_ref,
+        source_model_path: info.source_model_path,
+        source_model_sha256: info.source_model_sha256,
+        source_model_bytes: info.source_model_bytes,
+    }))
 }
 
 pub(crate) fn materialize_stage_config(
@@ -758,6 +826,81 @@ mod tests {
         }
     }
 
+    fn sha256_hex(bytes: &[u8]) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let digest = hasher.finalize();
+        let mut out = String::with_capacity(64);
+        for byte in digest {
+            out.push_str(&format!("{byte:02x}"));
+        }
+        out
+    }
+
+    fn write_cached_package_snapshot(snapshot: &Path, layer_sha: String) {
+        fs::create_dir_all(snapshot.join("shared")).unwrap();
+        fs::create_dir_all(snapshot.join("layers")).unwrap();
+        fs::write(snapshot.join("shared/metadata.gguf"), b"metadata").unwrap();
+        fs::write(snapshot.join("layers/layer-000.gguf"), b"layer").unwrap();
+        fs::write(
+            snapshot.join("model-package.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "schema_version": 1,
+                "model_id": "model-a",
+                "source_model": {
+                    "path": "model-a.gguf",
+                    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "files": [
+                        {
+                            "path": "model-a.gguf",
+                            "size_bytes": 123,
+                            "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ]
+                },
+                "format": "layer-package",
+                "layer_count": 1,
+                "activation_width": 4096,
+                "shared": {
+                    "metadata": {
+                        "path": "shared/metadata.gguf",
+                        "tensor_count": 1,
+                        "tensor_bytes": 1,
+                        "artifact_bytes": 8,
+                        "sha256": sha256_hex(b"metadata")
+                    },
+                    "embeddings": {
+                        "path": "shared/metadata.gguf",
+                        "tensor_count": 1,
+                        "tensor_bytes": 1,
+                        "artifact_bytes": 8,
+                        "sha256": sha256_hex(b"metadata")
+                    },
+                    "output": {
+                        "path": "shared/metadata.gguf",
+                        "tensor_count": 1,
+                        "tensor_bytes": 1,
+                        "artifact_bytes": 8,
+                        "sha256": sha256_hex(b"metadata")
+                    }
+                },
+                "layers": [
+                    {
+                        "layer_index": 0,
+                        "path": "layers/layer-000.gguf",
+                        "tensor_count": 1,
+                        "tensor_bytes": 1,
+                        "artifact_bytes": 5,
+                        "sha256": layer_sha
+                    }
+                ],
+                "skippy_abi_version": "0.1.0",
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
     #[test]
     fn layer_package_ref_detects_local_manifest_dir() {
         let dir = tempfile::tempdir().unwrap();
@@ -925,23 +1068,7 @@ mod tests {
             .join("models--owner--repo")
             .join("snapshots")
             .join("abc123");
-        fs::create_dir_all(snapshot.join("shared")).unwrap();
-        fs::create_dir_all(snapshot.join("layers")).unwrap();
-        fs::write(snapshot.join("shared/metadata.gguf"), b"metadata").unwrap();
-        fs::write(snapshot.join("layers/layer-000.gguf"), b"layer").unwrap();
-        fs::write(
-            snapshot.join("model-package.json"),
-            serde_json::json!({
-                "shared": {
-                    "metadata": { "path": "shared/metadata.gguf" }
-                },
-                "layers": [
-                    { "layer_index": 0, "path": "layers/layer-000.gguf" }
-                ]
-            })
-            .to_string(),
-        )
-        .unwrap();
+        write_cached_package_snapshot(&snapshot, sha256_hex(b"layer"));
 
         let resolved =
             resolve_hf_package_to_local("hf://owner/repo@abc123", 0, 1, false, false).unwrap();
@@ -951,6 +1078,92 @@ mod tests {
         restore_env("HF_HOME", prev_hf_home);
         restore_env("HF_HUB_CACHE", prev_hf_cache);
         restore_env("HUGGINGFACE_HUB_CACHE", prev_huggingface_cache);
+    }
+
+    #[test]
+    #[serial]
+    fn hf_package_resolution_verifies_cached_snapshot_artifact_checksums() {
+        let prev_hf_home = std::env::var_os("HF_HOME");
+        let prev_hf_cache = std::env::var_os("HF_HUB_CACHE");
+        let prev_huggingface_cache = std::env::var_os("HUGGINGFACE_HUB_CACHE");
+        let prev_xdg_cache = std::env::var_os("XDG_CACHE_HOME");
+
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HOME", temp.path().join("hf"));
+        std::env::set_var("XDG_CACHE_HOME", temp.path().join("mesh-cache"));
+        std::env::remove_var("HF_HUB_CACHE");
+        std::env::remove_var("HUGGINGFACE_HUB_CACHE");
+
+        let snapshot = temp
+            .path()
+            .join("hf")
+            .join("hub")
+            .join("models--owner--repo")
+            .join("snapshots")
+            .join("abc123");
+        write_cached_package_snapshot(
+            &snapshot,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        );
+
+        let error = resolve_hf_package_to_local("hf://owner/repo@abc123", 0, 1, false, false)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("checksum mismatch"), "{error}");
+
+        restore_env("HF_HOME", prev_hf_home);
+        restore_env("HF_HUB_CACHE", prev_hf_cache);
+        restore_env("HUGGINGFACE_HUB_CACHE", prev_huggingface_cache);
+        restore_env("XDG_CACHE_HOME", prev_xdg_cache);
+    }
+
+    #[test]
+    fn resolved_stage_load_package_keeps_local_path_out_of_source_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        write_cached_package_snapshot(dir.path(), sha256_hex(b"layer"));
+        let load = StageLoadRequest {
+            topology_id: "topology-a".to_string(),
+            run_id: "run-a".to_string(),
+            model_id: "model-a".to_string(),
+            backend: "skippy".to_string(),
+            package_ref: dir.path().to_string_lossy().to_string(),
+            manifest_sha256: "manifest".to_string(),
+            stage_id: "stage-0".to_string(),
+            stage_index: 0,
+            layer_start: 0,
+            layer_end: 1,
+            model_path: None,
+            source_model_bytes: None,
+            projector_path: None,
+            selected_device: None,
+            bind_addr: "127.0.0.1:0".to_string(),
+            activation_width: 4096,
+            wire_dtype: crate::inference::skippy::StageWireDType::F16,
+            ctx_size: 512,
+            lane_count: 1,
+            n_batch: None,
+            n_ubatch: None,
+            n_gpu_layers: 0,
+            cache_type_k: "f16".to_string(),
+            cache_type_v: "f16".to_string(),
+            flash_attn_type: skippy_protocol::FlashAttentionType::Auto,
+            shutdown_generation: 0,
+            load_mode: LoadMode::LayerPackage,
+            upstream: None,
+            downstream: None,
+        };
+
+        let resolved = resolve_stage_load_package(&load)
+            .unwrap()
+            .expect("layer package should resolve");
+
+        assert_eq!(resolved.local_ref, dir.path().to_string_lossy());
+        assert_eq!(resolved.source_model_path, "model-a.gguf");
+        assert_eq!(
+            resolved.source_model_sha256,
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
     }
 
     #[test]

--- a/crates/mesh-llm/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm/src/inference/skippy/materialization.rs
@@ -230,6 +230,15 @@ fn package_integrity_cache_dir() -> PathBuf {
     crate::models::mesh_llm_cache_dir().join("skippy-package-integrity")
 }
 
+fn is_metadata_only_package_inspection(
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+) -> bool {
+    layer_start == layer_end && !include_embeddings && !include_output
+}
+
 fn verify_resolved_hf_package_files(
     package_dir: &Path,
     layer_start: u32,
@@ -244,26 +253,35 @@ fn verify_resolved_hf_package_files(
         include_embeddings,
         include_output,
     )?;
-    let request = PackageStageRequest {
-        model_id: "hf-layer-package".to_string(),
-        topology_id: "hf-layer-package-resolver".to_string(),
-        package_ref: local_ref.clone(),
-        stage_id: format!("layers-{layer_start}-{layer_end}"),
+    let metadata_only = is_metadata_only_package_inspection(
         layer_start,
         layer_end,
         include_embeddings,
         include_output,
-    };
-    let report = package::verify_layer_package_integrity(
-        &request,
-        &PackageIntegrityOptions::verify_with_cache(package_integrity_cache_dir()),
-    )
+    );
+    let options = PackageIntegrityOptions::verify_with_cache(package_integrity_cache_dir());
+    let report = if metadata_only {
+        package::verify_layer_package_metadata_integrity(&local_ref, &options)
+    } else {
+        let request = PackageStageRequest {
+            model_id: "hf-layer-package".to_string(),
+            topology_id: "hf-layer-package-resolver".to_string(),
+            package_ref: local_ref.clone(),
+            stage_id: format!("layers-{layer_start}-{layer_end}"),
+            layer_start,
+            layer_end,
+            include_embeddings,
+            include_output,
+        };
+        package::verify_layer_package_integrity(&request, &options)
+    }
     .map_err(|error| anyhow::anyhow!("verify resolved HF layer package artifacts: {error:#}"))?;
     tracing::debug!(
         artifacts = report.artifacts,
         verified_artifacts = report.verified_artifacts,
         cached_artifacts = report.cached_artifacts,
         manifest_sha256 = %report.manifest_sha256,
+        metadata_only,
         "verified resolved HF layer package artifacts"
     );
     Ok(local_ref)
@@ -1078,6 +1096,53 @@ mod tests {
         restore_env("HF_HOME", prev_hf_home);
         restore_env("HF_HUB_CACHE", prev_hf_cache);
         restore_env("HUGGINGFACE_HUB_CACHE", prev_huggingface_cache);
+    }
+
+    #[test]
+    #[serial]
+    fn hf_package_metadata_only_cache_resolution_uses_metadata_integrity_scope() {
+        let prev_hf_home = std::env::var_os("HF_HOME");
+        let prev_hf_cache = std::env::var_os("HF_HUB_CACHE");
+        let prev_huggingface_cache = std::env::var_os("HUGGINGFACE_HUB_CACHE");
+        let prev_xdg_cache = std::env::var_os("XDG_CACHE_HOME");
+
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HOME", temp.path().join("hf"));
+        std::env::set_var("XDG_CACHE_HOME", temp.path().join("mesh-cache"));
+        std::env::remove_var("HF_HUB_CACHE");
+        std::env::remove_var("HUGGINGFACE_HUB_CACHE");
+
+        let snapshot = temp
+            .path()
+            .join("hf")
+            .join("hub")
+            .join("models--owner--repo")
+            .join("snapshots")
+            .join("abc123");
+        write_cached_package_snapshot(
+            &snapshot,
+            "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+        );
+
+        let resolved =
+            resolve_hf_package_to_local("hf://owner/repo@abc123", 0, 0, false, false).unwrap();
+        assert_eq!(PathBuf::from(resolved), snapshot);
+
+        let info = inspect_stage_package("hf://owner/repo@abc123").unwrap();
+        assert_eq!(info.model_id, "model-a");
+        assert_eq!(info.layer_count, 1);
+
+        fs::write(snapshot.join("shared/metadata.gguf"), b"metadota").unwrap();
+        let error = resolve_hf_package_to_local("hf://owner/repo@abc123", 0, 0, false, false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("checksum mismatch"), "{error}");
+        assert!(error.contains("shared/metadata.gguf"), "{error}");
+
+        restore_env("HF_HOME", prev_hf_home);
+        restore_env("HF_HUB_CACHE", prev_hf_cache);
+        restore_env("HUGGINGFACE_HUB_CACHE", prev_huggingface_cache);
+        restore_env("XDG_CACHE_HOME", prev_xdg_cache);
     }
 
     #[test]

--- a/crates/mesh-llm/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm/src/inference/skippy/stage/mod.rs
@@ -21,6 +21,7 @@ struct RunningStage {
     load: StageLoadRequest,
     server: EmbeddedServerHandle,
     materialized: Option<super::materialization::MaterializedStageArtifact>,
+    package: Option<super::materialization::ResolvedStagePackage>,
     _materialized_pin: Option<super::materialization::MaterializedStagePin>,
 }
 
@@ -180,15 +181,18 @@ impl StageControlState {
         effective_load.bind_addr = bind_addr.to_string();
         super::configure_materialized_stage_cache();
         let package_request = effective_load.clone();
-        if let Some(local_ref) = tokio::task::spawn_blocking(move || {
+        let mut resolved_package = None;
+        if let Some(package) = tokio::task::spawn_blocking(move || {
             super::materialization::resolve_stage_load_package(&package_request)
         })
         .await
         .context("join resolve stage load package task")??
         {
-            effective_load.model_path = Some(local_ref);
+            effective_load.model_path = Some(package.local_ref.clone());
+            effective_load.source_model_bytes = package.source_model_bytes;
+            resolved_package = Some(package);
         }
-        let config = stage_config(&effective_load, None)?;
+        let config = stage_config(&effective_load, None, resolved_package.as_ref())?;
         let server = skippy_server::start_binary_stage(BinaryStageOptions {
             config,
             topology: None,
@@ -218,6 +222,7 @@ impl StageControlState {
                 load: effective_load.clone(),
                 server,
                 materialized: None,
+                package: resolved_package,
                 _materialized_pin: None,
             },
         );
@@ -369,6 +374,7 @@ fn probe_binary_stage_ready(bind_addr: SocketAddr, timeout: Duration) -> Result<
 fn stage_config(
     load: &StageLoadRequest,
     materialized: Option<&super::materialization::MaterializedStageArtifact>,
+    package: Option<&super::materialization::ResolvedStagePackage>,
 ) -> Result<StageConfig> {
     anyhow::ensure!(!load.topology_id.is_empty(), "topology_id is required");
     anyhow::ensure!(!load.run_id.is_empty(), "run_id is required");
@@ -394,10 +400,14 @@ fn stage_config(
         manifest_sha256: Some(load.manifest_sha256.clone()),
         source_model_path: materialized
             .map(|artifact| artifact.source_model_path.clone())
+            .or_else(|| package.map(|package| package.source_model_path.clone()))
             .or_else(|| load.model_path.clone()),
-        source_model_sha256: materialized.map(|artifact| artifact.source_model_sha256.clone()),
+        source_model_sha256: materialized
+            .map(|artifact| artifact.source_model_sha256.clone())
+            .or_else(|| package.map(|package| package.source_model_sha256.clone())),
         source_model_bytes: materialized
             .and_then(|artifact| artifact.source_model_bytes)
+            .or_else(|| package.and_then(|package| package.source_model_bytes))
             .or(load.source_model_bytes),
         materialized_path: materialized.map(|artifact| artifact.path.to_string_lossy().to_string()),
         materialized_pinned: materialized.is_some(),
@@ -467,15 +477,33 @@ fn status_from_running(stage: &RunningStage) -> StageStatusSnapshot {
             .materialized
             .as_ref()
             .map(|artifact| artifact.source_model_path.clone())
+            .or_else(|| {
+                stage
+                    .package
+                    .as_ref()
+                    .map(|package| package.source_model_path.clone())
+            })
             .or_else(|| stage.load.model_path.clone()),
         source_model_sha256: stage
             .materialized
             .as_ref()
-            .map(|artifact| artifact.source_model_sha256.clone()),
+            .map(|artifact| artifact.source_model_sha256.clone())
+            .or_else(|| {
+                stage
+                    .package
+                    .as_ref()
+                    .map(|package| package.source_model_sha256.clone())
+            }),
         source_model_bytes: stage
             .materialized
             .as_ref()
             .and_then(|artifact| artifact.source_model_bytes)
+            .or_else(|| {
+                stage
+                    .package
+                    .as_ref()
+                    .and_then(|package| package.source_model_bytes)
+            })
             .or(stage.load.source_model_bytes),
         materialized_path: stage
             .materialized

--- a/crates/mesh-llm/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm/src/inference/skippy/stage/tests.rs
@@ -51,7 +51,7 @@ fn load_request() -> StageLoadRequest {
 #[test]
 fn stage_config_preserves_backend_neutral_load_fields() {
     let request = load_request();
-    let config = stage_config(&request, None).unwrap();
+    let config = stage_config(&request, None, None).unwrap();
 
     assert_eq!(config.topology_id, "topology-a");
     assert_eq!(config.run_id, "run-a");
@@ -92,6 +92,34 @@ fn stage_config_preserves_backend_neutral_load_fields() {
 }
 
 #[test]
+fn stage_config_prefers_package_source_identity_over_local_ref() {
+    let mut request = load_request();
+    request.load_mode = LoadMode::LayerPackage;
+    request.model_path = Some("/tmp/hf-cache/snapshots/abc123".to_string());
+    request.source_model_bytes = Some(123);
+    let package = super::super::materialization::ResolvedStagePackage {
+        local_ref: "/tmp/hf-cache/snapshots/abc123".to_string(),
+        source_model_path: "model-a.gguf".to_string(),
+        source_model_sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            .to_string(),
+        source_model_bytes: Some(456),
+    };
+
+    let config = stage_config(&request, None, Some(&package)).unwrap();
+
+    assert_eq!(
+        config.model_path.as_deref(),
+        Some("/tmp/hf-cache/snapshots/abc123")
+    );
+    assert_eq!(config.source_model_path.as_deref(), Some("model-a.gguf"));
+    assert_eq!(
+        config.source_model_sha256.as_deref(),
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+    );
+    assert_eq!(config.source_model_bytes, Some(456));
+}
+
+#[test]
 fn stage_config_rejects_empty_selected_backend_device() {
     let mut request = load_request();
     request.selected_device = Some(StageDevice {
@@ -101,7 +129,7 @@ fn stage_config_rejects_empty_selected_backend_device() {
         vram_bytes: Some(24_000_000_000),
     });
 
-    let err = stage_config(&request, None).unwrap_err().to_string();
+    let err = stage_config(&request, None, None).unwrap_err().to_string();
 
     assert!(err.contains("selected backend device"));
 }

--- a/crates/skippy-runtime/src/package.rs
+++ b/crates/skippy-runtime/src/package.rs
@@ -352,6 +352,36 @@ pub fn verify_layer_package_integrity(
     Ok(select_layer_package_parts_with_integrity(request, integrity_options)?.integrity)
 }
 
+pub fn verify_layer_package_metadata_integrity(
+    package_ref: &str,
+    integrity_options: &PackageIntegrityOptions,
+) -> Result<PackageIntegrityReport> {
+    let package_dir = resolve_package_dir(package_ref)?;
+    let manifest_path = package_dir.join("model-package.json");
+    let manifest_contents = fs::read(&manifest_path)
+        .with_context(|| format!("read package manifest {}", manifest_path.display()))?;
+    let manifest_sha256 = sha256_bytes(&manifest_contents);
+    let manifest = load_manifest(&manifest_path, &manifest_contents)?;
+    validate_manifest_identity(&manifest)?;
+    validate_layer_manifest(&manifest)?;
+
+    let mut parts = Vec::new();
+    push_part(
+        &mut parts,
+        "metadata",
+        None,
+        &manifest.shared.metadata,
+        &package_dir,
+    )?;
+    verify_package_artifacts(
+        &package_dir,
+        &manifest_sha256,
+        &parts,
+        &[],
+        integrity_options,
+    )
+}
+
 pub fn inspect_layer_package(package_ref: &str) -> Result<LayerPackageInfo> {
     let package_dir = resolve_package_dir(package_ref)?;
     let manifest_path = package_dir.join("model-package.json");
@@ -1238,6 +1268,45 @@ mod tests {
 
         assert!(error.contains("checksum mismatch"), "{error}");
         assert!(error.contains("layers/00000.gguf"), "{error}");
+    }
+
+    #[test]
+    fn verify_layer_package_metadata_integrity_allows_metadata_only_scope() {
+        let dir = tempfile::tempdir().unwrap();
+        write_package_fixture(dir.path());
+        fs::write(dir.path().join("layers/00000.gguf"), b"wrong0").unwrap();
+        fs::write(
+            dir.path().join("projectors/mmproj.gguf"),
+            b"wrong-projector",
+        )
+        .unwrap();
+
+        let report = verify_layer_package_metadata_integrity(
+            &dir.path().to_string_lossy(),
+            &PackageIntegrityOptions::verify_without_cache(),
+        )
+        .expect("metadata-only verification should not require a stage layer range");
+
+        assert_eq!(report.artifacts, 1);
+        assert_eq!(report.verified_artifacts, 1);
+        assert_eq!(report.cached_artifacts, 0);
+    }
+
+    #[test]
+    fn verify_layer_package_metadata_integrity_checks_metadata_sha() {
+        let dir = tempfile::tempdir().unwrap();
+        write_package_fixture(dir.path());
+        fs::write(dir.path().join("metadata.gguf"), b"metadota").unwrap();
+
+        let error = verify_layer_package_metadata_integrity(
+            &dir.path().to_string_lossy(),
+            &PackageIntegrityOptions::verify_without_cache(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("checksum mismatch"), "{error}");
+        assert!(error.contains("metadata.gguf"), "{error}");
     }
 
     #[test]

--- a/crates/skippy-runtime/src/package.rs
+++ b/crates/skippy-runtime/src/package.rs
@@ -3,10 +3,11 @@ use std::{
     fs,
     io::Read,
     path::{Path, PathBuf},
+    time::UNIX_EPOCH,
 };
 
 use anyhow::{bail, Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::write_gguf_from_parts;
@@ -37,6 +38,7 @@ pub struct SelectedPackageParts {
     pub selected_parts: Vec<PackagePart>,
     pub absolute_paths: Vec<PathBuf>,
     pub projector_paths: Vec<PathBuf>,
+    pub integrity: PackageIntegrityReport,
 }
 
 #[derive(Debug, Clone)]
@@ -75,6 +77,55 @@ pub struct PackagePart {
     pub path: PathBuf,
     pub sha256: String,
     pub artifact_bytes: u64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PackageIntegrityOptions {
+    verify_sha256: bool,
+    cache_dir: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct PackageIntegrityReport {
+    pub manifest_sha256: String,
+    pub artifacts: usize,
+    pub verified_artifacts: usize,
+    pub cached_artifacts: usize,
+}
+
+impl PackageIntegrityOptions {
+    pub fn manifest_only() -> Self {
+        Self {
+            verify_sha256: false,
+            cache_dir: None,
+        }
+    }
+
+    pub fn verify_without_cache() -> Self {
+        Self {
+            verify_sha256: true,
+            cache_dir: None,
+        }
+    }
+
+    pub fn verify_with_cache(cache_dir: impl AsRef<Path>) -> Self {
+        Self {
+            verify_sha256: true,
+            cache_dir: Some(cache_dir.as_ref().to_path_buf()),
+        }
+    }
+
+    fn from_env() -> Self {
+        let mut options = if env_flag("SKIPPY_VERIFY_PACKAGE_SHA") {
+            Self::verify_without_cache()
+        } else {
+            Self::manifest_only()
+        };
+        if let Some(cache_dir) = std::env::var_os("SKIPPY_PACKAGE_VERIFY_CACHE_DIR") {
+            options.cache_dir = Some(PathBuf::from(cache_dir));
+        }
+        options
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -196,6 +247,13 @@ pub fn materialize_layer_package_details(
 }
 
 pub fn select_layer_package_parts(request: &PackageStageRequest) -> Result<SelectedPackageParts> {
+    select_layer_package_parts_with_integrity(request, &PackageIntegrityOptions::from_env())
+}
+
+pub fn select_layer_package_parts_with_integrity(
+    request: &PackageStageRequest,
+    integrity_options: &PackageIntegrityOptions,
+) -> Result<SelectedPackageParts> {
     let package_dir = resolve_package_dir(&request.package_ref)?;
     let manifest_path = package_dir.join("model-package.json");
     let manifest_contents = fs::read(&manifest_path)
@@ -260,33 +318,6 @@ pub fn select_layer_package_parts(request: &PackageStageRequest) -> Result<Selec
         )?;
     }
 
-    if env_flag("SKIPPY_VERIFY_PACKAGE_SHA") {
-        for part in &parts {
-            let absolute = package_dir.join(&part.path);
-            let actual = file_sha256(&absolute)?;
-            if actual != part.sha256 {
-                bail!(
-                    "package part checksum mismatch for {}: expected {}, got {}",
-                    part.path.display(),
-                    part.sha256,
-                    actual
-                );
-            }
-        }
-        for projector in &manifest.projectors {
-            let absolute = package_dir.join(&projector.path);
-            let actual = file_sha256(&absolute)?;
-            if actual != projector.sha256 {
-                bail!(
-                    "package projector checksum mismatch for {}: expected {}, got {}",
-                    projector.path,
-                    projector.sha256,
-                    actual
-                );
-            }
-        }
-    }
-
     let absolute_paths = parts
         .iter()
         .map(|part| package_dir.join(&part.path))
@@ -296,6 +327,13 @@ pub fn select_layer_package_parts(request: &PackageStageRequest) -> Result<Selec
         .iter()
         .map(|projector| projector_path(projector, &package_dir))
         .collect::<Result<Vec<_>>>()?;
+    let integrity = verify_package_artifacts(
+        &package_dir,
+        &manifest_sha256,
+        &parts,
+        &manifest.projectors,
+        integrity_options,
+    )?;
 
     Ok(SelectedPackageParts {
         package_dir,
@@ -303,7 +341,15 @@ pub fn select_layer_package_parts(request: &PackageStageRequest) -> Result<Selec
         selected_parts: parts,
         absolute_paths,
         projector_paths,
+        integrity,
     })
+}
+
+pub fn verify_layer_package_integrity(
+    request: &PackageStageRequest,
+    integrity_options: &PackageIntegrityOptions,
+) -> Result<PackageIntegrityReport> {
+    Ok(select_layer_package_parts_with_integrity(request, integrity_options)?.integrity)
 }
 
 pub fn inspect_layer_package(package_ref: &str) -> Result<LayerPackageInfo> {
@@ -314,15 +360,19 @@ pub fn inspect_layer_package(package_ref: &str) -> Result<LayerPackageInfo> {
     let manifest_sha256 = sha256_bytes(&manifest_contents);
     let manifest = load_manifest(&manifest_path, &manifest_contents)?;
     validate_manifest_identity(&manifest)?;
+    validate_layer_manifest(&manifest)?;
     let projectors = manifest
         .projectors
         .into_iter()
-        .map(|projector| PackageProjectorInfo {
-            kind: projector.kind,
-            path: package_dir.join(projector.path),
-            artifact_bytes: projector.artifact_bytes,
+        .map(|projector| {
+            let path = safe_relative_manifest_path(&projector.path)?;
+            Ok(PackageProjectorInfo {
+                kind: projector.kind,
+                path: package_dir.join(path),
+                artifact_bytes: projector.artifact_bytes,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
     let activation_width = match manifest.activation_width {
         Some(width) => Some(width),
         None => infer_activation_width_from_layers(&package_dir, &manifest.layers)?,
@@ -371,7 +421,7 @@ fn infer_activation_width_from_layers(
     let Some(layer) = layers.first() else {
         return Ok(None);
     };
-    let layer_path = package_dir.join(&layer.path);
+    let layer_path = package_dir.join(safe_relative_manifest_path(&layer.path)?);
     let info = match crate::ModelInfo::open(&layer_path) {
         Ok(info) => info,
         Err(_) => return Ok(None),
@@ -469,6 +519,7 @@ fn load_manifest(path: &Path, contents: &[u8]) -> Result<PackageManifest> {
 
 fn validate_manifest(manifest: &PackageManifest, request: &PackageStageRequest) -> Result<()> {
     validate_manifest_identity(manifest)?;
+    let layer_counts = validate_layer_manifest(manifest)?;
     if request.layer_start >= request.layer_end {
         bail!("stage layer_start must be less than layer_end");
     }
@@ -480,6 +531,15 @@ fn validate_manifest(manifest: &PackageManifest, request: &PackageStageRequest) 
         );
     }
 
+    for layer_index in request.layer_start..request.layer_end {
+        if !layer_counts.contains_key(&layer_index) {
+            bail!("package is missing layer {layer_index}");
+        }
+    }
+    Ok(())
+}
+
+fn validate_layer_manifest(manifest: &PackageManifest) -> Result<BTreeMap<u32, usize>> {
     let mut layer_counts = BTreeMap::<u32, usize>::new();
     for layer in &manifest.layers {
         *layer_counts.entry(layer.layer_index).or_default() += 1;
@@ -508,12 +568,7 @@ fn validate_manifest(manifest: &PackageManifest, request: &PackageStageRequest) 
     if !duplicates.is_empty() {
         bail!("package manifest contains duplicate layers: {duplicates:?}");
     }
-    for layer_index in request.layer_start..request.layer_end {
-        if !layer_counts.contains_key(&layer_index) {
-            bail!("package is missing layer {layer_index}");
-        }
-    }
-    Ok(())
+    Ok(layer_counts)
 }
 
 fn validate_manifest_identity(manifest: &PackageManifest) -> Result<()> {
@@ -539,7 +594,6 @@ fn validate_manifest_identity(manifest: &PackageManifest) -> Result<()> {
         bail!("package manifest model_id must not be empty");
     }
     if manifest.source_model.path.trim().is_empty()
-        || manifest.source_model.sha256.trim().is_empty()
         || manifest
             .source_model
             .repo
@@ -568,6 +622,7 @@ fn validate_manifest_identity(manifest: &PackageManifest) -> Result<()> {
     {
         bail!("package manifest source_model identity fields must not be empty");
     }
+    validate_sha256_digest("source_model sha256", &manifest.source_model.sha256)?;
     for file in &manifest.source_model.files {
         if file.path.trim().is_empty()
             || file
@@ -576,6 +631,9 @@ fn validate_manifest_identity(manifest: &PackageManifest) -> Result<()> {
                 .is_some_and(|sha256| sha256.trim().is_empty())
         {
             bail!("package manifest source_model files must not contain empty path or sha256");
+        }
+        if let Some(sha256) = &file.sha256 {
+            validate_sha256_digest("source_model file sha256", sha256)?;
         }
         let _ = file.size_bytes;
     }
@@ -592,12 +650,9 @@ fn validate_artifact_manifest(role: &str, artifact: &PackageArtifact) -> Result<
     if artifact.path.trim().is_empty() {
         bail!("package {role} artifact path must not be empty");
     }
-    if Path::new(&artifact.path).is_absolute() {
-        bail!("package {role} artifact path must be relative");
-    }
-    if artifact.sha256.len() != 64 || !artifact.sha256.chars().all(|ch| ch.is_ascii_hexdigit()) {
-        bail!("package {role} artifact sha256 must be a hex SHA-256 digest");
-    }
+    let _ = safe_relative_manifest_path(&artifact.path)
+        .with_context(|| format!("package {role} artifact path must be a safe relative path"))?;
+    validate_sha256_digest(&format!("package {role} artifact sha256"), &artifact.sha256)?;
     if artifact.artifact_bytes == 0 {
         bail!("package {role} artifact_bytes must be greater than zero");
     }
@@ -636,15 +691,12 @@ fn push_part(
     artifact: &PackageArtifact,
     package_dir: &Path,
 ) -> Result<()> {
-    let path = PathBuf::from(&artifact.path);
-    if path.is_absolute() {
-        bail!("package part paths must be relative: {}", path.display());
-    }
+    let path = safe_relative_manifest_path(&artifact.path)?;
     let absolute = package_dir.join(&path);
     let metadata = fs::metadata(&absolute)
-        .with_context(|| format!("read package part metadata {}", absolute.display()))?;
+        .with_context(|| format!("read package part metadata {}", path.display()))?;
     if !metadata.is_file() {
-        bail!("package part is not a file: {}", absolute.display());
+        bail!("package part is not a file: {}", path.display());
     }
     if metadata.len() != artifact.artifact_bytes {
         bail!(
@@ -665,18 +717,12 @@ fn push_part(
 }
 
 fn projector_path(projector: &PackageProjector, package_dir: &Path) -> Result<PathBuf> {
-    let path = PathBuf::from(&projector.path);
-    if path.is_absolute() {
-        bail!(
-            "package projector paths must be relative: {}",
-            path.display()
-        );
-    }
+    let path = safe_relative_manifest_path(&projector.path)?;
     let absolute = package_dir.join(&path);
     let metadata = fs::metadata(&absolute)
-        .with_context(|| format!("read package projector metadata {}", absolute.display()))?;
+        .with_context(|| format!("read package projector metadata {}", path.display()))?;
     if !metadata.is_file() {
-        bail!("package projector is not a file: {}", absolute.display());
+        bail!("package projector is not a file: {}", path.display());
     }
     if metadata.len() != projector.artifact_bytes {
         bail!(
@@ -687,6 +733,202 @@ fn projector_path(projector: &PackageProjector, package_dir: &Path) -> Result<Pa
         );
     }
     Ok(absolute)
+}
+
+#[derive(Debug)]
+struct ArtifactVerification<'a> {
+    role: &'a str,
+    layer_index: Option<u32>,
+    path: PathBuf,
+    sha256: String,
+    artifact_bytes: u64,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct IntegrityCacheRecord {
+    schema_version: u32,
+    manifest_sha256: String,
+    artifact_sha256: String,
+    artifact_bytes: u64,
+    file_len: u64,
+    modified_unix_nanos: Option<u128>,
+}
+
+fn verify_package_artifacts(
+    package_dir: &Path,
+    manifest_sha256: &str,
+    parts: &[PackagePart],
+    projectors: &[PackageProjector],
+    options: &PackageIntegrityOptions,
+) -> Result<PackageIntegrityReport> {
+    let artifacts = parts
+        .iter()
+        .map(|part| ArtifactVerification {
+            role: &part.role,
+            layer_index: part.layer_index,
+            path: part.path.clone(),
+            sha256: part.sha256.clone(),
+            artifact_bytes: part.artifact_bytes,
+        })
+        .chain(projectors.iter().map(|projector| ArtifactVerification {
+            role: "projector",
+            layer_index: None,
+            path: PathBuf::from(&projector.path),
+            sha256: projector.sha256.to_ascii_lowercase(),
+            artifact_bytes: projector.artifact_bytes,
+        }))
+        .collect::<Vec<_>>();
+
+    let mut report = PackageIntegrityReport {
+        manifest_sha256: manifest_sha256.to_string(),
+        artifacts: artifacts.len(),
+        verified_artifacts: 0,
+        cached_artifacts: 0,
+    };
+
+    if !options.verify_sha256 {
+        return Ok(report);
+    }
+
+    for artifact in artifacts {
+        let relative_path = safe_relative_manifest_path(&artifact.path)?;
+        let absolute = package_dir.join(&relative_path);
+        let metadata = fs::metadata(&absolute).with_context(|| {
+            format!("read package artifact metadata {}", relative_path.display())
+        })?;
+        let fingerprint = file_fingerprint(&metadata);
+        if let Some(cache_dir) = &options.cache_dir {
+            if integrity_cache_hit(
+                cache_dir,
+                manifest_sha256,
+                &artifact,
+                metadata.len(),
+                fingerprint,
+            )? {
+                report.cached_artifacts += 1;
+                continue;
+            }
+        }
+
+        let actual = file_sha256(&absolute)?;
+        if actual != artifact.sha256 {
+            bail!(
+                "package artifact checksum mismatch for {}: expected {}, got {}",
+                relative_path.display(),
+                artifact.sha256,
+                actual
+            );
+        }
+        report.verified_artifacts += 1;
+        if let Some(cache_dir) = &options.cache_dir {
+            write_integrity_cache_record(
+                cache_dir,
+                manifest_sha256,
+                &artifact,
+                metadata.len(),
+                fingerprint,
+            )?;
+        }
+    }
+
+    Ok(report)
+}
+
+fn integrity_cache_hit(
+    cache_dir: &Path,
+    manifest_sha256: &str,
+    artifact: &ArtifactVerification<'_>,
+    file_len: u64,
+    modified_unix_nanos: Option<u128>,
+) -> Result<bool> {
+    let path = integrity_cache_path(cache_dir, manifest_sha256, artifact);
+    let Ok(bytes) = fs::read(&path) else {
+        return Ok(false);
+    };
+    let Ok(record) = serde_json::from_slice::<IntegrityCacheRecord>(&bytes) else {
+        return Ok(false);
+    };
+    Ok(record.schema_version == 1
+        && record.manifest_sha256 == manifest_sha256
+        && record.artifact_sha256 == artifact.sha256
+        && record.artifact_bytes == artifact.artifact_bytes
+        && record.file_len == file_len
+        && record.modified_unix_nanos == modified_unix_nanos)
+}
+
+fn write_integrity_cache_record(
+    cache_dir: &Path,
+    manifest_sha256: &str,
+    artifact: &ArtifactVerification<'_>,
+    file_len: u64,
+    modified_unix_nanos: Option<u128>,
+) -> Result<()> {
+    fs::create_dir_all(cache_dir)
+        .with_context(|| format!("create package integrity cache {}", cache_dir.display()))?;
+    let record = IntegrityCacheRecord {
+        schema_version: 1,
+        manifest_sha256: manifest_sha256.to_string(),
+        artifact_sha256: artifact.sha256.clone(),
+        artifact_bytes: artifact.artifact_bytes,
+        file_len,
+        modified_unix_nanos,
+    };
+    fs::write(
+        integrity_cache_path(cache_dir, manifest_sha256, artifact),
+        serde_json::to_vec_pretty(&record)?,
+    )
+    .with_context(|| format!("write package integrity cache {}", cache_dir.display()))
+}
+
+fn integrity_cache_path(
+    cache_dir: &Path,
+    manifest_sha256: &str,
+    artifact: &ArtifactVerification<'_>,
+) -> PathBuf {
+    let mut hasher = Sha256::new();
+    hasher.update(b"skippy-package-integrity-cache-v1\0");
+    hasher.update(manifest_sha256.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(artifact.role.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(artifact.layer_index.unwrap_or(u32::MAX).to_le_bytes());
+    hasher.update(b"\0");
+    hasher.update(artifact.path.to_string_lossy().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(artifact.sha256.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(artifact.artifact_bytes.to_le_bytes());
+    cache_dir.join(format!("{}.json", hex_lower(&hasher.finalize())))
+}
+
+fn file_fingerprint(metadata: &fs::Metadata) -> Option<u128> {
+    metadata
+        .modified()
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos())
+}
+
+fn safe_relative_manifest_path(path: impl AsRef<Path>) -> Result<PathBuf> {
+    let path = path.as_ref();
+    let mut components = path.components();
+    let Some(first) = components.next() else {
+        bail!("manifest file path is empty");
+    };
+    anyhow::ensure!(
+        matches!(first, std::path::Component::Normal(_))
+            && components.all(|component| matches!(component, std::path::Component::Normal(_))),
+        "manifest file path must be a safe relative path: {}",
+        path.display()
+    );
+    Ok(path.to_path_buf())
+}
+
+fn validate_sha256_digest(label: &str, value: &str) -> Result<()> {
+    if value.len() != 64 || !value.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("{label} must be a hex SHA-256 digest");
+    }
+    Ok(())
 }
 
 fn materialized_path(
@@ -812,78 +1054,23 @@ fn sanitize(value: &str) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn parses_hf_package_refs() {
-        assert_eq!(
-            parse_hf_package_ref("hf://Mesh-LLM/Qwen3.6-package").unwrap(),
-            HfPackageRef {
-                repo_id: "Mesh-LLM/Qwen3.6-package".to_string(),
-                revision: None,
-            }
-        );
-        assert_eq!(
-            parse_hf_package_ref("hf://Mesh-LLM/Qwen3.6-package:abc123").unwrap(),
-            HfPackageRef {
-                repo_id: "Mesh-LLM/Qwen3.6-package".to_string(),
-                revision: Some("abc123".to_string()),
-            }
-        );
-        assert_eq!(
-            parse_hf_package_ref("hf://Mesh-LLM/Qwen3.6-package@branch-name").unwrap(),
-            HfPackageRef {
-                repo_id: "Mesh-LLM/Qwen3.6-package".to_string(),
-                revision: Some("branch-name".to_string()),
-            }
-        );
-    }
-
-    #[test]
-    fn rejects_invalid_hf_package_refs() {
-        assert!(parse_hf_package_ref("hf://").is_err());
-        assert!(parse_hf_package_ref("hf://namespace-only").is_err());
-        assert!(parse_hf_package_ref("hf://namespace/repo@").is_err());
-        assert!(parse_hf_package_ref("hf://namespace/repo:").is_err());
-    }
-
-    #[test]
-    fn checks_abi_version_compatibility() {
-        assert!(abi_version_supported(&format!(
-            "{}.{}.0",
-            skippy_ffi::ABI_VERSION_MAJOR,
-            skippy_ffi::ABI_VERSION_MINOR
-        ))
-        .unwrap());
-        assert!(
-            !abi_version_supported(&format!("{}.{}.0", skippy_ffi::ABI_VERSION_MAJOR + 1, 0))
-                .unwrap()
-        );
-        assert!(!abi_version_supported(&format!(
-            "{}.{}.0",
-            skippy_ffi::ABI_VERSION_MAJOR,
-            skippy_ffi::ABI_VERSION_MINOR + 1
-        ))
-        .unwrap());
-    }
-
-    #[test]
-    fn inspect_layer_package_returns_manifest_identity() {
-        let dir = tempfile::tempdir().unwrap();
-        fs::create_dir_all(dir.path().join("layers")).unwrap();
-        fs::write(dir.path().join("metadata.gguf"), b"metadata").unwrap();
-        fs::write(dir.path().join("embeddings.gguf"), b"embeddings").unwrap();
-        fs::write(dir.path().join("output.gguf"), b"output").unwrap();
-        fs::write(dir.path().join("layers/00000.gguf"), b"layer0").unwrap();
-        fs::create_dir_all(dir.path().join("projectors")).unwrap();
-        fs::write(dir.path().join("projectors/mmproj.gguf"), b"projector").unwrap();
+    fn write_package_fixture(dir: &Path) -> serde_json::Value {
+        fs::create_dir_all(dir.join("layers")).unwrap();
+        fs::create_dir_all(dir.join("projectors")).unwrap();
+        fs::write(dir.join("metadata.gguf"), b"metadata").unwrap();
+        fs::write(dir.join("embeddings.gguf"), b"embeddings").unwrap();
+        fs::write(dir.join("output.gguf"), b"output").unwrap();
+        fs::write(dir.join("layers/00000.gguf"), b"layer0").unwrap();
+        fs::write(dir.join("projectors/mmproj.gguf"), b"projector").unwrap();
         let manifest = serde_json::json!({
             "schema_version": 1,
             "model_id": "model-a",
             "source_model": {
-                "path": "/models/model-a.gguf",
+                "path": "model-a.gguf",
                 "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
                 "files": [
                     {
-                        "path": "/models/model-a.gguf",
+                        "path": "model-a.gguf",
                         "size_bytes": 123,
                         "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     }
@@ -943,10 +1130,83 @@ mod tests {
             ),
         });
         fs::write(
-            dir.path().join("model-package.json"),
+            dir.join("model-package.json"),
             serde_json::to_vec_pretty(&manifest).unwrap(),
         )
         .unwrap();
+        manifest
+    }
+
+    fn package_stage_request(package_ref: &Path) -> PackageStageRequest {
+        PackageStageRequest {
+            model_id: "model-a".to_string(),
+            topology_id: "topology-a".to_string(),
+            package_ref: package_ref.to_string_lossy().to_string(),
+            stage_id: "stage-0".to_string(),
+            layer_start: 0,
+            layer_end: 1,
+            include_embeddings: true,
+            include_output: true,
+        }
+    }
+
+    #[test]
+    fn parses_hf_package_refs() {
+        assert_eq!(
+            parse_hf_package_ref("hf://Mesh-LLM/Qwen3.6-package").unwrap(),
+            HfPackageRef {
+                repo_id: "Mesh-LLM/Qwen3.6-package".to_string(),
+                revision: None,
+            }
+        );
+        assert_eq!(
+            parse_hf_package_ref("hf://Mesh-LLM/Qwen3.6-package:abc123").unwrap(),
+            HfPackageRef {
+                repo_id: "Mesh-LLM/Qwen3.6-package".to_string(),
+                revision: Some("abc123".to_string()),
+            }
+        );
+        assert_eq!(
+            parse_hf_package_ref("hf://Mesh-LLM/Qwen3.6-package@branch-name").unwrap(),
+            HfPackageRef {
+                repo_id: "Mesh-LLM/Qwen3.6-package".to_string(),
+                revision: Some("branch-name".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_hf_package_refs() {
+        assert!(parse_hf_package_ref("hf://").is_err());
+        assert!(parse_hf_package_ref("hf://namespace-only").is_err());
+        assert!(parse_hf_package_ref("hf://namespace/repo@").is_err());
+        assert!(parse_hf_package_ref("hf://namespace/repo:").is_err());
+    }
+
+    #[test]
+    fn checks_abi_version_compatibility() {
+        assert!(abi_version_supported(&format!(
+            "{}.{}.0",
+            skippy_ffi::ABI_VERSION_MAJOR,
+            skippy_ffi::ABI_VERSION_MINOR
+        ))
+        .unwrap());
+        assert!(
+            !abi_version_supported(&format!("{}.{}.0", skippy_ffi::ABI_VERSION_MAJOR + 1, 0))
+                .unwrap()
+        );
+        assert!(!abi_version_supported(&format!(
+            "{}.{}.0",
+            skippy_ffi::ABI_VERSION_MAJOR,
+            skippy_ffi::ABI_VERSION_MINOR + 1
+        ))
+        .unwrap());
+    }
+
+    #[test]
+    fn inspect_layer_package_returns_manifest_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        write_package_fixture(dir.path());
 
         let info = inspect_layer_package(&dir.path().to_string_lossy()).unwrap();
 
@@ -961,6 +1221,109 @@ mod tests {
             dir.path().join("projectors/mmproj.gguf")
         );
         assert_eq!(info.manifest_sha256.len(), 64);
+    }
+
+    #[test]
+    fn verify_layer_package_integrity_rejects_selected_artifact_sha_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        write_package_fixture(dir.path());
+        fs::write(dir.path().join("layers/00000.gguf"), b"wrong0").unwrap();
+
+        let error = verify_layer_package_integrity(
+            &package_stage_request(dir.path()),
+            &PackageIntegrityOptions::verify_without_cache(),
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("checksum mismatch"), "{error}");
+        assert!(error.contains("layers/00000.gguf"), "{error}");
+    }
+
+    #[test]
+    fn verify_layer_package_integrity_uses_private_cache_records() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache_dir = tempfile::tempdir().unwrap();
+        write_package_fixture(dir.path());
+
+        let options = PackageIntegrityOptions::verify_with_cache(cache_dir.path());
+        let first = verify_layer_package_integrity(&package_stage_request(dir.path()), &options)
+            .expect("first verification should hash artifacts");
+        assert_eq!(first.verified_artifacts, 5);
+        assert_eq!(first.cached_artifacts, 0);
+
+        let second = verify_layer_package_integrity(&package_stage_request(dir.path()), &options)
+            .expect("second verification should reuse cache");
+        assert_eq!(second.verified_artifacts, 0);
+        assert_eq!(second.cached_artifacts, 5);
+
+        let cache_blob = fs::read_to_string(
+            fs::read_dir(cache_dir.path())
+                .unwrap()
+                .next()
+                .unwrap()
+                .unwrap()
+                .path(),
+        )
+        .unwrap();
+        assert!(
+            !cache_blob.contains(&dir.path().to_string_lossy().to_string()),
+            "cache records must not store raw local package paths"
+        );
+    }
+
+    #[test]
+    fn validates_source_model_sha256_as_hex_digest() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = write_package_fixture(dir.path());
+        manifest["source_model"]["sha256"] = serde_json::Value::String("not-a-sha".to_string());
+        fs::write(
+            dir.path().join("model-package.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let error = inspect_layer_package(&dir.path().to_string_lossy())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("source_model sha256"), "{error}");
+    }
+
+    #[test]
+    fn rejects_package_artifact_paths_that_escape_package_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = write_package_fixture(dir.path());
+        manifest["layers"][0]["path"] = serde_json::Value::String("../outside.gguf".to_string());
+        fs::write(
+            dir.path().join("model-package.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let error = select_layer_package_parts(&package_stage_request(dir.path()))
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("safe relative"), "{error}");
+    }
+
+    #[test]
+    fn inspect_layer_package_rejects_unsafe_layer_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut manifest = write_package_fixture(dir.path());
+        manifest["layers"][0]["path"] = serde_json::Value::String("../outside.gguf".to_string());
+        fs::write(
+            dir.path().join("model-package.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+
+        let error = inspect_layer_package(&dir.path().to_string_lossy())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("safe relative"), "{error}");
     }
 
     #[test]

--- a/docs/specs/layer-package-repos.md
+++ b/docs/specs/layer-package-repos.md
@@ -309,6 +309,11 @@ Consumers MUST verify SHA-256 checksums for selected artifacts before using an
 directories MAY keep checksum verification behind `SKIPPY_VERIFY_PACKAGE_SHA`
 for development workflows.
 
+Metadata-only inspection for inventory, identity discovery, or prepare planning
+MAY validate only the manifest and shared metadata artifact, and must not
+require a non-empty stage layer range. A real stage load still requires the
+non-empty range and selected-artifact checks above.
+
 Implementations MAY cache successful checksum verification results. Cache keys
 and records should be derived from manifest and artifact identity plus file
 metadata, and should not store raw local package paths.

--- a/docs/specs/layer-package-repos.md
+++ b/docs/specs/layer-package-repos.md
@@ -300,14 +300,18 @@ Before a stage starts, consumers MUST validate:
 - requested layer range is non-empty and within `layer_count`;
 - requested layers exist and are not duplicated in the manifest;
 - selected artifact paths are relative, safe, and files;
-- selected artifact sizes match `artifact_bytes`.
+- selected artifact sizes match `artifact_bytes`;
 - declared projector paths are relative, safe, and files;
 - declared projector sizes match `artifact_bytes`.
 
-Consumers SHOULD verify SHA-256 checksums for selected artifacts when a package
-is first downloaded or when `SKIPPY_VERIFY_PACKAGE_SHA` is set. Implementations
-may cache checksum results keyed by package repo, revision, manifest digest, and
-artifact path.
+Consumers MUST verify SHA-256 checksums for selected artifacts before using an
+`hf://` layer package, including cache-hit resolutions. Local package
+directories MAY keep checksum verification behind `SKIPPY_VERIFY_PACKAGE_SHA`
+for development workflows.
+
+Implementations MAY cache successful checksum verification results. Cache keys
+and records should be derived from manifest and artifact identity plus file
+metadata, and should not store raw local package paths.
 
 Checksum verification SHOULD include declared projectors when the package is
 first downloaded, when the package is validated by tooling, or when a stage is


### PR DESCRIPTION
## Summary

Skippy layer packages resolved from `hf://` are now verified before a stage can use them. Cached Hugging Face snapshots no longer bypass package integrity checks, and stage status keeps source model identity tied to the package manifest instead of exposing local cache paths as the source model.

## Why

Layer packages are now part of the runtime path for distributed Skippy serving. That makes package provenance a runtime safety boundary, not only a packaging-tool concern.

Before this change, package consumers validated manifest shape, required files, and sizes, but cached `hf://` package snapshots could be reused without rechecking selected artifact SHA-256 values. That left a practical gap: a corrupted or tampered cached layer file could still be selected as long as it existed and had the expected size.

This PR closes that gap while keeping local development workflows usable: remote `hf://` package refs get mandatory selected-artifact verification, while direct local package directories keep checksum verification opt-in through the existing environment path.

## Diff Scope

- `crates/skippy-runtime/src/package.rs`
  - Adds explicit package integrity options and a structured verification report.
  - Verifies selected layer/shared artifacts and declared projectors against manifest SHA-256 values.
  - Adds a private verification cache keyed by package/artifact identity and file metadata, without storing raw local package paths.
  - Tightens manifest validation for source SHA-256 fields, unsafe artifact paths, duplicate layers, missing layers, and metadata-only inspection.

- `crates/mesh-llm/src/inference/skippy/materialization.rs`
  - Runs the integrity gate for `hf://` package resolution, including direct snapshot cache hits and ref-resolved snapshot cache hits.
  - Keeps verification errors tied to manifest-relative artifact paths.
  - Carries safe source model identity from the package manifest after resolution.

- `crates/mesh-llm/src/inference/skippy/stage/mod.rs`
  - Preserves resolved local package refs internally for loading.
  - Uses manifest source identity for stage config/status instead of reporting the local cache path as `source_model_path`.

- `crates/mesh-llm/src/inference/skippy/stage/tests.rs`
  - Adds coverage for package source identity precedence over local package refs.

- `docs/specs/layer-package-repos.md`
  - Documents the consumer-side integrity requirement for `hf://` package refs and the privacy expectation for verification cache records.

## Branch Integrity

- Base branch: `main`
- Validated base SHA: `7ea662e0e5242cdfffe5e9887207671cb19218b1`
- `git rev-list --left-right --count origin/main...HEAD`: `0 1`
- Ahead count: `1`
- Behind count: `0`
- Merge-base SHA: `7ea662e0e5242cdfffe5e9887207671cb19218b1`
- Fast-forward safety: `origin/main` is an ancestor of `HEAD`; no divergence.

## Commit Integrity

Introduced commit:

- `3f933628079dfa126b7c8f4d3dfb71a25dadf5e1` — `Gate Skippy layer packages with integrity verification`

One logical change: confirmed. The diff is scoped to Skippy package integrity, `hf://` package resolution, stage identity handling, focused tests, and the matching layer-package spec.

## Ledger and Version Proof

Ledger: not applicable — `scripts/ledger/` does not exist in this repository.

Version: not applicable — this is not a release commit, release metadata did not change, and repository release versioning remains handled by the existing release flow.

## Diff Hygiene

`git diff --name-status origin/main...HEAD`:

```text
M	crates/mesh-llm/src/inference/skippy/materialization.rs
M	crates/mesh-llm/src/inference/skippy/stage/mod.rs
M	crates/mesh-llm/src/inference/skippy/stage/tests.rs
M	crates/skippy-runtime/src/package.rs
M	docs/specs/layer-package-repos.md
```

`git diff --check origin/main...HEAD`: PASS, no output.


## Validation Mode and Proof

Validation mode: Mode 3 — shared backend/runtime behavior. The change affects package validation and Skippy stage-load behavior, but does not change wire protocol, migrations, auth, CI, deployment tooling, or UI assets.

Local validation:

```text
cargo fmt --all -- --check
PASS
```

```text
LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p skippy-runtime --lib
PASS — 17 passed, 0 failed
```

```text
LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm inference::skippy --lib
PASS — 68 passed, 2 ignored, 0 failed
```

```text
LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm
PASS
```

Not run:

- `just build` — not required for the selected validation mode because this is a Rust/docs-only change and no UI, bundle, release, or llama.cpp patch path changed.
- Full `cargo test -p mesh-llm` — not required locally for this scoped Skippy runtime change; targeted runtime and Skippy subsystem tests passed, and mandatory remote CI should provide final full-branch proof after PR creation.

## Verification-Pack Proof

Not applicable — no ops, governance, replay, release, or verification-pack tooling changed.

## Migration Notes

Not applicable — no database schema, migration, persisted data model, or data repair path changed.


## Runtime Safety

Reviewed runtime paths:

- `crates/skippy-runtime/src/package.rs`
- `crates/mesh-llm/src/inference/skippy/materialization.rs`
- `crates/mesh-llm/src/inference/skippy/stage/mod.rs`

Runtime safety notes:

- No new blocking locks.
- No new queues, channels, background workers, or buffering paths.
- No mesh protocol, protobuf, or plugin protocol changes.
- Package manifest schema remains version `1`; this is consumer-side validation hardening.
- First use of a large `hf://` package may hash selected artifacts before stage load; repeat resolutions use the verification cache when file identity is unchanged.
- No invariant removal: existing manifest/file/size checks remain, with checksum and path-safety coverage added around them.

No invariant regression introduced.

## Documentation Integrity

Updated `docs/specs/layer-package-repos.md` to match the new consumer-side behavior for `hf://` packages and to document that verification cache records should avoid raw local package paths.

No README, runbook, CLI command examples, deployment instructions, or release procedure changed.

## Rollback Plan

Rollback: revert this PR.

```bash
git revert <post_merge_commit_sha>
```

Replace `<post_merge_commit_sha>` with the final squash/merge commit SHA after merge.

DB downgrade required: no.
Data repair required: no.
Operational caveats: rollback restores the previous package consumer behavior, where cached `hf://` package snapshots are not forced through selected-artifact checksum verification before stage load.

## Known Residual Risks

- Large remote package refs can pay a first-use hashing cost for selected artifacts and projectors. The verification cache is intended to keep repeat resolutions cheap without storing raw local paths.