### PR TITLE
fix(debug-model-loading): fix extremely long model loading times in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,12 @@ clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+
+# Do not remove this section: direct GGUF debug startup spends most of its time
+# hashing the source model via sha2/sha2-asm before native skippy model open,
+# so keep those crates near release speed in dev builds.
+[profile.dev.package.sha2]
+opt-level = 3
+
+[profile.dev.package.sha2-asm]
+opt-level = 3


### PR DESCRIPTION
## Summary
Debug builds now startup-load `unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL` (the test model) in roughly 11 seconds again instead of taking more than 3.5 minutes. This would be much worse on larger models.

This branch traced the regression to direct GGUF package identity generation on the startup path: before skippy/native model open begins, mesh synthesizes a package identity for plain GGUF models and hashes the full source GGUF with Rust `sha2`. In debug builds that hashing dependency was still effectively unoptimized, so the hash step dominated startup time.

The fix is intentionally minimal: keep only `sha2` and `sha2-asm` near release speed in debug builds via targeted `[profile.dev.package.*]` overrides in the root `Cargo.toml`.
## What this branch discovered
Direct GGUF startup goes through this path before native model open:
`start_runtime_skippy_model()`
→ `SkippyModelHandle::load_with_hooks()`
→ `single_stage_config()`
→ `synthetic_direct_gguf_package()`
→ `source_file()`
→ `file_sha256()`

That hash is not required by llama.cpp itself. It exists because direct GGUF loads are wrapped into a synthetic package identity so the rest of mesh/skippy can treat them like real layer packages, with fields such as:
- `package_ref`
- `manifest_sha256`
- `source_model_sha256`
- `source_model_bytes`
The slow step was in-process Rust hashing, not Perl `shasum`, and not native skippy/llama model open.
## Slow timing results before the fix
Measured on `target/debug/mesh-llm serve --listen-all --log-format json` for `unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL`:
- `file_sha256.complete elapsed_s ≈ 207.64730125`
- hashed file size: `17,612,564,704` bytes
- hash throughput: about `80.89 MiB/s`
- total `model_loading` → `model_loaded`: `≈ 212.999s`
The later native portion was already fast once reached:
- `load_runtime.open_stage_model took ≈ 1.784s`
So nearly all of the debug-build regression happened before native model open.
## Fix
Root `Cargo.toml` now adds targeted debug-profile optimization for the hot hashing dependency only:
```toml
[profile.dev.package.sha2]
opt-level = 3
[profile.dev.package.sha2-asm]
opt-level = 3
```
This keeps the fix surgical:
- no new crate
- no startup-path refactor
- no runtime behavior change
- no broader release-style optimization sweep
## Fast timing results after the fix
Re-running the same debug startup path after the profile change produced:
- `file_sha256.complete elapsed_s ≈ 8.240051728`
- hash throughput: about `2038.42 MiB/s`
- `synthetic_direct_gguf_package elapsed_total_s ≈ 8.403s`
- `load_runtime.open_stage_model took ≈ 1.807s`
- total `model_loading` → `model_loaded`: `≈ 10.751s`
- wrapper-measured wall time: `≈ 13.6s`
Console output from the runtime also confirmed the fix on a follow-up run:
- `model_loading`: `2026-05-12T01:40:47.271Z`
- `model_loaded`: `2026-05-12T01:40:57.967Z`
- `ready`: `2026-05-12T01:40:57.968Z`
That puts debug startup back under the `<20s` target.
## Impact
- debug startup for large direct GGUF models is back near expected speed
- the dominant bottleneck was confirmed and removed
- native skippy model open was never the primary problem
## Validation
- `cargo fmt --all --check`
- `just build`
- real timed run of `./target/debug/mesh-llm serve --listen-all --log-format json`
- traced with:
  - `RUST_LOG=mesh_llm_host_runtime::inference::skippy::package=info,skippy_server=info`
  - `MESH_LLM_RUNTIME_ROOT=/tmp/opencode/runtime-loadtrace-after-sha2-opt`
## Architecture note
This change does not remove synthetic direct-GGUF package identity generation. It only prevents the SHA-256 backend from becoming the debug-build bottleneck while preserving the existing package/status/provenance contract.