### PR TITLE
Route around recently unhealthy inference targets

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -1,6 +1,7 @@
 //! Prefix affinity and sticky routing helpers for inference target selection.
 
 use crate::inference::election;
+use crate::network::target_health::{TargetHealth, TargetHealthOutcome};
 use iroh::EndpointId;
 use serde::Serialize;
 use serde_json::Value;
@@ -87,6 +88,7 @@ struct AffinityState {
 pub struct AffinityRouter {
     inner: Arc<Mutex<AffinityState>>,
     config: Arc<AffinityConfig>,
+    target_health: TargetHealth,
 }
 
 impl AffinityRouter {
@@ -94,6 +96,7 @@ impl AffinityRouter {
         Self {
             inner: Arc::new(Mutex::new(AffinityState::default())),
             config: Arc::new(AffinityConfig::from_env()),
+            target_health: TargetHealth::default(),
         }
     }
 
@@ -105,6 +108,7 @@ impl AffinityRouter {
                 prefix_enabled,
                 sticky_enabled,
             }),
+            target_health: TargetHealth::default(),
         }
     }
 
@@ -116,6 +120,23 @@ impl AffinityRouter {
         stats.prefix_enabled = self.config.prefix_enabled;
         stats.sticky_enabled = self.config.sticky_enabled;
         stats
+    }
+
+    pub(crate) fn route_eligible_candidates(
+        &self,
+        model: &str,
+        candidates: &[election::InferenceTarget],
+    ) -> Vec<election::InferenceTarget> {
+        self.target_health.eligible_candidates(model, candidates)
+    }
+
+    pub(crate) fn record_target_outcome(
+        &self,
+        model: Option<&str>,
+        target: &election::InferenceTarget,
+        outcome: TargetHealthOutcome,
+    ) {
+        self.target_health.record_outcome(model, target, outcome);
     }
 
     pub fn sticky_enabled(&self) -> bool {
@@ -590,6 +611,8 @@ pub fn select_model_target_from_candidates(
     parsed_body: Option<&Value>,
     affinity: &AffinityRouter,
 ) -> TargetSelection {
+    let eligible_candidates = affinity.route_eligible_candidates(model, candidates);
+    let candidates = eligible_candidates.as_slice();
     let routing = routing_keys(parsed_body);
 
     if let Some(session_hash) = routing.session_hash.filter(|_| affinity.sticky_enabled()) {
@@ -668,14 +691,7 @@ pub fn prepare_remote_targets_for_request(
     if let Some(session_hash) = routing.session_hash.filter(|_| affinity.sticky_enabled()) {
         affinity.record_session_route();
         rotate_targets_by_hash(&mut ordered, session_hash);
-        return PreparedTargets {
-            ordered,
-            learn_prefix_hash: None,
-            cached_target: None,
-        };
-    }
-
-    if let Some(prefix_hash) = routing.prefix_hash {
+    } else if let Some(prefix_hash) = routing.prefix_hash {
         learn_prefix_hash = Some(prefix_hash);
         if let Some(target) = affinity.lookup_target(model, prefix_hash, &ordered) {
             move_target_first(&mut ordered, &target);
@@ -692,6 +708,17 @@ pub fn prepare_remote_targets_for_request(
         rotate_targets_by_hash(&mut ordered, sticky_hash);
     }
 
+    let eligible = affinity.route_eligible_candidates(model, &ordered);
+    if eligible.len() != ordered.len() {
+        if let (Some(prefix_hash), Some(target)) = (learn_prefix_hash, cached_target.as_ref()) {
+            if !eligible.contains(target) {
+                affinity.forget_target(model, prefix_hash, target);
+                cached_target = None;
+            }
+        }
+        ordered = eligible;
+    }
+
     PreparedTargets {
         ordered,
         learn_prefix_hash,
@@ -702,6 +729,7 @@ pub fn prepare_remote_targets_for_request(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::network::target_health::TargetHealthOutcome;
     use iroh::SecretKey;
 
     fn make_id(seed: u8) -> EndpointId {
@@ -825,6 +853,43 @@ mod tests {
             prepared.cached_target,
             Some(election::InferenceTarget::Remote(id_b))
         );
+        affinity.record_target_outcome(
+            Some("qwen"),
+            &election::InferenceTarget::Remote(id_b),
+            TargetHealthOutcome::Unavailable,
+        );
+        let prepared = prepare_remote_targets_for_request("qwen", &hosts, Some(&req), &affinity);
+        assert_eq!(
+            prepared.ordered,
+            vec![election::InferenceTarget::Remote(id_a)]
+        );
+        assert_eq!(prepared.cached_target, None);
+    }
+
+    #[test]
+    fn test_prepare_remote_targets_filters_cooling_session_hint_target() {
+        let id_a = make_id(1);
+        let id_b = make_id(2);
+        let hosts = vec![id_a, id_b];
+        let affinity = AffinityRouter::with_config(true, true);
+        let req = parse_body(
+            r#"{"prompt_cache_key":"cache-1","messages":[{"role":"user","content":"task A"}]}"#,
+        );
+
+        let prepared = prepare_remote_targets_for_request("qwen", &hosts, Some(&req), &affinity);
+        let cooling_target = prepared.ordered.first().cloned().unwrap();
+
+        affinity.record_target_outcome(
+            Some("qwen"),
+            &cooling_target,
+            TargetHealthOutcome::Unavailable,
+        );
+
+        let prepared = prepare_remote_targets_for_request("qwen", &hosts, Some(&req), &affinity);
+        assert!(!prepared.ordered.contains(&cooling_target));
+        assert_eq!(prepared.ordered.len(), 1);
+        assert_eq!(prepared.learn_prefix_hash, None);
+        assert_eq!(prepared.cached_target, None);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/mod.rs
@@ -5,4 +5,5 @@ pub(crate) mod nostr;
 pub(crate) mod openai;
 pub(crate) mod proxy;
 pub(crate) mod router;
+pub(crate) mod target_health;
 pub(crate) mod tunnel;

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -10,6 +10,7 @@ use crate::network::affinity::{
 };
 use crate::network::openai::response_adapter;
 use crate::network::router;
+use crate::network::target_health::TargetHealthOutcome;
 use crate::plugin;
 use anyhow::{anyhow, bail, Context, Result};
 use serde::Deserialize;
@@ -114,6 +115,22 @@ fn route_attempt_result_label(result: &RouteAttemptResult) -> &'static str {
         RouteAttemptResult::RetryableUnavailable => "retryable_unavailable",
         RouteAttemptResult::RetryableContextOverflow => "retryable_context_overflow",
         RouteAttemptResult::ClientDisconnected => "client_disconnected",
+    }
+}
+
+fn target_health_outcome_for_attempt(result: &RouteAttemptResult) -> TargetHealthOutcome {
+    match result {
+        RouteAttemptResult::Delivered { status_code, .. } if (200..300).contains(status_code) => {
+            TargetHealthOutcome::Success
+        }
+        RouteAttemptResult::Delivered { status_code, .. } if (500..600).contains(status_code) => {
+            TargetHealthOutcome::Unavailable
+        }
+        RouteAttemptResult::Delivered { .. } => TargetHealthOutcome::Rejected,
+        RouteAttemptResult::RetryableTimeout => TargetHealthOutcome::Timeout,
+        RouteAttemptResult::RetryableUnavailable => TargetHealthOutcome::Unavailable,
+        RouteAttemptResult::RetryableContextOverflow => TargetHealthOutcome::ContextOverflow,
+        RouteAttemptResult::ClientDisconnected => TargetHealthOutcome::ClientDisconnected,
     }
 }
 
@@ -2610,6 +2627,11 @@ pub async fn handle_mesh_request(
             ),
             RouteAttemptResult::ClientDisconnected => {}
         }
+        affinity.record_target_outcome(
+            effective_model.as_deref(),
+            &attempt_target,
+            target_health_outcome_for_attempt(&attempt_result),
+        );
         match attempt_result {
             RouteAttemptResult::Delivered {
                 status_code,
@@ -2785,6 +2807,7 @@ pub async fn route_model_request(
     let mut tcp_stream = tcp_stream;
     let ordered_candidates =
         order_targets_by_context(&node, model, required_tokens, &targets.candidates(model)).await;
+    let ordered_candidates = affinity.route_eligible_candidates(model, &ordered_candidates);
     if ordered_candidates.is_empty() {
         node.record_routed_request(
             Some(model),
@@ -2894,6 +2917,11 @@ pub async fn route_model_request(
             ),
             RouteAttemptResult::ClientDisconnected => {}
         }
+        affinity.record_target_outcome(
+            Some(model),
+            &target,
+            target_health_outcome_for_attempt(&attempt_result),
+        );
         tracing::info!(
             model = model,
             target = ?target,
@@ -3854,6 +3882,39 @@ mod tests {
         assert_eq!(
             route_attempt_result_label(&RouteAttemptResult::ClientDisconnected),
             "client_disconnected"
+        );
+    }
+
+    #[test]
+    fn test_target_health_outcome_for_attempt_values() {
+        assert_eq!(
+            target_health_outcome_for_attempt(&RouteAttemptResult::Delivered {
+                status_code: 200,
+                completion_tokens: None,
+            }),
+            TargetHealthOutcome::Success
+        );
+        assert_eq!(
+            target_health_outcome_for_attempt(&RouteAttemptResult::Delivered {
+                status_code: 503,
+                completion_tokens: None,
+            }),
+            TargetHealthOutcome::Unavailable
+        );
+        assert_eq!(
+            target_health_outcome_for_attempt(&RouteAttemptResult::Delivered {
+                status_code: 400,
+                completion_tokens: None,
+            }),
+            TargetHealthOutcome::Rejected
+        );
+        assert_eq!(
+            target_health_outcome_for_attempt(&RouteAttemptResult::RetryableContextOverflow),
+            TargetHealthOutcome::ContextOverflow
+        );
+        assert_eq!(
+            target_health_outcome_for_attempt(&RouteAttemptResult::RetryableTimeout),
+            TargetHealthOutcome::Timeout
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/target_health.rs
+++ b/crates/mesh-llm-host-runtime/src/network/target_health.rs
@@ -1,0 +1,387 @@
+//! Local outcome-aware target health for routing decisions.
+//!
+//! This state is intentionally process-local. It helps the local proxy avoid a
+//! target that just timed out or returned unavailable, but it is not a mesh
+//! protocol signal and should not be gossiped.
+
+use crate::inference::election::InferenceTarget;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const DEFAULT_BASE_COOLDOWN: Duration = Duration::from_secs(30);
+const DEFAULT_MAX_COOLDOWN: Duration = Duration::from_secs(5 * 60);
+const DEFAULT_MAX_ENTRIES: usize = 2048;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TargetHealthOutcome {
+    Success,
+    Timeout,
+    Unavailable,
+    ContextOverflow,
+    Rejected,
+    ClientDisconnected,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct TargetKey {
+    model: String,
+    target: InferenceTarget,
+}
+
+#[derive(Clone, Debug)]
+struct TargetEntry {
+    failures: u32,
+    cool_until: Instant,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct TargetHealthConfig {
+    base_cooldown: Duration,
+    max_cooldown: Duration,
+    max_entries: usize,
+}
+
+impl Default for TargetHealthConfig {
+    fn default() -> Self {
+        Self {
+            base_cooldown: DEFAULT_BASE_COOLDOWN,
+            max_cooldown: DEFAULT_MAX_COOLDOWN,
+            max_entries: DEFAULT_MAX_ENTRIES,
+        }
+    }
+}
+
+#[derive(Default)]
+struct TargetHealthState {
+    entries: HashMap<TargetKey, TargetEntry>,
+    lru: VecDeque<TargetKey>,
+    routes_avoided: u64,
+}
+
+#[cfg(test)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct TargetHealthSnapshot {
+    pub cooling_targets: usize,
+    pub routes_avoided: u64,
+}
+
+#[derive(Clone)]
+pub(crate) struct TargetHealth {
+    inner: Arc<Mutex<TargetHealthState>>,
+    config: TargetHealthConfig,
+}
+
+impl Default for TargetHealth {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TargetHealth {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TargetHealthState::default())),
+            config: TargetHealthConfig::default(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_config(base_cooldown: Duration, max_cooldown: Duration, max_entries: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TargetHealthState::default())),
+            config: TargetHealthConfig {
+                base_cooldown,
+                max_cooldown,
+                max_entries,
+            },
+        }
+    }
+
+    pub(crate) fn record_outcome(
+        &self,
+        model: Option<&str>,
+        target: &InferenceTarget,
+        outcome: TargetHealthOutcome,
+    ) {
+        if matches!(target, InferenceTarget::None) {
+            return;
+        }
+        let Some(model) = normalized_model(model) else {
+            return;
+        };
+        let key = TargetKey {
+            model,
+            target: target.clone(),
+        };
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired(Instant::now());
+
+        match outcome {
+            TargetHealthOutcome::Success => state.remove_key(&key),
+            TargetHealthOutcome::Timeout | TargetHealthOutcome::Unavailable => {
+                state.record_failure(key, Instant::now(), self.config);
+            }
+            TargetHealthOutcome::ContextOverflow
+            | TargetHealthOutcome::Rejected
+            | TargetHealthOutcome::ClientDisconnected => {}
+        }
+    }
+
+    pub(crate) fn eligible_candidates(
+        &self,
+        model: &str,
+        candidates: &[InferenceTarget],
+    ) -> Vec<InferenceTarget> {
+        if candidates.len() <= 1 {
+            return candidates.to_vec();
+        }
+        let Some(model) = normalized_model(Some(model)) else {
+            return candidates.to_vec();
+        };
+        let now = Instant::now();
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired(now);
+
+        let mut eligible = Vec::with_capacity(candidates.len());
+        let mut cooling = 0usize;
+        for candidate in candidates {
+            let key = TargetKey {
+                model: model.clone(),
+                target: candidate.clone(),
+            };
+            if state.is_cooling(&key, now) {
+                cooling += 1;
+            } else {
+                eligible.push(candidate.clone());
+            }
+        }
+
+        if cooling == 0 || !has_routable_candidate(&eligible) {
+            candidates.to_vec()
+        } else {
+            state.routes_avoided = state.routes_avoided.saturating_add(cooling as u64);
+            eligible
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn snapshot(&self) -> TargetHealthSnapshot {
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired(Instant::now());
+        TargetHealthSnapshot {
+            cooling_targets: state.entries.len(),
+            routes_avoided: state.routes_avoided,
+        }
+    }
+}
+
+impl TargetHealthState {
+    fn record_failure(&mut self, key: TargetKey, now: Instant, config: TargetHealthConfig) {
+        let failures = self
+            .entries
+            .get(&key)
+            .map(|entry| entry.failures.saturating_add(1))
+            .unwrap_or(1);
+        let cooldown = cooldown_for_failure(failures, config);
+        self.entries.insert(
+            key.clone(),
+            TargetEntry {
+                failures,
+                cool_until: now + cooldown,
+            },
+        );
+        self.touch_key(&key);
+        self.prune_over_capacity(config.max_entries);
+    }
+
+    fn is_cooling(&self, key: &TargetKey, now: Instant) -> bool {
+        self.entries
+            .get(key)
+            .map(|entry| entry.cool_until > now)
+            .unwrap_or(false)
+    }
+
+    fn prune_expired(&mut self, now: Instant) {
+        let expired: Vec<TargetKey> = self
+            .entries
+            .iter()
+            .filter_map(|(key, entry)| (entry.cool_until <= now).then_some(key.clone()))
+            .collect();
+        for key in expired {
+            self.remove_key(&key);
+        }
+    }
+
+    fn prune_over_capacity(&mut self, max_entries: usize) {
+        while self.entries.len() > max_entries {
+            let Some(key) = self.lru.pop_front() else {
+                break;
+            };
+            self.entries.remove(&key);
+        }
+    }
+
+    fn touch_key(&mut self, key: &TargetKey) {
+        self.lru.retain(|existing| existing != key);
+        self.lru.push_back(key.clone());
+    }
+
+    fn remove_key(&mut self, key: &TargetKey) {
+        self.entries.remove(key);
+        self.lru.retain(|existing| existing != key);
+    }
+}
+
+fn normalized_model(model: Option<&str>) -> Option<String> {
+    model
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn has_routable_candidate(candidates: &[InferenceTarget]) -> bool {
+    candidates
+        .iter()
+        .any(|candidate| !matches!(candidate, InferenceTarget::None))
+}
+
+fn cooldown_for_failure(failures: u32, config: TargetHealthConfig) -> Duration {
+    let multiplier = 1u32
+        .checked_shl(failures.saturating_sub(1).min(6))
+        .unwrap_or(64);
+    config
+        .base_cooldown
+        .saturating_mul(multiplier)
+        .min(config.max_cooldown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local(port: u16) -> InferenceTarget {
+        InferenceTarget::Local(port)
+    }
+
+    #[test]
+    fn retryable_failure_cools_target_when_alternatives_exist() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Unavailable);
+
+        assert_eq!(
+            health.eligible_candidates("qwen", &candidates),
+            vec![local(9002)]
+        );
+        assert_eq!(
+            health.snapshot(),
+            TargetHealthSnapshot {
+                cooling_targets: 1,
+                routes_avoided: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn success_clears_target_cooldown() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Success);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(health.snapshot().cooling_targets, 0);
+    }
+
+    #[test]
+    fn context_overflow_and_rejected_do_not_cool_target() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(
+            Some("qwen"),
+            &local(9001),
+            TargetHealthOutcome::ContextOverflow,
+        );
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Rejected);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(health.snapshot().cooling_targets, 0);
+    }
+
+    #[test]
+    fn all_cooling_candidates_remain_eligible_to_preserve_availability() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+        health.record_outcome(Some("qwen"), &local(9002), TargetHealthOutcome::Unavailable);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(health.snapshot().cooling_targets, 2);
+    }
+
+    #[test]
+    fn none_does_not_count_as_a_routable_cooldown_alternative() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), InferenceTarget::None];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(
+            health.snapshot(),
+            TargetHealthSnapshot {
+                cooling_targets: 1,
+                routes_avoided: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn cooldowns_are_scoped_by_model_and_target() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+
+        assert_eq!(
+            health.eligible_candidates("qwen", &candidates),
+            vec![local(9002)]
+        );
+        assert_eq!(health.eligible_candidates("llama", &candidates), candidates);
+    }
+
+    #[test]
+    fn expired_cooldowns_are_pruned() {
+        let health = TargetHealth::with_config(
+            Duration::from_millis(0),
+            Duration::from_millis(0),
+            DEFAULT_MAX_ENTRIES,
+        );
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(health.snapshot().cooling_targets, 0);
+    }
+
+    #[test]
+    fn entry_limit_evicts_oldest_cooldown() {
+        let health = TargetHealth::with_config(Duration::from_secs(60), Duration::from_secs(60), 1);
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+        health.record_outcome(Some("qwen"), &local(9002), TargetHealthOutcome::Timeout);
+
+        assert_eq!(
+            health.eligible_candidates("qwen", &candidates),
+            vec![local(9001)]
+        );
+        assert_eq!(health.snapshot().cooling_targets, 1);
+    }
+}


### PR DESCRIPTION
## Summary

This adds outcome-aware routing cooldowns for inference targets. When a target recently times out, fails as unavailable, or returns a server-side failure, the local proxy temporarily routes around it when another eligible target exists.

- Adds a bounded local target-health tracker keyed by model and full inference target.
- Applies cooldown filtering after context-capacity ordering and before prefix, sticky, or round-robin target selection.
- Records routing outcomes from both explicit model routing and mesh remote-host routing.
- Keeps context-overflow responses, ordinary 4xx rejections, and client disconnects out of target cooldowns.
- Preserves availability by falling back to the original candidate order when every candidate is currently cooling.

## Why

Sticky routing and prefix affinity are useful when a target is healthy, but they can keep sending follow-up traffic to a target that just failed. This keeps the existing affinity behavior while giving the router a short local memory of unhealthy outcomes, so a transiently bad target does not keep winning while healthy alternatives are available.

## Design

The cooldown state is intentionally local-only. It is not gossiped, serialized into the mesh protocol, or exposed as a new public API contract.

- `Timeout`, tunnel/unavailable failures, and delivered 5xx responses cool the specific `(model, target)` pair.
- A successful attempt clears the cooldown for that pair.
- Context overflow remains a request-shape/context-capacity signal, not a peer-health signal.
- Cooldowns are bounded, expire automatically, and are scoped per model and target.
- If all candidates are cooling, routing still proceeds with the original candidates instead of failing closed.

## Compatibility

No mesh gossip, protobuf, plugin protocol, or public API schema changes are introduced. Mixed-version meshes continue to interoperate because this only affects local target ordering inside the current process.

## Validation

- `git fetch --no-tags origin main:refs/remotes/origin/main`
- `git diff --check`
- `git diff --cached --check`
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=<local llama-stage ABI build dir> cargo test -p mesh-llm-host-runtime target_health --lib`: PASS, 8 passed
- `LLAMA_STAGE_BUILD_DIR=<local llama-stage ABI build dir> cargo test -p mesh-llm-host-runtime network::affinity --lib`: PASS, 14 passed
- `LLAMA_STAGE_BUILD_DIR=<local llama-stage ABI build dir> cargo check -p mesh-llm-host-runtime`: PASS

Not run: `just build` - not required for this narrow runtime routing change; no UI or build artifact changed.

## Rollback

Revert this PR.