### PR TITLE
fix(ci): fix node cache action incompatability

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -40,17 +40,10 @@ jobs:
             .github/cache-version.txt
             ci/requirements-ci-python.txt
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: latest
-
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: pnpm
-          cache-dependency-path: |
-            .github/cache-version.txt
-            crates/mesh-llm-ui/pnpm-lock.yaml
+          package-manager-cache: false
 
       - name: Install smoke dependencies
         run: |


### PR DESCRIPTION
The failure is the deferred post-job hook from .github/workflows/smoke.yml:

```yaml
- uses: pnpm/action-setup@v4
- uses: actions/setup-node@v5
  with:
    node-version: 24
    cache: pnpm
    cache-dependency-path: |
      .github/cache-version.txt
      crates/mesh-llm-ui/pnpm-lock.yaml
```
But that reusable smoke workflow never runs pnpm install; it only does:

`npm install --global openai`

So `setup-node@v5` restores/configures a pnpm cache during the main step, then at job teardown its post-action tries to save the pnpm store. 

Since the pnpm store path it resolved does not exist by then, GitHub’s cache save throws:

`Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.`

Why it showed up only now: `setup-node@v5` runs on Node 24 and has changed package-manager caching behavior; there are known v5 reports of this exact post-run cache path validation error. 

The fix is likely to remove `cache: pnpm` from smoke.yml unless the smoke workflow actually installs pnpm dependencies, or add a real pnpm install/store creation step if that cache is intentional.