### PR TITLE
Harden Skippy layer-package materialization cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6887,6 +6887,7 @@ name = "skippy-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "libc",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -1198,8 +1198,9 @@ pub(crate) fn prune_unpinned_materialized_stages() -> Result<usize> {
         if pins.iter().any(|pin| pin == &path) {
             continue;
         }
-        fs::remove_file(&path).with_context(|| format!("remove {}", path.display()))?;
-        removed += 1;
+        if remove_materialized_stage_artifact(&path)? {
+            removed += 1;
+        }
     }
     for entry in fs::read_dir(&root).with_context(|| format!("read {}", root.display()))? {
         let path = entry?.path();
@@ -1229,9 +1230,7 @@ pub(crate) fn remove_materialized_stages_for_sources(sources: &[PathBuf]) -> Res
     let candidates = materialized_stage_removal_candidates(sources)?;
     let mut removed = 0usize;
     for candidate in candidates {
-        if candidate.artifact_path.exists() {
-            fs::remove_file(&candidate.artifact_path)
-                .with_context(|| format!("remove {}", candidate.artifact_path.display()))?;
+        if remove_materialized_stage_artifact(&candidate.artifact_path)? {
             removed += 1;
         }
         let _ = fs::remove_file(candidate.source_index_path);
@@ -1302,6 +1301,23 @@ fn materialized_stage_removal_candidates(
 struct MaterializedStageRemovalCandidate {
     artifact_path: PathBuf,
     source_index_path: PathBuf,
+}
+
+fn remove_materialized_stage_artifact(path: &Path) -> Result<bool> {
+    let removed = match fs::remove_file(path) {
+        Ok(()) => true,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error).with_context(|| format!("remove {}", path.display())),
+    };
+    let record_path = package::materialized_layer_package_cache_record_path(path);
+    match fs::remove_file(&record_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| format!("remove {}", record_path.display()));
+        }
+    }
+    Ok(removed)
 }
 
 fn stage_package_info(package_ref: &str, info: LayerPackageInfo) -> Result<StagePackageInfo> {
@@ -2089,6 +2105,8 @@ mod tests {
         let fixture_id = cache_key(&temp.path().to_string_lossy());
         let artifact = root.join(format!("stage-{fixture_id}.gguf"));
         fs::write(&artifact, b"stage").unwrap();
+        let cache_record_path = package::materialized_layer_package_cache_record_path(&artifact);
+        fs::write(&cache_record_path, b"{}").unwrap();
         let index = SourceIndex {
             artifact_path: artifact.clone(),
             source_model_path: source.to_string_lossy().to_string(),
@@ -2105,6 +2123,7 @@ mod tests {
             remove_materialized_stages_for_sources(std::slice::from_ref(&source)).unwrap();
         assert_eq!(removed, 1);
         assert!(!artifact.exists());
+        assert!(!cache_record_path.exists());
         assert!(!index_path.exists());
         fs::remove_dir(unreadable_index_path).unwrap();
     }

--- a/crates/skippy-runtime/Cargo.toml
+++ b/crates/skippy-runtime/Cargo.toml
@@ -10,6 +10,7 @@ skippy-ffi = { path = "../skippy-ffi" }
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+libc = "0.2"
 tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]

--- a/crates/skippy-runtime/src/package.rs
+++ b/crates/skippy-runtime/src/package.rs
@@ -12,6 +12,8 @@ use sha2::{Digest, Sha256};
 
 use crate::write_gguf_from_parts;
 
+mod materialized_cache;
+
 #[derive(Debug, Clone)]
 pub struct PackageStageRequest {
     pub model_id: String,
@@ -204,6 +206,10 @@ pub fn materialize_layer_package(request: &PackageStageRequest) -> Result<PathBu
     Ok(materialize_layer_package_details(request)?.output_path)
 }
 
+pub fn materialized_layer_package_cache_record_path(output: &Path) -> PathBuf {
+    materialized_cache::record_path(output)
+}
+
 pub fn materialize_layer_package_details(
     request: &PackageStageRequest,
 ) -> Result<MaterializedPackage> {
@@ -214,12 +220,14 @@ pub fn materialize_layer_package_details(
         &selection.manifest_sha256,
         &selection.selected_parts,
     );
-    if output.is_file()
-        && fs::metadata(&output)
-            .with_context(|| format!("read materialized model {}", output.display()))?
-            .len()
-            > 0
-        && !env_flag("SKIPPY_FORCE_MATERIALIZE")
+    let cache_identity = materialized_cache::MaterializedCacheIdentity::new(
+        request,
+        &selection.manifest_sha256,
+        &selection.selected_parts,
+    );
+    let force_materialize = env_flag("SKIPPY_FORCE_MATERIALIZE");
+    if !force_materialize
+        && materialized_cache::record_matches_output(&output, &cache_identity)?
         && crate::ModelInfo::open(&output).is_ok()
     {
         return Ok(MaterializedPackage {
@@ -229,17 +237,22 @@ pub fn materialize_layer_package_details(
         });
     }
 
-    if let Some(parent) = output.parent() {
-        fs::create_dir_all(parent)
-            .with_context(|| format!("create materialization directory {}", parent.display()))?;
+    let _lock = materialized_cache::lock_output(&output)?;
+    if !force_materialize
+        && materialized_cache::record_matches_output(&output, &cache_identity)?
+        && crate::ModelInfo::open(&output).is_ok()
+    {
+        return Ok(MaterializedPackage {
+            output_path: output,
+            manifest_sha256: selection.manifest_sha256,
+            selected_parts: selection.selected_parts,
+        });
     }
-    let tmp_output = output.with_extension(format!(
-        "tmp-{}-{}",
-        std::process::id(),
-        selection.manifest_sha256.get(..12).unwrap_or("manifest")
-    ));
-    if tmp_output.exists() {
-        let _ = fs::remove_file(&tmp_output);
+
+    let tmp_output = materialized_cache::temporary_output_path(&output, &selection.manifest_sha256);
+    if let Some(parent) = tmp_output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create materialization staging {}", parent.display()))?;
     }
     if let Err(error) =
         write_gguf_from_parts(&selection.absolute_paths, &tmp_output).with_context(|| {
@@ -249,20 +262,17 @@ pub fn materialize_layer_package_details(
             )
         })
     {
-        let _ = fs::remove_file(&tmp_output);
+        materialized_cache::cleanup_temporary_output(&tmp_output);
         return Err(error);
     }
-    if output.exists() {
-        fs::remove_file(&output)
-            .with_context(|| format!("remove stale materialized model {}", output.display()))?;
+    if let Err(error) = crate::ModelInfo::open(&tmp_output)
+        .with_context(|| format!("validate materialized model {}", tmp_output.display()))
+    {
+        materialized_cache::cleanup_temporary_output(&tmp_output);
+        return Err(error);
     }
-    fs::rename(&tmp_output, &output).with_context(|| {
-        format!(
-            "publish materialized model {} -> {}",
-            tmp_output.display(),
-            output.display()
-        )
-    })?;
+    materialized_cache::publish_output(&tmp_output, &output)?;
+    materialized_cache::write_record(&output, &cache_identity)?;
 
     Ok(MaterializedPackage {
         output_path: output,
@@ -1206,6 +1216,107 @@ mod tests {
             include_embeddings: true,
             include_output: true,
         }
+    }
+
+    fn materialized_cache_parts() -> Vec<PackagePart> {
+        vec![
+            PackagePart {
+                role: "metadata".to_string(),
+                layer_index: None,
+                path: PathBuf::from("metadata.gguf"),
+                sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_string(),
+                artifact_bytes: 8,
+            },
+            PackagePart {
+                role: "layer".to_string(),
+                layer_index: Some(0),
+                path: PathBuf::from("layers/00000.gguf"),
+                sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                    .to_string(),
+                artifact_bytes: 6,
+            },
+        ]
+    }
+
+    #[test]
+    fn materialized_cache_record_requires_matching_identity_and_output_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let package_dir = dir.path().join("package");
+        fs::create_dir_all(&package_dir).unwrap();
+        let request = package_stage_request(&package_dir);
+        let parts = materialized_cache_parts();
+        let manifest_sha = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+        let output = dir.path().join("stage.gguf");
+        fs::write(&output, b"materialized-output").unwrap();
+        let identity =
+            materialized_cache::MaterializedCacheIdentity::new(&request, manifest_sha, &parts);
+
+        assert!(
+            !materialized_cache::record_matches_output(&output, &identity).unwrap(),
+            "a final artifact without a provenance record must not be a cache hit"
+        );
+
+        materialized_cache::write_record(&output, &identity).unwrap();
+        assert!(materialized_cache::record_matches_output(&output, &identity).unwrap());
+
+        let mut changed_parts = parts.clone();
+        changed_parts[1].sha256 =
+            "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".to_string();
+        let changed_identity = materialized_cache::MaterializedCacheIdentity::new(
+            &request,
+            manifest_sha,
+            &changed_parts,
+        );
+        assert!(
+            !materialized_cache::record_matches_output(&output, &changed_identity).unwrap(),
+            "selected artifact identity must be part of the cache hit contract"
+        );
+
+        fs::write(&output, b"materialized-output-corrupted").unwrap();
+        assert!(
+            !materialized_cache::record_matches_output(&output, &identity).unwrap(),
+            "changed final output metadata must invalidate the provenance record"
+        );
+    }
+
+    #[test]
+    fn materialized_cache_tmp_paths_are_unique_for_same_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("stage.gguf");
+        let first = materialized_cache::temporary_output_path(
+            &output,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        );
+        let second = materialized_cache::temporary_output_path(
+            &output,
+            "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        );
+
+        assert_ne!(first, second);
+        assert!(
+            first.starts_with(dir.path().join(".staging")),
+            "temporary materialization must stay in the cache-owned staging directory"
+        );
+        assert!(
+            second.starts_with(dir.path().join(".staging")),
+            "temporary materialization must stay in the cache-owned staging directory"
+        );
+    }
+
+    #[test]
+    fn materialized_cache_publish_replaces_existing_output() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("stage.gguf");
+        let tmp = dir.path().join(".staging").join("stage.tmp");
+        fs::create_dir_all(tmp.parent().unwrap()).unwrap();
+        fs::write(&output, b"old-output").unwrap();
+        fs::write(&tmp, b"new-output").unwrap();
+
+        materialized_cache::publish_output(&tmp, &output).unwrap();
+
+        assert_eq!(fs::read(&output).unwrap(), b"new-output");
+        assert!(!tmp.exists());
     }
 
     #[test]

--- a/crates/skippy-runtime/src/package/materialized_cache.rs
+++ b/crates/skippy-runtime/src/package/materialized_cache.rs
@@ -1,0 +1,283 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::{file_fingerprint, PackagePart, PackageStageRequest};
+
+const RECORD_SCHEMA_VERSION: u32 = 1;
+
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub(super) struct MaterializedCacheIdentity {
+    schema_version: u32,
+    request: MaterializedRequestIdentity,
+    manifest_sha256: String,
+    selected_parts: Vec<MaterializedPartIdentity>,
+}
+
+impl MaterializedCacheIdentity {
+    pub(super) fn new(
+        request: &PackageStageRequest,
+        manifest_sha256: &str,
+        selected_parts: &[PackagePart],
+    ) -> Self {
+        Self {
+            schema_version: RECORD_SCHEMA_VERSION,
+            request: MaterializedRequestIdentity {
+                model_id: request.model_id.clone(),
+                topology_id: request.topology_id.clone(),
+                stage_id: request.stage_id.clone(),
+                layer_start: request.layer_start,
+                layer_end: request.layer_end,
+                include_embeddings: request.include_embeddings,
+                include_output: request.include_output,
+            },
+            manifest_sha256: manifest_sha256.to_string(),
+            selected_parts: selected_parts
+                .iter()
+                .map(MaterializedPartIdentity::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct MaterializedRequestIdentity {
+    model_id: String,
+    topology_id: String,
+    stage_id: String,
+    layer_start: u32,
+    layer_end: u32,
+    include_embeddings: bool,
+    include_output: bool,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct MaterializedPartIdentity {
+    role: String,
+    layer_index: Option<u32>,
+    path: String,
+    sha256: String,
+    artifact_bytes: u64,
+}
+
+impl From<&PackagePart> for MaterializedPartIdentity {
+    fn from(part: &PackagePart) -> Self {
+        Self {
+            role: part.role.clone(),
+            layer_index: part.layer_index,
+            path: part.path.to_string_lossy().to_string(),
+            sha256: part.sha256.clone(),
+            artifact_bytes: part.artifact_bytes,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+struct MaterializedCacheRecord {
+    schema_version: u32,
+    identity: MaterializedCacheIdentity,
+    output_len: u64,
+    output_modified_unix_nanos: Option<u128>,
+}
+
+pub(super) struct MaterializedOutputLock {
+    file: fs::File,
+}
+
+impl Drop for MaterializedOutputLock {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        unsafe {
+            let _ = libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+pub(super) fn lock_output(output: &Path) -> Result<MaterializedOutputLock> {
+    let lock_path = sibling_path(output, "lock");
+    if let Some(parent) = lock_path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create materialized cache lock dir {}", parent.display()))?;
+    }
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("open materialized cache lock {}", lock_path.display()))?;
+
+    #[cfg(unix)]
+    unsafe {
+        if libc::flock(file.as_raw_fd(), libc::LOCK_EX) != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("lock materialized cache {}", lock_path.display()));
+        }
+    }
+
+    Ok(MaterializedOutputLock { file })
+}
+
+pub(super) fn record_matches_output(
+    output: &Path,
+    identity: &MaterializedCacheIdentity,
+) -> Result<bool> {
+    let metadata = match fs::metadata(output) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error).with_context(|| format!("read {}", output.display()));
+        }
+    };
+    if !metadata.is_file() || metadata.len() == 0 {
+        return Ok(false);
+    }
+
+    let record_path = record_path(output);
+    let bytes = match fs::read(&record_path) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error).with_context(|| format!("read {}", record_path.display()));
+        }
+    };
+    let Ok(record) = serde_json::from_slice::<MaterializedCacheRecord>(&bytes) else {
+        return Ok(false);
+    };
+
+    Ok(record.schema_version == RECORD_SCHEMA_VERSION
+        && record.identity == *identity
+        && record.output_len == metadata.len()
+        && record.output_modified_unix_nanos == file_fingerprint(&metadata))
+}
+
+pub(super) fn write_record(output: &Path, identity: &MaterializedCacheIdentity) -> Result<()> {
+    let metadata =
+        fs::metadata(output).with_context(|| format!("read materialized {}", output.display()))?;
+    anyhow::ensure!(
+        metadata.is_file() && metadata.len() > 0,
+        "materialized output is empty or not a file: {}",
+        output.display()
+    );
+    let record = MaterializedCacheRecord {
+        schema_version: RECORD_SCHEMA_VERSION,
+        identity: identity.clone(),
+        output_len: metadata.len(),
+        output_modified_unix_nanos: file_fingerprint(&metadata),
+    };
+    let path = record_path(output);
+    let tmp = temporary_sibling_path(&path, "json");
+    if let Some(parent) = tmp.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create materialized cache dir {}", parent.display()))?;
+    }
+    fs::write(&tmp, serde_json::to_vec_pretty(&record)?)
+        .with_context(|| format!("write materialized cache record {}", tmp.display()))?;
+    publish_output(&tmp, &path)
+}
+
+pub(super) fn temporary_output_path(output: &Path, manifest_sha256: &str) -> PathBuf {
+    temporary_sibling_path(output, manifest_sha256.get(..12).unwrap_or("manifest"))
+}
+
+pub(super) fn cleanup_temporary_output(path: &Path) {
+    let _ = fs::remove_file(path);
+    if let Some(parent) = path.parent() {
+        let _ = fs::remove_dir(parent);
+    }
+}
+
+pub(super) fn publish_output(tmp: &Path, output: &Path) -> Result<()> {
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create materialized cache dir {}", parent.display()))?;
+    }
+    match fs::rename(tmp, output) {
+        Ok(()) => Ok(()),
+        Err(error) => publish_after_rename_error(error, tmp, output),
+    }
+}
+
+#[cfg(windows)]
+fn publish_after_rename_error(error: std::io::Error, tmp: &Path, output: &Path) -> Result<()> {
+    if !output.exists() {
+        return Err(error).with_context(|| {
+            format!(
+                "publish materialized output {} -> {}",
+                tmp.display(),
+                output.display()
+            )
+        });
+    }
+    fs::remove_file(output)
+        .with_context(|| format!("remove stale materialized output {}", output.display()))?;
+    fs::rename(tmp, output).with_context(|| {
+        format!(
+            "publish materialized output {} -> {}",
+            tmp.display(),
+            output.display()
+        )
+    })
+}
+
+#[cfg(not(windows))]
+fn publish_after_rename_error(error: std::io::Error, tmp: &Path, output: &Path) -> Result<()> {
+    Err(error).with_context(|| {
+        format!(
+            "publish materialized output {} -> {}",
+            tmp.display(),
+            output.display()
+        )
+    })
+}
+
+pub(super) fn record_path(output: &Path) -> PathBuf {
+    sibling_path(output, "cache.json")
+}
+
+fn temporary_sibling_path(output: &Path, suffix: &str) -> PathBuf {
+    let counter = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let name = output
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "materialized".into());
+    let parent = output.parent().unwrap_or_else(|| Path::new("."));
+    parent.join(".staging").join(format!(
+        "{}.tmp-{}-{}-{}",
+        name,
+        std::process::id(),
+        counter,
+        sanitize_suffix(suffix)
+    ))
+}
+
+fn sibling_path(output: &Path, suffix: &str) -> PathBuf {
+    let name = output
+        .file_name()
+        .map(|name| name.to_string_lossy())
+        .unwrap_or_else(|| "materialized".into());
+    output.with_file_name(format!("{}.{}", name, suffix))
+}
+
+fn sanitize_suffix(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary

Skippy layer-package stages now materialize into the local derived-stage cache with a stronger cache-safety contract.

- Adds a materialized-cache sidecar that binds a derived stage artifact to the request identity, manifest SHA, selected package parts, and final output metadata.
- Serializes writers for the same materialized output with a per-output advisory lock.
- Uses unique cache-owned staging paths so concurrent materialization attempts cannot collide on the same temporary file.
- Validates the staged GGUF before publishing it as the final derived artifact.
- Keeps cleanup paths honest by removing the sidecar record when derived stage artifacts are pruned or deleted.

## Why

The risky part of layer-package transfer and reuse is not only whether package artifacts are downloaded correctly. The final materialized GGUF is also a cache boundary: if it is reused after a partial write, concurrent publish race, stale final artifact, or mismatched package identity, Skippy can silently load the wrong derived stage.

This PR makes that boundary explicit. A materialized stage is only treated as reusable when its sidecar still matches the current request, manifest, selected artifacts, and output metadata. Otherwise Skippy rematerializes instead of trusting a valid-looking file path.

## Implementation

- Extracts materialized stage cache handling into a dedicated `skippy-runtime` module.
- Adds `MaterializedCacheIdentity` records for request identity, manifest SHA, and selected artifact path/size/SHA data.
- Adds per-output locking around the reuse/write/publish sequence and rechecks the cache after acquiring the lock.
- Writes materialization output through `.staging/` with unique names rather than pid-only temp paths.
- Publishes only after the staged GGUF opens successfully through the runtime metadata reader.
- Exposes the sidecar path to host-runtime cleanup so cache records do not outlive the artifact they describe.

## Compatibility

- No mesh gossip, peer protocol, plugin protocol, or API contract changes.
- Existing materialized `.gguf` files without sidecar records are treated as cache misses and rebuilt when needed.
- Layer-package manifest and artifact verification behavior is preserved; this adds a second safety boundary around the derived materialized output.

## Validation

Local validation passed with `LLAMA_STAGE_BUILD_DIR` set to the local stage ABI build directory:

- `git fetch --no-tags origin main:refs/remotes/origin/main`
- `git diff --check`
- `git diff --cached --check`
- `cargo fmt --all`
- `cargo fmt --all -- --check`
- `cargo test -p skippy-runtime --lib materialized_cache` - 3 passed
- `cargo test -p skippy-runtime --lib package::tests` - 15 passed
- `cargo test -p skippy-runtime --lib` - 36 passed
- `cargo test -p mesh-llm-host-runtime --lib materialized_stage_preview_matches_source_removal_candidates` - 1 passed
- `cargo test -p mesh-llm-host-runtime --lib inference::skippy::materialization::tests` - 16 passed, 2 ignored
- `cargo check -p mesh-llm`

Not run: `just build` - not required for this Rust-only runtime/cache change; no UI, bundle, or release artifact changed.

Remote CI will provide final PR-sha proof after the PR is opened.

## Rollback

Revert this PR. Existing package artifacts and source model caches are not migrated by this change.

## Related

Follow-up to the Skippy layer-package / HF cache-safety discussion around #471 and #485.