### PR TITLE
Add advisory capacity evaluation for model targets

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -40,6 +40,7 @@
 
 mod assets;
 mod http;
+mod model_target_capacity;
 mod model_targets;
 mod routes;
 mod server;

--- a/crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs
+++ b/crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs
@@ -1,0 +1,447 @@
+//! Advisory model-target capacity evaluation for management API responses.
+//!
+//! This is intentionally local to the API layer: it derives operator hints from
+//! existing mesh/catalog signals and does not affect routing, startup, gossip,
+//! or protocol compatibility.
+
+use super::status::{ModelTargetCapacityAdvicePayload, ModelTargetCapacityAdviceState};
+use crate::mesh::{NodeRole, PeerInfo};
+use crate::models;
+use crate::runtime;
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ModelTargetCapacityInput<'a> {
+    pub(crate) model_ref: &'a str,
+    pub(crate) model_name: Option<&'a str>,
+    pub(crate) serving_node_count: usize,
+    pub(crate) local_role: &'a NodeRole,
+    pub(crate) local_vram_bytes: u64,
+    pub(crate) peers: &'a [PeerInfo],
+    pub(crate) size_lookup: &'a ModelTargetSizeLookup,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ModelSizeHint {
+    model_bytes: u64,
+    split_capable: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ModelTargetSizeLookup {
+    hints_by_key: HashMap<String, ModelSizeHint>,
+}
+
+impl ModelTargetSizeLookup {
+    pub(crate) fn load() -> Self {
+        models::remote_catalog::catalog_entries()
+            .map(Self::from_entries)
+            .unwrap_or_default()
+    }
+
+    fn from_entries(entries: Vec<models::remote_catalog::CatalogEntry>) -> Self {
+        let mut lookup = Self::default();
+        for entry in entries {
+            let mut variants = entry.variants.iter().collect::<Vec<_>>();
+            variants.sort_by(|left, right| left.0.cmp(right.0));
+            for (variant_name, variant) in variants {
+                let source_file = variant
+                    .source
+                    .file
+                    .as_deref()
+                    .unwrap_or(variant_name.as_str());
+                let split_capable = variant
+                    .packages
+                    .iter()
+                    .any(|package| package.package_type == "layer-package");
+                if let Some(model_bytes) = variant
+                    .curated
+                    .size
+                    .as_deref()
+                    .and_then(parse_size_label_bytes)
+                {
+                    lookup.insert_model_aliases(
+                        variant_name,
+                        &variant.curated.name,
+                        &variant.source.repo,
+                        variant.source.revision.as_deref(),
+                        source_file,
+                        ModelSizeHint {
+                            model_bytes,
+                            split_capable,
+                        },
+                    );
+                }
+
+                for package in variant
+                    .packages
+                    .iter()
+                    .filter(|package| package.package_type == "layer-package")
+                {
+                    if let Some(model_bytes) = package.total_bytes {
+                        lookup.insert_package_alias(
+                            &package.repo,
+                            ModelSizeHint {
+                                model_bytes,
+                                split_capable: true,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        lookup
+    }
+
+    fn find(&self, query: &str) -> Option<ModelSizeHint> {
+        self.hints_by_key.get(&normalize_match_key(query)).copied()
+    }
+
+    fn insert_model_aliases(
+        &mut self,
+        variant_name: &str,
+        curated_name: &str,
+        repo: &str,
+        revision: Option<&str>,
+        source_file: &str,
+        hint: ModelSizeHint,
+    ) {
+        let basename = source_file.rsplit('/').next().unwrap_or(source_file);
+        let selector = model_ref::quant_selector_from_gguf_file(source_file);
+        let model_ref_with_revision =
+            model_ref::format_model_ref(repo, revision, selector.as_deref());
+        let model_ref_without_revision =
+            model_ref::format_model_ref(repo, None, selector.as_deref());
+        let canonical_ref =
+            revision.map(|revision| model_ref::format_canonical_ref(repo, revision, source_file));
+
+        for alias in [
+            variant_name,
+            curated_name,
+            repo,
+            source_file,
+            basename,
+            basename.trim_end_matches(".gguf"),
+            model_ref_with_revision.as_str(),
+            model_ref_without_revision.as_str(),
+        ] {
+            self.insert_model_alias(alias, hint);
+        }
+        if let Some(canonical_ref) = canonical_ref {
+            self.insert_model_alias(&canonical_ref, hint);
+        }
+    }
+
+    fn insert_model_alias(&mut self, alias: &str, hint: ModelSizeHint) {
+        self.hints_by_key
+            .entry(normalize_match_key(alias))
+            .or_insert(hint);
+    }
+
+    fn insert_package_alias(&mut self, alias: &str, hint: ModelSizeHint) {
+        self.hints_by_key.insert(normalize_match_key(alias), hint);
+    }
+}
+
+pub(crate) fn evaluate_model_target_capacity(
+    input: ModelTargetCapacityInput<'_>,
+) -> ModelTargetCapacityAdvicePayload {
+    let capacity = collect_capacity(input.local_role, input.local_vram_bytes, input.peers);
+    let size_hint = input.size_lookup.find(input.model_ref).or_else(|| {
+        input
+            .model_name
+            .and_then(|name| input.size_lookup.find(name))
+    });
+    let required_bytes = size_hint
+        .map(|hint| runtime::runtime_model_required_bytes(hint.model_bytes))
+        .filter(|required| *required > 0);
+    let split_capable = size_hint.map(|hint| hint.split_capable).unwrap_or(false);
+
+    if input.serving_node_count > 0 {
+        return advice(
+            ModelTargetCapacityAdviceState::AlreadyServing,
+            "already_serving",
+            capacity,
+            AdviceDetails {
+                required_bytes,
+                shortfall_bytes: None,
+                split_capable,
+            },
+        );
+    }
+
+    let Some(required_bytes) = required_bytes else {
+        return advice(
+            ModelTargetCapacityAdviceState::UnknownModelSize,
+            "model_size_unknown",
+            capacity,
+            AdviceDetails {
+                required_bytes: None,
+                shortfall_bytes: None,
+                split_capable,
+            },
+        );
+    };
+
+    if capacity.missing_capacity_node_count > 0 {
+        return advice(
+            ModelTargetCapacityAdviceState::UnknownCapacity,
+            "eligible_nodes_missing_capacity",
+            capacity,
+            AdviceDetails {
+                required_bytes: Some(required_bytes),
+                shortfall_bytes: None,
+                split_capable,
+            },
+        );
+    }
+
+    if capacity.eligible_node_count == 0 {
+        return advice(
+            ModelTargetCapacityAdviceState::NoEligibleHosts,
+            "no_worker_or_host_capacity",
+            capacity,
+            AdviceDetails {
+                required_bytes: Some(required_bytes),
+                shortfall_bytes: None,
+                split_capable,
+            },
+        );
+    }
+
+    if capacity
+        .best_single_node_capacity_bytes
+        .is_some_and(|best| best >= required_bytes)
+    {
+        return advice(
+            ModelTargetCapacityAdviceState::SingleNodeFit,
+            "single_node_capacity_available",
+            capacity,
+            AdviceDetails {
+                required_bytes: Some(required_bytes),
+                shortfall_bytes: None,
+                split_capable,
+            },
+        );
+    }
+
+    if split_capable
+        && capacity.eligible_node_count >= 2
+        && capacity.aggregate_capacity_bytes >= required_bytes
+    {
+        return advice(
+            ModelTargetCapacityAdviceState::SplitCandidate,
+            "aggregate_split_capacity_available",
+            capacity,
+            AdviceDetails {
+                required_bytes: Some(required_bytes),
+                shortfall_bytes: None,
+                split_capable,
+            },
+        );
+    }
+
+    let comparable_capacity = if split_capable && capacity.eligible_node_count >= 2 {
+        capacity.aggregate_capacity_bytes
+    } else {
+        capacity.best_single_node_capacity_bytes.unwrap_or_default()
+    };
+    debug_assert_eq!(capacity.missing_capacity_node_count, 0);
+    let shortfall_bytes = required_bytes.saturating_sub(comparable_capacity);
+    advice(
+        ModelTargetCapacityAdviceState::InsufficientCapacity,
+        "capacity_shortfall",
+        capacity,
+        AdviceDetails {
+            required_bytes: Some(required_bytes),
+            shortfall_bytes: Some(shortfall_bytes),
+            split_capable,
+        },
+    )
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct CapacitySummary {
+    best_single_node_capacity_bytes: Option<u64>,
+    aggregate_capacity_bytes: u64,
+    eligible_node_count: usize,
+    missing_capacity_node_count: usize,
+    excluded_client_node_count: usize,
+}
+
+fn collect_capacity(
+    local_role: &NodeRole,
+    local_vram_bytes: u64,
+    peers: &[PeerInfo],
+) -> CapacitySummary {
+    let mut summary = CapacitySummary::default();
+    record_node_capacity(&mut summary, local_role, local_vram_bytes);
+    for peer in peers {
+        record_node_capacity(&mut summary, &peer.role, peer.vram_bytes);
+    }
+    summary
+}
+
+fn record_node_capacity(summary: &mut CapacitySummary, role: &NodeRole, vram_bytes: u64) {
+    if matches!(role, NodeRole::Client) {
+        summary.excluded_client_node_count += 1;
+        return;
+    }
+    if vram_bytes == 0 {
+        summary.missing_capacity_node_count += 1;
+        return;
+    }
+
+    summary.eligible_node_count += 1;
+    summary.aggregate_capacity_bytes = summary.aggregate_capacity_bytes.saturating_add(vram_bytes);
+    summary.best_single_node_capacity_bytes = Some(
+        summary
+            .best_single_node_capacity_bytes
+            .map(|best| best.max(vram_bytes))
+            .unwrap_or(vram_bytes),
+    );
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct AdviceDetails {
+    required_bytes: Option<u64>,
+    shortfall_bytes: Option<u64>,
+    split_capable: bool,
+}
+
+fn advice(
+    state: ModelTargetCapacityAdviceState,
+    reason: &'static str,
+    capacity: CapacitySummary,
+    details: AdviceDetails,
+) -> ModelTargetCapacityAdvicePayload {
+    ModelTargetCapacityAdvicePayload {
+        state,
+        reason,
+        required_bytes: details.required_bytes,
+        best_single_node_capacity_bytes: capacity.best_single_node_capacity_bytes,
+        aggregate_capacity_bytes: capacity.aggregate_capacity_bytes,
+        shortfall_bytes: details.shortfall_bytes,
+        eligible_node_count: capacity.eligible_node_count,
+        missing_capacity_node_count: capacity.missing_capacity_node_count,
+        excluded_client_node_count: capacity.excluded_client_node_count,
+        split_capable: details.split_capable,
+    }
+}
+
+fn normalize_match_key(value: &str) -> String {
+    value.trim().trim_start_matches("hf://").to_lowercase()
+}
+
+fn parse_size_label_bytes(label: &str) -> Option<u64> {
+    let compact = label.trim().replace(' ', "");
+    if compact.is_empty() {
+        return None;
+    }
+
+    let split_at = compact
+        .find(|ch: char| !(ch.is_ascii_digit() || ch == '.'))
+        .unwrap_or(compact.len());
+    if split_at == 0 {
+        return None;
+    }
+    let value = compact[..split_at].parse::<f64>().ok()?;
+    if !value.is_finite() || value < 0.0 {
+        return None;
+    }
+
+    let unit = compact[split_at..].to_ascii_lowercase();
+    let multiplier = match unit.as_str() {
+        "" | "b" => 1.0,
+        "kb" => 1e3,
+        "mb" => 1e6,
+        "gb" => 1e9,
+        "tb" => 1e12,
+        "kib" => 1024.0,
+        "mib" => 1024.0_f64.powi(2),
+        "gib" => 1024.0_f64.powi(3),
+        "tib" => 1024.0_f64.powi(4),
+        _ => return None,
+    };
+
+    let bytes = value * multiplier;
+    if bytes > u64::MAX as f64 {
+        return None;
+    }
+    Some(bytes as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::remote_catalog::{
+        CatalogCurated, CatalogEntry, CatalogPackage, CatalogSource, CatalogVariant,
+    };
+
+    #[test]
+    fn parse_size_label_bytes_supports_decimal_and_binary_units() {
+        assert_eq!(parse_size_label_bytes("20GB"), Some(20_000_000_000));
+        assert_eq!(parse_size_label_bytes("1.5 GB"), Some(1_500_000_000));
+        assert_eq!(parse_size_label_bytes("2MiB"), Some(2 * 1024 * 1024));
+        assert_eq!(parse_size_label_bytes("bad"), None);
+    }
+
+    #[test]
+    fn size_lookup_matches_model_and_layer_package_aliases() {
+        let lookup = ModelTargetSizeLookup::from_entries(vec![catalog_entry()]);
+
+        assert_eq!(
+            lookup.find("hf://example/source@rev-a:Q4_K_M"),
+            Some(ModelSizeHint {
+                model_bytes: 20_000_000_000,
+                split_capable: true,
+            })
+        );
+        assert_eq!(
+            lookup.find("Model-Q4_K_M.gguf"),
+            Some(ModelSizeHint {
+                model_bytes: 20_000_000_000,
+                split_capable: true,
+            })
+        );
+        assert_eq!(
+            lookup.find("meshllm/model-q4_k_m-layers"),
+            Some(ModelSizeHint {
+                model_bytes: 24_000_000_000,
+                split_capable: true,
+            })
+        );
+    }
+
+    fn catalog_entry() -> CatalogEntry {
+        CatalogEntry {
+            schema_version: 1,
+            source_repo: "example/source".to_string(),
+            variants: HashMap::from([(
+                "Model-Q4_K_M".to_string(),
+                CatalogVariant {
+                    source: CatalogSource {
+                        repo: "example/source".to_string(),
+                        revision: Some("rev-a".to_string()),
+                        file: Some("nested/Model-Q4_K_M.gguf".to_string()),
+                    },
+                    curated: CatalogCurated {
+                        name: "Example Model Q4".to_string(),
+                        size: Some("20GB".to_string()),
+                        description: None,
+                        draft: None,
+                        moe: None,
+                        extra_files: Vec::new(),
+                        mmproj: None,
+                    },
+                    packages: vec![CatalogPackage {
+                        package_type: "layer-package".to_string(),
+                        repo: "meshllm/model-q4_k_m-layers".to_string(),
+                        layer_count: Some(32),
+                        total_bytes: Some(24_000_000_000),
+                    }],
+                },
+            )]),
+        }
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/api/model_targets.rs
+++ b/crates/mesh-llm-host-runtime/src/api/model_targets.rs
@@ -3,7 +3,13 @@
 //! This module keeps raw mesh signals separate from the derived ranking and
 //! wanted hints that API handlers expose to operators.
 
-use super::{status::ModelTargetPayload, LocalModelInterest, MeshApi};
+use super::{
+    model_target_capacity::{
+        evaluate_model_target_capacity, ModelTargetCapacityInput, ModelTargetSizeLookup,
+    },
+    status::ModelTargetPayload,
+    LocalModelInterest, MeshApi,
+};
 use crate::mesh;
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
@@ -74,6 +80,8 @@ impl MeshApi {
             )
         };
 
+        let local_role = node.role().await;
+        let local_vram_bytes = node.vram_bytes();
         let peers = node.peers().await;
         let catalog = node.mesh_catalog_entries().await;
         let active_demand = node.active_demand().await;
@@ -89,6 +97,8 @@ impl MeshApi {
             active_demand,
             requested_models,
             my_hosted_models,
+            local_role,
+            local_vram_bytes,
             now: current_unix_secs(),
         })
     }
@@ -102,6 +112,8 @@ struct ModelTargetSource {
     active_demand: HashMap<String, mesh::ModelDemand>,
     requested_models: Vec<String>,
     my_hosted_models: Vec<String>,
+    local_role: mesh::NodeRole,
+    local_vram_bytes: u64,
     now: u64,
 }
 
@@ -124,7 +136,14 @@ fn build_model_target_lookup(source: ModelTargetSource) -> ModelTargetLookup {
 
     let mut targets = targets.into_values().collect::<Vec<_>>();
     sort_model_targets(&mut targets);
-    let payloads = build_target_payloads(targets);
+    let size_lookup = ModelTargetSizeLookup::load();
+    let payloads = build_target_payloads(
+        targets,
+        &source.local_role,
+        source.local_vram_bytes,
+        &source.peers,
+        &size_lookup,
+    );
     build_target_lookup(payloads)
 }
 
@@ -270,12 +289,27 @@ fn apply_serving_signals(
     }
 }
 
-fn build_target_payloads(targets: Vec<ModelTargetAccumulator>) -> Vec<ModelTargetPayload> {
+fn build_target_payloads(
+    targets: Vec<ModelTargetAccumulator>,
+    local_role: &mesh::NodeRole,
+    local_vram_bytes: u64,
+    peers: &[mesh::PeerInfo],
+    size_lookup: &ModelTargetSizeLookup,
+) -> Vec<ModelTargetPayload> {
     targets
         .into_iter()
         .enumerate()
         .map(|(index, target)| {
             let wanted_reason = wanted_reason(&target);
+            let capacity_advice = evaluate_model_target_capacity(ModelTargetCapacityInput {
+                model_ref: &target.model_ref,
+                model_name: target.model_name.as_deref(),
+                serving_node_count: target.serving_node_count,
+                local_role,
+                local_vram_bytes,
+                peers,
+                size_lookup,
+            });
             ModelTargetPayload {
                 rank: index + 1,
                 model_ref: target.model_ref,
@@ -288,6 +322,7 @@ fn build_target_payloads(targets: Vec<ModelTargetAccumulator>) -> Vec<ModelTarge
                 requested: target.requested,
                 wanted: wanted_reason.is_some(),
                 wanted_reason: wanted_reason.map(WantedReason::as_str),
+                capacity_advice,
             }
         })
         .collect()

--- a/crates/mesh-llm-host-runtime/src/api/routes/model_targets.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/model_targets.rs
@@ -1,4 +1,8 @@
-use super::super::{http::respond_json, status::ModelTargetPayload, MeshApi};
+use super::super::{
+    http::respond_json,
+    status::{ModelTargetCapacityAdvicePayload, ModelTargetPayload},
+    MeshApi,
+};
 use serde::Serialize;
 use tokio::net::TcpStream;
 
@@ -33,6 +37,7 @@ struct ModelTargetDerived {
     wanted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     wanted_reason: Option<&'static str>,
+    capacity_advice: ModelTargetCapacityAdvicePayload,
 }
 
 impl From<ModelTargetPayload> for ModelTargetResponseItem {
@@ -52,6 +57,7 @@ impl From<ModelTargetPayload> for ModelTargetResponseItem {
                 target_rank: target.rank,
                 wanted: target.wanted,
                 wanted_reason: target.wanted_reason,
+                capacity_advice: target.capacity_advice,
             },
         }
     }

--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -534,6 +534,36 @@ pub(crate) struct ModelTargetPayload {
     pub(crate) wanted: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) wanted_reason: Option<&'static str>,
+    pub(crate) capacity_advice: ModelTargetCapacityAdvicePayload,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct ModelTargetCapacityAdvicePayload {
+    pub(crate) state: ModelTargetCapacityAdviceState,
+    pub(crate) reason: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) required_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) best_single_node_capacity_bytes: Option<u64>,
+    pub(crate) aggregate_capacity_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) shortfall_bytes: Option<u64>,
+    pub(crate) eligible_node_count: usize,
+    pub(crate) missing_capacity_node_count: usize,
+    pub(crate) excluded_client_node_count: usize,
+    pub(crate) split_capable: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ModelTargetCapacityAdviceState {
+    AlreadyServing,
+    SingleNodeFit,
+    SplitCandidate,
+    InsufficientCapacity,
+    UnknownModelSize,
+    UnknownCapacity,
+    NoEligibleHosts,
 }
 
 pub(crate) fn build_runtime_status_payload(

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -2509,6 +2509,190 @@ async fn test_api_model_targets_combine_interest_demand_and_serving_visibility()
 }
 
 #[tokio::test]
+#[serial]
+async fn test_api_model_targets_surface_capacity_advice_under_derived() {
+    let _catalog_guard = crate::models::remote_catalog::set_catalog_entries_for_test(vec![
+        qwen_coder_remote_catalog_entry(),
+    ]);
+    let state = build_test_mesh_api().await;
+    let node = {
+        let inner = state.inner.lock().await;
+        inner.node.clone()
+    };
+    node.set_role(mesh::NodeRole::Client).await;
+    let model_ref = qwen_coder_remote_catalog_ref();
+    let (interest, _) = state
+        .upsert_model_interest(model_ref.clone(), Some("ui".to_string()))
+        .await;
+
+    node.insert_test_peer(make_test_peer(
+        0x45,
+        mesh::NodeRole::Worker,
+        Vec::new(),
+        Vec::new(),
+        true,
+    ))
+    .await;
+
+    let (addr, handle) = spawn_management_test_server(state).await;
+    let response = send_management_request(
+        addr,
+        "GET /api/model-targets HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 200"));
+    let payload = json_body(&response);
+    let target = payload["model_targets"]
+        .as_array()
+        .and_then(|targets| {
+            targets
+                .iter()
+                .find(|entry| entry["model_ref"] == interest.model_ref)
+        })
+        .expect("target for explicit interest present");
+    assert_eq!(target["derived"]["target_rank"], json!(1));
+    assert_eq!(target["derived"]["wanted"], json!(true));
+    assert!(target.get("capacity_advice").is_none());
+
+    let advice = &target["derived"]["capacity_advice"];
+    assert_eq!(advice["state"], json!("single_node_fit"));
+    assert_eq!(advice["reason"], json!("single_node_capacity_available"));
+    assert_eq!(advice["required_bytes"], json!(22_000_000_000_u64));
+    assert_eq!(
+        advice["best_single_node_capacity_bytes"],
+        json!(24_000_000_000_u64)
+    );
+    assert_eq!(
+        advice["aggregate_capacity_bytes"],
+        json!(24_000_000_000_u64)
+    );
+    assert_eq!(advice["eligible_node_count"], json!(1));
+    assert_eq!(advice["missing_capacity_node_count"], json!(0));
+    assert_eq!(advice["excluded_client_node_count"], json!(1));
+
+    handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_api_model_targets_capacity_advice_stays_unknown_with_partial_capacity() {
+    let _catalog_guard = crate::models::remote_catalog::set_catalog_entries_for_test(vec![
+        qwen_coder_remote_catalog_entry(),
+    ]);
+    let state = build_test_mesh_api().await;
+    let node = {
+        let inner = state.inner.lock().await;
+        inner.node.clone()
+    };
+    let model_ref = qwen_coder_remote_catalog_ref();
+    let (interest, _) = state
+        .upsert_model_interest(model_ref.clone(), Some("ui".to_string()))
+        .await;
+
+    node.insert_test_peer(make_test_peer(
+        0x48,
+        mesh::NodeRole::Worker,
+        Vec::new(),
+        Vec::new(),
+        true,
+    ))
+    .await;
+
+    let (addr, handle) = spawn_management_test_server(state).await;
+    let response = send_management_request(
+        addr,
+        "GET /api/model-targets HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 200"));
+    let payload = json_body(&response);
+    let target = payload["model_targets"]
+        .as_array()
+        .and_then(|targets| {
+            targets
+                .iter()
+                .find(|entry| entry["model_ref"] == interest.model_ref)
+        })
+        .expect("target for explicit interest present");
+
+    let advice = &target["derived"]["capacity_advice"];
+    assert_eq!(advice["state"], json!("unknown_capacity"));
+    assert_eq!(advice["reason"], json!("eligible_nodes_missing_capacity"));
+    assert_eq!(advice["required_bytes"], json!(22_000_000_000_u64));
+    assert_eq!(
+        advice["best_single_node_capacity_bytes"],
+        json!(24_000_000_000_u64)
+    );
+    assert_eq!(
+        advice["aggregate_capacity_bytes"],
+        json!(24_000_000_000_u64)
+    );
+    assert!(advice.get("shortfall_bytes").is_none());
+    assert_eq!(advice["eligible_node_count"], json!(1));
+    assert_eq!(advice["missing_capacity_node_count"], json!(1));
+
+    handle.abort();
+}
+
+#[tokio::test]
+#[serial]
+async fn test_api_model_targets_capacity_advice_separates_clients_from_missing_vram() {
+    let _catalog_guard = crate::models::remote_catalog::set_catalog_entries_for_test(vec![
+        qwen_coder_remote_catalog_entry(),
+    ]);
+    let state = build_test_mesh_api().await;
+    let node = {
+        let inner = state.inner.lock().await;
+        inner.node.clone()
+    };
+    let model_ref = qwen_coder_remote_catalog_ref();
+    let (interest, _) = state
+        .upsert_model_interest(model_ref.clone(), Some("ui".to_string()))
+        .await;
+
+    let mut client_with_vram =
+        make_test_peer(0x46, mesh::NodeRole::Client, Vec::new(), Vec::new(), true);
+    client_with_vram.vram_bytes = 128_000_000_000;
+    node.insert_test_peer(client_with_vram).await;
+
+    let mut worker_missing_vram =
+        make_test_peer(0x47, mesh::NodeRole::Worker, Vec::new(), Vec::new(), true);
+    worker_missing_vram.vram_bytes = 0;
+    node.insert_test_peer(worker_missing_vram).await;
+
+    let (addr, handle) = spawn_management_test_server(state).await;
+    let response = send_management_request(
+        addr,
+        "GET /api/model-targets HTTP/1.1\r\nHost: localhost\r\n\r\n".into(),
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 200"));
+    let payload = json_body(&response);
+    let target = payload["model_targets"]
+        .as_array()
+        .and_then(|targets| {
+            targets
+                .iter()
+                .find(|entry| entry["model_ref"] == interest.model_ref)
+        })
+        .expect("target for explicit interest present");
+
+    let advice = &target["derived"]["capacity_advice"];
+    assert_eq!(advice["state"], json!("unknown_capacity"));
+    assert_eq!(advice["reason"], json!("eligible_nodes_missing_capacity"));
+    assert_eq!(advice["required_bytes"], json!(22_000_000_000_u64));
+    assert_eq!(advice["eligible_node_count"], json!(0));
+    assert_eq!(advice["missing_capacity_node_count"], json!(2));
+    assert_eq!(advice["excluded_client_node_count"], json!(1));
+    assert!(advice.get("best_single_node_capacity_bytes").is_none());
+
+    handle.abort();
+}
+
+#[tokio::test]
 async fn test_api_status_and_models_surface_wanted_targets() {
     let state = build_test_mesh_api().await;
     let node = {

--- a/crates/mesh-llm-host-runtime/src/runtime/capacity.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/capacity.rs
@@ -2,6 +2,9 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
+const RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR: u64 = 11;
+const RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR: u64 = 10;
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(super) enum RuntimeCapacityPool {
     Node,
@@ -187,6 +190,16 @@ impl Drop for RuntimeCapacityReservation {
 
 fn format_gb(bytes: u64) -> String {
     format!("{:.1}GB", bytes as f64 / 1e9)
+}
+
+pub(crate) fn model_fits_runtime_capacity(model_bytes: u64, local_vram_bytes: u64) -> bool {
+    local_vram_bytes >= runtime_model_required_bytes(model_bytes)
+}
+
+pub(crate) fn runtime_model_required_bytes(model_bytes: u64) -> u64 {
+    model_bytes
+        .saturating_mul(RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR)
+        .div_ceil(RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR)
 }
 
 #[cfg(test)]

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1,3 +1,4 @@
+use super::capacity::{model_fits_runtime_capacity, runtime_model_required_bytes};
 use super::context_planning::{
     plan_runtime_resources, RuntimeResourcePlan, RuntimeResourcePlanInput,
 };
@@ -29,8 +30,6 @@ const SPLIT_PARTICIPANT_STABLE_FOR: Duration = Duration::from_secs(2);
 pub(super) const SPLIT_DEFAULT_MIN_PARTICIPANTS: usize = 2;
 const SPLIT_INITIAL_SHUTDOWN_GENERATION: u64 = 1;
 const SPLIT_COORDINATOR_LEASE_SECS: u64 = 4 * 60 * 60;
-const RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR: u64 = 11;
-const RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR: u64 = 10;
 
 pub(super) enum RuntimeEvent {
     Exited {
@@ -570,16 +569,6 @@ pub(super) fn startup_runtime_plan(
             reason: SplitRuntimeReason::LocalCapacity,
         }
     }
-}
-
-pub(super) fn model_fits_runtime_capacity(model_bytes: u64, local_vram_bytes: u64) -> bool {
-    local_vram_bytes >= runtime_model_required_bytes(model_bytes)
-}
-
-pub(super) fn runtime_model_required_bytes(model_bytes: u64) -> u64 {
-    model_bytes
-        .saturating_mul(RUNTIME_MODEL_FIT_HEADROOM_NUMERATOR)
-        .div_ceil(RUNTIME_MODEL_FIT_HEADROOM_DENOMINATOR)
 }
 
 pub(super) async fn start_runtime_split_model(

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -10,20 +10,22 @@ mod split_planning;
 mod survey;
 pub(crate) mod wakeable;
 
+pub(crate) use self::capacity::runtime_model_required_bytes;
 use self::capacity::{
-    RuntimeCapacityLedger, RuntimeCapacityPool, RuntimeCapacityRequest, RuntimeCapacityReservation,
+    model_fits_runtime_capacity, RuntimeCapacityLedger, RuntimeCapacityPool,
+    RuntimeCapacityRequest, RuntimeCapacityReservation,
 };
 use self::discovery::{nostr_rediscovery, start_new_mesh};
 use self::interactive::InitialPromptMode;
 use self::local::{
     add_runtime_local_target, add_serving_assignment, advertise_model_ready, local_process_payload,
-    model_fits_runtime_capacity, remove_runtime_local_target, remove_serving_assignment,
-    resolved_model_name, runtime_model_planning_bytes, runtime_model_required_bytes,
-    set_advertised_model_context, set_runtime_verified_served_model_capabilities,
-    start_runtime_local_model, start_runtime_split_model, startup_runtime_plan,
-    stop_split_generation_cleanup, withdraw_advertised_model, LocalRuntimeModelHandle,
-    LocalRuntimeModelStartSpec, ManagedModelController, RuntimeEvent, SplitCoordinatorAck,
-    SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
+    remove_runtime_local_target, remove_serving_assignment, resolved_model_name,
+    runtime_model_planning_bytes, set_advertised_model_context,
+    set_runtime_verified_served_model_capabilities, start_runtime_local_model,
+    start_runtime_split_model, startup_runtime_plan, stop_split_generation_cleanup,
+    withdraw_advertised_model, LocalRuntimeModelHandle, LocalRuntimeModelStartSpec,
+    ManagedModelController, RuntimeEvent, SplitCoordinatorAck, SplitCoordinatorEvent,
+    SplitRuntimeReason, SplitRuntimeStart, StartupRuntimePlan,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -232,14 +232,21 @@ without the HTML via curl/scripts.
 reports `signals` from observed mesh state (`explicit_interest_count`,
 `request_count`, `last_active_secs_ago`, `serving_node_count`, and `requested`)
 alongside `derived` hints (`target_rank`, `wanted`, and optional
-`wanted_reason`). Ranking is advisory and deterministic: explicit interest is
-ordered first, active request demand second, requested-only unserved models
-third, then recent activity, display name, and canonical ref. A `requested`
-signal does not add a second rank boost when request demand is already present;
-it only breaks into the ranking as its own requested-only signal. `wanted` means
-the model is currently unserved and has at least one explicit-interest, active
-demand, or requested-model signal. It is not a desired replica count, a capacity
-decision, or an unload/load command.
+`wanted_reason`) plus `capacity_advice`. Capacity advice is also advisory: it
+uses existing catalog size and node VRAM signals to report whether a target is
+already served, has a single-node fit, is a split-capable aggregate candidate,
+has a known shortfall, or cannot be judged because model size or node capacity
+is unknown. Client-role exclusions and missing VRAM are reported separately so
+operators can distinguish "this node cannot host" from "this node did not
+advertise usable capacity." Ranking is advisory and deterministic: explicit
+interest is ordered first, active request demand second, requested-only unserved
+models third, then recent activity, display name, and canonical ref. A
+`requested` signal does not add a second rank boost when request demand is
+already present; it only breaks into the ranking as its own requested-only
+signal. `wanted` means the model is currently unserved and has at least one
+explicit-interest, active demand, or requested-model signal. It is not a
+desired replica count, an unload/load command, or proof that a split package is
+ready on every participant.
 
 Always enabled on port 3131 (configurable with `--console <port>`).
 

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -397,7 +397,7 @@ curl localhost:3131/api/discover # Nostr meshes (current mesh marked by mesh_id)
 - SSE events push every 2s and on topology changes
 - `/api/search` returns 200 JSON with canonical model refs for matching results
 - `/api/model-interests` stores and returns local explicit-interest entries keyed by canonical model refs
-- `/api/model-targets` returns ranked targets with explicit-interest counts, request counts, serving-node counts, and `wanted` for targets not currently served
+- `/api/model-targets` returns ranked targets with explicit-interest counts, request counts, serving-node counts, `wanted` for targets not currently served, and derived `capacity_advice` without changing ranking or routing behavior
 - Discover results can be matched to current mesh by `mesh_id`
 
 ### 24. HTTP proxy single-request connection contract


### PR DESCRIPTION
## Summary

This adds an advisory capacity signal to the ranked `/api/model-targets` surface, so operators can see whether a wanted target appears already served, single-node fit, split-capable through aggregate capacity, capacity-constrained, or currently unknown because model size or VRAM information is missing.

- Adds `derived.capacity_advice` to `/api/model-targets` while keeping existing raw `signals` and ranking fields unchanged.
- Evaluates catalog model size with the same runtime headroom used by startup capacity checks.
- Reports eligible host/worker capacity, aggregate capacity, best single-node capacity, shortfall, and split-capable status as advisory output.
- Keeps `Client` role exclusion separate from worker/host missing VRAM, so the API can explain role vs. capacity uncertainty clearly.
- Leaves routing, startup reconciliation, gossip/protobuf, and shared `ModelTargets` behavior unchanged.

## Why

#276 calls for Phase 4 advisory capacity evaluation before automatic load/unload reconciliation. This PR makes the current model-target ranking more explainable without taking runtime action: wanted models remain visible and now carry enough capacity context for operators and later UI work to understand why a target may or may not be immediately actionable.

## Architecture

The evaluator is API-local under `mesh-llm-host-runtime/src/api` and consumes existing node role, VRAM, peer, catalog, serving, interest, requested, and demand signals. Runtime fit sizing uses the shared `runtime_model_required_bytes` helper so API advice matches the existing startup headroom rule.

## Compatibility

- Additive management API response field only.
- No mesh gossip/protobuf change.
- No routing target ordering change.
- No automatic model load/unload or eviction behavior.
- Existing `/api/model-targets` flat-field hiding remains unchanged; new capacity data lives under `derived`.

## Validation

- `git fetch --no-tags origin main:refs/remotes/origin/main`
- `git diff --check`
- `git diff --cached --check`
- `cargo fmt --all -- --check`
- `LLAMA_STAGE_BUILD_DIR=<local stage ABI build dir> cargo test -p mesh-llm-host-runtime model_targets --lib` — PASS, 6 passed
- `LLAMA_STAGE_BUILD_DIR=<local stage ABI build dir> cargo test -p mesh-llm-host-runtime model_target_capacity --lib` — PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<local stage ABI build dir> cargo check -p mesh-llm-host-runtime` — PASS

Not run: `just build` — no UI build artifact changed; targeted backend validation covers the API/runtime diff.

## Rollback

Revert this PR.

## Known Residual Risk

`split_candidate` is deliberately a coarse advisory signal. Real activation still depends on runtime split/package readiness checks before any model is loaded.

## Related

Related: #276
