### PR TITLE
Sampler parity (min_p) + bounded max_tokens default + KV reclaim hardening

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -28,7 +28,7 @@ use skippy_runtime::ModelInfo;
 use skippy_server::{
     binary_transport::WireCondition, embedded_openai_backend, telemetry::Telemetry,
     telemetry::TelemetryLevel, EmbeddedOpenAiArgs, EmbeddedRuntimeOptions, EmbeddedRuntimeStatus,
-    EmbeddedServerHandle, EmbeddedState, SkippyRuntimeHandle, CONTEXT_BUDGET_MAX_TOKENS,
+    EmbeddedServerHandle, EmbeddedState, SkippyRuntimeHandle, DEFAULT_EMBEDDED_MAX_TOKENS,
 };
 
 pub(crate) use certification::{
@@ -177,7 +177,7 @@ impl SkippyModelLoadOptions {
             n_ubatch: None,
             flash_attn_type: FlashAttentionType::Auto,
             generation_concurrency: 1,
-            default_max_tokens: CONTEXT_BUDGET_MAX_TOKENS,
+            default_max_tokens: DEFAULT_EMBEDDED_MAX_TOKENS,
             layer_end: None,
             selected_device: None,
             package_identity: None,

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1128,7 +1128,7 @@ async fn load_split_runtime_generation_inner(
             config,
             activation_width,
             slots,
-            skippy_server::CONTEXT_BUDGET_MAX_TOKENS,
+            skippy_server::DEFAULT_EMBEDDED_MAX_TOKENS,
             Some(skippy::MeshAutoHookPolicy::new(node_for_hook)),
             skippy_telemetry,
         )
@@ -2842,7 +2842,7 @@ async fn start_runtime_layer_package_model(
             config,
             activation_width,
             slots,
-            skippy_server::CONTEXT_BUDGET_MAX_TOKENS,
+            skippy_server::DEFAULT_EMBEDDED_MAX_TOKENS,
             Some(skippy::MeshAutoHookPolicy::new(node_for_hook)),
             skippy_telemetry,
         )

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -83,7 +83,21 @@ use self::{prefill::*, request::*, speculative::*, util::*, wire_messages::*};
 
 static OPENAI_GENERATION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
+/// Sentinel meaning "no caller-specified max completion length; let the
+/// request consume the entire remaining context window when the client
+/// also omits max_tokens".
+///
+/// This is opt-in and should only be wired in by callers that have made
+/// a deliberate decision to allow unbounded chat completions. The
+/// embedded mesh-llm wiring uses [`DEFAULT_EMBEDDED_MAX_TOKENS`] instead.
 pub const CONTEXT_BUDGET_MAX_TOKENS: u32 = u32::MAX;
+
+/// Default max completion tokens for embedded mesh-llm chat serving when
+/// the client omits max_tokens. Bounded so that an adversarial or
+/// non-terminating generation cannot run for the full context window.
+/// Clients can still request more by sending max_tokens explicitly, up
+/// to the remaining context budget.
+pub const DEFAULT_EMBEDDED_MAX_TOKENS: u32 = 8192;
 const GENERATION_ADMISSION_TIMEOUT: Duration = Duration::from_secs(10);
 const GENERATION_RETRY_AFTER_SECS: u64 = 1;
 

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1423,6 +1423,19 @@ fn omitted_max_tokens_can_use_remaining_context_budget() {
 }
 
 #[test]
+fn omitted_max_tokens_with_embedded_default_is_bounded() {
+    // The embedded mesh-llm wiring uses DEFAULT_EMBEDDED_MAX_TOKENS as a
+    // bounded fallback when the client omits max_tokens. Omitting
+    // max_tokens must produce an Explicit cap rather than consume the
+    // entire remaining context window.
+    let limit = GenerationTokenLimit::from_request(None, DEFAULT_EMBEDDED_MAX_TOKENS);
+    let ctx_size = 32_000;
+    let resolved = limit.resolve(128, ctx_size).unwrap();
+    assert_eq!(resolved, DEFAULT_EMBEDDED_MAX_TOKENS);
+    assert!((resolved as usize) < ctx_size);
+}
+
+#[test]
 fn configured_default_max_tokens_remains_explicit() {
     let limit = GenerationTokenLimit::from_request(None, 4);
     assert_eq!(limit.resolve(4, 8).unwrap(), 4);

--- a/crates/skippy-server/src/lib.rs
+++ b/crates/skippy-server/src/lib.rs
@@ -25,5 +25,6 @@ pub use embedded::{
 };
 pub use frontend::{
     embedded_openai_backend, EmbeddedOpenAiArgs, EmbeddedOpenAiBackend, CONTEXT_BUDGET_MAX_TOKENS,
+    DEFAULT_EMBEDDED_MAX_TOKENS,
 };
 pub use skippy_protocol::StageConfig;

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -60,6 +60,13 @@ pub struct RuntimeSessionDropStats {
     pub reset_session: bool,
     pub reset_ms: f64,
     pub preserved_resident_prefix: bool,
+    /// True when the lane could not be returned to the idle pool because
+    /// the underlying StageSession failed to reset cleanly. The lane is
+    /// dropped (which invokes the C-side skippy_session_free) and the
+    /// pool capacity is restored on the next prewarm/admission cycle.
+    pub lane_discarded: bool,
+    /// Reset-error detail, when [`Self::lane_discarded`] is true.
+    pub lane_discard_reason: Option<String>,
     pub stats_after: RuntimeSessionStats,
 }
 
@@ -296,11 +303,43 @@ impl RuntimeState {
         Ok(self.session_stats())
     }
 
+    /// Release the session slot identified by `session_id`.
+    ///
+    /// This is the cleanup path called at the end of every chat
+    /// completion (success, cancellation, or backend error). It must
+    /// leave [`Self`] in a self-consistent state regardless of whether
+    /// the underlying StageSession can be reset cleanly:
+    ///
+    ///  - The lane is either returned to `idle_sessions` (reset OK) or
+    ///    dropped entirely (reset failed). Dropping the lane triggers
+    ///    `StageSession::drop`, which calls `skippy_session_free` on
+    ///    the C side — the authoritative path for releasing native KV
+    ///    cells held by that sequence id.
+    ///  - `session_token_counts`, `session_checkpoints`, and
+    ///    `session_resident_prefixes` for `session_id` are always
+    ///    removed.
+    ///  - The function always returns `Ok` so per-request cleanup at
+    ///    callsites never propagates a reset failure as a request
+    ///    error. The outcome is reported via [`RuntimeSessionDropStats`]
+    ///    fields (`lane_discarded`, `lane_discard_reason`) for
+    ///    telemetry.
+    ///
+    /// Previously a reset error propagated `?` through this function,
+    /// which left `session_token_counts` and `session_checkpoints`
+    /// holding stale entries and dropped the lane on the floor without
+    /// any record. That accumulated bookkeeping drift over time and
+    /// could leave the native KV cache reporting "all slots in use"
+    /// long after the owning sessions were gone, producing
+    /// `failed to find a memory slot` errors on subsequent admissions.
     pub fn drop_session_timed(&mut self, session_id: &str) -> Result<RuntimeSessionDropStats> {
         let reset_started = Instant::now();
         let mut reset_session = false;
         let mut preserved_resident_prefix = false;
+        let mut lane_discarded = false;
+        let mut lane_discard_reason: Option<String> = None;
+
         if let Some(mut lane_session) = self.sessions.remove(session_id) {
+            let lane_index = lane_session.index;
             if let Some(prefix) = self.session_resident_prefixes.remove(session_id) {
                 match lane_session.session.trim_session(prefix.token_count) {
                     Ok(()) => {
@@ -308,26 +347,65 @@ impl RuntimeState {
                         lane_session.resident_prefix = Some(prefix);
                         self.idle_sessions.push(lane_session);
                     }
-                    Err(_) => {
+                    Err(trim_err) => {
                         reset_session = true;
-                        lane_session.session.reset()?;
-                        lane_session.resident_prefix = None;
-                        self.idle_sessions.push(lane_session);
+                        match lane_session.session.reset() {
+                            Ok(()) => {
+                                lane_session.resident_prefix = None;
+                                self.idle_sessions.push(lane_session);
+                            }
+                            Err(reset_err) => {
+                                lane_discarded = true;
+                                let reason = format!(
+                                    "trim_session({}) failed ({trim_err:#}); fallback reset() also failed ({reset_err:#})",
+                                    prefix.token_count
+                                );
+                                eprintln!(
+                                    "skippy::runtime_state: drop_session_timed: \
+                                     discarding lane {lane_index} for session {session_id}: \
+                                     {reason}"
+                                );
+                                lane_discard_reason = Some(reason);
+                                // `lane_session` falls out of scope and its
+                                // StageSession::drop runs, which calls
+                                // skippy_session_free on the C side.
+                            }
+                        }
                     }
                 }
             } else {
                 reset_session = true;
-                lane_session.session.reset()?;
-                lane_session.resident_prefix = None;
-                self.idle_sessions.push(lane_session);
+                match lane_session.session.reset() {
+                    Ok(()) => {
+                        lane_session.resident_prefix = None;
+                        self.idle_sessions.push(lane_session);
+                    }
+                    Err(reset_err) => {
+                        lane_discarded = true;
+                        let reason = format!("reset() failed ({reset_err:#})");
+                        eprintln!(
+                            "skippy::runtime_state: drop_session_timed: \
+                             discarding lane {lane_index} for session {session_id}: \
+                             {reason}"
+                        );
+                        lane_discard_reason = Some(reason);
+                    }
+                }
             }
         }
+
+        // Always clear per-session bookkeeping. The previous version
+        // skipped these when reset returned Err, which leaked entries.
         self.session_token_counts.remove(session_id);
         self.session_checkpoints.remove(session_id);
+        // session_resident_prefixes was already removed above (or absent).
+
         Ok(RuntimeSessionDropStats {
             reset_session,
             reset_ms: reset_started.elapsed().as_secs_f64() * 1000.0,
             preserved_resident_prefix,
+            lane_discarded,
+            lane_discard_reason,
             stats_after: self.session_stats(),
         })
     }

--- a/third_party/llama.cpp/patches/0001-Draft-skippy-ABI-header.patch
+++ b/third_party/llama.cpp/patches/0001-Draft-skippy-ABI-header.patch
@@ -1,7 +1,7 @@
-From ab94f2cae57d05f2bdf3bf6b54807604c68cee26 Mon Sep 17 00:00:00 2001
+From b241fa23c0b9a49898c3fe5afb2f8cb0df969a5f Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 10:19:37 +1000
-Subject: [PATCH 01/80] Draft skippy ABI header
+Subject: [PATCH 01/81] Draft skippy ABI header
 
 ---
  include/skippy.h | 241 +++++++++++++++++++++++++++++++++++++++++++++++

--- a/third_party/llama.cpp/patches/0002-Implement-skippy-model-info-ABI.patch
+++ b/third_party/llama.cpp/patches/0002-Implement-skippy-model-info-ABI.patch
@@ -1,7 +1,7 @@
-From e280676463678fb39fb23c8d8850fb7b0a65f30f Mon Sep 17 00:00:00 2001
+From a02a3046c4cdeec343b9eb491654391099135c99 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 10:28:54 +1000
-Subject: [PATCH 02/80] Implement skippy model info ABI
+Subject: [PATCH 02/81] Implement skippy model info ABI
 
 ---
  CMakeLists.txt     |   1 +

--- a/third_party/llama.cpp/patches/0003-Implement-single-stage-runtime-ABI-baseline.patch
+++ b/third_party/llama.cpp/patches/0003-Implement-single-stage-runtime-ABI-baseline.patch
@@ -1,7 +1,7 @@
-From 83dade6ee46aea0f0d3cf512c780e5b1274ad029 Mon Sep 17 00:00:00 2001
+From 91b00b2cb5ab803ed5bb87b118e328f3885e787f Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 11:04:49 +1000
-Subject: [PATCH 03/80] Implement single-stage runtime ABI baseline
+Subject: [PATCH 03/81] Implement single-stage runtime ABI baseline
 
 ---
  src/skippy.cpp | 323 ++++++++++++++++++++++++++++++++++++++++++++++++-

--- a/third_party/llama.cpp/patches/0004-Implement-runtime-slice-tensor-filtering.patch
+++ b/third_party/llama.cpp/patches/0004-Implement-runtime-slice-tensor-filtering.patch
@@ -1,7 +1,7 @@
-From 25264a6ee55d39aaad7eb26e5890067ff522dda9 Mon Sep 17 00:00:00 2001
+From e02839a454a572e79ef43fadd4448d61df072c53 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 11:57:45 +1000
-Subject: [PATCH 04/80] Implement runtime-slice tensor filtering
+Subject: [PATCH 04/81] Implement runtime-slice tensor filtering
 
 ---
  src/llama-model-loader.cpp | 44 ++++++++++++++++++++++++++++++++++++++

--- a/third_party/llama.cpp/patches/0005-Add-activation-frame-runtime-ABI.patch
+++ b/third_party/llama.cpp/patches/0005-Add-activation-frame-runtime-ABI.patch
@@ -1,7 +1,7 @@
-From f8ee8abf2e7426b04ea487d7554fc13e258acad5 Mon Sep 17 00:00:00 2001
+From 82a7900af2387e9f48754e7d63090245e8d139d2 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 12:15:31 +1000
-Subject: [PATCH 05/80] Add activation frame runtime ABI
+Subject: [PATCH 05/81] Add activation frame runtime ABI
 
 ---
  include/skippy.h |  50 +++++++++++++++++++++

--- a/third_party/llama.cpp/patches/0006-Execute-runtime-slice-activation-frames.patch
+++ b/third_party/llama.cpp/patches/0006-Execute-runtime-slice-activation-frames.patch
@@ -1,7 +1,7 @@
-From aeed55734dbe4c0361ce83ff8ee00413d49ca727 Mon Sep 17 00:00:00 2001
+From 8c4d83bc5ad6eeade4f196a24b865505ee088798 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 12:33:30 +1000
-Subject: [PATCH 06/80] Execute runtime-slice activation frames
+Subject: [PATCH 06/81] Execute runtime-slice activation frames
 
 ---
  src/llama-graph.cpp  |  52 ++++---

--- a/third_party/llama.cpp/patches/0007-Implement-GGUF-slice-writer-ABI.patch
+++ b/third_party/llama.cpp/patches/0007-Implement-GGUF-slice-writer-ABI.patch
@@ -1,7 +1,7 @@
-From 775c6a15d64a4463490c5cbe68385a1dfd3a2682 Mon Sep 17 00:00:00 2001
+From d6c0ced3a49056ea31389eb4dbc465ccc7a6ff23 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 14:39:10 +1000
-Subject: [PATCH 07/80] Implement GGUF slice writer ABI
+Subject: [PATCH 07/81] Implement GGUF slice writer ABI
 
 ---
  src/skippy.cpp | 413 +++++++++++++++++++++++++++++++++++++++++++++++++

--- a/third_party/llama.cpp/patches/0008-Add-GGUF-package-part-composer-ABI.patch
+++ b/third_party/llama.cpp/patches/0008-Add-GGUF-package-part-composer-ABI.patch
@@ -1,7 +1,7 @@
-From 02e30a1fd9d208bb2906d4a83ef955324f44bd26 Mon Sep 17 00:00:00 2001
+From 8f5bffbde4f679b5f9d90c1281fa04013cf619fe Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 14:51:18 +1000
-Subject: [PATCH 08/80] Add GGUF package part composer ABI
+Subject: [PATCH 08/81] Add GGUF package part composer ABI
 
 ---
  include/skippy.h |   6 +

--- a/third_party/llama.cpp/patches/0009-Support-Qwen35MoE-runtime-slice-packages.patch
+++ b/third_party/llama.cpp/patches/0009-Support-Qwen35MoE-runtime-slice-packages.patch
@@ -1,7 +1,7 @@
-From b8d99ddbd8cbc806d9aac8a93acd9ecdf4aba427 Mon Sep 17 00:00:00 2001
+From c7d9766e30880060ff95e7c02e4ce54ec9db99d1 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 15:29:59 +1000
-Subject: [PATCH 09/80] Support Qwen35MoE runtime slice packages
+Subject: [PATCH 09/81] Support Qwen35MoE runtime slice packages
 
 ---
  src/llama-model-loader.cpp | 34 ++++++++++++++++++----------------

--- a/third_party/llama.cpp/patches/0010-Handle-Qwen35MoE-recurrent-only-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0010-Handle-Qwen35MoE-recurrent-only-runtime-slices.patch
@@ -1,7 +1,7 @@
-From c9d96e127102e92df56ff1e6c55119029952f8b8 Mon Sep 17 00:00:00 2001
+From 9dd8ce41e14b2195017a8cb689fd6aee8f587595 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sat, 25 Apr 2026 15:44:46 +1000
-Subject: [PATCH 10/80] Handle Qwen35MoE recurrent-only runtime slices
+Subject: [PATCH 10/81] Handle Qwen35MoE recurrent-only runtime slices
 
 ---
  src/llama-graph.cpp      | 24 +++++++++++++++++-------

--- a/third_party/llama.cpp/patches/0011-Add-native-stage-KV-page-ABI.patch
+++ b/third_party/llama.cpp/patches/0011-Add-native-stage-KV-page-ABI.patch
@@ -1,7 +1,7 @@
-From e0c84a74a03dfd781495ee052027483bae1fcb04 Mon Sep 17 00:00:00 2001
+From eb7774be709da05424dbb2a5996fcede2c3df212 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Sun, 26 Apr 2026 00:00:00 +1000
-Subject: [PATCH 11/80] Add native stage KV page ABI
+Subject: [PATCH 11/81] Add native stage KV page ABI
 
 ---
  include/skippy.h       |  40 +++++

--- a/third_party/llama.cpp/patches/0012-Add-stage-session-reset-ABI.patch
+++ b/third_party/llama.cpp/patches/0012-Add-stage-session-reset-ABI.patch
@@ -1,7 +1,7 @@
-From fc718a7e3f5ece1e9c10f20162d0ac0419e32c82 Mon Sep 17 00:00:00 2001
+From 1d94bce035742f00f98265a3b336998a81dc4762 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sun, 26 Apr 2026 13:20:03 +1000
-Subject: [PATCH 12/80] Add stage session reset ABI
+Subject: [PATCH 12/81] Add stage session reset ABI
 
 ---
  include/skippy.h |  7 ++++++-

--- a/third_party/llama.cpp/patches/0013-Expose-stage-token-EOG-ABI.patch
+++ b/third_party/llama.cpp/patches/0013-Expose-stage-token-EOG-ABI.patch
@@ -1,7 +1,7 @@
-From 4cb7a8f09a7bb52cd14a00dc7181d5b1ba234f6a Mon Sep 17 00:00:00 2001
+From 6cb266da3b91389705f2f7d5ed3494d32af59a14 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sun, 26 Apr 2026 18:45:00 +1000
-Subject: [PATCH 13/80] Expose stage token EOG ABI
+Subject: [PATCH 13/81] Expose stage token EOG ABI
 
 ---
  include/skippy.h |  6 ++++++

--- a/third_party/llama.cpp/patches/0014-Position-stage-token-batches-from-session-offset.patch
+++ b/third_party/llama.cpp/patches/0014-Position-stage-token-batches-from-session-offset.patch
@@ -1,7 +1,7 @@
-From b8b5899d1db1a7a448ffea51e5801cc542feab66 Mon Sep 17 00:00:00 2001
+From 93b4e3d1346f5b2c7a2aca72c9f273940c508244 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 09:05:00 +1000
-Subject: [PATCH 14/80] Position stage token batches from session offset
+Subject: [PATCH 14/81] Position stage token batches from session offset
 
 ---
  src/skippy.cpp | 17 +++++++++++++----

--- a/third_party/llama.cpp/patches/0015-Optimize-native-KV-page-cell-lookup.patch
+++ b/third_party/llama.cpp/patches/0015-Optimize-native-KV-page-cell-lookup.patch
@@ -1,7 +1,7 @@
-From 0ef03b58fa8c34c73eb1de7b35db5af42a459b6d Mon Sep 17 00:00:00 2001
+From 870e9a876bd2624a2223b853dc1a3921dcd5eef1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 09:17:13 +1000
-Subject: [PATCH 15/80] Optimize native KV page cell lookup
+Subject: [PATCH 15/81] Optimize native KV page cell lookup
 
 ---
  src/llama-kv-cache.cpp | 29 +++++++++++++++--------------

--- a/third_party/llama.cpp/patches/0016-Add-batched-token-verification-ABI.patch
+++ b/third_party/llama.cpp/patches/0016-Add-batched-token-verification-ABI.patch
@@ -1,7 +1,7 @@
-From b794e1f84ba3d1323710f55f1250e01019ba8b80 Mon Sep 17 00:00:00 2001
+From 904a11ff6c654b69ab668276082ee054dd555100 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 13:30:00 +1000
-Subject: [PATCH 16/80] Add batched token verification ABI
+Subject: [PATCH 16/81] Add batched token verification ABI
 
 ---
  include/skippy.h | 12 +++++++-

--- a/third_party/llama.cpp/patches/0017-Expose-stage-chat-template-ABI.patch
+++ b/third_party/llama.cpp/patches/0017-Expose-stage-chat-template-ABI.patch
@@ -1,7 +1,7 @@
-From f7f973a4ed051a4f4ddc8380b2b34d42f6026f84 Mon Sep 17 00:00:00 2001
+From 5e9ede3d114c49829d3e0cc7379f0f5309d8cb82 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 19:14:50 +1000
-Subject: [PATCH 17/80] Expose stage chat template ABI
+Subject: [PATCH 17/81] Expose stage chat template ABI
 
 ---
  common/CMakeLists.txt |   1 +

--- a/third_party/llama.cpp/patches/0018-Support-more-runtime-slice-model-families.patch
+++ b/third_party/llama.cpp/patches/0018-Support-more-runtime-slice-model-families.patch
@@ -1,7 +1,7 @@
-From d0eccc7068ea684a08c4a8e5200fe7e4ce160325 Mon Sep 17 00:00:00 2001
+From 18df1c83b39db756bcd4bc0277735973ffab45ed Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 16:07:00 +1000
-Subject: [PATCH 18/80] Support more runtime-slice model families
+Subject: [PATCH 18/81] Support more runtime-slice model families
 
 ---
  include/skippy.h           |  17 +++

--- a/third_party/llama.cpp/patches/0019-Add-stage-sampling-config-ABI.patch
+++ b/third_party/llama.cpp/patches/0019-Add-stage-sampling-config-ABI.patch
@@ -1,7 +1,7 @@
-From 9674a7ce54ddc94efd8077f6d550b63be640d55e Mon Sep 17 00:00:00 2001
+From 1201fbe7caf9bfec019e23e5d6483d8682dca0b1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 20:15:33 +1000
-Subject: [PATCH 19/80] Add stage sampling config ABI
+Subject: [PATCH 19/81] Add stage sampling config ABI
 
 ---
  include/skippy.h |  41 +++++++++++++++-

--- a/third_party/llama.cpp/patches/0020-Add-staged-batched-verification-frame-ABI.patch
+++ b/third_party/llama.cpp/patches/0020-Add-staged-batched-verification-frame-ABI.patch
@@ -1,7 +1,7 @@
-From da8c1e7d385e781c280199c07954ee06c827a706 Mon Sep 17 00:00:00 2001
+From 31e003a68afd9150335ff96db83c223adff67a09 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 13:47:51 +1000
-Subject: [PATCH 20/80] Add staged batched verification frame ABI
+Subject: [PATCH 20/81] Add staged batched verification frame ABI
 
 ---
  include/skippy.h |  18 ++++-

--- a/third_party/llama.cpp/patches/0021-Add-recurrent-state-checkpoint-ABI.patch
+++ b/third_party/llama.cpp/patches/0021-Add-recurrent-state-checkpoint-ABI.patch
@@ -1,7 +1,7 @@
-From 6947cf7c79796fe4145e14bc2bcc063949c2168f Mon Sep 17 00:00:00 2001
+From 67d6955cddceb18e03dc60a73eb58f508d115ac0 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 14:07:00 +1000
-Subject: [PATCH 21/80] Add recurrent state checkpoint ABI
+Subject: [PATCH 21/81] Add recurrent state checkpoint ABI
 
 ---
  include/skippy.h |  16 +++++-

--- a/third_party/llama.cpp/patches/0022-Add-stage-logit-bias-sampling-ABI.patch
+++ b/third_party/llama.cpp/patches/0022-Add-stage-logit-bias-sampling-ABI.patch
@@ -1,7 +1,7 @@
-From 8bb12d9c148659acf6d58de48dfc69ce2797e05f Mon Sep 17 00:00:00 2001
+From 58bff3ab2f821789f04a9be25618953c0a6042f2 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 20:52:31 +1000
-Subject: [PATCH 22/80] Add stage logit bias sampling ABI
+Subject: [PATCH 22/81] Add stage logit bias sampling ABI
 
 ---
  include/skippy.h |  8 +++++++-

--- a/third_party/llama.cpp/patches/0023-Add-stage-session-trim-ABI.patch
+++ b/third_party/llama.cpp/patches/0023-Add-stage-session-trim-ABI.patch
@@ -1,7 +1,7 @@
-From f8e30b93cf5bc6c07dc5438a98f3a6d4d9e8a55c Mon Sep 17 00:00:00 2001
+From 23d765bcc14697cc7032ced2ce587435070a0059 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 15:42:15 +1000
-Subject: [PATCH 23/80] Add stage session trim ABI
+Subject: [PATCH 23/81] Add stage session trim ABI
 
 ---
  include/skippy.h |  8 ++++++-

--- a/third_party/llama.cpp/patches/0024-Add-native-stage-session-checkpoint-ABI.patch
+++ b/third_party/llama.cpp/patches/0024-Add-native-stage-session-checkpoint-ABI.patch
@@ -1,7 +1,7 @@
-From ae069d2d04187153874ef6da76851b43f12c8095 Mon Sep 17 00:00:00 2001
+From 4a42747e909e775ec1368ecacc2b27094be186f9 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 15:57:39 +1000
-Subject: [PATCH 24/80] Add native stage session checkpoint ABI
+Subject: [PATCH 24/81] Add native stage session checkpoint ABI
 
 ---
  include/skippy.h | 13 ++++++-

--- a/third_party/llama.cpp/patches/0025-Fix-staged-verification-activation-handoff.patch
+++ b/third_party/llama.cpp/patches/0025-Fix-staged-verification-activation-handoff.patch
@@ -1,7 +1,7 @@
-From 426fbd309fcf3b6d9b22115cccda7fe1d995e3af Mon Sep 17 00:00:00 2001
+From 206b258907a029559ef5ade9197f8ba06e65e8a9 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 27 Apr 2026 21:35:20 +1000
-Subject: [PATCH 25/80] Fix staged verification activation handoff
+Subject: [PATCH 25/81] Fix staged verification activation handoff
 
 ---
  src/skippy.cpp | 2 +-

--- a/third_party/llama.cpp/patches/0026-Strip-split-metadata-from-stage-GGUF-artifacts.patch
+++ b/third_party/llama.cpp/patches/0026-Strip-split-metadata-from-stage-GGUF-artifacts.patch
@@ -1,7 +1,7 @@
-From 9c23f62e7c0b39c818ce969f6878985a7aa112ed Mon Sep 17 00:00:00 2001
+From 09a592402f514be3414881dddfbb353c42bfbb41 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 28 Apr 2026 07:38:29 +1000
-Subject: [PATCH 26/80] Strip split metadata from stage GGUF artifacts
+Subject: [PATCH 26/81] Strip split metadata from stage GGUF artifacts
 
 ---
  src/skippy.cpp | 8 ++++++++

--- a/third_party/llama.cpp/patches/0027-Expose-stage-chat-template-thinking-toggle.patch
+++ b/third_party/llama.cpp/patches/0027-Expose-stage-chat-template-thinking-toggle.patch
@@ -1,7 +1,7 @@
-From c9af7c0afe61072d28d9fde987c521a532da462b Mon Sep 17 00:00:00 2001
+From 5107525d4fc540be6501d5872086c0c7a4e6d34d Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 28 Apr 2026 00:00:00 +1000
-Subject: [PATCH 27/80] Expose stage chat template thinking toggle
+Subject: [PATCH 27/81] Expose stage chat template thinking toggle
 
 ---
  common/stage-chat.cpp | 15 +++++++++++++++

--- a/third_party/llama.cpp/patches/0028-Load-stage-models-from-ordered-GGUF-parts.patch
+++ b/third_party/llama.cpp/patches/0028-Load-stage-models-from-ordered-GGUF-parts.patch
@@ -1,7 +1,7 @@
-From bd284f5e74a76e5662638092db1ada38c3a5c096 Mon Sep 17 00:00:00 2001
+From 85b4b884143326839a3f3537ee036691e52711b2 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 29 Apr 2026 11:45:50 +1000
-Subject: [PATCH 28/80] Load stage models from ordered GGUF parts
+Subject: [PATCH 28/81] Load stage models from ordered GGUF parts
 
 ---
  include/llama.h            |   7 ++

--- a/third_party/llama.cpp/patches/0029-Support-Qwen3MoE-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0029-Support-Qwen3MoE-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From 178dac750aa3ed57d85d6c8548e2e4a9a12d1834 Mon Sep 17 00:00:00 2001
+From d833d08bdcce8c6264e1035f8b0b3492139df885 Mon Sep 17 00:00:00 2001
 From: James Dumay <jameswdumay@gmail.com>
 Date: Thu, 30 Apr 2026 18:55:00 +1000
-Subject: [PATCH 29/80] Support Qwen3MoE runtime-slice execution
+Subject: [PATCH 29/81] Support Qwen3MoE runtime-slice execution
 
 Add LLM_ARCH_QWEN3MOE to the supported architecture list in the stage
 filter gate and add stage filter hooks to the qwen3moe.cpp graph builder

--- a/third_party/llama.cpp/patches/0030-Expose-stage-KV-cache-type-config.patch
+++ b/third_party/llama.cpp/patches/0030-Expose-stage-KV-cache-type-config.patch
@@ -1,7 +1,7 @@
-From 155057aedb2518d6229bdc23aab43752cfb720e3 Mon Sep 17 00:00:00 2001
+From 72e14d5483268f8ae6c7426d8a22caae948dfa80 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 2 May 2026 08:41:07 +1000
-Subject: [PATCH 30/80] Expose stage KV cache type config
+Subject: [PATCH 30/81] Expose stage KV cache type config
 
 ---
  include/skippy.h | 4 +++-

--- a/third_party/llama.cpp/patches/0031-Expose-stage-generation-signal-ABI.patch
+++ b/third_party/llama.cpp/patches/0031-Expose-stage-generation-signal-ABI.patch
@@ -1,7 +1,7 @@
-From 7bf2543bc0a0f9b25a2237fd8f2fb07c9531241c Mon Sep 17 00:00:00 2001
+From fcad330f5ff457076b4e662f1c3702cd1a781ea6 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 2 May 2026 11:53:03 +1000
-Subject: [PATCH 31/80] Expose stage generation signal ABI
+Subject: [PATCH 31/81] Expose stage generation signal ABI
 
 ---
  include/skippy-signals.h |  44 ++++++++++

--- a/third_party/llama.cpp/patches/0032-Expose-selected-backend-device-ABI.patch
+++ b/third_party/llama.cpp/patches/0032-Expose-selected-backend-device-ABI.patch
@@ -1,11 +1,11 @@
-From 549da7d44d679d769df440ee982f5d77a9183ffd Mon Sep 17 00:00:00 2001
+From 759a7ce6a4a68298a98e7b1d6ec9552cba119da1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 2 May 2026 14:14:40 +1000
-Subject: [PATCH 32/80] Expose selected backend device ABI
+Subject: [PATCH 32/81] Expose selected backend device ABI
 
 ---
  include/skippy.h |  5 +++++
- src/skippy.cpp   | 51 +++++++++++++++++++++++++++++++++++++++++++++++++++
+ src/skippy.cpp   | 51 ++++++++++++++++++++++++++++++++++++++++++++++++
  2 files changed, 56 insertions(+)
 
 diff --git a/include/skippy.h b/include/skippy.h
@@ -25,7 +25,7 @@ index 4f1c8805..2f8f8466 100644
  
  struct skippy_tensor_info {
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 4b4bf8eb..26209b45 100644
+index 4b4bf8eb..3c714eff 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -471,6 +471,41 @@ static bool skippy_is_full_model_config(const struct skippy_runtime_config * con
@@ -72,7 +72,7 @@ index 4b4bf8eb..26209b45 100644
          if (config != nullptr && config->filter_tensors_on_load) {
 @@ -1211,6 +1246,14 @@ enum skippy_status skippy_model_open(
      }
-
+ 
      llama_backend_init();
 +    if (!ggml_backend_reg_count()) {
 +        ggml_backend_load_all();
@@ -85,7 +85,7 @@ index 4b4bf8eb..26209b45 100644
      skippy_filter_scope filter_scope(config);
      llama_model * model = llama_model_load_from_file(path, params);
      if (model == nullptr) {
-@@ -1262,6 +1302,14 @@ enum skippy_status skippy_model_open_from_parts(
+@@ -1262,6 +1305,14 @@ enum skippy_status skippy_model_open_from_parts(
      }
  
      llama_backend_init();

--- a/third_party/llama.cpp/patches/0033-Expose-external-media-prefill-ABI.patch
+++ b/third_party/llama.cpp/patches/0033-Expose-external-media-prefill-ABI.patch
@@ -1,7 +1,7 @@
-From 4b0b00d3a63f554a294d46a9678c50cccc7a6804 Mon Sep 17 00:00:00 2001
+From 32e5e9d80c0664dccd7cfbeaca70cacd3a41b8ae Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 2 May 2026 16:10:53 +1000
-Subject: [PATCH 33/80] Expose external media prefill ABI
+Subject: [PATCH 33/81] Expose external media prefill ABI
 
 ---
  include/skippy.h | 35 +++++++++++++++++++-
@@ -81,7 +81,7 @@ index 2f8f8466..1db835d5 100644
          struct skippy_session * session,
          int32_t layer_start,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 26209b45..a9ea0446 100644
+index 3c714eff..08cfeb20 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1126,7 +1126,8 @@ uint64_t skippy_abi_features(void) {
@@ -94,7 +94,7 @@ index 26209b45..a9ea0446 100644
  }
  
  const char * skippy_status_string(enum skippy_status status) {
-@@ -1327,6 +1328,11 @@ enum skippy_status skippy_model_free(
+@@ -1333,6 +1334,11 @@ enum skippy_status skippy_model_free(
      return skippy_success(out_error);
  }
  
@@ -106,7 +106,7 @@ index 26209b45..a9ea0446 100644
  enum skippy_status skippy_session_create(
          struct skippy_model * model,
          struct skippy_session ** out_session,
-@@ -1365,6 +1371,56 @@ enum skippy_status skippy_session_create(
+@@ -1371,6 +1377,56 @@ enum skippy_status skippy_session_create(
      return skippy_success(out_error);
  }
  
@@ -163,7 +163,7 @@ index 26209b45..a9ea0446 100644
  enum skippy_status skippy_session_reset(
          struct skippy_session * session,
          struct skippy_error ** out_error) {
-@@ -1811,6 +1867,32 @@ enum skippy_status skippy_verify_tokens_frame(
+@@ -1817,6 +1873,32 @@ enum skippy_status skippy_verify_tokens_frame(
      return skippy_success(out_error);
  }
  

--- a/third_party/llama.cpp/patches/0034-Add-shared-execution-lanes-to-skippy-ABI.patch
+++ b/third_party/llama.cpp/patches/0034-Add-shared-execution-lanes-to-skippy-ABI.patch
@@ -1,7 +1,7 @@
-From 7c3d60a657c8148497cff90a3bb1d4146d7322c0 Mon Sep 17 00:00:00 2001
+From 27fe6a9e3091bb7e009b7f422345b55897db1362 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 4 May 2026 17:49:03 +1000
-Subject: [PATCH 34/80] Add shared execution lanes to skippy ABI
+Subject: [PATCH 34/81] Add shared execution lanes to skippy ABI
 
 ---
  include/skippy.h       |  92 +-------
@@ -555,7 +555,7 @@ index 555cfc2c..2c54cec5 100644
      // graph_build API
      //
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index a9ea0446..0d128fc8 100644
+index 08cfeb20..152e2ffe 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -29,13 +29,18 @@
@@ -663,7 +663,7 @@ index a9ea0446..0d128fc8 100644
  
      *out_model = stage_model;
      return skippy_success(out_error);
-@@ -1322,6 +1350,9 @@ enum skippy_status skippy_model_free(
+@@ -1328,6 +1356,9 @@ enum skippy_status skippy_model_free(
          struct skippy_model * model,
          struct skippy_error ** out_error) {
      if (model != nullptr) {
@@ -673,7 +673,7 @@ index a9ea0446..0d128fc8 100644
          llama_model_free(model->model);
          delete model;
      }
-@@ -1337,33 +1368,30 @@ enum skippy_status skippy_session_create(
+@@ -1343,33 +1374,30 @@ enum skippy_status skippy_session_create(
          struct skippy_model * model,
          struct skippy_session ** out_session,
          struct skippy_error ** out_error) {
@@ -720,7 +720,7 @@ index a9ea0446..0d128fc8 100644
      session->n_past = 0;
      session->checkpoint_valid = false;
      session->checkpoint_n_past = 0;
-@@ -1436,7 +1464,11 @@ enum skippy_status skippy_session_reset(
+@@ -1442,7 +1470,11 @@ enum skippy_status skippy_session_reset(
          return SKIPPY_STATUS_RUNTIME_ERROR;
      }
  
@@ -733,7 +733,7 @@ index a9ea0446..0d128fc8 100644
      session->n_past = 0;
      session->checkpoint_valid = false;
      session->checkpoint_n_past = 0;
-@@ -1450,7 +1482,15 @@ enum skippy_status skippy_session_free(
+@@ -1456,7 +1488,15 @@ enum skippy_status skippy_session_free(
          struct skippy_session * session,
          struct skippy_error ** out_error) {
      if (session != nullptr) {
@@ -750,7 +750,7 @@ index a9ea0446..0d128fc8 100644
          delete session;
      }
      return skippy_success(out_error);
-@@ -1893,216 +1933,6 @@ enum skippy_status skippy_session_copy_output_activation_frame(
+@@ -1899,216 +1939,6 @@ enum skippy_status skippy_session_copy_output_activation_frame(
      return skippy_copy_output_activation_frame(session, token_count, output_payload, out_error);
  }
  
@@ -967,7 +967,7 @@ index a9ea0446..0d128fc8 100644
  static llama_memory_recurrent * skippy_get_recurrent_memory(
          skippy_session * session,
          skippy_error ** out_error) {
-@@ -2130,105 +1960,6 @@ static llama_memory_recurrent * skippy_get_recurrent_memory(
+@@ -2136,105 +1966,6 @@ static llama_memory_recurrent * skippy_get_recurrent_memory(
      return nullptr;
  }
  
@@ -1073,7 +1073,7 @@ index a9ea0446..0d128fc8 100644
  enum skippy_status skippy_trim_session(
          struct skippy_session * session,
          uint64_t token_count,
-@@ -2255,18 +1986,18 @@ enum skippy_status skippy_trim_session(
+@@ -2261,18 +1992,18 @@ enum skippy_status skippy_trim_session(
      const llama_pos p0 = static_cast<llama_pos>(token_count);
      if (auto * hybrid = dynamic_cast<llama_memory_hybrid *>(memory)) {
          llama_kv_cache * kv = hybrid->get_mem_attn();
@@ -1095,7 +1095,7 @@ index a9ea0446..0d128fc8 100644
              skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to trim native KV suffix");
              return SKIPPY_STATUS_RUNTIME_ERROR;
          }
-@@ -2314,7 +2045,7 @@ enum skippy_status skippy_checkpoint_session(
+@@ -2320,7 +2051,7 @@ enum skippy_status skippy_checkpoint_session(
              skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "native recurrent checkpoint requires n_seq_max >= 2");
              return SKIPPY_STATUS_UNSUPPORTED;
          }
@@ -1104,7 +1104,7 @@ index a9ea0446..0d128fc8 100644
      }
  
      session->checkpoint_valid = true;
-@@ -2362,8 +2093,8 @@ enum skippy_status skippy_restore_session_checkpoint(
+@@ -2368,8 +2099,8 @@ enum skippy_status skippy_restore_session_checkpoint(
              skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "native recurrent checkpoint requires n_seq_max >= 2");
              return SKIPPY_STATUS_UNSUPPORTED;
          }
@@ -1115,7 +1115,7 @@ index a9ea0446..0d128fc8 100644
          session->ctx->synchronize();
      }
  
-@@ -2378,108 +2109,6 @@ enum skippy_status skippy_restore_session_checkpoint(
+@@ -2384,108 +2115,6 @@ enum skippy_status skippy_restore_session_checkpoint(
      return skippy_success(out_error);
  }
  

--- a/third_party/llama.cpp/patches/0035-Expose-stage-batch-and-flash-attention-config.patch
+++ b/third_party/llama.cpp/patches/0035-Expose-stage-batch-and-flash-attention-config.patch
@@ -1,7 +1,7 @@
-From 7debbedc76a5169a2f8b86598ea62d0d2a3f2ede Mon Sep 17 00:00:00 2001
+From e593282f29967168bad66a159705d4d62346c8c4 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 4 May 2026 11:39:01 -0400
-Subject: [PATCH 35/80] Expose stage batch and flash attention config
+Subject: [PATCH 35/81] Expose stage batch and flash attention config
 
 ---
  include/skippy.h | 5 ++++-
@@ -35,7 +35,7 @@ index 9e91519d..2b95ccc8 100644
      enum skippy_load_mode load_mode;
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 0d128fc8..fd2cd3d0 100644
+index 152e2ffe..eec2c8b4 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1216,11 +1216,13 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0036-Expose-tool-aware-chat-template-ABI.patch
+++ b/third_party/llama.cpp/patches/0036-Expose-tool-aware-chat-template-ABI.patch
@@ -1,7 +1,7 @@
-From 7c3683bd6cabd9f2eea014fd6f746f281fd54515 Mon Sep 17 00:00:00 2001
+From 00eb130741d6bc1de5eb04c5f37feba278f697d1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 06:10:28 +1000
-Subject: [PATCH 36/80] Expose tool-aware chat template ABI
+Subject: [PATCH 36/81] Expose tool-aware chat template ABI
 
 ---
  common/stage-chat.cpp | 228 ++++++++++++++++++++++++++++++++++++++++++
@@ -9,7 +9,7 @@ Subject: [PATCH 36/80] Expose tool-aware chat template ABI
  2 files changed, 256 insertions(+), 1 deletion(-)
 
 diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
-index 60d53fc4..77d8fc8e 100644
+index 60d53fc4..a9e4c2de 100644
 --- a/common/stage-chat.cpp
 +++ b/common/stage-chat.cpp
 @@ -1,11 +1,16 @@
@@ -319,3 +319,4 @@ index 2b95ccc8..384c7e40 100644
          struct skippy_model_info ** out_info,
 -- 
 2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0037-Apply-chat-grammar-during-stage-sampling.patch
+++ b/third_party/llama.cpp/patches/0037-Apply-chat-grammar-during-stage-sampling.patch
@@ -1,7 +1,7 @@
-From 91d53e5f8363dc38f453f3eda4c3341a14987c83 Mon Sep 17 00:00:00 2001
+From 648455c37dbcb69118cac80698eb7f09c603f772 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 07:11:33 +1000
-Subject: [PATCH 37/80] Apply chat grammar during stage sampling
+Subject: [PATCH 37/81] Apply chat grammar during stage sampling
 
 ---
  include/skippy.h |  10 +-
@@ -44,7 +44,7 @@ index 384c7e40..3ffdb879 100644
          struct skippy_session * session,
          struct skippy_error ** out_error);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index fd2cd3d0..ae18f5fc 100644
+index eec2c8b4..94355b60 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -11,6 +11,7 @@
@@ -313,7 +313,7 @@ index fd2cd3d0..ae18f5fc 100644
      if (!skippy_sampling_enabled(sampling)) {
          return skippy_greedy_sample(session);
      }
-@@ -1431,6 +1659,7 @@ enum skippy_status skippy_session_set_position(
+@@ -1437,6 +1665,7 @@ enum skippy_status skippy_session_set_position(
      session->n_past = n_past;
      if (session->token_history.size() > static_cast<size_t>(n_past)) {
          session->token_history.resize(static_cast<size_t>(n_past));
@@ -321,7 +321,7 @@ index fd2cd3d0..ae18f5fc 100644
      }
      if (session->signal_history.size() > static_cast<size_t>(n_past)) {
          session->signal_history.resize(static_cast<size_t>(n_past));
-@@ -1451,6 +1680,48 @@ enum skippy_status skippy_session_sample_current(
+@@ -1457,6 +1686,48 @@ enum skippy_status skippy_session_sample_current(
      return skippy_success(out_error);
  }
  
@@ -370,7 +370,7 @@ index fd2cd3d0..ae18f5fc 100644
  enum skippy_status skippy_session_reset(
          struct skippy_session * session,
          struct skippy_error ** out_error) {
-@@ -1476,6 +1747,7 @@ enum skippy_status skippy_session_reset(
+@@ -1482,6 +1753,7 @@ enum skippy_status skippy_session_reset(
      session->checkpoint_n_past = 0;
      session->token_history.clear();
      session->signal_history.clear();
@@ -378,7 +378,7 @@ index fd2cd3d0..ae18f5fc 100644
      session->ctx->synchronize();
      return skippy_success(out_error);
  }
-@@ -2010,6 +2282,7 @@ enum skippy_status skippy_trim_session(
+@@ -2016,6 +2288,7 @@ enum skippy_status skippy_trim_session(
      session->n_past = static_cast<int32_t>(token_count);
      if (session->token_history.size() > token_count) {
          session->token_history.resize(static_cast<size_t>(token_count));

--- a/third_party/llama.cpp/patches/0038-Add-resident-prefix-cache-ABI.patch
+++ b/third_party/llama.cpp/patches/0038-Add-resident-prefix-cache-ABI.patch
@@ -1,7 +1,7 @@
-From d823fc68c7d3a0d27c32095fc87ac3aaf70ce7dd Mon Sep 17 00:00:00 2001
+From 819cfd2dd6712c1284c47e3040411eefe6d3bd52 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 4 May 2026 21:58:07 +1000
-Subject: [PATCH 38/80] Add resident prefix cache ABI
+Subject: [PATCH 38/81] Add resident prefix cache ABI
 
 ---
  include/skippy.h |  20 ++++++-
@@ -47,10 +47,10 @@ index 3ffdb879..d8dba876 100644
          struct skippy_model * model,
          const char * text,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index ae18f5fc..3002b720 100644
+index 94355b60..ed8b7c27 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -2292,6 +2292,158 @@ enum skippy_status skippy_trim_session(
+@@ -2298,6 +2298,158 @@ enum skippy_status skippy_trim_session(
      return skippy_success(out_error);
  }
  

--- a/third_party/llama.cpp/patches/0039-Restore-exact-prefix-state-cache-ABI.patch
+++ b/third_party/llama.cpp/patches/0039-Restore-exact-prefix-state-cache-ABI.patch
@@ -1,7 +1,7 @@
-From 99f9337e160cbd8aff82b314f0c0dfca542e714d Mon Sep 17 00:00:00 2001
+From 05ad181e10e0804ea33bc1e84327a6ee34ccb0dd Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 08:21:34 +1000
-Subject: [PATCH 39/80] Restore exact prefix state cache ABI
+Subject: [PATCH 39/81] Restore exact prefix state cache ABI
 
 ---
  include/skippy.h       |  91 ++++++++-
@@ -560,7 +560,7 @@ index 2c54cec5..d93120b9 100644
      // graph_build API
      //
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 3002b720..56ab40d7 100644
+index ed8b7c27..d3d47b9f 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1345,13 +1345,16 @@ uint64_t skippy_abi_features(void) {
@@ -580,7 +580,7 @@ index 3002b720..56ab40d7 100644
             SKIPPY_FEATURE_LOGIT_BIAS |
             SKIPPY_FEATURE_SESSION_TRIM |
             SKIPPY_FEATURE_SESSION_CHECKPOINT |
-@@ -2207,6 +2210,212 @@ enum skippy_status skippy_session_copy_output_activation_frame(
+@@ -2213,6 +2216,212 @@ enum skippy_status skippy_session_copy_output_activation_frame(
      return skippy_copy_output_activation_frame(session, token_count, output_payload, out_error);
  }
  
@@ -793,7 +793,7 @@ index 3002b720..56ab40d7 100644
  static llama_memory_recurrent * skippy_get_recurrent_memory(
          skippy_session * session,
          skippy_error ** out_error) {
-@@ -2234,6 +2443,207 @@ static llama_memory_recurrent * skippy_get_recurrent_memory(
+@@ -2240,6 +2449,207 @@ static llama_memory_recurrent * skippy_get_recurrent_memory(
      return nullptr;
  }
  

--- a/third_party/llama.cpp/patches/0040-Add-borrowed-resident-prefix-session-ABI.patch
+++ b/third_party/llama.cpp/patches/0040-Add-borrowed-resident-prefix-session-ABI.patch
@@ -1,7 +1,7 @@
-From 922aae9f49ad7c750f3910facb609b019e90c4f7 Mon Sep 17 00:00:00 2001
+From 10ebb846e61561514d7a6bb99173febd5cc3059f Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 19:20:00 +1000
-Subject: [PATCH 40/80] Add borrowed resident prefix session ABI
+Subject: [PATCH 40/81] Add borrowed resident prefix session ABI
 
 ---
  include/skippy.h |  10 ++++-
@@ -37,7 +37,7 @@ index b051b66c..fe166e3d 100644
          struct skippy_session * session);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 56ab40d7..b979cbb2 100644
+index d3d47b9f..dccea7d4 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -45,6 +45,8 @@ struct skippy_session {
@@ -49,7 +49,7 @@ index 56ab40d7..b979cbb2 100644
      bool checkpoint_valid = false;
      int32_t checkpoint_n_past = 0;
      size_t checkpoint_token_history_size = 0;
-@@ -1625,6 +1627,8 @@ enum skippy_status skippy_session_create(
+@@ -1631,6 +1633,8 @@ enum skippy_status skippy_session_create(
      session->ctx = model->ctx;
      session->seq_id = seq_id;
      session->checkpoint_seq_id = seq_id + static_cast<int32_t>(model->lane_count);
@@ -58,7 +58,7 @@ index 56ab40d7..b979cbb2 100644
      session->n_past = 0;
      session->checkpoint_valid = false;
      session->checkpoint_n_past = 0;
-@@ -1740,15 +1744,26 @@ enum skippy_status skippy_session_reset(
+@@ -1746,15 +1750,26 @@ enum skippy_status skippy_session_reset(
          return SKIPPY_STATUS_RUNTIME_ERROR;
      }
  
@@ -89,7 +89,7 @@ index 56ab40d7..b979cbb2 100644
      session->signal_history.clear();
      skippy_clear_chat_sampling(session);
      session->ctx->synchronize();
-@@ -1762,7 +1777,7 @@ enum skippy_status skippy_session_free(
+@@ -1768,7 +1783,7 @@ enum skippy_status skippy_session_free(
          if (session->ctx != nullptr) {
              skippy_session_reset(session, nullptr);
          }
@@ -98,7 +98,7 @@ index 56ab40d7..b979cbb2 100644
              const size_t lane = static_cast<size_t>(session->seq_id);
              if (lane < session->stage_model->lane_in_use.size()) {
                  session->stage_model->lane_in_use[lane] = false;
-@@ -2712,6 +2727,16 @@ static bool skippy_is_reserved_sequence_id(
+@@ -2718,6 +2733,16 @@ static bool skippy_is_reserved_sequence_id(
      return seq_id < reserved;
  }
  
@@ -115,7 +115,7 @@ index 56ab40d7..b979cbb2 100644
  static enum skippy_status skippy_get_resident_prefix_memory(
          skippy_session * session,
          llama_memory_t * out_memory,
-@@ -2834,6 +2859,74 @@ enum skippy_status skippy_session_restore_prefix(
+@@ -2840,6 +2865,74 @@ enum skippy_status skippy_session_restore_prefix(
      return skippy_success(out_error);
  }
  

--- a/third_party/llama.cpp/patches/0041-Compute-stage-generation-signals-lazily.patch
+++ b/third_party/llama.cpp/patches/0041-Compute-stage-generation-signals-lazily.patch
@@ -1,14 +1,14 @@
-From 395ef307172d9cc3f1f0f7ca10c7ef0dd2d4f854 Mon Sep 17 00:00:00 2001
+From faaecf67e949d7a20bfb7d9fd40a1fc5fd14f4c1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 19:35:00 +1000
-Subject: [PATCH 41/80] Compute stage generation signals lazily
+Subject: [PATCH 41/81] Compute stage generation signals lazily
 
 ---
  src/skippy.cpp | 6 +++---
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index b979cbb2..4c9592fe 100644
+index dccea7d4..e11c31f8 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -773,9 +773,6 @@ static enum skippy_status skippy_decode_tokens(
@@ -21,7 +21,7 @@ index b979cbb2..4c9592fe 100644
      }
      return status;
  }
-@@ -1796,6 +1793,9 @@ enum skippy_status skippy_session_last_token_signal(
+@@ -1802,6 +1799,9 @@ enum skippy_status skippy_session_last_token_signal(
          skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "session and out_signal are required");
          return SKIPPY_STATUS_INVALID_ARGUMENT;
      }

--- a/third_party/llama.cpp/patches/0042-Avoid-heap-batch-allocation-for-single-token-decode.patch
+++ b/third_party/llama.cpp/patches/0042-Avoid-heap-batch-allocation-for-single-token-decode.patch
@@ -1,14 +1,14 @@
-From 22723c29aeaff3ef10bc31051dc9681c19391c40 Mon Sep 17 00:00:00 2001
+From b6094c4709513d7d53f71c4146cc2c6bff743626 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 19:45:00 +1000
-Subject: [PATCH 42/80] Avoid heap batch allocation for single-token decode
+Subject: [PATCH 42/81] Avoid heap batch allocation for single-token decode
 
 ---
  src/skippy.cpp | 23 +++++++++++++++++++++++
  1 file changed, 23 insertions(+)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 4c9592fe..8c431715 100644
+index e11c31f8..3fc8b928 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -759,6 +759,29 @@ static enum skippy_status skippy_decode_tokens(

--- a/third_party/llama.cpp/patches/0043-Default-stage-threads-like-llama-server.patch
+++ b/third_party/llama.cpp/patches/0043-Default-stage-threads-like-llama-server.patch
@@ -1,7 +1,7 @@
-From 80c446964d2d3773eea39f146a25a34e88a45236 Mon Sep 17 00:00:00 2001
+From 22a461bfa66e00bcc9fb4544274ce3df123edf64 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 22:20:00 +1000
-Subject: [PATCH 43/80] Default stage threads like llama-server
+Subject: [PATCH 43/81] Default stage threads like llama-server
 
 ---
  include/skippy.h |  4 +++-
@@ -31,7 +31,7 @@ index fe166e3d..deb5151e 100644
      int32_t cache_type_k;
      int32_t cache_type_v;
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 8c431715..8b6a5503 100644
+index 3fc8b928..e0cc4a08 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -20,14 +20,23 @@

--- a/third_party/llama.cpp/patches/0044-Allow-borrowing-resident-prefix-cache-sequences.patch
+++ b/third_party/llama.cpp/patches/0044-Allow-borrowing-resident-prefix-cache-sequences.patch
@@ -1,17 +1,17 @@
-From 20258d6ccbc38b7b610ee19e004d3671c3fc10fd Mon Sep 17 00:00:00 2001
+From 855e65bdc53f14bc27ece226c77822addac808dd Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 22:34:00 +1000
-Subject: [PATCH 44/80] Allow borrowing resident prefix cache sequences
+Subject: [PATCH 44/81] Allow borrowing resident prefix cache sequences
 
 ---
  src/skippy.cpp | 40 +++++++++++++++++++++++++++++++---------
  1 file changed, 31 insertions(+), 9 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 8b6a5503..4c65dbc4 100644
+index e0cc4a08..5a5b123c 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -2949,9 +2949,18 @@ enum skippy_status skippy_session_create_from_resident_prefix(
+@@ -2955,9 +2955,18 @@ enum skippy_status skippy_session_create_from_resident_prefix(
          skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "cache sequence id overlaps execution lanes");
          return SKIPPY_STATUS_INVALID_ARGUMENT;
      }
@@ -33,7 +33,7 @@ index 8b6a5503..4c65dbc4 100644
      }
  
      skippy_session temp{};
-@@ -2960,6 +2969,7 @@ enum skippy_status skippy_session_create_from_resident_prefix(
+@@ -2966,6 +2975,7 @@ enum skippy_status skippy_session_create_from_resident_prefix(
      llama_memory_t memory = nullptr;
      enum skippy_status status = skippy_get_resident_prefix_memory(&temp, &memory, out_error);
      if (status != SKIPPY_STATUS_OK) {
@@ -41,7 +41,7 @@ index 8b6a5503..4c65dbc4 100644
          return status;
      }
  
-@@ -2968,22 +2978,34 @@ enum skippy_status skippy_session_create_from_resident_prefix(
+@@ -2974,22 +2984,34 @@ enum skippy_status skippy_session_create_from_resident_prefix(
          const llama_pos max_pos = llama_memory_seq_pos_max(memory, cache_seq_id);
          if (max_pos < static_cast<llama_pos>(token_count - 1)) {
              skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "resident prefix sequence is incomplete");

--- a/third_party/llama.cpp/patches/0045-Preserve-resident-prefix-lanes.patch
+++ b/third_party/llama.cpp/patches/0045-Preserve-resident-prefix-lanes.patch
@@ -1,14 +1,14 @@
-From a28e2a6b9bced5d1233cbc34245d7d28f4146f76 Mon Sep 17 00:00:00 2001
+From d97e8796de697c7242b81165909b3f0c7c104ca7 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 5 May 2026 22:05:49 +1000
-Subject: [PATCH 45/80] Preserve resident prefix lanes
+Subject: [PATCH 45/81] Preserve resident prefix lanes
 
 ---
  src/skippy.cpp | 65 ++++++++++++++++++++++++++++++++++++++++++++------
  1 file changed, 58 insertions(+), 7 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 4c65dbc4..4486ad78 100644
+index 5a5b123c..c3de4c89 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -16,6 +16,7 @@
@@ -44,7 +44,7 @@ index 4c65dbc4..4486ad78 100644
  
      *out_model = stage_model;
      return skippy_success(out_error);
-@@ -1695,6 +1700,12 @@ enum skippy_status skippy_session_create(
+@@ -1701,6 +1706,12 @@ enum skippy_status skippy_session_create(
      session->checkpoint_valid = false;
      session->checkpoint_n_past = 0;
      *out_session = session;
@@ -57,7 +57,7 @@ index 4c65dbc4..4486ad78 100644
      return skippy_success(out_error);
  }
  
-@@ -1837,7 +1848,26 @@ enum skippy_status skippy_session_free(
+@@ -1843,7 +1854,26 @@ enum skippy_status skippy_session_free(
          struct skippy_error ** out_error) {
      if (session != nullptr) {
          if (session->ctx != nullptr) {
@@ -85,7 +85,7 @@ index 4c65dbc4..4486ad78 100644
          }
          if (!session->borrowed_sequence && session->stage_model != nullptr && session->seq_id >= 0) {
              const size_t lane = static_cast<size_t>(session->seq_id);
-@@ -2865,6 +2895,18 @@ enum skippy_status skippy_session_save_prefix(
+@@ -2871,6 +2901,18 @@ enum skippy_status skippy_session_save_prefix(
      if (token_count > 0) {
          llama_memory_seq_cp(memory, session->seq_id, cache_seq_id, 0, static_cast<llama_pos>(token_count));
      }
@@ -104,7 +104,7 @@ index 4c65dbc4..4486ad78 100644
      session->ctx->synchronize();
      return skippy_success(out_error);
  }
-@@ -2982,13 +3024,22 @@ enum skippy_status skippy_session_create_from_resident_prefix(
+@@ -2988,13 +3030,22 @@ enum skippy_status skippy_session_create_from_resident_prefix(
              return SKIPPY_STATUS_INVALID_ARGUMENT;
          }
      }

--- a/third_party/llama.cpp/patches/0046-Remap-recurrent-state-imports-to-active-session.patch
+++ b/third_party/llama.cpp/patches/0046-Remap-recurrent-state-imports-to-active-session.patch
@@ -1,17 +1,17 @@
-From 2495cf73c41bddf7688bc477324c9656e11af4f7 Mon Sep 17 00:00:00 2001
+From d1716fec71bca66dee2f5a73b17d77bde40761e6 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 21:03:48 +1000
-Subject: [PATCH 46/80] Remap recurrent state imports to active session
+Subject: [PATCH 46/81] Remap recurrent state imports to active session
 
 ---
  src/skippy.cpp | 16 +++++++++++++---
  1 file changed, 13 insertions(+), 3 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 4486ad78..1f6fe94a 100644
+index c3de4c89..9ab53715 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -2635,14 +2635,24 @@ enum skippy_status skippy_import_recurrent_state(
+@@ -2641,14 +2641,24 @@ enum skippy_status skippy_import_recurrent_state(
          return SKIPPY_STATUS_UNSUPPORTED;
      }
  

--- a/third_party/llama.cpp/patches/0047-Support-initial-dense-runtime-slice-families.patch
+++ b/third_party/llama.cpp/patches/0047-Support-initial-dense-runtime-slice-families.patch
@@ -1,7 +1,7 @@
-From 0a0f04eb889fd7f58f499f9ef6cad6b761812fea Mon Sep 17 00:00:00 2001
+From 99aa08bd862977e345ddf1ecd6d385081dc4f37c Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 08:32:41 +1000
-Subject: [PATCH 47/80] Support initial dense runtime-slice families
+Subject: [PATCH 47/81] Support initial dense runtime-slice families
 
 ---
  src/models/baichuan.cpp | 20 ++++++++++++++++----
@@ -285,7 +285,7 @@ index 8f613e55..178803e6 100644
              model.output_norm,
              model.output_norm_b,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 1f6fe94a..a8a4f78e 100644
+index 9ab53715..fd1b9aad 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1461,6 +1461,9 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0048-Support-additional-dense-runtime-slice-families.patch
+++ b/third_party/llama.cpp/patches/0048-Support-additional-dense-runtime-slice-families.patch
@@ -1,7 +1,7 @@
-From 3f4fb5ab4d2bf0db9b2c96e36d95bdea67bc0fba Mon Sep 17 00:00:00 2001
+From 9fa45403be12e67daa2764e2d089660a7c9c60b5 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 08:38:54 +1000
-Subject: [PATCH 48/80] Support additional dense runtime-slice families
+Subject: [PATCH 48/81] Support additional dense runtime-slice families
 
 ---
  src/models/cohere2.cpp    | 20 ++++++++++++++++----
@@ -488,7 +488,7 @@ index 45dae060..0bc9aaa4 100644
              model.output_norm, model.output_norm_b,
              LLM_NORM, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index a8a4f78e..9b564cc6 100644
+index fd1b9aad..eeacbfa6 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1463,7 +1463,15 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0049-Avoid-rescaling-staged-activation-inputs.patch
+++ b/third_party/llama.cpp/patches/0049-Avoid-rescaling-staged-activation-inputs.patch
@@ -1,7 +1,7 @@
-From 31638cc7e2b3e0dc52da810ebc0c3f8889e7cb53 Mon Sep 17 00:00:00 2001
+From 506250ab1ad6dd680f67dcb8cdc54760c93c4199 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 08:42:26 +1000
-Subject: [PATCH 49/80] Avoid rescaling staged activation inputs
+Subject: [PATCH 49/81] Avoid rescaling staged activation inputs
 
 ---
  src/llama-graph.cpp | 8 ++++++--

--- a/third_party/llama.cpp/patches/0050-Support-more-decoder-runtime-slice-families.patch
+++ b/third_party/llama.cpp/patches/0050-Support-more-decoder-runtime-slice-families.patch
@@ -1,7 +1,7 @@
-From 63035d5f6cc8217d022f72c4a8afcda9b05b3bcf Mon Sep 17 00:00:00 2001
+From 1679538dd0222ea5d05df884b0c6fd325db85f40 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 08:58:17 +1000
-Subject: [PATCH 50/80] Support more decoder runtime-slice families
+Subject: [PATCH 50/81] Support more decoder runtime-slice families
 
 ---
  src/models/gpt2.cpp    | 33 +++++++++++++++++++++++----------
@@ -357,7 +357,7 @@ index 7871f8f7..5e2fc616 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 9b564cc6..6d9e2fcc 100644
+index eeacbfa6..3b97c709 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1468,13 +1468,19 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0051-Support-LFM2-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0051-Support-LFM2-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From 633b7cc04a649bca05489338cc5b30372a34399b Mon Sep 17 00:00:00 2001
+From 4721cf858e13f6b789fafe2cb7f18a60bfc65220 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 09:27:42 +1000
-Subject: [PATCH 51/80] Support LFM2 runtime-slice execution
+Subject: [PATCH 51/81] Support LFM2 runtime-slice execution
 
 ---
  src/models/lfm2.cpp | 30 +++++++++++++++++++++++++-----
@@ -72,7 +72,7 @@ index df6a8028..a02f25b2 100644
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 6d9e2fcc..891e9c41 100644
+index 3b97c709..39990dd4 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1472,6 +1472,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0052-Support-Mamba-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0052-Support-Mamba-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From e365274b06562fdc765956beb3f8765b2a624795 Mon Sep 17 00:00:00 2001
+From 7b174570fc683b360886cc117d4fd28d54735fd1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 09:32:21 +1000
-Subject: [PATCH 52/80] Support Mamba runtime-slice execution
+Subject: [PATCH 52/81] Support Mamba runtime-slice execution
 
 ---
  src/models/mamba.cpp | 20 ++++++++++++++++----
@@ -59,7 +59,7 @@ index b7708d7f..35cbce71 100644
      cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 891e9c41..cd9f1142 100644
+index 39990dd4..7bf311bb 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1473,6 +1473,8 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0053-Support-Jamba-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0053-Support-Jamba-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From ad14159a18de054e08d9d0553ce6e8f966c0ce96 Mon Sep 17 00:00:00 2001
+From 315a90871626e02d3713135dcb1b8fbe9248f7f7 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 09:36:46 +1000
-Subject: [PATCH 53/80] Support Jamba runtime-slice execution
+Subject: [PATCH 53/81] Support Jamba runtime-slice execution
 
 ---
  src/models/jamba.cpp | 20 ++++++++++++++++----
@@ -59,7 +59,7 @@ index e1b8d137..8c49fc68 100644
      cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index cd9f1142..a4c7d09f 100644
+index 7bf311bb..5e660d90 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1472,6 +1472,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0054-Support-RWKV6-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0054-Support-RWKV6-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From ea3e4856439ed5418ea984a053e9ebeaeb2e7b9d Mon Sep 17 00:00:00 2001
+From 32a23316a0a0f305a84926a6ae127858bf53458d Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 10:02:20 +1000
-Subject: [PATCH 54/80] Support RWKV6 runtime-slice execution
+Subject: [PATCH 54/81] Support RWKV6 runtime-slice execution
 
 ---
  src/models/rwkv6.cpp | 25 +++++++++++++++++++------
@@ -74,7 +74,7 @@ index 2944711a..dd4fad68 100644
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM, -1);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index a4c7d09f..5b914a78 100644
+index 5e660d90..3670218b 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1487,6 +1487,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0055-Support-Qwen2MoE-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0055-Support-Qwen2MoE-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From 9e3d4ad6b4894df20216ac1d3540ecfd84f586eb Mon Sep 17 00:00:00 2001
+From 662d995fc18eeeebac2fb91ea98c054235733da8 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 10:14:02 +1000
-Subject: [PATCH 55/80] Support Qwen2MoE runtime-slice execution
+Subject: [PATCH 55/81] Support Qwen2MoE runtime-slice execution
 
 ---
  src/models/qwen2moe.cpp | 25 ++++++++++++++++++++-----
@@ -73,7 +73,7 @@ index 7587c802..705abb47 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 5b914a78..9190dd8c 100644
+index 3670218b..65b57e37 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1485,6 +1485,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0056-Expose-skippy-session-native-sequence-id.patch
+++ b/third_party/llama.cpp/patches/0056-Expose-skippy-session-native-sequence-id.patch
@@ -1,7 +1,7 @@
-From e2af4e21c89e93239c5b561357be5fdba147b587 Mon Sep 17 00:00:00 2001
+From 818a8373d343cfa2b95875597ae93cc3bcc5ec26 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 10:29:41 +1000
-Subject: [PATCH 56/80] Expose skippy session native sequence id
+Subject: [PATCH 56/81] Expose skippy session native sequence id
 
 ---
  include/skippy.h | 3 +++
@@ -23,10 +23,10 @@ index deb5151e..84169398 100644
          const struct skippy_session * session);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 9190dd8c..940b420a 100644
+index 65b57e37..dbbd504b 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -1745,6 +1745,11 @@ int32_t skippy_session_position(
+@@ -1751,6 +1751,11 @@ int32_t skippy_session_position(
      return session != nullptr ? session->n_past : -1;
  }
  

--- a/third_party/llama.cpp/patches/0057-Support-RWKV7-activation-sideband.patch
+++ b/third_party/llama.cpp/patches/0057-Support-RWKV7-activation-sideband.patch
@@ -1,7 +1,7 @@
-From 645ed16bb29f31c753e2e327c961e7ae33276180 Mon Sep 17 00:00:00 2001
+From f32c16ccb72ed56337b2ef74eeeb3f3a85728c5c Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 11:23:13 +1000
-Subject: [PATCH 57/80] Support RWKV7 activation sideband
+Subject: [PATCH 57/81] Support RWKV7 activation sideband
 
 ---
  include/skippy.h      |   2 +
@@ -334,7 +334,7 @@ index b205e393..c3dc9eb0 100644
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM, -1);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 940b420a..18bbebf0 100644
+index dbbd504b..85f01123 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -631,6 +631,34 @@ struct skippy_activation_tokens_scope {
@@ -563,7 +563,7 @@ index 940b420a..18bbebf0 100644
              model->arch != LLM_ARCH_GEMMA &&
              model->arch != LLM_ARCH_GEMMA2 &&
              model->arch != LLM_ARCH_GEMMA3 &&
-@@ -2141,6 +2258,7 @@ enum skippy_status skippy_prefill_chunk_frame(
+@@ -2147,6 +2264,7 @@ enum skippy_status skippy_prefill_chunk_frame(
              output_payload_capacity,
              out_output_payload_bytes,
              output_desc,
@@ -571,7 +571,7 @@ index 940b420a..18bbebf0 100644
              out_error);
      if (status != SKIPPY_STATUS_OK) {
          return status;
-@@ -2155,7 +2273,7 @@ enum skippy_status skippy_prefill_chunk_frame(
+@@ -2161,7 +2279,7 @@ enum skippy_status skippy_prefill_chunk_frame(
          return status;
      }
  
@@ -580,7 +580,7 @@ index 940b420a..18bbebf0 100644
  }
  
  enum skippy_status skippy_decode_step_frame(
-@@ -2212,6 +2330,7 @@ enum skippy_status skippy_decode_step_frame_sampled(
+@@ -2218,6 +2336,7 @@ enum skippy_status skippy_decode_step_frame_sampled(
              output_payload_capacity,
              out_output_payload_bytes,
              output_desc,
@@ -588,7 +588,7 @@ index 940b420a..18bbebf0 100644
              out_error);
      if (status != SKIPPY_STATUS_OK) {
          return status;
-@@ -2230,7 +2349,7 @@ enum skippy_status skippy_decode_step_frame_sampled(
+@@ -2236,7 +2355,7 @@ enum skippy_status skippy_decode_step_frame_sampled(
          *out_predicted_token = session->stage_model->config.include_output ? skippy_sample_token(session, sampling) : -1;
      }
  
@@ -597,7 +597,7 @@ index 940b420a..18bbebf0 100644
  }
  
  enum skippy_status skippy_verify_tokens_frame(
-@@ -2280,6 +2399,7 @@ enum skippy_status skippy_verify_tokens_frame(
+@@ -2286,6 +2405,7 @@ enum skippy_status skippy_verify_tokens_frame(
              output_payload_capacity,
              out_output_payload_bytes,
              output_desc,
@@ -605,7 +605,7 @@ index 940b420a..18bbebf0 100644
              out_error);
      if (status != SKIPPY_STATUS_OK) {
          return status;
-@@ -2310,7 +2430,7 @@ enum skippy_status skippy_verify_tokens_frame(
+@@ -2316,7 +2436,7 @@ enum skippy_status skippy_verify_tokens_frame(
          return status;
      }
  
@@ -614,7 +614,7 @@ index 940b420a..18bbebf0 100644
      if (status != SKIPPY_STATUS_OK) {
          return status;
      }
-@@ -2344,11 +2464,12 @@ enum skippy_status skippy_session_copy_output_activation_frame(
+@@ -2350,11 +2470,12 @@ enum skippy_status skippy_session_copy_output_activation_frame(
              output_payload_capacity,
              out_output_payload_bytes,
              output_desc,

--- a/third_party/llama.cpp/patches/0058-Support-Phi2-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0058-Support-Phi2-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From cfabb1b93914cce374da44d1e862f0bc84f5efd1 Mon Sep 17 00:00:00 2001
+From 24feba715b6176fb0ce1bb0ff03af8ef5806649e Mon Sep 17 00:00:00 2001
 From: mesh-llm <mesh-llm@example.com>
 Date: Wed, 6 May 2026 00:00:00 +1000
-Subject: [PATCH 58/80] Support Phi2 runtime-slice execution
+Subject: [PATCH 58/81] Support Phi2 runtime-slice execution
 
 ---
  src/llama-model-loader.cpp | 11 +++++++++++
@@ -140,7 +140,7 @@ index a333602c..20a9752e 100644
              model.output_norm,
              model.output_norm_b,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 18bbebf0..8831d968 100644
+index 85f01123..f44ce6e9 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1615,6 +1615,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0059-Support-Granite-runtime-slice-variants.patch
+++ b/third_party/llama.cpp/patches/0059-Support-Granite-runtime-slice-variants.patch
@@ -1,7 +1,7 @@
-From ca77d4b34fd0b620e01250b9766ffb9850ce6c78 Mon Sep 17 00:00:00 2001
+From 09411c6fc59e92b92026ffab34080c04663236d0 Mon Sep 17 00:00:00 2001
 From: mesh-llm <mesh-llm@example.com>
 Date: Wed, 6 May 2026 00:00:00 +1000
-Subject: [PATCH 59/80] Support Granite runtime-slice variants
+Subject: [PATCH 59/81] Support Granite runtime-slice variants
 
 ---
  src/models/granite-hybrid.cpp | 17 ++++++++++++++---
@@ -54,7 +54,7 @@ index 12e4790a..1fde3b4e 100644
      cur = inpL;
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 8831d968..64faa7c8 100644
+index f44ce6e9..61069d90 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1586,6 +1586,8 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0060-Support-Hunyuan-Dense-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0060-Support-Hunyuan-Dense-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From 5739f20d6f4090ca89b1bfe6b829c28428241cdc Mon Sep 17 00:00:00 2001
+From bb81819fb00ea5c0c2d626e8ae8b4dc827fbaa58 Mon Sep 17 00:00:00 2001
 From: mesh-llm <mesh-llm@example.com>
 Date: Wed, 6 May 2026 00:00:00 +1000
-Subject: [PATCH 60/80] Support Hunyuan-Dense runtime-slice execution
+Subject: [PATCH 60/81] Support Hunyuan-Dense runtime-slice execution
 
 ---
  src/models/hunyuan-vl.cpp | 20 ++++++++++++++++----
@@ -62,7 +62,7 @@ index 5fb9154b..0daa6668 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 64faa7c8..73a66680 100644
+index 61069d90..7f427aba 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1588,6 +1588,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0061-Support-Hunyuan-MoE-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0061-Support-Hunyuan-MoE-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From 0d83872e349a1810e5c6a443b7e9bdfa52a9cf50 Mon Sep 17 00:00:00 2001
+From 998771f71f65bfe2dc9cfc1918881205bd2bbfd3 Mon Sep 17 00:00:00 2001
 From: mesh-llm <mesh-llm@example.com>
 Date: Wed, 6 May 2026 00:00:00 +1000
-Subject: [PATCH 61/80] Support Hunyuan-MoE runtime-slice execution
+Subject: [PATCH 61/81] Support Hunyuan-MoE runtime-slice execution
 
 ---
  src/models/hunyuan-moe.cpp | 20 ++++++++++++++++----
@@ -62,7 +62,7 @@ index 44af4241..0af4c646 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 73a66680..ff23bb7b 100644
+index 7f427aba..f977754c 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1589,6 +1589,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0062-Support-PhiMoE-runtime-slice-execution.patch
+++ b/third_party/llama.cpp/patches/0062-Support-PhiMoE-runtime-slice-execution.patch
@@ -1,7 +1,7 @@
-From 2ccb9aa902fefe5d9aa3c6a06e2cf8926e007c1c Mon Sep 17 00:00:00 2001
+From f022dfc38da6cd4baf6a40ea14643dc259cb1c49 Mon Sep 17 00:00:00 2001
 From: mesh-llm <mesh-llm@example.com>
 Date: Wed, 6 May 2026 00:00:00 +1000
-Subject: [PATCH 62/80] Support PhiMoE runtime-slice execution
+Subject: [PATCH 62/81] Support PhiMoE runtime-slice execution
 
 PhiMoE shares the Phi3 graph implementation, which already supports
 runtime-slice execution after the stage-filter work. Opt PhiMoE into the
@@ -11,7 +11,7 @@ stage ABI architecture allowlist so family certification can exercise it.
  1 file changed, 1 insertion(+)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index ff23bb7b..a9d682df 100644
+index f977754c..09096cf6 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1621,6 +1621,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0063-Allow-tied-output-embeddings-in-final-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0063-Allow-tied-output-embeddings-in-final-runtime-slices.patch
@@ -1,14 +1,14 @@
-From 750174c62ef83e920df7c511981fc74205eaf7a0 Mon Sep 17 00:00:00 2001
+From 694eae1aadf8e7787f0a4999877ea6277f986eba Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 18:52:05 +1000
-Subject: [PATCH 63/80] Allow tied output embeddings in final runtime slices
+Subject: [PATCH 63/81] Allow tied output embeddings in final runtime slices
 
 ---
  src/skippy.cpp | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index a9d682df..f316ba76 100644
+index 09096cf6..a2a44cbe 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1633,7 +1633,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0064-Support-Qwen35-and-Hunyuan-VL-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0064-Support-Qwen35-and-Hunyuan-VL-runtime-slices.patch
@@ -1,7 +1,7 @@
-From 71f1cc9d4a5118da92faa77949006c3961fa3ca9 Mon Sep 17 00:00:00 2001
+From ba201dc8392ac40b12226568eb8595a1580c950a Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 20:10:14 +1000
-Subject: [PATCH 64/80] Support Qwen35 and Hunyuan-VL runtime slices
+Subject: [PATCH 64/81] Support Qwen35 and Hunyuan-VL runtime slices
 
 ---
  src/models/qwen35.cpp | 27 +++++++++++++++++++++++----
@@ -60,7 +60,7 @@ index f276be61..1557ec15 100644
      cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
  
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index f316ba76..beb30637 100644
+index a2a44cbe..5da8f5a7 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1590,6 +1590,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0065-Support-broad-llama-family-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0065-Support-broad-llama-family-runtime-slices.patch
@@ -1,7 +1,7 @@
-From 50a0a9498353c9ddaf8ec967da2dda13147be237 Mon Sep 17 00:00:00 2001
+From 3807e3250961caaa4cb28a6594b9507fe99f8f39 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 6 May 2026 20:26:18 +1000
-Subject: [PATCH 65/80] Support broad llama family runtime slices
+Subject: [PATCH 65/81] Support broad llama family runtime slices
 
 ---
  src/models/afmoe.cpp        | 18 ++++++++++---
@@ -2033,7 +2033,7 @@ index e4d111e6..18ff3af4 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index beb30637..f3a92718 100644
+index 5da8f5a7..05aa0d18 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1576,30 +1576,63 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0066-Fix-BitNet-tied-output-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0066-Fix-BitNet-tied-output-runtime-slices.patch
@@ -1,7 +1,7 @@
-From 05dd8b9337744fc4c0d8ae96f6a5028e04aeefc6 Mon Sep 17 00:00:00 2001
+From af02e48a88ecb9deb1f1e4b5ea23c4d2d7b613f2 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 06:54:19 +1000
-Subject: [PATCH 66/80] Fix BitNet tied output runtime slices
+Subject: [PATCH 66/81] Fix BitNet tied output runtime slices
 
 ---
  src/models/bitnet.cpp | 4 ++--

--- a/third_party/llama.cpp/patches/0067-Fix-StarCoder-positional-embeddings-in-runtime-slice.patch
+++ b/third_party/llama.cpp/patches/0067-Fix-StarCoder-positional-embeddings-in-runtime-slice.patch
@@ -1,7 +1,7 @@
-From 7be2cbd7ce0c257c12ef59723ae9a8b0494761df Mon Sep 17 00:00:00 2001
+From a32805306fa67463a16bef2468775ddcb62a0af4 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 07:07:08 +1000
-Subject: [PATCH 67/80] Fix StarCoder positional embeddings in runtime slices
+Subject: [PATCH 67/81] Fix StarCoder positional embeddings in runtime slices
 
 ---
  src/models/starcoder.cpp | 16 +++++++++-------

--- a/third_party/llama.cpp/patches/0068-Support-DeepSeek-OCR-and-Qwen3-VL-MoE-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0068-Support-DeepSeek-OCR-and-Qwen3-VL-MoE-runtime-slices.patch
@@ -1,7 +1,7 @@
-From e8df0b7d6df10dbd3a41a9b4b9a2c78e0274b8e0 Mon Sep 17 00:00:00 2001
+From c50f90e3e8660f3b2a0643c90ef2b47d11b59dff Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 16:31:35 +1000
-Subject: [PATCH 68/80] Support DeepSeek OCR and Qwen3-VL-MoE runtime slices
+Subject: [PATCH 68/81] Support DeepSeek OCR and Qwen3-VL-MoE runtime slices
 
 ---
  src/models/qwen3vlmoe.cpp | 22 +++++++++++++++++-----
@@ -71,7 +71,7 @@ index b99143c8..2dc74ee0 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index f3a92718..7268502c 100644
+index 05aa0d18..584c90a6 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1638,6 +1638,7 @@ static enum skippy_status skippy_finish_model_open(

--- a/third_party/llama.cpp/patches/0069-Avoid-double-counting-optional-filtered-tensors.patch
+++ b/third_party/llama.cpp/patches/0069-Avoid-double-counting-optional-filtered-tensors.patch
@@ -1,7 +1,7 @@
-From c2ae1e4b70b60a3159d7d95a159753b9d6131f22 Mon Sep 17 00:00:00 2001
+From b615a90ff84f775acd8a82bf2f3768cabac7c75c Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 17:34:50 +1000
-Subject: [PATCH 69/80] Avoid double-counting optional filtered tensors
+Subject: [PATCH 69/81] Avoid double-counting optional filtered tensors
 
 ---
  src/llama-model-loader.cpp | 30 ++++++++++++++++++++++++++----

--- a/third_party/llama.cpp/patches/0070-Skip-recurrent-layers-in-native-KV-page-export.patch
+++ b/third_party/llama.cpp/patches/0070-Skip-recurrent-layers-in-native-KV-page-export.patch
@@ -1,7 +1,7 @@
-From 1832cc5f83ab5e002829f942c39e0ec7a4eec8c8 Mon Sep 17 00:00:00 2001
+From 5272a1015cdabc3ea08cb679f3c7255aa9bbd075 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 17:40:58 +1000
-Subject: [PATCH 70/80] Skip recurrent layers in native KV page export
+Subject: [PATCH 70/81] Skip recurrent layers in native KV page export
 
 ---
  src/llama-kv-cache.cpp | 42 ++++++++++++++++++++++++++----------------

--- a/third_party/llama.cpp/patches/0071-Expose-external-decode-stage-filter-ABI.patch
+++ b/third_party/llama.cpp/patches/0071-Expose-external-decode-stage-filter-ABI.patch
@@ -1,7 +1,7 @@
-From feaddd89973486ad154d009fdfd9959d84bb6eb3 Mon Sep 17 00:00:00 2001
+From 39e7da99962635c94852f39c62318315f3c224df Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 18:14:02 +1000
-Subject: [PATCH 71/80] Expose external decode stage filter ABI
+Subject: [PATCH 71/81] Expose external decode stage filter ABI
 
 ---
  include/skippy.h |  8 ++++++++
@@ -28,10 +28,10 @@ index 1c6d2c9f..c48bc240 100644
          struct skippy_session * session,
          int32_t n_past,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 7268502c..93b756a0 100644
+index 584c90a6..055eae0e 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -1931,6 +1931,39 @@ int32_t skippy_session_batch_size(
+@@ -1937,6 +1937,39 @@ int32_t skippy_session_batch_size(
      return session != nullptr && session->ctx != nullptr ? llama_n_batch(session->ctx) : 0;
  }
  

--- a/third_party/llama.cpp/patches/0072-Support-external-media-prefill-in-staged-runtime-ABI.patch
+++ b/third_party/llama.cpp/patches/0072-Support-external-media-prefill-in-staged-runtime-ABI.patch
@@ -1,7 +1,7 @@
-From c8bcb97e61e9b36657bc2e2647b183e58feaa0a9 Mon Sep 17 00:00:00 2001
+From 02b43ca010cef23c89778755b71743d9321e03b8 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 18:18:58 +1000
-Subject: [PATCH 72/80] Support external media prefill in staged runtime ABI
+Subject: [PATCH 72/81] Support external media prefill in staged runtime ABI
 
 ---
  include/skippy.h | 14 ++++++++++
@@ -34,10 +34,10 @@ index c48bc240..c588c862 100644
          struct skippy_session * session,
          llama_token token_id,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 93b756a0..34be30f7 100644
+index 055eae0e..f81d8fc7 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -2313,17 +2313,23 @@ enum skippy_status skippy_verify_tokens(
+@@ -2319,17 +2319,23 @@ enum skippy_status skippy_verify_tokens(
      return status;
  }
  
@@ -62,7 +62,7 @@ index 93b756a0..34be30f7 100644
      if (token_count == 0) {
          skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "token_count must be greater than zero");
          return SKIPPY_STATUS_INVALID_ARGUMENT;
-@@ -2357,17 +2363,78 @@ enum skippy_status skippy_prefill_chunk_frame(
+@@ -2363,17 +2369,78 @@ enum skippy_status skippy_prefill_chunk_frame(
      }
  
      if (skippy_is_filtered(session) && session->stage_model->config.layer_start > 0) {

--- a/third_party/llama.cpp/patches/0073-Expose-model-info-tensor-element-counts.patch
+++ b/third_party/llama.cpp/patches/0073-Expose-model-info-tensor-element-counts.patch
@@ -1,14 +1,14 @@
-From 4f4161eb6729faff8f474dcdcb3eb0ab4f0b171b Mon Sep 17 00:00:00 2001
+From 95ef05d3b73ae725b50ffe2d1914ab255208058f Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 18:20:30 +1000
-Subject: [PATCH 73/80] Expose model info tensor element counts
+Subject: [PATCH 73/81] Expose model info tensor element counts
 
 ---
  src/skippy.cpp | 14 +++++++++++++-
  1 file changed, 13 insertions(+), 1 deletion(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 34be30f7..a91fbc2b 100644
+index f81d8fc7..091d0c8c 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -83,6 +83,17 @@ struct skippy_tensor_meta {
@@ -29,7 +29,7 @@ index 34be30f7..a91fbc2b 100644
  struct skippy_slice_range {
      int32_t stage_index = -1;
      int32_t layer_start = 0;
-@@ -3666,7 +3677,8 @@ enum skippy_status skippy_model_info_tensor_at(
+@@ -3672,7 +3683,8 @@ enum skippy_status skippy_model_info_tensor_at(
      out_tensor->role = skippy_role_from_name(name, layer_index);
      out_tensor->ggml_type = static_cast<uint32_t>(gguf_get_tensor_type(info->ctx, tensor_id));
      out_tensor->byte_size = static_cast<uint64_t>(gguf_get_tensor_size(info->ctx, tensor_id));

--- a/third_party/llama.cpp/patches/0074-Pad-activation-frame-decode-batches-to-native-input-.patch
+++ b/third_party/llama.cpp/patches/0074-Pad-activation-frame-decode-batches-to-native-input-.patch
@@ -1,7 +1,7 @@
-From 2c999c27b013177a6303fee4ad34defbc6110bfb Mon Sep 17 00:00:00 2001
+From 20bfe1a60ca57e2cfeae19003fdbbb5d5609cfe4 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 18:34:54 +1000
-Subject: [PATCH 74/80] Pad activation frame decode batches to native input
+Subject: [PATCH 74/81] Pad activation frame decode batches to native input
  width
 
 ---
@@ -9,7 +9,7 @@ Subject: [PATCH 74/80] Pad activation frame decode batches to native input
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index a91fbc2b..9b01eda1 100644
+index 091d0c8c..be8e5719 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1469,10 +1469,20 @@ static enum skippy_status skippy_decode_activation_frame(

--- a/third_party/llama.cpp/patches/0075-Carry-activation-frame-position-sideband.patch
+++ b/third_party/llama.cpp/patches/0075-Carry-activation-frame-position-sideband.patch
@@ -1,7 +1,7 @@
-From 5c46f091c0f7c11f71879fefae381b9a5d9c1903 Mon Sep 17 00:00:00 2001
+From 2574aacb221061322961f7137334754e961d14a4 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 18:45:41 +1000
-Subject: [PATCH 75/80] Carry activation frame position sideband
+Subject: [PATCH 75/81] Carry activation frame position sideband
 
 ---
  include/skippy.h |  30 +++++++++++
@@ -50,7 +50,7 @@ index c588c862..eb6da73e 100644
          struct skippy_session * session,
          llama_token token_id,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 9b01eda1..558666e5 100644
+index be8e5719..e6cca846 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1455,6 +1455,8 @@ static enum skippy_status skippy_decode_activation_frame(
@@ -134,7 +134,7 @@ index 9b01eda1..558666e5 100644
      return status;
  }
  
-@@ -2338,6 +2371,8 @@ static enum skippy_status skippy_prefill_chunk_frame_impl(
+@@ -2344,6 +2377,8 @@ static enum skippy_status skippy_prefill_chunk_frame_impl(
          struct skippy_session * session,
          const llama_token * token_ids,
          size_t token_count,
@@ -143,7 +143,7 @@ index 9b01eda1..558666e5 100644
          bool request_logits,
          const struct skippy_sampling_config * sampling,
          const struct skippy_activation_desc * input_desc,
-@@ -2384,7 +2419,7 @@ static enum skippy_status skippy_prefill_chunk_frame_impl(
+@@ -2390,7 +2425,7 @@ static enum skippy_status skippy_prefill_chunk_frame_impl(
      }
  
      if (skippy_is_filtered(session) && session->stage_model->config.layer_start > 0) {
@@ -152,7 +152,7 @@ index 9b01eda1..558666e5 100644
      } else {
          status = skippy_decode_tokens(session, token_ids, token_count, request_logits, out_error);
      }
-@@ -2415,6 +2450,8 @@ enum skippy_status skippy_prefill_chunk_frame(
+@@ -2421,6 +2456,8 @@ enum skippy_status skippy_prefill_chunk_frame(
              session,
              token_ids,
              token_count,
@@ -161,7 +161,7 @@ index 9b01eda1..558666e5 100644
              false,
              nullptr,
              input_desc,
-@@ -2444,6 +2481,72 @@ enum skippy_status skippy_prefill_chunk_frame_sampled(
+@@ -2450,6 +2487,72 @@ enum skippy_status skippy_prefill_chunk_frame_sampled(
              session,
              token_ids,
              token_count,
@@ -234,7 +234,7 @@ index 9b01eda1..558666e5 100644
              true,
              sampling,
              input_desc,
-@@ -2517,7 +2620,7 @@ enum skippy_status skippy_decode_step_frame_sampled(
+@@ -2523,7 +2626,7 @@ enum skippy_status skippy_decode_step_frame_sampled(
      }
  
      if (skippy_is_filtered(session) && session->stage_model->config.layer_start > 0) {
@@ -243,7 +243,7 @@ index 9b01eda1..558666e5 100644
      } else {
          status = skippy_decode_tokens(session, &token_id, 1, true, out_error);
      }
-@@ -2600,7 +2703,7 @@ enum skippy_status skippy_verify_tokens_frame(
+@@ -2606,7 +2709,7 @@ enum skippy_status skippy_verify_tokens_frame(
      if (skippy_is_filtered(session) && session->stage_model->config.layer_start > 0) {
          status = session->stage_model->config.include_output ?
                  skippy_verify_activation_frame(session, input_desc, input_payload, token_count, out_error) :

--- a/third_party/llama.cpp/patches/0076-Support-Gemma3n-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0076-Support-Gemma3n-runtime-slices.patch
@@ -1,7 +1,7 @@
-From afdb2ceee14a9745d2b796c0deb9c7b4fb75e5ab Mon Sep 17 00:00:00 2001
+From 329d819ffa488a316c49f9dd7d764ccacff5ccf9 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 7 May 2026 20:29:25 +1000
-Subject: [PATCH 76/80] Support Gemma3n runtime slices
+Subject: [PATCH 76/81] Support Gemma3n runtime slices
 
 ---
  include/skippy.h           |   3 +-
@@ -298,7 +298,7 @@ index 881499b0..4260a608 100644
          // Multimodal embedding path: use padding token (ID=0) embedding
          // TODO: verify if this is the correct behavior in transformers implementation
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 558666e5..b7dd3791 100644
+index e6cca846..75479955 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -670,6 +670,34 @@ struct skippy_rwkv7_v_first_scope {

--- a/third_party/llama.cpp/patches/0077-Support-Llama4-and-Mistral4-runtime-slices.patch
+++ b/third_party/llama.cpp/patches/0077-Support-Llama4-and-Mistral4-runtime-slices.patch
@@ -1,7 +1,7 @@
-From 3983c0589fde2072359b46d842432010520be7a3 Mon Sep 17 00:00:00 2001
+From 01dfedb534818d8f613df8d316593ea90f66b7f6 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Fri, 8 May 2026 05:58:50 +1000
-Subject: [PATCH 77/80] Support Llama4 and Mistral4 runtime slices
+Subject: [PATCH 77/81] Support Llama4 and Mistral4 runtime slices
 
 ---
  src/llama-graph.cpp    | 66 ++++++++++++++++++++++++++++--------------
@@ -248,7 +248,7 @@ index 899611d5..5ca1078b 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index b7dd3791..e263bf14 100644
+index 75479955..acfc850c 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -1501,7 +1501,6 @@ static enum skippy_status skippy_copy_output_activation_frame(

--- a/third_party/llama.cpp/patches/0078-Contain-chat-grammar-sampler-exceptions.patch
+++ b/third_party/llama.cpp/patches/0078-Contain-chat-grammar-sampler-exceptions.patch
@@ -1,14 +1,14 @@
-From 4d483a1fa9d950c50e42e25edb2a43c39f1b5660 Mon Sep 17 00:00:00 2001
+From 03fa23df1f75188ea23d82db1a17a9c8fd64424b Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 9 May 2026 13:23:46 +1000
-Subject: [PATCH 78/80] Contain chat grammar sampler exceptions
+Subject: [PATCH 78/81] Contain chat grammar sampler exceptions
 
 ---
  src/skippy.cpp | 42 ++++++++++++++++++++++++++++++++++++++----
  1 file changed, 38 insertions(+), 4 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index e263bf14..083d59ac 100644
+index acfc850c..565c2837 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
 @@ -148,6 +148,20 @@ static void skippy_set_error(

--- a/third_party/llama.cpp/patches/0079-Trigger-lazy-chat-grammar-before-trailing-whitespace.patch
+++ b/third_party/llama.cpp/patches/0079-Trigger-lazy-chat-grammar-before-trailing-whitespace.patch
@@ -1,7 +1,7 @@
-From f97e709f4548541af1d847042f0a32bddaa57e51 Mon Sep 17 00:00:00 2001
+From 91cf8c316a8b7a64dcdb3228f4ba6802794e1dc4 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 9 May 2026 13:58:47 +1000
-Subject: [PATCH 79/80] Trigger lazy chat grammar before trailing whitespace
+Subject: [PATCH 79/81] Trigger lazy chat grammar before trailing whitespace
 
 ---
  common/chat-auto-parser-generator.cpp | 14 +++++++++++++-

--- a/third_party/llama.cpp/patches/0080-Expose-skippy-backend-device-enumeration-ABI.patch
+++ b/third_party/llama.cpp/patches/0080-Expose-skippy-backend-device-enumeration-ABI.patch
@@ -1,14 +1,14 @@
-From d415123692810ac3ce941cb18db333599e034193 Mon Sep 17 00:00:00 2001
+From 4861c8501ea4c4a581a85f3100ba9fee950ce19f Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 11 May 2026 05:38:23 +1000
-Subject: [PATCH 80/80] Expose skippy backend device enumeration ABI
+Subject: [PATCH 80/81] Expose skippy backend device enumeration ABI
 
 ---
- include/skippy.h         | 81 ++------------------------------
- include/skippy/common.h  | 92 +++++++++++++++++++++++++++++++++++++
- include/skippy/devices.h | 49 ++++++++++++++++++++
- src/skippy.cpp           | 101 ++++++++++++++++++++++++++++++++++++++++-
- 4 files changed, 244 insertions(+), 79 deletions(-)
+ include/skippy.h         |  81 ++----------------------------
+ include/skippy/common.h  |  92 ++++++++++++++++++++++++++++++++++
+ include/skippy/devices.h |  49 ++++++++++++++++++
+ src/skippy.cpp           | 105 ++++++++++++++++++++++++++++++++++++++-
+ 4 files changed, 248 insertions(+), 79 deletions(-)
  create mode 100644 include/skippy/common.h
  create mode 100644 include/skippy/devices.h
 
@@ -288,16 +288,18 @@ index 00000000..382f1e69
 +
 +#endif
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 083d59ac..7585abe1 100644
+index 565c2837..f25da57e 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -1,4 +1,6 @@
+@@ -1,6 +1,8 @@
  #include "skippy.h"
 +#include "skippy/devices.h"
  #include "skippy-signals.h"
  
 +#include <mutex>
  #include "gguf.h"
+ #include "llama-arch.h"
+ #include "llama-context.h"
 @@ -169,6 +171,40 @@ static enum skippy_status skippy_success(skippy_error ** out_error) {
      return SKIPPY_STATUS_OK;
  }
@@ -339,7 +341,7 @@ index 083d59ac..7585abe1 100644
  static int32_t skippy_layer_from_name(const char * name) {
      if (name == nullptr) {
          return -1;
-@@ -1722,7 +1757,8 @@ uint64_t skippy_abi_features(void) {
+@@ -1722,7 +1758,8 @@ uint64_t skippy_abi_features(void) {
             SKIPPY_FEATURE_SESSION_CHECKPOINT |
             SKIPPY_FEATURE_PACKAGE_PART_LOAD |
             SKIPPY_FEATURE_GENERATION_SIGNALS |
@@ -424,3 +426,4 @@ index 083d59ac..7585abe1 100644
          const struct skippy_runtime_config * config,
 -- 
 2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0081-Add-min-p-sampler-to-skippy-sampling-chain.patch
+++ b/third_party/llama.cpp/patches/0081-Add-min-p-sampler-to-skippy-sampling-chain.patch
@@ -1,0 +1,73 @@
+From e7b7e044dbebeb3fdefe182e4803736d181fc724 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Mon, 18 May 2026 14:57:16 +1000
+Subject: [PATCH 81/81] Add min-p sampler to skippy sampling chain
+
+Insert llama_sampler_init_min_p between top_p and temperature in both
+skippy_build_sampling_chain (chat sampler) and skippy_sample_token (legacy
+non-chat sampler), matching upstream llama-server's default chain order.
+
+Swap the trailing 'uint32_t reserved' in skippy_sampling_config for 'float
+min_p'. The Rust FFI side has already been carrying min_p in that 4-byte slot;
+the C side was reading it as a discarded reserved field. Wire layout is
+unchanged; only the field meaning changes. Bump SKIPPY_ABI_VERSION_PATCH
+23 -> 24 to mark the field-layout transition for external C consumers.
+---
+ include/skippy.h        | 2 +-
+ include/skippy/common.h | 2 +-
+ src/skippy.cpp          | 6 ++++++
+ 3 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/include/skippy.h b/include/skippy.h
+index 486e95dc..84173c02 100644
+--- a/include/skippy.h
++++ b/include/skippy.h
+@@ -111,7 +111,7 @@ struct skippy_sampling_config {
+     float frequency_penalty;
+     float repeat_penalty;
+     uint32_t logit_bias_count;
+-    uint32_t reserved;
++    float min_p;
+     llama_logit_bias logit_bias[SKIPPY_MAX_LOGIT_BIAS];
+ };
+ 
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index afef2749..26e944d8 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -26,7 +26,7 @@ extern "C" {
+ 
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 23
++#define SKIPPY_ABI_VERSION_PATCH 24
+ 
+ enum skippy_feature {
+     SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index f25da57e..ca7ac4c5 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -1283,6 +1283,9 @@ static llama_sampler * skippy_build_sampling_chain(
+     if (sampling->top_p > 0.0f && sampling->top_p < 1.0f) {
+         llama_sampler_chain_add(sampler, llama_sampler_init_top_p(sampling->top_p, 1));
+     }
++    if (sampling->min_p > 0.0f && sampling->min_p < 1.0f) {
++        llama_sampler_chain_add(sampler, llama_sampler_init_min_p(sampling->min_p, 1));
++    }
+     if (sampling->temperature != 1.0f) {
+         llama_sampler_chain_add(sampler, llama_sampler_init_temp(sampling->temperature));
+     }
+@@ -1483,6 +1486,9 @@ static llama_token skippy_sample_token(
+     if (sampling->top_p > 0.0f && sampling->top_p < 1.0f) {
+         llama_sampler_chain_add(sampler, llama_sampler_init_top_p(sampling->top_p, 1));
+     }
++    if (sampling->min_p > 0.0f && sampling->min_p < 1.0f) {
++        llama_sampler_chain_add(sampler, llama_sampler_init_min_p(sampling->min_p, 1));
++    }
+     if (sampling->temperature != 1.0f) {
+         llama_sampler_chain_add(sampler, llama_sampler_init_temp(sampling->temperature));
+     }
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
edit: https://github.com/Mesh-LLM/mesh-llm/pull/581 - has the new one. 

Three independent fixes for the wedge we hit on the studio running MiniMax-M2.5.

## min_p sampler parity (`b41a7022`)

Upstream llama-server's default sampler chain includes `min_p` between `top_p` and `temperature` (`common.h:245`, default `0.05`). Our skippy sampler chain skipped it entirely. The Rust FFI struct already carried a `min_p` field; the C side was reading those four bytes as `uint32_t reserved` and discarding them.

Added `llama_sampler_init_min_p` to both `skippy_build_sampling_chain` and `skippy_sample_token` in the right chain position, and swapped `reserved` for `float min_p` in `skippy_sampling_config`. ABI bumped 23→24. Wire layout unchanged; only the field interpretation changes.

Carried as `third_party/llama.cpp/patches/0081-Add-min-p-sampler-to-skippy-sampling-chain.patch`. The other 80 patches show as modified because `git format-patch` regenerates mail headers when the queue length changes; semantic content is unchanged and validated by re-applying to a fresh upstream checkout.

## Bounded default max_tokens (`28e142b6`)

The embedded mesh-llm wiring passed `CONTEXT_BUDGET_MAX_TOKENS = u32::MAX` as `default_max_tokens`. When a client omitted `max_tokens`, the server gave the request the entire remaining context window — on MiniMax that's ~262k tokens, hours of generation on Studio hardware.

Added `DEFAULT_EMBEDDED_MAX_TOKENS = 8192` and switched the three host-runtime callsites (`runtime/local.rs` ×2, `inference/skippy/mod.rs` builder default) to use it. `CONTEXT_BUDGET_MAX_TOKENS` is preserved as an opt-in sentinel.

The standalone `serve-openai` CLI already had a sane explicit default and is untouched.

## KV-slot reclaim hardening (`ab933b1d`)

`RuntimeState::drop_session_timed` previously returned `Err` via `?` when a lane's `reset()` failed. That left `session_token_counts` and `session_checkpoints` holding stale entries for the now-removed `session_id`, and dropped the lane on the floor with no log record. Every caller swallows the error (`if let Ok(...)` / `let _ = ...`), so the failure was invisible. Accumulating bookkeeping drift is consistent with the post-incident `failed to find a memory slot` symptom on Studio.

Rewrote so the function always returns `Ok`, always clears per-session bookkeeping, and on reset failure explicitly drops the lane (which fires `StageSession::drop` → `skippy_session_free` — the authoritative native KV release path). Added `lane_discarded: bool` and `lane_discard_reason: Option<String>` to `RuntimeSessionDropStats` for telemetry visibility.

## Validation

Local end-to-end test against Qwen2.5-0.5B with a process that was the same shape as the Studio incident:

| Test | Result |
|---|---|
| Coherent English, no max_tokens | `finish_reason=stop` at 219 tokens via normal EOS |
| **Adversarial Russian-drift prompt, no max_tokens** | **`finish_reason=length` at exactly 8192 tokens** — the cap fires |
| 10 back-to-back small requests | All clean, no `lane_discarded`, no `failed to find a memory slot` |

Standard cargo validation:

```
cargo fmt --all -- --check
cargo check -p skippy-server -p mesh-llm-host-runtime
cargo test -p skippy-server --lib    # 77 pass
cargo test -p skippy-runtime --lib   # 33 pass
just build                            # llama.cpp + workspace
```

## What's still open

- min_p stopping the language flip itself (vs just bounding it) needs verification on MiniMax specifically. The 0.5B model still flipped on the loaded prompt — either expected (the Russian tokens were genuinely top-1% given the prompt) or min_p is less effective on small models. Either way, this PR brings the chain to upstream parity and bounds the damage window.
- The reset-failure path of the KV reclaim fix is correct by inspection but isn't exercised by happy-path tests. Requires a real wedge reproduction to exercise the new `lane_discarded` path.
- Studio deploy + soak test on MiniMax is the next step after merge.

