### PR TITLE
Trim single-stage Skippy decode overhead

### DIFF
--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -359,6 +359,9 @@ impl StageOpenAiBackend {
                 .expect("checked non-empty prompt");
             let mut hook_request = request.hook_request;
             let hook_runtime = request.hook_runtime;
+            let generation_hooks_active =
+                self.generation_hooks_active(&hook_request, hook_runtime.as_ref());
+            let emit_token_debug = self.telemetry.is_debug_enabled();
             let mut post_prefill_hook_checked = false;
             let mut last_mid_generation_hook_at = None;
             while decoded_tokens < request.max_tokens as usize {
@@ -397,104 +400,125 @@ impl StageOpenAiBackend {
                             request.sampling.enabled.then_some(request.sampling),
                         )
                         .map_err(openai_backend_error)?;
-                    token_decode_ms = decode_call_timer.elapsed_ms();
-                    let signal_timer = PhaseTimer::start();
-                    token_signal = runtime.last_token_signal(&session_id).ok();
-                    signal_window = runtime.signal_window(&session_id, 16).ok();
-                    token_signal_ms = signal_timer.elapsed_ms();
+                    token_decode_ms = if emit_token_debug {
+                        decode_call_timer.elapsed_ms()
+                    } else {
+                        0.0
+                    };
+                    if generation_hooks_active {
+                        let signal_timer = PhaseTimer::start();
+                        token_signal = runtime.last_token_signal(&session_id).ok();
+                        signal_window = runtime.signal_window(&session_id, 16).ok();
+                        token_signal_ms = signal_timer.elapsed_ms();
+                    } else {
+                        token_signal = None;
+                        signal_window = None;
+                        token_signal_ms = 0.0;
+                    }
                     runtime_sessions_after = Some(runtime.session_stats());
-                    token_runtime_lock_hold_ms = hold_timer.elapsed_ms();
+                    token_runtime_lock_hold_ms = if emit_token_debug {
+                        hold_timer.elapsed_ms()
+                    } else {
+                        0.0
+                    };
                     runtime_lock_hold_ms += token_runtime_lock_hold_ms;
                     runtime_lock_hold_max_ms =
                         runtime_lock_hold_max_ms.max(token_runtime_lock_hold_ms);
                     predicted
                 };
-                if let Some(injected_current) = self.maybe_run_generation_hooks(
-                    &session_id,
-                    &mut hook_request,
-                    hook_runtime.as_ref(),
-                    decoded_tokens,
-                    &mut post_prefill_hook_checked,
-                    &mut last_mid_generation_hook_at,
-                    token_signal,
-                    signal_window,
-                )? {
-                    current = injected_current;
-                    continue;
+                if generation_hooks_active {
+                    if let Some(injected_current) = self.maybe_run_generation_hooks(
+                        &session_id,
+                        &mut hook_request,
+                        hook_runtime.as_ref(),
+                        decoded_tokens,
+                        &mut post_prefill_hook_checked,
+                        &mut last_mid_generation_hook_at,
+                        token_signal,
+                        signal_window,
+                    )? {
+                        current = injected_current;
+                        continue;
+                    }
                 }
                 decoded_tokens += 1;
-                let mut token_attrs = self.openai_attrs(request.ids);
-                token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
-                token_attrs.insert(
-                    "llama_stage.decode_token_phase".to_string(),
-                    json!(decode_token_phase(
-                        u32::try_from(decode_step).unwrap_or(u32::MAX)
-                    )),
-                );
-                token_attrs.insert(
-                    "llama_stage.stage0_compute_ms".to_string(),
-                    json!(token_timer.elapsed_ms()),
-                );
-                token_attrs.insert(
-                    "llama_stage.decode_call_ms".to_string(),
-                    json!(token_decode_ms),
-                );
-                token_attrs.insert("llama_stage.signal_ms".to_string(), json!(token_signal_ms));
-                token_attrs.insert(
-                    "llama_stage.runtime_lock_wait_ms".to_string(),
-                    json!(token_runtime_lock_wait_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.runtime_lock_hold_ms".to_string(),
-                    json!(token_runtime_lock_hold_ms),
-                );
-                token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
-                token_attrs.insert("llama_stage.message_kind".to_string(), json!("DecodeToken"));
-                self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
+                if emit_token_debug {
+                    let mut token_attrs = self.openai_attrs(request.ids);
+                    token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
+                    token_attrs.insert(
+                        "llama_stage.decode_token_phase".to_string(),
+                        json!(decode_token_phase(
+                            u32::try_from(decode_step).unwrap_or(u32::MAX)
+                        )),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.stage0_compute_ms".to_string(),
+                        json!(token_timer.elapsed_ms()),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.decode_call_ms".to_string(),
+                        json!(token_decode_ms),
+                    );
+                    token_attrs.insert("llama_stage.signal_ms".to_string(), json!(token_signal_ms));
+                    token_attrs.insert(
+                        "llama_stage.runtime_lock_wait_ms".to_string(),
+                        json!(token_runtime_lock_wait_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.runtime_lock_hold_ms".to_string(),
+                        json!(token_runtime_lock_hold_ms),
+                    );
+                    token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
+                    token_attrs
+                        .insert("llama_stage.message_kind".to_string(), json!("DecodeToken"));
+                    self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
+                }
                 if on_token(current)? == TokenControl::Stop {
                     break;
                 }
             }
-            let mut attrs = self.openai_attrs(request.ids);
-            attrs.insert(
-                "llama_stage.decode_token_count".to_string(),
-                json!(decoded_tokens),
-            );
-            attrs.insert(
-                "llama_stage.runtime_lock_wait_ms".to_string(),
-                json!(runtime_lock_wait_ms),
-            );
-            attrs.insert(
-                "llama_stage.runtime_lock_wait_max_ms".to_string(),
-                json!(runtime_lock_wait_max_ms),
-            );
-            attrs.insert(
-                "llama_stage.runtime_lock_hold_ms".to_string(),
-                json!(runtime_lock_hold_ms),
-            );
-            attrs.insert(
-                "llama_stage.runtime_lock_hold_max_ms".to_string(),
-                json!(runtime_lock_hold_max_ms),
-            );
-            attrs.insert(
-                "llama_stage.runtime_lock_acquires".to_string(),
-                json!(runtime_lock_acquires),
-            );
-            if let Some(stats) = runtime_sessions_before.as_ref() {
-                Self::insert_runtime_session_stats(
-                    &mut attrs,
-                    "llama_stage.runtime_sessions_before",
-                    stats,
+            if emit_token_debug {
+                let mut attrs = self.openai_attrs(request.ids);
+                attrs.insert(
+                    "llama_stage.decode_token_count".to_string(),
+                    json!(decoded_tokens),
                 );
-            }
-            if let Some(stats) = runtime_sessions_after.as_ref() {
-                Self::insert_runtime_session_stats(
-                    &mut attrs,
-                    "llama_stage.runtime_sessions_after",
-                    stats,
+                attrs.insert(
+                    "llama_stage.runtime_lock_wait_ms".to_string(),
+                    json!(runtime_lock_wait_ms),
                 );
+                attrs.insert(
+                    "llama_stage.runtime_lock_wait_max_ms".to_string(),
+                    json!(runtime_lock_wait_max_ms),
+                );
+                attrs.insert(
+                    "llama_stage.runtime_lock_hold_ms".to_string(),
+                    json!(runtime_lock_hold_ms),
+                );
+                attrs.insert(
+                    "llama_stage.runtime_lock_hold_max_ms".to_string(),
+                    json!(runtime_lock_hold_max_ms),
+                );
+                attrs.insert(
+                    "llama_stage.runtime_lock_acquires".to_string(),
+                    json!(runtime_lock_acquires),
+                );
+                if let Some(stats) = runtime_sessions_before.as_ref() {
+                    Self::insert_runtime_session_stats(
+                        &mut attrs,
+                        "llama_stage.runtime_sessions_before",
+                        stats,
+                    );
+                }
+                if let Some(stats) = runtime_sessions_after.as_ref() {
+                    Self::insert_runtime_session_stats(
+                        &mut attrs,
+                        "llama_stage.runtime_sessions_after",
+                        stats,
+                    );
+                }
+                self.emit_openai_phase("stage.openai_decode", decode_timer, attrs);
             }
-            self.emit_openai_phase("stage.openai_decode", decode_timer, attrs);
             Ok(())
         })();
         let lock_timer = PhaseTimer::start();

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -195,4 +195,14 @@ impl StageOpenAiBackend {
         }
         Ok(None)
     }
+
+    pub(super) fn generation_hooks_active(
+        &self,
+        hook_request: &Option<ChatCompletionRequest>,
+        hook_runtime: Option<&tokio::runtime::Handle>,
+    ) -> bool {
+        self.hook_policy.is_some()
+            && hook_runtime.is_some()
+            && hook_request.as_ref().is_some_and(chat_mesh_hooks_enabled)
+    }
 }

--- a/crates/skippy-server/src/telemetry.rs
+++ b/crates/skippy-server/src/telemetry.rs
@@ -205,6 +205,10 @@ impl Telemetry {
         self.level != TelemetryLevel::Off
     }
 
+    pub fn is_debug_enabled(&self) -> bool {
+        self.level == TelemetryLevel::Debug
+    }
+
     pub fn stats(&self) -> TelemetryStats {
         TelemetryStats {
             queued: self.stats.queued.load(Ordering::Relaxed),


### PR DESCRIPTION
## Summary
Single-stage Skippy decode now avoids debug-only and hook-only work on the normal serving path. This brings Skippy decode throughput back to roughly llama-server parity for the Qwen3-4B single-stage benchmark sweep.

## Root Cause
The single-stage Skippy OpenAI path was doing extra per-token bookkeeping even when the request did not enable mesh hooks and telemetry was not in debug mode. Every decoded token still collected generation signals, built debug telemetry attribute maps, and measured per-token timing fields before discovering that nothing would consume them.

That overhead was small per token, but large enough to show up as a steady decode regression. In the benchmark run, Skippy was about 9-10% slower than vanilla llama for 512-4096 token prompts, while prefill and end-to-end first-token time were already near parity. That pointed at per-token frontend/runtime bookkeeping rather than model load, Metal offload, or prompt processing.

## What Changed
- Added a `Telemetry::is_debug_enabled()` predicate.
- Added a `generation_hooks_active()` helper for the Skippy OpenAI frontend.
- Gated per-token generation signal collection behind active mesh hooks.
- Gated per-token decode telemetry attribute construction behind debug telemetry.

Hook behavior is preserved when mesh hooks are enabled, and detailed per-token debug spans are still available when telemetry level is `Debug`.

## Benchmark
Host: `studio54.local`  
Model: `unsloth/Qwen3-4B-GGUF:Q4_K_M`  
Runtime shape: single-stage Skippy vs vanilla `llama-server`  
Prompt tokens: `128 512 1024 2048 4096`  
Generation: `64` tokens, `3` runs, concurrency `1`  
Context: `8192`  
Metal offload: `37/37 layers to GPU` for both runtimes

| prompt | new Skippy tok/s | old Skippy tok/s | llama tok/s |
|---:|---:|---:|---:|
| 128 | 98.22 | 88.78 | 70.96 |
| 512 | 96.76 | 87.98 | 98.13 |
| 1024 | 95.14 | 86.19 | 95.67 |
| 2048 | 92.67 | 83.37 | 91.76 |
| 4096 | 87.26 | 77.12 | 84.29 |

Raw patched-run artifacts are on the benchmark host at:

```text
/tmp/skippy-lean-decode-bench-20260513-083906
```

The baseline comparison run is at:

```text
/tmp/skippy-vs-llama-bench-20260513-082951
```

## Validation
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p skippy-server --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`
- Rebuilt patched `skippy-server` on `studio54.local` and reran the focused benchmark sweep above.
