### PR TITLE
Add a Skippy package certification gate

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/commands/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/models/mod.rs
@@ -6,6 +6,9 @@ use crate::cli::commands::model_package;
 use crate::cli::models::ModelSearchSort;
 use crate::cli::models::ModelsCommand;
 use crate::cli::terminal_progress::{clear_stderr_line, start_spinner, DeterminateProgressLine};
+use crate::inference::skippy::{
+    certify_layer_package, CertificationGateStatus, SkippyCertificationRequest,
+};
 use crate::models::{
     delete, download_model_ref_with_progress_details, find_remote_catalog_model_exact,
     installed_model_capabilities, load_model_usage_record_for_path, model_usage_cache_dir,
@@ -198,6 +201,101 @@ pub fn run_model_installed(json_output: bool) -> Result<()> {
     formatter.render_installed(&rows)
 }
 
+pub async fn run_model_certify(
+    model: &str,
+    report_out: Option<&std::path::Path>,
+    json_output: bool,
+    package_only: bool,
+    api_base: Option<&str>,
+    prompt: &str,
+    max_tokens: u32,
+) -> Result<()> {
+    let api_base = api_base.map(str::trim).filter(|value| !value.is_empty());
+    validate_model_certify_options(package_only, api_base, prompt, max_tokens)?;
+
+    let report = certify_layer_package(SkippyCertificationRequest {
+        model_ref: model.to_string(),
+        package_only,
+        api_base: api_base.map(ToString::to_string),
+        prompt: prompt.to_string(),
+        max_tokens,
+    })
+    .await?;
+    let report_json = serde_json::to_string_pretty(&report)?;
+    if let Some(path) = report_out {
+        if let Some(parent) = path.parent() {
+            if !parent.as_os_str().is_empty() {
+                std::fs::create_dir_all(parent)?;
+            }
+        }
+        std::fs::write(path, format!("{report_json}\n"))?;
+    }
+    if json_output {
+        println!("{report_json}");
+    } else {
+        println!(
+            "Skippy package certification: {}",
+            status_label(report.status)
+        );
+        println!("Model: {}", report.model_id);
+        println!("Package: {}", report.resolved_package_ref);
+        println!("Manifest: {}", report.manifest_sha256);
+        println!("Layers: {}", report.layer_count);
+        if let Some(path) = report_out {
+            println!("Report: {}", path.display());
+        }
+    }
+    if report.status != CertificationGateStatus::Passed {
+        bail!(
+            "skippy package certification {}",
+            status_label(report.status)
+        );
+    }
+    Ok(())
+}
+
+fn validate_model_certify_options(
+    package_only: bool,
+    api_base: Option<&str>,
+    prompt: &str,
+    max_tokens: u32,
+) -> Result<()> {
+    let api_base = api_base.map(str::trim).filter(|value| !value.is_empty());
+    if package_only {
+        if api_base.is_some() {
+            bail!("Do not combine --package-only with --api-base; remove --package-only to run runtime smoke gates.");
+        }
+        return Ok(());
+    }
+
+    let Some(api_base) = api_base else {
+        bail!(
+            "models certify requires either --package-only or --api-base for runtime smoke gates"
+        );
+    };
+    let parsed = reqwest::Url::parse(api_base)
+        .map_err(|error| anyhow!("invalid --api-base {api_base:?}: {error}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        bail!("--api-base must be an http(s) URL with a host");
+    }
+    if prompt.trim().is_empty() {
+        bail!("--prompt must not be empty when runtime smoke gates are enabled");
+    }
+    if max_tokens == 0 {
+        bail!("--max-tokens must be greater than 0 when runtime smoke gates are enabled");
+    }
+    Ok(())
+}
+
+fn status_label(status: CertificationGateStatus) -> &'static str {
+    match status {
+        CertificationGateStatus::Passed => "passed",
+        CertificationGateStatus::Failed => "failed",
+        CertificationGateStatus::Incomplete => "incomplete",
+        CertificationGateStatus::NotRequired => "not required",
+    }
+}
+
 pub fn run_model_cleanup(unused_since: Option<&str>, yes: bool, json_output: bool) -> Result<()> {
     let unused_duration = unused_since.map(parse_cleanup_age).transpose()?;
     let plan = plan_model_cleanup(unused_duration)?;
@@ -368,6 +466,26 @@ pub async fn dispatch_models_command(command: &ModelsCommand) -> Result<()> {
             json,
         } => run_model_cleanup(unused_since.as_deref(), *yes, *json)?,
         ModelsCommand::Prune { yes, json } => run_model_prune(*yes, *json)?,
+        ModelsCommand::Certify {
+            model,
+            report_out,
+            json,
+            package_only,
+            api_base,
+            prompt,
+            max_tokens,
+        } => {
+            run_model_certify(
+                model,
+                report_out.as_deref(),
+                *json,
+                *package_only,
+                api_base.as_deref(),
+                prompt,
+                *max_tokens,
+            )
+            .await?
+        }
         ModelsCommand::Search {
             query,
             gguf,
@@ -652,7 +770,10 @@ fn map_search_sort(sort: ModelSearchSort) -> SearchSort {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_delete_preview_model, build_installed_rows, parse_cleanup_age};
+    use super::{
+        build_delete_preview_model, build_installed_rows, parse_cleanup_age,
+        validate_model_certify_options,
+    };
     use serial_test::serial;
     use std::ffi::OsString;
     use std::path::{Path, PathBuf};
@@ -716,6 +837,55 @@ mod tests {
         assert!(parse_cleanup_age("30").is_err());
         assert!(parse_cleanup_age("2months").is_err());
         assert!(parse_cleanup_age("").is_err());
+    }
+
+    #[test]
+    fn model_certify_requires_explicit_certification_mode() {
+        let error = validate_model_certify_options(false, None, "Say ok.", 2)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--package-only"), "{error}");
+        assert!(error.contains("--api-base"), "{error}");
+    }
+
+    #[test]
+    fn model_certify_rejects_ambiguous_package_and_runtime_modes() {
+        let error =
+            validate_model_certify_options(true, Some("http://127.0.0.1:9337"), "Say ok.", 2)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("Do not combine"), "{error}");
+    }
+
+    #[test]
+    fn model_certify_rejects_empty_runtime_prompt() {
+        let error = validate_model_certify_options(false, Some("http://127.0.0.1:9337"), "   ", 2)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--prompt"), "{error}");
+    }
+
+    #[test]
+    fn model_certify_rejects_zero_runtime_tokens() {
+        let error =
+            validate_model_certify_options(false, Some("http://127.0.0.1:9337"), "Say ok.", 0)
+                .unwrap_err()
+                .to_string();
+
+        assert!(error.contains("--max-tokens"), "{error}");
+    }
+
+    #[test]
+    fn model_certify_rejects_non_http_runtime_base() {
+        let error = validate_model_certify_options(false, Some("file:///tmp/api"), "Say ok.", 2)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("--api-base"), "{error}");
+        assert!(error.contains("http"), "{error}");
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -1300,4 +1300,42 @@ mod tests {
             other => panic!("unexpected command: {other:?}"),
         }
     }
+
+    #[test]
+    fn models_certify_parses_package_gate_options() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "models",
+            "certify",
+            "hf://meshllm/demo-layers@abc123",
+            "--package-only",
+            "--report-out",
+            "/tmp/cert.json",
+            "--json",
+            "--prompt",
+            "Say ok.",
+            "--max-tokens",
+            "2",
+        ]);
+
+        match cli.command.expect("models command expected") {
+            Command::Models {
+                command:
+                    ModelsCommand::Certify {
+                        model,
+                        package_only: true,
+                        json: true,
+                        report_out: Some(report_out),
+                        prompt,
+                        max_tokens: 2,
+                        ..
+                    },
+            } => {
+                assert_eq!(model, "hf://meshllm/demo-layers@abc123");
+                assert_eq!(report_out, std::path::PathBuf::from("/tmp/cert.json"));
+                assert_eq!(prompt, "Say ok.");
+            }
+            other => panic!("unexpected command: {other:?}"),
+        }
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/cli/models.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/models.rs
@@ -100,6 +100,29 @@ pub enum ModelsCommand {
         #[arg(long)]
         json: bool,
     },
+    /// Certify a Skippy layer package can be resolved, verified, and smoke-tested.
+    Certify {
+        /// Exact layer package ref, local package dir, or catalog model ref with a package mapping.
+        model: String,
+        /// Write the JSON certification report to this path.
+        #[arg(long)]
+        report_out: Option<std::path::PathBuf>,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+        /// Stop after package resolution, integrity checks, and local stage materialization.
+        #[arg(long)]
+        package_only: bool,
+        /// Existing mesh-llm OpenAI-compatible API base for runtime smoke gates.
+        #[arg(long)]
+        api_base: Option<String>,
+        /// Prompt for runtime smoke gates.
+        #[arg(long, default_value = "Say ok.")]
+        prompt: String,
+        /// Maximum tokens for runtime smoke gates.
+        #[arg(long, default_value_t = 2)]
+        max_tokens: u32,
+    },
     // Delete variant defined with explicit clap args later in file (existing block).
     /// List remote catalog models.
     #[command(hide = true)]

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/certification.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/certification.rs
@@ -1,0 +1,648 @@
+use std::{fs, path::PathBuf, time::Duration};
+
+use anyhow::{bail, Context, Result};
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use skippy_runtime::package::{self, PackageIntegrityOptions, PackageStageRequest};
+
+use super::materialization::{
+    inspect_stage_package, resolve_hf_package_to_local, StagePackageInfo, StagePackageRef,
+};
+
+const RUNTIME_SMOKE_TIMEOUT: Duration = Duration::from_secs(120);
+
+#[derive(Clone, Debug)]
+pub(crate) struct SkippyCertificationRequest {
+    pub(crate) model_ref: String,
+    pub(crate) package_only: bool,
+    pub(crate) api_base: Option<String>,
+    pub(crate) prompt: String,
+    pub(crate) max_tokens: u32,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum CertificationGateStatus {
+    Passed,
+    Failed,
+    Incomplete,
+    NotRequired,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SkippyCertificationReport {
+    pub(crate) schema_version: u32,
+    pub(crate) status: CertificationGateStatus,
+    pub(crate) input: String,
+    pub(crate) resolved_package_ref: String,
+    pub(crate) local_package_dir: String,
+    pub(crate) model_id: String,
+    pub(crate) manifest_sha256: String,
+    pub(crate) source_model_path: String,
+    pub(crate) source_model_sha256: String,
+    pub(crate) source_model_bytes: Option<u64>,
+    pub(crate) layer_count: u32,
+    pub(crate) package_gate: CertificationGate,
+    pub(crate) materialized_stages: Vec<CertifiedStage>,
+    pub(crate) runtime_gates: Vec<CertificationGate>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CertificationGate {
+    pub(crate) name: String,
+    pub(crate) status: CertificationGateStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) details: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct CertifiedStage {
+    pub(crate) stage_id: String,
+    pub(crate) layer_start: u32,
+    pub(crate) layer_end: u32,
+    pub(crate) include_embeddings: bool,
+    pub(crate) include_output: bool,
+    pub(crate) selected_part_count: usize,
+    pub(crate) verified_artifacts: usize,
+    pub(crate) cached_artifacts: usize,
+    pub(crate) materialized_path: String,
+    pub(crate) materialized_bytes: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CertificationStageRange {
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+}
+
+pub(crate) async fn certify_layer_package(
+    request: SkippyCertificationRequest,
+) -> Result<SkippyCertificationReport> {
+    let resolved_package_ref = resolve_certification_package_ref(&request.model_ref)?;
+    let info = inspect_stage_package(&resolved_package_ref)?;
+    let ranges = certification_stage_ranges(info.layer_count)?;
+    let materialized_stages = tokio::task::spawn_blocking({
+        let package_ref = resolved_package_ref.clone();
+        let model_id = info.model_id.clone();
+        move || materialize_certification_stages(&package_ref, &model_id, &ranges)
+    })
+    .await
+    .map_err(anyhow::Error::from)??;
+    let runtime_gates = runtime_smoke_gates(&request, &info).await;
+    let package_gate = CertificationGate {
+        name: "package_materialization".to_string(),
+        status: CertificationGateStatus::Passed,
+        details: Some("manifest, selected artifacts, and two local stage ranges verified".into()),
+    };
+    let status = aggregate_certification_status(
+        std::iter::once(package_gate.status).chain(runtime_gates.iter().map(|gate| gate.status)),
+    );
+
+    Ok(SkippyCertificationReport {
+        schema_version: 1,
+        status,
+        input: request.model_ref,
+        resolved_package_ref,
+        local_package_dir: info.package_dir.display().to_string(),
+        model_id: info.model_id,
+        manifest_sha256: info.manifest_sha256,
+        source_model_path: info.source_model_path,
+        source_model_sha256: info.source_model_sha256,
+        source_model_bytes: info.source_model_bytes,
+        layer_count: info.layer_count,
+        package_gate,
+        materialized_stages,
+        runtime_gates,
+    })
+}
+
+pub(crate) fn resolve_certification_package_ref(input: &str) -> Result<String> {
+    if let Ok(package_ref) = StagePackageRef::parse(input) {
+        if let Some(package_ref) = package_ref.as_package_ref() {
+            return Ok(package_ref);
+        }
+        bail!("direct GGUF inputs are not layer-package certification targets");
+    }
+    crate::models::remote_catalog::find_layer_package(input)
+        .with_context(|| format!("no layer package found for {input:?}"))
+}
+
+fn materialize_certification_stages(
+    package_ref: &str,
+    model_id: &str,
+    ranges: &[CertificationStageRange],
+) -> Result<Vec<CertifiedStage>> {
+    ranges
+        .iter()
+        .enumerate()
+        .map(|(index, range)| {
+            let local_ref = resolve_hf_package_to_local(
+                package_ref,
+                range.layer_start,
+                range.layer_end,
+                range.include_embeddings,
+                range.include_output,
+            )?;
+            let stage_id = format!("cert-stage-{index}");
+            let request = PackageStageRequest {
+                model_id: model_id.to_string(),
+                topology_id: "skippy-certification".to_string(),
+                package_ref: local_ref,
+                stage_id: stage_id.clone(),
+                layer_start: range.layer_start,
+                layer_end: range.layer_end,
+                include_embeddings: range.include_embeddings,
+                include_output: range.include_output,
+            };
+            let integrity_options =
+                PackageIntegrityOptions::verify_with_cache(package_integrity_cache_dir());
+            let selected =
+                package::select_layer_package_parts_with_integrity(&request, &integrity_options)?;
+            let materialized = package::materialize_layer_package_details(&request)?;
+            let materialized_bytes = fs::metadata(&materialized.output_path)
+                .with_context(|| {
+                    format!(
+                        "read materialized certification stage {}",
+                        materialized.output_path.display()
+                    )
+                })?
+                .len();
+            Ok(CertifiedStage {
+                stage_id,
+                layer_start: range.layer_start,
+                layer_end: range.layer_end,
+                include_embeddings: range.include_embeddings,
+                include_output: range.include_output,
+                selected_part_count: materialized.selected_parts.len(),
+                verified_artifacts: selected.integrity.verified_artifacts,
+                cached_artifacts: selected.integrity.cached_artifacts,
+                materialized_path: materialized.output_path.display().to_string(),
+                materialized_bytes,
+            })
+        })
+        .collect()
+}
+
+fn certification_stage_ranges(layer_count: u32) -> Result<Vec<CertificationStageRange>> {
+    if layer_count < 2 {
+        bail!("layer package certification requires at least two transformer layers");
+    }
+    let split = layer_count / 2;
+    Ok(vec![
+        CertificationStageRange {
+            layer_start: 0,
+            layer_end: split,
+            include_embeddings: true,
+            include_output: false,
+        },
+        CertificationStageRange {
+            layer_start: split,
+            layer_end: layer_count,
+            include_embeddings: false,
+            include_output: true,
+        },
+    ])
+}
+
+async fn runtime_smoke_gates(
+    request: &SkippyCertificationRequest,
+    package: &StagePackageInfo,
+) -> Vec<CertificationGate> {
+    if request.package_only {
+        return required_runtime_gate_names()
+            .iter()
+            .map(|name| CertificationGate {
+                name: (*name).to_string(),
+                status: CertificationGateStatus::NotRequired,
+                details: Some("package-only certification requested".to_string()),
+            })
+            .collect();
+    }
+
+    let Some(api_base) = request.api_base.as_deref() else {
+        return required_runtime_gate_names()
+            .iter()
+            .map(|name| CertificationGate {
+                name: (*name).to_string(),
+                status: CertificationGateStatus::Incomplete,
+                details: Some("pass --api-base to run runtime OpenAI smoke gates".to_string()),
+            })
+            .collect();
+    };
+
+    let client = match reqwest::Client::builder()
+        .timeout(RUNTIME_SMOKE_TIMEOUT)
+        .build()
+    {
+        Ok(client) => client,
+        Err(error) => {
+            return required_runtime_gate_names()
+                .iter()
+                .map(|name| failed_gate(name, &error))
+                .collect();
+        }
+    };
+    vec![
+        smoke_v1_models(&client, api_base, &package.model_id).await,
+        smoke_chat_completions(&client, api_base, package, request).await,
+        smoke_responses(&client, api_base, package, request).await,
+    ]
+}
+
+async fn smoke_v1_models(
+    client: &reqwest::Client,
+    api_base: &str,
+    model_id: &str,
+) -> CertificationGate {
+    let url = format!("{}/v1/models", api_base.trim_end_matches('/'));
+    match client.get(url).send().await {
+        Ok(response) if response.status() == StatusCode::OK => {
+            match response.json::<serde_json::Value>().await {
+                Ok(value) if models_response_contains(&value, model_id) => CertificationGate {
+                    name: "v1_models".to_string(),
+                    status: CertificationGateStatus::Passed,
+                    details: None,
+                },
+                Ok(_) => CertificationGate {
+                    name: "v1_models".to_string(),
+                    status: CertificationGateStatus::Failed,
+                    details: Some(format!("model {model_id:?} was not present in /v1/models")),
+                },
+                Err(error) => failed_gate("v1_models", error),
+            }
+        }
+        Ok(response) => failed_gate_message("v1_models", format!("HTTP {}", response.status())),
+        Err(error) => failed_gate("v1_models", error),
+    }
+}
+
+async fn smoke_chat_completions(
+    client: &reqwest::Client,
+    api_base: &str,
+    package: &StagePackageInfo,
+    request: &SkippyCertificationRequest,
+) -> CertificationGate {
+    let url = format!("{}/v1/chat/completions", api_base.trim_end_matches('/'));
+    let body = json!({
+        "model": package.model_id,
+        "messages": [{ "role": "user", "content": request.prompt }],
+        "max_tokens": request.max_tokens,
+        "stream": false
+    });
+    smoke_post_json(
+        client,
+        &url,
+        body,
+        "v1_chat_completions",
+        response_has_chat_choice_content,
+        "chat completion choice content",
+    )
+    .await
+}
+
+async fn smoke_responses(
+    client: &reqwest::Client,
+    api_base: &str,
+    package: &StagePackageInfo,
+    request: &SkippyCertificationRequest,
+) -> CertificationGate {
+    let url = format!("{}/v1/responses", api_base.trim_end_matches('/'));
+    let body = json!({
+        "model": package.model_id,
+        "input": request.prompt,
+        "max_output_tokens": request.max_tokens
+    });
+    smoke_post_json(
+        client,
+        &url,
+        body,
+        "v1_responses",
+        response_has_responses_output,
+        "Responses output",
+    )
+    .await
+}
+
+async fn smoke_post_json(
+    client: &reqwest::Client,
+    url: &str,
+    body: serde_json::Value,
+    name: &str,
+    valid_response: fn(&serde_json::Value) -> bool,
+    expected: &'static str,
+) -> CertificationGate {
+    match client.post(url).json(&body).send().await {
+        Ok(response) if response.status().is_success() => {
+            match response.json::<serde_json::Value>().await {
+                Ok(value) if valid_response(&value) => CertificationGate {
+                    name: name.to_string(),
+                    status: CertificationGateStatus::Passed,
+                    details: None,
+                },
+                Ok(_) => failed_gate_message(name, format!("response missing {expected}")),
+                Err(error) => failed_gate(name, error),
+            }
+        }
+        Ok(response) => failed_gate_message(name, format!("HTTP {}", response.status())),
+        Err(error) => failed_gate(name, error),
+    }
+}
+
+fn response_has_chat_choice_content(value: &serde_json::Value) -> bool {
+    value
+        .get("choices")
+        .and_then(|choices| choices.as_array())
+        .is_some_and(|choices| {
+            choices.iter().any(|choice| {
+                choice
+                    .pointer("/message/content")
+                    .is_some_and(response_content_has_text)
+            })
+        })
+}
+
+fn response_has_responses_output(value: &serde_json::Value) -> bool {
+    value
+        .get("output_text")
+        .and_then(|output_text| output_text.as_str())
+        .is_some_and(|output_text| !output_text.trim().is_empty())
+        || value
+            .get("output")
+            .and_then(|output| output.as_array())
+            .is_some_and(|items| {
+                items.iter().any(|item| {
+                    item.get("content")
+                        .and_then(|content| content.as_array())
+                        .is_some_and(|content| {
+                            content.iter().any(|part| {
+                                part.get("type").and_then(|kind| kind.as_str())
+                                    == Some("output_text")
+                                    && part
+                                        .get("text")
+                                        .and_then(|text| text.as_str())
+                                        .is_some_and(|text| !text.trim().is_empty())
+                            })
+                        })
+                })
+            })
+}
+
+fn response_content_has_text(value: &serde_json::Value) -> bool {
+    value.as_str().is_some_and(|text| !text.trim().is_empty())
+        || value.as_array().is_some_and(|parts| {
+            parts.iter().any(|part| {
+                part.as_str().is_some_and(|text| !text.trim().is_empty())
+                    || part
+                        .get("text")
+                        .and_then(|text| text.as_str())
+                        .is_some_and(|text| !text.trim().is_empty())
+            })
+        })
+}
+
+fn models_response_contains(value: &serde_json::Value, model_id: &str) -> bool {
+    value
+        .get("data")
+        .and_then(|data| data.as_array())
+        .is_some_and(|models| {
+            models
+                .iter()
+                .any(|model| model.get("id").and_then(|id| id.as_str()) == Some(model_id))
+        })
+}
+
+fn aggregate_certification_status(
+    statuses: impl IntoIterator<Item = CertificationGateStatus>,
+) -> CertificationGateStatus {
+    let mut saw_incomplete = false;
+    for status in statuses {
+        match status {
+            CertificationGateStatus::Failed => return CertificationGateStatus::Failed,
+            CertificationGateStatus::Incomplete => saw_incomplete = true,
+            CertificationGateStatus::Passed | CertificationGateStatus::NotRequired => {}
+        }
+    }
+    if saw_incomplete {
+        CertificationGateStatus::Incomplete
+    } else {
+        CertificationGateStatus::Passed
+    }
+}
+
+fn required_runtime_gate_names() -> &'static [&'static str] {
+    &["v1_models", "v1_chat_completions", "v1_responses"]
+}
+
+fn package_integrity_cache_dir() -> PathBuf {
+    crate::models::mesh_llm_cache_dir().join("skippy-package-integrity")
+}
+
+fn failed_gate(name: &str, error: impl std::fmt::Display) -> CertificationGate {
+    failed_gate_message(name, error.to_string())
+}
+
+fn failed_gate_message(name: &str, details: String) -> CertificationGate {
+    CertificationGate {
+        name: name.to_string(),
+        status: CertificationGateStatus::Failed,
+        details: Some(details),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        aggregate_certification_status, certification_stage_ranges, models_response_contains,
+        response_has_chat_choice_content, response_has_responses_output, smoke_chat_completions,
+        smoke_responses, CertificationGateStatus,
+    };
+    use crate::inference::skippy::materialization::{StagePackageInfo, StagePackageLayerInfo};
+    use serde_json::json;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    #[test]
+    fn certification_ranges_split_two_stage_package() {
+        let ranges = certification_stage_ranges(5).unwrap();
+
+        assert_eq!(ranges[0].layer_start, 0);
+        assert_eq!(ranges[0].layer_end, 2);
+        assert!(ranges[0].include_embeddings);
+        assert!(!ranges[0].include_output);
+        assert_eq!(ranges[1].layer_start, 2);
+        assert_eq!(ranges[1].layer_end, 5);
+        assert!(!ranges[1].include_embeddings);
+        assert!(ranges[1].include_output);
+    }
+
+    #[test]
+    fn certification_ranges_reject_single_layer_package() {
+        let error = certification_stage_ranges(1).unwrap_err().to_string();
+
+        assert!(error.contains("at least two transformer layers"), "{error}");
+    }
+
+    #[test]
+    fn aggregate_status_prefers_failed_over_incomplete() {
+        let status = aggregate_certification_status([
+            CertificationGateStatus::Passed,
+            CertificationGateStatus::Incomplete,
+            CertificationGateStatus::Failed,
+        ]);
+
+        assert_eq!(status, CertificationGateStatus::Failed);
+    }
+
+    #[test]
+    fn aggregate_status_allows_not_required_runtime_gates() {
+        let status = aggregate_certification_status([
+            CertificationGateStatus::Passed,
+            CertificationGateStatus::NotRequired,
+        ]);
+
+        assert_eq!(status, CertificationGateStatus::Passed);
+    }
+
+    #[test]
+    fn models_response_requires_matching_model_id() {
+        let response = json!({
+            "object": "list",
+            "data": [
+                { "id": "other" },
+                { "id": "org/repo:Q4_K_M" }
+            ]
+        });
+
+        assert!(models_response_contains(&response, "org/repo:Q4_K_M"));
+        assert!(!models_response_contains(&response, "missing"));
+    }
+
+    #[test]
+    fn chat_response_validator_accepts_string_and_structured_text_content() {
+        let string_content = json!({
+            "choices": [
+                { "message": { "content": "ok" } }
+            ]
+        });
+        let structured_content = json!({
+            "choices": [
+                {
+                    "message": {
+                        "content": [
+                            { "type": "text", "text": "ok" }
+                        ]
+                    }
+                }
+            ]
+        });
+
+        assert!(response_has_chat_choice_content(&string_content));
+        assert!(response_has_chat_choice_content(&structured_content));
+    }
+
+    #[test]
+    fn responses_response_validator_accepts_output_text_and_output_parts() {
+        let output_text = json!({
+            "output_text": "ok"
+        });
+        let output_parts = json!({
+            "output": [
+                {
+                    "content": [
+                        { "type": "output_text", "text": "ok" }
+                    ]
+                }
+            ]
+        });
+
+        assert!(response_has_responses_output(&output_text));
+        assert!(response_has_responses_output(&output_parts));
+    }
+
+    #[tokio::test]
+    async fn chat_smoke_rejects_success_status_without_choice_content() {
+        let api_base = spawn_single_response_server(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 14\r\n\r\n{\"choices\":[]}",
+        )
+        .await;
+        let package = fake_package_info();
+        let request = fake_certification_request();
+
+        let gate =
+            smoke_chat_completions(&reqwest::Client::new(), &api_base, &package, &request).await;
+
+        assert_eq!(gate.status, CertificationGateStatus::Failed);
+        assert!(
+            gate.details
+                .as_deref()
+                .is_some_and(|details| details.contains("choice content")),
+            "{gate:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_smoke_rejects_success_status_without_output() {
+        let api_base = spawn_single_response_server(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}",
+        )
+        .await;
+        let package = fake_package_info();
+        let request = fake_certification_request();
+
+        let gate = smoke_responses(&reqwest::Client::new(), &api_base, &package, &request).await;
+
+        assert_eq!(gate.status, CertificationGateStatus::Failed);
+        assert!(
+            gate.details
+                .as_deref()
+                .is_some_and(|details| details.contains("Responses output")),
+            "{gate:?}"
+        );
+    }
+
+    fn fake_certification_request() -> super::SkippyCertificationRequest {
+        super::SkippyCertificationRequest {
+            model_ref: "hf://meshllm/demo@abc123".to_string(),
+            package_only: false,
+            api_base: None,
+            prompt: "Say ok.".to_string(),
+            max_tokens: 2,
+        }
+    }
+
+    fn fake_package_info() -> StagePackageInfo {
+        StagePackageInfo {
+            package_ref: "hf://meshllm/demo@abc123".to_string(),
+            package_dir: std::path::PathBuf::from("/tmp/demo-package"),
+            manifest_sha256: "a".repeat(64),
+            model_id: "meshllm/demo".to_string(),
+            source_model_path: "model.gguf".to_string(),
+            source_model_sha256: "b".repeat(64),
+            source_model_bytes: Some(42),
+            layer_count: 2,
+            activation_width: 4096,
+            projector_path: None,
+            layers: vec![StagePackageLayerInfo {
+                layer_index: 0,
+                tensor_count: 1,
+                tensor_bytes: 1,
+                artifact_bytes: 1,
+            }],
+        }
+    }
+
+    async fn spawn_single_response_server(response: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 2048];
+            let _ = stream.read(&mut buf).await.unwrap();
+            stream.write_all(response.as_bytes()).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+mod certification;
 mod deployment;
 mod family_policy;
 mod hooks;
@@ -30,6 +31,9 @@ use skippy_server::{
     EmbeddedRuntimeStatus, EmbeddedServerHandle, EmbeddedState, SkippyRuntimeHandle,
 };
 
+pub(crate) use certification::{
+    certify_layer_package, CertificationGateStatus, SkippyCertificationRequest,
+};
 pub(crate) use family_policy::{family_policy_for_model_path, family_policy_for_stage_config};
 pub(crate) use hooks::MeshAutoHookPolicy;
 pub(crate) use kv_cache::KvCachePolicy;

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -99,6 +99,7 @@ Subcommands:
 - `search`
 - `show`
 - `download`
+- `certify`
 - `updates`
 
 ### `models recommended`
@@ -167,6 +168,33 @@ Switches:
 
 - `--draft`: also download the recommended draft model (if available).
 - `--json`: machine-readable output.
+
+### `models certify`
+
+Use this when you want a repeatable Skippy layer-package confidence report
+before treating a split package as ready for a release or rollout.
+
+Choose exactly one mode: use `--package-only` for package integrity and local
+stage materialization, or pass `--api-base` to also prove an already running
+OpenAI-compatible mesh endpoint. Runtime certification checks the model list and
+requires real text-bearing responses from both chat completions and Responses
+API smoke requests, not only successful HTTP status codes.
+
+Usage:
+
+```bash
+mesh-llm models certify hf://meshllm/Qwen3-8B-Q4_K_M-layers --package-only --report-out cert.json
+mesh-llm models certify unsloth/Qwen3-8B-GGUF:Q4_K_M --api-base http://127.0.0.1:9337 --json
+```
+
+Switches:
+
+- `--package-only`: verify package resolution, artifact integrity, and local stage materialization without claiming runtime OpenAI readiness.
+- `--api-base <URL>`: run `/v1/models`, `/v1/chat/completions`, and `/v1/responses` smoke gates against an already running mesh-llm API. The URL must be an `http` or `https` base URL.
+- `--report-out <PATH>`: write the JSON certification report to disk.
+- `--prompt <PROMPT>`: prompt for runtime smoke gates.
+- `--max-tokens <N>`: max tokens for runtime smoke gates. Must be greater than zero when runtime gates are enabled.
+- `--json`: print the certification report.
 
 ### `models updates`
 


### PR DESCRIPTION
## Summary
Adds a repeatable `mesh-llm models certify` gate for Skippy layer packages. The command can now produce a structured confidence report before a split package is treated as ready for release or rollout.

The gate covers package resolution, manifest/artifact integrity, representative local stage materialization, and optional runtime smoke checks against an already running OpenAI-compatible mesh endpoint.

## Why
Skippy layer packages are moving from experimental artifacts toward a real rollout path. Maintainers need a small, repeatable command that can answer the practical questions before a package is trusted:

- Does this model ref resolve to the intended layer package?
- Do the selected package artifacts pass integrity checks?
- Can representative first/final stage ranges be materialized locally?
- If runtime gates are requested, does the served model actually appear in `/v1/models` and return text-bearing outputs through both chat completions and Responses API paths?

## What changed
- Added `mesh-llm models certify`.
- Added a structured JSON certification report with package, manifest, source model, materialized stage, and gate status details.
- Added `--package-only` mode for package integrity and local materialization without claiming runtime readiness.
- Added runtime smoke gates for `/v1/models`, `/v1/chat/completions`, and `/v1/responses`.
- Hardened runtime smoke gates so a successful HTTP status is not enough; chat and Responses gates must return real text-bearing output.
- Added CLI validation for ambiguous modes, missing `--api-base`, invalid runtime base URLs, empty runtime prompts, and `--max-tokens 0`.
- Documented the command and mode contract in `docs/CLI.md`.

## Compatibility
No mesh protocol change.
No plugin protocol change.
No database migration.
The new CLI command is additive.

## Branch integrity
Base branch: `main`.
Validated base SHA: `8d12c0be26fb3af4ed309fde6df65acfabff0162`.
Branch status against `origin/main`: ahead `1`, behind `0`.
Merge-base SHA: `8d12c0be26fb3af4ed309fde6df65acfabff0162`.
Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity
Introduced commit:

- `ccf84df8cf7ccb9fbbb4a383b6c29f995af404d5 Add Skippy package certification gate`



## Diff scope
Changed files:

- `crates/mesh-llm-host-runtime/src/cli/commands/models/mod.rs`
- `crates/mesh-llm-host-runtime/src/cli/mod.rs`
- `crates/mesh-llm-host-runtime/src/cli/models.rs`
- `crates/mesh-llm-host-runtime/src/inference/skippy/certification.rs`
- `crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs`
- `docs/CLI.md`



## Validation
Local validation on final SHA `ccf84df8cf7ccb9fbbb4a383b6c29f995af404d5`:

- `git diff --check origin/main...HEAD`: PASS
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime model_certify --lib`: PASS, 5 passed
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime certification --lib`: PASS, 10 passed
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`: PASS
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib`: PASS
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo build -p mesh-llm --bin mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo-clippy clippy -p mesh-llm -- -D warnings`: PASS

Remote CI: pending until the PR is opened.

Additional non-gating note: a broader local `cargo test -p mesh-llm-host-runtime --lib` run currently fails on an existing `origin/main` runtime test with conflicting expectations for client dashboard mode. This PR does not touch that runtime path, and the repository CI path for this branch is covered above with `cargo test -p mesh-llm --lib`.

## Runtime safety
The runtime smoke gates use bounded HTTP client timeouts and do not add background tasks, blocking locks, queues, or new protocol state.
Existing package integrity and materialization paths remain the source of truth for artifact verification.
No invariant regression introduced.

## Documentation
`docs/CLI.md` now documents the new `models certify` command, the package-only/runtime mode split, runtime URL requirements, and smoke-gate token requirements.

## Rollback
Revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none expected.

## Known residual risks
No known functional residual risks in this diff.
Full runtime readiness for a specific model/package still depends on running `models certify --api-base ...` against the actual deployed endpoint and package intended for rollout.
