### PR TITLE
Validate selective PR CI crate checks

### DIFF
--- a/.github/actions/compute-changes/action.yml
+++ b/.github/actions/compute-changes/action.yml
@@ -1,0 +1,172 @@
+name: Compute changed files
+description: 'Compute changed files and affected crates for CI routing'
+
+inputs:
+  event_name:
+    description: 'GitHub event name (pull_request, push, workflow_dispatch)'
+    required: true
+  base_sha:
+    description: 'PR base SHA (empty for non-PR events)'
+    required: false
+    default: ''
+  head_sha:
+    description: 'PR head SHA (empty for non-PR events)'
+    required: false
+    default: ''
+
+outputs:
+  changed_files:
+    description: 'Newline-delimited list of changed files'
+    value: ${{ steps.derive.outputs.changed_files }}
+  affected_crates:
+    description: 'JSON array of affected crate names'
+    value: ${{ steps.derive.outputs.affected_crates }}
+  test_crates:
+    description: 'JSON array of crates to test'
+    value: ${{ steps.derive.outputs.test_crates }}
+  batches_json:
+    description: 'JSON array of test batches'
+    value: ${{ steps.derive.outputs.batches_json }}
+  clippy_batches_json:
+    description: 'JSON array of deterministic clippy matrix batches'
+    value: ${{ steps.derive.outputs.clippy_batches_json }}
+  all_rust:
+    description: 'Boolean: true if all changed files are Rust'
+    value: ${{ steps.derive.outputs.all_rust }}
+  ui_changed:
+    description: 'Boolean: true if UI files changed'
+    value: ${{ steps.derive.outputs.ui_changed }}
+  docs_only:
+    description: 'Boolean: true if only docs changed'
+    value: ${{ steps.derive.outputs.docs_only }}
+  rust_changed:
+    description: 'Boolean: true if Rust files changed'
+    value: ${{ steps.derive.outputs.rust_changed }}
+  backend_changed:
+    description: 'Boolean: true if PR platform/backend binaries must rebuild'
+    value: ${{ steps.derive.outputs.backend_changed }}
+  sdk_smoke_required:
+    description: 'Boolean: true if SDK smoke tests should run as soon as a binary is ready'
+    value: ${{ steps.derive.outputs.sdk_smoke_required }}
+
+runs:
+  using: composite
+  steps:
+    - name: Compute changed file list
+      id: files
+      shell: bash
+      run: |
+        if [[ "${{ inputs.event_name }}" == "pull_request" ]]; then
+          # For pull_request: use base_sha...head_sha
+          git diff --name-only "${{ inputs.base_sha }}...${{ inputs.head_sha }}" > /tmp/changed_files.txt
+        elif [[ "${{ inputs.event_name }}" == "push" ]]; then
+          # For push: use HEAD^ HEAD
+          git diff --name-only HEAD^ HEAD > /tmp/changed_files.txt
+        elif [[ "${{ inputs.event_name }}" == "workflow_dispatch" ]]; then
+          # For workflow_dispatch: force all by using a known Rust file
+          echo "__force_all__" > /tmp/changed_files.txt
+        else
+          echo "Unknown event type: ${{ inputs.event_name }}" >&2
+          exit 1
+        fi
+        
+        cat /tmp/changed_files.txt
+
+    - name: Run affected-crates.sh
+      id: crates
+      shell: bash
+      run: |
+        # Handle __force_all__ sentinel: if present, use a known Rust file to trigger all_rust=true
+        if grep -q "^__force_all__$" /tmp/changed_files.txt; then
+          echo "Cargo.lock" | bash scripts/affected-crates.sh --stdin > /tmp/crates_output.json
+        else
+          cat /tmp/changed_files.txt | bash scripts/affected-crates.sh --stdin > /tmp/crates_output.json
+        fi
+        
+        cat /tmp/crates_output.json
+
+    - name: Derive outputs
+      id: derive
+      shell: bash
+      run: |
+        # Read the JSON output from affected-crates.sh
+        CRATES_JSON=$(cat /tmp/crates_output.json)
+        
+        # Extract fields from JSON
+        AFFECTED_CRATES=$(echo "$CRATES_JSON" | jq -c '.affected // []')
+        TEST_CRATES=$(echo "$CRATES_JSON" | jq -c '.test_crates // []')
+        BATCHES=$(echo "$CRATES_JSON" | jq -c '.batches // []')
+        ALL_RUST=$(echo "$CRATES_JSON" | jq -r '.all_rust // false')
+        UI_CHANGED=$(echo "$CRATES_JSON" | jq -r '.ui_changed // false')
+
+        if [[ "$ALL_RUST" == "true" ]]; then
+          CLIPPY_BATCHES=$(bash scripts/plan-clippy-batches.sh --all)
+        else
+          CLIPPY_BATCHES=$(bash scripts/plan-clippy-batches.sh --crates-json "$AFFECTED_CRATES")
+        fi
+        
+        # Read changed files for docs_only and rust_changed logic
+        CHANGED_FILES=$(cat /tmp/changed_files.txt | grep -v "^__force_all__$" || true)
+        
+        # Determine docs_only: true if all_rust=false AND ui_changed=false AND all files match docs patterns
+        DOCS_ONLY="false"
+        if [[ "$ALL_RUST" == "false" ]] && [[ "$UI_CHANGED" == "false" ]]; then
+          # Check if all changed files match docs patterns (*.md or docs/**)
+          if [[ -n "$CHANGED_FILES" ]]; then
+            NON_DOCS=$(echo "$CHANGED_FILES" | grep -v -E '(\.md$|^docs/)' || true)
+            if [[ -z "$NON_DOCS" ]]; then
+              DOCS_ONLY="true"
+            fi
+          fi
+        fi
+        
+        # Determine rust_changed: true if all_rust=true OR affected_crates is non-empty
+        RUST_CHANGED="false"
+        if [[ "$ALL_RUST" == "true" ]]; then
+          RUST_CHANGED="true"
+        elif [[ $(echo "$AFFECTED_CRATES" | jq 'length') -gt 0 ]]; then
+          RUST_CHANGED="true"
+        fi
+
+        # Backend/platform lanes rebuild only for all-rust escalations or files
+        # that can alter the native ABI/backend build products.
+        BACKEND_CHANGED="false"
+        if [[ "$ALL_RUST" == "true" ]]; then
+          BACKEND_CHANGED="true"
+        elif [[ -n "$CHANGED_FILES" ]]; then
+          BACKEND_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^third_party/llama\.cpp/|^crates/skippy-ffi/|^scripts/(build-llama|prepare-llama|build-linux|build-mac|build-windows|install-windows-sdk)\.|^\.github/actions/setup-windows-rocm-sdk/|^\.github/workflows/pr_ci\.yml$|^\.github/workflows/pr_quality\.yml$|^\.github/cache-version\.txt$|^Justfile$)' || true)
+          if [[ -n "$BACKEND_INPUTS" ]]; then
+            BACKEND_CHANGED="true"
+          fi
+        fi
+
+        # SDK smokes are consumer tests: run for workflow dispatch, direct SDK
+        # files, or when affected crate analysis reaches the SDK/API crates.
+        SDK_SMOKE_REQUIRED="false"
+        if [[ "${{ inputs.event_name }}" == "workflow_dispatch" ]]; then
+          SDK_SMOKE_REQUIRED="true"
+        elif [[ -n "$CHANGED_FILES" ]]; then
+          DIRECT_SDK_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^sdk/|^Package\.swift$|^scripts/ci-(native|kotlin|swift)-sdk-smoke\.sh$|^scripts/ci-sdk-fixture\.sh$)' || true)
+          if [[ -n "$DIRECT_SDK_INPUTS" ]]; then
+            SDK_SMOKE_REQUIRED="true"
+          elif echo "$AFFECTED_CRATES" | jq -e 'index("mesh-llm-client") or index("mesh-api") or index("mesh-api-ffi") or index("mesh-llm-protocol") or index("mesh-llm-routing") or index("mesh-llm-types")' >/dev/null; then
+            SDK_SMOKE_REQUIRED="true"
+          fi
+        fi
+
+        # Set outputs using GITHUB_OUTPUT
+        {
+          echo "changed_files<<EOF"
+          cat /tmp/changed_files.txt | grep -v "^__force_all__$" || true
+          echo "EOF"
+          echo "affected_crates=$AFFECTED_CRATES"
+          echo "test_crates=$TEST_CRATES"
+          echo "batches_json=$BATCHES"
+          echo "clippy_batches_json=$CLIPPY_BATCHES"
+          echo "all_rust=$ALL_RUST"
+          echo "ui_changed=$UI_CHANGED"
+          echo "docs_only=$DOCS_ONLY"
+          echo "rust_changed=$RUST_CHANGED"
+          echo "backend_changed=$BACKEND_CHANGED"
+          echo "sdk_smoke_required=$SDK_SMOKE_REQUIRED"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pr_ci.yml
+++ b/.github/workflows/pr_ci.yml
@@ -1,13 +1,13 @@
-name: CI
+name: PR CI
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   CACHE_NAMESPACE: mesh-llm
@@ -38,6 +38,8 @@ jobs:
       all_rust: ${{ steps.compute.outputs.all_rust }}
       docs_only: ${{ steps.compute.outputs.docs_only }}
       rust_changed: ${{ steps.compute.outputs.rust_changed }}
+      backend_changed: ${{ steps.compute.outputs.backend_changed }}
+      sdk_smoke_required: ${{ steps.compute.outputs.sdk_smoke_required }}
       ui_dist_cache_key: ${{ steps.ui_key.outputs.ui_dist_cache_key }}
     steps:
       - uses: actions/checkout@v5
@@ -56,7 +58,8 @@ jobs:
               - 'scripts/**'
               - 'third_party/llama.cpp/**'
               - '.github/cache-version.txt'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/pr_ci.yml'
+              - '.github/workflows/pr_quality.yml'
               - '.github/workflows/smoke.yml'
 
             ui:
@@ -66,7 +69,7 @@ jobs:
               - 'crates/llama-spec-bench/**'
               - 'crates/mesh-llm-gpu-bench/**'
               - '.github/workflows/benchmark-smoke.yml'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/pr_ci.yml'
             sdk:
               - 'crates/mesh-api/**'
               - 'crates/mesh-api-ffi/**'
@@ -81,7 +84,7 @@ jobs:
               - 'scripts/ci-kotlin-sdk-smoke.sh'
               - 'scripts/ci-swift-sdk-smoke.sh'
               - 'scripts/ci-sdk-fixture.sh'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/pr_ci.yml'
             docker:
               - '.dockerignore'
               - 'docker/**'
@@ -89,7 +92,7 @@ jobs:
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'
-              - '.github/workflows/docker.yml'
+              - '.github/workflows/pr_docker.yml'
             windows_cpu:
               - 'crates/skippy-ffi/**'
               - 'scripts/build-windows.ps1'
@@ -98,7 +101,7 @@ jobs:
               - 'Cargo.lock'
               - 'Justfile'
               - '.github/cache-version.txt'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/pr_ci.yml'
               - '.github/workflows/windows-warm-caches.yml'
             windows_gpu:
               - 'crates/skippy-ffi/**'
@@ -108,7 +111,7 @@ jobs:
               - 'Justfile'
               - '.github/cache-version.txt'
               - '.github/actions/setup-windows-rocm-sdk/**'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/pr_ci.yml'
               - '.github/workflows/windows-warm-caches.yml'
 
             docs:
@@ -120,8 +123,8 @@ jobs:
         uses: ./.github/actions/compute-changes
         with:
           event_name: ${{ github.event_name }}
-          base_sha: ''
-          head_sha: ''
+          base_sha: ${{ github.event.pull_request.base.sha || '' }}
+          head_sha: ${{ github.event.pull_request.head.sha || '' }}
       - name: Compute UI dist cache key
         id: ui_key
         run: |
@@ -336,6 +339,7 @@ jobs:
           name: ci-linux-inference-binaries
           path: target/debug/mesh-llm
           if-no-files-found: error
+          retention-days: 3
 
       - name: Show sccache stats
         if: always()
@@ -383,7 +387,7 @@ jobs:
       artifact_name: ci-linux-inference-binaries
       mesh_binary_target: target/debug/mesh-llm
       cache_key_prefix: ''
-      workflow_cache_file: .github/workflows/ci.yml
+      workflow_cache_file: .github/workflows/pr_ci.yml
 
   agent_live_smokes:
     needs: [changes, linux]
@@ -454,7 +458,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-two-node-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-two-node-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/pr_ci.yml') }}
       - name: Download integration model
         if: steps.cache-two-node-model.outputs.cache-hit != 'true'
         run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
@@ -468,8 +472,8 @@ jobs:
         run: scripts/ci-two-node-client-serving-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MODEL_FILE"
 
   native_sdk_smoke:
-    needs: [changes, linux, inference_smoke_tests]
-    if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    needs: [changes, linux]
+    if: ${{ needs.linux.result == 'success' && needs.changes.outputs.sdk_smoke_required == 'true' && needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -500,7 +504,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/pr_ci.yml') }}
       - name: Download integration model
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
@@ -514,8 +518,8 @@ jobs:
         run: scripts/ci-native-sdk-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MODEL_FILE"
 
   kotlin_sdk_smoke:
-    needs: [changes, linux, inference_smoke_tests]
-    if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    needs: [changes, linux]
+    if: ${{ needs.linux.result == 'success' && needs.changes.outputs.sdk_smoke_required == 'true' && needs.changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -547,7 +551,7 @@ jobs:
         uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-kotlin-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-kotlin-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/pr_ci.yml') }}
       - name: Download integration model
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
@@ -555,59 +559,26 @@ jobs:
         run: scripts/ci-kotlin-sdk-smoke.sh target/debug/mesh-llm ci-artifacts/linux "$HOME/.models/$MODEL_FILE"
 
   swift_sdk_smoke:
-    needs: [changes, inference_smoke_tests]
-    if: ${{ needs.inference_smoke_tests.result == 'success' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.sdk == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    needs: [changes, macos]
+    if: ${{ needs.macos.result == 'success' && needs.changes.outputs.sdk_smoke_required == 'true' && needs.changes.outputs.docs_only != 'true' }}
     runs-on: macos-14
-    env:
-      LLAMA_STAGE_BACKEND: metal
-      LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-metal
     steps:
       - uses: actions/checkout@v5
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: actions/download-artifact@v7
         with:
-          workspaces: . -> target
-          cache-bin: "false"
-          prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ runner.os }}-${{ hashFiles('.github/cache-version.txt') }}
-          shared-key: swift-sdk
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-      - name: Install tools
-        run: brew install cmake ninja jq lld
-      - name: Configure macOS Rust linker
+          name: ci-macos-inference-binaries
+          path: ci-artifacts/macos
+      - name: Stage binary
         run: |
-          mkdir -p .cargo
-          lld_prefix="$(brew --prefix lld)"
-          cat > .cargo/config.toml <<EOF
-          [target.aarch64-apple-darwin]
-          rustflags = ["-C", "link-arg=-fuse-ld=$lld_prefix/bin/ld64.lld"]
-
-          [target.x86_64-apple-darwin]
-          rustflags = ["-C", "link-arg=-fuse-ld=$lld_prefix/bin/ld64.lld"]
-          EOF
-      - name: Build UI placeholder
-        run: mkdir -p crates/mesh-llm-ui/dist && printf '<html></html>' > crates/mesh-llm-ui/dist/index.html
-      - name: Ensure ABI cache directory
-        run: mkdir -p "$LLAMA_STAGE_BUILD_DIR"
-      - name: Cache patched llama.cpp ABI build
-        id: llama_cache
-        uses: actions/cache@v5
-        with:
-          path: .deps/llama.cpp/build-stage-abi-metal
-          key: ${{ env.CACHE_NAMESPACE }}-macos-14-skippy-abi-metal-${{ hashFiles('scripts/build-mac.sh', 'scripts/build-llama.sh', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', 'Justfile', '.github/cache-version.txt') }}
-      - name: Prepare patched llama.cpp ABI checkout
-        if: steps.llama_cache.outputs.cache-hit != 'true'
-        run: scripts/prepare-llama.sh pinned
-      - name: Build patched llama.cpp ABI libraries
-        if: steps.llama_cache.outputs.cache-hit != 'true'
-        run: scripts/build-llama.sh
-      - name: Build mesh-llm binary (debug)
-        run: cargo build -p mesh-llm --bin mesh-llm
+          mkdir -p target/debug
+          cp ci-artifacts/macos/mesh-llm target/debug/mesh-llm
+          chmod +x target/debug/mesh-llm
       - name: Cache integration model
         id: cache-model
         uses: actions/cache/restore@v5
         with:
           path: ~/.models/${{ env.MODEL_FILE }}
-          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-swift-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/ci.yml') }}
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-swift-sdk-model-${{ env.MODEL_FILE }}-${{ hashFiles('.github/cache-version.txt', '.github/workflows/pr_ci.yml') }}
       - name: Download integration model
         if: steps.cache-model.outputs.cache-hit != 'true'
         run: mkdir -p ~/.models && curl -fSL "$MODEL_URL" -o "$HOME/.models/$MODEL_FILE"
@@ -723,13 +694,20 @@ jobs:
         run: |
           target/debug/mesh-llm --version
           target/debug/mesh-llm --help | head -5
+      - name: Upload macOS inference binary
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-macos-inference-binaries
+          path: target/debug/mesh-llm
+          if-no-files-found: error
+          retention-days: 3
       - name: Mark benchmark artifact unavailable
         id: benchmark_artifact_ready
         run: echo "ready=false" >> "$GITHUB_OUTPUT"
 
   linux_cuda:
     needs: changes
-    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.benchmarks == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend_changed == 'true' || needs.changes.outputs.benchmarks == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Linux CUDA slim
     runs-on: ubuntu-latest
     outputs:
@@ -793,7 +771,7 @@ jobs:
 
   linux_rocm:
     needs: changes
-    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.benchmarks == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend_changed == 'true' || needs.changes.outputs.benchmarks == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Linux ROCm slim
     runs-on: ubuntu-latest
     outputs:
@@ -851,7 +829,7 @@ jobs:
 
   linux_vulkan:
     needs: changes
-    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.backend_changed == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Linux Vulkan
     runs-on: ubuntu-latest
     env:
@@ -899,7 +877,7 @@ jobs:
         run: target/release/mesh-llm --version
   windows_cpu:
     needs: changes
-    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.all_rust == 'true' || needs.changes.outputs.windows_cpu == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Windows CPU
     runs-on: windows-2022
     env:
@@ -963,7 +941,7 @@ jobs:
 
   windows_gpu:
     needs: changes
-    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') && needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.all_rust == 'true' || needs.changes.outputs.windows_gpu == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Windows ${{ matrix.name }}
     runs-on: windows-2022
     env:

--- a/.github/workflows/pr_cleanup.yml
+++ b/.github/workflows/pr_cleanup.yml
@@ -1,4 +1,4 @@
-name: Cleanup GitHub Actions caches on closed pull requests
+name: PR Cache Cleanup
 
 on:
   pull_request_target:

--- a/.github/workflows/pr_docker.yml
+++ b/.github/workflows/pr_docker.yml
@@ -1,13 +1,20 @@
-name: docker
+name: PR Docker Build
 
 on:
-  workflow_dispatch:
-  push:
-    tags: ['v*']
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - '.dockerignore'
+      - 'docker/**'
+      - 'fly/Dockerfile'
+      - 'crates/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - '.github/workflows/pr_docker.yml'
 
 concurrency:
-  group: docker-${{ github.ref }}
-  cancel-in-progress: false
+  group: pr-docker-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -15,7 +22,6 @@ env:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker-client:
@@ -24,6 +30,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
+        if: false
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,6 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
             type=semver,pattern={{version}}
             type=sha,prefix=sha-,format=short
             type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
@@ -43,6 +51,6 @@ jobs:
           context: .
           file: docker/Dockerfile.client
           platforms: linux/amd64
-          push: true
+          push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pr_quality.yml
+++ b/.github/workflows/pr_quality.yml
@@ -1,0 +1,159 @@
+name: PR Quality Checks
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CACHE_NAMESPACE: mesh-llm
+  CARGO_INCREMENTAL: "0"
+  SCCACHE_GHA_ENABLED: "true"
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      affected_crates: ${{ steps.compute.outputs.affected_crates }}
+      test_crates: ${{ steps.compute.outputs.test_crates }}
+      batches_json: ${{ steps.compute.outputs.batches_json }}
+      clippy_batches_json: ${{ steps.compute.outputs.clippy_batches_json }}
+      all_rust: ${{ steps.compute.outputs.all_rust }}
+      ui_changed: ${{ steps.compute.outputs.ui_changed }}
+      docs_only: ${{ steps.compute.outputs.docs_only }}
+      rust_changed: ${{ steps.compute.outputs.rust_changed }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/compute-changes
+        id: compute
+        with:
+          event_name: ${{ github.event_name }}
+          base_sha: ${{ github.event.pull_request.base.sha || '' }}
+          head_sha: ${{ github.event.pull_request.head.sha || '' }}
+
+  rust-fmt:
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  rust-clippy:
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        batch: ${{ fromJson(needs.changes.outputs.clippy_batches_json) }}
+    name: rust-clippy (${{ matrix.batch.idx }})
+    env:
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev lld
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: . -> target
+          cache-bin: "false"
+          prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ runner.os }}-${{ hashFiles('.github/cache-version.txt') }}
+          shared-key: pr-clippy
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Run clippy
+        env:
+          CLIPPY_CRATES: ${{ toJson(matrix.batch.crates) }}
+        run: |
+          CRATES=$(jq -r '.[]' <<<"$CLIPPY_CRATES")
+          if [[ -z "$CRATES" ]]; then
+            echo "Batch ${{ matrix.batch.idx }}: no crates to check"
+            exit 0
+          fi
+          echo "Batch ${{ matrix.batch.idx }} crates: $CRATES"
+          for CRATE in $CRATES; do
+            # skippy-ffi requires llama.cpp ABI build — skip in quality-only workflow
+            if [[ "$CRATE" == "skippy-ffi" ]]; then
+              echo "Skipping skippy-ffi: requires llama.cpp ABI build (not available in PR Quality Checks)"
+              continue
+            fi
+            cargo clippy -p "$CRATE" --all-targets -- -D warnings
+          done
+
+  ui-quality:
+    needs: changes
+    if: needs.changes.outputs.ui_changed == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: crates/mesh-llm-ui
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: crates/mesh-llm-ui/pnpm-lock.yaml
+      - name: Install dependencies
+        run: pnpm i --frozen-lockfile
+      - name: Lint
+        run: pnpm run lint
+      - name: Type check
+        run: pnpm run typecheck
+      - name: Test
+        run: pnpm test
+
+  summary:
+    needs: [rust-fmt, rust-clippy, ui-quality]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check quality gate
+        env:
+          FMT: ${{ needs.rust-fmt.result }}
+          CLIPPY: ${{ needs.rust-clippy.result }}
+          UI: ${{ needs.ui-quality.result }}
+        run: |
+          echo "┌────────────────────┬──────────────────────┐"
+          echo "│ Check              │ Result               │"
+          echo "├────────────────────┼──────────────────────┤"
+          printf "│ %-18s │ %-20s │\n" "rust-fmt"    "$FMT"
+          printf "│ %-18s │ %-20s │\n" "rust-clippy" "$CLIPPY"
+          printf "│ %-18s │ %-20s │\n" "ui-quality"  "$UI"
+          echo "└────────────────────┴──────────────────────┘"
+
+          FAILED=false
+          for STATUS in "$FMT" "$CLIPPY" "$UI"; do
+            if [[ "$STATUS" == "failure" || "$STATUS" == "cancelled" ]]; then
+              FAILED=true
+            fi
+          done
+
+          if [[ "$FAILED" == "true" ]]; then
+            echo "ERROR: One or more quality checks failed."
+            exit 1
+          fi
+
+          echo "All quality checks passed (or were skipped)."

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -1,113 +1,96 @@
 ```mermaid
 flowchart TD
-    subgraph Triggers["Triggers"]
-        PR["Pull Request / push main"]
+    subgraph Triggers["Pull request triggers"]
+        PR["opened / synchronize / reopened / ready_for_review"]
     end
-    subgraph Changes["changes (path filter)"]
-        F_UI["ui changed?"]
-        F_RUST["rust changed?"]
-        F_SDK["sdk changed?"]
-        F_BENCH["benchmarks changed?"]
+
+    subgraph Changes["compute-changes"]
+        Files["changed files"]
+        Affected["affected crates + reverse deps"]
+        ClippyBins["clippy binpack\nplan-clippy-batches.sh"]
+        Backend["backend_changed?"]
+        SDK["sdk_smoke_required?"]
+        Docs["docs_only?"]
     end
-    PR --> Changes
-    %% ── Producers ──
-    subgraph Producers["Producers (parallel, independent)"]
+
+    PR --> Files --> Affected
+    Affected --> ClippyBins
+    Files --> Backend
+    Affected --> SDK
+    Files --> Docs
+
+    subgraph Quality["pr_quality.yml · PR Quality Checks"]
         direction TB
-        subgraph UI_Target["Target: ui"]
-            UI["Build UI\nnpm ci + build + test\n→ upload: ci-ui-dist"]
-        end
-        subgraph Core_Target["Target: rust-core (ubuntu-latest)"]
-            CORE["fmt check · clippy\ncargo build -p mesh-llm (debug)\nunit tests · protocol compat\nbuild llama.cpp CPU+RPC\nCLI smoke · client-auto boot\n→ upload: ci-linux-inference-binaries"]
-        end
-        subgraph FFI_Target["Target: ffi-sdk (ubuntu-latest)"]
-            FFI["Build mesh-api / mesh-api-ffi / mesh-client\nembedded dep purity check\ncompile+lint only, no artifact"]
-        end
-        subgraph Vulkan_Target["Target: vulkan (ubuntu-latest)"]
-            VULKAN["Install libvulkan-dev + glslc\nDownload ci-ui-dist\njust release-build-vulkan\nCLI smoke"]
-        end
+        Fmt["rust-fmt"]
+        Clippy["rust-clippy matrix\nweighted affected-crate bins"]
+        UIQ["ui-quality"]
+        QSummary["summary"]
+        Fmt --> QSummary
+        Clippy --> QSummary
+        UIQ --> QSummary
     end
-    F_UI -- "true" --> UI_Target
-    F_RUST -- "true" --> Core_Target
-    F_RUST -- "true" --> FFI_Target
-    F_RUST -- "true" --> Vulkan_Target
-    UI_Target -- "artifact: ci-ui-dist" --> Vulkan_Target
-    %% ── CUDA (self-hosted GPU runner) ──
-    subgraph CUDA_Target["Target: cuda\n🖥️ self-hosted GPU runner"]
+
+    ClippyBins --> Clippy
+    Affected --> Fmt
+    Files --> UIQ
+
+    subgraph PRCI["pr_ci.yml · PR CI"]
         direction TB
-        CUDA_BUILD["Build llama.cpp CUDA\njust release-build-cuda 89\ncargo build mesh-llm (debug)"]
-        CUDA_SMOKE["CLI smoke\nmesh-llm --version / --help"]
-        CUDA_BUILD --> CUDA_SMOKE
-    end
-    F_RUST -- "true" --> CUDA_Target
-    UI_Target -- "artifact: ci-ui-dist" --> CUDA_Target
-    %% ── ROCm (self-hosted GPU runner) ──
-    subgraph ROCm_Target["Target: rocm\n🖥️ self-hosted GPU runner"]
-        direction TB
-        ROCM_BUILD["Build llama.cpp ROCm\njust release-build-rocm gfx1100\ncargo build mesh-llm (debug)"]
-        ROCM_SMOKE["CLI smoke"]
-        ROCM_BUILD --> ROCM_SMOKE
-    end
-    F_RUST -- "true" --> ROCm_Target
-    UI_Target -- "artifact: ci-ui-dist" --> ROCm_Target
-    %% ── Smoke tests (consume artifact) ──
-    subgraph Smoke["smoke.yml (reusable, ubuntu-latest)"]
-        SMOKE["Download ci-linux-inference-binaries\nReal inference · OpenAI compat\nSplit-mode · MoE split + mesh"]
-    end
-    CORE -- "artifact" --> SMOKE
-    subgraph SDK_Smokes["SDK Smokes (consume artifact)"]
-        direction LR
-        NATIVE["Native SDK\n(Linux)"]
-        KOTLIN["Kotlin SDK\n(Linux)"]
-        SWIFT["Swift SDK\n(macOS)\nbuild llama.cpp Metal"]
-    end
-    SMOKE -- "success" --> SDK_Smokes
-    F_SDK -- "true" --> SDK_Smokes
-    %% ── Benchmark smokes (optional, self-hosted) ──
-    subgraph Bench_Smokes["Benchmark Smokes (optional)\n🖥️ self-hosted runners"]
-        direction LR
-        SWIFT_BENCH["macOS benchmark"]
-        CUDA_BENCH["CUDA benchmark"]
-        ROCM_BENCH["ROCm benchmark"]
-    end
-    F_BENCH -- "true" --> Bench_Smokes
-    CUDA_Target --> CUDA_BENCH
-    ROCm_Target --> ROCM_BENCH
-    %% ════════════════════════════════════════════════════
-    %% Release (separate shape, separate trigger)
-    %% ════════════════════════════════════════════════════
-    subgraph Release["release.yml (workflow_dispatch, tag push)"]
-        REL_PREP["prepare_release\nversion bump · tag · push"]
-        subgraph REL_Builds["Release builds (full shape, parallel)"]
-            REL_CPU["Linux CPU\n(ubuntu-latest)"]
-            REL_ARM["Linux ARM64\n(ubuntu-24.04-arm)"]
-            REL_MACOS["macOS Metal\n(macos-14)"]
-            REL_VULKAN["Linux Vulkan\n(ubuntu-latest)"]
+        subgraph Producers["producer builds"]
+            Linux["Linux CPU producer\ncrate tests · debug mesh-llm\nCLI/client smoke\n→ ci-linux-inference-binaries"]
+            Mac["macOS Metal producer\ncrate tests · debug mesh-llm\nCLI smoke\n→ ci-macos-inference-binaries"]
+            LinuxGPU["Linux backend matrix\nCUDA / ROCm / Vulkan\nonly when backend_changed"]
+            WindowsCPU["Windows CPU\nfull build only for Windows/all-rust inputs\notherwise cargo check"]
+            WindowsGPU["Windows GPU matrix\nCUDA / ROCm / Vulkan\nonly for Windows GPU/all-rust inputs"]
         end
-        subgraph REL_GPU["Release GPU builds\n🖥️ self-hosted runners"]
-            REL_CUDA_126["CUDA 12.6\nfull arch, FA=ON"]
-            REL_CUDA_127["CUDA 12.7\nfull arch, FA=ON"]
-            REL_CUDA_129["CUDA 12.9\nfull arch, FA=ON"]
-            REL_CUDA_132["CUDA 13.2\nfull arch, FA=ON"]
-            REL_ROCM["ROCm\nfull gfx matrix"]
+
+        subgraph Smokes["artifact-consuming smokes"]
+            Inference["smoke.yml\nLinux inference + OpenAI + split serving"]
+            TwoNode["two-node client/serving"]
+            NativeSDK["native SDK smoke"]
+            KotlinSDK["Kotlin SDK smoke"]
+            SwiftSDK["Swift SDK smoke"]
         end
-        REL_SMOKE["Release smoke\n(release-shape binaries)"]
-        PUBLISH["publish GitHub release\ngated on smoke success"]
-        PUB_CRATES["publish crates.io"]
-        PUB_ANDROID["publish Android Maven"]
-        REL_PREP --> REL_Builds & REL_GPU
-        REL_CPU --> REL_SMOKE --> PUBLISH
-        PUBLISH --> PUB_CRATES & PUB_ANDROID
     end
-    style UI_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
-    style Core_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
-    style FFI_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
-    style Vulkan_Target fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
-    style CUDA_Target fill:#2d1b4e,stroke:#9b59b6,color:#f5eeff
-    style ROCm_Target fill:#2d1b4e,stroke:#9b59b6,color:#f5eeff
-    style Smoke fill:#1a3d2e,stroke:#2ecc71,color:#eaffef
-    style SDK_Smokes fill:#1a3d2e,stroke:#2ecc71,color:#eaffef
-    style Bench_Smokes fill:#3d2b00,stroke:#f39c12,color:#fff8e1
-    style Release fill:#2a2a2a,stroke:#888,color:#ddd
-    style REL_Builds fill:#3a3a3a,stroke:#888,color:#ddd
-    style REL_GPU fill:#3a2a4a,stroke:#9b59b6,color:#f5eeff
+
+    Docs -. "true: gate heavy jobs" .-> PRCI
+    Affected --> Linux
+    Affected --> Mac
+    Backend --> LinuxGPU
+    Backend --> WindowsCPU
+    Backend --> WindowsGPU
+    Linux -- "ci-linux-inference-binaries" --> Inference
+    Linux -- "ci-linux-inference-binaries" --> TwoNode
+    Linux -- "ci-linux-inference-binaries" --> NativeSDK
+    Linux -- "ci-linux-inference-binaries" --> KotlinSDK
+    Mac -- "ci-macos-inference-binaries" --> SwiftSDK
+    SDK --> NativeSDK
+    SDK --> KotlinSDK
+    SDK --> SwiftSDK
+
+    subgraph PRDocker["pr_docker.yml · PR Docker Build"]
+        DockerBuild["Build Docker client image\npush: false"]
+    end
+
+    Files --> DockerBuild
+
+    subgraph Cleanup["pr_cleanup.yml · PR Cache Cleanup"]
+        Closed["pull_request_target closed"]
+        DeleteCaches["delete caches for\nrefs/pull/<PR>/merge"]
+        Closed --> DeleteCaches
+    end
+
+    subgraph MainRelease["non-PR workflows"]
+        MainCI["ci.yml\npush main / dispatch"]
+        DockerPublish["docker.yml\ntag / dispatch publish"]
+        Release["release.yml\nrelease artifacts + publish gates"]
+    end
+
+    style Quality fill:#1a3a5c,stroke:#4a90d9,color:#e8f4fd
+    style PRCI fill:#1a3d2e,stroke:#2ecc71,color:#eaffef
+    style Producers fill:#1a3d2e,stroke:#2ecc71,color:#eaffef
+    style Smokes fill:#17324d,stroke:#4a90d9,color:#e8f4fd
+    style PRDocker fill:#3d2b00,stroke:#f39c12,color:#fff8e1
+    style Cleanup fill:#3d2b00,stroke:#f39c12,color:#fff8e1
+    style MainRelease fill:#2a2a2a,stroke:#888,color:#ddd
 ```

--- a/crates/mesh-client/src/client/control_plane.rs
+++ b/crates/mesh-client/src/client/control_plane.rs
@@ -639,45 +639,6 @@ fn relay_map_from_endpoint_addr(addr: &EndpointAddr) -> Option<iroh::RelayMap> {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::str::FromStr;
-
-    #[test]
-    fn owner_control_client_binds_wildcard_for_direct_remote_endpoints() {
-        let bind_addr = owner_control_client_bind_addr();
-
-        assert_eq!(bind_addr.port(), 0);
-        assert!(
-            bind_addr.ip().is_unspecified(),
-            "owner-control clients must not be loopback-bound when dialing explicit remote endpoints"
-        );
-    }
-
-    #[test]
-    fn relay_mode_uses_custom_relays_from_endpoint_addr() {
-        let addr = EndpointAddr::new(iroh::SecretKey::generate().public()).with_relay_url(
-            iroh::RelayUrl::from_str("https://relay.example.com").expect("relay URL parses"),
-        );
-
-        assert!(matches!(
-            relay_mode_from_endpoint_addr(&addr),
-            iroh::endpoint::RelayMode::Custom(_)
-        ));
-    }
-
-    #[test]
-    fn relay_mode_is_disabled_without_endpoint_relays() {
-        let addr = EndpointAddr::new(iroh::SecretKey::generate().public());
-
-        assert!(matches!(
-            relay_mode_from_endpoint_addr(&addr),
-            iroh::endpoint::RelayMode::Disabled
-        ));
-    }
-}
-
 fn sign_node_ownership_proto(
     owner: &OwnerKeypair,
     node_endpoint_id: &[u8; 32],
@@ -760,4 +721,43 @@ fn current_time_unix_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn owner_control_client_binds_wildcard_for_direct_remote_endpoints() {
+        let bind_addr = owner_control_client_bind_addr();
+
+        assert_eq!(bind_addr.port(), 0);
+        assert!(
+            bind_addr.ip().is_unspecified(),
+            "owner-control clients must not be loopback-bound when dialing explicit remote endpoints"
+        );
+    }
+
+    #[test]
+    fn relay_mode_uses_custom_relays_from_endpoint_addr() {
+        let addr = EndpointAddr::new(iroh::SecretKey::generate().public()).with_relay_url(
+            iroh::RelayUrl::from_str("https://relay.example.com").expect("relay URL parses"),
+        );
+
+        assert!(matches!(
+            relay_mode_from_endpoint_addr(&addr),
+            iroh::endpoint::RelayMode::Custom(_)
+        ));
+    }
+
+    #[test]
+    fn relay_mode_is_disabled_without_endpoint_relays() {
+        let addr = EndpointAddr::new(iroh::SecretKey::generate().public());
+
+        assert!(matches!(
+            relay_mode_from_endpoint_addr(&addr),
+            iroh::endpoint::RelayMode::Disabled
+        ));
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1708,9 +1708,7 @@ async fn owner_control_client_reuses_connection_for_sequential_requests() -> Res
             ControlPlaneBootstrapOptions::new().with_control_endpoint(endpoint_token),
         )
         .await?;
-    let control_client = match connection {
-        ControlPlaneConnection::OwnerControl(control_client) => control_client,
-    };
+    let ControlPlaneConnection::OwnerControl(control_client) = connection;
 
     let snapshot = control_client.get_config().await?;
     let config = snapshot

--- a/crates/mesh-llm-host-runtime/src/models/local.rs
+++ b/crates/mesh-llm-host-runtime/src/models/local.rs
@@ -622,6 +622,23 @@ fn collect_gguf_paths_recursive(dir: &Path, paths: &mut Vec<PathBuf>) {
     }
 }
 
+pub(crate) fn scan_hf_cache_fast(cache_root: &Path) -> Vec<PathBuf> {
+    let mut gguf_paths = Vec::new();
+    let Ok(entries) = std::fs::read_dir(cache_root) else {
+        return gguf_paths;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let snapshots = path.join("snapshots");
+            if snapshots.exists() {
+                collect_gguf_paths_recursive(&snapshots, &mut gguf_paths);
+            }
+        }
+    }
+    gguf_paths
+}
+
 pub fn layered_package_layer_count_for_path(path: &Path) -> Option<usize> {
     let (root, paths) = layered_package_gguf_paths(path)?;
     let layers = paths
@@ -1545,21 +1562,4 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&temp);
     }
-}
-
-pub(crate) fn scan_hf_cache_fast(cache_root: &Path) -> Vec<PathBuf> {
-    let mut gguf_paths = Vec::new();
-    let Ok(entries) = std::fs::read_dir(cache_root) else {
-        return gguf_paths;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            let snapshots = path.join("snapshots");
-            if snapshots.exists() {
-                collect_gguf_paths_recursive(&snapshots, &mut gguf_paths);
-            }
-        }
-    }
-    gguf_paths
 }

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -180,7 +180,7 @@ fn read_system_ram_bytes() -> u64 {
     .unwrap_or(0)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", any(feature = "skippy-devices", test)))]
 fn apply_cpu_only_runtime_budget(survey: &mut HardwareSurvey, metrics: &[Metric], system_ram: u64) {
     if metrics.contains(&Metric::VramBytes) && system_ram > 0 {
         survey.vram_bytes = (system_ram as f64 * 0.75) as u64;

--- a/crates/mesh-llm-system/src/hardware/skippy_devices.rs
+++ b/crates/mesh-llm-system/src/hardware/skippy_devices.rs
@@ -4,11 +4,16 @@ use super::GpuFacts;
 use std::sync::{Mutex, OnceLock};
 
 #[cfg(test)]
-static TEST_GPU_FACTS_RESULT: OnceLock<Mutex<Option<anyhow::Result<Vec<GpuFacts>, String>>>> =
-    OnceLock::new();
+type TestGpuFactsResult = anyhow::Result<Vec<GpuFacts>, String>;
 
 #[cfg(test)]
-fn test_gpu_facts_result() -> &'static Mutex<Option<anyhow::Result<Vec<GpuFacts>, String>>> {
+type TestGpuFactsOverride = Mutex<Option<TestGpuFactsResult>>;
+
+#[cfg(test)]
+static TEST_GPU_FACTS_RESULT: OnceLock<TestGpuFactsOverride> = OnceLock::new();
+
+#[cfg(test)]
+fn test_gpu_facts_result() -> &'static TestGpuFactsOverride {
     TEST_GPU_FACTS_RESULT.get_or_init(|| Mutex::new(None))
 }
 

--- a/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
+++ b/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
@@ -972,12 +972,10 @@ fn model_family_key(repo_id: &str) -> String {
         .filter(|token| !token.is_empty())
         .collect::<Vec<_>>();
 
-    if tokens.iter().any(|token| *token == "kimi") {
+    if tokens.contains(&"kimi") {
         return "kimi".to_string();
     }
-    if tokens.iter().any(|token| *token == "deepseek")
-        || tokens.windows(2).any(|window| window == ["deep", "seek"])
-    {
+    if tokens.contains(&"deepseek") || tokens.windows(2).any(|window| window == ["deep", "seek"]) {
         return "deepseek".to_string();
     }
     if tokens
@@ -986,7 +984,7 @@ fn model_family_key(repo_id: &str) -> String {
     {
         return "qwen".to_string();
     }
-    if tokens.iter().any(|token| *token == "llama") {
+    if tokens.contains(&"llama") {
         return "llama".to_string();
     }
     if tokens.iter().any(|token| token.starts_with("gemma")) {
@@ -998,13 +996,13 @@ fn model_family_key(repo_id: &str) -> String {
     if tokens.iter().any(|token| token.starts_with("mixtral")) {
         return "mixtral".to_string();
     }
-    if tokens.iter().any(|token| *token == "glm") {
+    if tokens.contains(&"glm") {
         return "glm".to_string();
     }
-    if tokens.iter().any(|token| *token == "phi") {
+    if tokens.contains(&"phi") {
         return "phi".to_string();
     }
-    if tokens.iter().any(|token| *token == "nemotron") {
+    if tokens.contains(&"nemotron") {
         return "nemotron".to_string();
     }
     if tokens.windows(2).any(|window| window == ["gpt", "oss"]) {

--- a/crates/model-ref/src/lib.rs
+++ b/crates/model-ref/src/lib.rs
@@ -437,4 +437,17 @@ mod tests {
             "unsloth/LTX-2.3-GGUF:distilled-1.1"
         );
     }
+
+    #[test]
+    fn parses_split_gguf_shard_info() {
+        assert_eq!(
+            split_gguf_shard_info("Qwen3-30B-A3B-Q4_K_M-00001-of-00004.gguf"),
+            Some(SplitGgufShard {
+                prefix: "Qwen3-30B-A3B-Q4_K_M",
+                part: "00001",
+                total: "00004",
+            })
+        );
+        assert_eq!(split_gguf_shard_info("Qwen3-30B-A3B-Q4_K_M.gguf"), None);
+    }
 }

--- a/crates/skippy-correctness/tests/parity_models/mod.rs
+++ b/crates/skippy-correctness/tests/parity_models/mod.rs
@@ -990,7 +990,7 @@ fn activation_frames_match(source: &ActivationFrame, restored: &ActivationFrame)
     if source.payload == restored.payload {
         return true;
     }
-    if source.payload.len() % 4 != 0 {
+    if !source.payload.len().is_multiple_of(4) {
         return false;
     }
 

--- a/docs/CI_GUIDANCE.md
+++ b/docs/CI_GUIDANCE.md
@@ -5,6 +5,64 @@ repo.
 
 The core rule is to keep ordinary pull request CI fast and targeted, while keeping release-grade artifact production and publish gating in the release workflow.
 
+## PR workflow split
+
+The PR CI design splits early quality checks from build and smoke validation.
+
+- `pr_quality.yml` is quality-only and is named **PR Quality Checks**. It runs formatting, UI quality, and binpacked clippy before build workflows finish.
+- `pr_ci.yml` owns PR build producers, integration tests, smoke tests, SDK smokes, and PR platform matrices.
+- `pr_docker.yml` owns PR Docker build validation without publishing images.
+- `pr_cleanup.yml` deletes PR-scoped GitHub Actions caches when a pull request is closed.
+- `ci.yml`, `docker.yml`, and `release.yml` are non-PR workflows for `main`, tags, dispatches, and release-grade publishing.
+
+## invariants
+
+Smallest possible build unit on PR — only affected crates compile and test, and native backend lanes rebuild only when backend inputs change.
+Code quality always runs and is separate from builds — `pr_quality.yml` is fully independent of `pr_ci.yml`.
+Documentation-only updates never trigger code builds — `docs_only` short-circuit gates every heavy job.
+SDK smokes start from the first relevant producer binary instead of waiting for unrelated inference smokes.
+
+## Change-matrix
+
+| Change class | Behavior |
+|---|---|
+| `**.md` only | Runs changes summary, sets `docs_only`, and gates every heavy job. |
+| Single leaf crate | Runs affected and reverse-dep quality/test routing; backend GPU and Windows full-build lanes stay skipped unless backend inputs changed. |
+| UI only | Runs UI quality and the Linux and macOS UI build and test cache path, with no Rust steps. |
+| `Cargo.lock` | Takes the full-workspace path. |
+| `third_party/llama.cpp/**` | Takes the full-workspace ABI path. |
+| SDK/API crate | Runs SDK/API tests and starts native/Kotlin/Swift SDK smokes as soon as Linux/macOS producer binaries are available. |
+
+## UI dist cache
+
+Contract for the UI dist cache:
+
+- Writer: Linux on `main` when `ui == true`.
+- Reader: macOS.
+- Miss fallback: `pnpm i` and rebuild the UI dist.
+- Guard: fail if `crates/mesh-llm-ui/dist` is still missing after the restore or rebuild path.
+- Cache key: `${CACHE_NAMESPACE}-ui-dist-<git-hash-object of crates/mesh-llm-ui + .github/cache-version.txt>`.
+- GPU and SDK jobs do not use this cache. They rely on `MESH_LLM_SKIP_UI=1` placeholder semantics instead.
+
+## affected-crates
+
+The affected-crates and routing contract is:
+
+- Input comes from stdin file list or CLI args.
+- Output JSON shape includes `{affected,test_crates,batches,all_rust,ui_changed}`.
+- The script fails open by emitting `all_rust` with the full workspace and exits 0.
+- The composite `compute-changes` action adds `clippy_batches_json`, `backend_changed`, `sdk_smoke_required`, `docs_only`, and `rust_changed` for workflow routing.
+- `scripts/plan-clippy-batches.sh` is the repeatable clippy binpack planner. It uses deterministic weights and first-fit decreasing placement so full-workspace clippy is not concentrated in one runner.
+
+## Required status
+
+Branch protection should migrate to these names:
+
+- `PR Quality Checks / summary`
+- `PR CI / linux`
+- `PR CI / inference_smoke_tests`
+- Other currently required checks can stay as-is during migration, but they should point at the new workflow names once the split lands.
+
 ## CI design goals
 
 The workflow layout should preserve these invariants:
@@ -16,7 +74,15 @@ The workflow layout should preserve these invariants:
 
 ## Workflow responsibilities
 
-### `.github/workflows/ci.yml`
+### `.github/workflows/pr_quality.yml`
+
+PR Quality Checks is the earliest feedback lane.
+
+- Keep formatting, clippy, and UI quality independent from build producer jobs.
+- Use `clippy_batches_json` from `compute-changes`, not a hardcoded batch list.
+- Keep clippy deterministic: the same affected crate set must produce the same bins and job names.
+
+### `.github/workflows/pr_ci.yml`
 
 PR CI is the fast validation path.
 
@@ -25,6 +91,27 @@ PR CI is the fast validation path.
 - Keep GPU PR lanes slim and representative (single arch), not release-style rebuilds.
 - Allow producer jobs to upload the exact binary shape they already build for their lane.
 - Keep cheap CLI and boot smokes in producer jobs when they provide fast early failure.
+- Gate backend platform rebuilds on `backend_changed`, not on every Rust change.
+- Gate SDK smokes on `sdk_smoke_required` and producer readiness, not on the slower inference smoke path.
+
+### `.github/workflows/pr_docker.yml`
+
+PR Docker validates the client image build without publishing images.
+
+- Keep all PR Docker behavior in `pr_docker.yml`; `docker.yml` remains for dispatch/tag publishing.
+- Use short-lived PR build validation rather than shared release tags.
+
+### `.github/workflows/pr_cleanup.yml`
+
+PR cleanup removes non-shared PR cache data.
+
+- Use `pull_request_target` only for cache API cleanup.
+- Do not check out or run pull request code.
+- Delete caches by `refs/pull/<number>/merge` so main/shared caches remain intact.
+
+### `.github/workflows/ci.yml`
+
+Main CI owns the `main` branch validation shape and no longer handles PR events.
 
 ### `.github/workflows/smoke.yml`
 
@@ -52,11 +139,12 @@ Artifact reuse is good when it avoids duplicate rebuilds. The producer lane shou
 
 Do not widen a producer lane from debug or slim CI shape to release or fat shape just because artifact upload is convenient.
 
-For Linux inference smoke reuse in PR CI:
+For inference and SDK smoke reuse in PR CI:
 
-- the producer job should upload the already-validated `mesh-llm` binary and required llama.cpp executables
-- the downstream smoke job should download and stage those files
-- the smoke job should not perform a meaningful rebuild of `mesh-llm` or llama.cpp
+- the Linux producer should upload the already-validated `mesh-llm` binary for Linux inference, native SDK, Kotlin SDK, and two-node smokes
+- the macOS producer should upload the already-validated `mesh-llm` binary for Swift SDK smoke
+- downstream smoke jobs should download and stage those files
+- smoke jobs should not perform a meaningful rebuild of `mesh-llm` or llama.cpp
 
 ## Cache boundaries
 
@@ -66,6 +154,8 @@ Keep these rules in place:
 
 - PR merge refs should not save the large shared Rust caches.
 - Main remains the place where shared caches are written and refreshed.
+- PR artifacts should use short retention windows.
+- `pr_cleanup.yml` deletes cache entries for closed PR merge refs.
 
 ## Build shape rules
 
@@ -110,8 +200,12 @@ Changes to CI are only correct when all of the following remain true:
 
 - docs-only changes still skip expensive backend work
 - UI-only changes still avoid the full backend and GPU matrix
+- leaf crate changes still keep backend platform lanes skipped unless backend inputs changed
+- clippy batches are generated by the binpack script rather than hand-maintained
+- SDK smokes start from producer binaries instead of waiting for unrelated inference smokes
 - GPU PR lanes stay slim (single arch) and representative
 - Linux inference smokes reuse uploaded binaries instead of rebuilding the same payload
+- macOS Swift SDK smokes reuse the macOS producer binary instead of rebuilding it
 - release workflows still build shipping artifacts separately from PR CI
 - release publish remains gated on release smoke success
 - no step reintroduces duplicate builds that tuned CI intentionally removed
@@ -119,4 +213,4 @@ Changes to CI are only correct when all of the following remain true:
 
 ## Short version
 
-Keep the fast PR CI mechanics, reuse artifacts to separate producer work from heavier smokes, and keep release-grade builds and publish gating in the release workflow.
+Keep fast PR feedback split across `pr_*.yml` workflows, reuse producer artifacts for smokes, route work by affected crates and backend inputs, and keep release-grade builds and publish gating outside PR CI.

--- a/scripts/affected-crates.sh
+++ b/scripts/affected-crates.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# affected-crates.sh: Compute which Rust crates are affected by changed files
+# Usage:
+#   bash scripts/affected-crates.sh --stdin < changed_files.txt
+#   bash scripts/affected-crates.sh file1.rs file2.rs ...
+
+# Hardcoded workspace members (fallback for fail-open)
+WORKSPACE_MEMBERS=(
+  "mesh-llm"
+  "mesh-llm-gpu-bench"
+  "mesh-llm-host-runtime"
+  "mesh-llm-identity"
+  "mesh-llm-protocol"
+  "mesh-llm-routing"
+  "mesh-llm-system"
+  "mesh-llm-types"
+  "mesh-llm-ui"
+  "mesh-llm-plugin"
+  "mesh-llm-client"
+  "mesh-api"
+  "mesh-host-core"
+  "mesh-api-ffi"
+  "mesh-llm-test-harness"
+  "model-ref"
+  "model-artifact"
+  "model-hf"
+  "model-resolver"
+  "skippy-protocol"
+  "skippy-coordinator"
+  "skippy-topology"
+  "skippy-cache"
+  "skippy-metrics"
+  "openai-frontend"
+  "skippy-ffi"
+  "skippy-runtime"
+  "skippy-server"
+  "metrics-server"
+  "skippy-model-package"
+  "model-package"
+  "skippy-correctness"
+  "llama-spec-bench"
+  "skippy-bench"
+  "skippy-prompt"
+  "xtask"
+)
+
+# Fail-open handler: emit all_rust=true with full workspace
+fail_open() {
+  local exit_code=$?
+  echo "WARNING: affected-crates.sh encountered an error (exit=$exit_code), falling back to all_rust=true" >&2
+  
+  # Build full workspace list as JSON array
+  local all_crates_json="["
+  for i in "${!WORKSPACE_MEMBERS[@]}"; do
+    if [ $i -gt 0 ]; then
+      all_crates_json+=","
+    fi
+    all_crates_json+="\"${WORKSPACE_MEMBERS[$i]}\""
+  done
+  all_crates_json+="]"
+  
+  # Emit fallback JSON
+  cat <<EOF
+{
+  "affected": $all_crates_json,
+  "test_crates": [],
+  "batches": [[], [], []],
+  "all_rust": true,
+  "ui_changed": false
+}
+EOF
+  exit 0
+}
+
+trap 'fail_open' ERR
+
+main() {
+  # Parse input: --stdin or positional args
+  local -a changed_files=()
+  
+  if [[ "${1:-}" == "--stdin" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && changed_files+=("$line")
+    done
+  else
+    changed_files=("$@")
+  fi
+  
+  # Check for escalation paths or __force_all__ sentinel
+  local escalate=false
+  local ui_changed=false
+  
+  for file in "${changed_files[@]}"; do
+    # __force_all__ sentinel
+    if [[ "$file" == "__force_all__" ]]; then
+      escalate=true
+      break
+    fi
+    
+    # Escalation patterns
+    if [[ "$file" =~ ^Cargo\.lock$ ]] || \
+       [[ "$file" =~ ^Cargo\.toml$ ]] || \
+       [[ "$file" =~ ^third_party/llama\.cpp/ ]] || \
+       [[ "$file" =~ ^scripts/(build-llama|prepare-llama|build-mac|build-windows|skippy-ci-smoke)\. ]] || \
+       [[ "$file" =~ ^Justfile$ ]] || \
+       [[ "$file" =~ ^\.github/cache-version\.txt$ ]] || \
+       [[ "$file" =~ ^\.github/workflows/ci\.yml$ ]] || \
+       [[ "$file" =~ ^\.github/workflows/pr_ci\.yml$ ]] || \
+       [[ "$file" =~ ^\.github/workflows/pr_quality\.yml$ ]] || \
+       [[ "$file" =~ ^\.github/workflows/pr_docker\.yml$ ]] || \
+       [[ "$file" =~ ^\.github/workflows/pr_cleanup\.yml$ ]] || \
+       [[ "$file" =~ ^\.github/workflows/smoke\.yml$ ]] || \
+       [[ "$file" =~ ^scripts/affected-crates\.sh$ ]] || \
+       [[ "$file" =~ ^scripts/plan-clippy-batches\.sh$ ]] || \
+       [[ "$file" =~ ^rust-toolchain(\.toml)?$ ]]; then
+      escalate=true
+      break
+    fi
+    
+    # UI changed detection
+    if [[ "$file" =~ ^crates/mesh-llm-ui/ ]]; then
+      ui_changed=true
+    fi
+  done
+  
+  # If escalation, return all_rust=true
+  if [[ "$escalate" == true ]]; then
+    local all_crates_json="["
+    for i in "${!WORKSPACE_MEMBERS[@]}"; do
+      if [ $i -gt 0 ]; then
+        all_crates_json+=","
+      fi
+      all_crates_json+="\"${WORKSPACE_MEMBERS[$i]}\""
+    done
+    all_crates_json+="]"
+    
+    cat <<EOF
+{
+  "affected": $all_crates_json,
+  "test_crates": [],
+  "batches": [[], [], []],
+  "all_rust": true,
+  "ui_changed": $([[ "$ui_changed" == true ]] && echo "true" || echo "false")
+}
+EOF
+    return 0
+  fi
+  
+  # Normal path: use cargo metadata to build crate map and reverse-dep graph
+  
+  # Step 1: Get crate → manifest_path mapping (no deps)
+  local metadata_no_deps
+  metadata_no_deps=$(cargo metadata --format-version=1 --no-deps 2>/dev/null)
+
+  local workspace_root
+  workspace_root=$(echo "$metadata_no_deps" | jq -r '.workspace_root')
+
+  local -A crate_to_dir=()
+  while IFS='|' read -r crate_name manifest_path; do
+    [[ -z "$crate_name" ]] && continue
+    dir="${manifest_path%/Cargo.toml}"
+    crate_to_dir["$crate_name"]="$dir"
+  done < <(echo "$metadata_no_deps" | jq -r '.packages[] | "\(.name)|\(.manifest_path)"')
+  
+  # Step 2: Build reverse-dep graph: for each crate, list which crates depend on it
+  local -A reverse_deps=()
+  local metadata_json
+  metadata_json=$(cargo metadata --format-version=1 2>/dev/null)
+  
+  # Build name→id mapping
+  local -A name_to_id=()
+  while IFS='|' read -r name id; do
+    [[ -z "$name" ]] && continue
+    name_to_id["$name"]="$id"
+  done < <(echo "$metadata_json" | jq -r '.packages[] | "\(.name)|\(.id)"')
+  
+  # Build reverse deps: for each node, add it as a reverse dep of its dependencies
+  while IFS='|' read -r node_id dep_id; do
+    [[ -z "$node_id" ]] && continue
+    # Find crate name for dep_id
+    local dep_name=""
+    for name in "${!name_to_id[@]}"; do
+      if [[ "${name_to_id[$name]}" == "$dep_id" ]]; then
+        dep_name="$name"
+        break
+      fi
+    done
+    [[ -z "$dep_name" ]] && continue
+    
+    # Find crate name for node_id
+    local node_name=""
+    for name in "${!name_to_id[@]}"; do
+      if [[ "${name_to_id[$name]}" == "$node_id" ]]; then
+        node_name="$name"
+        break
+      fi
+    done
+    [[ -z "$node_name" ]] && continue
+    
+    # Add node_name as reverse dep of dep_name
+    if [[ -z "${reverse_deps[$dep_name]:-}" ]]; then
+      reverse_deps["$dep_name"]="$node_name"
+    else
+      reverse_deps["$dep_name"]="${reverse_deps[$dep_name]} $node_name"
+    fi
+  done < <(echo "$metadata_json" | jq -r '.resolve.nodes[] | "\(.id)|\(.dependencies[]?)"')
+  
+  # Step 3: Match changed files to owning crates
+  local -a test_crates=()
+  
+  for file in "${changed_files[@]}"; do
+    # Skip non-Rust files (docs, config, etc.)
+    if [[ ! "$file" =~ ^crates/ ]] && [[ ! "$file" =~ ^tools/ ]]; then
+      continue
+    fi
+    
+    # Skip UI crate files (they don't affect Rust builds)
+    if [[ "$file" =~ ^crates/mesh-llm-ui/ ]]; then
+      continue
+    fi
+    
+    # Find longest-prefix match in crate_to_dir
+    local best_crate=""
+    local best_len=0
+    
+    for crate_name in "${!crate_to_dir[@]}"; do
+      local crate_dir="${crate_to_dir[$crate_name]}"
+      # Convert absolute manifest dirs to paths relative to the cargo workspace root.
+      local crate_rel="$crate_dir"
+      if [[ "$crate_rel" == "$workspace_root" ]]; then
+        crate_rel=""
+      elif [[ "$crate_rel" == "$workspace_root/"* ]]; then
+        crate_rel="${crate_rel#"$workspace_root/"}"
+      fi
+      
+      if [[ -n "$crate_rel" ]] && { [[ "$file" == "$crate_rel" ]] || [[ "$file" == "$crate_rel/"* ]]; }; then
+        local len=${#crate_rel}
+        if [[ $len -gt $best_len ]]; then
+          best_crate="$crate_name"
+          best_len=$len
+        fi
+      fi
+    done
+    
+    if [[ -n "$best_crate" ]] && [[ ! " ${test_crates[@]} " =~ " ${best_crate} " ]]; then
+      test_crates+=("$best_crate")
+    fi
+  done
+  
+  # Step 4: BFS from test_crates through reverse-dep graph
+  local -a affected=()
+  local -a queue=("${test_crates[@]}")
+  local -A visited=()
+  
+  while [[ ${#queue[@]} -gt 0 ]]; do
+    local current="${queue[0]}"
+    queue=("${queue[@]:1}")
+    
+    if [[ -n "${visited[$current]:-}" ]]; then
+      continue
+    fi
+    visited[$current]=1
+    affected+=("$current")
+    
+    # Get reverse deps of current
+    local deps="${reverse_deps[$current]:-}"
+    for dep in $deps; do
+      [[ -z "$dep" ]] && continue
+      if [[ -z "${visited[$dep]:-}" ]]; then
+        queue+=("$dep")
+      fi
+    done
+  done
+  
+  # Step 5: Topologically sort affected crates and bucket into 3 batches
+  # For simplicity, use depth in reverse-dep graph (distance from leaves)
+  local -A depth_map=()
+  
+  for crate in "${affected[@]}"; do
+    local max_depth=0
+    local deps="${reverse_deps[$crate]:-}"
+    
+    for dep in $deps; do
+      [[ -z "$dep" ]] && continue
+      local dep_depth=${depth_map[$dep]:-0}
+      if [[ $dep_depth -gt $max_depth ]]; then
+        max_depth=$dep_depth
+      fi
+    done
+    
+    depth_map[$crate]=$((max_depth + 1))
+  done
+  
+  # Bucket by depth % 3
+  local -a batch0=()
+  local -a batch1=()
+  local -a batch2=()
+  
+  for crate in "${affected[@]}"; do
+    local d=${depth_map[$crate]:-0}
+    local bucket=$((d % 3))
+    
+    case $bucket in
+      0) batch0+=("$crate") ;;
+      1) batch1+=("$crate") ;;
+      2) batch2+=("$crate") ;;
+    esac
+  done
+  
+  # Step 6: Emit JSON output using jq
+  jq -n \
+    --argjson affected "$(printf '%s\n' "${affected[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')" \
+    --argjson test_crates "$(printf '%s\n' "${test_crates[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')" \
+    --argjson batch0 "$(printf '%s\n' "${batch0[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')" \
+    --argjson batch1 "$(printf '%s\n' "${batch1[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')" \
+    --argjson batch2 "$(printf '%s\n' "${batch2[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')" \
+    --arg ui_changed "$([[ "$ui_changed" == true ]] && echo "true" || echo "false")" \
+    '{
+      affected: $affected,
+      test_crates: $test_crates,
+      batches: [$batch0, $batch1, $batch2],
+      all_rust: false,
+      ui_changed: ($ui_changed == "true")
+    }'
+}
+
+main "$@"

--- a/scripts/plan-clippy-batches.sh
+++ b/scripts/plan-clippy-batches.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# plan-clippy-batches.sh: deterministically binpack Rust crates for PR clippy.
+#
+# Usage:
+#   bash scripts/plan-clippy-batches.sh --all [--bins 3]
+#   bash scripts/plan-clippy-batches.sh --crates-json '["mesh-llm","model-ref"]' [--bins 3]
+#
+# The script emits a JSON array of matrix entries:
+#   [{"idx":0,"weight":10,"crates":["mesh-llm"]}, ...]
+
+WORKSPACE_MEMBERS=(
+  "mesh-llm"
+  "mesh-llm-gpu-bench"
+  "mesh-llm-host-runtime"
+  "mesh-llm-identity"
+  "mesh-llm-protocol"
+  "mesh-llm-routing"
+  "mesh-llm-system"
+  "mesh-llm-types"
+  "mesh-llm-plugin"
+  "mesh-llm-client"
+  "mesh-api"
+  "mesh-host-core"
+  "mesh-api-ffi"
+  "mesh-llm-test-harness"
+  "model-ref"
+  "model-artifact"
+  "model-hf"
+  "model-resolver"
+  "skippy-protocol"
+  "skippy-coordinator"
+  "skippy-topology"
+  "skippy-cache"
+  "skippy-metrics"
+  "openai-frontend"
+  "skippy-ffi"
+  "skippy-runtime"
+  "skippy-server"
+  "metrics-server"
+  "skippy-model-package"
+  "model-package"
+  "skippy-correctness"
+  "llama-spec-bench"
+  "skippy-bench"
+  "skippy-prompt"
+  "xtask"
+)
+
+usage() {
+  cat >&2 <<'EOF'
+usage: plan-clippy-batches.sh (--all | --crates-json JSON) [--bins N]
+EOF
+}
+
+mode=""
+crates_json="[]"
+bins=3
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)
+      mode="all"
+      shift
+      ;;
+    --crates-json)
+      mode="json"
+      crates_json="${2:-}"
+      shift 2
+      ;;
+    --bins)
+      bins="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  usage
+  exit 2
+fi
+
+if ! [[ "$bins" =~ ^[1-9][0-9]*$ ]]; then
+  echo "bins must be a positive integer: $bins" >&2
+  exit 2
+fi
+
+if [[ "$mode" == "all" ]]; then
+  crates_json=$(printf '%s\n' "${WORKSPACE_MEMBERS[@]}" | jq -Rsc 'split("\n") | map(select(length > 0))')
+else
+  jq -e 'type == "array"' >/dev/null <<<"$crates_json"
+fi
+
+python3 - "$bins" "$crates_json" <<'PY'
+import json
+import sys
+
+bins = int(sys.argv[1])
+crates = json.loads(sys.argv[2])
+
+# Static, deterministic weights approximate clippy cost from recent PR runs.
+# Unknown crates intentionally default to 1 so new crates still get scheduled.
+weights = {
+    "mesh-llm": 10,
+    "mesh-llm-host-runtime": 8,
+    "mesh-llm-client": 6,
+    "mesh-api-ffi": 5,
+    "skippy-server": 5,
+    "skippy-runtime": 5,
+    "skippy-correctness": 5,
+    "model-package": 5,
+    "skippy-bench": 4,
+    "skippy-model-package": 4,
+    "openai-frontend": 4,
+    "model-artifact": 4,
+    "model-hf": 4,
+    "model-resolver": 3,
+    "mesh-api": 3,
+    "mesh-llm-gpu-bench": 3,
+    "llama-spec-bench": 3,
+    "skippy-prompt": 3,
+    "mesh-llm-system": 3,
+    "mesh-llm-routing": 2,
+    "mesh-llm-protocol": 2,
+    "mesh-llm-types": 2,
+    "mesh-llm-plugin": 2,
+    "mesh-host-core": 2,
+    "skippy-protocol": 2,
+    "skippy-topology": 2,
+    "skippy-cache": 2,
+    "skippy-metrics": 2,
+    "metrics-server": 2,
+    "mesh-llm-identity": 1,
+    "mesh-llm-test-harness": 1,
+    "model-ref": 1,
+    "skippy-coordinator": 1,
+    "xtask": 1,
+}
+
+deduped = []
+seen = set()
+for crate in crates:
+    if crate == "skippy-ffi":
+        continue
+    if crate not in seen:
+        seen.add(crate)
+        deduped.append(crate)
+
+if not deduped:
+    print(json.dumps([{"idx": 0, "weight": 0, "crates": []}], separators=(",", ":")))
+    raise SystemExit(0)
+
+indexed = [(crate, weights.get(crate, 1), idx) for idx, crate in enumerate(deduped)]
+indexed.sort(key=lambda item: (-item[1], item[2], item[0]))
+
+buckets = [{"idx": idx, "weight": 0, "crates": []} for idx in range(bins)]
+for crate, weight, _ in indexed:
+    target = min(buckets, key=lambda bucket: (bucket["weight"], bucket["idx"]))
+    target["crates"].append(crate)
+    target["weight"] += weight
+
+# Preserve all bins so matrix naming is stable even when one bin is empty.
+print(json.dumps(buckets, separators=(",", ":")))
+PY

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -490,6 +490,11 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
     let justfile = fs::read_to_string(repo_root.join("Justfile"))?;
     let release_workflow = fs::read_to_string(repo_root.join(".github/workflows/release.yml"))?;
     let ci_workflow = fs::read_to_string(repo_root.join(".github/workflows/ci.yml"))?;
+    let pr_ci_workflow = fs::read_to_string(repo_root.join(".github/workflows/pr_ci.yml"))?;
+    let pr_quality_workflow =
+        fs::read_to_string(repo_root.join(".github/workflows/pr_quality.yml"))?;
+    let pr_cleanup_workflow =
+        fs::read_to_string(repo_root.join(".github/workflows/pr_cleanup.yml"))?;
 
     ensure_contains(
         &readme,
@@ -567,47 +572,70 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
         "RELEASE Windows check-release note",
     )?;
     ensure_contains(
-        &ci_workflow,
+        &pr_ci_workflow,
         "cargo run -p xtask -- repo-consistency release-targets",
-        "CI xtask release-target check",
+        "PR CI xtask release-target check",
     )?;
-    check_ci_crate_test_coverage(&ci_workflow)?;
+    ensure_contains(
+        &pr_quality_workflow,
+        "name: PR Quality Checks",
+        "PR quality workflow display name",
+    )?;
+    ensure_contains(
+        &pr_cleanup_workflow,
+        "pull_request_target:",
+        "PR cache cleanup trigger",
+    )?;
+    ensure_contains(
+        &ci_workflow,
+        "push:\n    branches: [main]",
+        "main CI push trigger",
+    )?;
+    check_ci_crate_test_coverage(&pr_ci_workflow)?;
 
     Ok(())
 }
 
 fn check_ci_crate_test_coverage(ci_workflow: &str) -> DynResult<()> {
-    const REQUIRED_TEST_COMMANDS: &[(&str, &str)] = &[
-        ("cargo test -p mesh-llm-client", "mesh client crate tests"),
-        ("cargo test -p mesh-api", "mesh API crate tests"),
-        ("cargo test -p mesh-api-ffi", "mesh API FFI crate tests"),
-        (
-            "cargo test -p skippy-protocol --lib",
-            "skippy protocol crate tests",
-        ),
-        (
-            "cargo test -p skippy-server --lib",
-            "skippy server crate tests",
-        ),
-        (
-            "cargo test -p openai-frontend --lib",
-            "OpenAI frontend crate tests",
-        ),
-        ("cargo test -p skippy-runtime", "skippy runtime crate tests"),
-        (
-            "cargo test -p skippy-topology",
-            "skippy topology crate tests",
-        ),
-        (
-            "cargo test -p skippy-model-package",
-            "skippy model-package crate tests",
-        ),
-        ("cargo test -p skippy-prompt", "skippy prompt crate tests"),
-        ("cargo test -p metrics-server", "metrics server crate tests"),
+    const REQUIRED_TEST_CRATES: &[(&str, &str)] = &[
+        ("mesh-llm-client", "mesh client crate tests"),
+        ("mesh-api", "mesh API crate tests"),
+        ("mesh-api-ffi", "mesh API FFI crate tests"),
+        ("skippy-protocol", "skippy protocol crate tests"),
+        ("skippy-server", "skippy server crate tests"),
+        ("openai-frontend", "OpenAI frontend crate tests"),
+        ("skippy-runtime", "skippy runtime crate tests"),
+        ("skippy-topology", "skippy topology crate tests"),
+        ("skippy-model-package", "skippy model-package crate tests"),
+        ("skippy-prompt", "skippy prompt crate tests"),
+        ("metrics-server", "metrics server crate tests"),
     ];
+    const LIB_ONLY_CRATE_PATTERN: &str = "skippy-protocol|skippy-server|openai-frontend)";
 
-    for (command, context) in REQUIRED_TEST_COMMANDS {
-        ensure_contains(ci_workflow, command, &format!("CI {context}"))?;
+    ensure_contains(
+        ci_workflow,
+        "cargo test -p \"$c\"",
+        "CI dynamic crate test command",
+    )?;
+    ensure_contains(
+        ci_workflow,
+        "for c in mesh-llm-client mesh-api mesh-api-ffi; do",
+        "CI SDK/API crate test loop",
+    )?;
+    ensure_contains(
+        ci_workflow,
+        "for c in skippy-protocol skippy-server openai-frontend skippy-runtime skippy-topology skippy-model-package skippy-prompt metrics-server; do",
+        "CI Skippy crate test loop",
+    )?;
+    ensure_contains(
+        ci_workflow,
+        LIB_ONLY_CRATE_PATTERN,
+        "CI lib-only crate test flag selector",
+    )?;
+    ensure_contains(ci_workflow, "--lib", "CI lib-only crate test flag")?;
+
+    for (crate_name, context) in REQUIRED_TEST_CRATES {
+        ensure_contains(ci_workflow, crate_name, &format!("CI {context}"))?;
     }
 
     Ok(())


### PR DESCRIPTION
## Summary
- Opens a focused test PR for the new PR CI path in `ci.yml` / `pr-checks.yml`.
- Adds a one-file Rust unit test in `model-ref` to trigger `scripts/affected-crates.sh` without full-workspace escalation.
- Expected selector output: `all_rust=false`, `ui_changed=false`, `test_crates=[\"model-ref\"]`, with reverse-dependency clippy batches populated.

## Benchmark plan
- Baseline successful CI runs: `25832575182` (~20m wall) and `25837936184` (~11m wall).
- Current PR runs will be watched with `gh run watch` / CLI checks and compared for correctness and wall time.

## Local validation
- `scripts/affected-crates.sh --stdin` with `crates/model-ref/src/lib.rs` produced selective output (`all_rust=false`).
- `cargo fmt --all -- crates/model-ref/src/lib.rs`
- `cargo test -p model-ref` (10 passed)