### PR TITLE
Harden relay health reconnect control

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
@@ -84,6 +84,131 @@ impl RelayReconnectReason {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum HomeRelayStatusTransition {
+    Missing { missing_secs: u64 },
+    Restored,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RelayPeerObservation {
+    pub(super) peer_id: EndpointId,
+    pub(super) snapshot: RelayPathSnapshot,
+}
+
+#[derive(Default)]
+pub(super) struct RelayReconnectController {
+    peer_health: HashMap<EndpointId, RelayPeerHealth>,
+    relay_missing_since: Option<std::time::Instant>,
+    relay_missing_reported: bool,
+}
+
+impl RelayReconnectController {
+    pub(super) fn observe_home_relay(
+        &mut self,
+        has_home_relay: bool,
+        now: std::time::Instant,
+    ) -> Option<HomeRelayStatusTransition> {
+        if has_home_relay {
+            self.relay_missing_reported = false;
+            return self
+                .relay_missing_since
+                .take()
+                .map(|_| HomeRelayStatusTransition::Restored);
+        }
+
+        let missing_since = *self.relay_missing_since.get_or_insert(now);
+        if self.relay_missing_reported {
+            return None;
+        }
+
+        let missing_secs = now.duration_since(missing_since).as_secs();
+        if missing_secs >= RELAY_MISSING_GRACE_SECS {
+            self.relay_missing_reported = true;
+            return Some(HomeRelayStatusTransition::Missing { missing_secs });
+        }
+        None
+    }
+
+    pub(super) fn plan_reconnect<I>(
+        &mut self,
+        observations: I,
+        now: std::time::Instant,
+        inflight_requests: u64,
+        has_home_relay: bool,
+    ) -> Option<(EndpointId, RelayReconnectReason)>
+    where
+        I: IntoIterator<Item = RelayPeerObservation>,
+    {
+        let mut observations: Vec<RelayPeerObservation> = observations.into_iter().collect();
+        observations.sort_by_key(|observation| endpoint_id_hex(observation.peer_id));
+
+        if observations.is_empty() {
+            self.peer_health.clear();
+            return None;
+        }
+
+        let active_peers: std::collections::HashSet<EndpointId> = observations
+            .iter()
+            .map(|observation| observation.peer_id)
+            .collect();
+        self.peer_health
+            .retain(|peer_id, _| active_peers.contains(peer_id));
+
+        let mut stale_candidate: Option<(EndpointId, RelayReconnectReason)> = None;
+        for observation in observations {
+            let health = self.peer_health.entry(observation.peer_id).or_default();
+            health.observe(observation.snapshot, now);
+
+            let Some(reason) = relay_reconnect_reason(
+                health,
+                observation.snapshot,
+                now,
+                inflight_requests,
+                has_home_relay,
+            ) else {
+                continue;
+            };
+
+            if reason == RelayReconnectReason::RelayRttDegraded {
+                return Some((observation.peer_id, reason));
+            }
+            if stale_candidate.is_none() {
+                stale_candidate = Some((observation.peer_id, reason));
+            }
+        }
+
+        stale_candidate
+    }
+
+    pub(super) fn record_reconnect_attempt(
+        &mut self,
+        peer_id: EndpointId,
+        _reason: RelayReconnectReason,
+        now: std::time::Instant,
+    ) {
+        let health = self.peer_health.entry(peer_id).or_default();
+        health.last_reconnect_at = Some(now);
+    }
+
+    pub(super) fn record_reconnect_result(
+        &mut self,
+        peer_id: EndpointId,
+        succeeded: bool,
+        now: std::time::Instant,
+    ) {
+        if succeeded {
+            let health = self.peer_health.entry(peer_id).or_default();
+            health.relay_since = Some(now);
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn peer_health(&self, peer_id: EndpointId) -> Option<&RelayPeerHealth> {
+        self.peer_health.get(&peer_id)
+    }
+}
+
 pub(super) fn selected_path_snapshot(conn: &Connection) -> RelayPathSnapshot {
     let path_list = conn.paths();
     for path_info in &path_list {
@@ -319,9 +444,7 @@ impl Node {
         let node = self.clone();
         tokio::spawn(async move {
             let mut addr_watch = node.endpoint.watch_addr();
-            let mut peer_health: HashMap<EndpointId, RelayPeerHealth> = HashMap::new();
-            let mut relay_missing_since: Option<std::time::Instant> = None;
-            let mut relay_missing_warned = false;
+            let mut controller = RelayReconnectController::default();
 
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(RELAY_HEALTH_CHECK_SECS)).await;
@@ -330,27 +453,18 @@ impl Node {
                 let endpoint_addr = iroh::Watcher::get(&mut addr_watch);
                 let has_home_relay = endpoint_addr.relay_urls().next().is_some();
 
-                if has_home_relay {
-                    if relay_missing_since.take().is_some() {
+                match controller.observe_home_relay(has_home_relay, now) {
+                    Some(HomeRelayStatusTransition::Restored) => {
                         tracing::info!("Relay health: home relay restored");
                     }
-                    relay_missing_warned = false;
-                } else {
-                    let missing_since = *relay_missing_since.get_or_insert(now);
-                    if !relay_missing_warned
-                        && now.duration_since(missing_since)
-                            >= std::time::Duration::from_secs(RELAY_MISSING_GRACE_SECS)
-                    {
-                        relay_missing_warned = true;
-                        tracing::warn!(
-                            "Relay health: no home relay for {}s",
-                            now.duration_since(missing_since).as_secs()
-                        );
+                    Some(HomeRelayStatusTransition::Missing { missing_secs }) => {
+                        tracing::warn!("Relay health: no home relay for {}s", missing_secs);
                     }
+                    None => {}
                 }
 
                 let inflight_requests = node.inflight_requests();
-                let mut connections: Vec<(EndpointId, Connection)> = {
+                let connections: Vec<(EndpointId, Connection)> = {
                     let state = node.state.lock().await;
                     state
                         .peers
@@ -358,53 +472,24 @@ impl Node {
                         .filter_map(|id| state.connections.get(id).cloned().map(|conn| (*id, conn)))
                         .collect()
                 };
+                let observations: Vec<RelayPeerObservation> = connections
+                    .into_iter()
+                    .map(|(peer_id, conn)| RelayPeerObservation {
+                        peer_id,
+                        snapshot: selected_path_snapshot(&conn),
+                    })
+                    .collect();
 
-                if connections.is_empty() {
-                    peer_health.clear();
-                    continue;
-                }
-
-                connections.sort_by_key(|(peer_id, _)| endpoint_id_hex(*peer_id));
-                peer_health.retain(|peer_id, _| connections.iter().any(|(id, _)| id == peer_id));
-
-                let mut stale_candidate: Option<(EndpointId, RelayReconnectReason)> = None;
-                for (peer_id, conn) in connections {
-                    let snapshot = selected_path_snapshot(&conn);
-                    let health = peer_health.entry(peer_id).or_default();
-                    health.observe(snapshot, now);
-
-                    let Some(reason) = relay_reconnect_reason(
-                        health,
-                        snapshot,
-                        now,
-                        inflight_requests,
-                        has_home_relay,
-                    ) else {
-                        continue;
-                    };
-
-                    if reason == RelayReconnectReason::RelayRttDegraded {
-                        stale_candidate = Some((peer_id, reason));
-                        break;
-                    }
-                    if stale_candidate.is_none() {
-                        stale_candidate = Some((peer_id, reason));
-                    }
-                }
-
-                let Some((peer_id, reason)) = stale_candidate else {
+                let Some((peer_id, reason)) =
+                    controller.plan_reconnect(observations, now, inflight_requests, has_home_relay)
+                else {
                     continue;
                 };
 
-                if let Some(health) = peer_health.get_mut(&peer_id) {
-                    health.last_reconnect_at = Some(now);
-                }
+                controller.record_reconnect_attempt(peer_id, reason, now);
 
-                if node.refresh_peer_connection(peer_id, reason).await {
-                    if let Some(health) = peer_health.get_mut(&peer_id) {
-                        health.relay_since = Some(now);
-                    }
-                }
+                let refreshed = node.refresh_peer_connection(peer_id, reason).await;
+                controller.record_reconnect_result(peer_id, refreshed, now);
             }
         });
     }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -104,6 +104,12 @@ struct AcceptedMeshStream {
     stream_type: u8,
 }
 
+enum ClosedConnectionRecovery {
+    Reconnect(EndpointAddr),
+    RemovePeer,
+    AlreadyReplaced,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct QuicBindSelection {
     pub ip: Option<IpAddr>,
@@ -4703,15 +4709,20 @@ impl Node {
         }
     }
 
-    async fn recover_closed_connection(&self, remote: EndpointId) {
-        let addr = self.remove_closed_connection(remote).await;
-        let Some(addr) = addr else {
-            self.remove_peer(remote).await;
-            return;
-        };
-
-        self.reconnect_closed_connection_or_remove(remote, addr)
-            .await;
+    async fn recover_closed_connection(&self, remote: EndpointId, closing_stable_id: usize) {
+        match self
+            .remove_closed_connection(remote, closing_stable_id)
+            .await
+        {
+            ClosedConnectionRecovery::Reconnect(addr) => {
+                self.reconnect_closed_connection_or_remove(remote, addr)
+                    .await;
+            }
+            ClosedConnectionRecovery::RemovePeer => {
+                self.remove_peer(remote).await;
+            }
+            ClosedConnectionRecovery::AlreadyReplaced => {}
+        }
     }
 
     async fn reconnect_closed_connection_or_remove(&self, remote: EndpointId, addr: EndpointAddr) {
@@ -4724,10 +4735,27 @@ impl Node {
         }
     }
 
-    async fn remove_closed_connection(&self, remote: EndpointId) -> Option<EndpointAddr> {
+    async fn remove_closed_connection(
+        &self,
+        remote: EndpointId,
+        closing_stable_id: usize,
+    ) -> ClosedConnectionRecovery {
         let mut state = self.state.lock().await;
+        if !heartbeat::should_remove_connection(
+            state.connections.get(&remote).map(|conn| conn.stable_id()),
+            closing_stable_id,
+        ) {
+            tracing::debug!(
+                "Connection dispatcher for {} closed after the tracked connection was replaced",
+                remote.fmt_short()
+            );
+            return ClosedConnectionRecovery::AlreadyReplaced;
+        }
         state.connections.remove(&remote);
-        state.peers.get(&remote).map(|peer| peer.addr.clone())
+        match state.peers.get(&remote).map(|peer| peer.addr.clone()) {
+            Some(addr) => ClosedConnectionRecovery::Reconnect(addr),
+            None => ClosedConnectionRecovery::RemovePeer,
+        }
     }
 
     async fn reconnect_closed_peer(
@@ -5268,11 +5296,13 @@ impl Node {
 
     async fn _dispatch_streams(&self, conn: Connection, remote: EndpointId) {
         let protocol = connection_protocol(&conn);
+        let dispatcher_stable_id = conn.stable_id();
         loop {
             let accepted = match self.accept_mesh_stream(&conn, remote).await {
                 Ok(accepted) => accepted,
                 Err(()) => {
-                    self.recover_closed_connection(remote).await;
+                    self.recover_closed_connection(remote, dispatcher_stable_id)
+                        .await;
                     break;
                 }
             };

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1,7 +1,8 @@
 use super::heartbeat::{
-    relay_reconnect_reason, should_remove_connection, HeartbeatFailurePolicy, RelayPathSnapshot,
-    RelayPeerHealth, RelayReconnectReason, SelectedPathKind, RELAY_DEGRADED_RTT_MS,
-    RELAY_ONLY_RECONNECT_SECS, RELAY_RECONNECT_COOLDOWN_SECS,
+    relay_reconnect_reason, should_remove_connection, HeartbeatFailurePolicy,
+    HomeRelayStatusTransition, RelayPathSnapshot, RelayPeerHealth, RelayPeerObservation,
+    RelayReconnectController, RelayReconnectReason, SelectedPathKind, RELAY_DEGRADED_RTT_MS,
+    RELAY_MISSING_GRACE_SECS, RELAY_ONLY_RECONNECT_SECS, RELAY_RECONNECT_COOLDOWN_SECS,
 };
 use super::*;
 use crate::api;
@@ -2480,6 +2481,167 @@ fn relay_health_respects_cooldown_and_inflight_requests() {
         ),
         None,
         "missing home relay should suppress churn"
+    );
+}
+
+#[test]
+fn relay_reconnect_controller_prioritizes_degraded_rtt_over_aged_relay() {
+    let now = std::time::Instant::now();
+    let degraded_peer = make_test_endpoint_id(21);
+    let aged_peer = make_test_endpoint_id(22);
+    let mut controller = RelayReconnectController::default();
+
+    let initial = now - std::time::Duration::from_secs(RELAY_ONLY_RECONNECT_SECS + 5);
+    assert_eq!(
+        controller.plan_reconnect(
+            vec![
+                RelayPeerObservation {
+                    peer_id: aged_peer,
+                    snapshot: RelayPathSnapshot {
+                        kind: SelectedPathKind::Relay,
+                        rtt_ms: Some(250),
+                    },
+                },
+                RelayPeerObservation {
+                    peer_id: degraded_peer,
+                    snapshot: RelayPathSnapshot {
+                        kind: SelectedPathKind::Relay,
+                        rtt_ms: Some(250),
+                    },
+                },
+            ],
+            initial,
+            0,
+            true,
+        ),
+        None
+    );
+
+    assert_eq!(
+        controller.plan_reconnect(
+            vec![
+                RelayPeerObservation {
+                    peer_id: aged_peer,
+                    snapshot: RelayPathSnapshot {
+                        kind: SelectedPathKind::Relay,
+                        rtt_ms: Some(250),
+                    },
+                },
+                RelayPeerObservation {
+                    peer_id: degraded_peer,
+                    snapshot: RelayPathSnapshot {
+                        kind: SelectedPathKind::Relay,
+                        rtt_ms: Some(RELAY_DEGRADED_RTT_MS + 25),
+                    },
+                },
+            ],
+            now,
+            0,
+            true,
+        ),
+        Some((degraded_peer, RelayReconnectReason::RelayRttDegraded)),
+        "high relay RTT should refresh before merely aged relay paths"
+    );
+}
+
+#[test]
+fn relay_reconnect_controller_tracks_home_relay_missing_and_restored_once() {
+    let now = std::time::Instant::now();
+    let mut controller = RelayReconnectController::default();
+
+    assert_eq!(controller.observe_home_relay(true, now), None);
+    assert_eq!(controller.observe_home_relay(false, now), None);
+    assert_eq!(
+        controller.observe_home_relay(
+            false,
+            now + std::time::Duration::from_secs(RELAY_MISSING_GRACE_SECS - 1),
+        ),
+        None,
+        "home relay warning should wait for the grace period"
+    );
+    assert_eq!(
+        controller.observe_home_relay(
+            false,
+            now + std::time::Duration::from_secs(RELAY_MISSING_GRACE_SECS + 2),
+        ),
+        Some(HomeRelayStatusTransition::Missing {
+            missing_secs: RELAY_MISSING_GRACE_SECS + 2
+        })
+    );
+    assert_eq!(
+        controller.observe_home_relay(
+            false,
+            now + std::time::Duration::from_secs(RELAY_MISSING_GRACE_SECS + 10),
+        ),
+        None,
+        "missing relay should not log on every monitor tick"
+    );
+    assert_eq!(
+        controller.observe_home_relay(
+            true,
+            now + std::time::Duration::from_secs(RELAY_MISSING_GRACE_SECS + 20),
+        ),
+        Some(HomeRelayStatusTransition::Restored)
+    );
+}
+
+#[test]
+fn relay_reconnect_controller_applies_cooldown_after_attempt_and_prunes_gone_peers() {
+    let now = std::time::Instant::now();
+    let peer = make_test_endpoint_id(23);
+    let other_peer = make_test_endpoint_id(24);
+    let mut controller = RelayReconnectController::default();
+
+    assert_eq!(
+        controller.plan_reconnect(
+            vec![RelayPeerObservation {
+                peer_id: peer,
+                snapshot: RelayPathSnapshot {
+                    kind: SelectedPathKind::Relay,
+                    rtt_ms: Some(RELAY_DEGRADED_RTT_MS + 10),
+                },
+            }],
+            now,
+            0,
+            true,
+        ),
+        Some((peer, RelayReconnectReason::RelayRttDegraded))
+    );
+
+    controller.record_reconnect_attempt(peer, RelayReconnectReason::RelayRttDegraded, now);
+    assert_eq!(
+        controller.plan_reconnect(
+            vec![RelayPeerObservation {
+                peer_id: peer,
+                snapshot: RelayPathSnapshot {
+                    kind: SelectedPathKind::Relay,
+                    rtt_ms: Some(RELAY_DEGRADED_RTT_MS + 10),
+                },
+            }],
+            now + std::time::Duration::from_secs(RELAY_RECONNECT_COOLDOWN_SECS - 1),
+            0,
+            true,
+        ),
+        None,
+        "attempted reconnects should suppress immediate retry even before the next tick"
+    );
+
+    controller.plan_reconnect(
+        vec![RelayPeerObservation {
+            peer_id: other_peer,
+            snapshot: RelayPathSnapshot {
+                kind: SelectedPathKind::Direct,
+                rtt_ms: Some(15),
+            },
+        }],
+        now + std::time::Duration::from_secs(RELAY_RECONNECT_COOLDOWN_SECS + 1),
+        0,
+        true,
+    );
+
+    assert!(
+        controller.peer_health(peer).is_none(),
+        "controller should prune peers that are no longer active"
     );
 }
 


### PR DESCRIPTION
## Summary

Mesh nodes can now monitor relay-backed peer paths with a dedicated reconnect controller and refresh degraded relay connections without letting stale dispatchers tear down replacements.

- Adds a relay reconnect controller for home-relay state, peer relay health, reconnect planning, cooldowns, and pruning peers that disappeared from the active connection set.
- Keeps relay refresh conservative: one reconnect candidate per monitor tick, degraded RTT before aged relay-only paths, no refresh while requests are in flight, no churn while the local endpoint has no home relay, and cooldown after each attempt.
- Guards connection teardown by iroh stable connection id so a stale dispatcher closing after relay refresh cannot remove the newer tracked connection.
- Keeps relay monitor mutex use tight by collecting cloned connections under the mesh-state lock and computing path snapshots after unlocking.
- Adds focused tests for degraded RTT priority, home relay missing/restored transitions, cooldown behavior, peer pruning, and stale-dispatcher connection ownership.

## Why

Relay-only paths can become long-lived or degraded, but the reconnect policy needs to be careful: reconnecting during active traffic or while the endpoint has no home relay can add churn, and refreshing a connection can race with the dispatcher for the previous connection.

This change makes the decision logic explicit and testable, then uses that controller from the existing relay health monitor. The dispatcher now only removes the connection slot it owns, which prevents a closed stale connection from removing a replacement installed by relay health refresh.

## Diff scope

- `crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs`
  - Adds `RelayReconnectController`, `RelayPeerObservation`, and `HomeRelayStatusTransition`.
  - Reworks `start_relay_health_monitor` to delegate planning/state transitions to the controller.
  - Computes `selected_path_snapshot` outside the mesh-state mutex and uses set-based active-peer pruning.
- `crates/mesh-llm-host-runtime/src/mesh/mod.rs`
  - Captures the dispatcher's connection stable id and only removes the tracked connection when the closing dispatcher still owns it.
- `crates/mesh-llm-host-runtime/src/mesh/tests.rs`
  - Adds relay controller and connection-ownership regression coverage.

## Compatibility

- No mesh gossip schema, protobuf, ALPN, stream type, plugin protocol, or API contract changes.
- Mixed-version behavior is unchanged: the reconnect controller only changes local runtime handling of existing iroh connections.
- The monitor remains conservative and does not try to reconnect relay paths while active requests are in flight.

## Branch integrity

- Base branch: `main`
- Validated base SHA: `efd8af4f287d82b24fb644a5c1e77b033da6b7f6`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `efd8af4f287d82b24fb644a5c1e77b033da6b7f6`
- Introduced commit: `93d9665681c0db2eb393b37dcf6c8c0c85e3ec93 Harden relay health reconnect control`

## Diff hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- Forbidden files: none. The PR only touches mesh host-runtime source/tests.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - not required for selected validation mode/change family.

## Validation

Validation mode: Tier 3 - shared mesh connection lifecycle change. Local proof covers the deterministic relay policy and host-runtime compile surface; required remote CI remains the final merge gate after the PR is opened.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<existing llama-stage ABI build dir> cargo test -p mesh-llm-host-runtime relay --lib`: PASS, 14 passed
- `LLAMA_STAGE_BUILD_DIR=<existing llama-stage ABI build dir> cargo check -p mesh-llm-host-runtime`: PASS
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- Not run: `just build` - not required for selected validation mode; no UI, bundle, or release artifact changed.

## Runtime safety

- No new blocking lock is held across dial, gossip, connection close, or path snapshot operations.
- No new unbounded queue or background task fan-out is introduced.
- Reconnect attempts remain bounded to one candidate per relay-health tick and are suppressed by active traffic, missing home relay, and per-peer cooldown.
- No invariant regression introduced.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

End-to-end relay recovery still depends on real multi-node relay conditions, so remote CI and any maintainer-side live relay checks should remain the final confidence gate before merge.