### PR TITLE
test: verify CI on fresh main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,5 @@ plus `glslc`.
 Mesh LLM is experimental distributed-systems software. When you report bugs,
 include the command you ran, platform/backend flavor, `/api/status` output if
 available, and whether the node was private, published, or joined with `--auto`.
+
+<!-- ci: macos runner pool test -->

--- a/crates/mesh-llm-protocol/src/lib.rs
+++ b/crates/mesh-llm-protocol/src/lib.rs
@@ -1,5 +1,7 @@
 #![forbid(unsafe_code)]
 
+// ci: macos runner pool test (sdk smoke trigger)
+
 pub mod proto;
 pub mod protocol;
 

--- a/crates/mesh-llm/src/main.rs
+++ b/crates/mesh-llm/src/main.rs
@@ -1,5 +1,7 @@
 #![recursion_limit = "256"]
 
+// ci: macos runner pool test (rust touch)
+
 /// Default Tokio worker thread stack size: 8 MB.
 ///
 /// The standard Tokio default is 2 MB, which is too small for several spawned


### PR DESCRIPTION
Trivial change off latest main to diagnose macOS runner pool issue. Will close after CI runs.