### PR TITLE
retry mesh joins via relay-only address

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -14,7 +14,7 @@ pub use mesh_llm_types::mesh::{
 use anyhow::{Context, Result};
 use base64::Engine;
 use iroh::endpoint::Connection;
-use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey};
+use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey, TransportAddr};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
@@ -45,6 +45,41 @@ fn emit_mesh_warning(message: String) {
         message,
         context: None,
     });
+}
+
+fn relay_only_endpoint_addr(addr: &EndpointAddr) -> Option<EndpointAddr> {
+    let addrs = addr
+        .addrs
+        .iter()
+        .filter(|transport| matches!(transport, TransportAddr::Relay(_)))
+        .cloned()
+        .collect();
+    Some(EndpointAddr { id: addr.id, addrs }).filter(|addr| !addr.addrs.is_empty())
+}
+
+async fn connect_peer_once(
+    endpoint: &Endpoint,
+    peer_id: EndpointId,
+    addr: EndpointAddr,
+) -> Result<Connection> {
+    match tokio::time::timeout(
+        PEER_CONNECT_AND_GOSSIP_TIMEOUT,
+        connect_mesh(endpoint, addr),
+    )
+    .await
+    {
+        Ok(Ok(c)) => Ok(c),
+        Ok(Err(e)) => {
+            anyhow::bail!("Failed to connect to {}: {e}", peer_id.fmt_short());
+        }
+        Err(_) => {
+            anyhow::bail!(
+                "Timeout connecting to {} ({}s)",
+                peer_id.fmt_short(),
+                PEER_CONNECT_AND_GOSSIP_TIMEOUT.as_secs()
+            );
+        }
+    }
 }
 
 fn now_secs() -> u64 {
@@ -5498,22 +5533,25 @@ impl Node {
         }
 
         tracing::info!("Connecting to peer {}...", peer_id.fmt_short());
-        let conn = match tokio::time::timeout(
-            PEER_CONNECT_AND_GOSSIP_TIMEOUT,
-            connect_mesh(&self.endpoint, addr.clone()),
-        )
-        .await
-        {
-            Ok(Ok(c)) => c,
-            Ok(Err(e)) => {
-                anyhow::bail!("Failed to connect to {}: {e}", peer_id.fmt_short());
-            }
-            Err(_) => {
-                anyhow::bail!(
-                    "Timeout connecting to {} ({}s)",
-                    peer_id.fmt_short(),
-                    PEER_CONNECT_AND_GOSSIP_TIMEOUT.as_secs()
+        let relay_fallback_addr =
+            relay_only_endpoint_addr(&addr).filter(|relay_addr| relay_addr.addrs != addr.addrs);
+        let conn = match connect_peer_once(&self.endpoint, peer_id, addr).await {
+            Ok(conn) => conn,
+            Err(first_err) => {
+                let Some(relay_addr) = relay_fallback_addr else {
+                    return Err(first_err);
+                };
+                tracing::warn!(
+                    "Peer {} was not reachable via advertised direct addresses; retrying with relay-only address",
+                    peer_id.fmt_short()
                 );
+                connect_peer_once(&self.endpoint, peer_id, relay_addr)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "relay-only retry failed after full endpoint address failed: {first_err}"
+                        )
+                    })?
             }
         };
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -794,6 +794,43 @@ fn control_frame_roundtrip() {
     assert_eq!(decoded.peers[0].role, NodeRole::Worker as i32);
 }
 
+#[test]
+fn relay_only_endpoint_addr_keeps_relays_and_drops_direct_ips() {
+    use iroh::TransportAddr;
+
+    let peer_id = EndpointId::from(SecretKey::from_bytes(&[0x7a; 32]).public());
+    let relay: TransportAddr = TransportAddr::Relay(
+        "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./"
+            .parse()
+            .unwrap(),
+    );
+    let private_ip: TransportAddr = TransportAddr::Ip("192.168.86.26:52398".parse().unwrap());
+    let tailscale_ip: TransportAddr = TransportAddr::Ip("100.107.22.123:52398".parse().unwrap());
+    let addr = EndpointAddr::from_parts(
+        peer_id,
+        [relay.clone(), private_ip, tailscale_ip].into_iter(),
+    );
+
+    let relay_only = super::relay_only_endpoint_addr(&addr).expect("relay should be preserved");
+
+    assert_eq!(relay_only.id, peer_id);
+    assert_eq!(relay_only.addrs.len(), 1);
+    assert!(relay_only.addrs.contains(&relay));
+}
+
+#[test]
+fn relay_only_endpoint_addr_returns_none_without_relay() {
+    use iroh::TransportAddr;
+
+    let peer_id = EndpointId::from(SecretKey::from_bytes(&[0x7b; 32]).public());
+    let addr = EndpointAddr::from_parts(
+        peer_id,
+        [TransportAddr::Ip("10.0.0.1:52398".parse().unwrap())].into_iter(),
+    );
+
+    assert!(super::relay_only_endpoint_addr(&addr).is_none());
+}
+
 fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
     PeerInfo {
         id: peer_id,


### PR DESCRIPTION
## Summary

Fix mesh joins where a token advertises a valid iroh relay plus direct IP addresses that are not reachable from the joining node.

The join path now tries the full advertised `EndpointAddr` first, preserving the normal iroh direct-path behavior. If that connect fails and the token contains relay transports, it retries once with a relay-only `EndpointAddr` so unusable direct addresses do not prevent relay connectivity.

## Token Breakdown

The reported token decodes to:

```json
{
  "id": "cb1737c6fb73a5d8173a335d8af291db8f5d605874fc1bf52ad4dcc390728287",
  "addrs": [
    { "Relay": "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./" },
    { "Ip": "10.0.0.1:52398" },
    { "Ip": "100.107.22.123:52398" },
    { "Ip": "100.112.37.220:40256" },
    { "Ip": "192.168.0.2:52398" },
    { "Ip": "192.168.86.26:52398" }
  ]
}
```

This token was produced on James' network. From James' node, those direct IPs are meaningful candidates because they describe local or overlay interfaces available in James' network context. From Michael's network, they are not generally usable:

- `10.0.0.1` is RFC1918 private LAN space.
- `192.168.0.2` and `192.168.86.26` are RFC1918 private LAN space.
- `100.107.22.123` and `100.112.37.220` are in `100.64.0.0/10`, commonly CGNAT or overlay VPN space such as Tailscale, and are not generally reachable from an unrelated LAN unless both sides share that routing context.
- The relay is the only address in the token that should be expected to work across James' LAN and Michael's LAN.

## Why Michael's Node Could Fail

Michael's node was handed an address card for James' node. The expected behavior is that Michael cannot reach James via James' LAN/private/overlay IPs, but can still reach James via the advertised relay.

The suspected failure is that our join path gave iroh the full mixed address list inside one 15-second connect window. With several plausible but unreachable direct candidates present, iroh could spend that window on direct-path attempts and fail before the relay path got a clean attempt. That makes a relay-capable token appear unreachable from Michael's third LAN.

Most tokens that join cleanly either contain a direct address reachable from the joiner, or iroh's normal path selection reaches the relay quickly enough after direct attempts. This token is different because it has several direct candidates that are valid for James' environment but unusable from Michael's network.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`

Targeted test note: `cargo test -p mesh-llm-host-runtime relay_only_endpoint_addr --lib` could not link in this worktree because `skippy-ffi` could not find the native static library `llama-common`. The new unit tests compile under `cargo check`; running them requires the local llama static ABI build artifacts.
