### PR TITLE
Advertise multimodal capabilities from runtime evidence

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -478,6 +478,7 @@ fn infer_remote_served_descriptors(
             };
             ServedModelDescriptor {
                 identity,
+                capabilities_known: false,
                 capabilities: crate::models::ModelCapabilities::default(),
                 topology: None,
             }
@@ -669,6 +670,7 @@ fn descriptor_from_identity(
     capabilities.moe = false;
     ServedModelDescriptor {
         identity,
+        capabilities_known: true,
         capabilities,
         topology,
     }
@@ -3020,7 +3022,14 @@ impl Node {
 
     async fn refresh_served_model_descriptors(&self) {
         let serving_models = self.serving_models.lock().await.clone();
-        let descriptors = if let Some(primary_model_name) = serving_models.first() {
+        let existing_by_name: HashMap<_, _> = self
+            .served_model_descriptors
+            .lock()
+            .await
+            .iter()
+            .map(|descriptor| (descriptor.identity.model_name.clone(), descriptor.clone()))
+            .collect();
+        let mut descriptors = if let Some(primary_model_name) = serving_models.first() {
             let model_source = self.model_source.lock().await.clone();
             let primary_model_path = crate::models::find_model_path(primary_model_name);
             infer_served_model_descriptors(
@@ -3032,6 +3041,15 @@ impl Node {
         } else {
             Vec::new()
         };
+        for descriptor in &mut descriptors {
+            if let Some(existing) = existing_by_name.get(&descriptor.identity.model_name) {
+                descriptor.capabilities = existing.capabilities;
+                descriptor.capabilities_known = existing.capabilities_known;
+                if existing.topology.is_some() {
+                    descriptor.topology = existing.topology.clone();
+                }
+            }
+        }
         self.set_served_model_descriptors(descriptors).await;
     }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -253,6 +253,62 @@ async fn make_test_node(role: super::NodeRole) -> Result<Node> {
 }
 
 #[tokio::test]
+async fn set_serving_models_preserves_existing_known_descriptor_capabilities_when_adding_model(
+) -> Result<()> {
+    let node = make_test_node(super::NodeRole::Worker).await?;
+    let vision_model = "Qwen3VL-2B-Instruct-Q4_K_M".to_string();
+    let text_model = "Qwen3-8B-Q4_K_M".to_string();
+
+    node.set_serving_models(vec![vision_model.clone()]).await;
+    node.upsert_served_model_descriptor(ServedModelDescriptor {
+        identity: ServedModelIdentity {
+            model_name: vision_model.clone(),
+            is_primary: true,
+            source_kind: ModelSourceKind::LocalGguf,
+            local_file_name: Some(format!("{vision_model}.gguf")),
+            ..Default::default()
+        },
+        capabilities_known: true,
+        capabilities: crate::models::ModelCapabilities {
+            multimodal: true,
+            vision: crate::models::CapabilityLevel::Supported,
+            ..Default::default()
+        },
+        topology: None,
+    })
+    .await;
+
+    node.set_serving_models(vec![vision_model.clone(), text_model.clone()])
+        .await;
+
+    let descriptors = node.served_model_descriptors().await;
+    let vision = descriptors
+        .iter()
+        .find(|descriptor| descriptor.identity.model_name == vision_model)
+        .expect("existing vision descriptor should remain served");
+    assert!(vision.identity.is_primary);
+    assert!(vision.capabilities_known);
+    assert_eq!(
+        vision.capabilities.vision,
+        crate::models::CapabilityLevel::Supported
+    );
+    assert!(vision.capabilities.multimodal);
+
+    let text = descriptors
+        .iter()
+        .find(|descriptor| descriptor.identity.model_name == text_model)
+        .expect("new text descriptor should be inferred");
+    assert!(!text.identity.is_primary);
+    assert!(!text.capabilities_known);
+    assert_eq!(
+        text.capabilities,
+        crate::models::ModelCapabilities::default()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn local_request_metrics_snapshot_tracks_accepted_and_completed_requests() {
     let node = make_test_node(super::NodeRole::Worker)
         .await
@@ -2784,6 +2840,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
                 local_file_name: Some("Qwen3-8B-Q4_K_M.gguf".into()),
                 identity_hash: Some("identity-hash".into()),
             },
+            capabilities_known: true,
             capabilities: crate::models::ModelCapabilities::default(),
             topology: None,
         }],
@@ -2822,6 +2879,14 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         0,
         "local_ann_to_proto_ann must strip passive available_model_sizes from gossip"
     );
+    assert_eq!(
+        proto_pa
+            .served_model_descriptors
+            .first()
+            .and_then(|descriptor| descriptor.capabilities_known),
+        Some(true),
+        "local_ann_to_proto_ann must carry descriptor capability provenance"
+    );
 
     let (_, roundtripped) =
         proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed on valid proto PA");
@@ -2843,6 +2908,14 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         "proto_ann_to_local must restore experts_summary"
     );
     assert!(roundtripped.available_model_sizes.is_empty());
+    assert!(
+        roundtripped
+            .served_model_descriptors
+            .first()
+            .map(|descriptor| descriptor.capabilities_known)
+            .unwrap_or(false),
+        "proto_ann_to_local must restore descriptor capability provenance"
+    );
     assert_eq!(
         roundtripped
             .served_model_runtime
@@ -2881,6 +2954,14 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         Some(32768),
         "build_gossip_frame must preserve served model runtime context length"
     );
+    assert_eq!(
+        wire_pa
+            .served_model_descriptors
+            .first()
+            .and_then(|descriptor| descriptor.capabilities_known),
+        Some(true),
+        "build_gossip_frame must preserve descriptor capability provenance"
+    );
     let (_, final_local) =
         proto_ann_to_local(wire_pa).expect("final proto_ann_to_local must succeed");
     assert!(final_local.available_model_metadata.is_empty());
@@ -2893,6 +2974,38 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
             .and_then(ModelRuntimeDescriptor::advertised_context_length),
         Some(32768)
     );
+    assert!(final_local
+        .served_model_descriptors
+        .first()
+        .map(|descriptor| descriptor.capabilities_known)
+        .unwrap_or(false));
+}
+
+#[test]
+fn proto_ann_to_local_treats_missing_default_capability_provenance_as_unknown() {
+    let peer_id = EndpointId::from(SecretKey::generate().public());
+    let proto_pa = PeerAnnouncement {
+        endpoint_id: peer_id.as_bytes().to_vec(),
+        role: NodeRole::Worker as i32,
+        served_model_descriptors: vec![crate::proto::node::ServedModelDescriptor {
+            identity: Some(crate::proto::node::ServedModelIdentity {
+                model_name: "Qwen3VL-2B-Instruct-Q4_K_M".to_string(),
+                source_kind: crate::proto::node::ModelSourceKind::LocalGguf as i32,
+                ..Default::default()
+            }),
+            capabilities: Some(crate::proto::node::ModelCapabilities::default()),
+            capabilities_known: None,
+            topology: None,
+        }],
+        ..Default::default()
+    };
+
+    let (_, ann) = proto_ann_to_local(&proto_pa).expect("valid proto announcement");
+    let descriptor = ann
+        .served_model_descriptors
+        .first()
+        .expect("descriptor should decode");
+    assert!(!descriptor.capabilities_known);
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/models/capabilities.rs
+++ b/crates/mesh-llm-host-runtime/src/models/capabilities.rs
@@ -9,6 +9,11 @@ use hf_hub::{RepoDownloadFileParams, RepoType};
 use serde_json::Value;
 use std::path::Path;
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct RuntimeMediaCapabilityEvidence {
+    pub vision_projector_loaded: bool,
+}
+
 pub fn infer_remote_catalog_capabilities(
     model: &remote_catalog::RemoteCatalogModel,
 ) -> ModelCapabilities {
@@ -43,6 +48,32 @@ pub fn infer_local_model_capabilities(model_name: &str, path: &Path) -> ModelCap
         caps = merge_config_signals(caps, &config);
     }
     caps.normalize()
+}
+
+pub fn runtime_verified_model_capabilities(
+    model_name: &str,
+    path: &Path,
+    evidence: RuntimeMediaCapabilityEvidence,
+) -> ModelCapabilities {
+    runtime_verified_capabilities_from_static(
+        infer_local_model_capabilities(model_name, path),
+        evidence,
+    )
+}
+
+pub fn runtime_verified_capabilities_from_static(
+    mut caps: ModelCapabilities,
+    evidence: RuntimeMediaCapabilityEvidence,
+) -> ModelCapabilities {
+    caps.audio = CapabilityLevel::None;
+    if evidence.vision_projector_loaded {
+        caps.vision = CapabilityLevel::Supported;
+        caps.multimodal = true;
+    } else {
+        caps.vision = CapabilityLevel::None;
+        caps.multimodal = false;
+    }
+    caps
 }
 
 pub async fn infer_remote_hf_capabilities(
@@ -138,4 +169,73 @@ async fn fetch_remote_json_with_api(
         .ok()?;
     let text = tokio::fs::read_to_string(path).await.ok()?;
     serde_json::from_str(&text).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        runtime_verified_capabilities_from_static, runtime_verified_model_capabilities,
+        CapabilityLevel, ModelCapabilities, RuntimeMediaCapabilityEvidence,
+    };
+    use std::path::Path;
+
+    #[test]
+    fn runtime_media_verification_downgrades_name_only_vision_without_loaded_projector() {
+        let caps = runtime_verified_model_capabilities(
+            "Qwen3VL-2B-Instruct-Q4_K_M",
+            Path::new("/models/Qwen3VL-2B-Instruct-Q4_K_M.gguf"),
+            RuntimeMediaCapabilityEvidence {
+                vision_projector_loaded: false,
+            },
+        );
+
+        assert_eq!(caps.vision, CapabilityLevel::None);
+        assert_eq!(caps.audio, CapabilityLevel::None);
+        assert!(!caps.multimodal);
+        assert!(!caps.supports_vision_runtime());
+        assert!(!caps.supports_multimodal_runtime());
+    }
+
+    #[test]
+    fn runtime_media_verification_promotes_loaded_projector_to_supported_vision() {
+        let caps = runtime_verified_model_capabilities(
+            "Qwen3VL-2B-Instruct-Q4_K_M",
+            Path::new("/models/Qwen3VL-2B-Instruct-Q4_K_M.gguf"),
+            RuntimeMediaCapabilityEvidence {
+                vision_projector_loaded: true,
+            },
+        );
+
+        assert_eq!(caps.vision, CapabilityLevel::Supported);
+        assert_eq!(caps.audio, CapabilityLevel::None);
+        assert!(caps.multimodal);
+        assert!(caps.supports_vision_runtime());
+        assert!(caps.supports_multimodal_runtime());
+    }
+
+    #[test]
+    fn runtime_media_verification_preserves_non_media_traits() {
+        let caps = ModelCapabilities {
+            multimodal: true,
+            vision: CapabilityLevel::Supported,
+            audio: CapabilityLevel::Supported,
+            reasoning: CapabilityLevel::Likely,
+            tool_use: CapabilityLevel::Supported,
+            moe: true,
+        };
+
+        let verified = runtime_verified_capabilities_from_static(
+            caps,
+            RuntimeMediaCapabilityEvidence {
+                vision_projector_loaded: false,
+            },
+        );
+
+        assert_eq!(verified.vision, CapabilityLevel::None);
+        assert_eq!(verified.audio, CapabilityLevel::None);
+        assert!(!verified.multimodal);
+        assert_eq!(verified.reasoning, CapabilityLevel::Likely);
+        assert_eq!(verified.tool_use, CapabilityLevel::Supported);
+        assert!(verified.moe);
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/models/capabilities.rs
+++ b/crates/mesh-llm-host-runtime/src/models/capabilities.rs
@@ -65,15 +65,16 @@ pub fn runtime_verified_capabilities_from_static(
     mut caps: ModelCapabilities,
     evidence: RuntimeMediaCapabilityEvidence,
 ) -> ModelCapabilities {
-    caps.audio = CapabilityLevel::None;
     if evidence.vision_projector_loaded {
         caps.vision = CapabilityLevel::Supported;
         caps.multimodal = true;
     } else {
         caps.vision = CapabilityLevel::None;
-        caps.multimodal = false;
+        if caps.audio == CapabilityLevel::None {
+            caps.multimodal = false;
+        }
     }
-    caps
+    caps.normalize()
 }
 
 pub async fn infer_remote_hf_capabilities(
@@ -214,7 +215,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_media_verification_preserves_non_media_traits() {
+    fn runtime_media_verification_preserves_audio_and_non_media_traits() {
         let caps = ModelCapabilities {
             multimodal: true,
             vision: CapabilityLevel::Supported,
@@ -232,10 +233,11 @@ mod tests {
         );
 
         assert_eq!(verified.vision, CapabilityLevel::None);
-        assert_eq!(verified.audio, CapabilityLevel::None);
-        assert!(!verified.multimodal);
+        assert_eq!(verified.audio, CapabilityLevel::Supported);
+        assert!(verified.multimodal);
         assert_eq!(verified.reasoning, CapabilityLevel::Likely);
         assert_eq!(verified.tool_use, CapabilityLevel::Supported);
         assert!(verified.moe);
+        assert!(verified.supports_audio_runtime());
     }
 }

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -19,7 +19,10 @@ mod usage;
 use anyhow::{Context, Result};
 use hf_hub::{HFClient, HFClientBuilder, HFClientSync};
 
-pub use capabilities::{CapabilityLevel, ModelCapabilities};
+pub use capabilities::{
+    runtime_verified_model_capabilities, CapabilityLevel, ModelCapabilities,
+    RuntimeMediaCapabilityEvidence,
+};
 pub use inventory::{scan_local_inventory_snapshot_with_progress, LocalModelInventorySnapshot};
 pub use local::{
     find_mmproj_path, find_model_path, huggingface_hub_cache_dir, huggingface_identity_for_path,

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -163,6 +163,7 @@ pub(crate) async fn api_proxy(
                         request.ensure_body_json();
                         if let Some(body_json) = request.body_json.as_ref() {
                             let cl = router::classify(body_json);
+                            let media = router::media_requirements(body_json);
                             let mut available_models = callable.clone();
                             if let Some(plugin_manager) = plugin_manager.as_ref() {
                                 if let Ok(external_models) = plugin_manager.inference_models().await
@@ -182,10 +183,22 @@ pub(crate) async fn api_proxy(
                                     .iter()
                                     .map(|name| {
                                         let caps =
-                                            crate::models::installed_model_capabilities(name);
+                                            proxy::capabilities_for_model(name, &descriptors);
                                         (name.as_str(), 0.0, caps)
                                     })
                                     .collect();
+                            let media_available: Vec<_> = available
+                                .iter()
+                                .filter(|(_, _, caps)| {
+                                    router::model_satisfies_media_requirements(caps, &media)
+                                })
+                                .cloned()
+                                .collect();
+                            let available = if media_available.is_empty() {
+                                available
+                            } else {
+                                media_available
+                            };
                             let picked = router::pick_model_classified(&cl, &available);
                             if let Some(name) = picked {
                                 tracing::info!(

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -187,17 +187,21 @@ pub(crate) async fn api_proxy(
                                         (name.as_str(), 0.0, caps)
                                     })
                                     .collect();
-                            let media_available: Vec<_> = available
-                                .iter()
-                                .filter(|(_, _, caps)| {
-                                    router::model_satisfies_media_requirements(caps, &media)
-                                })
-                                .cloned()
-                                .collect();
-                            let available = if media_available.is_empty() {
-                                available
-                            } else {
-                                media_available
+                            let Some(available) =
+                                router::filter_media_compatible_candidates(&available, &media)
+                            else {
+                                let _ = proxy::send_error(
+                                    tcp_stream,
+                                    422,
+                                    "no served model can satisfy the requested media inputs",
+                                )
+                                .await;
+                                proxy::release_request_objects(
+                                    &node,
+                                    &request.request_object_request_ids,
+                                )
+                                .await;
+                                return;
                             };
                             let picked = router::pick_model_classified(&cl, &available);
                             if let Some(name) = picked {

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -2237,9 +2237,19 @@ fn should_learn_affinity(status_code: u16) -> bool {
 fn cached_auto_model_satisfies_media_requirements(
     model: &str,
     media: &router::MediaRequirements,
+    descriptors: &[mesh::ServedModelDescriptor],
 ) -> bool {
-    let caps = crate::models::installed_model_capabilities(model);
+    let caps = capabilities_for_model(model, descriptors);
     router::model_satisfies_media_requirements(&caps, media)
+}
+
+pub(crate) fn capabilities_for_model(
+    model: &str,
+    descriptors: &[mesh::ServedModelDescriptor],
+) -> crate::models::ModelCapabilities {
+    descriptor_for_model(descriptors, model)
+        .map(|descriptor| descriptor.capabilities)
+        .unwrap_or_else(|| crate::models::installed_model_capabilities(model))
 }
 
 // ── Model-aware tunnel routing ──
@@ -2314,7 +2324,11 @@ pub async fn handle_mesh_request(
             let cached = if let Some(key) = auto_session_key {
                 if let Some(model) = affinity.lookup_auto_model(key) {
                     if !node.hosts_for_model(&model).await.is_empty() {
-                        if cached_auto_model_satisfies_media_requirements(&model, &media) {
+                        if cached_auto_model_satisfies_media_requirements(
+                            &model,
+                            &media,
+                            &descriptors,
+                        ) {
                             tracing::debug!(
                                 "auto: reusing cached model {model} for session {key:016x}"
                             );
@@ -2351,7 +2365,7 @@ pub async fn handle_mesh_request(
                 let with_caps: Vec<(&str, f64, crate::models::ModelCapabilities)> = served
                     .iter()
                     .map(|name| {
-                        let caps = crate::models::installed_model_capabilities(name);
+                        let caps = capabilities_for_model(name, &descriptors);
                         (name.as_str(), 0.0, caps)
                     })
                     .collect();
@@ -3188,7 +3202,7 @@ fn models_list_json(
             if !seen.insert(public_id.clone()) {
                 return None;
             }
-            let capabilities = crate::models::installed_model_capabilities(m);
+            let capabilities = capabilities_for_model(m, descriptors);
             let has_multimodal = capabilities.supports_multimodal_runtime();
             let has_vision = capabilities.supports_vision_runtime();
             let has_audio = capabilities.supports_audio_runtime();
@@ -3578,6 +3592,16 @@ mod tests {
         }
     }
 
+    fn local_gguf_descriptor_with_capabilities(
+        model_name: &str,
+        capabilities: crate::models::ModelCapabilities,
+    ) -> mesh::ServedModelDescriptor {
+        mesh::ServedModelDescriptor {
+            capabilities,
+            ..local_gguf_descriptor(model_name)
+        }
+    }
+
     async fn read_request_from_parts_with_limits(
         parts: Vec<Vec<u8>>,
         limits: HttpReadLimits,
@@ -3647,6 +3671,42 @@ mod tests {
 
         assert_eq!(body["data"][0]["id"], "smollm2-a");
         assert_eq!(body["data"][0]["display_name"], "smollm2-a");
+    }
+
+    #[test]
+    fn models_list_uses_descriptor_capabilities_not_filename_heuristics() {
+        let models = vec!["Qwen3VL-2B-Instruct-Q4_K_M".to_string()];
+        let descriptors = vec![local_gguf_descriptor_with_capabilities(
+            &models[0],
+            crate::models::ModelCapabilities::default(),
+        )];
+
+        let body = models_list_json(&models, &descriptors);
+
+        assert_eq!(body["data"][0]["capabilities"], serde_json::json!(["text"]));
+        assert_eq!(body["data"][0]["vision_status"], "none");
+        assert_eq!(body["data"][0]["multimodal_status"], "none");
+    }
+
+    #[test]
+    fn models_list_reports_runtime_verified_projector_capabilities() {
+        let models = vec!["Qwen3VL-2B-Instruct-Q4_K_M".to_string()];
+        let descriptors = vec![local_gguf_descriptor_with_capabilities(
+            &models[0],
+            crate::models::ModelCapabilities {
+                multimodal: true,
+                vision: crate::models::CapabilityLevel::Supported,
+                ..Default::default()
+            },
+        )];
+
+        let body = models_list_json(&models, &descriptors);
+        let capabilities = body["data"][0]["capabilities"].as_array().unwrap();
+
+        assert!(capabilities.iter().any(|cap| cap == "multimodal"));
+        assert!(capabilities.iter().any(|cap| cap == "vision"));
+        assert_eq!(body["data"][0]["vision_status"], "supported");
+        assert_eq!(body["data"][0]["multimodal_status"], "supported");
     }
 
     #[test]
@@ -3772,11 +3832,38 @@ mod tests {
 
         assert!(!cached_auto_model_satisfies_media_requirements(
             "Qwen3-8B-Q4_K_M",
-            &media
+            &media,
+            &[]
         ));
         assert!(cached_auto_model_satisfies_media_requirements(
             "Qwen3.5-0.8B-Vision-Q4_K_M",
-            &media
+            &media,
+            &[]
+        ));
+    }
+
+    #[test]
+    fn cached_auto_model_rejects_descriptor_text_only_even_when_name_looks_vision() {
+        let body = serde_json::json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+                ]
+            }]
+        });
+        let media = router::media_requirements(&body);
+        let model = "Qwen3VL-2B-Instruct-Q4_K_M";
+        let descriptors = vec![local_gguf_descriptor_with_capabilities(
+            model,
+            crate::models::ModelCapabilities::default(),
+        )];
+
+        assert!(!cached_auto_model_satisfies_media_requirements(
+            model,
+            &media,
+            &descriptors
         ));
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -2248,6 +2248,7 @@ pub(crate) fn capabilities_for_model(
     descriptors: &[mesh::ServedModelDescriptor],
 ) -> crate::models::ModelCapabilities {
     descriptor_for_model(descriptors, model)
+        .filter(|descriptor| descriptor.capabilities_known)
         .map(|descriptor| descriptor.capabilities)
         .unwrap_or_else(|| crate::models::installed_model_capabilities(model))
 }
@@ -2369,15 +2370,17 @@ pub async fn handle_mesh_request(
                         (name.as_str(), 0.0, caps)
                     })
                     .collect();
-                let available: Vec<(&str, f64, crate::models::ModelCapabilities)> = with_caps
-                    .iter()
-                    .filter(|(_, _, caps)| router::model_satisfies_media_requirements(caps, &media))
-                    .cloned()
-                    .collect();
-                let available = if available.is_empty() {
-                    with_caps
-                } else {
-                    available
+                let Some(available) =
+                    router::filter_media_compatible_candidates(&with_caps, &media)
+                else {
+                    let _ = send_error(
+                        tcp_stream,
+                        422,
+                        "no served model can satisfy the requested media inputs",
+                    )
+                    .await;
+                    release_request_objects(&node, &request.request_object_request_ids).await;
+                    return;
                 };
                 let picked = router::pick_model_classified(&cl, &available);
                 if let Some(name) = picked {
@@ -3597,6 +3600,7 @@ mod tests {
         capabilities: crate::models::ModelCapabilities,
     ) -> mesh::ServedModelDescriptor {
         mesh::ServedModelDescriptor {
+            capabilities_known: true,
             capabilities,
             ..local_gguf_descriptor(model_name)
         }
@@ -3686,6 +3690,20 @@ mod tests {
         assert_eq!(body["data"][0]["capabilities"], serde_json::json!(["text"]));
         assert_eq!(body["data"][0]["vision_status"], "none");
         assert_eq!(body["data"][0]["multimodal_status"], "none");
+    }
+
+    #[test]
+    fn models_list_uses_static_fallback_for_unknown_descriptor_capabilities() {
+        let models = vec!["Qwen3VL-2B-Instruct-Q4_K_M".to_string()];
+        let descriptors = vec![local_gguf_descriptor(&models[0])];
+
+        let body = models_list_json(&models, &descriptors);
+        let capabilities = body["data"][0]["capabilities"].as_array().unwrap();
+
+        assert!(capabilities.iter().any(|cap| cap == "multimodal"));
+        assert!(capabilities.iter().any(|cap| cap == "vision"));
+        assert_eq!(body["data"][0]["vision_status"], "supported");
+        assert_eq!(body["data"][0]["multimodal_status"], "supported");
     }
 
     #[test]
@@ -3861,6 +3879,28 @@ mod tests {
         )];
 
         assert!(!cached_auto_model_satisfies_media_requirements(
+            model,
+            &media,
+            &descriptors
+        ));
+    }
+
+    #[test]
+    fn cached_auto_model_uses_static_fallback_for_unknown_descriptor_capabilities() {
+        let body = serde_json::json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+                ]
+            }]
+        });
+        let media = router::media_requirements(&body);
+        let model = "Qwen3VL-2B-Instruct-Q4_K_M";
+        let descriptors = vec![local_gguf_descriptor(model)];
+
+        assert!(cached_auto_model_satisfies_media_requirements(
             model,
             &media,
             &descriptors

--- a/crates/mesh-llm-host-runtime/src/network/router.rs
+++ b/crates/mesh-llm-host-runtime/src/network/router.rs
@@ -40,6 +40,12 @@ pub struct MediaRequirements {
     pub needs_audio: bool,
 }
 
+impl MediaRequirements {
+    pub fn requires_runtime_modality(self) -> bool {
+        self.needs_vision || self.needs_audio
+    }
+}
+
 // ── Model capabilities for routing ──────────────────────────────────
 
 /// Strip split GGUF suffix like "-00001-of-00004" from a model name.
@@ -372,6 +378,24 @@ pub(crate) fn model_satisfies_media_requirements(
 ) -> bool {
     (!media.needs_vision || caps.supports_vision_runtime())
         && (!media.needs_audio || caps.supports_audio_runtime())
+}
+
+pub(crate) fn filter_media_compatible_candidates<'a>(
+    candidates: &[(&'a str, f64, crate::models::ModelCapabilities)],
+    media: &MediaRequirements,
+) -> Option<Vec<(&'a str, f64, crate::models::ModelCapabilities)>> {
+    let media_available: Vec<_> = candidates
+        .iter()
+        .filter(|(_, _, caps)| model_satisfies_media_requirements(caps, media))
+        .cloned()
+        .collect();
+    if media_available.is_empty() && media.requires_runtime_modality() {
+        None
+    } else if media_available.is_empty() {
+        Some(candidates.to_vec())
+    } else {
+        Some(media_available)
+    }
 }
 
 /// Length of last user message in characters (rough complexity proxy).
@@ -831,6 +855,36 @@ mod tests {
             &likely_vision_caps,
             &image
         ));
+    }
+
+    #[test]
+    fn test_filter_media_candidates_blocks_hard_media_miss() {
+        use crate::models::{CapabilityLevel, ModelCapabilities};
+
+        let text_caps = ModelCapabilities::default();
+        let vision_caps = ModelCapabilities {
+            vision: CapabilityLevel::Supported,
+            ..Default::default()
+        };
+        let image = MediaRequirements {
+            has_media: true,
+            needs_vision: true,
+            needs_audio: false,
+        };
+        let text_only = MediaRequirements::default();
+
+        let text_candidates = vec![("text", 0.0, text_caps)];
+        assert!(filter_media_compatible_candidates(&text_candidates, &image).is_none());
+
+        let mixed_candidates = vec![("text", 0.0, text_caps), ("vision", 0.0, vision_caps)];
+        let filtered = filter_media_compatible_candidates(&mixed_candidates, &image)
+            .expect("vision candidate should satisfy image media request");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].0, "vision");
+
+        let unfiltered = filter_media_compatible_candidates(&text_candidates, &text_only)
+            .expect("text-only requests should keep normal router fallback behavior");
+        assert_eq!(unfiltered, text_candidates);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/router.rs
+++ b/crates/mesh-llm-host-runtime/src/network/router.rs
@@ -370,8 +370,8 @@ pub(crate) fn model_satisfies_media_requirements(
     caps: &crate::models::ModelCapabilities,
     media: &MediaRequirements,
 ) -> bool {
-    (!media.needs_vision || caps.vision_label().is_some())
-        && (!media.needs_audio || caps.audio_label().is_some())
+    (!media.needs_vision || caps.supports_vision_runtime())
+        && (!media.needs_audio || caps.supports_audio_runtime())
 }
 
 /// Length of last user message in characters (rough complexity proxy).
@@ -820,6 +820,16 @@ mod tests {
         assert!(model_satisfies_media_requirements(
             &vision_audio_caps,
             &image_and_audio
+        ));
+
+        let likely_vision_caps = ModelCapabilities {
+            multimodal: true,
+            vision: CapabilityLevel::Likely,
+            ..Default::default()
+        };
+        assert!(!model_satisfies_media_requirements(
+            &likely_vision_caps,
+            &image
         ));
     }
 

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -247,6 +247,7 @@ fn legacy_descriptor_from_identity(
 ) -> crate::mesh::ServedModelDescriptor {
     crate::mesh::ServedModelDescriptor {
         identity: proto_identity_to_local(identity),
+        capabilities_known: false,
         capabilities: crate::models::ModelCapabilities::default(),
         topology: None,
     }
@@ -454,6 +455,7 @@ pub(crate) fn local_ann_to_proto_ann(
         .iter()
         .map(|descriptor| crate::proto::node::ServedModelDescriptor {
             identity: Some(descriptor_identity_to_proto(&descriptor.identity)),
+            capabilities_known: Some(descriptor.capabilities_known),
             capabilities: Some(crate::proto::node::ModelCapabilities {
                 vision: local_capability_level_to_proto(descriptor.capabilities.vision),
                 reasoning: local_capability_level_to_proto(descriptor.capabilities.reasoning),
@@ -644,49 +646,54 @@ pub(crate) fn proto_ann_to_local(
             .map(proto_runtime_descriptor_to_local)
             .collect(),
         served_model_descriptors: if !pa.served_model_descriptors.is_empty() {
-            let descriptors: Vec<_> = pa
-                .served_model_descriptors
-                .iter()
-                .filter(|descriptor| proto_descriptor_has_valid_identity(descriptor))
-                .map(|descriptor| crate::mesh::ServedModelDescriptor {
-                    identity: descriptor
-                        .identity
-                        .as_ref()
-                        .map(proto_identity_to_local)
-                        .unwrap_or_default(),
-                    capabilities: descriptor
-                        .capabilities
-                        .as_ref()
-                        .map(|caps| crate::models::ModelCapabilities {
-                            multimodal: caps.multimodal,
-                            vision: proto_capability_level_to_local(caps.vision),
-                            audio: proto_capability_level_to_local(caps.audio),
-                            reasoning: proto_capability_level_to_local(caps.reasoning),
-                            tool_use: proto_capability_level_to_local(caps.tool_use),
-                            moe: caps.moe,
-                        })
-                        .unwrap_or_default(),
-                    topology: descriptor.topology.as_ref().map(|topology| {
-                        crate::models::ModelTopology {
-                            moe: topology
-                                .moe
+            let descriptors: Vec<_> =
+                pa.served_model_descriptors
+                    .iter()
+                    .filter(|descriptor| proto_descriptor_has_valid_identity(descriptor))
+                    .map(|descriptor| {
+                        let capabilities = descriptor
+                            .capabilities
+                            .as_ref()
+                            .map(|caps| crate::models::ModelCapabilities {
+                                multimodal: caps.multimodal,
+                                vision: proto_capability_level_to_local(caps.vision),
+                                audio: proto_capability_level_to_local(caps.audio),
+                                reasoning: proto_capability_level_to_local(caps.reasoning),
+                                tool_use: proto_capability_level_to_local(caps.tool_use),
+                                moe: caps.moe,
+                            })
+                            .unwrap_or_default();
+                        crate::mesh::ServedModelDescriptor {
+                            identity: descriptor
+                                .identity
                                 .as_ref()
-                                .map(|moe| crate::models::ModelMoeInfo {
-                                    expert_count: moe.expert_count,
-                                    used_expert_count: moe.used_expert_count,
-                                    min_experts_per_node: moe.min_experts_per_node,
-                                    source: moe.source.clone(),
-                                    ranking_source: moe.ranking_source.clone(),
-                                    ranking_origin: moe.ranking_origin.clone(),
-                                    ranking: moe.ranking.clone(),
-                                    ranking_prompt_count: moe.ranking_prompt_count,
-                                    ranking_tokens: moe.ranking_tokens,
-                                    ranking_layer_scope: moe.ranking_layer_scope.clone(),
-                                }),
+                                .map(proto_identity_to_local)
+                                .unwrap_or_default(),
+                            capabilities_known: descriptor.capabilities_known.unwrap_or(
+                                capabilities != crate::models::ModelCapabilities::default(),
+                            ),
+                            capabilities,
+                            topology: descriptor.topology.as_ref().map(|topology| {
+                                crate::models::ModelTopology {
+                                    moe: topology.moe.as_ref().map(|moe| {
+                                        crate::models::ModelMoeInfo {
+                                            expert_count: moe.expert_count,
+                                            used_expert_count: moe.used_expert_count,
+                                            min_experts_per_node: moe.min_experts_per_node,
+                                            source: moe.source.clone(),
+                                            ranking_source: moe.ranking_source.clone(),
+                                            ranking_origin: moe.ranking_origin.clone(),
+                                            ranking: moe.ranking.clone(),
+                                            ranking_prompt_count: moe.ranking_prompt_count,
+                                            ranking_tokens: moe.ranking_tokens,
+                                            ranking_layer_scope: moe.ranking_layer_scope.clone(),
+                                        }
+                                    }),
+                                }
+                            }),
                         }
-                    }),
-                })
-                .collect();
+                    })
+                    .collect();
             if descriptors.is_empty() {
                 // All descriptors were invalid — fall back to legacy identity list.
                 pa.served_model_identities

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -53,6 +53,7 @@ pub(super) struct LocalRuntimeModelHandle {
     pub(super) backend: String,
     pub(super) context_length: u32,
     pub(super) slots: usize,
+    pub(super) capabilities: models::ModelCapabilities,
     inner: LocalRuntimeBackendHandle,
 }
 
@@ -358,6 +359,49 @@ pub(super) async fn add_serving_assignment(
         node.upsert_served_model_descriptor(descriptor).await;
     }
     node.regossip().await;
+}
+
+pub(super) async fn set_runtime_verified_served_model_capabilities(
+    node: &mesh::Node,
+    primary_model_name: &str,
+    model_name: &str,
+    capabilities: models::ModelCapabilities,
+) {
+    let existing = node
+        .served_model_descriptors()
+        .await
+        .into_iter()
+        .find(|descriptor| descriptor.identity.model_name == model_name);
+    let descriptor = runtime_verified_served_model_descriptor(
+        existing,
+        primary_model_name,
+        model_name,
+        capabilities,
+    );
+    node.upsert_served_model_descriptor(descriptor).await;
+}
+
+fn runtime_verified_served_model_descriptor(
+    existing: Option<mesh::ServedModelDescriptor>,
+    primary_model_name: &str,
+    model_name: &str,
+    capabilities: models::ModelCapabilities,
+) -> mesh::ServedModelDescriptor {
+    let mut descriptor = existing.unwrap_or_else(|| mesh::ServedModelDescriptor {
+        identity: mesh::ServedModelIdentity {
+            model_name: model_name.to_string(),
+            is_primary: model_name == primary_model_name,
+            source_kind: mesh::ModelSourceKind::Unknown,
+            local_file_name: Some(format!("{model_name}.gguf")),
+            ..Default::default()
+        },
+        capabilities: models::ModelCapabilities::default(),
+        topology: None,
+    });
+    descriptor.identity.model_name = model_name.to_string();
+    descriptor.identity.is_primary = model_name == primary_model_name;
+    descriptor.capabilities = capabilities;
+    descriptor
 }
 
 pub(super) async fn remove_serving_assignment(node: &mesh::Node, model_name: &str) {
@@ -1094,6 +1138,13 @@ async fn load_split_runtime_generation_inner(
     });
     let http = handle.start_http(alloc_local_port().await?);
     let (death_tx, death_rx) = tokio::sync::oneshot::channel();
+    let capabilities = models::runtime_verified_model_capabilities(
+        spec.model_ref,
+        spec.model_path,
+        models::RuntimeMediaCapabilityEvidence {
+            vision_projector_loaded: spec.projector_path.is_some(),
+        },
+    );
 
     spec.node
         .activate_stage_topology(split_stage_topology_instance(
@@ -1113,6 +1164,7 @@ async fn load_split_runtime_generation_inner(
             backend: "skippy".into(),
             context_length: spec.ctx_size,
             slots: spec.slots,
+            capabilities,
             inner: LocalRuntimeBackendHandle::Skippy {
                 model: handle,
                 http,
@@ -2589,6 +2641,13 @@ async fn start_runtime_skippy_model(
         .map(Path::to_path_buf)
         .or_else(|| mmproj_path_for_model(&model_name))
         .filter(|path| path.exists());
+    let capabilities = models::runtime_verified_model_capabilities(
+        &model_name,
+        spec.model_path,
+        models::RuntimeMediaCapabilityEvidence {
+            vision_projector_loaded: projector_path.is_some(),
+        },
+    );
     let mut options = skippy::SkippyModelLoadOptions::for_direct_gguf(&model_name, spec.model_path)
         .with_ctx_size(context_length)
         .with_generation_concurrency(plan.slots)
@@ -2636,6 +2695,7 @@ async fn start_runtime_skippy_model(
             backend: "skippy".into(),
             context_length,
             slots: plan.slots,
+            capabilities,
             inner: LocalRuntimeBackendHandle::Skippy {
                 model: skippy_model,
                 http,
@@ -2682,6 +2742,13 @@ async fn start_runtime_layer_package_model(
             mmproj_path_for_model(&model_name).map(|path| path.to_string_lossy().to_string())
         })
         .filter(|path| Path::new(path).exists());
+    let capabilities = models::runtime_verified_model_capabilities(
+        &model_name,
+        spec.model_path,
+        models::RuntimeMediaCapabilityEvidence {
+            vision_projector_loaded: projector_path.is_some(),
+        },
+    );
     let activation_width = skippy_stage_activation_width(package.activation_width, &model_name)?;
     let run_id = format!("mesh-skippy-{}", now_unix_nanos());
     let config = StageConfig {
@@ -2756,6 +2823,7 @@ async fn start_runtime_layer_package_model(
             backend: "skippy".into(),
             context_length,
             slots: plan.slots,
+            capabilities,
             inner: LocalRuntimeBackendHandle::Skippy {
                 model: handle,
                 http,
@@ -2984,6 +3052,70 @@ mod tests {
             layer_end,
             parameter_bytes: u64::from(layer_end.saturating_sub(layer_start)) * 1_000_000,
         }
+    }
+
+    #[test]
+    fn runtime_verified_served_model_descriptor_preserves_identity_and_updates_capabilities() {
+        let existing = mesh::ServedModelDescriptor {
+            identity: mesh::ServedModelIdentity {
+                model_name: "Qwen3VL-2B-Instruct-Q4_K_M".into(),
+                is_primary: false,
+                source_kind: mesh::ModelSourceKind::HuggingFace,
+                repository: Some("Qwen/Qwen3-VL-2B-Instruct-GGUF".into()),
+                artifact: Some("Qwen3VL-2B-Instruct-Q4_K_M.gguf".into()),
+                ..Default::default()
+            },
+            capabilities: models::ModelCapabilities::default(),
+            topology: None,
+        };
+        let capabilities = models::ModelCapabilities {
+            multimodal: true,
+            vision: models::CapabilityLevel::Supported,
+            ..Default::default()
+        };
+
+        let descriptor = runtime_verified_served_model_descriptor(
+            Some(existing),
+            "Qwen3VL-2B-Instruct-Q4_K_M",
+            "Qwen3VL-2B-Instruct-Q4_K_M",
+            capabilities,
+        );
+
+        assert_eq!(
+            descriptor.identity.source_kind,
+            mesh::ModelSourceKind::HuggingFace
+        );
+        assert_eq!(
+            descriptor.identity.repository.as_deref(),
+            Some("Qwen/Qwen3-VL-2B-Instruct-GGUF")
+        );
+        assert!(descriptor.identity.is_primary);
+        assert_eq!(descriptor.capabilities, capabilities);
+    }
+
+    #[test]
+    fn runtime_verified_served_model_descriptor_builds_fallback_identity() {
+        let descriptor = runtime_verified_served_model_descriptor(
+            None,
+            "Primary",
+            "Runtime",
+            models::ModelCapabilities::default(),
+        );
+
+        assert_eq!(descriptor.identity.model_name, "Runtime");
+        assert!(!descriptor.identity.is_primary);
+        assert_eq!(
+            descriptor.identity.source_kind,
+            mesh::ModelSourceKind::Unknown
+        );
+        assert_eq!(
+            descriptor.identity.local_file_name.as_deref(),
+            Some("Runtime.gguf")
+        );
+        assert_eq!(
+            descriptor.capabilities,
+            models::ModelCapabilities::default()
+        );
     }
 
     fn test_stage_status_from_load(

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -395,11 +395,13 @@ fn runtime_verified_served_model_descriptor(
             local_file_name: Some(format!("{model_name}.gguf")),
             ..Default::default()
         },
+        capabilities_known: false,
         capabilities: models::ModelCapabilities::default(),
         topology: None,
     });
     descriptor.identity.model_name = model_name.to_string();
     descriptor.identity.is_primary = model_name == primary_model_name;
+    descriptor.capabilities_known = true;
     descriptor.capabilities = capabilities;
     descriptor
 }
@@ -3065,6 +3067,7 @@ mod tests {
                 artifact: Some("Qwen3VL-2B-Instruct-Q4_K_M.gguf".into()),
                 ..Default::default()
             },
+            capabilities_known: false,
             capabilities: models::ModelCapabilities::default(),
             topology: None,
         };
@@ -3090,6 +3093,7 @@ mod tests {
             Some("Qwen/Qwen3-VL-2B-Instruct-GGUF")
         );
         assert!(descriptor.identity.is_primary);
+        assert!(descriptor.capabilities_known);
         assert_eq!(descriptor.capabilities, capabilities);
     }
 
@@ -3116,6 +3120,7 @@ mod tests {
             descriptor.capabilities,
             models::ModelCapabilities::default()
         );
+        assert!(descriptor.capabilities_known);
     }
 
     fn test_stage_status_from_load(

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -6583,6 +6583,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_runtime_instance_preserves_existing_known_descriptor_capabilities() {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
+            .await
+            .expect("test node should initialize");
+        let registry = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let vision_model = "Qwen3VL-2B-Instruct-Q4_K_M";
+        let text_model = "Qwen3-8B-Q4_K_M";
+        let vision_capabilities = models::ModelCapabilities {
+            multimodal: true,
+            vision: models::CapabilityLevel::Supported,
+            ..Default::default()
+        };
+
+        register_runtime_instance(
+            &registry,
+            &node,
+            vision_model,
+            vision_model,
+            "runtime-vision",
+            Some(8192),
+            vision_capabilities,
+        )
+        .await;
+        register_runtime_instance(
+            &registry,
+            &node,
+            vision_model,
+            text_model,
+            "runtime-text",
+            Some(8192),
+            models::ModelCapabilities::default(),
+        )
+        .await;
+
+        let descriptors = node.served_model_descriptors().await;
+        let vision = descriptors
+            .iter()
+            .find(|descriptor| descriptor.identity.model_name == vision_model)
+            .expect("vision descriptor should remain registered");
+        assert!(vision.capabilities_known);
+        assert_eq!(vision.capabilities, vision_capabilities);
+
+        let text = descriptors
+            .iter()
+            .find(|descriptor| descriptor.identity.model_name == text_model)
+            .expect("text descriptor should be registered");
+        assert!(text.capabilities_known);
+        assert_eq!(text.capabilities, models::ModelCapabilities::default());
+    }
+
+    #[tokio::test]
     async fn dashboard_snapshot_provider_reuses_cached_inventory_within_ttl() {
         let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
             .await

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -15,11 +15,11 @@ use self::local::{
     add_runtime_local_target, add_serving_assignment, advertise_model_ready, local_process_payload,
     model_fits_runtime_capacity, remove_runtime_local_target, remove_serving_assignment,
     resolved_model_name, runtime_model_planning_bytes, runtime_model_required_bytes,
-    set_advertised_model_context, start_runtime_local_model, start_runtime_split_model,
-    startup_runtime_plan, stop_split_generation_cleanup, withdraw_advertised_model,
-    LocalRuntimeModelHandle, LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent,
-    SplitCoordinatorAck, SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart,
-    StartupRuntimePlan,
+    set_advertised_model_context, set_runtime_verified_served_model_capabilities,
+    start_runtime_local_model, start_runtime_split_model, startup_runtime_plan,
+    stop_split_generation_cleanup, withdraw_advertised_model, LocalRuntimeModelHandle,
+    LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent, SplitCoordinatorAck,
+    SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
@@ -765,6 +765,7 @@ async fn register_runtime_instance(
     model_name: &str,
     instance_id: &str,
     context_length: Option<u32>,
+    capabilities: models::ModelCapabilities,
 ) {
     let (was_empty, context_changed, next_context) = {
         let mut guard = registry.lock().await;
@@ -781,6 +782,13 @@ async fn register_runtime_instance(
     }
     if was_empty {
         add_serving_assignment(node, primary_model_name, model_name).await;
+        set_runtime_verified_served_model_capabilities(
+            node,
+            primary_model_name,
+            model_name,
+            capabilities,
+        )
+        .await;
         advertise_model_ready(node, primary_model_name, model_name).await;
     }
 }
@@ -1327,6 +1335,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         &loaded_name,
         &instance_id,
         Some(handle.context_length),
+        handle.capabilities,
     )
     .await;
     let payload = local_process_payload(
@@ -1477,6 +1486,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                                     &loaded_name,
                                     &instance_id,
                                     Some(next_handle.context_length),
+                                    next_handle.capabilities,
                                 )
                                 .await;
                                 let payload = local_process_payload(
@@ -1641,6 +1651,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                     &next.loaded_name,
                     &instance_id,
                     Some(next.handle.context_length),
+                    next.handle.capabilities,
                 )
                 .await;
                 let payload = local_process_payload(
@@ -5437,6 +5448,7 @@ async fn run_auto(
                                 &loaded_name,
                                 &instance_id,
                                 Some(handle.context_length),
+                                handle.capabilities,
                             )
                             .await;
                             node.set_available_models(models::scan_local_models()).await;

--- a/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
@@ -487,8 +487,8 @@ impl RuntimeDataCollector {
                     None => (None, None),
                 };
                 let routing_metrics = routing_metrics_by_model.get(name).cloned();
-                let has_descriptor = descriptor.is_some();
                 let mut capabilities = descriptor
+                    .filter(|descriptor| descriptor.capabilities_known)
                     .map(|descriptor| descriptor.capabilities)
                     .unwrap_or_else(|| {
                         if local_known {
@@ -510,7 +510,9 @@ impl RuntimeDataCollector {
                         .max(crate::models::capabilities::CapabilityLevel::Likely);
                 }
                 if local_known
-                    && !has_descriptor
+                    && !descriptor
+                        .map(|descriptor| descriptor.capabilities_known)
+                        .unwrap_or(false)
                     && likely_vision_model(
                         name,
                         catalog_entry
@@ -524,7 +526,9 @@ impl RuntimeDataCollector {
                     capabilities.multimodal = true;
                 }
                 if local_known
-                    && !has_descriptor
+                    && !descriptor
+                        .map(|descriptor| descriptor.capabilities_known)
+                        .unwrap_or(false)
                     && likely_audio_model(
                         name,
                         catalog_entry

--- a/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
@@ -487,6 +487,7 @@ impl RuntimeDataCollector {
                     None => (None, None),
                 };
                 let routing_metrics = routing_metrics_by_model.get(name).cloned();
+                let has_descriptor = descriptor.is_some();
                 let mut capabilities = descriptor
                     .map(|descriptor| descriptor.capabilities)
                     .unwrap_or_else(|| {
@@ -509,6 +510,7 @@ impl RuntimeDataCollector {
                         .max(crate::models::capabilities::CapabilityLevel::Likely);
                 }
                 if local_known
+                    && !has_descriptor
                     && likely_vision_model(
                         name,
                         catalog_entry
@@ -522,6 +524,7 @@ impl RuntimeDataCollector {
                     capabilities.multimodal = true;
                 }
                 if local_known
+                    && !has_descriptor
                     && likely_audio_model(
                         name,
                         catalog_entry

--- a/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
@@ -496,6 +496,53 @@ mod tests {
         assert_eq!(model.size_gb, 22.0);
     }
 
+    #[test]
+    fn runtime_data_model_snapshot_keeps_warm_descriptor_media_capabilities_authoritative() {
+        let collector = RuntimeDataCollector::new();
+        let model_name = "Qwen3VL-2B-Instruct-Q4_K_M".to_string();
+        let descriptor = crate::mesh::ServedModelDescriptor {
+            identity: crate::mesh::ServedModelIdentity {
+                model_name: model_name.clone(),
+                source_kind: crate::mesh::ModelSourceKind::LocalGguf,
+                local_file_name: Some(format!("{model_name}.gguf")),
+                ..Default::default()
+            },
+            capabilities: crate::models::ModelCapabilities::default(),
+            topology: None,
+        };
+
+        let snapshot = collector.build_model_view(ModelViewInput {
+            peers: vec![],
+            catalog: vec![MeshCatalogEntry {
+                model_name: model_name.clone(),
+                descriptor: Some(descriptor),
+            }],
+            served_models: vec![model_name.clone()],
+            active_demand: HashMap::new(),
+            my_serving_models: vec![model_name.clone()],
+            my_hosted_models: vec![model_name.clone()],
+            local_inventory: LocalModelInventorySnapshot {
+                model_names: HashSet::from([model_name.clone()]),
+                size_by_name: HashMap::new(),
+                metadata_by_name: HashMap::new(),
+            },
+            node_hostname: Some("node.local".into()),
+            my_vram_gb: 24.0,
+            model_name: model_name.clone(),
+            model_size_bytes: 0,
+            now_unix_secs: 1_700_000_000,
+        });
+
+        let payload = mesh_models(snapshot);
+        assert_eq!(payload.len(), 1);
+        assert_eq!(payload[0].name, model_name);
+        assert_eq!(payload[0].status, "warm");
+        assert!(!payload[0].multimodal);
+        assert_eq!(payload[0].multimodal_status, None);
+        assert!(!payload[0].vision);
+        assert_eq!(payload[0].vision_status, None);
+    }
+
     #[tokio::test]
     async fn runtime_data_inventory_single_flight_scan_coalesces() {
         let collector = RuntimeDataCollector::new();

--- a/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
@@ -497,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_data_model_snapshot_keeps_warm_descriptor_media_capabilities_authoritative() {
+    fn runtime_data_model_snapshot_keeps_known_text_only_descriptor_authoritative() {
         let collector = RuntimeDataCollector::new();
         let model_name = "Qwen3VL-2B-Instruct-Q4_K_M".to_string();
         let descriptor = crate::mesh::ServedModelDescriptor {
@@ -507,6 +507,7 @@ mod tests {
                 local_file_name: Some(format!("{model_name}.gguf")),
                 ..Default::default()
             },
+            capabilities_known: true,
             capabilities: crate::models::ModelCapabilities::default(),
             topology: None,
         };
@@ -541,6 +542,104 @@ mod tests {
         assert_eq!(payload[0].multimodal_status, None);
         assert!(!payload[0].vision);
         assert_eq!(payload[0].vision_status, None);
+    }
+
+    #[test]
+    fn runtime_data_model_snapshot_uses_static_media_for_unknown_descriptor() {
+        let collector = RuntimeDataCollector::new();
+        let model_name = "Qwen3VL-2B-Instruct-Q4_K_M".to_string();
+        let descriptor = crate::mesh::ServedModelDescriptor {
+            identity: crate::mesh::ServedModelIdentity {
+                model_name: model_name.clone(),
+                source_kind: crate::mesh::ModelSourceKind::LocalGguf,
+                local_file_name: Some(format!("{model_name}.gguf")),
+                ..Default::default()
+            },
+            capabilities_known: false,
+            capabilities: crate::models::ModelCapabilities::default(),
+            topology: None,
+        };
+
+        let snapshot = collector.build_model_view(ModelViewInput {
+            peers: vec![],
+            catalog: vec![MeshCatalogEntry {
+                model_name: model_name.clone(),
+                descriptor: Some(descriptor),
+            }],
+            served_models: vec![model_name.clone()],
+            active_demand: HashMap::new(),
+            my_serving_models: vec![model_name.clone()],
+            my_hosted_models: vec![model_name.clone()],
+            local_inventory: LocalModelInventorySnapshot {
+                model_names: HashSet::from([model_name.clone()]),
+                size_by_name: HashMap::new(),
+                metadata_by_name: HashMap::new(),
+            },
+            node_hostname: Some("node.local".into()),
+            my_vram_gb: 24.0,
+            model_name: model_name.clone(),
+            model_size_bytes: 0,
+            now_unix_secs: 1_700_000_000,
+        });
+
+        let payload = mesh_models(snapshot);
+        assert_eq!(payload.len(), 1);
+        assert_eq!(payload[0].name, model_name);
+        assert!(payload[0].multimodal);
+        assert_eq!(payload[0].multimodal_status, Some("supported"));
+        assert!(payload[0].vision);
+        assert_eq!(payload[0].vision_status, Some("supported"));
+    }
+
+    #[test]
+    fn runtime_data_model_snapshot_reports_known_verified_vision_descriptor() {
+        let collector = RuntimeDataCollector::new();
+        let model_name = "Qwen3VL-2B-Instruct-Q4_K_M".to_string();
+        let descriptor = crate::mesh::ServedModelDescriptor {
+            identity: crate::mesh::ServedModelIdentity {
+                model_name: model_name.clone(),
+                source_kind: crate::mesh::ModelSourceKind::LocalGguf,
+                local_file_name: Some(format!("{model_name}.gguf")),
+                ..Default::default()
+            },
+            capabilities_known: true,
+            capabilities: crate::models::ModelCapabilities {
+                multimodal: true,
+                vision: crate::models::CapabilityLevel::Supported,
+                ..Default::default()
+            },
+            topology: None,
+        };
+
+        let snapshot = collector.build_model_view(ModelViewInput {
+            peers: vec![],
+            catalog: vec![MeshCatalogEntry {
+                model_name: model_name.clone(),
+                descriptor: Some(descriptor),
+            }],
+            served_models: vec![model_name.clone()],
+            active_demand: HashMap::new(),
+            my_serving_models: vec![model_name.clone()],
+            my_hosted_models: vec![model_name.clone()],
+            local_inventory: LocalModelInventorySnapshot {
+                model_names: HashSet::from([model_name.clone()]),
+                size_by_name: HashMap::new(),
+                metadata_by_name: HashMap::new(),
+            },
+            node_hostname: Some("node.local".into()),
+            my_vram_gb: 24.0,
+            model_name: model_name.clone(),
+            model_size_bytes: 0,
+            now_unix_secs: 1_700_000_000,
+        });
+
+        let payload = mesh_models(snapshot);
+        assert_eq!(payload.len(), 1);
+        assert_eq!(payload[0].name, model_name);
+        assert!(payload[0].multimodal);
+        assert_eq!(payload[0].multimodal_status, Some("supported"));
+        assert!(payload[0].vision);
+        assert_eq!(payload[0].vision_status, Some("supported"));
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-protocol/proto/node.proto
+++ b/crates/mesh-llm-protocol/proto/node.proto
@@ -107,6 +107,7 @@ message ServedModelDescriptor {
   ServedModelIdentity identity = 1;
   ModelCapabilities capabilities = 2;
   optional ModelTopology topology = 3;
+  optional bool capabilities_known = 4;
 }
 
 message ServedModelIdentity {

--- a/crates/mesh-llm-protocol/src/proto/node.rs
+++ b/crates/mesh-llm-protocol/src/proto/node.rs
@@ -199,6 +199,8 @@ pub struct ServedModelDescriptor {
     pub capabilities: ::core::option::Option<ModelCapabilities>,
     #[prost(message, optional, tag = "3")]
     pub topology: ::core::option::Option<ModelTopology>,
+    #[prost(bool, optional, tag = "4")]
+    pub capabilities_known: ::core::option::Option<bool>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ServedModelIdentity {

--- a/crates/mesh-llm-types/src/mesh/mod.rs
+++ b/crates/mesh-llm-types/src/mesh/mod.rs
@@ -39,9 +39,15 @@ pub struct ServedModelIdentity {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ServedModelDescriptor {
     pub identity: ServedModelIdentity,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub capabilities_known: bool,
     pub capabilities: ModelCapabilities,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topology: Option<ModelTopology>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -105,6 +111,7 @@ pub fn infer_served_model_descriptors(
             };
             ServedModelDescriptor {
                 identity,
+                capabilities_known: false,
                 capabilities: ModelCapabilities::default(),
                 topology: None,
             }


### PR DESCRIPTION
## Summary

This makes multimodal capability advertisement come from the runtime that actually loaded the model, rather than from catalog/name heuristics alone.

- Advertises vision/audio support from runtime-verified media capability evidence once a model is warm.
- Keeps served model descriptors authoritative for `/v1/models`, `/api/models`, cached auto-routing, and OpenAI ingress routing.
- Requires runtime evidence before routing image/audio requests to a model, avoiding false-positive multimodal matches from model names or catalog hints.
- Preserves the existing fallback capability inference for cold/catalog-only models where no runtime evidence exists yet.

## Why

The multimodal design depends on routing decisions reflecting what the active backend can actually serve. Name-based or catalog-based capability inference is useful before startup, but it can over-advertise a model as vision/audio-capable when the runtime has not loaded the required projector/media path.

This PR makes the warm runtime descriptor the source of truth: once the embedded runtime knows whether media support is actually available, that verified descriptor is what clients, routing, and runtime snapshots consume.

## Implementation

- Adds runtime media capability evidence to the model capability layer.
- Captures verified media support from the embedded runtime startup path and publishes it through the served model descriptor before model-ready advertisement.
- Teaches `/v1/models`, cached auto-routing, and OpenAI ingress routing to prefer warm served descriptors over colder catalog/name-derived metadata.
- Updates media routing checks so image/audio requests require runtime-verified support when choosing an active model.
- Surfaces verified capability details in runtime data snapshots so the management/UI model view can distinguish likely catalog capability from runtime evidence.

## Protocol / Compatibility

- No new protobuf fields, ALPN changes, stream types, or plugin protocol changes.
- Existing capability fields continue to be used; this only changes how this node derives them for warm served models.
- Cold/catalog-only descriptors still retain the previous inferred capability behavior until runtime evidence is available.

## Validation

- `git diff --check origin/main...HEAD`
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib runtime_media_verification`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib runtime_verified_served_model_descriptor`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib test_model_satisfies_media_requirements_matches_required_modalities`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib models_list_`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib cached_auto_model`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib runtime_data_model_snapshot_keeps_warm_descriptor_media_capabilities_authoritative`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime --lib`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm --lib`

## Related

Related to the multimodal capability and routing model in `docs/design/MULTI_MODAL.md`.

## Known residual risk

I did not run a mixed-version two-node runtime test with a released binary and a real multimodal projector in this local pass. The change intentionally avoids wire/protocol changes, but the final end-to-end proof for real multimodal hardware should still come from a multi-node runtime check.