### PR TITLE
fix: skip NCCL linking on driverless CUDA slim CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -452,7 +452,9 @@ jobs:
         if: steps.llama_cache.outputs.cache-hit == 'true'
         run: cargo build --release -p mesh-llm
       - name: CLI smoke test
-        run: target/release/mesh-llm --version
+        run: |
+          export LD_LIBRARY_PATH="/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH:-}"
+          target/release/mesh-llm --version
       - name: Build CUDA benchmark binary
         if: ${{ steps.benchmark_gate.outputs.ready == 'true' }}
         run: nvcc -O3 -o target/release/membench-fingerprint-cuda crates/mesh-llm/benchmarks/membench-fingerprint.cu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,9 +407,10 @@ jobs:
       LLAMA_STAGE_BACKEND: cuda
       LLAMA_STAGE_CUDA_ARCHITECTURES: "89"
       MESH_LLM_SKIP_UI: "1"
-      # CI containers have no GPU driver (libcuda.so.1). Disable VMM to avoid
-      # linking the CUDA driver library, which isn't needed for validation builds.
+      # CI containers have no GPU driver (libcuda.so.1). Disable VMM and NCCL
+      # to avoid linking libraries that require the CUDA driver at runtime.
       GGML_CUDA_NO_VMM: "1"
+      LLAMA_STAGE_SKIP_NCCL: "1"
     outputs:
       benchmark_artifact_ready: ${{ steps.benchmark_gate.outputs.ready }}
     steps:

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -152,30 +152,22 @@ fn link_linux_cuda_libs(cmake_cache: &std::path::Path) {
         link_linux_lib_from_cache(cmake_cache, cache_key, lib);
     }
     // NCCL is conditionally linked by CMake when found on the system.
-    // On driverless CI builds, libnccl transitively requires libcuda.so.1 which
-    // is absent. Set LLAMA_STAGE_SKIP_NCCL=1 to skip NCCL linking.
-    println!("cargo:rerun-if-env-changed=LLAMA_STAGE_SKIP_NCCL");
-    let skip_nccl = std::env::var("LLAMA_STAGE_SKIP_NCCL")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-
-    if !skip_nccl {
-        if let Ok(contents) = std::fs::read_to_string(cmake_cache) {
-            let mut nccl_found = cmake_cache_bool(&contents, "NCCL_FOUND");
-            if let Some(nccl_path) = cmake_cache_value(&contents, "NCCL_LIBRARY") {
-                if !nccl_path.contains("NOTFOUND") && !nccl_path.contains("-NOTFOUND") {
-                    nccl_found = true;
-                    let path = std::path::PathBuf::from(&nccl_path);
-                    if let Some(parent) = path.parent() {
-                        if parent.is_dir() {
-                            println!("cargo:rustc-link-search=native={}", parent.display());
-                        }
+    // Check CMakeCache for NCCL_FOUND or NCCL_LIBRARY to detect this and extract the search path.
+    if let Ok(contents) = std::fs::read_to_string(cmake_cache) {
+        let mut nccl_found = cmake_cache_bool(&contents, "NCCL_FOUND");
+        if let Some(nccl_path) = cmake_cache_value(&contents, "NCCL_LIBRARY") {
+            if !nccl_path.contains("NOTFOUND") && !nccl_path.contains("-NOTFOUND") {
+                nccl_found = true;
+                let path = std::path::PathBuf::from(&nccl_path);
+                if let Some(parent) = path.parent() {
+                    if parent.is_dir() {
+                        println!("cargo:rustc-link-search=native={}", parent.display());
                     }
                 }
             }
-            if nccl_found {
-                println!("cargo:rustc-link-lib=dylib=nccl");
-            }
+        }
+        if nccl_found {
+            println!("cargo:rustc-link-lib=dylib=nccl");
         }
     }
 }

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -152,22 +152,30 @@ fn link_linux_cuda_libs(cmake_cache: &std::path::Path) {
         link_linux_lib_from_cache(cmake_cache, cache_key, lib);
     }
     // NCCL is conditionally linked by CMake when found on the system.
-    // Check CMakeCache for NCCL_FOUND or NCCL_LIBRARY to detect this and extract the search path.
-    if let Ok(contents) = std::fs::read_to_string(cmake_cache) {
-        let mut nccl_found = cmake_cache_bool(&contents, "NCCL_FOUND");
-        if let Some(nccl_path) = cmake_cache_value(&contents, "NCCL_LIBRARY") {
-            if !nccl_path.contains("NOTFOUND") && !nccl_path.contains("-NOTFOUND") {
-                nccl_found = true;
-                let path = std::path::PathBuf::from(&nccl_path);
-                if let Some(parent) = path.parent() {
-                    if parent.is_dir() {
-                        println!("cargo:rustc-link-search=native={}", parent.display());
+    // On driverless CI builds, libnccl transitively requires libcuda.so.1 which
+    // is absent. Set LLAMA_STAGE_SKIP_NCCL=1 to skip NCCL linking.
+    println!("cargo:rerun-if-env-changed=LLAMA_STAGE_SKIP_NCCL");
+    let skip_nccl = std::env::var("LLAMA_STAGE_SKIP_NCCL")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+
+    if !skip_nccl {
+        if let Ok(contents) = std::fs::read_to_string(cmake_cache) {
+            let mut nccl_found = cmake_cache_bool(&contents, "NCCL_FOUND");
+            if let Some(nccl_path) = cmake_cache_value(&contents, "NCCL_LIBRARY") {
+                if !nccl_path.contains("NOTFOUND") && !nccl_path.contains("-NOTFOUND") {
+                    nccl_found = true;
+                    let path = std::path::PathBuf::from(&nccl_path);
+                    if let Some(parent) = path.parent() {
+                        if parent.is_dir() {
+                            println!("cargo:rustc-link-search=native={}", parent.display());
+                        }
                     }
                 }
             }
-        }
-        if nccl_found {
-            println!("cargo:rustc-link-lib=dylib=nccl");
+            if nccl_found {
+                println!("cargo:rustc-link-lib=dylib=nccl");
+            }
         }
     }
 }


### PR DESCRIPTION
The NCCL detection fix in PR #456 correctly detects NCCL in the CUDA 12.8 container, but `libnccl.so` transitively requires `libcuda.so.1` which doesn't exist on driverless CI runners. This was masked by sccache until PR #457 triggered a Rust recompile.

Adds `LLAMA_STAGE_SKIP_NCCL` env var to `skippy-ffi/build.rs` (honored at build time to skip NCCL linking) and sets it in the Linux CUDA slim CI job alongside the existing `GGML_CUDA_NO_VMM=1`.