### PR TITLE
Add explicit bind IP selection for mesh QUIC

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -1,5 +1,6 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use std::ffi::OsString;
+use std::net::IpAddr;
 use std::path::PathBuf;
 
 use crate::cli::benchmark::BenchmarkCommand;
@@ -383,6 +384,10 @@ pub(crate) struct Cli {
     #[arg(long, hide = true)]
     pub(crate) bind_port: Option<u16>,
 
+    /// Bind mesh QUIC to a specific local IP address.
+    #[arg(long, hide = true)]
+    pub(crate) bind_ip: Option<IpAddr>,
+
     /// Bind to 0.0.0.0 (for containers/Fly.io).
     #[arg(long, hide = true)]
     pub(crate) listen_all: bool,
@@ -750,18 +755,21 @@ where
     let mut explicit_surface = None;
 
     // Skip leading global flags to find the pseudo-subcommand position.
-    // Recognized value-taking flags: --log-format, --max-vram, --llama-flavor, --device,
-    // --tensor-split, --bind-port, --max-clients, --port, --console, --draft-max, --ctx-size.
+    // Recognized value-taking flags: --log-format, --mesh-discovery-mode, --max-vram,
+    // --llama-flavor, --device, --tensor-split, --bind-port, --bind-ip, --max-clients,
+    // --port, --console, --draft-max, --ctx-size.
     // Boolean flags: --help-advanced, --auto, --client, --headless, --publish, --blackboard,
     // --plugin, --auto-update, --no-draft, --split, --no-enumerate-host, --listen-all,
     // --no-console, --owner-required.
     let value_taking_flags = [
         "--log-format",
+        "--mesh-discovery-mode",
         "--max-vram",
         "--llama-flavor",
         "--device",
         "--tensor-split",
         "--bind-port",
+        "--bind-ip",
         "--max-clients",
         "--port",
         "--console",
@@ -1255,6 +1263,41 @@ mod tests {
 
         assert_eq!(cli.log_format, LogFormat::Json);
         assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Client));
+    }
+
+    #[test]
+    fn cli_accepts_global_bind_ip_before_serve() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "--bind-ip",
+            "10.1.2.3",
+            "serve",
+            "--bind-port",
+            "47916",
+        ]);
+        let cli = Cli::parse_from(normalized.normalized);
+
+        assert_eq!(cli.bind_ip, Some("10.1.2.3".parse().unwrap()));
+        assert_eq!(cli.bind_port, Some(47916));
+        assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Serve));
+    }
+
+    #[test]
+    fn cli_accepts_global_mesh_discovery_mode_before_serve() {
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "--mesh-discovery-mode",
+            "mdns",
+            "serve",
+            "--auto",
+        ]);
+        let cli = Cli::parse_from(normalized.normalized);
+
+        assert_eq!(
+            cli.mesh_discovery_mode,
+            crate::network::discovery::MeshDiscoveryMode::Mdns
+        );
+        assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Serve));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -734,7 +734,7 @@ impl Node {
         };
         let my_first_joined_mesh_ts = *self.first_joined_mesh_ts.lock().await;
         announcements.push(PeerAnnouncement {
-            addr: self.endpoint.addr(),
+            addr: self.endpoint_addr_for_advertisement(),
             role: my_role,
             first_joined_mesh_ts: my_first_joined_mesh_ts,
             models: my_models,

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -18,6 +18,7 @@ use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey, TransportAddr};
 use prost::Message;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, VecDeque};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
 
 use tokio::sync::{watch, Mutex};
@@ -32,6 +33,7 @@ use crate::protocol::*;
 use skippy_protocol::proto::stage as skippy_stage_proto;
 
 const PRETTY_LOCAL_REQUEST_WINDOW_SECS: u64 = 24 * 60 * 60;
+const EPHEMERAL_QUIC_PORT: u16 = 0;
 
 fn emit_mesh_info(message: String) {
     let _ = crate::cli::output::emit_event(crate::cli::output::OutputEvent::Info {
@@ -67,14 +69,30 @@ const ARTIFACT_TRANSFER_OPEN_TIMEOUT: std::time::Duration = std::time::Duration:
 const ARTIFACT_TRANSFER_READ_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const ARTIFACT_TRANSFER_BUFFER_BYTES: usize = 1024 * 1024;
 
-fn quic_bind_addr(bind_port: Option<u16>) -> Option<std::net::SocketAddr> {
-    if let Some(port) = bind_port {
-        return Some(std::net::SocketAddr::from(([0, 0, 0, 0], port)));
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct QuicBindSelection {
+    pub ip: Option<IpAddr>,
+    pub port: Option<u16>,
+}
+
+fn quic_bind_addr(bind: QuicBindSelection) -> Option<SocketAddr> {
+    if let Some(ip) = bind.ip {
+        return Some(SocketAddr::new(
+            ip,
+            bind.port.unwrap_or(EPHEMERAL_QUIC_PORT),
+        ));
+    }
+
+    if let Some(port) = bind.port {
+        return Some(SocketAddr::from(([0, 0, 0, 0], port)));
     }
 
     #[cfg(target_os = "windows")]
     {
-        Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        Some(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            EPHEMERAL_QUIC_PORT,
+        )))
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -85,6 +103,54 @@ fn quic_bind_addr(bind_port: Option<u16>) -> Option<std::net::SocketAddr> {
 
 fn default_control_bind_addr() -> std::net::SocketAddr {
     std::net::SocketAddr::from(([127, 0, 0, 1], 0))
+}
+
+fn is_public_ipv4_candidate(socket: &SocketAddr) -> bool {
+    match socket.ip() {
+        IpAddr::V4(ip) => is_global_ipv4_candidate(ip),
+        IpAddr::V6(_) => false,
+    }
+}
+
+fn is_global_ipv4_candidate(ip: Ipv4Addr) -> bool {
+    let [a, b, c, _] = ip.octets();
+    !(ip.is_private()
+        || ip.is_loopback()
+        || ip.is_link_local()
+        || ip.is_multicast()
+        || ip.is_broadcast()
+        || ip.is_unspecified()
+        || (a == 100 && (64..=127).contains(&b))
+        || (a == 192 && b == 0 && c == 0)
+        || (a == 192 && b == 0 && c == 2)
+        || (a == 198 && (b == 18 || b == 19))
+        || (a == 198 && b == 51 && c == 100)
+        || (a == 203 && b == 0 && c == 113)
+        || a >= 240)
+}
+
+fn endpoint_addr_has_public_ipv4(addr: &EndpointAddr) -> bool {
+    addr.addrs.iter().any(|candidate| match candidate {
+        TransportAddr::Ip(socket) => is_public_ipv4_candidate(socket),
+        _ => false,
+    })
+}
+
+// Host-network Docker and CNI bridges commonly reuse the same 172.* addresses
+// on every host. When a node selects a bind IP, only advertise that direct IP
+// while preserving relay and public candidates for non-LAN reachability.
+fn filter_endpoint_addr_for_bind_ip(
+    mut addr: EndpointAddr,
+    bind_ip: Option<IpAddr>,
+) -> EndpointAddr {
+    let Some(bind_ip) = bind_ip else {
+        return addr;
+    };
+    addr.addrs.retain(|candidate| match candidate {
+        TransportAddr::Ip(socket) => socket.ip() == bind_ip || is_public_ipv4_candidate(socket),
+        _ => true,
+    });
+    addr
 }
 
 fn effective_relay_urls(relay_urls: &[String]) -> Vec<String> {
@@ -1239,6 +1305,7 @@ async fn stun_public_addr(advertised_port: u16) -> Option<std::net::SocketAddr> 
 pub struct Node {
     endpoint: Endpoint,
     public_addr: Option<std::net::SocketAddr>,
+    quic_bind: QuicBindSelection,
     state: Arc<Mutex<MeshState>>,
     role: Arc<Mutex<NodeRole>>,
     models: Arc<Mutex<Vec<String>>>,
@@ -2244,7 +2311,7 @@ impl Node {
     pub async fn start(
         role: NodeRole,
         relay_urls: &[String],
-        bind_port: Option<u16>,
+        quic_bind: QuicBindSelection,
         max_vram_gb: Option<f64>,
         enumerate_host: bool,
         owner_config: Option<OwnerRuntimeConfig>,
@@ -2284,7 +2351,7 @@ impl Node {
                 &urls,
             )));
         }
-        if let Some(addr) = quic_bind_addr(bind_port) {
+        if let Some(addr) = quic_bind_addr(quic_bind) {
             tracing::info!("Binding QUIC to {addr}");
             builder = builder.bind_addr(addr)?;
         }
@@ -2300,9 +2367,10 @@ impl Node {
 
         // Discover public IP via STUN so the invite token includes it.
         // With --bind-port, the advertised port is the bound port (for port forwarding).
-        // Without --bind-port, we use port 0 — the IP is still useful for hole-punching.
+        // Without --bind-port, port 0 is intentional: it asks the OS for a conflict-free
+        // ephemeral port. The IP is still useful for hole-punching.
         // Relay STUN may not work on sinkholed networks, so we use raw STUN to Google/Cloudflare.
-        let stun_port = bind_port.unwrap_or(0);
+        let stun_port = quic_bind.port.unwrap_or(EPHEMERAL_QUIC_PORT);
         let public_addr = stun_public_addr(stun_port).await;
 
         let (peer_change_tx, peer_change_rx) = watch::channel(0usize);
@@ -2408,6 +2476,7 @@ impl Node {
         let node = Node {
             endpoint,
             public_addr,
+            quic_bind,
             state: Arc::new(Mutex::new(MeshState {
                 peers: HashMap::new(),
                 connections: HashMap::new(),
@@ -2548,6 +2617,7 @@ impl Node {
         Node {
             endpoint,
             public_addr: None,
+            quic_bind: QuicBindSelection::default(),
             state: Arc::new(Mutex::new(MeshState {
                 peers: HashMap::new(),
                 connections: HashMap::new(),
@@ -2677,23 +2747,24 @@ impl Node {
     }
 
     pub fn invite_token(&self) -> String {
-        let mut addr = self.endpoint.addr();
+        let mut addr = self.endpoint_addr_for_advertisement();
         // Inject STUN-discovered public address if relay STUN didn't provide one.
         if let Some(pub_addr) = self.public_addr {
-            use iroh::TransportAddr;
-            let has_public = addr.addrs.iter().any(|a| match a {
-                TransportAddr::Ip(sock) => match sock.ip() {
-                    std::net::IpAddr::V4(v4) => !v4.is_private() && !v4.is_loopback(),
-                    _ => false,
-                },
-                _ => false,
-            });
-            if !has_public {
+            if !endpoint_addr_has_public_ipv4(&addr) {
                 addr.addrs.insert(TransportAddr::Ip(pub_addr));
             }
         }
+        addr = filter_endpoint_addr_for_bind_ip(addr, self.quic_bind.ip);
         let json = serde_json::to_vec(&addr).expect("serializable");
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(&json)
+    }
+
+    fn endpoint_addr_for_advertisement(&self) -> EndpointAddr {
+        let mut addr = self.endpoint.addr();
+        if self.quic_bind.ip.is_some() {
+            addr = filter_endpoint_addr_for_bind_ip(addr, self.quic_bind.ip);
+        }
+        addr
     }
 
     /// Decode an invite token into an [`EndpointAddr`] without connecting.

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -16,8 +16,33 @@ use tokio::sync::watch;
 #[test]
 fn quic_bind_addr_uses_explicit_port_on_all_platforms() {
     assert_eq!(
-        quic_bind_addr(Some(7000)),
+        quic_bind_addr(QuicBindSelection {
+            ip: None,
+            port: Some(7000)
+        }),
         Some(std::net::SocketAddr::from(([0, 0, 0, 0], 7000)))
+    );
+}
+
+#[test]
+fn quic_bind_addr_uses_explicit_ip_and_port() {
+    assert_eq!(
+        quic_bind_addr(QuicBindSelection {
+            ip: Some("10.1.2.3".parse().unwrap()),
+            port: Some(7000)
+        }),
+        Some("10.1.2.3:7000".parse().unwrap())
+    );
+}
+
+#[test]
+fn quic_bind_addr_uses_explicit_ip_with_ephemeral_port() {
+    assert_eq!(
+        quic_bind_addr(QuicBindSelection {
+            ip: Some("10.1.2.3".parse().unwrap()),
+            port: None
+        }),
+        Some("10.1.2.3:0".parse().unwrap())
     );
 }
 
@@ -25,7 +50,7 @@ fn quic_bind_addr_uses_explicit_port_on_all_platforms() {
 #[cfg(target_os = "windows")]
 fn quic_bind_addr_falls_back_to_localhost_ephemeral_on_windows() {
     assert_eq!(
-        quic_bind_addr(None),
+        quic_bind_addr(QuicBindSelection::default()),
         Some(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
     );
 }
@@ -33,7 +58,51 @@ fn quic_bind_addr_falls_back_to_localhost_ephemeral_on_windows() {
 #[test]
 #[cfg(not(target_os = "windows"))]
 fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
-    assert_eq!(quic_bind_addr(None), None);
+    assert_eq!(quic_bind_addr(QuicBindSelection::default()), None);
+}
+
+#[test]
+fn endpoint_addr_filter_for_bind_ip_keeps_selected_ip_relay_and_public_candidates() {
+    let mut addr = EndpointAddr {
+        id: make_test_endpoint_id(0x42),
+        addrs: Default::default(),
+    };
+    addr.addrs
+        .insert(iroh::TransportAddr::Ip("10.1.2.3:47916".parse().unwrap()));
+    addr.addrs
+        .insert(iroh::TransportAddr::Ip("172.23.0.1:47916".parse().unwrap()));
+    addr.addrs.insert(iroh::TransportAddr::Ip(
+        "100.107.22.123:47916".parse().unwrap(),
+    ));
+    addr.addrs.insert(iroh::TransportAddr::Ip(
+        "192.168.1.20:47916".parse().unwrap(),
+    ));
+    addr.addrs.insert(iroh::TransportAddr::Ip(
+        "35.199.1.10:47916".parse().unwrap(),
+    ));
+    addr.addrs.insert(iroh::TransportAddr::Relay(
+        "https://relay.example.com".parse().unwrap(),
+    ));
+
+    let filtered = filter_endpoint_addr_for_bind_ip(addr, Some("10.1.2.3".parse().unwrap()));
+    let ip_addrs: HashSet<_> = filtered
+        .addrs
+        .iter()
+        .filter_map(|addr| match addr {
+            iroh::TransportAddr::Ip(socket) => Some(socket.to_string()),
+            _ => None,
+        })
+        .collect();
+
+    assert!(ip_addrs.contains("10.1.2.3:47916"));
+    assert!(ip_addrs.contains("35.199.1.10:47916"));
+    assert!(!ip_addrs.contains("172.23.0.1:47916"));
+    assert!(!ip_addrs.contains("100.107.22.123:47916"));
+    assert!(!ip_addrs.contains("192.168.1.20:47916"));
+    assert!(filtered
+        .addrs
+        .iter()
+        .any(|addr| matches!(addr, iroh::TransportAddr::Relay(_))));
 }
 
 fn stage_load_request() -> crate::inference::skippy::StageLoadRequest {
@@ -106,6 +175,7 @@ async fn make_test_node(role: super::NodeRole) -> Result<Node> {
     let node = Node {
         endpoint,
         public_addr: None,
+        quic_bind: QuicBindSelection::default(),
         state: Arc::new(Mutex::new(MeshState {
             peers: HashMap::new(),
             connections: HashMap::new(),

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -4212,7 +4212,10 @@ pub(crate) async fn run_plugin_mcp(cli: &Cli) -> Result<()> {
     let (node, _channels) = mesh::Node::start(
         NodeRole::Client,
         &cli.relay,
-        cli.bind_port,
+        mesh::QuicBindSelection {
+            ip: cli.bind_ip,
+            port: cli.bind_port,
+        },
         Some(0.0),
         !cli.no_enumerate_host,
         Some(owner_config),
@@ -4331,7 +4334,10 @@ async fn run_auto(
     let (node, channels) = mesh::Node::start(
         role,
         &cli.relay,
-        cli.bind_port,
+        mesh::QuicBindSelection {
+            ip: cli.bind_ip,
+            port: cli.bind_port,
+        },
         max_vram,
         !cli.no_enumerate_host,
         Some(owner_config),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -72,6 +72,11 @@ Runtime switches:
 - `--client`: API-only mode (no GPU/model serving).
 - `--console <CONSOLE>`: console/API management port (default `3131`).
 - `--headless`: disable the embedded web UI; keep the management API on the `--console` port.
+- `--bind-ip <IP>`: bind mesh QUIC to a specific local IP address and advertise
+  only that selected direct IP, plus relay/public candidates. Use this on
+  multi-interface hosts where Docker/CNI bridge addresses overlap across nodes.
+- `--bind-port <PORT>`: bind mesh QUIC to a fixed UDP port, usually paired
+  with `--bind-ip` for firewall or NAT rules.
 - `--publish`: publish your mesh for discovery.
 - `--mesh-name <MESH_NAME>`: friendly mesh name in discovery.
 - `--region <REGION>`: region hint for discovery.

--- a/docs/MESHES.md
+++ b/docs/MESHES.md
@@ -41,6 +41,29 @@ Join from an API-only client:
 mesh-llm client --join <token>
 ```
 
+### Multi-interface Linux and Docker hosts
+
+On Linux hosts with several kernel-visible interfaces, especially
+`docker run --network host` systems, iroh can discover and advertise Docker or
+CNI bridge addresses such as `172.17.0.1`. If every host has the same bridge
+address, peers may race the wrong local bridge instead of the real management
+network.
+
+Choose the host-to-host interface explicitly:
+
+```bash
+# seed
+mesh-llm serve --split --bind-ip 10.1.2.3 --bind-port 47916 --model Qwen3-8B-Q4_K_M
+
+# worker
+mesh-llm serve --split --join <token> --model Qwen3-8B-Q4_K_M
+```
+
+`--bind-ip` binds mesh QUIC to that local address and filters the invite/gossip
+direct-address set to the selected IP while keeping relay/public candidates.
+Use `--listen-all` only for the local HTTP API/console listener; it does not
+select the mesh QUIC interface.
+
 ## Publish your own mesh
 
 ```bash

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -153,6 +153,27 @@ mesh-llm serve --model Qwen2.5-32B --join <TOKEN>
 - Stage placement is proportional to available VRAM (e.g. `0.67,0.33`)
 - Draft model auto-detected and used
 
+#### Multi-interface Docker/Linux bind-IP validation
+
+For host-network Docker or multi-NIC Linux hosts, validate the selected
+host-to-host interface explicitly:
+
+```bash
+# seed on the routable management IP
+mesh-llm serve --model Qwen2.5-32B --split --bind-ip 10.1.2.3 --bind-port 7842
+
+# worker joins the printed token
+mesh-llm serve --model Qwen2.5-32B --split --join <TOKEN>
+```
+
+- Decode the invite token and confirm Docker/CNI bridge addresses such as
+  `172.17.0.1` or `172.23.0.1` are absent when `--bind-ip` is set.
+- The seed sees the worker in `/api/status`; it must not stay at
+  `Waiting for peers...`.
+- `/v1/models` becomes non-empty after split startup and inference works.
+- `--listen-all` is not a substitute for this test; it only affects local
+  HTTP API/console listeners.
+
 ### 4. Two GPU nodes, model too big for one
 
 When the model exceeds host VRAM, split happens automatically without `--split`.


### PR DESCRIPTION
## Summary
- Add `--bind-ip <IP>` so multi-interface Linux/Docker hosts can bind mesh QUIC to the routable host-to-host address.
- Filter advertised direct addresses in invite tokens and gossip when a bind IP is selected, keeping the selected IP, relay candidates, and public IPv4 candidates while dropping overlapping Docker/CNI/CGNAT/local ranges.
- Document the multi-interface Docker/Linux workflow and the expected verification path.

## Why
#542 reports split meshes failing on host-network Docker/CNI machines where hosts advertise identical bridge addresses. iroh can race those direct candidates and end up dialing the wrong local bridge instead of the intended seed. `--listen-all` only affects the HTTP API/console listeners; it does not select the mesh QUIC interface.

This PR gives operators an explicit, reviewable way to select the mesh-facing IP used by the QUIC endpoint and by the advertised direct-address set.

## Details
- Introduces a typed QUIC bind selection that carries the requested IP and optional port through runtime startup.
- Preserves existing `--bind-port` behavior when no bind IP is supplied.
- Uses `IP:0` when `--bind-ip` is supplied without `--bind-port`, so the OS can still choose the UDP port.
- Reuses the same filtered advertisement path for invite-token creation and gossip self-announcements.
- Keeps the invite-token envelope and mesh wire protocol unchanged.

## Compatibility
- No QUIC ALPN, protobuf, gossip schema, or invite-token format change.
- Existing `--bind-port` behavior remains `0.0.0.0:<port>`.
- New seed + old worker remains compatible because the token is still a normal iroh endpoint address with a narrower, better candidate set.
- Old seed + new worker remains unchanged; the seed must opt into `--bind-ip` for this specific network-selection fix to apply.

## Validation
- `git diff --check`
- `git diff --cached --check`
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime bind_ip --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime quic_bind_addr --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime cli_accepts_global_mesh_discovery_mode_before_serve --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime mesh::tests::artifact_transfer_stream_serves_authorized_stage_artifact --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm --lib`

## Notes
- Not run locally: the two-host Docker/CUDA repro from #542. That still needs the external multi-host environment that motivated the issue.

Fixes #542.
Related: #525.