### PR TITLE
Allow multiple local model instances when capacity remains

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -819,7 +819,10 @@ pub(crate) fn classify_runtime_error(msg: &str) -> u16 {
         404
     } else if msg.contains("already loaded") || msg.contains("multiple loaded instances") {
         409
-    } else if msg.contains("fit locally") || msg.contains("runtime load only supports") {
+    } else if msg.contains("fit locally")
+        || msg.contains("runtime load only supports")
+        || msg.contains("runtime capacity")
+    {
         422
     } else {
         400

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -517,6 +517,10 @@ fn test_classify_runtime_error_codes() {
         classify_runtime_error("runtime load only supports models that fit locally"),
         422
     );
+    assert_eq!(
+        classify_runtime_error("runtime capacity for model 'x' exceeds node pool"),
+        422
+    );
     assert_eq!(classify_runtime_error("bad request"), 400);
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/capacity.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/capacity.rs
@@ -1,0 +1,454 @@
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(super) enum RuntimeCapacityPool {
+    Node,
+    PinnedGpu(String),
+}
+
+impl fmt::Display for RuntimeCapacityPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Node => f.write_str("node"),
+            Self::PinnedGpu(stable_id) => write!(f, "pinned GPU {stable_id}"),
+        }
+    }
+}
+
+impl RuntimeCapacityPool {
+    fn overlaps(&self, other: &Self) -> bool {
+        // Node-wide local loads are not pinned to a backend device, so they
+        // share the physical placement domain with every pinned GPU pool.
+        // Pinned GPU pools remain independent from each other.
+        self == other || matches!((self, other), (Self::Node, _) | (_, Self::Node))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct RuntimeCapacityRequest {
+    pub(super) instance_id: String,
+    pub(super) model_name: String,
+    pub(super) pool: RuntimeCapacityPool,
+    pub(super) capacity_bytes: u64,
+    pub(super) required_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RuntimeCapacityAllocation {
+    model_name: String,
+    pool: RuntimeCapacityPool,
+    required_bytes: u64,
+    generation: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct RuntimeCapacityError {
+    pub(super) model_name: String,
+    pub(super) pool: RuntimeCapacityPool,
+    pub(super) capacity_bytes: u64,
+    pub(super) reserved_bytes: u64,
+    pub(super) required_bytes: u64,
+}
+
+impl RuntimeCapacityError {
+    pub(super) fn available_bytes(&self) -> u64 {
+        self.capacity_bytes.saturating_sub(self.reserved_bytes)
+    }
+
+    pub(super) fn shortfall_bytes(&self) -> u64 {
+        self.required_bytes.saturating_sub(self.available_bytes())
+    }
+}
+
+impl fmt::Display for RuntimeCapacityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "runtime capacity for model '{}' exceeds {} pool: requires {}, available {}, reserved {}, capacity {}, short by {}",
+            self.model_name,
+            self.pool,
+            format_gb(self.required_bytes),
+            format_gb(self.available_bytes()),
+            format_gb(self.reserved_bytes),
+            format_gb(self.capacity_bytes),
+            format_gb(self.shortfall_bytes())
+        )
+    }
+}
+
+impl std::error::Error for RuntimeCapacityError {}
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RuntimeCapacityLedger {
+    inner: Arc<Mutex<RuntimeCapacityLedgerState>>,
+}
+
+#[derive(Debug, Default)]
+struct RuntimeCapacityLedgerState {
+    reservations: HashMap<String, RuntimeCapacityAllocation>,
+    next_generation: u64,
+}
+
+#[derive(Debug)]
+pub(super) struct RuntimeCapacityReservation {
+    ledger: RuntimeCapacityLedger,
+    instance_id: String,
+    generation: u64,
+    capacity_bytes: u64,
+    reserved_bytes_excluding_self: u64,
+}
+
+impl RuntimeCapacityLedger {
+    pub(super) fn reserve(
+        &self,
+        request: RuntimeCapacityRequest,
+    ) -> Result<RuntimeCapacityReservation, RuntimeCapacityError> {
+        let mut state = self.inner.lock().expect("runtime capacity ledger poisoned");
+        let reserved_bytes = state
+            .reservations
+            .iter()
+            .filter(|(instance_id, allocation)| {
+                instance_id.as_str() != request.instance_id
+                    && allocation.pool.overlaps(&request.pool)
+            })
+            .map(|(_, allocation)| allocation.required_bytes)
+            .fold(0_u64, u64::saturating_add);
+
+        if reserved_bytes.saturating_add(request.required_bytes) > request.capacity_bytes {
+            return Err(RuntimeCapacityError {
+                model_name: request.model_name,
+                pool: request.pool,
+                capacity_bytes: request.capacity_bytes,
+                reserved_bytes,
+                required_bytes: request.required_bytes,
+            });
+        }
+
+        state.next_generation = state.next_generation.saturating_add(1);
+        let generation = state.next_generation;
+        state.reservations.insert(
+            request.instance_id.clone(),
+            RuntimeCapacityAllocation {
+                model_name: request.model_name,
+                pool: request.pool,
+                required_bytes: request.required_bytes,
+                generation,
+            },
+        );
+
+        Ok(RuntimeCapacityReservation {
+            ledger: self.clone(),
+            instance_id: request.instance_id,
+            generation,
+            capacity_bytes: request.capacity_bytes,
+            reserved_bytes_excluding_self: reserved_bytes,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn used_bytes(&self, pool: &RuntimeCapacityPool) -> u64 {
+        let state = self.inner.lock().expect("runtime capacity ledger poisoned");
+        state
+            .reservations
+            .values()
+            .filter(|allocation| &allocation.pool == pool)
+            .map(|allocation| allocation.required_bytes)
+            .fold(0_u64, u64::saturating_add)
+    }
+
+    fn release_generation(&self, instance_id: &str, generation: u64) {
+        let mut state = self.inner.lock().expect("runtime capacity ledger poisoned");
+        let should_release = state
+            .reservations
+            .get(instance_id)
+            .map(|allocation| allocation.generation == generation)
+            .unwrap_or(false);
+        if should_release {
+            state.reservations.remove(instance_id);
+        }
+    }
+}
+
+impl RuntimeCapacityReservation {
+    pub(super) fn capacity_budget_bytes(&self) -> u64 {
+        self.capacity_bytes
+            .saturating_sub(self.reserved_bytes_excluding_self)
+    }
+}
+
+impl Drop for RuntimeCapacityReservation {
+    fn drop(&mut self) {
+        self.ledger
+            .release_generation(&self.instance_id, self.generation);
+    }
+}
+
+fn format_gb(bytes: u64) -> String {
+    format!("{:.1}GB", bytes as f64 / 1e9)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(instance_id: &str, model_name: &str, required_bytes: u64) -> RuntimeCapacityRequest {
+        pooled_request(
+            instance_id,
+            model_name,
+            RuntimeCapacityPool::Node,
+            1_000,
+            required_bytes,
+        )
+    }
+
+    fn pooled_request(
+        instance_id: &str,
+        model_name: &str,
+        pool: RuntimeCapacityPool,
+        capacity_bytes: u64,
+        required_bytes: u64,
+    ) -> RuntimeCapacityRequest {
+        RuntimeCapacityRequest {
+            instance_id: instance_id.to_string(),
+            model_name: model_name.to_string(),
+            pool,
+            capacity_bytes,
+            required_bytes,
+        }
+    }
+
+    #[test]
+    fn runtime_capacity_allows_duplicate_model_instances_when_capacity_remains() {
+        let ledger = RuntimeCapacityLedger::default();
+
+        let first = ledger
+            .reserve(request("runtime-1", "Qwen", 400))
+            .expect("first duplicate instance should reserve capacity");
+        let second = ledger
+            .reserve(request("runtime-2", "Qwen", 500))
+            .expect("second duplicate instance should reserve remaining capacity");
+
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 900);
+
+        drop(first);
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 500);
+
+        drop(second);
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 0);
+    }
+
+    #[test]
+    fn runtime_capacity_rejects_instance_when_pool_is_short() {
+        let ledger = RuntimeCapacityLedger::default();
+        let _first = ledger
+            .reserve(request("runtime-1", "Qwen", 700))
+            .expect("first instance should reserve capacity");
+
+        let err = ledger
+            .reserve(request("runtime-2", "Qwen", 400))
+            .expect_err("second instance should not overcommit local capacity");
+
+        assert_eq!(err.model_name, "Qwen");
+        assert_eq!(err.capacity_bytes, 1_000);
+        assert_eq!(err.reserved_bytes, 700);
+        assert_eq!(err.required_bytes, 400);
+        assert_eq!(err.available_bytes(), 300);
+        assert_eq!(err.shortfall_bytes(), 100);
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 700);
+    }
+
+    #[test]
+    fn runtime_capacity_replaces_same_instance_reservation() {
+        let ledger = RuntimeCapacityLedger::default();
+        let first = ledger
+            .reserve(request("runtime-1", "Qwen", 400))
+            .expect("initial reservation should succeed");
+        let replacement = ledger
+            .reserve(request("runtime-1", "Qwen", 600))
+            .expect("same instance should be able to replace its reservation");
+
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 600);
+        assert_eq!(replacement.capacity_budget_bytes(), 1_000);
+
+        drop(first);
+        assert_eq!(
+            ledger.used_bytes(&RuntimeCapacityPool::Node),
+            600,
+            "dropping a stale reservation must not release a newer reservation"
+        );
+
+        drop(replacement);
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 0);
+    }
+
+    #[test]
+    fn runtime_capacity_separates_pinned_gpu_pools() {
+        let ledger = RuntimeCapacityLedger::default();
+
+        let _first = ledger
+            .reserve(pooled_request(
+                "runtime-1",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-a".to_string()),
+                1_000,
+                800,
+            ))
+            .expect("first pinned GPU should reserve capacity");
+        let _second = ledger
+            .reserve(pooled_request(
+                "runtime-2",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-b".to_string()),
+                1_000,
+                800,
+            ))
+            .expect("second pinned GPU should have independent capacity");
+
+        assert_eq!(
+            ledger.used_bytes(&RuntimeCapacityPool::PinnedGpu("gpu-a".to_string())),
+            800
+        );
+        assert_eq!(
+            ledger.used_bytes(&RuntimeCapacityPool::PinnedGpu("gpu-b".to_string())),
+            800
+        );
+    }
+
+    #[test]
+    fn runtime_capacity_node_reservation_accounts_for_pinned_gpu_reservation() {
+        let ledger = RuntimeCapacityLedger::default();
+        let _pinned = ledger
+            .reserve(pooled_request(
+                "startup-gpu-a",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-a".to_string()),
+                1_000,
+                800,
+            ))
+            .expect("pinned startup model should reserve GPU capacity");
+
+        let err = ledger
+            .reserve(request("runtime-control", "Qwen", 300))
+            .expect_err("node-wide runtime load should not bypass pinned GPU reservation");
+
+        assert_eq!(err.pool, RuntimeCapacityPool::Node);
+        assert_eq!(err.capacity_bytes, 1_000);
+        assert_eq!(err.reserved_bytes, 800);
+        assert_eq!(err.required_bytes, 300);
+        assert_eq!(err.available_bytes(), 200);
+        assert_eq!(err.shortfall_bytes(), 100);
+    }
+
+    #[test]
+    fn runtime_capacity_node_reservation_allows_exact_remaining_pinned_capacity() {
+        let ledger = RuntimeCapacityLedger::default();
+        let _pinned = ledger
+            .reserve(pooled_request(
+                "startup-gpu-a",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-a".to_string()),
+                1_000,
+                700,
+            ))
+            .expect("pinned startup model should reserve GPU capacity");
+
+        let node = ledger
+            .reserve(request("runtime-control", "Qwen", 300))
+            .expect("node-wide runtime load should use the exact remaining capacity");
+
+        assert_eq!(node.capacity_budget_bytes(), 300);
+        assert_eq!(ledger.used_bytes(&RuntimeCapacityPool::Node), 300);
+    }
+
+    #[test]
+    fn runtime_capacity_pinned_gpu_reservation_accounts_for_node_reservation() {
+        let ledger = RuntimeCapacityLedger::default();
+        let _node = ledger
+            .reserve(request("runtime-control", "Qwen", 700))
+            .expect("node-wide runtime model should reserve aggregate local capacity");
+
+        let err = ledger
+            .reserve(pooled_request(
+                "startup-gpu-a",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-a".to_string()),
+                1_000,
+                400,
+            ))
+            .expect_err("pinned GPU load should not bypass node-wide reservation");
+
+        assert_eq!(
+            err.pool,
+            RuntimeCapacityPool::PinnedGpu("gpu-a".to_string())
+        );
+        assert_eq!(err.capacity_bytes, 1_000);
+        assert_eq!(err.reserved_bytes, 700);
+        assert_eq!(err.required_bytes, 400);
+        assert_eq!(err.available_bytes(), 300);
+        assert_eq!(err.shortfall_bytes(), 100);
+    }
+
+    #[test]
+    fn runtime_capacity_node_reservation_counts_all_pinned_gpu_reservations() {
+        let ledger = RuntimeCapacityLedger::default();
+        let _first = ledger
+            .reserve(pooled_request(
+                "startup-gpu-a",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-a".to_string()),
+                1_000,
+                650,
+            ))
+            .expect("first pinned GPU should reserve capacity");
+        let _second = ledger
+            .reserve(pooled_request(
+                "startup-gpu-b",
+                "Qwen",
+                RuntimeCapacityPool::PinnedGpu("gpu-b".to_string()),
+                1_000,
+                550,
+            ))
+            .expect("second pinned GPU should reserve independent capacity");
+
+        let node = ledger
+            .reserve(pooled_request(
+                "runtime-control",
+                "Qwen",
+                RuntimeCapacityPool::Node,
+                2_000,
+                700,
+            ))
+            .expect("node-wide runtime load should fit in aggregate remaining capacity");
+
+        assert_eq!(node.capacity_budget_bytes(), 800);
+
+        let err = ledger
+            .reserve(pooled_request(
+                "runtime-control-2",
+                "Qwen",
+                RuntimeCapacityPool::Node,
+                2_000,
+                900,
+            ))
+            .expect_err("node-wide runtime load should include every pinned reservation");
+
+        assert_eq!(err.reserved_bytes, 1_900);
+        assert_eq!(err.available_bytes(), 100);
+        assert_eq!(err.shortfall_bytes(), 800);
+    }
+
+    #[test]
+    fn runtime_capacity_reservation_budget_excludes_other_instances() {
+        let ledger = RuntimeCapacityLedger::default();
+        let _first = ledger
+            .reserve(request("runtime-1", "Qwen", 250))
+            .expect("first instance should reserve capacity");
+        let second = ledger
+            .reserve(request("runtime-2", "Qwen", 400))
+            .expect("second instance should reserve remaining capacity");
+
+        assert_eq!(second.capacity_budget_bytes(), 750);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -147,6 +147,7 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
     pub(super) mmproj_override: Option<&'a Path>,
     pub(super) ctx_size_override: Option<u32>,
     pub(super) pinned_gpu: Option<&'a crate::runtime::StartupPinnedGpuTarget>,
+    pub(super) capacity_budget_bytes: Option<u64>,
     pub(super) cache_type_k_override: Option<&'a str>,
     pub(super) cache_type_v_override: Option<&'a str>,
     pub(super) n_batch_override: Option<u32>,
@@ -399,8 +400,8 @@ pub(super) async fn start_runtime_local_model(
         .map(|package| package.source_model_bytes)
         .unwrap_or_else(|| election::total_model_bytes(spec.model_path));
     let my_vram = spec
-        .pinned_gpu
-        .map(|gpu| gpu.vram_bytes)
+        .capacity_budget_bytes
+        .or_else(|| spec.pinned_gpu.map(|gpu| gpu.vram_bytes))
         .unwrap_or_else(|| spec.node.vram_bytes());
 
     // For split/layer-package models, compute the local share of model weights

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -1,3 +1,4 @@
+mod capacity;
 pub(crate) mod config_state;
 mod context_planning;
 mod discovery;
@@ -9,6 +10,9 @@ mod split_planning;
 mod survey;
 pub(crate) mod wakeable;
 
+use self::capacity::{
+    RuntimeCapacityLedger, RuntimeCapacityPool, RuntimeCapacityRequest, RuntimeCapacityReservation,
+};
 use self::discovery::{nostr_rediscovery, start_new_mesh};
 use self::interactive::InitialPromptMode;
 use self::local::{
@@ -75,6 +79,7 @@ struct DashboardContextUsageSource {
 struct RuntimeModelHandleEntry {
     model_name: String,
     handle: LocalRuntimeModelHandle,
+    capacity_reservation: RuntimeCapacityReservation,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -758,6 +763,47 @@ fn next_runtime_instance_id(next_sequence: &mut u64) -> String {
     instance_id
 }
 
+fn runtime_capacity_pool(pinned_gpu: Option<&StartupPinnedGpuTarget>) -> RuntimeCapacityPool {
+    pinned_gpu
+        .map(|gpu| RuntimeCapacityPool::PinnedGpu(gpu.stable_id.clone()))
+        .unwrap_or(RuntimeCapacityPool::Node)
+}
+
+fn runtime_capacity_request_for_model(
+    instance_id: &str,
+    model_name: &str,
+    pinned_gpu: Option<&StartupPinnedGpuTarget>,
+    capacity_bytes: u64,
+    model_bytes: u64,
+) -> RuntimeCapacityRequest {
+    RuntimeCapacityRequest {
+        instance_id: instance_id.to_string(),
+        model_name: model_name.to_string(),
+        pool: runtime_capacity_pool(pinned_gpu),
+        capacity_bytes,
+        required_bytes: runtime_model_required_bytes(model_bytes),
+    }
+}
+
+fn reserve_runtime_capacity_for_model(
+    ledger: &RuntimeCapacityLedger,
+    instance_id: &str,
+    model_name: &str,
+    pinned_gpu: Option<&StartupPinnedGpuTarget>,
+    capacity_bytes: u64,
+    model_bytes: u64,
+) -> Result<RuntimeCapacityReservation> {
+    ledger
+        .reserve(runtime_capacity_request_for_model(
+            instance_id,
+            model_name,
+            pinned_gpu,
+            capacity_bytes,
+            model_bytes,
+        ))
+        .map_err(Into::into)
+}
+
 async fn register_runtime_instance(
     registry: &RuntimeInstanceRegistry,
     node: &mesh::Node,
@@ -1025,6 +1071,7 @@ struct StartupLocalModelTask {
     mmproj_path: Option<PathBuf>,
     ctx_size: Option<u32>,
     pinned_gpu: Option<StartupPinnedGpuTarget>,
+    runtime_capacity_ledger: RuntimeCapacityLedger,
     cache_type_k: Option<String>,
     cache_type_v: Option<String>,
     n_batch: Option<u32>,
@@ -1062,6 +1109,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         mmproj_path,
         ctx_size,
         pinned_gpu,
+        runtime_capacity_ledger,
         cache_type_k,
         cache_type_v,
         n_batch,
@@ -1134,6 +1182,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         mmproj_override: mmproj_path.as_deref(),
         ctx_size_override: ctx_size,
         pinned_gpu: pinned_gpu.as_ref(),
+        capacity_budget_bytes: None,
         cache_type_k_override: cache_type_k.as_deref(),
         cache_type_v_override: cache_type_v.as_deref(),
         n_batch_override: n_batch,
@@ -1143,6 +1192,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         skippy_telemetry: skippy_telemetry.clone(),
     };
     let mut launch_started: Instant;
+    let mut capacity_reservation: Option<RuntimeCapacityReservation> = None;
     let (
         mut loaded_name,
         handle,
@@ -1271,13 +1321,50 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         StartupRuntimePlan::Local => {
             let startup_load_guard = startup_load_gate.lock().await;
             launch_started = Instant::now();
-            let start_result = start_runtime_local_model(make_start_spec(), &model_ref).await;
+            let reservation = match reserve_runtime_capacity_for_model(
+                &runtime_capacity_ledger,
+                &instance_id,
+                &model_name,
+                pinned_gpu.as_ref(),
+                local_capacity,
+                model_bytes,
+            ) {
+                Ok(reservation) => reservation,
+                Err(err) => {
+                    survey_telemetry.record_launch_failure(
+                        survey::SurveyModelSpec {
+                            model: &model_name,
+                            model_path: Some(&model_path),
+                            launch_kind,
+                            pinned_gpu: pinned_gpu.as_ref(),
+                            backend: None,
+                            context_length: ctx_size.map(u64::from),
+                        },
+                        launch_started.elapsed(),
+                        survey::classify_launch_failure(&err),
+                    );
+                    let _ = emit_event(OutputEvent::Error {
+                        message: format!("Failed to start model {model_name}: {err:#}"),
+                        context: Some(format!("model={model_name}")),
+                    });
+                    update_startup_target(&target_tx, &model_name, election::InferenceTarget::None);
+                    if let Some(cs) = console_state {
+                        cs.update(false, false).await;
+                    }
+                    return;
+                }
+            };
+            let mut start_spec = make_start_spec();
+            start_spec.capacity_budget_bytes = Some(reservation.capacity_budget_bytes());
+            let start_result = start_runtime_local_model(start_spec, &model_ref).await;
             drop(startup_load_guard);
             match start_result {
                 Ok((loaded_name, handle, death_rx)) => {
+                    capacity_reservation = Some(reservation);
                     (loaded_name, handle, death_rx, None, None, None)
                 }
                 Err(err) => {
+                    drop(reservation);
                     survey_telemetry.record_launch_failure(
                         survey::SurveyModelSpec {
                             model: &model_name,
@@ -1449,6 +1536,61 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                             .await;
                         }
                         let launch_started = Instant::now();
+                        let reservation = match reserve_runtime_capacity_for_model(
+                            &runtime_capacity_ledger,
+                            &instance_id,
+                            &old_loaded_name,
+                            pinned_gpu.as_ref(),
+                            local_capacity,
+                            model_bytes,
+                        ) {
+                            Ok(reservation) => reservation,
+                            Err(err) => {
+                                survey_telemetry.record_launch_failure(
+                                    survey::SurveyModelSpec {
+                                        model: &old_loaded_name,
+                                        model_path: Some(&model_path),
+                                        launch_kind: survey::SurveyLaunchKind::MoeFallback,
+                                        pinned_gpu: pinned_gpu.as_ref(),
+                                        backend: None,
+                                        context_length: ctx_size.map(u64::from),
+                                    },
+                                    launch_started.elapsed(),
+                                    survey::classify_launch_failure(&err),
+                                );
+                                let _ = emit_event(OutputEvent::Warning {
+                                    message: format!(
+                                        "Split runtime topology '{}' lost required stage peer(s); local fallback failed, withdrawing model '{}'",
+                                        event.topology_id, old_loaded_name
+                                    ),
+                                    context: Some(format!(
+                                        "reason={} generation={} missing_stage_nodes=[{}] error={err:#}",
+                                        event.reason, event.generation, missing_stage_nodes
+                                    )),
+                                });
+                                let _ = event.ack.send(SplitCoordinatorAck::Accepted);
+                                if unregister_runtime_instance(
+                                    &runtime_instance_registry,
+                                    &node,
+                                    &old_loaded_name,
+                                    &instance_id,
+                                )
+                                .await
+                                {
+                                    publish_runtime_llama_unavailable(
+                                        runtime_data_producer.as_ref(),
+                                        &old_loaded_name,
+                                        Some(&instance_id),
+                                    );
+                                }
+                                remove_dashboard_process(&dashboard_processes, &instance_id).await;
+                                if let Some(cs) = console_state {
+                                    cs.remove_local_process(&instance_id).await;
+                                    cs.update(false, false).await;
+                                }
+                                return;
+                            }
+                        };
                         match start_runtime_local_model(LocalRuntimeModelStartSpec {
                             node: &node,
                             model_path: &model_path,
@@ -1456,6 +1598,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                             mmproj_override: mmproj_path.as_deref(),
                             ctx_size_override: ctx_size,
                             pinned_gpu: pinned_gpu.as_ref(),
+                            capacity_budget_bytes: Some(reservation.capacity_budget_bytes()),
                             cache_type_k_override: cache_type_k.as_deref(),
                             cache_type_v_override: cache_type_v.as_deref(),
                             n_batch_override: n_batch,
@@ -1467,6 +1610,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                         .await
                         {
                             Ok((next_loaded_name, next_handle, next_death_rx)) => {
+                                capacity_reservation = Some(reservation);
                                 loaded_name = next_loaded_name;
                                 add_runtime_local_target(&target_tx, &loaded_name, next_handle.port);
                                 tunnel_mgr.set_http_port(api_port);
@@ -1541,6 +1685,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                                 continue;
                             }
                             Err(err) => {
+                                drop(reservation);
                                 survey_telemetry.record_launch_failure(
                                     survey::SurveyModelSpec {
                                         model: &old_loaded_name,
@@ -1692,6 +1837,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 handle = Some(next.handle);
                 let _ = event.ack.send(SplitCoordinatorAck::Accepted);
                 old_handle.shutdown().await;
+                drop(capacity_reservation.take());
                 let _ = emit_event(OutputEvent::Info {
                     message: format!(
                         "Split runtime cut over model '{}' from :{} to :{}",
@@ -1718,6 +1864,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         survey_telemetry.record_unload(&survey_loaded_model);
     }
     let Some(handle) = handle.take() else {
+        drop(capacity_reservation.take());
         return;
     };
     let port = handle.port;
@@ -1758,6 +1905,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
     }
     remove_dashboard_context_usage(&dashboard_context_usage, &loaded_name, &handle).await;
     handle.shutdown().await;
+    drop(capacity_reservation.take());
     if let Some(cleanup) = split_cleanup.take() {
         stop_split_generation_cleanup(&node, cleanup, u64::MAX).await;
     }
@@ -4779,6 +4927,7 @@ async fn run_auto(
     let mut managed_models: HashMap<String, ManagedModelController> = HashMap::new();
     let runtime_instance_registry: RuntimeInstanceRegistry =
         Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+    let runtime_capacity_ledger = RuntimeCapacityLedger::default();
     let mut next_runtime_instance_sequence = 1_u64;
     let dashboard_processes = Arc::new(tokio::sync::Mutex::new(Vec::new()));
     let dashboard_context_usage = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
@@ -5060,6 +5209,7 @@ async fn run_auto(
     let dashboard_processes_for_primary_task = dashboard_processes.clone();
     let dashboard_context_usage_for_primary_task = dashboard_context_usage.clone();
     let runtime_instance_registry_for_primary_task = runtime_instance_registry.clone();
+    let runtime_capacity_ledger_for_primary_task = runtime_capacity_ledger.clone();
     let primary_startup_load_gate = startup_load_gate.clone();
     let primary_task = tokio::spawn(Box::pin(startup_local_model_loop(StartupLocalModelTask {
         node: node2,
@@ -5073,6 +5223,7 @@ async fn run_auto(
         mmproj_path: primary_mmproj,
         ctx_size: primary_ctx_size,
         pinned_gpu: primary_pinned_gpu,
+        runtime_capacity_ledger: runtime_capacity_ledger_for_primary_task,
         cache_type_k: primary_cache_type_k,
         cache_type_v: primary_cache_type_v,
         n_batch: primary_n_batch,
@@ -5150,6 +5301,7 @@ async fn run_auto(
             let dashboard_processes_for_extra_task = dashboard_processes.clone();
             let dashboard_context_usage_for_extra_task = dashboard_context_usage.clone();
             let runtime_instance_registry_for_extra_task = runtime_instance_registry.clone();
+            let runtime_capacity_ledger_for_extra_task = runtime_capacity_ledger.clone();
             let extra_control_tx = control_tx.clone();
             let extra_survey_telemetry = survey_telemetry.clone();
             let extra_task =
@@ -5165,6 +5317,7 @@ async fn run_auto(
                     mmproj_path: extra_mmproj,
                     ctx_size: extra_ctx_size,
                     pinned_gpu: extra_pinned_gpu,
+                    runtime_capacity_ledger: runtime_capacity_ledger_for_extra_task,
                     cache_type_k: extra_cache_type_k,
                     cache_type_v: extra_cache_type_v,
                     n_batch: extra_n_batch,
@@ -5333,28 +5486,8 @@ async fn run_auto(
                                 .await
                                 .map(|model| models::remote_catalog_model_ref(&model))
                                 .unwrap_or_else(|| models::model_ref_for_path(&model_path));
-                            let already_loaded = managed_models.contains_key(&runtime_model_name)
-                                || runtime_models.contains_key(&runtime_model_name);
-                            anyhow::ensure!(
-                                !already_loaded,
-                                "model '{runtime_model_name}' is already loaded"
-                            );
-
-                            // Look up per-model overrides from TOML config by matching the
-                            // spec string against [[models]].model entries. Metadata-based
-                            // planning chooses direct-local defaults when no parallel
-                            // override matches.
-                            let model_overrides = config.models.iter().find(|m| m.model == spec);
-                            let parallel_override = model_overrides
-                                .and_then(|m| m.parallel)
-                                .or(config.gpu.parallel);
-
-                            let instance_id =
-                                next_runtime_instance_id(&mut next_runtime_instance_sequence);
                             let requested_model = spec.clone();
-                            add_serving_assignment(&node, &primary_model_name, &requested_model)
-                                .await;
-                            let runtime_model_bytes = {
+                            let model_bytes = {
                                 let p = model_path.clone();
                                 tokio::task::spawn_blocking(move || runtime_model_planning_bytes(&p))
                                     .await
@@ -5374,15 +5507,40 @@ async fn run_auto(
                                         fallback
                                     })
                             };
+
+                            // Look up per-model overrides from TOML config by matching the
+                            // spec string against [[models]].model entries. Metadata-based
+                            // planning chooses direct-local defaults when no parallel
+                            // override matches.
+                            let model_overrides = config.models.iter().find(|m| m.model == spec);
+                            let parallel_override = model_overrides
+                                .and_then(|m| m.parallel)
+                                .or(config.gpu.parallel);
+
+                            let instance_id =
+                                next_runtime_instance_id(&mut next_runtime_instance_sequence);
+                            let capacity_reservation = reserve_runtime_capacity_for_model(
+                                &runtime_capacity_ledger,
+                                &instance_id,
+                                &runtime_model_name,
+                                None,
+                                node.vram_bytes(),
+                                model_bytes,
+                            )?;
+                            add_serving_assignment(&node, &primary_model_name, &requested_model)
+                                .await;
                             let launch_started = Instant::now();
+                            let capacity_budget_bytes =
+                                capacity_reservation.capacity_budget_bytes();
                             let (loaded_name, handle, death_rx) = match start_runtime_local_model(
                                 LocalRuntimeModelStartSpec {
                                     node: &node,
                                     model_path: &model_path,
-                                    model_bytes: runtime_model_bytes,
+                                    model_bytes,
                                     mmproj_override: None,
                                     ctx_size_override: cli.ctx_size,
                                     pinned_gpu: None,
+                                    capacity_budget_bytes: Some(capacity_budget_bytes),
                                     cache_type_k_override: model_overrides
                                         .and_then(|m| m.cache_type_k.as_deref()),
                                     cache_type_v_override: model_overrides
@@ -5401,6 +5559,7 @@ async fn run_auto(
                             {
                                 Ok(result) => result,
                                 Err(err) => {
+                                    drop(capacity_reservation);
                                     remove_serving_assignment(&node, &requested_model).await;
                                     survey_telemetry.record_launch_failure(
                                         survey::SurveyModelSpec {
@@ -5496,6 +5655,7 @@ async fn run_auto(
                                 RuntimeModelHandleEntry {
                                     model_name: loaded_name.clone(),
                                     handle,
+                                    capacity_reservation,
                                 },
                             );
                             Ok(api::RuntimeLoadResponse {
@@ -5521,8 +5681,11 @@ async fn run_auto(
                                             unload.instance_id
                                         );
                                     };
-                                    let model = entry.model_name;
-                                    let handle = entry.handle;
+                                    let RuntimeModelHandleEntry {
+                                        model_name: model,
+                                        handle,
+                                        capacity_reservation,
+                                    } = entry;
                                     let port = handle.port;
                                     if let Some(survey_model) =
                                         runtime_survey_models.remove(&unload.instance_id)
@@ -5572,6 +5735,7 @@ async fn run_auto(
                                     )
                                     .await;
                                     handle.shutdown().await;
+                                    drop(capacity_reservation);
                                     remove_dashboard_process(
                                         &dashboard_processes,
                                         &unload.instance_id,
@@ -5648,7 +5812,11 @@ async fn run_auto(
                             .unwrap_or(false);
                         if matches {
                             if let Some(entry) = runtime_models.remove(&instance_id) {
-                                let handle = entry.handle;
+                                let RuntimeModelHandleEntry {
+                                    handle,
+                                    capacity_reservation,
+                                    ..
+                                } = entry;
                                 if let Some(survey_model) =
                                     runtime_survey_models.remove(&instance_id)
                                 {
@@ -5694,6 +5862,7 @@ async fn run_auto(
                                 )
                                 .await;
                                 handle.shutdown().await;
+                                drop(capacity_reservation);
                             }
                             remove_runtime_local_target(&target_tx, &model, port);
                             let _ = emit_event(OutputEvent::Warning {
@@ -5737,8 +5906,11 @@ async fn run_auto(
     }
 
     for (instance_id, entry) in runtime_models.drain() {
-        let name = entry.model_name;
-        let handle = entry.handle;
+        let RuntimeModelHandleEntry {
+            model_name: name,
+            handle,
+            capacity_reservation,
+        } = entry;
         if let Some(survey_model) = runtime_survey_models.remove(&instance_id) {
             survey_telemetry.record_unload(&survey_model);
         }
@@ -5768,6 +5940,7 @@ async fn run_auto(
         let stopped_payload =
             runtime_process_payload_with_status(&name, Some(&instance_id), &handle, "stopped");
         handle.shutdown().await;
+        drop(capacity_reservation);
         let _ = emit_event(OutputEvent::ModelUnloaded {
             model: name.clone(),
         });


### PR DESCRIPTION
## Summary

Allow a node to run multiple local runtime instances of the same model, or multiple local runtime instances across different models, as long as the aggregate local runtime capacity still fits.

This addresses the backend behavior reported in #370: duplicate local model starts could appear to launch, but the node did not reliably keep those runtime instances admitted, tracked, and unloadable as distinct local processes. The UI clarity work from #369 is intentionally left as a follow-up rather than mixed into this backend correctness PR.

## Why

Operators sometimes want independent copies of a model so each copy keeps its full context window instead of sharing capacity through one runtime instance. That should be supported when the machine still has enough local runtime memory.

The previous admission path checked each start against the full node capacity independently, and one runtime-control duplicate check was keyed by model name instead of instance identity. That made duplicate local instances ambiguous: capacity accounting did not represent the aggregate local runtime footprint, and duplicate instances could be rejected or lose correct lifecycle ownership.

## What Changed

- Add an instance-aware `RuntimeCapacityLedger` for local runtime starts.
- Reserve local runtime capacity by `instance_id`, not by model name.
- Allow duplicate model instances when there is remaining capacity in the relevant local capacity pool.
- Reject overcommit with an explicit capacity error that reports required, reserved, available, total capacity, and shortfall.
- Keep pinned GPU reservations isolated from the node-wide capacity pool.
- Release reservations on unload, unexpected runtime exit, shutdown, and split cutover.
- Pass the remaining capacity budget into local runtime planning so each later instance plans against the memory left after earlier local reservations.
- Update stale protocol/mesh test fixtures that had drifted from the current descriptor shape.

## Architecture

The new ledger is deliberately local to runtime orchestration. It does not change mesh gossip semantics, routing contracts, or the public API payload shape.

Reservations are RAII guards owned by runtime model handles or startup-local runtime tasks. Dropping the guard releases capacity. Same-instance replacement uses a generation check so an older stale guard cannot accidentally release a newer reservation for the same `instance_id`.

The PR covers full local runtime starts and local fallback starts after split-stage loss. Split-stage aggregate placement itself is not changed here.

## Protocol and Compatibility

No mesh wire protocol change.

No gossip schema change.

No mixed-version compatibility break: capacity admission remains local process state only. Older peers continue to see the same model/runtime gossip surface they already understand.

## Validation

Local validation was run from the PR branch against `origin/main`.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS
- `git diff --check`: PASS
- `git diff --cached --check`: PASS
- `git diff --check origin/main...HEAD`: PASS
- `cargo fmt --all -- --check`: PASS
- `cargo check -p mesh-llm-host-runtime`: PASS
- `cargo check -p mesh-llm`: PASS
- `cargo test -p mesh-llm-host-runtime runtime::capacity --lib`: PASS, 5 passed
- `cargo test -p mesh-llm-host-runtime duplicate --lib`: PASS, 6 passed
- `cargo test -p mesh-llm-host-runtime process_snapshots_keep_distinct_same_model_instances --lib`: PASS
- `cargo test -p mesh-llm-host-runtime gossip_frame_roundtrip_preserves_scanned_model_metadata --lib`: PASS
- `cargo test -p mesh-llm-host-runtime transitive_peer --lib`: PASS, 5 passed
- `cargo test -p mesh-llm-host-runtime owner_fields_roundtrip_through_proto_announcement --lib`: PASS
- `cargo test -p mesh-llm-host-runtime test_peer_announcement_first_joined_mesh_ts_roundtrip --lib`: PASS
- `cargo test -p mesh-llm-host-runtime initial_pretty_session_mode_allows_dashboard_for_runtime_surfaces --lib`: PASS

Local note: Rust checks used the repo's local llama stage ABI build directory through `LLAMA_STAGE_BUILD_DIR`; the machine-specific absolute path is intentionally omitted from the PR text.

Not completed locally:

- Full `cargo test -p mesh-llm-host-runtime --lib` was not completed locally after encountering an unrelated proxy streaming test failure in `crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs:1182` and long-running HF/cache tests. The targeted tests for the touched runtime, status, duplicate-instance, gossip fixture, and protocol fixture paths passed.

Remote CI:

- Running on GitHub for the published PR.

## Related

- Closes #370
- Related follow-up: #369, for UI deduplication and clearer display of multiple instances of the same model

## Rollback

Revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: any local runtime instances admitted only because of this change will no longer be admitted after rollback.

## Known Residual Risks

- This PR is backend/runtime correctness only. It does not attempt the topology and model-view UI cleanup tracked in #369.
- Split-stage aggregate placement is not reworked here; this change reserves full local runtime starts and local fallback starts.
