### PR TITLE
Recover split topology after peer death

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -201,7 +201,7 @@ pub(super) struct SplitCoordinatorLocalFallbackEvent {
     pub(super) reason: &'static str,
     pub(super) generation: u64,
     pub(super) topology_id: String,
-    pub(super) missing_stage_nodes: Vec<iroh::EndpointId>,
+    pub(super) unavailable_stage_nodes: Vec<iroh::EndpointId>,
     pub(super) ack: tokio::sync::oneshot::Sender<SplitCoordinatorAck>,
 }
 
@@ -209,7 +209,7 @@ pub(super) struct SplitCoordinatorWithdrawEvent {
     pub(super) reason: &'static str,
     pub(super) generation: u64,
     pub(super) topology_id: String,
-    pub(super) missing_stage_nodes: Vec<iroh::EndpointId>,
+    pub(super) unavailable_stage_nodes: Vec<iroh::EndpointId>,
     pub(super) ack: tokio::sync::oneshot::Sender<SplitCoordinatorAck>,
 }
 
@@ -1457,7 +1457,8 @@ impl SplitTopologyCoordinator {
             &snapshot.participants,
             &runtime_statuses,
         );
-        let planned_participants = snapshot.participants.clone();
+        let planned_participants =
+            split_recovery_candidate_participants(&snapshot.participants, &unavailable_stage_nodes);
         let candidate = if split_participants_meet_minimum(&planned_participants) {
             match self.plan_replan_candidate(&planned_participants) {
                 Ok(candidate) => {
@@ -1780,14 +1781,14 @@ impl SplitTopologyCoordinator {
     async fn request_local_fallback(
         &mut self,
         reason: &'static str,
-        missing_stage_nodes: Vec<iroh::EndpointId>,
+        unavailable_stage_nodes: Vec<iroh::EndpointId>,
     ) -> Result<()> {
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         let event = SplitCoordinatorEvent::LocalFallback(SplitCoordinatorLocalFallbackEvent {
             reason,
             generation: self.active.generation,
             topology_id: self.active.topology_id.clone(),
-            missing_stage_nodes,
+            unavailable_stage_nodes,
             ack: ack_tx,
         });
         if self.event_tx.send(event).await.is_err() {
@@ -1802,14 +1803,14 @@ impl SplitTopologyCoordinator {
     async fn withdraw_active_generation(
         &mut self,
         reason: &'static str,
-        missing_stage_nodes: Vec<iroh::EndpointId>,
+        unavailable_stage_nodes: Vec<iroh::EndpointId>,
     ) -> Result<()> {
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         let event = SplitCoordinatorEvent::Withdraw(SplitCoordinatorWithdrawEvent {
             reason,
             generation: self.active.generation,
             topology_id: self.active.topology_id.clone(),
-            missing_stage_nodes,
+            unavailable_stage_nodes,
             ack: ack_tx,
         });
         if self.event_tx.send(event).await.is_err() {
@@ -1871,7 +1872,9 @@ fn split_loss_recovery_decision(
     {
         return SplitLossRecoveryDecision::NoActiveStageLoss;
     }
-    if candidate.is_some_and(split_candidate_is_valid_replacement_split) {
+    if candidate.is_some_and(|candidate| {
+        split_candidate_is_valid_replacement_split_after_loss(candidate, unavailable_stage_nodes)
+    }) {
         return SplitLossRecoveryDecision::ReplacementSplit;
     }
     if local_model_fits {
@@ -1883,6 +1886,38 @@ fn split_loss_recovery_decision(
 fn split_candidate_is_valid_replacement_split(candidate: &SplitTopologyGeneration) -> bool {
     split_participants_meet_minimum(&candidate.participants)
         && split_stages_meet_minimum(&candidate.stages)
+}
+
+fn split_candidate_is_valid_replacement_split_after_loss(
+    candidate: &SplitTopologyGeneration,
+    unavailable_stage_nodes: &[iroh::EndpointId],
+) -> bool {
+    split_candidate_is_valid_replacement_split(candidate)
+        && !split_candidate_uses_unavailable_stage_node(candidate, unavailable_stage_nodes)
+}
+
+fn split_candidate_uses_unavailable_stage_node(
+    candidate: &SplitTopologyGeneration,
+    unavailable_stage_nodes: &[iroh::EndpointId],
+) -> bool {
+    candidate
+        .stages
+        .iter()
+        .any(|stage| unavailable_stage_nodes.contains(&stage.node_id))
+}
+
+fn split_recovery_candidate_participants(
+    participants: &[SplitParticipant],
+    unavailable_stage_nodes: &[iroh::EndpointId],
+) -> Vec<SplitParticipant> {
+    if unavailable_stage_nodes.is_empty() {
+        return participants.to_vec();
+    }
+    participants
+        .iter()
+        .copied()
+        .filter(|participant| !unavailable_stage_nodes.contains(&participant.node_id))
+        .collect()
 }
 
 fn split_participants_meet_minimum(participants: &[SplitParticipant]) -> bool {
@@ -1927,7 +1962,9 @@ fn split_unavailable_active_stage_nodes(
     for status in runtime_statuses {
         if !matches!(
             status.state,
-            skippy::StageRuntimeState::Failed | skippy::StageRuntimeState::Stopped
+            skippy::StageRuntimeState::Failed
+                | skippy::StageRuntimeState::Stopping
+                | skippy::StageRuntimeState::Stopped
         ) || status.topology_id != active.topology_id
             || status.run_id != active.run_id
             || active
@@ -3747,6 +3784,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn split_unavailable_active_stage_nodes_includes_stopping_stage_without_missing_peer() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+        let statuses = vec![runtime_status_for_stage(
+            &active,
+            &active.stages[1],
+            skippy::StageRuntimeState::Stopping,
+        )];
+
+        assert_eq!(
+            split_unavailable_active_stage_nodes(
+                &active,
+                &[participant(1), participant(2), participant(3)],
+                &statuses,
+            ),
+            vec![make_id(2)]
+        );
+    }
+
+    #[test]
+    fn split_recovery_candidate_participants_excludes_unavailable_stage_nodes() {
+        let participants = vec![participant(1), participant(2), participant(3)];
+
+        assert_eq!(
+            split_recovery_candidate_participants(&participants, &[make_id(2)]),
+            vec![participant(1), participant(3)]
+        );
+    }
+
     #[tokio::test]
     async fn load_split_runtime_generation_stops_candidate_stages_after_partial_load_failure() {
         let node = mesh::Node::new_for_tests(NodeRole::Host { http_port: 9337 })
@@ -4067,8 +4139,8 @@ mod tests {
             "topology-b".into(),
             "run-b".into(),
             2,
-            vec![participant(1), participant(2), participant(3)],
-            vec![stage(1, 0, 0, 15), stage(2, 1, 15, 30)],
+            vec![participant(1), participant(3)],
+            vec![stage(1, 0, 0, 15), stage(3, 1, 15, 30)],
         );
         assert_eq!(
             split_loss_recovery_decision(
@@ -4080,6 +4152,40 @@ mod tests {
             ),
             SplitLossRecoveryDecision::ReplacementSplit
         );
+    }
+
+    #[test]
+    fn split_loss_recovery_rejects_replacement_that_reuses_failed_stage_peer() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 10), stage(2, 1, 10, 20), stage(3, 2, 20, 30)],
+        );
+        let candidate = SplitTopologyGeneration::new(
+            "topology-b".into(),
+            "run-b".into(),
+            2,
+            vec![participant(1), participant(2), participant(3)],
+            vec![stage(1, 0, 0, 15), stage(2, 1, 15, 30)],
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(
+                &active,
+                &[participant(1), participant(2), participant(3)],
+                &[make_id(2)],
+                Some(&candidate),
+                true,
+            ),
+            SplitLossRecoveryDecision::LocalFallback
+        );
+        assert!(split_candidate_is_valid_replacement_split(&candidate));
+        assert!(!split_candidate_is_valid_replacement_split_after_loss(
+            &candidate,
+            &[make_id(2)]
+        ));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -1515,8 +1515,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                 let event = match event {
                     SplitCoordinatorEvent::Replace(event) => *event,
                     SplitCoordinatorEvent::LocalFallback(event) => {
-                        let missing_stage_nodes = event
-                            .missing_stage_nodes
+                        let unavailable_stage_nodes = event
+                            .unavailable_stage_nodes
                             .iter()
                             .map(|node| node.fmt_short().to_string())
                             .collect::<Vec<_>>()
@@ -1573,8 +1573,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                                         event.topology_id, old_loaded_name
                                     ),
                                     context: Some(format!(
-                                        "reason={} generation={} missing_stage_nodes=[{}] error={err:#}",
-                                        event.reason, event.generation, missing_stage_nodes
+                                        "reason={} generation={} unavailable_stage_nodes=[{}] error={err:#}",
+                                        event.reason, event.generation, unavailable_stage_nodes
                                     )),
                                 });
                                 let _ = event.ack.send(SplitCoordinatorAck::Accepted);
@@ -1683,10 +1683,10 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                                         event.topology_id, loaded_name
                                     ),
                                     context: Some(format!(
-                                        "reason={} generation={} missing_stage_nodes=[{}] previous_port={} new_port={} new_ctx={}",
+                                        "reason={} generation={} unavailable_stage_nodes=[{}] previous_port={} new_port={} new_ctx={}",
                                         event.reason,
                                         event.generation,
-                                        missing_stage_nodes,
+                                        unavailable_stage_nodes,
                                         old_port,
                                         new_port,
                                         new_context_length
@@ -1714,8 +1714,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                                         event.topology_id, old_loaded_name
                                     ),
                                     context: Some(format!(
-                                        "reason={} generation={} missing_stage_nodes=[{}] error={err:#}",
-                                        event.reason, event.generation, missing_stage_nodes
+                                        "reason={} generation={} unavailable_stage_nodes=[{}] error={err:#}",
+                                        event.reason, event.generation, unavailable_stage_nodes
                                     )),
                                 });
                                 let _ = event.ack.send(SplitCoordinatorAck::Accepted);
@@ -1743,8 +1743,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                         }
                     }
                     SplitCoordinatorEvent::Withdraw(event) => {
-                        let missing_stage_nodes = event
-                            .missing_stage_nodes
+                        let unavailable_stage_nodes = event
+                            .unavailable_stage_nodes
                             .iter()
                             .map(|node| node.fmt_short().to_string())
                             .collect::<Vec<_>>()
@@ -1755,8 +1755,8 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
                                 event.topology_id, loaded_name
                             ),
                             context: Some(format!(
-                                "reason={} generation={} missing_stage_nodes=[{}]",
-                                event.reason, event.generation, missing_stage_nodes
+                                "reason={} generation={} unavailable_stage_nodes=[{}]",
+                                event.reason, event.generation, unavailable_stage_nodes
                             )),
                         });
                         let _ = event.ack.send(SplitCoordinatorAck::Accepted);


### PR DESCRIPTION
## Summary

Split serving can now recover cleanly when an active split-stage peer dies or starts shutting down.

- Quarantines unavailable active stage owners during recovery replans.
- Treats `Stopping` stages as unavailable alongside `Failed` and `Stopped` stages.
- Filters replacement-planning participants before generating the next split topology.
- Rejects replacement candidates that would reuse an unavailable active-stage node.
- Updates split recovery diagnostics to report `unavailable_stage_nodes` instead of only missing peers.
- Adds focused unit coverage plus a live multi-node recovery certification run.

## Why

The split recovery path could detect an unavailable active stage, but still hand the full participant set back to the replacement planner. In a real peer-death path that meant the recovery attempt could accidentally reuse the same dead or stopping node instead of forcing the replacement topology onto healthy participants.

This is a narrow follow-up to the split startup and recovery certification work: the existing recovery harness gave us a good way to prove the behavior, and this change closes the planner-side gap it exposed.

## Implementation

- Builds the recovery participant set from `snapshot.participants` minus nodes that own unavailable active stages.
- Applies the same unavailable-node guard when validating replacement split candidates.
- Includes `StageRuntimeState::Stopping` in unavailable active-stage detection so recovery does not race a node that is already winding down.
- Keeps the change local to split runtime recovery planning and diagnostics.

## Protocol and compatibility

No wire protocol, gossip schema, protobuf, ALPN, plugin protocol, or API contract change is introduced.

Mixed-version mesh compatibility is preserved: older peers do not need new fields, and the recovery decision remains local to the coordinator running this code.

## Validation

Validation mode: Mode 2 - narrow runtime change, focused on split topology recovery planning.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_loss_recovery --lib`: PASS, 7 passed
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_unavailable_active_stage_nodes --lib`: PASS, 2 passed
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime load_split_runtime_generation_stops_candidate_stages_after_partial_load_failure --lib`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`: PASS
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`: PASS
- `just build`: PASS
- `MESH_LLM_BUILD_PROFILE=release just build`: PASS
- `scripts/certify-split-startup-recovery.sh target/release/mesh-llm <local split-capable GGUF>` with 3 workers, replacement expectation, and release binary: PASS; replacement recovered after 13s, killed node absent from replacement topology, cleanup left 0 tracked processes.

## Branch integrity

- Base branch: `main`
- Validated base: `8975f25da048858428dd12b3c4a96271118367f4`
- Branch state: 1 commit ahead, 0 behind the validated base
- Merge-base: `8975f25da048858428dd12b3c4a96271118367f4`
- `origin/main` is an ancestor of this branch.

## Commit integrity

- `6da2cade48a2d4b88805c8d46cc24606436c7ea3` - Quarantine failed split stages during recovery replans

The PR diff is limited to split runtime recovery planning and diagnostics.

## Diff hygiene

Changed files:

- `crates/mesh-llm-host-runtime/src/runtime/local.rs`
- `crates/mesh-llm-host-runtime/src/runtime/mod.rs`

`git diff --check origin/main...HEAD`: PASS, no output.



## Runtime safety

- No new blocking locks.
- No new unbounded queues.
- No invariant removal.
- No invariant regression introduced.
- Replacement planning is made stricter by excluding unavailable active-stage owners before the planner can reuse them.

## CI status

Pending - remote CI will run after the PR is opened.

## Rollback

Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

The live certification covered the local release-binary multi-node recovery path with a split-capable GGUF and 3 local workers. Remote CI and any maintainer hardware-specific validation still need to run after the PR is opened.

## Related

Related: #557
