### PR TITLE
[codex] Mount source models for layer package jobs

### DIFF
--- a/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
+++ b/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
@@ -886,12 +886,20 @@ fn job_spec_with_token(
         secrets,
         flavor: job_plan.flavor.clone(),
         timeout_seconds: job_plan.timeout_seconds,
-        volumes: vec![JobVolume {
-            volume_type: "bucket".into(),
-            source: "meshllm/layer-split-output".into(),
-            mount_path: "/bucket".into(),
-            read_only: None,
-        }],
+        volumes: vec![
+            JobVolume {
+                volume_type: "bucket".into(),
+                source: "meshllm/layer-split-output".into(),
+                mount_path: "/bucket".into(),
+                read_only: None,
+            },
+            JobVolume {
+                volume_type: "model".into(),
+                source: candidate.model.repo_id.clone(),
+                mount_path: "/source".into(),
+                read_only: Some(true),
+            },
+        ],
     })
 }
 
@@ -1201,13 +1209,13 @@ mod tests {
                 .map(String::as_str),
             Some("401")
         );
-        assert_eq!(spec.volumes.len(), 1);
+        assert_eq!(spec.volumes.len(), 2);
         assert_eq!(spec.volumes[0].volume_type, "bucket");
         assert_eq!(spec.volumes[0].mount_path, "/bucket");
-        assert!(!spec
-            .volumes
-            .iter()
-            .any(|volume| volume.volume_type == "model"));
+        assert_eq!(spec.volumes[1].volume_type, "model");
+        assert_eq!(spec.volumes[1].source, candidate.model.repo_id);
+        assert_eq!(spec.volumes[1].mount_path, "/source");
+        assert_eq!(spec.volumes[1].read_only, Some(true));
     }
 
     #[test]

--- a/crates/model-package/src/prepare.rs
+++ b/crates/model-package/src/prepare.rs
@@ -209,12 +209,20 @@ pub async fn resolve(
         secrets.insert("HF_TOKEN".into(), hf_token);
     }
 
-    let volumes = vec![JobVolume {
-        volume_type: "bucket".into(),
-        source: "meshllm/layer-split-output".into(),
-        mount_path: "/bucket".into(),
-        read_only: None,
-    }];
+    let volumes = vec![
+        JobVolume {
+            volume_type: "bucket".into(),
+            source: "meshllm/layer-split-output".into(),
+            mount_path: "/bucket".into(),
+            read_only: None,
+        },
+        JobVolume {
+            volume_type: "model".into(),
+            source: params.source_repo.clone(),
+            mount_path: "/source".into(),
+            read_only: Some(true),
+        },
+    ];
 
     let spec = JobSpec {
         docker_image: "ubuntu:22.04".into(),

--- a/crates/model-package/src/script.rs
+++ b/crates/model-package/src/script.rs
@@ -166,8 +166,10 @@ mod tests {
         assert!(EMBEDDED_SCRIPT.contains("log_storage_snapshot"));
         assert!(EMBEDDED_SCRIPT.contains("start_heartbeat"));
         assert!(EMBEDDED_SCRIPT.contains("Starting write-package"));
-        assert!(EMBEDDED_SCRIPT.contains(r#"time "$SLICER" write-package "$SOURCE_REF""#));
-        assert!(!EMBEDDED_SCRIPT.contains(r#"SOURCE_PATH="/source/${SOURCE_FILE}""#));
+        assert!(EMBEDDED_SCRIPT.contains(r#"MOUNTED_SOURCE_PATH="/source/${SOURCE_FILE}""#));
+        assert!(EMBEDDED_SCRIPT.contains(r#"WRITE_PACKAGE_INPUT="$MOUNTED_SOURCE_PATH""#));
+        assert!(EMBEDDED_SCRIPT.contains(r#"--source-file "$SOURCE_FILE""#));
+        assert!(EMBEDDED_SCRIPT.contains(r#"time "$SLICER" write-package "$WRITE_PACKAGE_INPUT""#));
         assert!(!EMBEDDED_SCRIPT.contains(r#"time $SLICER write-package "$SOURCE_PATH""#));
     }
 }

--- a/crates/model-package/src/scripts/split-model-job.sh
+++ b/crates/model-package/src/scripts/split-model-job.sh
@@ -230,6 +230,21 @@ if [ -n "${SOURCE_TOTAL_BYTES:-}" ]; then
     ESTIMATED_BUCKET_BYTES="$(estimate_bucket_workspace_bytes "$SOURCE_TOTAL_BYTES")"
     echo "  Estimated /bucket workspace needed: $(format_bytes "$ESTIMATED_BUCKET_BYTES")"
 fi
+MOUNTED_SOURCE_PATH="/source/${SOURCE_FILE}"
+if [ -f "$MOUNTED_SOURCE_PATH" ]; then
+    WRITE_PACKAGE_INPUT="$MOUNTED_SOURCE_PATH"
+    WRITE_PACKAGE_IDENTITY_ARGS=(
+        --model-id "$MODEL_ID"
+        --source-repo "$SOURCE_REPO"
+        --source-revision "$SOURCE_REVISION"
+        --source-file "$SOURCE_FILE"
+    )
+    echo "  Source mount: $MOUNTED_SOURCE_PATH"
+else
+    WRITE_PACKAGE_INPUT="$SOURCE_REF"
+    WRITE_PACKAGE_IDENTITY_ARGS=()
+    echo "  Source mount: not available; falling back to Hugging Face cache download"
+fi
 echo "  Hugging Face cache: $HF_HUB_CACHE"
 echo "  Package workspace: $PACKAGE_DIR"
 echo "  Temporary workspace: $TMPDIR"
@@ -249,8 +264,9 @@ fi
 echo "  Starting write-package at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 start_heartbeat "write-package"
 set +e
-time "$SLICER" write-package "$SOURCE_REF" \
-    --out-dir "$PACKAGE_DIR"
+time "$SLICER" write-package "$WRITE_PACKAGE_INPUT" \
+    --out-dir "$PACKAGE_DIR" \
+    "${WRITE_PACKAGE_IDENTITY_ARGS[@]}"
 WRITE_PACKAGE_STATUS=$?
 set -e
 stop_heartbeat


### PR DESCRIPTION
## Summary

Avoids downloading huge source GGUFs into the HF Job workspace by mounting the source model repository read-only at `/source`.

The split script now prefers `/source/$SOURCE_FILE` when the mount is present and passes explicit source identity flags to `skippy-model-package write-package`. If the source mount is unavailable, it falls back to the existing coordinate-based Hugging Face cache download path.

## Why

The latest large-model run proved that writing the Hugging Face cache under `/bucket` still consumes pod ephemeral local storage. The heartbeat showed `/bucket/.../hf-home/hub` at 35G while root ephemeral usage increased by roughly 41G, then the pod was evicted at the 50G container limit.

Mounting the source model repo removes the large HF download cache from the job path, so `write-package` reads the source GGUF shards directly from the read-only model volume instead of materializing them under `/bucket`.

## Notes

This addresses the source-cache side of the eviction. The job still writes package output under the bucket workspace; the existing heartbeat logs remain in place to show whether bucket output writes also consume ephemeral storage later in the split.

## Validation

- `bash -n crates/model-package/src/scripts/split-model-job.sh`
- `cargo fmt --all -- --check`
- `cargo test -p model-package`
- `cargo check -p mesh-llm-host-runtime`
