### PR TITLE
Wire mesh debug to Skippy telemetry

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -247,6 +247,10 @@ pub(crate) struct Cli {
     #[arg(long)]
     pub(crate) debug: bool,
 
+    /// OTLP/gRPC endpoint for embedded Skippy debug telemetry, for example http://127.0.0.1:14317.
+    #[arg(long, hide = true)]
+    pub(crate) skippy_metrics_otlp_grpc: Option<String>,
+
     /// Show all options (including advanced/niche ones).
     #[arg(long, hide = true)]
     pub(crate) help_advanced: bool,

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -133,6 +133,32 @@ pub(crate) struct SkippyModelLoadOptions {
     pub(crate) selected_device: Option<SkippyDeviceDescriptor>,
     pub(crate) package_identity: Option<SkippyPackageIdentity>,
     pub(crate) projector_path: Option<PathBuf>,
+    pub(crate) telemetry: SkippyTelemetryOptions,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SkippyTelemetryOptions {
+    pub(crate) metrics_otlp_grpc: Option<String>,
+    pub(crate) queue_capacity: usize,
+    pub(crate) level: TelemetryLevel,
+}
+
+impl SkippyTelemetryOptions {
+    pub(crate) fn off() -> Self {
+        Self {
+            metrics_otlp_grpc: None,
+            queue_capacity: 0,
+            level: TelemetryLevel::Off,
+        }
+    }
+
+    pub(crate) fn debug(metrics_otlp_grpc: Option<String>) -> Self {
+        Self {
+            metrics_otlp_grpc,
+            queue_capacity: 1024,
+            level: TelemetryLevel::Debug,
+        }
+    }
 }
 
 impl SkippyModelLoadOptions {
@@ -156,6 +182,7 @@ impl SkippyModelLoadOptions {
             selected_device: None,
             package_identity: None,
             projector_path: None,
+            telemetry: SkippyTelemetryOptions::off(),
         }
     }
 
@@ -198,6 +225,11 @@ impl SkippyModelLoadOptions {
 
     pub(crate) fn with_projector_path(mut self, projector_path: impl Into<PathBuf>) -> Self {
         self.projector_path = Some(projector_path.into());
+        self
+    }
+
+    pub(crate) fn with_telemetry(mut self, telemetry: SkippyTelemetryOptions) -> Self {
+        self.telemetry = telemetry;
         self
     }
 
@@ -252,9 +284,9 @@ impl SkippyModelHandle {
         let runtime = SkippyRuntimeHandle::load(EmbeddedRuntimeOptions {
             config: stage_config.clone(),
             topology: None,
-            metrics_otlp_grpc: None,
-            telemetry_queue_capacity: 0,
-            telemetry_level: TelemetryLevel::Off,
+            metrics_otlp_grpc: options.telemetry.metrics_otlp_grpc.clone(),
+            telemetry_queue_capacity: options.telemetry.queue_capacity,
+            telemetry_level: options.telemetry.level,
         })
         .with_context(|| {
             format!(
@@ -263,7 +295,12 @@ impl SkippyModelHandle {
                 options.model_path.display()
             )
         })?;
-        let telemetry = Telemetry::new(None, 0, stage_config.clone(), TelemetryLevel::Off);
+        let telemetry = Telemetry::new(
+            options.telemetry.metrics_otlp_grpc.clone(),
+            options.telemetry.queue_capacity,
+            stage_config.clone(),
+            options.telemetry.level,
+        );
         let family_policy = family_policy_for_stage_config(&stage_config);
         let binding = embedded_openai_backend(EmbeddedOpenAiArgs {
             bind_addr: "127.0.0.1:0"
@@ -312,6 +349,7 @@ impl SkippyModelHandle {
         generation_concurrency: usize,
         default_max_tokens: u32,
         hook_policy: Option<Arc<dyn OpenAiHookPolicy>>,
+        telemetry: SkippyTelemetryOptions,
     ) -> Result<Self> {
         configure_materialized_stage_cache();
         let materialized_pin = if config.load_mode == LoadMode::LayerPackage {
@@ -349,9 +387,9 @@ impl SkippyModelHandle {
         let runtime = SkippyRuntimeHandle::load(EmbeddedRuntimeOptions {
             config: config.clone(),
             topology: None,
-            metrics_otlp_grpc: None,
-            telemetry_queue_capacity: 0,
-            telemetry_level: TelemetryLevel::Off,
+            metrics_otlp_grpc: telemetry.metrics_otlp_grpc.clone(),
+            telemetry_queue_capacity: telemetry.queue_capacity,
+            telemetry_level: telemetry.level,
         })
         .with_context(|| {
             format!(
@@ -359,7 +397,12 @@ impl SkippyModelHandle {
                 config.model_id, config.model_path
             )
         })?;
-        let telemetry = Telemetry::new(None, 0, config.clone(), TelemetryLevel::Off);
+        let telemetry = Telemetry::new(
+            telemetry.metrics_otlp_grpc.clone(),
+            telemetry.queue_capacity,
+            config.clone(),
+            telemetry.level,
+        );
         let binding = embedded_openai_backend(EmbeddedOpenAiArgs {
             bind_addr: "127.0.0.1:0"
                 .parse()

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -153,6 +153,7 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
     pub(super) n_ubatch_override: Option<u32>,
     pub(super) flash_attention_override: FlashAttentionType,
     pub(super) parallel_override: Option<usize>,
+    pub(super) skippy_telemetry: skippy::SkippyTelemetryOptions,
 }
 
 pub(super) enum SplitRuntimeStart {
@@ -680,6 +681,7 @@ pub(super) async fn start_runtime_split_model(
         flash_attention_override: spec.flash_attention_override,
         pinned_gpu: spec.pinned_gpu,
         slots,
+        skippy_telemetry: spec.skippy_telemetry.clone(),
     })
     .await?;
     let (coordinator_tx, coordinator_rx) = tokio::sync::mpsc::channel(1);
@@ -706,6 +708,7 @@ pub(super) async fn start_runtime_split_model(
         flash_attention_override: spec.flash_attention_override,
         pinned_gpu: spec.pinned_gpu.cloned(),
         slots,
+        skippy_telemetry: spec.skippy_telemetry.clone(),
         event_tx: coordinator_tx,
     }));
 
@@ -854,6 +857,7 @@ struct SplitGenerationLoadSpec<'a> {
     n_batch_override: Option<u32>,
     n_ubatch_override: Option<u32>,
     flash_attention_override: FlashAttentionType,
+    skippy_telemetry: skippy::SkippyTelemetryOptions,
 }
 
 async fn load_split_runtime_generation(
@@ -1067,6 +1071,7 @@ async fn load_split_runtime_generation_inner(
     let slots = spec.slots;
     let node_for_hook = spec.node.clone();
     let model_ref = spec.model_ref.to_string();
+    let skippy_telemetry = spec.skippy_telemetry.clone();
     let _ = emit_event(OutputEvent::ModelLoading {
         model: model_ref.clone(),
         source: None,
@@ -1078,6 +1083,7 @@ async fn load_split_runtime_generation_inner(
             slots,
             skippy_server::CONTEXT_BUDGET_MAX_TOKENS,
             Some(skippy::MeshAutoHookPolicy::new(node_for_hook)),
+            skippy_telemetry,
         )
     })
     .await
@@ -1314,6 +1320,7 @@ struct SplitTopologyCoordinator {
     flash_attention_override: FlashAttentionType,
     pinned_gpu: Option<crate::runtime::StartupPinnedGpuTarget>,
     slots: usize,
+    skippy_telemetry: skippy::SkippyTelemetryOptions,
     event_tx: tokio::sync::mpsc::Sender<SplitCoordinatorEvent>,
 }
 
@@ -1676,6 +1683,7 @@ impl SplitTopologyCoordinator {
             flash_attention_override: self.flash_attention_override,
             pinned_gpu: self.pinned_gpu.as_ref(),
             slots: self.slots,
+            skippy_telemetry: self.skippy_telemetry.clone(),
         })
         .await?;
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
@@ -2585,7 +2593,8 @@ async fn start_runtime_skippy_model(
         .with_ctx_size(context_length)
         .with_generation_concurrency(plan.slots)
         .with_cache_types(effective_cache_type_k, effective_cache_type_v)
-        .with_flash_attn_type(resolved_flash_attn_type);
+        .with_flash_attn_type(resolved_flash_attn_type)
+        .with_telemetry(spec.skippy_telemetry.clone());
     if spec.n_batch_override.is_some() || spec.n_ubatch_override.is_some() {
         options = options.with_batch_sizes(spec.n_batch_override, spec.n_ubatch_override);
     }
@@ -2711,6 +2720,7 @@ async fn start_runtime_layer_package_model(
     let slots = plan.slots;
     let node_for_hook = spec.node.clone();
     let model_ref = model_name.clone();
+    let skippy_telemetry = spec.skippy_telemetry.clone();
     let _ = emit_event(OutputEvent::ModelLoading {
         model: model_ref.clone(),
         source: None,
@@ -2722,6 +2732,7 @@ async fn start_runtime_layer_package_model(
             slots,
             skippy_server::CONTEXT_BUDGET_MAX_TOKENS,
             Some(skippy::MeshAutoHookPolicy::new(node_for_hook)),
+            skippy_telemetry,
         )
     })
     .await
@@ -3690,6 +3701,7 @@ mod tests {
             n_batch_override: None,
             n_ubatch_override: None,
             flash_attention_override: FlashAttentionType::Auto,
+            skippy_telemetry: skippy::SkippyTelemetryOptions::off(),
         }))
         .await
         {

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -1032,6 +1032,7 @@ struct StartupLocalModelTask {
     flash_attention: FlashAttentionType,
     parallel_override: Option<usize>,
     split: bool,
+    skippy_telemetry: skippy::SkippyTelemetryOptions,
     survey_telemetry: survey::SurveyTelemetry,
     survey_launch_kind: survey::SurveyLaunchKind,
     stop_rx: tokio::sync::watch::Receiver<bool>,
@@ -1068,6 +1069,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         flash_attention,
         parallel_override,
         split,
+        skippy_telemetry,
         survey_telemetry,
         survey_launch_kind,
         mut stop_rx,
@@ -1138,6 +1140,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch_override: n_ubatch,
         flash_attention_override: flash_attention,
         parallel_override,
+        skippy_telemetry: skippy_telemetry.clone(),
     };
     let mut launch_started: Instant;
     let (
@@ -1459,6 +1462,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                             n_ubatch_override: n_ubatch,
                             flash_attention_override: flash_attention,
                             parallel_override,
+                            skippy_telemetry: skippy_telemetry.clone(),
                         }, &model_ref)
                         .await
                         {
@@ -4097,6 +4101,20 @@ async fn store_benchmark_metrics(
     *fp16_arc.lock().await = result.and_then(|r| r.compute_tflops_fp16.clone());
 }
 
+fn skippy_telemetry_options(cli: &Cli) -> skippy::SkippyTelemetryOptions {
+    if !cli.debug {
+        return skippy::SkippyTelemetryOptions::off();
+    }
+
+    skippy::SkippyTelemetryOptions::debug(
+        cli.skippy_metrics_otlp_grpc
+            .as_deref()
+            .map(str::trim)
+            .filter(|endpoint| !endpoint.is_empty())
+            .map(str::to_owned),
+    )
+}
+
 /// Serve mode: join the mesh and serve local models through the embedded runtime.
 async fn run_auto(
     mut cli: Cli,
@@ -4139,6 +4157,7 @@ async fn run_auto(
 
     let console_port = Some(cli.console);
     let is_client = cli.client;
+    let skippy_telemetry = skippy_telemetry_options(&cli);
 
     // Scan local models on disk
     let local_models = if is_client {
@@ -4887,6 +4906,7 @@ async fn run_auto(
         flash_attention: primary_flash_attention,
         parallel_override: primary_parallel_override,
         split: startup_split,
+        skippy_telemetry: skippy_telemetry.clone(),
         survey_telemetry: survey_telemetry_for_primary,
         survey_launch_kind: survey::SurveyLaunchKind::Startup,
         stop_rx: primary_stop_rx,
@@ -4978,6 +4998,7 @@ async fn run_auto(
                     flash_attention: extra_flash_attention,
                     parallel_override: extra_parallel_override,
                     split: startup_split,
+                    skippy_telemetry: skippy_telemetry.clone(),
                     survey_telemetry: extra_survey_telemetry,
                     survey_launch_kind: survey::SurveyLaunchKind::MultiModel,
                     stop_rx: extra_stop_rx,
@@ -5159,6 +5180,7 @@ async fn run_auto(
                                         .and_then(|m| m.flash_attention)
                                         .unwrap_or(FlashAttentionType::Auto),
                                     parallel_override,
+                                    skippy_telemetry: skippy_telemetry_options(&cli),
                                 },
                                 &runtime_model_name,
                             )


### PR DESCRIPTION
Users can now opt in to Skippy's detailed token-level telemetry through the existing `mesh-llm --debug` path, while normal mesh serving keeps embedded Skippy telemetry disabled.

Follows #537, which is now merged into `main`.

## What was wrong

#537 made per-token Skippy debug work conditional on `Telemetry::is_debug_enabled()` so production decode avoids building debug timing maps on every token. In the mesh-hosted path, embedded Skippy was still always constructed with `TelemetryLevel::Off`, so mesh's `--debug` flag could not make that condition true. That meant the new debug gate was effectively unreachable when hosting a model through `mesh-llm`.

## What changed

- Added embedded Skippy telemetry options with an off-by-default configuration.
- Wired `mesh-llm --debug` to use Skippy `TelemetryLevel::Debug` for local embedded Skippy model loads.
- Added a hidden `--skippy-metrics-otlp-grpc` endpoint for sending those debug spans to `metrics-server` during diagnostic runs.
- Propagated the same telemetry setting through direct GGUF, layer-package, and split stage-0 local load paths.

## CLI

Diagnostic collection can now be run as:

```bash
metrics-server serve \
  --db /tmp/metrics.sqlite \
  --http-addr 127.0.0.1:18080 \
  --otlp-grpc-addr 127.0.0.1:14317

mesh-llm --debug \
  --skippy-metrics-otlp-grpc http://127.0.0.1:14317 \
  serve --model /path/to/model.gguf
```

Production benchmarks should continue to omit `--debug`, because debug mode intentionally restores per-token instrumentation overhead.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- Attempted `cargo test -p mesh-llm --lib`; local link failed before tests because this worktree does not have the prepared llama.cpp static library (`llama-common`).
