### PR TITLE
Fuse warm chat prefix restore with first decode

### DIFF
--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -1821,6 +1821,17 @@ fn handle_binary_restore_prefill_decode_control(
         let mut runtime = runtime.lock().expect("runtime lock poisoned");
         let runtime_lock_wait_ms = elapsed_ms(lock_started);
         let lock_hold_started = Instant::now();
+        if let Some(metadata) = message.chat_sampling_metadata.as_deref() {
+            let sampling = runtime_sampling_config(message.sampling.as_ref());
+            runtime
+                .configure_chat_sampling(
+                    session_id,
+                    metadata,
+                    message.state.prompt_token_count.max(0) as u64,
+                    sampling.as_ref(),
+                )
+                .context("configure restore-decode chat sampling")?;
+        }
         let (predicted, _, output) = run_binary_stage_message(
             &mut runtime,
             session_id,

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -1,10 +1,14 @@
-use super::prepare_binary_stage_connection;
+use super::{prepare_binary_stage_connection, restore_prefill_decode_as_decode_message};
 use std::{
     io,
     net::{TcpListener, TcpStream},
     os::fd::AsRawFd,
     thread,
     time::Duration,
+};
+
+use skippy_protocol::binary::{
+    StageSamplingConfig, StageStateHeader, StageWireMessage, WireActivationDType, WireMessageKind,
 };
 
 #[test]
@@ -30,4 +34,46 @@ fn accepted_binary_stage_connection_is_blocking() {
     assert_ne!(flags, -1);
     assert_eq!(flags & libc::O_NONBLOCK, 0);
     drop(client.join().unwrap());
+}
+
+#[test]
+fn restore_prefill_decode_as_decode_preserves_chat_metadata() {
+    let metadata = r#"{"grammar":"chat"}"#;
+    let sampling = StageSamplingConfig {
+        flags: 1,
+        seed: 42,
+        ..StageSamplingConfig::default()
+    };
+    let mut state = StageStateHeader::new(
+        WireMessageKind::TryRestorePrefillDecode,
+        WireActivationDType::F16,
+    );
+    state.prompt_token_count = 4;
+    state.decode_step = 0;
+    state.current_token = 104;
+
+    let message = StageWireMessage {
+        kind: WireMessageKind::TryRestorePrefillDecode,
+        pos_start: 3,
+        token_count: 1,
+        state,
+        request_id: 11,
+        session_id: 13,
+        sampling: Some(sampling.clone()),
+        chat_sampling_metadata: Some(metadata.to_string()),
+        tokens: vec![101, 102, 103, 104],
+        positions: Vec::new(),
+        activation: vec![1, 2, 3, 4],
+        raw_bytes: Vec::new(),
+    };
+
+    let decode = restore_prefill_decode_as_decode_message(&message, 104);
+
+    assert_eq!(decode.kind, WireMessageKind::DecodeEmbd);
+    assert_eq!(decode.token_count, 1);
+    assert_eq!(decode.tokens, vec![104]);
+    assert_eq!(decode.sampling, Some(sampling));
+    assert_eq!(decode.chat_sampling_metadata.as_deref(), Some(metadata));
+    assert!(decode.activation.is_empty());
+    assert!(decode.positions.is_empty());
 }

--- a/crates/skippy-server/src/openai.rs
+++ b/crates/skippy-server/src/openai.rs
@@ -1902,18 +1902,6 @@ impl StageOpenAiBackend {
         reply_stats.kv_imported_tokens += local_restore.token_count as i64;
         reply_stats.kv_hit_stage_mask |= openai_stage_mask(request.config.stage_index);
 
-        let decode_message = embedded_decode_message(
-            request.wire_dtype,
-            DecodeMessageArgs {
-                request_id: request.ids.request_id,
-                session_id: request.ids.session_id,
-                prompt_token_count: request.prompt_token_ids.len(),
-                pos_start: prefill_tokens.len(),
-                decode_step: 0,
-                current,
-                sampling: wire_sampling.clone(),
-            },
-        )?;
         let stage0_timer = PhaseTimer::start();
         let token_runtime_lock_wait_ms;
         let token_runtime_lock_hold_ms;
@@ -1925,6 +1913,28 @@ impl StageOpenAiBackend {
                 .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
             token_runtime_lock_wait_ms = lock_timer.elapsed_ms();
             let lock_hold_timer = PhaseTimer::start();
+            if let Some(metadata) = request.chat_sampling_metadata {
+                runtime
+                    .configure_chat_sampling(
+                        session_key,
+                        metadata,
+                        request.prompt_token_ids.len() as u64,
+                        request.sampling.enabled.then_some(request.sampling),
+                    )
+                    .map_err(openai_backend_error)?;
+            }
+            let decode_message = embedded_decode_message(
+                request.wire_dtype,
+                DecodeMessageArgs {
+                    request_id: request.ids.request_id,
+                    session_id: request.ids.session_id,
+                    prompt_token_count: request.prompt_token_ids.len(),
+                    pos_start: prefill_tokens.len(),
+                    decode_step: 0,
+                    current,
+                    sampling: wire_sampling.clone(),
+                },
+            )?;
             let output = run_binary_stage_message(
                 &mut runtime,
                 session_key,
@@ -1951,6 +1961,7 @@ impl StageOpenAiBackend {
                 prefix_tokens: prefill_tokens,
                 current,
                 sampling: wire_sampling,
+                chat_sampling_metadata: request.chat_sampling_metadata,
             },
         )?;
         let forwarded = forwarded_stage_message_timed(
@@ -4116,10 +4127,7 @@ impl StageOpenAiBackend {
             let mut prefill_planner = request.prefill_chunk_policy.planner();
             if prefill_token_count > 0 {
                 let prefill_tokens = &request.prompt_token_ids[..prefill_token_count];
-                if request.max_tokens > 0
-                    && request.draft.is_none()
-                    && request.chat_sampling_metadata.is_none()
-                {
+                if request.max_tokens > 0 && request.draft.is_none() {
                     let current = *request
                         .prompt_token_ids
                         .last()
@@ -6737,6 +6745,7 @@ struct RestorePrefillDecodeMessageArgs<'a> {
     prefix_tokens: &'a [i32],
     current: i32,
     sampling: Option<WireSamplingConfig>,
+    chat_sampling_metadata: Option<&'a str>,
 }
 
 fn embedded_restore_prefill_decode_message(
@@ -6763,7 +6772,7 @@ fn embedded_restore_prefill_decode_message(
         request_id: args.request_id,
         session_id: args.session_id,
         sampling: args.sampling,
-        chat_sampling_metadata: None,
+        chat_sampling_metadata: args.chat_sampling_metadata.map(str::to_string),
         tokens,
         positions: Vec::new(),
         activation: Vec::new(),

--- a/crates/skippy-server/src/openai/tests.rs
+++ b/crates/skippy-server/src/openai/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::io::Cursor;
 use std::{env, fs, net::SocketAddr};
 
 use serde_json::json;
@@ -707,6 +708,45 @@ fn multimodal_final_prefill_message_requests_downstream_prediction() {
     assert_eq!(message.token_count, 17);
     assert_eq!(message.state.current_token, LLAMA_TOKEN_NULL);
     assert_eq!(message.sampling, Some(sampling));
+}
+
+#[test]
+fn restore_prefill_decode_message_carries_chat_sampling_metadata() {
+    let metadata = r#"{"grammar":"chat","prompt_tokens":4}"#;
+    let sampling = WireSamplingConfig {
+        flags: 1,
+        seed: 7,
+        ..WireSamplingConfig::default()
+    };
+
+    let message = embedded_restore_prefill_decode_message(
+        WireActivationDType::F16,
+        RestorePrefillDecodeMessageArgs {
+            request_id: 11,
+            session_id: 13,
+            prompt_token_count: 4,
+            pos_start: 3,
+            decode_step: 0,
+            prefix_tokens: &[101, 102, 103],
+            current: 104,
+            sampling: Some(sampling.clone()),
+            chat_sampling_metadata: Some(metadata),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(message.kind, WireMessageKind::TryRestorePrefillDecode);
+    assert_eq!(message.tokens, vec![101, 102, 103, 104]);
+    assert_eq!(message.sampling, Some(sampling.clone()));
+    assert_eq!(message.chat_sampling_metadata.as_deref(), Some(metadata));
+
+    let mut encoded = Vec::new();
+    write_stage_message(&mut encoded, &message, WireActivationDType::F16).unwrap();
+    let decoded = skippy_protocol::binary::read_stage_message(Cursor::new(encoded), 2816).unwrap();
+    assert_eq!(decoded.kind, WireMessageKind::TryRestorePrefillDecode);
+    assert_eq!(decoded.tokens, vec![101, 102, 103, 104]);
+    assert_eq!(decoded.sampling, Some(sampling));
+    assert_eq!(decoded.chat_sampling_metadata.as_deref(), Some(metadata));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
Warm repeated chat prompts can now use the fused prefix-restore plus first-decode path. `TryRestorePrefillDecode` carries chat sampling metadata, so a cached chat prefix no longer needs a separate generation-config control round trip before the first decode token.

## WAN Lab Benchmark
The benchmark was a two-request cold/warm repeat against the same 4-stage Docker WAN lab used for RTT work:

- Topology: 4 staged servers, unchanged stage split/topology
- Platform: Linux `aarch64` containers
- WAN shaping: `WAN_RTT_MS=26.454`, `WAN_DELAY_MS=13.227`, `WAN_RATE_MBIT=26`, `WAN_LOSS_PERCENT=0`
- Model: `unsloth/gemma-4-26B-A4B-it-GGUF:UD-Q4_K_M`
- Endpoint: `/v1/chat/completions`
- Cache mode for the run: `SKIPPY_KV_CACHE=lookup-record`, `SKIPPY_KV_CACHE_MIN_TOKENS=16`, `SKIPPY_KV_CACHE_PAYLOAD=resident-kv`
- Request params: `temperature=0`, `max_tokens=1`
- Prompt text: `Warm cache chat fused RTT test. ` followed by `latency` repeated 140 times
- Observed usage: `prompt_tokens=164`, `completion_tokens=1`; warm response reported `cached_tokens=163`

The first request was cold and populated resident prefix cache. The second request was byte-identical and measured the warm-cache path.

| Run | Wall time | Cache result | Trace result |
| --- | ---: | --- | --- |
| Cold identical chat request | `~24.95s` | `cached_tokens=0` | normal prefill + `DecodeEmbd` |
| Warm identical chat request | `~1.26s` | `cached_tokens=163` | `chain_fused_exact_prefix`; `TryRestorePrefillDecode` hits on all downstream stages |

This is a repeated-prefix win, not a cold-prompt win. It applies when the same prompt prefix has already been recorded on every stage.

## Details
- Preserve chat sampling metadata on fused restore-decode messages.
- Configure chat sampling on stage0 and downstream stages before the fused decode executes.
- Allow embedded stage0 chat requests to attempt `TryRestorePrefillDecode` when the prefix cache is warm.
- Add regression tests for metadata wire round-trip and downstream decode-message conversion.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p skippy-server`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-cpu cargo test -p skippy-server --lib`
- `cargo test -p skippy-protocol --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-cpu cargo test -p mesh-llm inference::skippy --lib`
