### PR TITLE
Validate React-only PR routing

### DIFF
--- a/crates/mesh-llm-ui/src/components/mesh-llm-wordmark.tsx
+++ b/crates/mesh-llm-ui/src/components/mesh-llm-wordmark.tsx
@@ -6,7 +6,7 @@ type MeshLlmWordmarkProps = {
 
 export function MeshLlmWordmark({ className }: MeshLlmWordmarkProps) {
   return (
-    <span className={cn('whitespace-nowrap tracking-tight', className)}>
+    <span className={cn('whitespace-nowrap tracking-tight leading-none', className)}>
       <span className="text-primary">mesh</span>
       llm
     </span>

--- a/crates/mesh-llm-ui/src/components/mesh-llm-wordmark.tsx
+++ b/crates/mesh-llm-ui/src/components/mesh-llm-wordmark.tsx
@@ -6,7 +6,7 @@ type MeshLlmWordmarkProps = {
 
 export function MeshLlmWordmark({ className }: MeshLlmWordmarkProps) {
   return (
-    <span className={cn('whitespace-nowrap tracking-tight leading-none', className)}>
+    <span className={cn('whitespace-nowrap tracking-tight leading-tight', className)}>
       <span className="text-primary">mesh</span>
       llm
     </span>


### PR DESCRIPTION
## Summary
- Adds a tiny React-only wordmark styling change on top of `ci/pr-builds-routing-cleanup`.
- Validates that the new `react_ui_only` CI routing runs UI quality/build checks without Rust binary/smoke fanout.

## Validation intent
- The diff against the base branch should contain only `crates/mesh-llm-ui/src/components/mesh-llm-wordmark.tsx`.
- Expected checks: PR Quality `ui-quality` with lint/typecheck/build/test; PR Builds should avoid Rust binary producers and smoke jobs for the React-only diff.