### PR TITLE
Emit fresh mesh invite tokens

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -4114,7 +4114,6 @@ async fn run_auto(
     ))))
     .await;
     node.start_accepting();
-    let token = node.invite_token();
     node.set_display_name(node_display_name(&cli, &node)).await;
     let (plugin_mesh_tx, plugin_mesh_rx) = tokio::sync::mpsc::channel(256);
     let plugin_manager =
@@ -4295,7 +4294,7 @@ async fn run_auto(
             .await
             .unwrap_or_else(|| "pending".to_string());
         let _ = emit_event(OutputEvent::InviteToken {
-            token: token.clone(),
+            token: node.invite_token(),
             mesh_id,
             mesh_name: cli.mesh_name.clone(),
         });
@@ -4349,7 +4348,7 @@ async fn run_auto(
         mesh::save_last_mesh_id(&mesh_id);
         tracing::info!("Mesh ID: {mesh_id}");
         let _ = emit_event(OutputEvent::InviteToken {
-            token: token.clone(),
+            token: node.invite_token(),
             mesh_id: mesh_id.clone(),
             mesh_name: cli.mesh_name.clone(),
         });


### PR DESCRIPTION
## Summary
Mesh startup now emits the invite token from the node's current endpoint address at the moment the invite event is published, instead of reusing the token captured immediately after accepting starts.

## Impact
This reduces the chance of sharing a stale invite token if relay or public endpoint address information changes during startup.

## Validation
- `LLAMA_STAGE_BUILD_DIR=.deps/llama.cpp/build-stage-abi-metal cargo check -p mesh-llm`
- `git diff --check`