### PR TITLE
Rescue audio requests through Virtual LLM peer handoff

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/routes/mesh_hook.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/mesh_hook.rs
@@ -68,11 +68,7 @@ async fn dispatch_hook(state: &MeshApi, payload: Value) -> Value {
     let messages: Vec<Value> = payload["messages"].as_array().cloned().unwrap_or_default();
 
     match hook {
-        "pre_inference" => {
-            let trigger = payload["trigger"].as_str().unwrap_or("unknown");
-            let (image_url, user_text) = virtual_llm::extract_image(&payload);
-            virtual_llm::handle_image(&node, trigger, &model, &image_url, &user_text).await
-        }
+        "pre_inference" => dispatch_pre_inference(&node, &payload, &model).await,
         "post_prefill" => {
             let entropy = payload["signals"]["first_token_entropy"]
                 .as_f64()
@@ -92,5 +88,19 @@ async fn dispatch_hook(state: &MeshApi, payload: Value) -> Value {
             tracing::warn!("mesh hook: unknown hook type: {hook}");
             serde_json::json!({ "action": "none" })
         }
+    }
+}
+
+async fn dispatch_pre_inference(node: &crate::mesh::Node, payload: &Value, model: &str) -> Value {
+    let trigger = payload["trigger"].as_str().unwrap_or("unknown");
+    let (media_url, user_text) = pre_inference_media(payload, trigger);
+    virtual_llm::handle_image(node, trigger, model, &media_url, &user_text).await
+}
+
+fn pre_inference_media(payload: &Value, trigger: &str) -> (String, String) {
+    if trigger == "audio_no_support" {
+        virtual_llm::extract_audio(payload)
+    } else {
+        virtual_llm::extract_image(payload)
     }
 }

--- a/crates/mesh-llm-host-runtime/src/inference/consult.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/consult.rs
@@ -8,6 +8,7 @@
 //! Three consultation patterns:
 //!
 //! - **Caption** — send an image to a vision-capable peer, get a text description
+//! - **Audio rescue** — send audio to an audio-capable peer, get concise text context
 //! - **Summarize** — send conversation history, get a condensed summary
 //! - **Second opinion** — send the same question to a different model, get its answer
 
@@ -249,6 +250,46 @@ pub async fn caption_image(
     chat_completion(node, peer_id, model, messages, 256, TIMEOUT_CONSULTATION).await
 }
 
+/// Ask an audio-capable peer to extract useful text context from audio.
+/// `audio_url` should be a URL or a data URL accepted by the peer's OpenAI
+/// chat surface.
+pub async fn transcribe_audio(
+    node: &mesh::Node,
+    peer_id: EndpointId,
+    model: &str,
+    audio_url: &str,
+    user_text: &str,
+) -> Result<String> {
+    chat_completion(
+        node,
+        peer_id,
+        model,
+        audio_rescue_messages(audio_url, user_text),
+        512,
+        TIMEOUT_CONSULTATION,
+    )
+    .await
+}
+
+fn audio_rescue_messages(audio_url: &str, user_text: &str) -> Vec<Value> {
+    let prompt = if user_text.is_empty() {
+        "Extract concise text context from this audio. If it contains speech, transcribe the speech. If it contains non-speech audio, describe the audible events. Return only the useful context."
+            .to_string()
+    } else {
+        format!(
+            "The user asked: \"{user_text}\"\n\nExtract concise text context from this audio for a text-only model. If it contains speech, transcribe the relevant speech. If it contains non-speech audio, describe the audible events relevant to the user's request. Return only the useful context."
+        )
+    };
+
+    vec![serde_json::json!({
+        "role": "user",
+        "content": [
+            {"type": "text", "text": prompt},
+            {"type": "input_audio", "input_audio": {"url": audio_url}}
+        ]
+    })]
+}
+
 /// Ask a peer for a second opinion on the user's question.
 ///
 /// Sends only the last user message (not the full conversation) and asks
@@ -416,6 +457,25 @@ mod tests {
         assert_eq!(body["mesh_hooks"], false);
         assert_eq!(body["model"], "vision-model");
         assert_eq!(body["stream"], false);
+    }
+
+    #[test]
+    fn audio_rescue_messages_attach_audio_and_user_prompt() {
+        let messages = audio_rescue_messages("data:audio/wav;base64,abc", "please transcribe this");
+        let body = consultation_request_body("audio-model", messages, 512);
+
+        assert_eq!(body["mesh_hooks"], false);
+        assert_eq!(body["model"], "audio-model");
+        assert_eq!(
+            body["messages"][0]["content"][1]["input_audio"]["url"],
+            "data:audio/wav;base64,abc"
+        );
+        assert!(
+            body["messages"][0]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("please transcribe this")
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/hooks.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/hooks.rs
@@ -2,9 +2,8 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use openai_frontend::{
-    ChatCompletionRequest, ChatHookAction, ChatHookOutcome, ChatMediaKind, GenerationHookSignals,
-    OpenAiHookPolicy, OpenAiResult, PrefillHookSignals, chat_mesh_hooks_enabled, first_chat_media,
-    inject_text_into_chat_messages,
+    ChatCompletionRequest, ChatHookOutcome, ChatMediaKind, GenerationHookSignals, OpenAiHookPolicy,
+    OpenAiResult, PrefillHookSignals, chat_mesh_hooks_enabled, first_chat_media,
 };
 use serde_json::Value;
 
@@ -61,7 +60,7 @@ impl OpenAiHookPolicy for MeshAutoHookPolicy {
             .executor
             .handle_image(trigger, &request.model, &media.url, &media.user_text)
             .await;
-        Ok(virtual_hook_response_to_outcome(&response))
+        Ok(virtual_media_hook_response_to_outcome(&response, media))
     }
 
     async fn after_prefill(
@@ -290,14 +289,28 @@ fn media_trigger(kind: ChatMediaKind) -> &'static str {
 }
 
 fn virtual_hook_response_to_outcome(response: &Value) -> ChatHookOutcome {
-    match response.get("action").and_then(Value::as_str) {
-        Some("inject") => response
-            .get("text")
-            .and_then(Value::as_str)
-            .map(ChatHookOutcome::injected)
-            .unwrap_or_else(ChatHookOutcome::none),
-        _ => ChatHookOutcome::none(),
+    virtual_hook_injected_text(response)
+        .map(ChatHookOutcome::injected)
+        .unwrap_or_else(ChatHookOutcome::none)
+}
+
+fn virtual_media_hook_response_to_outcome(
+    response: &Value,
+    media: openai_frontend::ChatMediaRef,
+) -> ChatHookOutcome {
+    virtual_hook_injected_text(response)
+        .map(|text| ChatHookOutcome::injected_with_consumed_media(text, media))
+        .unwrap_or_else(ChatHookOutcome::none)
+}
+
+fn virtual_hook_injected_text(response: &Value) -> Option<&str> {
+    if response.get("action").and_then(Value::as_str) != Some("inject") {
+        return None;
     }
+    response
+        .get("text")
+        .and_then(Value::as_str)
+        .filter(|text| !text.is_empty())
 }
 
 fn chat_messages_as_values(messages: &[openai_frontend::ChatMessage]) -> Vec<Value> {
@@ -313,22 +326,11 @@ fn mid_generation_signals_should_fire(signals: &GenerationHookSignals) -> bool {
     sustained_entropy || signals.repetition_count >= MID_GENERATION_REPETITION_THRESHOLD
 }
 
-fn apply_chat_hook_outcome(request: &mut ChatCompletionRequest, outcome: &ChatHookOutcome) {
-    for action in &outcome.actions {
-        match action {
-            ChatHookAction::InjectText { text } => {
-                inject_text_into_chat_messages(&mut request.messages, text.clone());
-            }
-            ChatHookAction::None => {}
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
-    use openai_frontend::{MessageContent, MessageContentPart};
+    use openai_frontend::{MessageContent, MessageContentPart, apply_chat_hook_outcome};
     use serde_json::json;
 
     use super::*;
@@ -439,6 +441,21 @@ mod tests {
                 "content": [
                     {"type": "text", "text": "what is this?"},
                     {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}}
+                ]
+            }],
+            "mesh_hooks": mesh_hooks
+        }))
+        .unwrap()
+    }
+
+    fn audio_request(mesh_hooks: bool) -> ChatCompletionRequest {
+        serde_json::from_value(json!({
+            "model": "auto",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "please transcribe this"},
+                    {"type": "input_audio", "input_audio": {"url": "data:audio/wav;base64,abc"}}
                 ]
             }],
             "mesh_hooks": mesh_hooks
@@ -572,7 +589,19 @@ mod tests {
 
         let outcome = policy.before_chat_completion(&mut request).await.unwrap();
 
-        assert_eq!(outcome, ChatHookOutcome::injected("[media fallback]\n\n"));
+        assert_eq!(
+            outcome,
+            ChatHookOutcome::injected_with_consumed_media(
+                "[media fallback]\n\n",
+                openai_frontend::ChatMediaRef {
+                    kind: ChatMediaKind::Image,
+                    url: "data:image/png;base64,abc".to_string(),
+                    user_text: "what is this?".to_string(),
+                    message_index: 0,
+                    part_index: 1,
+                }
+            )
+        );
         assert_eq!(
             executor.calls(),
             vec![RecordedHookCall::Image {
@@ -580,6 +609,37 @@ mod tests {
                 model: "auto".to_string(),
                 media_url: "data:image/png;base64,abc".to_string(),
                 user_text: "what is this?".to_string(),
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn media_fallback_hook_calls_audio_trigger_and_injects() {
+        let (policy, executor) = policy_with_recorder(HookDebugConfig::default());
+        let mut request = audio_request(true);
+
+        let outcome = policy.before_chat_completion(&mut request).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            ChatHookOutcome::injected_with_consumed_media(
+                "[media fallback]\n\n",
+                openai_frontend::ChatMediaRef {
+                    kind: ChatMediaKind::Audio,
+                    url: "data:audio/wav;base64,abc".to_string(),
+                    user_text: "please transcribe this".to_string(),
+                    message_index: 0,
+                    part_index: 1,
+                }
+            )
+        );
+        assert_eq!(
+            executor.calls(),
+            vec![RecordedHookCall::Image {
+                trigger: "audio_no_support".to_string(),
+                model: "auto".to_string(),
+                media_url: "data:audio/wav;base64,abc".to_string(),
+                user_text: "please transcribe this".to_string(),
             }]
         );
     }

--- a/crates/mesh-llm-host-runtime/src/inference/virtual_llm.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/virtual_llm.rs
@@ -23,23 +23,24 @@ use serde_json::{Value, json};
 /// description, and returns it for injection before tokenization.
 ///
 /// `trigger`: `"images_no_multimodal"` or `"audio_no_support"`
-/// `image_url`: data URL for the image (empty if audio trigger)
+/// `media_url`: data URL or URL for the media
 /// `user_text`: the user's text alongside the media
 ///
-/// Returns `{"action": "inject", "text": "[Image description: ...]"}` or
-/// `{"action": "none"}` if no capable peer or captioning fails.
+/// Returns `{"action": "inject", "text": "[Image description: ...]"}` (or
+/// audio context) or `{"action": "none"}` if no capable peer is available or
+/// the consultation fails.
 pub async fn handle_image(
     node: &mesh::Node,
     trigger: &str,
     model: &str,
-    image_url: &str,
+    media_url: &str,
     user_text: &str,
 ) -> Value {
     tracing::info!("virtual: handle_image trigger={trigger} model={model}");
 
     match trigger {
-        "images_no_multimodal" => handle_image_caption(node, model, image_url, user_text).await,
-        "audio_no_support" => transcribe_audio(node, model).await,
+        "images_no_multimodal" => handle_image_caption(node, model, media_url, user_text).await,
+        "audio_no_support" => handle_audio_rescue(node, model, media_url, user_text).await,
         "video_no_support" => video_not_supported(),
         _ => no_virtual_action(),
     }
@@ -125,26 +126,83 @@ fn image_caption_response(caption: String) -> Value {
     })
 }
 
-async fn transcribe_audio(node: &mesh::Node, current_model: &str) -> Value {
-    let peer_id = match consult::find_audio_peer(node, current_model).await {
-        Some(id) => id,
-        None => {
-            tracing::info!("virtual: no audio peer available");
-            return no_virtual_action();
-        }
+async fn handle_audio_rescue(
+    node: &mesh::Node,
+    model: &str,
+    audio_url: &str,
+    user_text: &str,
+) -> Value {
+    if audio_url.is_empty() {
+        tracing::warn!("virtual: audio trigger but no audio URL");
+        return no_virtual_action();
+    }
+
+    transcribe_audio(node, model, audio_url, user_text).await
+}
+
+async fn transcribe_audio(
+    node: &mesh::Node,
+    current_model: &str,
+    audio_url: &str,
+    user_text: &str,
+) -> Value {
+    let Some((peer_id, audio_model)) = audio_peer_model(node, current_model).await else {
+        tracing::info!("virtual: no audio peer available");
+        return no_virtual_action();
     };
 
+    tracing::info!(
+        "virtual: audio rescue via {} model={audio_model}",
+        peer_id.fmt_short()
+    );
+
+    let Some(context) =
+        request_audio_context(node, peer_id, &audio_model, audio_url, user_text).await
+    else {
+        return no_virtual_action();
+    };
+
+    audio_context_response(context)
+}
+
+async fn audio_peer_model(
+    node: &mesh::Node,
+    current_model: &str,
+) -> Option<(iroh::EndpointId, String)> {
+    let peer_id = consult::find_audio_peer(node, current_model).await?;
     let audio_model =
         peer_model_with_capability(node, peer_id, |d| d.capabilities.supports_audio_runtime())
             .await;
+    Some((peer_id, audio_model))
+}
 
-    // TODO: extract audio data from payload and send to peer
-    // For now, log that we found a peer but can't extract audio yet
-    tracing::info!(
-        "virtual: found audio peer {} model={audio_model}, but audio extraction not yet wired",
-        peer_id.fmt_short()
-    );
-    json!({ "action": "none" })
+async fn request_audio_context(
+    node: &mesh::Node,
+    peer_id: iroh::EndpointId,
+    audio_model: &str,
+    audio_url: &str,
+    user_text: &str,
+) -> Option<String> {
+    match consult::transcribe_audio(node, peer_id, audio_model, audio_url, user_text).await {
+        Ok(context) => Some(context),
+        Err(e) => {
+            tracing::warn!("virtual: audio rescue failed: {e}");
+            None
+        }
+    }
+}
+
+fn audio_context_response(context: String) -> Value {
+    let context = context.trim();
+    if context.is_empty() {
+        tracing::warn!("virtual: audio peer returned empty context");
+        return no_virtual_action();
+    }
+    tracing::info!("virtual: audio context ({} chars)", context.len());
+    json!({
+        "action": "inject",
+        "text": format!("[Audio context: {context}]\n\n"),
+    })
 }
 
 /// Look up a peer's model name matching a capability predicate.
@@ -346,4 +404,160 @@ pub fn extract_image(payload: &Value) -> (String, String) {
     }
 
     (String::new(), String::new())
+}
+
+pub fn extract_audio(payload: &Value) -> (String, String) {
+    let messages = match payload["messages"].as_array() {
+        Some(m) => m,
+        None => return (String::new(), String::new()),
+    };
+
+    for msg in messages.iter().rev() {
+        if msg["role"].as_str() != Some("user") {
+            continue;
+        }
+        if let Some(parts) = msg["content"].as_array() {
+            let mut audio_url = String::new();
+            let mut text = Vec::new();
+            for part in parts {
+                match part["type"].as_str() {
+                    Some("input_audio") if audio_url.is_empty() => {
+                        audio_url = media_container_url(part, "input_audio").unwrap_or_default();
+                    }
+                    Some("audio_url") if audio_url.is_empty() => {
+                        audio_url = media_container_url(part, "audio_url").unwrap_or_default();
+                    }
+                    Some("audio") if audio_url.is_empty() => {
+                        audio_url = media_container_url(part, "audio").unwrap_or_default();
+                    }
+                    Some("text") => {
+                        if audio_url.is_empty()
+                            && let Some(url) = part["mesh_audio_url"]["url"].as_str()
+                        {
+                            audio_url = url.to_string();
+                        }
+                        if let Some(part_text) = part["text"].as_str() {
+                            text.push(part_text);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if !audio_url.is_empty() {
+                return (audio_url, text.join("\n"));
+            }
+        }
+    }
+
+    (String::new(), String::new())
+}
+
+fn media_container_url(part: &Value, key: &str) -> Option<String> {
+    let value = part.get(key)?;
+    if let Some(url) = value.as_str() {
+        return Some(url.to_string());
+    }
+    if let Some(url) = value.get("url").and_then(Value::as_str) {
+        return Some(url.to_string());
+    }
+    inline_audio_data_url(value)
+}
+
+fn inline_audio_data_url(value: &Value) -> Option<String> {
+    let data = value.get("data").and_then(Value::as_str)?;
+    if data.trim_start().starts_with("data:") {
+        return Some(data.to_string());
+    }
+    let mime_type = value
+        .get("mime_type")
+        .or_else(|| value.get("media_type"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            value
+                .get("format")
+                .and_then(Value::as_str)
+                .and_then(audio_mime_type_from_format)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| "audio/wav".to_string());
+    Some(format!("data:{mime_type};base64,{data}"))
+}
+
+fn audio_mime_type_from_format(format: &str) -> Option<&'static str> {
+    let format = format.trim().trim_start_matches('.').to_ascii_lowercase();
+    match format.as_str() {
+        "wav" => Some("audio/wav"),
+        "mp3" | "mpeg" | "mpga" => Some("audio/mpeg"),
+        "m4a" | "mp4" => Some("audio/mp4"),
+        "flac" => Some("audio/flac"),
+        "ogg" | "opus" => Some("audio/ogg"),
+        "webm" => Some("audio/webm"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn extract_audio_reads_audio_url_and_user_text() {
+        let payload = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "please transcribe this"},
+                    {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,abc"}}
+                ]
+            }]
+        });
+
+        let (audio_url, user_text) = extract_audio(&payload);
+
+        assert_eq!(audio_url, "data:audio/wav;base64,abc");
+        assert_eq!(user_text, "please transcribe this");
+    }
+
+    #[test]
+    fn extract_audio_converts_inline_input_audio_data() {
+        let payload = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is said here?"},
+                    {"type": "input_audio", "input_audio": {
+                        "data": "YWJj",
+                        "format": "mp3"
+                    }}
+                ]
+            }]
+        });
+
+        let (audio_url, user_text) = extract_audio(&payload);
+
+        assert_eq!(audio_url, "data:audio/mpeg;base64,YWJj");
+        assert_eq!(user_text, "what is said here?");
+    }
+
+    #[test]
+    fn extract_audio_reads_mesh_audio_url_fallback_from_text_part() {
+        let payload = json!({
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "fallback text", "mesh_audio_url": {"url": "mesh://audio/ref"}}
+                ]
+            }]
+        });
+
+        let (audio_url, user_text) = extract_audio(&payload);
+
+        assert_eq!(audio_url, "mesh://audio/ref");
+        assert_eq!(user_text, "fallback text");
+    }
 }

--- a/crates/openai-frontend/src/hooks.rs
+++ b/crates/openai-frontend/src/hooks.rs
@@ -32,11 +32,21 @@ impl ChatHookOutcome {
             actions: vec![ChatHookAction::InjectText { text: text.into() }],
         }
     }
+
+    pub fn injected_with_consumed_media(text: impl Into<String>, media: ChatMediaRef) -> Self {
+        Self {
+            actions: vec![
+                ChatHookAction::ConsumeMedia { media },
+                ChatHookAction::InjectText { text: text.into() },
+            ],
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChatHookAction {
     InjectText { text: String },
+    ConsumeMedia { media: ChatMediaRef },
     None,
 }
 
@@ -63,6 +73,8 @@ pub struct ChatMediaRef {
     pub kind: ChatMediaKind,
     pub url: String,
     pub user_text: String,
+    pub message_index: usize,
+    pub part_index: usize,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -182,11 +194,14 @@ pub fn inject_text_into_chat_messages(messages: &mut Vec<ChatMessage>, text: imp
     }
 }
 
-fn apply_chat_hook_outcome(request: &mut ChatCompletionRequest, outcome: &ChatHookOutcome) {
+pub fn apply_chat_hook_outcome(request: &mut ChatCompletionRequest, outcome: &ChatHookOutcome) {
     for action in &outcome.actions {
         match action {
             ChatHookAction::InjectText { text } => {
                 inject_text_into_chat_messages(&mut request.messages, text.clone());
+            }
+            ChatHookAction::ConsumeMedia { media } => {
+                consume_chat_media(&mut request.messages, media);
             }
             ChatHookAction::None => {}
         }
@@ -196,9 +211,10 @@ fn apply_chat_hook_outcome(request: &mut ChatCompletionRequest, outcome: &ChatHo
 pub fn first_chat_media(messages: &[ChatMessage]) -> Option<ChatMediaRef> {
     messages
         .iter()
+        .enumerate()
         .rev()
-        .find(|message| message.role == "user")
-        .and_then(media_from_message)
+        .find(|(_, message)| message.role == "user")
+        .and_then(|(message_index, message)| media_from_message(message_index, message))
 }
 
 fn inject_text_into_message(message: &mut ChatMessage, text: String) {
@@ -223,7 +239,7 @@ fn inject_text_into_message(message: &mut ChatMessage, text: String) {
     }
 }
 
-fn media_from_message(message: &ChatMessage) -> Option<ChatMediaRef> {
+fn media_from_message(message_index: usize, message: &ChatMessage) -> Option<ChatMediaRef> {
     let parts = match message.content.as_ref()? {
         MessageContent::Parts(parts) => parts,
         MessageContent::Text(_) | MessageContent::Other(_) => return None,
@@ -234,15 +250,20 @@ fn media_from_message(message: &ChatMessage) -> Option<ChatMediaRef> {
         .filter_map(|part| part.text.as_deref())
         .collect::<Vec<_>>()
         .join("\n");
-    for part in parts {
-        if let Some(media) = media_from_part(part, &user_text) {
+    for (part_index, part) in parts.iter().enumerate() {
+        if let Some(media) = media_from_part(message_index, part_index, part, &user_text) {
             return Some(media);
         }
     }
     None
 }
 
-fn media_from_part(part: &MessageContentPart, user_text: &str) -> Option<ChatMediaRef> {
+fn media_from_part(
+    message_index: usize,
+    part_index: usize,
+    part: &MessageContentPart,
+    user_text: &str,
+) -> Option<ChatMediaRef> {
     let kind = match part.content_type.as_str() {
         "image_url" | "input_image" | "image" => ChatMediaKind::Image,
         "input_audio" | "audio" | "audio_url" => ChatMediaKind::Audio,
@@ -254,11 +275,53 @@ fn media_from_part(part: &MessageContentPart, user_text: &str) -> Option<ChatMed
         kind,
         url,
         user_text: user_text.to_string(),
+        message_index,
+        part_index,
     })
 }
 
+fn consume_chat_media(messages: &mut [ChatMessage], media: &ChatMediaRef) -> bool {
+    let Some(message) = messages.get_mut(media.message_index) else {
+        return false;
+    };
+    consume_message_media(message, media)
+}
+
+fn consume_message_media(message: &mut ChatMessage, media: &ChatMediaRef) -> bool {
+    if message.role != "user" {
+        return false;
+    }
+    let Some(MessageContent::Parts(parts)) = message.content.as_mut() else {
+        return false;
+    };
+    let Some(part) = parts.get(media.part_index) else {
+        return false;
+    };
+    if !media_part_matches(part, media) {
+        return false;
+    }
+    parts.remove(media.part_index);
+    true
+}
+
+fn media_part_matches(part: &MessageContentPart, media: &ChatMediaRef) -> bool {
+    media_from_part(media.message_index, media.part_index, part, "")
+        .is_some_and(|candidate| candidate.kind == media.kind && candidate.url == media.url)
+}
+
 fn media_url(part: &MessageContentPart) -> Option<String> {
-    for key in ["image_url", "input_image", "image", "audio", "video", "url"] {
+    for key in [
+        "image_url",
+        "input_image",
+        "image",
+        "input_audio",
+        "audio",
+        "audio_url",
+        "input_video",
+        "video",
+        "video_url",
+        "url",
+    ] {
         if let Some(value) = part.extra.get(key) {
             if let Some(url) = value.as_str() {
                 return Some(url.to_string());
@@ -266,9 +329,73 @@ fn media_url(part: &MessageContentPart) -> Option<String> {
             if let Some(url) = value.get("url").and_then(Value::as_str) {
                 return Some(url.to_string());
             }
+            if let Some(data_url) = inline_media_data_url(key, value) {
+                return Some(data_url);
+            }
         }
     }
     None
+}
+
+fn inline_media_data_url(container_key: &str, value: &Value) -> Option<String> {
+    let data = value.get("data").and_then(Value::as_str)?;
+    if data.trim_start().starts_with("data:") {
+        return Some(data.to_string());
+    }
+    let mime_type = value
+        .get("mime_type")
+        .or_else(|| value.get("media_type"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+        .or_else(|| {
+            value
+                .get("format")
+                .and_then(Value::as_str)
+                .and_then(|format| mime_type_from_format(container_key, format))
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| default_media_mime_type(container_key).to_string());
+    Some(format!("data:{mime_type};base64,{data}"))
+}
+
+fn mime_type_from_format(container_key: &str, format: &str) -> Option<&'static str> {
+    let format = format.trim().trim_start_matches('.').to_ascii_lowercase();
+    match format.as_str() {
+        "wav" => Some("audio/wav"),
+        "mp3" => Some("audio/mpeg"),
+        "flac" => Some("audio/flac"),
+        "ogg" | "opus" => Some("audio/ogg"),
+        "webm" if is_audio_container(container_key) => Some("audio/webm"),
+        "webm" => Some("video/webm"),
+        "m4a" | "mp4" if is_audio_container(container_key) => Some("audio/mp4"),
+        "mp4" => Some("video/mp4"),
+        "mpeg" | "mpga" if is_audio_container(container_key) => Some("audio/mpeg"),
+        "png" => Some("image/png"),
+        "jpg" | "jpeg" => Some("image/jpeg"),
+        "gif" => Some("image/gif"),
+        "webp" => Some("image/webp"),
+        _ => None,
+    }
+}
+
+fn default_media_mime_type(container_key: &str) -> &'static str {
+    if is_audio_container(container_key) {
+        "audio/wav"
+    } else if is_video_container(container_key) {
+        "video/mp4"
+    } else {
+        "image/png"
+    }
+}
+
+fn is_audio_container(container_key: &str) -> bool {
+    matches!(container_key, "input_audio" | "audio" | "audio_url")
+}
+
+fn is_video_container(container_key: &str) -> bool {
+    matches!(container_key, "input_video" | "video" | "video_url")
 }
 
 #[cfg(test)]
@@ -324,6 +451,22 @@ mod tests {
         }
     }
 
+    struct MediaRescueHook;
+
+    #[async_trait]
+    impl OpenAiHookPolicy for MediaRescueHook {
+        async fn before_chat_completion(
+            &self,
+            request: &mut ChatCompletionRequest,
+        ) -> OpenAiResult<ChatHookOutcome> {
+            let media = first_chat_media(&request.messages).expect("media");
+            Ok(ChatHookOutcome::injected_with_consumed_media(
+                "[Audio context: hello]\n\n",
+                media,
+            ))
+        }
+    }
+
     #[test]
     fn chat_mesh_hooks_enabled_reads_extra_flag() {
         let mut request: ChatCompletionRequest = serde_json::from_value(json!({
@@ -359,6 +502,57 @@ mod tests {
         assert_eq!(media.kind, ChatMediaKind::Image);
         assert_eq!(media.url, "data:image/png;base64,abc");
         assert_eq!(media.user_text, "what is this?");
+        assert_eq!(media.message_index, 0);
+        assert_eq!(media.part_index, 1);
+    }
+
+    #[test]
+    fn first_chat_media_extracts_audio_url_and_user_text() {
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "auto",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "please transcribe this"},
+                    {"type": "audio_url", "audio_url": {"url": "data:audio/wav;base64,abc"}}
+                ]
+            }]
+        }))
+        .unwrap();
+
+        let media = first_chat_media(&request.messages).expect("media");
+
+        assert_eq!(media.kind, ChatMediaKind::Audio);
+        assert_eq!(media.url, "data:audio/wav;base64,abc");
+        assert_eq!(media.user_text, "please transcribe this");
+        assert_eq!(media.message_index, 0);
+        assert_eq!(media.part_index, 1);
+    }
+
+    #[test]
+    fn first_chat_media_extracts_inline_input_audio_data() {
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "auto",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what does this say?"},
+                    {"type": "input_audio", "input_audio": {
+                        "data": "YWJj",
+                        "format": "wav"
+                    }}
+                ]
+            }]
+        }))
+        .unwrap();
+
+        let media = first_chat_media(&request.messages).expect("media");
+
+        assert_eq!(media.kind, ChatMediaKind::Audio);
+        assert_eq!(media.url, "data:audio/wav;base64,YWJj");
+        assert_eq!(media.user_text, "what does this say?");
+        assert_eq!(media.message_index, 0);
+        assert_eq!(media.part_index, 1);
     }
 
     #[test]
@@ -429,6 +623,96 @@ mod tests {
         assert_eq!(
             seen.messages[0].content,
             Some(MessageContent::Text("[hint]\noriginal".to_string()))
+        );
+    }
+
+    #[tokio::test]
+    async fn hooked_backend_consumes_rescued_audio_media_before_forwarding() {
+        let backend = Arc::new(RecordingBackend {
+            seen: Mutex::new(None),
+        });
+        let hooked = HookedOpenAiBackend::new(backend.clone(), Arc::new(MediaRescueHook));
+        let request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "auto",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "please transcribe this"},
+                    {"type": "input_audio", "input_audio": {
+                        "data": "YWJj",
+                        "format": "wav"
+                    }}
+                ]
+            }],
+            "mesh_hooks": true
+        }))
+        .unwrap();
+
+        hooked.chat_completion(request).await.unwrap();
+
+        let seen = backend.seen.lock().unwrap().clone().unwrap();
+        assert_eq!(first_chat_media(&seen.messages), None);
+        assert_eq!(
+            seen.messages[0].content,
+            Some(MessageContent::Parts(vec![
+                MessageContentPart {
+                    content_type: "text".to_string(),
+                    text: Some("[Audio context: hello]\n\n".to_string()),
+                    extra: Default::default(),
+                },
+                MessageContentPart {
+                    content_type: "text".to_string(),
+                    text: Some("please transcribe this".to_string()),
+                    extra: Default::default(),
+                },
+            ]))
+        );
+    }
+
+    #[test]
+    fn consumed_media_action_removes_only_matching_media_part() {
+        let mut request: ChatCompletionRequest = serde_json::from_value(json!({
+            "model": "auto",
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "what is here?"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                    {"type": "input_audio", "input_audio": {"url": "data:audio/wav;base64,def"}}
+                ]
+            }],
+            "mesh_hooks": true
+        }))
+        .unwrap();
+        let media = ChatMediaRef {
+            kind: ChatMediaKind::Audio,
+            url: "data:audio/wav;base64,def".to_string(),
+            user_text: "what is here?".to_string(),
+            message_index: 0,
+            part_index: 2,
+        };
+
+        apply_chat_hook_outcome(
+            &mut request,
+            &ChatHookOutcome::injected_with_consumed_media("[Audio context: beep]\n\n", media),
+        );
+
+        let Some(MessageContent::Parts(parts)) = &request.messages[0].content else {
+            panic!("expected multipart content");
+        };
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|part| part.content_type == "input_audio")
+                .count(),
+            0
+        );
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|part| part.content_type == "image_url")
+                .count(),
+            1
         );
     }
 }

--- a/crates/openai-frontend/src/lib.rs
+++ b/crates/openai-frontend/src/lib.rs
@@ -37,8 +37,8 @@ pub use guardrails::{
 pub use hooks::{
     ChatHookAction, ChatHookOutcome, ChatMediaKind, ChatMediaRef, GenerationHookSignals,
     HookedOpenAiBackend, MESH_HOOKS_FIELD, OpenAiHookPolicy, PrefillHookSignals,
-    chat_mesh_hooks_enabled, first_chat_media, inject_text_into_chat_messages,
-    set_chat_mesh_hooks_enabled,
+    apply_chat_hook_outcome, chat_mesh_hooks_enabled, first_chat_media,
+    inject_text_into_chat_messages, set_chat_mesh_hooks_enabled,
 };
 pub use models::{ModelId, ModelIdError, ModelObject, ModelsResponse};
 pub use responses::{

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -30,7 +30,7 @@ use openai_frontend::{
     GuardedOpenAiBackend, GuardrailMode, GuardrailPolicy, GuardrailPolicyHandle, MessageContent,
     MessageContentPart, ModelId, ModelObject, OpenAiBackend, OpenAiError, OpenAiErrorKind,
     OpenAiHookPolicy, OpenAiRequestContext, OpenAiResult, PrefillHookSignals, ReasoningEffort,
-    StreamingGuardrailMode, Usage, chat_mesh_hooks_enabled, inject_text_into_chat_messages,
+    StreamingGuardrailMode, Usage, apply_chat_hook_outcome, chat_mesh_hooks_enabled,
     normalize_reasoning_template_options,
 };
 use serde::Serialize;
@@ -1283,24 +1283,15 @@ fn strip_default_revision(id: &str) -> String {
     id.to_string()
 }
 
-fn apply_chat_hook_outcome(request: &mut ChatCompletionRequest, outcome: &ChatHookOutcome) {
-    for action in &outcome.actions {
-        match action {
-            ChatHookAction::InjectText { text } => {
-                inject_text_into_chat_messages(&mut request.messages, text.clone());
-            }
-            ChatHookAction::None => {}
-        }
-    }
-}
-
 fn hook_injected_text(outcome: &ChatHookOutcome) -> Option<String> {
     let text = outcome
         .actions
         .iter()
         .filter_map(|action| match action {
             ChatHookAction::InjectText { text } if !text.is_empty() => Some(text.as_str()),
-            ChatHookAction::InjectText { .. } | ChatHookAction::None => None,
+            ChatHookAction::InjectText { .. }
+            | ChatHookAction::ConsumeMedia { .. }
+            | ChatHookAction::None => None,
         })
         .collect::<Vec<_>>()
         .join("");

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1348,6 +1348,81 @@ fn message_content_to_generation_text_rejects_remote_media_urls() {
 }
 
 #[test]
+fn rescued_audio_media_becomes_text_only_before_prompt_media_extraction() {
+    let mut request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "auto",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "please transcribe this"},
+                {"type": "input_audio", "input_audio": {
+                    "data": "YWJj",
+                    "format": "wav"
+                }}
+            ]
+        }],
+        "mesh_hooks": true
+    }))
+    .unwrap();
+    let media = openai_frontend::first_chat_media(&request.messages).expect("media");
+
+    apply_chat_hook_outcome(
+        &mut request,
+        &ChatHookOutcome::injected_with_consumed_media("[Audio context: hello]\n\n", media),
+    );
+
+    let content = request.messages[0].content.as_ref().expect("content");
+    let mut media = Vec::new();
+    let text = message_content_to_generation_text(content, "<__media__>", &mut media)
+        .expect("generation text");
+
+    assert!(media.is_empty());
+    assert!(!text.contains("<__media__>"));
+    assert!(text.contains("[Audio context: hello]"));
+    assert!(text.contains("please transcribe this"));
+}
+
+#[test]
+fn rescued_media_leaves_unhandled_second_media_in_prompt_media() {
+    let mut request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "auto",
+        "messages": [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "compare these"},
+                {"type": "input_audio", "input_audio": {
+                    "data": "YXVkaW8=",
+                    "format": "wav"
+                }},
+                {"type": "image_url", "image_url": {
+                    "url": "data:image/png;base64,aW1hZ2U="
+                }}
+            ]
+        }],
+        "mesh_hooks": true
+    }))
+    .unwrap();
+    let media = openai_frontend::first_chat_media(&request.messages).expect("media");
+
+    apply_chat_hook_outcome(
+        &mut request,
+        &ChatHookOutcome::injected_with_consumed_media("[Audio context: hello]\n\n", media),
+    );
+
+    let content = request.messages[0].content.as_ref().expect("content");
+    let mut media = Vec::new();
+    let text = message_content_to_generation_text(content, "<__media__>", &mut media)
+        .expect("generation text");
+
+    assert_eq!(media.len(), 1);
+    assert_eq!(media[0].bytes, b"image");
+    assert_eq!(
+        text,
+        "[Audio context: hello]\n\n\ncompare these\n<__media__>"
+    );
+}
+
+#[test]
 fn multimodal_final_prefill_message_requests_downstream_prediction() {
     let sampling = WireSamplingConfig {
         flags: 1,

--- a/docs/design/VIRTUAL_LLM.md
+++ b/docs/design/VIRTUAL_LLM.md
@@ -25,7 +25,7 @@ Before generation starts. Fires when the request has media the model can't handl
 | `images_no_multimodal` | Request has images but model has no mmproj |
 | `audio_no_support` | Request has audio but model can't process it |
 
-When mesh hooks are enabled and the model can't handle images, the content parser strips images to `[image attached]` text (instead of rejecting with a 500 error) and preserves the original image URL as `mesh_image_url` in the messages JSON. The hook detects `mesh_image_url` and fires.
+When mesh hooks are enabled and the model can't handle media, the hook path preserves enough request media to consult a capable peer instead of rejecting the request. Image fallback can use direct `image_url`/`input_image` parts or legacy `mesh_image_url` preservation. Audio fallback can use direct `audio_url`/`input_audio` parts, inline audio `data` + `format` blocks, or legacy `mesh_audio_url` preservation.
 
 **What llama-server sends:**
 ```json
@@ -40,9 +40,9 @@ When mesh hooks are enabled and the model can't handle images, the content parse
 }
 ```
 
-**What mesh-llm does:** Extracts the image URL from `mesh_image_url` in messages, finds a vision-capable peer, sends the image for captioning, returns the caption for injection into the prompt.
+**What mesh-llm does:** Extracts the unsupported media reference from the user message, finds a peer with the required runtime capability, sends the media over the mesh for captioning or audio context extraction, and returns concise text for injection into the prompt.
 
-**Response:** `{"action": "inject", "text": "[Image description: ...]\n\n"}` or `{"action": "none"}`
+**Response:** `{"action": "inject", "text": "[Image description: ...]\n\n"}`, `{"action": "inject", "text": "[Audio context: ...]\n\n"}`, or `{"action": "none"}`
 
 ### Hook 2: Post-prefill
 
@@ -173,6 +173,7 @@ Files modified (all additive to upstream):
 
 | File | Purpose |
 |---|---|
+| `openai-frontend/src/hooks.rs` | Hook-time media extraction from OpenAI chat parts, including audio handoff shapes |
 | `inference/virtual_llm.rs` | Typed handlers: `handle_image`, `handle_uncertain`, `handle_drift`, `get_peer_hint` |
 | `inference/consult.rs` | Peer discovery, fan-out racing, QUIC consultation, recursion guard |
 | `api/routes/mesh_hook.rs` | Route handler — parses JSON, dispatches to typed handlers |


### PR DESCRIPTION
## Summary

Text-only Skippy/Virtual LLM requests with audio can now ask an audio-capable mesh peer for concise audio context, inject that context into the local request, and then continue locally as a real text-only request.

This also closes the reviewed case where the original handled `input_audio` / `audio_url` part survived after successful rescue. The handled media part is consumed before Skippy prompt preparation, so text-only Skippy no longer sees residual `prompt.media` and no longer falls into the multimodal/projector path after rescue.

## Why

The existing Virtual LLM path already recognized `audio_no_support` and could find an audio-capable peer, but the actual audio payload was not fully wired through. After the first implementation, i386 pointed out one remaining correctness gap: successful rescue injected `[Audio context: ...]`, but left the original audio content block in the forwarded request. Skippy prompt preparation still treated that as media and could reject the request with `multimodal request requires a configured projector`.

The fix keeps the rescue semantics explicit: successful pre-inference media rescue means "consume this exact handled media part, then inject the text context." If rescue does not succeed, media remains untouched. If there are multiple media parts, only the exact handled part is removed and unhandled media still routes through the normal multimodal path.

## Diff scope

- Extracts audio from `audio_url`, `input_audio.url`, inline `input_audio.data` + `format`, and the legacy `mesh_audio_url` preservation path.
- Routes `audio_no_support` through Virtual LLM peer consultation and injects `[Audio context: ...]` back into the prompt.
- Adds location-aware `ChatMediaRef` fields and a shared `ChatHookAction::ConsumeMedia` action for successful media rescue.
- Uses the shared hook outcome application in both the generic OpenAI hook backend and Skippy backend paths.
- Preserves peer consultation loop safety by sending the audio rescue request with `mesh_hooks: false`.
- Adds regression coverage proving rescued audio becomes text-only before Skippy prompt/media extraction, while unrelated second media remains visible.
- Updates the Virtual LLM design notes.

## Compatibility

- No mesh gossip, QUIC ALPN, protobuf, plugin protocol, Skippy ABI, or public API compatibility change.
- Audio support remains capability-gated by existing runtime capability advertisement.
- Existing image rescue behavior is preserved, with the same handled-media consumption semantics when rescue succeeds.
- Audio payloads are not logged; logs only record routing/action context.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@e9a920b3079e026ebaa0a934d51b3691c78fe9af`
- Branch state after rebase: `0 behind / 1 ahead`
- Merge base: `e9a920b3079e026ebaa0a934d51b3691c78fe9af`
- Head commit: `6921ee175f0c09a01803306954ae3867d228f444`

## Commit integrity

Introduced commit:

- `6921ee175f0c09a01803306954ae3867d228f444` - `Add Virtual LLM audio rescue`

This is one logical PR commit. The final diff is limited to the intended OpenAI hook, Virtual LLM consultation, Skippy prompt-prep, and design-note files.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: PASS, 9 intended files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- Forbidden files: none observed.

## Validation

Validation tier: Tier 3 - shared OpenAI/Skippy runtime hook path for Virtual LLM media rescue, refreshed on current main; no protocol/schema or release metadata change.

Local validation:

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `e9a920b3079e026ebaa0a934d51b3691c78fe9af`.
- `git rebase origin/main`: PASS, no conflicts.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS.
- `cargo test -p openai-frontend hooks --lib`: PASS, 10 passed.
- `cargo test -p openai-frontend --lib`: PASS, 154 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p mesh-llm-host-runtime inference::skippy::hooks::tests --lib -- --test-threads=1`: PASS, 15 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p mesh-llm-host-runtime inference::consult::tests --lib -- --test-threads=1`: PASS, 6 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p mesh-llm-host-runtime inference::virtual_llm::tests --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p skippy-server rescued --lib`: PASS, 2 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p skippy-server --lib`: PASS, 106 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo check -p mesh-llm`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo-clippy clippy -p openai-frontend -p skippy-server -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.

Remote gates on head `6921ee175f0c09a01803306954ae3867d228f444`:

- `PR Quality Checks`: PASS.
- `PR Builds`: PASS.
- Required build/test/smoke jobs passed, including Linux/macOS CPU, Linux unit/protocol/skippy/sdk-api/skippy-smoke, OpenAI inference smoke, client-auto boot, and two-node scripted smokes.
- Conditional jobs skipped as expected: matrix GPU builds, optional SDK smoke jobs, `agent_live_smokes`, and `ui-quality`.

Ledger: not applicable - not required for selected validation tier/change family.

Version: not applicable - no release/version sync required for this non-release runtime hook fix.

Not run:

- `just build` - not required for selected validation tier; no UI assets or release bundle changed.
- Live two-node audio-capable peer smoke - no local audio-capable mesh peer endpoint was available; deterministic OpenAI hook, host-runtime policy, and Skippy prompt-prep tests cover the reviewed failure path.

## Runtime safety

No protobuf, gossip schema, Skippy ABI, plugin protocol, workflow, or release metadata change.

The change only mutates the current OpenAI request body after a successful media rescue, and only for the exact handled media part. Unhandled media remains visible to the normal multimodal path.

No invariant regression introduced.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

A live two-node smoke with a real audio-capable peer would still be useful reviewer confidence, but the reviewed failure mode is covered locally and remotely: after successful rescue, the handled audio media part is removed before Skippy prompt/media extraction.
