### PR TITLE
Add split-family parity test coverage

### DIFF
--- a/crates/skippy-correctness/README.md
+++ b/crates/skippy-correctness/README.md
@@ -88,6 +88,67 @@ skippy-correctness state-handoff \
 All commands emit JSON, optionally write the same JSON with `--report-out`, and
 exit non-zero on mismatch unless `--allow-mismatch` is set.
 
+## Llama Family Parity Tests
+
+`tests/parity_models.rs` is the Rust regression lane for the P0/P1 llama.cpp
+family matrix in `docs/skippy/llama-parity-candidates.json`. Each P0/P1 family
+has its own test module so missing coverage is obvious in test output and code
+review. The cheap tests validate manifest completeness and fail if a P0/P1
+manifest row is added without a matching family module.
+
+```bash
+LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" \
+  cargo test -p skippy-correctness --test parity_models
+```
+
+The artifact-loading checks are ignored by default because they may download
+and load every representative GGUF/package. Run a single family while developing:
+
+```bash
+SKIPPY_PARITY_DOWNLOAD=1 \
+LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" \
+  cargo test -p skippy-correctness --test parity_models \
+  p0_qwen2_qwen2 -- --ignored
+```
+
+Run the full P0/P1 artifact lane before rebuilding the llama patch queue or
+promoting a broad family-parity change:
+
+```bash
+SKIPPY_PARITY_DOWNLOAD=1 \
+LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" \
+  cargo test -p skippy-correctness --test parity_models -- --ignored
+```
+
+The ignored tests prove two production contracts per family:
+
+- `activation_handoff_matches_full_model` compares a local three-stage split
+  against a full-model baseline for the same prompt.
+- `cache_state_restore_matches_recompute` records state from one session/lane,
+  restores it into a different session/lane, and compares the next token or
+  activation frame against normal recompute. Dense families use `ResidentKv`;
+  recurrent/hybrid families use `KvRecurrent`.
+
+Useful knobs:
+
+- `SKIPPY_PARITY_DOWNLOAD=0` requires the artifacts to already exist in the
+  Hugging Face cache.
+- `SKIPPY_PARITY_DOWNLOAD_PACKAGE_ONLY=1` opts into downloading
+  `certified_package_only` GGUF rows whose representative artifacts are often
+  tens or hundreds of GB. By default those rows only run when the artifact or
+  package is already local.
+- `SKIPPY_PARITY_REQUIRE_PACKAGE_ONLY=1` turns a missing package-only local
+  artifact into a test failure instead of a documented skip.
+- `SKIPPY_PARITY_N_GPU_LAYERS` controls runtime offload for the heavy checks.
+  It defaults to `999`, matching the family-certification lane; set it to `0`
+  for an explicit CPU-only repro.
+- `SKIPPY_PARITY_NATIVE_LOGS=1` leaves llama.cpp native logs on stdout; by
+  default the test redirects them to a temp file.
+
+Rows whose manifest `include` is `model-package.json` are package-backed tests:
+the harness downloads the package repo, materializes stage slices, and runs the
+same activation/cache contracts without requiring a monolithic full GGUF.
+
 ## Notes
 
 - `--model` is always the full GGUF baseline.

--- a/crates/skippy-correctness/src/support.rs
+++ b/crates/skippy-correctness/src/support.rs
@@ -46,7 +46,15 @@ pub fn connect_ready(addr: SocketAddr, timeout_secs: u64) -> Result<TcpStream> {
                     .set_write_timeout(Some(Duration::from_millis(500)))
                     .ok();
                 match recv_ready(&mut stream) {
-                    Ok(()) => return Ok(stream),
+                    Ok(()) => {
+                        stream
+                            .set_read_timeout(Some(Duration::from_secs(timeout_secs.max(1))))
+                            .ok();
+                        stream
+                            .set_write_timeout(Some(Duration::from_secs(timeout_secs.max(1))))
+                            .ok();
+                        return Ok(stream);
+                    }
                     Err(error) => {
                         last_error = Some(anyhow!(error).context("ready handshake failed"))
                     }

--- a/crates/skippy-correctness/tests/parity_models.rs
+++ b/crates/skippy-correctness/tests/parity_models.rs
@@ -1,0 +1,589 @@
+use std::collections::BTreeSet;
+
+#[path = "parity_models/mod.rs"]
+mod harness;
+
+use harness::{
+    activation_handoff_matches_full_model, assert_manifest_row_complete,
+    cache_state_restore_matches_recompute, p0_p1_manifest_rows,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct FamilySpec {
+    priority: &'static str,
+    llama_model: &'static str,
+    family: &'static str,
+}
+
+macro_rules! family_module {
+    ($module:ident, $priority:literal, $llama_model:literal, $family:literal) => {
+        mod $module {
+            const SPEC: super::FamilySpec = super::FamilySpec {
+                priority: $priority,
+                llama_model: $llama_model,
+                family: $family,
+            };
+
+            #[test]
+            fn manifest_row_is_complete() {
+                super::assert_manifest_row_complete(SPEC).unwrap();
+            }
+
+            #[test]
+            #[ignore = "downloads and loads model-family GGUF/package artifacts"]
+            fn activation_handoff_matches_full_model() {
+                super::activation_handoff_matches_full_model(SPEC).unwrap();
+            }
+
+            #[test]
+            #[ignore = "downloads and loads model-family GGUF/package artifacts"]
+            fn cache_state_restore_matches_recompute() {
+                super::cache_state_restore_matches_recompute(SPEC).unwrap();
+            }
+        }
+    };
+}
+
+family_module!(p0_llama_llama, "p0", "llama", "llama");
+family_module!(p0_qwen2_qwen2, "p0", "qwen2", "qwen2");
+family_module!(p0_qwen3_qwen3_dense, "p0", "qwen3", "qwen3_dense");
+family_module!(p0_qwen3next_qwen3next, "p0", "qwen3next", "qwen3next");
+family_module!(p0_qwen35moe_qwen35moe, "p0", "qwen35moe", "qwen35moe");
+family_module!(p0_qwen2vl_qwen2vl, "p0", "qwen2vl", "qwen2vl");
+family_module!(p0_qwen3vl_qwen3vl, "p0", "qwen3vl", "qwen3vl");
+family_module!(p0_qwen2moe_qwen2moe, "p0", "qwen2moe", "qwen2moe");
+family_module!(p0_qwen3moe_qwen3moe, "p0", "qwen3moe", "qwen3moe");
+family_module!(p0_mistral3_mistral, "p0", "mistral3", "mistral");
+family_module!(p0_mistral4_mistral4, "p0", "mistral4", "mistral4");
+family_module!(p0_phi3_phi, "p0", "phi3", "phi");
+family_module!(p0_phi2_phi2, "p0", "phi2", "phi2");
+family_module!(p0_phimoe_phimoe, "p0", "phimoe", "phimoe");
+family_module!(p0_gemma_gemma, "p0", "gemma", "gemma");
+family_module!(p0_gemma2_gemma2, "p0", "gemma2", "gemma2");
+family_module!(p0_gemma3_gemma3, "p0", "gemma3", "gemma3");
+family_module!(p0_gemma4_gemma4_a4b, "p0", "gemma4", "gemma4_a4b");
+family_module!(p0_gemma4_gemma4_e4b, "p0", "gemma4", "gemma4_e4b");
+family_module!(p0_gemma3n_gemma3n, "p0", "gemma3n", "gemma3n");
+family_module!(p0_deepseek_deepseek, "p0", "deepseek", "deepseek");
+family_module!(p0_deepseek2_deepseek2, "p0", "deepseek2", "deepseek2");
+family_module!(p0_deepseek2_deepseek3, "p0", "deepseek2", "deepseek3");
+family_module!(p0_glm4_glm4, "p0", "glm4", "glm4");
+family_module!(p0_glm4_glm47_flash, "p0", "glm4", "glm47_flash");
+family_module!(p0_glm4_moe_glm4_moe, "p0", "glm4-moe", "glm4_moe");
+family_module!(p0_granite_granite, "p0", "granite", "granite");
+family_module!(
+    p0_granite_hybrid_granite_hybrid,
+    "p0",
+    "granite-hybrid",
+    "granite_hybrid"
+);
+family_module!(p0_command_r_command_r, "p0", "command-r", "command_r");
+family_module!(p0_cohere2_cohere2, "p0", "cohere2", "cohere2");
+family_module!(p0_minimax_m2_minimax_m27, "p0", "minimax-m2", "minimax_m27");
+family_module!(p0_lfm2_lfm2, "p0", "lfm2", "lfm2");
+family_module!(
+    p0_hunyuan_dense_hunyuan_dense,
+    "p0",
+    "hunyuan-dense",
+    "hunyuan_dense"
+);
+family_module!(
+    p0_hunyuan_moe_hunyuan_moe,
+    "p0",
+    "hunyuan-moe",
+    "hunyuan_moe"
+);
+family_module!(p0_hunyuan_vl_hunyuan_vl, "p0", "hunyuan-vl", "hunyuan_vl");
+family_module!(p0_llama4_llama4, "p0", "llama4", "llama4");
+family_module!(p0_lfm2moe_lfm2moe, "p0", "lfm2moe", "lfm2moe");
+family_module!(p0_openai_moe_openai_moe, "p0", "openai-moe", "openai_moe");
+family_module!(p0_qwen_qwen, "p0", "qwen", "qwen");
+family_module!(p0_qwen35_qwen35, "p0", "qwen35", "qwen35");
+family_module!(p0_qwen3vlmoe_qwen3vlmoe, "p0", "qwen3vlmoe", "qwen3vlmoe");
+
+family_module!(p1_gptneox_gptneox, "p1", "gptneox", "gptneox");
+family_module!(p1_bloom_bloom, "p1", "bloom", "bloom");
+family_module!(p1_baichuan_baichuan, "p1", "baichuan", "baichuan");
+family_module!(p1_jamba_jamba, "p1", "jamba", "jamba");
+family_module!(p1_mamba_mamba, "p1", "mamba", "mamba");
+family_module!(p1_mamba2_mamba2, "p1", "mamba2", "mamba2");
+family_module!(p1_rwkv6_rwkv6, "p1", "rwkv6", "rwkv6");
+family_module!(p1_rwkv7_rwkv7, "p1", "rwkv7", "rwkv7");
+family_module!(p1_arwkv7_rwkv7, "p1", "arwkv7", "rwkv7");
+family_module!(p1_falcon_h1_falcon_h1, "p1", "falcon-h1", "falcon_h1");
+family_module!(p1_falcon_falcon, "p1", "falcon", "falcon");
+family_module!(p1_olmo_olmo, "p1", "olmo", "olmo");
+family_module!(p1_olmo2_olmo2, "p1", "olmo2", "olmo2");
+family_module!(p1_olmoe_olmoe, "p1", "olmoe", "olmoe");
+family_module!(p1_internlm2_internlm2, "p1", "internlm2", "internlm2");
+family_module!(p1_exaone_exaone, "p1", "exaone", "exaone");
+family_module!(p1_exaone4_exaone4, "p1", "exaone4", "exaone4");
+family_module!(p1_starcoder2_starcoder2, "p1", "starcoder2", "starcoder2");
+family_module!(p1_stablelm_stablelm, "p1", "stablelm", "stablelm");
+family_module!(p1_gpt2_gpt2, "p1", "gpt2", "gpt2");
+family_module!(p1_mpt_mpt, "p1", "mpt", "mpt");
+family_module!(p1_arcee_arcee, "p1", "arcee", "arcee");
+family_module!(p1_bitnet_bitnet, "p1", "bitnet", "bitnet");
+family_module!(p1_chatglm_chatglm, "p1", "chatglm", "chatglm");
+family_module!(p1_codeshell_codeshell, "p1", "codeshell", "codeshell");
+family_module!(
+    p1_deepseek2ocr_deepseek2ocr,
+    "p1",
+    "deepseek2ocr",
+    "deepseek2ocr"
+);
+family_module!(p1_ernie4_5_ernie4_5, "p1", "ernie4-5", "ernie4_5");
+family_module!(
+    p1_ernie4_5_moe_ernie4_5_moe,
+    "p1",
+    "ernie4-5-moe",
+    "ernie4_5_moe"
+);
+family_module!(p1_exaone_moe_exaone_moe, "p1", "exaone-moe", "exaone_moe");
+family_module!(
+    p1_kimi_linear_kimi_linear,
+    "p1",
+    "kimi-linear",
+    "kimi_linear"
+);
+family_module!(p1_minicpm_minicpm, "p1", "minicpm", "minicpm");
+family_module!(p1_minicpm3_minicpm3, "p1", "minicpm3", "minicpm3");
+family_module!(p1_nemotron_nemotron, "p1", "nemotron", "nemotron");
+family_module!(p1_nemotron_h_nemotron_h, "p1", "nemotron-h", "nemotron_h");
+family_module!(
+    p1_nemotron_h_moe_nemotron_h_moe,
+    "p1",
+    "nemotron-h-moe",
+    "nemotron_h_moe"
+);
+family_module!(p1_seed_oss_seed_oss, "p1", "seed-oss", "seed_oss");
+family_module!(
+    p1_smallthinker_smallthinker,
+    "p1",
+    "smallthinker",
+    "smallthinker"
+);
+family_module!(p1_smollm3_smollm3, "p1", "smollm3", "smollm3");
+family_module!(p1_starcoder_starcoder, "p1", "starcoder", "starcoder");
+
+const FAMILY_SPECS: &[FamilySpec] = &[
+    FamilySpec {
+        priority: "p0",
+        llama_model: "llama",
+        family: "llama",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen2",
+        family: "qwen2",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen3",
+        family: "qwen3_dense",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen3next",
+        family: "qwen3next",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen35moe",
+        family: "qwen35moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen2vl",
+        family: "qwen2vl",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen3vl",
+        family: "qwen3vl",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen2moe",
+        family: "qwen2moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen3moe",
+        family: "qwen3moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "mistral3",
+        family: "mistral",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "mistral4",
+        family: "mistral4",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "phi3",
+        family: "phi",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "phi2",
+        family: "phi2",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "phimoe",
+        family: "phimoe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "gemma",
+        family: "gemma",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "gemma2",
+        family: "gemma2",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "gemma3",
+        family: "gemma3",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "gemma4",
+        family: "gemma4_a4b",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "gemma4",
+        family: "gemma4_e4b",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "gemma3n",
+        family: "gemma3n",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "deepseek",
+        family: "deepseek",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "deepseek2",
+        family: "deepseek2",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "deepseek2",
+        family: "deepseek3",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "glm4",
+        family: "glm4",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "glm4",
+        family: "glm47_flash",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "glm4-moe",
+        family: "glm4_moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "granite",
+        family: "granite",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "granite-hybrid",
+        family: "granite_hybrid",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "command-r",
+        family: "command_r",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "cohere2",
+        family: "cohere2",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "minimax-m2",
+        family: "minimax_m27",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "lfm2",
+        family: "lfm2",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "hunyuan-dense",
+        family: "hunyuan_dense",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "hunyuan-moe",
+        family: "hunyuan_moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "hunyuan-vl",
+        family: "hunyuan_vl",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "llama4",
+        family: "llama4",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "lfm2moe",
+        family: "lfm2moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "openai-moe",
+        family: "openai_moe",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen",
+        family: "qwen",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen35",
+        family: "qwen35",
+    },
+    FamilySpec {
+        priority: "p0",
+        llama_model: "qwen3vlmoe",
+        family: "qwen3vlmoe",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "gptneox",
+        family: "gptneox",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "bloom",
+        family: "bloom",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "baichuan",
+        family: "baichuan",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "jamba",
+        family: "jamba",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "mamba",
+        family: "mamba",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "mamba2",
+        family: "mamba2",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "rwkv6",
+        family: "rwkv6",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "rwkv7",
+        family: "rwkv7",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "arwkv7",
+        family: "rwkv7",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "falcon-h1",
+        family: "falcon_h1",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "falcon",
+        family: "falcon",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "olmo",
+        family: "olmo",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "olmo2",
+        family: "olmo2",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "olmoe",
+        family: "olmoe",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "internlm2",
+        family: "internlm2",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "exaone",
+        family: "exaone",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "exaone4",
+        family: "exaone4",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "starcoder2",
+        family: "starcoder2",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "stablelm",
+        family: "stablelm",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "gpt2",
+        family: "gpt2",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "mpt",
+        family: "mpt",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "arcee",
+        family: "arcee",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "bitnet",
+        family: "bitnet",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "chatglm",
+        family: "chatglm",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "codeshell",
+        family: "codeshell",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "deepseek2ocr",
+        family: "deepseek2ocr",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "ernie4-5",
+        family: "ernie4_5",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "ernie4-5-moe",
+        family: "ernie4_5_moe",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "exaone-moe",
+        family: "exaone_moe",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "kimi-linear",
+        family: "kimi_linear",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "minicpm",
+        family: "minicpm",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "minicpm3",
+        family: "minicpm3",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "nemotron",
+        family: "nemotron",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "nemotron-h",
+        family: "nemotron_h",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "nemotron-h-moe",
+        family: "nemotron_h_moe",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "seed-oss",
+        family: "seed_oss",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "smallthinker",
+        family: "smallthinker",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "smollm3",
+        family: "smollm3",
+    },
+    FamilySpec {
+        priority: "p1",
+        llama_model: "starcoder",
+        family: "starcoder",
+    },
+];
+
+#[test]
+fn p0_p1_manifest_rows_all_have_family_modules() {
+    let expected = p0_p1_manifest_rows();
+    let declared = FAMILY_SPECS
+        .iter()
+        .map(|spec| {
+            (
+                spec.priority.to_string(),
+                spec.llama_model.to_string(),
+                spec.family.to_string(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        expected, declared,
+        "every P0/P1 manifest row must have a dedicated test module"
+    );
+}

--- a/crates/skippy-correctness/tests/parity_models/mod.rs
+++ b/crates/skippy-correctness/tests/parity_models/mod.rs
@@ -1,0 +1,1148 @@
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::OnceLock,
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use model_ref::split_gguf_shard_info;
+use serde::Deserialize;
+use serde_json::Value;
+use skippy_runtime::{
+    package::{inspect_layer_package, materialize_layer_package_details, PackageStageRequest},
+    redirect_native_logs_to_file, ActivationFrame, RuntimeConfig, RuntimeKvPage, RuntimeLoadMode,
+    StageModel, StageSession, GGML_TYPE_F16,
+};
+
+use crate::FamilySpec;
+
+const MANIFEST_JSON: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../docs/skippy/llama-parity-candidates.json"
+));
+
+const PROMPT: &str = "Hello from the Skippy llama parity harness.";
+const CTX_SIZE: u32 = 128;
+const CACHE_SEQ_ID: i32 = 17;
+
+pub(crate) fn p0_p1_manifest_rows() -> BTreeSet<(String, String, String)> {
+    let manifest = manifest();
+    manifest
+        .rows_by_priority(["p0", "p1"])
+        .into_iter()
+        .map(|row| {
+            (
+                manifest.priority_for(row).to_string(),
+                row.llama_model.clone(),
+                row.family.clone(),
+            )
+        })
+        .collect()
+}
+
+pub(crate) fn assert_manifest_row_complete(spec: FamilySpec) -> Result<()> {
+    let row = manifest_row(spec)?;
+    if !matches!(row.status.as_str(), "certified" | "certified_package_only") {
+        bail!(
+            "{} / {} is {}, but P0/P1 rows must be certified before getting a parity module",
+            row.llama_model,
+            row.family,
+            row.status
+        );
+    }
+    if row.repo.trim().is_empty() {
+        bail!("{} / {} is missing repo", row.llama_model, row.family);
+    }
+    if row.include()?.files().is_empty() {
+        bail!(
+            "{} / {} is missing include files",
+            row.llama_model,
+            row.family
+        );
+    }
+    Ok(())
+}
+
+pub(crate) fn activation_handoff_matches_full_model(spec: FamilySpec) -> Result<()> {
+    prepare_native_logs()?;
+    let Some(case) = resolve_case_for_ignored_test(spec)? else {
+        return Ok(());
+    };
+    let layout = case.layout()?;
+    if case.row.is_package_only() {
+        return run_lightweight_activation_smoke(&layout, spec);
+    }
+    let splits = split_layers_for(case.row, layout.layer_count)?;
+    run_correctness_chain(&layout, spec, splits)
+}
+
+pub(crate) fn cache_state_restore_matches_recompute(spec: FamilySpec) -> Result<()> {
+    prepare_native_logs()?;
+    let Some(case) = resolve_case_for_ignored_test(spec)? else {
+        return Ok(());
+    };
+    let layout = case.layout()?;
+    let (stage_start, stage_end) = cache_stage_range(case.row, &layout)?;
+    let state_kind = if case.row.is_recurrent() {
+        StateKind::KvRecurrent
+    } else {
+        StateKind::ResidentKv
+    };
+    run_stage_state_restore(&layout, spec, stage_start, stage_end, state_kind)
+}
+
+fn resolve_case_for_ignored_test(spec: FamilySpec) -> Result<Option<ResolvedCase>> {
+    match ResolvedCase::resolve(spec) {
+        Ok(case) => Ok(Some(case)),
+        Err(error)
+            if manifest_row(spec)?.is_package_only()
+                && !env_flag("SKIPPY_PARITY_REQUIRE_PACKAGE_ONLY", false) =>
+        {
+            eprintln!(
+                "skipping package-only parity artifact for {} / {}: {error:#}",
+                spec.llama_model, spec.family
+            );
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn prepare_native_logs() -> Result<()> {
+    static LOG_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+    if env_flag("SKIPPY_PARITY_NATIVE_LOGS", false) {
+        return Ok(());
+    }
+
+    let path = LOG_PATH.get_or_init(|| {
+        std::env::temp_dir().join(format!("skippy-parity-native-{}.log", std::process::id()))
+    });
+    redirect_native_logs_to_file(path)
+}
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    support_priority: SupportPriority,
+    candidates: Vec<CandidateRow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SupportPriority {
+    p0: PriorityRows,
+    p1: PriorityRows,
+}
+
+#[derive(Debug, Deserialize)]
+struct PriorityRows {
+    llama_models: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CandidateRow {
+    llama_model: String,
+    family: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    repo: String,
+    #[serde(default)]
+    include: Option<IncludeSpec>,
+    #[serde(default)]
+    recurrent: Option<String>,
+    #[serde(default)]
+    recurrent_ranges: Option<Vec<String>>,
+    #[serde(default)]
+    splits: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    wire_dtype: Option<String>,
+    #[serde(default)]
+    n_gpu_layers: Option<i32>,
+}
+
+impl CandidateRow {
+    fn include(&self) -> Result<&IncludeSpec> {
+        self.include
+            .as_ref()
+            .with_context(|| format!("{} / {} is missing include", self.llama_model, self.family))
+    }
+
+    fn is_package_only(&self) -> bool {
+        self.status == "certified_package_only"
+    }
+
+    fn is_recurrent(&self) -> bool {
+        self.recurrent.is_some()
+            || self
+                .recurrent_ranges
+                .as_ref()
+                .is_some_and(|ranges| !ranges.is_empty())
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum IncludeSpec {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl IncludeSpec {
+    fn files(&self) -> Vec<&str> {
+        match self {
+            Self::One(file) => vec![file.as_str()],
+            Self::Many(files) => files.iter().map(String::as_str).collect(),
+        }
+    }
+
+    fn is_package_manifest_only(&self) -> bool {
+        matches!(self, Self::One(value) if value == "model-package.json")
+    }
+}
+
+impl Manifest {
+    fn priority_for(&self, row: &CandidateRow) -> &'static str {
+        if self
+            .support_priority
+            .p0
+            .llama_models
+            .iter()
+            .any(|model| model == &row.llama_model)
+        {
+            "p0"
+        } else if self
+            .support_priority
+            .p1
+            .llama_models
+            .iter()
+            .any(|model| model == &row.llama_model)
+        {
+            "p1"
+        } else {
+            "p2"
+        }
+    }
+
+    fn rows_by_priority<const N: usize>(&self, priorities: [&str; N]) -> Vec<&CandidateRow> {
+        self.candidates
+            .iter()
+            .filter(|row| priorities.contains(&self.priority_for(row)))
+            .collect()
+    }
+}
+
+static MANIFEST: OnceLock<Manifest> = OnceLock::new();
+
+fn manifest() -> &'static Manifest {
+    MANIFEST.get_or_init(|| {
+        serde_json::from_str(MANIFEST_JSON).expect("parity candidate manifest must parse")
+    })
+}
+
+fn manifest_row(spec: FamilySpec) -> Result<&'static CandidateRow> {
+    let row = manifest()
+        .candidates
+        .iter()
+        .find(|row| row.llama_model == spec.llama_model && row.family == spec.family)
+        .with_context(|| {
+            format!(
+                "missing manifest row for {} / {}",
+                spec.llama_model, spec.family
+            )
+        })?;
+    let actual_priority = manifest().priority_for(row);
+    if actual_priority != spec.priority {
+        bail!(
+            "{} / {} declared as {}, manifest says {}",
+            spec.llama_model,
+            spec.family,
+            spec.priority,
+            actual_priority
+        );
+    }
+    Ok(row)
+}
+
+struct ResolvedCase {
+    row: &'static CandidateRow,
+    artifact: ResolvedArtifact,
+}
+
+enum ResolvedArtifact {
+    Gguf(PathBuf),
+    LayerPackage(PathBuf),
+}
+
+struct TestLayout {
+    layer_count: u32,
+    full_model: StagePath,
+    package_dir: Option<PathBuf>,
+}
+
+#[derive(Clone)]
+struct StagePath {
+    path: PathBuf,
+    load_mode: RuntimeLoadMode,
+    filter_tensors_on_load: bool,
+}
+
+impl ResolvedCase {
+    fn resolve(spec: FamilySpec) -> Result<Self> {
+        assert_manifest_row_complete(spec)?;
+        let row = manifest_row(spec)?;
+        download_if_requested(row)?;
+        let artifact = if row.include()?.is_package_manifest_only() {
+            ResolvedArtifact::LayerPackage(resolve_package_dir(row)?)
+        } else {
+            ResolvedArtifact::Gguf(resolve_primary_gguf(row)?)
+        };
+        Ok(Self { row, artifact })
+    }
+
+    fn layout(&self) -> Result<TestLayout> {
+        match &self.artifact {
+            ResolvedArtifact::Gguf(path) => {
+                let layer_count = layer_count_for_gguf(path)?;
+                Ok(TestLayout {
+                    layer_count,
+                    full_model: StagePath {
+                        path: path.clone(),
+                        load_mode: RuntimeLoadMode::RuntimeSlice,
+                        filter_tensors_on_load: false,
+                    },
+                    package_dir: None,
+                })
+            }
+            ResolvedArtifact::LayerPackage(package_dir) => {
+                let package_ref = package_dir.to_string_lossy();
+                let info = inspect_layer_package(&package_ref)
+                    .with_context(|| format!("inspect layer package {}", package_dir.display()))?;
+                Ok(TestLayout {
+                    layer_count: info.layer_count,
+                    full_model: StagePath {
+                        path: package_dir.clone(),
+                        load_mode: RuntimeLoadMode::LayerPackage,
+                        filter_tensors_on_load: true,
+                    },
+                    package_dir: Some(package_dir.clone()),
+                })
+            }
+        }
+    }
+}
+
+fn download_if_requested(row: &CandidateRow) -> Result<()> {
+    if env_flag("SKIPPY_PARITY_DOWNLOAD", true) {
+        if row.is_package_only()
+            && !row.include()?.is_package_manifest_only()
+            && !env_flag("SKIPPY_PARITY_DOWNLOAD_PACKAGE_ONLY", false)
+        {
+            return Ok(());
+        }
+        let mut command = Command::new("hf");
+        command.args(["download", &row.repo]);
+        if !row.include()?.is_package_manifest_only() {
+            for include in row.include()?.files() {
+                command.args(["--include", include]);
+            }
+        }
+        let status = command
+            .status()
+            .with_context(|| format!("run hf download for {}", row.repo))?;
+        if !status.success() {
+            bail!("hf download failed for {} with status {status}", row.repo);
+        }
+    }
+    Ok(())
+}
+
+fn resolve_primary_gguf(row: &CandidateRow) -> Result<PathBuf> {
+    let candidates = repo_snapshot_files(&row.repo)?
+        .into_iter()
+        .filter(|path| {
+            let rel = repo_relative_path(&row.repo, path)
+                .map(|path| path.to_string_lossy().replace('\\', "/"))
+                .unwrap_or_default();
+            row.include()
+                .map(IncludeSpec::files)
+                .unwrap_or_default()
+                .iter()
+                .any(|pattern| wildcard_match(pattern, &rel))
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| {
+                        let lower = name.to_ascii_lowercase();
+                        lower.ends_with(".gguf") && !lower.starts_with("mmproj")
+                    })
+        })
+        .collect::<Vec<_>>();
+    choose_primary_gguf(row, candidates)
+}
+
+fn resolve_package_dir(row: &CandidateRow) -> Result<PathBuf> {
+    repo_snapshot_dirs(&row.repo)?
+        .into_iter()
+        .find(|dir| dir.join("model-package.json").is_file())
+        .with_context(|| {
+            format!(
+                "no downloaded model-package.json for {}; run SKIPPY_PARITY_DOWNLOAD=1 cargo test -p skippy-correctness --test parity_models -- --ignored",
+                row.repo
+            )
+        })
+}
+
+fn choose_primary_gguf(row: &CandidateRow, mut candidates: Vec<PathBuf>) -> Result<PathBuf> {
+    candidates.sort_by_key(|path| {
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        (
+            !name.contains("-00001-of-"),
+            name.contains("-000") && !name.contains("-00001-of-"),
+            name,
+        )
+    });
+    candidates.into_iter().next().with_context(|| {
+        format!(
+            "no downloaded GGUF for {} include {:?}; run SKIPPY_PARITY_DOWNLOAD=1 cargo test -p skippy-correctness --test parity_models -- --ignored",
+            row.repo,
+            row.include().map(IncludeSpec::files).unwrap_or_default()
+        )
+    })
+}
+
+fn repo_snapshot_files(repo: &str) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for dir in repo_snapshot_dirs(repo)? {
+        collect_files(&dir, &mut files)?;
+    }
+    Ok(files)
+}
+
+fn repo_snapshot_dirs(repo: &str) -> Result<Vec<PathBuf>> {
+    let cache_dir = model_hf::huggingface_hub_cache_dir();
+    let repo_dir = cache_dir.join(format!("models--{}", repo.replace('/', "--")));
+    let snapshots = repo_dir.join("snapshots");
+    if !snapshots.is_dir() {
+        bail!(
+            "Hugging Face cache has no snapshots for {} at {}; run with SKIPPY_PARITY_DOWNLOAD=1",
+            repo,
+            snapshots.display()
+        );
+    }
+    let mut dirs = fs::read_dir(&snapshots)
+        .with_context(|| format!("read {}", snapshots.display()))?
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.is_dir())
+        .collect::<Vec<_>>();
+    dirs.sort();
+    dirs.reverse();
+    Ok(dirs)
+}
+
+fn repo_relative_path(repo: &str, path: &Path) -> Option<PathBuf> {
+    let cache_dir = model_hf::huggingface_hub_cache_dir();
+    let snapshots = cache_dir
+        .join(format!("models--{}", repo.replace('/', "--")))
+        .join("snapshots");
+    for snapshot in fs::read_dir(snapshots).ok()? {
+        let snapshot = snapshot.ok()?.path();
+        if let Ok(relative) = path.strip_prefix(snapshot) {
+            return Some(relative.to_path_buf());
+        }
+    }
+    None
+}
+
+fn collect_files(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_files(&path, out)?;
+        } else if path.is_file() {
+            out.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn wildcard_match(pattern: &str, value: &str) -> bool {
+    let pattern = pattern.replace('\\', "/");
+    if pattern == value {
+        return true;
+    }
+    let parts = pattern.split('*').collect::<Vec<_>>();
+    if parts.len() == 1 {
+        return pattern == value;
+    }
+    let mut remainder = value;
+    if let Some(first) = parts.first().filter(|part| !part.is_empty()) {
+        let Some(stripped) = remainder.strip_prefix(first) else {
+            return false;
+        };
+        remainder = stripped;
+    }
+    for part in parts.iter().skip(1).take(parts.len().saturating_sub(2)) {
+        if part.is_empty() {
+            continue;
+        }
+        let Some(index) = remainder.find(part) else {
+            return false;
+        };
+        remainder = &remainder[index + part.len()..];
+    }
+    if let Some(last) = parts.last().filter(|part| !part.is_empty()) {
+        return remainder.ends_with(last);
+    }
+    true
+}
+
+fn layer_count_for_gguf(path: &Path) -> Result<u32> {
+    let max_layer = tensors_for_gguf(path)?
+        .into_iter()
+        .filter_map(|tensor| tensor.layer_index)
+        .max()
+        .with_context(|| format!("{} has no layer-indexed tensors", path.display()))?;
+    Ok(max_layer.saturating_add(1))
+}
+
+fn tensors_for_gguf(path: &Path) -> Result<Vec<skippy_runtime::TensorInfo>> {
+    let info = skippy_runtime::ModelInfo::open(path)
+        .with_context(|| format!("inspect {}", path.display()))?;
+    let tensors = info.tensors()?;
+    if tensors.iter().any(|tensor| tensor.layer_index.is_some()) {
+        return Ok(tensors);
+    }
+
+    let shard_paths = split_gguf_sibling_paths(path)?;
+    if shard_paths.len() <= 1 {
+        return Ok(tensors);
+    }
+
+    let mut all_tensors = tensors;
+    for shard in shard_paths.into_iter().filter(|shard| shard != path) {
+        let info = skippy_runtime::ModelInfo::open(&shard)
+            .with_context(|| format!("inspect split GGUF shard {}", shard.display()))?;
+        all_tensors.extend(info.tensors()?);
+    }
+    Ok(all_tensors)
+}
+
+fn split_gguf_sibling_paths(path: &Path) -> Result<Vec<PathBuf>> {
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .context("split GGUF path has no UTF-8 file name")?;
+    let Some(shard) = split_gguf_shard_info(file_name) else {
+        return Ok(vec![path.to_path_buf()]);
+    };
+    let total = shard
+        .total
+        .parse::<u32>()
+        .context("parse split GGUF shard total")?;
+    let dir = path
+        .parent()
+        .ok_or_else(|| anyhow!("split GGUF path has no parent directory"))?;
+    let mut paths = Vec::new();
+    for part in 1..=total {
+        let shard_name = format!("{}-{part:05}-of-{}.gguf", shard.prefix, shard.total);
+        paths.push(dir.join(shard_name));
+    }
+    Ok(paths)
+}
+
+fn split_layers_for(row: &CandidateRow, layer_count: u32) -> Result<(u32, u32)> {
+    if let Some(splits) = row.splits.as_deref() {
+        return parse_reviewed_splits(row, splits, layer_count);
+    }
+    split_layers(layer_count)
+}
+
+fn parse_reviewed_splits(row: &CandidateRow, splits: &str, layer_count: u32) -> Result<(u32, u32)> {
+    let values = splits
+        .split(',')
+        .map(|value| {
+            value.trim().parse::<u32>().with_context(|| {
+                format!(
+                    "parse reviewed splits for {} / {}",
+                    row.llama_model, row.family
+                )
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    match values.as_slice() {
+        [split_1, split_2]
+            if *split_1 > 0 && split_1 < split_2 && *split_2 < layer_count =>
+        {
+            Ok((*split_1, *split_2))
+        }
+        _ => bail!(
+            "{} / {} reviewed splits {splits:?} must contain two increasing boundaries inside 0..{layer_count}",
+            row.llama_model,
+            row.family
+        ),
+    }
+}
+
+fn split_layers(layer_count: u32) -> Result<(u32, u32)> {
+    if layer_count < 3 {
+        bail!("parity activation handoff requires at least three layers, got {layer_count}");
+    }
+    let split_1 = (layer_count / 3).max(1);
+    let split_2 = ((layer_count * 2) / 3)
+        .max(split_1 + 1)
+        .min(layer_count - 1);
+    Ok((split_1, split_2))
+}
+
+fn cache_stage_range(row: &CandidateRow, layout: &TestLayout) -> Result<(u32, u32)> {
+    if row.is_package_only() {
+        if layout.layer_count == 0 {
+            bail!("package-only cache smoke requires at least one layer");
+        }
+        return Ok((0, 1));
+    }
+    let (split_1, split_2) = split_layers_for(row, layout.layer_count)?;
+    Ok((split_1, split_2))
+}
+
+fn run_lightweight_activation_smoke(layout: &TestLayout, spec: FamilySpec) -> Result<()> {
+    let n_gpu_layers = case_n_gpu_layers(manifest_row(spec)?);
+    if layout.layer_count < 2 {
+        bail!("package activation smoke requires at least two layers");
+    }
+    let stage0_shape = StageShape {
+        stage_index: 0,
+        layer_start: 0,
+        layer_end: 1,
+        include_embeddings: true,
+        include_output: false,
+    };
+    let stage1_shape = StageShape {
+        stage_index: 1,
+        layer_start: 1,
+        layer_end: 2,
+        include_embeddings: false,
+        include_output: false,
+    };
+    let stage0 = open_stage_model(
+        &stage_path(layout, spec, stage0_shape)?,
+        stage0_shape,
+        n_gpu_layers,
+    )?;
+    let stage1 = open_stage_model(
+        &stage_path(layout, spec, stage1_shape)?,
+        stage1_shape,
+        n_gpu_layers,
+    )?;
+    let token = first_prompt_token(&stage0)?;
+    let mut session0 = stage0.create_session()?;
+    let (_, activation0) = session0.decode_step_frame(token, None, 0)?;
+    ensure_activation_payload("package stage 0", &activation0)?;
+    let mut session1 = stage1.create_session()?;
+    let (_, activation1) = session1.decode_step_frame(token, Some(&activation0), 0)?;
+    ensure_activation_payload("package stage 1", &activation1)?;
+    Ok(())
+}
+
+fn run_correctness_chain(layout: &TestLayout, spec: FamilySpec, splits: (u32, u32)) -> Result<()> {
+    let binary = std::env::var("CARGO_BIN_EXE_skippy-correctness")
+        .unwrap_or_else(|_| "skippy-correctness".to_string());
+    let stage_server_bin = std::env::var_os("SKIPPY_STAGE_SERVER_BIN")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target/debug/skippy-server")
+        });
+    if !stage_server_bin.is_file() {
+        bail!(
+            "skippy-server binary is required for activation chain tests; build it with `cargo build -p skippy-server` or set SKIPPY_STAGE_SERVER_BIN"
+        );
+    }
+    let model_id = format!(
+        "meshllm/{}",
+        sanitize_model_id_part(&format!("{}-{}", spec.llama_model, spec.family))
+    );
+    let output = Command::new(&binary)
+        .args([
+            "chain",
+            "--model",
+            &layout.full_model.path.to_string_lossy(),
+            "--model-id",
+            &model_id,
+            "--splits",
+            &format!("{},{}", splits.0, splits.1),
+            "--layer-end",
+            &layout.layer_count.to_string(),
+            "--n-gpu-layers",
+            &case_n_gpu_layers(manifest_row(spec)?).to_string(),
+            "--stage-server-bin",
+            &stage_server_bin.to_string_lossy(),
+            "--prompt",
+            case_prompt(manifest_row(spec)?),
+            "--activation-wire-dtype",
+            case_wire_dtype(manifest_row(spec)?),
+        ])
+        .output()
+        .with_context(|| {
+            format!(
+                "run {binary} chain for {} / {}",
+                spec.llama_model, spec.family
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "{} / {} correctness chain failed with status {}\nstdout:\n{}\nstderr:\n{}",
+            spec.llama_model,
+            spec.family,
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    let report: Value = serde_json::from_slice(&output.stdout).with_context(|| {
+        format!(
+            "parse correctness chain report for {} / {}",
+            spec.llama_model, spec.family
+        )
+    })?;
+    if report.get("matches").and_then(Value::as_bool) != Some(true) {
+        bail!(
+            "{} / {} correctness chain did not match baseline: {}",
+            spec.llama_model,
+            spec.family,
+            report
+        );
+    }
+    Ok(())
+}
+
+fn case_prompt(row: &CandidateRow) -> &str {
+    row.prompt.as_deref().unwrap_or("Hello")
+}
+
+fn case_wire_dtype(row: &CandidateRow) -> &str {
+    row.wire_dtype.as_deref().unwrap_or("f16")
+}
+
+fn case_n_gpu_layers(row: &CandidateRow) -> i32 {
+    row.n_gpu_layers.unwrap_or_else(parity_n_gpu_layers)
+}
+
+fn sanitize_model_id_part(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.') {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+struct StageShape {
+    stage_index: u32,
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+}
+
+fn stage_path(layout: &TestLayout, spec: FamilySpec, shape: StageShape) -> Result<StagePath> {
+    if matches!(layout.full_model.load_mode, RuntimeLoadMode::RuntimeSlice) {
+        return Ok(StagePath {
+            path: layout.full_model.path.clone(),
+            load_mode: RuntimeLoadMode::RuntimeSlice,
+            filter_tensors_on_load: true,
+        });
+    }
+    let package_dir = layout
+        .package_dir
+        .as_deref()
+        .ok_or_else(|| anyhow!("layer-package stage requested without a package dir"))?;
+    materialize_stage(
+        package_dir,
+        manifest_row(spec)?,
+        shape.layer_start,
+        shape.layer_end,
+        shape.include_embeddings,
+        shape.include_output,
+    )
+}
+
+fn materialize_stage(
+    package_dir: &Path,
+    row: &CandidateRow,
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+) -> Result<StagePath> {
+    let materialized = materialize_layer_package_details(&PackageStageRequest {
+        model_id: format!("{}:{}", row.repo, row.family),
+        topology_id: "parity-model-tests".to_string(),
+        package_ref: package_dir.to_string_lossy().into_owned(),
+        stage_id: format!("stage-{layer_start}-{layer_end}"),
+        layer_start,
+        layer_end,
+        include_embeddings,
+        include_output,
+    })?;
+    Ok(StagePath {
+        path: materialized.output_path,
+        load_mode: RuntimeLoadMode::LayerPackage,
+        filter_tensors_on_load: true,
+    })
+}
+
+fn run_stage_state_restore(
+    layout: &TestLayout,
+    spec: FamilySpec,
+    stage_start: u32,
+    stage_end: u32,
+    state_kind: StateKind,
+) -> Result<()> {
+    let n_gpu_layers = case_n_gpu_layers(manifest_row(spec)?);
+    let input_shape = StageShape {
+        stage_index: 0,
+        layer_start: 0,
+        layer_end: stage_start,
+        include_embeddings: true,
+        include_output: false,
+    };
+    let target_shape = StageShape {
+        stage_index: 1,
+        layer_start: stage_start,
+        layer_end: stage_end,
+        include_embeddings: stage_start == 0,
+        include_output: stage_end == layout.layer_count,
+    };
+    let target = open_stage_model(
+        &stage_path(layout, spec, target_shape)?,
+        target_shape,
+        n_gpu_layers,
+    )?;
+    let token_source = if stage_start == 0 {
+        &target
+    } else {
+        &open_stage_model(
+            &stage_path(layout, spec, input_shape)?,
+            input_shape,
+            n_gpu_layers,
+        )?
+    };
+    let mut tokens = token_source.tokenize(PROMPT, true)?;
+    if tokens.len() < 2 {
+        bail!("prompt produced fewer than two tokens");
+    }
+    tokens.truncate(2);
+    let prefix = vec![tokens[0]];
+    let continuation = tokens[1];
+    let (prefill_input, decode_input) = if stage_start == 0 {
+        (None, None)
+    } else {
+        let input = open_stage_model(
+            &stage_path(layout, spec, input_shape)?,
+            input_shape,
+            n_gpu_layers,
+        )?;
+        let mut input_session = input.create_session()?;
+        let prefill = input_session.prefill_chunk_frame(&prefix, None, 0)?;
+        let (_, decode) = input_session.decode_step_frame(continuation, None, 0)?;
+        (Some(prefill), Some(decode))
+    };
+
+    let mut source = target.create_session()?;
+    source.prefill_chunk_frame(&prefix, prefill_input.as_ref(), 0)?;
+    let payload = export_state_payload(&mut source, state_kind, stage_start, stage_end, 1)?;
+    let (source_predicted, source_frame) =
+        source.decode_step_frame(continuation, decode_input.as_ref(), 0)?;
+
+    let mut restored = target.create_session()?;
+    import_state_payload(
+        &mut restored,
+        &payload,
+        state_kind,
+        stage_start,
+        stage_end,
+        1,
+        &prefix,
+    )?;
+    let (restored_predicted, restored_frame) =
+        restored.decode_step_frame(continuation, decode_input.as_ref(), 0)?;
+    if source_predicted != restored_predicted {
+        bail!(
+            "{} / {} restored token {restored_predicted} did not match source {source_predicted}",
+            spec.llama_model,
+            spec.family
+        );
+    }
+    if !activation_frames_match(&source_frame, &restored_frame) {
+        bail!(
+            "{} / {} restored activation payload did not match recompute",
+            spec.llama_model,
+            spec.family
+        );
+    }
+    let suffix_matches = verify_suffix_prefill_after_restore(
+        &target,
+        &payload,
+        state_kind,
+        stage_start,
+        stage_end,
+        &prefix,
+        continuation,
+        prefill_input.as_ref(),
+        decode_input.as_ref(),
+        target_shape.include_output,
+    )?;
+    if !suffix_matches {
+        bail!(
+            "{} / {} suffix prefill after cache restore did not match recompute",
+            spec.llama_model,
+            spec.family
+        );
+    }
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+enum StateKind {
+    ResidentKv,
+    KvRecurrent,
+}
+
+#[derive(Clone)]
+enum StatePayload {
+    ResidentKv,
+    KvRecurrent {
+        kv: Option<RuntimeKvPage>,
+        recurrent: Vec<u8>,
+    },
+}
+
+#[allow(clippy::too_many_arguments)]
+fn verify_suffix_prefill_after_restore(
+    target: &StageModel,
+    payload: &StatePayload,
+    state_kind: StateKind,
+    stage_start: u32,
+    stage_end: u32,
+    prefix: &[i32],
+    continuation: i32,
+    prefill_input: Option<&ActivationFrame>,
+    decode_input: Option<&ActivationFrame>,
+    include_output: bool,
+) -> Result<bool> {
+    let mut source = target.create_session()?;
+    source.prefill_chunk_frame(prefix, prefill_input, 0)?;
+    let (source_predicted, source_frame) = if include_output {
+        let (predicted, frame) = source.verify_tokens_frame(&[continuation], decode_input, 0)?;
+        (Some(predicted), frame)
+    } else {
+        (
+            None,
+            source.prefill_chunk_frame(&[continuation], decode_input, 0)?,
+        )
+    };
+
+    let mut restored = target.create_session()?;
+    import_state_payload(
+        &mut restored,
+        payload,
+        state_kind,
+        stage_start,
+        stage_end,
+        1,
+        prefix,
+    )?;
+    let (restored_predicted, restored_frame) = if include_output {
+        let (predicted, frame) = restored.verify_tokens_frame(&[continuation], decode_input, 0)?;
+        (Some(predicted), frame)
+    } else {
+        (
+            None,
+            restored.prefill_chunk_frame(&[continuation], decode_input, 0)?,
+        )
+    };
+
+    Ok(source_predicted == restored_predicted
+        && activation_frames_match(&source_frame, &restored_frame))
+}
+
+fn activation_frames_match(source: &ActivationFrame, restored: &ActivationFrame) -> bool {
+    if source.desc.token_count != restored.desc.token_count
+        || source.desc.flags != restored.desc.flags
+        || source.payload.len() != restored.payload.len()
+    {
+        return false;
+    }
+    if source.payload == restored.payload {
+        return true;
+    }
+    if source.payload.len() % 4 != 0 {
+        return false;
+    }
+
+    source
+        .payload
+        .chunks_exact(4)
+        .zip(restored.payload.chunks_exact(4))
+        .all(|(lhs, rhs)| {
+            let lhs = f32::from_le_bytes(lhs.try_into().expect("chunks_exact"));
+            let rhs = f32::from_le_bytes(rhs.try_into().expect("chunks_exact"));
+            if lhs.to_bits() == rhs.to_bits() {
+                return true;
+            }
+            if !lhs.is_finite() || !rhs.is_finite() {
+                return false;
+            }
+            let diff = (lhs - rhs).abs();
+            let scale = lhs.abs().max(rhs.abs()).max(1.0);
+            diff <= 1.0e-3 || diff / scale <= 1.0e-3
+        })
+}
+
+fn export_state_payload(
+    session: &mut StageSession,
+    state_kind: StateKind,
+    layer_start: u32,
+    layer_end: u32,
+    token_count: u64,
+) -> Result<StatePayload> {
+    match state_kind {
+        StateKind::ResidentKv => {
+            session.save_prefix(CACHE_SEQ_ID, token_count)?;
+            Ok(StatePayload::ResidentKv)
+        }
+        StateKind::KvRecurrent => {
+            let kv = match session.export_kv_page(
+                layer_start as i32,
+                layer_end as i32,
+                0,
+                token_count,
+            ) {
+                Ok(page) => Some(page),
+                Err(error) if native_kv_unavailable(&error) => None,
+                Err(error) => return Err(error),
+            };
+            let recurrent = session.export_recurrent_state()?;
+            if recurrent.is_empty() {
+                bail!("KvRecurrent family exported empty recurrent state");
+            }
+            Ok(StatePayload::KvRecurrent { kv, recurrent })
+        }
+    }
+}
+
+fn import_state_payload(
+    session: &mut StageSession,
+    payload: &StatePayload,
+    state_kind: StateKind,
+    layer_start: u32,
+    layer_end: u32,
+    token_count: u64,
+    token_ids: &[i32],
+) -> Result<()> {
+    match (state_kind, payload) {
+        (StateKind::ResidentKv, StatePayload::ResidentKv) => {
+            session.restore_prefix(CACHE_SEQ_ID, token_ids)
+        }
+        (StateKind::KvRecurrent, StatePayload::KvRecurrent { kv, recurrent }) => {
+            if let Some(kv) = kv {
+                session.import_kv_page(&kv.desc, &kv.payload)?;
+            }
+            session.import_recurrent_state_for_token_count(recurrent, token_count)
+        }
+        _ => bail!("state payload kind mismatch"),
+    }
+    .with_context(|| {
+        format!(
+            "import state payload for layers {layer_start}..{layer_end} and {token_count} tokens"
+        )
+    })
+}
+
+fn native_kv_unavailable(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        let message = cause.to_string();
+        message.contains("runtime memory type is not supported for native KV pages")
+            || message.contains("runtime has no attention KV cache")
+            || message.contains("no KV cache layers selected by layer range")
+    })
+}
+
+fn open_stage_model(path: &StagePath, shape: StageShape, n_gpu_layers: i32) -> Result<StageModel> {
+    StageModel::open(
+        &path.path,
+        &RuntimeConfig {
+            stage_index: shape.stage_index,
+            layer_start: shape.layer_start,
+            layer_end: shape.layer_end,
+            ctx_size: CTX_SIZE,
+            lane_count: 4,
+            n_batch: None,
+            n_ubatch: None,
+            n_threads: None,
+            n_threads_batch: None,
+            n_gpu_layers,
+            selected_backend_device: None,
+            cache_type_k: GGML_TYPE_F16,
+            cache_type_v: GGML_TYPE_F16,
+            flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+            load_mode: path.load_mode,
+            projector_path: None,
+            include_embeddings: shape.include_embeddings,
+            include_output: shape.include_output,
+            filter_tensors_on_load: path.filter_tensors_on_load,
+        },
+    )
+    .with_context(|| {
+        format!(
+            "open {} layers {}..{}",
+            path.path.display(),
+            shape.layer_start,
+            shape.layer_end
+        )
+    })
+}
+
+fn first_prompt_token(model: &StageModel) -> Result<i32> {
+    model
+        .tokenize(PROMPT, true)?
+        .into_iter()
+        .next()
+        .context("prompt produced no tokens")
+}
+
+fn ensure_activation_payload(label: &str, frame: &ActivationFrame) -> Result<()> {
+    if frame.payload.is_empty() {
+        bail!("{label} produced empty activation payload");
+    }
+    Ok(())
+}
+
+fn env_flag(name: &str, default: bool) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(default)
+}
+
+fn env_i32(name: &str) -> Option<i32> {
+    std::env::var(name).ok()?.parse().ok()
+}
+
+fn parity_n_gpu_layers() -> i32 {
+    env_i32("SKIPPY_PARITY_N_GPU_LAYERS").unwrap_or(999)
+}

--- a/crates/skippy-runtime/src/package.rs
+++ b/crates/skippy-runtime/src/package.rs
@@ -169,6 +169,7 @@ pub fn materialize_layer_package_details(
             .len()
             > 0
         && !env_flag("SKIPPY_FORCE_MATERIALIZE")
+        && crate::ModelInfo::open(&output).is_ok()
     {
         return Ok(MaterializedPackage {
             output_path: output,
@@ -181,10 +182,34 @@ pub fn materialize_layer_package_details(
         fs::create_dir_all(parent)
             .with_context(|| format!("create materialization directory {}", parent.display()))?;
     }
-    write_gguf_from_parts(&selection.absolute_paths, &output).with_context(|| {
+    let tmp_output = output.with_extension(format!(
+        "tmp-{}-{}",
+        std::process::id(),
+        selection.manifest_sha256.get(..12).unwrap_or("manifest")
+    ));
+    if tmp_output.exists() {
+        let _ = fs::remove_file(&tmp_output);
+    }
+    if let Err(error) =
+        write_gguf_from_parts(&selection.absolute_paths, &tmp_output).with_context(|| {
+            format!(
+                "materialize layer package {}",
+                selection.package_dir.display()
+            )
+        })
+    {
+        let _ = fs::remove_file(&tmp_output);
+        return Err(error);
+    }
+    if output.exists() {
+        fs::remove_file(&output)
+            .with_context(|| format!("remove stale materialized model {}", output.display()))?;
+    }
+    fs::rename(&tmp_output, &output).with_context(|| {
         format!(
-            "materialize layer package {}",
-            selection.package_dir.display()
+            "publish materialized model {} -> {}",
+            tmp_output.display(),
+            output.display()
         )
     })?;
 

--- a/docs/skippy/LLAMA_PARITY.md
+++ b/docs/skippy/LLAMA_PARITY.md
@@ -53,7 +53,46 @@ work together.
    only the split/debug lane and does not reproduce the production cache
    evidence below.
 
-4. Promote passing rows into:
+4. Keep the Rust regression lane green. `crates/skippy-correctness/tests/parity_models.rs`
+   has one module per P0/P1 family and a cheap coverage test that fails when a
+   P0/P1 manifest row does not have a module:
+
+   ```bash
+   LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" \
+     cargo test -p skippy-correctness --test parity_models
+   ```
+
+   The expensive checks are ignored by default. Run one family while debugging:
+
+   ```bash
+   SKIPPY_PARITY_DOWNLOAD=1 \
+   LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" \
+     cargo test -p skippy-correctness --test parity_models \
+     p0_qwen2_qwen2 -- --ignored
+   ```
+
+   Before patch-queue rebuilds or broad family promotions, run the full ignored
+   lane. It downloads missing representatives, compares a three-stage local
+   split against full-model decode, and verifies cache restore from one
+   session/lane into another session/lane with native sequence remapping:
+
+   ```bash
+   SKIPPY_PARITY_DOWNLOAD=1 \
+   LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" \
+     cargo test -p skippy-correctness --test parity_models -- --ignored
+   ```
+
+   Heavy parity tests default `SKIPPY_PARITY_N_GPU_LAYERS` to `999`, matching
+   the family-certification lane; set it to `0` for an explicit CPU-only repro.
+   Use `SKIPPY_PARITY_DOWNLOAD=0` when the Hugging Face cache must be treated as
+   fixed input. Package-only rows that point at monolithic GGUFs are not
+   downloaded by default, because some representatives are larger than 100GB.
+   Set `SKIPPY_PARITY_DOWNLOAD_PACKAGE_ONLY=1` to fetch those artifacts, and
+   set `SKIPPY_PARITY_REQUIRE_PACKAGE_ONLY=1` when a missing local package-only
+   artifact should fail the run instead of being reported as a skipped
+   package-only proof.
+
+5. Promote passing rows into:
 
    - `docs/skippy/FAMILY_STATUS.md`
    - `crates/skippy-topology/capabilities/reviewed-family-capabilities.json`

--- a/docs/skippy/llama-parity-candidates.json
+++ b/docs/skippy/llama-parity-candidates.json
@@ -230,9 +230,9 @@
       "llama_model": "gemma",
       "family": "gemma",
       "status": "certified",
-      "repo": "ggml-org/gemma-3-270m-it-GGUF",
-      "include": "*.gguf",
-      "notes": "repo currently provides Q8_0 only; text lane passed in llama-parity-gemma-f32-wire-1 with f32 activation wire; f16 and q8 activation wire changed the next-token argmax"
+      "repo": "lmstudio-community/gemma-1.1-2b-it-GGUF",
+      "include": "gemma-1.1-2b-it-Q4_K_M.gguf",
+      "notes": "Gemma 1.1 representative; replaces the previous accidental Gemma3 270M row so the P0 gemma module certifies the llama.cpp gemma architecture."
     },
     {
       "llama_model": "gemma2",
@@ -260,7 +260,9 @@
       "family": "gemma4_e4b",
       "status": "certified",
       "repo": "unsloth/gemma-4-E4B-it-GGUF",
-      "include": "*Q4_K_M.gguf"
+      "include": "*Q4_K_M.gguf",
+      "splits": "10,21",
+      "notes": "Gemma4 E4B rejects known shared-KV producer/consumer cuts at 12,14,24,28 for the 42-layer representative; use reviewed 0..10,10..21,21..42 split boundaries for parity smoke tests."
     },
     {
       "llama_model": "gemma3n",
@@ -270,7 +272,9 @@
       "include": "*Q4_K_M.gguf",
       "split_layer": 15,
       "splits": "10,15",
-      "notes": "certified with lmstudio-community/gemma-3n-E2B-it-GGUF Q4_K_M in llama-parity-gemma3n-cpu-20260507d; Gemma3n carries AltUp sideband state across activation frames and split topologies must keep KV-reuse layers with their KV-owner layers, so the reviewed three-stage split is 0..10,10..15,15..30 rather than an even 0..10,10..20,20..30 split"
+      "wire_dtype": "f32",
+      "n_gpu_layers": 0,
+      "notes": "certified with lmstudio-community/gemma-3n-E2B-it-GGUF Q4_K_M in llama-parity-gemma3n-cpu-20260507d; Gemma3n carries AltUp sideband state across activation frames and split topologies must keep KV-reuse layers with their KV-owner layers, so the reviewed three-stage split is 0..10,10..15,15..30 rather than an even 0..10,10..20,20..30 split. The local parity representative runs CPU-only because Metal on the M1 Ultra diverges for split Gemma3n AltUp handoff while CPU matches the full-model baseline."
     },
     {
       "llama_model": "deepseek",
@@ -660,9 +664,11 @@
       "llama_model": "chatglm",
       "family": "chatglm",
       "status": "certified",
-      "notes": "text split and dtype matrix passed in llama-parity-finish-batch2-20260506; ResidentKv borrowed-hit cache restore passed in llama-parity-finish-batch2-residentkv-20260506; q8 rejected",
-      "repo": "mradermacher/chatglm3-6b-i1-GGUF",
-      "include": "chatglm3-6b.i1-IQ2_M.gguf"
+      "notes": "text split and ResidentKv native-sequence remap cache restore pass on the Q4_K_M ChatGLM3 representative. The prior IQ2_M cheap artifact flips the first-token argmax at the activation boundary even with f32 wire, so the P1 certification row uses the less brittle Q4_K_M artifact and a stable multi-token prompt.",
+      "repo": "Junrui2021/chatglm3-6b-Q4_K_M-GGUF",
+      "include": "chatglm3-6b-q4_k_m.gguf",
+      "splits": "9,18",
+      "prompt": "The quick brown fox"
     },
     {
       "llama_model": "codeshell",
@@ -958,7 +964,8 @@
       "status": "certified",
       "repo": "ggml-org/gpt-oss-20b-GGUF",
       "include": "gpt-oss-20b-mxfp4.gguf",
-      "notes": "llama.cpp exposes this model file as openai-moe while GGUF metadata reports general.architecture=gpt-oss; text split, chain, dtype matrix, and ResidentKv state handoff passed in llama-parity-gpt-oss-openai-moe-20260507 on ggml-org/gpt-oss-20b-GGUF:gpt-oss-20b-mxfp4; f16 activation wire validated, q8 activation wire rejected"
+      "n_gpu_layers": 0,
+      "notes": "llama.cpp exposes this model file as openai-moe while GGUF metadata reports general.architecture=gpt-oss; text split, chain, dtype matrix, and ResidentKv state handoff passed in llama-parity-gpt-oss-openai-moe-20260507 on ggml-org/gpt-oss-20b-GGUF:gpt-oss-20b-mxfp4; f16 activation wire validated, q8 activation wire rejected. The local cache representative runs CPU-only because Metal on the M1 Ultra diverges for split OpenAI-MoE activation restore while CPU matches the full-model baseline."
     },
     {
       "llama_model": "openelm",

--- a/third_party/llama.cpp/patches/0077-Support-Llama4-and-Mistral4-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0077-Support-Llama4-and-Mistral4-runtime-slices.patch
@@ -1,0 +1,280 @@
+From 6dad914f678768ec115531bea3b3d3f6e715c6e3 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 8 May 2026 05:58:50 +1000
+Subject: [PATCH] Support Llama4 and Mistral4 runtime slices
+
+---
+ src/llama-graph.cpp    | 66 ++++++++++++++++++++++++++++--------------
+ src/models/gemma3n.cpp | 19 ++++++++++++
+ src/models/llama4.cpp  | 33 +++++++++++++++++----
+ src/skippy.cpp         |  3 +-
+ 4 files changed, 93 insertions(+), 28 deletions(-)
+
+diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
+index da88c629..7d9b8ea9 100644
+--- a/src/llama-graph.cpp
++++ b/src/llama-graph.cpp
+@@ -592,29 +592,33 @@ bool llm_graph_input_attn_k::can_reuse(const llm_graph_params & params) {
+ }
+ 
+ void llm_graph_input_attn_kv_iswa::set_input(const llama_ubatch * ubatch) {
+-    mctx->get_base()->set_input_k_idxs(self_k_idxs, ubatch);
+-    mctx->get_base()->set_input_v_idxs(self_v_idxs, ubatch);
++    if (self_k_idxs && self_k_idxs->buffer) {
++        mctx->get_base()->set_input_k_idxs(self_k_idxs, ubatch);
++        mctx->get_base()->set_input_v_idxs(self_v_idxs, ubatch);
+ 
+-    mctx->get_base()->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
++        mctx->get_base()->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
++    }
+ 
+-    mctx->get_swa()->set_input_k_idxs(self_k_idxs_swa, ubatch);
+-    mctx->get_swa()->set_input_v_idxs(self_v_idxs_swa, ubatch);
++    if (self_k_idxs_swa && self_k_idxs_swa->buffer) {
++        mctx->get_swa()->set_input_k_idxs(self_k_idxs_swa, ubatch);
++        mctx->get_swa()->set_input_v_idxs(self_v_idxs_swa, ubatch);
+ 
+-    mctx->get_swa()->set_input_kq_mask(self_kq_mask_swa, ubatch, cparams.causal_attn);
++        mctx->get_swa()->set_input_kq_mask(self_kq_mask_swa, ubatch, cparams.causal_attn);
++    }
+ 
+-    if (self_k_rot) {
++    if (self_k_rot && self_k_rot->buffer) {
+         mctx->get_base()->set_input_k_rot(self_k_rot);
+     }
+ 
+-    if (self_v_rot) {
++    if (self_v_rot && self_v_rot->buffer) {
+         mctx->get_base()->set_input_v_rot(self_v_rot);
+     }
+ 
+-    if (self_k_rot_swa) {
++    if (self_k_rot_swa && self_k_rot_swa->buffer) {
+         mctx->get_swa()->set_input_k_rot(self_k_rot_swa);
+     }
+ 
+-    if (self_v_rot_swa) {
++    if (self_v_rot_swa && self_v_rot_swa->buffer) {
+         mctx->get_swa()->set_input_v_rot(self_v_rot_swa);
+     }
+ }
+@@ -688,7 +692,7 @@ void llm_graph_input_mem_hybrid::set_input(const llama_ubatch * ubatch) {
+ 
+     const int64_t n_rs = mctx->get_recr()->get_n_rs();
+ 
+-    if (inp_rs->s_copy) {
++    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
+         GGML_ASSERT(ggml_backend_buffer_is_host(inp_rs->s_copy->buffer));
+         int32_t * data = (int32_t *) inp_rs->s_copy->data;
+ 
+@@ -711,10 +715,16 @@ bool llm_graph_input_mem_hybrid::can_reuse(const llm_graph_params & params) {
+ 
+     res &= can_reuse_kq_mask(inp_attn->self_kq_mask, mctx->get_attn(), params.ubatch, params.cparams);
+ 
+-    res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
++    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
++        res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
++    }
+ 
+-    res &= inp_rs->s_copy_main->ne[0]  == params.ubatch.n_seqs;
+-    res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
++    if (inp_rs->s_copy_main && inp_rs->s_copy_main->buffer) {
++        res &= inp_rs->s_copy_main->ne[0] == params.ubatch.n_seqs;
++    }
++    if (inp_rs->s_copy_extra && inp_rs->s_copy_extra->buffer) {
++        res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
++    }
+ 
+     res &= inp_rs->head == mctx->get_recr()->get_head();
+     res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
+@@ -737,7 +747,7 @@ void llm_graph_input_mem_hybrid_k::set_input(const llama_ubatch * ubatch) {
+ 
+     const int64_t n_rs = mctx->get_recr()->get_n_rs();
+ 
+-    if (inp_rs->s_copy) {
++    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
+         GGML_ASSERT(ggml_backend_buffer_is_host(inp_rs->s_copy->buffer));
+         int32_t * data = (int32_t *) inp_rs->s_copy->data;
+ 
+@@ -759,10 +769,16 @@ bool llm_graph_input_mem_hybrid_k::can_reuse(const llm_graph_params & params) {
+ 
+     res &= can_reuse_kq_mask(inp_attn->self_kq_mask, mctx->get_attn(), params.ubatch, params.cparams);
+ 
+-    res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
++    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
++        res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
++    }
+ 
+-    res &= inp_rs->s_copy_main->ne[0]  == params.ubatch.n_seqs;
+-    res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
++    if (inp_rs->s_copy_main && inp_rs->s_copy_main->buffer) {
++        res &= inp_rs->s_copy_main->ne[0] == params.ubatch.n_seqs;
++    }
++    if (inp_rs->s_copy_extra && inp_rs->s_copy_extra->buffer) {
++        res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
++    }
+ 
+     res &= inp_rs->head == mctx->get_recr()->get_head();
+     res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
+@@ -807,7 +823,7 @@ void llm_graph_input_mem_hybrid_iswa::set_input(const llama_ubatch * ubatch) {
+ 
+     const int64_t n_rs = mctx->get_recr()->get_n_rs();
+ 
+-    if (inp_rs->s_copy) {
++    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
+         GGML_ASSERT(ggml_backend_buffer_is_host(inp_rs->s_copy->buffer));
+         int32_t * data = (int32_t *) inp_rs->s_copy->data;
+ 
+@@ -843,10 +859,16 @@ bool llm_graph_input_mem_hybrid_iswa::can_reuse(const llm_graph_params & params)
+         res &= can_reuse_kq_mask(inp_attn->self_kq_mask_swa, attn_ctx->get_swa(), params.ubatch, params.cparams);
+     }
+ 
+-    res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
++    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
++        res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
++    }
+ 
+-    res &= inp_rs->s_copy_main->ne[0]  == params.ubatch.n_seqs;
+-    res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
++    if (inp_rs->s_copy_main && inp_rs->s_copy_main->buffer) {
++        res &= inp_rs->s_copy_main->ne[0] == params.ubatch.n_seqs;
++    }
++    if (inp_rs->s_copy_extra && inp_rs->s_copy_extra->buffer) {
++        res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
++    }
+ 
+     res &= inp_rs->head == mctx->get_recr()->get_head();
+     res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
+diff --git a/src/models/gemma3n.cpp b/src/models/gemma3n.cpp
+index 4260a608..ad244ef6 100644
+--- a/src/models/gemma3n.cpp
++++ b/src/models/gemma3n.cpp
+@@ -112,6 +112,25 @@ llama_model_gemma3n::graph::graph(const llama_model & model, const llm_graph_par
+         inpL = inp->values;
+         res->add_input(std::move(inp));
+ 
++        const skippy_activation_tokens & activation_tokens = skippy_graph_get_activation_tokens();
++        const bool use_activation_token_sideband =
++            activation_tokens.tokens != nullptr &&
++            activation_tokens.token_count == ubatch.n_tokens &&
++            model.tok_embd != nullptr;
++
++        if (use_activation_token_sideband) {
++            auto stage_inp = std::make_unique<llm_graph_input_stage_tokens>();
++            stage_inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ubatch.n_tokens);
++            cb(stage_inp->tokens, "inp_stage_tokens", -1);
++            ggml_set_input(stage_inp->tokens);
++
++            inp_per_layer_proj = ggml_get_rows(ctx0, model.tok_embd, stage_inp->tokens);
++            inp_per_layer_proj = ggml_scale(ctx0, inp_per_layer_proj, sqrtf(n_embd));
++            cb(inp_per_layer_proj, "inp_per_layer_proj_embd", -1);
++
++            res->add_input(std::move(stage_inp));
++        }
++
+     } else {
+         inpL = build_inp_embd(model.tok_embd);
+ 
+diff --git a/src/models/llama4.cpp b/src/models/llama4.cpp
+index 899611d5..5ca1078b 100644
+--- a/src/models/llama4.cpp
++++ b/src/models/llama4.cpp
+@@ -112,14 +112,30 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+     ggml_tensor * cur;
+     ggml_tensor * inpL;
+ 
+-    inpL = build_inp_embd(model.tok_embd);
++    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
++    const bool stage_filtered = stage_filter.enabled;
++    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
++    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
++
++    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
+ 
+     // inp_pos - contains the positions
+     ggml_tensor * inp_pos = build_inp_pos();
+ 
+     // temperature tuning
+     ggml_tensor * inp_attn_scale = nullptr;
+-    inp_attn_scale = build_inp_attn_scale();
++    bool uses_attn_temp = false;
++    for (int il = il_start; il < il_end; ++il) {
++        const bool use_rope = hparams.n_no_rope_layer_step > 0 &&
++                              (il + 1) % hparams.n_no_rope_layer_step != 0;
++        if (!use_rope) {
++            uses_attn_temp = true;
++            break;
++        }
++    }
++    if (uses_attn_temp) {
++        inp_attn_scale = build_inp_attn_scale();
++    }
+ 
+     using inp_attn_type = std::conditional_t<iswa, llm_graph_input_attn_kv_iswa, llm_graph_input_attn_kv>;
+     inp_attn_type * inp_attn = nullptr;
+@@ -132,9 +148,9 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+ 
+     const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
+ 
+-    ggml_tensor * inp_out_ids = build_inp_out_ids();
++    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
+ 
+-    for (int il = 0; il < n_layer; ++il) {
++    for (int il = il_start; il < il_end; ++il) {
+         const float freq_base_l  = model.get_rope_freq_base (cparams, il);
+         const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
+ 
+@@ -190,7 +206,7 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+                     Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
+             cb(cur, "attn_out", il);
+         }
+-        if (il == n_layer - 1 && inp_out_ids) {
++        if (il == il_end - 1 && inp_out_ids) {
+             cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
+             inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
+         }
+@@ -252,6 +268,13 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+     }
+     cur = inpL;
+ 
++    if (stage_filtered && !stage_filter.include_output) {
++        cb(cur, "stage_boundary", il_end - 1);
++        res->t_embd = cur;
++        ggml_build_forward_expand(gf, cur);
++        return;
++    }
++
+     cur = build_norm(cur,
+             model.output_norm, NULL,
+             LLM_NORM_RMS, -1);
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index b7dd3791..e263bf14 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -1501,7 +1501,6 @@ static enum skippy_status skippy_copy_output_activation_frame(
+     }
+ 
+     std::memcpy(output_payload, embeddings, hidden_bytes);
+-
+     if ((output_flags & SKIPPY_ACTIVATION_FLAG_RWKV7_V_FIRST) != 0) {
+         uint8_t * sideband_output = static_cast<uint8_t *>(output_payload) + hidden_bytes;
+         const skippy_runtime_config & config = session->stage_model->config;
+@@ -1762,6 +1761,7 @@ static enum skippy_status skippy_finish_model_open(
+             model->arch != LLM_ARCH_JAIS2 &&
+             model->arch != LLM_ARCH_JAMBA &&
+             model->arch != LLM_ARCH_LFM2 &&
++            model->arch != LLM_ARCH_LLAMA4 &&
+             model->arch != LLM_ARCH_LLADA &&
+             model->arch != LLM_ARCH_LLADA_MOE &&
+             model->arch != LLM_ARCH_MAINCODER &&
+@@ -1770,6 +1770,7 @@ static enum skippy_status skippy_finish_model_open(
+             model->arch != LLM_ARCH_MIMO2 &&
+             model->arch != LLM_ARCH_MINICPM3 &&
+             model->arch != LLM_ARCH_MISTRAL3 &&
++            model->arch != LLM_ARCH_MISTRAL4 &&
+             model->arch != LLM_ARCH_MPT &&
+             model->arch != LLM_ARCH_NEMOTRON &&
+             model->arch != LLM_ARCH_OLMO2 &&
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## Summary
This PR adds a Rust regression lane for the Skippy split-family support matrix. Each P0/P1 llama.cpp family now has its own test module, with cheap manifest coverage enabled by default and heavy activation/cache checks available behind ignored tests.

The branch is based on current `main` and carries only the follow-up split-family test work from the merged split-family certification PR.

## What Changed
- Added one Rust test module per P0/P1 family in `crates/skippy-correctness/tests/parity_models.rs`.
- Added a shared parity harness for resolving HF artifacts, materializing package-backed models, running split activation handoff checks, and verifying cache restore across native sequence remapping.
- Documented the default, single-family, and full artifact-loading test commands.
- Hardened package materialization so stale partial GGUFs are not reused.
- Carried the llama.cpp runtime-slice fixes needed by the tested family set, including Llama4, Mistral4, and Gemma3n sideband handling.

## Test Coverage Matrix
This matrix covers all `41` P0 rows and `39` P1 rows from `docs/skippy/llama-parity-candidates.json`. Size is the Hugging Face artifact storage required for the row when running the heavy parity tests with downloads enabled, including sharded/package rows and any projector files listed in the row include patterns.

**Total P0/P1 artifact storage required:** `1.03 TiB` (`1,136,602,826,502` bytes).

| Priority | llama.cpp architecture | Skippy family | Status | Model artifact | Size |
| --- | --- | --- | --- | --- | ---: |
| `p0` | `cohere2` | `cohere2` | `certified` | `Lumia101/c4ai-command-r7b-12-2024-Q4_K_M-GGUF:c4ai-command-r7b-12-2024-q4_k_m.gguf` | `4.71 GiB` |
| `p0` | `command-r` | `command_r` | `certified` | `qwp4w3hyb/c4ai-command-r-v01-iMat-GGUF:c4ai-command-r-v01-imat-IQ2_M.gguf` | `11.80 GiB` |
| `p0` | `deepseek` | `deepseek` | `certified` | `Morgen0052/deepseek-llm-7b-chat-Q4_K_M-GGUF:deepseek-llm-7b-chat-q4_k_m-imat.gguf` | `3.93 GiB` |
| `p0` | `deepseek2` | `deepseek2` | `certified` | `bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF:DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M.gguf` | `9.65 GiB` |
| `p0` | `deepseek2` | `deepseek3` | `certified_package_only` | `meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers:model-package.json` (65 package files) | `380.11 GiB` |
| `p0` | `gemma` | `gemma` | `certified` | `lmstudio-community/gemma-1.1-2b-it-GGUF:gemma-1.1-2b-it-Q4_K_M.gguf` | `1.52 GiB` |
| `p0` | `gemma2` | `gemma2` | `certified` | `bartowski/gemma-2-2b-it-GGUF:gemma-2-2b-it-Q4_K_M.gguf` | `1.59 GiB` |
| `p0` | `gemma3` | `gemma3` | `certified` | `ggml-org/gemma-3-1b-it-GGUF:gemma-3-1b-it-Q4_K_M.gguf` | `768.7 MiB` |
| `p0` | `gemma3n` | `gemma3n` | `certified` | `lmstudio-community/gemma-3n-E2B-it-GGUF:gemma-3n-E2B-it-Q4_K_M.gguf` | `2.60 GiB` |
| `p0` | `gemma4` | `gemma4_a4b` | `certified` | `batiai/Gemma-4-26B-A4B-it-GGUF:*Q6_K.gguf` (2 files) | `21.83 GiB` |
| `p0` | `gemma4` | `gemma4_e4b` | `certified` | `unsloth/gemma-4-E4B-it-GGUF:gemma-4-E4B-it-Q4_K_M.gguf` | `4.64 GiB` |
| `p0` | `glm4` | `glm4` | `certified` | `meshllm/glm-4-9b-0414-parity-q4_k_m-gguf:glm-4-9b-0414-q4_k_m.gguf` | `5.74 GiB` |
| `p0` | `glm4` | `glm47_flash` | `certified` | `unsloth/GLM-4.7-Flash-GGUF:GLM-4.7-Flash-Q4_K_M.gguf` | `17.05 GiB` |
| `p0` | `glm4-moe` | `glm4_moe` | `certified` | `noctrex/GLM-4.7-Flash-REAP-23B-A3B-MXFP4_MOE-GGUF:GLM-4.7-Flash-REAP-23B-A3B-MXFP4_MOE.gguf` | `12.64 GiB` |
| `p0` | `granite` | `granite` | `certified` | `bartowski/ibm-granite_granite-3.2-2b-instruct-GGUF:ibm-granite_granite-3.2-2b-instruct-Q4_K_M.gguf` | `1.44 GiB` |
| `p0` | `granite-hybrid` | `granite_hybrid` | `certified` | `magiccodingman/Granite-4.0-H-350M-Unsloth-MXFP4-Hybrid-GGUF:f16-hybrid-granite-4.0-h-350m-unsloth-MXFP4_MOE-output_q6_K-router_gate_emb_q6_K.gguf` | `319.3 MiB` |
| `p0` | `hunyuan-dense` | `hunyuan_dense` | `certified` | `Edge-Quant/Hunyuan-1.8B-Instruct-Q4_K_M-GGUF:hunyuan-1.8b-instruct-q4_k_m.gguf` | `1.06 GiB` |
| `p0` | `hunyuan-moe` | `hunyuan_moe` | `certified` | `unsloth/Hunyuan-A13B-Instruct-GGUF:Hunyuan-A13B-Instruct-UD-IQ2_XXS.gguf` | `25.73 GiB` |
| `p0` | `hunyuan-vl` | `hunyuan_vl` | `certified` | `ggml-org/HunyuanOCR-GGUF:HunyuanOCR-Q8_0.gguf, mmproj-HunyuanOCR-Q8_0.gguf` (2 files) | `1.22 GiB` |
| `p0` | `lfm2` | `lfm2` | `certified` | `meshllm/lfm2-350m-parity-q4_k_m-gguf:lfm2-350m-q4_k_m.gguf` | `218.7 MiB` |
| `p0` | `lfm2moe` | `lfm2moe` | `certified` | `noctrex/LFM2-8B-A1B-MXFP4_MOE-GGUF:LFM2-8B-A1B-MXFP4_MOE.gguf` | `4.42 GiB` |
| `p0` | `llama` | `llama` | `certified` | `hugging-quants/Llama-3.2-1B-Instruct-Q4_K_M-GGUF:llama-3.2-1b-instruct-q4_k_m.gguf` | `770.3 MiB` |
| `p0` | `llama4` | `llama4` | `certified_package_only` | `ggml-org/Llama-4-Scout-17B-16E-Instruct-GGUF:Llama-4-Scout-17B-16E-Instruct-Q4_K_M-*.gguf` (2 files) | `60.87 GiB` |
| `p0` | `minimax-m2` | `minimax_m27` | `certified` | `unsloth/MiniMax-M2.7-GGUF:UD-Q2_K_XL/*.gguf` (3 files) | `70.11 GiB` |
| `p0` | `mistral3` | `mistral` | `certified` | `lmstudio-community/Ministral-3-3B-Instruct-2512-GGUF:Ministral-3-3B-Instruct-2512-Q4_K_M.gguf` | `2.00 GiB` |
| `p0` | `mistral4` | `mistral4` | `certified_package_only` | `bartowski/mistralai_Mistral-Small-4-119B-2603-GGUF:mistralai_Mistral-Small-4-119B-2603-IQ2_XXS.gguf` | `31.35 GiB` |
| `p0` | `openai-moe` | `openai_moe` | `certified` | `ggml-org/gpt-oss-20b-GGUF:gpt-oss-20b-mxfp4.gguf` | `11.28 GiB` |
| `p0` | `phi2` | `phi2` | `certified` | `TheBloke/phi-2-GGUF:phi-2.Q4_K_M.gguf` | `1.67 GiB` |
| `p0` | `phi3` | `phi` | `certified` | `bartowski/Phi-3.5-mini-instruct-GGUF:Phi-3.5-mini-instruct-Q4_K_M.gguf` | `2.23 GiB` |
| `p0` | `phimoe` | `phimoe` | `certified` | `bartowski/Phi-3.5-MoE-instruct-GGUF:Phi-3.5-MoE-instruct-Q4_K_M.gguf` | `23.61 GiB` |
| `p0` | `qwen` | `qwen` | `certified` | `zhangtao103239/Qwen-1.8B-GGUF:qwen-1.8b-q5_k_m.gguf` | `1.31 GiB` |
| `p0` | `qwen2` | `qwen2` | `certified` | `meshllm/qwen2.5-0.5b-instruct-parity-q8_0-gguf:qwen2.5-0.5b-instruct-q8_0.gguf` | `506.5 MiB` |
| `p0` | `qwen2moe` | `qwen2moe` | `certified` | `mradermacher/Qwen2-1.5B-2x-MoE-GGUF:Qwen2-1.5B-2x-MoE.Q4_K_S.gguf` | `2.10 GiB` |
| `p0` | `qwen2vl` | `qwen2vl` | `certified` | `bartowski/Qwen2-VL-2B-Instruct-GGUF:Qwen2-VL-2B-Instruct-Q4_K_M.gguf, mmproj-Qwen2-VL-2B-Instruct-f16.gguf` (2 files) | `2.16 GiB` |
| `p0` | `qwen3` | `qwen3_dense` | `certified` | `meshllm/qwen3-0.6b-parity-q8_0-gguf:qwen3-0.6b-q8_0.gguf` | `767.5 MiB` |
| `p0` | `qwen35` | `qwen35` | `certified` | `mradermacher/UnifiedReward-Edit-qwen35-4b-i1-GGUF:UnifiedReward-Edit-qwen35-4b.i1-IQ2_M.gguf` | `1.76 GiB` |
| `p0` | `qwen35moe` | `qwen35moe` | `certified_package_only` | `unsloth/Qwen3.6-35B-A3B-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf` | `20.82 GiB` |
| `p0` | `qwen3moe` | `qwen3moe` | `certified` | `mradermacher/Qwen3-MOE-4x0.6B-2.4B-Writing-Thunder-GGUF:Qwen3-MOE-4x0.6B-2.4B-Writing-Thunder.Q4_K_M.gguf` | `920.0 MiB` |
| `p0` | `qwen3next` | `qwen3next` | `certified` | `bartowski/Qwen_Qwen3-Coder-Next-GGUF:Qwen_Qwen3-Coder-Next-IQ2_XS.gguf` | `20.69 GiB` |
| `p0` | `qwen3vl` | `qwen3vl` | `certified` | `Qwen/Qwen3-VL-2B-Instruct-GGUF:Qwen3VL-2B-Instruct-Q4_K_M.gguf, mmproj-Qwen3VL-2B-Instruct-Q8_0.gguf` (2 files) | `1.45 GiB` |
| `p0` | `qwen3vlmoe` | `qwen3vlmoe` | `certified` | `noctrex/Qwen3-VL-30B-A3B-Instruct-1M-MXFP4_MOE-GGUF:Qwen3-VL-30B-A3B-Instruct-1M-MXFP4_MOE.gguf, mmproj-F16.gguf` (2 files) | `16.92 GiB` |
| `p1` | `arcee` | `arcee` | `certified` | `bartowski/arcee-ai_AFM-4.5B-GGUF:arcee-ai_AFM-4.5B-IQ2_M.gguf` | `1.59 GiB` |
| `p1` | `arwkv7` | `rwkv7` | `certified` | `mradermacher/ARWKV-7B-Preview-0.1-i1-GGUF:ARWKV-7B-Preview-0.1.i1-IQ2_M.gguf` | `2.86 GiB` |
| `p1` | `baichuan` | `baichuan` | `certified` | `lucasxx/Baichuan2-7B-Chat-Q4_K_M-GGUF:baichuan2-7b-chat.Q4_K_M.gguf` | `4.30 GiB` |
| `p1` | `bitnet` | `bitnet` | `certified` | `Sarverott/bitnet_b1_58-large-Q4_K_M-GGUF:bitnet_b1_58-large-q4_k_m.gguf` | `430.0 MiB` |
| `p1` | `bloom` | `bloom` | `certified` | `QuantFactory/bloomz-560m-GGUF:bloomz-560m.Q4_K_M.gguf` | `535.4 MiB` |
| `p1` | `chatglm` | `chatglm` | `certified` | `Junrui2021/chatglm3-6b-Q4_K_M-GGUF:chatglm3-6b-q4_k_m.gguf` | `3.86 GiB` |
| `p1` | `codeshell` | `codeshell` | `certified` | `mradermacher/CodeShell-7B-i1-GGUF:CodeShell-7B.i1-IQ2_M.gguf` | `2.62 GiB` |
| `p1` | `deepseek2ocr` | `deepseek2ocr` | `certified` | `ggml-org/DeepSeek-OCR-GGUF:DeepSeek-OCR-Q8_0.gguf, mmproj-DeepSeek-OCR-Q8_0.gguf` (2 files) | `3.33 GiB` |
| `p1` | `ernie4-5` | `ernie4_5` | `certified` | `lmstudio-community/ERNIE-4.5-0.3B-GGUF:ERNIE-4.5-0.3B-Q4_K_M.gguf` | `229.5 MiB` |
| `p1` | `ernie4-5-moe` | `ernie4_5_moe` | `certified` | `lmstudio-community/ERNIE-4.5-21B-A3B-PT-GGUF:ERNIE-4.5-21B-A3B-PT-Q4_K_M.gguf` | `12.57 GiB` |
| `p1` | `exaone` | `exaone` | `certified` | `lmstudio-community/EXAONE-3.5-2.4B-Instruct-GGUF:EXAONE-3.5-2.4B-Instruct-Q4_K_M.gguf` | `1.53 GiB` |
| `p1` | `exaone-moe` | `exaone_moe` | `certified_package_only` | `LGAI-EXAONE/K-EXAONE-236B-A23B-GGUF:K-EXAONE-236B-A23B-Q4_K_M.gguf` | `133.62 GiB` |
| `p1` | `exaone4` | `exaone4` | `certified` | `bartowski/LGAI-EXAONE_EXAONE-4.0-1.2B-GGUF:LGAI-EXAONE_EXAONE-4.0-1.2B-Q4_K_M.gguf` | `774.8 MiB` |
| `p1` | `falcon` | `falcon` | `certified` | `Kondara/falcon-7b-instruct-Q4_K_M-GGUF:falcon-7b-instruct-q4_k_m.gguf` | `4.63 GiB` |
| `p1` | `falcon-h1` | `falcon_h1` | `certified` | `tiiuae/Falcon-H1-1.5B-Instruct-GGUF:Falcon-H1-1.5B-Instruct-Q4_K_M.gguf` | `901.0 MiB` |
| `p1` | `gpt2` | `gpt2` | `certified` | `QuantFactory/gpt2-GGUF:gpt2.Q4_K_M.gguf` | `107.6 MiB` |
| `p1` | `gptneox` | `gptneox` | `certified` | `warriorknight3/pythia-70m-Q4_K_M-GGUF:pythia-70m-q4_k_m.gguf` | `47.0 MiB` |
| `p1` | `internlm2` | `internlm2` | `certified` | `lmstudio-community/internlm2_5-1_8b-chat-GGUF:internlm2_5-1_8b-chat-Q4_K_M.gguf` | `1.09 GiB` |
| `p1` | `jamba` | `jamba` | `certified` | `bartowski/ai21labs_AI21-Jamba2-3B-GGUF:ai21labs_AI21-Jamba2-3B-Q4_K_M.gguf` | `1.80 GiB` |
| `p1` | `kimi-linear` | `kimi_linear` | `certified` | `bartowski/moonshotai_Kimi-Linear-48B-A3B-Instruct-GGUF:moonshotai_Kimi-Linear-48B-A3B-Instruct-IQ2_XXS.gguf` | `11.30 GiB` |
| `p1` | `mamba` | `mamba` | `certified` | `mradermacher/mamba-130m-hf-GGUF:mamba-130m-hf.Q4_K_M.gguf` | `85.7 MiB` |
| `p1` | `mamba2` | `mamba2` | `certified` | `mradermacher/mamba-2.8b-hf-GGUF:mamba-2.8b-hf.Q4_K_M.gguf` | `1.51 GiB` |
| `p1` | `minicpm` | `minicpm` | `certified` | `s3nh/MiniCPM-2B-dpo-fp32-GGUF:minicpm-2b-dpo-fp32.Q3_K_S.gguf` | `1.19 GiB` |
| `p1` | `minicpm3` | `minicpm3` | `certified` | `duyntnet/MiniCPM-3B-OpenHermes-2.5-v2-imatrix-GGUF:MiniCPM-3B-OpenHermes-2.5-v2-IQ2_XXS.gguf` | `1.02 GiB` |
| `p1` | `mpt` | `mpt` | `certified` | `mradermacher/mpt-7b-chat-GGUF:mpt-7b-chat.Q4_K_M.gguf` | `3.98 GiB` |
| `p1` | `nemotron` | `nemotron` | `certified` | `mradermacher/nemotron-3-8b-chat-4k-sft-hf-i1-GGUF:nemotron-3-8b-chat-4k-sft-hf.i1-IQ2_XS.gguf` | `2.76 GiB` |
| `p1` | `nemotron-h` | `nemotron_h` | `certified` | `nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF:NVIDIA-Nemotron3-Nano-4B-Q4_K_M.gguf` | `2.64 GiB` |
| `p1` | `nemotron-h-moe` | `nemotron_h_moe` | `certified_package_only` | `lmstudio-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-GGUF:Nemotron-3-Nano-Omni-30B-A3B-Reasoning-Q4_K_M.gguf` | `22.83 GiB` |
| `p1` | `olmo` | `olmo` | `certified` | `meshllm/olmo-7b-instruct-hf-parity-f16-gguf:olmo-7b-instruct-hf-f16.gguf` | `12.83 GiB` |
| `p1` | `olmo2` | `olmo2` | `certified` | `allenai/OLMo-2-1124-7B-Instruct-GGUF:olmo-2-1124-7B-instruct-Q4_K_M.gguf` | `4.16 GiB` |
| `p1` | `olmoe` | `olmoe` | `certified` | `bartowski/OLMoE-1B-7B-0924-Instruct-GGUF:OLMoE-1B-7B-0924-Instruct-Q4_K_M.gguf` | `3.92 GiB` |
| `p1` | `rwkv6` | `rwkv6` | `certified` | `latestissue/rwkv-6-finch-1b6-gguf:rwkv-6-finch-1b6-Q4_K.gguf` | `947.1 MiB` |
| `p1` | `rwkv7` | `rwkv7` | `certified` | `Mungert/rwkv7-191M-world-GGUF:*q4_k.gguf` (2 files) | `504.1 MiB` |
| `p1` | `seed-oss` | `seed_oss` | `certified_package_only` | `lmstudio-community/Seed-OSS-36B-Instruct-GGUF:Seed-OSS-36B-Instruct-Q4_K_M.gguf` | `20.27 GiB` |
| `p1` | `smallthinker` | `smallthinker` | `certified` | `bartowski/SmallThinker-3B-Preview-GGUF:SmallThinker-3B-Preview-IQ2_M.gguf` | `1.19 GiB` |
| `p1` | `smollm3` | `smollm3` | `certified` | `bartowski/HuggingFaceTB_SmolLM3-3B-GGUF:HuggingFaceTB_SmolLM3-3B-IQ2_M.gguf` | `1.05 GiB` |
| `p1` | `stablelm` | `stablelm` | `certified` | `TheBloke/stablelm-zephyr-3b-GGUF:stablelm-zephyr-3b.Q4_K_M.gguf` | `1.59 GiB` |
| `p1` | `starcoder` | `starcoder` | `certified` | `RichardErkhov/bigcode_-_tiny_starcoder_py-gguf:tiny_starcoder_py.Q2_K.gguf` | `99.1 MiB` |
| `p1` | `starcoder2` | `starcoder2` | `certified` | `combos/starcoder2-3b-Q4_K_M-GGUF:starcoder2-3b-q4_k_m.gguf` | `1.76 GiB` |

## Validation
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" cargo test -p skippy-correctness --test parity_models`
- `LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" cargo test -p skippy-correctness --test parity_models p0_llama_llama::cache_state_restore_matches_recompute -- --ignored --nocapture`
- `LLAMA_STAGE_BUILD_DIR="$PWD/.deps/llama-build/build-stage-abi-cpu" cargo check -p skippy-runtime -p skippy-correctness`
- `tmp_llama="$(mktemp -d /tmp/mesh-llama-patch.XXXXXX)"; rm -rf "$tmp_llama"; LLAMA_WORKDIR="$tmp_llama" scripts/prepare-llama.sh pinned`

A full ignored sweep was also run before creating this branch from `main`: `160 passed; 0 failed; 0 ignored; 81 filtered out`. Exaone-MoE is represented as package-only and remains a controlled package artifact skip unless `SKIPPY_PARITY_REQUIRE_PACKAGE_ONLY=1` is set with the huge GGUF present locally.
