### PR TITLE
Avoid Hugging Face sync panics inside Tokio

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -851,15 +851,35 @@ pub(crate) fn resolve_hf_package_to_local(
         }
     }
 
+    crate::models::run_hf_sync(move || {
+        download_hf_package_to_local_sync(
+            &repo,
+            &revision,
+            layer_start,
+            layer_end,
+            include_embeddings,
+            include_output,
+        )
+    })
+}
+
+fn download_hf_package_to_local_sync(
+    repo: &str,
+    revision: &str,
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+) -> Result<String> {
     let api = crate::models::build_hf_api(false)?;
     let (owner, name) = repo.split_once('/').context("invalid HF repo format")?;
     let model_api = api.model(owner, name);
-    let progress_label = layer_package_progress_label(&repo, &revision);
+    let progress_label = layer_package_progress_label(repo, revision);
 
     // Download manifest first
     let manifest_path = download_layer_package_file(
         &model_api,
-        &revision,
+        revision,
         &progress_label,
         "model-package.json",
         None,
@@ -959,7 +979,7 @@ pub(crate) fn resolve_hf_package_to_local(
         let file_name = file.to_string_lossy().to_string();
         download_layer_package_file(
             &model_api,
-            &revision,
+            revision,
             &progress_label,
             &file_name,
             *total_bytes,

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -493,6 +493,15 @@ fn download_hf_assets_blocking(
     assets: Vec<HfAsset>,
     progress: bool,
 ) -> Result<Vec<PathBuf>> {
+    let label = label.to_string();
+    super::run_hf_sync(move || download_hf_assets_sync(&label, assets, progress))
+}
+
+fn download_hf_assets_sync(
+    label: &str,
+    assets: Vec<HfAsset>,
+    progress: bool,
+) -> Result<Vec<PathBuf>> {
     let api = super::build_hf_api(false)?;
     let mut download_plan = initial_download_plan_for_assets(assets)?;
     let current_plan: Vec<(bool, HfAsset)> = download_plan.iter().cloned().collect();

--- a/crates/mesh-llm-host-runtime/src/models/maintenance.rs
+++ b/crates/mesh-llm-host-runtime/src/models/maintenance.rs
@@ -1,4 +1,4 @@
-use super::{build_hf_api, huggingface_hub_cache_dir, short_revision};
+use super::{build_hf_api, huggingface_hub_cache_dir, run_hf_sync, short_revision};
 use crate::cli::terminal_progress::{clear_stderr_line, DeterminateProgressLine};
 use anyhow::{Context, Result};
 use hf_hub::{RepoDownloadFileParams, RepoInfo, RepoInfoParams, RepoType};
@@ -18,6 +18,11 @@ struct UpdateCounts {
 }
 
 pub fn run_update(repo: Option<&str>, all: bool, check: bool) -> Result<()> {
+    let repo = repo.map(ToOwned::to_owned);
+    run_hf_sync(move || run_update_sync(repo.as_deref(), all, check))
+}
+
+fn run_update_sync(repo: Option<&str>, all: bool, check: bool) -> Result<()> {
     let api = build_hf_api(!check)?;
     let repos = cached_repos()?;
     if repos.is_empty() {
@@ -124,30 +129,30 @@ pub fn warn_about_updates_for_paths(paths: &[PathBuf]) {
         return;
     }
 
-    let api = match build_hf_api(false) {
-        Ok(api) => api,
-        Err(err) => {
-            eprintln!("Warning: could not initialize Hugging Face update checks: {err}");
-            return;
-        }
-    };
-    for repo in cache_models {
-        match check_repo_update(&api, &repo) {
-            Ok(Some(remote_revision)) => {
-                eprintln!("🆕 Update available for {}", repo.repo_id);
-                eprintln!("   local: {}", short_revision(&repo.local_revision));
-                eprintln!("   latest: {}", short_revision(&remote_revision));
-                eprintln!("   continuing with pinned local snapshot");
-                eprintln!("   update: mesh-llm models updates {}", repo.repo_id);
-            }
-            Ok(None) => {}
-            Err(err) => {
-                eprintln!(
-                    "Warning: could not check for updates for {}: {err}",
-                    repo.repo_id
-                );
+    let result = run_hf_sync(move || {
+        let api = build_hf_api(false)?;
+        for repo in cache_models {
+            match check_repo_update(&api, &repo) {
+                Ok(Some(remote_revision)) => {
+                    eprintln!("🆕 Update available for {}", repo.repo_id);
+                    eprintln!("   local: {}", short_revision(&repo.local_revision));
+                    eprintln!("   latest: {}", short_revision(&remote_revision));
+                    eprintln!("   continuing with pinned local snapshot");
+                    eprintln!("   update: mesh-llm models updates {}", repo.repo_id);
+                }
+                Ok(None) => {}
+                Err(err) => {
+                    eprintln!(
+                        "Warning: could not check for updates for {}: {err}",
+                        repo.repo_id
+                    );
+                }
             }
         }
+        Ok(())
+    });
+    if let Err(err) = result {
+        eprintln!("Warning: could not initialize Hugging Face update checks: {err}");
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -61,6 +61,26 @@ pub(crate) fn build_hf_api(_progress: bool) -> Result<HFClientSync> {
         .context("Build Hugging Face sync API client")
 }
 
+pub(crate) fn run_hf_sync<T, F>(operation: F) -> Result<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T> + Send + 'static,
+{
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::spawn(operation).join().map_err(|panic| {
+            if let Some(message) = panic.downcast_ref::<&str>() {
+                anyhow::anyhow!("Hugging Face sync task panicked: {message}")
+            } else if let Some(message) = panic.downcast_ref::<String>() {
+                anyhow::anyhow!("Hugging Face sync task panicked: {message}")
+            } else {
+                anyhow::anyhow!("Hugging Face sync task panicked")
+            }
+        })?
+    } else {
+        operation()
+    }
+}
+
 pub(crate) fn build_hf_tokio_api(_progress: bool) -> Result<HFClient> {
     let mut builder = HFClientBuilder::new().cache_dir(huggingface_hub_cache_dir());
     if let Ok(endpoint) = std::env::var("HF_ENDPOINT") {
@@ -136,5 +156,12 @@ mod tests {
         assert_eq!(repo, "Qwen/Qwen3-8B-GGUF");
         assert_eq!(revision.as_deref(), Some("main"));
         assert_eq!(file, "Qwen3-8B-Q4_K_M.gguf");
+    }
+
+    #[tokio::test]
+    async fn run_hf_sync_leaves_tokio_runtime_context() {
+        let saw_runtime = super::run_hf_sync(|| Ok(tokio::runtime::Handle::try_current().is_ok()))
+            .expect("sync operation should run");
+        assert!(!saw_runtime);
     }
 }

--- a/crates/mesh-llm-host-runtime/src/models/remote_catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/remote_catalog.rs
@@ -144,6 +144,10 @@ pub fn is_catalog_stale() -> bool {
 /// every `entries/**/*.json` file. No hardcoded file list — new models added to the
 /// catalog are discovered automatically.
 pub fn refresh_catalog() -> Result<()> {
+    super::run_hf_sync(refresh_catalog_sync)
+}
+
+fn refresh_catalog_sync() -> Result<()> {
     let api = super::build_hf_api(false)?;
     let dataset = api.dataset("meshllm", "catalog");
 
@@ -360,24 +364,25 @@ fn hf_model_repo_has_file(repo: &str, revision: &str, file: &str) -> Result<bool
         }
     }
 
-    let api = super::build_hf_api(false)?;
-    let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
-    let info = api
-        .model(owner, name)
-        .info(
-            &RepoInfoParams::builder()
-                .revision(revision.to_string())
-                .build(),
-        )
-        .with_context(|| format!("fetch Hugging Face model repo {repo}@{revision}"))?;
-    let RepoInfo::Model(detail) = info else {
-        bail!("expected Hugging Face model repo info for {repo}@{revision}");
-    };
-    Ok(detail
-        .siblings
-        .unwrap_or_default()
-        .iter()
-        .any(|sibling| sibling.rfilename == file))
+    let repo = repo.to_string();
+    let revision = revision.to_string();
+    let file = file.to_string();
+    super::run_hf_sync(move || {
+        let api = super::build_hf_api(false)?;
+        let (owner, name) = repo.split_once('/').unwrap_or(("", repo.as_str()));
+        let info = api
+            .model(owner, name)
+            .info(&RepoInfoParams::builder().revision(revision.clone()).build())
+            .with_context(|| format!("fetch Hugging Face model repo {repo}@{revision}"))?;
+        let RepoInfo::Model(detail) = info else {
+            bail!("expected Hugging Face model repo info for {repo}@{revision}");
+        };
+        Ok(detail
+            .siblings
+            .unwrap_or_default()
+            .iter()
+            .any(|sibling| sibling.rfilename == file))
+    })
 }
 
 /// A resolved model download reference from the remote catalog.


### PR DESCRIPTION
## Summary
Mesh nodes can now resolve and download Hugging Face-backed layer packages without letting the blocking `huggingface_hub_rust` client run inside an active Tokio runtime. The sync HF paths are funneled through a small wrapper that moves them onto a plain OS thread when mesh-llm is already running async work.

## Root Cause
Some Hugging Face sync client operations internally build and block on a Tokio runtime. When mesh-llm called those operations from Tokio tasks, the SDK could panic before a layer-package download had a chance to start.

## Validation
- `just build`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo test -p mesh-llm-host-runtime models::tests::run_hf_sync_leaves_tokio_runtime_context`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm`
- `git diff --check`