### PR TITLE
Allow peers to hydrate model files through the mesh

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -626,6 +626,7 @@ fn make_test_state_peer(seed: u8, role: mesh::NodeRole) -> mesh::PeerInfo {
         owner_attestation: None,
         artifact_transfer_supported: false,
         stage_status_list_supported: false,
+        model_transfer_supported: false,
         owner_summary: crate::crypto::OwnershipSummary::default(),
         first_joined_mesh_ts: None,
     }
@@ -900,6 +901,7 @@ fn make_test_peer(
         owner_attestation: None,
         artifact_transfer_supported: false,
         stage_status_list_supported: false,
+        model_transfer_supported: false,
         owner_summary: crate::crypto::OwnershipSummary::default(),
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -37,6 +37,7 @@ pub(super) fn peer_meaningfully_changed(old: &PeerInfo, new: &PeerInfo) -> bool 
         || old.served_model_runtime != new.served_model_runtime
         || old.artifact_transfer_supported != new.artifact_transfer_supported
         || old.stage_status_list_supported != new.stage_status_list_supported
+        || old.model_transfer_supported != new.model_transfer_supported
         || old.version != new.version
         || old.owner_summary != new.owner_summary
         || old.gpu_reserved_bytes != new.gpu_reserved_bytes
@@ -110,6 +111,7 @@ pub(super) fn apply_transitive_ann(
     existing.served_model_runtime = ann.served_model_runtime.clone();
     existing.artifact_transfer_supported = ann.artifact_transfer_supported;
     existing.stage_status_list_supported = ann.stage_status_list_supported;
+    existing.model_transfer_supported = ann.model_transfer_supported;
     if ann.experts_summary.is_some() {
         existing.experts_summary = ann.experts_summary.clone();
     }
@@ -461,7 +463,9 @@ impl Node {
             existing.owner_summary = owner_summary.clone();
             existing.served_model_descriptors = ann.served_model_descriptors.clone();
             existing.served_model_runtime = ann.served_model_runtime.clone();
+            existing.artifact_transfer_supported = ann.artifact_transfer_supported;
             existing.stage_status_list_supported = ann.stage_status_list_supported;
+            existing.model_transfer_supported = ann.model_transfer_supported;
             if ann.version.is_some() {
                 existing.version = ann.version.clone();
             }
@@ -685,6 +689,7 @@ impl Node {
                     owner_attestation: p.owner_attestation.clone(),
                     artifact_transfer_supported: p.artifact_transfer_supported,
                     stage_status_list_supported: p.stage_status_list_supported,
+                    model_transfer_supported: p.model_transfer_supported,
                 })
                 .collect()
         };
@@ -752,6 +757,7 @@ impl Node {
             artifact_transfer_supported:
                 crate::models::artifact_transfer::artifact_transfer_enabled(),
             stage_status_list_supported: true,
+            model_transfer_supported: crate::models::model_transfer::model_transfer_enabled(),
         });
         announcements
     }
@@ -807,6 +813,7 @@ mod tests {
             owner_attestation: None,
             artifact_transfer_supported: true,
             stage_status_list_supported: true,
+            model_transfer_supported: true,
         }
     }
 
@@ -896,6 +903,15 @@ mod tests {
     }
 
     #[test]
+    fn test_meaningfully_changed_model_transfer_support() {
+        let old_peer = test_peer(Some(100));
+        let mut new_peer = test_peer(Some(100));
+        new_peer.model_transfer_supported = !old_peer.model_transfer_supported;
+
+        assert!(peer_meaningfully_changed(&old_peer, &new_peer));
+    }
+
+    #[test]
     fn test_apply_transitive_ann_refreshes_explicit_model_interests() {
         let mut existing = test_peer(Some(100));
         let mut ann = test_announcement(Some(100));
@@ -921,6 +937,18 @@ mod tests {
         assert!(existing.stage_status_list_supported);
     }
 
+    #[test]
+    fn test_apply_transitive_ann_refreshes_model_transfer_support() {
+        let mut existing = test_peer(Some(100));
+        existing.model_transfer_supported = false;
+        let mut ann = test_announcement(Some(100));
+        ann.model_transfer_supported = true;
+
+        apply_transitive_ann(&mut existing, &test_addr(0x33), &ann);
+
+        assert!(existing.model_transfer_supported);
+    }
+
     #[tokio::test]
     async fn test_add_peer_refreshes_stage_status_list_support() {
         let node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
@@ -936,6 +964,23 @@ mod tests {
         let state = node.state.lock().await;
         let peer = state.peers.get(&peer_id).expect("peer should be tracked");
         assert!(peer.stage_status_list_supported);
+    }
+
+    #[tokio::test]
+    async fn test_add_peer_refreshes_model_transfer_support() {
+        let node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
+        let peer_id = test_endpoint_id(0x44);
+        let addr = test_addr(0x44);
+        let mut ann = test_announcement(Some(100));
+        ann.model_transfer_supported = false;
+
+        node.add_peer(peer_id, addr.clone(), &ann).await;
+        ann.model_transfer_supported = true;
+        node.add_peer(peer_id, addr, &ann).await;
+
+        let state = node.state.lock().await;
+        let peer = state.peers.get(&peer_id).expect("peer should be tracked");
+        assert!(peer.model_transfer_supported);
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -67,6 +67,9 @@ pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT: std::time::Duration =
 const ARTIFACT_TRANSFER_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const ARTIFACT_TRANSFER_READ_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const ARTIFACT_TRANSFER_BUFFER_BYTES: usize = 1024 * 1024;
+const MODEL_TRANSFER_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const MODEL_TRANSFER_READ_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+const MODEL_TRANSFER_BUFFER_BYTES: usize = 1024 * 1024;
 
 fn quic_bind_addr(bind_port: Option<u16>) -> Option<std::net::SocketAddr> {
     if let Some(port) = bind_port {
@@ -128,6 +131,38 @@ fn partial_artifact_path(destination: &std::path::Path) -> std::path::PathBuf {
     ))
 }
 
+fn partial_model_transfer_path(destination: &std::path::Path) -> std::path::PathBuf {
+    let file_name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("model");
+    destination.with_file_name(format!(".{file_name}.mesh-peer.part"))
+}
+
+fn partial_model_transfer_resume_offset(partial_path: &std::path::Path) -> Result<u64> {
+    match std::fs::symlink_metadata(partial_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                let _ = std::fs::remove_file(partial_path);
+                return Ok(0);
+            }
+            anyhow::ensure!(
+                metadata.is_file(),
+                "partial model transfer path is not a regular file"
+            );
+            Ok(metadata.len())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(0),
+        Err(error) => Err(error).context("stat partial model transfer"),
+    }
+}
+
+fn cached_hf_asset_path(
+    asset: &crate::models::catalog::HfAsset,
+) -> Result<Option<std::path::PathBuf>> {
+    crate::models::model_transfer::cached_hf_model_file(&asset.repo, &asset.revision, &asset.file)
+}
+
 struct PartialArtifactGuard {
     path: std::path::PathBuf,
     armed: bool,
@@ -172,6 +207,24 @@ where
     Ok(read)
 }
 
+async fn read_model_transfer_chunk<R>(
+    reader: &mut R,
+    buffer: &mut [u8],
+    idle_timeout: std::time::Duration,
+) -> Result<usize>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let read = tokio::time::timeout(idle_timeout, tokio::io::AsyncReadExt::read(reader, buffer))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("model transfer body read idle timeout after {idle_timeout:?}")
+        })?
+        .context("read model transfer bytes")?;
+    anyhow::ensure!(read > 0, "model transfer ended before expected byte count");
+    Ok(read)
+}
+
 async fn write_artifact_transfer_response(
     send: &mut iroh::endpoint::SendStream,
     accepted: bool,
@@ -189,6 +242,31 @@ async fn write_artifact_transfer_response(
     skippy_protocol::validate_stage_artifact_transfer_response(&response)
         .map_err(|error| anyhow::anyhow!("invalid artifact transfer response: {error}"))?;
     write_len_prefixed(send, &response.encode_to_vec()).await?;
+    if !accepted {
+        let _ = send.finish();
+    }
+    Ok(())
+}
+
+async fn write_model_transfer_response(
+    send: &mut iroh::endpoint::SendStream,
+    accepted: bool,
+    resolved_revision: Option<&str>,
+    total_size: u64,
+    sha256: Option<&str>,
+    offset: u64,
+    error: Option<&str>,
+) -> Result<()> {
+    let response = crate::models::model_transfer::ModelFileTransferResponse {
+        gen: crate::models::model_transfer::MODEL_TRANSFER_GENERATION,
+        accepted,
+        resolved_revision: resolved_revision.map(str::to_string),
+        total_size,
+        sha256: sha256.map(str::to_string),
+        offset,
+        error: error.map(str::to_string),
+    };
+    write_len_prefixed(send, &serde_json::to_vec(&response)?).await?;
     if !accepted {
         let _ = send.finish();
     }
@@ -756,6 +834,7 @@ pub(crate) struct PeerAnnouncement {
     pub(crate) owner_attestation: Option<SignedNodeOwnership>,
     pub(crate) artifact_transfer_supported: bool,
     pub(crate) stage_status_list_supported: bool,
+    pub(crate) model_transfer_supported: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -810,6 +889,7 @@ pub struct PeerInfo {
     pub owner_attestation: Option<SignedNodeOwnership>,
     pub artifact_transfer_supported: bool,
     pub stage_status_list_supported: bool,
+    pub model_transfer_supported: bool,
     pub owner_summary: OwnershipSummary,
 }
 
@@ -867,6 +947,7 @@ impl PeerInfo {
             owner_attestation: ann.owner_attestation.clone(),
             artifact_transfer_supported: ann.artifact_transfer_supported,
             stage_status_list_supported: ann.stage_status_list_supported,
+            model_transfer_supported: ann.model_transfer_supported,
             owner_summary,
         }
     }
@@ -1590,6 +1671,19 @@ impl crate::inference::skippy::StagePackagePrefetcher for Node {
         request: &crate::inference::skippy::StagePrepareRequest,
     ) -> Result<()> {
         self.prefetch_stage_package_from_coordinator(request).await
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::models::catalog::HfAssetHydrator for Node {
+    async fn hydrate_hf_asset_plan(
+        &self,
+        label: &str,
+        plan: Vec<(bool, crate::models::catalog::HfAsset)>,
+        progress: bool,
+    ) -> Result<Option<Vec<std::path::PathBuf>>> {
+        self.hydrate_hf_asset_plan_from_peers(label, plan, progress)
+            .await
     }
 }
 
@@ -3711,6 +3805,22 @@ impl Node {
         Ok((send, recv))
     }
 
+    async fn open_model_transfer_mesh_stream(
+        &self,
+        peer_id: EndpointId,
+        stream_kind: u8,
+    ) -> Result<(iroh::endpoint::SendStream, iroh::endpoint::RecvStream)> {
+        let (mut send, recv) = self
+            .open_mesh_subprotocol_stream(
+                peer_id,
+                crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_NAME,
+                crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_MAJOR,
+            )
+            .await?;
+        send.write_all(&[stream_kind]).await?;
+        Ok((send, recv))
+    }
+
     async fn stage_connection_to_peer(&self, peer_id: EndpointId) -> Result<Connection> {
         let addr = {
             let state = self.state.lock().await;
@@ -4401,6 +4511,13 @@ impl Node {
                 self.handle_skippy_stage_subprotocol_stream(remote, send, recv)
                     .await
             }
+            (
+                crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_NAME,
+                crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_MAJOR,
+            ) => {
+                self.handle_model_transfer_subprotocol_stream(remote, send, recv)
+                    .await
+            }
             _ => anyhow::bail!(
                 "unsupported mesh subprotocol {}/{} from {}",
                 open.name,
@@ -4430,6 +4547,23 @@ impl Node {
                 anyhow::bail!("skippy activation transport stays on skippy-stage/1")
             }
             other => anyhow::bail!("unknown skippy stage subprotocol stream kind {other:#04x}"),
+        }
+    }
+
+    async fn handle_model_transfer_subprotocol_stream(
+        &self,
+        remote: EndpointId,
+        send: iroh::endpoint::SendStream,
+        mut recv: iroh::endpoint::RecvStream,
+    ) -> Result<()> {
+        let mut type_buf = [0u8; 1];
+        recv.read_exact(&mut type_buf).await?;
+        match type_buf[0] {
+            crate::models::model_transfer::MODEL_TRANSFER_STREAM_FILE_GET => {
+                self.handle_model_file_transfer_stream(remote, send, recv)
+                    .await
+            }
+            other => anyhow::bail!("unknown model transfer subprotocol stream kind {other:#04x}"),
         }
     }
 
@@ -4516,7 +4650,12 @@ impl Node {
                     .filter(|candidate| !candidate.is_empty())
                     {
                         if let Ok(path) =
-                            crate::models::resolve_model_spec(std::path::Path::new(candidate)).await
+                            crate::models::resolve_model_spec_with_progress_and_hydrator(
+                                std::path::Path::new(candidate),
+                                true,
+                                Some(self),
+                            )
+                            .await
                         {
                             if path.exists() {
                                 load.model_path = Some(path.to_string_lossy().to_string());
@@ -4609,6 +4748,321 @@ impl Node {
             }
             _ => false,
         }
+    }
+
+    async fn hydrate_hf_asset_plan_from_peers(
+        &self,
+        _label: &str,
+        plan: Vec<(bool, crate::models::catalog::HfAsset)>,
+        _progress: bool,
+    ) -> Result<Option<Vec<std::path::PathBuf>>> {
+        if !crate::models::model_transfer::model_transfer_enabled() || plan.is_empty() {
+            return Ok(None);
+        }
+        let candidates = self.model_transfer_peer_candidates().await;
+        if candidates.is_empty() {
+            return Ok(None);
+        }
+
+        let mut primary_paths = Vec::new();
+        for (required, asset) in plan {
+            match cached_hf_asset_path(&asset) {
+                Ok(Some(path)) => {
+                    if required && asset.file != "config.json" {
+                        primary_paths.push(path);
+                    }
+                    continue;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::debug!(
+                        repo = %asset.repo,
+                        revision = %asset.revision,
+                        file = %asset.file,
+                        "cached model asset is not safe to reuse: {error}"
+                    );
+                    return Ok(None);
+                }
+            }
+
+            let mut hydrated = None;
+            for peer_id in &candidates {
+                match self.fetch_model_file_from_peer(*peer_id, &asset).await {
+                    Ok(path) => {
+                        hydrated = Some(path);
+                        break;
+                    }
+                    Err(error) => {
+                        tracing::debug!(
+                            peer = %peer_id.fmt_short(),
+                            repo = %asset.repo,
+                            revision = %asset.revision,
+                            file = %asset.file,
+                            "peer model transfer attempt failed: {error}"
+                        );
+                    }
+                }
+            }
+
+            match hydrated {
+                Some(path) if required && asset.file != "config.json" => {
+                    primary_paths.push(path);
+                }
+                Some(_) => {}
+                None if required => return Ok(None),
+                None => {}
+            }
+        }
+
+        if primary_paths.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(primary_paths))
+    }
+
+    async fn model_transfer_peer_candidates(&self) -> Vec<EndpointId> {
+        let mut peers = {
+            let state = self.state.lock().await;
+            state
+                .peers
+                .values()
+                .filter(|peer| peer.model_transfer_supported)
+                .map(|peer| (peer.id, peer.rtt_ms.unwrap_or(u32::MAX)))
+                .collect::<Vec<_>>()
+        };
+        peers.sort_by(|(left_id, left_rtt), (right_id, right_rtt)| {
+            left_rtt
+                .cmp(right_rtt)
+                .then_with(|| left_id.as_bytes().cmp(right_id.as_bytes()))
+        });
+        peers.into_iter().map(|(peer_id, _)| peer_id).collect()
+    }
+
+    async fn fetch_model_file_from_peer(
+        &self,
+        peer_id: EndpointId,
+        asset: &crate::models::catalog::HfAsset,
+    ) -> Result<std::path::PathBuf> {
+        use tokio::io::AsyncWriteExt;
+
+        let requested_destination =
+            if crate::models::model_transfer::is_immutable_hf_revision(&asset.revision) {
+                crate::models::model_transfer::hf_model_cache_path(
+                    &asset.repo,
+                    &asset.revision,
+                    &asset.file,
+                )
+                .ok()
+            } else {
+                None
+            };
+        let requested_offset = requested_destination
+            .as_ref()
+            .map(|destination| partial_model_transfer_path(destination))
+            .map(|partial| partial_model_transfer_resume_offset(&partial))
+            .transpose()?
+            .unwrap_or(0);
+
+        let request = crate::models::model_transfer::ModelFileTransferRequest {
+            gen: crate::models::model_transfer::MODEL_TRANSFER_GENERATION,
+            requester_id: self.endpoint.id().as_bytes().to_vec(),
+            request_id: format!(
+                "{}-{}-{}",
+                current_time_unix_ms(),
+                std::process::id(),
+                peer_id.fmt_short()
+            ),
+            repo: asset.repo.clone(),
+            revision: asset.revision.clone(),
+            file: asset.file.clone(),
+            offset: requested_offset,
+            expected_size: None,
+            expected_sha256: None,
+        };
+        crate::models::model_transfer::validate_model_file_transfer_request(&request)
+            .map_err(|error| anyhow::anyhow!("invalid model transfer request: {error}"))?;
+
+        let response = tokio::time::timeout(MODEL_TRANSFER_OPEN_TIMEOUT, async {
+            let (mut send, mut recv) = self
+                .open_model_transfer_mesh_stream(
+                    peer_id,
+                    crate::models::model_transfer::MODEL_TRANSFER_STREAM_FILE_GET,
+                )
+                .await?;
+            write_len_prefixed(&mut send, &serde_json::to_vec(&request)?).await?;
+            let _ = send.finish();
+            let response_buf = read_len_prefixed(&mut recv).await?;
+            let response: crate::models::model_transfer::ModelFileTransferResponse =
+                serde_json::from_slice(&response_buf).map_err(|error| {
+                    anyhow::anyhow!("ModelFileTransferResponse decode error: {error}")
+                })?;
+            crate::models::model_transfer::validate_model_file_transfer_response(
+                &response,
+                requested_offset,
+            )
+            .map_err(|error| {
+                anyhow::anyhow!("ModelFileTransferResponse validation error: {error}")
+            })?;
+            Ok::<_, anyhow::Error>((recv, response))
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("timeout opening model transfer stream"))??;
+        let (mut recv, response) = response;
+        if !response.accepted {
+            anyhow::bail!(
+                "peer model transfer rejected: {}",
+                response
+                    .error
+                    .unwrap_or_else(|| "model unavailable".to_string())
+            );
+        }
+
+        let resolved_revision = response
+            .resolved_revision
+            .as_deref()
+            .context("accepted model transfer response missing resolved revision")?;
+        let destination = crate::models::model_transfer::hf_model_cache_path(
+            &asset.repo,
+            resolved_revision,
+            &asset.file,
+        )?;
+        let expected_sha = response
+            .sha256
+            .as_deref()
+            .context("peer model transfer response missing sha256")?
+            .to_string();
+        if let Some(existing_destination) = crate::models::model_transfer::cached_hf_model_file(
+            &asset.repo,
+            resolved_revision,
+            &asset.file,
+        )? {
+            let existing_for_hash = existing_destination.clone();
+            let existing_sha = tokio::task::spawn_blocking(move || {
+                crate::models::model_transfer::file_sha256_hex(&existing_for_hash)
+            })
+            .await
+            .context("join existing model sha256 task")??;
+            anyhow::ensure!(
+                existing_sha.eq_ignore_ascii_case(&expected_sha),
+                "cached model sha256 mismatch"
+            );
+            crate::models::model_transfer::install_hf_revision_ref(
+                &asset.repo,
+                &asset.revision,
+                resolved_revision,
+            )?;
+            return Ok(existing_destination);
+        }
+
+        if let Some(parent) = destination.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .context("create model transfer destination directory")?;
+        }
+        crate::models::model_transfer::ensure_model_file_install_parent(&asset.repo, &destination)?;
+
+        let temp_path = partial_model_transfer_path(&destination);
+        let offset = if requested_destination.as_ref() == Some(&destination) {
+            requested_offset
+        } else {
+            0
+        };
+        if offset == 0 && temp_path.exists() {
+            tokio::fs::remove_file(&temp_path)
+                .await
+                .context("remove stale partial model transfer")?;
+        }
+        if offset > response.total_size {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            anyhow::bail!("partial model transfer is larger than peer response");
+        }
+
+        let transfer_result = async {
+            let mut file = if offset == 0 {
+                tokio::fs::OpenOptions::new()
+                    .create(true)
+                    .truncate(true)
+                    .write(true)
+                    .open(&temp_path)
+                    .await
+            } else {
+                tokio::fs::OpenOptions::new()
+                    .create(false)
+                    .append(true)
+                    .open(&temp_path)
+                    .await
+            }
+            .context("open partial model transfer")?;
+
+            let mut remaining = response.total_size.saturating_sub(offset);
+            let mut buffer = vec![0u8; MODEL_TRANSFER_BUFFER_BYTES];
+            while remaining > 0 {
+                let limit = buffer.len().min(remaining as usize);
+                let read = read_model_transfer_chunk(
+                    &mut recv,
+                    &mut buffer[..limit],
+                    MODEL_TRANSFER_READ_IDLE_TIMEOUT,
+                )
+                .await?;
+                file.write_all(&buffer[..read])
+                    .await
+                    .context("write partial model transfer")?;
+                remaining -= read as u64;
+            }
+            file.flush().await.context("flush partial model transfer")?;
+            drop(file);
+
+            let actual_size = tokio::fs::metadata(&temp_path)
+                .await
+                .context("stat partial model transfer")?
+                .len();
+            anyhow::ensure!(
+                actual_size == response.total_size,
+                "partial model transfer size mismatch after transfer"
+            );
+            let temp_for_hash = temp_path.clone();
+            let actual_sha = tokio::task::spawn_blocking(move || {
+                crate::models::model_transfer::file_sha256_hex(&temp_for_hash)
+            })
+            .await
+            .context("join model transfer sha256 task")??;
+            anyhow::ensure!(
+                actual_sha.eq_ignore_ascii_case(&expected_sha),
+                "transferred model sha256 mismatch"
+            );
+            if destination.exists() {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+                return Ok::<_, anyhow::Error>(());
+            }
+            tokio::fs::rename(&temp_path, &destination)
+                .await
+                .context("install transferred model file")?;
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+        if let Err(error) = transfer_result {
+            if !error.to_string().contains("read idle timeout") {
+                let _ = tokio::fs::remove_file(&temp_path).await;
+            }
+            return Err(error);
+        }
+
+        let destination_for_hash = destination.clone();
+        let installed_sha = tokio::task::spawn_blocking(move || {
+            crate::models::model_transfer::file_sha256_hex(&destination_for_hash)
+        })
+        .await
+        .context("join installed model sha256 task")??;
+        anyhow::ensure!(
+            installed_sha.eq_ignore_ascii_case(&expected_sha),
+            "installed model sha256 mismatch"
+        );
+        crate::models::model_transfer::install_hf_revision_ref(
+            &asset.repo,
+            &asset.revision,
+            resolved_revision,
+        )?;
+        Ok(destination)
     }
 
     async fn fetch_stage_package_artifacts_from_peer(
@@ -4828,6 +5282,96 @@ impl Node {
             return Err(error);
         }
         partial_guard.disarm();
+        Ok(())
+    }
+
+    async fn handle_model_file_transfer_stream(
+        &self,
+        remote: EndpointId,
+        mut send: iroh::endpoint::SendStream,
+        mut recv: iroh::endpoint::RecvStream,
+    ) -> anyhow::Result<()> {
+        use tokio::io::{AsyncReadExt, AsyncSeekExt};
+
+        let buf = read_len_prefixed(&mut recv).await?;
+        let request: crate::models::model_transfer::ModelFileTransferRequest =
+            serde_json::from_slice(&buf).map_err(|error| {
+                anyhow::anyhow!("ModelFileTransferRequest decode error: {error}")
+            })?;
+        crate::models::model_transfer::validate_model_file_transfer_request(&request).map_err(
+            |error| anyhow::anyhow!("ModelFileTransferRequest validation error: {error}"),
+        )?;
+        if request.requester_id.as_slice() != remote.as_bytes() {
+            anyhow::bail!("model transfer requester_id does not match QUIC peer identity");
+        }
+        if !crate::models::model_transfer::model_transfer_enabled() {
+            return write_model_transfer_response(
+                &mut send,
+                false,
+                None,
+                0,
+                None,
+                request.offset,
+                Some("model transfer disabled"),
+            )
+            .await;
+        }
+
+        let model_file =
+            match crate::models::model_transfer::servable_model_file_from_request(&request) {
+                Ok(model_file) => model_file,
+                Err(error) => {
+                    tracing::debug!(
+                        peer = %remote.fmt_short(),
+                        repo = %request.repo,
+                        revision = %request.revision,
+                        file = %request.file,
+                        "model transfer request cannot be served: {error}"
+                    );
+                    return write_model_transfer_response(
+                        &mut send,
+                        false,
+                        None,
+                        0,
+                        None,
+                        request.offset,
+                        Some("model unavailable"),
+                    )
+                    .await;
+                }
+            };
+
+        write_model_transfer_response(
+            &mut send,
+            true,
+            Some(&model_file.resolved_revision),
+            model_file.size,
+            Some(&model_file.sha256),
+            request.offset,
+            None,
+        )
+        .await?;
+        let mut file = tokio::fs::File::open(&model_file.path)
+            .await
+            .context("open model file for transfer")?;
+        file.seek(std::io::SeekFrom::Start(request.offset))
+            .await
+            .context("seek model file for transfer")?;
+        let mut buffer = vec![0u8; MODEL_TRANSFER_BUFFER_BYTES];
+        let mut remaining = model_file.size.saturating_sub(request.offset);
+        while remaining > 0 {
+            let limit = buffer.len().min(remaining as usize);
+            let read = file
+                .read(&mut buffer[..limit])
+                .await
+                .context("read model file for transfer")?;
+            anyhow::ensure!(read > 0, "model file ended before expected byte count");
+            send.write_all(&buffer[..read])
+                .await
+                .context("write model transfer bytes")?;
+            remaining -= read as u64;
+        }
+        let _ = send.finish();
         Ok(())
     }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -33,6 +33,31 @@ fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
     assert_eq!(quic_bind_addr(None), None);
 }
 
+#[test]
+fn partial_model_transfer_resume_offset_reads_regular_partial_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let partial = temp.path().join(".model.gguf.mesh-peer.part");
+    std::fs::write(&partial, b"partial").unwrap();
+
+    assert_eq!(partial_model_transfer_resume_offset(&partial).unwrap(), 7);
+}
+
+#[test]
+#[cfg(unix)]
+fn partial_model_transfer_resume_offset_removes_symlink_partial_file() {
+    use std::os::unix::fs as unix_fs;
+
+    let temp = tempfile::tempdir().unwrap();
+    let outside = temp.path().join("outside");
+    let partial = temp.path().join(".model.gguf.mesh-peer.part");
+    std::fs::write(&outside, b"outside").unwrap();
+    unix_fs::symlink(&outside, &partial).unwrap();
+
+    assert_eq!(partial_model_transfer_resume_offset(&partial).unwrap(), 0);
+    assert!(!partial.exists());
+    assert!(outside.exists());
+}
+
 fn stage_load_request() -> crate::inference::skippy::StageLoadRequest {
     crate::inference::skippy::StageLoadRequest {
         topology_id: "topology-a".to_string(),
@@ -832,6 +857,7 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
         owner_attestation: None,
         artifact_transfer_supported: false,
         stage_status_list_supported: false,
+        model_transfer_supported: false,
         owner_summary: OwnershipSummary::default(),
     }
 }
@@ -1126,6 +1152,74 @@ async fn artifact_transfer_stream_serves_authorized_stage_artifact() -> Result<(
     legacy_recv.read_exact(&mut legacy_bytes).await?;
     assert_eq!(legacy_bytes, b"layer000");
     assert!(package_dir.join("model-package.json").is_file());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn model_transfer_stream_serves_exact_hf_cache_file() -> Result<()> {
+    use crate::protocol::{read_len_prefixed, write_len_prefixed};
+    use base64::Engine as _;
+
+    let cache = tempfile::tempdir().unwrap();
+    let _cache_guard = EnvVarGuard::set("HF_HUB_CACHE", cache.path());
+    let revision = "0123456789abcdef0123456789abcdef01234567";
+    let model_path =
+        crate::models::model_transfer::hf_model_cache_path("org/model", revision, "model.gguf")?;
+    tokio::fs::create_dir_all(model_path.parent().unwrap()).await?;
+    tokio::fs::write(&model_path, b"model-bytes").await?;
+    let expected_sha = sha256_hex(b"model-bytes");
+
+    let server = make_test_node(super::NodeRole::Host { http_port: 9337 }).await?;
+    let client = make_test_node(super::NodeRole::Worker).await?;
+    server
+        .set_mesh_id("model-transfer-stream-mesh".to_string())
+        .await;
+    client
+        .set_mesh_id("model-transfer-stream-mesh".to_string())
+        .await;
+    server.start_accepting();
+    client.start_accepting();
+
+    let server_id = server.id();
+    let client_id = client.id();
+    let invite = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&server.endpoint.addr())?);
+    client.join(&invite).await?;
+    wait_for_peer(&client, server_id).await;
+    wait_for_peer(&server, client_id).await;
+
+    let request = crate::models::model_transfer::ModelFileTransferRequest {
+        gen: crate::models::model_transfer::MODEL_TRANSFER_GENERATION,
+        requester_id: client_id.as_bytes().to_vec(),
+        request_id: "request-model-transfer".to_string(),
+        repo: "org/model".to_string(),
+        revision: revision.to_string(),
+        file: "model.gguf".to_string(),
+        offset: 0,
+        expected_size: Some(11),
+        expected_sha256: Some(expected_sha.clone()),
+    };
+
+    let (mut send, mut recv) = client
+        .open_model_transfer_mesh_stream(
+            server_id,
+            crate::models::model_transfer::MODEL_TRANSFER_STREAM_FILE_GET,
+        )
+        .await?;
+    write_len_prefixed(&mut send, &serde_json::to_vec(&request)?).await?;
+    send.finish()?;
+    let response_buf = read_len_prefixed(&mut recv).await?;
+    let response: crate::models::model_transfer::ModelFileTransferResponse =
+        serde_json::from_slice(&response_buf)?;
+    assert!(response.accepted, "model response: {:?}", response.error);
+    assert_eq!(response.resolved_revision.as_deref(), Some(revision));
+    assert_eq!(response.total_size, 11);
+    assert_eq!(response.sha256.as_deref(), Some(expected_sha.as_str()));
+    let mut bytes = vec![0u8; response.total_size as usize];
+    recv.read_exact(&mut bytes).await?;
+    assert_eq!(bytes, b"model-bytes");
 
     Ok(())
 }
@@ -1688,6 +1782,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         owner_attestation: None,
         artifact_transfer_supported: true,
         stage_status_list_supported: true,
+        model_transfer_supported: true,
     };
 
     let proto_pa = local_ann_to_proto_ann(&local_ann);
@@ -1912,6 +2007,7 @@ fn transitive_peer_update_refreshes_metadata_fields() {
         owner_attestation: None,
         artifact_transfer_supported: true,
         stage_status_list_supported: true,
+        model_transfer_supported: true,
     };
 
     apply_transitive_ann(&mut existing, &addr, &ann);
@@ -1992,6 +2088,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
         owner_attestation: None,
         artifact_transfer_supported: true,
         stage_status_list_supported: true,
+        model_transfer_supported: true,
     };
 
     apply_transitive_ann(&mut existing, &weak_addr, &ann);
@@ -2046,6 +2143,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
         owner_attestation: None,
         artifact_transfer_supported: true,
         stage_status_list_supported: true,
+        model_transfer_supported: true,
     };
     apply_transitive_ann(&mut existing, &richer_addr, &ann2);
 
@@ -2618,6 +2716,7 @@ fn transitive_peer_update_refreshes_last_mentioned() {
         owner_attestation: None,
         artifact_transfer_supported: true,
         stage_status_list_supported: true,
+        model_transfer_supported: true,
     };
 
     apply_transitive_ann(&mut peer, &addr, &ann);
@@ -3364,6 +3463,7 @@ fn make_test_peer(id: EndpointId, rtt_ms: Option<u32>, vram_gb: u64) -> PeerInfo
         owner_attestation: None,
         artifact_transfer_supported: false,
         stage_status_list_supported: false,
+        model_transfer_supported: false,
         owner_summary: OwnershipSummary::default(),
     }
 }

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -31,10 +31,10 @@ pub fn parse_size_gb(s: &str) -> f64 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-struct HfAsset {
-    repo: String,
-    revision: String,
-    file: String,
+pub(crate) struct HfAsset {
+    pub(crate) repo: String,
+    pub(crate) revision: String,
+    pub(crate) file: String,
 }
 
 impl HfAsset {
@@ -191,6 +191,16 @@ type DownloadPlanObserverFn = Arc<dyn Fn(&str, Vec<(bool, String)>) + Send + Syn
 #[cfg(test)]
 type DownloadHfAssetsLabelOverrideFn = Arc<dyn Fn(&str) -> Result<Vec<PathBuf>> + Send + Sync>;
 
+#[async_trait::async_trait]
+pub(crate) trait HfAssetHydrator: Send + Sync {
+    async fn hydrate_hf_asset_plan(
+        &self,
+        label: &str,
+        plan: Vec<(bool, HfAsset)>,
+        progress: bool,
+    ) -> Result<Option<Vec<PathBuf>>>;
+}
+
 #[cfg(test)]
 static DOWNLOAD_HF_ASSETS_OVERRIDE: LazyLock<Mutex<HashMap<String, DownloadHfAssetsOverrideFn>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
@@ -265,6 +275,7 @@ async fn download_hf_assets(
     label: &str,
     assets: Vec<HfAsset>,
     progress: bool,
+    hydrator: Option<&dyn HfAssetHydrator>,
 ) -> Result<Vec<PathBuf>> {
     let label = label.to_string();
     #[cfg(test)]
@@ -276,6 +287,16 @@ async fn download_hf_assets(
             .cloned();
         if let Some(func) = func {
             return func(&label, assets);
+        }
+    }
+    if let Some(hydrator) = hydrator {
+        if let Some(plan) = peer_hydration_plan_for_assets(assets.clone())? {
+            if let Some(paths) = hydrator
+                .hydrate_hf_asset_plan(&label, plan, progress)
+                .await?
+            {
+                return Ok(paths);
+            }
         }
     }
     tokio::task::spawn_blocking(move || download_hf_assets_blocking(&label, assets, progress))
@@ -660,6 +681,26 @@ fn initial_download_plan_for_assets(
     Ok(download_plan)
 }
 
+fn peer_hydration_plan_for_assets(assets: Vec<HfAsset>) -> Result<Option<Vec<(bool, HfAsset)>>> {
+    let mut download_plan = initial_download_plan_for_assets(assets)?;
+    let current_plan: Vec<(bool, HfAsset)> = download_plan.iter().cloned().collect();
+    for (_, asset) in current_plan {
+        if !is_mlx_primary_asset(&asset.file) {
+            continue;
+        }
+        if asset.file == "model.safetensors.index.json" {
+            return Ok(None);
+        }
+        for sidecar in mlx_sidecar_assets(&asset) {
+            download_plan.insert(sidecar);
+        }
+        for shard in expand_split_mlx_first_shard(&asset) {
+            download_plan.insert((true, shard));
+        }
+    }
+    Ok(Some(download_plan.into_iter().collect()))
+}
+
 #[cfg(test)]
 pub async fn download_hf_repo_file(
     repo: &str,
@@ -693,13 +734,27 @@ pub async fn download_hf_repo_file_with_progress_label(
     label: &str,
     progress: bool,
 ) -> Result<PathBuf> {
+    download_hf_repo_file_with_progress_label_and_hydrator(
+        repo, revision, file, label, progress, None,
+    )
+    .await
+}
+
+pub(crate) async fn download_hf_repo_file_with_progress_label_and_hydrator(
+    repo: &str,
+    revision: Option<&str>,
+    file: &str,
+    label: &str,
+    progress: bool,
+    hydrator: Option<&dyn HfAssetHydrator>,
+) -> Result<PathBuf> {
     let revision = revision.unwrap_or("main").to_string();
     let asset = HfAsset {
         repo: repo.to_string(),
         revision: revision.clone(),
         file: file.to_string(),
     };
-    let mut paths = download_hf_assets(label, vec![asset.clone()], progress).await?;
+    let mut paths = download_hf_assets(label, vec![asset.clone()], progress, hydrator).await?;
     paths.sort();
     let path = paths
         .into_iter()
@@ -943,6 +998,59 @@ mod tests {
         assert_eq!(resolved, cached_file);
     }
 
+    struct StaticHydrator {
+        path: PathBuf,
+        seen_plan: Arc<Mutex<Vec<(bool, String)>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl HfAssetHydrator for StaticHydrator {
+        async fn hydrate_hf_asset_plan(
+            &self,
+            _label: &str,
+            plan: Vec<(bool, HfAsset)>,
+            _progress: bool,
+        ) -> Result<Option<Vec<PathBuf>>> {
+            *self.seen_plan.lock().unwrap() = plan
+                .into_iter()
+                .map(|(required, asset)| (required, asset.file))
+                .collect();
+            Ok(Some(vec![self.path.clone()]))
+        }
+    }
+
+    #[tokio::test]
+    async fn download_hf_repo_file_uses_hydrator_before_hf_download() {
+        let temp = tempfile::tempdir().unwrap();
+        let cached_file = temp.path().join("model.gguf");
+        std::fs::write(&cached_file, b"gguf").unwrap();
+        let seen_plan = Arc::new(Mutex::new(Vec::new()));
+        let hydrator = StaticHydrator {
+            path: cached_file.clone(),
+            seen_plan: seen_plan.clone(),
+        };
+
+        let resolved = download_hf_repo_file_with_progress_label_and_hydrator(
+            "org/model",
+            Some("main"),
+            "model.gguf",
+            "org/model/model.gguf@main",
+            false,
+            Some(&hydrator),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, cached_file);
+        assert_eq!(
+            *seen_plan.lock().unwrap(),
+            vec![
+                (false, "config.json".to_string()),
+                (true, "model.gguf".to_string()),
+            ]
+        );
+    }
+
     #[test]
     fn download_progress_state_merges_http_events_consistently() {
         let mut state = MeshDownloadProgressState {
@@ -1117,6 +1225,48 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn peer_hydration_plan_includes_known_mlx_sidecars_and_shards() {
+        let plan = peer_hydration_plan_for_assets(vec![HfAsset {
+            repo: "org/repo".to_string(),
+            revision: "main".to_string(),
+            file: "model-00001-of-00003.safetensors".to_string(),
+        }])
+        .unwrap()
+        .expect("first MLX shard has a deterministic peer hydration plan");
+
+        let files: Vec<_> = plan
+            .into_iter()
+            .map(|(required, asset)| (required, asset.file))
+            .collect();
+
+        assert_eq!(
+            files,
+            vec![
+                (false, "chat_template.jinja".to_string()),
+                (false, "chat_template.json".to_string()),
+                (false, "config.json".to_string()),
+                (false, "tokenizer_config.json".to_string()),
+                (true, "model-00001-of-00003.safetensors".to_string()),
+                (true, "model-00002-of-00003.safetensors".to_string()),
+                (true, "model-00003-of-00003.safetensors".to_string()),
+                (true, "tokenizer.json".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn peer_hydration_plan_defers_mlx_index_to_hf_downloader() {
+        let plan = peer_hydration_plan_for_assets(vec![HfAsset {
+            repo: "org/repo".to_string(),
+            revision: "main".to_string(),
+            file: "model.safetensors.index.json".to_string(),
+        }])
+        .unwrap();
+
+        assert!(plan.is_none());
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -7,6 +7,7 @@ pub mod gguf;
 pub mod inventory;
 pub mod local;
 mod maintenance;
+pub(crate) mod model_transfer;
 pub mod remote_catalog;
 pub mod resolve;
 pub use resolve::ResolvedModel;
@@ -27,6 +28,7 @@ pub use local::{
     model_ref_for_path, scan_installed_models, scan_local_models,
 };
 pub use maintenance::{run_update, warn_about_updates_for_paths};
+pub(crate) use resolve::resolve_model_spec_with_progress_and_hydrator;
 pub use resolve::{
     canonicalize_interest_model_ref, download_model_ref_with_progress_details,
     find_loaded_remote_catalog_model_exact, find_remote_catalog_model_exact,

--- a/crates/mesh-llm-host-runtime/src/models/model_transfer.rs
+++ b/crates/mesh-llm-host-runtime/src/models/model_transfer.rs
@@ -1,0 +1,561 @@
+use std::path::{Component, Path, PathBuf};
+use std::{fs, io::Read};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub(crate) const MODEL_TRANSFER_SUBPROTOCOL_NAME: &str = "mesh-model-transfer";
+pub(crate) const MODEL_TRANSFER_SUBPROTOCOL_MAJOR: u32 = 1;
+pub(crate) const MODEL_TRANSFER_FEATURE_FILE_GET: &str = "file-get";
+pub(crate) const MODEL_TRANSFER_FEATURE_RANGE: &str = "range";
+pub(crate) const MODEL_TRANSFER_FEATURE_SHA256: &str = "sha256";
+pub(crate) const MODEL_TRANSFER_STREAM_FILE_GET: u8 = 0x01;
+pub(crate) const MODEL_TRANSFER_GENERATION: u32 = 1;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub(crate) struct ModelFileTransferRequest {
+    pub(crate) gen: u32,
+    pub(crate) requester_id: Vec<u8>,
+    pub(crate) request_id: String,
+    pub(crate) repo: String,
+    pub(crate) revision: String,
+    pub(crate) file: String,
+    pub(crate) offset: u64,
+    pub(crate) expected_size: Option<u64>,
+    pub(crate) expected_sha256: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+pub(crate) struct ModelFileTransferResponse {
+    pub(crate) gen: u32,
+    pub(crate) accepted: bool,
+    pub(crate) resolved_revision: Option<String>,
+    pub(crate) total_size: u64,
+    pub(crate) sha256: Option<String>,
+    pub(crate) offset: u64,
+    pub(crate) error: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ServableModelFile {
+    pub(crate) path: PathBuf,
+    pub(crate) resolved_revision: String,
+    pub(crate) size: u64,
+    pub(crate) sha256: String,
+}
+
+pub(crate) fn model_transfer_enabled() -> bool {
+    std::env::var("MESH_LLM_MODEL_TRANSFER")
+        .ok()
+        .map(|value| {
+            !matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "0" | "false" | "off" | "no"
+            )
+        })
+        .unwrap_or(true)
+}
+
+pub(crate) fn safe_relative_model_file_path(path: &str) -> Result<PathBuf> {
+    anyhow::ensure!(!path.trim().is_empty(), "model file path is empty");
+    anyhow::ensure!(
+        !path.contains('\\'),
+        "model file path must use Hugging Face forward-slash separators"
+    );
+    let path = Path::new(path);
+    let mut components = path.components();
+    let Some(first) = components.next() else {
+        bail!("model file path is empty");
+    };
+    anyhow::ensure!(
+        matches!(first, Component::Normal(_))
+            && components.all(|component| matches!(component, Component::Normal(_))),
+        "model file path must be a safe relative path"
+    );
+    Ok(path.to_path_buf())
+}
+
+pub(crate) fn hf_model_cache_path(repo: &str, revision: &str, file: &str) -> Result<PathBuf> {
+    validate_hf_model_repo(repo)?;
+    validate_immutable_revision(revision)?;
+    let file = safe_relative_model_file_path(file)?;
+    Ok(hf_repo_cache_root(repo)
+        .join("snapshots")
+        .join(revision)
+        .join(file))
+}
+
+pub(crate) fn cached_hf_model_file(
+    repo: &str,
+    revision: &str,
+    file: &str,
+) -> Result<Option<PathBuf>> {
+    let resolved_revision = resolve_cached_hf_revision(repo, revision)?;
+    let path = hf_model_cache_path(repo, &resolved_revision, file)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    ensure_path_inside_repo_root(&hf_repo_cache_root(repo), &path)?;
+    let metadata = fs::metadata(&path).context("stat cached HF model file")?;
+    anyhow::ensure!(metadata.is_file(), "cached HF model path is not a file");
+    Ok(Some(path))
+}
+
+pub(crate) fn resolve_cached_hf_revision(repo: &str, revision: &str) -> Result<String> {
+    validate_hf_model_repo(repo)?;
+    validate_hf_revision_ref(revision)?;
+    if is_sha_revision(revision) {
+        return Ok(revision.to_ascii_lowercase());
+    }
+    let refs_path = hf_repo_cache_root(repo).join("refs").join(revision);
+    let parent = refs_path
+        .parent()
+        .context("HF revision ref path has no parent directory")?;
+    ensure_path_inside_repo_root(&hf_repo_cache_root(repo), parent)
+        .context("HF revision ref escapes the managed cache repo")?;
+    let resolved = fs::read_to_string(&refs_path)
+        .with_context(|| format!("read cached HF revision ref {}", refs_path.display()))?;
+    let resolved = resolved.trim();
+    validate_immutable_revision(resolved)?;
+    Ok(resolved.to_ascii_lowercase())
+}
+
+pub(crate) fn install_hf_revision_ref(
+    repo: &str,
+    revision: &str,
+    resolved_revision: &str,
+) -> Result<()> {
+    validate_hf_model_repo(repo)?;
+    validate_hf_revision_ref(revision)?;
+    validate_immutable_revision(resolved_revision)?;
+    if is_sha_revision(revision) {
+        return Ok(());
+    }
+    let refs_path = hf_repo_cache_root(repo).join("refs").join(revision);
+    let parent = refs_path
+        .parent()
+        .context("HF revision ref path has no parent directory")?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create HF revision refs dir {}", parent.display()))?;
+    ensure_path_inside_repo_root(&hf_repo_cache_root(repo), parent)
+        .context("HF revision ref escapes the managed cache repo")?;
+    fs::write(&refs_path, resolved_revision.to_ascii_lowercase())
+        .with_context(|| format!("write HF revision ref {}", refs_path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn is_immutable_hf_revision(revision: &str) -> bool {
+    is_sha_revision(revision)
+}
+
+pub(crate) fn validate_model_file_transfer_request(
+    request: &ModelFileTransferRequest,
+) -> Result<()> {
+    anyhow::ensure!(
+        request.gen == MODEL_TRANSFER_GENERATION,
+        "unsupported model transfer generation"
+    );
+    anyhow::ensure!(
+        request.requester_id.len() == 32,
+        "requester_id must be a 32-byte endpoint id"
+    );
+    anyhow::ensure!(
+        !request.request_id.trim().is_empty(),
+        "request_id is required"
+    );
+    validate_hf_model_repo(&request.repo)?;
+    validate_hf_revision_ref(&request.revision)?;
+    safe_relative_model_file_path(&request.file)?;
+    if let Some(expected_sha) = request.expected_sha256.as_deref() {
+        validate_sha256(expected_sha)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_model_file_transfer_response(
+    response: &ModelFileTransferResponse,
+    requested_offset: u64,
+) -> Result<()> {
+    anyhow::ensure!(
+        response.gen == MODEL_TRANSFER_GENERATION,
+        "unsupported model transfer response generation"
+    );
+    anyhow::ensure!(
+        response.offset == requested_offset,
+        "model transfer response offset mismatch"
+    );
+    if !response.accepted {
+        return Ok(());
+    }
+    let resolved_revision = response
+        .resolved_revision
+        .as_deref()
+        .context("accepted model transfer response missing resolved revision")?;
+    validate_immutable_revision(resolved_revision)?;
+    if let Some(sha256) = response.sha256.as_deref() {
+        validate_sha256(sha256)?;
+    } else {
+        bail!("accepted model transfer response missing sha256");
+    }
+    anyhow::ensure!(
+        requested_offset <= response.total_size,
+        "model transfer response is smaller than resume offset"
+    );
+    Ok(())
+}
+
+pub(crate) fn servable_model_file_from_request(
+    request: &ModelFileTransferRequest,
+) -> Result<ServableModelFile> {
+    validate_model_file_transfer_request(request)?;
+    let resolved_revision = resolve_cached_hf_revision(&request.repo, &request.revision)?;
+    let path = hf_model_cache_path(&request.repo, &resolved_revision, &request.file)?;
+    let repo_root = hf_repo_cache_root(&request.repo);
+    ensure_path_inside_repo_root(&repo_root, &path)?;
+    let metadata = fs::metadata(&path).context("model file is not cached")?;
+    anyhow::ensure!(metadata.is_file(), "model cache entry is not a file");
+    if let Some(expected_size) = request.expected_size {
+        anyhow::ensure!(metadata.len() == expected_size, "model file size mismatch");
+    }
+    anyhow::ensure!(
+        request.offset <= metadata.len(),
+        "model transfer offset exceeds file size"
+    );
+    let sha256 = file_sha256_hex(&path)?;
+    if let Some(expected_sha) = request.expected_sha256.as_deref() {
+        anyhow::ensure!(
+            sha256.eq_ignore_ascii_case(expected_sha),
+            "model file sha256 mismatch"
+        );
+    }
+    Ok(ServableModelFile {
+        path,
+        resolved_revision,
+        size: metadata.len(),
+        sha256,
+    })
+}
+
+pub(crate) fn ensure_model_file_install_parent(repo: &str, destination: &Path) -> Result<()> {
+    validate_hf_model_repo(repo)?;
+    let parent = destination
+        .parent()
+        .context("model file destination has no parent directory")?;
+    ensure_path_inside_repo_root(&hf_repo_cache_root(repo), parent)
+        .context("model file destination escapes the managed HF cache repo")
+}
+
+pub(crate) fn model_file_transfer_features() -> Vec<String> {
+    vec![
+        MODEL_TRANSFER_FEATURE_FILE_GET.to_string(),
+        MODEL_TRANSFER_FEATURE_RANGE.to_string(),
+        MODEL_TRANSFER_FEATURE_SHA256.to_string(),
+    ]
+}
+
+pub(crate) fn file_sha256_hex(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path).context("open model file for sha256")?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 1024 * 1024];
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .context("read model file for sha256")?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex::encode(hasher.finalize()))
+}
+
+fn validate_hf_model_repo(repo: &str) -> Result<()> {
+    let parts = repo.split('/').collect::<Vec<_>>();
+    anyhow::ensure!(
+        parts.len() == 2 && parts.iter().all(|part| safe_hf_component(part)),
+        "HF model repo id must look like namespace/repo"
+    );
+    Ok(())
+}
+
+fn safe_hf_component(component: &str) -> bool {
+    !component.is_empty()
+        && component != "."
+        && component != ".."
+        && !component.contains('/')
+        && !component.contains(':')
+        && !component.contains('@')
+        && !component.contains('\\')
+}
+
+fn validate_immutable_revision(revision: &str) -> Result<()> {
+    anyhow::ensure!(!revision.trim().is_empty(), "HF model revision is empty");
+    anyhow::ensure!(
+        is_sha_revision(revision),
+        "peer model transfer requires an immutable Hugging Face commit revision"
+    );
+    Ok(())
+}
+
+fn validate_hf_revision_ref(revision: &str) -> Result<()> {
+    anyhow::ensure!(!revision.trim().is_empty(), "HF model revision is empty");
+    anyhow::ensure!(
+        is_sha_revision(revision) || safe_hf_component(revision),
+        "HF model revision must be a safe branch, tag, or commit id"
+    );
+    Ok(())
+}
+
+fn is_sha_revision(revision: &str) -> bool {
+    revision.len() == 40 && revision.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+fn validate_sha256(value: &str) -> Result<()> {
+    anyhow::ensure!(
+        value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()),
+        "sha256 must be 64 hex characters"
+    );
+    Ok(())
+}
+
+fn hf_repo_cache_root(repo: &str) -> PathBuf {
+    crate::models::huggingface_hub_cache_dir().join(
+        crate::models::local::huggingface_repo_folder_name(repo, hf_hub::RepoType::Model),
+    )
+}
+
+fn ensure_path_inside_repo_root(repo_root: &Path, path: &Path) -> Result<()> {
+    let repo_root = repo_root
+        .canonicalize()
+        .unwrap_or_else(|_| repo_root.to_path_buf());
+    let path = path
+        .canonicalize()
+        .with_context(|| format!("canonicalize {}", path.display()))?;
+    anyhow::ensure!(
+        path.starts_with(&repo_root),
+        "{} escapes {}",
+        path.display(),
+        repo_root.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    fn restore_env(key: &str, previous: Option<std::ffi::OsString>) {
+        match previous {
+            Some(value) => std::env::set_var(key, value),
+            None => std::env::remove_var(key),
+        }
+    }
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        hex::encode(hasher.finalize())
+    }
+
+    #[test]
+    #[serial]
+    fn model_transfer_enabled_defaults_on_and_honors_opt_out() {
+        let previous = std::env::var_os("MESH_LLM_MODEL_TRANSFER");
+        std::env::remove_var("MESH_LLM_MODEL_TRANSFER");
+        assert!(model_transfer_enabled());
+
+        for disabled in ["0", "false", "off", "no"] {
+            std::env::set_var("MESH_LLM_MODEL_TRANSFER", disabled);
+            assert!(
+                !model_transfer_enabled(),
+                "{disabled} should disable transfer"
+            );
+        }
+
+        std::env::set_var("MESH_LLM_MODEL_TRANSFER", "true");
+        assert!(model_transfer_enabled());
+        restore_env("MESH_LLM_MODEL_TRANSFER", previous);
+    }
+
+    #[test]
+    fn safe_relative_model_file_path_rejects_escape_paths() {
+        assert_eq!(
+            safe_relative_model_file_path("nested/model.gguf").unwrap(),
+            std::path::PathBuf::from("nested/model.gguf")
+        );
+
+        for value in [
+            "",
+            ".",
+            "..",
+            "../model.gguf",
+            "nested/../model.gguf",
+            "/tmp/model.gguf",
+            "nested\\model.gguf",
+        ] {
+            assert!(
+                safe_relative_model_file_path(value).is_err(),
+                "{value:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn model_transfer_request_rejects_unsafe_revision() {
+        let request = ModelFileTransferRequest {
+            gen: MODEL_TRANSFER_GENERATION,
+            requester_id: vec![7; 32],
+            request_id: "request-a".to_string(),
+            repo: "org/model".to_string(),
+            revision: "../main".to_string(),
+            file: "model.gguf".to_string(),
+            offset: 0,
+            expected_size: Some(5),
+            expected_sha256: Some(sha256_hex(b"model")),
+        };
+
+        assert!(validate_model_file_transfer_request(&request).is_err());
+    }
+
+    #[test]
+    #[serial]
+    fn servable_model_file_requires_managed_hf_cache_file() {
+        let previous = std::env::var_os("HF_HUB_CACHE");
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HUB_CACHE", temp.path());
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        let model_path = hf_model_cache_path("org/model", revision, "model.gguf").unwrap();
+        std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
+        std::fs::write(&model_path, b"model").unwrap();
+
+        let request = ModelFileTransferRequest {
+            gen: MODEL_TRANSFER_GENERATION,
+            requester_id: vec![7; 32],
+            request_id: "request-a".to_string(),
+            repo: "org/model".to_string(),
+            revision: revision.to_string(),
+            file: "model.gguf".to_string(),
+            offset: 0,
+            expected_size: Some(5),
+            expected_sha256: Some(sha256_hex(b"model")),
+        };
+
+        let artifact = servable_model_file_from_request(&request).unwrap();
+        assert_eq!(artifact.path, model_path);
+        assert_eq!(artifact.resolved_revision, revision);
+        assert_eq!(artifact.size, 5);
+        assert_eq!(artifact.sha256, sha256_hex(b"model"));
+
+        restore_env("HF_HUB_CACHE", previous);
+    }
+
+    #[test]
+    #[serial]
+    fn servable_model_file_resolves_mutable_ref_to_cached_commit() {
+        let previous = std::env::var_os("HF_HUB_CACHE");
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HUB_CACHE", temp.path());
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        install_hf_revision_ref("org/model", "main", revision).unwrap();
+        let model_path = hf_model_cache_path("org/model", revision, "model.gguf").unwrap();
+        std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
+        std::fs::write(&model_path, b"model").unwrap();
+
+        let request = ModelFileTransferRequest {
+            gen: MODEL_TRANSFER_GENERATION,
+            requester_id: vec![7; 32],
+            request_id: "request-a".to_string(),
+            repo: "org/model".to_string(),
+            revision: "main".to_string(),
+            file: "model.gguf".to_string(),
+            offset: 0,
+            expected_size: Some(5),
+            expected_sha256: Some(sha256_hex(b"model")),
+        };
+
+        let artifact = servable_model_file_from_request(&request).unwrap();
+        assert_eq!(artifact.path, model_path);
+        assert_eq!(artifact.resolved_revision, revision);
+
+        restore_env("HF_HUB_CACHE", previous);
+    }
+
+    #[test]
+    #[serial]
+    fn cached_hf_model_file_returns_safe_existing_snapshot_file() {
+        let previous = std::env::var_os("HF_HUB_CACHE");
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HUB_CACHE", temp.path());
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        install_hf_revision_ref("org/model", "main", revision).unwrap();
+        let model_path = hf_model_cache_path("org/model", revision, "model.gguf").unwrap();
+        std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
+        std::fs::write(&model_path, b"model").unwrap();
+
+        assert_eq!(
+            cached_hf_model_file("org/model", "main", "model.gguf").unwrap(),
+            Some(model_path)
+        );
+
+        restore_env("HF_HUB_CACHE", previous);
+    }
+
+    #[test]
+    fn model_transfer_response_requires_commit_and_sha_when_accepted() {
+        let valid = ModelFileTransferResponse {
+            gen: MODEL_TRANSFER_GENERATION,
+            accepted: true,
+            resolved_revision: Some("0123456789abcdef0123456789abcdef01234567".to_string()),
+            total_size: 5,
+            sha256: Some(sha256_hex(b"model")),
+            offset: 0,
+            error: None,
+        };
+        validate_model_file_transfer_response(&valid, 0).unwrap();
+
+        let mut missing_revision = valid.clone();
+        missing_revision.resolved_revision = None;
+        assert!(validate_model_file_transfer_response(&missing_revision, 0).is_err());
+
+        let mut missing_sha = valid;
+        missing_sha.sha256 = None;
+        assert!(validate_model_file_transfer_response(&missing_sha, 0).is_err());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    #[serial]
+    fn servable_model_file_rejects_symlink_escape_from_hf_cache() {
+        use std::os::unix::fs as unix_fs;
+
+        let previous = std::env::var_os("HF_HUB_CACHE");
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HUB_CACHE", temp.path());
+        let revision = "0123456789abcdef0123456789abcdef01234567";
+        let model_path = hf_model_cache_path("org/model", revision, "model.gguf").unwrap();
+        std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
+        let outside = temp.path().join("outside.gguf");
+        std::fs::write(&outside, b"model").unwrap();
+        unix_fs::symlink(&outside, &model_path).unwrap();
+
+        let request = ModelFileTransferRequest {
+            gen: MODEL_TRANSFER_GENERATION,
+            requester_id: vec![7; 32],
+            request_id: "request-a".to_string(),
+            repo: "org/model".to_string(),
+            revision: revision.to_string(),
+            file: "model.gguf".to_string(),
+            offset: 0,
+            expected_size: Some(5),
+            expected_sha256: Some(sha256_hex(b"model")),
+        };
+
+        assert!(servable_model_file_from_request(&request).is_err());
+
+        restore_env("HF_HUB_CACHE", previous);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
@@ -150,6 +150,14 @@ pub async fn download_model_ref_with_progress_details(
     input: &str,
     progress: bool,
 ) -> Result<(PathBuf, Option<ModelDetails>)> {
+    download_model_ref_with_progress_details_and_hydrator(input, progress, None).await
+}
+
+pub(crate) async fn download_model_ref_with_progress_details_and_hydrator(
+    input: &str,
+    progress: bool,
+    hydrator: Option<&dyn catalog::HfAssetHydrator>,
+) -> Result<(PathBuf, Option<ModelDetails>)> {
     let details = if progress {
         let mut spinner = start_spinner(&format!("Resolving {input}"));
         let details = show_exact_model(input).await.ok();
@@ -162,14 +170,30 @@ pub async fn download_model_ref_with_progress_details(
         .as_ref()
         .map(|detail| detail.download_url.as_str())
         .unwrap_or(input);
-    let path = download_exact_ref_with_progress(download_ref, progress).await?;
+    let path = match hydrator {
+        Some(hydrator) => {
+            download_exact_ref_with_progress_and_hydrator(download_ref, progress, Some(hydrator))
+                .await?
+        }
+        None => download_exact_ref_with_progress(download_ref, progress).await?,
+    };
     Ok((path, details))
 }
 
 pub async fn download_exact_ref_with_progress(input: &str, progress: bool) -> Result<PathBuf> {
+    download_exact_ref_with_progress_and_hydrator(input, progress, None).await
+}
+
+pub(crate) async fn download_exact_ref_with_progress_and_hydrator(
+    input: &str,
+    progress: bool,
+    hydrator: Option<&dyn catalog::HfAssetHydrator>,
+) -> Result<PathBuf> {
     let input = canonicalize_model_ref_input(input).await?;
     match parse_exact_model_ref(&input)? {
-        ExactModelRef::Catalog(model) => download_remote_catalog_model(&model, progress).await,
+        ExactModelRef::Catalog(model) => {
+            download_remote_catalog_model(&model, progress, hydrator).await
+        }
         ExactModelRef::HuggingFace {
             repo,
             revision,
@@ -179,14 +203,15 @@ pub async fn download_exact_ref_with_progress(input: &str, progress: bool) -> Re
             if let Some(model) =
                 matching_remote_catalog_primary_for_huggingface(&repo, revision.as_deref(), &file)
             {
-                return download_remote_catalog_model(&model, progress).await;
+                return download_remote_catalog_model(&model, progress, hydrator).await;
             }
-            catalog::download_hf_repo_file_with_progress_label(
+            download_hf_repo_file_with_optional_hydrator(
                 &repo,
                 revision.as_deref(),
                 &file,
                 &input,
                 progress,
+                hydrator,
             )
             .await
         }
@@ -198,6 +223,14 @@ pub async fn resolve_model_spec(input: &Path) -> Result<PathBuf> {
 }
 
 pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> Result<PathBuf> {
+    resolve_model_spec_with_progress_and_hydrator(input, progress, None).await
+}
+
+pub(crate) async fn resolve_model_spec_with_progress_and_hydrator(
+    input: &Path,
+    progress: bool,
+    hydrator: Option<&dyn catalog::HfAssetHydrator>,
+) -> Result<PathBuf> {
     let raw = input.to_string_lossy();
 
     if raw.starts_with("hf://") {
@@ -225,12 +258,13 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
             if progress {
                 eprintln!("📥 Found in remote catalog: {}", hf_ref.name);
             }
-            return catalog::download_hf_repo_file_with_progress_label(
+            return download_hf_repo_file_with_optional_hydrator(
                 &hf_ref.repo,
                 hf_ref.revision.as_deref(),
                 &hf_ref.file,
                 &hf_ref.name,
                 progress,
+                hydrator,
             )
             .await;
         }
@@ -244,9 +278,11 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
         }
         if let Ok(canonical) = canonicalize_model_ref_input(&raw).await {
             if canonical != raw {
-                return download_exact_ref_with_progress(&canonical, progress)
-                    .await
-                    .with_context(|| format!("Resolve model spec {raw}"));
+                return download_exact_ref_with_progress_and_hydrator(
+                    &canonical, progress, hydrator,
+                )
+                .await
+                .with_context(|| format!("Resolve model spec {raw}"));
             }
         }
         bail!(
@@ -255,10 +291,39 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
         );
     }
 
-    let (path, _) = download_model_ref_with_progress_details(&raw, progress)
+    let (path, _) = download_model_ref_with_progress_details_and_hydrator(&raw, progress, hydrator)
         .await
         .with_context(|| format!("Resolve model spec {raw}"))?;
     Ok(path)
+}
+
+async fn download_hf_repo_file_with_optional_hydrator(
+    repo: &str,
+    revision: Option<&str>,
+    file: &str,
+    label: &str,
+    progress: bool,
+    hydrator: Option<&dyn catalog::HfAssetHydrator>,
+) -> Result<PathBuf> {
+    match hydrator {
+        Some(hydrator) => {
+            catalog::download_hf_repo_file_with_progress_label_and_hydrator(
+                repo,
+                revision,
+                file,
+                label,
+                progress,
+                Some(hydrator),
+            )
+            .await
+        }
+        None => {
+            catalog::download_hf_repo_file_with_progress_label(
+                repo, revision, file, label, progress,
+            )
+            .await
+        }
+    }
 }
 
 fn record_resolved_model_usage(path: &Path, model_ref: Option<&str>) {
@@ -1111,13 +1176,15 @@ async fn remote_size_label(url: &str) -> Option<String> {
 async fn download_remote_catalog_model(
     model: &remote_catalog::RemoteCatalogModel,
     progress: bool,
+    hydrator: Option<&dyn catalog::HfAssetHydrator>,
 ) -> Result<PathBuf> {
-    catalog::download_hf_repo_file_with_progress_label(
+    download_hf_repo_file_with_optional_hydrator(
         &model.repo,
         model.revision.as_deref(),
         &model.source_file,
         &model.name,
         progress,
+        hydrator,
     )
     .await
 }

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -23,6 +23,28 @@ fn skippy_stage_subprotocols(
     }]
 }
 
+fn model_transfer_subprotocols(
+    model_transfer_supported: bool,
+) -> Vec<crate::proto::node::MeshSubprotocol> {
+    if !model_transfer_supported {
+        return Vec::new();
+    }
+    vec![crate::proto::node::MeshSubprotocol {
+        name: crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_NAME.to_string(),
+        major: crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_MAJOR,
+        features: crate::models::model_transfer::model_file_transfer_features(),
+    }]
+}
+
+fn mesh_subprotocols_for_ann(ann: &PeerAnnouncement) -> Vec<crate::proto::node::MeshSubprotocol> {
+    let mut subprotocols = skippy_stage_subprotocols(
+        ann.artifact_transfer_supported,
+        ann.stage_status_list_supported,
+    );
+    subprotocols.extend(model_transfer_subprotocols(ann.model_transfer_supported));
+    subprotocols
+}
+
 fn supports_skippy_artifact_transfer(subprotocols: &[crate::proto::node::MeshSubprotocol]) -> bool {
     supports_skippy_stage_feature(
         subprotocols,
@@ -35,6 +57,21 @@ fn supports_skippy_status_list(subprotocols: &[crate::proto::node::MeshSubprotoc
         subprotocols,
         skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST,
     )
+}
+
+fn supports_model_file_transfer(subprotocols: &[crate::proto::node::MeshSubprotocol]) -> bool {
+    subprotocols.iter().any(|subprotocol| {
+        subprotocol.name == crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_NAME
+            && subprotocol.major == crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_MAJOR
+            && crate::models::model_transfer::model_file_transfer_features()
+                .iter()
+                .all(|expected| {
+                    subprotocol
+                        .features
+                        .iter()
+                        .any(|feature| feature == expected)
+                })
+    })
 }
 
 fn supports_skippy_stage_feature(
@@ -531,10 +568,7 @@ pub(crate) fn local_ann_to_proto_ann(
         gpu_reserved_bytes: ann.gpu_reserved_bytes.clone(),
         hardware,
         first_joined_mesh_ts: ann.first_joined_mesh_ts,
-        subprotocols: skippy_stage_subprotocols(
-            ann.artifact_transfer_supported,
-            ann.stage_status_list_supported,
-        ),
+        subprotocols: mesh_subprotocols_for_ann(&ann),
     }
 }
 
@@ -698,6 +732,7 @@ pub(crate) fn proto_ann_to_local(
             .map(proto_owner_attestation_to_local),
         artifact_transfer_supported: supports_skippy_artifact_transfer(&pa.subprotocols),
         stage_status_list_supported: supports_skippy_status_list(&pa.subprotocols),
+        model_transfer_supported: supports_model_file_transfer(&pa.subprotocols),
     };
     crate::mesh::backfill_legacy_descriptors(&mut ann);
     Some((addr, ann))

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -577,6 +577,7 @@ mod tests {
             owner_attestation: None,
             artifact_transfer_supported: false,
             stage_status_list_supported: false,
+            model_transfer_supported: false,
             owner_summary: OwnershipSummary::default(),
         }
     }
@@ -1282,6 +1283,7 @@ mod tests {
             }),
             artifact_transfer_supported: true,
             stage_status_list_supported: true,
+            model_transfer_supported: true,
         };
         let proto_pa = local_ann_to_proto_ann(&ann);
         let skippy = proto_pa
@@ -1301,6 +1303,21 @@ mod tests {
             .features
             .iter()
             .any(|feature| feature == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST));
+        let model_transfer = proto_pa
+            .subprotocols
+            .iter()
+            .find(|subprotocol| {
+                subprotocol.name == crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_NAME
+            })
+            .expect("model transfer subprotocol should be advertised");
+        assert_eq!(
+            model_transfer.major,
+            crate::models::model_transfer::MODEL_TRANSFER_SUBPROTOCOL_MAJOR
+        );
+        assert_eq!(
+            model_transfer.features,
+            crate::models::model_transfer::model_file_transfer_features()
+        );
         assert_eq!(
             proto_pa
                 .owner_attestation
@@ -1313,6 +1330,7 @@ mod tests {
             proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
         assert!(roundtripped.artifact_transfer_supported);
         assert!(roundtripped.stage_status_list_supported);
+        assert!(roundtripped.model_transfer_supported);
         let roundtripped = roundtripped
             .owner_attestation
             .expect("owner attestation must round-trip");
@@ -1358,6 +1376,7 @@ mod tests {
             owner_attestation: None,
             artifact_transfer_supported: true,
             stage_status_list_supported: true,
+            model_transfer_supported: true,
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann);
@@ -2082,6 +2101,7 @@ mod tests {
             owner_attestation: None,
             artifact_transfer_supported: true,
             stage_status_list_supported: true,
+            model_transfer_supported: true,
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann_with_timestamp);
@@ -2128,6 +2148,7 @@ mod tests {
             owner_attestation: None,
             artifact_transfer_supported: false,
             stage_status_list_supported: false,
+            model_transfer_supported: false,
         };
 
         let proto_pa = local_ann_to_proto_ann(&ann_without_timestamp);

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -2432,6 +2432,13 @@ async fn resolve_model(input: &std::path::Path) -> Result<PathBuf> {
     models::resolve_model_spec(input).await
 }
 
+async fn resolve_model_with_peer_hydrator(
+    node: &mesh::Node,
+    input: &std::path::Path,
+) -> Result<PathBuf> {
+    models::resolve_model_spec_with_progress_and_hydrator(input, true, Some(node)).await
+}
+
 fn cli_has_explicit_models(cli: &Cli) -> bool {
     !cli.model.is_empty() || !cli.gguf.is_empty()
 }
@@ -4439,7 +4446,7 @@ async fn run_auto(
                     context: None,
                 });
                 let model_ref = models::remote_catalog_model_ref(&cat);
-                resolve_model(&PathBuf::from(model_ref)).await?
+                resolve_model_with_peer_hydrator(&node, &PathBuf::from(model_ref)).await?
             } else {
                 model_path
             }
@@ -5062,7 +5069,9 @@ async fn run_auto(
                 match cmd {
                     api::RuntimeControlRequest::Load { spec, resp } => {
                         let result = async {
-                            let model_path = resolve_model(&PathBuf::from(&spec)).await?;
+                            let model_path =
+                                resolve_model_with_peer_hydrator(&node, &PathBuf::from(&spec))
+                                    .await?;
                             let runtime_model_name = find_remote_catalog_model_exact_blocking(spec.clone())
                                 .await
                                 .map(|model| models::remote_catalog_model_ref(&model))


### PR DESCRIPTION
## Summary

Nodes can now hydrate missing Hugging Face model files from capable mesh peers before falling back to the normal Hugging Face download path. This helps mesh nodes without direct HF access or a local HF token reuse model files already present on another peer.

## Why

Skippy/runtime flows can coordinate serving across machines, but model acquisition still assumed each node could independently download the same files. This adds a peer-assisted path for exact model assets while keeping the existing HF downloader as the fallback whenever peer hydration is unavailable, incomplete, disabled, or unsafe.

## What changed

- Added a `mesh-model-transfer` stream over the existing mesh subprotocol path.
- Advertised peer model-transfer support through additive `MeshSubprotocol` gossip.
- Refreshed the new capability through direct and transitive peer update paths.
- Added a peer-aware HF asset hydrator before the normal HF fallback.
- Wired hydration into auto assignment, `/mesh/load`, and runtime-slice stage preparation once a `Node` is available.
- Installed transferred files into the normal HF cache layout, resolving mutable refs such as `main` to immutable cached snapshot commits.

## Protocol and compatibility

- No new ALPN was added.
- The new advertised subprotocol is `mesh-model-transfer` major `1`, with `file-get`, `range`, and `sha256` features.
- Older peers can ignore the unknown subprotocol and continue using the existing HF fallback.
- No existing protobuf fields are removed, repurposed, or made required.

## Safety and privacy

- No model cache inventory is gossiped or exposed through status.
- Peers are only tried when they explicitly advertise model-transfer support.
- Requests are exact `repo` / `revision` / `file` lookups.
- Unsafe repo ids, revision refs, traversal paths, absolute paths, and backslash paths are rejected.
- Serving peers only read from managed HF cache snapshots and reject symlink escapes.
- Requesters validate generation, immutable resolved revision, offset, size, and sha256 before installing.
- Partial downloads use `.mesh-peer.part`, support safe resume, and remove unsafe symlink partials.
- `MESH_LLM_MODEL_TRANSFER=0|false|off|no` disables this path.

## Validation

Branch proof:

- Base: `origin/main` at `b9c9c67b0e61c8bda541db6965f42a50db1f89f8`
- Head: `d4aa0d5b1de0ba519a8fc697d99653374c6eabd5`
- Ahead / behind: `0 1`
- `git diff --check origin/main...HEAD`: PASS

Local checks:

- `cargo fmt --all -- --check`: PASS
- `cargo test -p mesh-llm-host-runtime model_transfer --lib`: PASS, 14 passed
- `cargo test -p mesh-llm-host-runtime peer_hydration_plan --lib`: PASS, 2 passed
- `cargo test -p mesh-llm-host-runtime download_hf_repo_file_uses_hydrator_before_hf_download --lib`: PASS, 1 passed
- `cargo check -p mesh-llm-host-runtime`: PASS
- `cargo test -p mesh-llm --lib`: PASS
- `cargo test -p mesh-llm --test protocol_compat_v0_client`: PASS, 10 passed
- `cargo test -p mesh-llm --test protocol_convert_matrix`: PASS, 11 passed
- `rustup run stable cargo clippy -p mesh-llm -- -D warnings`: PASS


## Migration and rollback

- DB migration: not applicable.
- Rollback: revert this PR, or run `git revert <post_merge_commit_sha>` after merge.
- Operational caveat: rollback restores the previous HF-only model acquisition behavior.

## Known residual risks

Real multi-node transfer behavior should still be exercised during review/deployment on representative mesh nodes, especially for machines without direct Hugging Face access.
