### PR TITLE
Add network doctor for direct mesh UDP

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -887,6 +887,7 @@ impl MeshApi {
         ));
         payload.runtime = runtime;
         payload.wanted_model_refs = self.wanted_model_refs().await;
+        payload.direct_connectivity = node.direct_connectivity_status();
         payload
     }
 

--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -4,6 +4,7 @@
 
 use super::{RuntimeModelPayload, RuntimeProcessPayload};
 use crate::crypto::{OwnershipStatus, OwnershipSummary};
+use crate::mesh::DirectConnectivityStatus;
 use crate::network::{affinity, metrics};
 use crate::runtime_data;
 use crate::system::hardware::expand_gpu_names;
@@ -349,6 +350,7 @@ pub(crate) struct StatusPayload {
     /// Local-only routing outcome and current-node pressure snapshot measured on
     /// this node only; not mesh-wide aggregates.
     pub(crate) routing_metrics: metrics::RoutingMetricsStatusSnapshot,
+    pub(crate) direct_connectivity: DirectConnectivityStatus,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) first_joined_mesh_ts: Option<u64>,
 }
@@ -1001,6 +1003,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            direct_connectivity: DirectConnectivityStatus::default(),
             first_joined_mesh_ts: None,
         };
 
@@ -1053,6 +1056,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            direct_connectivity: DirectConnectivityStatus::default(),
             first_joined_mesh_ts: None,
         };
 
@@ -1112,6 +1116,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            direct_connectivity: DirectConnectivityStatus::default(),
             first_joined_mesh_ts: None,
         };
 
@@ -1166,6 +1171,7 @@ mod tests {
             gpus: vec![],
             routing_affinity: affinity::AffinityStatsSnapshot::default(),
             routing_metrics: metrics::RoutingMetricsStatusSnapshot::default(),
+            direct_connectivity: DirectConnectivityStatus::default(),
             first_joined_mesh_ts: None,
         };
 

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -7,6 +7,7 @@ mod gpus;
 mod integrations;
 mod model_package;
 mod models;
+mod network;
 mod plugin;
 mod runtime;
 mod update;
@@ -20,6 +21,7 @@ use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
 use crate::cli::commands::integrations::{run_claude, run_goose, run_opencode, run_pi};
 use crate::cli::commands::models::dispatch_models_command;
+use crate::cli::commands::network::dispatch_network_command;
 use crate::cli::commands::plugin::run_plugin_command;
 use crate::cli::commands::runtime::{dispatch_runtime_command, run_drop, run_load, run_status};
 use crate::cli::commands::update::run_update;
@@ -41,6 +43,10 @@ pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
         Command::Update { .. } => run_update(cli).await,
         Command::Gpus { json, command } => {
             dispatch_gpu_command(*json, command.as_ref())?;
+            Ok(())
+        }
+        Command::Network { command } => {
+            dispatch_network_command(command).await?;
             Ok(())
         }
         Command::Runtime { command } => dispatch_runtime_command(command.as_ref()).await,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/network.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/network.rs
@@ -1,0 +1,27 @@
+use anyhow::Result;
+
+use crate::cli::NetworkCommand;
+
+pub(crate) async fn dispatch_network_command(command: &NetworkCommand) -> Result<()> {
+    match command {
+        NetworkCommand::Doctor {
+            bind_port,
+            relay,
+            json,
+        } => run_network_doctor(*bind_port, relay, *json).await,
+    }
+}
+
+async fn run_network_doctor(
+    bind_port: Option<u16>,
+    relay_urls: &[String],
+    json: bool,
+) -> Result<()> {
+    let report = crate::mesh::network_doctor(bind_port, relay_urls).await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        println!("{}", crate::mesh::format_network_doctor(&report));
+    }
+    Ok(())
+}

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -36,6 +36,22 @@ pub(crate) enum TrustCommand {
 }
 
 #[derive(Subcommand, Debug)]
+pub(crate) enum NetworkCommand {
+    /// Diagnose direct UDP reachability using iroh and local router signals.
+    Doctor {
+        /// Bind QUIC to this fixed UDP port while probing direct reachability.
+        #[arg(long)]
+        bind_port: Option<u16>,
+        /// Override iroh relay URLs used for address discovery.
+        #[arg(long)]
+        relay: Vec<String>,
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+#[derive(Subcommand, Debug)]
 pub(crate) enum AuthCommand {
     /// Generate a new owner keypair and save to keystore.
     Init {
@@ -444,6 +460,11 @@ pub(crate) enum Command {
         json: bool,
         #[command(subcommand)]
         command: Option<GpuCommand>,
+    },
+    /// Diagnose mesh networking and direct UDP reachability.
+    Network {
+        #[command(subcommand)]
+        command: NetworkCommand,
     },
     /// Inspect and manage local runtime-served models.
     #[command(hide = true)]

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
@@ -1,0 +1,295 @@
+use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+/// Discover our public IP via STUN, then pair it with the given port.
+/// We can't send STUN from the bound port (iroh owns it), but we only need
+/// the public IP; the port is known from --bind-port plus router forwarding.
+pub(super) async fn stun_public_addr(advertised_port: u16) -> Option<SocketAddr> {
+    let stun_servers = [
+        "stun.l.google.com:19302",
+        "stun.cloudflare.com:3478",
+        "stun.stunprotocol.org:3478",
+    ];
+
+    // Bind to an ephemeral port; we only care about the IP, not the mapped port.
+    let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.ok()?;
+
+    for server in &stun_servers {
+        // STUN Binding Request: type=0x0001, len=0, magic=0x2112A442, txn=random.
+        let mut req = [0u8; 20];
+        req[0] = 0x00;
+        req[1] = 0x01;
+        req[4] = 0x21;
+        req[5] = 0x12;
+        req[6] = 0xA4;
+        req[7] = 0x42;
+        rand::fill(&mut req[8..20]);
+
+        let addrs = match tokio::net::lookup_host(server).await {
+            Ok(addrs) => addrs,
+            Err(_) => continue,
+        };
+
+        for dest in addrs.filter(SocketAddr::is_ipv4) {
+            if sock.send_to(&req, dest).await.is_err() {
+                continue;
+            }
+
+            let mut buf = [0u8; 256];
+            let len = match tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                sock.recv_from(&mut buf),
+            )
+            .await
+            {
+                Ok(Ok((len, _))) if len >= 20 => len,
+                _ => continue,
+            };
+
+            if let Some(addr) = parse_stun_mapped_ipv4(&req, &buf[..len], advertised_port) {
+                tracing::info!("STUN discovered public address: {addr}");
+                return Some(addr);
+            }
+        }
+    }
+
+    tracing::warn!("STUN: could not discover public address");
+    None
+}
+
+fn parse_stun_mapped_ipv4(
+    request: &[u8; 20],
+    response: &[u8],
+    advertised_port: u16,
+) -> Option<SocketAddr> {
+    let magic = &request[4..8];
+    let mut i = 20;
+    while i + 4 <= response.len() {
+        let attr_type = u16::from_be_bytes([response[i], response[i + 1]]);
+        let attr_len = u16::from_be_bytes([response[i + 2], response[i + 3]]) as usize;
+        if i + 4 + attr_len > response.len() {
+            break;
+        }
+        let val = &response[i + 4..i + 4 + attr_len];
+
+        if attr_type == 0x0020 && attr_len >= 8 && val[1] == 0x01 {
+            let ip = Ipv4Addr::new(
+                val[4] ^ magic[0],
+                val[5] ^ magic[1],
+                val[6] ^ magic[2],
+                val[7] ^ magic[3],
+            );
+            return Some(SocketAddr::V4(SocketAddrV4::new(ip, advertised_port)));
+        }
+        if attr_type == 0x0001 && attr_len >= 8 && val[1] == 0x01 {
+            let ip = Ipv4Addr::new(val[4], val[5], val[6], val[7]);
+            return Some(SocketAddr::V4(SocketAddrV4::new(ip, advertised_port)));
+        }
+
+        i += (4 + (attr_len + 3)) & !3;
+    }
+    None
+}
+
+pub(super) fn is_cgnat_ipv4_addr(addr: Ipv4Addr) -> bool {
+    let octets = addr.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+pub(super) fn is_public_ipv4_addr(addr: Ipv4Addr) -> bool {
+    !addr.is_private()
+        && !addr.is_loopback()
+        && !addr.is_link_local()
+        && !addr.is_multicast()
+        && !addr.is_broadcast()
+        && !addr.is_documentation()
+        && !addr.is_unspecified()
+        && !is_cgnat_ipv4_addr(addr)
+}
+
+async fn upnp_router_wan_ipv4() -> Option<Ipv4Addr> {
+    let location = upnp_igd_location().await?;
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .ok()?;
+    let description = client
+        .get(location.clone())
+        .send()
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+    let control_url = upnp_wan_control_url(&location, &description)?;
+    let service_type = upnp_wan_service_type(&description)?;
+    let body = format!(
+        r#"<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body><u:GetExternalIPAddress xmlns:u="{service_type}"></u:GetExternalIPAddress></s:Body>
+</s:Envelope>"#
+    );
+    let response = client
+        .post(control_url)
+        .header("content-type", r#"text/xml; charset="utf-8""#)
+        .header(
+            "soapaction",
+            format!(r#""{service_type}#GetExternalIPAddress""#),
+        )
+        .body(body)
+        .send()
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+    xml_tag_text(&response, "NewExternalIPAddress")?
+        .parse()
+        .ok()
+}
+
+async fn upnp_igd_location() -> Option<String> {
+    let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.ok()?;
+    let request = concat!(
+        "M-SEARCH * HTTP/1.1\r\n",
+        "HOST: 239.255.255.250:1900\r\n",
+        "MAN: \"ssdp:discover\"\r\n",
+        "MX: 2\r\n",
+        "ST: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n",
+        "\r\n"
+    );
+    sock.send_to(request.as_bytes(), "239.255.255.250:1900")
+        .await
+        .ok()?;
+
+    let mut buf = [0u8; 2048];
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
+        let (len, _) = tokio::time::timeout(remaining, sock.recv_from(&mut buf))
+            .await
+            .ok()?
+            .ok()?;
+        let response = std::str::from_utf8(&buf[..len]).ok()?;
+        if let Some(location) = http_header_value(response, "location") {
+            return Some(location);
+        }
+    }
+}
+
+fn http_header_value(response: &str, name: &str) -> Option<String> {
+    response.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        key.trim()
+            .eq_ignore_ascii_case(name)
+            .then(|| value.trim().to_string())
+    })
+}
+
+fn upnp_wan_control_url(location: &str, description: &str) -> Option<String> {
+    let block = upnp_wan_service_block(description)?;
+    let control_url = xml_tag_text(block, "controlURL")?;
+    let base = url::Url::parse(location).ok()?;
+    base.join(&control_url).ok().map(|url| url.to_string())
+}
+
+fn upnp_wan_service_type(description: &str) -> Option<String> {
+    let block = upnp_wan_service_block(description)?;
+    xml_tag_text(block, "serviceType")
+}
+
+fn upnp_wan_service_block(description: &str) -> Option<&str> {
+    description.split("</service>").find(|block| {
+        block.contains("urn:schemas-upnp-org:service:WANIPConnection:")
+            || block.contains("urn:schemas-upnp-org:service:WANPPPConnection:")
+    })
+}
+
+fn xml_tag_text(xml: &str, tag: &str) -> Option<String> {
+    let start_tag = format!("<{tag}>");
+    let end_tag = format!("</{tag}>");
+    let start = xml.find(&start_tag)? + start_tag.len();
+    let end = xml[start..].find(&end_tag)? + start;
+    Some(xml[start..end].trim().to_string())
+}
+
+pub(super) async fn warn_if_cgnat_likely(bind_port: Option<u16>, public_addr: Option<SocketAddr>) {
+    let Some(bind_port) = bind_port else {
+        return;
+    };
+    let Some(SocketAddr::V4(public_addr)) = public_addr else {
+        return;
+    };
+    let public_ip = *public_addr.ip();
+    if !is_public_ipv4_addr(public_ip) {
+        return;
+    }
+    let Some(router_wan_ip) = upnp_router_wan_ipv4().await else {
+        return;
+    };
+    if router_wan_ip == public_ip || is_public_ipv4_addr(router_wan_ip) {
+        return;
+    }
+
+    let nat_kind = if is_cgnat_ipv4_addr(router_wan_ip) {
+        "CGNAT"
+    } else {
+        "private/double NAT"
+    };
+    emit_warning(format!(
+        "Direct UDP port forwarding may not work on --bind-port {bind_port}: router WAN appears to be {nat_kind} while STUN sees a different public IPv4. Router port forwards only cover the local router; ask the ISP to opt out of CGNAT/provide a public IPv4, bridge the upstream router, or use relay/tunnel mode."
+    ));
+}
+
+fn emit_warning(message: String) {
+    let _ = crate::cli::output::emit_event(crate::cli::output::OutputEvent::Warning {
+        message,
+        context: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_ipv4_classification_excludes_cgnat_and_private_ranges() {
+        assert!(is_public_ipv4_addr("8.8.8.8".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("100.64.0.1".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("100.127.255.254".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("10.0.0.1".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("172.16.0.1".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("192.168.1.1".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("169.254.1.1".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("127.0.0.1".parse().unwrap()));
+        assert!(!is_public_ipv4_addr("192.0.2.10".parse().unwrap()));
+    }
+
+    #[test]
+    fn upnp_wan_helpers_extract_wan_service_endpoint() {
+        let description = r#"
+            <root>
+              <device>
+                <serviceList>
+                  <service>
+                    <serviceType>urn:schemas-upnp-org:service:Layer3Forwarding:1</serviceType>
+                    <controlURL>/ctl/L3F</controlURL>
+                  </service>
+                  <service>
+                    <serviceType>urn:schemas-upnp-org:service:WANIPConnection:2</serviceType>
+                    <controlURL>/ctl/IPConn</controlURL>
+                  </service>
+                </serviceList>
+              </device>
+            </root>
+        "#;
+
+        assert_eq!(
+            upnp_wan_service_type(description).as_deref(),
+            Some("urn:schemas-upnp-org:service:WANIPConnection:2")
+        );
+        assert_eq!(
+            upnp_wan_control_url("http://192.168.1.1:5000/rootDesc.xml", description).as_deref(),
+            Some("http://192.168.1.1:5000/ctl/IPConn")
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
@@ -3,9 +3,8 @@ use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
 /// Return the first public IPv4 candidate iroh already discovered.
 ///
-/// iroh relays provide address discovery, so prefer their endpoint candidates
-/// before falling back to external STUN. When a fixed bind port is supplied,
-/// pair the discovered public IP with that port for user-managed forwarding.
+/// iroh relays provide address discovery. When a fixed bind port is supplied,
+/// pair the iroh-discovered public IP with that port for user-managed forwarding.
 pub(super) fn iroh_public_addr(addr: &EndpointAddr, advertised_port: u16) -> Option<SocketAddr> {
     addr.addrs
         .iter()
@@ -18,97 +17,6 @@ pub(super) fn iroh_public_addr(addr: &EndpointAddr, advertised_port: u16) -> Opt
             },
             _ => None,
         })
-}
-
-/// Discover our public IP via external STUN only when iroh did not provide it.
-///
-/// We can't send STUN from the bound port (iroh owns it), but we only need
-/// the public IP; the port is known from --bind-port plus router forwarding.
-pub(super) async fn fallback_stun_public_addr(advertised_port: u16) -> Option<SocketAddr> {
-    let stun_servers = [
-        "stun.l.google.com:19302",
-        "stun.cloudflare.com:3478",
-        "stun.stunprotocol.org:3478",
-    ];
-
-    // Bind to an ephemeral port; we only care about the IP, not the mapped port.
-    let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.ok()?;
-
-    for server in &stun_servers {
-        // STUN Binding Request: type=0x0001, len=0, magic=0x2112A442, txn=random.
-        let mut req = [0u8; 20];
-        req[0] = 0x00;
-        req[1] = 0x01;
-        req[4] = 0x21;
-        req[5] = 0x12;
-        req[6] = 0xA4;
-        req[7] = 0x42;
-        rand::fill(&mut req[8..20]);
-
-        let addrs = match tokio::net::lookup_host(server).await {
-            Ok(addrs) => addrs,
-            Err(_) => continue,
-        };
-
-        for dest in addrs.filter(SocketAddr::is_ipv4) {
-            if sock.send_to(&req, dest).await.is_err() {
-                continue;
-            }
-
-            let mut buf = [0u8; 256];
-            let len = match tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                sock.recv_from(&mut buf),
-            )
-            .await
-            {
-                Ok(Ok((len, _))) if len >= 20 => len,
-                _ => continue,
-            };
-
-            if let Some(addr) = parse_stun_mapped_ipv4(&req, &buf[..len], advertised_port) {
-                tracing::info!("STUN discovered public address: {addr}");
-                return Some(addr);
-            }
-        }
-    }
-
-    tracing::warn!("STUN: could not discover public address");
-    None
-}
-
-fn parse_stun_mapped_ipv4(
-    request: &[u8; 20],
-    response: &[u8],
-    advertised_port: u16,
-) -> Option<SocketAddr> {
-    let magic = &request[4..8];
-    let mut i = 20;
-    while i + 4 <= response.len() {
-        let attr_type = u16::from_be_bytes([response[i], response[i + 1]]);
-        let attr_len = u16::from_be_bytes([response[i + 2], response[i + 3]]) as usize;
-        if i + 4 + attr_len > response.len() {
-            break;
-        }
-        let val = &response[i + 4..i + 4 + attr_len];
-
-        if attr_type == 0x0020 && attr_len >= 8 && val[1] == 0x01 {
-            let ip = Ipv4Addr::new(
-                val[4] ^ magic[0],
-                val[5] ^ magic[1],
-                val[6] ^ magic[2],
-                val[7] ^ magic[3],
-            );
-            return Some(SocketAddr::V4(SocketAddrV4::new(ip, advertised_port)));
-        }
-        if attr_type == 0x0001 && attr_len >= 8 && val[1] == 0x01 {
-            let ip = Ipv4Addr::new(val[4], val[5], val[6], val[7]);
-            return Some(SocketAddr::V4(SocketAddrV4::new(ip, advertised_port)));
-        }
-
-        i += (4 + (attr_len + 3)) & !3;
-    }
-    None
 }
 
 pub(super) fn is_cgnat_ipv4_addr(addr: Ipv4Addr) -> bool {
@@ -257,7 +165,7 @@ pub(super) async fn warn_if_cgnat_likely(bind_port: Option<u16>, public_addr: Op
         "private/double NAT"
     };
     emit_warning(format!(
-        "Direct UDP port forwarding may not work on --bind-port {bind_port}: router WAN appears to be {nat_kind} while STUN sees a different public IPv4. Router port forwards only cover the local router; ask the ISP to opt out of CGNAT/provide a public IPv4, bridge the upstream router, or use relay/tunnel mode."
+        "Direct UDP port forwarding may not work on --bind-port {bind_port}: router WAN appears to be {nat_kind} while iroh discovered a different public IPv4. Router port forwards only cover the local router; ask the ISP to opt out of CGNAT/provide a public IPv4, bridge the upstream router, or use relay/tunnel mode."
     ));
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use iroh::{Endpoint, EndpointAddr, TransportAddr};
 use serde::Serialize;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
@@ -19,6 +20,56 @@ pub(crate) struct IrohPortmapperStatus {
     pub(crate) mapping_attempts: u64,
     pub(crate) external_address_updates: u64,
     pub(crate) has_reported_external_address: bool,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct NetworkDoctorReport {
+    pub(crate) bind_port: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) iroh_public_ipv4: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) router_wan_ipv4: Option<String>,
+    pub(crate) router_wan_type: RouterWanType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) invite_public_candidate: Option<String>,
+    pub(crate) upnp_igd: UpnpIgdReport,
+    pub(crate) direct_udp: DirectUdpReport,
+    pub(crate) iroh: DirectConnectivityStatus,
+    pub(crate) recommendation: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RouterWanType {
+    PublicIpv4,
+    Cgnat,
+    PrivateUpstreamNat,
+    Unavailable,
+}
+
+impl RouterWanType {
+    const fn label(self) -> &'static str {
+        match self {
+            Self::PublicIpv4 => "public IPv4",
+            Self::Cgnat => "CGNAT",
+            Self::PrivateUpstreamNat => "private upstream NAT",
+            Self::Unavailable => "unavailable",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct UpnpIgdReport {
+    pub(crate) discovered: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) wan_matches_iroh: Option<bool>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct DirectUdpReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) expected_reachable: Option<bool>,
+    pub(crate) reason: String,
 }
 
 /// Return the first public IPv4 candidate iroh already discovered.
@@ -75,6 +126,260 @@ pub(crate) fn iroh_status(
             external_address_updates,
             has_reported_external_address: external_address_updates > 0,
         },
+    }
+}
+
+pub(crate) async fn network_doctor(
+    bind_port: Option<u16>,
+    relay_urls: &[String],
+) -> anyhow::Result<NetworkDoctorReport> {
+    let endpoint = bind_doctor_endpoint(bind_port, relay_urls).await?;
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), endpoint.online()).await;
+
+    let invite_public_candidate = wait_for_invite_public_candidate(&endpoint, bind_port).await;
+    let iroh = iroh_status(&endpoint, invite_public_candidate);
+    let router_wan_ip = upnp_router_wan_ipv4().await;
+    let report = build_network_doctor_report(bind_port, router_wan_ip, iroh);
+    endpoint.close().await;
+    Ok(report)
+}
+
+async fn bind_doctor_endpoint(
+    bind_port: Option<u16>,
+    relay_urls: &[String],
+) -> anyhow::Result<Endpoint> {
+    use iroh::endpoint::QuicTransportConfig;
+    let transport_config = QuicTransportConfig::builder()
+        .max_concurrent_bidi_streams(1024u32.into())
+        .build();
+    let mut builder = Endpoint::builder(iroh::endpoint::presets::Minimal)
+        .secret_key(iroh::SecretKey::generate())
+        .transport_config(transport_config);
+
+    {
+        use iroh::{RelayConfig, RelayMap};
+        let urls: Vec<String> = if relay_urls.is_empty() {
+            vec![
+                "https://usw1-2.relay.michaelneale.mesh-llm.iroh.link./".into(),
+                "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
+            ]
+        } else {
+            relay_urls.to_vec()
+        };
+        let configs: Vec<RelayConfig> = urls
+            .iter()
+            .map(|url| {
+                let relay_url = url
+                    .parse()
+                    .with_context(|| format!("invalid relay URL: {url}"))?;
+                Ok(RelayConfig::new(relay_url, None))
+            })
+            .collect::<anyhow::Result<_>>()?;
+        builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(RelayMap::from_iter(
+            configs,
+        )));
+    }
+
+    if let Some(port) = bind_port {
+        builder = builder.bind_addr(SocketAddr::from(([0, 0, 0, 0], port)))?;
+    }
+
+    Ok(builder.bind().await?)
+}
+
+async fn wait_for_invite_public_candidate(
+    endpoint: &Endpoint,
+    bind_port: Option<u16>,
+) -> Option<SocketAddr> {
+    let started = std::time::Instant::now();
+    loop {
+        let addr = endpoint.addr();
+        let advertised_port = bind_port.unwrap_or(0);
+        let candidate = if bind_port.is_some() {
+            iroh_public_addr(&addr, advertised_port)
+        } else {
+            first_iroh_public_addr(&addr)
+        };
+        if candidate.is_some() || started.elapsed() >= std::time::Duration::from_secs(5) {
+            return candidate;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+    }
+}
+
+fn first_iroh_public_addr(addr: &EndpointAddr) -> Option<SocketAddr> {
+    addr.addrs
+        .iter()
+        .find_map(|transport_addr| match transport_addr {
+            TransportAddr::Ip(sock) => match sock.ip() {
+                std::net::IpAddr::V4(v4) if is_public_ipv4_addr(v4) => Some(*sock),
+                _ => None,
+            },
+            _ => None,
+        })
+}
+
+fn build_network_doctor_report(
+    bind_port: Option<u16>,
+    router_wan_ip: Option<Ipv4Addr>,
+    iroh: DirectConnectivityStatus,
+) -> NetworkDoctorReport {
+    let public_candidate = iroh
+        .invite_public_candidate
+        .as_deref()
+        .or(iroh.public_ipv4_candidate.as_deref())
+        .and_then(|addr| addr.parse::<SocketAddr>().ok());
+    let iroh_public_ipv4 = public_candidate.and_then(|addr| match addr {
+        SocketAddr::V4(addr) => Some(addr.ip().to_string()),
+        SocketAddr::V6(_) => None,
+    });
+    let router_wan_type = router_wan_ip
+        .map(classify_router_wan)
+        .unwrap_or(RouterWanType::Unavailable);
+    let wan_matches_iroh = match (&iroh_public_ipv4, router_wan_ip) {
+        (Some(public_ip), Some(router_ip)) => Some(public_ip == &router_ip.to_string()),
+        _ => None,
+    };
+    let (expected_reachable, reason, recommendation) = direct_udp_assessment(
+        bind_port,
+        iroh_public_ipv4.as_deref(),
+        router_wan_type,
+        wan_matches_iroh,
+    );
+
+    NetworkDoctorReport {
+        bind_port,
+        iroh_public_ipv4,
+        router_wan_ipv4: router_wan_ip.map(|ip| ip.to_string()),
+        router_wan_type,
+        invite_public_candidate: iroh.invite_public_candidate.clone(),
+        upnp_igd: UpnpIgdReport {
+            discovered: router_wan_ip.is_some(),
+            wan_matches_iroh,
+        },
+        direct_udp: DirectUdpReport {
+            expected_reachable,
+            reason,
+        },
+        iroh,
+        recommendation,
+    }
+}
+
+fn classify_router_wan(addr: Ipv4Addr) -> RouterWanType {
+    if is_public_ipv4_addr(addr) {
+        RouterWanType::PublicIpv4
+    } else if is_cgnat_ipv4_addr(addr) {
+        RouterWanType::Cgnat
+    } else {
+        RouterWanType::PrivateUpstreamNat
+    }
+}
+
+fn direct_udp_assessment(
+    bind_port: Option<u16>,
+    iroh_public_ipv4: Option<&str>,
+    router_wan_type: RouterWanType,
+    wan_matches_iroh: Option<bool>,
+) -> (Option<bool>, String, String) {
+    if bind_port.is_none() {
+        return (
+            Some(false),
+            "missing_bind_port".into(),
+            "Run with --bind-port so the same UDP port can be forwarded and advertised.".into(),
+        );
+    }
+    if iroh_public_ipv4.is_none() {
+        return (
+            None,
+            "iroh_public_ipv4_unavailable".into(),
+            "Wait for iroh relay address discovery, then retry. Relay mode remains available."
+                .into(),
+        );
+    }
+    match (router_wan_type, wan_matches_iroh) {
+        (RouterWanType::Cgnat | RouterWanType::PrivateUpstreamNat, Some(false)) => (
+            Some(false),
+            "router_wan_differs_from_iroh_public_ipv4".into(),
+            "Ask the ISP to opt out of CGNAT/provide a public IPv4, bridge the upstream router, or use relay/tunnel mode.".into(),
+        ),
+        (RouterWanType::PublicIpv4, Some(true)) => (
+            Some(true),
+            "router_wan_matches_iroh_public_ipv4".into(),
+            "If the UDP bind port is forwarded to this host, direct mesh paths can be tested.".into(),
+        ),
+        (RouterWanType::PublicIpv4, Some(false)) => (
+            None,
+            "router_wan_differs_from_iroh_public_ipv4".into(),
+            "The router reports a public IPv4, but it differs from iroh's public candidate; verify router WAN state and upstream routing.".into(),
+        ),
+        (RouterWanType::Unavailable, None) => (
+            None,
+            "upnp_igd_unavailable".into(),
+            "UPnP/IGD did not report a router WAN address; verify the router manually or use relay/tunnel mode.".into(),
+        ),
+        _ => (
+            None,
+            "wan_match_unknown".into(),
+            "Could not prove direct UDP reachability from local diagnostics alone; use a second network to test the bind port.".into(),
+        ),
+    }
+}
+
+pub(crate) fn format_network_doctor(report: &NetworkDoctorReport) -> String {
+    let bind_port = report
+        .bind_port
+        .map(|port| port.to_string())
+        .unwrap_or_else(|| "none".into());
+    let iroh_public = report.iroh_public_ipv4.as_deref().unwrap_or("unavailable");
+    let router_wan = report.router_wan_ipv4.as_deref().unwrap_or("unavailable");
+    let invite = report
+        .invite_public_candidate
+        .as_deref()
+        .unwrap_or("unavailable");
+    let upnp = if report.upnp_igd.discovered {
+        "discovered router"
+    } else {
+        "not discovered"
+    };
+    let wan_match = match report.upnp_igd.wan_matches_iroh {
+        Some(true) => "router WAN matches iroh public candidate",
+        Some(false) => "router WAN differs from iroh public candidate",
+        None => "unknown",
+    };
+    let result = match report.direct_udp.expected_reachable {
+        Some(true) => "✅ Result: router WAN matches public IPv4. If UDP is forwarded to this host, direct mesh paths can be tested.",
+        Some(false) => "❌ Result: direct inbound UDP is unlikely to work from the public internet.",
+        None => "⚠️ Result: direct inbound UDP reachability is unknown from local diagnostics alone.",
+    };
+
+    format!(
+        "🩺 Direct UDP readiness\n  bind port:               {bind_port}\n  🌍 iroh public IPv4:     {iroh_public}\n  🛜 router WAN IPv4:      {router_wan}\n  {} router WAN type:      {}\n  📣 invite candidate:     {invite}\n  {} UPnP/IGD:             {upnp}\n  {} WAN/public match:     {wan_match}\n  🧭 iroh candidates:      {}\n  🗺️ iroh portmapper:      attempts={}, external_updates={}\n\n{result}\nReason: {}\nFix: {}",
+        router_wan_icon(report.router_wan_type),
+        report.router_wan_type.label(),
+        if report.upnp_igd.discovered { "✅" } else { "⚠️" },
+        wan_match_icon(report.upnp_igd.wan_matches_iroh),
+        report.iroh.direct_candidate_count,
+        report.iroh.iroh_portmapper.mapping_attempts,
+        report.iroh.iroh_portmapper.external_address_updates,
+        report.direct_udp.reason,
+        report.recommendation
+    )
+}
+
+fn router_wan_icon(wan_type: RouterWanType) -> &'static str {
+    match wan_type {
+        RouterWanType::PublicIpv4 => "✅",
+        RouterWanType::Cgnat | RouterWanType::PrivateUpstreamNat => "⚠️",
+        RouterWanType::Unavailable => "⚠️",
+    }
+}
+
+fn wan_match_icon(wan_matches_iroh: Option<bool>) -> &'static str {
+    match wan_matches_iroh {
+        Some(true) => "✅",
+        Some(false) => "❌",
+        None => "⚠️",
     }
 }
 
@@ -314,6 +619,44 @@ mod tests {
         assert_eq!(
             iroh_public_addr(&addr, 53238),
             Some("8.8.8.8:53238".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn network_doctor_flags_cgnat_mismatch() {
+        let iroh = DirectConnectivityStatus {
+            public_ipv4_candidate: Some("8.8.8.8:53238".into()),
+            invite_public_candidate: Some("8.8.8.8:53238".into()),
+            ..Default::default()
+        };
+        let report =
+            build_network_doctor_report(Some(53238), Some("100.72.12.34".parse().unwrap()), iroh);
+
+        assert_eq!(report.router_wan_type, RouterWanType::Cgnat);
+        assert_eq!(report.upnp_igd.wan_matches_iroh, Some(false));
+        assert_eq!(report.direct_udp.expected_reachable, Some(false));
+        assert_eq!(
+            report.direct_udp.reason,
+            "router_wan_differs_from_iroh_public_ipv4"
+        );
+    }
+
+    #[test]
+    fn network_doctor_accepts_matching_public_wan() {
+        let iroh = DirectConnectivityStatus {
+            public_ipv4_candidate: Some("8.8.8.8:53238".into()),
+            invite_public_candidate: Some("8.8.8.8:53238".into()),
+            ..Default::default()
+        };
+        let report =
+            build_network_doctor_report(Some(53238), Some("8.8.8.8".parse().unwrap()), iroh);
+
+        assert_eq!(report.router_wan_type, RouterWanType::PublicIpv4);
+        assert_eq!(report.upnp_igd.wan_matches_iroh, Some(true));
+        assert_eq!(report.direct_udp.expected_reachable, Some(true));
+        assert_eq!(
+            report.direct_udp.reason,
+            "router_wan_matches_iroh_public_ipv4"
         );
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
@@ -1,9 +1,30 @@
+use iroh::{EndpointAddr, TransportAddr};
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
 
-/// Discover our public IP via STUN, then pair it with the given port.
+/// Return the first public IPv4 candidate iroh already discovered.
+///
+/// iroh relays provide address discovery, so prefer their endpoint candidates
+/// before falling back to external STUN. When a fixed bind port is supplied,
+/// pair the discovered public IP with that port for user-managed forwarding.
+pub(super) fn iroh_public_addr(addr: &EndpointAddr, advertised_port: u16) -> Option<SocketAddr> {
+    addr.addrs
+        .iter()
+        .find_map(|transport_addr| match transport_addr {
+            TransportAddr::Ip(sock) => match sock.ip() {
+                std::net::IpAddr::V4(v4) if is_public_ipv4_addr(v4) => {
+                    Some(SocketAddr::V4(SocketAddrV4::new(v4, advertised_port)))
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+}
+
+/// Discover our public IP via external STUN only when iroh did not provide it.
+///
 /// We can't send STUN from the bound port (iroh owns it), but we only need
 /// the public IP; the port is known from --bind-port plus router forwarding.
-pub(super) async fn stun_public_addr(advertised_port: u16) -> Option<SocketAddr> {
+pub(super) async fn fallback_stun_public_addr(advertised_port: u16) -> Option<SocketAddr> {
     let stun_servers = [
         "stun.l.google.com:19302",
         "stun.cloudflare.com:3478",
@@ -290,6 +311,24 @@ mod tests {
         assert_eq!(
             upnp_wan_control_url("http://192.168.1.1:5000/rootDesc.xml", description).as_deref(),
             Some("http://192.168.1.1:5000/ctl/IPConn")
+        );
+    }
+
+    #[test]
+    fn iroh_public_addr_prefers_endpoint_candidates() {
+        let mut addrs = std::collections::BTreeSet::new();
+        addrs.insert(TransportAddr::Ip("100.72.12.34:9999".parse().unwrap()));
+        addrs.insert(TransportAddr::Ip("198.51.100.10:9999".parse().unwrap()));
+        addrs.insert(TransportAddr::Ip("203.0.113.10:9999".parse().unwrap()));
+        addrs.insert(TransportAddr::Ip("8.8.8.8:9999".parse().unwrap()));
+        let addr = EndpointAddr {
+            id: iroh::SecretKey::generate().public(),
+            addrs,
+        };
+
+        assert_eq!(
+            iroh_public_addr(&addr, 53238),
+            Some("8.8.8.8:53238".parse().unwrap())
         );
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_connectivity.rs
@@ -1,5 +1,25 @@
-use iroh::{EndpointAddr, TransportAddr};
+use iroh::{Endpoint, EndpointAddr, TransportAddr};
+use serde::Serialize;
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct DirectConnectivityStatus {
+    pub(crate) direct_candidates: Vec<String>,
+    pub(crate) direct_candidate_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) public_ipv4_candidate: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) invite_public_candidate: Option<String>,
+    pub(crate) iroh_portmapper: IrohPortmapperStatus,
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+pub(crate) struct IrohPortmapperStatus {
+    pub(crate) enabled: bool,
+    pub(crate) mapping_attempts: u64,
+    pub(crate) external_address_updates: u64,
+    pub(crate) has_reported_external_address: bool,
+}
 
 /// Return the first public IPv4 candidate iroh already discovered.
 ///
@@ -17,6 +37,63 @@ pub(super) fn iroh_public_addr(addr: &EndpointAddr, advertised_port: u16) -> Opt
             },
             _ => None,
         })
+}
+
+pub(crate) fn iroh_status(
+    endpoint: &Endpoint,
+    invite_public_candidate: Option<SocketAddr>,
+) -> DirectConnectivityStatus {
+    let endpoint_addr = endpoint.addr();
+    let direct_candidates: Vec<SocketAddr> = endpoint_addr
+        .addrs
+        .iter()
+        .filter_map(|addr| match addr {
+            TransportAddr::Ip(sock) => Some(*sock),
+            TransportAddr::Relay(_) => None,
+            _ => None,
+        })
+        .collect();
+    let public_ipv4_candidate = direct_candidates.iter().find_map(|sock| match sock.ip() {
+        std::net::IpAddr::V4(v4) if is_public_ipv4_addr(v4) => Some(sock.to_string()),
+        _ => None,
+    });
+    let metrics = endpoint.metrics();
+    let mapping_attempts = metrics.net_report.portmap_attempts.get();
+    let external_address_updates = metrics.net_report.portmap_external_address_updated.get();
+
+    DirectConnectivityStatus {
+        direct_candidate_count: direct_candidates.len(),
+        direct_candidates: direct_candidates
+            .into_iter()
+            .map(|addr| addr.to_string())
+            .collect(),
+        public_ipv4_candidate,
+        invite_public_candidate: invite_public_candidate.map(|addr| addr.to_string()),
+        iroh_portmapper: IrohPortmapperStatus {
+            enabled: true,
+            mapping_attempts,
+            external_address_updates,
+            has_reported_external_address: external_address_updates > 0,
+        },
+    }
+}
+
+pub(super) fn emit_iroh_status(endpoint: &Endpoint, invite_public_candidate: Option<SocketAddr>) {
+    let status = iroh_status(endpoint, invite_public_candidate);
+    let candidate = status
+        .invite_public_candidate
+        .as_deref()
+        .or(status.public_ipv4_candidate.as_deref())
+        .unwrap_or("none");
+    let _ = crate::cli::output::emit_event(crate::cli::output::OutputEvent::Info {
+        message: format!(
+            "iroh direct connectivity: {} direct candidate(s), public candidate {candidate}, portmapper enabled (attempts={}, external_updates={})",
+            status.direct_candidate_count,
+            status.iroh_portmapper.mapping_attempts,
+            status.iroh_portmapper.external_address_updates
+        ),
+        context: None,
+    });
 }
 
 pub(super) fn is_cgnat_ipv4_addr(addr: Ipv4Addr) -> bool {

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -1117,66 +1117,220 @@ async fn stun_public_addr(advertised_port: u16) -> Option<std::net::SocketAddr> 
         req[7] = 0x42; // Magic Cookie
         rand::fill(&mut req[8..20]);
 
-        let dest: SocketAddr = match tokio::net::lookup_host(server).await {
-            Ok(mut addrs) => match addrs.next() {
-                Some(a) => a,
-                None => continue,
-            },
+        let addrs = match tokio::net::lookup_host(server).await {
+            Ok(addrs) => addrs,
             Err(_) => continue,
         };
 
-        if sock.send_to(&req, dest).await.is_err() {
-            continue;
-        }
-
-        let mut buf = [0u8; 256];
-        match tokio::time::timeout(std::time::Duration::from_secs(2), sock.recv_from(&mut buf))
-            .await
-        {
-            Ok(Ok((len, _))) if len >= 20 => {
-                // Parse STUN response for XOR-MAPPED-ADDRESS (0x0020)
-                // or MAPPED-ADDRESS (0x0001)
-                let magic = &req[4..8];
-                let _txn = &req[8..20];
-                let mut i = 20;
-                while i + 4 <= len {
-                    let attr_type = u16::from_be_bytes([buf[i], buf[i + 1]]);
-                    let attr_len = u16::from_be_bytes([buf[i + 2], buf[i + 3]]) as usize;
-                    if i + 4 + attr_len > len {
-                        break;
-                    }
-                    let val = &buf[i + 4..i + 4 + attr_len];
-
-                    if attr_type == 0x0020 && attr_len >= 8 && val[1] == 0x01 {
-                        // XOR-MAPPED-ADDRESS, IPv4 — extract IP only
-                        let ip = Ipv4Addr::new(
-                            val[4] ^ magic[0],
-                            val[5] ^ magic[1],
-                            val[6] ^ magic[2],
-                            val[7] ^ magic[3],
-                        );
-                        let addr = SocketAddr::V4(SocketAddrV4::new(ip, advertised_port));
-                        tracing::info!("STUN discovered public address: {addr}");
-                        return Some(addr);
-                    }
-                    if attr_type == 0x0001 && attr_len >= 8 && val[1] == 0x01 {
-                        // MAPPED-ADDRESS, IPv4 — extract IP only
-                        let ip = Ipv4Addr::new(val[4], val[5], val[6], val[7]);
-                        let addr = SocketAddr::V4(SocketAddrV4::new(ip, advertised_port));
-                        tracing::info!("STUN discovered public address: {addr}");
-                        return Some(addr);
-                    }
-
-                    // Attributes are padded to 4-byte boundary
-                    i += (4 + (attr_len + 3)) & !3;
-                }
+        for dest in addrs.filter(SocketAddr::is_ipv4) {
+            if sock.send_to(&req, dest).await.is_err() {
+                continue;
             }
-            _ => continue,
+
+            let mut buf = [0u8; 256];
+            let len = match tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                sock.recv_from(&mut buf),
+            )
+            .await
+            {
+                Ok(Ok((len, _))) if len >= 20 => len,
+                _ => continue,
+            };
+
+            // Parse STUN response for XOR-MAPPED-ADDRESS (0x0020)
+            // or MAPPED-ADDRESS (0x0001)
+            let magic = &req[4..8];
+            let _txn = &req[8..20];
+            let mut i = 20;
+            while i + 4 <= len {
+                let attr_type = u16::from_be_bytes([buf[i], buf[i + 1]]);
+                let attr_len = u16::from_be_bytes([buf[i + 2], buf[i + 3]]) as usize;
+                if i + 4 + attr_len > len {
+                    break;
+                }
+                let val = &buf[i + 4..i + 4 + attr_len];
+
+                if attr_type == 0x0020 && attr_len >= 8 && val[1] == 0x01 {
+                    // XOR-MAPPED-ADDRESS, IPv4 — extract IP only
+                    let ip = Ipv4Addr::new(
+                        val[4] ^ magic[0],
+                        val[5] ^ magic[1],
+                        val[6] ^ magic[2],
+                        val[7] ^ magic[3],
+                    );
+                    let addr = SocketAddr::V4(SocketAddrV4::new(ip, advertised_port));
+                    tracing::info!("STUN discovered public address: {addr}");
+                    return Some(addr);
+                }
+                if attr_type == 0x0001 && attr_len >= 8 && val[1] == 0x01 {
+                    // MAPPED-ADDRESS, IPv4 — extract IP only
+                    let ip = Ipv4Addr::new(val[4], val[5], val[6], val[7]);
+                    let addr = SocketAddr::V4(SocketAddrV4::new(ip, advertised_port));
+                    tracing::info!("STUN discovered public address: {addr}");
+                    return Some(addr);
+                }
+
+                // Attributes are padded to 4-byte boundary
+                i += (4 + (attr_len + 3)) & !3;
+            }
         }
     }
 
     tracing::warn!("STUN: could not discover public address");
     None
+}
+
+fn is_cgnat_ipv4_addr(addr: std::net::Ipv4Addr) -> bool {
+    let octets = addr.octets();
+    octets[0] == 100 && (64..=127).contains(&octets[1])
+}
+
+fn is_public_ipv4_addr(addr: std::net::Ipv4Addr) -> bool {
+    !addr.is_private()
+        && !addr.is_loopback()
+        && !addr.is_link_local()
+        && !addr.is_multicast()
+        && !addr.is_broadcast()
+        && !addr.is_documentation()
+        && !addr.is_unspecified()
+        && !is_cgnat_ipv4_addr(addr)
+}
+
+async fn upnp_router_wan_ipv4() -> Option<std::net::Ipv4Addr> {
+    let location = upnp_igd_location().await?;
+    let description = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .ok()?
+        .get(location.clone())
+        .send()
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+    let control_url = upnp_wan_control_url(&location, &description)?;
+    let service_type = upnp_wan_service_type(&description)?;
+    let body = format!(
+        r#"<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+<s:Body><u:GetExternalIPAddress xmlns:u="{service_type}"></u:GetExternalIPAddress></s:Body>
+</s:Envelope>"#
+    );
+    let response = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .ok()?
+        .post(control_url)
+        .header("content-type", r#"text/xml; charset="utf-8""#)
+        .header(
+            "soapaction",
+            format!(r#""{service_type}#GetExternalIPAddress""#),
+        )
+        .body(body)
+        .send()
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+    xml_tag_text(&response, "NewExternalIPAddress")?
+        .parse()
+        .ok()
+}
+
+async fn upnp_igd_location() -> Option<String> {
+    let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.ok()?;
+    let request = concat!(
+        "M-SEARCH * HTTP/1.1\r\n",
+        "HOST: 239.255.255.250:1900\r\n",
+        "MAN: \"ssdp:discover\"\r\n",
+        "MX: 2\r\n",
+        "ST: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n",
+        "\r\n"
+    );
+    sock.send_to(request.as_bytes(), "239.255.255.250:1900")
+        .await
+        .ok()?;
+
+    let mut buf = [0u8; 2048];
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    loop {
+        let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
+        let (len, _) = tokio::time::timeout(remaining, sock.recv_from(&mut buf))
+            .await
+            .ok()?
+            .ok()?;
+        let response = std::str::from_utf8(&buf[..len]).ok()?;
+        if let Some(location) = http_header_value(response, "location") {
+            return Some(location);
+        }
+    }
+}
+
+fn http_header_value(response: &str, name: &str) -> Option<String> {
+    response.lines().find_map(|line| {
+        let (key, value) = line.split_once(':')?;
+        key.trim()
+            .eq_ignore_ascii_case(name)
+            .then(|| value.trim().to_string())
+    })
+}
+
+fn upnp_wan_control_url(location: &str, description: &str) -> Option<String> {
+    let block = upnp_wan_service_block(description)?;
+    let control_url = xml_tag_text(block, "controlURL")?;
+    let base = url::Url::parse(location).ok()?;
+    base.join(&control_url).ok().map(|url| url.to_string())
+}
+
+fn upnp_wan_service_type(description: &str) -> Option<String> {
+    let block = upnp_wan_service_block(description)?;
+    xml_tag_text(block, "serviceType")
+}
+
+fn upnp_wan_service_block(description: &str) -> Option<&str> {
+    description.split("</service>").find(|block| {
+        block.contains("urn:schemas-upnp-org:service:WANIPConnection:")
+            || block.contains("urn:schemas-upnp-org:service:WANPPPConnection:")
+    })
+}
+
+fn xml_tag_text(xml: &str, tag: &str) -> Option<String> {
+    let start_tag = format!("<{tag}>");
+    let end_tag = format!("</{tag}>");
+    let start = xml.find(&start_tag)? + start_tag.len();
+    let end = xml[start..].find(&end_tag)? + start;
+    Some(xml[start..end].trim().to_string())
+}
+
+async fn warn_if_cgnat_likely(bind_port: Option<u16>, public_addr: Option<std::net::SocketAddr>) {
+    let Some(bind_port) = bind_port else {
+        return;
+    };
+    let Some(std::net::SocketAddr::V4(public_addr)) = public_addr else {
+        return;
+    };
+    let public_ip = *public_addr.ip();
+    if !is_public_ipv4_addr(public_ip) {
+        return;
+    }
+    let Some(router_wan_ip) = upnp_router_wan_ipv4().await else {
+        return;
+    };
+    if router_wan_ip == public_ip || is_public_ipv4_addr(router_wan_ip) {
+        return;
+    }
+
+    let nat_kind = if is_cgnat_ipv4_addr(router_wan_ip) {
+        "CGNAT"
+    } else {
+        "private/double NAT"
+    };
+    emit_mesh_warning(format!(
+        "Direct UDP port forwarding may not work on --bind-port {bind_port}: router WAN appears to be {nat_kind} while STUN sees a different public IPv4. Router port forwards only cover the local router; ask the ISP to opt out of CGNAT/provide a public IPv4, bridge the upstream router, or use relay/tunnel mode."
+    ));
 }
 
 #[derive(Clone)]
@@ -2241,6 +2395,7 @@ impl Node {
         // Relay STUN may not work on sinkholed networks, so we use raw STUN to Google/Cloudflare.
         let stun_port = bind_port.unwrap_or(0);
         let public_addr = stun_public_addr(stun_port).await;
+        warn_if_cgnat_likely(bind_port, public_addr).await;
 
         let (peer_change_tx, peer_change_rx) = watch::channel(0usize);
         let (inflight_change_tx, _inflight_change_rx) = watch::channel(0u64);
@@ -2545,7 +2700,7 @@ impl Node {
             use iroh::TransportAddr;
             let has_public = addr.addrs.iter().any(|a| match a {
                 TransportAddr::Ip(sock) => match sock.ip() {
-                    std::net::IpAddr::V4(v4) => !v4.is_private() && !v4.is_loopback(),
+                    std::net::IpAddr::V4(v4) => is_public_ipv4_addr(v4),
                     _ => false,
                 },
                 _ => false,

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -11,6 +11,8 @@ pub use mesh_llm_types::mesh::{
     ModelSourceKind, ServedModelDescriptor, ServedModelIdentity, DEMAND_TTL_SECS, MAX_SPLIT_RTT_MS,
 };
 
+mod direct_connectivity;
+
 use anyhow::{Context, Result};
 use base64::Engine;
 use iroh::endpoint::Connection;
@@ -1090,249 +1092,6 @@ pub struct RouteEntry {
     pub vram_gb: f64,
 }
 
-/// Discover our public IP via STUN, then pair it with the given port.
-/// We can't send STUN from the bound port (iroh owns it), but we only need
-/// the public IP — the port is known from --bind-port + router forwarding.
-async fn stun_public_addr(advertised_port: u16) -> Option<std::net::SocketAddr> {
-    use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-
-    let stun_servers = [
-        "stun.l.google.com:19302",
-        "stun.cloudflare.com:3478",
-        "stun.stunprotocol.org:3478",
-    ];
-
-    // Bind to ephemeral port — we only care about the IP, not the mapped port.
-    let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.ok()?;
-
-    for server in &stun_servers {
-        // STUN Binding Request: type=0x0001, len=0, magic=0x2112A442, txn=random
-        let mut req = [0u8; 20];
-        req[0] = 0x00;
-        req[1] = 0x01; // Binding Request
-                       // length = 0
-        req[4] = 0x21;
-        req[5] = 0x12;
-        req[6] = 0xA4;
-        req[7] = 0x42; // Magic Cookie
-        rand::fill(&mut req[8..20]);
-
-        let addrs = match tokio::net::lookup_host(server).await {
-            Ok(addrs) => addrs,
-            Err(_) => continue,
-        };
-
-        for dest in addrs.filter(SocketAddr::is_ipv4) {
-            if sock.send_to(&req, dest).await.is_err() {
-                continue;
-            }
-
-            let mut buf = [0u8; 256];
-            let len = match tokio::time::timeout(
-                std::time::Duration::from_secs(2),
-                sock.recv_from(&mut buf),
-            )
-            .await
-            {
-                Ok(Ok((len, _))) if len >= 20 => len,
-                _ => continue,
-            };
-
-            // Parse STUN response for XOR-MAPPED-ADDRESS (0x0020)
-            // or MAPPED-ADDRESS (0x0001)
-            let magic = &req[4..8];
-            let _txn = &req[8..20];
-            let mut i = 20;
-            while i + 4 <= len {
-                let attr_type = u16::from_be_bytes([buf[i], buf[i + 1]]);
-                let attr_len = u16::from_be_bytes([buf[i + 2], buf[i + 3]]) as usize;
-                if i + 4 + attr_len > len {
-                    break;
-                }
-                let val = &buf[i + 4..i + 4 + attr_len];
-
-                if attr_type == 0x0020 && attr_len >= 8 && val[1] == 0x01 {
-                    // XOR-MAPPED-ADDRESS, IPv4 — extract IP only
-                    let ip = Ipv4Addr::new(
-                        val[4] ^ magic[0],
-                        val[5] ^ magic[1],
-                        val[6] ^ magic[2],
-                        val[7] ^ magic[3],
-                    );
-                    let addr = SocketAddr::V4(SocketAddrV4::new(ip, advertised_port));
-                    tracing::info!("STUN discovered public address: {addr}");
-                    return Some(addr);
-                }
-                if attr_type == 0x0001 && attr_len >= 8 && val[1] == 0x01 {
-                    // MAPPED-ADDRESS, IPv4 — extract IP only
-                    let ip = Ipv4Addr::new(val[4], val[5], val[6], val[7]);
-                    let addr = SocketAddr::V4(SocketAddrV4::new(ip, advertised_port));
-                    tracing::info!("STUN discovered public address: {addr}");
-                    return Some(addr);
-                }
-
-                // Attributes are padded to 4-byte boundary
-                i += (4 + (attr_len + 3)) & !3;
-            }
-        }
-    }
-
-    tracing::warn!("STUN: could not discover public address");
-    None
-}
-
-fn is_cgnat_ipv4_addr(addr: std::net::Ipv4Addr) -> bool {
-    let octets = addr.octets();
-    octets[0] == 100 && (64..=127).contains(&octets[1])
-}
-
-fn is_public_ipv4_addr(addr: std::net::Ipv4Addr) -> bool {
-    !addr.is_private()
-        && !addr.is_loopback()
-        && !addr.is_link_local()
-        && !addr.is_multicast()
-        && !addr.is_broadcast()
-        && !addr.is_documentation()
-        && !addr.is_unspecified()
-        && !is_cgnat_ipv4_addr(addr)
-}
-
-async fn upnp_router_wan_ipv4() -> Option<std::net::Ipv4Addr> {
-    let location = upnp_igd_location().await?;
-    let description = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(3))
-        .build()
-        .ok()?
-        .get(location.clone())
-        .send()
-        .await
-        .ok()?
-        .text()
-        .await
-        .ok()?;
-    let control_url = upnp_wan_control_url(&location, &description)?;
-    let service_type = upnp_wan_service_type(&description)?;
-    let body = format!(
-        r#"<?xml version="1.0"?>
-<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
-<s:Body><u:GetExternalIPAddress xmlns:u="{service_type}"></u:GetExternalIPAddress></s:Body>
-</s:Envelope>"#
-    );
-    let response = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(3))
-        .build()
-        .ok()?
-        .post(control_url)
-        .header("content-type", r#"text/xml; charset="utf-8""#)
-        .header(
-            "soapaction",
-            format!(r#""{service_type}#GetExternalIPAddress""#),
-        )
-        .body(body)
-        .send()
-        .await
-        .ok()?
-        .text()
-        .await
-        .ok()?;
-    xml_tag_text(&response, "NewExternalIPAddress")?
-        .parse()
-        .ok()
-}
-
-async fn upnp_igd_location() -> Option<String> {
-    let sock = tokio::net::UdpSocket::bind("0.0.0.0:0").await.ok()?;
-    let request = concat!(
-        "M-SEARCH * HTTP/1.1\r\n",
-        "HOST: 239.255.255.250:1900\r\n",
-        "MAN: \"ssdp:discover\"\r\n",
-        "MX: 2\r\n",
-        "ST: urn:schemas-upnp-org:device:InternetGatewayDevice:1\r\n",
-        "\r\n"
-    );
-    sock.send_to(request.as_bytes(), "239.255.255.250:1900")
-        .await
-        .ok()?;
-
-    let mut buf = [0u8; 2048];
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-    loop {
-        let remaining = deadline.checked_duration_since(std::time::Instant::now())?;
-        let (len, _) = tokio::time::timeout(remaining, sock.recv_from(&mut buf))
-            .await
-            .ok()?
-            .ok()?;
-        let response = std::str::from_utf8(&buf[..len]).ok()?;
-        if let Some(location) = http_header_value(response, "location") {
-            return Some(location);
-        }
-    }
-}
-
-fn http_header_value(response: &str, name: &str) -> Option<String> {
-    response.lines().find_map(|line| {
-        let (key, value) = line.split_once(':')?;
-        key.trim()
-            .eq_ignore_ascii_case(name)
-            .then(|| value.trim().to_string())
-    })
-}
-
-fn upnp_wan_control_url(location: &str, description: &str) -> Option<String> {
-    let block = upnp_wan_service_block(description)?;
-    let control_url = xml_tag_text(block, "controlURL")?;
-    let base = url::Url::parse(location).ok()?;
-    base.join(&control_url).ok().map(|url| url.to_string())
-}
-
-fn upnp_wan_service_type(description: &str) -> Option<String> {
-    let block = upnp_wan_service_block(description)?;
-    xml_tag_text(block, "serviceType")
-}
-
-fn upnp_wan_service_block(description: &str) -> Option<&str> {
-    description.split("</service>").find(|block| {
-        block.contains("urn:schemas-upnp-org:service:WANIPConnection:")
-            || block.contains("urn:schemas-upnp-org:service:WANPPPConnection:")
-    })
-}
-
-fn xml_tag_text(xml: &str, tag: &str) -> Option<String> {
-    let start_tag = format!("<{tag}>");
-    let end_tag = format!("</{tag}>");
-    let start = xml.find(&start_tag)? + start_tag.len();
-    let end = xml[start..].find(&end_tag)? + start;
-    Some(xml[start..end].trim().to_string())
-}
-
-async fn warn_if_cgnat_likely(bind_port: Option<u16>, public_addr: Option<std::net::SocketAddr>) {
-    let Some(bind_port) = bind_port else {
-        return;
-    };
-    let Some(std::net::SocketAddr::V4(public_addr)) = public_addr else {
-        return;
-    };
-    let public_ip = *public_addr.ip();
-    if !is_public_ipv4_addr(public_ip) {
-        return;
-    }
-    let Some(router_wan_ip) = upnp_router_wan_ipv4().await else {
-        return;
-    };
-    if router_wan_ip == public_ip || is_public_ipv4_addr(router_wan_ip) {
-        return;
-    }
-
-    let nat_kind = if is_cgnat_ipv4_addr(router_wan_ip) {
-        "CGNAT"
-    } else {
-        "private/double NAT"
-    };
-    emit_mesh_warning(format!(
-        "Direct UDP port forwarding may not work on --bind-port {bind_port}: router WAN appears to be {nat_kind} while STUN sees a different public IPv4. Router port forwards only cover the local router; ask the ISP to opt out of CGNAT/provide a public IPv4, bridge the upstream router, or use relay/tunnel mode."
-    ));
-}
-
 #[derive(Clone)]
 pub struct Node {
     endpoint: Endpoint,
@@ -2394,8 +2153,8 @@ impl Node {
         // Without --bind-port, we use port 0 — the IP is still useful for hole-punching.
         // Relay STUN may not work on sinkholed networks, so we use raw STUN to Google/Cloudflare.
         let stun_port = bind_port.unwrap_or(0);
-        let public_addr = stun_public_addr(stun_port).await;
-        warn_if_cgnat_likely(bind_port, public_addr).await;
+        let public_addr = direct_connectivity::stun_public_addr(stun_port).await;
+        direct_connectivity::warn_if_cgnat_likely(bind_port, public_addr).await;
 
         let (peer_change_tx, peer_change_rx) = watch::channel(0usize);
         let (inflight_change_tx, _inflight_change_rx) = watch::channel(0u64);
@@ -2700,7 +2459,7 @@ impl Node {
             use iroh::TransportAddr;
             let has_public = addr.addrs.iter().any(|a| match a {
                 TransportAddr::Ip(sock) => match sock.ip() {
-                    std::net::IpAddr::V4(v4) => is_public_ipv4_addr(v4),
+                    std::net::IpAddr::V4(v4) => direct_connectivity::is_public_ipv4_addr(v4),
                     _ => false,
                 },
                 _ => false,

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -2148,16 +2148,10 @@ impl Node {
             }
         }
 
-        // Discover public IP via STUN so the invite token includes it.
-        // With --bind-port, the advertised port is the bound port (for port forwarding).
-        // Without --bind-port, we use port 0 — the IP is still useful for hole-punching.
-        // Prefer iroh's own relay-discovered candidates; fall back to raw STUN
-        // only when the endpoint has not learned a public IPv4.
-        let stun_port = bind_port.unwrap_or(0);
-        let public_addr = match direct_connectivity::iroh_public_addr(&endpoint.addr(), stun_port) {
-            Some(addr) => Some(addr),
-            None => direct_connectivity::fallback_stun_public_addr(stun_port).await,
-        };
+        // Use iroh's relay-discovered public candidate so invite tokens can
+        // include the fixed forwarding port when --bind-port is set.
+        let advertised_port = bind_port.unwrap_or(0);
+        let public_addr = direct_connectivity::iroh_public_addr(&endpoint.addr(), advertised_port);
         direct_connectivity::warn_if_cgnat_likely(bind_port, public_addr).await;
 
         let (peer_change_tx, peer_change_rx) = watch::channel(0usize);
@@ -2458,7 +2452,8 @@ impl Node {
 
     pub fn invite_token(&self) -> String {
         let mut addr = self.endpoint.addr();
-        // Inject STUN-discovered public address if relay STUN didn't provide one.
+        // Inject iroh-discovered public address with the user-advertised port
+        // when no public IPv4 candidate is already present.
         if let Some(pub_addr) = self.public_addr {
             use iroh::TransportAddr;
             let has_public = addr.addrs.iter().any(|a| match a {

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -2151,9 +2151,13 @@ impl Node {
         // Discover public IP via STUN so the invite token includes it.
         // With --bind-port, the advertised port is the bound port (for port forwarding).
         // Without --bind-port, we use port 0 — the IP is still useful for hole-punching.
-        // Relay STUN may not work on sinkholed networks, so we use raw STUN to Google/Cloudflare.
+        // Prefer iroh's own relay-discovered candidates; fall back to raw STUN
+        // only when the endpoint has not learned a public IPv4.
         let stun_port = bind_port.unwrap_or(0);
-        let public_addr = direct_connectivity::stun_public_addr(stun_port).await;
+        let public_addr = match direct_connectivity::iroh_public_addr(&endpoint.addr(), stun_port) {
+            Some(addr) => Some(addr),
+            None => direct_connectivity::fallback_stun_public_addr(stun_port).await,
+        };
         direct_connectivity::warn_if_cgnat_likely(bind_port, public_addr).await;
 
         let (peer_change_tx, peer_change_rx) = watch::channel(0usize);

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -13,6 +13,8 @@ pub use mesh_llm_types::mesh::{
 
 mod direct_connectivity;
 
+pub(crate) use direct_connectivity::DirectConnectivityStatus;
+
 use anyhow::{Context, Result};
 use base64::Engine;
 use iroh::endpoint::Connection;
@@ -2152,6 +2154,7 @@ impl Node {
         // include the fixed forwarding port when --bind-port is set.
         let advertised_port = bind_port.unwrap_or(0);
         let public_addr = direct_connectivity::iroh_public_addr(&endpoint.addr(), advertised_port);
+        direct_connectivity::emit_iroh_status(&endpoint, public_addr);
         direct_connectivity::warn_if_cgnat_likely(bind_port, public_addr).await;
 
         let (peer_change_tx, peer_change_rx) = watch::channel(0usize);
@@ -2469,6 +2472,12 @@ impl Node {
         }
         let json = serde_json::to_vec(&addr).expect("serializable");
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&json)
+    }
+
+    pub(crate) fn direct_connectivity_status(
+        &self,
+    ) -> direct_connectivity::DirectConnectivityStatus {
+        direct_connectivity::iroh_status(&self.endpoint, self.public_addr)
     }
 
     /// Decode an invite token into an [`EndpointAddr`] without connecting.

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -13,7 +13,9 @@ pub use mesh_llm_types::mesh::{
 
 mod direct_connectivity;
 
-pub(crate) use direct_connectivity::DirectConnectivityStatus;
+pub(crate) use direct_connectivity::{
+    format_network_doctor, network_doctor, DirectConnectivityStatus,
+};
 
 use anyhow::{Context, Result};
 use base64::Engine;

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -33,6 +33,48 @@ fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
     assert_eq!(quic_bind_addr(None), None);
 }
 
+#[test]
+fn public_ipv4_classification_excludes_cgnat_and_private_ranges() {
+    assert!(is_public_ipv4_addr("8.8.8.8".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("100.64.0.1".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("100.127.255.254".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("10.0.0.1".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("172.16.0.1".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("192.168.1.1".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("169.254.1.1".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("127.0.0.1".parse().unwrap()));
+    assert!(!is_public_ipv4_addr("192.0.2.10".parse().unwrap()));
+}
+
+#[test]
+fn upnp_wan_helpers_extract_wan_service_endpoint() {
+    let description = r#"
+        <root>
+          <device>
+            <serviceList>
+              <service>
+                <serviceType>urn:schemas-upnp-org:service:Layer3Forwarding:1</serviceType>
+                <controlURL>/ctl/L3F</controlURL>
+              </service>
+              <service>
+                <serviceType>urn:schemas-upnp-org:service:WANIPConnection:2</serviceType>
+                <controlURL>/ctl/IPConn</controlURL>
+              </service>
+            </serviceList>
+          </device>
+        </root>
+    "#;
+
+    assert_eq!(
+        upnp_wan_service_type(description).as_deref(),
+        Some("urn:schemas-upnp-org:service:WANIPConnection:2")
+    );
+    assert_eq!(
+        upnp_wan_control_url("http://192.168.1.1:5000/rootDesc.xml", description).as_deref(),
+        Some("http://192.168.1.1:5000/ctl/IPConn")
+    );
+}
+
 fn stage_load_request() -> crate::inference::skippy::StageLoadRequest {
     crate::inference::skippy::StageLoadRequest {
         topology_id: "topology-a".to_string(),

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -33,48 +33,6 @@ fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
     assert_eq!(quic_bind_addr(None), None);
 }
 
-#[test]
-fn public_ipv4_classification_excludes_cgnat_and_private_ranges() {
-    assert!(is_public_ipv4_addr("8.8.8.8".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("100.64.0.1".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("100.127.255.254".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("10.0.0.1".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("172.16.0.1".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("192.168.1.1".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("169.254.1.1".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("127.0.0.1".parse().unwrap()));
-    assert!(!is_public_ipv4_addr("192.0.2.10".parse().unwrap()));
-}
-
-#[test]
-fn upnp_wan_helpers_extract_wan_service_endpoint() {
-    let description = r#"
-        <root>
-          <device>
-            <serviceList>
-              <service>
-                <serviceType>urn:schemas-upnp-org:service:Layer3Forwarding:1</serviceType>
-                <controlURL>/ctl/L3F</controlURL>
-              </service>
-              <service>
-                <serviceType>urn:schemas-upnp-org:service:WANIPConnection:2</serviceType>
-                <controlURL>/ctl/IPConn</controlURL>
-              </service>
-            </serviceList>
-          </device>
-        </root>
-    "#;
-
-    assert_eq!(
-        upnp_wan_service_type(description).as_deref(),
-        Some("urn:schemas-upnp-org:service:WANIPConnection:2")
-    );
-    assert_eq!(
-        upnp_wan_control_url("http://192.168.1.1:5000/rootDesc.xml", description).as_deref(),
-        Some("http://192.168.1.1:5000/ctl/IPConn")
-    );
-}
-
 fn stage_load_request() -> crate::inference::skippy::StageLoadRequest {
     crate::inference::skippy::StageLoadRequest {
         topology_id: "topology-a".to_string(),

--- a/crates/mesh-llm-host-runtime/src/runtime_data/api_views.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/api_views.rs
@@ -65,6 +65,7 @@ pub(crate) fn status_payload(snapshot: StatusViewSnapshot) -> StatusPayload {
         gpus: snapshot.hardware.gpus,
         routing_affinity: snapshot.routing_affinity,
         routing_metrics: snapshot.routing_metrics,
+        direct_connectivity: Default::default(),
         first_joined_mesh_ts: snapshot.hardware.first_joined_mesh_ts,
     }
 }
@@ -199,6 +200,7 @@ mod tests {
             ),
             routing_affinity: crate::network::affinity::AffinityStatsSnapshot::default(),
             routing_metrics: crate::network::metrics::RoutingMetricsStatusSnapshot::default(),
+            direct_connectivity: Default::default(),
             first_joined_mesh_ts: Some(123),
         };
 

--- a/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
@@ -411,6 +411,7 @@ mod tests {
             ),
             routing_affinity: crate::network::affinity::AffinityStatsSnapshot::default(),
             routing_metrics: crate::network::metrics::RoutingMetricsStatusSnapshot::default(),
+            direct_connectivity: Default::default(),
             first_joined_mesh_ts: Some(123),
         };
 

--- a/docs/CGNAT.md
+++ b/docs/CGNAT.md
@@ -1,0 +1,167 @@
+# CGNAT and Direct Mesh Connectivity
+
+mesh-llm direct peer connections use UDP. Relays can keep a mesh usable, but
+direct UDP is the path you want for lower latency and predictable split
+inference. If direct connections work in one direction but not the other, check
+for carrier-grade NAT (CGNAT) before chasing application-level issues.
+
+## Symptom
+
+A typical CGNAT failure looks like this:
+
+- The local router has a port-forward rule, such as `UDP 53238 -> 192.168.1.50:53238`.
+- The local machine advertises a public-looking internet address in its invite token.
+- A remote peer cannot reach the forwarded UDP port.
+- Raw UDP tests from the remote peer time out.
+- Relay paths may still work, or direct paths may work only from the non-CGNAT side.
+
+This can be asymmetric. One network may have a real public IPv4 address on its
+router, while the other router only has a CGNAT address.
+
+## What CGNAT Is
+
+With normal home NAT, your router owns the public IPv4 address:
+
+```text
+internet
+  -> public IPv4 on router
+  -> LAN device, for example 192.168.1.50
+```
+
+With CGNAT, the ISP adds another NAT layer in front of your router:
+
+```text
+internet
+  -> ISP shared public IPv4
+  -> router WAN address from 100.64.0.0/10
+  -> LAN device, for example 192.168.1.50
+```
+
+Your router can only forward ports from its own WAN address to a LAN device. It
+cannot create a port forward through the ISP's CGNAT layer. That means a router
+port-forward rule may be correct and still be unreachable from the internet.
+
+## Diagnostic Pattern
+
+Compare the IPv4 address the internet sees with the IPv4 address your router
+believes is its WAN address.
+
+On the mesh host:
+
+```bash
+curl -4 https://ifconfig.me
+```
+
+Then check your router's WAN address in its admin UI or via UPnP/IGD if your
+router exposes it. A CGNAT case looks like this:
+
+```text
+internet-visible IPv4: 198.51.100.10
+router WAN IPv4:       100.72.12.34
+```
+
+Any router WAN IPv4 in `100.64.0.0/10` is CGNAT space. Other private ranges,
+such as `10.0.0.0/8`, `172.16.0.0/12`, and `192.168.0.0/16`, also mean the
+router does not directly own the public IPv4 address.
+
+A healthy direct-forwarding setup looks like this:
+
+```text
+internet-visible IPv4: 198.51.100.10
+router WAN IPv4:       198.51.100.10
+```
+
+## Raw UDP Probe
+
+Before debugging mesh-llm itself, prove that inbound UDP reaches the host. Run a
+listener on the local mesh host:
+
+```bash
+python3 - <<'PY'
+import socket
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("0.0.0.0", 53238))
+print("listening on UDP 53238", flush=True)
+while True:
+    data, peer = sock.recvfrom(2048)
+    print(f"received {len(data)} bytes from {peer}", flush=True)
+    sock.sendto(b"ack:" + data, peer)
+PY
+```
+
+From a remote network, send packets to the public IPv4 and forwarded UDP port:
+
+```bash
+python3 - <<'PY'
+import socket
+import time
+
+target = ("198.51.100.10", 53238)
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.settimeout(2)
+
+for i in range(6):
+    payload = f"udp-probe-{i}".encode()
+    sock.sendto(payload, target)
+    try:
+        data, peer = sock.recvfrom(2048)
+    except socket.timeout:
+        print(f"timeout waiting for reply {i}")
+    else:
+        print(f"reply from {peer}: {data.decode(errors='replace')}")
+    time.sleep(1)
+PY
+```
+
+If the listener receives nothing, the failure is below mesh-llm. Check router
+port-forwarding, CGNAT, local firewall policy, and upstream ISP filtering before
+debugging QUIC or mesh protocol behavior.
+
+## mesh-llm Check
+
+When testing a fixed UDP port, bind mesh-llm to that port so the advertised
+candidate and router forward agree:
+
+```bash
+mesh-llm serve \
+  --model hf://example/model-layers \
+  --split \
+  --bind-port 53238
+```
+
+The peer status should report a direct path:
+
+```text
+peer_count=1
+latency_source=direct
+```
+
+If UDP probing works but mesh-llm still falls back to relay, inspect the invite
+token candidates and mesh logs. If the token advertises private or CGNAT
+addresses ahead of a usable public candidate, direct dialing may fail or take
+longer than expected.
+
+## Fixes
+
+For CGNAT:
+
+- Ask the ISP to disable CGNAT, opt out of CGNAT, or provide a static public
+  IPv4 address.
+- Reboot or reconnect the router after the ISP change so it renews its WAN
+  lease.
+- Re-check that the router WAN IPv4 matches the internet-visible IPv4.
+- Keep the router UDP port-forward rule pointed at the mesh host.
+
+For dual-router setups:
+
+- Put the upstream device into bridge mode, or
+- Add matching UDP forwards at every NAT layer, from the public edge to the mesh
+  host.
+
+For overlapping private LANs:
+
+- Do not rely on private `192.168.x.x` candidates across sites.
+- Prefer a real public IPv4 candidate, IPv6 when both networks have working
+  global IPv6, or an overlay network that mesh-llm can actually dial.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ This directory holds project documentation that is not owned by a single Rust cr
 | [SKIPPY_RUNTIME_README.md](SKIPPY_RUNTIME_README.md) | Imported standalone skippy runtime README for background context |
 | [CLI.md](CLI.md) | CLI reference |
 | [CI_GUIDANCE.md](CI_GUIDANCE.md) | CI workflow responsibilities and path filtering guidance |
+| [CGNAT.md](CGNAT.md) | Diagnosing carrier-grade NAT when direct mesh UDP paths fail |
 | [specs/layer-package-repos.md](specs/layer-package-repos.md) | Layer package repository layout, manifest, publishing, and validation spec |
 
 ## Topic Areas


### PR DESCRIPTION
## Summary

Users can now run `mesh-llm network doctor --bind-port <port>` to diagnose direct mesh UDP readiness from the local machine.

The doctor command reports the public IPv4 candidate discovered by iroh, the local router WAN IPv4 reported by UPnP/IGD, whether those addresses match, iroh direct candidate counts, and iroh portmapper counters. This makes CGNAT, double NAT, missing public candidates, and fixed-port forwarding mistakes visible without falling back to external STUN services.

Startup also warns when a fixed `--bind-port` is used and the router appears to sit behind CGNAT/private upstream NAT while iroh discovers a different public IPv4.

## User-Facing Changes

- Adds `mesh-llm network doctor --bind-port <port>`.
- Adds `mesh-llm network doctor --bind-port <port> --json`.
- Adds `direct_connectivity` to `/api/status` with iroh direct candidates and portmapper counters.
- Adds a startup `info` event summarizing iroh direct candidates and portmapper counters.
- Adds `docs/CGNAT.md` and links it from the docs index.

## Implementation

- Uses iroh relay-discovered endpoint candidates as the public-address source for invite-port rewriting and direct-connectivity diagnostics.
- Does not query external STUN servers; iroh's relay/discovery path is the source of public endpoint candidates.
- Treats `100.64.0.0/10` shared address space as non-public invite candidates.
- Uses UPnP/IGD `GetExternalIPAddress` as a best-effort router WAN check when `--bind-port` is set.
- Emits a normal `warning` event when UPnP reports a private/shared WAN address while iroh has discovered a different public IPv4.
- Keeps UPnP/direct-connectivity heuristics in `mesh::direct_connectivity` instead of growing `mesh/mod.rs`.

## Doctor Output

Live run on this network, with public IPs obscured here:

```text
mesh-llm network doctor --bind-port 53238

🩺 Direct UDP readiness
  bind port:               53238
  🌍 iroh public IPv4:     159.196.xxx.xxx
  🛜 router WAN IPv4:      159.196.xxx.xxx
  ✅ router WAN type:      public IPv4
  📣 invite candidate:     159.196.xxx.xxx:53238
  ✅ UPnP/IGD:             discovered router
  ✅ WAN/public match:     router WAN matches iroh public candidate
  🧭 iroh candidates:      5
  🗺️ iroh portmapper:      attempts=2, external_updates=1

✅ Result: router WAN matches public IPv4. If UDP is forwarded to this host, direct mesh paths can be tested.
Reason: router_wan_matches_iroh_public_ipv4
Fix: If the UDP bind port is forwarded to this host, direct mesh paths can be tested.
```

Machine-readable form:

```bash
mesh-llm network doctor --bind-port 53238 --json
```

```json
{
  "bind_port": 53238,
  "iroh_public_ipv4": "159.196.xxx.xxx",
  "router_wan_ipv4": "159.196.xxx.xxx",
  "router_wan_type": "public_ipv4",
  "invite_public_candidate": "159.196.xxx.xxx:53238",
  "upnp_igd": {
    "discovered": true,
    "wan_matches_iroh": true
  },
  "direct_udp": {
    "expected_reachable": true,
    "reason": "router_wan_matches_iroh_public_ipv4"
  },
  "iroh": {
    "direct_candidate_count": 5,
    "iroh_portmapper": {
      "enabled": true,
      "mapping_attempts": 2,
      "external_address_updates": 1,
      "has_reported_external_address": true
    }
  },
  "recommendation": "If the UDP bind port is forwarded to this host, direct mesh paths can be tested."
}
```

## Status Output

`/api/status` includes local iroh direct-connectivity state:

```json
{
  "direct_connectivity": {
    "direct_candidates": ["192.168.86.54:53238", "159.196.xxx.xxx:53238"],
    "direct_candidate_count": 2,
    "public_ipv4_candidate": "159.196.xxx.xxx:53238",
    "invite_public_candidate": "159.196.xxx.xxx:53238",
    "iroh_portmapper": {
      "enabled": true,
      "mapping_attempts": 1,
      "external_address_updates": 1,
      "has_reported_external_address": true
    }
  }
}
```

## Privacy

The documentation and PR examples obscure real public IPs and avoid real hostnames, MAC addresses, node IDs, or personal network details.

## Validation

- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime network_doctor`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --no-run`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo run -p mesh-llm -- network doctor --bind-port 53238`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo run -p mesh-llm -- network doctor --bind-port 53238 --json`
- `cargo fmt --all -- --check`
- `git diff --check`
