### PR TITLE
Hide cold models from chat selector

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
@@ -544,6 +544,25 @@ describe('ChatPage', () => {
     expect(options[0]).toHaveTextContent('Auto')
   })
 
+  it('excludes cold live models from the chat model selector', async () => {
+    const user = userEvent.setup()
+    vi.mocked(adaptModelsToSummary).mockReturnValue([
+      { ...CHAT_HARNESS.models[0], name: 'warm-model', status: 'warm' },
+      { ...CHAT_HARNESS.models[1], name: 'cold-model', status: 'offline' }
+    ])
+
+    renderChatPage({ mode: 'live' })
+
+    await user.click(screen.getByRole('combobox', { name: 'Select model' }))
+
+    const options = await screen.findAllByRole('option')
+    expect(options.map((option) => option.textContent)).toEqual([
+      expect.stringContaining('Auto'),
+      expect.stringContaining('warm-model')
+    ])
+    expect(screen.queryByText('cold-model')).not.toBeInTheDocument()
+  })
+
   it('loads the default system prompt when no user override is stored', async () => {
     const user = userEvent.setup()
     localStorage.clear()

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
@@ -438,6 +438,10 @@ function modelStatusBadge(model: ModelSummary): ModelSelectOption['status'] {
   return { label: 'Warm', tone: 'good' }
 }
 
+function isChatSelectableModel(model: ModelSummary): boolean {
+  return model.status === 'ready' || model.status === 'warm'
+}
+
 export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   const { mode, setMode } = useDataMode()
   const liveMode = mode === 'live'
@@ -447,9 +451,10 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   const liveModels = modelsQuery.data ? adaptModelsToSummary(modelsQuery.data.mesh_models) : undefined
   const resolvedModels = liveMode ? liveModels : data.models
   const displayModels = resolvedModels ?? data.models
+  const selectableModels = useMemo(() => displayModels.filter(isChatSelectableModel), [displayModels])
   const showLiveError = liveMode && !liveModels && !modelsQuery.isFetching && modelsQuery.isError
   const showLiveLoading = liveMode && !liveModels && !showLiveError
-  const warmModelCount = liveModels?.filter((m) => m.status === 'ready' || m.status === 'warm').length ?? 0
+  const warmModelCount = liveModels?.filter(isChatSelectableModel).length ?? 0
   const canChat =
     !liveMode ||
     (liveStatus?.llama_ready ?? false) ||
@@ -463,7 +468,7 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   const [systemPromptDraft, setSystemPromptDraft] = useState('')
   const [composerDrafts, setComposerDrafts] = useState<Record<string, ConversationComposerDraft>>({})
   const [model, setModel] = useState('')
-  const modelExists = displayModels.some((item) => item.name === model)
+  const modelExists = selectableModels.some((item) => item.name === model)
   const activeModelName = model === AUTO_MODEL_VALUE ? AUTO_MODEL_VALUE : modelExists ? model : AUTO_MODEL_VALUE
   const [queuedSubmissions, setQueuedSubmissions] = useState<QueuedSubmission[]>([])
   const [attachmentProcessingStatus, setAttachmentProcessingStatus] = useState<AttachmentProcessingStatus | null>(null)
@@ -626,14 +631,14 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   const options = useMemo<ModelSelectOption[]>(
     () => [
       AUTO_MODEL_OPTION,
-      ...displayModels.map((item) => ({
+      ...selectableModels.map((item) => ({
         value: item.name,
         label: item.name,
         meta: `${item.family} · ${item.context}`,
         status: modelStatusBadge(item)
       }))
     ],
-    [displayModels]
+    [selectableModels]
   )
   const canRetry = hasLastUserTurn(activeMessages.map((message) => ({ role: message.messageRole })))
 


### PR DESCRIPTION
## Summary
Chat users will now only see warm or ready models in the model selector. Cold catalog rows remain visible elsewhere in the console, but they no longer appear as selectable chat targets.

## Root Cause
The chat page built its dropdown directly from the full model catalog summary. The API maps cold rows to the UI's offline status, so cold models were rendered as offline options in the chat selector.

## Changes
- Add a chat-selectable model filter for warm/ready models.
- Use that same filter for selected-model validity so stale cold selections fall back to Auto.
- Add a live-mode regression test covering a warm model plus a cold/offline model.

## Validation
- `just ui-test` — 612 passed, 3 skipped
- `just build` — completed successfully; existing UI bundle size/dynamic import warnings only