### PR TITLE
Add opt-in mDNS LAN mesh discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,6 +1995,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,7 +2098,7 @@ dependencies = [
  "diatomic-waker",
  "futures-core",
  "pin-project-lite",
- "spin",
+ "spin 0.10.0",
 ]
 
 [[package]]
@@ -2891,6 +2902,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "igd-next"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3556,6 +3577,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "mdns-sd"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2bb8ce26633738d98ffcef71ec58bff967c6675be50229823c2835f6316e67e"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3683,6 +3719,7 @@ dependencies = [
  "iroh",
  "keyring",
  "libc",
+ "mdns-sd",
  "mesh-llm-client",
  "mesh-llm-identity",
  "mesh-llm-plugin",
@@ -6912,6 +6949,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6936,6 +6984,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -67,6 +67,7 @@ ratatui = "0.30"
 url = "2"
 urlencoding = "2"
 libc = "0.2.183"
+mdns-sd = "0.19"
 regex-lite = "0.1"
 rmcp = { version = "1.2", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 schemars = "1"

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -212,6 +212,7 @@ impl MeshApi {
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
+                mesh_discovery_mode: crate::network::discovery::MeshDiscoveryMode::Nostr,
                 nostr_discovery: false,
                 publication_state: state::PublicationState::Private,
                 runtime_control: None,
@@ -342,6 +343,13 @@ impl MeshApi {
 
     pub async fn set_nostr_relays(&self, relays: Vec<String>) {
         self.inner.lock().await.nostr_relays = relays;
+    }
+
+    pub async fn set_mesh_discovery_mode(
+        &self,
+        mode: crate::network::discovery::MeshDiscoveryMode,
+    ) {
+        self.inner.lock().await.mesh_discovery_mode = mode;
     }
 
     pub async fn set_nostr_discovery(&self, v: bool) {

--- a/crates/mesh-llm-host-runtime/src/api/routes/discover.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/discover.rs
@@ -1,27 +1,45 @@
 use super::super::{http::respond_error, MeshApi};
-use crate::network::nostr;
+use crate::network::{discovery, nostr};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
 pub(super) async fn handle(stream: &mut TcpStream, state: &MeshApi) -> anyhow::Result<()> {
-    let relays = state.inner.lock().await.nostr_relays.clone();
+    let (mode, relays) = {
+        let inner = state.inner.lock().await;
+        (inner.mesh_discovery_mode, inner.nostr_relays.clone())
+    };
     let filter = nostr::MeshFilter::default();
-    match nostr::discover(&relays, &filter, None).await {
-        Ok(meshes) => {
-            if let Ok(json) = serde_json::to_string(&meshes) {
-                let resp = format!(
-                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-                    json.len(),
-                    json
-                );
-                stream.write_all(resp.as_bytes()).await?;
-            } else {
-                respond_error(stream, 500, "Failed to serialize").await?;
+    let json = match mode {
+        discovery::MeshDiscoveryMode::Nostr => {
+            match nostr::discover(&relays, &filter, None).await {
+                Ok(meshes) => serde_json::to_string(&meshes),
+                Err(e) => {
+                    respond_error(stream, 500, &format!("Discovery failed: {e}")).await?;
+                    return Ok(());
+                }
             }
         }
-        Err(e) => {
-            respond_error(stream, 500, &format!("Discovery failed: {e}")).await?;
+        discovery::MeshDiscoveryMode::Mdns => {
+            match discovery::discover_lan(&filter, None, std::time::Duration::from_secs(3)).await {
+                Ok(meshes) => serde_json::to_string(&meshes),
+                Err(e) => {
+                    respond_error(stream, 500, &format!("Discovery failed: {e}")).await?;
+                    return Ok(());
+                }
+            }
         }
+    };
+
+    match json {
+        Ok(json) => {
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+                json.len(),
+                json
+            );
+            stream.write_all(resp.as_bytes()).await?;
+        }
+        Err(_) => respond_error(stream, 500, "Failed to serialize").await?,
     }
     Ok(())
 }

--- a/crates/mesh-llm-host-runtime/src/api/state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/state.rs
@@ -1,5 +1,6 @@
 use crate::mesh;
 use crate::network::affinity;
+use crate::network::discovery::MeshDiscoveryMode;
 use crate::plugin;
 use crate::runtime_data;
 use serde::{Serialize, Serializer};
@@ -118,6 +119,7 @@ pub(super) struct ApiInner {
     pub(super) mesh_name: Option<String>,
     pub(super) latest_version: Option<String>,
     pub(super) nostr_relays: Vec<String>,
+    pub(super) mesh_discovery_mode: MeshDiscoveryMode,
     pub(super) nostr_discovery: bool,
     pub(super) publication_state: PublicationState,
     pub(super) runtime_control: Option<tokio::sync::mpsc::UnboundedSender<RuntimeControlRequest>>,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/discover.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/discover.rs
@@ -1,26 +1,51 @@
 use anyhow::Result;
 
 use crate::mesh;
-use crate::network::nostr;
+use crate::network::{discovery, nostr};
 use crate::runtime;
 use crate::system::backend;
 
-pub(crate) async fn run_discover(
-    name: Option<String>,
-    model: Option<String>,
-    min_vram: Option<f64>,
-    region: Option<String>,
+pub(crate) struct DiscoverOptions {
+    pub(crate) name: Option<String>,
+    pub(crate) model: Option<String>,
+    pub(crate) min_vram_gb: Option<f64>,
+    pub(crate) region: Option<String>,
+    pub(crate) auto_join: bool,
+    pub(crate) relays: Vec<String>,
+    pub(crate) discovery_mode: discovery::MeshDiscoveryMode,
+    pub(crate) supplied_join_tokens: Vec<String>,
+}
+
+impl DiscoverOptions {
+    fn filter(&self) -> nostr::MeshFilter {
+        nostr::MeshFilter {
+            name: self.name.clone(),
+            model: self.model.clone(),
+            min_vram_gb: self.min_vram_gb,
+            region: self.region.clone(),
+        }
+    }
+}
+
+pub(crate) async fn run_discover(options: DiscoverOptions) -> Result<()> {
+    let filter = options.filter();
+
+    match options.discovery_mode {
+        discovery::MeshDiscoveryMode::Nostr => {
+            run_nostr_discover(filter, options.auto_join, options.relays).await
+        }
+        discovery::MeshDiscoveryMode::Mdns => {
+            run_lan_discover(filter, options.auto_join, options.supplied_join_tokens).await
+        }
+    }
+}
+
+async fn run_nostr_discover(
+    filter: nostr::MeshFilter,
     auto_join: bool,
     relays: Vec<String>,
 ) -> Result<()> {
     let relays = runtime::nostr_relays(&relays);
-
-    let filter = nostr::MeshFilter {
-        name,
-        model,
-        min_vram_gb: min_vram,
-        region,
-    };
 
     eprintln!("🔍 Searching Nostr relays for mesh-llm meshes...");
     let meshes = nostr::discover(&relays, &filter, None).await?;
@@ -94,6 +119,82 @@ pub(crate) async fn run_discover(
         eprintln!("  mesh-llm --join <token>");
         eprintln!("  mesh-llm --discover <name>       # join by mesh name");
         eprintln!("  mesh-llm client --discover <name> # join as client by mesh name");
+    }
+
+    Ok(())
+}
+
+async fn run_lan_discover(
+    filter: nostr::MeshFilter,
+    auto_join: bool,
+    supplied_join_tokens: Vec<String>,
+) -> Result<()> {
+    let supplied_join_token = supplied_join_tokens.first().map(String::as_str);
+    eprintln!(
+        "Searching local LAN for mesh-llm meshes via {}...",
+        discovery::LAN_SERVICE_TYPE
+    );
+    let meshes = discovery::discover_lan(
+        &filter,
+        supplied_join_token,
+        std::time::Duration::from_secs(5),
+    )
+    .await?;
+
+    if meshes.is_empty() {
+        eprintln!("No LAN meshes found.");
+        if supplied_join_token.is_none() {
+            eprintln!("mDNS advertisements do not include reusable invite tokens.");
+            eprintln!("Pass --join <token> to verify a LAN advertisement by token fingerprint.");
+        }
+        return Ok(());
+    }
+
+    eprintln!("Found {} LAN mesh(es):\n", meshes.len());
+    for (i, mesh) in meshes.iter().enumerate() {
+        let vram_gb = mesh.listing.total_vram_bytes as f64 / 1e9;
+        let models = if mesh.listing.serving.is_empty() {
+            "(no models loaded)".to_string()
+        } else {
+            mesh.listing.serving.join(", ")
+        };
+        let join_state = if mesh.joinable_with_supplied_token {
+            "token fingerprint matched"
+        } else {
+            "requires supplied token"
+        };
+        eprintln!(
+            "  [{}] {}  {} node(s), {:.0}GB capacity  serving: {}",
+            i + 1,
+            mesh.listing.name.as_deref().unwrap_or("(unnamed)"),
+            mesh.listing.node_count,
+            vram_gb,
+            models
+        );
+        eprintln!(
+            "      instance: {}  host: {}:{}  {}",
+            mesh.instance_name, mesh.host, mesh.port, join_state
+        );
+        if let Some(version) = &mesh.published_version {
+            eprintln!("      version: {version}");
+        }
+        if !mesh.listing.on_disk.is_empty() {
+            eprintln!("      on disk: {}", mesh.listing.on_disk.join(", "));
+        }
+        eprintln!();
+    }
+
+    if auto_join {
+        if let Some(token) = meshes.iter().find_map(|mesh| mesh.join_token()) {
+            println!("{token}");
+        } else {
+            eprintln!("No LAN mesh matched the supplied token fingerprint.");
+            eprintln!("mDNS intentionally does not advertise raw invite tokens.");
+        }
+    } else {
+        eprintln!("To join a LAN mesh:");
+        eprintln!("  mesh-llm --join <token>");
+        eprintln!("  mesh-llm --join <token> discover --mesh-discovery-mode mdns --auto");
     }
 
     Ok(())

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 
 use crate::cli::commands::benchmark::dispatch_benchmark_command;
 use crate::cli::commands::blackboard::{install_skill, run_blackboard};
-use crate::cli::commands::discover::{run_discover, run_stop};
+use crate::cli::commands::discover::{run_discover, run_stop, DiscoverOptions};
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
 use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode, run_pi};
@@ -56,14 +56,16 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
             auto,
             relay,
         } => {
-            run_discover(
-                name.clone(),
-                model.clone(),
-                *min_vram,
-                region.clone(),
-                *auto,
-                relay.clone(),
-            )
+            run_discover(DiscoverOptions {
+                name: name.clone(),
+                model: model.clone(),
+                min_vram_gb: *min_vram,
+                region: region.clone(),
+                auto_join: *auto,
+                relays: relay.clone(),
+                discovery_mode: cli.mesh_discovery_mode,
+                supplied_join_tokens: cli.join.clone(),
+            })
             .await
         }
         Command::RotateKey => nostr::rotate_keys(),

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 use crate::cli::benchmark::BenchmarkCommand;
 use crate::cli::runtime::RuntimeCommand;
 use crate::crypto::TrustPolicy;
+use crate::network::discovery::MeshDiscoveryMode;
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum TrustCommand {
@@ -255,13 +256,17 @@ pub(crate) struct Cli {
     #[arg(long, short)]
     pub(crate) join: Vec<String>,
 
-    /// Discover a mesh via Nostr and join it.
+    /// Discover a mesh and join it.
     #[arg(long, default_missing_value = "", num_args = 0..=1)]
     pub(crate) discover: Option<String>,
 
-    /// Auto-join the best mesh found via Nostr.
+    /// Auto-join the best mesh found via discovery.
     #[arg(long)]
     pub(crate) auto: bool,
+
+    /// Discovery provider for --auto, --discover, --publish, and the discover command.
+    #[arg(long, value_enum, default_value_t = MeshDiscoveryMode::Nostr, global = true)]
+    pub(crate) mesh_discovery_mode: MeshDiscoveryMode,
 
     /// Model to serve (path, remote catalog name, or Hugging Face ref).
     #[arg(long)]
@@ -291,7 +296,7 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) headless: bool,
 
-    /// Publish this mesh to Nostr for public discovery by other nodes.
+    /// Publish this mesh for discovery by other nodes.
     /// Without this flag, your mesh is private and only joinable via invite token.
     #[arg(long)]
     pub(crate) publish: bool,
@@ -419,6 +424,23 @@ pub(crate) struct Cli {
     pub(crate) nostr_discovery: bool,
 }
 
+pub(crate) fn validate_discovery_mode_args(cli: &Cli) -> anyhow::Result<()> {
+    if cli.mesh_discovery_mode != MeshDiscoveryMode::Mdns {
+        return Ok(());
+    }
+
+    if !cli.nostr_relay.is_empty() {
+        anyhow::bail!("--nostr-relay is only valid with --mesh-discovery-mode nostr");
+    }
+    if let Some(Command::Discover { relay, .. }) = cli.command.as_ref() {
+        if !relay.is_empty() {
+            anyhow::bail!("discover --relay is only valid with --mesh-discovery-mode nostr");
+        }
+    }
+
+    Ok(())
+}
+
 #[derive(Subcommand, Debug)]
 pub(crate) enum Command {
     /// Manage model storage, migration, and update checks.
@@ -478,7 +500,7 @@ pub(crate) enum Command {
         #[arg(long, default_value = "3131")]
         port: u16,
     },
-    /// Discover meshes on Nostr and optionally auto-join one.
+    /// Discover meshes and optionally auto-join one.
     Discover {
         /// Filter by mesh name (case-insensitive exact match)
         #[arg(long)]
@@ -1219,6 +1241,47 @@ mod tests {
 
         assert_eq!(cli.log_format, LogFormat::Json);
         assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Client));
+    }
+
+    #[test]
+    fn cli_defaults_mesh_discovery_mode_to_nostr() {
+        let normalized = normalize_runtime_surface_args(["mesh-llm", "serve", "--auto"]);
+        let cli = Cli::parse_from(normalized.normalized);
+
+        assert_eq!(
+            cli.mesh_discovery_mode,
+            crate::network::discovery::MeshDiscoveryMode::Nostr
+        );
+    }
+
+    #[test]
+    fn cli_accepts_mdns_discovery_mode_for_runtime_surfaces() {
+        let normalized =
+            normalize_runtime_surface_args(["mesh-llm", "client", "--mesh-discovery-mode", "mdns"]);
+        let cli = Cli::parse_from(normalized.normalized);
+
+        assert!(cli.client);
+        assert_eq!(
+            cli.mesh_discovery_mode,
+            crate::network::discovery::MeshDiscoveryMode::Mdns
+        );
+    }
+
+    #[test]
+    fn cli_rejects_nostr_relays_in_mdns_mode() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "serve",
+            "--mesh-discovery-mode",
+            "mdns",
+            "--nostr-relay",
+            "wss://relay.example",
+        ]);
+        let cli = Cli::parse_from(normalized.normalized);
+
+        let err = validate_discovery_mode_args(&cli)
+            .expect_err("mdns mode must reject Nostr relay overrides");
+        assert!(err.to_string().contains("--nostr-relay"));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/discovery.rs
+++ b/crates/mesh-llm-host-runtime/src/network/discovery.rs
@@ -1,0 +1,833 @@
+use anyhow::{Context, Result};
+use clap::ValueEnum;
+use mdns_sd::{DaemonStatus, ResolvedService, ServiceDaemon, ServiceEvent, ServiceInfo};
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::network::nostr;
+
+pub(crate) const LAN_SERVICE_TYPE: &str = "_mesh-llm._tcp.local.";
+const TXT_SCHEMA_VERSION: u8 = 1;
+const TXT_LIST_SEPARATOR: char = '|';
+const TXT_VALUE_LIMIT: usize = 220;
+const DAEMON_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub(crate) enum MeshDiscoveryMode {
+    #[default]
+    Nostr,
+    Mdns,
+}
+
+impl MeshDiscoveryMode {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Nostr => "nostr",
+            Self::Mdns => "mdns",
+        }
+    }
+
+    pub(crate) fn source(self) -> &'static str {
+        match self {
+            Self::Nostr => "nostr-relay",
+            Self::Mdns => "mdns-sd",
+        }
+    }
+
+    pub(crate) fn scope(self) -> DiscoveryScope {
+        match self {
+            Self::Nostr => DiscoveryScope::Public,
+            Self::Mdns => DiscoveryScope::Lan,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum DiscoveryScope {
+    Public,
+    Lan,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum LanJoinMaterial {
+    RequiresSuppliedToken,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct LanMeshAdvertisement {
+    pub(crate) mesh_id: Option<String>,
+    pub(crate) mesh_name: Option<String>,
+    pub(crate) region: Option<String>,
+    pub(crate) serving_summary: Vec<String>,
+    pub(crate) wanted_summary: Vec<String>,
+    pub(crate) on_disk_summary: Vec<String>,
+    pub(crate) total_vram_bytes: u64,
+    pub(crate) node_count: usize,
+    pub(crate) client_count: usize,
+    pub(crate) max_clients: usize,
+    pub(crate) token_fingerprint: Option<String>,
+    pub(crate) app_version: Option<String>,
+    pub(crate) join_material: LanJoinMaterial,
+}
+
+impl LanMeshAdvertisement {
+    pub(crate) fn from_listing(
+        listing: &nostr::MeshListing,
+        supplied_invite_token: Option<&str>,
+        app_version: Option<&str>,
+    ) -> Self {
+        let token_fingerprint = supplied_invite_token
+            .filter(|token| !token.trim().is_empty())
+            .map(lan_token_fingerprint)
+            .or_else(|| {
+                (!listing.invite_token.trim().is_empty())
+                    .then(|| lan_token_fingerprint(&listing.invite_token))
+            });
+
+        Self {
+            mesh_id: listing.mesh_id.clone(),
+            mesh_name: listing.name.clone(),
+            region: listing.region.clone(),
+            serving_summary: bounded_list(&listing.serving),
+            wanted_summary: bounded_list(&listing.wanted),
+            on_disk_summary: bounded_list(&listing.on_disk),
+            total_vram_bytes: listing.total_vram_bytes,
+            node_count: listing.node_count,
+            client_count: listing.client_count,
+            max_clients: listing.max_clients,
+            token_fingerprint,
+            app_version: app_version.map(str::to_owned),
+            join_material: LanJoinMaterial::RequiresSuppliedToken,
+        }
+    }
+
+    pub(crate) fn matches_supplied_token(&self, supplied_invite_token: Option<&str>) -> bool {
+        let Some(expected) = self.token_fingerprint.as_deref() else {
+            return false;
+        };
+        supplied_invite_token
+            .filter(|token| !token.trim().is_empty())
+            .map(lan_token_fingerprint)
+            .as_deref()
+            == Some(expected)
+    }
+
+    pub(crate) fn to_txt_properties(&self) -> Result<Vec<(String, String)>> {
+        let mut txt = vec![
+            ("svc".to_string(), "mesh-llm".to_string()),
+            ("schema".to_string(), TXT_SCHEMA_VERSION.to_string()),
+            ("join".to_string(), "token-fingerprint".to_string()),
+            ("nodes".to_string(), self.node_count.to_string()),
+            ("clients".to_string(), self.client_count.to_string()),
+            ("max_clients".to_string(), self.max_clients.to_string()),
+            ("vram".to_string(), self.total_vram_bytes.to_string()),
+            ("serving".to_string(), pack_txt_list(&self.serving_summary)),
+            ("wanted".to_string(), pack_txt_list(&self.wanted_summary)),
+            ("on_disk".to_string(), pack_txt_list(&self.on_disk_summary)),
+        ];
+        push_optional_txt(&mut txt, "mesh_id", self.mesh_id.as_deref());
+        push_optional_txt(&mut txt, "name", self.mesh_name.as_deref());
+        push_optional_txt(&mut txt, "region", self.region.as_deref());
+        push_optional_txt(&mut txt, "tok_fp", self.token_fingerprint.as_deref());
+        push_optional_txt(&mut txt, "version", self.app_version.as_deref());
+
+        for (key, value) in &txt {
+            anyhow::ensure!(
+                key.len() + value.len() < u8::MAX as usize,
+                "mDNS TXT property '{key}' exceeds DNS-SD length limit"
+            );
+        }
+        Ok(txt)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_txt_properties(properties: &[(String, String)]) -> Result<Self> {
+        let props: HashMap<&str, &str> = properties
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect();
+
+        parse_txt_properties(&props)
+    }
+
+    fn from_resolved_service(service: &ResolvedService) -> Result<Self> {
+        let props = [
+            "svc",
+            "schema",
+            "join",
+            "nodes",
+            "clients",
+            "max_clients",
+            "vram",
+            "serving",
+            "wanted",
+            "on_disk",
+            "mesh_id",
+            "name",
+            "region",
+            "tok_fp",
+            "version",
+        ]
+        .into_iter()
+        .filter_map(|key| service.get_property_val_str(key).map(|value| (key, value)))
+        .collect::<HashMap<_, _>>();
+
+        parse_txt_properties(&props)
+    }
+
+    fn sanitized_listing(&self) -> nostr::MeshListing {
+        nostr::MeshListing {
+            invite_token: String::new(),
+            serving: self.serving_summary.clone(),
+            wanted: self.wanted_summary.clone(),
+            on_disk: self.on_disk_summary.clone(),
+            total_vram_bytes: self.total_vram_bytes,
+            node_count: self.node_count,
+            client_count: self.client_count,
+            max_clients: self.max_clients,
+            name: self.mesh_name.clone(),
+            region: self.region.clone(),
+            mesh_id: self.mesh_id.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct LanDiscoveredMesh {
+    pub(crate) mode: &'static str,
+    pub(crate) scope: DiscoveryScope,
+    pub(crate) source: &'static str,
+    pub(crate) service_type: &'static str,
+    pub(crate) instance_name: String,
+    pub(crate) host: String,
+    pub(crate) port: u16,
+    pub(crate) addresses: Vec<String>,
+    pub(crate) listing: nostr::MeshListing,
+    pub(crate) token_fingerprint: Option<String>,
+    pub(crate) join_material: LanJoinMaterial,
+    pub(crate) joinable_with_supplied_token: bool,
+    pub(crate) published_version: Option<String>,
+    pub(crate) discovered_at: u64,
+    #[serde(skip)]
+    join_token: Option<String>,
+}
+
+impl LanDiscoveredMesh {
+    pub(crate) fn join_token(&self) -> Option<&str> {
+        self.join_token.as_deref()
+    }
+
+    pub(crate) fn to_join_candidate(&self) -> Option<(String, nostr::DiscoveredMesh)> {
+        let token = self.join_token.clone()?;
+        let mut listing = self.listing.clone();
+        listing.invite_token = token.clone();
+        Some((
+            token,
+            nostr::DiscoveredMesh {
+                listing,
+                publisher_npub: format!("mdns:{}", self.instance_name),
+                published_at: self.discovered_at,
+                expires_at: None,
+            },
+        ))
+    }
+}
+
+pub(crate) struct LanPublishConfig {
+    pub(crate) name: Option<String>,
+    pub(crate) region: Option<String>,
+    pub(crate) max_clients: Option<usize>,
+    pub(crate) api_port: u16,
+    pub(crate) interval_secs: u64,
+    pub(crate) status_tx: Option<tokio::sync::watch::Sender<Option<nostr::PublishStateUpdate>>>,
+}
+
+pub(crate) async fn publish_lan_loop(node: crate::mesh::Node, config: LanPublishConfig) {
+    let daemon = match ServiceDaemon::new() {
+        Ok(daemon) => daemon,
+        Err(err) => {
+            tracing::warn!("Failed to create mDNS daemon: {err}");
+            let _ = send_publish_state(&config.status_tx, nostr::PublishStateUpdate::PublishFailed);
+            return;
+        }
+    };
+
+    let instance_name = lan_instance_name(&node).await;
+    let host_name = format!("{instance_name}.local.");
+    eprintln!("Publishing mesh on local LAN via mDNS ({LAN_SERVICE_TYPE})");
+
+    let mut last_reported = None;
+    loop {
+        let listing = build_local_mesh_listing(
+            &node,
+            config.name.clone(),
+            config.region.clone(),
+            config.max_clients,
+        )
+        .await;
+        let advert = LanMeshAdvertisement::from_listing(
+            &listing,
+            Some(&listing.invite_token),
+            Some(crate::VERSION),
+        );
+
+        let service_info = match service_info_for_advertisement(
+            &advert,
+            &instance_name,
+            &host_name,
+            config.api_port,
+        ) {
+            Ok(info) => info,
+            Err(err) => {
+                tracing::warn!("Failed to encode mDNS mesh advertisement: {err}");
+                report_publish_state(
+                    &config.status_tx,
+                    &mut last_reported,
+                    nostr::PublishStateUpdate::PublishFailed,
+                );
+                tokio::time::sleep(Duration::from_secs(config.interval_secs)).await;
+                continue;
+            }
+        };
+
+        match daemon.register(service_info) {
+            Ok(()) => {
+                report_publish_state(
+                    &config.status_tx,
+                    &mut last_reported,
+                    nostr::PublishStateUpdate::Public,
+                );
+            }
+            Err(err) => {
+                tracing::warn!("Failed to register mDNS mesh advertisement: {err}");
+                report_publish_state(
+                    &config.status_tx,
+                    &mut last_reported,
+                    nostr::PublishStateUpdate::PublishFailed,
+                );
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(config.interval_secs)).await;
+    }
+}
+
+pub(crate) async fn discover_lan(
+    filter: &nostr::MeshFilter,
+    supplied_invite_token: Option<&str>,
+    timeout: Duration,
+) -> Result<Vec<LanDiscoveredMesh>> {
+    let daemon = ServiceDaemon::new().context("create mDNS daemon")?;
+    let receiver = match daemon.browse(LAN_SERVICE_TYPE) {
+        Ok(receiver) => receiver,
+        Err(err) => {
+            shutdown_lan_daemon(daemon).await;
+            return Err(anyhow::Error::new(err).context(format!("browse {LAN_SERVICE_TYPE}")));
+        }
+    };
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut by_instance: HashMap<String, LanDiscoveredMesh> = HashMap::new();
+
+    while tokio::time::Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        let event = match tokio::time::timeout(remaining, receiver.recv_async()).await {
+            Ok(Ok(event)) => event,
+            Ok(Err(_)) => break,
+            Err(_) => break,
+        };
+
+        let ServiceEvent::ServiceResolved(service) = event else {
+            continue;
+        };
+        if !service.is_valid() {
+            continue;
+        }
+
+        let advert = match LanMeshAdvertisement::from_resolved_service(service.as_ref()) {
+            Ok(advert) => advert,
+            Err(err) => {
+                tracing::debug!(
+                    "Skipping malformed mDNS mesh advertisement {}: {err}",
+                    service.get_fullname()
+                );
+                continue;
+            }
+        };
+        let listing = advert.sanitized_listing();
+        let discovered = nostr::DiscoveredMesh {
+            listing: listing.clone(),
+            publisher_npub: format!("mdns:{}", service.get_fullname()),
+            published_at: current_unix_secs(),
+            expires_at: None,
+        };
+        if !filter.matches(&discovered) {
+            continue;
+        }
+
+        let joinable = advert.matches_supplied_token(supplied_invite_token);
+        by_instance.insert(
+            service.get_fullname().to_string(),
+            LanDiscoveredMesh {
+                mode: MeshDiscoveryMode::Mdns.as_str(),
+                scope: MeshDiscoveryMode::Mdns.scope(),
+                source: MeshDiscoveryMode::Mdns.source(),
+                service_type: LAN_SERVICE_TYPE,
+                instance_name: service.get_fullname().to_string(),
+                host: service.get_hostname().to_string(),
+                port: service.get_port(),
+                addresses: service
+                    .get_addresses()
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect(),
+                listing,
+                token_fingerprint: advert.token_fingerprint.clone(),
+                join_material: advert.join_material,
+                joinable_with_supplied_token: joinable,
+                published_version: advert.app_version.clone(),
+                discovered_at: current_unix_secs(),
+                join_token: joinable.then(|| supplied_invite_token.unwrap_or_default().to_string()),
+            },
+        );
+    }
+
+    drop(receiver);
+    if let Err(err) = daemon.stop_browse(LAN_SERVICE_TYPE) {
+        tracing::debug!("Failed to stop mDNS LAN browse before daemon shutdown: {err}");
+    }
+    shutdown_lan_daemon(daemon).await;
+    let mut meshes = by_instance.into_values().collect::<Vec<_>>();
+    meshes.sort_by(|left, right| {
+        right
+            .listing
+            .node_count
+            .cmp(&left.listing.node_count)
+            .then(
+                right
+                    .listing
+                    .total_vram_bytes
+                    .cmp(&left.listing.total_vram_bytes),
+            )
+            .then(left.instance_name.cmp(&right.instance_name))
+    });
+    Ok(meshes)
+}
+
+async fn shutdown_lan_daemon(daemon: ServiceDaemon) -> bool {
+    let shutdown = tokio::task::spawn_blocking(move || {
+        match daemon.shutdown() {
+            Ok(receiver) => receiver.recv_timeout(DAEMON_SHUTDOWN_TIMEOUT),
+            Err(err) => {
+                tracing::debug!("Failed to request mDNS daemon shutdown: {err}");
+                return false;
+            }
+        }
+        .map(|status| status == DaemonStatus::Shutdown)
+        .unwrap_or(false)
+    })
+    .await
+    .unwrap_or(false);
+
+    if !shutdown {
+        tracing::debug!("mDNS daemon shutdown did not report completion before timeout");
+    }
+    shutdown
+}
+
+pub(crate) async fn discover_lan_join_candidates(
+    filter: &nostr::MeshFilter,
+    supplied_invite_token: Option<&str>,
+    timeout: Duration,
+) -> Result<Vec<(String, nostr::DiscoveredMesh)>> {
+    Ok(discover_lan(filter, supplied_invite_token, timeout)
+        .await?
+        .into_iter()
+        .filter_map(|mesh| mesh.to_join_candidate())
+        .collect())
+}
+
+pub(crate) fn lan_token_fingerprint(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"mesh-llm-lan-invite-token-v1\0");
+    hasher.update(token.trim().as_bytes());
+    let digest = hasher.finalize();
+    hex::encode(&digest[..16])
+}
+
+pub(crate) fn discovery_source_label(mode: MeshDiscoveryMode, operation: &str) -> String {
+    match mode {
+        MeshDiscoveryMode::Nostr => format!("Nostr {operation}"),
+        MeshDiscoveryMode::Mdns => format!("mDNS LAN {operation}"),
+    }
+}
+
+async fn build_local_mesh_listing(
+    node: &crate::mesh::Node,
+    name: Option<String>,
+    region: Option<String>,
+    max_clients: Option<usize>,
+) -> nostr::MeshListing {
+    let peers = node.peers().await;
+    let client_count = peers
+        .iter()
+        .filter(|p| matches!(p.role, crate::mesh::NodeRole::Client))
+        .count();
+
+    let my_role = node.role().await;
+    let mut actually_serving: Vec<String> = Vec::new();
+    if matches!(my_role, crate::mesh::NodeRole::Host { .. }) {
+        for model in node.hosted_models().await {
+            push_unique(&mut actually_serving, model);
+        }
+    }
+    for peer in &peers {
+        if matches!(peer.role, crate::mesh::NodeRole::Host { .. }) {
+            for model in peer.routable_models() {
+                push_unique(&mut actually_serving, model);
+            }
+        }
+    }
+
+    let served_set = actually_serving
+        .iter()
+        .map(String::as_str)
+        .collect::<std::collections::HashSet<_>>();
+
+    let active_demand = node.active_demand().await;
+    let mut wanted = Vec::new();
+    for model in active_demand.keys() {
+        if !served_set.contains(model.as_str()) {
+            push_unique(&mut wanted, model.clone());
+        }
+    }
+
+    let mut available = Vec::new();
+    for model in node.available_models().await {
+        if !served_set.contains(model.as_str()) {
+            push_unique(&mut available, model);
+        }
+    }
+    for peer in &peers {
+        for model in &peer.available_models {
+            if !served_set.contains(model.as_str()) {
+                push_unique(&mut available, model.clone());
+            }
+        }
+    }
+
+    let total_vram_bytes = peers
+        .iter()
+        .filter(|peer| !matches!(peer.role, crate::mesh::NodeRole::Client))
+        .map(|peer| peer.vram_bytes)
+        .sum::<u64>()
+        + node.vram_bytes();
+    let node_count = peers
+        .iter()
+        .filter(|peer| !matches!(peer.role, crate::mesh::NodeRole::Client))
+        .count()
+        + 1;
+
+    nostr::MeshListing {
+        invite_token: node.invite_token(),
+        serving: actually_serving,
+        wanted,
+        on_disk: available,
+        total_vram_bytes,
+        node_count,
+        client_count,
+        max_clients: max_clients.unwrap_or(0),
+        name,
+        region,
+        mesh_id: node.mesh_id().await,
+    }
+}
+
+async fn lan_instance_name(node: &crate::mesh::Node) -> String {
+    let identity = node
+        .mesh_id()
+        .await
+        .unwrap_or_else(|| node.id().fmt_short().to_string());
+    let suffix = sanitize_dns_label(&identity);
+    format!("mesh-llm-{suffix}")
+}
+
+fn service_info_for_advertisement(
+    advert: &LanMeshAdvertisement,
+    instance_name: &str,
+    host_name: &str,
+    port: u16,
+) -> Result<ServiceInfo> {
+    let txt = advert.to_txt_properties()?;
+    ServiceInfo::new(
+        LAN_SERVICE_TYPE,
+        instance_name,
+        host_name,
+        "",
+        port,
+        txt.as_slice(),
+    )
+    .map(ServiceInfo::enable_addr_auto)
+    .context("create mDNS service info")
+}
+
+fn parse_txt_properties(props: &HashMap<&str, &str>) -> Result<LanMeshAdvertisement> {
+    anyhow::ensure!(
+        props.get("svc") == Some(&"mesh-llm"),
+        "not a mesh-llm advertisement"
+    );
+    let schema = props
+        .get("schema")
+        .and_then(|value| value.parse::<u8>().ok())
+        .unwrap_or(0);
+    anyhow::ensure!(
+        schema == TXT_SCHEMA_VERSION,
+        "unsupported mDNS mesh schema version {schema}"
+    );
+    anyhow::ensure!(
+        props.get("join") == Some(&"token-fingerprint"),
+        "unsupported mDNS join material"
+    );
+
+    Ok(LanMeshAdvertisement {
+        mesh_id: optional_txt(props, "mesh_id"),
+        mesh_name: optional_txt(props, "name"),
+        region: optional_txt(props, "region"),
+        serving_summary: unpack_txt_list(props.get("serving").copied().unwrap_or_default()),
+        wanted_summary: unpack_txt_list(props.get("wanted").copied().unwrap_or_default()),
+        on_disk_summary: unpack_txt_list(props.get("on_disk").copied().unwrap_or_default()),
+        total_vram_bytes: parse_txt_number(props, "vram")?,
+        node_count: parse_txt_number(props, "nodes")?,
+        client_count: parse_txt_number(props, "clients").unwrap_or(0),
+        max_clients: parse_txt_number(props, "max_clients").unwrap_or(0),
+        token_fingerprint: optional_txt(props, "tok_fp"),
+        app_version: optional_txt(props, "version"),
+        join_material: LanJoinMaterial::RequiresSuppliedToken,
+    })
+}
+
+fn parse_txt_number<T>(props: &HashMap<&str, &str>, key: &str) -> Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    let value = props
+        .get(key)
+        .with_context(|| format!("missing mDNS TXT property '{key}'"))?;
+    value
+        .parse::<T>()
+        .map_err(|err| anyhow::anyhow!("invalid mDNS TXT property '{key}': {err}"))
+}
+
+fn optional_txt(props: &HashMap<&str, &str>, key: &str) -> Option<String> {
+    props
+        .get(key)
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn push_optional_txt(txt: &mut Vec<(String, String)>, key: &str, value: Option<&str>) {
+    if let Some(value) = value.map(str::trim).filter(|value| !value.is_empty()) {
+        txt.push((key.to_string(), truncate_txt_value(value)));
+    }
+}
+
+fn bounded_list(values: &[String]) -> Vec<String> {
+    values
+        .iter()
+        .filter_map(|value| {
+            let trimmed = value.trim();
+            (!trimmed.is_empty()).then(|| truncate_txt_value(trimmed))
+        })
+        .take(8)
+        .collect()
+}
+
+fn pack_txt_list(values: &[String]) -> String {
+    truncate_txt_value(
+        &values
+            .iter()
+            .map(|value| value.replace(TXT_LIST_SEPARATOR, " "))
+            .collect::<Vec<_>>()
+            .join(&TXT_LIST_SEPARATOR.to_string()),
+    )
+}
+
+fn unpack_txt_list(value: &str) -> Vec<String> {
+    if value.trim().is_empty() {
+        return Vec::new();
+    }
+    value
+        .split(TXT_LIST_SEPARATOR)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+fn truncate_txt_value(value: &str) -> String {
+    value.chars().take(TXT_VALUE_LIMIT).collect()
+}
+
+fn sanitize_dns_label(value: &str) -> String {
+    let mut label = value
+        .chars()
+        .filter_map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                Some(ch.to_ascii_lowercase())
+            } else if ch == '-' || ch == '_' {
+                Some('-')
+            } else {
+                None
+            }
+        })
+        .collect::<String>();
+    label.truncate(48);
+    let label = label.trim_matches('-');
+    if label.is_empty() {
+        "node".to_string()
+    } else {
+        label.to_string()
+    }
+}
+
+fn push_unique(values: &mut Vec<String>, value: String) {
+    if !values.contains(&value) {
+        values.push(value);
+    }
+}
+
+fn current_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn report_publish_state(
+    status_tx: &Option<tokio::sync::watch::Sender<Option<nostr::PublishStateUpdate>>>,
+    last_reported: &mut Option<nostr::PublishStateUpdate>,
+    next: nostr::PublishStateUpdate,
+) {
+    if *last_reported == Some(next) {
+        return;
+    }
+    let _ = send_publish_state(status_tx, next);
+    *last_reported = Some(next);
+}
+
+fn send_publish_state(
+    status_tx: &Option<tokio::sync::watch::Sender<Option<nostr::PublishStateUpdate>>>,
+    next: nostr::PublishStateUpdate,
+) -> Result<(), tokio::sync::watch::error::SendError<Option<nostr::PublishStateUpdate>>> {
+    if let Some(tx) = status_tx {
+        tx.send(Some(next))?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::nostr::MeshListing;
+
+    fn sample_listing(invite_token: &str) -> MeshListing {
+        MeshListing {
+            invite_token: invite_token.to_string(),
+            serving: vec!["Qwen3-8B-Q4_K_M".to_string()],
+            wanted: vec!["Qwen3-32B-Q4_K_M".to_string()],
+            on_disk: vec!["Qwen3-14B-Q4_K_M".to_string()],
+            total_vram_bytes: 64_000_000_000,
+            node_count: 2,
+            client_count: 1,
+            max_clients: 4,
+            name: Some("lab-cluster".to_string()),
+            region: Some("LAN".to_string()),
+            mesh_id: Some("mesh-lab-01".to_string()),
+        }
+    }
+
+    #[test]
+    fn discovery_modes_have_stable_cli_names_and_metadata() {
+        assert_eq!(MeshDiscoveryMode::default(), MeshDiscoveryMode::Nostr);
+        assert_eq!(MeshDiscoveryMode::Nostr.as_str(), "nostr");
+        assert_eq!(MeshDiscoveryMode::Nostr.source(), "nostr-relay");
+        assert_eq!(MeshDiscoveryMode::Nostr.scope(), DiscoveryScope::Public);
+        assert_eq!(MeshDiscoveryMode::Mdns.as_str(), "mdns");
+        assert_eq!(MeshDiscoveryMode::Mdns.source(), "mdns-sd");
+        assert_eq!(MeshDiscoveryMode::Mdns.scope(), DiscoveryScope::Lan);
+    }
+
+    #[test]
+    fn lan_token_fingerprint_is_stable_and_does_not_expose_token() {
+        let token = "very-secret-reusable-invite-token";
+        let first = lan_token_fingerprint(token);
+        let second = lan_token_fingerprint(token);
+
+        assert_eq!(first, second);
+        assert!(!first.contains(token));
+        assert_ne!(first, lan_token_fingerprint("different-token"));
+    }
+
+    #[test]
+    fn lan_advertisement_txt_round_trips_without_raw_invite_token() {
+        let invite_token = "invite-token-that-must-not-leak";
+        let listing = sample_listing(invite_token);
+        let advert =
+            LanMeshAdvertisement::from_listing(&listing, Some(invite_token), Some(crate::VERSION));
+
+        let txt = advert.to_txt_properties().expect("txt should encode");
+        let serialized = txt
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(";");
+
+        assert!(!serialized.contains(invite_token));
+        assert!(serialized.contains("tok_fp="));
+
+        let decoded = LanMeshAdvertisement::from_txt_properties(&txt).expect("txt should decode");
+        assert_eq!(decoded.mesh_id.as_deref(), Some("mesh-lab-01"));
+        assert_eq!(decoded.mesh_name.as_deref(), Some("lab-cluster"));
+        assert_eq!(decoded.serving_summary, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(
+            decoded.token_fingerprint.as_deref(),
+            Some(lan_token_fingerprint(invite_token).as_str())
+        );
+        assert_eq!(
+            decoded.join_material,
+            LanJoinMaterial::RequiresSuppliedToken
+        );
+    }
+
+    #[test]
+    fn lan_advertisement_requires_matching_supplied_join_token() {
+        let invite_token = "invite-token-for-lab-mesh";
+        let advert = LanMeshAdvertisement::from_listing(
+            &sample_listing(invite_token),
+            Some(invite_token),
+            Some(crate::VERSION),
+        );
+
+        assert!(advert.matches_supplied_token(Some(invite_token)));
+        assert!(!advert.matches_supplied_token(None));
+        assert!(!advert.matches_supplied_token(Some("wrong-token")));
+    }
+
+    #[tokio::test]
+    async fn shutdown_lan_daemon_reports_completion_when_available() {
+        let Ok(daemon) = ServiceDaemon::new() else {
+            eprintln!("mDNS daemon unavailable in this test environment");
+            return;
+        };
+
+        assert!(shutdown_lan_daemon(daemon).await);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod affinity;
+pub(crate) mod discovery;
 pub(crate) mod metrics;
 pub(crate) mod nostr;
 pub(crate) mod openai;

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -3801,8 +3801,10 @@ mod tests {
 
     #[test]
     fn chat_stream_normalizer_adds_missing_tool_call_id() {
-        let mut state = ChatStreamNormalizationState::default();
-        state.synthetic_seed = Some(42);
+        let mut state = ChatStreamNormalizationState {
+            synthetic_seed: Some(42),
+            ..Default::default()
+        };
         let normalized = state.normalize_data(
             r#"{"id":"chatcmpl-a","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"type":"function","function":{"name":"read_file","arguments":"{\"path\":\"AGENTS.md\"}"}}]},"finish_reason":null}]}"#,
         );
@@ -3817,8 +3819,10 @@ mod tests {
 
     #[test]
     fn chat_stream_normalizer_keeps_completion_and_tool_ids_stable() {
-        let mut state = ChatStreamNormalizationState::default();
-        state.synthetic_seed = Some(7);
+        let mut state = ChatStreamNormalizationState {
+            synthetic_seed: Some(7),
+            ..Default::default()
+        };
 
         let first = state.normalize_data(
             r#"{"id":"chatcmpl-first","object":"chat.completion.chunk","created":1,"model":"test","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}"#,

--- a/crates/mesh-llm-host-runtime/src/runtime/discovery.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/discovery.rs
@@ -171,9 +171,9 @@ pub(super) fn start_new_mesh(
         format!("serving: {primary}")
     };
     let discovery = if cli.publish {
-        "publishing to Nostr for public discovery"
+        "publishing for discovery"
     } else {
-        "mesh is private — add --publish for public discovery"
+        "mesh is private — add --publish to advertise it for discovery"
     };
     let _ = emit_event(OutputEvent::Info {
         message: format!(

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -38,7 +38,7 @@ use crate::inference::{election, skippy};
 use crate::mesh;
 use crate::mesh::NodeRole;
 use crate::models;
-use crate::network::{affinity, nostr, tunnel};
+use crate::network::{affinity, discovery as mesh_discovery, nostr, tunnel};
 use crate::plugin;
 use crate::system::{autoupdate, backend, benchmark, hardware};
 use anyhow::{Context, Result};
@@ -2129,6 +2129,7 @@ pub(crate) async fn run() -> Result<()> {
 
     let normalized_args = crate::cli::normalize_runtime_surface_args(std::env::args_os());
     let mut cli = Cli::parse_from(normalized_args.normalized.clone());
+    crate::cli::validate_discovery_mode_args(&cli)?;
     crate::cli::output::OutputManager::init_global(
         cli.log_format,
         initial_console_session_mode(normalized_args.explicit_surface),
@@ -2229,7 +2230,8 @@ pub(crate) async fn run() -> Result<()> {
     // If the previous run was public (--auto or --publish) but this run is
     // private, clear the stored identity so the private mesh gets a fresh key
     // that isn't associated with the old public listing.
-    let is_public = cli.auto || cli.publish || cli.discover.is_some();
+    let is_public = cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr
+        && (cli.auto || cli.publish || cli.discover.is_some());
     if is_public {
         mesh::mark_was_public();
     } else if mesh::was_previously_public() {
@@ -2256,90 +2258,115 @@ pub(crate) async fn run() -> Result<()> {
                 cli.mesh_name = Some(name.clone());
             }
         }
-        cli.nostr_discovery = true;
-        let _ = emit_event(OutputEvent::DiscoveryStarting {
-            source: "Nostr auto-discovery".to_string(),
-        });
-
-        let relays = nostr_relays(&cli.nostr_relay);
-        let filter = nostr::MeshFilter::default();
-        let meshes = match nostr::discover(&relays, &filter, None).await {
-            Ok(meshes) => meshes,
-            Err(err) => {
-                let _ = emit_event(OutputEvent::DiscoveryFailed {
-                    message: "Nostr auto-discovery failed".to_string(),
-                    detail: Some(err.to_string()),
-                });
-                return Err(err);
-            }
-        };
-
         let my_vram_gb = mesh::detect_vram_bytes_capped(cli.max_vram) as f64 / 1e9;
-        let now = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
-
-        let last_mesh_id = mesh::load_last_mesh_id();
         let target_name = cli.mesh_name.clone();
-        // When the user did not target a specific mesh, `--auto` only joins
-        // the community mesh (unnamed or name == "mesh-llm"). Other named
-        // meshes are still publicly discoverable on Nostr, but the user has
-        // to opt in by name. Hide them from the listing so the output matches
-        // what auto will actually consider.
-        let listed: Vec<&nostr::DiscoveredMesh> = if target_name.is_some() {
-            meshes.iter().collect()
-        } else {
-            meshes
-                .iter()
-                .filter(|m| nostr::is_auto_eligible(m))
-                .collect()
-        };
-        for m in &listed {
-            let score = nostr::score_mesh(m, now, last_mesh_id.as_deref());
-            let _ = emit_event(OutputEvent::MeshFound {
-                mesh: m.listing.name.as_deref().unwrap_or("unnamed").to_string(),
-                peers: m.listing.node_count,
-                region: m.listing.region.clone(),
-            });
-            tracing::debug!(
-                "Nostr auto-discovery candidate: {} score={} nodes={} vram_gb={:.0} clients={}",
-                m.listing.name.as_deref().unwrap_or("unnamed"),
-                score,
-                m.listing.node_count,
-                m.listing.total_vram_bytes as f64 / 1e9,
-                m.listing.client_count
-            );
-        }
 
-        match smart_auto_blocking(meshes.clone(), my_vram_gb, target_name.clone()).await? {
-            nostr::AutoDecision::Join { candidates } => {
-                if cli.client {
-                    // Clients skip health probe — joining itself is the test.
-                    // Queue all candidates so we can fall back if the top one is unreachable.
-                    let (_, mesh) = &candidates[0];
-                    if cli.mesh_name.is_none() {
-                        if let Some(ref name) = mesh.listing.name {
-                            cli.mesh_name = Some(name.clone());
-                        }
+        match cli.mesh_discovery_mode {
+            mesh_discovery::MeshDiscoveryMode::Nostr => {
+                cli.nostr_discovery = true;
+                let _ = emit_event(OutputEvent::DiscoveryStarting {
+                    source: mesh_discovery::discovery_source_label(
+                        cli.mesh_discovery_mode,
+                        "auto-discovery",
+                    ),
+                });
+
+                let relays = nostr_relays(&cli.nostr_relay);
+                let filter = nostr::MeshFilter::default();
+                let meshes = match nostr::discover(&relays, &filter, None).await {
+                    Ok(meshes) => meshes,
+                    Err(err) => {
+                        let _ = emit_event(OutputEvent::DiscoveryFailed {
+                            message: "Nostr auto-discovery failed".to_string(),
+                            detail: Some(err.to_string()),
+                        });
+                        return Err(err);
                     }
-                    let _ = emit_event(OutputEvent::DiscoveryJoined {
-                        mesh: mesh
-                            .listing
-                            .name
-                            .as_deref()
-                            .unwrap_or("unnamed")
-                            .to_string(),
+                };
+
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs();
+                let last_mesh_id = mesh::load_last_mesh_id();
+                // When the user did not target a specific mesh, `--auto` only joins
+                // the community mesh (unnamed or name == "mesh-llm"). Other named
+                // meshes are still publicly discoverable on Nostr, but the user has
+                // to opt in by name. Hide them from the listing so the output matches
+                // what auto will actually consider.
+                let listed: Vec<&nostr::DiscoveredMesh> = if target_name.is_some() {
+                    meshes.iter().collect()
+                } else {
+                    meshes
+                        .iter()
+                        .filter(|m| nostr::is_auto_eligible(m))
+                        .collect()
+                };
+                for m in &listed {
+                    let score = nostr::score_mesh(m, now, last_mesh_id.as_deref());
+                    let _ = emit_event(OutputEvent::MeshFound {
+                        mesh: m.listing.name.as_deref().unwrap_or("unnamed").to_string(),
+                        peers: m.listing.node_count,
+                        region: m.listing.region.clone(),
                     });
-                    for (token, _) in &candidates {
-                        cli.join.push(token.clone());
+                    tracing::debug!(
+                        "Nostr auto-discovery candidate: {} score={} nodes={} vram_gb={:.0} clients={}",
+                        m.listing.name.as_deref().unwrap_or("unnamed"),
+                        score,
+                        m.listing.node_count,
+                        m.listing.total_vram_bytes as f64 / 1e9,
+                        m.listing.client_count
+                    );
+                }
+
+                handle_auto_decision(
+                    &mut cli,
+                    smart_auto_blocking(meshes.clone(), my_vram_gb, target_name.clone()).await?,
+                    &mut auto_join_candidates,
+                    my_vram_gb,
+                    has_startup_models,
+                )
+                .await?;
+            }
+            mesh_discovery::MeshDiscoveryMode::Mdns => {
+                let _ = emit_event(OutputEvent::DiscoveryStarting {
+                    source: mesh_discovery::discovery_source_label(
+                        cli.mesh_discovery_mode,
+                        "auto-discovery",
+                    ),
+                });
+                let filter = nostr::MeshFilter {
+                    name: target_name.clone(),
+                    region: cli.region.clone(),
+                    ..Default::default()
+                };
+                let candidates = mesh_discovery::discover_lan_join_candidates(
+                    &filter,
+                    cli.join.first().map(String::as_str),
+                    std::time::Duration::from_secs(5),
+                )
+                .await?;
+
+                if candidates.is_empty() {
+                    let _ = emit_event(OutputEvent::DiscoveryFailed {
+                        message:
+                            "No joinable LAN meshes found — mDNS requires a supplied invite token"
+                                .to_string(),
+                        detail: Some("Pass --join <token> or start a new LAN mesh.".to_string()),
+                    });
+                    let models = default_models_for_vram_blocking(my_vram_gb).await?;
+                    if cli.client {
+                        let _ = emit_event(OutputEvent::Info {
+                            message:
+                                "No joinable LAN mesh yet — starting client API; pass --join with a LAN invite token to connect"
+                                    .to_string(),
+                            context: None,
+                        });
+                    } else {
+                        start_new_mesh(&mut cli, &models, my_vram_gb, has_startup_models);
                     }
                 } else {
-                    // GPU nodes: try to join each candidate directly.
-                    // No ephemeral probe — it fails when the target has a firewall
-                    // even though the real join (via relay) would succeed.
-                    let mut joined = false;
-                    for (token, mesh) in &candidates {
+                    for (token, mesh) in candidates {
                         let _ = emit_event(OutputEvent::MeshFound {
                             mesh: mesh
                                 .listing
@@ -2350,34 +2377,8 @@ pub(crate) async fn run() -> Result<()> {
                             peers: mesh.listing.node_count,
                             region: mesh.listing.region.clone(),
                         });
-                        auto_join_candidates.push((token.clone(), mesh.listing.name.clone()));
-                        joined = true;
+                        auto_join_candidates.push((token, mesh.listing.name));
                     }
-                    if !joined {
-                        let _ = emit_event(OutputEvent::DiscoveryFailed {
-                            message: "No meshes found — starting new".to_string(),
-                            detail: None,
-                        });
-                        let models = default_models_for_vram_blocking(my_vram_gb).await?;
-                        start_new_mesh(&mut cli, &models, my_vram_gb, has_startup_models);
-                    }
-                }
-            }
-            nostr::AutoDecision::StartNew { models } => {
-                if cli.client {
-                    // Client mode should still expose its local proxy and
-                    // management API while it waits for a mesh to appear.
-                    // The passive runtime path starts background Nostr
-                    // rediscovery, so leave the join list empty and continue
-                    // startup instead of blocking before the API can bind.
-                    let _ = emit_event(OutputEvent::Info {
-                        message:
-                            "No meshes found yet — starting client API while discovery continues"
-                                .to_string(),
-                        context: None,
-                    });
-                } else {
-                    start_new_mesh(&mut cli, &models, my_vram_gb, has_startup_models);
                 }
             }
         }
@@ -3595,6 +3596,80 @@ async fn smart_auto_blocking(
     .context("join smart auto task")
 }
 
+async fn handle_auto_decision(
+    cli: &mut Cli,
+    decision: nostr::AutoDecision,
+    auto_join_candidates: &mut Vec<(String, Option<String>)>,
+    my_vram_gb: f64,
+    has_startup_models: bool,
+) -> Result<()> {
+    match decision {
+        nostr::AutoDecision::Join { candidates } => {
+            if cli.client {
+                // Clients skip health probe — joining itself is the test.
+                // Queue all candidates so we can fall back if the top one is unreachable.
+                let (_, mesh) = &candidates[0];
+                if cli.mesh_name.is_none() {
+                    if let Some(ref name) = mesh.listing.name {
+                        cli.mesh_name = Some(name.clone());
+                    }
+                }
+                let _ = emit_event(OutputEvent::DiscoveryJoined {
+                    mesh: mesh
+                        .listing
+                        .name
+                        .as_deref()
+                        .unwrap_or("unnamed")
+                        .to_string(),
+                });
+                for (token, _) in &candidates {
+                    cli.join.push(token.clone());
+                }
+            } else {
+                // GPU nodes try each candidate directly. The real join path can use relays,
+                // so a separate local probe would reject reachable meshes behind firewalls.
+                let mut joined = false;
+                for (token, mesh) in &candidates {
+                    let _ = emit_event(OutputEvent::MeshFound {
+                        mesh: mesh
+                            .listing
+                            .name
+                            .as_deref()
+                            .unwrap_or("unnamed")
+                            .to_string(),
+                        peers: mesh.listing.node_count,
+                        region: mesh.listing.region.clone(),
+                    });
+                    auto_join_candidates.push((token.clone(), mesh.listing.name.clone()));
+                    joined = true;
+                }
+                if !joined {
+                    let _ = emit_event(OutputEvent::DiscoveryFailed {
+                        message: "No meshes found — starting new".to_string(),
+                        detail: None,
+                    });
+                    let models = default_models_for_vram_blocking(my_vram_gb).await?;
+                    start_new_mesh(cli, &models, my_vram_gb, has_startup_models);
+                }
+            }
+        }
+        nostr::AutoDecision::StartNew { models } => {
+            if cli.client {
+                // Client mode should still expose its local proxy and management API while
+                // it waits for a mesh to appear.
+                let _ = emit_event(OutputEvent::Info {
+                    message: "No meshes found yet — starting client API while discovery continues"
+                        .to_string(),
+                    context: None,
+                });
+            } else {
+                start_new_mesh(cli, &models, my_vram_gb, has_startup_models);
+            }
+        }
+    }
+    Ok(())
+}
+
 async fn default_models_for_vram_blocking(my_vram_gb: f64) -> Result<Vec<String>> {
     tokio::task::spawn_blocking(move || nostr::default_models_for_vram(my_vram_gb))
         .await
@@ -3964,6 +4039,75 @@ async fn join_mesh_for_mcp(cli: &Cli, node: &mesh::Node) -> Result<()> {
     }
 
     if cli.auto || cli.discover.is_some() {
+        if cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Mdns {
+            let filter = nostr::MeshFilter {
+                region: cli.region.clone(),
+                name: cli
+                    .discover
+                    .as_deref()
+                    .filter(|s| !s.is_empty())
+                    .or(cli.mesh_name.as_deref())
+                    .map(str::to_owned),
+                ..Default::default()
+            };
+            let _ = emit_event(OutputEvent::DiscoveryStarting {
+                source: mesh_discovery::discovery_source_label(
+                    cli.mesh_discovery_mode,
+                    "discovery",
+                ),
+            });
+            let candidates = mesh_discovery::discover_lan_join_candidates(
+                &filter,
+                cli.join.first().map(String::as_str),
+                std::time::Duration::from_secs(5),
+            )
+            .await?;
+            if candidates.is_empty() {
+                let _ = emit_event(OutputEvent::DiscoveryFailed {
+                    message: "No joinable LAN mesh found for MCP mode".to_string(),
+                    detail: Some("Pass --join or start a LAN mesh first.".to_string()),
+                });
+                anyhow::bail!(
+                    "No joinable LAN mesh found for MCP mode. Pass --join or start a LAN mesh first."
+                );
+            }
+
+            let mut last_err = None;
+            for (token, mesh) in candidates {
+                let label = mesh
+                    .listing
+                    .name
+                    .as_deref()
+                    .unwrap_or("unnamed")
+                    .to_string();
+                let _ = emit_event(OutputEvent::MeshFound {
+                    mesh: label.clone(),
+                    peers: mesh.listing.node_count,
+                    region: mesh.listing.region.clone(),
+                });
+                match node.join_with_retry(&token).await {
+                    Ok(()) => {
+                        if node.mesh_id().await.is_some() {
+                            record_first_joined_mesh_ts(node).await;
+                        }
+                        let _ = emit_event(OutputEvent::DiscoveryJoined { mesh: label });
+                        return Ok(());
+                    }
+                    Err(err) => {
+                        let _ = emit_event(OutputEvent::DiscoveryFailed {
+                            message: format!("Failed to join LAN mesh {label}"),
+                            detail: Some(err.to_string()),
+                        });
+                        last_err = Some(err);
+                    }
+                }
+            }
+            if let Some(err) = last_err {
+                return Err(err);
+            }
+            return Ok(());
+        }
+
         let relays = nostr_relays(&cli.nostr_relay);
         let filter = nostr::MeshFilter {
             region: cli.region.clone(),
@@ -4382,7 +4526,9 @@ async fn run_auto(
         // Nostr re-discovery: if we joined via --auto or --discover and lose
         // all peers, re-discover and join a new mesh. This handles the case where
         // the original mesh publisher restarts with a new identity.
-        if cli.auto || cli.discover.is_some() {
+        if cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr
+            && (cli.auto || cli.discover.is_some())
+        {
             let rediscover_node = node.clone();
             let rediscover_relays = nostr_relays(&cli.nostr_relay);
             let rediscover_relay_urls = cli.relay.clone();
@@ -4396,13 +4542,14 @@ async fn run_auto(
         }
     } else {
         // Originator — generate mesh_id
-        let nostr_pubkey = if cli.publish {
-            nostr::load_or_create_keys()
-                .ok()
-                .map(|k| k.public_key().to_hex())
-        } else {
-            None
-        };
+        let nostr_pubkey =
+            if cli.publish && cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr {
+                nostr::load_or_create_keys()
+                    .ok()
+                    .map(|k| k.public_key().to_hex())
+            } else {
+                None
+            };
         let mesh_id = mesh::generate_mesh_id(cli.mesh_name.as_deref(), nostr_pubkey.as_deref());
         node.set_mesh_id_force(mesh_id.clone()).await;
         record_first_joined_mesh_ts(&node).await;
@@ -4417,7 +4564,9 @@ async fn run_auto(
 
         // Originator also re-discovers: if we started solo and a matching mesh
         // already exists on Nostr, we should join it instead of staying alone.
-        if cli.auto || cli.discover.is_some() {
+        if cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr
+            && (cli.auto || cli.discover.is_some())
+        {
             let rediscover_node = node.clone();
             let rediscover_relays = nostr_relays(&cli.nostr_relay);
             let rediscover_relay_urls = cli.relay.clone();
@@ -4627,6 +4776,7 @@ async fn run_auto(
         cs.set_primary_backend("skippy".into()).await;
         cs.set_runtime_control(control_tx.clone()).await;
         cs.set_nostr_relays(nostr_relays(&cli.nostr_relay)).await;
+        cs.set_mesh_discovery_mode(cli.mesh_discovery_mode).await;
         cs.set_nostr_discovery(cli.nostr_discovery).await;
         if let Some(draft) = &cli.draft {
             let dn = draft
@@ -5004,48 +5154,74 @@ async fn run_auto(
         }
     }
 
-    // Nostr publish loop (if --publish) or watchdog (if --auto, to take over if publisher dies)
-    let nostr_publisher = if cli.publish {
-        match nostr::load_or_create_keys() {
-            Ok(nostr_keys) => {
-                let relays = nostr_relays(&cli.nostr_relay);
+    // Discovery publish loop (if --publish) or Nostr watchdog (if --auto, to take over if publisher dies).
+    let discovery_publisher = if cli.publish {
+        match cli.mesh_discovery_mode {
+            mesh_discovery::MeshDiscoveryMode::Nostr => match nostr::load_or_create_keys() {
+                Ok(nostr_keys) => {
+                    let relays = nostr_relays(&cli.nostr_relay);
+                    let pub_node = node.clone();
+                    let pub_name = cli.mesh_name.clone();
+                    let pub_region = cli.region.clone();
+                    let pub_max_clients = cli.max_clients;
+                    let (status_tx, status_rx) = tokio::sync::watch::channel(None);
+                    if let Some(ref cs) = console_state {
+                        bridge_publication_state(cs.clone(), status_rx);
+                    }
+                    Some(tokio::spawn(Box::pin(nostr::publish_loop(
+                        pub_node,
+                        nostr_keys,
+                        nostr::PublishLoopConfig {
+                            relays,
+                            name: pub_name,
+                            region: pub_region,
+                            max_clients: pub_max_clients,
+                            interval_secs: 60,
+                            status_tx: Some(status_tx),
+                        },
+                    ))))
+                }
+                Err(e) => {
+                    let _ = emit_event(OutputEvent::Warning {
+                        message: format!(
+                            "Publishing to Nostr failed: {e}. Mesh is running privately — add --publish after fixing the issue to make discoverable."
+                        ),
+                        context: cli.mesh_name.as_ref().map(|mesh_name| format!("mesh={mesh_name}")),
+                    });
+                    tracing::warn!("Nostr publish failed: {e}");
+                    if let Some(ref cs) = console_state {
+                        cs.set_publication_state(api::PublicationState::PublishFailed)
+                            .await;
+                    }
+                    None
+                }
+            },
+            mesh_discovery::MeshDiscoveryMode::Mdns => {
                 let pub_node = node.clone();
                 let pub_name = cli.mesh_name.clone();
                 let pub_region = cli.region.clone();
                 let pub_max_clients = cli.max_clients;
+                let pub_api_port = cli.console;
                 let (status_tx, status_rx) = tokio::sync::watch::channel(None);
                 if let Some(ref cs) = console_state {
                     bridge_publication_state(cs.clone(), status_rx);
                 }
-                Some(tokio::spawn(Box::pin(nostr::publish_loop(
+                Some(tokio::spawn(Box::pin(mesh_discovery::publish_lan_loop(
                     pub_node,
-                    nostr_keys,
-                    nostr::PublishLoopConfig {
-                        relays,
+                    mesh_discovery::LanPublishConfig {
                         name: pub_name,
                         region: pub_region,
                         max_clients: pub_max_clients,
+                        api_port: pub_api_port,
                         interval_secs: 60,
                         status_tx: Some(status_tx),
                     },
                 ))))
             }
-            Err(e) => {
-                let _ = emit_event(OutputEvent::Warning {
-                    message: format!(
-                        "Publishing to Nostr failed: {e}. Mesh is running privately — add --publish after fixing the issue to make discoverable."
-                    ),
-                    context: cli.mesh_name.as_ref().map(|mesh_name| format!("mesh={mesh_name}")),
-                });
-                tracing::warn!("Nostr publish failed: {e}");
-                if let Some(ref cs) = console_state {
-                    cs.set_publication_state(api::PublicationState::PublishFailed)
-                        .await;
-                }
-                None
-            }
         }
-    } else if cli.auto || cli.discover.is_some() {
+    } else if cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr
+        && (cli.auto || cli.discover.is_some())
+    {
         // Watchdog: if we joined via --auto/--discover, watch for the publisher to die and take over
         let relays = nostr_relays(&cli.nostr_relay);
         let wd_node = node.clone();
@@ -5476,7 +5652,7 @@ async fn run_auto(
     node.broadcast_leaving().await;
 
     // Clean up Nostr listing on shutdown
-    if cli.publish {
+    if cli.publish && cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr {
         if let Ok(keys) = nostr::load_or_create_keys() {
             let relays = nostr_relays(&cli.nostr_relay);
             if let Ok(publisher) = nostr::Publisher::new(keys, &relays).await {
@@ -5488,7 +5664,7 @@ async fn run_auto(
             }
         }
     }
-    if let Some(handle) = nostr_publisher {
+    if let Some(handle) = discovery_publisher {
         handle.abort();
     }
 
@@ -5600,42 +5776,66 @@ async fn run_passive(
     let mut passive_publication_state = None;
     let mut passive_publication_rx = None;
 
-    // Nostr publishing (if --publish, for standby GPU nodes advertising capacity)
+    // Discovery publishing (if --publish, for standby GPU nodes advertising capacity)
     if cli.publish && !is_client {
         let pub_node = node.clone();
-        match nostr::load_or_create_keys() {
-            Ok(nostr_keys) => {
-                let relays = nostr_relays(&cli.nostr_relay);
+        match cli.mesh_discovery_mode {
+            mesh_discovery::MeshDiscoveryMode::Nostr => match nostr::load_or_create_keys() {
+                Ok(nostr_keys) => {
+                    let relays = nostr_relays(&cli.nostr_relay);
+                    let pub_name = cli.mesh_name.clone();
+                    let pub_region = cli.region.clone();
+                    let pub_max_clients = cli.max_clients;
+                    let (status_tx, status_rx) = tokio::sync::watch::channel(None);
+                    passive_publication_rx = Some(status_rx);
+                    tokio::spawn(Box::pin(nostr::publish_loop(
+                        pub_node,
+                        nostr_keys,
+                        nostr::PublishLoopConfig {
+                            relays,
+                            name: pub_name,
+                            region: pub_region,
+                            max_clients: pub_max_clients,
+                            interval_secs: 60,
+                            status_tx: Some(status_tx),
+                        },
+                    )));
+                }
+                Err(e) => {
+                    let _ = emit_event(OutputEvent::Warning {
+                        message: format!(
+                            "Publishing to Nostr failed: {e}. Standby node is running privately — add --publish after fixing the issue to make discoverable."
+                        ),
+                        context: cli.mesh_name.as_ref().map(|mesh_name| format!("mesh={mesh_name}")),
+                    });
+                    tracing::warn!("Passive Nostr publish failed: {e}");
+                    passive_publication_state = Some(api::PublicationState::PublishFailed);
+                }
+            },
+            mesh_discovery::MeshDiscoveryMode::Mdns => {
                 let pub_name = cli.mesh_name.clone();
                 let pub_region = cli.region.clone();
                 let pub_max_clients = cli.max_clients;
+                let pub_api_port = cli.console;
                 let (status_tx, status_rx) = tokio::sync::watch::channel(None);
                 passive_publication_rx = Some(status_rx);
-                tokio::spawn(Box::pin(nostr::publish_loop(
+                tokio::spawn(Box::pin(mesh_discovery::publish_lan_loop(
                     pub_node,
-                    nostr_keys,
-                    nostr::PublishLoopConfig {
-                        relays,
+                    mesh_discovery::LanPublishConfig {
                         name: pub_name,
                         region: pub_region,
                         max_clients: pub_max_clients,
+                        api_port: pub_api_port,
                         interval_secs: 60,
                         status_tx: Some(status_tx),
                     },
                 )));
             }
-            Err(e) => {
-                let _ = emit_event(OutputEvent::Warning {
-                    message: format!(
-                        "Publishing to Nostr failed: {e}. Standby node is running privately — add --publish after fixing the issue to make discoverable."
-                    ),
-                    context: cli.mesh_name.as_ref().map(|mesh_name| format!("mesh={mesh_name}")),
-                });
-                tracing::warn!("Passive Nostr publish failed: {e}");
-                passive_publication_state = Some(api::PublicationState::PublishFailed);
-            }
         }
-    } else if (cli.auto || cli.discover.is_some()) && !is_client {
+    } else if cli.mesh_discovery_mode == mesh_discovery::MeshDiscoveryMode::Nostr
+        && (cli.auto || cli.discover.is_some())
+        && !is_client
+    {
         // Watchdog: take over publishing if the original publisher dies
         let relays = nostr_relays(&cli.nostr_relay);
         let wd_node = node.clone();
@@ -5728,6 +5928,9 @@ async fn run_passive(
     });
     console_state
         .set_nostr_relays(nostr_relays(&cli.nostr_relay))
+        .await;
+    console_state
+        .set_mesh_discovery_mode(cli.mesh_discovery_mode)
         .await;
     console_state.set_nostr_discovery(cli.nostr_discovery).await;
     if is_client {


### PR DESCRIPTION
## Summary

This adds an opt-in local LAN discovery mode for mesh-llm so nodes on the same network can find a mesh through mDNS without using public Nostr discovery.

Nostr remains the default and current public discovery behavior is preserved. The new mode is selected explicitly with:

```bash
mesh-llm --mesh-discovery-mode mdns discover
mesh-llm --mesh-discovery-mode mdns --publish
mesh-llm --mesh-discovery-mode mdns --join <token>
```

## What changed

- Added `--mesh-discovery-mode nostr|mdns`, defaulting to `nostr`.
- Added mDNS-SD mesh advertisements on `_mesh-llm._tcp.local.`.
- Added compact LAN advertisement encode/decode with schema-versioned TXT records.
- Added token fingerprint matching for LAN discovery while keeping raw reusable invite tokens out of mDNS TXT.
- Routed `discover`, `/api/discover`, `--publish`, and the startup discovery paths through the selected discovery mode.
- Rejected Nostr relay overrides when `--mesh-discovery-mode mdns` is selected.
- Kept joining on the existing invite-token path through `Node::join(...)`.
- Shut down and drain the mDNS daemon after every bounded LAN discovery scan, including browse setup failures.
- Preserved the upstream boxed-spawn runtime pattern while rebasing onto current `main`.
- Cleaned up stale test fixtures that prevented the host-runtime test harness and clippy-with-tests from compiling.

## Architecture

The LAN discovery implementation lives under `crates/mesh-llm-host-runtime/src/network/discovery.rs` and keeps mDNS-specific behavior separate from `network::nostr`.

The mDNS provider advertises mesh-level records, not generic transport peers. A discovered LAN record includes compact mesh metadata for filtering and display, plus a salted token fingerprint. The sanitized API response intentionally leaves `listing.invite_token` empty for LAN records.

This PR does not change gossip, protobuf schemas, routing, election, model placement, or inference behavior.

## Protocol and compatibility

- Default behavior remains `nostr`.
- Existing Nostr publish/discover flows remain available without new flags.
- mDNS TXT records are versioned and additive.
- Raw reusable invite tokens are not placed in mDNS records.
- Older nodes are unaffected because they neither advertise nor browse the new mDNS service type.
- Mixed mesh protocol compatibility is unchanged; this does not add or repurpose gossip fields.

## Scope notes

This is a bounded first production slice of the LAN discovery work discussed in #414. It intentionally does not claim the full air-gapped mode from the broader spec yet.

Remaining follow-up work from that discussion includes:

- token-gated LAN details endpoint, if we decide TXT metadata is not enough;
- LAN rediscovery/failover behavior for mDNS mode;
- explicit no-public-relay/no-STUN operating mode;
- TUI discovery-status fields;
- user-facing docs and two-node no-WAN validation.

## Related

Related to #414.

## Branch and diff proof

- Base branch: `main`
- Validated base SHA: `ee52d73ef1251ee890b53a9950d826e3b7d5a5b6`
- Head SHA: `225a88c7aa7de68fc68eaca3c8a362848328231c`
- Ahead/behind: `0 behind, 1 ahead`
- Merge base: `ee52d73ef1251ee890b53a9950d826e3b7d5a5b6`
- `origin/main` is an ancestor of this branch.
- Diff scope: 15 files, one logical commit.
- `git diff --check origin/main...HEAD`: PASS, no output.
- Ledger: not applicable - not required for this change family.
- Version: not applicable - not required for this change family.

## Validation

Local validation passed:

```bash
cargo fmt --all -- --check
git diff --check
git diff --cached --check
git diff --check origin/main...HEAD
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo check -p mesh-llm-host-runtime
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo check -p mesh-llm
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo clippy -p mesh-llm-host-runtime --tests -- -D warnings
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo clippy -p mesh-llm -- -D warnings
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo test -p mesh-llm-host-runtime network::discovery::tests -- --nocapture
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo test -p mesh-llm-host-runtime cli_defaults_mesh_discovery_mode_to_nostr -- --nocapture
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo test -p mesh-llm-host-runtime cli_accepts_mdns_discovery_mode_for_runtime_surfaces -- --nocapture
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo test -p mesh-llm-host-runtime cli_rejects_nostr_relays_in_mdns_mode -- --nocapture
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo test -p mesh-llm-host-runtime chat_stream_normalizer_ -- --nocapture
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo test -p mesh-llm-host-runtime --lib --no-run
LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal rustup run stable cargo run -p mesh-llm -- --mesh-discovery-mode mdns discover
```

Targeted test results:

- `network::discovery::tests`: 5 passed, including daemon shutdown completion.
- CLI discovery-mode tests: 3 targeted tests passed.
- `chat_stream_normalizer_`: 2 passed.
- Empty-LAN mDNS discover smoke: exits 0 and reports that mDNS advertisements do not include reusable invite tokens.

Not run:

- `just build` - not required for the selected Rust-only validation tier; targeted Rust build, clippy, and tests covered the touched runtime paths.
- Two-node no-WAN LAN validation - not available in this local environment and should be part of follow-up/manual validation before claiming full air-gapped behavior.

Remote CI:

- Pending - GitHub checks started after the latest push.

## Runtime safety

- No new gossip or protobuf fields.
- No changes to routing, election, model placement, or inference.
- mDNS browsing is bounded by timeout.
- `discover_lan` now calls `stop_browse`, shuts down the per-scan mDNS daemon, and drains the shutdown status on a blocking worker before returning.
- mDNS publishing updates on a fixed interval and reports publication state through the existing API/TUI state bridge.
- LAN API discovery responses are sanitized and do not expose raw invite tokens.

No invariant regression introduced.

## Rollback

Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: mDNS LAN discovery would be removed; default Nostr discovery behavior would remain the fallback.
