### PR TITLE
feat: flip embedded console to preview UI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -318,12 +318,12 @@ llama-summary old new:
 [unix]
 clean-ui:
     cd "{{ ui_preview_dir }}" && rm -rf node_modules dist
-    rm -rf "{{ ui_dir }}/dist"
+    rm -rf "{{ ui_dir }}/dist" "{{ ui_dir }}/node_modules"
     echo "Cleaned UI: node_modules + dist removed"
 
 [windows]
 clean-ui:
-    @powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '{{ ui_preview_dir }}'; Remove-Item -Recurse -Force node_modules,dist -ErrorAction SilentlyContinue; Set-Location '{{ ui_dir }}'; Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue"
+    @powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '{{ ui_preview_dir }}'; Remove-Item -Recurse -Force node_modules,dist -ErrorAction SilentlyContinue; Set-Location '{{ ui_dir }}'; Remove-Item -Recurse -Force dist,node_modules -ErrorAction SilentlyContinue"
     echo "Cleaned UI: node_modules + dist removed"
 # Stop mesh-llm processes
 stop:

--- a/Justfile
+++ b/Justfile
@@ -274,7 +274,7 @@ benchmark-build-intel-windows:
 ui-dev api="http://127.0.0.1:3131" port="5173":
     #!/usr/bin/env bash
     set -euo pipefail
-    cd "{{ ui_dir }}"
+    cd "{{ ui_preview_dir }}"
     MESH_UI_API_ORIGIN="{{ api }}" npm run dev -- --host 0.0.0.0 --port {{ port }}
 
 # Run the preview UI with Vite HMR and proxy /api to mesh-llm (default: http://127.0.0.1:3131)
@@ -292,7 +292,7 @@ ui-preview-public: (ui-dev-preview "https://meshllm.cloud" "5174" "https://meshl
 
 # Run UI unit tests (vitest)
 ui-test:
-    cd "{{ ui_dir }}" && npm test
+    cd "{{ ui_preview_dir }}" && npm test
 
 # Start a lite client — no GPU, no model, just a local HTTP proxy to the mesh host.
 
@@ -317,12 +317,13 @@ llama-summary old new:
 # Clean UI build artifacts (node_modules, dist). Fixes stale npm state.
 [unix]
 clean-ui:
-    cd "{{ ui_dir }}" && rm -rf node_modules dist
+    cd "{{ ui_preview_dir }}" && rm -rf node_modules dist
+    rm -rf "{{ ui_dir }}/dist"
     echo "Cleaned UI: node_modules + dist removed"
 
 [windows]
 clean-ui:
-    @powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '{{ ui_dir }}'; Remove-Item -Recurse -Force node_modules,dist -ErrorAction SilentlyContinue"
+    @powershell -NoProfile -ExecutionPolicy Bypass -Command "Set-Location '{{ ui_preview_dir }}'; Remove-Item -Recurse -Force node_modules,dist -ErrorAction SilentlyContinue; Set-Location '{{ ui_dir }}'; Remove-Item -Recurse -Force dist -ErrorAction SilentlyContinue"
     echo "Cleaned UI: node_modules + dist removed"
 # Stop mesh-llm processes
 stop:

--- a/crates/mesh-llm-ui/preview/src/app.tsx
+++ b/crates/mesh-llm-ui/preview/src/app.tsx
@@ -2,9 +2,12 @@ import { RouterProvider } from '@tanstack/react-router'
 import { AppProviders } from '@/app/providers/AppProviders'
 import { router } from '@/app/router/router'
 
+// Production builds default to live mesh data; dev keeps harness for playground work.
+const defaultDataMode = import.meta.env.DEV ? 'harness' : 'live'
+
 export function App() {
   return (
-    <AppProviders>
+    <AppProviders initialDataMode={defaultDataMode}>
       <RouterProvider router={router} />
     </AppProviders>
   )

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -3,19 +3,22 @@
 set -euo pipefail
 
 UI_DIR="${1:?usage: build-ui.sh /path/to/ui}"
+
+# Build the preview console app and copy its dist/ to the crate root so
+# build.rs finds it at $CARGO_MANIFEST_DIR/dist unchanged.
+PREVIEW_DIR="$UI_DIR/preview"
 DIST_DIR="$UI_DIR/dist"
-NODE_MODULES_DIR="$UI_DIR/node_modules"
+NODE_MODULES_DIR="$PREVIEW_DIR/node_modules"
 
 ui_build_inputs=(
-    "$UI_DIR/package.json"
-    "$UI_DIR/package-lock.json"
-    "$UI_DIR/vite.config.ts"
-    "$UI_DIR/tsconfig.json"
-    "$UI_DIR/postcss.config.cjs"
-    "$UI_DIR/tailwind.config.ts"
-    "$UI_DIR/index.html"
-    "$UI_DIR/src"
-    "$UI_DIR/public"
+    "$PREVIEW_DIR/package.json"
+    "$PREVIEW_DIR/package-lock.json"
+    "$PREVIEW_DIR/vite.config.ts"
+    "$PREVIEW_DIR/tsconfig.json"
+    "$PREVIEW_DIR/tsconfig.app.json"
+    "$PREVIEW_DIR/index.html"
+    "$PREVIEW_DIR/src"
+    "$PREVIEW_DIR/public"
 )
 
 dist_has_output() {
@@ -43,7 +46,7 @@ npm_install_is_stale() {
     fi
 
     local manifest
-    for manifest in "$UI_DIR/package.json" "$UI_DIR/package-lock.json"; do
+    for manifest in "$PREVIEW_DIR/package.json" "$PREVIEW_DIR/package-lock.json"; do
         [[ -e "$manifest" ]] || continue
         if [[ "$manifest" -nt "$NODE_MODULES_DIR" ]]; then
             return 0
@@ -54,8 +57,8 @@ npm_install_is_stale() {
 }
 
 if ui_build_is_stale; then
-    echo "Building mesh-llm UI..."
-    cd "$UI_DIR"
+    echo "Building mesh-llm UI (preview console)..."
+    cd "$PREVIEW_DIR"
 
     if npm_install_is_stale; then
         export ONNXRUNTIME_NODE_INSTALL_CUDA="${ONNXRUNTIME_NODE_INSTALL_CUDA:-skip}"
@@ -63,6 +66,10 @@ if ui_build_is_stale; then
     fi
 
     npm run build
+
+    # Copy dist/ to the crate root where build.rs expects it.
+    rm -rf "$DIST_DIR"
+    cp -r "$PREVIEW_DIR/dist" "$DIST_DIR"
 else
     echo "Skipping mesh-llm UI build; dist is up to date."
 fi

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -16,6 +16,7 @@ ui_build_inputs=(
     "$PREVIEW_DIR/vite.config.ts"
     "$PREVIEW_DIR/tsconfig.json"
     "$PREVIEW_DIR/tsconfig.app.json"
+    "$PREVIEW_DIR/tsconfig.node.json"
     "$PREVIEW_DIR/index.html"
     "$PREVIEW_DIR/src"
     "$PREVIEW_DIR/public"

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-UI_DIR="${1:?usage: build-ui.sh /path/to/ui}"
+UI_DIR="$(cd "${1:?usage: build-ui.sh /path/to/ui}" && pwd)"
 
 # Build the preview console app and copy its dist/ to the crate root so
 # build.rs finds it at $CARGO_MANIFEST_DIR/dist unchanged.


### PR DESCRIPTION
## What

Switches the embedded web console from the legacy root UI to the new preview console app (`crates/mesh-llm-ui/preview/`).

The new console is a clean-room rewrite with React 19, Tailwind 4, TanStack Router, a full design system, feature flags, and a live/harness data mode. It hits the same `/api/*` endpoints the legacy UI used — no backend changes needed.

## How

**2 files, ~25 lines changed.** The build pipeline is retargeted; nothing else moves:

- `scripts/build-ui.sh` — builds `preview/` instead of the crate root, copies `dist/` back so `build.rs` finds it unchanged
- `Justfile` — `ui-dev`, `ui-test`, `clean-ui` point at `preview/`

All platform build scripts (`build-mac.sh`, `build-linux.sh`, `build-release.sh`), `build.rs`, `lib.rs`, `Cargo.toml`, and CI call the same `build-ui.sh` with the same arguments — they work unmodified.

## Rollback

Revert this commit. The old UI source is still in place, untouched.

## Follow-up

Delete the legacy UI source files in a separate cleanup PR once the preview console is validated in production.