### PR TITLE
Improve agent OpenAI compatibility and client routing smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,7 +234,7 @@ jobs:
   agent_live_smokes:
     needs: [changes, linux]
     if: ${{ (vars.MESH_AGENT_BASE_URL != '' || vars.MESH_OPENCODE_BASE_URL != '') && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 45
     env:
       MESH_AGENT_BASE_URL: ${{ vars.MESH_AGENT_BASE_URL || vars.MESH_OPENCODE_BASE_URL }}
@@ -253,8 +253,13 @@ jobs:
           node-version: 24
       - name: Install agent CLIs
         run: |
-          npm install --global opencode-ai@latest
-          npm install --global @earendil-works/pi-coding-agent@latest
+          corepack enable
+          corepack prepare pnpm@10 --activate
+          export PNPM_HOME="$HOME/.local/share/pnpm"
+          mkdir -p "$PNPM_HOME"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+          pnpm add --global opencode-ai@latest @earendil-works/pi-coding-agent@latest
           opencode --version
           pi --version
       - name: Install Goose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,16 +231,16 @@ jobs:
       cache_key_prefix: ''
       workflow_cache_file: .github/workflows/ci.yml
 
-  opencode_smoke:
+  agent_live_smokes:
     needs: [changes, linux]
-    if: ${{ (vars.MESH_OPENCODE_BASE_URL != '' || vars.OPENCODE_TWO_NODE_SMOKE == 'true') && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
+    if: ${{ (vars.MESH_AGENT_BASE_URL != '' || vars.MESH_OPENCODE_BASE_URL != '') && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
     env:
-      MESH_OPENCODE_BASE_URL: ${{ vars.MESH_OPENCODE_BASE_URL }}
-      MESH_OPENCODE_MODEL: ${{ vars.MESH_OPENCODE_MODEL }}
-      MESH_OPENCODE_TWO_NODE_MODEL_URL: ${{ vars.MESH_OPENCODE_TWO_NODE_MODEL_URL }}
-      MESH_OPENCODE_TWO_NODE_MODEL_FILE: ${{ vars.MESH_OPENCODE_TWO_NODE_MODEL_FILE }}
+      MESH_AGENT_BASE_URL: ${{ vars.MESH_AGENT_BASE_URL || vars.MESH_OPENCODE_BASE_URL }}
+      MESH_AGENT_MODEL: ${{ vars.MESH_AGENT_MODEL || vars.MESH_OPENCODE_MODEL }}
+      MESH_OPENCODE_BASE_URL: ${{ vars.MESH_AGENT_BASE_URL || vars.MESH_OPENCODE_BASE_URL }}
+      MESH_OPENCODE_MODEL: ${{ vars.MESH_AGENT_MODEL || vars.MESH_OPENCODE_MODEL }}
       OPENCODE_SMOKE_LONG_PROMPT_CHARS: ${{ vars.OPENCODE_SMOKE_LONG_PROMPT_CHARS || '65536' }}
       OPENCODE_DISABLE_AUTOUPDATE: "true"
       OPENCODE_DISABLE_PRUNE: "true"
@@ -250,42 +250,60 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-      - name: Install OpenCode
+      - name: Install agent CLIs
         run: |
           npm install --global opencode-ai@latest
+          npm install --global @earendil-works/pi-coding-agent@latest
           opencode --version
+          pi --version
+      - name: Install Goose
+        run: |
+          curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Check Goose
+        run: goose --version
       - name: OpenCode configured mesh coding smoke
-        if: ${{ vars.MESH_OPENCODE_BASE_URL != '' }}
         run: scripts/ci-opencode-smoke.sh
+      - name: Pi configured mesh coding smoke
+        run: scripts/ci-pi-smoke.sh
+      - name: Goose configured mesh coding smoke
+        run: scripts/ci-goose-smoke.sh
+
+  two_node_client_serving_smoke:
+    needs: [changes, linux]
+    if: ${{ needs.linux.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install smoke dependencies
+        run: sudo apt-get update && sudo apt-get install -y curl jq lsof
       - uses: actions/download-artifact@v7
-        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
         with:
           name: ci-linux-inference-binaries
           path: ci-artifacts/linux
       - name: Stage binary
-        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
         run: |
           mkdir -p target/debug
           cp ci-artifacts/linux/mesh-llm target/debug/mesh-llm
           chmod +x target/debug/mesh-llm
-      - name: Validate two-node model config
-        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
-        run: |
-          test -n "$MESH_OPENCODE_TWO_NODE_MODEL_URL" || { echo "Set MESH_OPENCODE_TWO_NODE_MODEL_URL to a capable coding/tool GGUF URL"; exit 1; }
-          test -n "$MESH_OPENCODE_TWO_NODE_MODEL_FILE" || { echo "Set MESH_OPENCODE_TWO_NODE_MODEL_FILE to the GGUF filename"; exit 1; }
       - name: Cache integration model
-        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
-        id: cache-opencode-model
+        id: cache-two-node-model
         uses: actions/cache/restore@v5
         with:
-          path: ~/.models/${{ env.MESH_OPENCODE_TWO_NODE_MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-opencode-model-${{ env.MESH_OPENCODE_TWO_NODE_MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-two-node-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
       - name: Download integration model
-        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' && steps.cache-opencode-model.outputs.cache-hit != 'true' }}
-        run: mkdir -p ~/.models && curl -fSL "$MESH_OPENCODE_TWO_NODE_MODEL_URL" -o "$HOME/.models/$MESH_OPENCODE_TWO_NODE_MODEL_FILE"
-      - name: OpenCode two-node client routing smoke
-        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
-        run: scripts/ci-opencode-two-node-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MESH_OPENCODE_TWO_NODE_MODEL_FILE"
+        if: steps.cache-two-node-model.outputs.cache-hit != 'true'
+        run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
+      - name: Save integration model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.cache-two-node-model.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ~/.models/${{ env.MODEL_FILE }}
+          key: ${{ steps.cache-two-node-model.outputs.cache-primary-key }}
+      - name: Two-node client/serving smoke
+        run: scripts/ci-two-node-client-serving-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MODEL_FILE"
 
   native_sdk_smoke:
     needs: [changes, linux, inference_smoke_tests]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,12 +235,13 @@ jobs:
     needs: [changes, linux]
     if: ${{ (vars.MESH_AGENT_BASE_URL != '' || vars.MESH_OPENCODE_BASE_URL != '') && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 45
     env:
       MESH_AGENT_BASE_URL: ${{ vars.MESH_AGENT_BASE_URL || vars.MESH_OPENCODE_BASE_URL }}
       MESH_AGENT_MODEL: ${{ vars.MESH_AGENT_MODEL || vars.MESH_OPENCODE_MODEL }}
       MESH_OPENCODE_BASE_URL: ${{ vars.MESH_AGENT_BASE_URL || vars.MESH_OPENCODE_BASE_URL }}
       MESH_OPENCODE_MODEL: ${{ vars.MESH_AGENT_MODEL || vars.MESH_OPENCODE_MODEL }}
+      AGENT_SMOKE_LONG_PROMPT_CHARS: ${{ vars.AGENT_SMOKE_LONG_PROMPT_CHARS || vars.OPENCODE_SMOKE_LONG_PROMPT_CHARS || '65536' }}
       OPENCODE_SMOKE_LONG_PROMPT_CHARS: ${{ vars.OPENCODE_SMOKE_LONG_PROMPT_CHARS || '65536' }}
       OPENCODE_DISABLE_AUTOUPDATE: "true"
       OPENCODE_DISABLE_PRUNE: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,62 @@ jobs:
       cache_key_prefix: ''
       workflow_cache_file: .github/workflows/ci.yml
 
+  opencode_smoke:
+    needs: [changes, linux]
+    if: ${{ (vars.MESH_OPENCODE_BASE_URL != '' || vars.OPENCODE_TWO_NODE_SMOKE == 'true') && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      MESH_OPENCODE_BASE_URL: ${{ vars.MESH_OPENCODE_BASE_URL }}
+      MESH_OPENCODE_MODEL: ${{ vars.MESH_OPENCODE_MODEL }}
+      MESH_OPENCODE_TWO_NODE_MODEL_URL: ${{ vars.MESH_OPENCODE_TWO_NODE_MODEL_URL }}
+      MESH_OPENCODE_TWO_NODE_MODEL_FILE: ${{ vars.MESH_OPENCODE_TWO_NODE_MODEL_FILE }}
+      OPENCODE_SMOKE_LONG_PROMPT_CHARS: ${{ vars.OPENCODE_SMOKE_LONG_PROMPT_CHARS || '65536' }}
+      OPENCODE_DISABLE_AUTOUPDATE: "true"
+      OPENCODE_DISABLE_PRUNE: "true"
+      OPENCODE_DISABLE_LSP_DOWNLOAD: "true"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      - name: Install OpenCode
+        run: |
+          npm install --global opencode-ai@latest
+          opencode --version
+      - name: OpenCode configured mesh coding smoke
+        if: ${{ vars.MESH_OPENCODE_BASE_URL != '' }}
+        run: scripts/ci-opencode-smoke.sh
+      - uses: actions/download-artifact@v7
+        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
+        with:
+          name: ci-linux-inference-binaries
+          path: ci-artifacts/linux
+      - name: Stage binary
+        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
+        run: |
+          mkdir -p target/debug
+          cp ci-artifacts/linux/mesh-llm target/debug/mesh-llm
+          chmod +x target/debug/mesh-llm
+      - name: Validate two-node model config
+        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
+        run: |
+          test -n "$MESH_OPENCODE_TWO_NODE_MODEL_URL" || { echo "Set MESH_OPENCODE_TWO_NODE_MODEL_URL to a capable coding/tool GGUF URL"; exit 1; }
+          test -n "$MESH_OPENCODE_TWO_NODE_MODEL_FILE" || { echo "Set MESH_OPENCODE_TWO_NODE_MODEL_FILE to the GGUF filename"; exit 1; }
+      - name: Cache integration model
+        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
+        id: cache-opencode-model
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.models/${{ env.MESH_OPENCODE_TWO_NODE_MODEL_FILE }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-opencode-model-${{ env.MESH_OPENCODE_TWO_NODE_MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+      - name: Download integration model
+        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' && steps.cache-opencode-model.outputs.cache-hit != 'true' }}
+        run: mkdir -p ~/.models && curl -fSL "$MESH_OPENCODE_TWO_NODE_MODEL_URL" -o "$HOME/.models/$MESH_OPENCODE_TWO_NODE_MODEL_FILE"
+      - name: OpenCode two-node client routing smoke
+        if: ${{ vars.OPENCODE_TWO_NODE_SMOKE == 'true' }}
+        run: scripts/ci-opencode-two-node-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MESH_OPENCODE_TWO_NODE_MODEL_FILE"
+
   native_sdk_smoke:
     needs: [changes, linux, inference_smoke_tests]
     if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') }}

--- a/crates/mesh-llm-host-runtime/src/cli/commands/integrations.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/integrations.rs
@@ -451,6 +451,14 @@ fn build_pi_provider_config_with_limits(
     provider.insert("api".to_string(), serde_json::json!("openai-completions"));
     provider.insert("apiKey".to_string(), serde_json::json!("mesh"));
     provider.insert("baseUrl".to_string(), serde_json::json!(api_base_url));
+    provider.insert(
+        "compat".to_string(),
+        serde_json::json!({
+            "supportsStore": false,
+            "supportsDeveloperRole": false,
+            "supportsUsageInStreaming": true,
+        }),
+    );
     provider.insert("models".to_string(), serde_json::Value::Array(models));
 
     serde_json::Value::Object(provider)
@@ -1257,6 +1265,9 @@ mod tests {
         assert_eq!(provider["api"], "openai-completions");
         assert_eq!(provider["apiKey"], "mesh");
         assert_eq!(provider["baseUrl"], "http://localhost:9337/v1");
+        assert_eq!(provider["compat"]["supportsStore"], false);
+        assert_eq!(provider["compat"]["supportsDeveloperRole"], false);
+        assert_eq!(provider["compat"]["supportsUsageInStreaming"], true);
         assert_eq!(provider["models"].as_array().map(Vec::len), Some(2));
         assert_eq!(provider["models"][0]["id"], "Qwen 3.6 27B");
         assert_eq!(provider["models"][0]["name"], "Qwen 3.6 27B");

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -3648,6 +3648,23 @@ impl Node {
                     .await
                     .connections
                     .insert(peer_id, conn.clone());
+                let node_for_dispatch = self.clone();
+                let conn_for_dispatch = conn.clone();
+                tokio::spawn(async move {
+                    node_for_dispatch
+                        .dispatch_streams(conn_for_dispatch, peer_id)
+                        .await;
+                });
+                if let Err(error) = self
+                    .initiate_gossip_inner(conn.clone(), peer_id, false)
+                    .await
+                {
+                    self.state.lock().await.connections.remove(&peer_id);
+                    anyhow::bail!(
+                        "Failed to complete gossip with {} before opening mesh stream: {error}",
+                        peer_id.fmt_short()
+                    );
+                }
                 Ok(conn)
             }
         }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -3527,6 +3527,55 @@ async fn test_connect_to_peer_skips_known_peer_without_connection() -> Result<()
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_on_demand_transitive_peer_connection_completes_gossip() -> Result<()> {
+    let host = make_test_node(super::NodeRole::Host { http_port: 9337 }).await?;
+    let bridge = make_test_node(super::NodeRole::Worker).await?;
+    let client = make_test_node(super::NodeRole::Client).await?;
+
+    host.set_hosted_models(vec!["remote-coding-model".to_string()])
+        .await;
+    host.start_accepting();
+    bridge.start_accepting();
+    client.start_accepting();
+
+    bridge.join(&host.invite_token()).await?;
+    wait_for_peer(&bridge, host.id()).await;
+    wait_for_peer(&host, bridge.id()).await;
+
+    client.join(&bridge.invite_token()).await?;
+    wait_for_peer(&client, bridge.id()).await;
+    wait_for_peer(&client, host.id()).await;
+
+    {
+        let state = client.state.lock().await;
+        assert!(
+            !state.connections.contains_key(&host.id()),
+            "setup: host should be known transitively but not directly connected"
+        );
+    }
+    assert!(
+        client
+            .hosts_for_model("remote-coding-model")
+            .await
+            .contains(&host.id()),
+        "setup: client should route the remote model to the transitive host"
+    );
+
+    let _conn = client.connection_to_peer(host.id()).await?;
+
+    wait_for_peer(&host, client.id()).await;
+    {
+        let state = client.state.lock().await;
+        assert!(
+            state.connections.contains_key(&host.id()),
+            "on-demand connection should be retained after gossip succeeds"
+        );
+    }
+
+    Ok(())
+}
+
 #[test]
 fn config_sync_subscribe_snapshot_encode_decode() {
     use crate::proto::node::{ConfigSnapshotResponse, NodeConfigSnapshot, NodeGpuConfig};

--- a/crates/mesh-llm-host-runtime/src/network/openai/response_adapter.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response_adapter.rs
@@ -2,9 +2,12 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
 pub(crate) use openai_frontend::{
-    responses_stream_completed_event, responses_stream_created_event,
-    responses_stream_delta_event_with_logprobs, responses_stream_text_done_event,
-    stream_usage_to_responses_usage, translate_chat_completion_to_responses,
+    responses_stream_completed_event_with_sequence, responses_stream_content_part_added_event,
+    responses_stream_content_part_done_event, responses_stream_created_event_with_sequence,
+    responses_stream_delta_event_with_logprobs_and_sequence,
+    responses_stream_output_item_added_event, responses_stream_output_item_done_event,
+    responses_stream_text_done_event_with_sequence, stream_usage_to_responses_usage,
+    translate_chat_completion_to_responses,
 };
 
 fn sse_frame(event: Option<&str>, data: &str) -> Vec<u8> {

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -1202,11 +1202,17 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
     let mut output_text = String::new();
     let mut usage = None;
     let mut observed_completion_tokens = None;
+    let mut sequence_number = 0i32;
     let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
     tcp_stream.write_all(header.as_bytes()).await?;
 
     let mut created_emitted = false;
+    let mut output_item_emitted = false;
     let mut done_seen = false;
+    let mut next_sequence_number = || {
+        sequence_number = sequence_number.saturating_add(1);
+        sequence_number
+    };
     loop {
         let mut processed = 0usize;
         while let Some(frame_end_rel) = carry[processed..].find("\n\n") {
@@ -1240,8 +1246,13 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
             }
             // Emit response.created once we have the model from the first chunk.
             if !created_emitted && !model.is_empty() {
+                let sequence_number = next_sequence_number();
                 let created = serde_json::to_string(
-                    &response_adapter::responses_stream_created_event(&model, created_at),
+                    &response_adapter::responses_stream_created_event_with_sequence(
+                        &model,
+                        created_at,
+                        sequence_number,
+                    ),
                 )
                 .context("serialize response.created stream event")?;
                 response_adapter::write_chunked_sse_event(
@@ -1258,14 +1269,49 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
                 .and_then(|choice| choice.delta.as_ref())
                 .and_then(|delta| delta.content.as_deref())
             {
+                if !output_item_emitted {
+                    let sequence_number = next_sequence_number();
+                    let item_added = serde_json::to_string(
+                        &response_adapter::responses_stream_output_item_added_event(
+                            &item_id,
+                            sequence_number,
+                        ),
+                    )
+                    .context("serialize response.output_item.added event")?;
+                    response_adapter::write_chunked_sse_event(
+                        tcp_stream,
+                        Some("response.output_item.added"),
+                        &item_added,
+                    )
+                    .await?;
+                    let sequence_number = next_sequence_number();
+                    let part_added = serde_json::to_string(
+                        &response_adapter::responses_stream_content_part_added_event(
+                            &item_id,
+                            sequence_number,
+                        ),
+                    )
+                    .context("serialize response.content_part.added event")?;
+                    response_adapter::write_chunked_sse_event(
+                        tcp_stream,
+                        Some("response.content_part.added"),
+                        &part_added,
+                    )
+                    .await?;
+                    output_item_emitted = true;
+                }
                 let logprobs = chunk
                     .choices
                     .first()
                     .and_then(|choice| choice.logprobs.clone());
                 output_text.push_str(delta);
+                let sequence_number = next_sequence_number();
                 let event = serde_json::to_string(
-                    &response_adapter::responses_stream_delta_event_with_logprobs(
-                        &item_id, delta, logprobs,
+                    &response_adapter::responses_stream_delta_event_with_logprobs_and_sequence(
+                        &item_id,
+                        delta,
+                        logprobs,
+                        sequence_number,
                     ),
                 )
                 .context("serialize response.output_text.delta event")?;
@@ -1312,18 +1358,52 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
 
     // If upstream sent no model field at all (e.g. empty stream), still emit response.created.
     if !created_emitted {
-        let created = serde_json::to_string(&response_adapter::responses_stream_created_event(
-            &model, created_at,
-        ))
+        let sequence_number = next_sequence_number();
+        let created = serde_json::to_string(
+            &response_adapter::responses_stream_created_event_with_sequence(
+                &model,
+                created_at,
+                sequence_number,
+            ),
+        )
         .context("serialize response.created stream event")?;
         response_adapter::write_chunked_sse_event(tcp_stream, Some("response.created"), &created)
             .await?;
     }
 
-    let text_done = serde_json::to_string(&response_adapter::responses_stream_text_done_event(
-        &item_id,
-        &output_text,
-    ))
+    if !output_item_emitted {
+        let sequence_number = next_sequence_number();
+        let item_added = serde_json::to_string(
+            &response_adapter::responses_stream_output_item_added_event(&item_id, sequence_number),
+        )
+        .context("serialize response.output_item.added event")?;
+        response_adapter::write_chunked_sse_event(
+            tcp_stream,
+            Some("response.output_item.added"),
+            &item_added,
+        )
+        .await?;
+        let sequence_number = next_sequence_number();
+        let part_added = serde_json::to_string(
+            &response_adapter::responses_stream_content_part_added_event(&item_id, sequence_number),
+        )
+        .context("serialize response.content_part.added event")?;
+        response_adapter::write_chunked_sse_event(
+            tcp_stream,
+            Some("response.content_part.added"),
+            &part_added,
+        )
+        .await?;
+    }
+
+    let sequence_number = next_sequence_number();
+    let text_done = serde_json::to_string(
+        &response_adapter::responses_stream_text_done_event_with_sequence(
+            &item_id,
+            &output_text,
+            sequence_number,
+        ),
+    )
     .context("serialize response.output_text.done event")?;
     response_adapter::write_chunked_sse_event(
         tcp_stream,
@@ -1331,14 +1411,46 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
         &text_done,
     )
     .await?;
-    let completed = serde_json::to_string(&response_adapter::responses_stream_completed_event(
-        &response_id,
-        created_at,
-        &model,
-        &item_id,
-        &output_text,
-        usage,
-    ))
+    let sequence_number = next_sequence_number();
+    let part_done =
+        serde_json::to_string(&response_adapter::responses_stream_content_part_done_event(
+            &item_id,
+            &output_text,
+            sequence_number,
+        ))
+        .context("serialize response.content_part.done event")?;
+    response_adapter::write_chunked_sse_event(
+        tcp_stream,
+        Some("response.content_part.done"),
+        &part_done,
+    )
+    .await?;
+    let sequence_number = next_sequence_number();
+    let item_done =
+        serde_json::to_string(&response_adapter::responses_stream_output_item_done_event(
+            &item_id,
+            &output_text,
+            sequence_number,
+        ))
+        .context("serialize response.output_item.done event")?;
+    response_adapter::write_chunked_sse_event(
+        tcp_stream,
+        Some("response.output_item.done"),
+        &item_done,
+    )
+    .await?;
+    let sequence_number = next_sequence_number();
+    let completed = serde_json::to_string(
+        &response_adapter::responses_stream_completed_event_with_sequence(
+            &response_id,
+            created_at,
+            &model,
+            &item_id,
+            &output_text,
+            usage,
+            sequence_number,
+        ),
+    )
     .context("serialize response.completed event")?;
     response_adapter::write_chunked_sse_event(tcp_stream, Some("response.completed"), &completed)
         .await?;

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -13,6 +13,7 @@ use crate::network::router;
 use crate::plugin;
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Deserialize;
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
@@ -83,6 +84,7 @@ impl BufferedHttpRequest {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResponseAdapter {
     None,
+    OpenAiChatCompletionsStream,
     OpenAiResponsesJson,
     OpenAiResponsesStream,
 }
@@ -149,12 +151,15 @@ struct ParsedResponseHeaders {
     header_end: usize,
     status_code: u16,
     content_length: Option<usize>,
+    content_type: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
 struct RequestMetadata {
     #[serde(default)]
     model: Option<String>,
+    #[serde(default)]
+    stream: Option<bool>,
     #[serde(default)]
     max_completion_tokens: Option<u32>,
     #[serde(default)]
@@ -292,6 +297,12 @@ async fn read_http_request_with_limits(
     } else {
         None
     };
+    if response_adapter == ResponseAdapter::None
+        && parsed.path.split('?').next().unwrap_or(&parsed.path) == "/v1/chat/completions"
+        && metadata.as_ref().and_then(|value| value.stream) == Some(true)
+    {
+        response_adapter = ResponseAdapter::OpenAiChatCompletionsStream;
+    }
     let model_name = metadata.as_ref().and_then(|value| value.model.clone());
     let completion_tokens = metadata.as_ref().and_then(|value| {
         value
@@ -949,6 +960,193 @@ fn parse_completion_tokens_from_json_body(body: &[u8]) -> Option<u64> {
         .and_then(|value| value.as_u64())
 }
 
+fn response_is_event_stream(headers: &ParsedResponseHeaders) -> bool {
+    headers
+        .content_type
+        .as_deref()
+        .map(|value| {
+            value
+                .split(';')
+                .next()
+                .unwrap_or(value)
+                .trim()
+                .eq_ignore_ascii_case("text/event-stream")
+        })
+        .unwrap_or(false)
+}
+
+fn synthetic_id_seed() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or(0)
+}
+
+#[derive(Debug, Default)]
+struct ChatStreamNormalizationState {
+    completion_id: Option<String>,
+    tool_call_ids: HashMap<u64, String>,
+    synthetic_seed: Option<u128>,
+}
+
+impl ChatStreamNormalizationState {
+    fn seed(&mut self) -> u128 {
+        *self.synthetic_seed.get_or_insert_with(synthetic_id_seed)
+    }
+
+    fn completion_id(&mut self, object: &Map<String, Value>) -> String {
+        if let Some(existing) = self.completion_id.clone() {
+            return existing;
+        }
+        let id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("chatcmpl-mesh-{}", self.seed()));
+        self.completion_id = Some(id.clone());
+        id
+    }
+
+    fn tool_call_id(&mut self, index: u64, tool_call: &Map<String, Value>) -> String {
+        if let Some(existing) = self.tool_call_ids.get(&index) {
+            return existing.clone();
+        }
+        let id = tool_call
+            .get("id")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("call_mesh_{}_{}", self.seed(), index));
+        self.tool_call_ids.insert(index, id.clone());
+        id
+    }
+
+    fn normalize_data(&mut self, data: &str) -> String {
+        let Ok(mut value) = serde_json::from_str::<Value>(data) else {
+            return data.to_string();
+        };
+        let Some(object) = value.as_object_mut() else {
+            return data.to_string();
+        };
+
+        let completion_id = self.completion_id(object);
+        object.insert("id".into(), Value::String(completion_id));
+
+        let Some(choices) = object.get_mut("choices").and_then(Value::as_array_mut) else {
+            return serde_json::to_string(&value).unwrap_or_else(|_| data.to_string());
+        };
+        for choice in choices {
+            let Some(tool_calls) = choice
+                .get_mut("delta")
+                .and_then(Value::as_object_mut)
+                .and_then(|delta| delta.get_mut("tool_calls"))
+                .and_then(Value::as_array_mut)
+            else {
+                continue;
+            };
+            for (position, tool_call) in tool_calls.iter_mut().enumerate() {
+                let Some(tool_call_object) = tool_call.as_object_mut() else {
+                    continue;
+                };
+                let index = tool_call_object
+                    .get("index")
+                    .and_then(Value::as_u64)
+                    .unwrap_or(position as u64);
+                let id = self.tool_call_id(index, tool_call_object);
+                tool_call_object.insert("id".into(), Value::String(id));
+            }
+        }
+
+        serde_json::to_string(&value).unwrap_or_else(|_| data.to_string())
+    }
+}
+
+async fn relay_normalized_chat_completion_stream<R: AsyncRead + Unpin>(
+    tcp_stream: &mut TcpStream,
+    reader: &mut R,
+    probe: ResponseProbe,
+    retry_context_overflow: bool,
+) -> Result<RouteAttemptResult> {
+    if retry_context_overflow && probe.retryable_context_overflow {
+        return Ok(RouteAttemptResult::RetryableContextOverflow);
+    }
+
+    if !(200..300).contains(&probe.status_code) {
+        return relay_error_response(tcp_stream, reader, probe).await;
+    }
+
+    let parsed = try_parse_response_headers(&probe.buffered)?
+        .ok_or_else(|| anyhow!("incomplete HTTP response"))?;
+    if !response_is_event_stream(&parsed) {
+        return relay_success_response(tcp_stream, reader, probe, parsed).await;
+    }
+
+    let mut carry = String::from_utf8_lossy(&probe.buffered[parsed.header_end..]).to_string();
+    let mut state = ChatStreamNormalizationState::default();
+    let mut observed_completion_tokens = None;
+    let header = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nCache-Control: no-cache\r\nConnection: close\r\n\r\n";
+    tcp_stream.write_all(header.as_bytes()).await?;
+
+    let mut done_seen = false;
+    loop {
+        let mut processed = 0usize;
+        while let Some(frame_end_rel) = carry[processed..].find("\n\n") {
+            let frame_end = processed + frame_end_rel;
+            let frame = &carry[processed..frame_end];
+            processed = frame_end + 2;
+            let data_lines = frame
+                .lines()
+                .filter_map(|line| line.strip_prefix("data:"))
+                .map(str::trim_start)
+                .collect::<Vec<_>>();
+            if data_lines.is_empty() {
+                continue;
+            }
+            let data = data_lines.join("\n");
+            if data == "[DONE]" {
+                done_seen = true;
+                response_adapter::write_chunked_sse_event(tcp_stream, None, "[DONE]").await?;
+                break;
+            }
+
+            if observed_completion_tokens.is_none() {
+                observed_completion_tokens =
+                    parse_completion_tokens_from_json_body(data.as_bytes());
+            }
+            let normalized = state.normalize_data(&data);
+            response_adapter::write_chunked_sse_event(tcp_stream, None, &normalized).await?;
+        }
+        if processed > 0 {
+            carry = carry[processed..].to_string();
+        }
+
+        if done_seen {
+            break;
+        }
+
+        let mut chunk = [0u8; 8192];
+        let n = reader.read(&mut chunk).await?;
+        if n == 0 {
+            break;
+        }
+        let new_data = String::from_utf8_lossy(&chunk[..n]);
+        carry.push_str(&new_data);
+        if carry.contains('\r') {
+            carry = carry.replace("\r\n", "\n");
+        }
+    }
+
+    let _ = tcp_stream.write_all(b"0\r\n\r\n").await;
+    let _ = tcp_stream.shutdown().await;
+    Ok(RouteAttemptResult::Delivered {
+        status_code: probe.status_code,
+        completion_tokens: observed_completion_tokens,
+    })
+}
+
 fn delivered_attempt_outcome(status_code: u16) -> crate::network::metrics::AttemptOutcome {
     match status_code {
         200..=299 => crate::network::metrics::AttemptOutcome::Success,
@@ -1304,6 +1502,7 @@ fn try_parse_response_headers(buf: &[u8]) -> Result<Option<ParsedResponseHeaders
     match response.parse(buf) {
         Ok(httparse::Status::Complete(header_end)) => {
             let mut content_length = None;
+            let mut content_type = None;
             for header in response.headers.iter() {
                 if header.name.eq_ignore_ascii_case("content-length") {
                     let value = std::str::from_utf8(header.value)
@@ -1312,12 +1511,20 @@ fn try_parse_response_headers(buf: &[u8]) -> Result<Option<ParsedResponseHeaders
                         Some(value.trim().parse::<usize>().with_context(|| {
                             format!("invalid response Content-Length: {value}")
                         })?);
+                } else if header.name.eq_ignore_ascii_case("content-type") {
+                    content_type = Some(
+                        std::str::from_utf8(header.value)
+                            .context("invalid response Content-Type encoding")?
+                            .trim()
+                            .to_string(),
+                    );
                 }
             }
             Ok(Some(ParsedResponseHeaders {
                 header_end,
                 status_code: response.code.unwrap_or(0),
                 content_length,
+                content_type,
             }))
         }
         Ok(httparse::Status::Partial) => Ok(None),
@@ -1512,13 +1719,57 @@ async fn relay_error_response<R: AsyncRead + Unpin>(
     })
 }
 
+async fn relay_success_response<R: AsyncRead + Unpin>(
+    tcp_stream: &mut TcpStream,
+    reader: &mut R,
+    probe: ResponseProbe,
+    parsed: ParsedResponseHeaders,
+) -> Result<RouteAttemptResult> {
+    if let Some(content_length) = parsed.content_length {
+        const MAX_SUCCESS_METRICS_BODY_BYTES: usize = 1024 * 1024;
+        if content_length <= MAX_SUCCESS_METRICS_BODY_BYTES {
+            let mut buffered = probe.buffered;
+            while buffered.len() < parsed.header_end + content_length {
+                read_response_chunk(reader, &mut buffered).await?;
+            }
+            let completion_tokens =
+                parse_completion_tokens_from_json_body(&buffered[parsed.header_end..]);
+            tcp_stream.write_all(&buffered).await?;
+            let _ = tcp_stream.shutdown().await;
+            return Ok(RouteAttemptResult::Delivered {
+                status_code: probe.status_code,
+                completion_tokens,
+            });
+        }
+    }
+
+    tcp_stream.write_all(&probe.buffered).await?;
+    if let Err(err) = tokio::io::copy(reader, &mut *tcp_stream).await {
+        tracing::debug!("response relay ended after headers were committed: {err}");
+    }
+    let _ = tcp_stream.shutdown().await;
+    Ok(RouteAttemptResult::Delivered {
+        status_code: probe.status_code,
+        completion_tokens: None,
+    })
+}
+
 async fn relay_probed_response<R: AsyncRead + Unpin>(
-    mut tcp_stream: &mut TcpStream,
+    tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
     retry_context_overflow: bool,
     response_adapter: ResponseAdapter,
 ) -> Result<RouteAttemptResult> {
+    if response_adapter == ResponseAdapter::OpenAiChatCompletionsStream {
+        return relay_normalized_chat_completion_stream(
+            tcp_stream,
+            reader,
+            probe,
+            retry_context_overflow,
+        )
+        .await;
+    }
     if response_adapter == ResponseAdapter::OpenAiResponsesJson {
         return relay_translated_responses_json(tcp_stream, reader, probe, retry_context_overflow)
             .await;
@@ -1542,33 +1793,7 @@ async fn relay_probed_response<R: AsyncRead + Unpin>(
 
     let parsed = try_parse_response_headers(&probe.buffered)?
         .ok_or_else(|| anyhow!("incomplete HTTP response"))?;
-    if let Some(content_length) = parsed.content_length {
-        const MAX_SUCCESS_METRICS_BODY_BYTES: usize = 1024 * 1024;
-        if content_length <= MAX_SUCCESS_METRICS_BODY_BYTES {
-            let mut buffered = probe.buffered;
-            while buffered.len() < parsed.header_end + content_length {
-                read_response_chunk(reader, &mut buffered).await?;
-            }
-            let completion_tokens =
-                parse_completion_tokens_from_json_body(&buffered[parsed.header_end..]);
-            tcp_stream.write_all(&buffered).await?;
-            let _ = tcp_stream.shutdown().await;
-            return Ok(RouteAttemptResult::Delivered {
-                status_code: probe.status_code,
-                completion_tokens,
-            });
-        }
-    }
-
-    tcp_stream.write_all(&probe.buffered).await?;
-    if let Err(err) = tokio::io::copy(reader, &mut tcp_stream).await {
-        tracing::debug!("response relay ended after headers were committed: {err}");
-    }
-    let _ = tcp_stream.shutdown().await;
-    Ok(RouteAttemptResult::Delivered {
-        status_code: probe.status_code,
-        completion_tokens: None,
-    })
+    relay_success_response(tcp_stream, reader, probe, parsed).await
 }
 
 async fn route_local_attempt(
@@ -3448,6 +3673,53 @@ mod tests {
         assert_eq!(
             parse_completion_tokens_from_json_body(responses.to_string().as_bytes()),
             Some(4)
+        );
+    }
+
+    #[test]
+    fn chat_stream_normalizer_adds_missing_tool_call_id() {
+        let mut state = ChatStreamNormalizationState::default();
+        state.synthetic_seed = Some(42);
+        let normalized = state.normalize_data(
+            r#"{"id":"chatcmpl-a","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"read_file","arguments":"{\"path\":\"AGENTS.md\"}"}}]},"finish_reason":null}]}"#,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&normalized).unwrap();
+
+        assert_eq!(parsed["id"], "chatcmpl-a");
+        assert_eq!(
+            parsed["choices"][0]["delta"]["tool_calls"][0]["id"],
+            "call_mesh_42_0"
+        );
+    }
+
+    #[test]
+    fn chat_stream_normalizer_keeps_completion_and_tool_ids_stable() {
+        let mut state = ChatStreamNormalizationState::default();
+        state.synthetic_seed = Some(7);
+
+        let first = state.normalize_data(
+            r#"{"id":"chatcmpl-first","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}"#,
+        );
+        let second = state.normalize_data(
+            r#"{"id":"chatcmpl-second","object":"chat.completion.chunk","created":2,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":"{}"}}]},"finish_reason":null}]}"#,
+        );
+        let third = state.normalize_data(
+            r#"{"id":"chatcmpl-third","object":"chat.completion.chunk","created":3,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"arguments":" more"}}]},"finish_reason":null}]}"#,
+        );
+        let first: serde_json::Value = serde_json::from_str(&first).unwrap();
+        let second: serde_json::Value = serde_json::from_str(&second).unwrap();
+        let third: serde_json::Value = serde_json::from_str(&third).unwrap();
+
+        assert_eq!(first["id"], "chatcmpl-first");
+        assert_eq!(second["id"], "chatcmpl-first");
+        assert_eq!(third["id"], "chatcmpl-first");
+        assert_eq!(
+            second["choices"][0]["delta"]["tool_calls"][0]["id"],
+            "call_mesh_7_0"
+        );
+        assert_eq!(
+            third["choices"][0]["delta"]["tool_calls"][0]["id"],
+            "call_mesh_7_0"
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -4444,10 +4444,24 @@ async fn run_auto(
                 model_path
             }
         } else {
-            // Nothing on disk matches — go passive, act as proxy
-            // Stop bootstrap proxy first (run_passive binds its own listener)
-            drop(bootstrap_listener_tx.take());
-            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            // Nothing on disk matches — go passive, act as proxy. If the
+            // bootstrap proxy already owns the API port, hand its listener to
+            // passive mode so joined clients do not see a connection-refused
+            // gap during startup.
+            let passive_api_listener = if let Some(tx) = bootstrap_listener_tx.take() {
+                let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+                if tx.send(resp_tx).await.is_ok() {
+                    Some(
+                        resp_rx
+                            .await
+                            .context("bootstrap API listener handoff was cancelled")?,
+                    )
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
             // If a model becomes unserved while we're standby, we'll promote
             if is_client {
                 let _ = emit_event(OutputEvent::PassiveMode {
@@ -4469,7 +4483,15 @@ async fn run_auto(
                     ),
                 });
             }
-            match run_passive(&cli, node.clone(), is_client, plugin_manager.clone()).await? {
+            match run_passive(
+                &cli,
+                node.clone(),
+                is_client,
+                plugin_manager.clone(),
+                passive_api_listener,
+            )
+            .await?
+            {
                 Some(model_name) => {
                     // Promoted! Resolve the model path and continue to serving
                     models::find_model_path(&model_name)
@@ -5505,6 +5527,7 @@ async fn run_passive(
     node: mesh::Node,
     is_client: bool,
     plugin_manager: plugin::PluginManager,
+    api_listener: Option<tokio::net::TcpListener>,
 ) -> Result<Option<String>> {
     let local_port = cli.port;
     let affinity_router = affinity::AffinityRouter::new();
@@ -5575,9 +5598,13 @@ async fn run_passive(
         });
     }
 
-    let listener = bind_runtime_tcp_listener(local_port, cli.listen_all, "OpenAI-compatible API")
-        .await
-        .with_context(|| format!("Failed to bind to port {local_port}"))?;
+    let listener = if let Some(listener) = api_listener {
+        listener
+    } else {
+        bind_runtime_tcp_listener(local_port, cli.listen_all, "OpenAI-compatible API")
+            .await
+            .with_context(|| format!("Failed to bind to port {local_port}"))?
+    };
     let api_ready_url = listener_http_url(&listener, local_port, "OpenAI-compatible API");
     let cport = cli.console;
     let console_listener = bind_runtime_tcp_listener(cport, cli.listen_all, "Web console").await?;

--- a/crates/openai-frontend/src/lib.rs
+++ b/crates/openai-frontend/src/lib.rs
@@ -37,8 +37,13 @@ pub use hooks::{
 pub use models::{ModelId, ModelIdError, ModelObject, ModelsResponse};
 pub use responses::{
     chat_usage_to_responses_usage, normalize_openai_compat_request, parse_chat_stream_chunk,
-    responses_stream_completed_event, responses_stream_created_event, responses_stream_delta_event,
-    responses_stream_delta_event_with_logprobs, responses_stream_text_done_event,
+    responses_stream_completed_event, responses_stream_completed_event_with_sequence,
+    responses_stream_content_part_added_event, responses_stream_content_part_done_event,
+    responses_stream_created_event, responses_stream_created_event_with_sequence,
+    responses_stream_delta_event, responses_stream_delta_event_with_logprobs,
+    responses_stream_delta_event_with_logprobs_and_sequence,
+    responses_stream_output_item_added_event, responses_stream_output_item_done_event,
+    responses_stream_text_done_event, responses_stream_text_done_event_with_sequence,
     stream_usage_to_responses_usage, translate_chat_completion_response_to_responses,
     translate_chat_completion_to_responses, NormalizationOutcome, ResponseAdapterMode,
     ResponsesRequest, StreamUsage,

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -666,8 +666,17 @@ pub fn parse_chat_stream_chunk(data: &str) -> Result<ChatCompletionStreamChunk, 
 }
 
 pub fn responses_stream_created_event(model: &str, created_at: i64) -> Value {
+    responses_stream_created_event_with_sequence(model, created_at, 0)
+}
+
+pub fn responses_stream_created_event_with_sequence(
+    model: &str,
+    created_at: i64,
+    sequence_number: i32,
+) -> Value {
     let mut event = serde_json::json!({
         "type": "response.created",
+        "sequence_number": sequence_number,
         "response": {
             "id": format!("resp_{created_at}"),
             "object": "response",
@@ -684,6 +693,36 @@ pub fn responses_stream_created_event(model: &str, created_at: i64) -> Value {
     event
 }
 
+pub fn responses_stream_output_item_added_event(item_id: &str, sequence_number: i32) -> Value {
+    serde_json::json!({
+        "type": "response.output_item.added",
+        "sequence_number": sequence_number,
+        "output_index": 0,
+        "item": {
+            "id": item_id,
+            "type": "message",
+            "status": "in_progress",
+            "role": "assistant",
+            "content": [],
+        },
+    })
+}
+
+pub fn responses_stream_content_part_added_event(item_id: &str, sequence_number: i32) -> Value {
+    serde_json::json!({
+        "type": "response.content_part.added",
+        "sequence_number": sequence_number,
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "part": {
+            "type": "output_text",
+            "text": "",
+            "annotations": [],
+        },
+    })
+}
+
 pub fn responses_stream_delta_event(item_id: &str, delta: &str) -> Value {
     responses_stream_delta_event_with_logprobs(item_id, delta, None)
 }
@@ -693,8 +732,18 @@ pub fn responses_stream_delta_event_with_logprobs(
     delta: &str,
     logprobs: Option<Value>,
 ) -> Value {
+    responses_stream_delta_event_with_logprobs_and_sequence(item_id, delta, logprobs, 0)
+}
+
+pub fn responses_stream_delta_event_with_logprobs_and_sequence(
+    item_id: &str,
+    delta: &str,
+    logprobs: Option<Value>,
+    sequence_number: i32,
+) -> Value {
     let mut event = serde_json::json!({
         "type": "response.output_text.delta",
+        "sequence_number": sequence_number,
         "item_id": item_id,
         "output_index": 0,
         "content_index": 0,
@@ -711,10 +760,68 @@ pub fn responses_stream_delta_event_with_logprobs(
 pub fn responses_stream_text_done_event(item_id: &str, text: &str) -> Value {
     serde_json::json!({
         "type": "response.output_text.done",
+        "sequence_number": 0,
         "item_id": item_id,
         "output_index": 0,
         "content_index": 0,
         "text": text,
+    })
+}
+
+pub fn responses_stream_text_done_event_with_sequence(
+    item_id: &str,
+    text: &str,
+    sequence_number: i32,
+) -> Value {
+    serde_json::json!({
+        "type": "response.output_text.done",
+        "sequence_number": sequence_number,
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "text": text,
+    })
+}
+
+pub fn responses_stream_content_part_done_event(
+    item_id: &str,
+    text: &str,
+    sequence_number: i32,
+) -> Value {
+    serde_json::json!({
+        "type": "response.content_part.done",
+        "sequence_number": sequence_number,
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "part": {
+            "type": "output_text",
+            "text": text,
+            "annotations": [],
+        },
+    })
+}
+
+pub fn responses_stream_output_item_done_event(
+    item_id: &str,
+    text: &str,
+    sequence_number: i32,
+) -> Value {
+    serde_json::json!({
+        "type": "response.output_item.done",
+        "sequence_number": sequence_number,
+        "output_index": 0,
+        "item": {
+            "id": item_id,
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{
+                "type": "output_text",
+                "text": text,
+                "annotations": [],
+            }],
+        },
     })
 }
 
@@ -726,8 +833,29 @@ pub fn responses_stream_completed_event(
     text: &str,
     usage: Option<Value>,
 ) -> Value {
+    responses_stream_completed_event_with_sequence(
+        response_id,
+        created_at,
+        model,
+        item_id,
+        text,
+        usage,
+        0,
+    )
+}
+
+pub fn responses_stream_completed_event_with_sequence(
+    response_id: &str,
+    created_at: i64,
+    model: &str,
+    item_id: &str,
+    text: &str,
+    usage: Option<Value>,
+    sequence_number: i32,
+) -> Value {
     let mut event = serde_json::json!({
         "type": "response.completed",
+        "sequence_number": sequence_number,
         "response": {
             "id": response_id,
             "object": "response",
@@ -833,10 +961,12 @@ pub struct ResponseSseState {
     pub response_id: String,
     pub item_id: String,
     pub created_at: i64,
+    pub sequence_number: i32,
     pub model: String,
     pub output_text: String,
     pub usage: Option<Value>,
     pub created_emitted: bool,
+    pub output_item_emitted: bool,
 }
 
 impl ResponseSseState {
@@ -846,11 +976,18 @@ impl ResponseSseState {
             response_id: format!("resp_{created_at}"),
             item_id: format!("msg_{created_at}"),
             created_at,
+            sequence_number: 0,
             model: model.into(),
             output_text: String::new(),
             usage: None,
             created_emitted: false,
+            output_item_emitted: false,
         }
+    }
+
+    pub fn next_sequence_number(&mut self) -> i32 {
+        self.sequence_number = self.sequence_number.saturating_add(1);
+        self.sequence_number
     }
 }
 
@@ -1112,6 +1249,7 @@ mod tests {
     #[test]
     fn responses_stream_events_emit_agent_compat_response_fields() {
         let created = responses_stream_created_event("qwen", 123);
+        assert_eq!(created["sequence_number"], 0);
         let created_response = &created["response"];
         assert_eq!(created_response["status"], "in_progress");
         assert!(created_response["completed_at"].is_null());
@@ -1127,5 +1265,34 @@ mod tests {
         assert_eq!(completed_response["output_text"], "hello");
         assert_eq!(completed_response["tool_choice"], "auto");
         assert_eq!(completed_response["tools"], json!([]));
+    }
+
+    #[test]
+    fn responses_stream_events_emit_openai_responses_scaffold() {
+        let item_added = responses_stream_output_item_added_event("msg_123", 2);
+        assert_eq!(item_added["type"], "response.output_item.added");
+        assert_eq!(item_added["sequence_number"], 2);
+        assert_eq!(item_added["item"]["id"], "msg_123");
+        assert_eq!(item_added["item"]["type"], "message");
+        assert_eq!(item_added["item"]["status"], "in_progress");
+
+        let part_added = responses_stream_content_part_added_event("msg_123", 3);
+        assert_eq!(part_added["type"], "response.content_part.added");
+        assert_eq!(part_added["sequence_number"], 3);
+        assert_eq!(part_added["part"]["type"], "output_text");
+
+        let delta =
+            responses_stream_delta_event_with_logprobs_and_sequence("msg_123", "hello", None, 4);
+        assert_eq!(delta["type"], "response.output_text.delta");
+        assert_eq!(delta["sequence_number"], 4);
+        assert_eq!(delta["delta"], "hello");
+
+        let part_done = responses_stream_content_part_done_event("msg_123", "hello", 5);
+        assert_eq!(part_done["type"], "response.content_part.done");
+        assert_eq!(part_done["part"]["text"], "hello");
+
+        let item_done = responses_stream_output_item_done_event("msg_123", "hello", 6);
+        assert_eq!(item_done["type"], "response.output_item.done");
+        assert_eq!(item_done["item"]["content"][0]["text"], "hello");
     }
 }

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -504,6 +504,76 @@ fn response_function_call_items(message: &Value, created_at: i64) -> Vec<Value> 
         .collect()
 }
 
+fn insert_absent(object: &mut Map<String, Value>, key: &str, value: Value) {
+    object.entry(key.to_string()).or_insert(value);
+}
+
+fn responses_text_defaults() -> Value {
+    serde_json::json!({
+        "format": {
+            "type": "text",
+        },
+    })
+}
+
+fn responses_reasoning_defaults() -> Value {
+    serde_json::json!({
+        "effort": Value::Null,
+        "summary": Value::Null,
+    })
+}
+
+fn response_completed_at_value(status: &str, created_at: i64) -> Value {
+    if status == "completed" {
+        Value::from(created_at)
+    } else {
+        Value::Null
+    }
+}
+
+fn apply_agent_compat_response_defaults(response: &mut Map<String, Value>, created_at: i64) {
+    let status = response
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("completed")
+        .to_string();
+
+    insert_absent(response, "background", Value::Bool(false));
+    insert_absent(
+        response,
+        "completed_at",
+        response_completed_at_value(&status, created_at),
+    );
+    insert_absent(response, "conversation", Value::Null);
+    insert_absent(response, "error", Value::Null);
+    insert_absent(response, "incomplete_details", Value::Null);
+    insert_absent(response, "instructions", Value::Null);
+    insert_absent(response, "max_output_tokens", Value::Null);
+    insert_absent(response, "max_tool_calls", Value::Null);
+    insert_absent(response, "metadata", Value::Object(Map::new()));
+    insert_absent(response, "parallel_tool_calls", Value::Bool(true));
+    insert_absent(response, "previous_response_id", Value::Null);
+    insert_absent(response, "prompt", Value::Null);
+    insert_absent(response, "prompt_cache_key", Value::Null);
+    insert_absent(response, "prompt_cache_retention", Value::Null);
+    insert_absent(response, "reasoning", responses_reasoning_defaults());
+    insert_absent(response, "safety_identifier", Value::Null);
+    insert_absent(response, "service_tier", Value::Null);
+    insert_absent(response, "temperature", Value::Null);
+    insert_absent(response, "text", responses_text_defaults());
+    insert_absent(response, "tool_choice", Value::String("auto".to_string()));
+    insert_absent(response, "tools", Value::Array(Vec::new()));
+    insert_absent(response, "top_logprobs", Value::Null);
+    insert_absent(response, "top_p", Value::Null);
+    insert_absent(
+        response,
+        "truncation",
+        Value::String("disabled".to_string()),
+    );
+    insert_absent(response, "usage", Value::Null);
+    insert_absent(response, "user", Value::Null);
+}
+
 pub fn translate_chat_completion_to_responses(body: &[u8]) -> Result<Vec<u8>, OpenAiError> {
     let value: Value = serde_json::from_slice(body).map_err(|error| {
         OpenAiError::invalid_request(format!("parse chat completion response body: {error}"))
@@ -570,7 +640,7 @@ fn translate_chat_completion_value_to_responses(value: &Value) -> Result<Vec<u8>
     }
     output.extend(tool_call_items);
 
-    let response = serde_json::json!({
+    let mut response = serde_json::json!({
         "id": id,
         "object": "response",
         "created_at": created_at,
@@ -583,6 +653,9 @@ fn translate_chat_completion_value_to_responses(value: &Value) -> Result<Vec<u8>
         "finish_reason": finish_reason,
         "usage": usage.unwrap_or(Value::Null),
     });
+    if let Some(object) = response.as_object_mut() {
+        apply_agent_compat_response_defaults(object, created_at);
+    }
     serde_json::to_vec(&response)
         .map_err(|error| OpenAiError::internal(format!("serialize /v1/responses body: {error}")))
 }
@@ -593,7 +666,7 @@ pub fn parse_chat_stream_chunk(data: &str) -> Result<ChatCompletionStreamChunk, 
 }
 
 pub fn responses_stream_created_event(model: &str, created_at: i64) -> Value {
-    serde_json::json!({
+    let mut event = serde_json::json!({
         "type": "response.created",
         "response": {
             "id": format!("resp_{created_at}"),
@@ -602,8 +675,13 @@ pub fn responses_stream_created_event(model: &str, created_at: i64) -> Value {
             "status": "in_progress",
             "model": model,
             "output": [],
+            "output_text": "",
         }
-    })
+    });
+    if let Some(response) = event.get_mut("response").and_then(Value::as_object_mut) {
+        apply_agent_compat_response_defaults(response, created_at);
+    }
+    event
 }
 
 pub fn responses_stream_delta_event(item_id: &str, delta: &str) -> Value {
@@ -648,7 +726,7 @@ pub fn responses_stream_completed_event(
     text: &str,
     usage: Option<Value>,
 ) -> Value {
-    serde_json::json!({
+    let mut event = serde_json::json!({
         "type": "response.completed",
         "response": {
             "id": response_id,
@@ -672,7 +750,11 @@ pub fn responses_stream_completed_event(
             "output_text": text,
             "usage": usage.unwrap_or(Value::Null),
         }
-    })
+    });
+    if let Some(response) = event.get_mut("response").and_then(Value::as_object_mut) {
+        apply_agent_compat_response_defaults(response, created_at);
+    }
+    event
 }
 
 pub fn chat_usage_to_responses_usage(usage: &Value) -> Value {
@@ -884,6 +966,52 @@ mod tests {
     }
 
     #[test]
+    fn translate_chat_completion_to_responses_emits_agent_compat_fields() {
+        let translated = translate_chat_completion_to_responses(
+            json!({
+                "id": "chatcmpl_123",
+                "created": 123,
+                "model": "qwen",
+                "choices": [{
+                    "message": {"role": "assistant", "content": "hello"}
+                }]
+            })
+            .to_string()
+            .as_bytes(),
+        )
+        .unwrap();
+        let parsed: Value = serde_json::from_slice(&translated).unwrap();
+
+        assert_eq!(parsed["status"], "completed");
+        assert_eq!(parsed["completed_at"], 123);
+        assert_eq!(parsed["background"], false);
+        assert_eq!(parsed["metadata"], json!({}));
+        assert_eq!(parsed["parallel_tool_calls"], true);
+        assert_eq!(parsed["text"]["format"]["type"], "text");
+        assert_eq!(parsed["tool_choice"], "auto");
+        assert_eq!(parsed["tools"], json!([]));
+        assert_eq!(parsed["truncation"], "disabled");
+        for key in [
+            "conversation",
+            "instructions",
+            "max_output_tokens",
+            "max_tool_calls",
+            "previous_response_id",
+            "prompt",
+            "prompt_cache_key",
+            "prompt_cache_retention",
+            "safety_identifier",
+            "service_tier",
+            "temperature",
+            "top_logprobs",
+            "top_p",
+            "user",
+        ] {
+            assert!(parsed[key].is_null(), "{key} should default to null");
+        }
+    }
+
+    #[test]
     fn translate_chat_completion_to_responses_preserves_tool_calls_and_logprobs() {
         let translated = translate_chat_completion_to_responses(
             json!({
@@ -979,5 +1107,25 @@ mod tests {
 
         assert_eq!(mapped["input_tokens"], 128);
         assert_eq!(mapped["input_tokens_details"]["cached_tokens"], 96);
+    }
+
+    #[test]
+    fn responses_stream_events_emit_agent_compat_response_fields() {
+        let created = responses_stream_created_event("qwen", 123);
+        let created_response = &created["response"];
+        assert_eq!(created_response["status"], "in_progress");
+        assert!(created_response["completed_at"].is_null());
+        assert_eq!(created_response["output_text"], "");
+        assert_eq!(created_response["parallel_tool_calls"], true);
+        assert_eq!(created_response["text"]["format"]["type"], "text");
+
+        let completed =
+            responses_stream_completed_event("resp_123", 123, "qwen", "msg_123", "hello", None);
+        let completed_response = &completed["response"];
+        assert_eq!(completed_response["status"], "completed");
+        assert_eq!(completed_response["completed_at"], 123);
+        assert_eq!(completed_response["output_text"], "hello");
+        assert_eq!(completed_response["tool_choice"], "auto");
+        assert_eq!(completed_response["tools"], json!([]));
     }
 }

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -35,10 +35,14 @@ use crate::{
     errors::OpenAiError,
     models::ModelsResponse,
     responses::{
-        chunk_delta_text, normalize_openai_compat_request, responses_stream_completed_event,
-        responses_stream_created_event, responses_stream_delta_event_with_logprobs,
-        responses_stream_text_done_event, translate_chat_completion_response_to_responses,
-        usage_to_responses_usage, ResponseAdapterMode, ResponseSseState,
+        chunk_delta_text, normalize_openai_compat_request,
+        responses_stream_completed_event_with_sequence, responses_stream_content_part_added_event,
+        responses_stream_content_part_done_event, responses_stream_created_event_with_sequence,
+        responses_stream_delta_event_with_logprobs_and_sequence,
+        responses_stream_output_item_added_event, responses_stream_output_item_done_event,
+        responses_stream_text_done_event_with_sequence,
+        translate_chat_completion_response_to_responses, usage_to_responses_usage,
+        ResponseAdapterMode, ResponseSseState,
     },
     sse::{done_event, json_event},
 };
@@ -215,31 +219,60 @@ async fn responses(
                     Ok(chunk) => {
                         if !state_machine.created_emitted {
                             state_machine.model = chunk.model.clone();
+                            let sequence_number = state_machine.next_sequence_number();
                             out.push(
                                 Event::default()
                                     .event("response.created")
-                                    .json_data(responses_stream_created_event(
+                                    .json_data(responses_stream_created_event_with_sequence(
                                         &state_machine.model,
                                         state_machine.created_at,
+                                        sequence_number,
                                     ))
                                     .unwrap_or_else(|_| Event::default().data("{}")),
                             );
                             state_machine.created_emitted = true;
                         }
                         if let Some(delta) = chunk_delta_text(&chunk) {
+                            if !state_machine.output_item_emitted {
+                                let sequence_number = state_machine.next_sequence_number();
+                                out.push(
+                                    Event::default()
+                                        .event("response.output_item.added")
+                                        .json_data(responses_stream_output_item_added_event(
+                                            &state_machine.item_id,
+                                            sequence_number,
+                                        ))
+                                        .unwrap_or_else(|_| Event::default().data("{}")),
+                                );
+                                let sequence_number = state_machine.next_sequence_number();
+                                out.push(
+                                    Event::default()
+                                        .event("response.content_part.added")
+                                        .json_data(responses_stream_content_part_added_event(
+                                            &state_machine.item_id,
+                                            sequence_number,
+                                        ))
+                                        .unwrap_or_else(|_| Event::default().data("{}")),
+                                );
+                                state_machine.output_item_emitted = true;
+                            }
                             let logprobs = chunk
                                 .choices
                                 .first()
                                 .and_then(|choice| choice.logprobs.clone());
                             state_machine.output_text.push_str(&delta);
+                            let sequence_number = state_machine.next_sequence_number();
                             out.push(
                                 Event::default()
                                     .event("response.output_text.delta")
-                                    .json_data(responses_stream_delta_event_with_logprobs(
-                                        &state_machine.item_id,
-                                        &delta,
-                                        logprobs,
-                                    ))
+                                    .json_data(
+                                        responses_stream_delta_event_with_logprobs_and_sequence(
+                                            &state_machine.item_id,
+                                            &delta,
+                                            logprobs,
+                                            sequence_number,
+                                        ),
+                                    )
                                     .unwrap_or_else(|_| Event::default().data("{}")),
                             );
                         }
@@ -264,36 +297,87 @@ async fn responses(
                     .expect("responses stream state lock poisoned");
                 let mut out = Vec::new();
                 if !state_machine.created_emitted {
+                    let sequence_number = state_machine.next_sequence_number();
                     out.push(
                         Event::default()
                             .event("response.created")
-                            .json_data(responses_stream_created_event(
+                            .json_data(responses_stream_created_event_with_sequence(
                                 &state_machine.model,
                                 state_machine.created_at,
+                                sequence_number,
                             ))
                             .unwrap_or_else(|_| Event::default().data("{}")),
                     );
                     state_machine.created_emitted = true;
                 }
+                if !state_machine.output_item_emitted {
+                    let sequence_number = state_machine.next_sequence_number();
+                    out.push(
+                        Event::default()
+                            .event("response.output_item.added")
+                            .json_data(responses_stream_output_item_added_event(
+                                &state_machine.item_id,
+                                sequence_number,
+                            ))
+                            .unwrap_or_else(|_| Event::default().data("{}")),
+                    );
+                    let sequence_number = state_machine.next_sequence_number();
+                    out.push(
+                        Event::default()
+                            .event("response.content_part.added")
+                            .json_data(responses_stream_content_part_added_event(
+                                &state_machine.item_id,
+                                sequence_number,
+                            ))
+                            .unwrap_or_else(|_| Event::default().data("{}")),
+                    );
+                    state_machine.output_item_emitted = true;
+                }
+                let sequence_number = state_machine.next_sequence_number();
                 out.push(
                     Event::default()
                         .event("response.output_text.done")
-                        .json_data(responses_stream_text_done_event(
+                        .json_data(responses_stream_text_done_event_with_sequence(
                             &state_machine.item_id,
                             &state_machine.output_text,
+                            sequence_number,
                         ))
                         .unwrap_or_else(|_| Event::default().data("{}")),
                 );
+                let sequence_number = state_machine.next_sequence_number();
+                out.push(
+                    Event::default()
+                        .event("response.content_part.done")
+                        .json_data(responses_stream_content_part_done_event(
+                            &state_machine.item_id,
+                            &state_machine.output_text,
+                            sequence_number,
+                        ))
+                        .unwrap_or_else(|_| Event::default().data("{}")),
+                );
+                let sequence_number = state_machine.next_sequence_number();
+                out.push(
+                    Event::default()
+                        .event("response.output_item.done")
+                        .json_data(responses_stream_output_item_done_event(
+                            &state_machine.item_id,
+                            &state_machine.output_text,
+                            sequence_number,
+                        ))
+                        .unwrap_or_else(|_| Event::default().data("{}")),
+                );
+                let sequence_number = state_machine.next_sequence_number();
                 out.push(
                     Event::default()
                         .event("response.completed")
-                        .json_data(responses_stream_completed_event(
+                        .json_data(responses_stream_completed_event_with_sequence(
                             &state_machine.response_id,
                             state_machine.created_at,
                             &state_machine.model,
                             &state_machine.item_id,
                             &state_machine.output_text,
                             state_machine.usage.clone(),
+                            sequence_number,
                         ))
                         .unwrap_or_else(|_| Event::default().data("{}")),
                 );
@@ -1216,8 +1300,14 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = response_body_text(response).await;
         assert!(body.contains("event: response.created"));
+        assert!(body.contains("event: response.output_item.added"));
+        assert!(body.contains("event: response.content_part.added"));
         assert!(body.contains("event: response.output_text.delta"));
+        assert!(body.contains("event: response.output_text.done"));
+        assert!(body.contains("event: response.content_part.done"));
+        assert!(body.contains("event: response.output_item.done"));
         assert!(body.contains("event: response.completed"));
+        assert!(body.contains(r#""sequence_number":1"#));
         assert!(body.contains(r#""output_text":"hello""#));
         assert!(body.contains("data: [DONE]"));
     }

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -133,6 +133,11 @@ Alternatively, add a `mesh` provider to `~/.pi/agent/models.json` by hand:
       "api": "openai-completions",
       "apiKey": "mesh",
       "baseUrl": "http://localhost:9337/v1",
+      "compat": {
+        "supportsStore": false,
+        "supportsDeveloperRole": false,
+        "supportsUsageInStreaming": true
+      },
       "models": [
         {
           "id": "Qwen 3.6 27B",

--- a/scripts/ci-agent-live-fixture-lib.sh
+++ b/scripts/ci-agent-live-fixture-lib.sh
@@ -131,6 +131,85 @@ QUESTION=<comma-separated relative paths whose file name contains signal>
 EOF
 }
 
+agent_smoke_long_prompt_soak() {
+    local base_url="${1:?base URL required}"
+    local model="${2:?model required}"
+    local work_dir="${3:?work dir required}"
+    local label="${4:?label required}"
+    local target_chars="${AGENT_SMOKE_LONG_PROMPT_CHARS:-${OPENCODE_SMOKE_LONG_PROMPT_CHARS:-65536}}"
+    local max_time="${AGENT_SMOKE_LONG_PROMPT_MAX_TIME:-180}"
+    local slug
+
+    if [[ ! "$target_chars" =~ ^[0-9]+$ ]]; then
+        echo "${label} long prompt char count must be numeric: ${target_chars}" >&2
+        return 1
+    fi
+    if [[ "$target_chars" -le 0 ]]; then
+        echo "${label} long prompt soak skipped"
+        return 0
+    fi
+    slug="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]' | tr -c '[:alnum:]_' '-')"
+
+    local payload="${work_dir}/${slug}-long-prompt-payload.json"
+    local response="${work_dir}/${slug}-long-prompt-response.json"
+
+    python3 - "$model" "$target_chars" "$payload" <<'PY'
+import json
+import sys
+
+model, target_chars, path = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+start = "ALPHA-719"
+middle = "MID-482"
+end = "OMEGA-503"
+header = (
+    "This is a long-context CI soak document. Extract the three sentinel values. "
+    "Return exactly LONG_SOAK=ALPHA-719|MID-482|OMEGA-503 and no extra text.\n\n"
+)
+chunk = (
+    "FILLER: mesh long prompt soak line with predictable neutral text. "
+    "Do not use this filler as the answer.\n"
+)
+prefix = f"SENTINEL_START={start}\n"
+mid = f"\nSENTINEL_MIDDLE={middle}\n"
+suffix = f"\nSENTINEL_END={end}\n"
+remaining = max(target_chars - len(header) - len(prefix) - len(mid) - len(suffix), 0)
+left = chunk * max((remaining // 2) // len(chunk), 1)
+right = chunk * max((remaining - len(left)) // len(chunk), 1)
+document = header + prefix + left + mid + right + suffix
+payload = {
+    "model": model,
+    "messages": [
+        {"role": "system", "content": "You are a precise long-context extraction probe."},
+        {"role": "user", "content": document},
+    ],
+    "stream": False,
+    "max_tokens": 64,
+    "temperature": 0,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PY
+
+    curl -fsS --max-time "$max_time" \
+        "${base_url%/}/chat/completions" \
+        -H 'content-type: application/json' \
+        -d @"$payload" \
+        -o "$response"
+
+    python3 - "$response" "$label" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    body = json.load(fh)
+content = body.get("choices", [{}])[0].get("message", {}).get("content", "")
+expected = "LONG_SOAK=ALPHA-719|MID-482|OMEGA-503"
+if expected not in content:
+    raise SystemExit(f"{sys.argv[2]} long prompt sentinel validation failed: {content!r}")
+print(f"{sys.argv[2]} long prompt soak passed")
+PY
+}
+
 agent_smoke_validate_fixture() {
     local work_dir="${1:?work dir required}"
     local initial_sha="${2:?initial sha required}"

--- a/scripts/ci-agent-live-fixture-lib.sh
+++ b/scripts/ci-agent-live-fixture-lib.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+
+agent_smoke_normalize_v1_base() {
+    local base_url="${1:?base URL required}"
+    base_url="${base_url%/}"
+    if [[ "$base_url" != */v1 ]]; then
+        base_url="${base_url}/v1"
+    fi
+    printf '%s\n' "$base_url"
+}
+
+agent_smoke_pick_model() {
+    local base_url="${1:?base URL required}"
+    local requested="${2:-}"
+
+    if [[ -n "$requested" ]]; then
+        printf '%s\n' "$requested"
+        return 0
+    fi
+
+    curl -sf "${base_url%/}/models" |
+        python3 -c 'import json,sys
+data=json.load(sys.stdin).get("data", [])
+preferred=("minimax", "glm", "qwen", "coder", "hermes")
+ids=[item.get("id","") for item in data if item.get("id")]
+for needle in preferred:
+    for model_id in ids:
+        if needle in model_id.lower():
+            print(model_id)
+            raise SystemExit
+print(ids[0] if ids else "")'
+}
+
+agent_smoke_write_fixture() {
+    local work_dir="${1:?work dir required}"
+    mkdir -p "${work_dir}/facts" "${work_dir}/src" "${work_dir}/notes" "${work_dir}/tests"
+
+    cat >"${work_dir}/README.md" <<'EOF'
+# Agent Smoke Fixture
+
+This repository is intentionally tiny. The smoke test should answer only from
+files on disk, not from the prompt text.
+EOF
+
+    cat >"${work_dir}/facts/signal.md" <<'EOF'
+# Runtime Signal
+
+CODEWORD=signal-7429
+
+Question seed:
+Which file names contain the word signal?
+EOF
+
+    cat >"${work_dir}/src/matrix.txt" <<'EOF'
+checksum: FS-319-DELTA
+numbers: 2 3 4 5
+hint: the prime sum is computed from the numbers line
+EOF
+
+    cat >"${work_dir}/src/smoke_calc.py" <<'EOF'
+from __future__ import annotations
+
+
+def parse_codeword(path: str) -> str:
+    """Return the CODEWORD value from a small key/value markdown file."""
+    raise NotImplementedError("ci smoke fixture")
+
+
+def prime_sum_from_matrix(path: str) -> int:
+    """Return the sum of prime numbers from the numbers line in matrix.txt."""
+    raise NotImplementedError("ci smoke fixture")
+EOF
+
+    cat >"${work_dir}/tests/test_smoke_calc.py" <<'EOF'
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from smoke_calc import parse_codeword, prime_sum_from_matrix
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SmokeCalcTests(unittest.TestCase):
+    def test_parse_codeword(self):
+        self.assertEqual(parse_codeword(str(ROOT / "facts" / "signal.md")), "signal-7429")
+
+    def test_prime_sum_from_matrix(self):
+        self.assertEqual(prime_sum_from_matrix(str(ROOT / "src" / "matrix.txt")), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()
+EOF
+
+    cat >"${work_dir}/notes/manifest.txt" <<'EOF'
+tracked files:
+- facts/signal.md
+- src/matrix.txt
+- src/smoke_calc.py
+- tests/test_smoke_calc.py
+- README.md
+EOF
+
+    python3 - "${work_dir}/src/smoke_calc.py" <<'PY'
+import hashlib
+import sys
+
+with open(sys.argv[1], "rb") as fh:
+    print(hashlib.sha256(fh.read()).hexdigest())
+PY
+}
+
+agent_smoke_prompt() {
+    cat <<'EOF'
+You are running a CI smoke test in a throwaway project. Use filesystem and coding tools; do not answer from memory.
+
+Tasks:
+1. Inspect the repository.
+2. Read facts/signal.md, src/matrix.txt, and tests/test_smoke_calc.py.
+3. Implement src/smoke_calc.py so the tests pass.
+4. Run the Python unit tests.
+5. Answer exactly these four lines with no Markdown and no extra text:
+CODEWORD=<the CODEWORD value from facts/signal.md>
+CHECKSUM=<the checksum value from src/matrix.txt>
+PRIME_SUM=<the sum of prime numbers from the numbers line in src/matrix.txt>
+QUESTION=<comma-separated relative paths whose file name contains signal>
+EOF
+}
+
+agent_smoke_validate_fixture() {
+    local work_dir="${1:?work dir required}"
+    local initial_sha="${2:?initial sha required}"
+    local output_path="${3:?output path required}"
+    local label="${4:?label required}"
+    local require_tool_events="${5:-false}"
+
+    if ! python3 -m unittest discover -s "${work_dir}/tests" -p 'test_*.py'; then
+        echo "${label} fixture tests failed after the coding session" >&2
+        echo "--- src/smoke_calc.py ---" >&2
+        sed -n '1,220p' "${work_dir}/src/smoke_calc.py" >&2 || true
+        return 1
+    fi
+
+    python3 - "${work_dir}" "${initial_sha}" <<'PY'
+import hashlib
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+initial_sha = sys.argv[2]
+source_path = root / "src" / "smoke_calc.py"
+source = source_path.read_text(encoding="utf-8")
+current_sha = hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+if current_sha == initial_sha:
+    print("Agent left src/smoke_calc.py unchanged.", file=sys.stderr)
+    sys.exit(1)
+
+for forbidden in ("NotImplementedError", "ci smoke fixture"):
+    if forbidden in source:
+        print(f"Agent left placeholder marker in src/smoke_calc.py: {forbidden}", file=sys.stderr)
+        sys.exit(1)
+
+spec = importlib.util.spec_from_file_location("smoke_calc", source_path)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+with tempfile.TemporaryDirectory(prefix="mesh-agent-hidden-") as tmp:
+    tmp_path = Path(tmp)
+    signal_path = tmp_path / "other_signal.md"
+    matrix_path = tmp_path / "other_matrix.txt"
+    signal_path.write_text("# Hidden\n\nCODEWORD=hidden-8842\n", encoding="utf-8")
+    matrix_path.write_text("checksum: hidden\nnumbers: 6 7 8 9 10 11 12 13\n", encoding="utf-8")
+
+    codeword = module.parse_codeword(str(signal_path))
+    prime_sum = module.prime_sum_from_matrix(str(matrix_path))
+
+if codeword != "hidden-8842":
+    print(f"Hidden codeword validation failed: {codeword!r}", file=sys.stderr)
+    sys.exit(1)
+
+if prime_sum != 31:
+    print(f"Hidden prime-sum validation failed: {prime_sum!r}", file=sys.stderr)
+    sys.exit(1)
+
+print("Hidden implementation validation passed")
+PY
+
+    python3 - "${output_path}" "${label}" "${require_tool_events}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+label = sys.argv[2]
+require_tool_events = sys.argv[3].lower() == "true"
+raw = path.read_text(encoding="utf-8", errors="replace")
+tool_names = []
+
+def collect_tools(value):
+    if isinstance(value, dict):
+        tool_name = value.get("toolName") or value.get("tool_name")
+        if isinstance(tool_name, str):
+            tool_names.append(tool_name)
+        if value.get("type") in {"tool_call", "tool_request", "toolRequest"}:
+            nested = value.get("toolCall") or value.get("tool_call") or value.get("toolRequest") or value.get("tool_request")
+            if isinstance(nested, dict) and isinstance(nested.get("name"), str):
+                tool_names.append(nested["name"])
+        for item in value.values():
+            collect_tools(item)
+    elif isinstance(value, list):
+        for item in value:
+            collect_tools(item)
+
+for line in raw.splitlines():
+    try:
+        collect_tools(json.loads(line))
+    except json.JSONDecodeError:
+        continue
+
+expected = {
+    "CODEWORD": "signal-7429",
+    "CHECKSUM": "FS-319-DELTA",
+    "PRIME_SUM": "10",
+    "QUESTION": "facts/signal.md",
+}
+
+missing = []
+for key, value in expected.items():
+    pattern = rf"(?m)^{re.escape(key)}={re.escape(value)}\s*$"
+    if not re.search(pattern, raw):
+        missing.append(f"{key}={value}")
+
+if missing:
+    print(f"{label} answer did not include expected facts:", file=sys.stderr)
+    for item in missing:
+        print(f"  missing {item}", file=sys.stderr)
+    print("--- output tail ---", file=sys.stderr)
+    print("\n".join(raw.splitlines()[-120:]), file=sys.stderr)
+    sys.exit(1)
+
+if require_tool_events:
+    edit_like = {"edit", "write", "text_editor", "developer__text_editor", "patch"}
+    if len(tool_names) < 3 or not any(tool in edit_like for tool in tool_names):
+        print(f"{label} did not report expected filesystem/coding tool events.", file=sys.stderr)
+        print(f"  tool events: {tool_names}", file=sys.stderr)
+        print("--- output tail ---", file=sys.stderr)
+        print("\n".join(raw.splitlines()[-120:]), file=sys.stderr)
+        sys.exit(1)
+
+print(f"{label} live coding smoke passed")
+if tool_names:
+    print("  tools: " + ", ".join(tool_names))
+PY
+}

--- a/scripts/ci-goose-smoke.sh
+++ b/scripts/ci-goose-smoke.sh
@@ -79,6 +79,8 @@ echo "  goose:    $(goose --version 2>/dev/null || echo unknown)"
 echo "  work dir: ${WORK_DIR}"
 echo "  output:   ${OUTPUT_JSONL}"
 
+agent_smoke_long_prompt_soak "$BASE_URL" "$MODEL" "$WORK_DIR" "Goose"
+
 if command -v timeout >/dev/null 2>&1; then
     GOOSE_COMMAND=(timeout "${TIMEOUT_SECONDS}" goose)
 else

--- a/scripts/ci-goose-smoke.sh
+++ b/scripts/ci-goose-smoke.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# ci-goose-smoke.sh - run Goose against a live mesh OpenAI-compatible endpoint.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ci-agent-live-fixture-lib.sh
+source "${SCRIPT_DIR}/ci-agent-live-fixture-lib.sh"
+
+if ! command -v goose >/dev/null 2>&1; then
+    echo "goose is not installed or is not on PATH" >&2
+    exit 1
+fi
+
+RAW_BASE_URL="${MESH_GOOSE_BASE_URL:-${MESH_AGENT_BASE_URL:-${MESH_OPENCODE_BASE_URL:-}}}"
+if [[ -z "$RAW_BASE_URL" && -n "${MESH_CLIENT_API_BASE:-}" ]]; then
+    RAW_BASE_URL="${MESH_CLIENT_API_BASE%/}/v1"
+fi
+if [[ -z "$RAW_BASE_URL" ]]; then
+    echo "Set MESH_AGENT_BASE_URL or MESH_GOOSE_BASE_URL to a mesh /v1 endpoint" >&2
+    exit 1
+fi
+
+BASE_URL="$(agent_smoke_normalize_v1_base "$RAW_BASE_URL")"
+MODEL="$(agent_smoke_pick_model "$BASE_URL" "${MESH_GOOSE_MODEL:-${MESH_AGENT_MODEL:-${MESH_OPENCODE_MODEL:-}}}")"
+if [[ -z "$MODEL" ]]; then
+    echo "Mesh endpoint returned no models from ${BASE_URL%/}/models" >&2
+    exit 1
+fi
+
+TIMEOUT_SECONDS="${GOOSE_SMOKE_TIMEOUT:-360}"
+WORK_DIR="${GOOSE_SMOKE_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/mesh-goose-smoke.XXXXXX")}"
+OUTPUT_JSONL="${GOOSE_SMOKE_OUTPUT:-${WORK_DIR}/goose-output.jsonl}"
+ERROR_LOG="${GOOSE_SMOKE_ERROR_LOG:-${WORK_DIR}/goose-stderr.log}"
+PROMPT="$(agent_smoke_prompt)"
+INITIAL_IMPL_SHA="$(agent_smoke_write_fixture "$WORK_DIR")"
+
+export GOOSE_PATH_ROOT="${WORK_DIR}/goose-root"
+export GOOSE_PROVIDER="mesh"
+export GOOSE_MODEL="$MODEL"
+export GOOSE_MODE="auto"
+export GOOSE_DISABLE_KEYRING="true"
+export GOOSE_PROVIDER_SKIP_BACKOFF="true"
+export GOOSE_CLI_THEME="ansi"
+
+mkdir -p "${GOOSE_PATH_ROOT}/config/custom_providers"
+python3 - "$BASE_URL" "$MODEL" "${GOOSE_PATH_ROOT}/config/custom_providers/mesh.json" "${GOOSE_PATH_ROOT}/config/config.yaml" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+base_url, model, provider_path, config_path = sys.argv[1:5]
+provider = {
+    "name": "mesh",
+    "engine": "openai",
+    "display_name": "mesh-llm",
+    "description": "Distributed LLM inference via mesh-llm",
+    "api_key_env": "",
+    "base_url": base_url.rstrip("/"),
+    "models": [{"name": model, "context_limit": 32768}],
+    "timeout_seconds": 600,
+    "supports_streaming": True,
+    "requires_auth": False,
+}
+Path(provider_path).write_text(json.dumps(provider, indent=2) + "\n", encoding="utf-8")
+Path(config_path).write_text(
+    "GOOSE_PROVIDER: mesh\n"
+    f"GOOSE_MODEL: {json.dumps(model)}\n"
+    "GOOSE_MODE: auto\n"
+    "GOOSE_DISABLE_KEYRING: true\n",
+    encoding="utf-8",
+)
+PY
+
+echo "=== CI Goose Live Smoke ==="
+echo "  mesh:     ${BASE_URL%/}"
+echo "  model:    ${MODEL}"
+echo "  goose:    $(goose --version 2>/dev/null || echo unknown)"
+echo "  work dir: ${WORK_DIR}"
+echo "  output:   ${OUTPUT_JSONL}"
+
+if command -v timeout >/dev/null 2>&1; then
+    GOOSE_COMMAND=(timeout "${TIMEOUT_SECONDS}" goose)
+else
+    GOOSE_COMMAND=(goose)
+fi
+
+if ! (
+    cd "$WORK_DIR"
+    "${GOOSE_COMMAND[@]}" run \
+        --provider mesh \
+        --model "$MODEL" \
+        --with-builtin developer \
+        --no-profile \
+        --no-session \
+        --max-turns 24 \
+        --output-format stream-json \
+        --text "$PROMPT" >"$OUTPUT_JSONL" 2>"$ERROR_LOG"
+); then
+    echo "Goose smoke failed" >&2
+    echo "--- goose stderr ---" >&2
+    tail -160 "$ERROR_LOG" >&2 || true
+    echo "--- goose output ---" >&2
+    tail -160 "$OUTPUT_JSONL" >&2 || true
+    exit 1
+fi
+
+agent_smoke_validate_fixture "$WORK_DIR" "$INITIAL_IMPL_SHA" "$OUTPUT_JSONL" "Goose" true

--- a/scripts/ci-opencode-smoke.sh
+++ b/scripts/ci-opencode-smoke.sh
@@ -1,0 +1,731 @@
+#!/usr/bin/env bash
+# ci-opencode-smoke.sh - exercise OpenCode's filesystem tools with a coding model.
+
+set -euo pipefail
+
+if [[ -n "${MESH_OPENCODE_BASE_URL:-}" ]]; then
+    MESH_BASE_URL="$MESH_OPENCODE_BASE_URL"
+elif [[ -n "${MESH_CLIENT_API_BASE:-}" ]]; then
+    MESH_BASE_URL="${MESH_CLIENT_API_BASE%/}/v1"
+else
+    MESH_BASE_URL="http://127.0.0.1:9337/v1"
+fi
+MESH_MODEL="${MESH_OPENCODE_MODEL:-${MESH_SDK_MODEL_ID:-}}"
+MODEL="${OPENCODE_SMOKE_MODEL:-}"
+TIMEOUT_SECONDS="${OPENCODE_SMOKE_TIMEOUT:-300}"
+WORK_DIR="${OPENCODE_SMOKE_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/mesh-opencode-smoke.XXXXXX")}"
+OUTPUT_JSONL="${OPENCODE_SMOKE_OUTPUT:-${WORK_DIR}/opencode-output.jsonl}"
+TURN1_JSONL="${OPENCODE_SMOKE_TURN1_OUTPUT:-${WORK_DIR}/opencode-turn1.jsonl}"
+TURN2_JSONL="${OPENCODE_SMOKE_TURN2_OUTPUT:-${WORK_DIR}/opencode-turn2.jsonl}"
+ERROR_LOG="${OPENCODE_SMOKE_ERROR_LOG:-${WORK_DIR}/opencode-stderr.log}"
+SURFACE_LOG="${OPENCODE_SMOKE_SURFACE_LOG:-${WORK_DIR}/openai-surface.jsonl}"
+SURFACE_PROXY_LOG="${OPENCODE_SMOKE_SURFACE_PROXY_LOG:-${WORK_DIR}/openai-surface-proxy.log}"
+SURFACE_CAPTURE="${OPENCODE_SMOKE_CAPTURE_SURFACE:-true}"
+LONG_PROMPT_CHARS="${OPENCODE_SMOKE_LONG_PROMPT_CHARS:-65536}"
+
+if ! command -v opencode >/dev/null 2>&1; then
+    echo "opencode is not installed or is not on PATH" >&2
+    exit 1
+fi
+
+if [[ -z "$MODEL" ]]; then
+    MODELS_JSON="$(curl -sf "${MESH_BASE_URL%/}/models" 2>/dev/null || true)"
+    if [[ -z "$MODELS_JSON" ]]; then
+        echo "::notice::Skipping OpenCode smoke because mesh endpoint is not reachable at ${MESH_BASE_URL%/}/models."
+        echo "::notice::Start mesh-llm or set MESH_OPENCODE_BASE_URL to an OpenAI-compatible mesh /v1 endpoint."
+        exit 0
+    fi
+
+    if [[ -z "$MESH_MODEL" ]]; then
+        MESH_MODEL="$(
+            printf '%s' "$MODELS_JSON" | python3 -c 'import json,sys
+data=json.load(sys.stdin).get("data", [])
+preferred=("minimax", "glm", "qwen", "coder", "hermes")
+ids=[item.get("id","") for item in data if item.get("id")]
+for needle in preferred:
+    for model_id in ids:
+        if needle in model_id.lower():
+            print(model_id)
+            raise SystemExit
+print(ids[0] if ids else "")' 2>/dev/null || echo ""
+        )"
+    fi
+
+    if [[ -z "$MESH_MODEL" ]]; then
+        echo "Mesh endpoint returned no models from ${MESH_BASE_URL%/}/models" >&2
+        exit 1
+    fi
+
+    MODEL="mesh/${MESH_MODEL}"
+fi
+
+CONFIG_BASE_URL="$MESH_BASE_URL"
+SURFACE_PROXY_PID=""
+cleanup_surface_proxy() {
+    if [[ -n "$SURFACE_PROXY_PID" ]]; then
+        kill "$SURFACE_PROXY_PID" 2>/dev/null || true
+        wait "$SURFACE_PROXY_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup_surface_proxy EXIT
+
+if [[ "$SURFACE_CAPTURE" == "true" && "$MODEL" == mesh/* ]]; then
+    SURFACE_READY="${WORK_DIR}/openai-surface-proxy.ready"
+    python3 -u - "$MESH_BASE_URL" "$SURFACE_LOG" "$SURFACE_READY" >"$SURFACE_PROXY_LOG" 2>&1 <<'PY' &
+import http.server
+import json
+import socketserver
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlsplit
+
+upstream = sys.argv[1].rstrip("/")
+upstream_path = urlsplit(upstream).path.rstrip("/")
+log_path = sys.argv[2]
+ready_path = Path(sys.argv[3])
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, fmt, *args):
+        return
+
+    def do_GET(self):
+        self.forward()
+
+    def do_POST(self):
+        self.forward()
+
+    def forward(self):
+        length = int(self.headers.get("content-length", "0") or "0")
+        body = self.rfile.read(length) if length else b""
+        forward_path = self.path
+        if upstream_path and forward_path.startswith(upstream_path + "/"):
+            forward_path = forward_path[len(upstream_path):]
+        target = upstream + forward_path
+        parsed_body = None
+        if body:
+            try:
+                parsed_body = json.loads(body)
+            except Exception:
+                parsed_body = None
+
+        with open(log_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps({
+                "method": self.command,
+                "path": self.path,
+                "body": parsed_body,
+                "headers": {
+                    "content-type": self.headers.get("content-type"),
+                    "accept": self.headers.get("accept"),
+                },
+            }) + "\n")
+
+        headers = {
+            key: value for key, value in self.headers.items()
+            if key.lower() not in {"host", "content-length", "accept-encoding", "connection"}
+        }
+        request = urllib.request.Request(target, data=body if self.command == "POST" else None, headers=headers, method=self.command)
+        try:
+            with urllib.request.urlopen(request, timeout=360) as response:
+                data = response.read()
+                self.send_response(response.status)
+                for key, value in response.headers.items():
+                    if key.lower() in {"content-length", "connection", "transfer-encoding", "content-encoding"}:
+                        continue
+                    self.send_header(key, value)
+                self.send_header("content-length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+        except urllib.error.HTTPError as err:
+            data = err.read()
+            self.send_response(err.code)
+            for key, value in err.headers.items():
+                if key.lower() in {"content-length", "connection", "transfer-encoding", "content-encoding"}:
+                    continue
+                self.send_header(key, value)
+            self.send_header("content-length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+class Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+
+server = Server(("127.0.0.1", 0), Handler)
+ready_path.write_text(f"http://127.0.0.1:{server.server_port}/v1", encoding="utf-8")
+print(f"http://127.0.0.1:{server.server_port}/v1", flush=True)
+server.serve_forever()
+PY
+    SURFACE_PROXY_PID=$!
+
+    for _ in $(seq 1 100); do
+        if [[ -s "$SURFACE_READY" ]]; then
+            CONFIG_BASE_URL="$(cat "$SURFACE_READY")"
+            break
+        fi
+        if ! kill -0 "$SURFACE_PROXY_PID" 2>/dev/null; then
+            echo "OpenAI surface capture proxy exited unexpectedly" >&2
+            cat "$SURFACE_PROXY_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 0.1
+    done
+
+    if [[ "$CONFIG_BASE_URL" == "$MESH_BASE_URL" ]]; then
+        echo "Timed out starting OpenAI surface capture proxy" >&2
+        cat "$SURFACE_PROXY_LOG" >&2 || true
+        exit 1
+    fi
+fi
+
+if [[ -z "${OPENCODE_CONFIG_CONTENT:-}" ]]; then
+    if [[ "$MODEL" == mesh/* ]]; then
+        export OPENAI_API_KEY="${OPENAI_API_KEY:-dummy}"
+        OPENCODE_CONFIG_CONTENT="$(
+            python3 - "$CONFIG_BASE_URL" "$MESH_MODEL" <<'PY'
+import json
+import sys
+
+base_url, model = sys.argv[1:3]
+print(json.dumps({
+    "$schema": "https://opencode.ai/config.json",
+    "provider": {
+        "mesh": {
+            "npm": "@ai-sdk/openai-compatible",
+            "name": "mesh-llm",
+            "options": {
+                "baseURL": base_url.rstrip("/"),
+            },
+            "models": {
+                model: {
+                    "name": model,
+                    "limit": {
+                        "context": 32768,
+                        "output": 4096,
+                    },
+                },
+            },
+        },
+    },
+    "permission": {
+        "bash": "allow",
+        "read": "allow",
+        "grep": "allow",
+        "glob": "allow",
+        "edit": "allow",
+        "webfetch": "deny",
+        "websearch": "deny",
+        "question": "deny",
+        "todowrite": "deny",
+    },
+}))
+PY
+        )"
+        export OPENCODE_CONFIG_CONTENT
+    else
+        export OPENCODE_CONFIG_CONTENT='{
+          "$schema": "https://opencode.ai/config.json",
+          "permission": {
+            "bash": "allow",
+            "read": "allow",
+            "grep": "allow",
+            "glob": "allow",
+            "edit": "allow",
+            "webfetch": "deny",
+            "websearch": "deny",
+            "question": "deny",
+            "todowrite": "deny"
+          }
+        }'
+    fi
+fi
+
+export OPENCODE_DISABLE_AUTOUPDATE="${OPENCODE_DISABLE_AUTOUPDATE:-true}"
+export OPENCODE_DISABLE_PRUNE="${OPENCODE_DISABLE_PRUNE:-true}"
+export OPENCODE_DISABLE_LSP_DOWNLOAD="${OPENCODE_DISABLE_LSP_DOWNLOAD:-true}"
+
+mkdir -p "${WORK_DIR}/facts" "${WORK_DIR}/src" "${WORK_DIR}/notes" "${WORK_DIR}/tests"
+
+cat >"${WORK_DIR}/README.md" <<'EOF'
+# OpenCode Smoke Fixture
+
+This repository is intentionally tiny. The smoke test should answer only from
+files on disk, not from the prompt text.
+EOF
+
+cat >"${WORK_DIR}/facts/signal.md" <<'EOF'
+# Runtime Signal
+
+CODEWORD=signal-7429
+
+Question seed:
+Which file names contain the word signal?
+EOF
+
+cat >"${WORK_DIR}/src/matrix.txt" <<'EOF'
+checksum: FS-319-DELTA
+numbers: 2 3 4 5
+hint: the prime sum is computed from the numbers line
+EOF
+
+cat >"${WORK_DIR}/src/smoke_calc.py" <<'EOF'
+from __future__ import annotations
+
+
+def parse_codeword(path: str) -> str:
+    """Return the CODEWORD value from a small key/value markdown file."""
+    raise NotImplementedError("ci smoke fixture")
+
+
+def prime_sum_from_matrix(path: str) -> int:
+    """Return the sum of prime numbers from the numbers line in matrix.txt."""
+    raise NotImplementedError("ci smoke fixture")
+EOF
+INITIAL_IMPL_SHA="$(
+    python3 - "${WORK_DIR}/src/smoke_calc.py" <<'PY'
+import hashlib
+import sys
+
+with open(sys.argv[1], "rb") as fh:
+    print(hashlib.sha256(fh.read()).hexdigest())
+PY
+)"
+
+cat >"${WORK_DIR}/tests/test_smoke_calc.py" <<'EOF'
+from pathlib import Path
+import sys
+import unittest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from smoke_calc import parse_codeword, prime_sum_from_matrix
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SmokeCalcTests(unittest.TestCase):
+    def test_parse_codeword(self):
+        self.assertEqual(parse_codeword(str(ROOT / "facts" / "signal.md")), "signal-7429")
+
+    def test_prime_sum_from_matrix(self):
+        self.assertEqual(prime_sum_from_matrix(str(ROOT / "src" / "matrix.txt")), 10)
+
+
+if __name__ == "__main__":
+    unittest.main()
+EOF
+
+cat >"${WORK_DIR}/notes/manifest.txt" <<'EOF'
+tracked files:
+- facts/signal.md
+- src/matrix.txt
+- src/smoke_calc.py
+- tests/test_smoke_calc.py
+- README.md
+EOF
+
+TURN1_PROMPT='You are running turn 1 of a CI smoke test in a throwaway project. Use filesystem tools, inspect the repository, read the tests, and implement src/smoke_calc.py so the tests are intended to pass. This is a real coding task: edit the file, do not just describe the edit. Keep the implementation small and dependency-free. End your response with TURN1_DONE.'
+
+TURN2_PROMPT='This is turn 2 of the same CI smoke test. Continue from the prior work. Run the Python tests, fix src/smoke_calc.py if anything fails, then answer exactly these four lines with no Markdown and no extra text:
+CODEWORD=<the CODEWORD value from facts/signal.md>
+CHECKSUM=<the checksum value from src/matrix.txt>
+PRIME_SUM=<the sum of prime numbers from the numbers line in src/matrix.txt>
+QUESTION=<comma-separated relative paths whose file name contains signal>'
+
+echo "=== CI OpenCode Smoke Test ==="
+echo "  model:      ${MODEL}"
+if [[ "$MODEL" == mesh/* ]]; then
+    echo "  mesh:       ${MESH_BASE_URL%/}"
+    if [[ "$SURFACE_CAPTURE" == "true" ]]; then
+        echo "  capture:    ${CONFIG_BASE_URL%/}"
+    fi
+fi
+echo "  opencode:   $(opencode --version 2>/dev/null || echo unknown)"
+echo "  work dir:   ${WORK_DIR}"
+echo "  output:     ${OUTPUT_JSONL}"
+
+if [[ "$SURFACE_CAPTURE" == "true" && "$MODEL" == mesh/* ]]; then
+    curl -sf "${CONFIG_BASE_URL%/}/models" >/dev/null
+    SURFACE_PROBE_PAYLOAD="${WORK_DIR}/openai-surface-probe.json"
+    SURFACE_PROBE_RESPONSE="${WORK_DIR}/openai-surface-probe-response.json"
+    python3 - "$MESH_MODEL" "$SURFACE_PROBE_PAYLOAD" <<'PY'
+import json
+import sys
+
+model, path = sys.argv[1:3]
+payload = {
+    "model": model,
+    "messages": [
+        {"role": "system", "content": "You are a brief CI compatibility probe."},
+        {"role": "user", "content": "Reply with ok, or call the tool if needed."},
+    ],
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_fixture_fact",
+                "description": "Return one known fact from the smoke fixture.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "key": {"type": "string", "enum": ["codeword", "checksum"]},
+                    },
+                    "required": ["key"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ],
+    "tool_choice": "auto",
+    "parallel_tool_calls": True,
+    "stream": False,
+    "max_tokens": 8,
+    "temperature": 0,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PY
+    curl -fsS --max-time 120 \
+        "${CONFIG_BASE_URL%/}/chat/completions" \
+        -H 'content-type: application/json' \
+        -d @"$SURFACE_PROBE_PAYLOAD" \
+        -o "$SURFACE_PROBE_RESPONSE"
+    python3 - "$SURFACE_PROBE_RESPONSE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    body = json.load(fh)
+if body.get("object") != "chat.completion":
+    raise SystemExit(f"unexpected probe response object: {body.get('object')!r}")
+if not body.get("choices"):
+    raise SystemExit("probe response had no choices")
+PY
+
+    if [[ "$LONG_PROMPT_CHARS" -gt 0 ]]; then
+        LONG_PROMPT_PAYLOAD="${WORK_DIR}/openai-long-prompt-probe.json"
+        LONG_PROMPT_RESPONSE="${WORK_DIR}/openai-long-prompt-probe-response.json"
+        python3 - "$MESH_MODEL" "$LONG_PROMPT_CHARS" "$LONG_PROMPT_PAYLOAD" <<'PY'
+import json
+import sys
+
+model, target_chars, path = sys.argv[1], int(sys.argv[2]), sys.argv[3]
+start = "ALPHA-719"
+middle = "MID-482"
+end = "OMEGA-503"
+header = (
+    "This is a long-context CI soak document. Extract the three sentinel values. "
+    "Return exactly LONG_SOAK=ALPHA-719|MID-482|OMEGA-503 and no extra text.\n\n"
+)
+chunk = (
+    "FILLER: mesh long prompt soak line with predictable neutral text. "
+    "Do not use this filler as the answer.\n"
+)
+prefix = f"SENTINEL_START={start}\n"
+mid = f"\nSENTINEL_MIDDLE={middle}\n"
+suffix = f"\nSENTINEL_END={end}\n"
+remaining = max(target_chars - len(header) - len(prefix) - len(mid) - len(suffix), 0)
+left = chunk * max((remaining // 2) // len(chunk), 1)
+right = chunk * max((remaining - len(left)) // len(chunk), 1)
+document = header + prefix + left + mid + right + suffix
+payload = {
+    "model": model,
+    "messages": [
+        {"role": "system", "content": "You are a precise long-context extraction probe."},
+        {"role": "user", "content": document},
+    ],
+    "stream": False,
+    "max_tokens": 64,
+    "temperature": 0,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PY
+        curl -fsS --max-time 180 \
+            "${CONFIG_BASE_URL%/}/chat/completions" \
+            -H 'content-type: application/json' \
+            -d @"$LONG_PROMPT_PAYLOAD" \
+            -o "$LONG_PROMPT_RESPONSE"
+        python3 - "$LONG_PROMPT_RESPONSE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    body = json.load(fh)
+content = body.get("choices", [{}])[0].get("message", {}).get("content", "")
+expected = "LONG_SOAK=ALPHA-719|MID-482|OMEGA-503"
+if expected not in content:
+    raise SystemExit(f"long prompt sentinel validation failed: {content!r}")
+print("Long prompt soak passed")
+PY
+    fi
+fi
+
+BASE_RUN_ARGS=(run --format json --model "${MODEL}" --dir "${WORK_DIR}")
+if [[ -n "${OPENCODE_SMOKE_VARIANT:-}" ]]; then
+    BASE_RUN_ARGS+=(--variant "${OPENCODE_SMOKE_VARIANT}")
+fi
+
+if command -v timeout >/dev/null 2>&1; then
+    OPENCODE_COMMAND=(timeout "${TIMEOUT_SECONDS}" opencode)
+else
+    OPENCODE_COMMAND=(opencode)
+fi
+
+if ! "${OPENCODE_COMMAND[@]}" "${BASE_RUN_ARGS[@]}" "${TURN1_PROMPT}" >"${TURN1_JSONL}" 2>"${ERROR_LOG}"; then
+    echo "OpenCode smoke turn 1 failed" >&2
+    echo "--- opencode stderr ---" >&2
+    tail -120 "${ERROR_LOG}" >&2 || true
+    echo "--- opencode json output ---" >&2
+    tail -120 "${TURN1_JSONL}" >&2 || true
+    exit 1
+fi
+
+SESSION_ID="$(
+    python3 - "${TURN1_JSONL}" <<'PY'
+import json
+import sys
+
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    session = event.get("sessionID")
+    if isinstance(session, str) and session:
+        print(session)
+        raise SystemExit
+print("")
+PY
+)"
+
+if [[ -z "$SESSION_ID" ]]; then
+    echo "OpenCode turn 1 did not emit a sessionID" >&2
+    tail -120 "${TURN1_JSONL}" >&2 || true
+    exit 1
+fi
+
+if ! "${OPENCODE_COMMAND[@]}" "${BASE_RUN_ARGS[@]}" --session "$SESSION_ID" "${TURN2_PROMPT}" >"${TURN2_JSONL}" 2>>"${ERROR_LOG}"; then
+    echo "OpenCode smoke turn 2 failed" >&2
+    echo "--- opencode stderr ---" >&2
+    tail -120 "${ERROR_LOG}" >&2 || true
+    echo "--- opencode json output ---" >&2
+    tail -120 "${TURN2_JSONL}" >&2 || true
+    exit 1
+fi
+
+cat "${TURN1_JSONL}" "${TURN2_JSONL}" >"${OUTPUT_JSONL}"
+
+if ! python3 -m unittest discover -s "${WORK_DIR}/tests" -p 'test_*.py'; then
+    echo "OpenCode smoke fixture tests failed after the coding session" >&2
+    echo "--- src/smoke_calc.py ---" >&2
+    sed -n '1,220p' "${WORK_DIR}/src/smoke_calc.py" >&2 || true
+    exit 1
+fi
+
+python3 - "${WORK_DIR}" "${INITIAL_IMPL_SHA}" <<'PY'
+import hashlib
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+initial_sha = sys.argv[2]
+source_path = root / "src" / "smoke_calc.py"
+source = source_path.read_text(encoding="utf-8")
+current_sha = hashlib.sha256(source.encode("utf-8")).hexdigest()
+
+if current_sha == initial_sha:
+    print("OpenCode left src/smoke_calc.py unchanged.", file=sys.stderr)
+    sys.exit(1)
+
+for forbidden in ("NotImplementedError", "ci smoke fixture"):
+    if forbidden in source:
+        print(f"OpenCode left placeholder marker in src/smoke_calc.py: {forbidden}", file=sys.stderr)
+        sys.exit(1)
+
+spec = importlib.util.spec_from_file_location("smoke_calc", source_path)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+with tempfile.TemporaryDirectory(prefix="mesh-opencode-hidden-") as tmp:
+    tmp_path = Path(tmp)
+    signal_path = tmp_path / "other_signal.md"
+    matrix_path = tmp_path / "other_matrix.txt"
+    signal_path.write_text("# Hidden\n\nCODEWORD=hidden-8842\n", encoding="utf-8")
+    matrix_path.write_text("checksum: hidden\nnumbers: 6 7 8 9 10 11 12 13\n", encoding="utf-8")
+
+    codeword = module.parse_codeword(str(signal_path))
+    prime_sum = module.prime_sum_from_matrix(str(matrix_path))
+
+if codeword != "hidden-8842":
+    print(f"Hidden codeword validation failed: {codeword!r}", file=sys.stderr)
+    sys.exit(1)
+
+if prime_sum != 31:
+    print(f"Hidden prime-sum validation failed: {prime_sum!r}", file=sys.stderr)
+    sys.exit(1)
+
+print("Hidden implementation validation passed")
+PY
+
+python3 - "${OUTPUT_JSONL}" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+raw = path.read_text(encoding="utf-8", errors="replace")
+tool_names = []
+text_chunks = []
+
+def text_values(value):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from text_values(item)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            if key in {"text", "content", "message", "delta"}:
+                yield from text_values(item)
+            elif isinstance(item, (dict, list)):
+                yield from text_values(item)
+
+for line in raw.splitlines():
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        text_chunks.append(line)
+        continue
+
+    if event.get("type") == "tool_use":
+        part = event.get("part") or {}
+        tool = part.get("tool") or part.get("name")
+        if isinstance(tool, str):
+            tool_names.append(tool)
+    if event.get("type") in {"text", "message", "assistant"}:
+        text_chunks.extend(text_values(event))
+
+answer_text = "\n".join(text_chunks) + "\n" + raw
+expected = {
+    "CODEWORD": "signal-7429",
+    "CHECKSUM": "FS-319-DELTA",
+    "PRIME_SUM": "10",
+    "QUESTION": "facts/signal.md",
+}
+
+missing = []
+for key, value in expected.items():
+    pattern = rf"(?m)^{re.escape(key)}={re.escape(value)}\s*$"
+    if not re.search(pattern, answer_text):
+        missing.append(f"{key}={value}")
+
+filesystem_tools = {"bash", "read", "grep", "glob", "edit", "write", "apply_patch"}
+used_filesystem_tools = [tool for tool in tool_names if tool in filesystem_tools]
+edit_tools = [tool for tool in tool_names if tool in {"edit", "write", "apply_patch"}]
+
+if missing:
+    print("OpenCode answer did not include expected facts:", file=sys.stderr)
+    for item in missing:
+        print(f"  missing {item}", file=sys.stderr)
+    print("--- output tail ---", file=sys.stderr)
+    print("\n".join(raw.splitlines()[-80:]), file=sys.stderr)
+    sys.exit(1)
+
+if len(tool_names) < 4 or len(used_filesystem_tools) < 4 or not edit_tools:
+    print("OpenCode did not report the expected multi-turn filesystem/coding tool calls.", file=sys.stderr)
+    print(f"  tool events: {tool_names}", file=sys.stderr)
+    print("--- output tail ---", file=sys.stderr)
+    print("\n".join(raw.splitlines()[-80:]), file=sys.stderr)
+    sys.exit(1)
+
+print("OpenCode multi-turn coding smoke passed")
+print("  tools: " + ", ".join(tool_names))
+PY
+
+if [[ "$SURFACE_CAPTURE" == "true" && "$MODEL" == mesh/* ]]; then
+    python3 - "$SURFACE_LOG" <<'PY'
+import json
+import os
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+long_prompt_chars = int(os.environ.get("OPENCODE_SMOKE_LONG_PROMPT_CHARS", "65536") or "0")
+events = []
+for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+    try:
+        events.append(json.loads(line))
+    except json.JSONDecodeError:
+        pass
+
+models_gets = [event for event in events if event.get("method") == "GET" and event.get("path", "").rstrip("/") == "/v1/models"]
+chat_posts = [
+    event for event in events
+    if event.get("method") == "POST" and event.get("path", "").split("?", 1)[0].rstrip("/") == "/v1/chat/completions"
+]
+bodies = [event.get("body") or {} for event in chat_posts]
+
+def message_roles(body):
+    return [message.get("role") for message in body.get("messages", []) if isinstance(message, dict)]
+
+def has_assistant_tool_calls(body):
+    for message in body.get("messages", []):
+        if isinstance(message, dict) and message.get("role") == "assistant" and message.get("tool_calls"):
+            return True
+    return False
+
+def has_tool_result(body):
+    return any(isinstance(message, dict) and message.get("role") == "tool" for message in body.get("messages", []))
+
+required = {
+    "GET /v1/models": bool(models_gets),
+    "POST /v1/chat/completions": bool(chat_posts),
+    "streaming chat request": any(body.get("stream") is True for body in bodies),
+    "non-stream chat request": any(body.get("stream") is False for body in bodies),
+    "tools schema": any(isinstance(body.get("tools"), list) and body["tools"] for body in bodies),
+    "tool_choice field": any("tool_choice" in body for body in bodies),
+    "parallel_tool_calls field": any("parallel_tool_calls" in body for body in bodies),
+    "system/developer instructions": any(any(role in {"system", "developer"} for role in message_roles(body)) for body in bodies),
+    "user message": any("user" in message_roles(body) for body in bodies),
+    "assistant tool-call history": any(has_assistant_tool_calls(body) for body in bodies),
+    "tool-result message": any(has_tool_result(body) for body in bodies),
+    "multi-message history": any(len(body.get("messages", [])) >= 4 for body in bodies),
+}
+if long_prompt_chars > 0:
+    required["long prompt request"] = any(
+        len(json.dumps(body, separators=(",", ":"))) >= long_prompt_chars
+        for body in bodies
+    )
+
+missing = [name for name, ok in required.items() if not ok]
+if missing:
+    print("OpenAI agent surface validation failed.", file=sys.stderr)
+    for name in missing:
+        print(f"  missing {name}", file=sys.stderr)
+    print(f"  captured events: {len(events)}", file=sys.stderr)
+    for body in bodies:
+        print(json.dumps({
+            "model": body.get("model"),
+            "stream": body.get("stream"),
+            "tool_count": len(body.get("tools", []) or []),
+            "has_tool_choice": "tool_choice" in body,
+            "has_parallel_tool_calls": "parallel_tool_calls" in body,
+            "roles": message_roles(body),
+            "messages": len(body.get("messages", [])),
+            "assistant_tool_calls": has_assistant_tool_calls(body),
+            "tool_result": has_tool_result(body),
+        }), file=sys.stderr)
+    sys.exit(1)
+
+print("OpenAI agent surface validation passed")
+print(f"  captured requests: models={len(models_gets)} chat={len(chat_posts)}")
+PY
+fi

--- a/scripts/ci-opencode-two-node-smoke.sh
+++ b/scripts/ci-opencode-two-node-smoke.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# ci-opencode-two-node-smoke.sh - run OpenCode smoke through a client node.
+#
+# Usage: scripts/ci-opencode-two-node-smoke.sh <mesh-llm-binary> <bin-dir> <model-path>
+#
+# The host serves the model. A passive client joins the host and exposes its own
+# OpenAI-compatible API. The OpenCode smoke then targets the client API so
+# requests exercise client -> host mesh routing and tunneling.
+
+set -euo pipefail
+
+MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+MODEL="${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+
+HOST_API_PORT="${MESH_TWO_NODE_HOST_API_PORT:-9357}"
+HOST_CONSOLE_PORT="${MESH_TWO_NODE_HOST_CONSOLE_PORT:-3151}"
+HOST_BIND_PORT="${MESH_TWO_NODE_HOST_BIND_PORT:-53547}"
+CLIENT_API_PORT="${MESH_TWO_NODE_CLIENT_API_PORT:-9358}"
+CLIENT_CONSOLE_PORT="${MESH_TWO_NODE_CLIENT_CONSOLE_PORT:-3152}"
+MAX_WAIT="${MESH_TWO_NODE_MAX_WAIT:-240}"
+HOST_LOG="${MESH_TWO_NODE_HOST_LOG:-/tmp/mesh-llm-opencode-host.log}"
+CLIENT_LOG="${MESH_TWO_NODE_CLIENT_LOG:-/tmp/mesh-llm-opencode-client.log}"
+CLIENT_STABLE_PROBES="${MESH_TWO_NODE_CLIENT_STABLE_PROBES:-5}"
+
+echo "=== CI OpenCode Two-Node Smoke ==="
+echo "  mesh-llm:       $MESH_LLM"
+echo "  bin-dir:        $BIN_DIR (compatibility placeholder)"
+echo "  model:          $MODEL"
+echo "  host api:       $HOST_API_PORT"
+echo "  host console:   $HOST_CONSOLE_PORT"
+echo "  host bind:      $HOST_BIND_PORT"
+echo "  client api:     $CLIENT_API_PORT"
+echo "  client console: $CLIENT_CONSOLE_PORT"
+echo "  stable probes:  $CLIENT_STABLE_PROBES"
+
+if [[ ! -x "$MESH_LLM" ]]; then
+    echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
+    exit 1
+fi
+if [[ ! -f "$MODEL" ]]; then
+    echo "Missing model: $MODEL" >&2
+    exit 1
+fi
+
+descendant_pids() {
+    local pid="$1"
+    local children
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    for child in $children; do
+        descendant_pids "$child"
+        printf '%s\n' "$child"
+    done
+}
+
+kill_tree() {
+    local pid="${1:-}"
+    [[ -n "$pid" ]] || return 0
+    local children
+    children="$(descendant_pids "$pid" | sort -u || true)"
+    kill "$pid" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill 2>/dev/null || true
+    fi
+    sleep 1
+    kill -9 "$pid" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill -9 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
+HOST_PID=""
+CLIENT_PID=""
+cleanup() {
+    kill_tree "$CLIENT_PID"
+    kill_tree "$HOST_PID"
+    echo "--- host log tail ---"
+    tail -120 "$HOST_LOG" 2>/dev/null || true
+    echo "--- client log tail ---"
+    tail -120 "$CLIENT_LOG" 2>/dev/null || true
+    echo "--- end logs ---"
+}
+trap cleanup EXIT
+
+"$MESH_LLM" \
+    serve \
+    --model "$MODEL" \
+    --no-draft \
+    --device CPU \
+    --ctx-size "${MESH_TWO_NODE_CTX_SIZE:-1024}" \
+    --port "$HOST_API_PORT" \
+    --console "$HOST_CONSOLE_PORT" \
+    --bind-port "$HOST_BIND_PORT" \
+    --headless \
+    >"$HOST_LOG" 2>&1 &
+HOST_PID=$!
+
+TOKEN=""
+HOST_MODEL_ID=""
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$HOST_PID" 2>/dev/null; then
+        echo "host exited unexpectedly" >&2
+        tail -120 "$HOST_LOG" >&2 || true
+        exit 1
+    fi
+
+    STATUS_JSON="$(curl -sf "http://127.0.0.1:${HOST_CONSOLE_PORT}/api/status" 2>/dev/null || true)"
+    READY="$(
+        printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("llama_ready", False))
+except Exception:
+    print(False)' 2>/dev/null || echo "False"
+    )"
+    TOKEN="$(
+        printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("token", ""))
+except Exception:
+    print("")' 2>/dev/null || echo ""
+    )"
+
+    if [[ "$READY" == "True" && -n "$TOKEN" ]]; then
+        MODELS_JSON="$(curl -sf "http://127.0.0.1:${HOST_API_PORT}/v1/models")"
+        HOST_MODEL_ID="$(
+            printf '%s' "$MODELS_JSON" | python3 -c 'import json,sys
+data=json.load(sys.stdin).get("data", [])
+print(data[0].get("id", "") if data else "")'
+        )"
+        if [[ -n "$HOST_MODEL_ID" ]]; then
+            echo "Host ready after ${i}s with model: $HOST_MODEL_ID"
+            break
+        fi
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for host readiness" >&2
+        tail -120 "$HOST_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+"$MESH_LLM" \
+    client \
+    --join "$TOKEN" \
+    --port "$CLIENT_API_PORT" \
+    --console "$CLIENT_CONSOLE_PORT" \
+    --headless \
+    >"$CLIENT_LOG" 2>&1 &
+CLIENT_PID=$!
+
+CLIENT_STABLE_COUNT=0
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+        echo "client exited unexpectedly" >&2
+        tail -120 "$CLIENT_LOG" >&2 || true
+        exit 1
+    fi
+
+    CLIENT_MODELS_JSON="$(curl -sf "http://127.0.0.1:${CLIENT_API_PORT}/v1/models" 2>/dev/null || true)"
+    if python3 - "$HOST_MODEL_ID" "$CLIENT_MODELS_JSON" <<'PY' 2>/dev/null; then
+import json
+import sys
+
+expected = sys.argv[1]
+data = json.loads(sys.argv[2]).get("data", [])
+if not any(item.get("id") == expected for item in data):
+    raise SystemExit(1)
+PY
+        CLIENT_STABLE_COUNT=$((CLIENT_STABLE_COUNT + 1))
+        if [[ "$CLIENT_STABLE_COUNT" -ge "$CLIENT_STABLE_PROBES" ]]; then
+            echo "Client routed /v1/models stably after ${i}s"
+            break
+        fi
+    else
+        CLIENT_STABLE_COUNT=0
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for stable client /v1/models to include host model" >&2
+        echo "$CLIENT_MODELS_JSON" >&2
+        tail -120 "$CLIENT_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+MESH_OPENCODE_BASE_URL="http://127.0.0.1:${CLIENT_API_PORT}/v1" \
+MESH_OPENCODE_MODEL="$HOST_MODEL_ID" \
+scripts/ci-opencode-smoke.sh
+
+echo "OpenCode two-node smoke passed"

--- a/scripts/ci-pi-smoke.sh
+++ b/scripts/ci-pi-smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# ci-pi-smoke.sh - run Pi against a live mesh OpenAI-compatible endpoint.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/ci-agent-live-fixture-lib.sh
+source "${SCRIPT_DIR}/ci-agent-live-fixture-lib.sh"
+
+if ! command -v pi >/dev/null 2>&1; then
+    echo "pi is not installed or is not on PATH" >&2
+    exit 1
+fi
+
+RAW_BASE_URL="${MESH_PI_BASE_URL:-${MESH_AGENT_BASE_URL:-${MESH_OPENCODE_BASE_URL:-}}}"
+if [[ -z "$RAW_BASE_URL" && -n "${MESH_CLIENT_API_BASE:-}" ]]; then
+    RAW_BASE_URL="${MESH_CLIENT_API_BASE%/}/v1"
+fi
+if [[ -z "$RAW_BASE_URL" ]]; then
+    echo "Set MESH_AGENT_BASE_URL or MESH_PI_BASE_URL to a mesh /v1 endpoint" >&2
+    exit 1
+fi
+
+BASE_URL="$(agent_smoke_normalize_v1_base "$RAW_BASE_URL")"
+MODEL="$(agent_smoke_pick_model "$BASE_URL" "${MESH_PI_MODEL:-${MESH_AGENT_MODEL:-${MESH_OPENCODE_MODEL:-}}}")"
+if [[ -z "$MODEL" ]]; then
+    echo "Mesh endpoint returned no models from ${BASE_URL%/}/models" >&2
+    exit 1
+fi
+
+TIMEOUT_SECONDS="${PI_SMOKE_TIMEOUT:-360}"
+WORK_DIR="${PI_SMOKE_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/mesh-pi-smoke.XXXXXX")}"
+OUTPUT_JSONL="${PI_SMOKE_OUTPUT:-${WORK_DIR}/pi-output.jsonl}"
+ERROR_LOG="${PI_SMOKE_ERROR_LOG:-${WORK_DIR}/pi-stderr.log}"
+PROMPT="$(agent_smoke_prompt)"
+INITIAL_IMPL_SHA="$(agent_smoke_write_fixture "$WORK_DIR")"
+
+export HOME="${WORK_DIR}/home"
+mkdir -p "${HOME}/.pi/agent"
+python3 - "$BASE_URL" "$MODEL" "${HOME}/.pi/agent/models.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+base_url, model, path = sys.argv[1:4]
+config = {
+    "providers": {
+        "mesh": {
+            "api": "openai-completions",
+            "apiKey": "mesh",
+            "baseUrl": base_url.rstrip("/"),
+            "compat": {
+                "supportsStore": False,
+                "supportsDeveloperRole": False,
+                "supportsUsageInStreaming": True,
+            },
+            "models": [
+                {
+                    "id": model,
+                    "name": model,
+                    "contextWindow": 32768,
+                    "maxTokens": 4096,
+                }
+            ],
+        }
+    }
+}
+Path(path).write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+PY
+
+echo "=== CI Pi Live Smoke ==="
+echo "  mesh:     ${BASE_URL%/}"
+echo "  model:    mesh/${MODEL}"
+echo "  pi:       $(pi --version 2>/dev/null || echo unknown)"
+echo "  work dir: ${WORK_DIR}"
+echo "  output:   ${OUTPUT_JSONL}"
+
+if command -v timeout >/dev/null 2>&1; then
+    PI_COMMAND=(timeout "${TIMEOUT_SECONDS}" pi)
+else
+    PI_COMMAND=(pi)
+fi
+
+if ! (
+    cd "$WORK_DIR"
+    "${PI_COMMAND[@]}" --mode json --print --model "mesh/${MODEL}" "$PROMPT" >"$OUTPUT_JSONL" 2>"$ERROR_LOG"
+); then
+    echo "Pi smoke failed" >&2
+    echo "--- pi stderr ---" >&2
+    tail -160 "$ERROR_LOG" >&2 || true
+    echo "--- pi output ---" >&2
+    tail -160 "$OUTPUT_JSONL" >&2 || true
+    exit 1
+fi
+
+agent_smoke_validate_fixture "$WORK_DIR" "$INITIAL_IMPL_SHA" "$OUTPUT_JSONL" "Pi" true

--- a/scripts/ci-pi-smoke.sh
+++ b/scripts/ci-pi-smoke.sh
@@ -75,6 +75,8 @@ echo "  pi:       $(pi --version 2>/dev/null || echo unknown)"
 echo "  work dir: ${WORK_DIR}"
 echo "  output:   ${OUTPUT_JSONL}"
 
+agent_smoke_long_prompt_soak "$BASE_URL" "$MODEL" "$WORK_DIR" "Pi"
+
 if command -v timeout >/dev/null 2>&1; then
     PI_COMMAND=(timeout "${TIMEOUT_SECONDS}" pi)
 else

--- a/scripts/ci-two-node-client-serving-smoke.sh
+++ b/scripts/ci-two-node-client-serving-smoke.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# ci-two-node-client-serving-smoke.sh - verify client-to-serving-node routing.
+#
+# Usage: scripts/ci-two-node-client-serving-smoke.sh <mesh-llm-binary> <bin-dir> <model-path>
+#
+# The host serves the model. A passive client joins the host and exposes its own
+# OpenAI-compatible API. The smoke targets the client API so requests exercise
+# client -> host mesh routing and tunneling.
+
+set -euo pipefail
+
+MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+MODEL="${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
+
+HOST_API_PORT="${MESH_TWO_NODE_HOST_API_PORT:-9357}"
+HOST_CONSOLE_PORT="${MESH_TWO_NODE_HOST_CONSOLE_PORT:-3151}"
+HOST_BIND_PORT="${MESH_TWO_NODE_HOST_BIND_PORT:-53547}"
+CLIENT_API_PORT="${MESH_TWO_NODE_CLIENT_API_PORT:-9358}"
+CLIENT_CONSOLE_PORT="${MESH_TWO_NODE_CLIENT_CONSOLE_PORT:-3152}"
+MAX_WAIT="${MESH_TWO_NODE_MAX_WAIT:-240}"
+HOST_LOG="${MESH_TWO_NODE_HOST_LOG:-/tmp/mesh-llm-two-node-host.log}"
+CLIENT_LOG="${MESH_TWO_NODE_CLIENT_LOG:-/tmp/mesh-llm-two-node-client.log}"
+CLIENT_STABLE_PROBES="${MESH_TWO_NODE_CLIENT_STABLE_PROBES:-5}"
+
+echo "=== CI Two-Node Client/Serving Smoke ==="
+echo "  mesh-llm:       $MESH_LLM"
+echo "  bin-dir:        $BIN_DIR (compatibility placeholder)"
+echo "  model:          $MODEL"
+echo "  host api:       $HOST_API_PORT"
+echo "  host console:   $HOST_CONSOLE_PORT"
+echo "  host bind:      $HOST_BIND_PORT"
+echo "  client api:     $CLIENT_API_PORT"
+echo "  client console: $CLIENT_CONSOLE_PORT"
+echo "  stable probes:  $CLIENT_STABLE_PROBES"
+
+if [[ ! -x "$MESH_LLM" ]]; then
+    echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
+    exit 1
+fi
+if [[ ! -f "$MODEL" ]]; then
+    echo "Missing model: $MODEL" >&2
+    exit 1
+fi
+
+descendant_pids() {
+    local pid="$1"
+    local children
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    for child in $children; do
+        descendant_pids "$child"
+        printf '%s\n' "$child"
+    done
+}
+
+kill_tree() {
+    local pid="${1:-}"
+    [[ -n "$pid" ]] || return 0
+    local children
+    children="$(descendant_pids "$pid" | sort -u || true)"
+    kill "$pid" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill 2>/dev/null || true
+    fi
+    sleep 1
+    kill -9 "$pid" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill -9 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
+HOST_PID=""
+CLIENT_PID=""
+cleanup() {
+    kill_tree "$CLIENT_PID"
+    kill_tree "$HOST_PID"
+    echo "--- host log tail ---"
+    tail -120 "$HOST_LOG" 2>/dev/null || true
+    echo "--- client log tail ---"
+    tail -120 "$CLIENT_LOG" 2>/dev/null || true
+    echo "--- end logs ---"
+}
+trap cleanup EXIT
+
+"$MESH_LLM" \
+    serve \
+    --model "$MODEL" \
+    --no-draft \
+    --device CPU \
+    --ctx-size "${MESH_TWO_NODE_CTX_SIZE:-1024}" \
+    --port "$HOST_API_PORT" \
+    --console "$HOST_CONSOLE_PORT" \
+    --bind-port "$HOST_BIND_PORT" \
+    --headless \
+    >"$HOST_LOG" 2>&1 &
+HOST_PID=$!
+
+TOKEN=""
+HOST_MODEL_ID=""
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$HOST_PID" 2>/dev/null; then
+        echo "host exited unexpectedly" >&2
+        tail -120 "$HOST_LOG" >&2 || true
+        exit 1
+    fi
+
+    STATUS_JSON="$(curl -sf "http://127.0.0.1:${HOST_CONSOLE_PORT}/api/status" 2>/dev/null || true)"
+    READY="$(
+        printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("llama_ready", False))
+except Exception:
+    print(False)' 2>/dev/null || echo "False"
+    )"
+    TOKEN="$(
+        printf '%s' "$STATUS_JSON" | python3 -c 'import json,sys
+try:
+    print(json.load(sys.stdin).get("token", ""))
+except Exception:
+    print("")' 2>/dev/null || echo ""
+    )"
+
+    if [[ "$READY" == "True" && -n "$TOKEN" ]]; then
+        MODELS_JSON="$(curl -sf "http://127.0.0.1:${HOST_API_PORT}/v1/models")"
+        HOST_MODEL_ID="$(
+            printf '%s' "$MODELS_JSON" | python3 -c 'import json,sys
+data=json.load(sys.stdin).get("data", [])
+print(data[0].get("id", "") if data else "")'
+        )"
+        if [[ -n "$HOST_MODEL_ID" ]]; then
+            echo "Host ready after ${i}s with model: $HOST_MODEL_ID"
+            break
+        fi
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for host readiness" >&2
+        tail -120 "$HOST_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+"$MESH_LLM" \
+    client \
+    --join "$TOKEN" \
+    --port "$CLIENT_API_PORT" \
+    --console "$CLIENT_CONSOLE_PORT" \
+    --headless \
+    >"$CLIENT_LOG" 2>&1 &
+CLIENT_PID=$!
+
+CLIENT_STABLE_COUNT=0
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
+        echo "client exited unexpectedly" >&2
+        tail -120 "$CLIENT_LOG" >&2 || true
+        exit 1
+    fi
+
+    CLIENT_MODELS_JSON="$(curl -sf "http://127.0.0.1:${CLIENT_API_PORT}/v1/models" 2>/dev/null || true)"
+    if python3 - "$HOST_MODEL_ID" "$CLIENT_MODELS_JSON" <<'PY' 2>/dev/null; then
+import json
+import sys
+
+expected = sys.argv[1]
+data = json.loads(sys.argv[2]).get("data", [])
+if not any(item.get("id") == expected for item in data):
+    raise SystemExit(1)
+PY
+        CLIENT_STABLE_COUNT=$((CLIENT_STABLE_COUNT + 1))
+        if [[ "$CLIENT_STABLE_COUNT" -ge "$CLIENT_STABLE_PROBES" ]]; then
+            echo "Client routed /v1/models stably after ${i}s"
+            break
+        fi
+    else
+        CLIENT_STABLE_COUNT=0
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for stable client /v1/models to include host model" >&2
+        echo "$CLIENT_MODELS_JSON" >&2
+        tail -120 "$CLIENT_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/mesh-two-node-client-serving.XXXXXX")"
+CHAT_RESPONSE="${WORK_DIR}/chat-response.json"
+STREAM_RESPONSE="${WORK_DIR}/chat-stream.txt"
+
+python3 - "$HOST_MODEL_ID" "${WORK_DIR}/chat-payload.json" <<'PY'
+import json
+import sys
+
+model, path = sys.argv[1:3]
+payload = {
+    "model": model,
+    "messages": [
+        {"role": "system", "content": "You are a terse CI smoke probe."},
+        {"role": "user", "content": "Reply with one short sentence."},
+    ],
+    "stream": False,
+    "max_tokens": 16,
+    "temperature": 0,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PY
+
+curl -fsS --max-time 120 \
+    "http://127.0.0.1:${CLIENT_API_PORT}/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d @"${WORK_DIR}/chat-payload.json" \
+    -o "$CHAT_RESPONSE"
+
+python3 - "$CHAT_RESPONSE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    body = json.load(fh)
+if body.get("object") != "chat.completion":
+    raise SystemExit(f"unexpected chat object: {body.get('object')!r}")
+if not isinstance(body.get("id"), str) or not body["id"]:
+    raise SystemExit("chat response id was not a non-empty string")
+if not body.get("choices"):
+    raise SystemExit("chat response had no choices")
+print("Client-routed non-stream chat response validated")
+PY
+
+python3 - "$HOST_MODEL_ID" "${WORK_DIR}/stream-payload.json" <<'PY'
+import json
+import sys
+
+model, path = sys.argv[1:3]
+payload = {
+    "model": model,
+    "messages": [{"role": "user", "content": "Say ok."}],
+    "stream": True,
+    "max_tokens": 8,
+    "temperature": 0,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PY
+
+curl -fsS --max-time 120 \
+    "http://127.0.0.1:${CLIENT_API_PORT}/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d @"${WORK_DIR}/stream-payload.json" \
+    -o "$STREAM_RESPONSE"
+
+python3 - "$STREAM_RESPONSE" <<'PY'
+import json
+import sys
+
+top_ids = set()
+chunk_count = 0
+done = False
+for line in open(sys.argv[1], encoding="utf-8", errors="replace"):
+    line = line.strip()
+    if not line.startswith("data: "):
+        continue
+    data = line[6:]
+    if data == "[DONE]":
+        done = True
+        continue
+    body = json.loads(data)
+    if not isinstance(body.get("id"), str) or not body["id"]:
+        raise SystemExit("stream chunk id was not a non-empty string")
+    top_ids.add(body["id"])
+    chunk_count += 1
+
+if chunk_count == 0:
+    raise SystemExit("stream response had no chunks")
+if len(top_ids) != 1:
+    raise SystemExit(f"stream response used unstable top-level ids: {sorted(top_ids)}")
+if not done:
+    raise SystemExit("stream response did not finish with [DONE]")
+print("Client-routed streaming chat response validated")
+PY
+
+echo "Two-node client/serving smoke passed"


### PR DESCRIPTION
## Summary

This makes Mesh LLM a much stronger OpenAI-compatible target for agent harnesses. OpenCode, Pi, and Goose now have CI-backed validation that exercises real agent-shaped traffic: model listing, chat completions, streaming, tools, tool-result history, filesystem work, code edits, unit tests, hidden validation, and long-prompt soak behavior.

It also fixes the client-node routing bug that made passive-client OpenCode runs fail, normalizes streamed OpenAI tool-call IDs so OpenCode/AI SDK parsers accept our chunks, and fills more Responses API fields/events expected by current agent clients.

## What Introduced The Bugs

The passive-client routing regression was introduced by `42b818fa4` (`feat(protocol): cut over control-plane streams to protobuf v1`, 2026-03-31). That commit correctly added admission quarantine for non-gossip streams, including `STREAM_TUNNEL_HTTP`, but the existing on-demand HTTP tunnel path could dial a transitively learned host and immediately open a tunnel before gossip admission completed. Later Skippy/runtime work, especially `5454baac0` (`Replace llama-server with skippy runtime`, #422), preserved and exposed that path, making agent workloads through passive clients fail with `503` / `unexpected EOF`.

The OpenCode `AI_InvalidResponseDataError: Expected 'id' to be a string` issue came from the Skippy OpenAI chat-completions streaming path: streamed tool-call deltas could omit `delta.tool_calls[].id`, and later chunks could use unstable top-level completion IDs. That was made visible once agent tool-calling traffic moved through the Skippy runtime by default in #422.

## Changes

- Complete gossip and start stream dispatch for on-demand peer connections before opening mesh streams.
- Add a three-node regression for client -> bridge -> transitive host routing.
- Add OpenCode multi-turn coding smoke validation with filesystem reads, edits, test runs, hidden validation, and OpenAI surface capture.
- Normalize streamed chat-completion IDs and synthesize stable tool-call IDs when upstream chunks omit them.
- Fill conservative Responses API compatibility fields for `/v1/responses` non-stream and stream events.
- Emit fuller Responses stream events with `sequence_number`, output-item/content-part lifecycle events, text deltas, text done, and completed events.
- Declare Pi provider compatibility flags for Mesh (`supportsStore=false`, `supportsDeveloperRole=false`, `supportsUsageInStreaming=true`).
- Move agent live smokes into PR CI for OpenCode, Pi, and Goose when a live mesh endpoint is configured.
- Add a PR CI two-node client/serving-node smoke that validates `/v1/models`, non-stream chat, and streaming chat through the client node.
- Add long-prompt soak to the agent CI path, defaulting to a 65,536-character sentinel extraction probe and configurable with `AGENT_SMOKE_LONG_PROMPT_CHARS`.

## CI Behavior

PR CI now has two distinct agent lanes:

- `agent_live_smokes`: runs OpenCode, Pi, and Goose against `MESH_AGENT_BASE_URL` (or the legacy `MESH_OPENCODE_BASE_URL`) when configured. This lane uses a capable live model and includes the long-prompt soak.
- `two_node_client_serving_smoke`: always runs on Rust PR changes after the Linux build, using the cached small GGUF model to prove passive client -> serving node routing works without requiring a large coding model.

The long-prompt soak can be disabled or resized with `AGENT_SMOKE_LONG_PROMPT_CHARS=0` or another numeric value. Each long-prompt request has a default 180-second request timeout.

## Validation

- `just build`
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime mesh::tests::test_on_demand_transitive_peer_connection_completes_gossip -- --nocapture`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime mesh::tests::test_connect_to_peer_skips_known_peer_without_connection -- --nocapture`
- `cargo test -p openai-frontend --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime responses_stream --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime streaming_responses --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime integrations::tests::pi_provider_config --lib`
- `bash -n scripts/ci-opencode-smoke.sh scripts/ci-opencode-two-node-smoke.sh scripts/ci-agent-live-fixture-lib.sh scripts/ci-pi-smoke.sh scripts/ci-goose-smoke.sh scripts/ci-two-node-client-serving-smoke.sh`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

Live proof gathered during the investigation:

- Passive client path to `MiniMax-M2.5-Q4_K_M` changed from `503 all tunnel(s) failed` to `HTTP 200` with exact `ROUTE_OK`.
- OpenCode-through-client smoke passed with filesystem reads, edits, test runs, expected answers, and hidden implementation validation.
- Streaming chat-completions tool-call chunks now preserve one top-level completion ID and include string tool-call IDs.
  * Fresh PR CI on `8c9be90`: `two_node_client_serving_smoke` passed after `/v1/models`, non-stream chat, and streaming chat validation through the client node; full PR matrix passed with live agent smokes skipped because no live mesh endpoint secrets were configured.
