### PR TITLE
Update all crate versions during release

### DIFF
--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -49,6 +49,9 @@ update_manifest_version() {
     local next="$2"
     local before
     local after
+    if perl -0777 -ne 'exit((/\[package\][^[]*?\nversion\.workspace\s*=\s*true/s) ? 0 : 1)' "$file"; then
+        return
+    fi
     before="$(cat "$file")"
     after="$(perl -0777 -pe 's/(\[package\][^[]*?\nversion\s*=\s*")[^"]+(")/${1}'"$next"'$2/s' "$file")"
     if [[ "$before" == "$after" ]]; then
@@ -56,6 +59,23 @@ update_manifest_version() {
             return
         fi
         echo "failed to update [package].version in $file" >&2
+        exit 1
+    fi
+    printf '%s\n' "$after" >"$file"
+}
+
+update_workspace_version() {
+    local file="$1"
+    local next="$2"
+    local before
+    local after
+    before="$(cat "$file")"
+    after="$(perl -0777 -pe 's/(\[workspace\.package\][^[]*?\nversion\s*=\s*")[^"]+(")/${1}'"$next"'$2/s' "$file")"
+    if [[ "$before" == "$after" ]]; then
+        if perl -0777 -ne 'exit((/\[workspace\.package\][^[]*?\nversion\s*=\s*"'"$next"'"/s) ? 0 : 1)' "$file"; then
+            return
+        fi
+        echo "failed to update [workspace.package].version in $file" >&2
         exit 1
     fi
     printf '%s\n' "$after" >"$file"
@@ -97,26 +117,22 @@ while IFS= read -r manifest; do
 done < <(
     cd "$REPO_ROOT"
     git ls-files \
-        'crates/mesh-llm/Cargo.toml' \
-        'crates/mesh-llm-host-runtime/Cargo.toml' \
-        'crates/mesh-llm-identity/Cargo.toml' \
-        'crates/mesh-llm-plugin/Cargo.toml' \
-        'crates/mesh-llm-protocol/Cargo.toml' \
-        'crates/mesh-llm-routing/Cargo.toml' \
-        'crates/mesh-llm-system/Cargo.toml' \
-        'crates/mesh-llm-types/Cargo.toml' \
-        'crates/mesh-llm-ui/Cargo.toml' \
-        'crates/mesh-api/Cargo.toml' \
-        'crates/mesh-client/Cargo.toml' \
+        'crates/*/Cargo.toml' \
+        'tools/*/Cargo.toml' \
         | sort -u
 )
 
 if [[ "${#manifests[@]}" -eq 0 ]]; then
-    echo "no Cargo.toml manifests found under crates/" >&2
+    echo "no Cargo.toml manifests found under crates/ or tools/" >&2
     exit 1
 fi
 
 versioned_files=()
+
+workspace_manifest="$REPO_ROOT/Cargo.toml"
+require_file "$workspace_manifest"
+update_workspace_version "$workspace_manifest" "$version"
+versioned_files+=("$workspace_manifest")
 
 lib_file="$REPO_ROOT/crates/mesh-llm-host-runtime/src/lib.rs"
 require_file "$lib_file"


### PR DESCRIPTION
## Summary

Release version bumps now propagate to every Rust package in the workspace, including crates that inherit `workspace.package.version` and package manifests under `tools/`.

## Details

- Updates the root `[workspace.package].version` during `scripts/release-version.sh`.
- Discovers tracked `crates/*/Cargo.toml` and `tools/*/Cargo.toml` manifests instead of maintaining a hardcoded subset.
- Skips direct manifest rewrites for packages using `version.workspace = true`, since the workspace version drives them.

## Validation

- `bash -n scripts/release-version.sh`
- Ran the patched release version script in a throwaway git worktree with `9.8.7-test.1`, then confirmed via `cargo metadata --format-version 1 --no-deps` that every package under `crates/` and `tools/` reported `9.8.7-test.1`.
