### PR TITLE
Preserve llama.cpp caches and speed warm dev builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,19 @@ Build everything (patched llama.cpp, mesh binary, and UI production build):
 just build
 ```
 
+`just build` builds the mesh binary in release mode. For day-to-day iteration
+where the final release link is the slow step, use the debug-profile shortcut:
+
+```bash
+just build-dev
+```
+
+You can also keep the normal recipe shape and select the profile explicitly:
+
+```bash
+MESH_LLM_BUILD_PROFILE=dev just build
+```
+
 On Linux, `just build` auto-detects CUDA vs ROCm vs Vulkan. For NVIDIA, make sure `nvcc` is in your `PATH` first:
 
 ```bash

--- a/Justfile
+++ b/Justfile
@@ -114,8 +114,8 @@ family-certify *ARGS:
 
 # Run target/draft speculative compatibility checks.
 spec-bench target draft *ARGS:
-    LLAMA_STAGE_BUILD_DIR=".deps/llama.cpp/build-stage-abi-static" cargo build -p llama-spec-bench
-    LLAMA_STAGE_BUILD_DIR=".deps/llama.cpp/build-stage-abi-static" target/debug/llama-spec-bench --target-model-path "{{ target }}" --draft-model-path "{{ draft }}" {{ ARGS }}
+    LLAMA_STAGE_BUILD_DIR=".deps/llama-build/build-stage-abi-static" cargo build -p llama-spec-bench
+    LLAMA_STAGE_BUILD_DIR=".deps/llama-build/build-stage-abi-static" target/debug/llama-spec-bench --target-model-path "{{ target }}" --draft-model-path "{{ draft }}" {{ ARGS }}
 
 # Smoke a standalone skippy OpenAI frontend stage.
 skippy-openai-smoke *ARGS:

--- a/Justfile
+++ b/Justfile
@@ -17,6 +17,11 @@ model := models_dir / "GLM-4.7-Flash-Q4_K_M.gguf"
 [macos]
 build: build-mac
 
+# Fast local iteration build: patched llama.cpp + UI + debug mesh-llm.
+[macos]
+build-dev:
+    @MESH_LLM_BUILD_PROFILE=dev scripts/build-mac.sh
+
 # Linux overrides:
 #   just build backend=cpu
 #   just build backend=cuda cuda_arch='120;86'
@@ -26,6 +31,11 @@ build: build-mac
 build backend="" cuda_arch="" rocm_arch="":
     @scripts/build-linux.sh --backend "{{ backend }}" --cuda-arch "{{ cuda_arch }}" --rocm-arch "{{ rocm_arch }}"
 
+# Fast local iteration build: patched llama.cpp + UI + debug mesh-llm.
+[linux]
+build-dev backend="" cuda_arch="" rocm_arch="":
+    @MESH_LLM_BUILD_PROFILE=dev scripts/build-linux.sh --backend "{{ backend }}" --cuda-arch "{{ cuda_arch }}" --rocm-arch "{{ rocm_arch }}"
+
 # Windows overrides:
 #   just build backend=cpu
 #   just build backend=cuda cuda_arch='120;86'
@@ -34,6 +44,11 @@ build backend="" cuda_arch="" rocm_arch="":
 [windows]
 build backend="" cuda_arch="" rocm_arch="":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend "{{backend}}" -CudaArch "{{cuda_arch}}" -RocmArch "{{rocm_arch}}"
+
+# Fast local iteration build: patched llama.cpp + UI + debug mesh-llm.
+[windows]
+build-dev backend="" cuda_arch="" rocm_arch="":
+    @powershell -NoProfile -ExecutionPolicy Bypass -Command "$env:MESH_LLM_BUILD_PROFILE='dev'; & './scripts/build-windows.ps1' -Backend '{{backend}}' -CudaArch '{{cuda_arch}}' -RocmArch '{{rocm_arch}}'"
 
 # Build on macOS Apple Silicon (Metal ABI)
 build-mac:

--- a/docs/SKIPPY_RUNTIME_README.md
+++ b/docs/SKIPPY_RUNTIME_README.md
@@ -447,9 +447,12 @@ This repo carries the llama-side ABI as clean patches on top of upstream
 - `third_party/llama.cpp/patches/*.patch` is the Mesh-LLM stage ABI patch
   stack.
 - `just llama-prepare` checks out the pinned upstream commit into
-  `.deps/llama.cpp` and applies the patches.
+  `.deps/llama.cpp` and applies the patches. Re-running it skips the reset and
+  patch application when the checkout already matches the pin and patch stack.
 - `just llama-build` builds patched llama.cpp as static archives, using
-  `sccache` when it is installed.
+  `sccache` when it is installed. Build outputs default to
+  `.deps/llama-build/` so the generated source checkout can be cleaned without
+  deleting CMake's cache.
 
 Linux GPU backend builds use the same patch stack but should write to distinct
 build directories. `scripts/build-llama.sh` accepts `LLAMA_STAGE_BACKEND`
@@ -461,18 +464,18 @@ just llama-prepare
 LLAMA_STAGE_BACKEND=cuda \
 LLAMA_STAGE_CUDA_ARCHITECTURES=89 \
   scripts/build-llama.sh
-LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-cuda \
+LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-cuda \
   cargo build --workspace
 
 LLAMA_STAGE_BACKEND=rocm \
 LLAMA_STAGE_AMDGPU_TARGETS=gfx1036 \
   scripts/build-llama.sh
-LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-rocm \
+LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-rocm \
   cargo build --workspace
 
 LLAMA_STAGE_BACKEND=vulkan \
   scripts/build-llama.sh
-LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-vulkan \
+LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-vulkan \
   cargo build --workspace
 ```
 
@@ -489,7 +492,7 @@ Rust builds also use `sccache` automatically when it is available and
 that local auto-detection.
 
 By default, `skippy-ffi` statically links the patched `libllama.a` and
-ggml archives from `.deps/llama.cpp/build-stage-abi-static`. Dynamic linking is
+ggml archives from `LLAMA_STAGE_BUILD_DIR`. Dynamic linking is
 kept as an explicit escape hatch with `LLAMA_STAGE_LINK_MODE=dynamic` and
 `LLAMA_STAGE_LIB_DIR=/path/to/lib`.
 On Linux static builds, `skippy-ffi` also detects and links ggml CUDA, HIP, and

--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -50,6 +50,20 @@ detect_jobs() {
   fi
 }
 
+required_archives() {
+  printf '%s\n' \
+    "$LLAMA_BUILD_DIR/src/libllama.a" \
+    "$LLAMA_BUILD_DIR/common/libllama-common.a" \
+    "$LLAMA_BUILD_DIR/tools/mtmd/libmtmd.a"
+}
+
+required_archives_exist() {
+  local archive
+  while IFS= read -r archive; do
+    [[ -f "$archive" ]] || return 1
+  done < <(required_archives)
+}
+
 if [[ -z "${LLAMA_BUILD_DIR:-}" ]]; then
   if [[ -n "${LLAMA_STAGE_BUILD_DIR:-}" ]]; then
     LLAMA_BUILD_DIR="$LLAMA_STAGE_BUILD_DIR"
@@ -139,9 +153,39 @@ if [[ "$#" -gt 0 ]]; then
   CMAKE_ARGS+=("$@")
 fi
 
+PATCHED_SHA="$(tr -d '[:space:]' < "$LLAMA_WORKDIR/.mesh-llm-patched-sha" 2>/dev/null || git -C "$LLAMA_WORKDIR" rev-parse HEAD)"
+BUILD_STAMP="$LLAMA_BUILD_DIR/.mesh-llm-build-stamp"
+CURRENT_BUILD_STAMP="$(
+  printf 'stamp-version=1\n'
+  printf 'patched-sha=%s\n' "$PATCHED_SHA"
+  printf 'backend=%s\n' "$LLAMA_BACKEND"
+  printf 'build-type=%s\n' "${CMAKE_BUILD_TYPE:-Release}"
+  printf 'ggml-native=%s\n' "${LLAMA_STAGE_GGML_NATIVE:-${SKIPPY_GGML_NATIVE:-OFF}}"
+  printf 'cuda-architectures=%s\n' "${LLAMA_STAGE_CUDA_ARCHITECTURES:-${SKIPPY_CUDA_ARCHITECTURES:-}}"
+  printf 'amdgpu-targets=%s\n' "${LLAMA_STAGE_AMDGPU_TARGETS:-${SKIPPY_AMDGPU_TARGETS:-}}"
+  printf 'cuda-no-vmm=%s\n' "${GGML_CUDA_NO_VMM:-}"
+  printf 'use-sccache=%s\n' "$USE_SCCACHE"
+  for arg in "${CMAKE_ARGS[@]}"; do
+    printf 'cmake-arg=%s\n' "$arg"
+  done
+)"
+
+if [[ "${LLAMA_STAGE_FORCE_BUILD:-${SKIPPY_FORCE_LLAMA_BUILD:-0}}" != "1" &&
+      -f "$BUILD_STAMP" &&
+      "$(cat "$BUILD_STAMP")" == "$CURRENT_BUILD_STAMP" ]] &&
+   git -C "$LLAMA_WORKDIR" diff-index --quiet HEAD -- &&
+   required_archives_exist; then
+  echo "patched llama.cpp ABI already built"
+  echo "  backend:   $LLAMA_BACKEND"
+  echo "  build dir: $LLAMA_BUILD_DIR"
+  exit 0
+fi
+
 cmake "${CMAKE_ARGS[@]}"
 
 cmake --build "$LLAMA_BUILD_DIR" --config "${CMAKE_BUILD_TYPE:-Release}" --parallel "$(detect_jobs)" --target llama llama-common mtmd
+
+printf '%s\n' "$CURRENT_BUILD_STAMP" > "$BUILD_STAMP"
 
 echo "built patched llama.cpp"
 echo "  backend:   $LLAMA_BACKEND"

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -12,6 +12,8 @@ MESH_DIR="$REPO_ROOT/crates/mesh-llm"
 UI_DIR="$REPO_ROOT/crates/mesh-llm-ui"
 
 rustc_wrapper=""
+build_profile="${MESH_LLM_BUILD_PROFILE:-release}"
+build_profile="${build_profile:l}"
 
 configure_rust_cache() {
     if (( $+commands[sccache] )); then
@@ -37,11 +39,29 @@ if [[ -d "$MESH_DIR" ]]; then
     fi
 
     configure_rust_cache
-    if [[ -n "$rustc_wrapper" ]]; then
-        (cd "$REPO_ROOT" && RUSTC_WRAPPER="$rustc_wrapper" cargo build --release -p mesh-llm)
-    else
-        (cd "$REPO_ROOT" && cargo build --release -p mesh-llm)
-    fi
-
-    echo "Mesh binary: target/release/mesh-llm"
+    case "$build_profile" in
+        dev|debug)
+            echo "Building mesh-llm (profile: dev, bin only)..."
+            if [[ -n "$rustc_wrapper" ]]; then
+                (cd "$REPO_ROOT" && RUSTC_WRAPPER="$rustc_wrapper" cargo build -p mesh-llm --bin mesh-llm)
+            else
+                (cd "$REPO_ROOT" && cargo build -p mesh-llm --bin mesh-llm)
+            fi
+            echo "Mesh binary: target/debug/mesh-llm"
+            ;;
+        release)
+            echo "Building mesh-llm (profile: release)..."
+            if [[ -n "$rustc_wrapper" ]]; then
+                (cd "$REPO_ROOT" && RUSTC_WRAPPER="$rustc_wrapper" cargo build --release -p mesh-llm)
+            else
+                (cd "$REPO_ROOT" && cargo build --release -p mesh-llm)
+            fi
+            echo "Mesh binary: target/release/mesh-llm"
+            ;;
+        *)
+            echo "unsupported MESH_LLM_BUILD_PROFILE: $build_profile" >&2
+            echo "expected one of: dev, debug, release" >&2
+            exit 1
+            ;;
+    esac
 fi

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -7,6 +7,7 @@ SCRIPT_DIR="${0:A:h}"
 REPO_ROOT="${SCRIPT_DIR:h}"
 
 LLAMA_DIR="${MESH_LLM_LLAMA_DIR:-$REPO_ROOT/.deps/llama.cpp}"
+LLAMA_BUILD_ROOT="${MESH_LLM_LLAMA_BUILD_ROOT:-$REPO_ROOT/.deps/llama-build}"
 MESH_DIR="$REPO_ROOT/crates/mesh-llm"
 UI_DIR="$REPO_ROOT/crates/mesh-llm-ui"
 
@@ -19,7 +20,7 @@ configure_rust_cache() {
     fi
 }
 
-export LLAMA_STAGE_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-${SKIPPY_LLAMA_BUILD_DIR:-$LLAMA_DIR/build-stage-abi-metal}}"
+export LLAMA_STAGE_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-${SKIPPY_LLAMA_BUILD_DIR:-$LLAMA_BUILD_ROOT/build-stage-abi-metal}}"
 
 echo "Preparing patched llama.cpp ABI checkout..."
 LLAMA_WORKDIR="$LLAMA_DIR" "$SCRIPT_DIR/prepare-llama.sh" "${MESH_LLM_LLAMA_PIN_SHA:-pinned}"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 LLAMA_DIR="${MESH_LLM_LLAMA_DIR:-$REPO_ROOT/.deps/llama.cpp}"
+LLAMA_BUILD_ROOT="${MESH_LLM_LLAMA_BUILD_ROOT:-$REPO_ROOT/.deps/llama-build}"
 UI_DIR="$REPO_ROOT/crates/mesh-llm-ui"
 
 os_name="$(uname -s)"
@@ -27,9 +28,9 @@ if [[ -z "${LLAMA_STAGE_BUILD_DIR:-}" && -n "${SKIPPY_LLAMA_BUILD_DIR:-}" ]]; th
 fi
 if [[ -z "${LLAMA_STAGE_BUILD_DIR:-}" ]]; then
     if [[ "$BACKEND" == "cpu" ]]; then
-        export LLAMA_STAGE_BUILD_DIR="$LLAMA_DIR/build-stage-abi-static"
+        export LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_ROOT/build-stage-abi-static"
     else
-        export LLAMA_STAGE_BUILD_DIR="$LLAMA_DIR/build-stage-abi-$BACKEND"
+        export LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_ROOT/build-stage-abi-$BACKEND"
     fi
 fi
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -9,7 +9,8 @@ $ErrorActionPreference = "Stop"
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $scriptDir ".."))
 $llamaDir = if ($env:MESH_LLM_LLAMA_DIR) { $env:MESH_LLM_LLAMA_DIR } else { Join-Path $repoRoot ".deps\llama.cpp" }
-$buildDir = if ($env:LLAMA_STAGE_BUILD_DIR) { $env:LLAMA_STAGE_BUILD_DIR } else { Join-Path $llamaDir "build-stage-abi" }
+$llamaBuildRoot = if ($env:MESH_LLM_LLAMA_BUILD_ROOT) { $env:MESH_LLM_LLAMA_BUILD_ROOT } else { Join-Path $repoRoot ".deps\llama-build" }
+$buildDir = if ($env:LLAMA_STAGE_BUILD_DIR) { $env:LLAMA_STAGE_BUILD_DIR } else { Join-Path $llamaBuildRoot "build-stage-abi" }
 $meshUiDir = Join-Path $repoRoot "crates\mesh-llm-ui"
 $compilerLauncherArgs = @()
 $compilerCacheBin = $null
@@ -607,7 +608,7 @@ $CudaArch = Normalize-RecipeArgument $CudaArch @("cuda_arch", "cudaarch")
 $RocmArch = Normalize-RecipeArgument $RocmArch @("rocm_arch", "rocmarch", "amd_arch", "amdarch")
 
 $backendName = Resolve-Backend $Backend
-$buildDir = if ($env:LLAMA_STAGE_BUILD_DIR) { $env:LLAMA_STAGE_BUILD_DIR } else { Join-Path $llamaDir "build-stage-abi-$backendName" }
+$buildDir = if ($env:LLAMA_STAGE_BUILD_DIR) { $env:LLAMA_STAGE_BUILD_DIR } else { Join-Path $llamaBuildRoot "build-stage-abi-$backendName" }
 Write-Host "Using Windows backend: $backendName"
 
 Ensure-MsvcToolchain

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -12,6 +12,7 @@ $llamaDir = if ($env:MESH_LLM_LLAMA_DIR) { $env:MESH_LLM_LLAMA_DIR } else { Join
 $llamaBuildRoot = if ($env:MESH_LLM_LLAMA_BUILD_ROOT) { $env:MESH_LLM_LLAMA_BUILD_ROOT } else { Join-Path $repoRoot ".deps\llama-build" }
 $buildDir = if ($env:LLAMA_STAGE_BUILD_DIR) { $env:LLAMA_STAGE_BUILD_DIR } else { Join-Path $llamaBuildRoot "build-stage-abi" }
 $meshUiDir = Join-Path $repoRoot "crates\mesh-llm-ui"
+$buildProfile = if ($env:MESH_LLM_BUILD_PROFILE) { $env:MESH_LLM_BUILD_PROFILE.ToLowerInvariant() } else { "release" }
 $compilerLauncherArgs = @()
 $compilerCacheBin = $null
 
@@ -727,6 +728,21 @@ Invoke-InRepo {
 
     Write-Host "Building mesh-llm..."
     $env:LLAMA_STAGE_BUILD_DIR = $buildDir
-    Invoke-NativeCommand "cargo" @("build", "--release", "--locked", "-p", "mesh-llm")
-    Write-Host "Mesh binary: target\release\mesh-llm.exe"
+    switch ($buildProfile) {
+        "dev" {
+            Invoke-NativeCommand "cargo" @("build", "-p", "mesh-llm", "--bin", "mesh-llm")
+            Write-Host "Mesh binary: target\debug\mesh-llm.exe"
+        }
+        "debug" {
+            Invoke-NativeCommand "cargo" @("build", "-p", "mesh-llm", "--bin", "mesh-llm")
+            Write-Host "Mesh binary: target\debug\mesh-llm.exe"
+        }
+        "release" {
+            Invoke-NativeCommand "cargo" @("build", "--release", "--locked", "-p", "mesh-llm")
+            Write-Host "Mesh binary: target\release\mesh-llm.exe"
+        }
+        default {
+            throw "Unsupported MESH_LLM_BUILD_PROFILE: $buildProfile (expected dev, debug, or release)"
+        }
+    }
 }

--- a/scripts/family-certify.sh
+++ b/scripts/family-certify.sh
@@ -322,7 +322,7 @@ maybe_build() {
     return
   fi
   run_logged "build" "" \
-    env LLAMA_STAGE_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-$ROOT/.deps/llama.cpp/build-stage-abi-static}" \
+    env LLAMA_STAGE_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-$ROOT/.deps/llama-build/build-stage-abi-static}" \
     cargo build -p skippy-correctness -p skippy-server -p llama-spec-bench
 }
 
@@ -455,7 +455,7 @@ if [[ -n "$DRAFT_MODEL_PATH" ]]; then
   mkdir -p "$SPEC_DIR"
   spec_args=(
     env
-    "LLAMA_STAGE_BUILD_DIR=${LLAMA_STAGE_BUILD_DIR:-$ROOT/.deps/llama.cpp/build-stage-abi-static}"
+    "LLAMA_STAGE_BUILD_DIR=${LLAMA_STAGE_BUILD_DIR:-$ROOT/.deps/llama-build/build-stage-abi-static}"
     "$ROOT/target/debug/llama-spec-bench"
     --target-model-path "$TARGET_MODEL_PATH"
     --draft-model-path "$DRAFT_MODEL_PATH"

--- a/scripts/prepare-llama.sh
+++ b/scripts/prepare-llama.sh
@@ -26,23 +26,66 @@ if [[ ! -d "$LLAMA_WORKDIR/.git" ]]; then
   git clone --filter=blob:none "$LLAMA_UPSTREAM_URL" "$LLAMA_WORKDIR"
 fi
 
-git -C "$LLAMA_WORKDIR" am --abort >/dev/null 2>&1 || true
-git -C "$LLAMA_WORKDIR" remote set-url origin "$LLAMA_UPSTREAM_URL"
-git -C "$LLAMA_WORKDIR" fetch origin master --tags
-git -C "$LLAMA_WORKDIR" config user.name "${GIT_AUTHOR_NAME:-Mesh-LLM CI}"
-git -C "$LLAMA_WORKDIR" config user.email "${GIT_AUTHOR_EMAIL:-ci@mesh-llm.local}"
-
 case "$MODE" in
   pinned)
     TARGET_SHA="$(tr -d '[:space:]' < "$PIN_FILE")"
     ;;
   latest)
+    git -C "$LLAMA_WORKDIR" remote set-url origin "$LLAMA_UPSTREAM_URL"
+    git -C "$LLAMA_WORKDIR" fetch origin master --tags
     TARGET_SHA="$(git -C "$LLAMA_WORKDIR" rev-parse origin/master)"
     ;;
   *)
     TARGET_SHA="$MODE"
     ;;
 esac
+
+PATCHES=()
+while IFS= read -r patch; do
+  PATCHES+=("$patch")
+done < <(find "$PATCH_DIR" -maxdepth 1 -type f -name '*.patch' | sort)
+
+compute_patch_digest() {
+  (
+    for patch in "${PATCHES[@]}"; do
+      rel="${patch#$PATCH_DIR/}"
+      checksum="$(shasum -a 256 "$patch" | awk '{print $1}')"
+      printf '%s\n' "$rel"
+      printf '%s\n' "$checksum"
+    done
+  ) | shasum -a 256 | awk '{print $1}'
+}
+
+PATCH_DIGEST="$(compute_patch_digest)"
+
+if [[ -f "$LLAMA_WORKDIR/.mesh-llm-upstream-sha" &&
+      -f "$LLAMA_WORKDIR/.mesh-llm-patched-sha" &&
+      -f "$LLAMA_WORKDIR/.mesh-llm-patch-digest" ]]; then
+  PREPARED_UPSTREAM="$(tr -d '[:space:]' < "$LLAMA_WORKDIR/.mesh-llm-upstream-sha")"
+  PREPARED_PATCHED="$(tr -d '[:space:]' < "$LLAMA_WORKDIR/.mesh-llm-patched-sha")"
+  PREPARED_DIGEST="$(tr -d '[:space:]' < "$LLAMA_WORKDIR/.mesh-llm-patch-digest")"
+  CURRENT_HEAD="$(git -C "$LLAMA_WORKDIR" rev-parse HEAD 2>/dev/null || true)"
+
+  if [[ "$PREPARED_UPSTREAM" == "$TARGET_SHA" &&
+        "$PREPARED_PATCHED" == "$CURRENT_HEAD" &&
+        "$PREPARED_DIGEST" == "$PATCH_DIGEST" &&
+        ! -d "$LLAMA_WORKDIR/.git/rebase-apply" ]] &&
+     git -C "$LLAMA_WORKDIR" diff-index --quiet HEAD --; then
+    echo "llama.cpp already prepared"
+    echo "  upstream: $TARGET_SHA"
+    echo "  patched:  $PREPARED_PATCHED"
+    echo "  workdir:  $LLAMA_WORKDIR"
+    exit 0
+  fi
+fi
+
+git -C "$LLAMA_WORKDIR" am --abort >/dev/null 2>&1 || true
+git -C "$LLAMA_WORKDIR" remote set-url origin "$LLAMA_UPSTREAM_URL"
+if [[ "$MODE" != "latest" ]]; then
+  git -C "$LLAMA_WORKDIR" fetch origin master --tags
+fi
+git -C "$LLAMA_WORKDIR" config user.name "${GIT_AUTHOR_NAME:-Mesh-LLM CI}"
+git -C "$LLAMA_WORKDIR" config user.email "${GIT_AUTHOR_EMAIL:-ci@mesh-llm.local}"
 
 # The llama.cpp checkout is a generated dependency worktree. Local edits there
 # should live in third_party/llama.cpp/patches, so reset before switching pins.
@@ -54,15 +97,12 @@ git -C "$LLAMA_WORKDIR" clean -fdx
 
 printf '%s\n' "$TARGET_SHA" > "$LLAMA_WORKDIR/.mesh-llm-upstream-sha"
 
-PATCHES=()
-while IFS= read -r patch; do
-  PATCHES+=("$patch")
-done < <(find "$PATCH_DIR" -maxdepth 1 -type f -name '*.patch' | sort)
 if (( ${#PATCHES[@]} > 0 )); then
   git -C "$LLAMA_WORKDIR" am --3way "${PATCHES[@]}"
 fi
 
 git -C "$LLAMA_WORKDIR" rev-parse HEAD > "$LLAMA_WORKDIR/.mesh-llm-patched-sha"
+printf '%s\n' "$PATCH_DIGEST" > "$LLAMA_WORKDIR/.mesh-llm-patch-digest"
 
 echo "prepared llama.cpp"
 echo "  upstream: $TARGET_SHA"

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LLAMA_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-.deps/llama.cpp/build-stage-abi-static}"
+LLAMA_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-.deps/llama-build/build-stage-abi-static}"
 WORK_DIR="${WORK_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/skippy-ci-smoke}"
 REPORT_DIR="${WORK_DIR}/reports"
 MODEL_DIR="${WORK_DIR}/models"

--- a/scripts/skippy-llama-parity.py
+++ b/scripts/skippy-llama-parity.py
@@ -291,7 +291,10 @@ def split_args(layer_count: int) -> tuple[int, str]:
 def default_stage_build_dir() -> str | None:
     if os.environ.get("LLAMA_STAGE_BUILD_DIR"):
         return os.environ["LLAMA_STAGE_BUILD_DIR"]
-    llama_root = ROOT / ".deps/llama.cpp"
+    llama_build_roots = (
+        ROOT / ".deps/llama-build",
+        ROOT / ".deps/llama.cpp",
+    )
     for name in (
         "build-stage-abi-metal",
         "build-stage-abi-static",
@@ -299,9 +302,10 @@ def default_stage_build_dir() -> str | None:
         "build-stage-abi-vulkan",
         "build-stage-abi-rocm",
     ):
-        candidate = llama_root / name
-        if candidate.is_dir():
-            return str(candidate)
+        for llama_root in llama_build_roots:
+            candidate = llama_root / name
+            if candidate.is_dir():
+                return str(candidate)
     return None
 
 

--- a/scripts/skippy-openai-smoke.sh
+++ b/scripts/skippy-openai-smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LLAMA_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-.deps/llama.cpp/build-stage-abi-static}"
+LLAMA_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-.deps/llama-build/build-stage-abi-static}"
 MODEL_REPO="${MODEL_REPO:-jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF}"
 MODEL_FILE="${MODEL_FILE:-SmolLM2-135M-Instruct.Q4_K_M.gguf}"
 MODEL_SELECTOR="${MODEL_SELECTOR:-Q4_K_M}"


### PR DESCRIPTION
## Summary
- Keep patched llama.cpp builds out of the generated source checkout so `git clean` in prepare steps no longer wipes CMake outputs.
- Make `prepare-llama.sh` idempotent when the pinned upstream SHA, patch queue digest, and patched checkout already match.
- Add a native llama.cpp build stamp so unchanged patched ABI builds skip CMake entirely instead of relinking archives and forcing Cargo to rebuild `skippy-ffi`/`mesh-llm`.
- Add `just build-dev` and `MESH_LLM_BUILD_PROFILE=dev` support across macOS, Linux, and Windows for faster local iteration.

## Developer Impact
- Warm dev builds no longer bump llama archive mtimes, so Cargo can stay warm instead of relinking `mesh-llm` after every `just` run.
- On macOS, the fast dev path now builds the mesh binary with Cargo's debug profile. Use `target/debug/mesh-llm` for `just build-dev` or `MESH_LLM_BUILD_PROFILE=dev just build`; release builds still write `target/release/mesh-llm`.
- Build outputs default to `.deps/llama-build/` instead of living inside `.deps/llama.cpp`, preserving CMake caches across prepare runs.

## Validation
- `bash -n scripts/build-llama.sh scripts/build-linux.sh scripts/build-release.sh scripts/prepare-llama.sh scripts/skippy-openai-smoke.sh scripts/skippy-ci-smoke.sh scripts/family-certify.sh`
- `zsh -n scripts/build-mac.sh`
- `python3 -m py_compile scripts/skippy-llama-parity.py`
- `just --list >/dev/null`
- Local prepare smoke confirmed the second `prepare-llama.sh` run skips patch reapplication when the checkout is already prepared.
- Warm macOS dev build confirmed native CMake is skipped and Cargo finishes in about `1.36s` (`target/debug/mesh-llm`).
- PowerShell parse check skipped locally because `pwsh` is not installed.
