### PR TITLE
Prefer package-ready peers when planning Skippy splits

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/deployment.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/deployment.rs
@@ -235,6 +235,7 @@ mod tests {
                 node_id: make_id(1),
                 layer_start: 4,
                 layer_end: 8,
+                parameter_bytes: 50,
             },
             None,
         );
@@ -258,6 +259,7 @@ mod tests {
                 node_id: make_id(0),
                 layer_start: 0,
                 layer_end: 4,
+                parameter_bytes: 50,
             },
             &MeshStagePlan {
                 stage_id: "stage-1".to_string(),
@@ -265,6 +267,7 @@ mod tests {
                 node_id: make_id(1),
                 layer_start: 4,
                 layer_end: 8,
+                parameter_bytes: 50,
             },
             "127.0.0.1:9001".to_string(),
             None,

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -49,6 +49,7 @@ pub(crate) use stage::{
     StagePrepareAcceptedResponse, StagePrepareRequest, StageReadyResponse, StageRuntimeState,
     StageStatusAck, StageStatusFilter, StageStatusSnapshot, StageStopRequest, StageWireDType,
 };
+pub(crate) use topology::{plan_package_identity_topology, StageTopologyParticipant};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum SkippyModelState {

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/topology.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/topology.rs
@@ -2,8 +2,9 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, bail, Result};
 use skippy_topology::{
-    infer_family_capability, plan_weighted_contiguous, BoundaryDecision, DiagnosticSeverity,
-    LayerSpec, NodeSpec, PlannerPolicy, TopologyPlanRequest,
+    infer_family_capability, plan_package_aware_contiguous_with_signals, BoundaryDecision,
+    DiagnosticSeverity, LayerSpec, NodePlacementSignal, NodeSpec, PlannerPolicy,
+    TopologyPlanRequest,
 };
 
 use super::materialization::StagePackageInfo;
@@ -12,6 +13,11 @@ use super::materialization::StagePackageInfo;
 pub(crate) struct StageTopologyParticipant {
     pub(crate) node_id: iroh::EndpointId,
     pub(crate) vram_bytes: u64,
+    pub(crate) cached_slice_bytes: u64,
+    pub(crate) missing_artifact_bytes: u64,
+    pub(crate) rtt_ms: Option<u32>,
+    pub(crate) artifact_transfer_supported: bool,
+    pub(crate) availability_score: u32,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -60,14 +66,25 @@ pub(crate) fn plan_package_topology(
             .iter()
             .map(|participant| NodeSpec {
                 node_id: participant.node_id.to_string(),
-                cached_slice_bytes: 0,
+                cached_slice_bytes: participant.cached_slice_bytes,
                 vram_bytes: participant.vram_bytes,
             })
             .collect(),
         family,
         policy: PlannerPolicy::default(),
     };
-    let plan = plan_weighted_contiguous(&request)?;
+    let placement_signals = participants
+        .iter()
+        .map(|participant| NodePlacementSignal {
+            node_id: participant.node_id.to_string(),
+            cached_slice_bytes: participant.cached_slice_bytes,
+            missing_artifact_bytes: participant.missing_artifact_bytes,
+            rtt_ms: participant.rtt_ms,
+            artifact_transfer_supported: participant.artifact_transfer_supported,
+            availability_score: participant.availability_score,
+        })
+        .collect::<Vec<_>>();
+    let plan = plan_package_aware_contiguous_with_signals(&request, &placement_signals)?;
 
     let rejected = plan
         .boundaries
@@ -165,6 +182,18 @@ mod tests {
         SecretKey::from_bytes(&bytes).public()
     }
 
+    fn participant(node_id: iroh::EndpointId, vram_bytes: u64) -> StageTopologyParticipant {
+        StageTopologyParticipant {
+            node_id,
+            vram_bytes,
+            cached_slice_bytes: 0,
+            missing_artifact_bytes: 0,
+            rtt_ms: None,
+            artifact_transfer_supported: false,
+            availability_score: 0,
+        }
+    }
+
     fn package(layer_count: u32) -> StagePackageInfo {
         StagePackageInfo {
             package_ref: "hf://Mesh-LLM/demo-package".to_string(),
@@ -198,18 +227,9 @@ mod tests {
             "topology-a",
             &package(12),
             &[
-                StageTopologyParticipant {
-                    node_id: id_a,
-                    vram_bytes: 60,
-                },
-                StageTopologyParticipant {
-                    node_id: id_b,
-                    vram_bytes: 30,
-                },
-                StageTopologyParticipant {
-                    node_id: id_c,
-                    vram_bytes: 30,
-                },
+                participant(id_a, 60),
+                participant(id_b, 30),
+                participant(id_c, 30),
             ],
         )
         .unwrap();
@@ -251,18 +271,9 @@ mod tests {
             "topology-a",
             &package(2),
             &[
-                StageTopologyParticipant {
-                    node_id: id_a,
-                    vram_bytes: 10,
-                },
-                StageTopologyParticipant {
-                    node_id: id_b,
-                    vram_bytes: 10,
-                },
-                StageTopologyParticipant {
-                    node_id: id_c,
-                    vram_bytes: 10,
-                },
+                participant(id_a, 10),
+                participant(id_b, 10),
+                participant(id_c, 10),
             ],
         )
         .unwrap();
@@ -288,5 +299,27 @@ mod tests {
             .stages
             .iter()
             .all(|stage| stage.layer_start < stage.layer_end));
+    }
+
+    #[test]
+    fn topology_adapter_prefers_cached_peer_for_equal_capacity() {
+        let id_a = make_id(1);
+        let id_b = make_id(2);
+
+        let mut cold = participant(id_a, 40);
+        cold.missing_artifact_bytes = 32;
+        let mut warm = participant(id_b, 40);
+        warm.cached_slice_bytes = 64;
+        warm.artifact_transfer_supported = true;
+
+        let plan = plan_package_topology("topology-a", &package(8), &[cold, warm]).unwrap();
+
+        assert_eq!(plan.stages.len(), 2);
+        assert_eq!(plan.stages[0].node_id, id_b);
+        assert_eq!(
+            (plan.stages[0].layer_start, plan.stages[0].layer_end),
+            (0, 4)
+        );
+        assert_eq!(plan.stages[1].node_id, id_a);
     }
 }

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/topology.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/topology.rs
@@ -7,7 +7,7 @@ use skippy_topology::{
     TopologyPlanRequest,
 };
 
-use super::materialization::StagePackageInfo;
+use super::{materialization::StagePackageInfo, package::SkippyPackageIdentity};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct StageTopologyParticipant {
@@ -27,6 +27,7 @@ pub(crate) struct MeshStagePlan {
     pub(crate) node_id: iroh::EndpointId,
     pub(crate) layer_start: u32,
     pub(crate) layer_end: u32,
+    pub(crate) parameter_bytes: u64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -124,6 +125,7 @@ pub(crate) fn plan_package_topology(
                 node_id,
                 layer_start: stage.layer_start,
                 layer_end: stage.layer_end,
+                parameter_bytes: stage.parameter_bytes,
             })
         })
         .collect::<Result<Vec<_>>>()?;
@@ -138,6 +140,33 @@ pub(crate) fn plan_package_topology(
             .map(|diagnostic| diagnostic.message)
             .collect(),
     })
+}
+
+pub(crate) fn plan_package_identity_topology(
+    topology_id: &str,
+    model_id: &str,
+    package: &SkippyPackageIdentity,
+    participants: &[StageTopologyParticipant],
+) -> Result<MeshTopologyPlan> {
+    let package_dir = package
+        .source_model_path
+        .parent()
+        .map(ToOwned::to_owned)
+        .unwrap_or_default();
+    let package = StagePackageInfo {
+        package_ref: package.package_ref.clone(),
+        package_dir,
+        manifest_sha256: package.manifest_sha256.clone(),
+        model_id: model_id.to_string(),
+        source_model_path: package.source_model_path.to_string_lossy().to_string(),
+        source_model_sha256: package.source_model_sha256.clone(),
+        source_model_bytes: Some(package.source_model_bytes),
+        layer_count: package.layer_count,
+        activation_width: package.activation_width,
+        projector_path: None,
+        layers: Vec::new(),
+    };
+    plan_package_topology(topology_id, &package, participants)
 }
 
 fn layer_specs(package: &StagePackageInfo) -> Vec<LayerSpec> {

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -12,7 +12,7 @@ use crate::runtime_data::{
 use anyhow::{Context, Result};
 use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig};
 use skippy_topology::{
-    infer_family_capability, plan_weighted_contiguous, BoundaryDecision, DiagnosticSeverity,
+    infer_family_capability, plan_package_aware_contiguous, BoundaryDecision, DiagnosticSeverity,
     LayerSpec, NodeSpec, PlannerPolicy, TopologyPlanRequest,
 };
 use std::collections::HashMap;
@@ -1736,7 +1736,7 @@ fn plan_runtime_slice_topology(
         layer_count = package.layer_count,
         "planning split runtime topology"
     );
-    let plan = plan_weighted_contiguous(&request)?;
+    let plan = plan_package_aware_contiguous(&request)?;
     let rejected = plan
         .boundaries
         .iter()

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -11,10 +11,6 @@ use crate::runtime_data::{
 };
 use anyhow::{Context, Result};
 use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig};
-use skippy_topology::{
-    infer_family_capability, plan_package_aware_contiguous, BoundaryDecision, DiagnosticSeverity,
-    LayerSpec, NodeSpec, PlannerPolicy, TopologyPlanRequest,
-};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -568,6 +564,78 @@ struct SplitParticipant {
     node_id: iroh::EndpointId,
     vram_bytes: u64,
     first_joined_mesh_ts: Option<u64>,
+    cached_slice_bytes: u64,
+    missing_artifact_bytes: u64,
+    rtt_ms: Option<u32>,
+    artifact_transfer_supported: bool,
+    availability_score: u32,
+}
+
+impl SplitParticipant {
+    fn new(node_id: iroh::EndpointId, vram_bytes: u64, first_joined_mesh_ts: Option<u64>) -> Self {
+        Self {
+            node_id,
+            vram_bytes,
+            first_joined_mesh_ts,
+            cached_slice_bytes: 0,
+            missing_artifact_bytes: 0,
+            rtt_ms: None,
+            artifact_transfer_supported: false,
+            availability_score: 0,
+        }
+    }
+
+    fn local_package(
+        node_id: iroh::EndpointId,
+        vram_bytes: u64,
+        first_joined_mesh_ts: Option<u64>,
+        package: &skippy::SkippyPackageIdentity,
+    ) -> Self {
+        let mut participant = Self::new(node_id, vram_bytes, first_joined_mesh_ts);
+        participant.cached_slice_bytes = package.source_model_bytes;
+        participant.artifact_transfer_supported = true;
+        participant.availability_score = package.layer_count;
+        participant
+    }
+
+    fn with_package_signals(
+        mut self,
+        signal: SplitParticipantPackageSignal,
+        rtt_ms: Option<u32>,
+        artifact_transfer_supported: bool,
+    ) -> Self {
+        self.cached_slice_bytes = signal.cached_slice_bytes;
+        self.missing_artifact_bytes = signal.missing_artifact_bytes;
+        self.availability_score = signal.availability_score;
+        self.rtt_ms = rtt_ms;
+        self.artifact_transfer_supported = artifact_transfer_supported;
+        self
+    }
+
+    fn to_topology_participant(self) -> skippy::StageTopologyParticipant {
+        skippy::StageTopologyParticipant {
+            node_id: self.node_id,
+            vram_bytes: self.vram_bytes,
+            cached_slice_bytes: self.cached_slice_bytes,
+            missing_artifact_bytes: self.missing_artifact_bytes,
+            rtt_ms: self.rtt_ms,
+            artifact_transfer_supported: self.artifact_transfer_supported,
+            availability_score: self.availability_score,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SplitParticipantPackageSignal {
+    cached_slice_bytes: u64,
+    missing_artifact_bytes: u64,
+    availability_score: u32,
+}
+
+impl SplitParticipantPackageSignal {
+    fn can_stage_with(self, artifact_transfer_supported: bool) -> bool {
+        self.missing_artifact_bytes == 0 || artifact_transfer_supported
+    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1490,6 +1558,8 @@ fn split_stage_balance_score(stages: &[RuntimeSliceStagePlan]) -> u32 {
     max.saturating_sub(min)
 }
 
+type SplitParticipantSignature = Vec<(String, u64, u64, u64, Option<u32>, bool, u32)>;
+
 async fn wait_for_split_participants(
     node: &mesh::Node,
     model_name: &str,
@@ -1501,7 +1571,7 @@ async fn wait_for_split_participants(
     let deadline = tokio::time::Instant::now() + timeout;
     let mut best: Vec<SplitParticipant> = Vec::new();
     let mut best_excluded: Vec<SplitParticipantExclusion> = Vec::new();
-    let mut last_signature: Vec<(String, u64)> = Vec::new();
+    let mut last_signature: SplitParticipantSignature = Vec::new();
     let mut stable_since = tokio::time::Instant::now();
     loop {
         let snapshot =
@@ -1565,11 +1635,12 @@ async fn collect_split_participants(
     package: &skippy::SkippyPackageIdentity,
     local_vram_override: Option<u64>,
 ) -> SplitParticipantSnapshot {
-    let mut participants = vec![SplitParticipant {
-        node_id: node.id(),
-        vram_bytes: local_vram_override.unwrap_or_else(|| node.vram_bytes()),
-        first_joined_mesh_ts: Some(node.first_joined_mesh_ts().await.unwrap_or(0)),
-    }];
+    let mut participants = vec![SplitParticipant::local_package(
+        node.id(),
+        local_vram_override.unwrap_or_else(|| node.vram_bytes()),
+        Some(node.first_joined_mesh_ts().await.unwrap_or(0)),
+        package,
+    )];
     let mut excluded = Vec::new();
     for peer in node.peers().await {
         if matches!(peer.role, NodeRole::Client) {
@@ -1608,12 +1679,24 @@ async fn collect_split_participants(
             continue;
         }
 
-        if split_peer_source_available(node, peer.id, model_ref, package).await {
-            participants.push(SplitParticipant {
-                node_id: peer.id,
-                vram_bytes: peer.vram_bytes,
-                first_joined_mesh_ts: peer.first_joined_mesh_ts,
-            });
+        if let Some(package_signal) =
+            split_peer_package_signal(node, peer.id, model_ref, package).await
+        {
+            if package_signal.can_stage_with(peer.artifact_transfer_supported) {
+                participants.push(
+                    SplitParticipant::new(peer.id, peer.vram_bytes, peer.first_joined_mesh_ts)
+                        .with_package_signals(
+                            package_signal,
+                            peer.rtt_ms,
+                            peer.artifact_transfer_supported,
+                        ),
+                );
+            } else {
+                excluded.push(SplitParticipantExclusion {
+                    node_id: peer.id,
+                    reason: SplitParticipantExclusionReason::MissingModelSource,
+                });
+            }
         } else {
             excluded.push(SplitParticipantExclusion {
                 node_id: peer.id,
@@ -1631,12 +1714,12 @@ async fn collect_split_participants(
     }
 }
 
-async fn split_peer_source_available(
+async fn split_peer_package_signal(
     node: &mesh::Node,
     peer_id: iroh::EndpointId,
     model_ref: &str,
     package: &skippy::SkippyPackageIdentity,
-) -> bool {
+) -> Option<SplitParticipantPackageSignal> {
     let request = skippy::StageInventoryRequest {
         model_id: model_ref.to_string(),
         package_ref: package.package_ref.clone(),
@@ -1646,19 +1729,107 @@ async fn split_peer_source_available(
         .send_stage_control(peer_id, skippy::StageControlRequest::Inventory(request))
         .await;
     let Ok(skippy::StageControlResponse::Inventory(inventory)) = result else {
-        return false;
+        return None;
     };
-    inventory
-        .available_ranges
-        .iter()
-        .chain(inventory.ready_ranges.iter())
-        .any(|range| range.layer_start == 0 && range.layer_end >= package.layer_count)
+    Some(split_inventory_package_signal(&inventory, package))
 }
 
-fn split_participant_signature(participants: &[SplitParticipant]) -> Vec<(String, u64)> {
+fn split_inventory_package_signal(
+    inventory: &skippy::StageLayerInventory,
+    package: &skippy::SkippyPackageIdentity,
+) -> SplitParticipantPackageSignal {
+    let cached_slice_bytes = split_inventory_range_bytes(
+        inventory
+            .available_ranges
+            .iter()
+            .chain(inventory.ready_ranges.iter()),
+        package,
+    );
+    let explicit_missing_bytes =
+        split_inventory_range_bytes(inventory.missing_ranges.iter(), package);
+    let missing_artifact_bytes = if explicit_missing_bytes > 0 {
+        explicit_missing_bytes
+    } else if cached_slice_bytes >= package.source_model_bytes {
+        0
+    } else if inventory.layer_count == 0 && cached_slice_bytes == 0 {
+        package.source_model_bytes
+    } else {
+        package
+            .source_model_bytes
+            .saturating_sub(cached_slice_bytes)
+    };
+    SplitParticipantPackageSignal {
+        cached_slice_bytes,
+        missing_artifact_bytes,
+        availability_score: split_inventory_covered_layers(
+            inventory
+                .available_ranges
+                .iter()
+                .chain(inventory.ready_ranges.iter()),
+            package.layer_count,
+        ),
+    }
+}
+
+fn split_inventory_range_bytes<'a>(
+    ranges: impl Iterator<Item = &'a skippy::LayerRange>,
+    package: &skippy::SkippyPackageIdentity,
+) -> u64 {
+    if package.layer_count == 0 || package.source_model_bytes == 0 {
+        return 0;
+    }
+    let covered_layers = u128::from(split_inventory_covered_layers(ranges, package.layer_count));
+    let layer_count = u128::from(package.layer_count);
+    let bytes = u128::from(package.source_model_bytes).saturating_mul(covered_layers) / layer_count;
+    bytes.min(u128::from(package.source_model_bytes)) as u64
+}
+
+fn split_inventory_covered_layers<'a>(
+    ranges: impl Iterator<Item = &'a skippy::LayerRange>,
+    layer_count: u32,
+) -> u32 {
+    let mut ranges = ranges
+        .filter_map(|range| {
+            let start = range.layer_start.min(layer_count);
+            let end = range.layer_end.min(layer_count);
+            (start < end).then_some((start, end))
+        })
+        .collect::<Vec<_>>();
+    ranges.sort_unstable();
+    let mut covered = 0u32;
+    let mut current: Option<(u32, u32)> = None;
+    for (start, end) in ranges {
+        match current {
+            Some((current_start, current_end)) if start <= current_end => {
+                current = Some((current_start, current_end.max(end)));
+            }
+            Some((current_start, current_end)) => {
+                covered = covered.saturating_add(current_end.saturating_sub(current_start));
+                current = Some((start, end));
+            }
+            None => current = Some((start, end)),
+        }
+    }
+    if let Some((start, end)) = current {
+        covered = covered.saturating_add(end.saturating_sub(start));
+    }
+    covered
+}
+
+fn split_participant_signature(participants: &[SplitParticipant]) -> SplitParticipantSignature {
     participants
         .iter()
-        .map(|participant| (participant.node_id.to_string(), participant.vram_bytes))
+        .map(|participant| {
+            (
+                participant.node_id.to_string(),
+                participant.vram_bytes,
+                participant.cached_slice_bytes,
+                participant.missing_artifact_bytes,
+                participant.rtt_ms,
+                participant.artifact_transfer_supported,
+                participant.availability_score,
+            )
+        })
         .collect()
 }
 
@@ -1667,9 +1838,13 @@ fn split_participant_labels(participants: &[SplitParticipant]) -> Vec<String> {
         .iter()
         .map(|participant| {
             format!(
-                "{}:{}GB",
+                "{}:{}GB cached={}GB missing={}GB rtt={}ms transfer={}",
                 participant.node_id.fmt_short(),
-                participant.vram_bytes / 1_000_000_000
+                participant.vram_bytes / 1_000_000_000,
+                participant.cached_slice_bytes / 1_000_000_000,
+                participant.missing_artifact_bytes / 1_000_000_000,
+                participant.rtt_ms.unwrap_or_default(),
+                participant.artifact_transfer_supported
             )
         })
         .collect()
@@ -1701,34 +1876,6 @@ fn plan_runtime_slice_topology(
     package: &skippy::SkippyPackageIdentity,
     participants: &[SplitParticipant],
 ) -> Result<Vec<RuntimeSliceStagePlan>> {
-    let node_by_id = participants
-        .iter()
-        .map(|participant| (participant.node_id.to_string(), participant.node_id))
-        .collect::<HashMap<_, _>>();
-    let fallback_layer_bytes = package.source_model_bytes / u64::from(package.layer_count.max(1));
-    let layers = (0..package.layer_count)
-        .map(|index| LayerSpec {
-            index,
-            attention: true,
-            recurrent: false,
-            parameter_bytes: fallback_layer_bytes,
-        })
-        .collect();
-    let request = TopologyPlanRequest {
-        topology_id: topology_id.to_string(),
-        model_id: model_ref.to_string(),
-        layers,
-        nodes: participants
-            .iter()
-            .map(|participant| NodeSpec {
-                node_id: participant.node_id.to_string(),
-                cached_slice_bytes: 0,
-                vram_bytes: participant.vram_bytes,
-            })
-            .collect(),
-        family: infer_family_capability(model_ref, package.layer_count, package.activation_width),
-        policy: PlannerPolicy::default(),
-    };
     tracing::info!(
         topology_id,
         model_ref,
@@ -1736,48 +1883,37 @@ fn plan_runtime_slice_topology(
         layer_count = package.layer_count,
         "planning split runtime topology"
     );
-    let plan = plan_package_aware_contiguous(&request)?;
-    let rejected = plan
-        .boundaries
+    let topology_participants = participants
         .iter()
-        .filter(|boundary| boundary.decision == BoundaryDecision::Rejected)
-        .map(|boundary| {
-            format!(
-                "rejected boundary at layer {}: {}",
-                boundary.layer_boundary,
-                boundary.messages.join("; ")
-            )
-        })
+        .copied()
+        .map(SplitParticipant::to_topology_participant)
         .collect::<Vec<_>>();
-    if !rejected.is_empty() {
-        anyhow::bail!("{}", rejected.join("; "));
-    }
-    let errors = plan
-        .diagnostics
-        .iter()
-        .filter(|diagnostic| diagnostic.severity == DiagnosticSeverity::Error)
-        .map(|diagnostic| diagnostic.message.clone())
-        .collect::<Vec<_>>();
-    if !errors.is_empty() {
-        anyhow::bail!("{}", errors.join("; "));
+    let plan = skippy::plan_package_identity_topology(
+        topology_id,
+        model_ref,
+        package,
+        &topology_participants,
+    )?;
+    if !plan.diagnostics.is_empty() {
+        tracing::debug!(
+            topology_id,
+            model_ref,
+            diagnostics = ?plan.diagnostics,
+            "package-aware split topology planner emitted diagnostics"
+        );
     }
     let mut stages = plan
         .stages
         .into_iter()
-        .map(|stage| {
-            let node_id = node_by_id.get(&stage.node_id).copied().with_context(|| {
-                format!("topology planner returned unknown node {}", stage.node_id)
-            })?;
-            Ok(RuntimeSliceStagePlan {
-                stage_id: stage.stage_id,
-                stage_index: stage.stage_index,
-                node_id,
-                layer_start: stage.layer_start,
-                layer_end: stage.layer_end,
-                parameter_bytes: stage.parameter_bytes,
-            })
+        .map(|stage| RuntimeSliceStagePlan {
+            stage_id: stage.stage_id,
+            stage_index: stage.stage_index,
+            node_id: stage.node_id,
+            layer_start: stage.layer_start,
+            layer_end: stage.layer_end,
+            parameter_bytes: stage.parameter_bytes,
         })
-        .collect::<Result<Vec<_>>>()?;
+        .collect::<Vec<_>>();
     stages.sort_by_key(|stage| stage.stage_index);
     validate_split_capacity(model_ref, package, participants, &stages)?;
     tracing::info!(
@@ -2401,11 +2537,7 @@ mod tests {
     }
 
     fn participant(seed: u8) -> SplitParticipant {
-        SplitParticipant {
-            node_id: make_id(seed),
-            vram_bytes: 24_000_000_000,
-            first_joined_mesh_ts: None,
-        }
+        SplitParticipant::new(make_id(seed), 24_000_000_000, None)
     }
 
     fn stage(
@@ -2576,26 +2708,10 @@ mod tests {
     #[test]
     fn split_topology_planner_uses_all_eligible_participants() {
         let participants = vec![
-            SplitParticipant {
-                node_id: make_id(1),
-                vram_bytes: 16_000_000_000,
-                first_joined_mesh_ts: None,
-            },
-            SplitParticipant {
-                node_id: make_id(2),
-                vram_bytes: 24_000_000_000,
-                first_joined_mesh_ts: None,
-            },
-            SplitParticipant {
-                node_id: make_id(3),
-                vram_bytes: 32_000_000_000,
-                first_joined_mesh_ts: None,
-            },
-            SplitParticipant {
-                node_id: make_id(4),
-                vram_bytes: 48_000_000_000,
-                first_joined_mesh_ts: None,
-            },
+            SplitParticipant::new(make_id(1), 16_000_000_000, None),
+            SplitParticipant::new(make_id(2), 24_000_000_000, None),
+            SplitParticipant::new(make_id(3), 32_000_000_000, None),
+            SplitParticipant::new(make_id(4), 48_000_000_000, None),
         ];
 
         let stages = plan_runtime_slice_topology(
@@ -2618,6 +2734,117 @@ mod tests {
         );
         assert_eq!(stages.first().unwrap().layer_start, 0);
         assert_eq!(stages.last().unwrap().layer_end, 40);
+    }
+
+    #[test]
+    fn split_topology_planner_prefers_cached_participant_in_runtime_path() {
+        let cold = SplitParticipant::new(make_id(1), 24_000_000_000, None).with_package_signals(
+            SplitParticipantPackageSignal {
+                cached_slice_bytes: 0,
+                missing_artifact_bytes: 40_000_000,
+                availability_score: 0,
+            },
+            Some(80),
+            true,
+        );
+        let warm = SplitParticipant::new(make_id(2), 24_000_000_000, None).with_package_signals(
+            SplitParticipantPackageSignal {
+                cached_slice_bytes: 40_000_000,
+                missing_artifact_bytes: 0,
+                availability_score: 40,
+            },
+            Some(5),
+            true,
+        );
+
+        let stages = plan_runtime_slice_topology(
+            "topology-test",
+            "unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL",
+            &package(40),
+            &[cold, warm],
+        )
+        .expect("package-aware topology plan");
+
+        assert_eq!(stages.len(), 2);
+        assert_eq!(stages[0].node_id, make_id(2));
+        assert_eq!((stages[0].layer_start, stages[0].layer_end), (0, 20));
+    }
+
+    #[test]
+    fn split_inventory_package_signal_counts_cached_and_missing_ranges() {
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        let inventory = skippy::StageLayerInventory {
+            model_id: "model-a".to_string(),
+            package_ref: package.package_ref.clone(),
+            manifest_sha256: package.manifest_sha256.clone(),
+            layer_count: 10,
+            ready_ranges: vec![skippy::LayerRange {
+                layer_start: 4,
+                layer_end: 6,
+            }],
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 4,
+            }],
+            missing_ranges: vec![skippy::LayerRange {
+                layer_start: 6,
+                layer_end: 10,
+            }],
+            preparing_ranges: Vec::new(),
+            source_model_path: None,
+            source_model_bytes: None,
+            source_model_kind: skippy::SourceModelKind::LayerPackage,
+        };
+
+        let signal = split_inventory_package_signal(&inventory, &package);
+
+        assert_eq!(
+            signal,
+            SplitParticipantPackageSignal {
+                cached_slice_bytes: 600,
+                missing_artifact_bytes: 400,
+                availability_score: 6,
+            }
+        );
+        assert!(signal.can_stage_with(true));
+        assert!(!signal.can_stage_with(false));
+    }
+
+    #[test]
+    fn split_inventory_package_signal_treats_unknown_inventory_as_missing_package() {
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        let inventory = skippy::StageLayerInventory {
+            model_id: "model-a".to_string(),
+            package_ref: package.package_ref.clone(),
+            manifest_sha256: package.manifest_sha256.clone(),
+            layer_count: 0,
+            ready_ranges: Vec::new(),
+            available_ranges: Vec::new(),
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: None,
+            source_model_bytes: None,
+            source_model_kind: skippy::SourceModelKind::Unknown,
+        };
+
+        let signal = split_inventory_package_signal(&inventory, &package);
+
+        assert_eq!(
+            signal,
+            SplitParticipantPackageSignal {
+                cached_slice_bytes: 0,
+                missing_artifact_bytes: 1_000,
+                availability_score: 0,
+            }
+        );
     }
 
     #[test]
@@ -2667,16 +2894,8 @@ mod tests {
     #[test]
     fn split_topology_planner_accepts_constrained_nodes_with_enough_aggregate_capacity() {
         let participants = vec![
-            SplitParticipant {
-                node_id: make_id(1),
-                vram_bytes: 3_000_000_000,
-                first_joined_mesh_ts: None,
-            },
-            SplitParticipant {
-                node_id: make_id(2),
-                vram_bytes: 3_000_000_000,
-                first_joined_mesh_ts: None,
-            },
+            SplitParticipant::new(make_id(1), 3_000_000_000, None),
+            SplitParticipant::new(make_id(2), 3_000_000_000, None),
         ];
         let package = skippy::SkippyPackageIdentity {
             source_model_bytes: 4_800_000_000,
@@ -2705,16 +2924,8 @@ mod tests {
     #[test]
     fn split_topology_planner_rejects_insufficient_aggregate_capacity() {
         let participants = vec![
-            SplitParticipant {
-                node_id: make_id(1),
-                vram_bytes: 2_000_000_000,
-                first_joined_mesh_ts: None,
-            },
-            SplitParticipant {
-                node_id: make_id(2),
-                vram_bytes: 2_000_000_000,
-                first_joined_mesh_ts: None,
-            },
+            SplitParticipant::new(make_id(1), 2_000_000_000, None),
+            SplitParticipant::new(make_id(2), 2_000_000_000, None),
         ];
         let package = skippy::SkippyPackageIdentity {
             source_model_bytes: 4_800_000_000,
@@ -2739,16 +2950,8 @@ mod tests {
     #[test]
     fn split_topology_planner_rejects_stage_that_exceeds_participant_capacity() {
         let participants = vec![
-            SplitParticipant {
-                node_id: make_id(1),
-                vram_bytes: 900,
-                first_joined_mesh_ts: None,
-            },
-            SplitParticipant {
-                node_id: make_id(2),
-                vram_bytes: 200,
-                first_joined_mesh_ts: None,
-            },
+            SplitParticipant::new(make_id(1), 900, None),
+            SplitParticipant::new(make_id(2), 200, None),
         ];
         let package = skippy::SkippyPackageIdentity {
             source_model_bytes: 1_000,
@@ -2799,16 +3002,29 @@ mod tests {
     #[test]
     fn split_participant_signature_includes_vram_for_stability() {
         let node_id = make_id(9);
-        let first = vec![SplitParticipant {
-            node_id,
-            vram_bytes: 16_000_000_000,
-            first_joined_mesh_ts: None,
-        }];
-        let second = vec![SplitParticipant {
-            node_id,
-            vram_bytes: 24_000_000_000,
-            first_joined_mesh_ts: None,
-        }];
+        let first = vec![SplitParticipant::new(node_id, 16_000_000_000, None)];
+        let second = vec![SplitParticipant::new(node_id, 24_000_000_000, None)];
+
+        assert_ne!(
+            split_participant_signature(&first),
+            split_participant_signature(&second)
+        );
+    }
+
+    #[test]
+    fn split_participant_signature_includes_package_signals_for_stability() {
+        let node_id = make_id(9);
+        let first = vec![SplitParticipant::new(node_id, 24_000_000_000, None)];
+        let second = vec![SplitParticipant::new(node_id, 24_000_000_000, None)
+            .with_package_signals(
+                SplitParticipantPackageSignal {
+                    cached_slice_bytes: 12_000_000,
+                    missing_artifact_bytes: 0,
+                    availability_score: 12,
+                },
+                Some(20),
+                true,
+            )];
 
         assert_ne!(
             split_participant_signature(&first),
@@ -2898,11 +3114,7 @@ mod tests {
             "candidate-topology".into(),
             "candidate-run".into(),
             2,
-            vec![SplitParticipant {
-                node_id: local_id,
-                vram_bytes: 24_000_000_000,
-                first_joined_mesh_ts: None,
-            }],
+            vec![SplitParticipant::new(local_id, 24_000_000_000, None)],
             vec![
                 local_stage(local_id, 0, 0, 12),
                 local_stage(local_id, 1, 12, 24),
@@ -2967,11 +3179,7 @@ mod tests {
 
     #[test]
     fn split_replan_decision_accepts_more_stage_capacity() {
-        let participants = vec![SplitParticipant {
-            node_id: make_id(1),
-            vram_bytes: 16_000_000_000,
-            first_joined_mesh_ts: None,
-        }];
+        let participants = vec![SplitParticipant::new(make_id(1), 16_000_000_000, None)];
         let active = SplitTopologyGeneration::new(
             "topology-a".into(),
             "run-a".into(),
@@ -3027,11 +3235,7 @@ mod tests {
             layer_end: 40,
             parameter_bytes: 40_000_000,
         }];
-        let participants = vec![SplitParticipant {
-            node_id: make_id(1),
-            vram_bytes: 16_000_000_000,
-            first_joined_mesh_ts: None,
-        }];
+        let participants = vec![SplitParticipant::new(make_id(1), 16_000_000_000, None)];
         let active = SplitTopologyGeneration::new(
             "topology-a".into(),
             "run-a".into(),

--- a/crates/skippy-topology/src/lib.rs
+++ b/crates/skippy-topology/src/lib.rs
@@ -32,6 +32,21 @@ pub struct NodeSpec {
     pub vram_bytes: u64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct NodePlacementSignal {
+    pub node_id: String,
+    #[serde(default)]
+    pub cached_slice_bytes: u64,
+    #[serde(default)]
+    pub missing_artifact_bytes: u64,
+    #[serde(default)]
+    pub rtt_ms: Option<u32>,
+    #[serde(default)]
+    pub artifact_transfer_supported: bool,
+    #[serde(default)]
+    pub availability_score: u32,
+}
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub struct PlannerPolicy {
@@ -63,6 +78,12 @@ pub struct StagePlan {
     pub migration_policy: MigrationPolicy,
     #[serde(default)]
     pub reason_codes: Vec<PlanReasonCode>,
+    #[serde(default)]
+    pub cached_slice_bytes: u64,
+    #[serde(default)]
+    pub missing_artifact_bytes: u64,
+    #[serde(default)]
+    pub rtt_ms: Option<u32>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -136,6 +157,10 @@ pub enum PlanReasonCode {
     Q8WireRejected,
     ExactStateMobilityAccepted,
     ExactStateMobilityRejected,
+    CacheLocalityPreferred,
+    ArtifactTransferPenalty,
+    NetworkPipelineCost,
+    PeerAvailabilityPreferred,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -859,13 +884,31 @@ pub fn plan_even_contiguous(request: &TopologyPlanRequest) -> Result<TopologyPla
 }
 
 pub fn plan_weighted_contiguous(request: &TopologyPlanRequest) -> Result<TopologyPlan, PlanError> {
+    plan_weighted_contiguous_with_signals(request, &[])
+}
+
+fn plan_weighted_contiguous_with_signals(
+    request: &TopologyPlanRequest,
+    placement_signals: &[NodePlacementSignal],
+) -> Result<TopologyPlan, PlanError> {
     validate_request(request)?;
 
     let stage_count = request.nodes.len().min(request.layers.len());
     let nodes = &request.nodes[..stage_count];
     let total_weight: u64 = nodes.iter().map(|node| node.vram_bytes).sum();
     if total_weight == 0 {
-        return plan_even_contiguous(request);
+        let base = request.layers.len() / stage_count;
+        let remainder = request.layers.len() % stage_count;
+        let mut next_layer = 0usize;
+        let mut ranges = Vec::with_capacity(stage_count);
+
+        for stage_index in 0..stage_count {
+            let layer_count = base + usize::from(stage_index < remainder);
+            ranges.push((next_layer, next_layer + layer_count));
+            next_layer += layer_count;
+        }
+
+        return plan_ranges_with_signals(request, &ranges, placement_signals);
     }
 
     let mut ranges = Vec::with_capacity(stage_count);
@@ -886,7 +929,51 @@ pub fn plan_weighted_contiguous(request: &TopologyPlanRequest) -> Result<Topolog
         layer_start = layer_end;
     }
 
-    plan_ranges(request, &ranges)
+    plan_ranges_with_signals(request, &ranges, placement_signals)
+}
+
+pub fn plan_package_aware_contiguous(
+    request: &TopologyPlanRequest,
+) -> Result<TopologyPlan, PlanError> {
+    plan_package_aware_contiguous_with_signals(request, &[])
+}
+
+pub fn plan_package_aware_contiguous_with_signals(
+    request: &TopologyPlanRequest,
+    placement_signals: &[NodePlacementSignal],
+) -> Result<TopologyPlan, PlanError> {
+    validate_request(request)?;
+
+    if !request.nodes.iter().any(|node| node.cached_slice_bytes > 0)
+        && !placement_signals.iter().any(has_package_aware_signal)
+    {
+        return plan_weighted_contiguous(request);
+    }
+
+    let mut nodes = request
+        .nodes
+        .iter()
+        .cloned()
+        .enumerate()
+        .collect::<Vec<_>>();
+    nodes.sort_by(|(left_index, left), (right_index, right)| {
+        let left_signal = placement_signal_for(placement_signals, &left.node_id);
+        let right_signal = placement_signal_for(placement_signals, &right.node_id);
+        node_package_score(right, right_signal)
+            .cmp(&node_package_score(left, left_signal))
+            .then_with(|| left_index.cmp(right_index))
+            .then_with(|| left.node_id.cmp(&right.node_id))
+    });
+
+    let sorted_request = TopologyPlanRequest {
+        topology_id: request.topology_id.clone(),
+        model_id: request.model_id.clone(),
+        layers: request.layers.clone(),
+        nodes: nodes.into_iter().map(|(_, node)| node).collect(),
+        family: request.family.clone(),
+        policy: request.policy,
+    };
+    plan_weighted_contiguous_with_signals(&sorted_request, placement_signals)
 }
 
 pub fn plan_contiguous_with_splits(
@@ -951,6 +1038,14 @@ fn plan_ranges(
     request: &TopologyPlanRequest,
     ranges: &[(usize, usize)],
 ) -> Result<TopologyPlan, PlanError> {
+    plan_ranges_with_signals(request, ranges, &[])
+}
+
+fn plan_ranges_with_signals(
+    request: &TopologyPlanRequest,
+    ranges: &[(usize, usize)],
+    placement_signals: &[NodePlacementSignal],
+) -> Result<TopologyPlan, PlanError> {
     let mut stages = Vec::with_capacity(ranges.len());
 
     for (stage_index, &(start, end)) in ranges.iter().enumerate() {
@@ -960,9 +1055,12 @@ fn plan_ranges(
         let state_affinity = classify_layers_with_family(layers, request.family.as_ref());
         let migration_policy = migration_policy(state_affinity, request.policy);
         let parameter_bytes = layers.iter().map(|layer| layer.parameter_bytes).sum();
-        let node_id = request.nodes[stage_index].node_id.clone();
-        let reason_codes =
+        let node = &request.nodes[stage_index];
+        let node_id = node.node_id.clone();
+        let placement_signal = placement_signal_for(placement_signals, &node_id);
+        let mut reason_codes =
             stage_reason_codes(state_affinity, migration_policy, request.family.as_ref());
+        reason_codes.extend(node_reason_codes(node, placement_signal));
 
         stages.push(StagePlan {
             stage_id: format!("stage-{stage_index}"),
@@ -975,6 +1073,13 @@ fn plan_ranges(
             state_affinity,
             migration_policy,
             reason_codes,
+            cached_slice_bytes: placement_signal
+                .map(|signal| signal.cached_slice_bytes.max(node.cached_slice_bytes))
+                .unwrap_or(node.cached_slice_bytes),
+            missing_artifact_bytes: placement_signal
+                .map(|signal| signal.missing_artifact_bytes)
+                .unwrap_or_default(),
+            rtt_ms: placement_signal.and_then(|signal| signal.rtt_ms),
         });
     }
 
@@ -997,6 +1102,64 @@ fn plan_ranges(
         boundaries,
         diagnostics,
     })
+}
+
+fn placement_signal_for<'a>(
+    placement_signals: &'a [NodePlacementSignal],
+    node_id: &str,
+) -> Option<&'a NodePlacementSignal> {
+    placement_signals
+        .iter()
+        .find(|signal| signal.node_id == node_id)
+}
+
+fn has_package_aware_signal(signal: &NodePlacementSignal) -> bool {
+    signal.cached_slice_bytes > 0
+        || signal.missing_artifact_bytes > 0
+        || signal.rtt_ms.is_some()
+        || signal.artifact_transfer_supported
+        || signal.availability_score > 0
+}
+
+fn node_package_score(node: &NodeSpec, signal: Option<&NodePlacementSignal>) -> i128 {
+    let mut score = i128::from(node.vram_bytes);
+    let cached_slice_bytes = signal
+        .map(|signal| signal.cached_slice_bytes.max(node.cached_slice_bytes))
+        .unwrap_or(node.cached_slice_bytes);
+    score += i128::from(cached_slice_bytes).saturating_mul(2);
+    if let Some(signal) = signal {
+        score -= i128::from(signal.missing_artifact_bytes).saturating_mul(4);
+        if signal.missing_artifact_bytes > 0 && !signal.artifact_transfer_supported {
+            score -= i128::from(signal.missing_artifact_bytes).saturating_mul(4);
+        }
+        if let Some(rtt_ms) = signal.rtt_ms {
+            score -= i128::from(rtt_ms).saturating_mul(16 * 1024 * 1024);
+        }
+        score += i128::from(signal.availability_score).saturating_mul(1024 * 1024);
+    }
+    score
+}
+
+fn node_reason_codes(node: &NodeSpec, signal: Option<&NodePlacementSignal>) -> Vec<PlanReasonCode> {
+    let mut codes = Vec::new();
+    let cached_slice_bytes = signal
+        .map(|signal| signal.cached_slice_bytes.max(node.cached_slice_bytes))
+        .unwrap_or(node.cached_slice_bytes);
+    if cached_slice_bytes > 0 {
+        codes.push(PlanReasonCode::CacheLocalityPreferred);
+    }
+    if let Some(signal) = signal {
+        if signal.missing_artifact_bytes > 0 {
+            codes.push(PlanReasonCode::ArtifactTransferPenalty);
+        }
+        if signal.rtt_ms.is_some_and(|rtt| rtt > 0) {
+            codes.push(PlanReasonCode::NetworkPipelineCost);
+        }
+        if signal.availability_score > 0 {
+            codes.push(PlanReasonCode::PeerAvailabilityPreferred);
+        }
+    }
+    codes
 }
 
 pub fn classify_layers(layers: &[LayerSpec]) -> StateAffinity {

--- a/crates/skippy-topology/src/tests.rs
+++ b/crates/skippy-topology/src/tests.rs
@@ -23,6 +23,24 @@ fn weighted_node(node_id: &str, vram_bytes: u64) -> NodeSpec {
     }
 }
 
+fn placement_signal(node_id: &str) -> NodePlacementSignal {
+    NodePlacementSignal {
+        node_id: node_id.to_string(),
+        cached_slice_bytes: 0,
+        missing_artifact_bytes: 0,
+        rtt_ms: None,
+        artifact_transfer_supported: false,
+        availability_score: 0,
+    }
+}
+
+fn stage_layout(plan: &TopologyPlan) -> Vec<(&str, u32, u32)> {
+    plan.stages
+        .iter()
+        .map(|stage| (stage.node_id.as_str(), stage.layer_start, stage.layer_end))
+        .collect()
+}
+
 #[test]
 fn dense_attention_plan_allows_costed_kv_migration() {
     let request = TopologyPlanRequest {
@@ -94,6 +112,136 @@ fn weighted_contiguous_plan_falls_back_to_even_without_weights() {
             .collect::<Vec<_>>(),
         vec![("node-a", 0, 3), ("node-b", 3, 6)]
     );
+}
+
+#[test]
+fn package_aware_plan_matches_weighted_without_package_signals() {
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(12, 10),
+        nodes: vec![
+            weighted_node("node-a", 60),
+            weighted_node("node-b", 30),
+            weighted_node("node-c", 30),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let weighted_plan = plan_weighted_contiguous(&request).expect("weighted plan");
+    let package_plan =
+        plan_package_aware_contiguous_with_signals(&request, &[]).expect("package-aware plan");
+
+    assert_eq!(stage_layout(&package_plan), stage_layout(&weighted_plan));
+}
+
+#[test]
+fn package_aware_plan_prefers_cached_peer_for_equal_capacity() {
+    let mut cold = placement_signal("cold");
+    cold.missing_artifact_bytes = 32;
+    let mut warm = placement_signal("warm");
+    warm.cached_slice_bytes = 64;
+    warm.artifact_transfer_supported = true;
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(8, 10),
+        nodes: vec![weighted_node("cold", 40), weighted_node("warm", 40)],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_signals(&request, &[cold, warm]).expect("plan");
+
+    assert_eq!(stage_layout(&plan), vec![("warm", 0, 4), ("cold", 4, 8)]);
+    assert!(plan.stages[0]
+        .reason_codes
+        .contains(&PlanReasonCode::CacheLocalityPreferred));
+    assert!(plan.stages[1]
+        .reason_codes
+        .contains(&PlanReasonCode::ArtifactTransferPenalty));
+}
+
+#[test]
+fn package_aware_plan_penalizes_missing_untransferable_artifacts() {
+    let mut cold = placement_signal("cold-high-vram");
+    cold.missing_artifact_bytes = 64;
+    cold.artifact_transfer_supported = false;
+    let mut ready = placement_signal("ready-lower-vram");
+    ready.cached_slice_bytes = 16;
+    ready.artifact_transfer_supported = true;
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(8, 10),
+        nodes: vec![
+            weighted_node("cold-high-vram", 100),
+            weighted_node("ready-lower-vram", 80),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_signals(&request, &[cold, ready]).expect("plan");
+
+    assert_eq!(plan.stages[0].node_id, "ready-lower-vram");
+    assert!(plan.stages[1]
+        .reason_codes
+        .contains(&PlanReasonCode::ArtifactTransferPenalty));
+}
+
+#[test]
+fn package_aware_plan_treats_high_rtt_as_cost_not_exclusion() {
+    let mut distant = placement_signal("distant");
+    distant.rtt_ms = Some(250);
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(8, 10),
+        nodes: vec![weighted_node("distant", 100), weighted_node("nearby", 80)],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_signals(&request, &[distant]).expect("plan");
+
+    assert!(plan.stages.iter().any(|stage| stage.node_id == "distant"));
+    let distant_stage = plan
+        .stages
+        .iter()
+        .find(|stage| stage.node_id == "distant")
+        .expect("distant stage");
+    assert!(distant_stage
+        .reason_codes
+        .contains(&PlanReasonCode::NetworkPipelineCost));
+}
+
+#[test]
+fn package_aware_plan_can_promote_extra_cached_peer() {
+    let mut cached_extra = placement_signal("cached-extra");
+    cached_extra.cached_slice_bytes = 100;
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(2, 10),
+        nodes: vec![
+            weighted_node("cold-a", 40),
+            weighted_node("cold-b", 40),
+            weighted_node("cached-extra", 40),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_signals(&request, &[cached_extra]).expect("plan");
+
+    assert_eq!(plan.stages.len(), 2);
+    assert_eq!(plan.stages[0].node_id, "cached-extra");
+    assert!(plan
+        .stages
+        .iter()
+        .any(|stage| stage.node_id == "cold-a" || stage.node_id == "cold-b"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Skippy split planning can now account for layer-package readiness before assigning contiguous layer ranges. When peers have comparable capacity, the planner prefers nodes that already have the needed package bytes, penalizes missing or non-transferable artifacts, treats RTT as a cost instead of a hard exclusion, and preserves the existing weighted behavior when no package signals are available.

## Why
Recent Skippy package work makes layer artifacts a first-class part of distributed serving. Capacity-only planning can still choose a topology that looks balanced but causes avoidable package movement, startup delay, or a failed placement when a peer cannot fetch missing artifacts.

This keeps the existing capacity balancing model, but gives the planner enough optional locality and transfer signals to choose a more realistic split topology for package-backed Skippy runs.

## Diff scope
- Adds `NodePlacementSignal` to `skippy-topology` for optional cache-locality, missing-artifact, RTT, transfer-support, and availability inputs.
- Adds `plan_package_aware_contiguous` while keeping `plan_weighted_contiguous` as the no-signal compatibility path.
- Extends `StagePlan` with defaulted package-readiness metadata for cached bytes, missing bytes, and RTT.
- Wires the host-runtime Skippy topology adapter and local runtime planning through the package-aware planner.
- Adds focused tests for no-signal parity, cached peer preference, untransferable artifact penalties, high-RTT cost handling, extra cached peer promotion, and host-runtime adapter mapping.

## Protocol / compatibility
No mesh protocol, gossip, protobuf, ALPN, or CLI contract changes are introduced.

The new `StagePlan` fields are additive and defaulted for deserialization. Existing callers of `plan_weighted_contiguous` continue to get the previous behavior. When no package placement signals are provided, the package-aware planner intentionally matches the existing weighted planner output.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `8d12c0be26fb3af4ed309fde6df65acfabff0162`
- `git rev-list --left-right --count origin/main...HEAD`: `0 1`
- Merge-base SHA: `8d12c0be26fb3af4ed309fde6df65acfabff0162`
- Fast-forward safety: `origin/main` is an ancestor of `HEAD`; no divergence.

## Commit integrity
- Introduced commit: `1c0c85b1c4e749cd7a06cce8b0485bcfc6c68137 Add package-aware Skippy topology planning`
- One logical change: package-aware Skippy topology planning and the runtime adapter wiring needed to use it.
- Ledger: not applicable - not required for this change family.
- Version: not applicable - no release/version metadata changed.

## Diff hygiene
```text
M crates/mesh-llm-host-runtime/src/inference/skippy/topology.rs
M crates/mesh-llm-host-runtime/src/runtime/local.rs
M crates/skippy-topology/src/lib.rs
M crates/skippy-topology/src/tests.rs
```

- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation
Validation mode: Mode 3 - shared Skippy planning/runtime behavior. This changes topology scoring inputs and the runtime planner adapter, so local proof covers both the planner crate and the host-runtime adapter.

```text
git diff --check origin/main...HEAD
PASS

cargo fmt --all -- --check
PASS

cargo test -p skippy-topology --lib package_aware
PASS, 5 passed

cargo test -p skippy-topology --lib
PASS, 26 passed

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime inference::skippy::topology --lib
PASS, 3 passed

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm-host-runtime
PASS

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm
PASS
```

Not run: multi-node Skippy split smoke. This local PR-ready slice is covered by planner and runtime-adapter tests; required GitHub CI should still be treated as the final merge gate after the PR is opened.

## CI context confirmation
Pending - GitHub Actions cannot run until the PR is opened. No workflow files or CI context names changed.

## Runtime safety
- Reviewed runtime paths: `crates/skippy-topology/src/lib.rs`, `crates/mesh-llm-host-runtime/src/inference/skippy/topology.rs`, and `crates/mesh-llm-host-runtime/src/runtime/local.rs`.
- No new locks, queues, background tasks, network protocols, or blocking runtime paths were added.
- The existing weighted capacity behavior is preserved when package signals are absent.
- Missing artifacts and transfer support affect placement score; they do not introduce new download or transport behavior in this PR.
- No invariant regression introduced.

## Documentation integrity
Not applicable - no README, runbook, command, or user-facing CLI behavior changed.

## Migration notes
Not applicable - no database or persisted-state migration changed.

## Rollback plan
Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: rollback restores capacity-only Skippy topology planning.

## Known residual risks
- Real multi-node package-transfer behavior still depends on callers supplying accurate placement signals. When those signals are unavailable, the planner deliberately falls back to the existing weighted behavior.

