### PR TITLE
Harden Skippy stage control recovery

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -625,6 +625,7 @@ fn make_test_state_peer(seed: u8, role: mesh::NodeRole) -> mesh::PeerInfo {
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: false,
+        stage_status_list_supported: false,
         owner_summary: crate::crypto::OwnershipSummary::default(),
         first_joined_mesh_ts: None,
     }
@@ -898,6 +899,7 @@ fn make_test_peer(
         served_model_runtime: Vec::new(),
         owner_attestation: None,
         artifact_transfer_supported: false,
+        stage_status_list_supported: false,
         owner_summary: crate::crypto::OwnershipSummary::default(),
     }
 }

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
@@ -1,7 +1,10 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
 };
 
 use anyhow::Result;
@@ -80,28 +83,40 @@ pub(super) async fn run_stage_prepare_task(
     key: String,
     request: StagePrepareRequest,
     package_prefetcher: Option<Arc<dyn StagePackagePrefetcher>>,
+    cancelled: Arc<AtomicBool>,
 ) {
     let load = request.load.clone();
-    update_preparation(
+    if !update_preparation(
         &preparations,
         &key,
         preparation_status_from_load(&load, StagePreparationState::Resolving),
     )
-    .await;
+    .await
+        || cancelled.load(Ordering::Acquire)
+    {
+        return;
+    }
     let peer_prefetch_error =
         prefetch_stage_package_if_needed(&preparations, &key, &request, package_prefetcher).await;
+    if cancelled.load(Ordering::Acquire) {
+        return;
+    }
     if peer_prefetch_error.is_none()
         && load.load_mode != LoadMode::LayerPackage
         && !is_layer_package_ref(&load.package_ref)
-    {
-        update_preparation(
+        && !update_preparation(
             &preparations,
             &key,
             preparation_status_from_load(&load, StagePreparationState::Downloading),
         )
-        .await;
+        .await
+    {
+        return;
     }
     let result = prepare_stage_source(&load).await;
+    if cancelled.load(Ordering::Acquire) {
+        return;
+    }
     let state = match result {
         Ok(PrepareSourceResult { bytes_total }) => {
             let mut status = preparation_status_from_load(&load, StagePreparationState::Available);
@@ -134,7 +149,7 @@ async fn prefetch_stage_package_if_needed(
         return None;
     }
     let prefetcher = package_prefetcher?;
-    update_preparation(
+    let _ = update_preparation(
         preparations,
         key,
         preparation_status_from_load(load, StagePreparationState::Downloading),
@@ -199,6 +214,14 @@ async fn update_preparation(
     preparations: &Arc<Mutex<HashMap<String, StagePreparationStatus>>>,
     key: &str,
     status: StagePreparationStatus,
-) {
-    preparations.lock().await.insert(key.to_string(), status);
+) -> bool {
+    let mut preparations = preparations.lock().await;
+    if preparations.get(key).is_some_and(|existing| {
+        matches!(existing.state, StagePreparationState::Cancelled)
+            && existing.shutdown_generation >= status.shutdown_generation
+    }) {
+        return false;
+    }
+    preparations.insert(key.to_string(), status);
+    true
 }

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -1,4 +1,12 @@
-use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
 
 use anyhow::{anyhow, Context, Result};
 use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig};
@@ -7,7 +15,10 @@ use skippy_server::{
     telemetry::TelemetryLevel,
     EmbeddedServerHandle,
 };
-use tokio::sync::{mpsc, Mutex};
+use tokio::{
+    sync::{mpsc, Mutex},
+    task::JoinHandle,
+};
 
 mod inventory;
 #[cfg(test)]
@@ -29,7 +40,13 @@ struct RunningStage {
 struct StageControlState {
     stages: HashMap<String, RunningStage>,
     preparations: Arc<Mutex<HashMap<String, StagePreparationStatus>>>,
+    preparation_tasks: HashMap<String, StagePreparationTask>,
     package_prefetcher: Option<Arc<dyn StagePackagePrefetcher>>,
+}
+
+struct StagePreparationTask {
+    cancelled: Arc<AtomicBool>,
+    handle: JoinHandle<()>,
 }
 
 #[async_trait::async_trait]
@@ -73,14 +90,11 @@ impl StageControlState {
                 self.prepare(request).await?,
             )),
             StageControlRequest::CancelPrepare(cancel) => Ok(
-                StageControlResponse::PreparationStatus(preparation_status_from_cancel(cancel)),
+                StageControlResponse::PreparationStatus(self.cancel_prepare(cancel).await),
             ),
-            StageControlRequest::StatusUpdate(_status) => {
-                Ok(StageControlResponse::StatusAck(StageStatusAck {
-                    accepted: true,
-                    error: None,
-                }))
-            }
+            StageControlRequest::StatusUpdate(_status) => Ok(StageControlResponse::StatusAck(
+                self.apply_status_update(_status).await,
+            )),
         }
     }
 
@@ -165,16 +179,93 @@ impl StageControlState {
             .lock()
             .await
             .insert(key.clone(), status.clone());
+        if let Some(task) = self.preparation_tasks.remove(&key) {
+            task.cancelled.store(true, Ordering::Release);
+            task.handle.abort();
+        }
         let preparations = Arc::clone(&self.preparations);
         let package_prefetcher = self.package_prefetcher.clone();
-        tokio::spawn(async move {
-            run_stage_prepare_task(preparations, key, request, package_prefetcher).await;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let task_cancelled = Arc::clone(&cancelled);
+        let task_key = key.clone();
+        let handle = tokio::spawn(async move {
+            run_stage_prepare_task(
+                preparations,
+                task_key,
+                request,
+                package_prefetcher,
+                task_cancelled,
+            )
+            .await;
         });
+        self.preparation_tasks
+            .insert(key.clone(), StagePreparationTask { cancelled, handle });
         Ok(StagePrepareAcceptedResponse {
             accepted: true,
             status,
             error: None,
         })
+    }
+
+    async fn cancel_prepare(
+        &mut self,
+        cancel: StageCancelPrepareRequest,
+    ) -> StagePreparationStatus {
+        let key = stage_key(&cancel.topology_id, &cancel.run_id, &cancel.stage_id);
+        let mut preparations = self.preparations.lock().await;
+        if let Some(existing) = preparations.get(&key) {
+            if cancel.shutdown_generation < existing.shutdown_generation {
+                let mut status = existing.clone();
+                status.error = Some("stale shutdown generation".to_string());
+                return status;
+            }
+        }
+
+        if let Some(task) = self.preparation_tasks.remove(&key) {
+            task.cancelled.store(true, Ordering::Release);
+            task.handle.abort();
+        }
+
+        let status = preparations
+            .get(&key)
+            .cloned()
+            .map(|mut status| {
+                status.state = StagePreparationState::Cancelled;
+                status.shutdown_generation = cancel.shutdown_generation;
+                status.error = None;
+                status
+            })
+            .unwrap_or_else(|| preparation_status_from_cancel(cancel));
+        preparations.insert(key, status.clone());
+        status
+    }
+
+    async fn apply_status_update(&mut self, status: StagePreparationStatus) -> StageStatusAck {
+        if status.topology_id.is_empty() || status.run_id.is_empty() || status.stage_id.is_empty() {
+            return StageStatusAck {
+                accepted: false,
+                error: Some(
+                    "stage status update requires topology_id, run_id, and stage_id".into(),
+                ),
+            };
+        }
+        let key = stage_key(&status.topology_id, &status.run_id, &status.stage_id);
+        let mut preparations = self.preparations.lock().await;
+        if preparations.get(&key).is_some_and(|existing| {
+            status.shutdown_generation < existing.shutdown_generation
+                || (matches!(existing.state, StagePreparationState::Cancelled)
+                    && status.shutdown_generation <= existing.shutdown_generation)
+        }) {
+            return StageStatusAck {
+                accepted: false,
+                error: Some("stale shutdown generation".to_string()),
+            };
+        }
+        preparations.insert(key, status);
+        StageStatusAck {
+            accepted: true,
+            error: None,
+        }
     }
 
     async fn load(&mut self, load: StageLoadRequest) -> Result<StageReadyResponse> {

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -175,10 +175,23 @@ impl StageControlState {
             &request.load.stage_id,
         );
         let status = preparation_status_from_load(&request.load, StagePreparationState::Assigned);
-        self.preparations
-            .lock()
-            .await
-            .insert(key.clone(), status.clone());
+        {
+            let mut preparations = self.preparations.lock().await;
+            if let Some(existing) = preparations.get(&key) {
+                if existing.state == StagePreparationState::Cancelled
+                    && existing.shutdown_generation >= request.load.shutdown_generation
+                {
+                    let mut status = existing.clone();
+                    status.error = Some("stale shutdown generation".to_string());
+                    return Ok(StagePrepareAcceptedResponse {
+                        accepted: false,
+                        status,
+                        error: Some("stale shutdown generation".to_string()),
+                    });
+                }
+            }
+            preparations.insert(key.clone(), status.clone());
+        }
         if let Some(task) = self.preparation_tasks.remove(&key) {
             task.cancelled.store(true, Ordering::Release);
             task.handle.abort();

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
@@ -414,6 +414,78 @@ async fn cancel_prepare_persists_cancelled_status_and_blocks_late_prefetch_resul
 }
 
 #[tokio::test]
+async fn prepare_preserves_equal_or_newer_cancelled_status() {
+    let mut load = load_request();
+    load.load_mode = LoadMode::LayerPackage;
+    load.package_ref = "missing-layer-package".to_string();
+    load.manifest_sha256 = "a".repeat(64);
+    load.downstream = None;
+
+    let (prefetcher, started_rx, release_tx) = BlockingPackagePrefetcher::new();
+    let mut state = StageControlState {
+        package_prefetcher: Some(Arc::new(prefetcher)),
+        ..Default::default()
+    };
+    state
+        .prepare(StagePrepareRequest {
+            load: load.clone(),
+            coordinator_id: None,
+        })
+        .await
+        .unwrap();
+    started_rx.await.expect("prefetch must start before cancel");
+
+    let status = state
+        .cancel_prepare(StageCancelPrepareRequest {
+            topology_id: load.topology_id.clone(),
+            run_id: load.run_id.clone(),
+            stage_id: load.stage_id.clone(),
+            shutdown_generation: load.shutdown_generation + 1,
+        })
+        .await;
+    assert_eq!(status.state, StagePreparationState::Cancelled);
+
+    let response = state
+        .prepare(StagePrepareRequest {
+            load: load.clone(),
+            coordinator_id: None,
+        })
+        .await
+        .unwrap();
+
+    assert!(!response.accepted);
+    assert_eq!(response.error.as_deref(), Some("stale shutdown generation"));
+    assert_eq!(response.status.state, StagePreparationState::Cancelled);
+    assert_eq!(
+        response.status.error.as_deref(),
+        Some("stale shutdown generation")
+    );
+    assert_eq!(
+        response.status.shutdown_generation,
+        load.shutdown_generation + 1
+    );
+
+    let _ = release_tx.send(Ok(()));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let inventory = state
+        .inventory(StageInventoryRequest {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+        })
+        .await;
+    let stored = inventory
+        .preparing_ranges
+        .iter()
+        .find(|status| status.stage_id == load.stage_id)
+        .expect("cancelled prepare status should remain visible");
+    assert_eq!(stored.state, StagePreparationState::Cancelled);
+    assert_eq!(stored.shutdown_generation, load.shutdown_generation + 1);
+    assert!(stored.error.is_none());
+}
+
+#[tokio::test]
 async fn stale_cancel_prepare_keeps_newer_prepare_status() {
     let load = load_request();
     let key = stage_key(&load.topology_id, &load.run_id, &load.stage_id);

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
@@ -359,6 +359,135 @@ async fn prepare_layer_package_fails_only_after_peer_prefetch_and_local_resoluti
 }
 
 #[tokio::test]
+async fn cancel_prepare_persists_cancelled_status_and_blocks_late_prefetch_result() {
+    let mut load = load_request();
+    load.load_mode = LoadMode::LayerPackage;
+    load.package_ref = "missing-layer-package".to_string();
+    load.manifest_sha256 = "a".repeat(64);
+    load.downstream = None;
+
+    let (prefetcher, started_rx, release_tx) = BlockingPackagePrefetcher::new();
+    let mut state = StageControlState {
+        package_prefetcher: Some(Arc::new(prefetcher)),
+        ..Default::default()
+    };
+
+    state
+        .prepare(StagePrepareRequest {
+            load: load.clone(),
+            coordinator_id: None,
+        })
+        .await
+        .unwrap();
+    started_rx.await.expect("prefetch must start before cancel");
+
+    let status = state
+        .cancel_prepare(StageCancelPrepareRequest {
+            topology_id: load.topology_id.clone(),
+            run_id: load.run_id.clone(),
+            stage_id: load.stage_id.clone(),
+            shutdown_generation: load.shutdown_generation + 1,
+        })
+        .await;
+
+    assert_eq!(status.state, StagePreparationState::Cancelled);
+    assert_eq!(status.model_id, load.model_id);
+    assert_eq!(status.package_ref, load.package_ref);
+    assert_eq!(status.shutdown_generation, load.shutdown_generation + 1);
+
+    let _ = release_tx.send(Ok(()));
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let inventory = state
+        .inventory(StageInventoryRequest {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+        })
+        .await;
+    let status = inventory
+        .preparing_ranges
+        .iter()
+        .find(|status| status.stage_id == load.stage_id)
+        .expect("cancelled prepare status should remain visible");
+    assert_eq!(status.state, StagePreparationState::Cancelled);
+}
+
+#[tokio::test]
+async fn stale_cancel_prepare_keeps_newer_prepare_status() {
+    let load = load_request();
+    let key = stage_key(&load.topology_id, &load.run_id, &load.stage_id);
+    let mut state = StageControlState::default();
+    let current = preparation_status_from_load(&load, StagePreparationState::Resolving);
+    state.preparations.lock().await.insert(key, current.clone());
+
+    let status = state
+        .cancel_prepare(StageCancelPrepareRequest {
+            topology_id: load.topology_id.clone(),
+            run_id: load.run_id.clone(),
+            stage_id: load.stage_id.clone(),
+            shutdown_generation: load.shutdown_generation.saturating_sub(1),
+        })
+        .await;
+
+    assert_eq!(status.state, StagePreparationState::Resolving);
+    assert_eq!(status.shutdown_generation, current.shutdown_generation);
+    assert_eq!(status.error.as_deref(), Some("stale shutdown generation"));
+}
+
+#[tokio::test]
+async fn status_update_upserts_preparation_status_and_rejects_stale_generation() {
+    let load = load_request();
+    let mut state = StageControlState::default();
+    let mut update = preparation_status_from_load(&load, StagePreparationState::Loading);
+    update.bytes_done = Some(1024);
+    update.bytes_total = Some(4096);
+
+    let ack = state.apply_status_update(update.clone()).await;
+
+    assert!(ack.accepted);
+    assert!(ack.error.is_none());
+    let inventory = state
+        .inventory(StageInventoryRequest {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+        })
+        .await;
+    let status = inventory
+        .preparing_ranges
+        .iter()
+        .find(|status| status.stage_id == load.stage_id)
+        .expect("status update should be visible through inventory");
+    assert_eq!(status.state, StagePreparationState::Loading);
+    assert_eq!(status.bytes_done, Some(1024));
+
+    let mut stale = update;
+    stale.shutdown_generation = stale.shutdown_generation.saturating_sub(1);
+    stale.state = StagePreparationState::Failed;
+    stale.error = Some("late failure".to_string());
+
+    let ack = state.apply_status_update(stale).await;
+
+    assert!(!ack.accepted);
+    assert_eq!(ack.error.as_deref(), Some("stale shutdown generation"));
+    let inventory = state
+        .inventory(StageInventoryRequest {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+        })
+        .await;
+    let status = inventory
+        .preparing_ranges
+        .iter()
+        .find(|status| status.stage_id == load.stage_id)
+        .expect("newer status should remain visible");
+    assert_eq!(status.state, StagePreparationState::Loading);
+    assert!(status.error.is_none());
+}
+
+#[tokio::test]
 async fn inventory_retains_failed_prepare_status() {
     let load = load_request();
     let key = stage_key(&load.topology_id, &load.run_id, &load.stage_id);

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -681,6 +681,7 @@ impl Node {
                     served_model_runtime: p.served_model_runtime.clone(),
                     owner_attestation: p.owner_attestation.clone(),
                     artifact_transfer_supported: p.artifact_transfer_supported,
+                    stage_status_list_supported: p.stage_status_list_supported,
                 })
                 .collect()
         };
@@ -747,6 +748,7 @@ impl Node {
             owner_attestation: my_owner_attestation,
             artifact_transfer_supported:
                 crate::models::artifact_transfer::artifact_transfer_enabled(),
+            stage_status_list_supported: true,
         });
         announcements
     }
@@ -801,6 +803,7 @@ mod tests {
             served_model_runtime: vec![],
             owner_attestation: None,
             artifact_transfer_supported: true,
+            stage_status_list_supported: true,
         }
     }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -36,6 +36,7 @@ pub(super) fn peer_meaningfully_changed(old: &PeerInfo, new: &PeerInfo) -> bool 
         || old.served_model_descriptors != new.served_model_descriptors
         || old.served_model_runtime != new.served_model_runtime
         || old.artifact_transfer_supported != new.artifact_transfer_supported
+        || old.stage_status_list_supported != new.stage_status_list_supported
         || old.version != new.version
         || old.owner_summary != new.owner_summary
         || old.gpu_reserved_bytes != new.gpu_reserved_bytes
@@ -108,6 +109,7 @@ pub(super) fn apply_transitive_ann(
     existing.served_model_descriptors = ann.served_model_descriptors.clone();
     existing.served_model_runtime = ann.served_model_runtime.clone();
     existing.artifact_transfer_supported = ann.artifact_transfer_supported;
+    existing.stage_status_list_supported = ann.stage_status_list_supported;
     if ann.experts_summary.is_some() {
         existing.experts_summary = ann.experts_summary.clone();
     }
@@ -459,6 +461,7 @@ impl Node {
             existing.owner_summary = owner_summary.clone();
             existing.served_model_descriptors = ann.served_model_descriptors.clone();
             existing.served_model_runtime = ann.served_model_runtime.clone();
+            existing.stage_status_list_supported = ann.stage_status_list_supported;
             if ann.version.is_some() {
                 existing.version = ann.version.clone();
             }
@@ -884,6 +887,15 @@ mod tests {
     }
 
     #[test]
+    fn test_meaningfully_changed_stage_status_list_support() {
+        let old_peer = test_peer(Some(100));
+        let mut new_peer = test_peer(Some(100));
+        new_peer.stage_status_list_supported = !old_peer.stage_status_list_supported;
+
+        assert!(peer_meaningfully_changed(&old_peer, &new_peer));
+    }
+
+    #[test]
     fn test_apply_transitive_ann_refreshes_explicit_model_interests() {
         let mut existing = test_peer(Some(100));
         let mut ann = test_announcement(Some(100));
@@ -895,6 +907,35 @@ mod tests {
             existing.explicit_model_interests,
             vec!["Qwen/Qwen3-Coder-Next-GGUF@main:Q4_K_M".to_string()]
         );
+    }
+
+    #[test]
+    fn test_apply_transitive_ann_refreshes_stage_status_list_support() {
+        let mut existing = test_peer(Some(100));
+        existing.stage_status_list_supported = false;
+        let mut ann = test_announcement(Some(100));
+        ann.stage_status_list_supported = true;
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert!(existing.stage_status_list_supported);
+    }
+
+    #[tokio::test]
+    async fn test_add_peer_refreshes_stage_status_list_support() {
+        let node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
+        let peer_id = test_endpoint_id(0x44);
+        let addr = test_addr(0x44);
+        let mut ann = test_announcement(Some(100));
+        ann.stage_status_list_supported = false;
+
+        node.add_peer(peer_id, addr.clone(), &ann).await;
+        ann.stage_status_list_supported = true;
+        node.add_peer(peer_id, addr, &ann).await;
+
+        let state = node.state.lock().await;
+        let peer = state.peers.get(&peer_id).expect("peer should be tracked");
+        assert!(peer.stage_status_list_supported);
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -755,6 +755,7 @@ pub(crate) struct PeerAnnouncement {
     pub(crate) served_model_runtime: Vec<ModelRuntimeDescriptor>,
     pub(crate) owner_attestation: Option<SignedNodeOwnership>,
     pub(crate) artifact_transfer_supported: bool,
+    pub(crate) stage_status_list_supported: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -808,6 +809,7 @@ pub struct PeerInfo {
     pub served_model_runtime: Vec<ModelRuntimeDescriptor>,
     pub owner_attestation: Option<SignedNodeOwnership>,
     pub artifact_transfer_supported: bool,
+    pub stage_status_list_supported: bool,
     pub owner_summary: OwnershipSummary,
 }
 
@@ -864,6 +866,7 @@ impl PeerInfo {
             served_model_runtime: ann.served_model_runtime.clone(),
             owner_attestation: ann.owner_attestation.clone(),
             artifact_transfer_supported: ann.artifact_transfer_supported,
+            stage_status_list_supported: ann.stage_status_list_supported,
             owner_summary,
         }
     }
@@ -4464,7 +4467,13 @@ impl Node {
             }
             _ => {}
         }
-        let proto_response = stage_control_response_to_proto(response);
+        let status_list_supported = self
+            .peer_supports_skippy_subprotocol_feature(
+                remote,
+                skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST,
+            )
+            .await;
+        let proto_response = stage_control_response_to_proto(response, status_list_supported);
         write_len_prefixed(&mut send, &proto_response.encode_to_vec()).await?;
         let _ = send.finish();
         Ok(())
@@ -4577,6 +4586,9 @@ impl Node {
             skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL
             | skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER => {
                 peer.artifact_transfer_supported
+            }
+            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST => {
+                peer.stage_status_list_supported
             }
             _ => false,
         }
@@ -6195,6 +6207,7 @@ fn stage_preparation_status_from_cancel(
 
 fn stage_control_response_to_proto(
     response: crate::inference::skippy::StageControlResponse,
+    status_list_supported: bool,
 ) -> skippy_stage_proto::StageControlResponse {
     use skippy_stage_proto::stage_control_response::Response;
 
@@ -6207,13 +6220,19 @@ fn stage_control_response_to_proto(
             })
         }
         crate::inference::skippy::StageControlResponse::Status(statuses) => {
-            Response::StageStatus(statuses.into_iter().next().map_or_else(
-                || skippy_stage_proto::StageStatus {
-                    state: skippy_stage_proto::StageRuntimeState::Stopped as i32,
-                    ..Default::default()
-                },
-                stage_status_to_proto,
-            ))
+            if status_list_supported {
+                Response::StageStatuses(skippy_stage_proto::StageStatusList {
+                    statuses: statuses.into_iter().map(stage_status_to_proto).collect(),
+                })
+            } else {
+                Response::StageStatus(statuses.into_iter().next().map_or_else(
+                    || skippy_stage_proto::StageStatus {
+                        state: skippy_stage_proto::StageRuntimeState::Stopped as i32,
+                        ..Default::default()
+                    },
+                    stage_status_to_proto,
+                ))
+            }
         }
         crate::inference::skippy::StageControlResponse::Inventory(inventory) => {
             Response::LayerInventory(layer_inventory_to_proto(inventory))
@@ -6266,6 +6285,15 @@ fn stage_control_response_from_proto(
         Response::StageStatus(status) => {
             Ok(crate::inference::skippy::StageControlResponse::Status(
                 vec![stage_status_from_proto(status)?],
+            ))
+        }
+        Response::StageStatuses(statuses) => {
+            Ok(crate::inference::skippy::StageControlResponse::Status(
+                statuses
+                    .statuses
+                    .into_iter()
+                    .map(stage_status_from_proto)
+                    .collect::<anyhow::Result<Vec<_>>>()?,
             ))
         }
         Response::LayerInventory(inventory) => {

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -831,6 +831,7 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: false,
+        stage_status_list_supported: false,
         owner_summary: OwnershipSummary::default(),
     }
 }
@@ -1686,6 +1687,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         }],
         owner_attestation: None,
         artifact_transfer_supported: true,
+        stage_status_list_supported: true,
     };
 
     let proto_pa = local_ann_to_proto_ann(&local_ann);
@@ -1909,6 +1911,7 @@ fn transitive_peer_update_refreshes_metadata_fields() {
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: true,
+        stage_status_list_supported: true,
     };
 
     apply_transitive_ann(&mut existing, &addr, &ann);
@@ -1988,6 +1991,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: true,
+        stage_status_list_supported: true,
     };
 
     apply_transitive_ann(&mut existing, &weak_addr, &ann);
@@ -2041,6 +2045,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: true,
+        stage_status_list_supported: true,
     };
     apply_transitive_ann(&mut existing, &richer_addr, &ann2);
 
@@ -2612,6 +2617,7 @@ fn transitive_peer_update_refreshes_last_mentioned() {
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: true,
+        stage_status_list_supported: true,
     };
 
     apply_transitive_ann(&mut peer, &addr, &ann);
@@ -3357,6 +3363,7 @@ fn make_test_peer(id: EndpointId, rtt_ms: Option<u32>, vram_gb: u64) -> PeerInfo
         served_model_runtime: vec![],
         owner_attestation: None,
         artifact_transfer_supported: false,
+        stage_status_list_supported: false,
         owner_summary: OwnershipSummary::default(),
     }
 }
@@ -5495,7 +5502,7 @@ fn stage_control_inventory_response_round_trips_plain_gguf_source() {
     );
 
     let decoded =
-        stage_control_response_from_proto(stage_control_response_to_proto(response)).unwrap();
+        stage_control_response_from_proto(stage_control_response_to_proto(response, true)).unwrap();
 
     let crate::inference::skippy::StageControlResponse::Inventory(inventory) = decoded else {
         panic!("expected inventory response");
@@ -5528,7 +5535,7 @@ fn stage_control_prepare_response_round_trips_failed_status() {
     );
 
     let decoded =
-        stage_control_response_from_proto(stage_control_response_to_proto(response)).unwrap();
+        stage_control_response_from_proto(stage_control_response_to_proto(response, true)).unwrap();
 
     let crate::inference::skippy::StageControlResponse::PrepareAccepted(accepted) = decoded else {
         panic!("expected prepare response");
@@ -5543,6 +5550,65 @@ fn stage_control_prepare_response_round_trips_failed_status() {
         accepted.status.error.as_deref(),
         Some("source GGUF missing")
     );
+}
+
+#[test]
+fn stage_control_status_list_response_round_trips_all_statuses() {
+    let first = stage_status_from_load(
+        &test_stage_load_request(),
+        crate::inference::skippy::StageRuntimeState::Ready,
+    );
+    let mut second = first.clone();
+    second.stage_id = "stage-2".to_string();
+    second.stage_index = 2;
+    second.layer_start = 24;
+    second.layer_end = 36;
+    second.bind_addr = "127.0.0.1:51235".to_string();
+    let response =
+        crate::inference::skippy::StageControlResponse::Status(vec![first.clone(), second.clone()]);
+
+    let decoded =
+        stage_control_response_from_proto(stage_control_response_to_proto(response, true)).unwrap();
+
+    let crate::inference::skippy::StageControlResponse::Status(statuses) = decoded else {
+        panic!("expected status response");
+    };
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[0].stage_id, first.stage_id);
+    assert_eq!(statuses[1].stage_id, second.stage_id);
+    assert_eq!(statuses[1].bind_addr, "127.0.0.1:51235");
+}
+
+#[test]
+fn empty_stage_control_status_list_response_round_trips_as_empty() {
+    let response = crate::inference::skippy::StageControlResponse::Status(Vec::new());
+
+    let decoded =
+        stage_control_response_from_proto(stage_control_response_to_proto(response, true)).unwrap();
+
+    let crate::inference::skippy::StageControlResponse::Status(statuses) = decoded else {
+        panic!("expected status response");
+    };
+    assert!(statuses.is_empty());
+}
+
+#[test]
+fn legacy_stage_control_status_response_still_decodes() {
+    let status = stage_status_from_load(
+        &test_stage_load_request(),
+        crate::inference::skippy::StageRuntimeState::Ready,
+    );
+    let response = crate::inference::skippy::StageControlResponse::Status(vec![status.clone()]);
+
+    let decoded =
+        stage_control_response_from_proto(stage_control_response_to_proto(response, false))
+            .unwrap();
+
+    let crate::inference::skippy::StageControlResponse::Status(statuses) = decoded else {
+        panic!("expected status response");
+    };
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].stage_id, status.stage_id);
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -7,10 +7,14 @@ use std::collections::HashMap;
 
 fn skippy_stage_subprotocols(
     artifact_transfer_supported: bool,
+    status_list_supported: bool,
 ) -> Vec<crate::proto::node::MeshSubprotocol> {
     let mut features = vec![skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL.to_string()];
     if artifact_transfer_supported {
         features.push(skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER.to_string());
+    }
+    if status_list_supported {
+        features.push(skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST.to_string());
     }
     vec![crate::proto::node::MeshSubprotocol {
         name: skippy_protocol::STAGE_SUBPROTOCOL_NAME.to_string(),
@@ -20,12 +24,30 @@ fn skippy_stage_subprotocols(
 }
 
 fn supports_skippy_artifact_transfer(subprotocols: &[crate::proto::node::MeshSubprotocol]) -> bool {
+    supports_skippy_stage_feature(
+        subprotocols,
+        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER,
+    )
+}
+
+fn supports_skippy_status_list(subprotocols: &[crate::proto::node::MeshSubprotocol]) -> bool {
+    supports_skippy_stage_feature(
+        subprotocols,
+        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST,
+    )
+}
+
+fn supports_skippy_stage_feature(
+    subprotocols: &[crate::proto::node::MeshSubprotocol],
+    expected_feature: &str,
+) -> bool {
     subprotocols.iter().any(|subprotocol| {
         subprotocol.name == skippy_protocol::STAGE_SUBPROTOCOL_NAME
             && subprotocol.major == skippy_protocol::STAGE_SUBPROTOCOL_MAJOR
-            && subprotocol.features.iter().any(|feature| {
-                feature == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER
-            })
+            && subprotocol
+                .features
+                .iter()
+                .any(|feature| feature == expected_feature)
     })
 }
 
@@ -509,7 +531,10 @@ pub(crate) fn local_ann_to_proto_ann(
         gpu_reserved_bytes: ann.gpu_reserved_bytes.clone(),
         hardware,
         first_joined_mesh_ts: ann.first_joined_mesh_ts,
-        subprotocols: skippy_stage_subprotocols(ann.artifact_transfer_supported),
+        subprotocols: skippy_stage_subprotocols(
+            ann.artifact_transfer_supported,
+            ann.stage_status_list_supported,
+        ),
     }
 }
 
@@ -672,6 +697,7 @@ pub(crate) fn proto_ann_to_local(
             .as_ref()
             .map(proto_owner_attestation_to_local),
         artifact_transfer_supported: supports_skippy_artifact_transfer(&pa.subprotocols),
+        stage_status_list_supported: supports_skippy_status_list(&pa.subprotocols),
     };
     crate::mesh::backfill_legacy_descriptors(&mut ann);
     Some((addr, ann))

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -576,6 +576,7 @@ mod tests {
             served_model_runtime: vec![],
             owner_attestation: None,
             artifact_transfer_supported: false,
+            stage_status_list_supported: false,
             owner_summary: OwnershipSummary::default(),
         }
     }
@@ -1280,6 +1281,7 @@ mod tests {
                 signature: "33".repeat(64),
             }),
             artifact_transfer_supported: true,
+            stage_status_list_supported: true,
         };
         let proto_pa = local_ann_to_proto_ann(&ann);
         let skippy = proto_pa
@@ -1295,6 +1297,10 @@ mod tests {
                 .any(|feature| feature
                     == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER)
         );
+        assert!(skippy
+            .features
+            .iter()
+            .any(|feature| feature == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST));
         assert_eq!(
             proto_pa
                 .owner_attestation
@@ -1306,6 +1312,7 @@ mod tests {
         let (_, roundtripped) =
             proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
         assert!(roundtripped.artifact_transfer_supported);
+        assert!(roundtripped.stage_status_list_supported);
         let roundtripped = roundtripped
             .owner_attestation
             .expect("owner attestation must round-trip");
@@ -1350,6 +1357,7 @@ mod tests {
             served_model_runtime: vec![],
             owner_attestation: None,
             artifact_transfer_supported: true,
+            stage_status_list_supported: true,
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann);
@@ -2073,6 +2081,7 @@ mod tests {
             served_model_runtime: vec![],
             owner_attestation: None,
             artifact_transfer_supported: true,
+            stage_status_list_supported: true,
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann_with_timestamp);
@@ -2118,6 +2127,7 @@ mod tests {
             served_model_runtime: vec![],
             owner_attestation: None,
             artifact_transfer_supported: false,
+            stage_status_list_supported: false,
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann_without_timestamp);

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1008,8 +1008,17 @@ impl SplitTopologyCoordinator {
             self.pinned_gpu.as_ref().map(|gpu| gpu.vram_bytes),
         )
         .await;
+        self.node
+            .refresh_stage_runtime_statuses(Duration::from_secs(2))
+            .await;
+        let runtime_statuses = self.node.stage_runtime_statuses().await;
         let missing_stage_nodes =
             split_missing_active_stage_nodes(&self.active, &snapshot.participants);
+        let unavailable_stage_nodes = split_unavailable_active_stage_nodes(
+            &self.active,
+            &snapshot.participants,
+            &runtime_statuses,
+        );
         let planned_participants = snapshot.participants.clone();
         let candidate = if split_participants_meet_minimum(&planned_participants) {
             match self.plan_replan_candidate(&planned_participants) {
@@ -1056,6 +1065,7 @@ impl SplitTopologyCoordinator {
         match split_loss_recovery_decision(
             &self.active,
             &snapshot.participants,
+            &unavailable_stage_nodes,
             candidate.as_ref(),
             self.local_model_fits(),
         ) {
@@ -1070,6 +1080,7 @@ impl SplitTopologyCoordinator {
                     candidate_topology_id = candidate.topology_id,
                     candidate_generation = candidate.generation,
                     missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
+                    unavailable_stage_nodes = ?split_node_labels(&unavailable_stage_nodes),
                     active_stages = ?split_stage_plan_labels(&self.active.stages),
                     candidate_stages = ?split_stage_plan_labels(&candidate.stages),
                     participants = ?split_participant_labels(&candidate.participants),
@@ -1088,7 +1099,7 @@ impl SplitTopologyCoordinator {
                 }
                 if self.local_model_fits() {
                     if let Err(err) = self
-                        .request_local_fallback(reason, missing_stage_nodes.clone())
+                        .request_local_fallback(reason, unavailable_stage_nodes.clone())
                         .await
                     {
                         tracing::warn!(
@@ -1102,7 +1113,7 @@ impl SplitTopologyCoordinator {
                     }
                 }
                 if let Err(err) = self
-                    .withdraw_active_generation(reason, missing_stage_nodes.clone())
+                    .withdraw_active_generation(reason, unavailable_stage_nodes.clone())
                     .await
                 {
                     tracing::warn!(
@@ -1123,10 +1134,11 @@ impl SplitTopologyCoordinator {
                     topology_id = self.active.topology_id,
                     generation = self.active.generation,
                     missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
+                    unavailable_stage_nodes = ?split_node_labels(&unavailable_stage_nodes),
                     "split topology lost an active stage peer; requesting local runtime fallback"
                 );
                 if let Err(err) = self
-                    .request_local_fallback(reason, missing_stage_nodes.clone())
+                    .request_local_fallback(reason, unavailable_stage_nodes.clone())
                     .await
                 {
                     tracing::warn!(
@@ -1146,10 +1158,11 @@ impl SplitTopologyCoordinator {
                     topology_id = self.active.topology_id,
                     generation = self.active.generation,
                     missing_stage_nodes = ?split_node_labels(&missing_stage_nodes),
+                    unavailable_stage_nodes = ?split_node_labels(&unavailable_stage_nodes),
                     "split topology lost an active stage peer and no replacement path is available; withdrawing active generation"
                 );
                 if let Err(err) = self
-                    .withdraw_active_generation(reason, missing_stage_nodes.clone())
+                    .withdraw_active_generation(reason, unavailable_stage_nodes.clone())
                     .await
                 {
                     tracing::warn!(
@@ -1377,10 +1390,13 @@ fn split_replan_decision(
 fn split_loss_recovery_decision(
     active: &SplitTopologyGeneration,
     current_participants: &[SplitParticipant],
+    unavailable_stage_nodes: &[iroh::EndpointId],
     candidate: Option<&SplitTopologyGeneration>,
     local_model_fits: bool,
 ) -> SplitLossRecoveryDecision {
-    if !split_active_stage_participant_missing(active, current_participants) {
+    if !split_active_stage_participant_missing(active, current_participants)
+        && unavailable_stage_nodes.is_empty()
+    {
         return SplitLossRecoveryDecision::NoActiveStageLoss;
     }
     if candidate.is_some_and(split_candidate_is_valid_replacement_split) {
@@ -1428,6 +1444,35 @@ fn split_missing_active_stage_nodes(
         missing.push(stage.node_id);
     }
     missing
+}
+
+fn split_unavailable_active_stage_nodes(
+    active: &SplitTopologyGeneration,
+    current_participants: &[SplitParticipant],
+    runtime_statuses: &[mesh::StageRuntimeStatus],
+) -> Vec<iroh::EndpointId> {
+    let mut unavailable = split_missing_active_stage_nodes(active, current_participants);
+    for status in runtime_statuses {
+        if !matches!(
+            status.state,
+            skippy::StageRuntimeState::Failed | skippy::StageRuntimeState::Stopped
+        ) || status.topology_id != active.topology_id
+            || status.run_id != active.run_id
+            || active
+                .stages
+                .iter()
+                .all(|stage| stage.stage_id != status.stage_id)
+        {
+            continue;
+        }
+        let Some(node_id) = status.node_id else {
+            continue;
+        };
+        if !unavailable.contains(&node_id) {
+            unavailable.push(node_id);
+        }
+    }
+    unavailable
 }
 
 async fn stop_split_generation(
@@ -2424,6 +2469,44 @@ mod tests {
         }
     }
 
+    fn runtime_status_for_stage(
+        generation: &SplitTopologyGeneration,
+        stage: &RuntimeSliceStagePlan,
+        state: skippy::StageRuntimeState,
+    ) -> mesh::StageRuntimeStatus {
+        mesh::StageRuntimeStatus {
+            topology_id: generation.topology_id.clone(),
+            run_id: generation.run_id.clone(),
+            model_id: "model-a".to_string(),
+            backend: "skippy".to_string(),
+            package_ref: Some("gguf:///model.gguf".to_string()),
+            manifest_sha256: Some("direct-gguf:1:model.gguf".to_string()),
+            source_model_path: Some("/model.gguf".to_string()),
+            source_model_sha256: None,
+            source_model_bytes: Some(1),
+            materialized_path: None,
+            materialized_pinned: false,
+            projector_path: None,
+            stage_id: stage.stage_id.clone(),
+            stage_index: stage.stage_index,
+            node_id: Some(stage.node_id),
+            layer_start: stage.layer_start,
+            layer_end: stage.layer_end,
+            state,
+            bind_addr: "127.0.0.1:31000".to_string(),
+            activation_width: 896,
+            wire_dtype: skippy::StageWireDType::F16,
+            selected_device: None,
+            ctx_size: 512,
+            lane_count: 4,
+            n_batch: None,
+            n_ubatch: None,
+            flash_attn_type: FlashAttentionType::Auto,
+            error: None,
+            shutdown_generation: generation.generation,
+        }
+    }
+
     fn local_stage(
         node_id: iroh::EndpointId,
         stage_index: u32,
@@ -2833,6 +2916,31 @@ mod tests {
         );
     }
 
+    #[test]
+    fn split_unavailable_active_stage_nodes_includes_failed_stage_without_missing_peer() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+        let statuses = vec![runtime_status_for_stage(
+            &active,
+            &active.stages[1],
+            skippy::StageRuntimeState::Failed,
+        )];
+
+        assert_eq!(
+            split_unavailable_active_stage_nodes(
+                &active,
+                &[participant(1), participant(2), participant(3)],
+                &statuses,
+            ),
+            vec![make_id(2)]
+        );
+    }
+
     #[tokio::test]
     async fn load_split_runtime_generation_stops_candidate_stages_after_partial_load_failure() {
         let node = mesh::Node::new_for_tests(NodeRole::Host { http_port: 9337 })
@@ -3121,6 +3229,35 @@ mod tests {
             split_loss_recovery_decision(
                 &active,
                 &[participant(1), participant(3)],
+                &[],
+                Some(&candidate),
+                true,
+            ),
+            SplitLossRecoveryDecision::ReplacementSplit
+        );
+    }
+
+    #[test]
+    fn split_loss_recovery_uses_replacement_split_when_active_stage_has_failed() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 10), stage(2, 1, 10, 20), stage(3, 2, 20, 30)],
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 15), stage(2, 1, 15, 30)],
+        );
+        assert_eq!(
+            split_loss_recovery_decision(
+                &active,
+                &[participant(1), participant(2), participant(3)],
+                &[make_id(2)],
                 Some(&candidate),
                 true,
             ),
@@ -3139,7 +3276,7 @@ mod tests {
         );
 
         assert_eq!(
-            split_loss_recovery_decision(&active, &[participant(1)], None, true),
+            split_loss_recovery_decision(&active, &[participant(1)], &[], None, true),
             SplitLossRecoveryDecision::LocalFallback
         );
     }
@@ -3155,7 +3292,7 @@ mod tests {
         );
 
         assert_eq!(
-            split_loss_recovery_decision(&active, &[participant(1)], None, false),
+            split_loss_recovery_decision(&active, &[participant(1)], &[], None, false),
             SplitLossRecoveryDecision::Withdraw
         );
     }
@@ -3178,7 +3315,7 @@ mod tests {
         );
 
         assert_eq!(
-            split_loss_recovery_decision(&active, &[participant(1)], Some(&candidate), true),
+            split_loss_recovery_decision(&active, &[participant(1)], &[], Some(&candidate), true),
             SplitLossRecoveryDecision::LocalFallback
         );
         assert!(!split_candidate_is_valid_replacement_split(&candidate));
@@ -3206,6 +3343,7 @@ mod tests {
             split_loss_recovery_decision(
                 &active,
                 &[participant(1), participant(2)],
+                &[],
                 Some(&candidate),
                 false,
             ),

--- a/crates/skippy-protocol/proto/stage.proto
+++ b/crates/skippy-protocol/proto/stage.proto
@@ -30,6 +30,7 @@ message StageControlResponse {
     PrepareStageAccepted prepare_stage_accepted = 5;
     StagePreparationStatus stage_preparation_status = 6;
     StageStatusAck stage_status_ack = 7;
+    StageStatusList stage_statuses = 8;
   }
 }
 
@@ -168,6 +169,10 @@ message StageStatus {
   optional uint32 n_batch = 26;
   optional uint32 n_ubatch = 27;
   StageFlashAttnType flash_attn_type = 28;
+}
+
+message StageStatusList {
+  repeated StageStatus statuses = 1;
 }
 
 message LayerInventory {

--- a/crates/skippy-protocol/src/lib.rs
+++ b/crates/skippy-protocol/src/lib.rs
@@ -13,6 +13,7 @@ pub const STAGE_SUBPROTOCOL_NAME: &str = "skippy-stage";
 pub const STAGE_SUBPROTOCOL_MAJOR: u32 = 1;
 pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL: &str = "stage-control";
 pub const STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER: &str = "artifact-transfer";
+pub const STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST: &str = "status-list";
 pub const STAGE_PROTOCOL_GENERATION: u32 = 2;
 pub const STAGE_STREAM_CONTROL: u8 = 0x01;
 pub const STAGE_STREAM_TRANSPORT: u8 = 0x02;
@@ -640,8 +641,8 @@ mod tests {
         GetStageStatus, LayerInventory, LayerRange, LoadStage, PrepareStage, PrepareStageAccepted,
         SourceModelKind, StageArtifactTransferRequest, StageArtifactTransferResponse,
         StageControlRequest, StageControlResponse, StagePreparationState, StagePreparationStatus,
-        StageReady, StageRuntimeState, StageStatus, StageStatusAck, StageStatusUpdate,
-        StageTransportOpen, StageWireDType, StopStage,
+        StageReady, StageRuntimeState, StageStatus, StageStatusAck, StageStatusList,
+        StageStatusUpdate, StageTransportOpen, StageWireDType, StopStage,
     };
     use super::{
         validate_stage_artifact_transfer_request, validate_stage_artifact_transfer_response,
@@ -885,6 +886,33 @@ mod tests {
             ..frame.clone()
         };
         validate_stage_control_response(&ack_response).unwrap();
+
+        let status_list_response = StageControlResponse {
+            response: Some(stage_control_response::Response::StageStatuses(
+                StageStatusList {
+                    statuses: vec![StageStatus {
+                        topology_id: "topology-a".to_string(),
+                        run_id: "run-a".to_string(),
+                        model_id: "qwen".to_string(),
+                        backend: "skippy".to_string(),
+                        stage_id: "stage-0".to_string(),
+                        stage_index: 0,
+                        layer_start: 0,
+                        layer_end: 16,
+                        state: StageRuntimeState::Ready as i32,
+                        bind_addr: "127.0.0.1:51234".to_string(),
+                        activation_width: 4096,
+                        wire_dtype: StageWireDType::StageWireDtypeF16 as i32,
+                        shutdown_generation: 7,
+                        ctx_size: 8192,
+                        lane_count: 2,
+                        ..Default::default()
+                    }],
+                },
+            )),
+            ..frame.clone()
+        };
+        validate_stage_control_response(&status_list_response).unwrap();
 
         let missing_response = StageControlResponse {
             response: None,


### PR DESCRIPTION
## Summary

Skippy split-stage serving now has a more reliable control plane for cancelled prepares and failed active stages.

This PR preserves full stage-status visibility for capable peers, makes prepare cancellation mutate real local state, applies status updates to inventory, and lets split topology recovery react when an active stage is `Failed` or `Stopped` even if the peer is still present.

## Why

This closes concrete Skippy orchestration gaps from the short-term roadmap: stage control should not lose multi-stage status evidence, cancelled prepare work should not be overwritten by late background tasks, and split recovery should not wait for a peer to disappear before recovering from a failed active stage.

## What Changed

- Added additive `StageStatusList` support to stage-control responses.
- Advertised the new `status-list` capability through existing `skippy-stage/1` subprotocol metadata.
- Kept mixed-version compatibility by sending legacy singular `StageStatus` responses to peers that do not advertise `status-list`.
- Persisted `CancelPrepare` as real `Cancelled` preparation state and aborts the tracked prepare task.
- Rejected stale shutdown-generation cancels and stale late status writes.
- Made `StatusUpdate` upsert preparation inventory with validation and explicit ack errors.
- Extended split recovery to treat `Failed`/`Stopped` active stage status as unavailable capacity, reusing the existing replacement split, local fallback, and withdraw paths.

## Protocol

Additive only:

- New protobuf field: `StageControlResponse.stage_statuses = 8`.
- New feature flag: `status-list` under `skippy-stage/1`.
- No existing fields, stream kinds, or legacy behavior are removed or repurposed.

## Validation

Base: `main` at `8d12c0be26fb3af4ed309fde6df65acfabff0162`  
Head: `e13559b923c08f6ea083ae95c9e1b7b214f7a4b4`  
Ahead/behind: `0 1`  
Merge-base: `8d12c0be26fb3af4ed309fde6df65acfabff0162`  
Fast-forward safety: `origin/main` is an ancestor of `HEAD`.

```text
git diff --check origin/main...HEAD: PASS, no output
cargo fmt --all -- --check: PASS
rustup run stable cargo clippy -p mesh-llm -- -D warnings: PASS
cargo test -p skippy-protocol --lib: PASS, 18 passed
cargo test -p mesh-llm-host-runtime inference::skippy::stage::tests --lib: PASS, 16 passed
cargo test -p mesh-llm-host-runtime stage_control --lib: PASS, 9 passed
cargo test -p mesh-llm-host-runtime split_loss_recovery --lib: PASS, 6 passed
cargo test -p mesh-llm-host-runtime split_unavailable_active_stage_nodes --lib: PASS, 1 passed
cargo check -p mesh-llm: PASS
```

The Rust commands above used:

```text
LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal
```

Broader local-suite note: `cargo test -p mesh-llm-host-runtime --lib` is blocked in this local environment by `runtime::tests::initial_pretty_session_mode_allows_dashboard_only_for_serve_surface`. The same exact test also fails on clean `origin/main` at the validated base SHA with the same `InteractiveDashboard` vs `None` assertion, so this is treated as a baseline/local-environment caveat rather than a regression from this diff.

Remote CI: PASS on the updated head SHA. `CI` completed successfully, including `linux`, `macos`, `Linux Vulkan`, `Linux CUDA slim`, `Linux ROCm slim`, and Skippy inference smoke tests. `docker-client` also completed successfully.

## Runtime Safety

- No new unbounded queues or broad background pipelines were added.
- Prepare tasks are now tracked so cancel/replacement paths can stop stale work explicitly.
- Cancelled or newer generations are guarded against late background writes.
- Existing split recovery outcomes are reused; the health signal is expanded from missing peers to missing-or-failed active stages.
- No invariant regression introduced.

## Rollback

Rollback: revert this PR.  
DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveats: rollback restores the previous stage-control status, prepare-cancel, and failed-stage recovery behavior.
