### PR TITLE
Return first-class reasoning_content for Skippy thinking models

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/response_adapter.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response_adapter.rs
@@ -6,6 +6,7 @@ pub(crate) use openai_frontend::{
     responses_stream_content_part_done_event, responses_stream_created_event_with_sequence,
     responses_stream_delta_event_with_logprobs_and_sequence,
     responses_stream_output_item_added_event, responses_stream_output_item_done_event,
+    responses_stream_reasoning_delta_event_with_sequence,
     responses_stream_text_done_event_with_sequence, stream_usage_to_responses_usage,
     translate_chat_completion_to_responses,
 };

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -1267,6 +1267,28 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
                 .choices
                 .first()
                 .and_then(|choice| choice.delta.as_ref())
+                .and_then(|delta| delta.reasoning_content.as_deref())
+            {
+                let sequence_number = next_sequence_number();
+                let event = serde_json::to_string(
+                    &response_adapter::responses_stream_reasoning_delta_event_with_sequence(
+                        &item_id,
+                        delta,
+                        sequence_number,
+                    ),
+                )
+                .context("serialize response.reasoning_text.delta event")?;
+                response_adapter::write_chunked_sse_event(
+                    tcp_stream,
+                    Some("response.reasoning_text.delta"),
+                    &event,
+                )
+                .await?;
+            }
+            if let Some(delta) = chunk
+                .choices
+                .first()
+                .and_then(|choice| choice.delta.as_ref())
                 .and_then(|delta| delta.content.as_deref())
             {
                 if !output_item_emitted {

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs
@@ -1232,6 +1232,80 @@ data: {"#,
 }
 
 #[tokio::test]
+async fn test_api_proxy_translates_streaming_reasoning_content_events() {
+    let chunks = vec![
+        (
+            Duration::ZERO,
+            br#"data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":123,"model":"test","choices":[{"index":0,"delta":{"reasoning_content":"thinking"},"finish_reason":null}]}
+
+"#
+            .to_vec(),
+        ),
+        (
+            Duration::from_millis(10),
+            br#"data: {"id":"chatcmpl_1","object":"chat.completion.chunk","created":123,"model":"test","choices":[{"index":0,"delta":{"content":"answer"},"finish_reason":"stop"}],"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}}
+
+data: [DONE]
+
+"#
+            .to_vec(),
+        ),
+    ];
+    let (upstream_port, upstream_rx, upstream_handle) =
+        spawn_streaming_upstream("text/event-stream", chunks).await;
+    let (proxy_addr, proxy_handle) =
+        spawn_api_proxy_test_harness(local_targets(&[("test", upstream_port)])).await;
+
+    let body = json!({
+        "model": "test",
+        "stream": true,
+        "input": "stream responses",
+    })
+    .to_string();
+    let request = format!(
+        "POST /v1/responses HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+
+    let mut stream = TcpStream::connect(proxy_addr).await.unwrap();
+    stream.write_all(request.as_bytes()).await.unwrap();
+    stream.shutdown().await.unwrap();
+
+    let first = read_until_contains(
+        &mut stream,
+        br#"event: response.reasoning_text.delta
+data: {"#,
+        Duration::from_secs(2),
+    )
+    .await;
+    let first_text = String::from_utf8_lossy(&first);
+    assert!(first_text.contains("event: response.created"));
+    assert!(first_text.contains("event: response.reasoning_text.delta"));
+    assert!(first_text.contains(r#""delta":"thinking""#));
+    assert!(!first_text.contains("event: response.output_text.delta"));
+    assert!(!first_text.contains(r#""delta":"answer""#));
+
+    let mut rest = Vec::new();
+    stream.read_to_end(&mut rest).await.unwrap();
+    let mut full = first;
+    full.extend_from_slice(&rest);
+    let full_text = String::from_utf8(full).unwrap();
+    assert!(full_text.contains("event: response.output_text.delta"));
+    assert!(full_text.contains(r#""delta":"answer""#));
+    assert!(full_text.contains("event: response.completed"));
+    assert!(full_text.contains(r#""output_text":"answer""#));
+    assert!(full_text.contains("data: [DONE]"));
+
+    let raw = String::from_utf8(upstream_rx.await.unwrap()).unwrap();
+    assert!(raw.starts_with("POST /v1/chat/completions HTTP/1.1"));
+    assert!(raw.contains("\"stream\":true"));
+
+    proxy_handle.abort();
+    let _ = upstream_handle.await;
+}
+
+#[tokio::test]
 async fn test_api_proxy_integration_pipeline_fallback_uses_direct_proxy() {
     // Pipeline fallback test: when only one model is available, auto routes
     // to it directly without attempting a pipeline plan.

--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
@@ -158,6 +158,41 @@ describe('createMeshConnectionAdapter', () => {
     ])
   })
 
+  it('emits first-class reasoning deltas before visible text', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          createSSEStream([
+            'data: {"type":"response.reasoning_text.delta","delta":"Checked facts."}\n',
+            'data: {"type":"response.output_text.delta","delta":" Final answer."}\n',
+            'data: [DONE]\n'
+          ]),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const adapter = createMeshConnectionAdapter('model-a')
+
+    const chunks: StreamChunk[] = []
+    for await (const chunk of adapter.connect(createMessages(), undefined, undefined)) {
+      chunks.push(chunk)
+    }
+
+    const reasoningDelta = chunks.find((chunk) => chunk.type === EventType.REASONING_MESSAGE_CONTENT)
+    const contentDeltas = chunks
+      .filter((chunk) => chunk.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((chunk) => (chunk.type === EventType.TEXT_MESSAGE_CONTENT ? chunk.delta : ''))
+
+    expect(chunks.map((chunk) => chunk.type)).toContain(EventType.REASONING_START)
+    expect(chunks.map((chunk) => chunk.type)).toContain(EventType.REASONING_MESSAGE_START)
+    expect(reasoningDelta).toMatchObject({ type: EventType.REASONING_MESSAGE_CONTENT, delta: 'Checked facts.' })
+    expect(chunks.map((chunk) => chunk.type)).toContain(EventType.REASONING_MESSAGE_END)
+    expect(chunks.map((chunk) => chunk.type)).toContain(EventType.REASONING_END)
+    expect(contentDeltas).toEqual([' Final answer.'])
+  })
+
   it('includes the latest system prompt in responses requests', async () => {
     let currentSystemPrompt = 'Be concise about mesh routing.'
     const fetchMock = vi.fn().mockResolvedValue(new Response(createSSEStream(['data: [DONE]\n']), { status: 200 }))

--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
@@ -196,16 +196,37 @@ async function* runConnect(
   }
 
   let messageStarted = false
+  let reasoningOpen = false
   let firstDeltaAt: number | undefined
 
   for await (const event of parseSSEStream(response.body, abortSignal)) {
     if (abortSignal?.aborted) break
+
+    if (event.type === 'response.reasoning_text.delta') {
+      firstDeltaAt ??= nowMs()
+      if (!messageStarted) {
+        messageStarted = true
+        yield { type: EventType.TEXT_MESSAGE_START, messageId, role: 'assistant' }
+      }
+      if (!reasoningOpen) {
+        reasoningOpen = true
+        yield { type: EventType.REASONING_START, messageId }
+        yield { type: EventType.REASONING_MESSAGE_START, messageId, role: 'reasoning' }
+      }
+      yield { type: EventType.REASONING_MESSAGE_CONTENT, messageId, delta: event.delta }
+      continue
+    }
 
     if (event.type === 'response.output_text.delta') {
       firstDeltaAt ??= nowMs()
       if (!messageStarted) {
         messageStarted = true
         yield { type: EventType.TEXT_MESSAGE_START, messageId, role: 'assistant' }
+      }
+      if (reasoningOpen) {
+        reasoningOpen = false
+        yield { type: EventType.REASONING_MESSAGE_END, messageId }
+        yield { type: EventType.REASONING_END, messageId }
       }
       yield { type: EventType.TEXT_MESSAGE_CONTENT, messageId, delta: event.delta }
       continue
@@ -236,6 +257,10 @@ async function* runConnect(
   if (abortSignal?.aborted) return
 
   if (messageStarted) {
+    if (reasoningOpen) {
+      yield { type: EventType.REASONING_MESSAGE_END, messageId }
+      yield { type: EventType.REASONING_END, messageId }
+    }
     yield { type: EventType.TEXT_MESSAGE_END, messageId }
   }
 

--- a/crates/mesh-llm-ui/src/features/chat/api/use-chat-messages.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/use-chat-messages.test.ts
@@ -1,0 +1,28 @@
+import type { UIMessage } from '@tanstack/ai-react'
+
+import { uiMessagesToThreadMessages } from '@/features/chat/api/use-chat-messages'
+
+describe('uiMessagesToThreadMessages', () => {
+  it('preserves first-class thinking parts for the existing thinking renderer', () => {
+    const messages: UIMessage[] = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        createdAt: new Date('2026-05-14T12:00:00.000Z'),
+        parts: [
+          { type: 'thinking', content: 'Checked facts.' },
+          { type: 'text', content: ' Final answer.' }
+        ]
+      }
+    ]
+
+    expect(uiMessagesToThreadMessages(messages)).toEqual([
+      {
+        id: 'assistant-1',
+        messageRole: 'assistant',
+        timestamp: '2026-05-14T12:00:00.000Z',
+        body: '<think>Checked facts.</think> Final answer.'
+      }
+    ])
+  })
+})

--- a/crates/mesh-llm-ui/src/features/chat/api/use-chat-messages.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/use-chat-messages.ts
@@ -11,6 +11,16 @@ function formatTimestamp(value: Date | undefined): string {
   return value && !Number.isNaN(value.getTime()) ? value.toISOString() : new Date().toISOString()
 }
 
+function messagePartsToThreadBody(parts: UIMessage['parts']): string {
+  return parts
+    .map((part) => {
+      if (part.type === 'thinking') return `<think>${part.content}</think>`
+      if (part.type === 'text') return part.content
+      return ''
+    })
+    .join('')
+}
+
 export function threadMessagesToUIMessages(messages: ThreadMessage[]): UIMessage[] {
   return messages.map((message) => ({
     id: message.id,
@@ -24,13 +34,11 @@ export function uiMessagesToThreadMessages(messages: UIMessage[]): ThreadMessage
   return messages
     .filter((m): m is UIMessage & { role: 'user' | 'assistant' } => m.role === 'user' || m.role === 'assistant')
     .map((message) => {
-      const textPart = message.parts.find((part) => part.type === 'text')
-      const body = textPart?.type === 'text' ? textPart.content : ''
       return {
         id: message.id,
         messageRole: message.role,
         timestamp: formatTimestamp(message.createdAt),
-        body
+        body: messagePartsToThreadBody(message.parts)
       }
     })
 }

--- a/crates/mesh-llm-ui/src/lib/api/types.ts
+++ b/crates/mesh-llm-ui/src/lib/api/types.ts
@@ -248,6 +248,14 @@ export interface ChatSSEDeltaEvent {
   content_index?: number
 }
 
+export interface ChatSSEReasoningDeltaEvent {
+  type: 'response.reasoning_text.delta'
+  delta: string
+  response_id?: string
+  output_index?: number
+  content_index?: number
+}
+
 export interface ChatUsage {
   input_tokens: number
   output_tokens: number
@@ -271,7 +279,7 @@ export interface ChatSSECompletedEvent {
   }
 }
 
-export type ChatSSEEvent = ChatSSEDeltaEvent | ChatSSECompletedEvent
+export type ChatSSEEvent = ChatSSEDeltaEvent | ChatSSEReasoningDeltaEvent | ChatSSECompletedEvent
 
 // ============================================================
 // ATTACHMENT / OBJECTS API TYPES (POST /api/objects)

--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -197,6 +197,7 @@ impl ChatCompletionResponse {
                 message: AssistantMessage {
                     role: "assistant",
                     content: Some(content.into()),
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 logprobs: None,
@@ -220,6 +221,8 @@ pub struct ChatCompletionChoice {
 pub struct AssistantMessage {
     pub role: &'static str,
     pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Value>,
 }
@@ -247,6 +250,7 @@ impl ChatCompletionChunk {
                 delta: ChatCompletionDelta {
                     role: Some("assistant"),
                     content: None,
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 logprobs: None,
@@ -267,6 +271,7 @@ impl ChatCompletionChunk {
                 delta: ChatCompletionDelta {
                     role: None,
                     content: Some(content.into()),
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 logprobs: None,
@@ -291,6 +296,7 @@ impl ChatCompletionChunk {
                 delta: ChatCompletionDelta {
                     role: None,
                     content: None,
+                    reasoning_content: None,
                     tool_calls: None,
                 },
                 logprobs: None,
@@ -328,5 +334,49 @@ pub struct ChatCompletionDelta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn assistant_message_serializes_reasoning_content_when_present() {
+        let message = AssistantMessage {
+            role: "assistant",
+            content: Some("Final answer.".to_string()),
+            reasoning_content: Some("Checked the facts first.".to_string()),
+            tool_calls: None,
+        };
+
+        let value = serde_json::to_value(message).unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "role": "assistant",
+                "content": "Final answer.",
+                "reasoning_content": "Checked the facts first."
+            })
+        );
+    }
+
+    #[test]
+    fn chat_delta_serializes_reasoning_content_without_text_content() {
+        let delta = ChatCompletionDelta {
+            role: None,
+            content: None,
+            reasoning_content: Some("Still thinking.".to_string()),
+            tool_calls: None,
+        };
+
+        let value = serde_json::to_value(delta).unwrap();
+
+        assert_eq!(value, json!({ "reasoning_content": "Still thinking." }));
+    }
 }

--- a/crates/openai-frontend/src/lib.rs
+++ b/crates/openai-frontend/src/lib.rs
@@ -43,10 +43,10 @@ pub use responses::{
     responses_stream_delta_event, responses_stream_delta_event_with_logprobs,
     responses_stream_delta_event_with_logprobs_and_sequence,
     responses_stream_output_item_added_event, responses_stream_output_item_done_event,
-    responses_stream_text_done_event, responses_stream_text_done_event_with_sequence,
-    stream_usage_to_responses_usage, translate_chat_completion_response_to_responses,
-    translate_chat_completion_to_responses, NormalizationOutcome, ResponseAdapterMode,
-    ResponsesRequest, StreamUsage,
+    responses_stream_reasoning_delta_event_with_sequence, responses_stream_text_done_event,
+    responses_stream_text_done_event_with_sequence, stream_usage_to_responses_usage,
+    translate_chat_completion_response_to_responses, translate_chat_completion_to_responses,
+    NormalizationOutcome, ResponseAdapterMode, ResponsesRequest, StreamUsage,
 };
 pub use router::{
     router, router_for, router_for_with_config, router_with_config, OpenAiFrontendConfig,

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -59,6 +59,8 @@ pub struct ChatCompletionStreamDelta {
     #[serde(default)]
     pub content: Option<String>,
     #[serde(default)]
+    pub reasoning_content: Option<String>,
+    #[serde(default)]
     pub tool_calls: Option<Value>,
     #[serde(rename = "role", default)]
     _role: Option<String>,
@@ -757,6 +759,21 @@ pub fn responses_stream_delta_event_with_logprobs_and_sequence(
     event
 }
 
+pub fn responses_stream_reasoning_delta_event_with_sequence(
+    item_id: &str,
+    delta: &str,
+    sequence_number: i32,
+) -> Value {
+    serde_json::json!({
+        "type": "response.reasoning_text.delta",
+        "sequence_number": sequence_number,
+        "item_id": item_id,
+        "output_index": 0,
+        "content_index": 0,
+        "delta": delta,
+    })
+}
+
 pub fn responses_stream_text_done_event(item_id: &str, text: &str) -> Value {
     serde_json::json!({
         "type": "response.output_text.done",
@@ -1238,6 +1255,26 @@ mod tests {
     }
 
     #[test]
+    fn parse_chat_stream_chunk_reads_reasoning_delta() {
+        let payload = json!({
+            "model": "qwen",
+            "choices": [{
+                "delta": {"reasoning_content": "Checking facts."},
+                "finish_reason": null
+            }]
+        })
+        .to_string();
+
+        let parsed = parse_chat_stream_chunk(&payload).expect("stream chunk parse should succeed");
+        let delta = parsed
+            .choices
+            .first()
+            .and_then(|choice| choice.delta.as_ref())
+            .and_then(|delta| delta.reasoning_content.as_deref());
+        assert_eq!(delta, Some("Checking facts."));
+    }
+
+    #[test]
     fn usage_to_responses_usage_maps_cached_tokens() {
         let usage = Usage::new(128, 8).with_cached_tokens(96);
         let mapped = usage_to_responses_usage(&usage);
@@ -1287,11 +1324,17 @@ mod tests {
         assert_eq!(delta["sequence_number"], 4);
         assert_eq!(delta["delta"], "hello");
 
-        let part_done = responses_stream_content_part_done_event("msg_123", "hello", 5);
+        let reasoning_delta =
+            responses_stream_reasoning_delta_event_with_sequence("msg_123", "Checking facts.", 5);
+        assert_eq!(reasoning_delta["type"], "response.reasoning_text.delta");
+        assert_eq!(reasoning_delta["sequence_number"], 5);
+        assert_eq!(reasoning_delta["delta"], "Checking facts.");
+
+        let part_done = responses_stream_content_part_done_event("msg_123", "hello", 6);
         assert_eq!(part_done["type"], "response.content_part.done");
         assert_eq!(part_done["part"]["text"], "hello");
 
-        let item_done = responses_stream_output_item_done_event("msg_123", "hello", 6);
+        let item_done = responses_stream_output_item_done_event("msg_123", "hello", 7);
         assert_eq!(item_done["type"], "response.output_item.done");
         assert_eq!(item_done["item"]["content"][0]["text"], "hello");
     }

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -618,6 +618,7 @@ mod tests {
                         message: AssistantMessage {
                             role: "assistant",
                             content: Some("calling lookup".to_string()),
+                            reasoning_content: None,
                             tool_calls: Some(json!([{
                                 "id": "call_123",
                                 "type": "function",
@@ -671,6 +672,7 @@ mod tests {
                             delta: crate::chat::ChatCompletionDelta {
                                 role: None,
                                 content: Some("tok".to_string()),
+                                reasoning_content: None,
                                 tool_calls: None,
                             },
                             logprobs: Some(json!({

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1171,6 +1171,13 @@ struct ParsedToolCalls {
     tool_calls: Value,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedChatMessage {
+    content: Option<String>,
+    reasoning_content: Option<String>,
+    tool_calls: Option<Value>,
+}
+
 fn tool_calls_requested(request: &ChatCompletionRequest) -> bool {
     request.tools.as_ref().is_some_and(has_requested_tools)
         && !request
@@ -1182,9 +1189,14 @@ fn tool_calls_requested(request: &ChatCompletionRequest) -> bool {
 fn chat_response_from_generated_text(
     model: String,
     output: &GeneratedText,
-    parsed_tool_calls: Option<ParsedToolCalls>,
+    parsed_message: Option<ParsedChatMessage>,
 ) -> ChatCompletionResponse {
-    if let Some(parsed) = parsed_tool_calls {
+    if let Some(parsed) = parsed_message {
+        let finish_reason = if parsed.tool_calls.is_some() {
+            FinishReason::ToolCalls
+        } else {
+            output.finish_reason
+        };
         return ChatCompletionResponse {
             id: openai_frontend::completion_id("chatcmpl"),
             object: "chat.completion",
@@ -1195,10 +1207,11 @@ fn chat_response_from_generated_text(
                 message: openai_frontend::AssistantMessage {
                     role: "assistant",
                     content: parsed.content,
-                    tool_calls: Some(parsed.tool_calls),
+                    reasoning_content: parsed.reasoning_content,
+                    tool_calls: parsed.tool_calls,
                 },
                 logprobs: None,
-                finish_reason: Some(FinishReason::ToolCalls),
+                finish_reason: Some(finish_reason),
             }],
             usage: output.usage(),
         };
@@ -1212,11 +1225,36 @@ fn chat_response_from_generated_text(
     )
 }
 
+fn parsed_chat_message_from_json(
+    message_json: &str,
+    request: &ChatCompletionRequest,
+) -> Option<ParsedChatMessage> {
+    let value = serde_json::from_str::<Value>(message_json).ok()?;
+    let tool_calls =
+        parsed_tool_calls_from_message_value(&value, request).map(|parsed| parsed.tool_calls);
+    Some(ParsedChatMessage {
+        content: string_field(&value, "content"),
+        reasoning_content: string_field(&value, "reasoning_content"),
+        tool_calls,
+    })
+}
+
+#[cfg(test)]
 fn parsed_tool_calls_from_message_json(
     message_json: &str,
     request: &ChatCompletionRequest,
 ) -> Option<ParsedToolCalls> {
     let value = serde_json::from_str::<Value>(message_json).ok()?;
+    parsed_tool_calls_from_message_value(&value, request)
+}
+
+fn parsed_tool_calls_from_message_value(
+    value: &Value,
+    request: &ChatCompletionRequest,
+) -> Option<ParsedToolCalls> {
+    if !tool_calls_requested(request) {
+        return None;
+    }
     let allowed_names = request_allowed_tool_names(request);
     let mut tool_calls = value
         .get("tool_calls")
@@ -1232,13 +1270,17 @@ fn parsed_tool_calls_from_message_json(
         return None;
     }
     Some(ParsedToolCalls {
-        content: value
-            .get("content")
-            .and_then(Value::as_str)
-            .filter(|content| !content.is_empty())
-            .map(ToString::to_string),
+        content: string_field(value, "content"),
         tool_calls: Value::Array(tool_calls),
     })
+}
+
+fn string_field(value: &Value, field: &str) -> Option<String> {
+    value
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|content| !content.is_empty())
+        .map(ToString::to_string)
 }
 
 fn request_allowed_tool_names(request: &ChatCompletionRequest) -> Vec<String> {
@@ -1448,9 +1490,93 @@ type GenerationStream =
 
 enum GenerationStreamEvent {
     Delta(String),
+    ReasoningDelta(String),
     ToolCalls(Value),
     Usage(Usage),
     Done(FinishReason),
+}
+
+struct ChatOutputStreamParser {
+    backend: StageOpenAiBackend,
+    request: ChatCompletionRequest,
+    metadata: String,
+    text: String,
+    emitted_content: String,
+    emitted_reasoning_content: String,
+    emitted_tool_calls: bool,
+}
+
+impl ChatOutputStreamParser {
+    fn new(backend: StageOpenAiBackend, request: ChatCompletionRequest, metadata: String) -> Self {
+        Self {
+            backend,
+            request,
+            metadata,
+            text: String::new(),
+            emitted_content: String::new(),
+            emitted_reasoning_content: String::new(),
+            emitted_tool_calls: false,
+        }
+    }
+
+    fn push_delta(&mut self, delta: &str) -> OpenAiResult<Vec<GenerationStreamEvent>> {
+        self.text.push_str(delta);
+        self.events_for_text(true)
+    }
+
+    fn finish(&mut self, text: &str) -> OpenAiResult<Vec<GenerationStreamEvent>> {
+        if self.text != text {
+            self.text = text.to_string();
+        }
+        self.events_for_text(false)
+    }
+
+    fn events_for_text(&mut self, is_partial: bool) -> OpenAiResult<Vec<GenerationStreamEvent>> {
+        let Some(parsed) = self.backend.parse_chat_output(
+            &self.text,
+            &self.request,
+            Some(&self.metadata),
+            is_partial,
+        )?
+        else {
+            return Ok(Vec::new());
+        };
+        let mut events = Vec::new();
+        if let Some(delta) = suffix_delta(
+            parsed.reasoning_content.as_deref(),
+            &mut self.emitted_reasoning_content,
+        ) {
+            events.push(GenerationStreamEvent::ReasoningDelta(delta));
+        }
+        if let Some(delta) = suffix_delta(parsed.content.as_deref(), &mut self.emitted_content) {
+            events.push(GenerationStreamEvent::Delta(delta));
+        }
+        if !is_partial && !self.emitted_tool_calls {
+            if let Some(tool_calls) = parsed.tool_calls {
+                self.emitted_tool_calls = true;
+                events.push(GenerationStreamEvent::ToolCalls(tool_calls));
+            }
+        }
+        Ok(events)
+    }
+
+    fn finish_reason(&self, fallback: FinishReason) -> FinishReason {
+        if self.emitted_tool_calls {
+            FinishReason::ToolCalls
+        } else {
+            fallback
+        }
+    }
+}
+
+fn suffix_delta(current: Option<&str>, emitted: &mut String) -> Option<String> {
+    let current = current?;
+    let delta = current.strip_prefix(emitted.as_str())?;
+    if delta.is_empty() {
+        return None;
+    }
+    emitted.push_str(delta);
+    Some(delta.to_string())
 }
 
 fn generation_event_to_chat_chunk(
@@ -1461,6 +1587,24 @@ fn generation_event_to_chat_chunk(
         GenerationStreamEvent::Delta(delta) => {
             Ok(ChatCompletionChunk::delta(model.to_string(), delta))
         }
+        GenerationStreamEvent::ReasoningDelta(delta) => Ok(ChatCompletionChunk {
+            id: openai_frontend::completion_id("chatcmpl"),
+            object: "chat.completion.chunk",
+            created: openai_frontend::now_unix_secs(),
+            model: model.to_string(),
+            choices: vec![openai_frontend::ChatCompletionChunkChoice {
+                index: 0,
+                delta: openai_frontend::ChatCompletionDelta {
+                    role: None,
+                    content: None,
+                    reasoning_content: Some(delta),
+                    tool_calls: None,
+                },
+                logprobs: None,
+                finish_reason: None,
+            }],
+            usage: None,
+        }),
         GenerationStreamEvent::ToolCalls(tool_calls) => Ok(ChatCompletionChunk {
             id: openai_frontend::completion_id("chatcmpl"),
             object: "chat.completion.chunk",
@@ -1471,6 +1615,7 @@ fn generation_event_to_chat_chunk(
                 delta: openai_frontend::ChatCompletionDelta {
                     role: None,
                     content: None,
+                    reasoning_content: None,
                     tool_calls: Some(tool_calls_stream_delta(tool_calls)),
                 },
                 logprobs: None,
@@ -1494,6 +1639,9 @@ fn generation_event_to_completion_chunk(
 ) -> OpenAiResult<CompletionChunk> {
     match event? {
         GenerationStreamEvent::Delta(delta) => Ok(CompletionChunk::delta(model.to_string(), delta)),
+        GenerationStreamEvent::ReasoningDelta(_) => {
+            Ok(CompletionChunk::delta(model.to_string(), ""))
+        }
         GenerationStreamEvent::ToolCalls(_) => Ok(CompletionChunk::delta(model.to_string(), "")),
         GenerationStreamEvent::Usage(usage) => Ok(CompletionChunk::usage(model.to_string(), usage)),
         GenerationStreamEvent::Done(reason) => {

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -53,10 +53,14 @@ impl OpenAiBackend for StageOpenAiBackend {
             )
             .await?;
         let response_timer = PhaseTimer::start();
-        let parsed_tool_calls =
-            self.parse_tool_call_output(&output.text, &request, chat_parse_metadata.as_deref())?;
+        let parsed_message = self.parse_chat_output(
+            &output.text,
+            &request,
+            chat_parse_metadata.as_deref(),
+            false,
+        )?;
         let response =
-            chat_response_from_generated_text(request.model.clone(), &output, parsed_tool_calls);
+            chat_response_from_generated_text(request.model.clone(), &output, parsed_message);
         let mut response_attrs = self.openai_attrs(&ids);
         response_attrs.insert(
             "llama_stage.openai_operation".to_string(),
@@ -429,12 +433,19 @@ impl StageOpenAiBackend {
         );
         self.emit_openai_phase("stage.openai_generation_admit", admit_timer, admit_attrs);
         let backend = self.clone();
-        let tool_call_stream = hook_request.as_ref().is_some_and(tool_calls_requested)
-            && prompt.chat_parse_metadata.is_some();
         let chat_parse_metadata = prompt.chat_parse_metadata.clone();
         let (tx, rx) = mpsc::channel(16);
         let hook_runtime = Some(tokio::runtime::Handle::current());
-        let stream_tool_request = hook_request.clone();
+        let mut chat_stream_parser =
+            if let (Some(request), Some(metadata)) = (hook_request.clone(), chat_parse_metadata) {
+                Some(ChatOutputStreamParser::new(
+                    backend.clone(),
+                    request,
+                    metadata,
+                ))
+            } else {
+                None
+            };
         task::spawn_blocking(move || {
             let _permit = permit;
             let result = backend.generate_text(
@@ -447,17 +458,21 @@ impl StageOpenAiBackend {
                 Some(&context.cancellation_token()),
                 ids,
                 |chunk| {
-                    if tool_call_stream {
-                        return Ok(());
-                    }
                     if context.is_cancelled() {
                         return Err(OpenAiError::backend("stream receiver cancelled"));
                     }
-                    tx.blocking_send(Ok(GenerationStreamEvent::Delta(chunk.to_string())))
-                        .map_err(|_| {
+                    let events = if let Some(parser) = chat_stream_parser.as_mut() {
+                        parser.push_delta(chunk)?
+                    } else {
+                        vec![GenerationStreamEvent::Delta(chunk.to_string())]
+                    };
+                    for event in events {
+                        tx.blocking_send(Ok(event)).map_err(|_| {
                             context.cancel();
                             OpenAiError::backend("stream receiver dropped")
-                        })
+                        })?;
+                    }
+                    Ok(())
                 },
             );
             if context.is_cancelled() {
@@ -465,58 +480,25 @@ impl StageOpenAiBackend {
             }
             match result {
                 Ok(output) => {
-                    if tool_call_stream {
-                        if let (Some(request), Some(metadata)) =
-                            (stream_tool_request.as_ref(), chat_parse_metadata.as_deref())
-                        {
-                            match backend.parse_tool_call_output(
-                                &output.text,
-                                request,
-                                Some(metadata),
-                            ) {
-                                Ok(Some(tool_output)) => {
-                                    if tx
-                                        .blocking_send(Ok(GenerationStreamEvent::ToolCalls(
-                                            tool_output.tool_calls,
-                                        )))
-                                        .is_err()
-                                    {
+                    let finish_reason = if let Some(parser) = chat_stream_parser.as_mut() {
+                        match parser.finish(&output.text) {
+                            Ok(events) => {
+                                for event in events {
+                                    if tx.blocking_send(Ok(event)).is_err() {
                                         context.cancel();
                                         return;
                                     }
-                                    if include_usage
-                                        && tx
-                                            .blocking_send(Ok(GenerationStreamEvent::Usage(
-                                                output.usage(),
-                                            )))
-                                            .is_err()
-                                    {
-                                        context.cancel();
-                                        return;
-                                    }
-                                    let _ = tx.blocking_send(Ok(GenerationStreamEvent::Done(
-                                        FinishReason::ToolCalls,
-                                    )));
-                                    return;
                                 }
-                                Ok(None) => {}
-                                Err(error) => {
-                                    let _ = tx.blocking_send(Err(error));
-                                    return;
-                                }
+                                parser.finish_reason(output.finish_reason)
+                            }
+                            Err(error) => {
+                                let _ = tx.blocking_send(Err(error));
+                                return;
                             }
                         }
-                        if !output.text.is_empty()
-                            && tx
-                                .blocking_send(Ok(GenerationStreamEvent::Delta(
-                                    output.text.clone(),
-                                )))
-                                .is_err()
-                        {
-                            context.cancel();
-                            return;
-                        }
-                    }
+                    } else {
+                        output.finish_reason
+                    };
                     if include_usage
                         && tx
                             .blocking_send(Ok(GenerationStreamEvent::Usage(output.usage())))
@@ -525,7 +507,7 @@ impl StageOpenAiBackend {
                         context.cancel();
                         return;
                     }
-                    let _ = tx.blocking_send(Ok(GenerationStreamEvent::Done(output.finish_reason)));
+                    let _ = tx.blocking_send(Ok(GenerationStreamEvent::Done(finish_reason)));
                 }
                 Err(error) => {
                     let _ = tx.blocking_send(Err(error));

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -60,15 +60,13 @@ impl StageOpenAiBackend {
         })
     }
 
-    pub(super) fn parse_tool_call_output(
+    pub(super) fn parse_chat_output(
         &self,
         text: &str,
         request: &ChatCompletionRequest,
         metadata: Option<&str>,
-    ) -> OpenAiResult<Option<ParsedToolCalls>> {
-        if !tool_calls_requested(request) {
-            return Ok(None);
-        }
+        is_partial: bool,
+    ) -> OpenAiResult<Option<ParsedChatMessage>> {
         let Some(metadata) = metadata else {
             return Ok(None);
         };
@@ -79,10 +77,10 @@ impl StageOpenAiBackend {
                 .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
             runtime
                 .model
-                .parse_chat_response_json(text, metadata, false)
+                .parse_chat_response_json(text, metadata, is_partial)
                 .map_err(openai_backend_error)?
         };
-        Ok(parsed_tool_calls_from_message_json(&parsed_json, request))
+        Ok(parsed_chat_message_from_json(&parsed_json, request))
     }
 
     pub(super) fn tokenize(&self, prompt: &str) -> OpenAiResult<Vec<i32>> {

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -348,6 +348,77 @@ fn parses_llama_message_tool_calls() {
 }
 
 #[test]
+fn parses_llama_message_reasoning_content() {
+    let parsed = parsed_chat_message_from_json(
+        r#"{"role":"assistant","reasoning_content":"Checked facts first.","content":"Final answer."}"#,
+        &ChatCompletionRequest {
+            tools: None,
+            ..tool_request()
+        },
+    )
+    .expect("parsed message");
+
+    assert_eq!(parsed.content.as_deref(), Some("Final answer."));
+    assert_eq!(
+        parsed.reasoning_content.as_deref(),
+        Some("Checked facts first.")
+    );
+    assert_eq!(parsed.tool_calls, None);
+}
+
+#[test]
+fn chat_response_from_parsed_message_separates_reasoning_content() {
+    let output = GeneratedText {
+        prompt_tokens: 4,
+        completion_tokens: 7,
+        cached_prompt_tokens: 0,
+        matched_prefix_tokens: 0,
+        suffix_prefill_tokens: 0,
+        cache_hit_kind: None,
+        text: "Checked facts first.</think>Final answer.".to_string(),
+        finish_reason: FinishReason::Stop,
+        detokenize_ms: 0.0,
+        text_emit_ms: 0.0,
+        eog_check_ms: 0.0,
+    };
+    let parsed = ParsedChatMessage {
+        content: Some("Final answer.".to_string()),
+        reasoning_content: Some("Checked facts first.".to_string()),
+        tool_calls: None,
+    };
+
+    let response = chat_response_from_generated_text("qwen".to_string(), &output, Some(parsed));
+
+    let message = &response.choices[0].message;
+    assert_eq!(message.content.as_deref(), Some("Final answer."));
+    assert_eq!(
+        message.reasoning_content.as_deref(),
+        Some("Checked facts first.")
+    );
+    assert_eq!(message.tool_calls, None);
+    assert_eq!(response.choices[0].finish_reason, Some(FinishReason::Stop));
+}
+
+#[test]
+fn generation_event_to_chat_chunk_emits_reasoning_delta() {
+    let chunk = generation_event_to_chat_chunk(
+        Ok(GenerationStreamEvent::ReasoningDelta(
+            "Checking the premise.".to_string(),
+        )),
+        "qwen",
+    )
+    .unwrap();
+
+    let delta = &chunk.choices[0].delta;
+    assert_eq!(delta.content, None);
+    assert_eq!(
+        delta.reasoning_content.as_deref(),
+        Some("Checking the premise.")
+    );
+    assert_eq!(delta.tool_calls, None);
+}
+
+#[test]
 fn llama_message_tool_parser_rejects_unknown_tool() {
     let request = tool_request();
     let parsed = parsed_tool_calls_from_message_json(

--- a/third_party/llama.cpp/patches/0036-Expose-tool-aware-chat-template-ABI.patch
+++ b/third_party/llama.cpp/patches/0036-Expose-tool-aware-chat-template-ABI.patch
@@ -4,9 +4,9 @@ Date: Tue, 5 May 2026 06:10:28 +1000
 Subject: [PATCH 36/80] Expose tool-aware chat template ABI
 
 ---
- common/stage-chat.cpp | 222 ++++++++++++++++++++++++++++++++++++++++++
+ common/stage-chat.cpp | 228 ++++++++++++++++++++++++++++++++++++++++++
  include/skippy.h      |  29 +++++-
- 2 files changed, 250 insertions(+), 1 deletion(-)
+ 2 files changed, 256 insertions(+), 1 deletion(-)
 
 diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
 index 60d53fc4..77d8fc8e 100644
@@ -29,7 +29,7 @@ index 60d53fc4..77d8fc8e 100644
  
  static skippy_error * skippy_common_make_error(enum skippy_status status, const char * message) {
      skippy_error * error = new skippy_error{};
-@@ -45,6 +50,84 @@ static enum skippy_status skippy_common_success(skippy_error ** out_error) {
+@@ -45,6 +50,86 @@ static enum skippy_status skippy_common_success(skippy_error ** out_error) {
      return SKIPPY_STATUS_OK;
  }
  
@@ -97,9 +97,11 @@ index 60d53fc4..77d8fc8e 100644
 +
 +static json skippy_common_chat_metadata_json(
 +        const common_chat_params & params,
++        common_reasoning_format reasoning_format,
 +        bool parse_tool_calls) {
 +    return {
 +        {"chat_format", static_cast<int>(params.format)},
++        {"reasoning_format", common_reasoning_format_name(reasoning_format)},
 +        {"generation_prompt", params.generation_prompt},
 +        {"parse_tool_calls", parse_tool_calls},
 +        {"chat_parser", params.parser},
@@ -114,7 +116,7 @@ index 60d53fc4..77d8fc8e 100644
  enum skippy_status skippy_apply_chat_template(
          struct skippy_model * model,
          const struct llama_chat_message * messages,
-@@ -135,3 +218,142 @@ enum skippy_status skippy_apply_chat_template(
+@@ -135,3 +220,146 @@ enum skippy_status skippy_apply_chat_template(
      }
      return skippy_common_success(out_error);
  }
@@ -186,7 +188,7 @@ index 60d53fc4..77d8fc8e 100644
 +        prompt = params.prompt;
 +
 +        const bool parse_tool_calls = !inputs.tools.empty() && inputs.tool_choice != COMMON_CHAT_TOOL_CHOICE_NONE;
-+        metadata = skippy_common_chat_metadata_json(params, parse_tool_calls).dump();
++        metadata = skippy_common_chat_metadata_json(params, inputs.reasoning_format, parse_tool_calls).dump();
 +    } catch (const std::exception & e) {
 +        skippy_common_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, e.what());
 +        return SKIPPY_STATUS_UNSUPPORTED;
@@ -233,6 +235,10 @@ index 60d53fc4..77d8fc8e 100644
 +        json metadata = json::parse(metadata_json);
 +        common_chat_parser_params params;
 +        params.format = static_cast<common_chat_format>(metadata.value("chat_format", 0));
++        const std::string reasoning_format = metadata.value("reasoning_format", std::string());
++        if (!reasoning_format.empty()) {
++            params.reasoning_format = common_reasoning_format_from_name(reasoning_format);
++        }
 +        params.generation_prompt = metadata.value("generation_prompt", std::string());
 +        params.parse_tool_calls = metadata.value("parse_tool_calls", true);
 +        const std::string parser = metadata.value("chat_parser", std::string());
@@ -313,4 +319,3 @@ index 2b95ccc8..384c7e40 100644
          struct skippy_model_info ** out_info,
 -- 
 2.50.1 (Apple Git-155)
-


### PR DESCRIPTION
## Summary

This makes Skippy return thinking-model reasoning as first-class OpenAI-compatible reasoning data instead of mixing it into the visible assistant answer.

- Adds optional `reasoning_content` fields to chat completion messages and streaming deltas.
- Persists llama.cpp `reasoning_format` through Skippy chat metadata so `common_chat_parse` can extract thinking traces correctly.
- Parses Skippy chat output for every chat response, not only the tool-call path.
- Streams reasoning deltas separately from visible answer deltas and translates them to `response.reasoning_text.delta` for the Responses API bridge.
- Updates the console adapter to consume first-class reasoning events while preserving the existing `<think>`-compatible transcript fallback.

## Why

Thinking models such as Qwen and DeepSeek-style models can emit reasoning traces separately from the final answer. llama.cpp already supports this via `reasoning_content`, but Skippy was losing the parser mode because `reasoning_format` was not round-tripped through the stage chat metadata. As a result, clients saw reasoning mixed into `content` instead of receiving a clean final answer plus a separate reasoning field.

## Implementation

- Round-trip `reasoning_format` in the durable llama.cpp stage-chat ABI patch and restore it into `common_chat_parser_params` before parsing generated output.
- Add `reasoning_content` to the shared OpenAI chat message and stream delta types, omitted when absent for existing clients.
- Replace the tool-call-only parse path with a parsed chat-message path that can carry visible content, reasoning content, and tool calls together.
- Add a Skippy streaming parser that tracks the cumulative generated text, emits only new reasoning/content suffixes, and still emits tool-call chunks at final parse time.
- Add Responses stream translation for upstream `delta.reasoning_content` as `response.reasoning_text.delta`.
- Map Responses reasoning SSE events to AG-UI reasoning events in the console, while saving thinking parts back into the existing `<think>...</think>` transcript format for compatibility with current rendering and storage.

## Compatibility

- API changes are additive: `reasoning_content` is skipped when absent.
- Non-thinking models continue to return normal `content` only.
- Existing `<think>` parsing/rendering remains supported in the console.
- No mesh gossip, peer protocol, or plugin protocol compatibility change is introduced.

## Validation

- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p openai-frontend`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p skippy-server`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime test_api_proxy_translates_streaming_reasoning_content_events`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime test_api_proxy_translates_streaming_responses_events_incrementally`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`
- `pnpm --dir ./crates/mesh-llm-ui exec vitest run src/features/chat/api/mesh-connection.test.ts src/features/chat/api/use-chat-messages.test.ts`
- `pnpm --dir ./crates/mesh-llm-ui exec vitest run src/features/chat/pages/ChatPage.test.tsx --testNamePattern thinking`
- `just build`

## Related

Related: #544
