### PR TITLE
Stream layer package artifacts from HF jobs

### DIFF
--- a/crates/model-package/src/script.rs
+++ b/crates/model-package/src/script.rs
@@ -137,18 +137,21 @@ mod tests {
             "For upstream architecture details, chat template guidance, sampling recommendations"
         ));
         assert!(EMBEDDED_SCRIPT.contains("Package manifest SHA-256"));
-        assert!(EMBEDDED_SCRIPT.contains("skippy-model-package validate-package"));
+        assert!(EMBEDDED_SCRIPT.contains("uploaded to this repository"));
     }
 
     #[test]
-    fn embedded_script_keeps_large_source_cache_on_bucket_volume() {
+    fn embedded_script_streams_package_artifacts_to_hub() {
         assert!(EMBEDDED_SCRIPT.contains("SOURCE_QUANT"));
         assert!(EMBEDDED_SCRIPT.contains("SOURCE_TOTAL_BYTES"));
-        assert!(EMBEDDED_SCRIPT.contains("Estimated /bucket workspace needed"));
+        assert!(EMBEDDED_SCRIPT.contains("Estimated fallback /bucket cache needed"));
         assert!(EMBEDDED_SCRIPT.contains("estimate_bucket_workspace_bytes"));
         assert!(EMBEDDED_SCRIPT.contains(r#"HF_HUB_CACHE="${HF_HUB_CACHE:-${HF_HOME}/hub}""#));
         assert!(EMBEDDED_SCRIPT.contains(r#"HF_XET_CACHE="${HF_XET_CACHE:-${HF_HOME}/xet}""#));
-        assert!(EMBEDDED_SCRIPT.contains(r#"JOB_TMP_DIR="${JOB_TMP_DIR:-${JOB_WORK_DIR}/tmp}""#));
+        assert!(
+            EMBEDDED_SCRIPT.contains(r#"PACKAGE_DIR="${PACKAGE_DIR:-${LOCAL_WORK_DIR}/package}""#)
+        );
+        assert!(EMBEDDED_SCRIPT.contains(r#"JOB_TMP_DIR="${JOB_TMP_DIR:-${LOCAL_WORK_DIR}/tmp}""#));
         assert!(EMBEDDED_SCRIPT.contains(r#"LOCAL_WORK_DIR="${LOCAL_WORK_DIR:-/tmp/"#));
         assert!(
             EMBEDDED_SCRIPT.contains(r#"BUILD_TMP_DIR="${BUILD_TMP_DIR:-${LOCAL_WORK_DIR}/tmp}""#)
@@ -166,6 +169,12 @@ mod tests {
         assert!(EMBEDDED_SCRIPT.contains("log_storage_snapshot"));
         assert!(EMBEDDED_SCRIPT.contains("start_heartbeat"));
         assert!(EMBEDDED_SCRIPT.contains("Starting write-package"));
+        assert!(EMBEDDED_SCRIPT.contains("upload-package-artifact.py"));
+        assert!(EMBEDDED_SCRIPT.contains("SKIPPY_PACKAGE_ARTIFACT_PATH"));
+        assert!(EMBEDDED_SCRIPT.contains("SKIPPY_PACKAGE_ARTIFACT_RELATIVE_PATH"));
+        assert!(EMBEDDED_SCRIPT.contains(r#"--after-artifact-command "$ARTIFACT_UPLOAD_HOOK""#));
+        assert!(EMBEDDED_SCRIPT.contains("Uploaded and removed"));
+        assert!(!EMBEDDED_SCRIPT.contains("api.upload_folder"));
         assert!(EMBEDDED_SCRIPT.contains(r#"MOUNTED_SOURCE_PATH="/source/${SOURCE_FILE}""#));
         assert!(EMBEDDED_SCRIPT.contains(r#"WRITE_PACKAGE_INPUT="$MOUNTED_SOURCE_PATH""#));
         assert!(EMBEDDED_SCRIPT.contains(r#"--source-file "$SOURCE_FILE""#));

--- a/crates/model-package/src/scripts/split-model-job.sh
+++ b/crates/model-package/src/scripts/split-model-job.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 #   HF_TOKEN — injected as a secret by HF Jobs
 #
 # Volumes:
-#   /bucket  — writable storage bucket for script, source cache, and package workspace
+#   /bucket  — writable storage bucket for script and fallback source cache
 
 MESH_LLM_REF="${MESH_LLM_REF:-main}"
 SOURCE_REVISION="${SOURCE_REVISION:-main}"
@@ -35,26 +35,29 @@ echo "║  Build:  mesh-llm @ ${MESH_LLM_REF}"
 echo "╚══════════════════════════════════════════════════════════╝"
 echo ""
 
-# Keep the model-scale cache, split scratch, and package output on the bucket
-# volume. Keep executable toolchains/build products on local ephemeral storage:
+# Keep executable toolchains/build products on local ephemeral storage:
 # HF bucket mounts can be unsuitable for dynamic loader/toolchain execution.
+# Package artifacts are also written locally, uploaded one at a time, and
+# removed immediately so the job never accumulates a full 400GB+ package.
 JOB_WORK_ROOT="${JOB_WORK_ROOT:-/bucket/job-work}"
 SAFE_TARGET_REPO="$(printf '%s' "$TARGET_REPO" | tr -c '[:alnum:]._-' '_')"
+LOCAL_WORK_DIR="${LOCAL_WORK_DIR:-/tmp/meshllm-layer-job-${SAFE_TARGET_REPO}-$$}"
 if [ -z "${JOB_WORK_DIR:-}" ]; then
     JOB_WORK_DIR="${JOB_WORK_ROOT}/${SAFE_TARGET_REPO}-$(date +%Y%m%d%H%M%S)-$$"
     CLEANUP_JOB_WORK_DIR="${CLEANUP_JOB_WORK_DIR:-true}"
 else
     CLEANUP_JOB_WORK_DIR="${CLEANUP_JOB_WORK_DIR:-false}"
 fi
-PACKAGE_DIR="${PACKAGE_DIR:-${JOB_WORK_DIR}/package}"
+PACKAGE_DIR="${PACKAGE_DIR:-${LOCAL_WORK_DIR}/package}"
 HF_HOME="${HF_HOME:-${JOB_WORK_DIR}/hf-home}"
 HF_HUB_CACHE="${HF_HUB_CACHE:-${HF_HOME}/hub}"
 HF_XET_CACHE="${HF_XET_CACHE:-${HF_HOME}/xet}"
-JOB_TMP_DIR="${JOB_TMP_DIR:-${JOB_WORK_DIR}/tmp}"
-LOCAL_WORK_DIR="${LOCAL_WORK_DIR:-/tmp/meshllm-layer-job-${SAFE_TARGET_REPO}-$$}"
+JOB_TMP_DIR="${JOB_TMP_DIR:-${LOCAL_WORK_DIR}/tmp}"
 BUILD_DIR="${BUILD_DIR:-${LOCAL_WORK_DIR}/build}"
 TOOL_DIR="${TOOL_DIR:-${LOCAL_WORK_DIR}/tools}"
 VENV_DIR="${VENV_DIR:-${LOCAL_WORK_DIR}/venv}"
+ARTIFACT_UPLOAD_SCRIPT="${ARTIFACT_UPLOAD_SCRIPT:-${LOCAL_WORK_DIR}/upload-package-artifact.py}"
+ARTIFACT_UPLOAD_HOOK="${ARTIFACT_UPLOAD_HOOK:-${LOCAL_WORK_DIR}/upload-package-artifact.sh}"
 CARGO_HOME="${CARGO_HOME:-${LOCAL_WORK_DIR}/cargo-home}"
 RUSTUP_HOME="${RUSTUP_HOME:-${LOCAL_WORK_DIR}/rustup-home}"
 CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-${LOCAL_WORK_DIR}/cargo-target}"
@@ -64,7 +67,7 @@ BUILD_TMP_DIR="${BUILD_TMP_DIR:-${LOCAL_WORK_DIR}/tmp}"
 TMPDIR="$BUILD_TMP_DIR"
 TEMP="$BUILD_TMP_DIR"
 TMP="$BUILD_TMP_DIR"
-export JOB_WORK_DIR PACKAGE_DIR HF_HOME HF_HUB_CACHE HF_XET_CACHE
+export JOB_WORK_DIR PACKAGE_DIR HF_HOME HF_HUB_CACHE HF_XET_CACHE VENV_DIR ARTIFACT_UPLOAD_SCRIPT
 export TMPDIR TEMP TMP CARGO_HOME RUSTUP_HOME CARGO_TARGET_DIR XDG_CACHE_HOME PIP_CACHE_DIR
 
 cleanup_job_work_dir() {
@@ -146,10 +149,11 @@ estimate_bucket_workspace_bytes() {
     python3 - "$1" <<'PYTHON'
 import sys
 source = int(sys.argv[1])
-# Peak workspace is source cache + generated package + one current artifact's
-# transient sharded-slice scratch, plus fixed tool/cache headroom.
+# Source and package artifacts are not meant to accumulate in the bucket. This
+# estimate is retained only as a fallback-source-cache warning when /source is
+# unavailable.
 headroom = 32 * 1024 ** 3
-print((source * 9 + 3) // 4 + headroom)
+print(source + headroom)
 PYTHON
 }
 
@@ -216,6 +220,44 @@ echo "  ✓ Built: $SLICER"
 echo "  Root filesystem after build cleanup:"
 df -h / || true
 
+echo "  Preparing Hugging Face uploader..."
+python3 -m venv "$VENV_DIR" > /dev/null
+"$VENV_DIR/bin/pip" install -q huggingface_hub
+"$VENV_DIR/bin/python3" << 'PYTHON'
+from huggingface_hub import HfApi
+import os
+
+api = HfApi(token=os.environ["HF_TOKEN"])
+api.create_repo(os.environ["TARGET_REPO"], exist_ok=True)
+PYTHON
+cat > "$ARTIFACT_UPLOAD_SCRIPT" <<'PYTHON'
+from huggingface_hub import HfApi
+from pathlib import Path
+import os
+
+path = Path(os.environ["SKIPPY_PACKAGE_ARTIFACT_PATH"])
+relative = os.environ["SKIPPY_PACKAGE_ARTIFACT_RELATIVE_PATH"]
+target_repo = os.environ["TARGET_REPO"]
+
+api = HfApi(token=os.environ["HF_TOKEN"])
+api.upload_file(
+    repo_id=target_repo,
+    path_or_fileobj=str(path),
+    path_in_repo=relative,
+    repo_type="model",
+    commit_message=f"Add package artifact {relative}",
+)
+size = path.stat().st_size
+path.unlink()
+print(f"  Uploaded and removed {relative} ({size} bytes)")
+PYTHON
+cat > "$ARTIFACT_UPLOAD_HOOK" <<'BASH'
+#!/bin/bash
+set -euo pipefail
+"${VENV_DIR}/bin/python3" "${ARTIFACT_UPLOAD_SCRIPT}"
+BASH
+chmod +x "$ARTIFACT_UPLOAD_HOOK"
+
 # ─── Split ────────────────────────────────────────────────────────────────
 echo ""
 echo "=== [4/9] Splitting model ==="
@@ -228,7 +270,7 @@ echo "  Source ref: $SOURCE_REF"
 if [ -n "${SOURCE_TOTAL_BYTES:-}" ]; then
     echo "  Source bytes: $SOURCE_TOTAL_BYTES"
     ESTIMATED_BUCKET_BYTES="$(estimate_bucket_workspace_bytes "$SOURCE_TOTAL_BYTES")"
-    echo "  Estimated /bucket workspace needed: $(format_bytes "$ESTIMATED_BUCKET_BYTES")"
+    echo "  Estimated fallback /bucket cache needed: $(format_bytes "$ESTIMATED_BUCKET_BYTES")"
 fi
 MOUNTED_SOURCE_PATH="/source/${SOURCE_FILE}"
 if [ -f "$MOUNTED_SOURCE_PATH" ]; then
@@ -266,6 +308,7 @@ start_heartbeat "write-package"
 set +e
 time "$SLICER" write-package "$WRITE_PACKAGE_INPUT" \
     --out-dir "$PACKAGE_DIR" \
+    --after-artifact-command "$ARTIFACT_UPLOAD_HOOK" \
     "${WRITE_PACKAGE_IDENTITY_ARGS[@]}"
 WRITE_PACKAGE_STATUS=$?
 set -e
@@ -281,43 +324,58 @@ log_storage_snapshot "after write-package"
 SOURCE_PATH="$(python3 -c "import json, os; m=json.load(open(os.path.join(os.environ['PACKAGE_DIR'], 'model-package.json'))); print(m['source_model']['path'])")"
 echo "  Cached source: $SOURCE_PATH ($(du -h "$SOURCE_PATH" | cut -f1))"
 
-LAYER_COUNT=$(ls "$PACKAGE_DIR"/layers/ | wc -l)
-TOTAL_SIZE=$(du -sh "$PACKAGE_DIR" | cut -f1)
-echo "  ✓ Split into $LAYER_COUNT layers ($TOTAL_SIZE total)"
+LAYER_COUNT="$(python3 -c "import json, os; m=json.load(open(os.path.join(os.environ['PACKAGE_DIR'], 'model-package.json'))); print(m['layer_count'])")"
+TOTAL_SIZE="$(python3 -c "import json, os; m=json.load(open(os.path.join(os.environ['PACKAGE_DIR'], 'model-package.json'))); print(sum(int(a.get('artifact_bytes') or 0) for a in list(m['shared'].values()) + m.get('layers', []) + m.get('projectors', [])))")"
+TOTAL_SIZE_LABEL="$(format_bytes "$TOTAL_SIZE")"
+echo "  ✓ Split into $LAYER_COUNT layers; artifacts uploaded incrementally (${TOTAL_SIZE_LABEL} total)"
 
-# ─── Validate ─────────────────────────────────────────────────────────────
+# ─── Verify manifest ──────────────────────────────────────────────────────
 echo ""
-echo "=== [5/9] Validating package ==="
-time $SLICER validate-package "$SOURCE_PATH" "$PACKAGE_DIR"
-echo "  ✓ Validation passed — all tensors accounted for"
+echo "=== [5/9] Verifying package manifest ==="
+"$VENV_DIR/bin/python3" << 'PYTHON'
+import json
+import os
+from pathlib import Path
+
+manifest_path = Path(os.environ["PACKAGE_DIR"]) / "model-package.json"
+manifest = json.loads(manifest_path.read_text())
+required = [
+    manifest["shared"]["metadata"],
+    manifest["shared"]["embeddings"],
+    manifest["shared"]["output"],
+    *manifest.get("layers", []),
+    *manifest.get("projectors", []),
+]
+missing = [artifact for artifact in required if not artifact.get("path") or not artifact.get("sha256")]
+if missing:
+    raise SystemExit(f"manifest contains {len(missing)} artifacts without path/checksum")
+print(f"  ✓ Manifest records {len(required)} uploaded artifacts")
+PYTHON
 
 # ─── Publish ──────────────────────────────────────────────────────────────
 echo ""
 echo "=== [6/9] Publishing to HuggingFace ==="
-python3 -m venv "$VENV_DIR" > /dev/null
-"$VENV_DIR/bin/pip" install -q huggingface_hub
-
 "$VENV_DIR/bin/python3" << PYTHON
 from huggingface_hub import HfApi
 import os, json
+from pathlib import Path
 
 api = HfApi(token=os.environ['HF_TOKEN'])
 target_repo = os.environ['TARGET_REPO']
 source_repo = os.environ['SOURCE_REPO']
 model_id = os.environ.get('MODEL_ID', '')
+manifest_path = Path(os.environ['PACKAGE_DIR']) / 'model-package.json'
 
-# Create repo (idempotent)
-api.create_repo(target_repo, exist_ok=True)
-
-# Upload the entire package
-api.upload_folder(
+api.upload_file(
     repo_id=target_repo,
-    folder_path=os.environ['PACKAGE_DIR'],
-    commit_message=f'Layer package from {source_repo} ({model_id})',
+    path_or_fileobj=str(manifest_path),
+    path_in_repo='model-package.json',
+    repo_type='model',
+    commit_message=f'Add layer package manifest from {source_repo} ({model_id})',
 )
 
 # Print summary
-manifest = json.load(open(os.path.join(os.environ['PACKAGE_DIR'], 'model-package.json')))
+manifest = json.load(open(manifest_path))
 print(f'  ✓ Published: https://huggingface.co/{target_repo}')
 print(f'    Model:  {manifest["model_id"]}')
 print(f'    Layers: {manifest["layer_count"]}')
@@ -704,10 +762,11 @@ for label, path, contents, checksum in file_rows:
 readme += f"""
 ## Validation
 
-Generated by the Mesh LLM HF Jobs splitter from `mesh-llm` ref `{mesh_llm_ref}` and validated before upload:
+Generated by the Mesh LLM HF Jobs splitter from `mesh-llm` ref `{mesh_llm_ref}`.
+Each artifact is checksummed as it is written, uploaded to this repository, and removed from the job workspace before the next artifact is produced.
 
 ```bash
-skippy-model-package validate-package "{source_path}" "{package_dir}"
+skippy-model-package write-package "{source_path}" --out-dir "{package_dir}"
 ```
 
 ## Links
@@ -738,7 +797,7 @@ echo "=== [9/9] Done ==="
 echo ""
 echo "  Published:  https://huggingface.co/${TARGET_REPO}"
 echo "  Layers:     ${LAYER_COUNT}"
-echo "  Total size: ${TOTAL_SIZE}"
+echo "  Total size: ${TOTAL_SIZE_LABEL}"
 echo ""
 echo "  Use with mesh-llm:"
 echo "    mesh-llm serve --model ${TARGET_REPO} --split"

--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -64,6 +64,8 @@ enum Command {
         #[arg(long = "projector")]
         projectors: Vec<PathBuf>,
         #[arg(long)]
+        after_artifact_command: Option<PathBuf>,
+        #[arg(long)]
         model_id: Option<String>,
         #[arg(long)]
         source_repo: Option<String>,
@@ -289,6 +291,11 @@ struct PackageArtifactSpec {
     relative_path: PathBuf,
 }
 
+#[derive(Debug, Clone)]
+struct ArtifactHook {
+    command: Option<PathBuf>,
+}
+
 #[derive(Debug, Default)]
 struct ExplicitSourceIdentity {
     model_id: Option<String>,
@@ -351,6 +358,7 @@ fn main() -> Result<()> {
             model,
             out_dir,
             projectors,
+            after_artifact_command,
             model_id,
             source_repo,
             source_revision,
@@ -359,6 +367,9 @@ fn main() -> Result<()> {
             model,
             out_dir,
             projectors,
+            ArtifactHook {
+                command: after_artifact_command,
+            },
             ExplicitSourceIdentity {
                 model_id,
                 source_repo,
@@ -454,6 +465,7 @@ fn write_package(
     model: String,
     out_dir: PathBuf,
     projectors: Vec<PathBuf>,
+    artifact_hook: ArtifactHook,
     explicit: ExplicitSourceIdentity,
 ) -> Result<()> {
     let input = resolve_package_input(model, explicit)?;
@@ -486,6 +498,7 @@ fn write_package(
             relative_path: PathBuf::from("shared/metadata.gguf"),
         },
         &out_dir,
+        &artifact_hook,
     )?;
     let embeddings = write_package_artifact(
         &source,
@@ -499,6 +512,7 @@ fn write_package(
             relative_path: PathBuf::from("shared/embeddings.gguf"),
         },
         &out_dir,
+        &artifact_hook,
     )?;
     let output = write_package_artifact(
         &source,
@@ -512,6 +526,7 @@ fn write_package(
             relative_path: PathBuf::from("shared/output.gguf"),
         },
         &out_dir,
+        &artifact_hook,
     )?;
 
     let mut layers = Vec::new();
@@ -529,6 +544,7 @@ fn write_package(
                 relative_path: relative,
             },
             &out_dir,
+            &artifact_hook,
         )?;
         layers.push(PackageLayer {
             layer_index,
@@ -543,7 +559,9 @@ fn write_package(
     let projectors = projectors
         .iter()
         .enumerate()
-        .map(|(index, projector)| copy_projector_artifact(projector, index, &out_dir))
+        .map(|(index, projector)| {
+            copy_projector_artifact(projector, index, &out_dir, &artifact_hook)
+        })
         .collect::<Result<Vec<_>>>()?;
 
     let manifest = PackageManifest {
@@ -1055,6 +1073,7 @@ fn write_package_artifact(
     tensors: &[TensorInfo],
     spec: PackageArtifactSpec,
     out_dir: &Path,
+    artifact_hook: &ArtifactHook,
 ) -> Result<PackageArtifact> {
     let stage = stage_plan_from_tensors(
         spec.stage_index as usize,
@@ -1068,19 +1087,22 @@ fn write_package_artifact(
     write_stage_artifact(source, &stage, &path)?;
     let metadata = fs::metadata(&path)
         .with_context(|| format!("read artifact metadata {}", path.display()))?;
-    Ok(PackageArtifact {
+    let artifact = PackageArtifact {
         path: spec.relative_path.display().to_string(),
         tensor_count: stage.tensor_count,
         tensor_bytes: stage.tensor_bytes,
         artifact_bytes: metadata.len(),
         sha256: file_sha256(&path)?,
-    })
+    };
+    run_artifact_hook(artifact_hook, &path, &artifact.path)?;
+    Ok(artifact)
 }
 
 fn copy_projector_artifact(
     projector: &Path,
     index: usize,
     out_dir: &Path,
+    artifact_hook: &ArtifactHook,
 ) -> Result<PackageProjector> {
     if !projector.is_file() {
         bail!("projector is not a file: {}", projector.display());
@@ -1112,14 +1134,39 @@ fn copy_projector_artifact(
     let metadata = fs::metadata(&output_path)
         .with_context(|| format!("read projector metadata {}", output_path.display()))?;
 
-    Ok(PackageProjector {
+    let package_projector = PackageProjector {
         kind: "mmproj".to_string(),
         path: relative_path.to_string_lossy().replace('\\', "/"),
         tensor_count: tensors.len(),
         tensor_bytes: tensors.iter().map(|tensor| tensor.byte_size).sum(),
         artifact_bytes: metadata.len(),
         sha256: file_sha256(&output_path)?,
-    })
+    };
+    run_artifact_hook(artifact_hook, &output_path, &package_projector.path)?;
+    Ok(package_projector)
+}
+
+fn run_artifact_hook(
+    artifact_hook: &ArtifactHook,
+    absolute_path: &Path,
+    relative_path: &str,
+) -> Result<()> {
+    let Some(command) = &artifact_hook.command else {
+        return Ok(());
+    };
+    let status = ProcessCommand::new(command)
+        .env("SKIPPY_PACKAGE_ARTIFACT_PATH", absolute_path)
+        .env("SKIPPY_PACKAGE_ARTIFACT_RELATIVE_PATH", relative_path)
+        .status()
+        .with_context(|| format!("run artifact hook {}", command.display()))?;
+    if !status.success() {
+        bail!(
+            "artifact hook {} failed for {} with status {status}",
+            command.display(),
+            relative_path
+        );
+    }
+    Ok(())
 }
 
 fn build_manifest(


### PR DESCRIPTION
Layer package jobs can now split very large GGUFs without accumulating the full package directory on the HF Jobs pod. Each artifact is written, checksummed, uploaded to the target model repo, and removed before the next artifact is produced.

## What changed
- Added an optional `skippy-model-package write-package --after-artifact-command` hook that runs after each artifact is fully written and hashed.
- Updated the HF layer package job script to create the target repo before splitting, upload each artifact through the hook, then delete it immediately.
- Replaced full-folder upload with manifest upload after artifact streaming completes.
- Kept package metadata/model-card generation based on the manifest so the job does not need the full artifact set locally.

## Why
The latest failed jobs confirmed that writing package output under `/bucket` still increases the pod's ephemeral overlay usage and trips the 50G HF Jobs limit. Streaming artifacts bounds local disk usage to the current artifact plus shard scratch instead of the full 400-600GB package.

## Validation
- `bash -n crates/model-package/src/scripts/split-model-job.sh`
- `cargo fmt --all -- --check`
- `cargo test -p model-package`
- `cargo check -p skippy-model-package`
- `cargo check -p mesh-llm-host-runtime`