### PR TITLE
Use mounted bucket workspace for HF package jobs

### DIFF
--- a/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
+++ b/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
@@ -881,7 +881,7 @@ fn job_spec(
                 volume_type: "bucket".into(),
                 source: "meshllm/layer-split-output".into(),
                 mount_path: "/bucket".into(),
-                read_only: Some(true),
+                read_only: None,
             },
         ],
     })

--- a/crates/model-package/src/prepare.rs
+++ b/crates/model-package/src/prepare.rs
@@ -218,7 +218,7 @@ pub async fn resolve(
             volume_type: "bucket".into(),
             source: "meshllm/layer-split-output".into(),
             mount_path: "/bucket".into(),
-            read_only: Some(true),
+            read_only: None,
         },
     ];
 

--- a/crates/model-package/src/scripts/split-model-job.sh
+++ b/crates/model-package/src/scripts/split-model-job.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 #
 # Volumes:
 #   /source  — source GGUF repo (read-only mount)
+#   /bucket  — writable storage bucket for script + large package workspace
 
 MESH_LLM_REF="${MESH_LLM_REF:-main}"
 
@@ -79,7 +80,25 @@ echo "  ✓ Built: $SLICER"
 echo ""
 echo "=== [4/9] Splitting model ==="
 SOURCE_PATH="/source/${SOURCE_FILE}"
-PACKAGE_DIR="/tmp/package"
+JOB_WORK_ROOT="${JOB_WORK_ROOT:-/bucket/job-work}"
+if [ -z "${JOB_WORK_DIR:-}" ]; then
+    SAFE_TARGET_REPO="$(printf '%s' "$TARGET_REPO" | tr -c '[:alnum:]._-' '_')"
+    JOB_WORK_DIR="${JOB_WORK_ROOT}/${SAFE_TARGET_REPO}-$(date +%Y%m%d%H%M%S)-$$"
+    CLEANUP_JOB_WORK_DIR="${CLEANUP_JOB_WORK_DIR:-true}"
+else
+    CLEANUP_JOB_WORK_DIR="${CLEANUP_JOB_WORK_DIR:-false}"
+fi
+PACKAGE_DIR="${PACKAGE_DIR:-${JOB_WORK_DIR}/package}"
+export JOB_WORK_DIR PACKAGE_DIR
+
+cleanup_job_work_dir() {
+    if [ "${CLEANUP_JOB_WORK_DIR}" = "true" ] && [ -n "${JOB_WORK_DIR:-}" ]; then
+        echo "Cleaning job work dir: ${JOB_WORK_DIR}"
+        rm -rf "$JOB_WORK_DIR"
+    fi
+}
+trap cleanup_job_work_dir EXIT
+
 mkdir -p "$PACKAGE_DIR"
 
 if [ ! -f "$SOURCE_PATH" ]; then
@@ -91,6 +110,7 @@ if [ ! -f "$SOURCE_PATH" ]; then
 fi
 
 echo "  Source: $SOURCE_PATH ($(du -h "$SOURCE_PATH" | cut -f1))"
+echo "  Package workspace: $PACKAGE_DIR"
 time $SLICER write-package "$SOURCE_PATH" \
     --out-dir "$PACKAGE_DIR" \
     --model-id "$MODEL_ID" \
@@ -129,12 +149,12 @@ api.create_repo(target_repo, exist_ok=True)
 # Upload the entire package
 api.upload_folder(
     repo_id=target_repo,
-    folder_path='/tmp/package',
+    folder_path=os.environ['PACKAGE_DIR'],
     commit_message=f'Layer package from {source_repo} ({model_id})',
 )
 
 # Print summary
-manifest = json.load(open('/tmp/package/model-package.json'))
+manifest = json.load(open(os.path.join(os.environ['PACKAGE_DIR'], 'model-package.json')))
 print(f'  ✓ Published: https://huggingface.co/{target_repo}')
 print(f'    Model:  {manifest["model_id"]}')
 print(f'    Layers: {manifest["layer_count"]}')
@@ -154,9 +174,10 @@ target_repo = os.environ['TARGET_REPO']
 source_file = os.environ['SOURCE_FILE']
 source_revision = os.environ.get('SOURCE_REVISION', 'main')
 model_id = os.environ.get('MODEL_ID', '')
+package_dir = os.environ['PACKAGE_DIR']
 
 # Read manifest for metadata
-manifest = json.load(open('/tmp/package/model-package.json'))
+manifest = json.load(open(os.path.join(package_dir, 'model-package.json')))
 layer_count = manifest['layer_count']
 
 # Determine catalog entry path: entries/<owner>/<repo-name>.json
@@ -263,7 +284,7 @@ PYTHON
 # ─── Model Card ────────────────────────────────────────────────────────────
 echo ""
 echo "=== [8/9] Uploading model card ==="
-ACTIVATION_WIDTH=$(python3 -c "import json; m=json.load(open('/tmp/package/model-package.json')); print(m.get('activation_width', 'unknown'))")
+ACTIVATION_WIDTH=$(python3 -c "import json, os; m=json.load(open(os.path.join(os.environ['PACKAGE_DIR'], 'model-package.json'))); print(m.get('activation_width', 'unknown'))")
 
 cat > /tmp/README.md << EOF
 ---


### PR DESCRIPTION
## Summary
- keep HF layer-package jobs reading source models from mounted model repos
- move generated package output from pod-local `/tmp` into the mounted `layer-split-output` bucket workspace
- make both the explicit package CLI path and Unsloth queue path mount the bucket writable

## Root Cause
Large package jobs can generate hundreds of GB of layer artifacts. Writing those artifacts under `/tmp` can exceed the HF Job pod's 50 GB ephemeral storage limit and evict the job before upload.

## Validation
- `cargo test -p model-package`
- `bash -n crates/model-package/src/scripts/split-model-job.sh`
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm-host-runtime`
- `cargo run -p model-package --bin queue-unsloth-layer-packages -- --max-jobs 1 --recent-limit 3 --popular-limit 3 --dry-run`
