### PR TITLE
Gate Skippy artifact transfer behind trust policy

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -640,6 +640,7 @@ impl Node {
         let my_explicit_model_interests = self.explicit_model_interests.lock().await.clone();
         let my_mesh_id = self.mesh_id.lock().await.clone();
         let my_owner_attestation = self.owner_attestation.lock().await.clone();
+        let my_owner_summary = self.owner_summary.lock().await.clone();
         let my_demand = self.get_demand();
         let stale_cutoff =
             std::time::Instant::now() - std::time::Duration::from_secs(PEER_STALE_SECS);
@@ -750,7 +751,7 @@ impl Node {
             served_model_runtime: my_model_runtime_descriptors,
             owner_attestation: my_owner_attestation,
             artifact_transfer_supported:
-                crate::models::artifact_transfer::artifact_transfer_enabled(),
+                crate::models::artifact_transfer::artifact_transfer_advertised(&my_owner_summary),
             stage_status_list_supported: true,
         });
         announcements

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -4592,17 +4592,22 @@ impl Node {
         peer_id: EndpointId,
         feature: &str,
     ) -> bool {
-        let state = self.state.lock().await;
-        let Some(peer) = state.peers.get(&peer_id) else {
+        let peer = {
+            let state = self.state.lock().await;
+            state.peers.get(&peer_id).cloned()
+        };
+        let Some(peer) = peer else {
             return false;
         };
         match feature {
             // Current PR peers advertise `stage-control` together with the
             // artifact-transfer feature. Older peers fall back to the legacy
             // skippy-stage ALPN control path.
-            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL
-            | skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER => {
+            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL => {
                 peer.artifact_transfer_supported
+            }
+            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER => {
+                self.artifact_transfer_allowed_for_peer(&peer).await
             }
             skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST => {
                 peer.stage_status_list_supported
@@ -4850,7 +4855,10 @@ impl Node {
         if request.requester_id.as_slice() != remote.as_bytes() {
             anyhow::bail!("artifact transfer requester_id does not match QUIC peer identity");
         }
-        if !crate::models::artifact_transfer::artifact_transfer_enabled() {
+        if !self
+            .artifact_transfer_serving_allowed_for_remote(remote)
+            .await
+        {
             return write_artifact_transfer_response(
                 &mut send,
                 false,
@@ -5173,6 +5181,41 @@ impl Node {
         } else {
             None
         }
+    }
+
+    pub(crate) async fn artifact_transfer_allowed_for_peer(&self, peer: &PeerInfo) -> bool {
+        peer.artifact_transfer_supported
+            && self
+                .artifact_transfer_policy_allows_peer_owner(&peer.owner_summary)
+                .await
+    }
+
+    async fn artifact_transfer_serving_allowed_for_remote(&self, remote: EndpointId) -> bool {
+        let peer_owner = {
+            let state = self.state.lock().await;
+            state
+                .peers
+                .get(&remote)
+                .map(|peer| peer.owner_summary.clone())
+        };
+        let Some(peer_owner) = peer_owner else {
+            return false;
+        };
+        self.artifact_transfer_policy_allows_peer_owner(&peer_owner)
+            .await
+    }
+
+    async fn artifact_transfer_policy_allows_peer_owner(
+        &self,
+        peer_owner: &OwnershipSummary,
+    ) -> bool {
+        let local_owner = self.owner_summary.lock().await.clone();
+        let trust_store = self.trust_store.lock().await.clone();
+        crate::models::artifact_transfer::artifact_transfer_allowed_between(
+            &local_owner,
+            peer_owner,
+            &trust_store,
+        )
     }
 
     async fn local_owner_status_error(&self) -> String {

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -859,6 +859,18 @@ impl EnvVarGuard {
         std::env::set_var(key, value);
         Self { key, previous }
     }
+
+    fn set_str(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+
+    fn unset(key: &'static str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::remove_var(key);
+        Self { key, previous }
+    }
 }
 
 impl Drop for EnvVarGuard {
@@ -914,6 +926,68 @@ fn write_hf_artifact_stream_package(
         "hf://meshllm/stream-package@abc123".to_string(),
         manifest_sha,
     )
+}
+
+fn verified_owner_summary(owner_id: &str) -> OwnershipSummary {
+    OwnershipSummary {
+        owner_id: Some(owner_id.to_string()),
+        status: OwnershipStatus::Verified,
+        verified: true,
+        ..OwnershipSummary::default()
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn artifact_transfer_peer_eligibility_ignores_public_advertisement_by_default() -> Result<()>
+{
+    let _transfer_guard = EnvVarGuard::unset("MESH_LLM_ARTIFACT_TRANSFER");
+    let node = make_test_node(super::NodeRole::Worker).await?;
+    let mut peer = make_test_peer_info(make_test_endpoint_id(0x71));
+    peer.artifact_transfer_supported = true;
+
+    assert!(
+        !node.artifact_transfer_allowed_for_peer(&peer).await,
+        "raw public artifact-transfer advertisement must not make a peer eligible"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn artifact_transfer_peer_eligibility_allows_same_or_trusted_owner() -> Result<()> {
+    let _transfer_guard = EnvVarGuard::set_str("MESH_LLM_ARTIFACT_TRANSFER", "trusted");
+    let node = make_test_node(super::NodeRole::Worker).await?;
+    *node.owner_summary.lock().await = verified_owner_summary("owner-a");
+
+    let mut same_owner = make_test_peer_info(make_test_endpoint_id(0x72));
+    same_owner.artifact_transfer_supported = true;
+    same_owner.owner_summary = verified_owner_summary("owner-a");
+    assert!(node.artifact_transfer_allowed_for_peer(&same_owner).await);
+
+    let mut trusted_owner = make_test_peer_info(make_test_endpoint_id(0x73));
+    trusted_owner.artifact_transfer_supported = true;
+    trusted_owner.owner_summary = verified_owner_summary("owner-b");
+    {
+        let mut store = node.trust_store.lock().await;
+        store.add_trusted_owner("owner-b".to_string(), None);
+    }
+    assert!(
+        node.artifact_transfer_allowed_for_peer(&trusted_owner)
+            .await
+    );
+
+    let mut untrusted_owner = make_test_peer_info(make_test_endpoint_id(0x74));
+    untrusted_owner.artifact_transfer_supported = true;
+    untrusted_owner.owner_summary = verified_owner_summary("owner-c");
+    assert!(
+        !node
+            .artifact_transfer_allowed_for_peer(&untrusted_owner)
+            .await
+    );
+
+    Ok(())
 }
 
 #[test]
@@ -1032,6 +1106,7 @@ async fn artifact_transfer_stream_serves_authorized_stage_artifact() -> Result<(
 
     let cache = tempfile::tempdir().unwrap();
     let _cache_guard = EnvVarGuard::set("HF_HUB_CACHE", cache.path());
+    let _transfer_guard = EnvVarGuard::set_str("MESH_LLM_ARTIFACT_TRANSFER", "1");
     let (package_dir, package_ref, manifest_sha256) =
         write_hf_artifact_stream_package(cache.path());
     let server = make_test_node(super::NodeRole::Host { http_port: 9337 }).await?;
@@ -1126,6 +1201,87 @@ async fn artifact_transfer_stream_serves_authorized_stage_artifact() -> Result<(
     legacy_recv.read_exact(&mut legacy_bytes).await?;
     assert_eq!(legacy_bytes, b"layer000");
     assert!(package_dir.join("model-package.json").is_file());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn artifact_transfer_stream_rejects_public_mesh_without_opt_in() -> Result<()> {
+    use crate::protocol::{read_len_prefixed, write_len_prefixed};
+    use base64::Engine as _;
+    use prost::Message as _;
+
+    let cache = tempfile::tempdir().unwrap();
+    let _cache_guard = EnvVarGuard::set("HF_HUB_CACHE", cache.path());
+    let _transfer_guard = EnvVarGuard::unset("MESH_LLM_ARTIFACT_TRANSFER");
+    let (_package_dir, package_ref, manifest_sha256) =
+        write_hf_artifact_stream_package(cache.path());
+    let server = make_test_node(super::NodeRole::Host { http_port: 9337 }).await?;
+    let client = make_test_node(super::NodeRole::Worker).await?;
+    server
+        .set_mesh_id("artifact-transfer-disabled-mesh".to_string())
+        .await;
+    client
+        .set_mesh_id("artifact-transfer-disabled-mesh".to_string())
+        .await;
+    server.start_accepting();
+    client.start_accepting();
+
+    let server_id = server.id();
+    let client_id = client.id();
+    let invite = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&server.endpoint.addr())?);
+    client.join(&invite).await?;
+    wait_for_peer(&client, server_id).await;
+    wait_for_peer(&server, client_id).await;
+    server
+        .record_stage_topology(StageTopologyInstance {
+            topology_id: "topology-artifact-disabled".to_string(),
+            run_id: "run-artifact-disabled".to_string(),
+            model_id: "model-artifact".to_string(),
+            package_ref: package_ref.clone(),
+            manifest_sha256: manifest_sha256.clone(),
+            stages: vec![StageAssignment {
+                stage_id: "stage-0".to_string(),
+                stage_index: 0,
+                node_id: client_id,
+                layer_start: 0,
+                layer_end: 1,
+                endpoint: StageEndpoint {
+                    bind_addr: String::new(),
+                },
+            }],
+        })
+        .await;
+
+    let request = skippy_stage_proto::StageArtifactTransferRequest {
+        gen: skippy_protocol::STAGE_PROTOCOL_GENERATION,
+        requester_id: client_id.as_bytes().to_vec(),
+        topology_id: "topology-artifact-disabled".to_string(),
+        run_id: "run-artifact-disabled".to_string(),
+        stage_id: "stage-0".to_string(),
+        package_ref,
+        manifest_sha256,
+        relative_path: "layers/layer-000.gguf".to_string(),
+        offset: 0,
+        expected_size: Some(8),
+        expected_sha256: Some(sha256_hex(b"layer000")),
+    };
+
+    let (mut send, mut recv) = client
+        .open_skippy_stage_mesh_stream(server_id, skippy_protocol::STAGE_STREAM_ARTIFACT_TRANSFER)
+        .await?;
+    write_len_prefixed(&mut send, &request.encode_to_vec()).await?;
+    send.finish()?;
+    let response_buf = read_len_prefixed(&mut recv).await?;
+    let response =
+        skippy_stage_proto::StageArtifactTransferResponse::decode(response_buf.as_slice())?;
+    assert!(!response.accepted);
+    assert_eq!(
+        response.error.as_deref(),
+        Some("artifact transfer disabled")
+    );
 
     Ok(())
 }

--- a/crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
+++ b/crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
@@ -11,6 +11,13 @@ use sha2::{Digest, Sha256};
 pub(crate) const PACKAGE_MANIFEST_FILE: &str = "model-package.json";
 pub(crate) const MAX_PACKAGE_MANIFEST_BYTES: u64 = 16 * 1024 * 1024;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ArtifactTransferMode {
+    Disabled,
+    TrustedOnly,
+    Open,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct PackageArtifactRequest {
     pub(crate) package_ref: String,
@@ -49,16 +56,61 @@ pub(crate) struct StageArtifactSelection {
     pub(crate) include_projectors: bool,
 }
 
-pub(crate) fn artifact_transfer_enabled() -> bool {
+pub(crate) fn artifact_transfer_mode() -> ArtifactTransferMode {
     std::env::var("MESH_LLM_ARTIFACT_TRANSFER")
         .ok()
-        .map(|value| {
-            !matches!(
-                value.trim().to_ascii_lowercase().as_str(),
-                "0" | "false" | "off" | "no"
-            )
+        .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "on" | "yes" | "open" | "any" | "public" => ArtifactTransferMode::Open,
+            "trusted" | "trust" | "owner" | "owners" | "same-owner" | "allowlist" => {
+                ArtifactTransferMode::TrustedOnly
+            }
+            _ => ArtifactTransferMode::Disabled,
         })
-        .unwrap_or(true)
+        .unwrap_or(ArtifactTransferMode::Disabled)
+}
+
+pub(crate) fn artifact_transfer_enabled() -> bool {
+    artifact_transfer_mode() != ArtifactTransferMode::Disabled
+}
+
+pub(crate) fn artifact_transfer_advertised(local_owner: &crate::crypto::OwnershipSummary) -> bool {
+    match artifact_transfer_mode() {
+        ArtifactTransferMode::Disabled => false,
+        ArtifactTransferMode::Open => true,
+        ArtifactTransferMode::TrustedOnly => verified_owner_id(local_owner).is_some(),
+    }
+}
+
+pub(crate) fn artifact_transfer_allowed_between(
+    local_owner: &crate::crypto::OwnershipSummary,
+    peer_owner: &crate::crypto::OwnershipSummary,
+    trust_store: &crate::crypto::TrustStore,
+) -> bool {
+    match artifact_transfer_mode() {
+        ArtifactTransferMode::Disabled => false,
+        ArtifactTransferMode::Open => true,
+        ArtifactTransferMode::TrustedOnly => {
+            let Some(local_owner_id) = verified_owner_id(local_owner) else {
+                return false;
+            };
+            let Some(peer_owner_id) = verified_owner_id(peer_owner) else {
+                return false;
+            };
+            local_owner_id == peer_owner_id
+                || trust_store
+                    .trusted_owners
+                    .iter()
+                    .any(|entry| entry.owner_id == peer_owner_id)
+        }
+    }
+}
+
+fn verified_owner_id(summary: &crate::crypto::OwnershipSummary) -> Option<&str> {
+    if summary.status == crate::crypto::OwnershipStatus::Verified && summary.verified {
+        summary.owner_id.as_deref()
+    } else {
+        None
+    }
 }
 
 pub(crate) fn safe_relative_artifact_path(path: &str) -> Result<PathBuf> {
@@ -477,6 +529,15 @@ mod tests {
         hex::encode(hasher.finalize())
     }
 
+    fn verified_owner(owner_id: &str) -> crate::crypto::OwnershipSummary {
+        crate::crypto::OwnershipSummary {
+            owner_id: Some(owner_id.to_string()),
+            status: crate::crypto::OwnershipStatus::Verified,
+            verified: true,
+            ..crate::crypto::OwnershipSummary::default()
+        }
+    }
+
     fn write_package_fixture(root: &Path) -> (PathBuf, String, String) {
         let package_dir = root
             .join("models--meshllm--demo-layers")
@@ -544,17 +605,95 @@ mod tests {
 
     #[test]
     #[serial]
-    fn artifact_transfer_enabled_defaults_on_and_supports_opt_out() {
+    fn artifact_transfer_policy_defaults_to_disabled_and_supports_opt_in_modes() {
         let prev = std::env::var_os("MESH_LLM_ARTIFACT_TRANSFER");
 
         std::env::remove_var("MESH_LLM_ARTIFACT_TRANSFER");
-        assert!(artifact_transfer_enabled());
-
-        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "off");
+        assert_eq!(artifact_transfer_mode(), ArtifactTransferMode::Disabled);
         assert!(!artifact_transfer_enabled());
 
-        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "1");
+        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "off");
+        assert_eq!(artifact_transfer_mode(), ArtifactTransferMode::Disabled);
+        assert!(!artifact_transfer_enabled());
+
+        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "trusted");
+        assert_eq!(artifact_transfer_mode(), ArtifactTransferMode::TrustedOnly);
         assert!(artifact_transfer_enabled());
+
+        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "1");
+        assert_eq!(artifact_transfer_mode(), ArtifactTransferMode::Open);
+        assert!(artifact_transfer_enabled());
+
+        restore_env("MESH_LLM_ARTIFACT_TRANSFER", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn artifact_transfer_default_policy_does_not_advertise_or_serve_public_mesh() {
+        let prev = std::env::var_os("MESH_LLM_ARTIFACT_TRANSFER");
+        std::env::remove_var("MESH_LLM_ARTIFACT_TRANSFER");
+
+        let unsigned = crate::crypto::OwnershipSummary::default();
+        let trust_store = crate::crypto::TrustStore::default();
+
+        assert!(!artifact_transfer_advertised(&unsigned));
+        assert!(!artifact_transfer_allowed_between(
+            &unsigned,
+            &unsigned,
+            &trust_store
+        ));
+
+        restore_env("MESH_LLM_ARTIFACT_TRANSFER", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn artifact_transfer_trusted_policy_requires_owned_or_allowlisted_peer() {
+        let prev = std::env::var_os("MESH_LLM_ARTIFACT_TRANSFER");
+        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "trusted");
+
+        let local = verified_owner("owner-a");
+        let same_owner_peer = verified_owner("owner-a");
+        let trusted_peer = verified_owner("owner-b");
+        let untrusted_peer = verified_owner("owner-c");
+        let mut trust_store = crate::crypto::TrustStore::default();
+        trust_store.add_trusted_owner("owner-b".to_string(), None);
+
+        assert!(artifact_transfer_advertised(&local));
+        assert!(artifact_transfer_allowed_between(
+            &local,
+            &same_owner_peer,
+            &trust_store
+        ));
+        assert!(artifact_transfer_allowed_between(
+            &local,
+            &trusted_peer,
+            &trust_store
+        ));
+        assert!(!artifact_transfer_allowed_between(
+            &local,
+            &untrusted_peer,
+            &trust_store
+        ));
+
+        restore_env("MESH_LLM_ARTIFACT_TRANSFER", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn artifact_transfer_open_policy_is_explicit_public_mesh_opt_in() {
+        let prev = std::env::var_os("MESH_LLM_ARTIFACT_TRANSFER");
+        std::env::set_var("MESH_LLM_ARTIFACT_TRANSFER", "open");
+
+        let unsigned = crate::crypto::OwnershipSummary::default();
+        let trust_store = crate::crypto::TrustStore::default();
+
+        assert!(artifact_transfer_advertised(&unsigned));
+        assert!(artifact_transfer_allowed_between(
+            &unsigned,
+            &unsigned,
+            &trust_store
+        ));
 
         restore_env("MESH_LLM_ARTIFACT_TRANSFER", prev);
     }

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -633,9 +633,21 @@ struct SplitParticipantPackageSignal {
 }
 
 impl SplitParticipantPackageSignal {
-    fn can_stage_with(self, artifact_transfer_supported: bool) -> bool {
-        self.missing_artifact_bytes == 0 || artifact_transfer_supported
+    fn can_stage_with(
+        self,
+        package: &skippy::SkippyPackageIdentity,
+        artifact_transfer_supported: bool,
+    ) -> bool {
+        self.missing_artifact_bytes == 0
+            || artifact_transfer_supported
+            || package_ref_has_independent_prepare_source(&package.package_ref)
     }
+}
+
+fn package_ref_has_independent_prepare_source(package_ref: &str) -> bool {
+    // HF layer packages can be resolved by the selected worker during prepare;
+    // peer artifact transfer is only an optional cache warm path.
+    skippy_runtime::package::is_hf_package_ref(package_ref)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1727,13 +1739,14 @@ async fn collect_split_participants(
         if let Some(package_signal) =
             split_peer_package_signal(node, peer.id, model_ref, package).await
         {
-            if package_signal.can_stage_with(peer.artifact_transfer_supported) {
+            let artifact_transfer_allowed = node.artifact_transfer_allowed_for_peer(&peer).await;
+            if package_signal.can_stage_with(package, artifact_transfer_allowed) {
                 participants.push(
                     SplitParticipant::new(peer.id, peer.vram_bytes, peer.first_joined_mesh_ts)
                         .with_package_signals(
                             package_signal,
                             peer.rtt_ms,
-                            peer.artifact_transfer_supported,
+                            artifact_transfer_allowed,
                         ),
                 );
             } else {
@@ -2893,8 +2906,42 @@ mod tests {
                 availability_score: 6,
             }
         );
-        assert!(signal.can_stage_with(true));
-        assert!(!signal.can_stage_with(false));
+        assert!(signal.can_stage_with(&package, true));
+        assert!(!signal.can_stage_with(&package, false));
+    }
+
+    #[test]
+    fn split_package_signal_allows_hf_fallback_when_peer_transfer_is_disabled() {
+        let mut package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        package.package_ref = "hf://meshllm/demo-layer-package@abc123".to_string();
+        let signal = SplitParticipantPackageSignal {
+            cached_slice_bytes: 200,
+            missing_artifact_bytes: 800,
+            availability_score: 2,
+        };
+
+        assert!(signal.can_stage_with(&package, false));
+    }
+
+    #[test]
+    fn split_package_signal_still_requires_transfer_for_missing_local_package() {
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        let signal = SplitParticipantPackageSignal {
+            cached_slice_bytes: 200,
+            missing_artifact_bytes: 800,
+            availability_score: 2,
+        };
+
+        assert!(!signal.can_stage_with(&package, false));
+        assert!(signal.can_stage_with(&package, true));
     }
 
     #[test]

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -459,8 +459,14 @@ cached and a worker does not:
   advertised `skippy-stage/1` `artifact-transfer` support must not be dialed
   for artifact transfer; the worker must fall back to local/HF package
   resolution.
-- Opt-out: with `MESH_LLM_ARTIFACT_TRANSFER=off`, the node must advertise
-  no `artifact-transfer` feature and reject inbound artifact transfer requests.
+- Default public-mesh safety: with `MESH_LLM_ARTIFACT_TRANSFER` unset, the node
+  must advertise no `artifact-transfer` feature, reject inbound artifact
+  transfer requests, and continue through local/HF fallback resolution.
+- Trusted-owner opt-in: with `MESH_LLM_ARTIFACT_TRANSFER=trusted`, artifact
+  transfer is eligible only for same-owner or explicitly trusted-owner peers.
+- Explicit lab opt-in: with `MESH_LLM_ARTIFACT_TRANSFER=open`, the node may
+  advertise and serve artifact transfer to any peer that is authorized by the
+  active split topology.
 - Privacy check: gossip/status output must not include local package inventory,
   cache roots, or artifact file lists; only subprotocol feature support is
   advertised.

--- a/docs/specs/layer-package-repos.md
+++ b/docs/specs/layer-package-repos.md
@@ -127,8 +127,10 @@ Privacy and compatibility boundaries:
   size, and SHA-256 digest.
 - Received artifacts are written to a fresh hidden partial file and installed
   atomically only after size and SHA-256 verification.
-- Set `MESH_LLM_ARTIFACT_TRANSFER=off` to opt out of advertising and serving
-  peer artifact transfer.
+- Peer artifact transfer is not advertised or served by default on public mesh
+  nodes. Set `MESH_LLM_ARTIFACT_TRANSFER=trusted` to enable same-owner or
+  explicitly trusted-owner transfer, or `MESH_LLM_ARTIFACT_TRANSFER=open` for
+  lab deployments that intentionally allow any peer.
 
 ## Manifest Schema
 


### PR DESCRIPTION
## Summary
Skippy layer-package peer artifact transfer is now opt-in instead of advertised and served by default.

Public mesh nodes now fail closed unless a deployment explicitly enables transfer:

- unset / `off`: do not advertise artifact transfer and reject inbound artifact requests;
- `trusted`: allow transfer only for same verified owner or explicitly trusted-owner peers;
- `open`: explicit lab/public opt-in for topology-authorized peers.

Normal local/Hugging Face package fallback remains intact when peer transfer is unavailable, so package-backed split planning should not hard-fail just because a peer cannot be used as an artifact source.

## Why
This follows the discussion in https://github.com/Mesh-LLM/mesh-llm/pull/479. The broader model/blob-transfer work is useful directionally, but current Skippy peer artifact transfer already exists on `main`. Until a unified blob-transfer layer lands, this keeps the existing Skippy path usable for intentional deployments while avoiding default public-mesh advertisement or serving.

## Related
- Related discussion: https://github.com/Mesh-LLM/mesh-llm/pull/479
- Follow-up tracking issue to open separately: remove or migrate this Skippy-specific stopgap once the unified blob-transfer layer lands.

## Diff scope
- `crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs`: adds the shared artifact-transfer policy parser and the advertise/allow predicates.
- `crates/mesh-llm-host-runtime/src/mesh/gossip.rs`: advertises artifact transfer only when the local policy allows it.
- `crates/mesh-llm-host-runtime/src/mesh/mod.rs`: applies effective artifact-transfer eligibility to subprotocol negotiation and inbound serving.
- `crates/mesh-llm-host-runtime/src/runtime/local.rs`: uses effective peer eligibility for package-aware split participant planning.
- `crates/mesh-llm-host-runtime/src/mesh/tests.rs`: covers default-deny behavior, trusted-owner eligibility, explicit opt-in serving, and public-mesh rejection.
- `docs/design/TESTING.md` and `docs/specs/layer-package-repos.md`: document the new opt-in policy and testing expectations.

## Compatibility
- No protobuf schema changes.
- No new stream type or ALPN change.
- Existing stage-control compatibility is preserved; the trust gate is applied to artifact-transfer use, not to the legacy stage-control fallback.
- Older peers that only expose the raw `artifact_transfer_supported` bit are no longer treated as effective artifact sources unless the local policy also allows transfer.

## Branch integrity
- Base branch: `main`
- Validated base SHA: `6d5bd98dfc4259266dc1dd77255285c0524bcf19`
- Head SHA: `dd3baa7efea2a6941f1e7572885073cbafddc531`
- `git rev-list --left-right --count origin/main...HEAD`: `0 1`
- Merge base: `6d5bd98dfc4259266dc1dd77255285c0524bcf19`
- Fast-forward safety: `git merge-base --is-ancestor origin/main HEAD` exited `0`.

## Commit integrity
- Introduced commit: `dd3baa7efea2a6941f1e7572885073cbafddc531 Gate Skippy artifact transfer by trust policy`
- One logical change per commit: confirmed.
- Ledger: not applicable — this repository has no `scripts/ledger/` directory and this change family does not require a ledger record.
- Version: not applicable — no release/version metadata changed.

## Diff hygiene
`git diff --name-status origin/main...HEAD`:

```text
M	crates/mesh-llm-host-runtime/src/mesh/gossip.rs
M	crates/mesh-llm-host-runtime/src/mesh/mod.rs
M	crates/mesh-llm-host-runtime/src/mesh/tests.rs
M	crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
M	crates/mesh-llm-host-runtime/src/runtime/local.rs
M	docs/design/TESTING.md
M	docs/specs/layer-package-repos.md
```

`git diff --check origin/main...HEAD`: PASS, no output.



## Validation
Validation tier: Tier 3 — shared runtime behavior, because this touches mesh gossip advertisement, Skippy artifact-transfer serving, and package-backed split participant eligibility.

Local validation:

```text
cargo fmt --all -- --check
PASS

git diff --check origin/main...HEAD
PASS

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm-host-runtime
PASS

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime artifact_transfer --lib
PASS, 16 passed

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_inventory_package_signal --lib
PASS, 2 passed

LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm --lib
PASS, 0 tests
```

Remote validation:

- Required PR CI: pending until this PR is opened.
- Current `main` CI for `6d5bd98dfc4259266dc1dd77255285c0524bcf19`: PASS.

## Runtime safety
- No new blocking locks.
- No new unbounded queues, background tasks, or buffering paths.
- Existing topology authorization, requester identity validation, manifest digest validation, artifact digest validation, partial-file cleanup, and atomic install behavior remain in place.
- Public/default behavior is stricter than before: unset configuration no longer advertises or serves peer artifact transfer.
- No invariant regression introduced.

## Documentation integrity
Updated the layer-package spec and testing guide so the documented behavior matches the new opt-in transfer policy.

## Rollback plan
Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: rollback restores the previous default-on Skippy peer artifact-transfer behavior.

## Known residual risks
- This is an intentional stopgap until the unified blob-transfer layer lands; the follow-up tracking issue should remove or migrate the Skippy-specific gate at that point.

