### PR TITLE
Validate selective model-ref CI routing

### DIFF
--- a/crates/model-ref/src/lib.rs
+++ b/crates/model-ref/src/lib.rs
@@ -437,4 +437,17 @@ mod tests {
             "unsloth/LTX-2.3-GGUF:distilled-1.1"
         );
     }
+
+    #[test]
+    fn parses_split_gguf_shard_info() {
+        assert_eq!(
+            split_gguf_shard_info("Qwen3-30B-A3B-Q4_K_M-00001-of-00004.gguf"),
+            Some(SplitGgufShard {
+                prefix: "Qwen3-30B-A3B-Q4_K_M",
+                part: "00001",
+                total: "00004",
+            })
+        );
+        assert_eq!(split_gguf_shard_info("Qwen3-30B-A3B-Q4_K_M.gguf"), None);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a single `model-ref` unit test on top of the CI optimization base branch.
- This stacked PR is intentionally scoped to one Rust crate source file so the new affected-crates routing should stay on the selective `all_rust=false` path.

## Expected selector output
- `all_rust=false`
- `ui_changed=false`
- `test_crates=[\"model-ref\"]`
- affected crates include `model-ref` plus reverse dependents such as `mesh-llm-host-runtime`, `model-artifact`, `model-hf`, `model-package`, `model-resolver`, `skippy-bench`, `skippy-correctness`, `skippy-model-package`, `mesh-llm`, `mesh-llm-client`, `mesh-api`, `skippy-prompt`, and `mesh-api-ffi`.

## Local validation
- `bash -n scripts/affected-crates.sh`
- `printf '%s\\n' crates/model-ref/src/lib.rs | bash scripts/affected-crates.sh --stdin`
- `cargo test -p model-ref`