### PR TITLE
feature(configuration-ui): integrate configuration UI settings for the local host

### DIFF
--- a/crates/mesh-client/src/client/control_plane.rs
+++ b/crates/mesh-client/src/client/control_plane.rs
@@ -256,15 +256,14 @@ impl OwnerControlClient {
         {
             Ok(Ok(connection)) => connection,
             Ok(Err(error)) => {
-                return Err(configured_endpoint_connect_error(
-                    &endpoint,
-                    control_addr,
-                    options,
-                    error,
-                )
-                .await)
+                let error =
+                    configured_endpoint_connect_error(&endpoint, control_addr, options, error)
+                        .await;
+                endpoint.close().await;
+                return Err(error);
             }
             Err(_) => {
+                endpoint.close().await;
                 return Err(ControlPlaneClientError::Negotiation(options.configured_endpoint_failure(
                     OwnerControlErrorCode::ControlUnavailable,
                     format!(
@@ -292,6 +291,12 @@ impl OwnerControlClient {
 
     pub fn target_node_id(&self) -> [u8; 32] {
         *self.connection.remote_id().as_bytes()
+    }
+
+    pub async fn close(&self) {
+        self.connection
+            .close(0u32.into(), b"owner-control-client-close");
+        self.endpoint.close().await;
     }
 
     pub async fn get_config(&self) -> Result<OwnerControlConfigSnapshot, ControlPlaneClientError> {
@@ -591,18 +596,20 @@ async fn legacy_mesh_probe(_endpoint: &Endpoint, control_addr: EndpointAddr) -> 
         let _ =
             tokio::time::timeout(std::time::Duration::from_secs(3), probe_endpoint.online()).await;
     }
-    match tokio::time::timeout(
+    let reachable = match tokio::time::timeout(
         std::time::Duration::from_secs(3),
         probe_endpoint.connect(control_addr, ALPN_V1),
     )
     .await
     {
         Ok(Ok(connection)) => {
-            drop(connection);
+            connection.close(0u32.into(), b"owner-control-legacy-probe-complete");
             true
         }
         _ => false,
-    }
+    };
+    probe_endpoint.close().await;
+    reachable
 }
 
 fn relay_mode_from_endpoint_addr(addr: &EndpointAddr) -> iroh::endpoint::RelayMode {

--- a/crates/mesh-client/tests/control_plane_client.rs
+++ b/crates/mesh-client/tests/control_plane_client.rs
@@ -372,7 +372,7 @@ fn owner_control_client(connection: ControlPlaneConnection) -> OwnerControlClien
 async fn control_plane_client_apply_config_get_watch_refresh_and_close() {
     let owner_keypair = test_owner_keypair(0x11, 0x12);
     let client = make_client().await;
-    let (_server, token, state, watch_closed_rx) = spawn_success_server(&owner_keypair).await;
+    let (server, token, state, watch_closed_rx) = spawn_success_server(&owner_keypair).await;
 
     let connection = client
         .connect_control_plane(ControlPlaneBootstrapOptions::new().with_control_endpoint(token))
@@ -432,20 +432,24 @@ async fn control_plane_client_apply_config_get_watch_refresh_and_close() {
         .expect("server should observe watch close")
         .expect("watch close signal should succeed");
 
-    let apply_requests = state.received_apply.lock().await;
-    assert_eq!(apply_requests.len(), 1);
-    assert_eq!(apply_requests[0].expected_revision, 3);
-    assert_eq!(
-        apply_requests[0].config.as_ref().unwrap().models[0].model,
-        "applied-model.gguf"
-    );
+    {
+        let apply_requests = state.received_apply.lock().await;
+        assert_eq!(apply_requests.len(), 1);
+        assert_eq!(apply_requests[0].expected_revision, 3);
+        assert_eq!(
+            apply_requests[0].config.as_ref().unwrap().models[0].model,
+            "applied-model.gguf"
+        );
+    }
+    control.close().await;
+    server.close().await;
 }
 
 #[tokio::test]
 async fn control_plane_client_watch_without_snapshot_returns_accepted() {
     let client = make_client().await;
     let owner_keypair = test_owner_keypair(0x11, 0x12);
-    let (_server, token, _state, watch_closed_rx) = spawn_success_server(&owner_keypair).await;
+    let (server, token, _state, watch_closed_rx) = spawn_success_server(&owner_keypair).await;
     let control = owner_control_client(
         client
             .connect_control_plane(ControlPlaneBootstrapOptions::new().with_control_endpoint(token))
@@ -468,12 +472,14 @@ async fn control_plane_client_watch_without_snapshot_returns_accepted() {
         .await
         .expect("server should observe watch close")
         .expect("watch close signal should succeed");
+    control.close().await;
+    server.close().await;
 }
 
 #[tokio::test]
 async fn control_plane_client_auth_failure_surfaces_structured_error() {
     let client = make_client().await;
-    let (_server, token) = spawn_auth_failure_server().await;
+    let (server, token) = spawn_auth_failure_server().await;
     let control = owner_control_client(
         client
             .connect_control_plane(ControlPlaneBootstrapOptions::new().with_control_endpoint(token))
@@ -492,12 +498,14 @@ async fn control_plane_client_auth_failure_surfaces_structured_error() {
         }
         other => panic!("expected structured remote auth error, got {other:?}"),
     }
+    control.close().await;
+    server.close().await;
 }
 
 #[tokio::test]
 async fn control_plane_client_rejects_alpn_mismatch() {
     let client = make_client().await;
-    let (_server, token) = spawn_control_unsupported_server().await;
+    let (server, token) = spawn_control_unsupported_server().await;
     let control = owner_control_client(
         client
             .connect_control_plane(ControlPlaneBootstrapOptions::new().with_control_endpoint(token))
@@ -515,6 +523,8 @@ async fn control_plane_client_rejects_alpn_mismatch() {
         }
         other => panic!("expected structured unsupported error, got {other:?}"),
     }
+    control.close().await;
+    server.close().await;
 }
 
 #[tokio::test]
@@ -529,7 +539,7 @@ async fn control_plane_client_unreachable_listener_returns_structured_negotiatio
         .await
         .unwrap();
     let token = control_endpoint_token(&endpoint.addr());
-    drop(endpoint);
+    endpoint.close().await;
 
     let client = make_client().await;
     let err = match client
@@ -558,7 +568,7 @@ async fn control_plane_client_unreachable_listener_returns_structured_negotiatio
 #[tokio::test]
 async fn control_plane_client_does_not_silently_fallback_when_endpoint_fails() {
     let client = make_client().await;
-    let (_server, token) = spawn_control_unsupported_server().await;
+    let (server, token) = spawn_control_unsupported_server().await;
     let control = owner_control_client(
         client
             .connect_control_plane(ControlPlaneBootstrapOptions::new().with_control_endpoint(token))
@@ -576,4 +586,6 @@ async fn control_plane_client_does_not_silently_fallback_when_endpoint_fails() {
         }
         other => panic!("expected structured unsupported error, got {other:?}"),
     }
+    control.close().await;
+    server.close().await;
 }

--- a/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
@@ -5,7 +5,7 @@ mod model_interests;
 mod model_targets;
 mod objects;
 mod plugins;
-mod runtime;
+pub(crate) mod runtime;
 mod search;
 
 use super::MeshApi;

--- a/crates/mesh-llm-host-runtime/src/api/routes/runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/runtime.rs
@@ -120,7 +120,9 @@ async fn handle_control_get_config(
     };
     match connect_owner_control_client(state, &endpoint).await {
         Ok(client) => {
-            match client.get_config().await {
+            let result = client.get_config().await;
+            client.close().await;
+            match result {
                 Ok(snapshot) => respond_json(
                     stream,
                     200,
@@ -152,7 +154,9 @@ async fn handle_control_refresh_inventory(
     };
     match connect_owner_control_client(state, &endpoint).await {
         Ok(client) => {
-            match client.refresh_inventory().await {
+            let result = client.refresh_inventory().await;
+            client.close().await;
+            match result {
                 Ok(snapshot) => respond_json(
                     stream,
                     200,
@@ -183,29 +187,32 @@ async fn handle_control_apply_config(
         Err(error) => return respond_control_error(stream, error).await,
     };
     match connect_owner_control_client(state, &endpoint).await {
-        Ok(client) => match client
-            .apply_config(
-                request.expected_revision,
-                crate::protocol::convert::mesh_config_to_proto(&request.config),
-            )
-            .await
-        {
-            Ok(response) => {
-                respond_json(
-                    stream,
-                    200,
-                    &LocalControlApplyPayload {
-                        success: response.success,
-                        current_revision: response.current_revision,
-                        config_hash: hex::encode(response.config_hash),
-                        apply_mode: control_apply_mode_label(response.apply_mode),
-                        error: response.error,
-                    },
+        Ok(client) => {
+            let result = client
+                .apply_config(
+                    request.expected_revision,
+                    crate::protocol::convert::mesh_config_to_proto(&request.config),
                 )
-                .await
+                .await;
+            client.close().await;
+            match result {
+                Ok(response) => {
+                    respond_json(
+                        stream,
+                        200,
+                        &LocalControlApplyPayload {
+                            success: response.success,
+                            current_revision: response.current_revision,
+                            config_hash: hex::encode(response.config_hash),
+                            apply_mode: control_apply_mode_label(response.apply_mode),
+                            error: response.error,
+                        },
+                    )
+                    .await
+                }
+                Err(error) => respond_control_error(stream, control_error_from_client(error)).await,
             }
-            Err(error) => respond_control_error(stream, control_error_from_client(error)).await,
-        },
+        }
         Err(error) => respond_control_error(stream, error).await,
     }
 }
@@ -244,7 +251,14 @@ fn required_control_endpoint(endpoint: Option<String>) -> Result<String, LocalCo
 }
 
 async fn ensure_loopback_control_caller(stream: &mut TcpStream) -> anyhow::Result<bool> {
-    match stream.peer_addr() {
+    ensure_loopback_control_caller_for_peer_addr(stream, stream.peer_addr()).await
+}
+
+pub(crate) async fn ensure_loopback_control_caller_for_peer_addr(
+    stream: &mut TcpStream,
+    peer_addr: std::io::Result<std::net::SocketAddr>,
+) -> anyhow::Result<bool> {
+    match peer_addr {
         Ok(addr) if addr.ip().is_loopback() => Ok(true),
         Ok(addr) => {
             tracing::warn!("runtime control: rejected non-loopback caller {addr}");

--- a/crates/mesh-llm-host-runtime/src/api/server.rs
+++ b/crates/mesh-llm-host-runtime/src/api/server.rs
@@ -161,14 +161,29 @@ fn management_url(listener: &TcpListener, port: u16) -> String {
 
 // ── Request dispatch ──
 
-pub(crate) fn is_ui_only_route(path: &str) -> bool {
+pub(crate) fn is_console_index_route(path: &str) -> bool {
     matches!(
         path,
-        "/" | "/dashboard" | "/dashboard/" | "/chat" | "/chat/"
+        "/" | "/dashboard"
+            | "/dashboard/"
+            | "/chat"
+            | "/chat/"
+            | "/configuration"
+            | "/configuration/"
+            | "/__playground"
+            | "/__meshviz-perf"
     ) || path.starts_with("/chat/")
-        || path.starts_with("/assets/")
+        || path.starts_with("/configuration/")
+}
+
+pub(crate) fn is_console_asset_route(path: &str) -> bool {
+    path.starts_with("/assets/")
         || matches!(path.rsplit('.').next(), Some("png" | "ico" | "webmanifest"))
         || (path.ends_with(".json") && !path.starts_with("/api/"))
+}
+
+pub(crate) fn is_ui_only_route(path: &str) -> bool {
+    is_console_index_route(path) || is_console_asset_route(path)
 }
 
 pub(crate) async fn handle_request(mut stream: TcpStream, state: &MeshApi) -> anyhow::Result<()> {
@@ -187,26 +202,17 @@ pub(crate) async fn handle_request(mut stream: TcpStream, state: &MeshApi) -> an
     }
 
     match (method, path_only) {
-        // ── Dashboard UI ──
-        ("GET", "/") => {
-            respond_dashboard_index(&mut stream).await?;
-        }
-
-        ("GET", "/dashboard") | ("GET", "/chat") | ("GET", "/dashboard/") | ("GET", "/chat/") => {
-            respond_dashboard_index(&mut stream).await?;
-        }
-
-        ("GET", p) if p.starts_with("/chat/") => {
-            respond_dashboard_index(&mut stream).await?;
+        ("GET", p) if is_console_index_route(p) => {
+            if !respond_console_index(&mut stream).await? {
+                respond_error(&mut stream, 500, "Dashboard bundle missing").await?;
+            }
         }
 
         // ── Frontend static assets (bundled UI dist) ──
-        ("GET", p)
-            if p.starts_with("/assets/")
-                || matches!(p.rsplit('.').next(), Some("png" | "ico" | "webmanifest"))
-                || (p.ends_with(".json") && !p.starts_with("/api/")) =>
-        {
-            respond_static_asset(&mut stream, p).await?;
+        ("GET", p) if is_console_asset_route(p) => {
+            if !respond_console_asset(&mut stream, p).await? {
+                respond_error(&mut stream, 404, "Not found").await?;
+            }
         }
 
         _ => {
@@ -242,18 +248,4 @@ async fn read_management_request(
         Ok(Err(e)) => Err(e),
         Err(_) => Ok(None), // read timeout — health check probe, just close
     }
-}
-
-async fn respond_dashboard_index(stream: &mut TcpStream) -> anyhow::Result<()> {
-    if !respond_console_index(stream).await? {
-        respond_error(stream, 500, "Dashboard bundle missing").await?;
-    }
-    Ok(())
-}
-
-async fn respond_static_asset(stream: &mut TcpStream, path: &str) -> anyhow::Result<()> {
-    if !respond_console_asset(stream, path).await? {
-        respond_error(stream, 404, "Not found").await?;
-    }
-    Ok(())
 }

--- a/crates/mesh-llm-host-runtime/src/api/state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/state.rs
@@ -104,15 +104,49 @@ pub struct ControlBootstrapPayload {
     pub requires_explicit_remote_endpoint: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub disabled_reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggested_commands: Option<Vec<String>>,
 }
 
 impl Default for ControlBootstrapPayload {
     fn default() -> Self {
+        Self::missing_owner_identity()
+    }
+}
+
+impl ControlBootstrapPayload {
+    pub fn from_control_endpoint(endpoint: Option<String>) -> Self {
+        match endpoint {
+            Some(endpoint) => Self {
+                enabled: true,
+                local_only: true,
+                requires_explicit_remote_endpoint: true,
+                endpoint: Some(endpoint),
+                disabled_reason: None,
+                message: None,
+                suggested_commands: None,
+            },
+            None => Self::missing_owner_identity(),
+        }
+    }
+
+    pub fn missing_owner_identity() -> Self {
         Self {
             enabled: false,
             local_only: true,
             requires_explicit_remote_endpoint: true,
             endpoint: None,
+            disabled_reason: Some("missing_owner_identity".to_string()),
+            message: Some("Configuration saving requires a local owner identity.".to_string()),
+            suggested_commands: Some(vec![
+                "mesh-llm auth status".to_string(),
+                "mesh-llm auth init --no-passphrase".to_string(),
+                "mesh-llm serve --owner-required".to_string(),
+            ]),
         }
     }
 }

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -5,7 +5,9 @@ use crate::plugin;
 use crate::plugins::{blackboard, blobstore};
 use base64::Engine;
 use mesh_client::proto::node::{
-    NodeConfigSnapshot, OwnerControlEnvelope, OwnerControlGetConfigResponse, OwnerControlResponse,
+    ConfigApplyMode, NodeConfigSnapshot, OwnerControlApplyConfigRequest,
+    OwnerControlApplyConfigResponse, OwnerControlConfigSnapshot, OwnerControlEnvelope,
+    OwnerControlError, OwnerControlErrorCode, OwnerControlGetConfigResponse, OwnerControlResponse,
 };
 use mesh_llm_plugin::MeshVisibility;
 use mesh_llm_protocol::{decode_owner_control_envelope, write_len_prefixed, ALPN_CONTROL_V1};
@@ -837,6 +839,9 @@ async fn control_plane_api_exposes_local_endpoint_only() {
             local_only: true,
             requires_explicit_remote_endpoint: true,
             endpoint: Some("http://127.0.0.1:7447".to_string()),
+            disabled_reason: None,
+            message: None,
+            suggested_commands: None,
         })
         .await;
     let (addr, handle) = spawn_management_test_server(state).await;
@@ -863,6 +868,38 @@ async fn control_plane_api_exposes_local_endpoint_only() {
 }
 
 #[tokio::test]
+async fn control_plane_api_explains_disabled_owner_control() {
+    let state = build_test_mesh_api().await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let response = send_management_request(
+        addr,
+        "GET /api/runtime/control-bootstrap HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+    )
+    .await;
+    let body = json_body(&response);
+
+    assert_eq!(body["enabled"], serde_json::Value::Bool(false));
+    assert_eq!(body["local_only"], serde_json::Value::Bool(true));
+    assert_eq!(body["disabled_reason"], "missing_owner_identity");
+    assert_eq!(
+        body["message"],
+        "Configuration saving requires a local owner identity."
+    );
+    assert_eq!(
+        body["suggested_commands"],
+        serde_json::json!([
+            "mesh-llm auth status",
+            "mesh-llm auth init --no-passphrase",
+            "mesh-llm serve --owner-required"
+        ])
+    );
+    assert!(body.get("endpoint").is_none());
+
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn status_payload_control_plane_compat() {
     let state = build_test_mesh_api().await;
     state
@@ -871,6 +908,9 @@ async fn status_payload_control_plane_compat() {
             local_only: true,
             requires_explicit_remote_endpoint: true,
             endpoint: Some("control-endpoint-token".to_string()),
+            disabled_reason: None,
+            message: None,
+            suggested_commands: None,
         })
         .await;
 
@@ -906,6 +946,9 @@ async fn config_apply_does_not_emit_peer_churn() {
             local_only: true,
             requires_explicit_remote_endpoint: true,
             endpoint: Some("control-endpoint-token".to_string()),
+            disabled_reason: None,
+            message: None,
+            suggested_commands: None,
         })
         .await;
     state.push_status().await;
@@ -969,6 +1012,195 @@ async fn control_plane_api_cli_requires_explicit_endpoint_and_runs_local_orchest
 
     handle.await.unwrap().unwrap();
     control_server.task.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn control_plane_api_apply_config_uses_full_mesh_config_contract() {
+    let temp = tempfile::tempdir().unwrap();
+    std::env::set_var("HOME", temp.path());
+    let owner = OwnerKeypair::generate();
+    let keystore_path = default_keystore_path().unwrap();
+    save_keystore(&keystore_path, &owner, None, true).unwrap();
+
+    let get_server = spawn_owner_control_test_server().await;
+    let OwnerControlApplyTestServer {
+        endpoint_token: apply_endpoint_token,
+        task: control_task,
+        received_apply,
+    } = spawn_owner_control_apply_test_server(OwnerControlApplyTestResponse::Success(
+        OwnerControlApplyConfigResponse {
+            success: true,
+            current_revision: 43,
+            config_hash: vec![0xab; 32],
+            error: None,
+            apply_mode: ConfigApplyMode::Staged as i32,
+        },
+    ))
+    .await;
+    let state = build_test_mesh_api().await;
+    state.set_owner_key_path(Some(keystore_path)).await;
+    let (addr, handle) = spawn_management_test_server(state.clone()).await;
+
+    let get_request_body = json!({ "endpoint": get_server.endpoint_token }).to_string();
+    let get_response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/get-config", &get_request_body),
+    )
+    .await;
+    let get_body = json_body(&get_response);
+    assert_eq!(
+        get_body["snapshot"]["revision"], 42,
+        "response: {get_response}"
+    );
+    let mut merged_config_json = get_body["snapshot"]["config"].clone();
+    merge_json_object(
+        &mut merged_config_json,
+        serde_json::to_value(full_mesh_config_fixture()).unwrap(),
+    );
+    let expected_config: crate::plugin::MeshConfig =
+        serde_json::from_value(merged_config_json).unwrap();
+    handle.await.unwrap().unwrap();
+
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let apply_request_body = json!({
+        "endpoint": apply_endpoint_token,
+        "expected_revision": get_body["snapshot"]["revision"],
+        "config": expected_config.clone(),
+    })
+    .to_string();
+    let apply_response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/apply-config", &apply_request_body),
+    )
+    .await;
+    let apply_body = json_body(&apply_response);
+    assert!(
+        apply_response.starts_with("HTTP/1.1 200"),
+        "response: {apply_response}"
+    );
+    assert_eq!(apply_body["success"], true);
+    assert_eq!(apply_body["current_revision"], 43);
+    assert_eq!(apply_body["apply_mode"], "staged");
+    assert_eq!(
+        apply_body["config_hash"],
+        "abababababababababababababababababababababababababababababababab"
+    );
+
+    let received_apply = received_apply
+        .expect("apply-config flow should capture the forwarded full MeshConfig")
+        .await
+        .unwrap();
+    assert_eq!(received_apply.expected_revision, 42);
+    assert_eq!(
+        received_apply.config,
+        Some(crate::protocol::convert::mesh_config_to_proto(
+            &expected_config
+        ))
+    );
+
+    handle.await.unwrap().unwrap();
+    get_server.task.abort();
+    control_task.await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn control_plane_api_apply_config_reports_revision_conflict() {
+    let temp = tempfile::tempdir().unwrap();
+    std::env::set_var("HOME", temp.path());
+    let owner = OwnerKeypair::generate();
+    let keystore_path = default_keystore_path().unwrap();
+    save_keystore(&keystore_path, &owner, None, true).unwrap();
+
+    let OwnerControlApplyTestServer {
+        endpoint_token,
+        task: control_task,
+        received_apply,
+    } = spawn_owner_control_apply_test_server(OwnerControlApplyTestResponse::Error {
+        code: OwnerControlErrorCode::RevisionConflict,
+        message: "stale config revision".to_string(),
+        current_revision: Some(7),
+    })
+    .await;
+    let state = build_test_mesh_api().await;
+    state.set_owner_key_path(Some(keystore_path)).await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let request_body = json!({
+        "endpoint": endpoint_token,
+        "expected_revision": 6,
+        "config": full_mesh_config_fixture(),
+    })
+    .to_string();
+    let response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/apply-config", &request_body),
+    )
+    .await;
+    let body = json_body(&response);
+    assert!(response.starts_with("HTTP/1.1 409"), "response: {response}");
+    assert_eq!(body["error"]["code"], "revision_conflict");
+    assert_eq!(body["error"]["message"], "stale config revision");
+    assert_eq!(body["error"]["current_revision"], 7);
+
+    let received_apply = received_apply
+        .expect("revision conflict path should still capture apply requests")
+        .await
+        .unwrap();
+    assert_eq!(received_apply.expected_revision, 6);
+
+    handle.await.unwrap().unwrap();
+    control_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn control_plane_api_apply_config_rejects_invalid_json() {
+    let state = build_test_mesh_api().await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let request_body = "{\"endpoint\":";
+    let response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/apply-config", request_body),
+    )
+    .await;
+    let body = json_body(&response);
+    assert!(response.starts_with("HTTP/1.1 400"), "response: {response}");
+    assert_eq!(body["error"], "Invalid JSON body");
+
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn control_route_rejects_non_loopback() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let client = tokio::spawn(async move {
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        String::from_utf8(response).unwrap()
+    });
+
+    let (mut server_stream, _) = listener.accept().await.unwrap();
+    let allowed = crate::api::routes::runtime::ensure_loopback_control_caller_for_peer_addr(
+        &mut server_stream,
+        Ok(std::net::SocketAddr::from(([192, 0, 2, 10], 40123))),
+    )
+    .await
+    .unwrap();
+    assert!(!allowed);
+    drop(server_stream);
+
+    let response = client.await.unwrap();
+    let body = json_body(&response);
+    assert!(response.starts_with("HTTP/1.1 403"), "response: {response}");
+    assert_eq!(
+        body["error"],
+        "runtime control endpoints only accept localhost connections"
+    );
 }
 
 #[tokio::test]
@@ -1083,7 +1315,7 @@ async fn spawn_owner_control_test_server() -> OwnerControlTestServer {
             response: Some(OwnerControlResponse {
                 request_id,
                 get_config: Some(OwnerControlGetConfigResponse {
-                    snapshot: Some(mesh_client::proto::node::OwnerControlConfigSnapshot {
+                    snapshot: Some(OwnerControlConfigSnapshot {
                         node_id: vec![7; 32],
                         revision: 42,
                         config_hash: vec![9; 32],
@@ -1113,6 +1345,170 @@ async fn spawn_owner_control_test_server() -> OwnerControlTestServer {
         endpoint_token,
         task,
     }
+}
+
+struct OwnerControlApplyTestServer {
+    endpoint_token: String,
+    task: tokio::task::JoinHandle<()>,
+    received_apply: Option<oneshot::Receiver<OwnerControlApplyConfigRequest>>,
+}
+
+enum OwnerControlApplyTestResponse {
+    Success(OwnerControlApplyConfigResponse),
+    Error {
+        code: OwnerControlErrorCode,
+        message: String,
+        current_revision: Option<u64>,
+    },
+}
+
+async fn spawn_owner_control_apply_test_server(
+    response: OwnerControlApplyTestResponse,
+) -> OwnerControlApplyTestServer {
+    let endpoint = iroh::Endpoint::builder(iroh::endpoint::presets::Minimal)
+        .secret_key(iroh::SecretKey::generate())
+        .alpns(vec![ALPN_CONTROL_V1.to_vec()])
+        .relay_mode(iroh::endpoint::RelayMode::Disabled)
+        .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let endpoint_token = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&endpoint.addr()).unwrap());
+    let (apply_tx, apply_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
+        let Some(incoming) = endpoint.accept().await else {
+            return;
+        };
+        let mut accepting = incoming.accept().unwrap();
+        let _ = accepting.alpn().await.unwrap();
+        let conn = accepting.await.unwrap();
+        let (mut send, mut recv) = conn.accept_bi().await.unwrap();
+        let handshake = mesh_llm_protocol::read_len_prefixed(&mut recv)
+            .await
+            .unwrap();
+        let _ = decode_owner_control_envelope(&handshake).unwrap();
+        let request = mesh_llm_protocol::read_len_prefixed(&mut recv)
+            .await
+            .unwrap();
+        let envelope = decode_owner_control_envelope(&request).unwrap();
+        let request = envelope
+            .request
+            .expect("owner-control request should be present");
+        let request_id = request.request_id;
+        let apply = request
+            .apply_config
+            .expect("expected apply-config request for apply response");
+        let _ = apply_tx.send(apply);
+        let envelope = match response {
+            OwnerControlApplyTestResponse::Success(response) => OwnerControlEnvelope {
+                gen: mesh_llm_protocol::NODE_PROTOCOL_GENERATION,
+                handshake: None,
+                request: None,
+                response: Some(OwnerControlResponse {
+                    request_id,
+                    get_config: None,
+                    watch_config: None,
+                    apply_config: Some(response),
+                    refresh_inventory: None,
+                }),
+                error: None,
+            },
+            OwnerControlApplyTestResponse::Error {
+                code,
+                message,
+                current_revision,
+            } => OwnerControlEnvelope {
+                gen: mesh_llm_protocol::NODE_PROTOCOL_GENERATION,
+                handshake: None,
+                request: None,
+                response: None,
+                error: Some(OwnerControlError {
+                    code: code as i32,
+                    message,
+                    request_id: Some(request_id),
+                    current_revision,
+                }),
+            },
+        };
+        write_len_prefixed(&mut send, &envelope.encode_to_vec())
+            .await
+            .unwrap();
+        let _ = send.finish();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    });
+    OwnerControlApplyTestServer {
+        endpoint_token,
+        task,
+        received_apply: Some(apply_rx),
+    }
+}
+
+fn management_post_request(path: &str, body: &str) -> String {
+    format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    )
+}
+
+fn full_mesh_config_fixture() -> crate::plugin::MeshConfig {
+    serde_json::from_value(json!({
+        "version": 1,
+        "gpu": {
+            "assignment": "auto",
+            "parallel": 2
+        },
+        "owner_control": {
+            "bind": "127.0.0.1:7447",
+            "advertise_addr": "127.0.0.1:7447"
+        },
+        "telemetry": {
+            "enabled": true,
+            "service_name": "mesh-llm-control",
+            "endpoint": "http://127.0.0.1:4317",
+            "headers": {
+                "authorization": "Bearer control-test"
+            },
+            "export_interval_secs": 30,
+            "queue_size": 256,
+            "prompt_shape_metrics": false,
+            "metrics": {
+                "endpoint": "http://127.0.0.1:4318"
+            }
+        },
+        "models": [
+            {
+                "model": "hf://meshllm/base@main:Q4_K_M",
+                "mmproj": "hf://meshllm/base@main:mmproj.gguf",
+                "ctx_size": 8192,
+                "parallel": 1,
+                "cache_type_k": "q8_0",
+                "cache_type_v": "q8_0",
+                "batch": 512,
+                "ubatch": 256
+            }
+        ],
+        "plugin": [
+            {
+                "name": "telemetry",
+                "enabled": true,
+                "command": "mesh-telemetry"
+            }
+        ]
+    }))
+    .unwrap()
+}
+
+fn merge_json_object(target: &mut serde_json::Value, source: serde_json::Value) {
+    let target = target
+        .as_object_mut()
+        .expect("target JSON should be an object for config merge");
+    let source = source
+        .as_object()
+        .expect("source JSON should be an object for config merge");
+    target.extend(source.clone());
 }
 
 async fn unreachable_owner_control_endpoint_token() -> String {
@@ -3490,6 +3886,8 @@ fn headless_mode_disables_ui_routes_but_preserves_api() {
     assert!(is_ui_only_route("/"));
     assert!(is_ui_only_route("/dashboard"));
     assert!(is_ui_only_route("/chat"));
+    assert!(is_ui_only_route("/configuration"));
+    assert!(is_ui_only_route("/configuration/defaults"));
 
     assert!(!is_ui_only_route("/api/status"));
     assert!(!is_ui_only_route("/api/events"));
@@ -3503,6 +3901,8 @@ fn headless_mode_returns_404_for_assets_and_dashboard_routes() {
     assert!(is_ui_only_route("/dashboard/"));
     assert!(is_ui_only_route("/chat/"));
     assert!(is_ui_only_route("/chat/some-room"));
+    assert!(is_ui_only_route("/configuration/"));
+    assert!(is_ui_only_route("/configuration/toml-review"));
     assert!(is_ui_only_route("/assets/main.js"));
     assert!(is_ui_only_route("/assets/index-abc123.css"));
     assert!(is_ui_only_route("/favicon.ico"));
@@ -3518,10 +3918,45 @@ fn default_mode_still_serves_embedded_ui_routes() {
     assert!(is_ui_only_route("/"));
     assert!(is_ui_only_route("/dashboard"));
     assert!(is_ui_only_route("/chat"));
+    assert!(is_ui_only_route("/configuration/defaults"));
     assert!(is_ui_only_route("/assets/app.js"));
 
     assert!(!is_ui_only_route("/api/status"));
     assert!(!is_ui_only_route("/api/events"));
+}
+
+#[tokio::test]
+async fn direct_configuration_deep_link_serves_embedded_ui_index() {
+    assert!(crate::api::server::is_console_index_route(
+        "/configuration/defaults"
+    ));
+
+    if mesh_llm_ui::index().is_none() {
+        return;
+    }
+
+    let state = build_test_mesh_api().await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let response = send_management_request(
+        addr,
+        "GET /configuration/defaults HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+    )
+    .await;
+
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK"),
+        "expected direct configuration deep link to serve UI index, got: {response}"
+    );
+    assert!(
+        response.contains("Content-Type: text/html; charset=utf-8"),
+        "expected HTML response for UI deep link, got: {response}"
+    );
+    assert!(
+        !response.contains(r#"{"error":"Not found"}"#),
+        "UI deep link must not fall through to JSON 404"
+    );
+    handle.await.unwrap().unwrap();
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
@@ -251,25 +251,59 @@ pub(crate) async fn run_control_bootstrap(port: u16, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    println!("🔐 Owner-control bootstrap");
-    println!();
-    println!("Scope: Local node only");
-    println!(
-        "Remote control requires explicit endpoint: {}",
-        yes_no(
-            payload["requires_explicit_remote_endpoint"]
-                .as_bool()
-                .unwrap_or(true)
-        )
-    );
-    if payload["enabled"].as_bool().unwrap_or(false) {
-        let endpoint = payload["endpoint"].as_str().unwrap_or("pending");
-        println!("Endpoint: {endpoint}");
-    } else {
-        println!("Endpoint: disabled");
+    for line in control_bootstrap_lines(&payload) {
+        println!("{line}");
     }
 
     Ok(())
+}
+
+fn control_bootstrap_lines(payload: &serde_json::Value) -> Vec<String> {
+    let mut lines = vec![
+        "🔐 Owner-control bootstrap".to_string(),
+        String::new(),
+        "Scope: Local node only".to_string(),
+        format!(
+            "Remote control requires explicit endpoint: {}",
+            yes_no(
+                payload["requires_explicit_remote_endpoint"]
+                    .as_bool()
+                    .unwrap_or(true)
+            )
+        ),
+    ];
+
+    if payload["enabled"].as_bool().unwrap_or(false) {
+        let endpoint = payload["endpoint"].as_str().unwrap_or("pending");
+        lines.push(format!("Endpoint: {endpoint}"));
+        return lines;
+    }
+
+    lines.push("Endpoint: disabled".to_string());
+    if let Some(reason) = payload["disabled_reason"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Disabled reason: {}", reason.replace('_', " ")));
+    }
+    if let Some(message) = payload["message"]
+        .as_str()
+        .filter(|value| !value.is_empty())
+    {
+        lines.push(format!("Message: {message}"));
+    }
+    if let Some(commands) = payload["suggested_commands"].as_array() {
+        let commands: Vec<&str> = commands
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .filter(|value| !value.is_empty())
+            .collect();
+        if !commands.is_empty() {
+            lines.push("Suggested commands:".to_string());
+            lines.extend(commands.into_iter().map(|command| format!("  {command}")));
+        }
+    }
+    lines
 }
 
 fn build_control_endpoint_request(endpoint: &str) -> serde_json::Value {
@@ -396,7 +430,8 @@ fn find_pid(processes: &[serde_json::Value], model: &serde_json::Value) -> Optio
 #[cfg(test)]
 mod tests {
     use super::{
-        build_apply_config_request, build_control_endpoint_request, runtime_success_lines, yes_no,
+        build_apply_config_request, build_control_endpoint_request, control_bootstrap_lines,
+        runtime_success_lines, yes_no,
     };
     use crate::plugin::{GpuAssignment, GpuConfig, MeshConfig};
     use serde_json::json;
@@ -459,6 +494,39 @@ mod tests {
     }
 
     #[test]
+    fn control_plane_bootstrap_lines_explain_disabled_owner_control() {
+        let payload = json!({
+            "enabled": false,
+            "local_only": true,
+            "requires_explicit_remote_endpoint": true,
+            "disabled_reason": "missing_owner_identity",
+            "message": "Configuration saving requires a local owner identity.",
+            "suggested_commands": [
+                "mesh-llm auth status",
+                "mesh-llm auth init --no-passphrase",
+                "mesh-llm serve --owner-required"
+            ]
+        });
+
+        assert_eq!(
+            control_bootstrap_lines(&payload),
+            vec![
+                "🔐 Owner-control bootstrap".to_string(),
+                String::new(),
+                "Scope: Local node only".to_string(),
+                "Remote control requires explicit endpoint: yes".to_string(),
+                "Endpoint: disabled".to_string(),
+                "Disabled reason: missing owner identity".to_string(),
+                "Message: Configuration saving requires a local owner identity.".to_string(),
+                "Suggested commands:".to_string(),
+                "  mesh-llm auth status".to_string(),
+                "  mesh-llm auth init --no-passphrase".to_string(),
+                "  mesh-llm serve --owner-required".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn control_plane_api_cli_builds_explicit_endpoint_request_body() {
         assert_eq!(
             build_control_endpoint_request("endpoint-token"),
@@ -479,6 +547,7 @@ mod tests {
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            extra: Default::default(),
         };
 
         assert_eq!(

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -15,8 +15,6 @@ const FULL_SURFACE_VALID_FIXTURE: &str =
 const FULL_SURFACE_INVALID_FIXTURE: &str =
     include_str!("../../../../tests/fixtures/skippy_full_surface_invalid.toml");
 
-type FullSurfaceFixture = (MeshConfig, NamedTempFile, NamedTempFile, NamedTempFile);
-
 fn fake_package_identity(layer_count: u32) -> SkippyPackageIdentity {
     SkippyPackageIdentity {
         package_ref: "gguf:///models/qwen.gguf".to_string(),
@@ -72,6 +70,216 @@ fn temp_model_file() -> NamedTempFile {
     file.write_all(&bytes).expect("write fake gguf");
     file.flush().expect("flush fake gguf");
     file
+}
+
+fn resolve_qwen_config_with_request_defaults(
+    mesh_config: &MeshConfig,
+    model_path: &Path,
+    request_defaults: Option<&RequestDefaultsConfig>,
+) -> ResolvedSkippyConfig {
+    resolve_skippy_config(SkippyConfigResolveRequest {
+        mesh_config,
+        model_id: "Qwen/Qwen3-0.6B:Q4_K_M",
+        model_path,
+        model_bytes: 10 * 1024 * 1024 * 1024,
+        allocatable_memory_bytes: None,
+        request_defaults,
+    })
+    .expect("qwen config should resolve")
+}
+
+fn assert_request_override_keeps_load_time_config(
+    without_request: &ResolvedSkippyConfig,
+    with_request: &ResolvedSkippyConfig,
+) {
+    assert_eq!(without_request.model_fit, with_request.model_fit);
+    assert_eq!(without_request.hardware, with_request.hardware);
+    assert_eq!(without_request.skippy, with_request.skippy);
+}
+
+fn assert_stage_configs_match_for_request_override(
+    without_request: &ResolvedSkippyConfig,
+    with_request: &ResolvedSkippyConfig,
+) {
+    let baseline_stage = without_request
+        .to_stage_config(Some(fake_package_identity(28)), LoadMode::RuntimeSlice)
+        .expect("baseline stage config should build");
+    let override_stage = with_request
+        .to_stage_config(Some(fake_package_identity(28)), LoadMode::RuntimeSlice)
+        .expect("override stage config should build");
+
+    assert_eq!(baseline_stage.model_id, override_stage.model_id);
+    assert_eq!(baseline_stage.model_path, override_stage.model_path);
+    assert_eq!(baseline_stage.ctx_size, override_stage.ctx_size);
+    assert_eq!(baseline_stage.lane_count, override_stage.lane_count);
+    assert_eq!(baseline_stage.n_batch, override_stage.n_batch);
+    assert_eq!(baseline_stage.n_ubatch, override_stage.n_ubatch);
+    assert_eq!(baseline_stage.n_gpu_layers, override_stage.n_gpu_layers);
+    assert_eq!(baseline_stage.cache_type_k, override_stage.cache_type_k);
+    assert_eq!(baseline_stage.cache_type_v, override_stage.cache_type_v);
+    assert_eq!(
+        baseline_stage.flash_attn_type,
+        override_stage.flash_attn_type
+    );
+    assert_eq!(
+        baseline_stage.selected_device,
+        override_stage.selected_device
+    );
+    assert_eq!(baseline_stage.load_mode, override_stage.load_mode);
+}
+
+fn assert_openai_args_use_request_time_defaults(
+    without_request: &ResolvedSkippyConfig,
+    with_request: &ResolvedSkippyConfig,
+) {
+    let baseline_openai = without_request
+        .to_embedded_openai_args(4096, true)
+        .expect("baseline openai args should build");
+    let override_openai = with_request
+        .to_embedded_openai_args(4096, true)
+        .expect("override openai args should build");
+
+    assert_eq!(baseline_openai.default_max_tokens, 128);
+    assert_eq!(override_openai.default_max_tokens, 32);
+}
+
+struct FullSurfaceFixture {
+    mesh_config: MeshConfig,
+    explicit_model: NamedTempFile,
+    defaults_model: NamedTempFile,
+    _projector_file: NamedTempFile,
+}
+
+fn full_surface_fixture_with_model_paths() -> FullSurfaceFixture {
+    let mut mesh_config = parse_config(FULL_SURFACE_VALID_FIXTURE);
+    let explicit_model = temp_model_file();
+    let defaults_model = temp_model_file();
+    let projector_file = NamedTempFile::new().expect("temp projector");
+
+    mesh_config.models[0]
+        .hardware
+        .as_mut()
+        .expect("explicit hardware")
+        .model_path = Some(explicit_model.path().display().to_string());
+    mesh_config.models[0]
+        .hardware
+        .as_mut()
+        .expect("explicit hardware")
+        .mmproj = Some(projector_file.path().display().to_string());
+    mesh_config.models[0]
+        .multimodal
+        .as_mut()
+        .expect("explicit multimodal")
+        .mmproj = Some(projector_file.path().display().to_string());
+    mesh_config.models[1]
+        .hardware
+        .as_mut()
+        .expect("defaults hardware")
+        .model_path = Some(defaults_model.path().display().to_string());
+
+    FullSurfaceFixture {
+        mesh_config,
+        explicit_model,
+        defaults_model,
+        _projector_file: projector_file,
+    }
+}
+
+fn resolve_explicit_full_surface_config(
+    fixture: &FullSurfaceFixture,
+    request_defaults: &RequestDefaultsConfig,
+) -> ResolvedSkippyConfig {
+    resolve_skippy_config(SkippyConfigResolveRequest {
+        mesh_config: &fixture.mesh_config,
+        model_id: "Qwen/Qwen3-0.6B:Q4_K_M",
+        model_path: fixture.explicit_model.path(),
+        model_bytes: 4 * 1024 * 1024 * 1024,
+        allocatable_memory_bytes: Some(12 * 1024 * 1024 * 1024),
+        request_defaults: Some(request_defaults),
+    })
+    .expect("explicit model should resolve")
+}
+
+fn resolve_defaults_full_surface_config(fixture: &FullSurfaceFixture) -> ResolvedSkippyConfig {
+    resolve_skippy_config(SkippyConfigResolveRequest {
+        mesh_config: &fixture.mesh_config,
+        model_id: "ggml-org/gemma-3-270m-it-GGUF:Q8_0",
+        model_path: fixture.defaults_model.path(),
+        model_bytes: 2 * 1024 * 1024 * 1024,
+        allocatable_memory_bytes: Some(12 * 1024 * 1024 * 1024),
+        request_defaults: None,
+    })
+    .expect("defaults-only model should resolve")
+}
+
+fn assert_explicit_full_surface_resolution(explicit: &ResolvedSkippyConfig) {
+    assert_eq!(explicit.model_fit.ctx_size, 16384);
+    assert_eq!(explicit.model_fit.batch, 1024);
+    assert_eq!(explicit.model_fit.ubatch, 128);
+    assert_eq!(explicit.hardware.device.as_deref(), Some("CUDA1"));
+    assert_eq!(explicit.hardware.stage_layer_start, Some(12));
+    assert_eq!(explicit.hardware.stage_layer_end, Some(24));
+    assert_eq!(explicit.throughput.parallel, 3);
+    assert_eq!(explicit.throughput.threads, Some(10));
+    assert_eq!(explicit.throughput.threads_batch, Some(6));
+    assert_eq!(explicit.request_defaults.temperature, Some(0.7));
+    assert_eq!(explicit.request_defaults.max_tokens, 256);
+}
+
+fn assert_explicit_full_surface_stage_config(explicit: &ResolvedSkippyConfig) {
+    let stage = explicit
+        .to_stage_config(Some(fake_package_identity(32)), LoadMode::RuntimeSlice)
+        .expect("stage config should build");
+    assert_eq!((stage.layer_start, stage.layer_end), (12, 24));
+    assert_eq!(stage.n_batch, Some(1024));
+    assert_eq!(stage.n_ubatch, Some(128));
+    assert_eq!(stage.n_gpu_layers, 99);
+}
+
+fn assert_explicit_full_surface_runtime_options(explicit: &ResolvedSkippyConfig) {
+    let runtime = explicit
+        .to_embedded_runtime_options(
+            &SkippyTelemetryOptions::off(),
+            Some(fake_package_identity(32)),
+            LoadMode::RuntimeSlice,
+        )
+        .expect("embedded runtime options should build");
+    assert_eq!(runtime.n_threads, Some(10));
+    assert_eq!(runtime.n_threads_batch, Some(6));
+    assert_eq!(runtime.config.layer_start, 12);
+    assert_eq!(runtime.config.layer_end, 24);
+}
+
+fn assert_explicit_full_surface_openai_args(explicit: &ResolvedSkippyConfig) {
+    let openai = explicit
+        .to_embedded_openai_args(4096, true)
+        .expect("embedded openai args should build");
+    assert_eq!(openai.prefill_chunk_policy, "schedule");
+    assert_eq!(openai.prefill_chunk_size, 128);
+    assert_eq!(
+        openai.prefill_chunk_schedule.as_deref(),
+        Some("128,256,384")
+    );
+    assert_eq!(openai.speculative_window, 8);
+    assert_eq!(openai.draft_n_gpu_layers, Some(12));
+    assert_eq!(openai.default_max_tokens, 256);
+}
+
+fn assert_defaults_full_surface_resolution(omitted: &ResolvedSkippyConfig) {
+    assert_eq!(omitted.model_fit.ctx_size, 8192);
+    assert_eq!(omitted.model_fit.batch, 512);
+    assert_eq!(omitted.model_fit.ubatch, 128);
+    assert_eq!(omitted.hardware.device.as_deref(), Some("CUDA2"));
+    assert_eq!(omitted.throughput.parallel, 2);
+    assert_eq!(omitted.request_defaults.temperature, Some(0.2));
+    assert_eq!(omitted.request_defaults.max_tokens, 128);
+
+    let single_stage = omitted
+        .to_model_load_options(SkippyTelemetryOptions::off())
+        .expect("defaults-only model should remain single-stage safe");
+    assert_eq!(single_stage.ctx_size, 8192);
+    assert_eq!(single_stage.n_batch, Some(512));
+    assert_eq!(single_stage.n_ubatch, Some(128));
 }
 
 #[test]
@@ -271,87 +479,6 @@ parallel = 11
     assert_eq!(resolved.throughput.continuous_batching, "true");
 }
 
-fn resolve_qwen_test_config(
-    mesh_config: &MeshConfig,
-    model_path: &Path,
-    request_defaults: Option<&RequestDefaultsConfig>,
-) -> ResolvedSkippyConfig {
-    resolve_skippy_config(SkippyConfigResolveRequest {
-        mesh_config,
-        model_id: "Qwen/Qwen3-0.6B:Q4_K_M",
-        model_path,
-        model_bytes: 10 * 1024 * 1024 * 1024,
-        allocatable_memory_bytes: None,
-        request_defaults,
-    })
-    .unwrap()
-}
-
-fn assert_load_time_config_unchanged(
-    without_request: &ResolvedSkippyConfig,
-    with_request: &ResolvedSkippyConfig,
-) {
-    assert_eq!(without_request.model_fit, with_request.model_fit);
-    assert_eq!(without_request.hardware, with_request.hardware);
-    assert_eq!(without_request.skippy, with_request.skippy);
-}
-
-fn assert_request_defaults_follow_request_overrides(
-    without_request: &ResolvedSkippyConfig,
-    with_request: &ResolvedSkippyConfig,
-) {
-    assert_eq!(without_request.request_defaults.temperature, Some(0.2));
-    assert_eq!(with_request.request_defaults.temperature, Some(0.9));
-    assert_eq!(without_request.request_defaults.max_tokens, 128);
-    assert_eq!(with_request.request_defaults.max_tokens, 32);
-}
-
-fn assert_stage_config_ignores_request_defaults(
-    without_request: &ResolvedSkippyConfig,
-    with_request: &ResolvedSkippyConfig,
-) {
-    let baseline_stage = without_request
-        .to_stage_config(Some(fake_package_identity(28)), LoadMode::RuntimeSlice)
-        .expect("baseline stage config should build");
-    let override_stage = with_request
-        .to_stage_config(Some(fake_package_identity(28)), LoadMode::RuntimeSlice)
-        .expect("override stage config should build");
-
-    assert_eq!(baseline_stage.model_id, override_stage.model_id);
-    assert_eq!(baseline_stage.model_path, override_stage.model_path);
-    assert_eq!(baseline_stage.ctx_size, override_stage.ctx_size);
-    assert_eq!(baseline_stage.lane_count, override_stage.lane_count);
-    assert_eq!(baseline_stage.n_batch, override_stage.n_batch);
-    assert_eq!(baseline_stage.n_ubatch, override_stage.n_ubatch);
-    assert_eq!(baseline_stage.n_gpu_layers, override_stage.n_gpu_layers);
-    assert_eq!(baseline_stage.cache_type_k, override_stage.cache_type_k);
-    assert_eq!(baseline_stage.cache_type_v, override_stage.cache_type_v);
-    assert_eq!(
-        baseline_stage.flash_attn_type,
-        override_stage.flash_attn_type
-    );
-    assert_eq!(
-        baseline_stage.selected_device,
-        override_stage.selected_device
-    );
-    assert_eq!(baseline_stage.load_mode, override_stage.load_mode);
-}
-
-fn assert_embedded_openai_max_tokens_follow_request_overrides(
-    without_request: &ResolvedSkippyConfig,
-    with_request: &ResolvedSkippyConfig,
-) {
-    let baseline_openai = without_request
-        .to_embedded_openai_args(4096, true)
-        .expect("baseline openai args should build");
-    let override_openai = with_request
-        .to_embedded_openai_args(4096, true)
-        .expect("override openai args should build");
-
-    assert_eq!(baseline_openai.default_max_tokens, 128);
-    assert_eq!(override_openai.default_max_tokens, 32);
-}
-
 #[test]
 fn request_overrides_change_request_time_defaults_without_mutating_load_time_stage_config() {
     let mesh_config = parse_config(
@@ -365,19 +492,26 @@ max_tokens = 128
 "#,
     );
     let model_file = temp_model_file();
-    let without_request = resolve_qwen_test_config(&mesh_config, model_file.path(), None);
     let request_defaults = RequestDefaultsConfig {
         temperature: Some(0.9),
         max_tokens: Some(32),
         ..Default::default()
     };
-    let with_request =
-        resolve_qwen_test_config(&mesh_config, model_file.path(), Some(&request_defaults));
+    let without_request =
+        resolve_qwen_config_with_request_defaults(&mesh_config, model_file.path(), None);
+    let with_request = resolve_qwen_config_with_request_defaults(
+        &mesh_config,
+        model_file.path(),
+        Some(&request_defaults),
+    );
 
-    assert_load_time_config_unchanged(&without_request, &with_request);
-    assert_request_defaults_follow_request_overrides(&without_request, &with_request);
-    assert_stage_config_ignores_request_defaults(&without_request, &with_request);
-    assert_embedded_openai_max_tokens_follow_request_overrides(&without_request, &with_request);
+    assert_request_override_keeps_load_time_config(&without_request, &with_request);
+    assert_eq!(without_request.request_defaults.temperature, Some(0.2));
+    assert_eq!(with_request.request_defaults.temperature, Some(0.9));
+    assert_eq!(without_request.request_defaults.max_tokens, 128);
+    assert_eq!(with_request.request_defaults.max_tokens, 32);
+    assert_stage_configs_match_for_request_override(&without_request, &with_request);
+    assert_openai_args_use_request_time_defaults(&without_request, &with_request);
 }
 
 #[test]
@@ -719,158 +853,23 @@ draft_acceptance_threshold = 0.5
     assert!(err.contains("draft_acceptance_threshold"));
 }
 
-fn full_surface_fixture_with_model_paths() -> FullSurfaceFixture {
-    let mut mesh_config = parse_config(FULL_SURFACE_VALID_FIXTURE);
-    let explicit_model = temp_model_file();
-    let defaults_model = temp_model_file();
-    let projector_file = NamedTempFile::new().expect("temp projector");
-
-    let explicit_projector_path = projector_file.path().display().to_string();
-    let explicit_hardware = mesh_config.models[0]
-        .hardware
-        .as_mut()
-        .expect("explicit hardware");
-    explicit_hardware.model_path = Some(explicit_model.path().display().to_string());
-    explicit_hardware.mmproj = Some(explicit_projector_path.clone());
-    mesh_config.models[0]
-        .multimodal
-        .as_mut()
-        .expect("explicit multimodal")
-        .mmproj = Some(explicit_projector_path);
-    mesh_config.models[1]
-        .hardware
-        .as_mut()
-        .expect("defaults hardware")
-        .model_path = Some(defaults_model.path().display().to_string());
-
-    (mesh_config, explicit_model, defaults_model, projector_file)
-}
-
-fn resolve_full_surface_model(
-    mesh_config: &MeshConfig,
-    model_id: &str,
-    model_path: &Path,
-    model_bytes: u64,
-    request_defaults: Option<&RequestDefaultsConfig>,
-) -> ResolvedSkippyConfig {
-    resolve_skippy_config(SkippyConfigResolveRequest {
-        mesh_config,
-        model_id,
-        model_path,
-        model_bytes,
-        allocatable_memory_bytes: Some(12 * 1024 * 1024 * 1024),
-        request_defaults,
-    })
-    .expect("full-surface fixture model should resolve")
-}
-
-fn assert_explicit_full_surface_resolution(explicit: &ResolvedSkippyConfig) {
-    assert_eq!(explicit.model_fit.ctx_size, 16384);
-    assert_eq!(explicit.model_fit.batch, 1024);
-    assert_eq!(explicit.model_fit.ubatch, 128);
-    assert_eq!(explicit.hardware.device.as_deref(), Some("CUDA1"));
-    assert_eq!(explicit.hardware.stage_layer_start, Some(12));
-    assert_eq!(explicit.hardware.stage_layer_end, Some(24));
-    assert_eq!(explicit.throughput.parallel, 3);
-    assert_eq!(explicit.throughput.threads, Some(10));
-    assert_eq!(explicit.throughput.threads_batch, Some(6));
-    assert_eq!(explicit.request_defaults.temperature, Some(0.7));
-    assert_eq!(explicit.request_defaults.max_tokens, 256);
-}
-
-fn assert_explicit_full_surface_stage_config(explicit: &ResolvedSkippyConfig) {
-    let stage = explicit
-        .to_stage_config(Some(fake_package_identity(32)), LoadMode::RuntimeSlice)
-        .expect("stage config should build");
-
-    assert_eq!((stage.layer_start, stage.layer_end), (12, 24));
-    assert_eq!(stage.n_batch, Some(1024));
-    assert_eq!(stage.n_ubatch, Some(128));
-    assert_eq!(stage.n_gpu_layers, 99);
-}
-
-fn assert_explicit_full_surface_runtime_options(explicit: &ResolvedSkippyConfig) {
-    let runtime = explicit
-        .to_embedded_runtime_options(
-            &SkippyTelemetryOptions::off(),
-            Some(fake_package_identity(32)),
-            LoadMode::RuntimeSlice,
-        )
-        .expect("embedded runtime options should build");
-
-    assert_eq!(runtime.n_threads, Some(10));
-    assert_eq!(runtime.n_threads_batch, Some(6));
-    assert_eq!(runtime.config.layer_start, 12);
-    assert_eq!(runtime.config.layer_end, 24);
-}
-
-fn assert_explicit_full_surface_openai_args(explicit: &ResolvedSkippyConfig) {
-    let openai = explicit
-        .to_embedded_openai_args(4096, true)
-        .expect("embedded openai args should build");
-
-    assert_eq!(openai.prefill_chunk_policy, "schedule");
-    assert_eq!(openai.prefill_chunk_size, 128);
-    assert_eq!(
-        openai.prefill_chunk_schedule.as_deref(),
-        Some("128,256,384")
-    );
-    assert_eq!(openai.speculative_window, 8);
-    assert_eq!(openai.draft_n_gpu_layers, Some(12));
-    assert_eq!(openai.default_max_tokens, 256);
-}
-
-fn assert_defaults_only_full_surface_resolution(omitted: &ResolvedSkippyConfig) {
-    assert_eq!(omitted.model_fit.ctx_size, 8192);
-    assert_eq!(omitted.model_fit.batch, 512);
-    assert_eq!(omitted.model_fit.ubatch, 128);
-    assert_eq!(omitted.hardware.device.as_deref(), Some("CUDA2"));
-    assert_eq!(omitted.throughput.parallel, 2);
-    assert_eq!(omitted.request_defaults.temperature, Some(0.2));
-    assert_eq!(omitted.request_defaults.max_tokens, 128);
-}
-
-fn assert_defaults_only_full_surface_model_load_options(omitted: &ResolvedSkippyConfig) {
-    let single_stage = omitted
-        .to_model_load_options(SkippyTelemetryOptions::off())
-        .expect("defaults-only model should remain single-stage safe");
-
-    assert_eq!(single_stage.ctx_size, 8192);
-    assert_eq!(single_stage.n_batch, Some(512));
-    assert_eq!(single_stage.n_ubatch, Some(128));
-}
-
 #[test]
 fn integrated_full_surface_fixture_resolves_defaults_overrides_staged_and_runtime_paths() {
-    let (mesh_config, explicit_model, defaults_model, _projector_file) =
-        full_surface_fixture_with_model_paths();
+    let fixture = full_surface_fixture_with_model_paths();
     let request_defaults = RequestDefaultsConfig {
         temperature: Some(0.7),
         max_tokens: Some(256),
         ..Default::default()
     };
 
-    let explicit = resolve_full_surface_model(
-        &mesh_config,
-        "Qwen/Qwen3-0.6B:Q4_K_M",
-        explicit_model.path(),
-        4 * 1024 * 1024 * 1024,
-        Some(&request_defaults),
-    );
+    let explicit = resolve_explicit_full_surface_config(&fixture, &request_defaults);
     assert_explicit_full_surface_resolution(&explicit);
     assert_explicit_full_surface_stage_config(&explicit);
     assert_explicit_full_surface_runtime_options(&explicit);
     assert_explicit_full_surface_openai_args(&explicit);
 
-    let omitted = resolve_full_surface_model(
-        &mesh_config,
-        "ggml-org/gemma-3-270m-it-GGUF:Q8_0",
-        defaults_model.path(),
-        2 * 1024 * 1024 * 1024,
-        None,
-    );
-    assert_defaults_only_full_surface_resolution(&omitted);
-    assert_defaults_only_full_surface_model_load_options(&omitted);
+    let omitted = resolve_defaults_full_surface_config(&fixture);
+    assert_defaults_full_surface_resolution(&omitted);
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1232,6 +1232,9 @@ async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> 
         local_only: true,
         requires_explicit_remote_endpoint: true,
         endpoint: Some(control_endpoint.clone()),
+        disabled_reason: None,
+        message: None,
+        suggested_commands: None,
     })
     .await;
     let status_snapshot = api.status_snapshot_string().await;

--- a/crates/mesh-llm-host-runtime/src/plugin/config.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/config.rs
@@ -29,6 +29,8 @@ pub struct MeshConfig {
     pub models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     pub plugins: Vec<PluginConfigEntry>,
+    #[serde(flatten, default)]
+    pub extra: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -549,6 +551,8 @@ struct RawMeshConfig {
     models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     plugins: Vec<PluginConfigEntry>,
+    #[serde(flatten, default)]
+    extra: BTreeMap<String, toml::Value>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -642,6 +646,7 @@ impl<'de> Deserialize<'de> for MeshConfig {
             defaults: raw.defaults,
             models: raw.models,
             plugins: raw.plugins,
+            extra: raw.extra,
         })
     }
 }

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -969,6 +969,7 @@ fn legacy_proto_config_to_mesh(
         defaults: None,
         models,
         plugins,
+        extra: Default::default(),
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -1966,6 +1966,7 @@ alias = "model-alias"
                 args: vec!["--plugin".to_string()],
                 url: None,
             }],
+            extra: Default::default(),
         };
         let snapshot = mesh_config_to_proto(&config);
         let restored = proto_config_to_mesh(&snapshot);
@@ -1995,6 +1996,70 @@ alias = "model-alias"
     }
 
     #[test]
+    fn config_sync_config_toml_roundtrips_additive_defaults_sections() {
+        let mut config = crate::plugin::MeshConfig {
+            version: Some(1),
+            ..Default::default()
+        };
+        config.extra = toml::from_str(
+            r#"[defaults.throughput]
+parallel = 6
+
+[defaults.model_fit]
+flash_attention = "disabled"
+
+[defaults.request_defaults]
+reasoning_format = "qwen"
+"#,
+        )
+        .expect("parse additive defaults table");
+
+        let snapshot = mesh_config_to_proto(&config);
+        assert!(
+            snapshot
+                .config_toml
+                .as_deref()
+                .is_some_and(|toml| toml.contains("[defaults.model_fit]")),
+            "config TOML should carry additive defaults sections"
+        );
+
+        let restored = proto_config_to_mesh(&snapshot);
+        assert_eq!(
+            restored
+                .extra
+                .get("defaults")
+                .and_then(|defaults| defaults.get("throughput"))
+                .and_then(|throughput| throughput.get("parallel"))
+                .and_then(toml::Value::as_integer)
+                .or_else(|| {
+                    restored
+                        .defaults
+                        .as_ref()
+                        .and_then(|defaults| defaults.throughput.as_ref())
+                        .and_then(|throughput| throughput.parallel)
+                        .map(|parallel| parallel as i64)
+                }),
+            Some(6)
+        );
+        assert_eq!(
+            restored
+                .extra
+                .get("defaults")
+                .and_then(|defaults| defaults.get("request_defaults"))
+                .and_then(|request_defaults| request_defaults.get("reasoning_format"))
+                .and_then(toml::Value::as_str)
+                .or_else(|| {
+                    restored
+                        .defaults
+                        .as_ref()
+                        .and_then(|defaults| defaults.request_defaults.as_ref())
+                        .and_then(|request_defaults| request_defaults.reasoning_format.as_deref())
+                }),
+            Some("qwen")
+        );
+    }
+
+    #[test]
     fn config_sync_config_hash_determinism() {
         use crate::plugin::{GpuAssignment, GpuConfig, ModelConfigEntry};
         let config = crate::plugin::MeshConfig {
@@ -2020,6 +2085,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            extra: Default::default(),
         };
         let snap1 = mesh_config_to_proto(&config);
         let snap2 = mesh_config_to_proto(&config);
@@ -2050,6 +2116,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            extra: Default::default(),
         };
         let snap3 = mesh_config_to_proto(&config2);
         let h3 = canonical_config_hash(&snap3);
@@ -2112,6 +2179,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            extra: Default::default(),
         };
 
         let snapshot = mesh_config_to_proto(&config);

--- a/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
@@ -252,6 +252,7 @@ mod tests {
             defaults: None,
             models: vec![],
             plugins: vec![],
+            extra: Default::default(),
         }
     }
 
@@ -420,6 +421,84 @@ alias = "model-alias"
     }
 
     #[test]
+    fn config_sync_state_apply_preserves_additive_defaults_sections() {
+        let dir = test_dir();
+        let config_path = dir.join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"version = 1
+
+[defaults.throughput]
+parallel = 2
+
+[defaults.model_fit]
+flash_attention = "auto"
+
+[defaults.request_defaults]
+reasoning_format = "deepseek"
+"#,
+        )
+        .expect("write baseline config");
+
+        let mut state = ConfigState::load(&config_path).expect("load baseline config");
+        let mut config = minimal_valid_config();
+        config.extra = toml::from_str(
+            r#"[defaults.throughput]
+parallel = 6
+
+[defaults.model_fit]
+flash_attention = "disabled"
+
+[defaults.request_defaults]
+reasoning_format = "qwen"
+"#,
+        )
+        .expect("parse additive defaults table");
+
+        let result = state.apply(config, 0);
+        match result {
+            ApplyResult::Applied {
+                revision,
+                apply_mode,
+                ..
+            } => {
+                assert_eq!(revision, 1);
+                assert_eq!(apply_mode, ConfigApplyMode::Staged);
+            }
+            other => panic!("expected additive defaults to be written, got {other:?}"),
+        }
+
+        let written = std::fs::read_to_string(&config_path).expect("read written config");
+        let written: toml::Value = toml::from_str(&written).expect("written TOML parses");
+        assert_eq!(
+            written
+                .get("defaults")
+                .and_then(|defaults| defaults.get("throughput"))
+                .and_then(|throughput| throughput.get("parallel"))
+                .and_then(toml::Value::as_integer),
+            Some(6)
+        );
+        assert_eq!(
+            written
+                .get("defaults")
+                .and_then(|defaults| defaults.get("model_fit"))
+                .and_then(|model_fit| model_fit.get("flash_attention"))
+                .and_then(toml::Value::as_str),
+            Some("disabled")
+        );
+        assert_eq!(
+            written
+                .get("defaults")
+                .and_then(|defaults| defaults.get("request_defaults"))
+                .and_then(|request_defaults| request_defaults.get("reasoning_format"))
+                .and_then(toml::Value::as_str),
+            Some("qwen")
+        );
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
     fn config_sync_state_conflict() {
         let dir = test_dir();
         let config_path = dir.join("config.toml");
@@ -498,6 +577,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            extra: Default::default(),
         };
 
         assert_eq!(state.revision(), 0);
@@ -541,6 +621,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            extra: Default::default(),
         };
         state.apply(config_with_model, 0);
         let new_hash = *state.config_hash();
@@ -697,6 +778,7 @@ temperature = 0.2
                 ..Default::default()
             }],
             plugins: vec![],
+            extra: Default::default(),
         };
 
         let r1 = state.apply(config_with_model.clone(), 0);

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3693,9 +3693,6 @@ stop = ["END"]
         .expect("test mesh config should parse");
         let mut package = package(40);
         package.package_ref = "hf://Mesh-LLM/test-split-package".to_string();
-        let temp_dir = tempfile::tempdir().unwrap();
-        let model_path = temp_dir.path().join("qwen.gguf");
-        write_fake_gguf_model(&model_path);
         let local_id = node.id();
         let generation = SplitTopologyGeneration::new(
             "resolver-topology".into(),

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3693,6 +3693,9 @@ stop = ["END"]
         .expect("test mesh config should parse");
         let mut package = package(40);
         package.package_ref = "hf://Mesh-LLM/test-split-package".to_string();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let model_path = temp_dir.path().join("qwen.gguf");
+        write_fake_gguf_model(&model_path);
         let local_id = node.id();
         let generation = SplitTopologyGeneration::new(
             "resolver-topology".into(),

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -2739,7 +2739,7 @@ fn owner_runtime_config(
         },
         None if cli.owner_required => {
             anyhow::bail!(
-                "Owner identity is required but no keystore was found. Use --owner-key or run `mesh-llm auth init`."
+                "Owner identity is required but no keystore was found. To enable owner control, run `mesh-llm auth init --no-passphrase`, then restart with `mesh-llm serve --owner-required`."
             );
         }
         None => None,
@@ -2755,6 +2755,13 @@ fn owner_runtime_config(
         trust_store,
         trust_policy,
     })
+}
+
+fn emit_configuration_ui_read_only_hint() {
+    let _ = emit_event(OutputEvent::Warning {
+        message: "Configuration UI is read-only: no owner identity found. To enable saving config from the UI:\n  mesh-llm auth init --no-passphrase\n  mesh-llm serve --owner-required".to_string(),
+        context: None,
+    });
 }
 
 /// Wait for either SIGINT (ctrl-c) or SIGTERM. Without this, an unhandled
@@ -5154,6 +5161,9 @@ async fn start_run_auto_node_and_plugins(
         NodeRole::Worker
     };
     let owner_config = owner_runtime_config(cli, config)?;
+    if !cli.headless && owner_config.keypair.is_none() {
+        emit_configuration_ui_read_only_hint();
+    }
     let max_vram = if cli.client { Some(0.0) } else { cli.max_vram };
     let (node, channels) = mesh::Node::start(
         role,
@@ -6611,14 +6621,10 @@ async fn setup_run_auto_console_state(
     console_state
         .set_runtime_control(ctx.control_tx.clone())
         .await;
-    let control_endpoint = ctx.node.control_endpoint().await;
     console_state
-        .set_control_bootstrap(api::ControlBootstrapPayload {
-            enabled: control_endpoint.is_some(),
-            local_only: true,
-            requires_explicit_remote_endpoint: true,
-            endpoint: control_endpoint,
-        })
+        .set_control_bootstrap(api::ControlBootstrapPayload::from_control_endpoint(
+            ctx.node.control_endpoint().await,
+        ))
         .await;
     console_state
         .set_nostr_relays(nostr_relays(&ctx.cli.nostr_relay))
@@ -7294,14 +7300,10 @@ async fn setup_passive_console_runtime(
         runtime_data_collector,
         runtime_data_producer,
     });
-    let control_endpoint = node.control_endpoint().await;
     console_state
-        .set_control_bootstrap(api::ControlBootstrapPayload {
-            enabled: control_endpoint.is_some(),
-            local_only: true,
-            requires_explicit_remote_endpoint: true,
-            endpoint: control_endpoint,
-        })
+        .set_control_bootstrap(api::ControlBootstrapPayload::from_control_endpoint(
+            node.control_endpoint().await,
+        ))
         .await;
     console_state
         .set_nostr_relays(nostr_relays(&cli.nostr_relay))

--- a/crates/mesh-llm-ui/AGENTS.md
+++ b/crates/mesh-llm-ui/AGENTS.md
@@ -72,7 +72,7 @@ Package-local scripts:
 - Use `cn(...)` for conditional Tailwind class composition.
 - Preserve dark-mode classes when changing UI.
 - Avoid introducing new global state unless the app shell truly owns it.
-- Keep dev-only features behind `import.meta.env.DEV`; do not ship playground-only code in production bundles.
+- Keep dev-only features behind `env.isDevelopment` from `@/lib/env`; this also enables embedded debug UI bundles for debug `mesh-llm` binaries while release builds force it off.
 
 ## UI conventions
 

--- a/crates/mesh-llm-ui/src/app/layout/RootLayout.tsx
+++ b/crates/mesh-llm-ui/src/app/layout/RootLayout.tsx
@@ -24,7 +24,7 @@ function pathToTab(pathname: string): AppTab | null {
   if (pathname.startsWith('/chat')) return 'chat'
   if (pathname.startsWith('/reserves')) return 'reserves'
   if (pathname.startsWith('/configuration')) return 'configuration'
-  if (import.meta.env.DEV && pathname.startsWith('/__playground')) return null
+  if (env.isDevelopment && pathname.startsWith('/__playground')) return null
   return 'network'
 }
 
@@ -96,13 +96,13 @@ export function RootLayout({ data = SHELL_HARNESS }: RootLayoutProps = {}) {
     }),
     [enabledConfigurationTabs, pathname]
   )
-  const showDevelopmentNavControls = import.meta.env.DEV
   const visibleActiveTab =
     activeTab === 'configuration' && !newConfigurationPageEnabled
       ? null
       : activeTab === 'reserves' && !newReservesPageEnabled
         ? null
         : activeTab
+  const showDevelopmentNavControls = env.isDevelopment
 
   const onTabChange = useCallback(
     (tab: AppTab | null) => {

--- a/crates/mesh-llm-ui/src/app/router/router.tsx
+++ b/crates/mesh-llm-ui/src/app/router/router.tsx
@@ -5,7 +5,7 @@ import { RootLayout } from '@/app/layout/RootLayout'
 import { parseDeveloperPlaygroundSearch } from '@/features/developer/playground/developer-playground-tabs'
 import { env } from '@/lib/env'
 
-const enableMeshVizPerfRoute = import.meta.env.DEV || import.meta.env.VITE_ENABLE_PERF_ROUTE === 'true'
+const enableMeshVizPerfRoute = env.isDevelopment || import.meta.env.VITE_ENABLE_PERF_ROUTE === 'true'
 
 const rootRoute = createRootRoute({
   component: RootLayout,
@@ -53,7 +53,7 @@ const configurationTabRoute = createRoute({
   ),
   errorComponent: FeatureErrorBoundary
 })
-const developerPlaygroundRoute = import.meta.env.DEV
+const developerPlaygroundRoute = env.isDevelopment
   ? createRoute({
       getParentRoute: () => rootRoute,
       path: '/__playground',

--- a/crates/mesh-llm-ui/src/features/app-shell/components/AppHeader.tsx
+++ b/crates/mesh-llm-ui/src/features/app-shell/components/AppHeader.tsx
@@ -16,6 +16,7 @@ import {
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { TooltipContent, TooltipRoot, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { env } from '@/lib/env'
 import type { TopSection } from '@/features/app-shell/lib/routes'
 
 const DOCS_URL = 'https://docs.anarchai.org'
@@ -154,7 +155,7 @@ export function AppHeader({
           </NavigationMenuList>
         </NavigationMenu>
         <div className="ml-auto flex items-center gap-2">
-          {import.meta.env.DEV && (
+          {env.isDevelopment && (
             <Button
               variant="secondary"
               size="sm"

--- a/crates/mesh-llm-ui/src/features/app-shell/lib/routes.ts
+++ b/crates/mesh-llm-ui/src/features/app-shell/lib/routes.ts
@@ -1,3 +1,5 @@
+import { env } from '@/lib/env'
+
 export type TopSection = 'dashboard' | 'chat' | 'playground'
 
 export type AppRoute = {
@@ -5,14 +7,14 @@ export type AppRoute = {
   chatId: string | null
 }
 
-export function normalizeSection(section: TopSection, allowPlayground = import.meta.env.DEV): TopSection {
+export function normalizeSection(section: TopSection, allowPlayground = env.isDevelopment): TopSection {
   if (!allowPlayground && section === 'playground') {
     return 'dashboard'
   }
   return section
 }
 
-function normalizeRoute(route: AppRoute, allowPlayground = import.meta.env.DEV): AppRoute {
+function normalizeRoute(route: AppRoute, allowPlayground = env.isDevelopment): AppRoute {
   const section = normalizeSection(route.section, allowPlayground)
   if (section !== route.section) {
     return { section, chatId: null }
@@ -20,7 +22,7 @@ function normalizeRoute(route: AppRoute, allowPlayground = import.meta.env.DEV):
   return route
 }
 
-export function sectionFromPathname(pathname: string, allowPlayground = import.meta.env.DEV): TopSection | null {
+export function sectionFromPathname(pathname: string, allowPlayground = env.isDevelopment): TopSection | null {
   if (pathname === '/dashboard' || pathname === '/dashboard/') {
     return 'dashboard'
   }
@@ -33,7 +35,7 @@ export function sectionFromPathname(pathname: string, allowPlayground = import.m
   return null
 }
 
-export function readRouteFromLocation(allowPlayground = import.meta.env.DEV): AppRoute {
+export function readRouteFromLocation(allowPlayground = env.isDevelopment): AppRoute {
   if (typeof window === 'undefined') {
     return { section: 'dashboard', chatId: null }
   }
@@ -57,7 +59,7 @@ export function readRouteFromLocation(allowPlayground = import.meta.env.DEV): Ap
   return { section: 'dashboard', chatId: null }
 }
 
-export function pathnameForRoute(route: AppRoute, allowPlayground = import.meta.env.DEV): string {
+export function pathnameForRoute(route: AppRoute, allowPlayground = env.isDevelopment): string {
   const normalizedRoute = normalizeRoute(route, allowPlayground)
 
   if (normalizedRoute.section === 'dashboard') {

--- a/crates/mesh-llm-ui/src/features/app-shell/playground/components/PlaygroundPage.tsx
+++ b/crates/mesh-llm-ui/src/features/app-shell/playground/components/PlaygroundPage.tsx
@@ -1,4 +1,5 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { env } from '@/lib/env'
 
 type PlaygroundPageProps = Record<string, unknown>
 
@@ -6,7 +7,7 @@ import PlaygroundBaseUI from '@/features/app-shell/playground/components/Playgro
 import PlaygroundCards from '@/features/app-shell/playground/components/PlaygroundCards'
 
 export default function PlaygroundPage(_props: PlaygroundPageProps) {
-  if (!import.meta.env.DEV) {
+  if (!env.isDevelopment) {
     return null
   }
 

--- a/crates/mesh-llm-ui/src/features/app-tabs/data.test.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/data.test.ts
@@ -1,31 +1,231 @@
 import { describe, expect, it } from 'vitest'
 import { CONFIGURATION_DEFAULTS } from '@/features/app-tabs/data'
+import type {
+  ConfigurationDefaultsCategory,
+  ConfigurationDefaultsControl,
+  ConfigurationDefaultsSetting
+} from '@/features/app-tabs/types'
+
+function settingById(id: string): ConfigurationDefaultsSetting {
+  const setting = CONFIGURATION_DEFAULTS.settings.find((entry) => entry.id === id)
+
+  if (!setting) {
+    throw new Error(`Expected setting ${id}`)
+  }
+
+  return setting
+}
+
+function categoryById(id: string): ConfigurationDefaultsCategory {
+  const category = CONFIGURATION_DEFAULTS.categories.find((entry) => entry.id === id)
+
+  if (!category) {
+    throw new Error(`Expected category ${id}`)
+  }
+
+  return category
+}
+
+function settingIdsForCategory(categoryId: ConfigurationDefaultsCategory['id']) {
+  return CONFIGURATION_DEFAULTS.settings
+    .filter((setting) => setting.categoryId === categoryId)
+    .map((setting) => setting.id)
+}
+
+function expectChoice(id: string, name: string, value: string, presentation?: 'segmented' | 'select' | 'toggle') {
+  const control = settingById(id).control as Extract<ConfigurationDefaultsControl, { kind: 'choice' }>
+
+  expect(control.kind).toBe('choice')
+  expect(control.name).toBe(name)
+  expect(control.value).toBe(value)
+  if (presentation) expect(control.presentation).toBe(presentation)
+}
+
+function choiceValues(id: string) {
+  const control = settingById(id).control
+  if (control.kind !== 'choice') return []
+  return control.options.map((option) => option.value)
+}
 
 describe('CONFIGURATION_DEFAULTS', () => {
-  it('uses Request Defaults for request-scoped sampling controls', () => {
-    expect(CONFIGURATION_DEFAULTS.categories).toEqual(
-      expect.arrayContaining([expect.objectContaining({ id: 'request-defaults', label: 'Request Defaults' })])
-    )
-
-    const requestDefaultIds = CONFIGURATION_DEFAULTS.settings
-      .filter((setting) => setting.categoryId === 'request-defaults')
-      .map((setting) => setting.id)
-
-    expect(requestDefaultIds).toEqual(
-      expect.arrayContaining(['temperature', 'top-p', 'reasoning-format', 'reasoning-budget', 'repeat-penalty'])
-    )
+  it('declares merged defaults categories in deterministic UI order', () => {
+    expect(CONFIGURATION_DEFAULTS.categories).toEqual([
+      {
+        id: 'runtime',
+        label: 'Runtime',
+        summary: 'Model fit, hardware, and throughput defaults.',
+        help: 'Load-time runtime behavior and concurrency defaults'
+      },
+      {
+        id: 'memory',
+        label: 'Memory',
+        summary: 'KV cache policy and fit headroom.',
+        help: 'VRAM accounting and fit headroom'
+      },
+      {
+        id: 'speculative-decoding',
+        label: 'Speculative Decoding',
+        summary: 'Draft acceleration defaults.',
+        help: 'Speculative draft policy defaults',
+        tomlSection: 'defaults.speculative'
+      },
+      {
+        id: 'advanced',
+        label: 'Reasoning',
+        summary: 'Reasoning and repetition controls.',
+        help: 'Reasoning and sampling defaults'
+      },
+      {
+        id: 'request-defaults',
+        label: 'Request Defaults',
+        summary: 'Sampling, reasoning, and request-time fallback defaults.',
+        help: 'Request-time sampling and reasoning defaults'
+      },
+      {
+        id: 'skippy-transport',
+        label: 'Skippy Transport',
+        summary: 'Activation wire dtype, prefill chunking, and lifecycle timing.',
+        help: 'Stage transport, chunking, and lifecycle defaults',
+        tomlSection: 'defaults.skippy'
+      },
+      {
+        id: 'multimodal',
+        label: 'Multimodal',
+        summary: 'Projector and image token defaults.',
+        help: 'Vision projector and image token defaults',
+        tomlSection: 'defaults.multimodal'
+      },
+      {
+        id: 'advanced-server',
+        label: 'Advanced Server',
+        summary: 'Server identity and operator overrides.',
+        help: 'Advanced server defaults and identity overrides',
+        tomlSection: 'defaults.advanced.server'
+      }
+    ])
   })
 
-  it('matches the canonical reasoning format options and omits stale speculative controls', () => {
-    const reasoningFormat = CONFIGURATION_DEFAULTS.settings.find((setting) => setting.id === 'reasoning-format')
+  it('keeps current request-default semantics while adding advanced sampling controls', () => {
+    expect(categoryById('request-defaults').label).toBe('Request Defaults')
+    expect(settingIdsForCategory('request-defaults')).toEqual(
+      expect.arrayContaining([
+        'temperature',
+        'top-p',
+        'reasoning-format',
+        'reasoning-budget',
+        'repeat-penalty',
+        'repeat-last-n',
+        'top-k',
+        'min-p',
+        'presence-penalty',
+        'frequency-penalty',
+        'max-tokens',
+        'seed',
+        'ignore-eos',
+        'mirostat-mode',
+        'mirostat-entropy',
+        'mirostat-learning-rate',
+        'samplers',
+        'sampler-sequence',
+        'stop'
+      ])
+    )
+    expect(settingById('temperature').control).toMatchObject({ kind: 'range', name: 'temperature', value: '0.70' })
+    expect(settingById('top-p').control).toMatchObject({ kind: 'range', name: 'top_p', value: '0.95' })
+    expectChoice('reasoning-format', 'reasoning_format', 'auto')
+    expect(choiceValues('reasoning-format')).toEqual(['auto', 'none', 'deepseek', 'deepseek-legacy'])
+
+    for (const id of settingIdsForCategory('request-defaults')) {
+      expect(settingById(id).tomlSection).toBe('defaults.request_defaults')
+    }
+  })
+
+  it('uses current speculation values and includes incoming draft tuning controls', () => {
+    expectChoice('speculation-mode', 'mode', 'auto', 'segmented')
+    expect(choiceValues('speculation-mode')).toEqual(['auto', 'disabled', 'draft', 'ngram'])
+    expectChoice('incompatible-pairing-behavior', 'pairing_fault', 'warn_disable', 'toggle')
+    expect(choiceValues('incompatible-pairing-behavior')).toEqual(['warn_disable', 'fail_closed'])
+
+    for (const id of [
+      'draft-selection-policy',
+      'incompatible-pairing-behavior',
+      'draft-max-tokens',
+      'draft-min-tokens',
+      'draft-acceptance-threshold'
+    ]) {
+      const setting = settingById(id)
+      expect(setting.tomlSection).toBe('defaults.speculative')
+      expect(setting.dependsOn?.settingId).toBe('speculation-mode')
+      expect(setting.dependsOn?.condition('draft')).toBe(true)
+      expect(setting.dependsOn?.condition('disabled')).toBe(false)
+    }
+
+    expect(settingById('draft-min-tokens').control).toMatchObject({
+      kind: 'range',
+      name: 'draft_min_tokens',
+      value: '0',
+      min: 0,
+      max: 32,
+      step: 1,
+      unit: 'tokens'
+    })
+    expect(settingById('draft-acceptance-threshold').visibility).toBe('advanced')
+    expect(settingById('draft-acceptance-threshold').control).toMatchObject({
+      kind: 'range',
+      name: 'draft_acceptance_threshold',
+      value: '0.70',
+      min: 0,
+      max: 1,
+      step: 0.05
+    })
+  })
+
+  it('includes skippy transport, multimodal, and advanced server inventories', () => {
+    expect(settingIdsForCategory('skippy-transport')).toEqual(
+      expect.arrayContaining([
+        'activation-wire-dtype',
+        'stage-model-path',
+        'stage-role',
+        'stage-topology',
+        'prefill-chunking',
+        'prefill-chunk-size',
+        'prefill-chunk-schedule',
+        'binary-stage-transport',
+        'lifecycle-startup-timeout-ms',
+        'lifecycle-readiness-interval-ms',
+        'lifecycle-health-interval-ms'
+      ])
+    )
+    expect(settingById('activation-wire-dtype').tomlSection).toBe('defaults.skippy')
+    expect(settingById('prefill-chunk-size').dependsOn?.settingId).toBe('prefill-chunking')
+    expect(settingById('prefill-chunk-size').dependsOn?.condition('fixed')).toBe(true)
+    expect(settingById('prefill-chunk-schedule').dependsOn?.condition('schedule')).toBe(true)
+
+    expect(settingIdsForCategory('multimodal')).toEqual([
+      'mmproj-offload',
+      'image-min-tokens',
+      'image-max-tokens',
+      'mmproj',
+      'mmproj-url'
+    ])
+    for (const id of settingIdsForCategory('multimodal')) {
+      expect(settingById(id).tomlSection).toBe('defaults.multimodal')
+    }
+
+    expect(settingIdsForCategory('advanced-server')).toEqual(['server-alias'])
+    expect(settingById('server-alias')).toMatchObject({
+      tomlSection: 'defaults.advanced.server',
+      mutability: 'restart-required',
+      visibility: 'advanced'
+    })
+    expect(settingById('server-alias').control).toMatchObject({ kind: 'text', name: 'alias', value: '' })
+  })
+
+  it('keeps all settings keyed to canonical TOML sections without duplicate ids', () => {
     const settingIds = CONFIGURATION_DEFAULTS.settings.map((setting) => setting.id)
 
-    expect(reasoningFormat?.control.kind).toBe('choice')
-    expect(
-      reasoningFormat?.control.kind === 'choice' ? reasoningFormat.control.options.map((option) => option.value) : []
-    ).toEqual(['auto', 'none', 'deepseek', 'deepseek-legacy'])
-
-    expect(settingIds).not.toContain('draft-min-tokens')
-    expect(settingIds).not.toContain('draft-acceptance-threshold')
+    expect(CONFIGURATION_DEFAULTS.settings.length).toBeGreaterThanOrEqual(75)
+    expect(new Set(settingIds).size).toBe(settingIds.length)
+    expect(CONFIGURATION_DEFAULTS.settings.every((setting) => setting.tomlSection.startsWith('defaults.'))).toBe(true)
   })
 })

--- a/crates/mesh-llm-ui/src/features/app-tabs/data.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/data.ts
@@ -533,6 +533,40 @@ export const INITIAL_ASSIGNS: ConfigAssign[] = [
   { id: 'a5', modelId: 'qwenud', nodeId: 'node-b', containerIdx: 0, ctx: 262144 }
 ]
 
+const DRAFT_MODEL_SPECULATION_DEPENDENCY = {
+  settingId: 'speculation-mode',
+  condition: (value: string) => value === 'draft'
+}
+
+const THROUGHPUT_TOML_SECTION = 'defaults.throughput'
+
+const HARDWARE_TOML_SECTION = 'defaults.hardware'
+
+const MODEL_FIT_TOML_SECTION = 'defaults.model_fit'
+
+const SKIPPY_TRANSPORT_TOML_SECTION = 'defaults.skippy'
+
+const REQUEST_DEFAULTS_TOML_SECTION = 'defaults.request_defaults'
+
+const MULTIMODAL_TOML_SECTION = 'defaults.multimodal'
+
+const ADVANCED_SERVER_TOML_SECTION = 'defaults.advanced.server'
+
+const MIROSTAT_MODE_DEPENDENCY = {
+  settingId: 'mirostat-mode',
+  condition: (value: string) => value !== 'disabled'
+}
+
+const PREFILL_CHUNKING_FIXED_DEPENDENCY = {
+  settingId: 'prefill-chunking',
+  condition: (value: string) => value === 'fixed'
+}
+
+const PREFILL_CHUNKING_SCHEDULE_DEPENDENCY = {
+  settingId: 'prefill-chunking',
+  condition: (value: string) => value === 'schedule'
+}
+
 export const CONFIGURATION_DEFAULTS = {
   categories: [
     {
@@ -551,16 +585,327 @@ export const CONFIGURATION_DEFAULTS = {
       id: 'speculative-decoding',
       label: 'Speculative Decoding',
       summary: 'Draft acceleration defaults.',
-      help: 'Speculative draft policy defaults'
+      help: 'Speculative draft policy defaults',
+      tomlSection: 'defaults.speculative'
+    },
+    {
+      id: 'advanced',
+      label: 'Reasoning',
+      summary: 'Reasoning and repetition controls.',
+      help: 'Reasoning and sampling defaults'
     },
     {
       id: 'request-defaults',
       label: 'Request Defaults',
       summary: 'Sampling, reasoning, and request-time fallback defaults.',
       help: 'Request-time sampling and reasoning defaults'
+    },
+    {
+      id: 'skippy-transport',
+      label: 'Skippy Transport',
+      summary: 'Activation wire dtype, prefill chunking, and lifecycle timing.',
+      help: 'Stage transport, chunking, and lifecycle defaults',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION
+    },
+    {
+      id: 'multimodal',
+      label: 'Multimodal',
+      summary: 'Projector and image token defaults.',
+      help: 'Vision projector and image token defaults',
+      tomlSection: MULTIMODAL_TOML_SECTION
+    },
+    {
+      id: 'advanced-server',
+      label: 'Advanced Server',
+      summary: 'Server identity and operator overrides.',
+      help: 'Advanced server defaults and identity overrides',
+      tomlSection: ADVANCED_SERVER_TOML_SECTION
     }
   ],
   settings: [
+    {
+      id: 'threads',
+      categoryId: 'runtime',
+      icon: 'cpu',
+      label: 'CPU threads',
+      description:
+        'Sets the default CPU thread count. Use 0 for auto; 256 is a safe UI ceiling for general-purpose systems.',
+      inheritedLabel: 'Inherited by placements without a thread override',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'threads', value: '0', min: 0, max: 256, step: 1, unit: 'threads' }
+    },
+    {
+      id: 'threads-batch',
+      categoryId: 'runtime',
+      icon: 'cpu',
+      label: 'Batch threads',
+      description:
+        'Sets the thread count used for batching. Use 0 for auto; 256 is a safe UI ceiling for general-purpose systems.',
+      inheritedLabel: 'Inherited by placements without a batch-thread override',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'threads_batch', value: '0', min: 0, max: 256, step: 1, unit: 'threads' }
+    },
+    {
+      id: 'continuous-batching',
+      categoryId: 'runtime',
+      icon: 'layers',
+      label: 'Continuous batching',
+      description: 'Choose whether the runtime should keep batching continuously when supported.',
+      inheritedLabel: 'Inherited by placements without a batching override',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'continuous_batching',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'numa',
+      categoryId: 'runtime',
+      icon: 'cpu',
+      label: 'NUMA policy',
+      description: 'Choose the NUMA policy used when launching the runtime.',
+      inheritedLabel: 'Inherited by placements without a NUMA override',
+      visibility: 'advanced',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'numa',
+        value: 'auto',
+        presentation: 'select',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'disabled', label: 'disabled' },
+          { value: 'distribute', label: 'distribute' },
+          { value: 'isolate', label: 'isolate' },
+          { value: 'numactl', label: 'numactl' }
+        ]
+      }
+    },
+    {
+      id: 'cpu-affinity',
+      categoryId: 'runtime',
+      icon: 'cpu',
+      label: 'CPU affinity',
+      description: 'Pin runtime threads to a specific CPU mask such as 0-3,8-11.',
+      inheritedLabel: 'Inherited by placements without an affinity override',
+      visibility: 'advanced',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'text', name: 'cpu_affinity', value: '', placeholder: 'e.g. 0-3,8-11' }
+    },
+    {
+      id: 'priority',
+      categoryId: 'runtime',
+      icon: 'gauge',
+      label: 'Process priority',
+      description: 'Set the scheduler priority or nice value for the runtime process.',
+      inheritedLabel: 'Inherited by placements without a priority override',
+      visibility: 'advanced',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'text', name: 'priority', value: '', placeholder: 'e.g. 0 or normal' }
+    },
+    {
+      id: 'poll',
+      categoryId: 'runtime',
+      icon: 'zap',
+      label: 'Poll mode',
+      description: 'Choose how the runtime polls for work when busy-waiting is available.',
+      inheritedLabel: 'Inherited by placements without a poll override',
+      visibility: 'advanced',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'poll',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'busy', label: 'busy' },
+          { value: 'sleep', label: 'sleep' }
+        ]
+      }
+    },
+    {
+      id: 'slot-prompt-similarity',
+      categoryId: 'runtime',
+      icon: 'gauge',
+      label: 'Slot prompt similarity',
+      description: 'Tune the similarity threshold used when comparing slot prompts before reuse.',
+      inheritedLabel: 'Inherited by placements without a slot similarity override',
+      visibility: 'advanced',
+      tomlSection: THROUGHPUT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'range',
+        name: 'slot_prompt_similarity',
+        value: '0.50',
+        min: 0,
+        max: 1,
+        step: 0.01
+      }
+    },
+    {
+      id: 'gpu-layers',
+      categoryId: 'runtime',
+      icon: 'layers',
+      label: 'GPU layers',
+      description: 'Set the GPU layer count, or use auto. The backend also accepts -1 to mean all layers.',
+      inheritedLabel: 'Inherited by placements without a GPU layer override',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'text',
+        name: 'gpu_layers',
+        value: 'auto',
+        placeholder: 'auto or integer layer count'
+      }
+    },
+    {
+      id: 'mmap',
+      categoryId: 'runtime',
+      icon: 'memory',
+      label: 'Memory map',
+      description: 'Choose whether model files are memory-mapped when loaded.',
+      inheritedLabel: 'Inherited by placements without a memory-map override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'mmap',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'mlock',
+      categoryId: 'runtime',
+      icon: 'shield',
+      label: 'Memory lock',
+      description: 'Choose whether loaded model pages should be locked into RAM.',
+      inheritedLabel: 'Inherited by placements without a memory-lock override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'mlock',
+        value: 'off',
+        presentation: 'toggle',
+        options: [
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'warmup',
+      categoryId: 'runtime',
+      icon: 'zap',
+      label: 'Warmup',
+      description: 'Choose whether the runtime should perform a warmup pass after load.',
+      inheritedLabel: 'Inherited by placements without a warmup override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'warmup',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'direct-io',
+      categoryId: 'runtime',
+      icon: 'folder',
+      label: 'Direct I/O',
+      description: 'Choose whether model files are opened with direct I/O when supported.',
+      inheritedLabel: 'Inherited by placements without a direct I/O override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'direct_io',
+        value: 'off',
+        presentation: 'toggle',
+        options: [
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'split-mode',
+      categoryId: 'runtime',
+      icon: 'layers',
+      label: 'Split mode',
+      description: 'Choose how layers are split across devices when model sharding is enabled.',
+      inheritedLabel: 'Inherited by placements without a split-mode override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'split_mode',
+        value: 'auto',
+        presentation: 'select',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'none', label: 'none' },
+          { value: 'layer', label: 'layer' },
+          { value: 'row', label: 'row' }
+        ]
+      }
+    },
+    {
+      id: 'main-gpu',
+      categoryId: 'runtime',
+      icon: 'server',
+      label: 'Main GPU',
+      description: 'Select the primary GPU index used for loading and dispatch.',
+      inheritedLabel: 'Inherited by placements without a main-GPU override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'main_gpu', value: '0', min: 0, max: 7, step: 1, unit: 'GPU index' }
+    },
+    {
+      id: 'tensor-split',
+      categoryId: 'runtime',
+      icon: 'layers',
+      label: 'Tensor split',
+      description: 'Set the tensor split ratios for multi-GPU placement, for example 0.5,0.5.',
+      inheritedLabel: 'Inherited by placements without a tensor-split override',
+      visibility: 'advanced',
+      tomlSection: HARDWARE_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'text', name: 'tensor_split', value: '', placeholder: 'e.g. 0.5,0.5' }
+    },
     {
       id: 'parallel-slots',
       categoryId: 'runtime',
@@ -647,17 +992,6 @@ export const CONFIGURATION_DEFAULTS = {
       control: { kind: 'text', name: 'device', value: '', placeholder: 'cuda:0 or CUDA0' }
     },
     {
-      id: 'gpu-layers',
-      categoryId: 'runtime',
-      tomlSection: 'defaults.hardware',
-      tomlKey: 'gpu_layers',
-      icon: 'layers',
-      label: 'GPU layers',
-      description: 'Set the default llama.cpp GPU layer count; -1 keeps the runtime in auto/all-layers mode.',
-      inheritedLabel: 'Applies when a placement does not override hardware.gpu_layers',
-      control: { kind: 'range', name: 'gpu_layers', value: '-1', min: -1, max: 256, step: 1, unit: 'layers' }
-    },
-    {
       id: 'kv-cache',
       categoryId: 'memory',
       tomlSection: 'defaults.model_fit',
@@ -690,6 +1024,194 @@ export const CONFIGURATION_DEFAULTS = {
       control: { kind: 'range', name: 'safety_margin_gb', value: '2', min: 0, max: 8, step: 0.5, unit: 'GB' }
     },
     {
+      id: 'ctx-size',
+      categoryId: 'memory',
+      icon: 'gauge',
+      label: 'Context window size',
+      description: 'Set the default context window size in tokens.',
+      inheritedLabel: 'Applied when a placement does not override context size',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'ctx_size', value: '512', min: 512, max: 131072, step: 512, unit: 'tokens' }
+    },
+    {
+      id: 'batch',
+      categoryId: 'memory',
+      icon: 'layers',
+      label: 'Batch size',
+      description: 'Set the default prefill batch size.',
+      inheritedLabel: 'Applied when a placement does not override batch size',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'batch', value: '512', min: 32, max: 4096, step: 32, unit: 'tokens' }
+    },
+    {
+      id: 'ubatch',
+      categoryId: 'memory',
+      icon: 'layers',
+      label: 'Micro-batch size',
+      description: 'Set the default decode micro-batch size.',
+      inheritedLabel: 'Applied when a placement does not override micro-batch size',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'ubatch', value: '512', min: 32, max: 4096, step: 32, unit: 'tokens' }
+    },
+    {
+      id: 'cache-type-k',
+      categoryId: 'memory',
+      icon: 'filter',
+      label: 'KV cache type (K)',
+      description: 'Choose the KV cache dtype used for keys.',
+      inheritedLabel: 'Applied when a placement does not override key cache dtype',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'cache_type_k',
+        value: 'f16',
+        presentation: 'segmented',
+        options: [
+          { value: 'f16', label: 'f16' },
+          { value: 'q8_0', label: 'q8_0' },
+          { value: 'q4_0', label: 'q4_0' }
+        ]
+      }
+    },
+    {
+      id: 'cache-type-v',
+      categoryId: 'memory',
+      icon: 'filter',
+      label: 'KV cache type (V)',
+      description: 'Choose the KV cache dtype used for values.',
+      inheritedLabel: 'Applied when a placement does not override value cache dtype',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'cache_type_v',
+        value: 'f16',
+        presentation: 'segmented',
+        options: [
+          { value: 'f16', label: 'f16' },
+          { value: 'q8_0', label: 'q8_0' },
+          { value: 'q4_0', label: 'q4_0' }
+        ]
+      }
+    },
+    {
+      id: 'kv-offload',
+      categoryId: 'memory',
+      icon: 'server',
+      label: 'KV offload',
+      description: 'Choose whether KV cache offloading stays enabled.',
+      inheritedLabel: 'Applied when a placement does not override KV offload',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'kv_offload',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'kv-unified',
+      categoryId: 'memory',
+      icon: 'memory',
+      label: 'Unified KV',
+      description: 'Choose whether sequences share one unified KV buffer.',
+      inheritedLabel: 'Applied when a placement does not override unified KV',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'kv_unified',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'cache-ram-mib',
+      categoryId: 'memory',
+      icon: 'memory',
+      label: 'Prompt cache RAM',
+      description: 'Set the maximum prompt cache size in MiB. Use 0 to disable the cache.',
+      inheritedLabel: 'Applied when a placement does not override prompt cache RAM',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'cache_ram_mib', value: '8192', min: 0, max: 65536, step: 256, unit: 'MiB' }
+    },
+    {
+      id: 'cache-idle-slots',
+      categoryId: 'memory',
+      icon: 'layers',
+      label: 'Idle slot caching',
+      description: 'Save and clear idle slots when a new task starts; requires unified KV and cache RAM.',
+      inheritedLabel: 'Applied when a placement does not override idle slot caching',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'cache_idle_slots', value: '4', min: 0, max: 64, step: 1, unit: 'slots' }
+    },
+    {
+      id: 'prompt-cache',
+      categoryId: 'memory',
+      icon: 'filter',
+      label: 'Prompt cache',
+      description: 'Choose whether prompt caching stays auto-managed or explicitly on or off.',
+      inheritedLabel: 'Applied when a placement does not override prompt caching',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'prompt_cache',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'context-shift',
+      categoryId: 'memory',
+      icon: 'layers',
+      label: 'Context shift',
+      description: 'Allow context shifting for long-running generations when supported, or leave it on auto.',
+      inheritedLabel: 'Applied when a placement does not override context shift',
+      visibility: 'advanced',
+      tomlSection: MODEL_FIT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'context_shift',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
       id: 'speculation-mode',
       categoryId: 'speculative-decoding',
       tomlSection: 'defaults.speculative',
@@ -720,6 +1242,7 @@ export const CONFIGURATION_DEFAULTS = {
       label: 'Default draft selection policy',
       description: 'Choose how draft models are selected when draft-model speculation is active.',
       inheritedLabel: 'Controls whether Mesh chooses a draft from catalog metadata',
+      dependsOn: DRAFT_MODEL_SPECULATION_DEPENDENCY,
       control: {
         kind: 'choice',
         name: 'draft_selection_policy',
@@ -740,6 +1263,7 @@ export const CONFIGURATION_DEFAULTS = {
       label: 'Incompatible pairing behavior',
       description: 'Choose what happens when the draft and target models cannot pair.',
       inheritedLabel: 'Determines launch behavior when draft and target models cannot pair',
+      dependsOn: DRAFT_MODEL_SPECULATION_DEPENDENCY,
       control: {
         kind: 'choice',
         name: 'pairing_fault',
@@ -760,7 +1284,35 @@ export const CONFIGURATION_DEFAULTS = {
       label: 'Default draft max tokens',
       description: 'Limit how many draft tokens can be proposed before verification.',
       inheritedLabel: 'Higher values can improve throughput when acceptance stays high',
+      dependsOn: DRAFT_MODEL_SPECULATION_DEPENDENCY,
       control: { kind: 'range', name: 'draft_max_tokens', value: '16', min: 1, max: 64, step: 1, unit: 'tokens' }
+    },
+    {
+      id: 'draft-min-tokens',
+      categoryId: 'speculative-decoding',
+      tomlSection: 'defaults.speculative',
+      tomlKey: 'draft_min_tokens',
+      icon: 'gauge',
+      label: 'Default draft minimum tokens',
+      description: 'Set the smallest draft batch attempted before verification.',
+      inheritedLabel: '0 lets the runtime verify as soon as the draft becomes uncertain',
+      mutability: 'restart-required',
+      dependsOn: DRAFT_MODEL_SPECULATION_DEPENDENCY,
+      control: { kind: 'range', name: 'draft_min_tokens', value: '0', min: 0, max: 32, step: 1, unit: 'tokens' }
+    },
+    {
+      id: 'draft-acceptance-threshold',
+      categoryId: 'speculative-decoding',
+      tomlSection: 'defaults.speculative',
+      tomlKey: 'draft_acceptance_threshold',
+      icon: 'gauge',
+      label: 'Default draft acceptance threshold',
+      description: 'Set the confidence needed before draft tokens are accepted.',
+      inheritedLabel: 'Lower values speculate more aggressively; higher values reject earlier',
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      dependsOn: DRAFT_MODEL_SPECULATION_DEPENDENCY,
+      control: { kind: 'range', name: 'draft_acceptance_threshold', value: '0.70', min: 0, max: 1, step: 0.05 }
     },
     {
       id: 'temperature',
@@ -837,12 +1389,489 @@ export const CONFIGURATION_DEFAULTS = {
       description: 'Set how much recent token history the repeat penalty checks.',
       inheritedLabel: 'Inherited by placements with default sampling',
       control: { kind: 'range', name: 'repeat_last_n', value: '256', min: 0, max: 1024, step: 32, unit: 'tok' }
+    },
+    {
+      id: 'top-k',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Top-k',
+      description: 'Limit sampling to the top-k tokens.',
+      inheritedLabel: 'Applied when a request does not override top-k',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: { kind: 'range', name: 'top_k', value: '40', min: 0, max: 100, step: 1 }
+    },
+    {
+      id: 'min-p',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Min-p',
+      description: 'Filter tokens below a dynamic probability floor.',
+      inheritedLabel: 'Applied when a request does not override min-p',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: { kind: 'range', name: 'min_p', value: '0.05', min: 0, max: 1, step: 0.05 }
+    },
+    {
+      id: 'presence-penalty',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Presence penalty',
+      description: 'Increase or reduce the penalty for introducing new tokens.',
+      inheritedLabel: 'Applied when a request does not override presence penalty',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: { kind: 'range', name: 'presence_penalty', value: '0', min: 0, max: 2, step: 0.1 }
+    },
+    {
+      id: 'frequency-penalty',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Frequency penalty',
+      description: 'Increase or reduce the penalty for repeated tokens.',
+      inheritedLabel: 'Applied when a request does not override frequency penalty',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: { kind: 'range', name: 'frequency_penalty', value: '0', min: 0, max: 2, step: 0.1 }
+    },
+    {
+      id: 'max-tokens',
+      categoryId: 'request-defaults',
+      icon: 'gauge',
+      label: 'Max tokens',
+      description: 'Cap the number of generated tokens for a request.',
+      inheritedLabel: 'Applied when a request does not override the token cap',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: { kind: 'range', name: 'max_tokens', value: '0', min: 0, max: 32768, step: 256, unit: 'tokens' }
+    },
+    {
+      id: 'seed',
+      categoryId: 'request-defaults',
+      icon: 'cog',
+      label: 'Seed',
+      description: 'Set the RNG seed for deterministic sampling when needed.',
+      inheritedLabel: 'Applied when a request does not override the seed',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: { kind: 'text', name: 'seed', value: '-1', placeholder: '-1 (random)' }
+    },
+    {
+      id: 'ignore-eos',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Ignore EOS',
+      description: 'Choose whether the model should ignore end-of-sequence tokens.',
+      inheritedLabel: 'Applied when a request does not override EOS handling',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: {
+        kind: 'choice',
+        name: 'ignore_eos',
+        value: 'off',
+        presentation: 'toggle',
+        options: [
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'mirostat-mode',
+      categoryId: 'request-defaults',
+      icon: 'brain',
+      label: 'Mirostat mode',
+      description: 'Choose the Mirostat sampling mode, or disable it.',
+      inheritedLabel: 'Applied when a request does not override Mirostat mode',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: {
+        kind: 'choice',
+        name: 'mirostat_mode',
+        value: 'disabled',
+        presentation: 'segmented',
+        options: [
+          { value: 'disabled', label: 'disabled' },
+          { value: '1', label: '1' },
+          { value: '2', label: '2' }
+        ]
+      }
+    },
+    {
+      id: 'mirostat-entropy',
+      categoryId: 'request-defaults',
+      icon: 'gauge',
+      label: 'Mirostat entropy',
+      description: 'Set the Mirostat target entropy.',
+      inheritedLabel: 'Applied when Mirostat mode is enabled',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      dependsOn: MIROSTAT_MODE_DEPENDENCY,
+      control: { kind: 'range', name: 'mirostat_entropy', value: '5', min: 0.1, max: 10, step: 0.1 }
+    },
+    {
+      id: 'mirostat-learning-rate',
+      categoryId: 'request-defaults',
+      icon: 'gauge',
+      label: 'Mirostat learning rate',
+      description: 'Set the Mirostat learning rate.',
+      inheritedLabel: 'Applied when Mirostat mode is enabled',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      dependsOn: MIROSTAT_MODE_DEPENDENCY,
+      control: { kind: 'range', name: 'mirostat_learning_rate', value: '0.1', min: 0.01, max: 1, step: 0.01 }
+    },
+    {
+      id: 'samplers',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Samplers',
+      description: 'Set the comma-separated sampler list.',
+      inheritedLabel: 'Applied when a request does not override the sampler list',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: {
+        kind: 'text',
+        name: 'samplers',
+        value: '',
+        placeholder: 'top_k,tfs_z,typical_p,top_p,min_p,temperature'
+      }
+    },
+    {
+      id: 'sampler-sequence',
+      categoryId: 'request-defaults',
+      icon: 'layers',
+      label: 'Sampler sequence',
+      description: 'Set the sampler execution order.',
+      inheritedLabel: 'Applied when a request does not override sampler ordering',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: {
+        kind: 'text',
+        name: 'sampler_sequence',
+        value: '',
+        placeholder: 'e.g. top_k;top_p;temperature'
+      }
+    },
+    {
+      id: 'stop',
+      categoryId: 'request-defaults',
+      icon: 'shield',
+      label: 'Stop sequences',
+      description: 'Set comma-separated stop sequences for a request.',
+      inheritedLabel: 'Applied when a request does not override stop sequences',
+      visibility: 'advanced',
+      tomlSection: REQUEST_DEFAULTS_TOML_SECTION,
+      mutability: 'runtime',
+      control: {
+        kind: 'text',
+        name: 'stop',
+        value: '',
+        placeholder: 'comma-separated stop sequences'
+      }
+    },
+    {
+      id: 'activation-wire-dtype',
+      categoryId: 'skippy-transport',
+      icon: 'zap',
+      label: 'Activation wire dtype',
+      description: 'Choose the dtype used when activation frames travel between skippy stages.',
+      inheritedLabel: 'Inherited by stage chains without a wire-dtype override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'activation_wire_dtype',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'f16', label: 'f16' },
+          { value: 'f32', label: 'f32' },
+          { value: 'q8', label: 'q8' }
+        ]
+      }
+    },
+    {
+      id: 'stage-model-path',
+      categoryId: 'skippy-transport',
+      icon: 'folder',
+      label: 'Stage model path',
+      description: 'Set the model or package path used for this skippy stage.',
+      inheritedLabel: 'Inherited by stage chains without an explicit model path',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      control: {
+        kind: 'text',
+        name: 'stage_model_path',
+        value: '',
+        placeholder: 'e.g. hf://meshllm/... or /path/to/stage.gguf'
+      }
+    },
+    {
+      id: 'stage-role',
+      categoryId: 'skippy-transport',
+      icon: 'server',
+      label: 'Stage role',
+      description: 'Choose the stage-chain role when topology is not inferred automatically.',
+      inheritedLabel: 'Inherited by stage chains without an explicit role override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'stage_role',
+        value: 'auto',
+        presentation: 'select',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'prompt', label: 'prompt' },
+          { value: 'stage', label: 'stage' }
+        ]
+      }
+    },
+    {
+      id: 'stage-topology',
+      categoryId: 'skippy-transport',
+      icon: 'layers',
+      label: 'Stage topology',
+      description: 'Describe the stage chain topology when it is supplied as a text override.',
+      inheritedLabel: 'Inherited by stage chains without a topology override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      control: {
+        kind: 'text',
+        name: 'stage_topology',
+        value: '',
+        placeholder: 'topology name or path'
+      }
+    },
+    {
+      id: 'prefill-chunking',
+      categoryId: 'skippy-transport',
+      icon: 'layers',
+      label: 'Prefill chunking',
+      description: 'Choose how prefill chunks are scheduled across a skippy stage chain.',
+      inheritedLabel: 'Inherited by stage chains without a chunking override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'prefill_chunking',
+        value: 'auto',
+        presentation: 'select',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'fixed', label: 'fixed' },
+          { value: 'schedule', label: 'schedule' },
+          { value: 'adaptive-ramp', label: 'adaptive-ramp' }
+        ]
+      }
+    },
+    {
+      id: 'prefill-chunk-size',
+      categoryId: 'skippy-transport',
+      icon: 'gauge',
+      label: 'Prefill chunk size',
+      description: 'Set the fixed prefill chunk size. Use 0 to keep the backend auto sentinel.',
+      inheritedLabel: 'Inherited by fixed chunking when a stage does not override the size',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      mutability: 'restart-required',
+      dependsOn: PREFILL_CHUNKING_FIXED_DEPENDENCY,
+      control: { kind: 'range', name: 'prefill_chunk_size', value: '0', min: 0, max: 8192, step: 64, unit: 'tokens' }
+    },
+    {
+      id: 'prefill-chunk-schedule',
+      categoryId: 'skippy-transport',
+      icon: 'layers',
+      label: 'Prefill chunk schedule',
+      description: 'Provide a comma-separated schedule for scheduled prefill chunking.',
+      inheritedLabel: 'Inherited by scheduled chunking when a stage does not override the schedule',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      dependsOn: PREFILL_CHUNKING_SCHEDULE_DEPENDENCY,
+      control: {
+        kind: 'text',
+        name: 'prefill_chunk_schedule',
+        value: '',
+        placeholder: 'e.g. 512,1024,2048'
+      }
+    },
+    {
+      id: 'binary-stage-transport',
+      categoryId: 'skippy-transport',
+      icon: 'binary',
+      label: 'Binary stage transport',
+      description: 'Choose whether the binary stage transport is enabled or left to auto selection.',
+      inheritedLabel: 'Inherited by stage chains without a transport override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'binary_stage_transport',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'lifecycle-startup-timeout-ms',
+      categoryId: 'skippy-transport',
+      icon: 'gauge',
+      label: 'Lifecycle startup timeout',
+      description: 'Set how long the orchestrator waits for a stage to become ready during startup.',
+      inheritedLabel: 'Inherited by stage chains without a startup timeout override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      control: {
+        kind: 'range',
+        name: 'lifecycle_startup_timeout_ms',
+        value: '30000',
+        min: 1,
+        max: 600000,
+        step: 1000,
+        unit: 'ms'
+      }
+    },
+    {
+      id: 'lifecycle-readiness-interval-ms',
+      categoryId: 'skippy-transport',
+      icon: 'gauge',
+      label: 'Lifecycle readiness interval',
+      description: 'Set how often readiness is re-checked while startup is in flight.',
+      inheritedLabel: 'Inherited by stage chains without a readiness polling override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      control: {
+        kind: 'range',
+        name: 'lifecycle_readiness_interval_ms',
+        value: '1000',
+        min: 100,
+        max: 60000,
+        step: 100,
+        unit: 'ms'
+      }
+    },
+    {
+      id: 'lifecycle-health-interval-ms',
+      categoryId: 'skippy-transport',
+      icon: 'shield',
+      label: 'Lifecycle health interval',
+      description: 'Set how often background health checks run after a stage is up.',
+      inheritedLabel: 'Inherited by stage chains without a health polling override',
+      tomlSection: SKIPPY_TRANSPORT_TOML_SECTION,
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      control: {
+        kind: 'range',
+        name: 'lifecycle_health_interval_ms',
+        value: '15000',
+        min: 100,
+        max: 60000,
+        step: 100,
+        unit: 'ms'
+      }
+    },
+    {
+      id: 'mmproj-offload',
+      categoryId: 'multimodal',
+      icon: 'image',
+      label: 'MMProj offload',
+      description: 'Choose whether the multimodal projector stays auto-managed or explicitly on or off.',
+      inheritedLabel: 'Inherited by placements without a projector-offload override',
+      tomlSection: MULTIMODAL_TOML_SECTION,
+      mutability: 'restart-required',
+      control: {
+        kind: 'choice',
+        name: 'mmproj_offload',
+        value: 'auto',
+        presentation: 'segmented',
+        options: [
+          { value: 'auto', label: 'auto' },
+          { value: 'on', label: 'on' },
+          { value: 'off', label: 'off' }
+        ]
+      }
+    },
+    {
+      id: 'image-min-tokens',
+      categoryId: 'multimodal',
+      icon: 'image',
+      label: 'Image minimum tokens',
+      description: 'Set the minimum token budget reserved for each image input.',
+      inheritedLabel: 'Inherited by placements without an image minimum override',
+      tomlSection: MULTIMODAL_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'image_min_tokens', value: '0', min: 0, max: 2048, step: 32, unit: 'tokens' }
+    },
+    {
+      id: 'image-max-tokens',
+      categoryId: 'multimodal',
+      icon: 'image',
+      label: 'Image maximum tokens',
+      description: 'Set the maximum token budget allowed for each image input.',
+      inheritedLabel: 'Inherited by placements without an image maximum override',
+      tomlSection: MULTIMODAL_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'range', name: 'image_max_tokens', value: '2048', min: 0, max: 4096, step: 32, unit: 'tokens' }
+    },
+    {
+      id: 'mmproj',
+      categoryId: 'multimodal',
+      icon: 'image',
+      label: 'MMProj path',
+      description: 'Set an explicit local path to the multimodal projector file.',
+      inheritedLabel: 'Inherited by placements without an explicit projector path',
+      visibility: 'advanced',
+      tomlSection: MULTIMODAL_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'text', name: 'mmproj', value: '', placeholder: 'e.g. /path/to/mmproj.gguf' }
+    },
+    {
+      id: 'mmproj-url',
+      categoryId: 'multimodal',
+      icon: 'image',
+      label: 'MMProj URL',
+      description: 'Set a URL used to download or reference the multimodal projector file.',
+      inheritedLabel: 'Inherited by placements without a projector URL override',
+      visibility: 'advanced',
+      tomlSection: MULTIMODAL_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'text', name: 'mmproj_url', value: '', placeholder: 'e.g. https://example.com/mmproj.gguf' }
+    },
+    {
+      id: 'server-alias',
+      categoryId: 'advanced-server',
+      icon: 'server',
+      label: 'Server alias',
+      description: 'Set a human-friendly alias for the server in advanced deployments.',
+      inheritedLabel: 'Inherited by deployments without an explicit server alias',
+      visibility: 'advanced',
+      tomlSection: ADVANCED_SERVER_TOML_SECTION,
+      mutability: 'restart-required',
+      control: { kind: 'text', name: 'alias', value: '', placeholder: 'model alias' }
     }
   ],
   preview: [
     { label: 'Scope', value: 'carrack only', meta: 'remote nodes are read-only context' },
     { label: 'Config path', value: '~/.mesh-llm/config.toml' },
-    { label: 'Generated defaults', value: '16 settings', meta: 'deployment overrides win' },
+    { label: 'Generated defaults', value: '73 settings', meta: 'deployment overrides win' },
     { label: 'Signing', value: 'Unsigned', meta: 'attestation pending' }
   ]
 } as const

--- a/crates/mesh-llm-ui/src/features/app-tabs/types.test.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/types.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  ConfigurationDefaultsCategory,
+  ConfigurationDefaultsCategoryId,
+  ConfigurationDefaultsControl,
+  ConfigurationDefaultsSetting,
+  ConfigurationDefaultsSettingIcon
+} from '@/features/app-tabs/types'
+
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type -- Type-level check for optional keys
+type OptionalKey<T, K extends keyof T> = {} extends Pick<T, K> ? true : false
+
+const VISIBILITY_OPTIONAL = true satisfies OptionalKey<ConfigurationDefaultsSetting, 'visibility'>
+const MUTABILITY_OPTIONAL = true satisfies OptionalKey<ConfigurationDefaultsSetting, 'mutability'>
+const DEPENDS_ON_OPTIONAL = true satisfies OptionalKey<ConfigurationDefaultsSetting, 'dependsOn'>
+
+describe('configuration defaults type contracts', () => {
+  it('accepts the expanded category and icon unions without changing control kinds', () => {
+    const categoryIds = [
+      'runtime',
+      'memory',
+      'speculative-decoding',
+      'advanced',
+      'request-defaults',
+      'skippy-transport',
+      'multimodal',
+      'advanced-server'
+    ] as const satisfies readonly ConfigurationDefaultsCategoryId[]
+
+    const iconNames = [
+      'brain',
+      'cpu',
+      'layers',
+      'memory',
+      'binary',
+      'folder',
+      'gauge',
+      'shield',
+      'cog',
+      'filter',
+      'zap',
+      'image',
+      'server'
+    ] as const satisfies readonly ConfigurationDefaultsSettingIcon[]
+
+    const controlKinds = [
+      'choice',
+      'text',
+      'range',
+      'metric'
+    ] as const satisfies readonly ConfigurationDefaultsControl['kind'][]
+
+    expect(categoryIds).toContain('request-defaults')
+    expect(iconNames).toContain('server')
+    expect(controlKinds).toEqual(['choice', 'text', 'range', 'metric'])
+    expect(VISIBILITY_OPTIONAL).toBe(true)
+    expect(MUTABILITY_OPTIONAL).toBe(true)
+    expect(DEPENDS_ON_OPTIONAL).toBe(true)
+  })
+
+  it('keeps the existing exported defaults inventory type-compatible', () => {
+    const expandedSetting = {
+      id: 'transport-buffering',
+      categoryId: 'skippy-transport',
+      icon: 'server',
+      label: 'Transport buffering',
+      description: 'Buffer stage transport messages before dispatch.',
+      inheritedLabel: 'Inherited by stage transport children',
+      visibility: 'advanced',
+      mutability: 'restart-required',
+      dependsOn: {
+        settingId: 'speculation-mode',
+        condition: (value: string) => value === 'draft_model'
+      },
+      control: {
+        kind: 'choice',
+        name: 'transport_buffering',
+        value: 'enabled',
+        options: [
+          { value: 'enabled', label: 'enabled' },
+          { value: 'disabled', label: 'disabled' }
+        ]
+      }
+    } satisfies ConfigurationDefaultsSetting
+
+    expect(expandedSetting.dependsOn?.condition('draft_model')).toBe(true)
+  })
+
+  it('allows tomlSection on categories and settings', () => {
+    const category = {
+      id: 'request-defaults',
+      label: 'Request Defaults',
+      summary: 'Sampling and response defaults.',
+      help: 'Sampling, stopping, and repeat-penalty defaults',
+      tomlSection: 'defaults.request_defaults'
+    } satisfies ConfigurationDefaultsCategory
+
+    const setting = {
+      id: 'top-k',
+      categoryId: 'request-defaults',
+      icon: 'filter',
+      label: 'Top-k',
+      description: 'Limit sampling to the top-k tokens.',
+      inheritedLabel: 'Applied when a request does not override top-k',
+      tomlSection: 'defaults.request_defaults',
+      mutability: 'runtime',
+      control: {
+        kind: 'range',
+        name: 'top_k',
+        value: '40',
+        min: 0,
+        max: 100,
+        step: 1
+      }
+    } satisfies ConfigurationDefaultsSetting
+
+    expect(category.tomlSection).toBe('defaults.request_defaults')
+    expect(setting.tomlSection).toBe('defaults.request_defaults')
+  })
+})

--- a/crates/mesh-llm-ui/src/features/app-tabs/types.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/types.ts
@@ -251,7 +251,15 @@ export type ConfigModel = {
   tags: string[]
 }
 export type ConfigAssign = { id: string; modelId: string; nodeId: string; containerIdx: number; ctx: number }
-export type ConfigurationDefaultsCategoryId = 'runtime' | 'memory' | 'speculative-decoding' | 'request-defaults'
+export type ConfigurationDefaultsCategoryId =
+  | 'runtime'
+  | 'memory'
+  | 'speculative-decoding'
+  | 'advanced'
+  | 'request-defaults'
+  | 'skippy-transport'
+  | 'multimodal'
+  | 'advanced-server'
 export type ConfigurationTomlSectionId =
   | 'defaults.model_fit'
   | 'defaults.hardware'
@@ -266,6 +274,7 @@ export type ConfigurationDefaultsCategory = {
   label: string
   summary: string
   help: string
+  tomlSection?: ConfigurationTomlSectionId
 }
 export type ConfigurationDefaultsChoice = { value: string; label: string; description?: string }
 export type ConfigurationDefaultsControl =
@@ -290,16 +299,22 @@ export type ConfigurationDefaultsSettingIcon =
   | 'shield'
   | 'cog'
   | 'filter'
+  | 'zap'
+  | 'image'
+  | 'server'
 export type ConfigurationDefaultsSetting = {
   id: string
   categoryId: ConfigurationDefaultsCategoryId
-  tomlSection: ConfigurationTomlSectionId
-  tomlKey: string
+  tomlSection?: ConfigurationTomlSectionId
+  tomlKey?: string
   icon: ConfigurationDefaultsSettingIcon
   label: string
   description: string
   inheritedLabel: string
   control: ConfigurationDefaultsControl
+  visibility?: 'standard' | 'advanced'
+  mutability?: 'runtime' | 'restart-required'
+  dependsOn?: { settingId: string; condition: (value: string) => boolean }
 }
 export type ConfigurationDefaultsPreviewItem = { label: string; value: string; meta?: string }
 export type ConfigurationDefaultsValues = Record<string, string>

--- a/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { adaptStatusToConfiguration } from '@/features/configuration/api/config-adapter'
+import {
+  adaptStatusToConfiguration,
+  createConfigurationDefaultsValuesFromMeshConfig,
+  mergeConfigurationDefaultsIntoMeshConfig,
+  runtimeControlApplyErrorMessage,
+  type RuntimeControlMeshConfig
+} from '@/features/configuration/api/config-adapter'
 import type { MeshModelRaw, StatusPayload } from '@/lib/api/types'
 
 const STATUS_PAYLOAD: StatusPayload = {
@@ -65,5 +71,209 @@ describe('adaptStatusToConfiguration', () => {
         vision: false
       })
     )
+  })
+
+  it('overlays hydrated runtime-control defaults onto the harness settings', () => {
+    const defaultsValues = createConfigurationDefaultsValuesFromMeshConfig({
+      defaults: {
+        throughput: {
+          threads: 12
+        },
+        hardware: {
+          mlock: true
+        },
+        model_fit: {
+          kv_cache_policy: 'quality'
+        },
+        speculative: {
+          draft_max_tokens: 24
+        },
+        request_defaults: {
+          temperature: 0.8,
+          top_p: 0.95,
+          reasoning_format: 'qwen',
+          top_k: 55,
+          repeat_penalty: 1.35,
+          repeat_last_n: 384
+        },
+        skippy: {
+          activation_wire_dtype: 'q8'
+        },
+        multimodal: {
+          image_min_tokens: 64
+        },
+        advanced: {
+          server: {
+            alias: 'carrack-mesh'
+          }
+        }
+      }
+    })
+
+    const configuration = adaptStatusToConfiguration(STATUS_PAYLOAD, [], defaultsValues)
+    const values = Object.fromEntries(
+      configuration.defaults.settings.map((setting) => [setting.id, setting.control.value])
+    )
+
+    expect(values['threads']).toBe('12')
+    expect(values['mlock']).toBe('on')
+    expect(values['kv-cache']).toBe('quality')
+    expect(values['draft-max-tokens']).toBe('24')
+    expect(values['temperature']).toBe('0.8')
+    expect(values['top-p']).toBe('0.95')
+    expect(values['reasoning-format']).toBe('qwen')
+    expect(values['top-k']).toBe('55')
+    expect(values['repeat-penalty']).toBe('1.35')
+    expect(values['repeat-last-n']).toBe('384')
+    expect(values['activation-wire-dtype']).toBe('q8')
+    expect(values['image-min-tokens']).toBe('64')
+    expect(values['server-alias']).toBe('carrack-mesh')
+  })
+
+  it('merges only modified defaults back into the full mesh config without dropping unrelated fields', () => {
+    const meshConfig: RuntimeControlMeshConfig = {
+      version: 1,
+      owner_control: {
+        bind: '127.0.0.1:7447'
+      },
+      telemetry: {
+        enabled: true
+      },
+      models: [{ model: 'hf://meshllm/base@main:Q4_K_M', ctx_size: 8192 }],
+      plugin: [{ name: 'telemetry', enabled: true }],
+      defaults: {
+        throughput: {
+          threads: 6
+        },
+        hardware: {
+          mlock: false
+        },
+        request_defaults: {
+          temperature: 0.8,
+          reasoning_format: 'deepseek'
+        },
+        speculative: {
+          draft_max_tokens: 16
+        },
+        advanced: {
+          server: {
+            alias: 'existing-alias'
+          }
+        }
+      }
+    }
+
+    const merged = mergeConfigurationDefaultsIntoMeshConfig(meshConfig, {
+      threads: '0',
+      mlock: 'off',
+      'reasoning-format': 'qwen',
+      temperature: '1.0',
+      'top-p': '1.0',
+      'top-k': '55',
+      'draft-max-tokens': '16',
+      'repeat-last-n': '64',
+      'activation-wire-dtype': 'auto',
+      'image-min-tokens': '0',
+      'server-alias': 'carrack-mesh'
+    })
+
+    expect(merged).toEqual({
+      version: 1,
+      owner_control: {
+        bind: '127.0.0.1:7447'
+      },
+      telemetry: {
+        enabled: true
+      },
+      models: [{ model: 'hf://meshllm/base@main:Q4_K_M', ctx_size: 8192 }],
+      plugin: [{ name: 'telemetry', enabled: true }],
+      defaults: {
+        request_defaults: {
+          reasoning_format: 'qwen',
+          temperature: 1,
+          top_p: 1,
+          top_k: 55,
+          repeat_last_n: 64
+        },
+        advanced: {
+          server: {
+            alias: 'carrack-mesh'
+          }
+        }
+      }
+    })
+    expect(meshConfig.defaults).toEqual({
+      throughput: {
+        threads: 6
+      },
+      hardware: {
+        mlock: false
+      },
+      request_defaults: {
+        temperature: 0.8,
+        reasoning_format: 'deepseek'
+      },
+      speculative: {
+        draft_max_tokens: 16
+      },
+      advanced: {
+        server: {
+          alias: 'existing-alias'
+        }
+      }
+    })
+  })
+
+  it('removes known defaults when saved UI values return to canonical defaults', () => {
+    const meshConfig: RuntimeControlMeshConfig = {
+      version: 1,
+      defaults: {
+        request_defaults: {
+          temperature: 0.7,
+          top_p: 0.82,
+          reasoning_format: 'qwen'
+        },
+        custom_extension: {
+          keep: true
+        }
+      }
+    }
+
+    const merged = mergeConfigurationDefaultsIntoMeshConfig(meshConfig, {
+      temperature: '0.70',
+      'top-p': '0.95',
+      'reasoning-format': 'auto'
+    })
+
+    expect(merged).toEqual({
+      version: 1,
+      defaults: {
+        custom_extension: {
+          keep: true
+        }
+      }
+    })
+  })
+
+  it('extracts runtime-control apply error messages from structured payloads', () => {
+    expect(
+      runtimeControlApplyErrorMessage({
+        success: false,
+        current_revision: 7,
+        config_hash: 'abc123',
+        apply_mode: 'unspecified',
+        error: { code: 'revision_conflict', message: 'config revision changed on disk' }
+      })
+    ).toBe('config revision changed on disk')
+
+    expect(
+      runtimeControlApplyErrorMessage({
+        success: false,
+        current_revision: 7,
+        config_hash: 'abc123',
+        apply_mode: 'unspecified',
+        error: { code: 'control_unavailable' }
+      })
+    ).toBe('control unavailable')
   })
 })

--- a/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.test.ts
@@ -77,10 +77,12 @@ describe('adaptStatusToConfiguration', () => {
     const defaultsValues = createConfigurationDefaultsValuesFromMeshConfig({
       defaults: {
         throughput: {
-          threads: 12
+          threads: 12,
+          parallel: 8
         },
         hardware: {
-          mlock: true
+          mlock: true,
+          safety_margin_gb: 3.5
         },
         model_fit: {
           kv_cache_policy: 'quality'
@@ -116,7 +118,9 @@ describe('adaptStatusToConfiguration', () => {
     )
 
     expect(values['threads']).toBe('12')
+    expect(values['parallel-slots']).toBe('8')
     expect(values['mlock']).toBe('on')
+    expect(values['memory-margin']).toBe('3.5')
     expect(values['kv-cache']).toBe('quality')
     expect(values['draft-max-tokens']).toBe('24')
     expect(values['temperature']).toBe('0.8')
@@ -143,10 +147,12 @@ describe('adaptStatusToConfiguration', () => {
       plugin: [{ name: 'telemetry', enabled: true }],
       defaults: {
         throughput: {
-          threads: 6
+          threads: 6,
+          parallel: 5
         },
         hardware: {
-          mlock: false
+          mlock: false,
+          safety_margin_gb: 1.5
         },
         request_defaults: {
           temperature: 0.8,
@@ -165,7 +171,9 @@ describe('adaptStatusToConfiguration', () => {
 
     const merged = mergeConfigurationDefaultsIntoMeshConfig(meshConfig, {
       threads: '0',
+      'parallel-slots': '8',
       mlock: 'off',
+      'memory-margin': '3.5',
       'reasoning-format': 'qwen',
       temperature: '1.0',
       'top-p': '1.0',
@@ -188,6 +196,12 @@ describe('adaptStatusToConfiguration', () => {
       models: [{ model: 'hf://meshllm/base@main:Q4_K_M', ctx_size: 8192 }],
       plugin: [{ name: 'telemetry', enabled: true }],
       defaults: {
+        throughput: {
+          parallel: 8
+        },
+        hardware: {
+          safety_margin_gb: 3.5
+        },
         request_defaults: {
           reasoning_format: 'qwen',
           temperature: 1,
@@ -204,10 +218,12 @@ describe('adaptStatusToConfiguration', () => {
     })
     expect(meshConfig.defaults).toEqual({
       throughput: {
-        threads: 6
+        threads: 6,
+        parallel: 5
       },
       hardware: {
-        mlock: false
+        mlock: false,
+        safety_margin_gb: 1.5
       },
       request_defaults: {
         temperature: 0.8,

--- a/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts
@@ -1,6 +1,94 @@
 import type { StatusPayload, MeshModelRaw, PeerInfo } from '@/lib/api/types'
-import type { ConfigurationHarnessData, ConfigNode, ConfigModel } from '@/features/app-tabs/types'
-import { CONFIGURATION_HARNESS } from '@/features/app-tabs/data'
+import type {
+  ConfigurationDefaultsHarnessData,
+  ConfigurationDefaultsSetting,
+  ConfigurationDefaultsValues,
+  ConfigurationHarnessData,
+  ConfigNode,
+  ConfigModel
+} from '@/features/app-tabs/types'
+import { CONFIGURATION_DEFAULTS, CONFIGURATION_HARNESS } from '@/features/app-tabs/data'
+import { getSettingBaselineValue, isSettingDisabled } from '@/features/configuration/lib/settings-utils'
+import { ApiError, parseApiErrorBody } from '@/lib/api/errors'
+import { env } from '@/lib/env'
+
+export type RuntimeControlBootstrapPayload = {
+  enabled: boolean
+  local_only: boolean
+  requires_explicit_remote_endpoint: boolean
+  endpoint?: string
+  disabled_reason?: string
+  message?: string
+  suggested_commands?: string[]
+}
+
+export type RuntimeControlDefaultsConfig = Record<string, unknown>
+
+export type RuntimeControlMeshConfig = {
+  defaults?: RuntimeControlDefaultsConfig
+  [key: string]: unknown
+}
+
+export type RuntimeControlConfigSnapshot = {
+  revision: number
+  config: RuntimeControlMeshConfig
+  [key: string]: unknown
+}
+
+type RuntimeControlConfigResponse = {
+  snapshot: RuntimeControlConfigSnapshot
+}
+
+export type RuntimeControlConfigResult = {
+  bootstrap: RuntimeControlBootstrapPayload
+  snapshot?: RuntimeControlConfigSnapshot
+}
+
+export type RuntimeControlApplyResponse = {
+  success: boolean
+  current_revision: number
+  config_hash: string
+  apply_mode: string
+  error?: unknown
+}
+
+export function runtimeControlApplyErrorMessage(response: RuntimeControlApplyResponse | null | undefined) {
+  if (!response) return undefined
+  return runtimeControlErrorMessage(response.error)
+}
+
+function runtimeControlErrorMessage(error: unknown): string | undefined {
+  if (typeof error === 'string') return error.trim() || undefined
+  if (!error || typeof error !== 'object') return undefined
+
+  const details = error as Record<string, unknown>
+  if (typeof details['message'] === 'string') return details['message'].trim() || undefined
+  if (typeof details['code'] === 'string') return details['code'].replace(/_/g, ' ')
+  return undefined
+}
+
+const LEGACY_CONTROL_DEFAULTS_SECTION_PATHS: Record<string, readonly string[]> = {
+  'parallel-slots': ['model_fit', 'parallel'],
+  'tuning-profile': ['throughput', 'tuning_profile'],
+  'flash-attention': ['model_fit', 'flash_attention'],
+  'llamacpp-flavor': ['hardware', 'model_runtime'],
+  'kv-cache': ['model_fit', 'kv_cache_policy'],
+  'memory-margin': ['model_fit', 'safety_margin_gb'],
+  'speculation-mode': ['speculative', 'mode'],
+  'draft-selection-policy': ['speculative', 'draft_selection_policy'],
+  'incompatible-pairing-behavior': ['speculative', 'pairing_fault'],
+  'draft-max-tokens': ['speculative', 'draft_max_tokens'],
+  'draft-min-tokens': ['speculative', 'draft_min_tokens'],
+  'draft-acceptance-threshold': ['speculative', 'draft_acceptance_threshold'],
+  'reasoning-format': ['request_defaults', 'reasoning_format'],
+  'reasoning-budget': ['request_defaults', 'reasoning_budget'],
+  'repeat-penalty': ['request_defaults', 'repeat_penalty'],
+  'repeat-last-n': ['request_defaults', 'repeat_last_n']
+}
+
+const CONTROL_DEFAULTS_KEY_OVERRIDES: Record<string, string> = {
+  'server-alias': 'alias'
+}
 
 function mapNodeState(state: string | undefined): 'online' | 'degraded' | 'offline' {
   if (state === 'client') return 'offline'
@@ -42,14 +130,243 @@ function adaptModelToConfigModel(model: MeshModelRaw): ConfigModel {
   }
 }
 
-export function adaptStatusToConfiguration(payload: StatusPayload, models: MeshModelRaw[]): ConfigurationHarnessData {
+function cloneControlValue(
+  control: ConfigurationDefaultsSetting['control'],
+  value: string
+): ConfigurationDefaultsSetting['control'] {
+  return { ...control, value }
+}
+
+function parseDefaultsSectionPath(section: string | undefined): string[] {
+  if (!section?.startsWith('defaults.')) return []
+  return section.slice('defaults.'.length).split('.').filter(Boolean)
+}
+
+function resolveControlDefaultsPath(setting: ConfigurationDefaultsSetting): string[] {
+  const legacyPath = LEGACY_CONTROL_DEFAULTS_SECTION_PATHS[setting.id]
+  if (legacyPath) return [...legacyPath]
+
+  const key =
+    CONTROL_DEFAULTS_KEY_OVERRIDES[setting.id] ?? ('name' in setting.control ? setting.control.name : setting.id)
+  const categorySection = CONFIGURATION_DEFAULTS.categories.find((category) => category.id === setting.categoryId) as
+    | { tomlSection?: string }
+    | undefined
+  const sectionPath = parseDefaultsSectionPath(setting.tomlSection ?? categorySection?.tomlSection)
+
+  return [...sectionPath, key]
+}
+
+function overlayDefaultsValues(
+  harnessDefaults: ConfigurationDefaultsHarnessData,
+  defaultsValues: ConfigurationDefaultsValues
+): ConfigurationDefaultsHarnessData {
+  return {
+    ...harnessDefaults,
+    settings: harnessDefaults.settings.map((setting) => ({
+      ...setting,
+      control: cloneControlValue(setting.control, defaultsValues[setting.id] ?? setting.control.value)
+    }))
+  }
+}
+
+function readPath(source: unknown, path: readonly string[]): unknown {
+  let current = source
+  for (const segment of path) {
+    if (!current || typeof current !== 'object' || !(segment in current)) return undefined
+    current = (current as Record<string, unknown>)[segment]
+  }
+  return current
+}
+
+function writePath(target: Record<string, unknown>, path: readonly string[], value: unknown) {
+  let current = target
+  path.forEach((segment, index) => {
+    const isLeaf = index === path.length - 1
+    if (isLeaf) {
+      current[segment] = value
+      return
+    }
+
+    const next = current[segment]
+    if (!next || typeof next !== 'object' || Array.isArray(next)) {
+      current[segment] = {}
+    }
+    current = current[segment] as Record<string, unknown>
+  })
+}
+
+function deletePath(target: Record<string, unknown>, path: readonly string[]): boolean {
+  const [segment, ...rest] = path
+  if (!segment || !(segment in target)) return Object.keys(target).length === 0
+
+  if (rest.length === 0) {
+    delete target[segment]
+    return Object.keys(target).length === 0
+  }
+
+  const next = target[segment]
+  if (!next || typeof next !== 'object' || Array.isArray(next)) return Object.keys(target).length === 0
+
+  if (deletePath(next as Record<string, unknown>, rest)) delete target[segment]
+  return Object.keys(target).length === 0
+}
+
+function serializeDefaultSettingValue(setting: ConfigurationDefaultsSetting, value: unknown): string | undefined {
+  if (value == null) return undefined
+  if (typeof value === 'boolean' && setting.control.kind === 'choice') {
+    const optionValues = new Set(setting.control.options.map((option) => option.value))
+    if (optionValues.has('on') && optionValues.has('off')) {
+      return value ? 'on' : 'off'
+    }
+  }
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  if (setting.control.kind === 'choice') return String(value)
+  return undefined
+}
+
+function parseDefaultSettingValue(setting: ConfigurationDefaultsSetting, value: string): unknown {
+  if (setting.control.kind === 'choice') {
+    const optionValues = new Set(setting.control.options.map((option) => option.value))
+    if (optionValues.has('on') && optionValues.has('off') && !optionValues.has('auto')) {
+      return value === 'on'
+    }
+  }
+  if (setting.control.kind !== 'range') return value
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : value
+}
+
+function cloneMeshConfig(config: RuntimeControlMeshConfig): RuntimeControlMeshConfig {
+  return JSON.parse(JSON.stringify(config)) as RuntimeControlMeshConfig
+}
+
+export function createConfigurationDefaultsValuesFromMeshConfig(
+  config: RuntimeControlMeshConfig
+): ConfigurationDefaultsValues {
+  const values: ConfigurationDefaultsValues = {}
+  const defaults = config.defaults
+
+  for (const setting of CONFIGURATION_DEFAULTS.settings) {
+    if (!defaults) continue
+
+    const path = resolveControlDefaultsPath(setting)
+    const value = readPath(defaults, path)
+    const serialized = serializeDefaultSettingValue(setting, value)
+    if (serialized !== undefined) values[setting.id] = serialized
+  }
+
+  return values
+}
+
+export function mergeConfigurationDefaultsIntoMeshConfig(
+  config: RuntimeControlMeshConfig,
+  defaultsValues: ConfigurationDefaultsValues
+): RuntimeControlMeshConfig {
+  const nextConfig = cloneMeshConfig(config)
+  const defaults =
+    nextConfig.defaults && typeof nextConfig.defaults === 'object' && !Array.isArray(nextConfig.defaults)
+      ? { ...nextConfig.defaults }
+      : {}
+
+  for (const setting of CONFIGURATION_DEFAULTS.settings) {
+    const path = resolveControlDefaultsPath(setting)
+    deletePath(defaults, path)
+
+    const nextValue = defaultsValues[setting.id]
+    if (nextValue == null) continue
+    if (isSettingDisabled(setting, CONFIGURATION_DEFAULTS.settings, defaultsValues)) continue
+    if (nextValue === getSettingBaselineValue(setting)) continue
+    if (setting.control.kind === 'text' && nextValue.trim().length === 0) continue
+
+    writePath(defaults, path, parseDefaultSettingValue(setting, nextValue))
+  }
+
+  if (Object.keys(defaults).length === 0) {
+    delete nextConfig.defaults
+  } else {
+    nextConfig.defaults = defaults
+  }
+  return nextConfig
+}
+
+async function expectJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const message = await parseApiErrorBody(response)
+    throw new ApiError(response.status, message, message)
+  }
+
+  return response.json() as Promise<T>
+}
+
+export async function fetchRuntimeControlBootstrap(): Promise<RuntimeControlBootstrapPayload> {
+  const response = await fetch(`${env.managementApiUrl}/api/runtime/control-bootstrap`)
+  return expectJson<RuntimeControlBootstrapPayload>(response)
+}
+
+export async function fetchRuntimeControlConfigSnapshot(endpoint: string): Promise<RuntimeControlConfigSnapshot> {
+  const response = await fetch(`${env.managementApiUrl}/api/runtime/control/get-config`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ endpoint })
+  })
+  const payload = await expectJson<RuntimeControlConfigResponse>(response)
+  return payload.snapshot
+}
+
+export async function fetchRuntimeControlConfig(): Promise<RuntimeControlConfigResult> {
+  const bootstrap = await fetchRuntimeControlBootstrap()
+  const endpoint = bootstrap.endpoint?.trim()
+
+  if (!bootstrap.enabled || !endpoint) return { bootstrap }
+
+  const snapshot = await fetchRuntimeControlConfigSnapshot(endpoint)
+  return { bootstrap: { ...bootstrap, endpoint }, snapshot }
+}
+
+export async function applyRuntimeControlConfig(
+  endpoint: string,
+  snapshot: RuntimeControlConfigSnapshot,
+  defaultsValues: ConfigurationDefaultsValues
+): Promise<{ response: RuntimeControlApplyResponse; snapshot: RuntimeControlConfigSnapshot }> {
+  const config = mergeConfigurationDefaultsIntoMeshConfig(snapshot.config, defaultsValues)
+  const response = await fetch(`${env.managementApiUrl}/api/runtime/control/apply-config`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      endpoint,
+      expected_revision: snapshot.revision,
+      config
+    })
+  })
+  const payload = await expectJson<RuntimeControlApplyResponse>(response)
+
+  return {
+    response: payload,
+    snapshot: {
+      ...snapshot,
+      revision: payload.current_revision,
+      config
+    }
+  }
+}
+
+export function adaptStatusToConfiguration(
+  payload: StatusPayload,
+  models: MeshModelRaw[],
+  defaultsValues?: ConfigurationDefaultsValues
+): ConfigurationHarnessData {
   const nodes: ConfigNode[] = payload.peers.map(adaptPeerToConfigNode)
   const catalog: ConfigModel[] = models.map(adaptModelToConfigModel)
+  const defaults = defaultsValues
+    ? overlayDefaultsValues(CONFIGURATION_HARNESS.defaults, defaultsValues)
+    : CONFIGURATION_HARNESS.defaults
 
   return {
     ...CONFIGURATION_HARNESS,
     nodes,
     catalog,
+    defaults,
     assigns: [],
     preferredAssignId: undefined
   }

--- a/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts
@@ -68,12 +68,12 @@ function runtimeControlErrorMessage(error: unknown): string | undefined {
 }
 
 const LEGACY_CONTROL_DEFAULTS_SECTION_PATHS: Record<string, readonly string[]> = {
-  'parallel-slots': ['model_fit', 'parallel'],
+  'parallel-slots': ['throughput', 'parallel'],
   'tuning-profile': ['throughput', 'tuning_profile'],
   'flash-attention': ['model_fit', 'flash_attention'],
   'llamacpp-flavor': ['hardware', 'model_runtime'],
   'kv-cache': ['model_fit', 'kv_cache_policy'],
-  'memory-margin': ['model_fit', 'safety_margin_gb'],
+  'memory-margin': ['hardware', 'safety_margin_gb'],
   'speculation-mode': ['speculative', 'mode'],
   'draft-selection-policy': ['speculative', 'draft_selection_policy'],
   'incompatible-pairing-behavior': ['speculative', 'pairing_fault'],

--- a/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.test.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.test.tsx
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+import { useConfigQuery } from '@/features/configuration/api/use-config-query'
+import type { ModelsResponse, StatusPayload } from '@/lib/api/types'
+
+const STATUS_PAYLOAD: StatusPayload = {
+  node_id: 'self',
+  node_state: 'serving',
+  model_name: 'Hermes-2-Pro-Mistral-7B-Q4_K_M',
+  peers: [],
+  models: [],
+  my_vram_gb: 0,
+  gpus: [],
+  serving_models: []
+}
+
+const MODELS_RESPONSE: ModelsResponse = {
+  mesh_models: [
+    {
+      name: 'Hermes-2-Pro-Mistral-7B-Q4_K_M',
+      status: 'warm',
+      node_count: 1,
+      quantization: 'Q4_K_M'
+    }
+  ]
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+describe('useConfigQuery', () => {
+  it('keeps local defaults visible while runtime-control hydration is still loading', async () => {
+    const getConfigDeferred = createDeferredResponse({
+      snapshot: {
+        revision: 7,
+        config: {
+          version: 1,
+          defaults: {
+            request_defaults: {
+              reasoning_format: 'qwen'
+            }
+          }
+        }
+      }
+    })
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/api/status')) return jsonResponse(STATUS_PAYLOAD)
+      if (url.endsWith('/api/models')) return jsonResponse(MODELS_RESPONSE)
+      if (url.endsWith('/api/runtime/control-bootstrap')) {
+        return jsonResponse({
+          enabled: true,
+          local_only: true,
+          requires_explicit_remote_endpoint: false,
+          endpoint: 'control://owner'
+        })
+      }
+      if (url.endsWith('/api/runtime/control/get-config')) {
+        expect(JSON.parse(String(init?.body))).toEqual({ endpoint: 'control://owner' })
+        return getConfigDeferred.promise
+      }
+
+      throw new Error(`Unexpected fetch request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useConfigQuery({ enabled: true }), {
+      wrapper: createWrapper()
+    })
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('auto')
+
+    getConfigDeferred.resolve(jsonResponse(getConfigDeferred.body))
+
+    await waitFor(() => expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('qwen'))
+    expect(fetchMock).toHaveBeenCalledWith('/api/runtime/control-bootstrap')
+  })
+
+  it('keeps the local defaults fallback when bootstrap is disabled', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+
+      if (url.endsWith('/api/status')) return jsonResponse(STATUS_PAYLOAD)
+      if (url.endsWith('/api/models')) return jsonResponse(MODELS_RESPONSE)
+      if (url.endsWith('/api/runtime/control-bootstrap')) {
+        return jsonResponse({
+          enabled: false,
+          local_only: true,
+          requires_explicit_remote_endpoint: true,
+          disabled_reason: 'missing_owner_identity',
+          message: 'Configuration saving requires a local owner identity.',
+          suggested_commands: [
+            'mesh-llm auth status',
+            'mesh-llm auth init --no-passphrase',
+            'mesh-llm serve --owner-required'
+          ]
+        })
+      }
+
+      throw new Error(`Unexpected fetch request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useConfigQuery({ enabled: true }), {
+      wrapper: createWrapper()
+    })
+
+    await waitFor(() => expect(result.current.data).toBeDefined())
+
+    expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('auto')
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/runtime/control/get-config',
+      expect.objectContaining({ method: 'POST' })
+    )
+    expect(result.current.isError).toBe(false)
+    expect(result.current.controlConfigQuery.data?.bootstrap).toMatchObject({
+      enabled: false,
+      disabled_reason: 'missing_owner_identity',
+      suggested_commands: expect.arrayContaining(['mesh-llm auth init --no-passphrase'])
+    })
+    expect(result.current.controlConfigQuery.data?.snapshot).toBeUndefined()
+  })
+
+  it('applies full mesh config updates with expected revision and preserved fields', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/api/status')) return jsonResponse(STATUS_PAYLOAD)
+      if (url.endsWith('/api/models')) return jsonResponse(MODELS_RESPONSE)
+      if (url.endsWith('/api/runtime/control-bootstrap')) {
+        return jsonResponse({
+          enabled: true,
+          local_only: true,
+          requires_explicit_remote_endpoint: false,
+          endpoint: 'control://owner'
+        })
+      }
+      if (url.endsWith('/api/runtime/control/get-config')) {
+        return jsonResponse({
+          snapshot: {
+            revision: 7,
+            config: {
+              version: 1,
+              owner_control: {
+                bind: '127.0.0.1:7447'
+              },
+              telemetry: {
+                enabled: true
+              },
+              models: [{ model: 'hf://meshllm/base@main:Q4_K_M', ctx_size: 8192 }],
+              plugin: [{ name: 'telemetry', enabled: true }],
+              defaults: {
+                threads: 6,
+                request_defaults: {
+                  temperature: 0.8,
+                  reasoning_format: 'deepseek',
+                  top_k: 40
+                },
+                speculative: {
+                  draft_max_tokens: 16
+                },
+                skippy: {
+                  activation_wire_dtype: 'f16'
+                },
+                multimodal: {
+                  image_min_tokens: 32
+                },
+                advanced: {
+                  server: {
+                    alias: 'existing-alias'
+                  }
+                }
+              }
+            }
+          }
+        })
+      }
+      if (url.endsWith('/api/runtime/control/apply-config')) {
+        const body = JSON.parse(String(init?.body)) as {
+          endpoint: string
+          expected_revision: number
+          config: Record<string, unknown>
+        }
+
+        expect(body.endpoint).toBe('control://owner')
+        expect(body.expected_revision).toBe(7)
+        expect(body.config).toMatchObject({
+          version: 1,
+          owner_control: {
+            bind: '127.0.0.1:7447'
+          },
+          telemetry: {
+            enabled: true
+          },
+          models: [{ model: 'hf://meshllm/base@main:Q4_K_M', ctx_size: 8192 }],
+          plugin: [{ name: 'telemetry', enabled: true }],
+          defaults: {
+            threads: 6,
+            request_defaults: {
+              temperature: 0.8,
+              reasoning_format: 'qwen',
+              top_k: 55
+            },
+            speculative: {
+              mode: 'draft',
+              draft_max_tokens: 20
+            },
+            skippy: {
+              activation_wire_dtype: 'q8'
+            },
+            multimodal: {
+              image_min_tokens: 64
+            },
+            advanced: {
+              server: {
+                alias: 'carrack-mesh'
+              }
+            }
+          }
+        })
+
+        return jsonResponse({
+          success: true,
+          current_revision: 8,
+          config_hash: 'abc123',
+          apply_mode: 'live'
+        })
+      }
+
+      throw new Error(`Unexpected fetch request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useConfigQuery({ enabled: true }), {
+      wrapper: createWrapper()
+    })
+
+    await waitFor(() => expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('deepseek'))
+
+    const nextDefaults = readDefaultsValues(result.current.data!)
+    nextDefaults['reasoning-format'] = 'qwen'
+    nextDefaults['top-k'] = '55'
+    nextDefaults['speculation-mode'] = 'draft'
+    nextDefaults['draft-max-tokens'] = '20'
+    nextDefaults['activation-wire-dtype'] = 'q8'
+    nextDefaults['image-min-tokens'] = '64'
+    nextDefaults['server-alias'] = 'carrack-mesh'
+
+    await act(async () => {
+      const response = await result.current.applyDefaults(nextDefaults)
+      expect(response).toMatchObject({
+        success: true,
+        current_revision: 8,
+        apply_mode: 'live'
+      })
+    })
+
+    await waitFor(() => expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('qwen'))
+    expect(readSettingValue(result.current.data!, 'top-k')).toBe('55')
+    expect(readSettingValue(result.current.data!, 'activation-wire-dtype')).toBe('q8')
+    expect(readSettingValue(result.current.data!, 'image-min-tokens')).toBe('64')
+    expect(readSettingValue(result.current.data!, 'server-alias')).toBe('carrack-mesh')
+    expect(result.current.controlConfigQuery.data?.snapshot?.revision).toBe(8)
+  })
+})
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false
+      }
+    }
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function readSettingValue(data: NonNullable<ReturnType<typeof useConfigQuery>['data']>, settingId: string) {
+  return data.defaults.settings.find((setting) => setting.id === settingId)?.control.value
+}
+
+function readDefaultsValues(data: NonNullable<ReturnType<typeof useConfigQuery>['data']>) {
+  return Object.fromEntries(data.defaults.settings.map((setting) => [setting.id, setting.control.value]))
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' }
+  })
+}
+
+function createDeferredResponse(body: unknown) {
+  let resolve: (response: Response) => void = () => undefined
+  const promise = new Promise<Response>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+
+  return {
+    body,
+    promise,
+    resolve
+  }
+}

--- a/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.test.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.test.tsx
@@ -273,6 +273,78 @@ describe('useConfigQuery', () => {
     expect(readSettingValue(result.current.data!, 'server-alias')).toBe('carrack-mesh')
     expect(result.current.controlConfigQuery.data?.snapshot?.revision).toBe(8)
   })
+
+  it('does not replace the cached runtime-control snapshot when apply returns success false', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url.endsWith('/api/status')) return jsonResponse(STATUS_PAYLOAD)
+      if (url.endsWith('/api/models')) return jsonResponse(MODELS_RESPONSE)
+      if (url.endsWith('/api/runtime/control-bootstrap')) {
+        return jsonResponse({
+          enabled: true,
+          local_only: true,
+          requires_explicit_remote_endpoint: false,
+          endpoint: 'control://owner'
+        })
+      }
+      if (url.endsWith('/api/runtime/control/get-config')) {
+        return jsonResponse({
+          snapshot: {
+            revision: 7,
+            config: {
+              version: 1,
+              defaults: {
+                request_defaults: {
+                  reasoning_format: 'deepseek'
+                }
+              }
+            }
+          }
+        })
+      }
+      if (url.endsWith('/api/runtime/control/apply-config')) {
+        const body = JSON.parse(String(init?.body)) as {
+          expected_revision: number
+          config: { defaults?: { request_defaults?: { reasoning_format?: string } } }
+        }
+
+        expect(body.expected_revision).toBe(7)
+        expect(body.config.defaults?.request_defaults?.reasoning_format).toBe('qwen')
+
+        return jsonResponse({
+          success: false,
+          current_revision: 8,
+          config_hash: 'rejected',
+          apply_mode: 'unspecified',
+          error: { code: 'validation_error', message: 'invalid config' }
+        })
+      }
+
+      throw new Error(`Unexpected fetch request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useConfigQuery({ enabled: true }), {
+      wrapper: createWrapper()
+    })
+
+    await waitFor(() => expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('deepseek'))
+
+    const nextDefaults = readDefaultsValues(result.current.data!)
+    nextDefaults['reasoning-format'] = 'qwen'
+
+    await act(async () => {
+      const response = await result.current.applyDefaults(nextDefaults)
+      expect(response).toMatchObject({
+        success: false,
+        current_revision: 8
+      })
+    })
+
+    expect(readSettingValue(result.current.data!, 'reasoning-format')).toBe('deepseek')
+    expect(result.current.controlConfigQuery.data?.snapshot?.revision).toBe(7)
+  })
 })
 
 function createWrapper() {

--- a/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.ts
@@ -1,10 +1,19 @@
-import { useMemo } from 'react'
-import type { UseQueryResult } from '@tanstack/react-query'
+import { useCallback, useMemo } from 'react'
+import { useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query'
 import type { ModelsResponse, StatusPayload } from '@/lib/api/types'
-import type { ConfigurationHarnessData } from '@/features/app-tabs/types'
+import type { ConfigurationDefaultsValues, ConfigurationHarnessData } from '@/features/app-tabs/types'
 import { useStatusQuery } from '@/features/network/api/use-status-query'
 import { useModelsQuery } from '@/features/network/api/use-models-query'
-import { adaptStatusToConfiguration } from '@/features/configuration/api/config-adapter'
+import {
+  adaptStatusToConfiguration,
+  applyRuntimeControlConfig,
+  createConfigurationDefaultsValuesFromMeshConfig,
+  fetchRuntimeControlConfig,
+  type RuntimeControlApplyResponse,
+  type RuntimeControlConfigResult
+} from '@/features/configuration/api/config-adapter'
+
+const CONFIG_CONTROL_QUERY_KEY = ['configuration', 'runtime-control'] as const
 
 type ConfigQueryResult = {
   data: ConfigurationHarnessData | undefined
@@ -13,26 +22,66 @@ type ConfigQueryResult = {
   isPending: boolean
   statusQuery: UseQueryResult<StatusPayload, Error>
   modelsQuery: UseQueryResult<ModelsResponse, Error>
+  controlConfigQuery: UseQueryResult<RuntimeControlConfigResult, Error>
+  applyDefaults: (defaultsValues: ConfigurationDefaultsValues) => Promise<RuntimeControlApplyResponse | null>
 }
 
 export function useConfigQuery(options?: { enabled?: boolean }): ConfigQueryResult {
+  const queryClient = useQueryClient()
   const statusQuery = useStatusQuery(options)
   const modelsQuery = useModelsQuery(options)
+  const controlConfigQuery = useQuery({
+    queryKey: CONFIG_CONTROL_QUERY_KEY,
+    queryFn: fetchRuntimeControlConfig,
+    staleTime: 30_000,
+    retry: false,
+    enabled: options?.enabled ?? true
+  })
+
+  const defaultsValues = useMemo(
+    () =>
+      controlConfigQuery.data?.snapshot
+        ? createConfigurationDefaultsValuesFromMeshConfig(controlConfigQuery.data.snapshot.config)
+        : undefined,
+    [controlConfigQuery.data]
+  )
 
   const data = useMemo(
     () =>
       statusQuery.data && modelsQuery.data
-        ? adaptStatusToConfiguration(statusQuery.data, modelsQuery.data.mesh_models ?? [])
+        ? adaptStatusToConfiguration(statusQuery.data, modelsQuery.data.mesh_models ?? [], defaultsValues)
         : undefined,
-    [modelsQuery.data, statusQuery.data]
+    [defaultsValues, modelsQuery.data, statusQuery.data]
+  )
+
+  const applyDefaults = useCallback(
+    async (nextDefaultsValues: ConfigurationDefaultsValues) => {
+      const endpoint = controlConfigQuery.data?.bootstrap.endpoint?.trim()
+      const snapshot = controlConfigQuery.data?.snapshot
+
+      if (!endpoint || !snapshot) return null
+
+      const applied = await applyRuntimeControlConfig(endpoint, snapshot, nextDefaultsValues)
+      queryClient.setQueryData<RuntimeControlConfigResult>(CONFIG_CONTROL_QUERY_KEY, (current) => {
+        if (!current) return current
+        return {
+          ...current,
+          snapshot: applied.snapshot
+        }
+      })
+      return applied.response
+    },
+    [controlConfigQuery.data, queryClient]
   )
 
   return {
     data,
     isPending: statusQuery.isPending || modelsQuery.isPending,
-    isFetching: statusQuery.isFetching || modelsQuery.isFetching,
-    isError: statusQuery.isError || modelsQuery.isError,
+    isFetching: statusQuery.isFetching || modelsQuery.isFetching || controlConfigQuery.isFetching,
+    isError: statusQuery.isError || modelsQuery.isError || controlConfigQuery.isError,
     statusQuery,
-    modelsQuery
+    modelsQuery,
+    controlConfigQuery,
+    applyDefaults
   }
 }

--- a/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/use-config-query.ts
@@ -62,13 +62,15 @@ export function useConfigQuery(options?: { enabled?: boolean }): ConfigQueryResu
       if (!endpoint || !snapshot) return null
 
       const applied = await applyRuntimeControlConfig(endpoint, snapshot, nextDefaultsValues)
-      queryClient.setQueryData<RuntimeControlConfigResult>(CONFIG_CONTROL_QUERY_KEY, (current) => {
-        if (!current) return current
-        return {
-          ...current,
-          snapshot: applied.snapshot
-        }
-      })
+      if (applied.response.success) {
+        queryClient.setQueryData<RuntimeControlConfigResult>(CONFIG_CONTROL_QUERY_KEY, (current) => {
+          if (!current) return current
+          return {
+            ...current,
+            snapshot: applied.snapshot
+          }
+        })
+      }
       return applied.response
     },
     [controlConfigQuery.data, queryClient]

--- a/crates/mesh-llm-ui/src/features/configuration/components/ConfigurationHeader.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/components/ConfigurationHeader.tsx
@@ -1,4 +1,4 @@
-import { Network, RotateCcw, Save, Undo2, Redo2, UserRound } from 'lucide-react'
+import { LoaderCircle, Network, RotateCcw, Save, Undo2, Redo2, UserRound } from 'lucide-react'
 import type { ReactNode } from 'react'
 import type { ConfigNode } from '@/features/app-tabs/types'
 import { cn } from '@/lib/cn'
@@ -11,6 +11,8 @@ type ConfigurationHeaderProps = {
   canRedo: boolean
   hasUnsavedChanges: boolean
   hasInvalidNode: boolean
+  isSaving?: boolean
+  saveDisabledReason?: string
   onUndo: () => void
   onRedo: () => void
   onRevert: () => void
@@ -47,11 +49,24 @@ export function ConfigurationHistoryActions({
   canRedo,
   hasUnsavedChanges,
   hasInvalidNode,
+  isSaving = false,
+  saveDisabledReason,
   onUndo,
   onRedo,
   onRevert,
   onSave
 }: Omit<ConfigurationHeaderProps, 'title' | 'description' | 'nodes'>) {
+  const saveDisabled = isSaving || hasInvalidNode || !hasUnsavedChanges || Boolean(saveDisabledReason)
+  const saveTitle = saveDisabledReason
+    ? saveDisabledReason
+    : isSaving
+      ? 'Saving config'
+      : hasInvalidNode
+        ? 'Resolve invalid model allocations before saving'
+        : hasUnsavedChanges
+          ? 'Save config'
+          : 'No changes to save'
+
   return (
     <fieldset aria-label="Configuration history actions" className="flex items-center gap-1.5 border-0 p-0">
       <button
@@ -84,20 +99,19 @@ export function ConfigurationHistoryActions({
           'inline-flex h-[30px] items-center gap-1.5 rounded-[var(--radius)] border px-4 text-[length:var(--density-type-control)] font-semibold leading-none',
           hasInvalidNode ? 'ui-control-destructive' : 'ui-control-primary'
         )}
-        disabled={hasInvalidNode || !hasUnsavedChanges}
+        aria-busy={isSaving || undefined}
+        disabled={saveDisabled}
         onClick={onSave}
-        title={
-          hasInvalidNode
-            ? 'Resolve invalid model allocations before saving'
-            : hasUnsavedChanges
-              ? 'Save config'
-              : 'No changes to save'
-        }
+        title={saveTitle}
         type="button"
         aria-keyshortcuts="Control+S"
       >
-        <Save aria-hidden="true" className="size-3.5" />
-        Save config
+        {isSaving ? (
+          <LoaderCircle aria-hidden="true" className="size-3.5 animate-spin" />
+        ) : (
+          <Save aria-hidden="true" className="size-3.5" />
+        )}
+        {isSaving ? 'Saving config' : 'Save config'}
       </button>
     </fieldset>
   )

--- a/crates/mesh-llm-ui/src/features/configuration/components/DefaultsTab.test.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/components/DefaultsTab.test.tsx
@@ -1,0 +1,583 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { CONFIGURATION_DEFAULTS } from '@/features/app-tabs/data'
+import { DefaultsTab } from '@/features/configuration/components/DefaultsTab'
+import type {
+  ConfigurationDefaultsHarnessData,
+  ConfigurationDefaultsSetting,
+  ConfigurationDefaultsValues
+} from '@/features/app-tabs/types'
+import { env } from '@/lib/env'
+import { RESTART_REQUIRED_TOOLTIP } from '@/features/configuration/components/settings/RestartBadge'
+
+const SHOW_ADVANCED_STORAGE_KEY = `${env.storageNamespace}:configuration-defaults:show-advanced:v1`
+
+const defaultSettings = [
+  {
+    id: 'runtime-mode',
+    categoryId: 'runtime',
+    icon: 'cpu',
+    label: 'Runtime mode',
+    description: 'Controls the standard runtime selection.',
+    inheritedLabel: 'Inherited by default placements',
+    control: {
+      kind: 'choice',
+      name: 'runtime_mode',
+      value: 'auto',
+      options: [
+        { value: 'auto', label: 'auto' },
+        { value: 'manual', label: 'manual' }
+      ]
+    }
+  },
+  {
+    id: 'advanced-reasoning',
+    categoryId: 'advanced',
+    icon: 'cog',
+    label: 'Reasoning budget',
+    description: 'Advanced reasoning control.',
+    inheritedLabel: 'Inherited by reasoning-capable placements',
+    visibility: 'advanced',
+    control: {
+      kind: 'range',
+      name: 'reasoning_budget',
+      value: '128',
+      min: 0,
+      max: 512,
+      step: 32,
+      unit: 'tok'
+    }
+  },
+  {
+    id: 'advanced-note',
+    categoryId: 'advanced',
+    icon: 'filter',
+    label: 'Advanced note',
+    description: 'Extra advanced guidance.',
+    inheritedLabel: 'Inherited by advanced defaults',
+    visibility: 'advanced',
+    control: {
+      kind: 'text',
+      name: 'advanced_note',
+      value: '',
+      placeholder: 'Optional note'
+    }
+  }
+] satisfies readonly ConfigurationDefaultsSetting[]
+
+const defaultsData = {
+  categories: [
+    { id: 'runtime', label: 'Runtime', summary: 'Standard defaults.', help: 'Runtime defaults' },
+    { id: 'advanced', label: 'Reasoning', summary: 'Advanced defaults.', help: 'Reasoning defaults' }
+  ],
+  settings: defaultSettings,
+  preview: []
+} satisfies ConfigurationDefaultsHarnessData
+
+const dependencySettings = [
+  {
+    id: 'speculation-mode',
+    categoryId: 'speculative-decoding',
+    icon: 'brain',
+    label: 'Speculation mode',
+    description: 'Controls whether draft-model speculation is active.',
+    inheritedLabel: 'Inherited by speculative decoding defaults',
+    control: {
+      kind: 'choice',
+      name: 'speculation_mode',
+      value: 'ngram',
+      presentation: 'segmented',
+      options: [
+        { value: 'off', label: 'off' },
+        { value: 'draft_model', label: 'draft model' },
+        { value: 'ngram', label: 'n-gram' }
+      ]
+    }
+  },
+  {
+    id: 'draft-selection-policy',
+    categoryId: 'speculative-decoding',
+    icon: 'filter',
+    label: 'Draft selection policy',
+    description: 'Chooses the draft selection behavior.',
+    inheritedLabel: 'Only available when draft-model speculation is enabled',
+    dependsOn: {
+      settingId: 'speculation-mode',
+      condition: (value: string) => value === 'draft_model'
+    },
+    control: {
+      kind: 'choice',
+      name: 'draft_selection_policy',
+      value: 'auto',
+      presentation: 'toggle',
+      options: [
+        { value: 'auto', label: 'auto' },
+        { value: 'manual_only', label: 'Manual only' }
+      ]
+    }
+  },
+  {
+    id: 'mirostat-mode',
+    categoryId: 'request-defaults',
+    icon: 'brain',
+    label: 'Mirostat mode',
+    description: 'Controls whether Mirostat is active.',
+    inheritedLabel: 'Inherited by request defaults',
+    control: {
+      kind: 'choice',
+      name: 'mirostat_mode',
+      value: 'disabled',
+      presentation: 'segmented',
+      options: [
+        { value: 'disabled', label: 'disabled' },
+        { value: '1', label: '1' },
+        { value: '2', label: '2' }
+      ]
+    }
+  },
+  {
+    id: 'mirostat-entropy',
+    categoryId: 'request-defaults',
+    icon: 'gauge',
+    label: 'Mirostat entropy',
+    description: 'Depends on the Mirostat mode.',
+    inheritedLabel: 'Only available when Mirostat is enabled',
+    dependsOn: {
+      settingId: 'mirostat-mode',
+      condition: (value: string) => value !== 'disabled'
+    },
+    control: {
+      kind: 'range',
+      name: 'mirostat_entropy',
+      value: '5',
+      min: 0.1,
+      max: 10,
+      step: 0.1
+    }
+  }
+] satisfies readonly ConfigurationDefaultsSetting[]
+
+const dependencyData = {
+  categories: [
+    {
+      id: 'speculative-decoding',
+      label: 'Speculative Decoding',
+      summary: 'Speculative defaults.',
+      help: 'Speculative defaults'
+    },
+    {
+      id: 'request-defaults',
+      label: 'Request Defaults',
+      summary: 'Sampling defaults.',
+      help: 'Sampling defaults'
+    }
+  ],
+  settings: dependencySettings,
+  preview: []
+} satisfies ConfigurationDefaultsHarnessData
+
+const defaultValues: ConfigurationDefaultsValues = {}
+
+function renderDefaultsTab(overrides: Partial<Parameters<typeof DefaultsTab>[0]> = {}) {
+  return render(
+    <DefaultsTab
+      data={overrides.data ?? defaultsData}
+      values={overrides.values ?? defaultValues}
+      onSettingValueChange={overrides.onSettingValueChange ?? vi.fn()}
+      onResetAll={overrides.onResetAll ?? vi.fn()}
+      configFilePath={overrides.configFilePath}
+    />
+  )
+}
+
+function previewSource() {
+  const source = screen.getByRole('textbox', { name: /\[defaults\] preview code/i })
+
+  if (!(source instanceof HTMLTextAreaElement)) throw new Error('Expected TOML preview textarea')
+
+  return source
+}
+
+function defaultsRail() {
+  return within(screen.getByRole('navigation', { name: /defaults sections/i }))
+}
+
+function settingsRow(label: string) {
+  const row = screen.getByText(label).closest('[data-settings-row="true"]')
+
+  if (!(row instanceof HTMLElement)) throw new Error(`Expected settings row for ${label}`)
+
+  return row
+}
+
+describe('DefaultsTab', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('hides advanced settings by default and persists the toggle', async () => {
+    const user = userEvent.setup()
+
+    renderDefaultsTab({
+      values: {
+        'advanced-reasoning': '256'
+      }
+    })
+
+    expect(screen.getByRole('button', { name: /show advanced/i })).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.getByRole('heading', { name: 'Runtime' })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Reasoning' })).not.toBeInTheDocument()
+    expect(previewSource().value).not.toContain('runtime_mode = "auto"')
+    expect(previewSource().value).toContain('reasoning_budget = 256')
+
+    await user.click(screen.getByRole('button', { name: /show advanced/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /hide advanced/i })).toHaveAttribute('aria-pressed', 'true')
+      expect(screen.getByRole('heading', { name: 'Reasoning' })).toBeInTheDocument()
+      expect(previewSource().value).toContain('[defaults.runtime]')
+      expect(previewSource().value).toContain('reasoning_budget = 256')
+      expect(window.localStorage.getItem(SHOW_ADVANCED_STORAGE_KEY)).toBe('true')
+    })
+
+    await user.click(screen.getByRole('button', { name: /hide advanced/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /show advanced/i })).toHaveAttribute('aria-pressed', 'false')
+      expect(screen.queryByRole('heading', { name: 'Reasoning' })).not.toBeInTheDocument()
+      expect(previewSource().value).toContain('[defaults.runtime]')
+      expect(previewSource().value).toContain('reasoning_budget = 256')
+      expect(window.localStorage.getItem(SHOW_ADVANCED_STORAGE_KEY)).toBeNull()
+    })
+  })
+
+  it('hydrates show advanced from localStorage', () => {
+    window.localStorage.setItem(SHOW_ADVANCED_STORAGE_KEY, 'true')
+
+    renderDefaultsTab()
+
+    expect(screen.getByRole('button', { name: /hide advanced/i })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('heading', { name: 'Reasoning' })).toBeInTheDocument()
+    expect(previewSource().value).not.toContain('draft_selection_policy')
+    expect(previewSource().value).not.toContain('prefill_chunk_size')
+    expect(previewSource().value).not.toContain('prefill_chunk_schedule')
+    expect(previewSource().value).not.toContain('mirostat_entropy')
+  })
+
+  it('renders the real defaults inventory with integrated categories and section previews', async () => {
+    const user = userEvent.setup()
+
+    const { rerender } = renderDefaultsTab({
+      data: CONFIGURATION_DEFAULTS,
+      values: {
+        threads: '12',
+        temperature: '0.8',
+        'top-k': '55',
+        'activation-wire-dtype': 'q8',
+        'binary-stage-transport': 'on',
+        'image-min-tokens': '64',
+        'mmproj-offload': 'on',
+        'server-alias': 'carrack-mesh',
+        'direct-io': 'off',
+        mlock: 'on'
+      }
+    })
+
+    const rail = defaultsRail()
+    expect(rail.getAllByRole('button')).toHaveLength(6)
+    expect(rail.getByRole('button', { name: /runtime/i })).toBeInTheDocument()
+    expect(rail.getByRole('button', { name: /request defaults/i })).toBeInTheDocument()
+    expect(rail.getByRole('button', { name: /skippy transport/i })).toBeInTheDocument()
+    expect(rail.getByRole('button', { name: /multimodal/i })).toBeInTheDocument()
+    expect(rail.queryByRole('button', { name: /advanced server/i })).not.toBeInTheDocument()
+    expect(screen.queryByText('Server alias')).not.toBeInTheDocument()
+    expect(screen.queryByText('Memory lock')).not.toBeInTheDocument()
+
+    await user.click(rail.getByRole('button', { name: /request defaults/i }))
+    expect(rail.getByRole('button', { name: /request defaults/i })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('heading', { name: 'Request Defaults' })).toBeInTheDocument()
+    expect(screen.getByText('Temperature')).toBeInTheDocument()
+    expect(screen.getByText('Top-k')).toBeInTheDocument()
+
+    await user.click(rail.getByRole('button', { name: /skippy transport/i }))
+    expect(rail.getByRole('button', { name: /skippy transport/i })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('heading', { name: 'Skippy Transport' })).toBeInTheDocument()
+    expect(screen.getByText('Activation wire dtype')).toBeInTheDocument()
+
+    await user.click(rail.getByRole('button', { name: /multimodal/i }))
+    expect(rail.getByRole('button', { name: /multimodal/i })).toHaveAttribute('aria-current', 'true')
+    expect(screen.getByRole('heading', { name: 'Multimodal' })).toBeInTheDocument()
+    expect(screen.getByText('MMProj offload')).toBeInTheDocument()
+
+    expect(screen.getByRole('slider', { name: 'CPU threads' })).toHaveValue('12')
+    expect(screen.getByRole('slider', { name: 'Temperature' })).toHaveValue('0.8')
+    expect(screen.getByRole('slider', { name: 'Top-k' })).toHaveValue('55')
+    expect(previewSource().value).toContain('threads = 12')
+    expect(previewSource().value).toContain('[defaults.request_defaults]')
+    expect(previewSource().value).toContain('temperature = 0.8')
+    expect(previewSource().value).toContain('top_k = 55')
+    expect(previewSource().value).toContain('[defaults.skippy]')
+    expect(previewSource().value).toContain('activation_wire_dtype = "q8"')
+    expect(previewSource().value).toContain('binary_stage_transport = "on"')
+    expect(previewSource().value).toContain('mlock = true')
+    expect(previewSource().value).toContain('[defaults.multimodal]')
+    expect(previewSource().value).toContain('image_min_tokens = 64')
+    expect(previewSource().value).toContain('mmproj_offload = "on"')
+    expect(previewSource().value).toContain('[defaults.advanced.server]')
+    expect(previewSource().value).toContain('alias = "carrack-mesh"')
+
+    rerender(
+      <DefaultsTab
+        data={CONFIGURATION_DEFAULTS}
+        values={{
+          threads: '12',
+          temperature: '0.8',
+          'top-k': '55',
+          'activation-wire-dtype': 'q8',
+          'binary-stage-transport': 'on',
+          'image-min-tokens': '64',
+          'mmproj-offload': 'on',
+          'direct-io': 'off',
+          mlock: 'on'
+        }}
+        onSettingValueChange={vi.fn()}
+        onResetAll={vi.fn()}
+      />
+    )
+
+    expect(previewSource().value).not.toContain('[defaults.advanced.server]')
+  })
+
+  it('omits default-only metadata sections while keeping hidden advanced non-default values in preview', () => {
+    renderDefaultsTab({
+      data: CONFIGURATION_DEFAULTS,
+      values: {
+        mlock: 'on',
+        'server-alias': 'carrack-mesh'
+      }
+    })
+
+    expect(screen.queryByText('Memory lock')).not.toBeInTheDocument()
+    expect(screen.queryByText('Server alias')).not.toBeInTheDocument()
+    expect(previewSource().value).toContain('[defaults.hardware]')
+    expect(previewSource().value).toContain('mlock = true')
+    expect(previewSource().value).toContain('[defaults.advanced.server]')
+    expect(previewSource().value).toContain('alias = "carrack-mesh"')
+    expect(previewSource().value).not.toContain('[defaults.skippy]')
+    expect(previewSource().value).not.toContain('[defaults.multimodal]')
+  })
+
+  it('uses canonical inventory defaults when previewing hydrated live settings', () => {
+    const liveHydratedDefaults = {
+      ...CONFIGURATION_DEFAULTS,
+      settings: CONFIGURATION_DEFAULTS.settings.map((setting) => {
+        if (setting.id === 'activation-wire-dtype') {
+          return {
+            ...setting,
+            control: {
+              ...setting.control,
+              value: 'q8'
+            }
+          }
+        }
+
+        if (setting.id === 'image-min-tokens') {
+          return {
+            ...setting,
+            control: {
+              ...setting.control,
+              value: '64'
+            }
+          }
+        }
+
+        if (setting.id === 'server-alias') {
+          return {
+            ...setting,
+            control: {
+              ...setting.control,
+              value: 'carrack-mesh'
+            }
+          }
+        }
+
+        return setting
+      })
+    } satisfies ConfigurationDefaultsHarnessData
+
+    renderDefaultsTab({
+      data: liveHydratedDefaults,
+      values: {}
+    })
+
+    expect(screen.queryByText('Server alias')).not.toBeInTheDocument()
+    expect(previewSource().value).toContain('[defaults.skippy]')
+    expect(previewSource().value).toContain('activation_wire_dtype = "q8"')
+    expect(previewSource().value).toContain('[defaults.multimodal]')
+    expect(previewSource().value).toContain('image_min_tokens = 64')
+    expect(previewSource().value).toContain('[defaults.advanced.server]')
+    expect(previewSource().value).toContain('alias = "carrack-mesh"')
+    expect(previewSource().value).not.toContain('[defaults.request_defaults]')
+  })
+
+  it('shows restart badges only for restart-required settings and exposes the exact tooltip copy on hover and focus', async () => {
+    const user = userEvent.setup()
+
+    const { unmount } = renderDefaultsTab({ data: CONFIGURATION_DEFAULTS })
+
+    const cpuThreadsRow = within(settingsRow('CPU threads'))
+    const topKRow = within(settingsRow('Top-k'))
+    const restartBadge = cpuThreadsRow.getByRole('button', { name: 'Restart required' })
+
+    expect(restartBadge).toBeInTheDocument()
+    expect(topKRow.queryByRole('button', { name: 'Restart required' })).not.toBeInTheDocument()
+
+    await user.hover(restartBadge)
+    expect(await screen.findByText(RESTART_REQUIRED_TOOLTIP, { selector: 'div' })).toBeInTheDocument()
+
+    unmount()
+    renderDefaultsTab({ data: CONFIGURATION_DEFAULTS })
+
+    within(settingsRow('CPU threads')).getByRole('button', { name: 'Restart required' }).focus()
+    expect(await screen.findByText(RESTART_REQUIRED_TOOLTIP, { selector: 'div' })).toBeInTheDocument()
+  })
+
+  it('keeps advanced filtering consistent across real category counts, rows, and section visibility', async () => {
+    const user = userEvent.setup()
+
+    renderDefaultsTab({ data: CONFIGURATION_DEFAULTS })
+
+    const rail = defaultsRail()
+    expect(rail.getAllByRole('button')).toHaveLength(6)
+    expect(screen.queryByText('Mirostat mode')).not.toBeInTheDocument()
+    expect(screen.queryByText('Server alias')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /show advanced/i }))
+
+    await waitFor(() => {
+      expect(rail.getAllByRole('button')).toHaveLength(7)
+      expect(rail.getByRole('button', { name: /advanced server/i })).toBeInTheDocument()
+      expect(screen.getByText('Mirostat mode')).toBeInTheDocument()
+      expect(screen.getByText('Server alias')).toBeInTheDocument()
+    })
+
+    await user.click(rail.getByRole('button', { name: /advanced server/i }))
+    expect(rail.getByRole('button', { name: /advanced server/i })).toHaveAttribute('aria-current', 'true')
+
+    await user.click(screen.getByRole('button', { name: /hide advanced/i }))
+
+    await waitFor(() => {
+      expect(rail.getAllByRole('button')).toHaveLength(6)
+      expect(rail.queryByRole('button', { name: /advanced server/i })).not.toBeInTheDocument()
+      expect(screen.queryByText('Mirostat mode')).not.toBeInTheDocument()
+      expect(screen.queryByText('Server alias')).not.toBeInTheDocument()
+      expect(rail.getByRole('button', { name: /runtime/i })).toHaveAttribute('aria-current', 'true')
+    })
+  })
+
+  it('keeps integrated dependency disable states and explanations working across real dependency pairs', () => {
+    window.localStorage.setItem(SHOW_ADVANCED_STORAGE_KEY, 'true')
+
+    const { rerender } = renderDefaultsTab({
+      data: CONFIGURATION_DEFAULTS,
+      values: {
+        'speculation-mode': 'ngram'
+      }
+    })
+
+    expect(
+      screen.getByText('Default draft selection policy').closest('[data-settings-row-disabled="true"]')
+    ).not.toBeNull()
+    expect(screen.getAllByText('Requires speculation-mode = draft')).toHaveLength(5)
+    expect(screen.getByText('Prefill chunk size').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Requires prefill-chunking = fixed')).toBeInTheDocument()
+    expect(screen.getByText('Prefill chunk schedule').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Requires prefill-chunking = schedule')).toBeInTheDocument()
+    expect(screen.getByText('Mirostat entropy').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Mirostat learning rate').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getAllByText('Requires mirostat-mode = 1 or 2')).toHaveLength(2)
+    expect(previewSource().value).not.toContain('draft_selection_policy')
+    expect(previewSource().value).not.toContain('prefill_chunk_size')
+    expect(previewSource().value).not.toContain('prefill_chunk_schedule')
+    expect(previewSource().value).not.toContain('mirostat_entropy')
+
+    rerender(
+      <DefaultsTab
+        data={CONFIGURATION_DEFAULTS}
+        values={{
+          'speculation-mode': 'draft',
+          'mirostat-mode': '2',
+          'prefill-chunking': 'fixed'
+        }}
+        onSettingValueChange={vi.fn()}
+        onResetAll={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Default draft selection policy').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.queryAllByText('Requires speculation-mode = draft')).toHaveLength(0)
+    expect(screen.getByText('Prefill chunk size').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.queryByText('Requires prefill-chunking = fixed')).not.toBeInTheDocument()
+    expect(screen.getByText('Prefill chunk schedule').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Requires prefill-chunking = schedule')).toBeInTheDocument()
+    expect(screen.getByText('Mirostat entropy').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.getByText('Mirostat learning rate').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.queryByText('Requires mirostat-mode = 1 or 2')).not.toBeInTheDocument()
+    expect(previewSource().value).toContain('mirostat_mode = 2')
+    expect(previewSource().value).toContain('prefill_chunking = "fixed"')
+    expect(previewSource().value).not.toContain('draft_selection_policy')
+    expect(previewSource().value).not.toContain('prefill_chunk_size')
+    expect(previewSource().value).not.toContain('mirostat_entropy')
+
+    rerender(
+      <DefaultsTab
+        data={CONFIGURATION_DEFAULTS}
+        values={{
+          'speculation-mode': 'draft',
+          'mirostat-mode': '2',
+          'prefill-chunking': 'schedule',
+          'prefill-chunk-schedule': '128,256'
+        }}
+        onSettingValueChange={vi.fn()}
+        onResetAll={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Prefill chunk size').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Requires prefill-chunking = fixed')).toBeInTheDocument()
+    expect(screen.getByText('Prefill chunk schedule').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.queryByText('Requires prefill-chunking = schedule')).not.toBeInTheDocument()
+    expect(previewSource().value).toContain('prefill_chunk_schedule = "128,256"')
+    expect(previewSource().value).not.toContain('draft_selection_policy')
+    expect(previewSource().value).not.toContain('prefill_chunk_size')
+    expect(previewSource().value).not.toContain('mirostat_entropy')
+  })
+
+  it('disables dependent settings until their dependency is satisfied', () => {
+    const { rerender } = renderDefaultsTab({ data: dependencyData })
+
+    expect(screen.getByText('Draft selection policy').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Requires speculation-mode = draft_model')).toBeInTheDocument()
+    expect(screen.getByText('Mirostat entropy').closest('[data-settings-row-disabled="true"]')).not.toBeNull()
+    expect(screen.getByText('Requires mirostat-mode = 1 or 2')).toBeInTheDocument()
+    expect(previewSource().value).not.toContain('draft_selection_policy')
+    expect(previewSource().value).not.toContain('mirostat_entropy')
+
+    rerender(
+      <DefaultsTab
+        data={dependencyData}
+        values={{ 'speculation-mode': 'draft_model', 'mirostat-mode': '2' }}
+        onSettingValueChange={vi.fn()}
+        onResetAll={vi.fn()}
+      />
+    )
+
+    expect(screen.getByText('Draft selection policy').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.queryByText('Requires speculation-mode = draft_model')).not.toBeInTheDocument()
+    expect(screen.getByText('Mirostat entropy').closest('[data-settings-row-disabled="true"]')).toBeNull()
+    expect(screen.queryByText('Requires mirostat-mode = 1 or 2')).not.toBeInTheDocument()
+    expect(previewSource().value).not.toContain('draft_selection_policy')
+    expect(previewSource().value).not.toContain('mirostat_entropy')
+  })
+})

--- a/crates/mesh-llm-ui/src/features/configuration/components/DefaultsTab.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/components/DefaultsTab.tsx
@@ -1,19 +1,36 @@
-import { useMemo, type PointerEvent } from 'react'
+import { useEffect, useMemo, useState, type PointerEvent, type ReactNode } from 'react'
 import * as RadioGroup from '@radix-ui/react-radio-group'
 import { NativeSelect } from '@/components/ui/NativeSelect'
 import { SegmentedControl, type SegmentedControlOption } from '@/components/ui/SegmentedControl'
 import { Slider } from '@/components/ui/Slider'
-import { BrainCircuit, Cog, Cpu, MemoryStick, RotateCcw, type LucideIcon } from 'lucide-react'
+import {
+  BrainCircuit,
+  Cog,
+  Cpu,
+  Filter,
+  Image,
+  MemoryStick,
+  Network,
+  RotateCcw,
+  Server,
+  type LucideIcon
+} from 'lucide-react'
 import { configurationNavigationIconClassName } from '@/features/configuration/components/configuration-navigation-class-names'
 import {
   SettingsCategoryRail,
   SettingsPreviewRail,
   SettingsRow,
   SettingsSection,
-  SettingsSummaryBanner,
-  type SettingsCategoryItem
+  SettingsSummaryBanner
 } from '@/features/configuration/components/settings/SettingsScaffold'
+import { RestartBadge } from '@/features/configuration/components/settings/RestartBadge'
 import { useDefaultsSettingsState } from '@/features/configuration/hooks/useDefaultsSettingsState'
+import {
+  getSettingBaselineValue,
+  getSettingDependencyStatus,
+  getSettingValue,
+  isSettingDisabled
+} from '@/features/configuration/lib/settings-utils'
 import type {
   ConfigurationDefaultsCategory,
   ConfigurationDefaultsCategoryId,
@@ -23,13 +40,34 @@ import type {
   ConfigurationDefaultsValues,
   ConfigurationTomlSectionId
 } from '@/features/app-tabs/types'
+import { env } from '@/lib/env'
 import { cn } from '@/lib/cn'
 
 const categoryIcons: Record<ConfigurationDefaultsCategoryId, LucideIcon> = {
   runtime: Cpu,
   memory: MemoryStick,
   'speculative-decoding': BrainCircuit,
-  'request-defaults': Cog
+  advanced: Cog,
+  'request-defaults': Filter,
+  'skippy-transport': Network,
+  multimodal: Image,
+  'advanced-server': Server
+}
+
+const defaultsCategoryOrder: readonly ConfigurationDefaultsCategoryId[] = [
+  'runtime',
+  'memory',
+  'speculative-decoding',
+  'advanced',
+  'request-defaults',
+  'skippy-transport',
+  'multimodal',
+  'advanced-server'
+]
+
+const legacyCategoryTomlSections: Partial<Record<ConfigurationDefaultsCategoryId, string>> = {
+  advanced: 'defaults.runtime',
+  'speculative-decoding': 'defaults.speculative'
 }
 
 const slotOptions = Array.from({ length: 16 }, (_, index) => index + 1)
@@ -56,14 +94,6 @@ function LlamaFlavorOption({ option, selected }: { option: SegmentedControlOptio
   )
 }
 
-const draftModelModeSettingId = 'speculation-mode'
-const draftModelModeValue = 'draft'
-const incompatiblePairingBehaviorSettingId = 'incompatible-pairing-behavior'
-const draftModelOnlySettingIds = new Set([
-  'draft-selection-policy',
-  'draft-max-tokens',
-  incompatiblePairingBehaviorSettingId
-])
 const defaultsSectionOrder: readonly ConfigurationTomlSectionId[] = [
   'defaults.model_fit',
   'defaults.hardware',
@@ -74,6 +104,7 @@ const defaultsSectionOrder: readonly ConfigurationTomlSectionId[] = [
   'defaults.multimodal',
   'defaults.advanced.server'
 ]
+const SHOW_ADVANCED_STORAGE_KEY = `${env.storageNamespace}:configuration-defaults:show-advanced:v1`
 
 type DefaultsTabProps = {
   data: ConfigurationDefaultsHarnessData
@@ -81,10 +112,7 @@ type DefaultsTabProps = {
   onSettingValueChange: (settingId: string, value: string) => void
   onResetAll?: () => void
   configFilePath?: string
-}
-
-function getSettingValue(setting: ConfigurationDefaultsSetting, values: ConfigurationDefaultsValues) {
-  return values[setting.id] ?? setting.control.value
+  readOnlyNotice?: ReactNode
 }
 
 function tomlValue(value: string) {
@@ -163,43 +191,76 @@ function tomlPreviewValue(setting: ConfigurationDefaultsSetting, value: string) 
   return tomlValue(value)
 }
 
+function categoryOrderIndex(categoryId: ConfigurationDefaultsCategoryId) {
+  const index = defaultsCategoryOrder.indexOf(categoryId)
+  return index === -1 ? defaultsCategoryOrder.length : index
+}
+
+function defaultsTomlSectionPath(
+  setting: ConfigurationDefaultsSetting,
+  categoryById: ReadonlyMap<ConfigurationDefaultsCategoryId, ConfigurationDefaultsCategory>
+) {
+  return (
+    setting.tomlSection ??
+    categoryById.get(setting.categoryId)?.tomlSection ??
+    legacyCategoryTomlSections[setting.categoryId] ??
+    null
+  )
+}
+
 function buildDefaultsPreviewLines(
   data: ConfigurationDefaultsHarnessData,
-  values: ConfigurationDefaultsValues
+  values: ConfigurationDefaultsValues,
+  settings: readonly ConfigurationDefaultsSetting[] = data.settings
 ): DefaultsPreviewLine[] {
+  const mainLines: DefaultsPreviewLine[] = []
   const sectionGroups = new Map<string, DefaultsPreviewLine[]>()
-  const speculationModeSetting = data.settings.find((setting) => setting.id === draftModelModeSettingId)
-  const speculationMode = speculationModeSetting ? getSettingValue(speculationModeSetting, values) : null
+  const categoryById = new Map(data.categories.map((category) => [category.id, category] as const))
 
-  for (const setting of data.settings) {
-    if (draftModelOnlySettingIds.has(setting.id) && speculationMode !== draftModelModeValue) continue
+  for (const setting of settings) {
+    if (isSettingDisabled(setting, data.settings, values)) continue
 
     const value = getSettingValue(setting, values)
+    if (value === getSettingBaselineValue(setting)) continue
     if (setting.control.kind === 'text' && value.trim().length === 0) continue
 
     const line: DefaultsPreviewLine = {
       kind: 'pair',
       id: setting.id,
-      keyName: setting.tomlKey,
+      keyName: setting.tomlKey ?? (setting.control.kind === 'metric' ? setting.id : setting.control.name),
       value: tomlPreviewValue(setting, value)
     }
-    const groupLines = sectionGroups.get(setting.tomlSection) ?? [
-      { kind: 'section', id: `defaults-${setting.tomlSection}-section`, value: `[${setting.tomlSection}]` }
+    const sectionPath = defaultsTomlSectionPath(setting, categoryById)
+    if (!sectionPath) {
+      mainLines.push(line)
+      continue
+    }
+
+    const groupLines = sectionGroups.get(sectionPath) ?? [
+      {
+        kind: 'section',
+        id: `defaults-${sectionPath.replaceAll('.', '-')}-section`,
+        value: `[${sectionPath}]`
+      }
     ]
     groupLines.push(line)
-    sectionGroups.set(setting.tomlSection, groupLines)
+    sectionGroups.set(sectionPath, groupLines)
   }
 
-  let emittedSections = 0
+  const orderedSectionPaths = [
+    ...defaultsSectionOrder.filter((sectionPath) => sectionGroups.has(sectionPath)),
+    ...Array.from(sectionGroups.keys()).filter(
+      (sectionPath) => !defaultsSectionOrder.includes(sectionPath as ConfigurationTomlSectionId)
+    )
+  ]
 
-  return defaultsSectionOrder.flatMap((sectionId) => {
-    const lines = sectionGroups.get(sectionId)
-    if (!lines) return []
-    const renderedLines =
-      emittedSections === 0 ? lines : [{ kind: 'blank' as const, id: `defaults-preview-${sectionId}-spacer` }, ...lines]
-    emittedSections += 1
-    return renderedLines
+  const groupedLines = orderedSectionPaths.flatMap((sectionPath, index) => {
+    const lines = sectionGroups.get(sectionPath) ?? []
+    const spacer = { kind: 'blank' as const, id: `defaults-preview-${sectionPath.replaceAll('.', '-')}-spacer` }
+    return mainLines.length > 0 || index > 0 ? [spacer, ...lines] : lines
   })
+
+  return [...mainLines, ...groupedLines]
 }
 
 function renderDefaultsPreview(lines: readonly DefaultsPreviewLine[]) {
@@ -214,6 +275,27 @@ function renderDefaultsPreview(lines: readonly DefaultsPreviewLine[]) {
 
 function settingDescription(setting: ConfigurationDefaultsSetting) {
   return setting.description
+}
+
+function readShowAdvancedSettings() {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return window.localStorage.getItem(SHOW_ADVANCED_STORAGE_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function writeShowAdvancedSettings(showAdvanced: boolean) {
+  if (typeof window === 'undefined') return
+
+  try {
+    if (showAdvanced) window.localStorage.setItem(SHOW_ADVANCED_STORAGE_KEY, 'true')
+    else window.localStorage.removeItem(SHOW_ADVANCED_STORAGE_KEY)
+  } catch {
+    return
+  }
 }
 
 function sectionSubtitle(category: ConfigurationDefaultsCategory) {
@@ -459,23 +541,17 @@ function SettingControl({
 function DefaultsSection({
   category,
   settings,
+  allSettings,
   values,
   onSettingValueChange
 }: {
   category: ConfigurationDefaultsCategory
   settings: readonly ConfigurationDefaultsSetting[]
+  allSettings: readonly ConfigurationDefaultsSetting[]
   values: ConfigurationDefaultsValues
   onSettingValueChange: (settingId: string, value: string) => void
 }) {
   const Icon = categoryIcons[category.id]
-  const speculationModeSetting = settings.find((setting) => setting.id === draftModelModeSettingId)
-  const speculationMode =
-    category.id === 'speculative-decoding' && speculationModeSetting
-      ? getSettingValue(speculationModeSetting, values)
-      : null
-  const draftModelControlsDisabled = speculationMode !== null && speculationMode !== draftModelModeValue
-  const isSettingDisabled = (setting: ConfigurationDefaultsSetting) =>
-    draftModelControlsDisabled && draftModelOnlySettingIds.has(setting.id)
 
   return (
     <SettingsSection
@@ -486,17 +562,20 @@ function DefaultsSection({
     >
       {settings.map((setting, settingIndex) => {
         const value = getSettingValue(setting, values)
-        const disabled = isSettingDisabled(setting)
+        const disabledInfo = getSettingDependencyStatus(setting, allSettings, values)
 
         return (
           <SettingsRow
-            className={cn(settingIndex === 0 && 'border-t-0', disabled && 'opacity-55')}
+            className={cn(settingIndex === 0 && 'border-t-0')}
+            disabled={disabledInfo.disabled}
+            disabledReason={disabledInfo.reason}
             key={setting.id}
             label={setting.label}
+            labelAccessory={setting.mutability === 'restart-required' ? <RestartBadge /> : undefined}
             hint={settingDescription(setting)}
           >
             <SettingControl
-              disabled={disabled}
+              disabled={disabledInfo.disabled}
               setting={setting}
               value={value}
               onChange={(nextValue) => onSettingValueChange(setting.id, nextValue)}
@@ -508,25 +587,70 @@ function DefaultsSection({
   )
 }
 
-export function DefaultsTab({ data, values, onSettingValueChange, onResetAll, configFilePath }: DefaultsTabProps) {
+export function DefaultsTab({
+  data,
+  values,
+  onSettingValueChange,
+  onResetAll,
+  configFilePath,
+  readOnlyNotice
+}: DefaultsTabProps) {
   const { activeCategoryId, setActiveCategoryId } = useDefaultsSettingsState(data)
+  const [showAdvancedSettings, setShowAdvancedSettings] = useState(() => readShowAdvancedSettings())
   const changedCount = data.settings.filter(
     (setting) => getSettingValue(setting, values) !== setting.control.value
   ).length
-  const previewLines = useMemo(() => buildDefaultsPreviewLines(data, values), [data, values])
-  const categories: SettingsCategoryItem[] = useMemo(
-    () =>
-      data.categories.map((category) => {
-        const Icon = categoryIcons[category.id]
+  useEffect(() => {
+    writeShowAdvancedSettings(showAdvancedSettings)
+  }, [showAdvancedSettings])
 
-        return {
-          ...category,
-          count: data.settings.filter((setting) => setting.categoryId === category.id).length,
-          icon: <Icon aria-hidden="true" className={configurationNavigationIconClassName} strokeWidth={1.7} />
-        }
-      }),
-    [data.categories, data.settings]
+  const visibleSettings = useMemo(
+    () => data.settings.filter((setting) => showAdvancedSettings || setting.visibility !== 'advanced'),
+    [data.settings, showAdvancedSettings]
   )
+  const settingsByCategory = useMemo(() => {
+    const grouped = new Map<ConfigurationDefaultsCategoryId, ConfigurationDefaultsSetting[]>()
+
+    for (const setting of visibleSettings) {
+      const group = grouped.get(setting.categoryId) ?? []
+      group.push(setting)
+      grouped.set(setting.categoryId, group)
+    }
+
+    return grouped
+  }, [visibleSettings])
+  const categories = useMemo(
+    () =>
+      data.categories
+        .map((category, originalIndex) => ({
+          ...category,
+          originalIndex,
+          count: settingsByCategory.get(category.id)?.length ?? 0
+        }))
+        .filter((category) => category.count > 0)
+        .sort(
+          (left, right) =>
+            categoryOrderIndex(left.id) - categoryOrderIndex(right.id) || left.originalIndex - right.originalIndex
+        )
+        .map((category) => {
+          const Icon = categoryIcons[category.id]
+          const { originalIndex: _originalIndex, ...resolvedCategory } = category
+
+          return {
+            ...resolvedCategory,
+            icon: <Icon aria-hidden="true" className={configurationNavigationIconClassName} strokeWidth={1.7} />
+          }
+        }),
+    [data.categories, settingsByCategory]
+  )
+  const previewLines = useMemo(() => buildDefaultsPreviewLines(data, values, data.settings), [data, values])
+
+  useEffect(() => {
+    if (categories.length === 0) return
+    if (categories.some((category) => category.id === activeCategoryId)) return
+
+    setActiveCategoryId(categories[0].id)
+  }, [activeCategoryId, categories, setActiveCategoryId])
 
   const selectCategory = (categoryId: string) => {
     setActiveCategoryId(categoryId)
@@ -542,17 +666,30 @@ export function DefaultsTab({ data, values, onSettingValueChange, onResetAll, co
     >
       <SettingsSummaryBanner
         action={
-          <button
-            className={cn(
-              'ui-control inline-flex h-[30px] items-center gap-1.5 rounded-[var(--radius)] border px-2.5 text-[length:var(--density-type-control)] font-semibold'
-            )}
-            disabled={changedCount === 0}
-            onClick={onResetAll}
-            type="button"
-          >
-            <RotateCcw aria-hidden="true" className="size-3.5" />
-            Reset all
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              aria-pressed={showAdvancedSettings}
+              className={cn(
+                'ui-control inline-flex h-[30px] items-center gap-1.5 rounded-[var(--radius)] border px-2.5 text-[length:var(--density-type-control)] font-semibold',
+                showAdvancedSettings && 'border-accent bg-accent/10 text-accent'
+              )}
+              onClick={() => setShowAdvancedSettings((current) => !current)}
+              type="button"
+            >
+              {showAdvancedSettings ? 'Hide advanced' : 'Show advanced'}
+            </button>
+            <button
+              className={cn(
+                'ui-control inline-flex h-[30px] items-center gap-1.5 rounded-[var(--radius)] border px-2.5 text-[length:var(--density-type-control)] font-semibold'
+              )}
+              disabled={changedCount === 0}
+              onClick={onResetAll}
+              type="button"
+            >
+              <RotateCcw aria-hidden="true" className="size-3.5" />
+              Reset all
+            </button>
+          </div>
         }
         description={
           <>
@@ -573,6 +710,8 @@ export function DefaultsTab({ data, values, onSettingValueChange, onResetAll, co
         title="Inherited defaults"
       />
 
+      {readOnlyNotice}
+
       <div className="grid min-w-0 gap-[14px] xl:grid-cols-[250px_minmax(0,1fr)_minmax(280px,340px)]">
         <SettingsCategoryRail
           activeId={activeCategoryId}
@@ -589,12 +728,13 @@ export function DefaultsTab({ data, values, onSettingValueChange, onResetAll, co
         />
 
         <div className="min-w-0 space-y-[14px]">
-          {data.categories.map((category) => (
+          {categories.map((category) => (
             <DefaultsSection
               category={category}
+              allSettings={data.settings}
               key={category.id}
               onSettingValueChange={onSettingValueChange}
-              settings={data.settings.filter((setting) => setting.categoryId === category.id)}
+              settings={settingsByCategory.get(category.id) ?? []}
               values={values}
             />
           ))}

--- a/crates/mesh-llm-ui/src/features/configuration/components/settings/RestartBadge.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/components/settings/RestartBadge.tsx
@@ -1,0 +1,29 @@
+import { Badge } from '@/components/ui/badge'
+import { Tooltip } from '@/components/ui/tooltip'
+import { cn } from '@/lib/cn'
+
+export const RESTART_REQUIRED_TOOLTIP = 'This setting requires a restart to take effect'
+
+type RestartBadgeProps = {
+  className?: string
+}
+
+export function RestartBadge({ className }: RestartBadgeProps) {
+  return (
+    <Tooltip content={RESTART_REQUIRED_TOOLTIP} side="bottom">
+      <button
+        type="button"
+        className="inline-flex rounded-full bg-transparent p-0 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <Badge
+          className={cn(
+            'h-5 shrink-0 rounded-full border-border-soft bg-surface px-1.5 py-0 text-[length:var(--density-type-annotation)] font-medium text-fg-dim',
+            className
+          )}
+        >
+          Restart required
+        </Badge>
+      </button>
+    </Tooltip>
+  )
+}

--- a/crates/mesh-llm-ui/src/features/configuration/components/settings/SettingsScaffold.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/components/settings/SettingsScaffold.tsx
@@ -38,7 +38,10 @@ type SettingsSectionProps = {
 
 type SettingsRowProps = {
   className?: string
-  label: string
+  disabled?: boolean
+  disabledReason?: string
+  label: ReactNode
+  labelAccessory?: ReactNode
   hint: string
   children: ReactNode
 }
@@ -115,20 +118,37 @@ export function SettingsSection({ id, icon, title, subtitle, children }: Setting
   )
 }
 
-export function SettingsRow({ className, label, hint, children }: SettingsRowProps) {
+export function SettingsRow({
+  className,
+  disabled = false,
+  disabledReason,
+  label,
+  labelAccessory,
+  hint,
+  children
+}: SettingsRowProps) {
   return (
     <div
       className={cn(
-        'grid gap-4 border-t border-border-soft py-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-center',
+        'grid gap-3 border-t border-border-soft py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center',
+        disabled && 'opacity-55',
         className
       )}
       data-settings-row="true"
+      data-settings-row-disabled={disabled ? 'true' : undefined}
+      aria-disabled={disabled ? 'true' : undefined}
     >
       <div className="min-w-0">
-        <p className="text-[length:var(--density-type-control-lg)] font-medium leading-tight text-foreground">
-          {label}
-        </p>
-        <p className="mt-1.5 text-[length:var(--density-type-caption-lg)] leading-relaxed text-fg-faint">{hint}</p>
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="text-[length:var(--density-type-control)] font-medium leading-tight text-foreground">{label}</p>
+          {labelAccessory ? <div className="shrink-0">{labelAccessory}</div> : null}
+        </div>
+        <p className="mt-1 text-[length:var(--density-type-caption)] leading-relaxed text-fg-faint">{hint}</p>
+        {disabledReason ? (
+          <p className="mt-1 text-[length:var(--density-type-caption)] leading-relaxed text-fg-faint">
+            {disabledReason}
+          </p>
+        ) : null}
       </div>
       <div className="min-w-0 md:justify-self-end">{children}</div>
     </div>

--- a/crates/mesh-llm-ui/src/features/configuration/layouts/ConfigurationLayout.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/layouts/ConfigurationLayout.tsx
@@ -2,13 +2,15 @@ import type { ReactNode } from 'react'
 import type { LucideIcon } from 'lucide-react'
 
 type ConfigurationLayoutProps = {
+  banner?: ReactNode
   header: ReactNode
   children: ReactNode
 }
 
-export function ConfigurationLayout({ header, children }: ConfigurationLayoutProps) {
+export function ConfigurationLayout({ banner, header, children }: ConfigurationLayoutProps) {
   return (
-    <div className="flex min-w-0 flex-col gap-[14px]">
+    <div className="-mt-[18px] md:-mx-5">
+      {banner ? <div className="px-5 pt-3">{banner}</div> : null}
       {header}
       {children}
     </div>

--- a/crates/mesh-llm-ui/src/features/configuration/lib/build-toml.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/lib/build-toml.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
-import { buildTOML } from '@/features/configuration/lib/build-toml'
 import { CONFIGURATION_DEFAULTS, CONFIGURATION_HARNESS } from '@/features/app-tabs/data'
-import type { ConfigAssign, ConfigNode } from '@/features/app-tabs/types'
+import type { ConfigAssign, ConfigNode, ConfigurationDefaultsHarnessData } from '@/features/app-tabs/types'
+import { buildTOML } from '@/features/configuration/lib/build-toml'
 
 describe('buildTOML', () => {
   it('escapes generated string values and omits legacy model keys', () => {
@@ -34,11 +34,13 @@ describe('buildTOML', () => {
     expect(toml).not.toContain(`id = ${JSON.stringify(assign.id)}`)
   })
 
-  it('emits canonical nested defaults and model override sections', () => {
+  it('emits changed canonical nested defaults and model override sections', () => {
     const toml = buildTOML(CONFIGURATION_HARNESS.nodes, CONFIGURATION_HARNESS.assigns, CONFIGURATION_HARNESS.catalog, {
       defaults: CONFIGURATION_DEFAULTS,
       defaultsValues: {
         'flash-attention': 'enabled',
+        'llamacpp-flavor': 'metal',
+        'memory-margin': '3.5',
         'speculation-mode': 'draft',
         'incompatible-pairing-behavior': 'fail_closed',
         'draft-max-tokens': '32',
@@ -50,26 +52,16 @@ describe('buildTOML', () => {
     expect(toml).toContain('version = 1')
     expect(toml).toContain('[defaults.model_fit]')
     expect(toml).toContain('flash_attention = "enabled"')
-    expect(toml).toContain('kv_cache_policy = "auto"')
     expect(toml).toContain('[defaults.hardware]')
-    expect(toml).toContain('model_runtime = "cuda"')
-    expect(toml).toContain('gpu_layers = -1')
-    expect(toml).toContain('safety_margin_gb = 2.0')
-    expect(toml).toContain('[defaults.throughput]')
-    expect(toml).toContain('parallel = 4')
-    expect(toml).toContain('tuning_profile = "balanced"')
+    expect(toml).toContain('model_runtime = "metal"')
+    expect(toml).toContain('safety_margin_gb = 3.5')
     expect(toml).toContain('[defaults.speculative]')
     expect(toml).toContain('mode = "draft"')
-    expect(toml).toContain('draft_selection_policy = "auto"')
     expect(toml).toContain('pairing_fault = "fail_closed"')
     expect(toml).toContain('draft_max_tokens = 32')
     expect(toml).toContain('[defaults.request_defaults]')
     expect(toml).toContain('temperature = 0.55')
-    expect(toml).toContain('top_p = 0.95')
     expect(toml).toContain('reasoning_format = "deepseek-legacy"')
-    expect(toml).toContain('reasoning_budget = 0')
-    expect(toml).toContain('repeat_penalty = 1.10')
-    expect(toml).toContain('repeat_last_n = 256')
     expect(toml).toContain('[[models]]')
     expect(toml).toContain('[models.model_fit]')
     expect(toml).toContain('ctx_size = 16384')
@@ -77,34 +69,92 @@ describe('buildTOML', () => {
     expect(toml).toContain('device = "cuda:0"')
     expect(toml).toContain('gpu_layers = -1')
     expect(toml).not.toContain('[defaults.speculative_decoding]')
+    expect(toml).not.toContain('draft_selection_policy = "auto"')
+    expect(toml).not.toContain('top_p = 0.95')
+    expect(toml).not.toContain('reasoning_budget = 0')
     expect(toml).not.toContain('ctx = ')
     expect(toml).not.toContain('gpu_index =')
     expect(toml).not.toContain('[node]')
     expect(toml).not.toContain('fail_launch')
-    expect(toml).not.toContain('draft_min_tokens')
-    expect(toml).not.toContain('draft_acceptance_threshold')
     expect(toml).not.toContain('chat_template =')
     expect(toml).not.toContain(`id = ${JSON.stringify(CONFIGURATION_HARNESS.assigns[0]?.id)}`)
   })
 
-  it('emits draft-only speculative settings only when draft mode is selected', () => {
+  it('omits disabled draft speculative settings unless draft mode is selected and changed', () => {
     const draftToml = buildTOML([], [], [], {
       defaults: CONFIGURATION_DEFAULTS,
-      defaultsValues: { 'speculation-mode': 'draft' }
+      defaultsValues: { 'speculation-mode': 'draft', 'draft-max-tokens': '32' }
     })
     const autoToml = buildTOML([], [], [], {
       defaults: CONFIGURATION_DEFAULTS,
       defaultsValues: { 'speculation-mode': 'auto', 'incompatible-pairing-behavior': 'fail_closed' }
     })
+    const ngramToml = buildTOML([], [], [], {
+      defaults: CONFIGURATION_DEFAULTS,
+      defaultsValues: { 'speculation-mode': 'ngram', 'incompatible-pairing-behavior': 'fail_closed' }
+    })
 
+    expect(draftToml).toContain('[defaults.speculative]')
     expect(draftToml).toContain('mode = "draft"')
-    expect(draftToml).toContain('draft_selection_policy = "auto"')
-    expect(draftToml).toContain('pairing_fault = "warn_disable"')
-    expect(draftToml).toContain('draft_max_tokens = 16')
-    expect(autoToml).toContain('mode = "auto"')
-    expect(autoToml).not.toContain('draft_selection_policy')
+    expect(draftToml).toContain('draft_max_tokens = 32')
+    expect(draftToml).not.toContain('pairing_fault = "warn_disable"')
+    expect(autoToml).not.toContain('[defaults.speculative]')
     expect(autoToml).not.toContain('pairing_fault')
-    expect(autoToml).not.toContain('draft_max_tokens')
+    expect(ngramToml).toContain('mode = "ngram"')
+    expect(ngramToml).not.toContain('pairing_fault')
+    expect(ngramToml).not.toContain('draft_selection_policy')
+  })
+
+  it('uses canonical inventory defaults when live defaults are hydrated into control values', () => {
+    const liveHydratedDefaults = {
+      ...CONFIGURATION_DEFAULTS,
+      settings: CONFIGURATION_DEFAULTS.settings.map((setting) => {
+        if (setting.id === 'activation-wire-dtype') {
+          return {
+            ...setting,
+            control: {
+              ...setting.control,
+              value: 'q8'
+            }
+          }
+        }
+
+        if (setting.id === 'image-min-tokens') {
+          return {
+            ...setting,
+            control: {
+              ...setting.control,
+              value: '64'
+            }
+          }
+        }
+
+        if (setting.id === 'server-alias') {
+          return {
+            ...setting,
+            control: {
+              ...setting.control,
+              value: 'carrack-mesh'
+            }
+          }
+        }
+
+        return setting
+      })
+    } satisfies ConfigurationDefaultsHarnessData
+
+    const toml = buildTOML([], [], [], {
+      defaults: liveHydratedDefaults,
+      defaultsValues: {}
+    })
+
+    expect(toml).toContain('[defaults.skippy]')
+    expect(toml).toContain('activation_wire_dtype = "q8"')
+    expect(toml).toContain('[defaults.multimodal]')
+    expect(toml).toContain('image_min_tokens = 64')
+    expect(toml).toContain('[defaults.advanced.server]')
+    expect(toml).toContain('alias = "carrack-mesh"')
+    expect(toml).not.toContain('[defaults.request_defaults]')
   })
 
   it('emits optional default hardware device and numeric gpu layer sentinel', () => {

--- a/crates/mesh-llm-ui/src/features/configuration/lib/build-toml.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/lib/build-toml.ts
@@ -1,5 +1,10 @@
 import { CFG_CATALOG } from '@/features/app-tabs/data'
 import { isUnifiedMemoryNode } from '@/features/configuration/lib/config-math'
+import {
+  getSettingBaselineValue,
+  getSettingValue,
+  isSettingDisabled
+} from '@/features/configuration/lib/settings-utils'
 import type {
   ConfigAssign,
   ConfigModel,
@@ -15,13 +20,6 @@ type BuildTomlOptions = {
   defaultsValues?: ConfigurationDefaultsValues
 }
 
-const draftModelModeSettingId = 'speculation-mode'
-const draftModelModeValue = 'draft'
-const draftModelOnlySettingIds = new Set([
-  'draft-selection-policy',
-  'draft-max-tokens',
-  'incompatible-pairing-behavior'
-])
 const defaultSectionOrder: readonly ConfigurationTomlSectionId[] = [
   'defaults.model_fit',
   'defaults.hardware',
@@ -32,7 +30,6 @@ const defaultSectionOrder: readonly ConfigurationTomlSectionId[] = [
   'defaults.multimodal',
   'defaults.advanced.server'
 ]
-
 function tomlString(value: string): string {
   return JSON.stringify(value)
 }
@@ -52,6 +49,7 @@ function isBooleanToggleChoice(setting: ConfigurationDefaultsSetting): boolean {
 
 function defaultTomlScalar(setting: ConfigurationDefaultsSetting, value: string): string {
   if (isBooleanToggleChoice(setting)) return value === 'on' ? 'true' : 'false'
+  if (setting.id === 'gpu-layers') return tomlScalar(value)
   if (setting.control.kind === 'text') return tomlString(value)
   if (setting.id === 'memory-margin') return Number(value).toFixed(1)
   if (setting.id === 'temperature' || setting.id === 'top-p' || setting.id === 'repeat-penalty')
@@ -59,22 +57,25 @@ function defaultTomlScalar(setting: ConfigurationDefaultsSetting, value: string)
   return tomlScalar(value)
 }
 
+const legacySectionPaths: Partial<Record<ConfigurationDefaultsSetting['categoryId'], string>> = {
+  advanced: 'defaults.runtime',
+  'speculative-decoding': 'defaults.speculative'
+}
+
+function defaultSectionPath(
+  setting: ConfigurationDefaultsSetting,
+  categoryById: ReadonlyMap<string, ConfigurationDefaultsHarnessData['categories'][number]>
+) {
+  return (
+    setting.tomlSection ??
+    categoryById.get(setting.categoryId)?.tomlSection ??
+    legacySectionPaths[setting.categoryId] ??
+    null
+  )
+}
+
 function tomlKey(value: string): string {
   return value.replaceAll('-', '_')
-}
-
-function defaultValue(setting: ConfigurationDefaultsSetting, values: ConfigurationDefaultsValues | undefined): string {
-  return values?.[setting.id] ?? setting.control.value
-}
-
-function shouldEmitDefaultSetting(
-  setting: ConfigurationDefaultsSetting,
-  settings: readonly ConfigurationDefaultsSetting[],
-  values: ConfigurationDefaultsValues | undefined
-): boolean {
-  const speculationModeSetting = settings.find((item) => item.id === draftModelModeSettingId)
-  if (!draftModelOnlySettingIds.has(setting.id)) return true
-  return speculationModeSetting ? defaultValue(speculationModeSetting, values) === draftModelModeValue : false
 }
 
 export function buildTOML(
@@ -92,27 +93,45 @@ export function buildTOML(
   ]
 
   if (options.defaults) {
-    const sectionSettings = new Map<ConfigurationTomlSectionId, ConfigurationDefaultsSetting[]>()
+    const sectionSettings = new Map<string, ConfigurationDefaultsSetting[]>()
+    const defaultsValues = options.defaultsValues ?? {}
+    const categoryById = new Map(options.defaults.categories.map((category) => [category.id, category] as const))
 
     for (const setting of options.defaults.settings) {
-      if (!shouldEmitDefaultSetting(setting, options.defaults.settings, options.defaultsValues)) continue
-      sectionSettings.set(setting.tomlSection, [...(sectionSettings.get(setting.tomlSection) ?? []), setting])
+      if (isSettingDisabled(setting, options.defaults.settings, defaultsValues)) continue
+
+      const value = getSettingValue(setting, defaultsValues)
+      if (value === getSettingBaselineValue(setting)) continue
+      if (setting.control.kind === 'text' && value.trim().length === 0) continue
+
+      const sectionPath = defaultSectionPath(setting, categoryById)
+      if (sectionPath) {
+        sectionSettings.set(sectionPath, [...(sectionSettings.get(sectionPath) ?? []), setting])
+        continue
+      }
+
+      const key = setting.control.kind === 'metric' ? setting.id : setting.control.name
+      lines.push(`${tomlKey(key)} = ${defaultTomlScalar(setting, value)}`)
     }
 
+    const orderedSectionPaths = [
+      ...defaultSectionOrder.filter((sectionPath) => sectionSettings.has(sectionPath)),
+      ...Array.from(sectionSettings.keys()).filter(
+        (sectionPath) => !defaultSectionOrder.includes(sectionPath as ConfigurationTomlSectionId)
+      )
+    ]
+
     let emittedDefaultsSectionCount = 0
-    for (const sectionName of defaultSectionOrder) {
-      const settings = sectionSettings.get(sectionName)
+    for (const sectionPath of orderedSectionPaths) {
+      const settings = sectionSettings.get(sectionPath)
       if (!settings) continue
 
+      if (lines[lines.length - 1] !== '') lines.push('')
       if (emittedDefaultsSectionCount > 0) lines.push('')
-      lines.push(`[${sectionName}]`)
+      lines.push(`[${sectionPath}]`)
       for (const setting of settings) {
-        if (!shouldEmitDefaultSetting(setting, options.defaults.settings, options.defaultsValues)) continue
-
-        const value = defaultValue(setting, options.defaultsValues)
-        if (setting.control.kind === 'text' && value.trim().length === 0) continue
-
-        const key = setting.tomlKey
+        const value = getSettingValue(setting, defaultsValues)
+        const key = setting.tomlKey ?? (setting.control.kind === 'metric' ? setting.id : setting.control.name)
         lines.push(`${tomlKey(key)} = ${defaultTomlScalar(setting, value)}`)
       }
       emittedDefaultsSectionCount += 1

--- a/crates/mesh-llm-ui/src/features/configuration/lib/settings-utils.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/lib/settings-utils.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getSettingDependencyStatus,
+  getSettingDisabledReason,
+  getSettingValue,
+  isSettingDisabled
+} from '@/features/configuration/lib/settings-utils'
+import type { ConfigurationDefaultsSetting, ConfigurationDefaultsValues } from '@/features/app-tabs/types'
+
+const parentSetting = {
+  id: 'test-parent-mode',
+  categoryId: 'runtime',
+  icon: 'cpu',
+  label: 'Parent mode',
+  description: 'Controls the dependent setting.',
+  inheritedLabel: 'Inherited by children',
+  control: {
+    kind: 'choice',
+    name: 'test_parent_mode',
+    value: 'off',
+    options: [
+      { value: 'off', label: 'off' },
+      { value: 'on', label: 'on' }
+    ]
+  }
+} satisfies ConfigurationDefaultsSetting
+
+const multiChoiceParentSetting = {
+  id: 'mirostat-mode',
+  categoryId: 'request-defaults',
+  icon: 'brain',
+  label: 'Mirostat mode',
+  description: 'Controls the dependent setting.',
+  inheritedLabel: 'Inherited by children',
+  control: {
+    kind: 'choice',
+    name: 'mirostat_mode',
+    value: 'disabled',
+    presentation: 'segmented',
+    options: [
+      { value: 'disabled', label: 'disabled' },
+      { value: '1', label: '1' },
+      { value: '2', label: '2' }
+    ]
+  }
+} satisfies ConfigurationDefaultsSetting
+
+const multiChoiceDependentSetting = {
+  id: 'mirostat-entropy',
+  categoryId: 'request-defaults',
+  icon: 'gauge',
+  label: 'Mirostat entropy',
+  description: 'Only usable when Mirostat is on.',
+  inheritedLabel: 'Inherited by dependent placements',
+  dependsOn: {
+    settingId: 'mirostat-mode',
+    condition: (value: string) => value !== 'disabled'
+  },
+  control: {
+    kind: 'range',
+    name: 'mirostat_entropy',
+    value: '5',
+    min: 0.1,
+    max: 10,
+    step: 0.1
+  }
+} satisfies ConfigurationDefaultsSetting
+
+const dependentSetting = {
+  id: 'test-dependent-setting',
+  categoryId: 'runtime',
+  icon: 'filter',
+  label: 'Dependent setting',
+  description: 'Only usable when the parent is on.',
+  inheritedLabel: 'Inherited by dependent placements',
+  dependsOn: {
+    settingId: 'test-parent-mode',
+    condition: (value: string) => value === 'on'
+  },
+  control: {
+    kind: 'text',
+    name: 'test_dependent_setting',
+    value: '',
+    placeholder: 'Optional value'
+  }
+} satisfies ConfigurationDefaultsSetting
+
+const settings = [parentSetting, dependentSetting] as const
+const multiChoiceSettings = [multiChoiceParentSetting, multiChoiceDependentSetting] as const
+
+describe('settings-utils', () => {
+  it('disables dependent settings and explains the requirement', () => {
+    const values: ConfigurationDefaultsValues = {}
+    const disabled = getSettingDependencyStatus(dependentSetting, settings, values)
+
+    expect(isSettingDisabled(dependentSetting, settings, values)).toBe(true)
+    expect(disabled).toEqual({ disabled: true, reason: 'Requires test-parent-mode = on' })
+    expect(getSettingDisabledReason(dependentSetting, settings, values)).toBe('Requires test-parent-mode = on')
+  })
+
+  it('uses the current value and clears the disabled state when satisfied', () => {
+    const values = { 'test-parent-mode': 'on' } satisfies ConfigurationDefaultsValues
+
+    expect(getSettingValue(parentSetting, values)).toBe('on')
+    expect(isSettingDisabled(dependentSetting, settings, values)).toBe(false)
+    expect(getSettingDependencyStatus(dependentSetting, settings, values)).toEqual({ disabled: false })
+  })
+
+  it('describes multi-option choice dependencies honestly', () => {
+    const values: ConfigurationDefaultsValues = {}
+    const disabled = getSettingDependencyStatus(multiChoiceDependentSetting, multiChoiceSettings, values)
+
+    expect(isSettingDisabled(multiChoiceDependentSetting, multiChoiceSettings, values)).toBe(true)
+    expect(disabled).toEqual({ disabled: true, reason: 'Requires mirostat-mode = 1 or 2' })
+    expect(getSettingDisabledReason(multiChoiceDependentSetting, multiChoiceSettings, values)).toBe(
+      'Requires mirostat-mode = 1 or 2'
+    )
+  })
+})

--- a/crates/mesh-llm-ui/src/features/configuration/lib/settings-utils.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/lib/settings-utils.ts
@@ -1,0 +1,84 @@
+import { CONFIGURATION_DEFAULTS } from '@/features/app-tabs/data'
+import type { ConfigurationDefaultsSetting, ConfigurationDefaultsValues } from '@/features/app-tabs/types'
+
+const canonicalDefaultsById = new Map<string, ConfigurationDefaultsSetting>(
+  CONFIGURATION_DEFAULTS.settings.map((setting) => [setting.id, setting] as const)
+)
+
+export type SettingDependencyStatus = {
+  disabled: boolean
+  reason?: string
+}
+
+export function getSettingValue(setting: ConfigurationDefaultsSetting, values: ConfigurationDefaultsValues) {
+  return values[setting.id] ?? setting.control.value
+}
+
+export function getSettingBaselineValue(setting: ConfigurationDefaultsSetting) {
+  return canonicalDefaultsById.get(setting.id)?.control.value ?? setting.control.value
+}
+
+function dependencyRequirementValue(
+  setting: ConfigurationDefaultsSetting,
+  allSettings: readonly ConfigurationDefaultsSetting[],
+  values: ConfigurationDefaultsValues
+) {
+  const dependency = setting.dependsOn
+  if (!dependency) return undefined
+
+  const parentSetting = allSettings.find((item) => item.id === dependency.settingId)
+  if (!parentSetting) return undefined
+
+  const currentValue = getSettingValue(parentSetting, values)
+  if (dependency.condition(currentValue)) return currentValue
+
+  if (parentSetting.control.kind === 'choice') {
+    const matchingOptions = parentSetting.control.options.filter((option) => dependency.condition(option.value))
+    if (matchingOptions.length > 0) return matchingOptions.map((option) => option.value)
+  }
+
+  return undefined
+}
+
+function formatRequirementValue(value: string | readonly string[]) {
+  return Array.isArray(value) ? value.join(' or ') : value
+}
+
+export function getSettingDependencyStatus(
+  setting: ConfigurationDefaultsSetting,
+  allSettings: readonly ConfigurationDefaultsSetting[],
+  values: ConfigurationDefaultsValues
+): SettingDependencyStatus {
+  if (!setting.dependsOn) return { disabled: false }
+
+  const parentSetting = allSettings.find((item) => item.id === setting.dependsOn?.settingId)
+  if (!parentSetting) {
+    return { disabled: true, reason: `Requires ${setting.dependsOn.settingId}` }
+  }
+
+  const parentValue = getSettingValue(parentSetting, values)
+  if (setting.dependsOn.condition(parentValue)) return { disabled: false }
+
+  const requiredValue = dependencyRequirementValue(setting, allSettings, values)
+  if (requiredValue !== undefined) {
+    return { disabled: true, reason: `Requires ${parentSetting.id} = ${formatRequirementValue(requiredValue)}` }
+  }
+
+  return { disabled: true, reason: `Requires ${parentSetting.id} to satisfy its dependency` }
+}
+
+export function isSettingDisabled(
+  setting: ConfigurationDefaultsSetting,
+  allSettings: readonly ConfigurationDefaultsSetting[],
+  values: ConfigurationDefaultsValues
+) {
+  return getSettingDependencyStatus(setting, allSettings, values).disabled
+}
+
+export function getSettingDisabledReason(
+  setting: ConfigurationDefaultsSetting,
+  allSettings: readonly ConfigurationDefaultsSetting[],
+  values: ConfigurationDefaultsValues
+) {
+  return getSettingDependencyStatus(setting, allSettings, values).reason
+}

--- a/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationPage.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render as rtlRender, screen, waitFor, within } from '@t
 import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AppProviders } from '@/app/providers/AppProviders'
+import * as configQueryModule from '@/features/configuration/api/use-config-query'
 
 const blockedBlocker = vi.hoisted(() => ({ status: 'blocked', proceed: vi.fn(), reset: vi.fn() }))
 const idleBlocker = vi.hoisted(() => ({ status: 'idle', proceed: vi.fn(), reset: vi.fn() }))
@@ -37,17 +38,20 @@ vi.mock('@/lib/feature-flags', async (importOriginal) => {
 
 import { ConfigurationPage } from '@/features/configuration/pages/ConfigurationPage'
 import { CONFIGURATION_HARNESS } from '@/features/app-tabs/data'
+import type { DataMode } from '@/lib/data-mode/data-mode-context'
 
-function TestProviders({ children }: { children: ReactNode }) {
+function TestProviders({ children, dataMode = 'harness' }: { children: ReactNode; dataMode?: DataMode }) {
   return (
-    <AppProviders initialDataMode="harness" persistDataMode={false}>
+    <AppProviders initialDataMode={dataMode} persistDataMode={false}>
       {children}
     </AppProviders>
   )
 }
 
-function render(ui: ReactElement) {
-  return rtlRender(ui, { wrapper: TestProviders })
+function render(ui: ReactElement, options?: { dataMode?: DataMode }) {
+  return rtlRender(ui, {
+    wrapper: ({ children }) => <TestProviders dataMode={options?.dataMode}>{children}</TestProviders>
+  })
 }
 
 function getCarrackSection() {
@@ -82,9 +86,25 @@ async function dispatchShortcut(key: string, init: KeyboardEventInit = {}) {
   return event
 }
 
+function liveControlConfigData() {
+  return {
+    bootstrap: {
+      enabled: true,
+      local_only: true,
+      requires_explicit_remote_endpoint: true,
+      endpoint: 'control://owner'
+    },
+    snapshot: {
+      revision: 7,
+      config: {}
+    }
+  }
+}
+
 describe('ConfigurationPage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
     featureFlagMocks.integrationsEnabled = false
     featureFlagMocks.signingAttestationEnabled = false
     featureFlagMocks.wakePolicyConfigurationEnabled = false
@@ -246,6 +266,379 @@ describe('ConfigurationPage', () => {
     expect(getTomlSource().value).toContain('tuning_profile = "throughput"')
   })
 
+  it('saves live defaults through useConfigQuery.applyDefaults only when Save config is clicked', async () => {
+    const applyDefaults = vi.fn().mockResolvedValue({
+      success: true,
+      current_revision: 8,
+      config_hash: 'abc123',
+      apply_mode: 'live'
+    })
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockReturnValue({
+      data: CONFIGURATION_HARNESS,
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: liveControlConfigData(),
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults
+    })
+
+    render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'live' })
+
+    const tuningProfileControl = within(screen.getByRole('radiogroup', { name: 'Default tuning profile' }))
+    const saveButton = screen.getByRole('button', { name: /save config/i })
+
+    fireEvent.click(tuningProfileControl.getByRole('radio', { name: 'throughput' }))
+    expect(applyDefaults).not.toHaveBeenCalled()
+
+    fireEvent.click(tuningProfileControl.getByRole('radio', { name: 'saver' }))
+    expect(applyDefaults).not.toHaveBeenCalled()
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(applyDefaults).toHaveBeenCalledTimes(1))
+    expect(applyDefaults).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'tuning-profile': 'saver'
+      })
+    )
+
+    useConfigQuerySpy.mockRestore()
+  })
+
+  it('shows owner-control remediation and keeps dirty state when live saving is disabled', async () => {
+    const applyDefaults = vi.fn()
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockReturnValue({
+      data: CONFIGURATION_HARNESS,
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: {
+          bootstrap: {
+            enabled: false,
+            local_only: true,
+            requires_explicit_remote_endpoint: true,
+            disabled_reason: 'missing_owner_identity',
+            message: 'Configuration saving requires a local owner identity.',
+            suggested_commands: [
+              'mesh-llm auth status',
+              'mesh-llm auth init --no-passphrase',
+              'mesh-llm serve --owner-required'
+            ]
+          }
+        },
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults
+    })
+
+    render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'live' })
+
+    const readOnlyHeading = screen.getByRole('heading', { name: 'Configuration UI is read-only' })
+    const inheritedDefaultsHeading = screen.getByRole('heading', { name: /inherited defaults/i })
+    const defaultsTab = screen.getByRole('tab', { name: 'Defaults' })
+    expect(readOnlyHeading).toBeInTheDocument()
+    expect(defaultsTab.compareDocumentPosition(readOnlyHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(
+      inheritedDefaultsHeading.compareDocumentPosition(readOnlyHeading) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      screen.getByText('No owner-control identity on this node, run both commands to unlock saving.')
+    ).toBeInTheDocument()
+    expect(screen.getByText('missing owner identity')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /docs/i })).toHaveAttribute('href', 'https://docs.meshllm.cloud/')
+    expect(screen.queryByRole('button', { name: /copy both/i })).not.toBeInTheDocument()
+    expect(screen.getAllByText('mesh-llm')).toHaveLength(2)
+    expect(screen.getByText('auth')).toBeInTheDocument()
+    expect(screen.getByText('init')).toBeInTheDocument()
+    expect(screen.getByText('serve')).toBeInTheDocument()
+    expect(screen.getByText('--no-passphrase')).toBeInTheDocument()
+    expect(screen.getByText('--owner-required')).toBeInTheDocument()
+    expect(screen.getByText('Initialize owner identity (creates a local keypair)')).toBeInTheDocument()
+    expect(screen.getByText('Restart the daemon so the new identity takes effect')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy mesh-llm auth init --no-passphrase' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Copy mesh-llm serve --owner-required' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('radio', { name: 'throughput' }))
+    const saveButton = screen.getByRole('button', { name: /save config/i })
+    expect(saveButton).toBeDisabled()
+    expect(saveButton).toHaveAttribute('title', 'Runtime control is disabled: missing owner identity')
+    expect(defaultsTab).toHaveAttribute('data-tab-dirty', 'true')
+
+    await dispatchShortcut('s', { ctrlKey: true })
+
+    expect(applyDefaults).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Config was not saved. Runtime control is disabled: missing owner identity.'
+    )
+    expect(defaultsTab).toHaveAttribute('data-tab-dirty', 'true')
+
+    useConfigQuerySpy.mockRestore()
+  })
+
+  it('shows runtime-control apply errors without rewriting them as missing owner identity', async () => {
+    const applyDefaults = vi.fn().mockResolvedValue({
+      success: false,
+      current_revision: 7,
+      config_hash: 'abc123',
+      apply_mode: 'unspecified',
+      error: 'revision conflict: current revision is 9'
+    })
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockReturnValue({
+      data: CONFIGURATION_HARNESS,
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: liveControlConfigData(),
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults
+    })
+
+    render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'live' })
+
+    fireEvent.click(screen.getByRole('radio', { name: 'throughput' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+
+    await waitFor(() => expect(applyDefaults).toHaveBeenCalledTimes(1))
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent(
+      'Config was not saved. Runtime control rejected the update: revision conflict: current revision is 9'
+    )
+    expect(alert).not.toHaveTextContent('missing owner identity')
+    expect(screen.getByRole('tab', { name: 'Defaults' })).toHaveAttribute('data-tab-dirty', 'true')
+
+    useConfigQuerySpy.mockRestore()
+  })
+
+  it('shows a busy Save config button while live defaults are being written', async () => {
+    let resolveApply: (value: {
+      success: boolean
+      current_revision: number
+      config_hash: string
+      apply_mode: string
+    }) => void = () => undefined
+    const applyDefaults = vi.fn(
+      () =>
+        new Promise<{
+          success: boolean
+          current_revision: number
+          config_hash: string
+          apply_mode: string
+        }>((resolve) => {
+          resolveApply = resolve
+        })
+    )
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockReturnValue({
+      data: CONFIGURATION_HARNESS,
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: liveControlConfigData(),
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults
+    })
+
+    render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'live' })
+
+    fireEvent.click(screen.getByRole('radio', { name: 'throughput' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+
+    const savingButton = screen.getByRole('button', { name: /saving config/i })
+    expect(savingButton).toBeDisabled()
+    expect(savingButton).toHaveAttribute('aria-busy', 'true')
+
+    await act(async () => {
+      resolveApply({ success: true, current_revision: 8, config_hash: 'abc123', apply_mode: 'live' })
+    })
+
+    expect(screen.getByRole('button', { name: /save config/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /save config/i })).not.toHaveAttribute('aria-busy', 'true')
+
+    useConfigQuerySpy.mockRestore()
+  })
+
+  it('does not re-apply saved live defaults when the hook callback identity changes', async () => {
+    const firstApplyDefaults = vi.fn().mockResolvedValue({
+      success: true,
+      current_revision: 8,
+      config_hash: 'abc123',
+      apply_mode: 'live'
+    })
+    const secondApplyDefaults = vi.fn().mockResolvedValue({
+      success: true,
+      current_revision: 9,
+      config_hash: 'def456',
+      apply_mode: 'live'
+    })
+    let currentApplyDefaults = firstApplyDefaults
+
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockImplementation(() => ({
+      data: CONFIGURATION_HARNESS,
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: liveControlConfigData(),
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults: currentApplyDefaults
+    }))
+
+    const { rerender } = render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'live' })
+
+    fireEvent.click(screen.getByRole('radio', { name: 'throughput' }))
+    fireEvent.click(screen.getByRole('button', { name: /save config/i }))
+
+    await waitFor(() => expect(firstApplyDefaults).toHaveBeenCalledTimes(1))
+
+    currentApplyDefaults = secondApplyDefaults
+    rerender(<ConfigurationPage enableNavigationBlocker={false} />)
+
+    expect(firstApplyDefaults).toHaveBeenCalledTimes(1)
+    expect(secondApplyDefaults).not.toHaveBeenCalled()
+
+    useConfigQuerySpy.mockRestore()
+  })
+
+  it('shows hydrated live non-default defaults while omitting unchanged metadata sections', async () => {
+    const user = userEvent.setup()
+    const liveDefaults = {
+      ...CONFIGURATION_HARNESS.defaults,
+      settings: CONFIGURATION_HARNESS.defaults.settings.map((setting) =>
+        setting.id === 'temperature'
+          ? {
+              ...setting,
+              control: {
+                ...setting.control,
+                value: '0.8'
+              }
+            }
+          : setting.id === 'server-alias'
+            ? {
+                ...setting,
+                control: {
+                  ...setting.control,
+                  value: 'carrack-mesh'
+                }
+              }
+            : setting.id === 'activation-wire-dtype'
+              ? {
+                  ...setting,
+                  control: {
+                    ...setting.control,
+                    value: 'q8'
+                  }
+                }
+              : setting.id === 'image-min-tokens'
+                ? {
+                    ...setting,
+                    control: {
+                      ...setting.control,
+                      value: '64'
+                    }
+                  }
+                : setting
+      )
+    }
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockReturnValue({
+      data: { ...CONFIGURATION_HARNESS, defaults: liveDefaults },
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: null,
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults: vi.fn()
+    })
+
+    render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'live' })
+
+    const initialTomlSource = await openTomlOutput(user)
+    expect(initialTomlSource.value).toContain('[defaults.request_defaults]')
+    expect(initialTomlSource.value).toContain('temperature = 0.8')
+    expect(initialTomlSource.value).toContain('[defaults.skippy]')
+    expect(initialTomlSource.value).toContain('activation_wire_dtype = "q8"')
+    expect(initialTomlSource.value).toContain('[defaults.multimodal]')
+    expect(initialTomlSource.value).toContain('image_min_tokens = 64')
+    expect(initialTomlSource.value).toContain('[defaults.advanced.server]')
+    expect(initialTomlSource.value).toContain('alias = "carrack-mesh"')
+
+    await user.click(screen.getByRole('tab', { name: 'Defaults' }))
+    await user.click(screen.getByRole('button', { name: /request defaults/i }))
+    expect(screen.getByRole('slider', { name: 'Temperature' })).toHaveValue('0.8')
+    const skippyTransport = within(screen.getByRole('radiogroup', { name: 'Binary stage transport' }))
+    const multimodalOffload = within(screen.getByRole('radiogroup', { name: 'MMProj offload' }))
+    await user.click(skippyTransport.getByRole('radio', { name: 'on' }))
+    await user.click(multimodalOffload.getByRole('radio', { name: 'on' }))
+    const updatedTomlSource = await openTomlOutput(user)
+    expect(updatedTomlSource.value).toContain('[defaults.skippy]')
+    expect(updatedTomlSource.value).toContain('[defaults.multimodal]')
+
+    useConfigQuerySpy.mockRestore()
+  })
+
+  it('does not call applyDefaults for defaults edits outside live mode', async () => {
+    const user = userEvent.setup()
+    const applyDefaults = vi.fn()
+    const useConfigQuerySpy = vi.spyOn(configQueryModule, 'useConfigQuery').mockReturnValue({
+      data: CONFIGURATION_HARNESS,
+      isError: false,
+      isFetching: false,
+      isPending: false,
+      statusQuery: { refetch: vi.fn() } as never,
+      modelsQuery: { refetch: vi.fn() } as never,
+      controlConfigQuery: {
+        data: null,
+        isError: false,
+        isFetching: false,
+        isPending: false
+      } as never,
+      applyDefaults
+    })
+
+    render(<ConfigurationPage enableNavigationBlocker={false} />, { dataMode: 'harness' })
+
+    await user.click(screen.getByRole('radio', { name: 'throughput' }))
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /save config/i })).toBeEnabled())
+    await user.click(screen.getByRole('button', { name: /save config/i }))
+    expect(applyDefaults).not.toHaveBeenCalled()
+
+    useConfigQuerySpy.mockRestore()
+  })
+
   it('uses an interactive slot meter instead of a Defaults slot slider', async () => {
     const user = userEvent.setup()
 
@@ -348,15 +741,15 @@ describe('ConfigurationPage', () => {
     expect(getTomlSource().value).toContain('[defaults.speculative]')
     expect(getTomlSource().value).not.toContain('enabled =')
     expect(getTomlSource().value).toContain('mode = "draft"')
-    expect(getTomlSource().value).toContain('draft_selection_policy = "auto"')
     expect(getTomlSource().value).toContain('draft_max_tokens = 32')
     expect(getTomlSource().value).toContain('pairing_fault = "fail_closed"')
+    expect(getTomlSource().value).not.toContain('draft_selection_policy = "auto"')
     expect(getTomlSource().value).not.toMatch(/^pairing_behavior =/m)
     expect(getTomlSource().value).not.toContain('incompatible_pairing_behavior')
-    expect(getTomlSource().value).toContain('model_runtime = "cuda"')
-    expect(getTomlSource().value).toContain('[defaults.request_defaults]')
-    expect(getTomlSource().value).toContain('temperature = 0.70')
-    expect(getTomlSource().value).toContain('reasoning_format = "auto"')
+    expect(getTomlSource().value).not.toContain('model_runtime = "cuda"')
+    expect(getTomlSource().value).not.toContain('[defaults.request_defaults]')
+    expect(getTomlSource().value).not.toContain('temperature = 0.70')
+    expect(getTomlSource().value).not.toContain('reasoning_format = "auto"')
     expect(getTomlSource().value).not.toContain('llama_flavor')
     expect(getTomlSource().value).not.toContain('allow_cpu_speculation')
     expect(getTomlSource().value).not.toContain('diagnostics =')
@@ -389,7 +782,12 @@ describe('ConfigurationPage', () => {
     expect(pairingBehaviorControl.getByRole('radio', { name: 'Warn & Disable' })).toBeDisabled()
     expect(pairingBehaviorControl.getByRole('radio', { name: 'Fail launch' })).toBeDisabled()
     expect(screen.getByRole('slider', { name: 'Default draft max tokens' })).toBeDisabled()
+    expect(screen.getByRole('slider', { name: 'Default draft minimum tokens' })).toBeDisabled()
+    expect(screen.queryByRole('slider', { name: 'Default draft acceptance threshold' })).not.toBeInTheDocument()
     expect(screen.queryByRole('radiogroup', { name: 'Allow CPU speculation' })).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /show advanced/i }))
+    expect(screen.getByRole('slider', { name: 'Default draft acceptance threshold' })).toBeDisabled()
 
     await user.click(modeControl.getByRole('radio', { name: 'n-gram' }))
     expect(draftPolicyControl.getByRole('radio', { name: 'auto' })).toBeDisabled()

--- a/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationPage.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationPage.tsx
@@ -1,5 +1,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { Binary, Blocks, Brackets, Computer, LockKeyhole, ShieldCheck, SlidersHorizontal } from 'lucide-react'
+import {
+  AlertTriangle,
+  Binary,
+  Blocks,
+  BookOpen,
+  Brackets,
+  Computer,
+  Copy,
+  LockKeyhole,
+  ShieldCheck,
+  SlidersHorizontal
+} from 'lucide-react'
+import { Alert, AlertDescription } from '@/components/ui/alert'
 import { LiveDataUnavailableOverlay } from '@/components/ui/LiveDataUnavailableOverlay'
 import { CatalogPopover } from '@/features/configuration/components/CatalogPopover'
 import { ConfigurationHeader } from '@/features/configuration/components/ConfigurationHeader'
@@ -39,8 +51,14 @@ import { useConfigurationPageKeyboardShortcuts } from '@/features/configuration/
 import { CONFIGURATION_HARNESS } from '@/features/app-tabs/data'
 import type { ConfigurationHarnessData, Placement } from '@/features/app-tabs/types'
 import { useConfigQuery } from '@/features/configuration/api/use-config-query'
+import {
+  runtimeControlApplyErrorMessage,
+  type RuntimeControlBootstrapPayload
+} from '@/features/configuration/api/config-adapter'
 import { useDataMode } from '@/lib/data-mode'
 import { useBooleanFeatureFlag } from '@/lib/feature-flags'
+import { copyStateLabel } from '@/lib/copyStateLabel'
+import { useClipboardCopy } from '@/lib/useClipboardCopy'
 
 type ConfigurationPageProps = {
   activeTab?: ConfigurationTabId
@@ -48,6 +66,145 @@ type ConfigurationPageProps = {
   enableNavigationBlocker?: boolean
   initialTab?: ConfigurationTabId
   onTabChange?: (tab: ConfigurationTabId) => void
+}
+
+const OWNER_CONTROL_READ_ONLY_MESSAGE = 'No owner-control identity on this node, run both commands to unlock saving.'
+const OWNER_CONTROL_SAVE_ERROR = 'Config was not saved. Runtime control is disabled: missing owner identity.'
+const RUNTIME_CONTROL_SAVE_UNAVAILABLE_ERROR = 'Config was not saved. Runtime control config is unavailable.'
+const OWNER_CONTROL_DOCS_URL = 'https://docs.meshllm.cloud/'
+
+function formatRuntimeControlDisabledReason(bootstrap: RuntimeControlBootstrapPayload | undefined) {
+  if (bootstrap?.disabled_reason === 'missing_owner_identity') return 'missing owner identity'
+  return bootstrap?.disabled_reason?.replace(/_/g, ' ') ?? 'unavailable'
+}
+
+function formatRuntimeControlDisabledMessage(bootstrap: RuntimeControlBootstrapPayload) {
+  if (bootstrap.disabled_reason === 'missing_owner_identity') return OWNER_CONTROL_READ_ONLY_MESSAGE
+  return (
+    bootstrap.message ??
+    `Configuration saving is unavailable because runtime control is disabled: ${formatRuntimeControlDisabledReason(bootstrap)}.`
+  )
+}
+
+function formatRuntimeControlDisabledSaveError(bootstrap: RuntimeControlBootstrapPayload | undefined) {
+  if (bootstrap?.disabled_reason === 'missing_owner_identity') return OWNER_CONTROL_SAVE_ERROR
+  return `Config was not saved. Runtime control is disabled: ${formatRuntimeControlDisabledReason(bootstrap)}.`
+}
+
+function formatRuntimeControlFailure(error: unknown) {
+  if (error instanceof Error && error.message.trim())
+    return `Config was not saved. Runtime control failed: ${error.message}`
+  return 'Config was not saved. Runtime control failed.'
+}
+
+function RuntimeCommandRow({ command, hint, index }: { command: string; hint: string; index: number }) {
+  const { copyState, copyText } = useClipboardCopy()
+  const [binary, action, ...args] = command.split(' ')
+
+  return (
+    <div className="grid grid-cols-[1.5rem_minmax(0,1fr)_4.5rem] items-start gap-2 px-5 py-2.5 sm:grid-cols-[1.75rem_minmax(0,1fr)_4.5rem]">
+      <div className="pt-1.5 text-right font-mono text-[length:var(--density-type-annotation)] font-medium leading-none text-fg-faint">
+        {index}
+      </div>
+      <div className="min-w-0">
+        <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto whitespace-nowrap font-mono text-[length:var(--density-type-caption-lg)] font-semibold leading-6">
+          <span className="text-accent">$</span>
+          <span className="text-accent">{binary}</span>
+          <span className="text-warn">{action}</span>
+          {args.map((arg) => (
+            <span key={arg} className="text-accent-contrast">
+              {arg}
+            </span>
+          ))}
+        </div>
+        <div className="mt-1 flex items-center gap-2 text-[length:var(--density-type-caption)] leading-5 text-fg-faint">
+          <span aria-hidden="true" className="font-mono text-warn">
+            →
+          </span>
+          <span>{hint}</span>
+        </div>
+      </div>
+      <button
+        aria-label={`Copy ${command}`}
+        className="ui-control inline-flex h-[30px] items-center justify-center gap-1.5 rounded-[var(--radius)] border px-2.5 text-[length:var(--density-type-control)] font-medium leading-none"
+        onClick={() => void copyText(command)}
+        type="button"
+      >
+        <Copy aria-hidden="true" className="size-3.5 shrink-0" />
+        {copyStateLabel(copyState)}
+      </button>
+    </div>
+  )
+}
+
+function ConfigurationRuntimeControlBanner({ bootstrap }: { bootstrap: RuntimeControlBootstrapPayload }) {
+  const suggestedCommands = bootstrap.suggested_commands?.length
+    ? bootstrap.suggested_commands
+    : ['mesh-llm auth init --no-passphrase', 'mesh-llm serve --owner-required']
+  const authInitCommand = suggestedCommands.includes('mesh-llm auth init --no-passphrase')
+    ? 'mesh-llm auth init --no-passphrase'
+    : suggestedCommands[0]
+  const restartCommand = suggestedCommands.includes('mesh-llm serve --owner-required')
+    ? 'mesh-llm serve --owner-required'
+    : (suggestedCommands[1] ?? 'mesh-llm serve --owner-required')
+  const commandPairs = [
+    {
+      command: authInitCommand,
+      hint: 'Initialize owner identity (creates a local keypair)'
+    },
+    {
+      command: restartCommand,
+      hint: 'Restart the daemon so the new identity takes effect'
+    }
+  ]
+
+  return (
+    <section
+      aria-labelledby="configuration-runtime-control-read-only"
+      className="panel-shell overflow-hidden rounded-[var(--radius-lg)] border border-border bg-panel text-foreground"
+    >
+      <div className="panel-divider flex flex-col gap-3 border-b border-border-soft px-[14px] py-[10px] sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <div className="flex size-8 shrink-0 items-center justify-center rounded-[var(--radius)] border border-[color:color-mix(in_oklab,var(--color-warn)_42%,var(--color-border))] bg-[color:color-mix(in_oklab,var(--color-warn)_10%,var(--color-panel))] text-warn shadow-surface-inset">
+            <LockKeyhole aria-hidden="true" className="size-4" strokeWidth={1.8} />
+          </div>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2
+                id="configuration-runtime-control-read-only"
+                className="text-[length:var(--density-type-control-lg)] font-semibold leading-tight text-foreground"
+              >
+                Configuration UI is read-only
+              </h2>
+              <span className="inline-flex items-center gap-1.5 rounded-[var(--radius)] border border-[color:color-mix(in_oklab,var(--color-warn)_48%,var(--color-border))] bg-[color:color-mix(in_oklab,var(--color-warn)_8%,var(--color-panel))] px-2 py-0.5 font-mono text-[length:var(--density-type-annotation)] font-semibold uppercase leading-none tracking-[0.14em] text-warn">
+                <AlertTriangle aria-hidden="true" className="size-3" strokeWidth={1.9} />
+                {formatRuntimeControlDisabledReason(bootstrap)}
+              </span>
+            </div>
+            <p className="mt-1 max-w-[72ch] text-[length:var(--density-type-caption)] leading-snug text-fg-faint">
+              {formatRuntimeControlDisabledMessage(bootstrap)}
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 sm:self-start">
+          <a
+            className="ui-control inline-flex h-[30px] items-center justify-center gap-1.5 rounded-[var(--radius)] border px-3 text-[length:var(--density-type-control)] font-medium leading-none"
+            href={OWNER_CONTROL_DOCS_URL}
+            rel="noreferrer"
+            target="_blank"
+          >
+            <BookOpen aria-hidden="true" className="size-3.5" strokeWidth={1.8} />
+            Docs
+          </a>
+        </div>
+      </div>
+      <div className="bg-background py-3">
+        {commandPairs.map((commandPair, index) => (
+          <RuntimeCommandRow key={commandPair.command} index={index + 1} {...commandPair} />
+        ))}
+      </div>
+    </section>
+  )
 }
 
 function ReadOnlyNodesDivider() {
@@ -75,7 +232,27 @@ export function ConfigurationPageContent({
   const signingAttestationEnabled = useBooleanFeatureFlag('configuration/signingAttestation')
   const integrationsEnabled = useBooleanFeatureFlag('configuration/integrations')
   const wakePolicyConfigurationEnabled = useBooleanFeatureFlag('configuration/wakePolicyConfiguration')
-  const { data: liveData, isFetching, isError, modelsQuery, statusQuery } = useConfigQuery({ enabled: liveMode })
+  const {
+    data: liveData,
+    isFetching,
+    isError,
+    modelsQuery,
+    statusQuery,
+    controlConfigQuery,
+    applyDefaults
+  } = useConfigQuery({
+    enabled: liveMode
+  })
+  const runtimeControlBootstrap = controlConfigQuery.data?.bootstrap
+  const runtimeControlDisabled = liveMode && Boolean(runtimeControlBootstrap && !runtimeControlBootstrap.enabled)
+  const runtimeControlDisabledReason = runtimeControlDisabled
+    ? `Runtime control is disabled: ${formatRuntimeControlDisabledReason(runtimeControlBootstrap)}`
+    : undefined
+  const runtimeControlConfigUnavailableReason =
+    liveMode && !runtimeControlDisabled && !controlConfigQuery.isFetching && !controlConfigQuery.data?.snapshot
+      ? 'Runtime control config is unavailable'
+      : undefined
+  const runtimeControlSaveDisabledReason = runtimeControlDisabledReason ?? runtimeControlConfigUnavailableReason
   const resolvedData = liveMode ? liveData : data
   const displayData = resolvedData ?? data
   const showLiveError = liveMode && !liveData && !isFetching && isError
@@ -135,6 +312,8 @@ export function ConfigurationPageContent({
   const [savedConfiguration, setSavedConfiguration] = useState<ConfigurationState>(() =>
     cloneConfigurationState(initialConfiguration)
   )
+  const [isSavingConfiguration, setIsSavingConfiguration] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const appliedConfigurationSourceKeyRef = useRef(configurationSourceKey)
   useEffect(() => {
     if (appliedConfigurationSourceKeyRef.current === configurationSourceKey) return
@@ -142,6 +321,7 @@ export function ConfigurationPageContent({
     const nextConfiguration = latestInitialConfigurationRef.current
     resetConfiguration(nextConfiguration)
     setSavedConfiguration(cloneConfigurationState(nextConfiguration))
+    setSaveError(null)
     appliedConfigurationSourceKeyRef.current = configurationSourceKey
   }, [configurationSourceKey, resetConfiguration])
   const {
@@ -226,6 +406,16 @@ export function ConfigurationPageContent({
     [savedConfiguration]
   )
   const hasUnsavedChanges = currentSnapshot !== savedSnapshot
+  const saveAlertMessage = useMemo(() => {
+    if (!hasUnsavedChanges || !saveError) return null
+    if (saveError === RUNTIME_CONTROL_SAVE_UNAVAILABLE_ERROR) {
+      return runtimeControlConfigUnavailableReason ? saveError : null
+    }
+    if (saveError.startsWith('Config was not saved. Runtime control is disabled:')) {
+      return runtimeControlDisabledReason ? saveError : null
+    }
+    return saveError
+  }, [hasUnsavedChanges, runtimeControlConfigUnavailableReason, runtimeControlDisabledReason, saveError])
   const defaultsDirty = useMemo(
     () => JSON.stringify(defaultsValues) !== JSON.stringify(savedConfiguration.defaultsValues),
     [defaultsValues, savedConfiguration.defaultsValues]
@@ -278,9 +468,53 @@ export function ConfigurationPageContent({
   }, [displayData.preferredAssignId, resetConfiguration, restorePreferredSelection, savedConfiguration])
 
   const saveConfiguration = useCallback(() => {
-    if (hasInvalidNode || !hasUnsavedChanges) return
+    if (isSavingConfiguration || hasInvalidNode || !hasUnsavedChanges) return
+
+    setSaveError(null)
+
+    if (runtimeControlDisabled) {
+      setSaveError(formatRuntimeControlDisabledSaveError(runtimeControlBootstrap))
+      return
+    }
+
+    if (runtimeControlConfigUnavailableReason) {
+      setSaveError(RUNTIME_CONTROL_SAVE_UNAVAILABLE_ERROR)
+      return
+    }
+
+    if (liveMode && defaultsDirty) {
+      setIsSavingConfiguration(true)
+      void applyDefaults(configuration.defaultsValues)
+        .then((response) => {
+          if (!response?.success) {
+            const message = runtimeControlApplyErrorMessage(response)
+            setSaveError(
+              message
+                ? `Config was not saved. Runtime control rejected the update: ${message}`
+                : RUNTIME_CONTROL_SAVE_UNAVAILABLE_ERROR
+            )
+            return
+          }
+          setSavedConfiguration(cloneConfigurationState(configuration))
+        })
+        .catch((error: unknown) => setSaveError(formatRuntimeControlFailure(error)))
+        .finally(() => setIsSavingConfiguration(false))
+      return
+    }
+
     setSavedConfiguration(cloneConfigurationState(configuration))
-  }, [configuration, hasInvalidNode, hasUnsavedChanges])
+  }, [
+    applyDefaults,
+    configuration,
+    defaultsDirty,
+    hasInvalidNode,
+    hasUnsavedChanges,
+    isSavingConfiguration,
+    liveMode,
+    runtimeControlBootstrap,
+    runtimeControlConfigUnavailableReason,
+    runtimeControlDisabled
+  ])
   const retryLiveData = useCallback(() => {
     void Promise.all([statusQuery.refetch(), modelsQuery.refetch()])
   }, [modelsQuery, statusQuery])
@@ -414,6 +648,11 @@ export function ConfigurationPageContent({
           onResetAll={resetDefaultSettings}
           onSettingValueChange={updateDefaultSetting}
           configFilePath={displayData.configFilePath}
+          readOnlyNotice={
+            runtimeControlDisabled && runtimeControlBootstrap ? (
+              <ConfigurationRuntimeControlBanner bootstrap={runtimeControlBootstrap} />
+            ) : undefined
+          }
         />
       )
     },
@@ -525,6 +764,8 @@ export function ConfigurationPageContent({
             canRedo={canRedo}
             hasUnsavedChanges={hasUnsavedChanges}
             hasInvalidNode={hasInvalidNode}
+            isSaving={isSavingConfiguration}
+            saveDisabledReason={runtimeControlSaveDisabledReason}
             onUndo={undoConfigurationChange}
             onRedo={redoConfigurationChange}
             onRevert={revertConfiguration}
@@ -532,6 +773,14 @@ export function ConfigurationPageContent({
           />
         }
       >
+        {saveAlertMessage ? (
+          <div className="px-5 pb-3">
+            <Alert variant="destructive">
+              <AlertTriangle aria-hidden="true" className="size-4" />
+              <AlertDescription>{saveAlertMessage}</AlertDescription>
+            </Alert>
+          </div>
+        ) : null}
         <ConfigurationTabs value={renderedActiveTab} onValueChange={setActiveTab} tabs={tabs} />
       </ConfigurationLayout>
       {enableNavigationBlocker ? <UnsavedConfigurationNavigationBlocker hasUnsavedChanges={hasUnsavedChanges} /> : null}

--- a/crates/mesh-llm-ui/src/features/dashboard/components/topology/ui/MeshRadarField.tsx
+++ b/crates/mesh-llm-ui/src/features/dashboard/components/topology/ui/MeshRadarField.tsx
@@ -10,6 +10,7 @@ import {
 import { Clock3, Cpu, MemoryStick, Minus, Plus, RotateCcw, Sparkles, Wifi } from 'lucide-react'
 
 import { formatShortDuration } from '@/lib/format-duration'
+import { env } from '@/lib/env'
 import { useResolvedTheme } from '@/lib/resolved-theme'
 import { cn } from '@/lib/utils'
 import { formatLiveNodeState, modelRefLabel } from '@/features/app-shell/lib/status-helpers'
@@ -410,7 +411,7 @@ export function MeshRadarField({
     top: `${selfScreenY}px`,
     transform: `translate(-50%, -50%) scale(${selfAccentScale})`
   }
-  const showDebugControls = import.meta.env.DEV
+  const showDebugControls = env.isDevelopment
   const hoveredNodeSecondaryLabel = hoveredNode && hoveredNode.label !== hoveredNode.id ? hoveredNode.id : null
   const hoveredNodeShowsModel =
     hoveredNode != null && !(hoveredNode.role === 'Client' && hoveredNode.modelLabel === 'API-only')

--- a/crates/mesh-llm-ui/src/features/shell/components/TopNav.test.tsx
+++ b/crates/mesh-llm-ui/src/features/shell/components/TopNav.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TopNav } from '@/features/shell/components/TopNav'
 import { DataModeProvider } from '@/lib/data-mode'
+import { env } from '@/lib/env'
 import type { DataMode } from '@/lib/data-mode'
 
 function installClipboard(writeText: (text: string) => Promise<void>) {
@@ -65,6 +66,7 @@ async function waitForHoverDelay() {
 
 describe('TopNav', () => {
   beforeEach(() => {
+    env.isDevelopment = true
     installPointerCaptureShim()
   })
 
@@ -300,7 +302,7 @@ describe('TopNav', () => {
   })
 
   it('hides development-only navigation controls outside dev mode', async () => {
-    vi.stubEnv('DEV', false)
+    env.isDevelopment = false
     const user = userEvent.setup()
 
     renderTopNav({ onOpenDeveloperPlayground: vi.fn(), showDeveloperPlayground: true })

--- a/crates/mesh-llm-ui/src/features/shell/components/TopNav.tsx
+++ b/crates/mesh-llm-ui/src/features/shell/components/TopNav.tsx
@@ -22,6 +22,7 @@ import { CopyInstructionRow } from '@/components/ui/CopyInstructionRow'
 import type { LinkItem, TopNavJoinCommand, Theme, AppTab } from '@/features/app-tabs/types'
 import { cn } from '@/lib/cn'
 import { useDataMode, type DataMode } from '@/lib/data-mode'
+import { env } from '@/lib/env'
 import { useI18n } from '@/lib/i18n'
 
 type TopNavProps = {
@@ -266,7 +267,7 @@ const DEFAULT_API_ACCESS_LINKS: LinkItem[] = [
 function ApiAccessContent({ apiUrl, dataMode, links }: { apiUrl: string; dataMode: DataMode; links?: LinkItem[] }) {
   const listModelsCommand = `curl ${apiUrl}/models`
   const harnessMode = dataMode === 'harness'
-  const showDevelopmentNavControls = import.meta.env.DEV
+  const showDevelopmentNavControls = env.isDevelopment
 
   return (
     <>
@@ -503,7 +504,7 @@ function CompactActionsMenu({
 >) {
   const { mode } = useDataMode()
   const [activePanel, setActivePanel] = useState<CompactActionPanel>(null)
-  const showDevelopmentNavControls = import.meta.env.DEV
+  const showDevelopmentNavControls = env.isDevelopment
   const actionRow =
     'ui-row-action flex w-full items-center justify-between gap-3 rounded-[var(--radius)] border border-border-soft px-3 py-2 text-left text-[length:var(--density-type-caption-lg)] font-medium text-foreground'
 
@@ -638,7 +639,7 @@ function UtilityActions({
   | 'joinLinks'
 >) {
   const { mode } = useDataMode()
-  const showDevelopmentNavControls = import.meta.env.DEV
+  const showDevelopmentNavControls = env.isDevelopment
   const iconBtn =
     'ui-control inline-flex size-[var(--nav-action-size)] items-center justify-center rounded-[var(--radius)] border'
   const utilityBtn =

--- a/crates/mesh-llm-ui/src/lib/env.ts
+++ b/crates/mesh-llm-ui/src/lib/env.ts
@@ -31,7 +31,8 @@ export const env = {
   managementApiUrl: import.meta.env.VITE_MANAGEMENT_API_URL ?? '',
   routerBasePath: normalizeRouterBasePath(import.meta.env.VITE_ROUTER_BASE_PATH ?? import.meta.env.BASE_URL),
   storageNamespace: import.meta.env.VITE_STORAGE_NAMESPACE ?? 'mesh-llm-ui-preview',
-  isDevelopment: import.meta.env.DEV
+  // True for Vite's dev server and for embedded UI bundles built into debug mesh-llm binaries.
+  isDevelopment: import.meta.env.DEV || import.meta.env.VITE_MESH_LLM_DEBUG_UI === 'true'
 }
 
 export function isDevelopmentMode() {

--- a/crates/mesh-llm-ui/src/vite-env.d.ts
+++ b/crates/mesh-llm-ui/src/vite-env.d.ts
@@ -1,5 +1,9 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_MESH_LLM_DEBUG_UI?: string
+}
+
 declare module '*.svg' {
   const src: string
   export default src

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -236,7 +236,7 @@ LLAMA_WORKDIR="$LLAMA_DIR" \
 if [[ "$SKIP_UI" == "1" ]]; then
     echo "Skipping UI build (MESH_LLM_SKIP_UI=1 or --skip-ui)."
 elif [[ -d "$UI_DIR" ]]; then
-    "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
+    MESH_LLM_BUILD_PROFILE="${MESH_LLM_BUILD_PROFILE:-debug}" "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
 fi
 
 if [[ "${MESH_LLM_BUILD_PROFILE:-debug}" == "dev" || "${MESH_LLM_BUILD_PROFILE:-debug}" == "debug" ]]; then

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -86,7 +86,7 @@ LLAMA_WORKDIR="$LLAMA_DIR" \
 
 if [[ -d "$MESH_DIR" ]]; then
     if [[ -d "$UI_DIR" ]]; then
-        "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
+        MESH_LLM_BUILD_PROFILE="$build_profile" "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
     fi
 
     configure_rust_cache

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -121,7 +121,7 @@ LLAMA_WORKDIR="$LLAMA_DIR" \
     "$SCRIPT_DIR/build-llama.sh"
 
 echo "Building UI..."
-"$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
+MESH_LLM_BUILD_PROFILE=release "$SCRIPT_DIR/build-ui.sh" "$UI_DIR"
 
 echo "Building mesh-llm..."
 (cd "$REPO_ROOT" && cargo build --release --locked -p mesh-llm)

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -3,8 +3,27 @@
 set -euo pipefail
 
 UI_DIR="${1:?usage: build-ui.sh /path/to/ui}"
+UI_DIR="$(cd "$UI_DIR" && pwd)"
 DIST_DIR="$UI_DIR/dist"
 NODE_MODULES_DIR="$UI_DIR/node_modules"
+UI_BUILD_ENV_STAMP="$DIST_DIR/.mesh-llm-ui-build-env"
+MESH_LLM_UI_BUILD_PROFILE="${MESH_LLM_BUILD_PROFILE:-debug}"
+MESH_LLM_UI_BUILD_PROFILE="${MESH_LLM_UI_BUILD_PROFILE,,}"
+
+case "$MESH_LLM_UI_BUILD_PROFILE" in
+    dev|debug)
+        : "${VITE_MESH_LLM_DEBUG_UI:=true}"
+        ;;
+    release)
+        VITE_MESH_LLM_DEBUG_UI=false
+        ;;
+    *)
+        echo "Unsupported MESH_LLM_BUILD_PROFILE '$MESH_LLM_UI_BUILD_PROFILE'. Expected debug, dev, or release." >&2
+        exit 1
+        ;;
+esac
+
+export VITE_MESH_LLM_DEBUG_UI
 
 ui_build_inputs=(
     "$UI_DIR/package.json"
@@ -23,8 +42,34 @@ dist_has_output() {
     [[ -d "$DIST_DIR" ]] && find "$DIST_DIR" -type f -print -quit | grep -q .
 }
 
+expected_build_env_stamp() {
+    cat <<EOF
+MESH_LLM_BUILD_PROFILE=$MESH_LLM_UI_BUILD_PROFILE
+VITE_MESH_LLM_DEBUG_UI=$VITE_MESH_LLM_DEBUG_UI
+VITE_BASE_PATH=${VITE_BASE_PATH:-}
+VITE_ROUTER_BASE_PATH=${VITE_ROUTER_BASE_PATH:-}
+VITE_STORAGE_NAMESPACE=${VITE_STORAGE_NAMESPACE:-}
+EOF
+}
+
+ui_build_env_is_stale() {
+    if [[ ! -f "$UI_BUILD_ENV_STAMP" ]]; then
+        return 0
+    fi
+
+    if ! diff -q <(expected_build_env_stamp) "$UI_BUILD_ENV_STAMP" >/dev/null; then
+        return 0
+    fi
+
+    return 1
+}
+
 ui_build_is_stale() {
     if ! dist_has_output; then
+        return 0
+    fi
+
+    if ui_build_env_is_stale; then
         return 0
     fi
 
@@ -55,7 +100,7 @@ pnpm_install_is_stale() {
 }
 
 if ui_build_is_stale; then
-    echo "Building mesh-llm UI..."
+    echo "Building mesh-llm UI (profile: $MESH_LLM_UI_BUILD_PROFILE, debug UI: $VITE_MESH_LLM_DEBUG_UI)..."
     cd "$UI_DIR"
 
     if pnpm_install_is_stale; then
@@ -63,6 +108,7 @@ if ui_build_is_stale; then
     fi
 
     pnpm run build
+    expected_build_env_stamp > "$UI_BUILD_ENV_STAMP"
 else
-    echo "Skipping mesh-llm UI build; dist is up to date."
+    echo "Skipping mesh-llm UI build; dist is up to date (profile: $MESH_LLM_UI_BUILD_PROFILE, debug UI: $VITE_MESH_LLM_DEBUG_UI)."
 fi

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -8,7 +8,7 @@ DIST_DIR="$UI_DIR/dist"
 NODE_MODULES_DIR="$UI_DIR/node_modules"
 UI_BUILD_ENV_STAMP="$DIST_DIR/.mesh-llm-ui-build-env"
 MESH_LLM_UI_BUILD_PROFILE="${MESH_LLM_BUILD_PROFILE:-debug}"
-MESH_LLM_UI_BUILD_PROFILE="${MESH_LLM_UI_BUILD_PROFILE,,}"
+MESH_LLM_UI_BUILD_PROFILE="$(printf '%s' "$MESH_LLM_UI_BUILD_PROFILE" | tr '[:upper:]' '[:lower:]')"
 
 case "$MESH_LLM_UI_BUILD_PROFILE" in
     dev|debug)

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -17,6 +17,13 @@ $compilerLauncherArgs = @()
 $compilerCacheBin = $null
 $buildProfile = if ($BuildProfile) { $BuildProfile.ToLowerInvariant() } elseif ($env:MESH_LLM_BUILD_PROFILE) { $env:MESH_LLM_BUILD_PROFILE.ToLowerInvariant() } else { "debug" }
 
+switch ($buildProfile) {
+    "debug" { if (-not $env:VITE_MESH_LLM_DEBUG_UI) { $env:VITE_MESH_LLM_DEBUG_UI = "true" } }
+    "dev" { if (-not $env:VITE_MESH_LLM_DEBUG_UI) { $env:VITE_MESH_LLM_DEBUG_UI = "true" } }
+    "release" { $env:VITE_MESH_LLM_DEBUG_UI = "false" }
+    default { throw "Unsupported MESH_LLM_BUILD_PROFILE/BuildProfile '$buildProfile'. Expected debug, dev, or release." }
+}
+
 function Prepare-Llama {
     $pinFile = Join-Path $repoRoot "third_party\llama.cpp\upstream.txt"
     $patchDir = Join-Path $repoRoot "third_party\llama.cpp\patches"
@@ -356,6 +363,16 @@ function Invoke-CmakeBuild {
     }
 }
 
+function Get-UiBuildEnvStampContent {
+    return @(
+        "MESH_LLM_BUILD_PROFILE=$buildProfile",
+        "VITE_MESH_LLM_DEBUG_UI=$($env:VITE_MESH_LLM_DEBUG_UI)",
+        "VITE_BASE_PATH=$($env:VITE_BASE_PATH)",
+        "VITE_ROUTER_BASE_PATH=$($env:VITE_ROUTER_BASE_PATH)",
+        "VITE_STORAGE_NAMESPACE=$($env:VITE_STORAGE_NAMESPACE)"
+    ) -join "`n"
+}
+
 function Test-UiBuildRequired {
     param(
         [Parameter(Mandatory = $true)]
@@ -369,6 +386,17 @@ function Test-UiBuildRequired {
 
     $distFiles = Get-ChildItem -Path $distDir -File -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
     if (-not $distFiles) {
+        return $true
+    }
+
+    $buildEnvStamp = Join-Path $distDir ".mesh-llm-ui-build-env"
+    if (-not (Test-Path $buildEnvStamp)) {
+        return $true
+    }
+
+    $expectedBuildEnvStamp = Get-UiBuildEnvStampContent
+    $actualBuildEnvStamp = Get-Content -Path $buildEnvStamp -Raw
+    if ($actualBuildEnvStamp.TrimEnd() -ne $expectedBuildEnvStamp.TrimEnd()) {
         return $true
     }
 
@@ -935,18 +963,19 @@ Invoke-InRepo {
         Write-Host "Skipping mesh-llm UI build because MESH_LLM_SKIP_UI=1."
     } elseif (Test-Path $meshUiDir) {
         if (Test-UiBuildRequired -UiDirectory $meshUiDir) {
-            Write-Host "Building mesh-llm UI..."
+            Write-Host "Building mesh-llm UI (profile: $buildProfile, debug UI: $($env:VITE_MESH_LLM_DEBUG_UI))..."
             Push-Location $meshUiDir
             try {
                 if (Test-PnpmInstallRequired -UiDirectory $meshUiDir) {
                     Invoke-NativeCommand "pnpm" @("install", "--frozen-lockfile")
                 }
                 Invoke-NativeCommand "pnpm" @("run", "build")
+                Set-Content -Path (Join-Path (Join-Path $meshUiDir "dist") ".mesh-llm-ui-build-env") -Value (Get-UiBuildEnvStampContent)
             } finally {
                 Pop-Location
             }
         } else {
-            Write-Host "Skipping mesh-llm UI build; dist is up to date."
+            Write-Host "Skipping mesh-llm UI build; dist is up to date (profile: $buildProfile, debug UI: $($env:VITE_MESH_LLM_DEBUG_UI))."
         }
     }
 

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "build-ui.sh"
+
+
+class BuildUiScriptTests(unittest.TestCase):
+    def test_mixed_case_release_profile_uses_release_ui_env(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            ui_dir = Path(tmp) / "ui"
+            self._write_up_to_date_ui_fixture(ui_dir, profile="release", debug_ui="false")
+
+            env = os.environ.copy()
+            env["MESH_LLM_BUILD_PROFILE"] = "ReLeAsE"
+            for key in ("VITE_BASE_PATH", "VITE_ROUTER_BASE_PATH", "VITE_STORAGE_NAMESPACE"):
+                env.pop(key, None)
+
+            result = subprocess.run(
+                ["bash", str(SCRIPT), str(ui_dir)],
+                cwd=ROOT,
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("profile: release", result.stdout)
+        self.assertIn("debug UI: false", result.stdout)
+
+    def _write_up_to_date_ui_fixture(self, ui_dir: Path, *, profile: str, debug_ui: str) -> None:
+        ui_dir.mkdir()
+        for relative in (
+            "package.json",
+            "pnpm-lock.yaml",
+            "vite.config.ts",
+            "tsconfig.json",
+            "tsconfig.app.json",
+            "tsconfig.node.json",
+            "biome.json",
+            "index.html",
+        ):
+            (ui_dir / relative).write_text("{}\n", encoding="utf-8")
+        (ui_dir / "src").mkdir()
+        (ui_dir / "public").mkdir()
+
+        dist_dir = ui_dir / "dist"
+        dist_dir.mkdir()
+        (dist_dir / "asset.js").write_text("// built\n", encoding="utf-8")
+        (dist_dir / ".mesh-llm-ui-build-env").write_text(
+            f"MESH_LLM_BUILD_PROFILE={profile}\n"
+            f"VITE_MESH_LLM_DEBUG_UI={debug_ui}\n"
+            "VITE_BASE_PATH=\n"
+            "VITE_ROUTER_BASE_PATH=\n"
+            "VITE_STORAGE_NAMESPACE=\n",
+            encoding="utf-8",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
This PR adds the UI surface to connect all of the settings from PR #564 to their respective UI components.

## Screenshot
<img width="1300" height="1852" alt="image" src="https://github.com/user-attachments/assets/fc7f77ff-0d9a-4278-a396-0284a3ff3ab3" />

### What changed
- Added a broader configuration defaults inventory for runtime, memory, speculative decoding, request defaults, Skippy transport, multimodal, and advanced server settings.
- Wired configuration UI state to runtime-control APIs so local defaults can be fetched, edited, previewed as TOML, and applied back to the host config.
- Added canonical TOML generation for nested `[defaults.*]` sections with baseline/default omission and dependency-aware setting emission.
- Extended runtime config parsing/resolution for Skippy, request defaults, speculative decoding, multimodal, advanced server, and preserved unknown config fields.
- Added protocol support for canonical config TOML snapshots via `NodeConfigSnapshot.config_toml`.
- Added/updated tests for config adapters, runtime-control query/apply flow, defaults UI behavior, TOML generation, protocol conversion, Skippy resolver behavior, and smoke coverage.
- Added Skippy configuration documentation and manual smoke fixtures/scripts.

### Validation
Full validation passed with:
- `just test-all`
That included:
- Rust format check
- Clippy with warnings denied
- Rust tests
- UI ESLint + Prettier
- UI TypeScript typecheck
- Vitest unit tests: `83 passed`, `671 passed`, `3 skipped`
- Playwright smoke tests: `2 passed`, `1 skipped`




