### PR TITLE
Prevent tool-call grammar crashes in Skippy

### DIFF
--- a/third_party/llama.cpp/patches/0078-Contain-chat-grammar-sampler-exceptions.patch
+++ b/third_party/llama.cpp/patches/0078-Contain-chat-grammar-sampler-exceptions.patch
@@ -1,0 +1,86 @@
+From 0e97eb7cd891a876f7e68a22f9efcc219554c349 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 9 May 2026 13:23:46 +1000
+Subject: [PATCH] Contain chat grammar sampler exceptions
+
+---
+ src/skippy.cpp | 42 ++++++++++++++++++++++++++++++++++++++----
+ 1 file changed, 38 insertions(+), 4 deletions(-)
+
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index e263bf14..083d59ac 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -148,6 +148,20 @@ static void skippy_set_error(
+     }
+ }
+ 
++static void skippy_disable_chat_grammar_after_exception(
++        skippy_session * session,
++        const char * operation,
++        const char * message) {
++    if (session == nullptr || session->grammar_sampler == nullptr) {
++        return;
++    }
++    fprintf(stderr, "skippy: disabling chat grammar after %s failed: %s\n",
++            operation != nullptr ? operation : "grammar operation",
++            message != nullptr ? message : "unknown native exception");
++    llama_sampler_free(session->grammar_sampler);
++    session->grammar_sampler = nullptr;
++}
++
+ static enum skippy_status skippy_success(skippy_error ** out_error) {
+     if (out_error != nullptr) {
+         *out_error = nullptr;
+@@ -1317,8 +1331,16 @@ static bool skippy_init_chat_grammar_sampler(
+ 
+     if (!grammar_lazy) {
+         const std::string generation_prompt = metadata.value("generation_prompt", std::string());
+-        for (const llama_token token : skippy_tokenize_text(vocab, generation_prompt, false, true)) {
+-            llama_sampler_accept(session->grammar_sampler, token);
++        try {
++            for (const llama_token token : skippy_tokenize_text(vocab, generation_prompt, false, true)) {
++                llama_sampler_accept(session->grammar_sampler, token);
++            }
++        } catch (const std::exception & e) {
++            skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, e.what());
++            return false;
++        } catch (...) {
++            skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to prefill chat grammar sampler");
++            return false;
+         }
+     }
+     return true;
+@@ -1333,7 +1355,13 @@ static void skippy_sync_chat_sampling_history(skippy_session * session) {
+         const llama_token token = session->token_history[index];
+         llama_sampler_accept(session->sampling_chain, token);
+         if (session->grammar_sampler != nullptr && index >= session->grammar_generated_start) {
+-            llama_sampler_accept(session->grammar_sampler, token);
++            try {
++                llama_sampler_accept(session->grammar_sampler, token);
++            } catch (const std::exception & e) {
++                skippy_disable_chat_grammar_after_exception(session, "accept", e.what());
++            } catch (...) {
++                skippy_disable_chat_grammar_after_exception(session, "accept", nullptr);
++            }
+         }
+         session->sampling_accepted_token_count++;
+     }
+@@ -1361,7 +1389,13 @@ static llama_token skippy_chat_sample_token(skippy_session * session) {
+         false,
+     };
+     if (session->grammar_sampler != nullptr) {
+-        llama_sampler_apply(session->grammar_sampler, &cur);
++        try {
++            llama_sampler_apply(session->grammar_sampler, &cur);
++        } catch (const std::exception & e) {
++            skippy_disable_chat_grammar_after_exception(session, "apply", e.what());
++        } catch (...) {
++            skippy_disable_chat_grammar_after_exception(session, "apply", nullptr);
++        }
+     }
+     llama_sampler_apply(session->sampling_chain, &cur);
+     if (cur.selected < 0 || static_cast<size_t>(cur.selected) >= cur.size) {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0079-Trigger-lazy-chat-grammar-before-trailing-whitespace.patch
+++ b/third_party/llama.cpp/patches/0079-Trigger-lazy-chat-grammar-before-trailing-whitespace.patch
@@ -1,0 +1,101 @@
+From 0f3e85111332c4d664835eb6e2d92c9bc536e09d Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 9 May 2026 13:58:47 +1000
+Subject: [PATCH] Trigger lazy chat grammar before trailing whitespace
+
+---
+ common/chat-auto-parser-generator.cpp | 14 +++++++++++++-
+ tests/test-chat-auto-parser.cpp       | 27 ++++++++++++++++++++++++++-
+ 2 files changed, 39 insertions(+), 2 deletions(-)
+
+diff --git a/common/chat-auto-parser-generator.cpp b/common/chat-auto-parser-generator.cpp
+index 2fac0ea5..1e07043b 100644
+--- a/common/chat-auto-parser-generator.cpp
++++ b/common/chat-auto-parser-generator.cpp
+@@ -23,6 +23,18 @@ static void foreach_function(const json & tools, const std::function<void(const
+     }
+ }
+ 
++static bool is_ascii_space(char c) {
++    return c == ' ' || c == '\n' || c == '\r' || c == '\t' || c == '\f' || c == '\v';
++}
++
++static std::string lazy_trigger_marker(const std::string & marker) {
++    std::string trimmed = marker;
++    while (!trimmed.empty() && is_ascii_space(trimmed.back())) {
++        trimmed.pop_back();
++    }
++    return trimmed.empty() ? marker : trimmed;
++}
++
+ namespace autoparser {
+ 
+ parser_build_context::parser_build_context(common_chat_peg_builder & p, const generation_params & inputs) :
+@@ -79,7 +91,7 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &
+         // Set grammar triggers based on tool section markers (fall back to per-call markers)
+         if (data.grammar_lazy) {
+             data.grammar_triggers = {
+-                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, trigger_marker }
++                { COMMON_GRAMMAR_TRIGGER_TYPE_WORD, lazy_trigger_marker(trigger_marker) }
+             };
+         }
+     }
+diff --git a/tests/test-chat-auto-parser.cpp b/tests/test-chat-auto-parser.cpp
+index 1d96de71..e6f20521 100644
+--- a/tests/test-chat-auto-parser.cpp
++++ b/tests/test-chat-auto-parser.cpp
+@@ -57,6 +57,7 @@ static void test_seed_oss_tool_with_reasoning(testing & t);
+ static void test_nemotron_analysis(testing & t);
+ static void test_nemotron_reasoning_detection(testing & t);
+ static void test_nemotron_tool_format(testing & t);
++static void test_nemotron_lazy_tool_trigger(testing & t);
+ 
+ // CohereForAI template analysis tests
+ static void test_cohere_reasoning_detection(testing & t);
+@@ -1303,6 +1304,7 @@ static common_chat_template load_nemotron_template(testing & t) {
+ static void test_nemotron_analysis(testing & t) {
+     t.test("Nemotron reasoning detection", test_nemotron_reasoning_detection);
+     t.test("Nemotron tool format", test_nemotron_tool_format);
++    t.test("Nemotron lazy tool trigger", test_nemotron_lazy_tool_trigger);
+ }
+ 
+ static void test_nemotron_reasoning_detection(testing & t) {
+@@ -1375,6 +1377,30 @@ static void test_nemotron_tool_format(testing & t) {
+     t.assert_true("should support tools", analysis.jinja_caps.supports_tools);
+ }
+ 
++static void test_nemotron_lazy_tool_trigger(testing & t) {
++    common_chat_template tmpl = load_nemotron_template(t);
++
++    generation_params params;
++    params.messages              = json::array({ json{{"role", "user"}, {"content", "Call the test function."}} });
++    params.tools                 = build_tools_definition();
++    params.tool_choice           = COMMON_CHAT_TOOL_CHOICE_AUTO;
++    params.add_generation_prompt = true;
++    params.enable_thinking       = true;
++    params.extra_context         = json::object();
++
++    auto generated = peg_generator::generate_parser(tmpl, params);
++
++    t.assert_true("auto tools should use lazy grammar", generated.grammar_lazy);
++    t.assert_equal("should emit one lazy grammar trigger", size_t(1), generated.grammar_triggers.size());
++    if (!generated.grammar_triggers.empty()) {
++        t.assert_equal("lazy trigger should be a word trigger", static_cast<int>(COMMON_GRAMMAR_TRIGGER_TYPE_WORD),
++                       static_cast<int>(generated.grammar_triggers[0].type));
++        t.assert_equal("lazy trigger should trim trailing whitespace", "<tool_call>", generated.grammar_triggers[0].value);
++    }
++    t.assert_true("grammar should still preserve the full tool marker",
++                  generated.grammar.find("tool-call ::= \"<tool_call>\\n\"") != std::string::npos);
++}
++
+ static common_chat_template load_cohere_template(testing & t) {
+     return load_template(t, "models/templates/CohereForAI-c4ai-command-r7b-12-2024-tool_use.jinja");
+ }
+@@ -1966,4 +1992,3 @@ static void test_tagged_args_with_embedded_quotes(testing & t) {
+         }
+     }
+ }
+-
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## Summary

Skippy can now survive and avoid Qwen-style lazy tool-call grammar crashes when a model begins a `<tool_call>` block.

This adds two carried llama.cpp patches:

- contain native chat grammar sampler exceptions so they cannot escape across the Rust FFI boundary and abort the process
- trigger lazy chat grammar on the structural marker before trailing whitespace, changing the Qwen/Nemotron-style trigger from `<tool_call>\n` to `<tool_call>` while preserving the grammar itself

## Root Cause

The lazy grammar trigger was waiting for the full marker including trailing newline. That left the token after `<tool_call>` unconstrained. If that token included the newline plus invalid following bytes, the lazy replay path could throw from native grammar code. Because that exception crossed into Rust, the whole process aborted.

## Validation

- `LLAMA_WORKDIR=$(mktemp -d /tmp/mesh-llm-llama.XXXXXX) scripts/prepare-llama.sh pinned` succeeded in a fresh checkout
- `just build` succeeded locally on Metal
- `PATH=/usr/local/cuda/bin:$PATH just build cuda 120` succeeded on `white.local`
- Restarted the public test node on `white.local`; it served `bartowski/Qwen2.5-Coder-7B-Instruct-GGUF:Q4_K_M`
- Sent the repro request against the embedded Skippy OpenAI endpoint; native log showed `Grammar triggered on regex: '<tool_call>'` and the process stayed alive

## Protocol

No mesh wire protocol changes.
