### PR TITLE
Keep live-agent CI compatible with self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,8 +247,10 @@ jobs:
       OPENCODE_DISABLE_PRUNE: "true"
       OPENCODE_DISABLE_LSP_DOWNLOAD: "true"
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      # Keep the self-hosted live-agent smoke on Node 20 actions so CI does not
+      # depend on the runner being upgraded in lockstep with GitHub-hosted images.
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
       - name: Install agent CLIs


### PR DESCRIPTION
## Summary

The live-agent smoke job can now run on self-hosted runners that have not yet been upgraded for Node 24 JavaScript actions.

## Root Cause

The new `agent_live_smokes` job runs on `self-hosted`, but it used `actions/checkout@v5` and `actions/setup-node@v5`. Those actions run on the Node 24 action runtime, which requires newer Actions runner versions. If the self-hosted runner lags behind GitHub-hosted images, the job can fail before any mesh smoke script starts.

## Change

- Pin only the self-hosted `agent_live_smokes` setup actions back to `actions/checkout@v4` and `actions/setup-node@v4`.
- Keep `node-version: 24` for the actual agent CLI installation and smoke execution.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm -- -D warnings`
- `cargo test -p openai-frontend --lib`

Note: `cargo test -p mesh-llm --lib` was attempted locally but stopped because the patched llama static libraries were not prepared in this worktree (`llama-common` missing). CI prepares those libraries before running that test.