### PR TITLE
Fix release bundle CI setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
 
       - uses: actions/setup-node@v5
         with:
@@ -120,8 +120,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -lc ${{ matrix.build_recipe }}
-          just --shell bash --shell-arg -lc ${{ matrix.bundle_recipe }} "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c ${{ matrix.build_recipe }}
+          just --shell bash --shell-arg -c ${{ matrix.bundle_recipe }} "$RELEASE_TAG" dist
 
       - name: Upload release bundle
         uses: actions/upload-artifact@v6
@@ -159,7 +159,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -175,8 +175,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -lc release-build-arm64
-          just --shell bash --shell-arg -lc release-bundle-arm64 "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c release-build-arm64
+          just --shell bash --shell-arg -c release-bundle-arm64 "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
           name: release-linux-arm64
@@ -208,7 +208,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -222,8 +222,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -lc release-build-cuda
-          just --shell bash --shell-arg -lc release-bundle-cuda "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c release-build-cuda
+          just --shell bash --shell-arg -c release-bundle-cuda "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
           name: release-linux-cuda
@@ -255,7 +255,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -269,8 +269,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -lc release-build-cuda-blackwell
-          just --shell bash --shell-arg -lc release-bundle-cuda-blackwell "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c release-build-cuda-blackwell
+          just --shell bash --shell-arg -c release-bundle-cuda-blackwell "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
           name: release-linux-cuda-blackwell
@@ -302,7 +302,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -316,8 +316,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -lc release-build-rocm
-          just --shell bash --shell-arg -lc release-bundle-rocm "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c release-build-rocm
+          just --shell bash --shell-arg -c release-bundle-rocm "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
           name: release-linux-rocm
@@ -335,7 +335,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: pnpm/action-setup@v4
         with:
-          version: latest
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -351,8 +351,8 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -lc release-build-vulkan
-          just --shell bash --shell-arg -lc release-bundle-vulkan "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c release-build-vulkan
+          just --shell bash --shell-arg -c release-bundle-vulkan "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
           name: release-linux-vulkan
@@ -367,13 +367,16 @@ jobs:
       LLAMA_STAGE_BACKEND: cpu
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: npm
+          cache: pnpm
           cache-dependency-path: |
             .github/cache-version.txt
-            crates/mesh-llm-ui/package-lock.json
+            crates/mesh-llm-ui/pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: mozilla-actions/sccache-action@v0.0.9
@@ -419,13 +422,16 @@ jobs:
             artifact_name: release-windows-vulkan
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v5
         with:
           node-version: 24
-          cache: npm
+          cache: pnpm
           cache-dependency-path: |
             .github/cache-version.txt
-            crates/mesh-llm-ui/package-lock.json
+            crates/mesh-llm-ui/pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: mozilla-actions/sccache-action@v0.0.9
@@ -446,6 +452,7 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
           MESH_LLM_REQUIRE_SCCACHE: "1"
+          MESH_LLM_WINDOWS_BUILD_JOBS: ${{ matrix.backend == 'cuda' && '1' || '' }}
         run: |
           just ${{ matrix.build_recipe }}
           just ${{ matrix.bundle_recipe }} "$env:RELEASE_TAG" dist

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -322,6 +322,30 @@ function Invoke-NativeCommand {
     }
 }
 
+function Invoke-CmakeBuild {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BuildDir,
+        [Parameter(Mandatory = $true)]
+        [int]$ParallelJobs
+    )
+
+    $arguments = @("--build", $BuildDir, "--config", "Release", "--parallel", "$ParallelJobs", "--target", "llama", "llama-common", "mtmd")
+    try {
+        Invoke-NativeCommand "cmake" $arguments
+    } catch {
+        if ($backendName -ne "cuda" -or -not (Test-Sccache) -or $env:MESH_LLM_RETRY_SCCACHE_CUDA_BUILD -eq "0") {
+            throw
+        }
+
+        Write-Warning "CUDA ABI build failed while using sccache; restarting sccache and retrying once."
+        & $compilerCacheBin --stop-server 2>&1 | Out-Null
+        Start-Sleep -Seconds 2
+        Reset-SccacheStats
+        Invoke-NativeCommand "cmake" $arguments
+    }
+}
+
 function Test-UiBuildRequired {
     param(
         [Parameter(Mandatory = $true)]
@@ -891,7 +915,7 @@ Invoke-InRepo {
         [Environment]::ProcessorCount
     }
     Invoke-NativeCommand "cmake" $cmakeArgs
-    Invoke-NativeCommand "cmake" @("--build", $buildDir, "--config", "Release", "--parallel", "$parallelJobs", "--target", "llama", "llama-common", "mtmd")
+    Invoke-CmakeBuild -BuildDir $buildDir -ParallelJobs $parallelJobs
     Write-Host "Patched llama.cpp ABI build complete: $buildDir"
     $sccacheStats = Get-SccacheStats
     Show-SccacheStats


### PR DESCRIPTION
Release bundle jobs should now use a stable pnpm setup across macOS, Linux, and Windows, and the Windows CUDA bundle has a retry path for transient sccache daemon disconnects.

## What changed
- Pin release workflow pnpm setup to v10 instead of `latest`, avoiding pnpm 11 running under older runner Node paths.
- Run Unix release `just` commands with `bash -c` so the Actions Node 24 PATH survives on macOS.
- Install pnpm in Windows release jobs and cache from `pnpm-lock.yaml`, matching the UI build script.
- Serialize Windows CUDA ABI builds and retry once if sccache drops the compile connection.

## CI context
Investigated failed release run: https://github.com/Mesh-LLM/mesh-llm/actions/runs/25981970337

Observed failures:
- macOS aarch64 Metal: pnpm 11 crashed under Node 20 with missing `node:sqlite`.
- Windows CPU/ROCm/Vulkan: `pnpm` was not installed before `scripts/build-windows.ps1` built the UI.
- Windows CUDA: sccache daemon connection closed during an nvcc compile.

## Validation
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- `just check-release`

Note: I could not run Windows PowerShell parsing locally because `pwsh` is not installed in this macOS workspace.