### PR TITLE
build: ozempic — slim binary -42 MB / -47 MB

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,24 @@ opt-level = 3
 
 [profile.dev.package.sha2-asm]
 opt-level = 3
+
+# Tightened release profile for shipped binaries.
+#
+# - `lto = "thin"`: parallel link-time optimization across the crate graph.
+#   Roughly 80% of fat-LTO's binary-size and perf benefit at ~30% of the
+#   link cost. Fat LTO would shave a few more MB but pushes release link
+#   from ~30 s to several minutes on this codebase.
+# - `codegen-units = 1`: pairs with thin LTO so the optimizer can inline
+#   across the whole crate without re-link boundaries. Trades parallelism
+#   in codegen for output quality; cargo still parallelises the dep graph.
+# - `strip = "debuginfo"`: drops DWARF from the Mach-O / ELF output. We
+#   keep function symbols so backtraces from production nodes remain
+#   readable (`nm`, `addr2line` on the symbol table still works). DWARF
+#   on macOS arm64 alone is several MB of dead weight in the binary.
+# - panic stays at the default ("unwind"). Plugin / MCP error recovery
+#   relies on unwinding; the AGENTS.md notes explicitly forbid switching
+#   to `abort`.
+[profile.release]
+lto = "thin"
+codegen-units = 1
+strip = "debuginfo"

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.65.1"
 edition = "2021"
 
 [features]
+default = ["web-ui"]
+# Embed the React web console into the binary. Default on; turn off for
+# lib-style / headless consumers that don't need the console assets.
+# Propagates to `mesh-llm-ui/embed-assets`.
+web-ui = ["mesh-llm-ui/embed-assets"]
 gpu-bench-cuda = ["mesh-llm-system/gpu-bench-cuda"]
 gpu-bench-hip = ["mesh-llm-system/gpu-bench-hip"]
 gpu-bench-intel = ["mesh-llm-system/gpu-bench-intel"]
@@ -19,7 +24,7 @@ mesh-llm-protocol = { path = "../mesh-llm-protocol" }
 mesh-llm-routing = { path = "../mesh-llm-routing" }
 mesh-llm-system = { path = "../mesh-llm-system", features = ["skippy-devices"] }
 mesh-llm-types = { path = "../mesh-llm-types" }
-mesh-llm-ui = { path = "../mesh-llm-ui" }
+mesh-llm-ui = { path = "../mesh-llm-ui", default-features = false }
 mesh-client = { package = "mesh-llm-client", path = "../mesh-client", features = ["host-io"] }
 model-artifact = { path = "../model-artifact" }
 model-package = { path = "../model-package" }

--- a/crates/mesh-llm-ui/Cargo.toml
+++ b/crates/mesh-llm-ui/Cargo.toml
@@ -8,5 +8,13 @@ repository = "https://github.com/Mesh-LLM/mesh-llm"
 homepage = "https://github.com/Mesh-LLM/mesh-llm"
 readme = "README.md"
 
+[features]
+# Embed the built React console (dist/) into the binary via include_dir!.
+# Default on so the shipped binary keeps shipping the web console.
+# Turn off (`default-features = false`) for headless / lib-style consumers
+# that want to drop the ~5–6 MB of embedded assets.
+default = ["embed-assets"]
+embed-assets = ["dep:include_dir"]
+
 [dependencies]
-include_dir = "0.7"
+include_dir = { version = "0.7", optional = true }

--- a/crates/mesh-llm-ui/src/lib.rs
+++ b/crates/mesh-llm-ui/src/lib.rs
@@ -1,12 +1,29 @@
-use include_dir::{include_dir, Dir};
-
-static CONSOLE_DIST: Dir<'_> = include_dir!("$MESH_LLM_UI_DIST");
+//! Embedded web-console asset accessor.
+//!
+//! With the default `embed-assets` feature, `include_dir!` bundles the
+//! built React console (`dist/`) into the crate at compile time and
+//! [`index`] / [`asset`] serve those bytes.
+//!
+//! With `embed-assets` disabled, the crate compiles down to ~nothing and
+//! both accessors return `None`. Callers (notably
+//! `mesh-llm-host-runtime`'s console asset routes) treat that as "no UI
+//! bundled" and surface 404s for the asset paths while keeping every
+//! other management-API surface working. This lets lib-style consumers
+//! of `mesh-llm-host-runtime` drop several MB of embedded payload by
+//! opting out of `default-features`.
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct UiAsset {
     pub contents: &'static [u8],
     pub content_type: &'static str,
     pub cache_control: &'static str,
+}
+
+#[cfg(feature = "embed-assets")]
+mod embedded {
+    use include_dir::{include_dir, Dir};
+
+    pub(super) static CONSOLE_DIST: Dir<'_> = include_dir!("$MESH_LLM_UI_DIST");
 }
 
 pub fn index() -> Option<UiAsset> {
@@ -16,13 +33,14 @@ pub fn index() -> Option<UiAsset> {
     })
 }
 
+#[cfg(feature = "embed-assets")]
 pub fn asset(path: &str) -> Option<UiAsset> {
     let rel = path.trim_start_matches('/');
     if rel.contains("..") {
         return None;
     }
 
-    let file = CONSOLE_DIST.get_file(rel)?;
+    let file = embedded::CONSOLE_DIST.get_file(rel)?;
     Some(UiAsset {
         contents: file.contents(),
         content_type: content_type(rel),
@@ -30,6 +48,15 @@ pub fn asset(path: &str) -> Option<UiAsset> {
     })
 }
 
+#[cfg(not(feature = "embed-assets"))]
+pub fn asset(_path: &str) -> Option<UiAsset> {
+    None
+}
+
+// Helpers below are only used when `embed-assets` is on (the stub `asset`
+// returns `None` without ever needing to derive a content type or cache
+// header). Tests likewise only exercise the embedded path.
+#[cfg(feature = "embed-assets")]
 fn content_type(path: &str) -> &'static str {
     match path.rsplit('.').next().unwrap_or("") {
         "html" => "text/html; charset=utf-8",
@@ -46,6 +73,7 @@ fn content_type(path: &str) -> &'static str {
     }
 }
 
+#[cfg(feature = "embed-assets")]
 fn cache_control(path: &str) -> &'static str {
     if path.starts_with("assets/") {
         "public, max-age=31536000, immutable"
@@ -54,7 +82,7 @@ fn cache_control(path: &str) -> &'static str {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "embed-assets"))]
 mod tests {
     use super::{asset, content_type};
 
@@ -75,5 +103,17 @@ mod tests {
             content_type("manifest.json"),
             "application/json; charset=utf-8"
         );
+    }
+}
+
+#[cfg(all(test, not(feature = "embed-assets")))]
+mod stub_tests {
+    use super::{asset, index};
+
+    #[test]
+    fn returns_none_when_assets_not_embedded() {
+        assert!(index().is_none());
+        assert!(asset("index.html").is_none());
+        assert!(asset("assets/app.js").is_none());
     }
 }

--- a/crates/mesh-llm-ui/src/lib/image-describe.ts
+++ b/crates/mesh-llm-ui/src/lib/image-describe.ts
@@ -4,9 +4,27 @@
  * The model is loaded only when an image attachment needs description. Its
  * output is injected as text so regular text models can still reason about
  * attached images, matching the legacy console behavior.
+ *
+ * Bundle policy: the Transformers.js JS module is dynamic-imported (lazy code
+ * split). The ONNX Runtime WASM (~21 MB) is NOT bundled — we point
+ * Transformers.js at a jsDelivr CDN URL so the runtime fetches it on first
+ * use. This keeps the embedded UI dist small (the WASM is the single biggest
+ * file in the binary's `include_dir!` blob) at the cost of one CDN fetch the
+ * first time a user attaches an image. The model weights themselves were
+ * already CDN-streamed from HuggingFace; this just applies the same policy
+ * to the runtime.
+ *
+ * Kept in sync with the @huggingface/transformers version in package.json so
+ * the CDN URL serves the matching wasm/jsep artifacts.
  */
 
 import type { Tensor } from '@huggingface/transformers'
+
+// Must match the @huggingface/transformers dependency in package.json. The
+// jsDelivr CDN serves the WASM and JSEP shader assets from the same dist/
+// directory the npm package uses, so we just point at the pinned version.
+const TRANSFORMERS_JS_VERSION = '3.8.1'
+const TRANSFORMERS_WASM_CDN_BASE = `https://cdn.jsdelivr.net/npm/@huggingface/transformers@${TRANSFORMERS_JS_VERSION}/dist/`
 
 let pipelineCache: DescriptionPipeline | null = null
 let loadingPromise: Promise<DescriptionPipeline> | null = null
@@ -17,8 +35,17 @@ type DescriptionPipeline = Awaited<ReturnType<typeof createDescriptionPipeline>>
 type SliceableTensor = { slice: (start: null, end: [number, null]) => Tensor }
 
 async function createDescriptionPipeline() {
-  const { Florence2ForConditionalGeneration, AutoProcessor, AutoTokenizer, RawImage } =
-    await import('@huggingface/transformers')
+  const transformers = await import('@huggingface/transformers')
+  // Redirect the ONNX Runtime WASM lookup away from Vite's bundle and toward
+  // the CDN copy. Doing this before any model load — and before the first
+  // reference to a static asset path — is what convinces Rollup to drop the
+  // WASM from dist/. The `wasm` backend object is optional in the upstream
+  // typings (some builds omit it), so we guard before assigning.
+  const wasmBackend = transformers.env.backends.onnx.wasm
+  if (wasmBackend) {
+    wasmBackend.wasmPaths = TRANSFORMERS_WASM_CDN_BASE
+  }
+  const { Florence2ForConditionalGeneration, AutoProcessor, AutoTokenizer, RawImage } = transformers
 
   const [model, processor, tokenizer] = await Promise.all([
     Florence2ForConditionalGeneration.from_pretrained(MODEL_ID, {

--- a/crates/mesh-llm-ui/vite.config.ts
+++ b/crates/mesh-llm-ui/vite.config.ts
@@ -9,6 +9,67 @@ import { defineConfig } from 'vitest/config'
 const dirname = path.dirname(fileURLToPath(import.meta.url))
 const apiTarget = process.env.MESH_UI_API_ORIGIN ?? 'http://127.0.0.1:3131'
 
+/**
+ * Stop Vite from bundling the ~21 MB ONNX Runtime WASM blob that ships inside
+ * onnxruntime-web (pulled in transitively by @huggingface/transformers).
+ *
+ * Background: the ORT loader contains literals like
+ *   new URL("ort-wasm-simd-threaded.jsep.wasm", import.meta.url)
+ * which Vite/Rollup's `assetImportMetaUrl` pass recognises and aggressively
+ * copies the .wasm into `dist/assets/` — even when Transformers.js sets
+ * `env.backends.onnx.wasm.wasmPaths` to a jsDelivr CDN URL at runtime (which
+ * makes the bundled copy completely unused at runtime).
+ *
+ * Strategy: defeat Vite's pattern matcher by transforming any source that
+ * contains the offending pattern. We rewrite
+ *   new URL("ort-wasm-*.wasm", import.meta.url)
+ * to a semantically-equivalent runtime expression that does NOT match Vite's
+ * AST pattern (it requires both args to be the exact literal forms).
+ *
+ * After this transform, Vite has no static asset reference to follow, so it
+ * never emits the WASM. At runtime, Transformers.js's `wasmPaths` CDN setting
+ * takes over via `config.locateFile` (see onnxruntime-web/wasm-factory.ts),
+ * so behaviour is unchanged from the user's perspective — only the bundle is
+ * lighter by ~21 MB.
+ *
+ * Affects only files that contain `ort-wasm-*` URL literals (the few ORT
+ * bundles), so it is safe to run across the whole graph.
+ */
+function stripBundledOnnxWasm(): PluginOption {
+  // Matches both jsep and non-jsep variants. The pattern is intentionally
+  // strict about whitespace and quoting so we only touch the ORT loader
+  // literals and not any user code that happens to mention "ort-wasm".
+  const PATTERN = /new URL\((['"])(ort-wasm[a-zA-Z0-9._-]*\.wasm)\1,\s*import\.meta\.url\)/g
+  return {
+    name: 'mesh-llm:strip-bundled-onnx-wasm',
+    enforce: 'pre',
+    transform(code, id) {
+      if (!id.includes('onnxruntime-web')) return null
+      if (!PATTERN.test(code)) return null
+      // Reset lastIndex because we tested with `.test()` above.
+      PATTERN.lastIndex = 0
+      // Replace `new URL("ort-wasm-*.wasm", import.meta.url)` with an
+      // equivalent runtime expression that doesn't trip Vite's asset emitter.
+      // The wrapping IIFE evaluates to the same URL object/string the loader
+      // expects; ORT only uses it as a fallback when `locateFile` is not set.
+      // Split the filename across a runtime concat so Vite's literal-only
+      // asset-emitter pattern matcher does not constant-fold it back into a
+      // static URL. We also alias `import.meta` to a binding so it stops
+      // being a syntactic match for `import.meta.url`.
+      const rewritten = code.replace(
+        PATTERN,
+        (_match, _quote, file) => {
+          const half = Math.floor(file.length / 2)
+          const a = JSON.stringify(file.slice(0, half))
+          const b = JSON.stringify(file.slice(half))
+          return `new URL(${a}+${b}, (0,()=>import.meta)().url)`
+        }
+      )
+      return { code: rewritten, map: null }
+    }
+  }
+}
+
 function plugins(): PluginOption[] {
   const vitePlugins: PluginOption[] = []
   // The app uses code-defined TanStack routes by default. Keep the file-router generator
@@ -23,7 +84,7 @@ function plugins(): PluginOption[] {
       })
     )
   }
-  vitePlugins.push(react(), tailwindcss())
+  vitePlugins.push(stripBundledOnnxWasm(), react(), tailwindcss())
   return vitePlugins
 }
 

--- a/crates/mesh-llm/Cargo.toml
+++ b/crates/mesh-llm/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.65.1"
 edition = "2021"
 
 [features]
+default = ["web-ui"]
+# Embed the React web console into the binary. Default on so the shipped
+# binary keeps shipping the console; turn off (`--no-default-features`)
+# for a lean variant that drops the embedded UI assets.
+web-ui = ["mesh-llm-host-runtime/web-ui"]
 gpu-bench-cuda = ["mesh-llm-host-runtime/gpu-bench-cuda"]
 gpu-bench-hip = ["mesh-llm-host-runtime/gpu-bench-hip"]
 gpu-bench-intel = ["mesh-llm-host-runtime/gpu-bench-intel"]
@@ -12,7 +17,7 @@ gpu-bench-intel = ["mesh-llm-host-runtime/gpu-bench-intel"]
 workspace = true
 
 [dependencies]
-mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime" }
+mesh-llm-host-runtime = { path = "../mesh-llm-host-runtime", default-features = false }
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Slims the shipped `mesh-llm` binary substantially and adds a feature flag so future lib-crate consumers can opt out of the embedded web console.

**macOS arm64 release binary:**

| Build | Size | Δ vs main |
|---|---|---|
| `main` (baseline) | 106 MB | — |
| `micn/ozempic` default | 64 MB | **-42 MB (-40%)** |
| `micn/ozempic --no-default-features` | 59 MB | **-47 MB (-44%)** |

The default-features build is what gets shipped — same user experience, just smaller. The `--no-default-features` build is for future lib consumers who want the runtime without the embedded UI assets.

## What changed

Three focused commits, easy to review independently:

### 1. UI: strip bundled ONNX WASM, lazy-load via CDN

The chat composer's "describe attached image" feature uses `@huggingface/transformers` (Transformers.js + Florence-2). That pulled `onnxruntime-web` into the bundle, which contains literals like

```js
new URL("ort-wasm-simd-threaded.jsep.wasm", import.meta.url)
```

Vite's asset emitter recognises that pattern and aggressively copied the **21 MB WASM** into `dist/assets/` — even though at runtime, Transformers.js defaults `wasmPaths` to a jsDelivr CDN URL and never touches the bundled copy.

A small Vite `transform` plugin rewrites the offending literals in `onnxruntime-web` modules so Rollup never emits the asset. Runtime behaviour is unchanged because ORT's `locateFile` callback still resolves the file from the CDN via `wasmPaths`.

`dist/` size: **26 MB → 5.7 MB** (-20.3 MB).

The Transformers.js JS module (~830 KB) stays dynamic-imported as before, so it's a separate chunk only loaded on first use. The Florence-2 model itself was already CDN-streamed from HuggingFace at runtime; this just applies the same policy to the runtime.

637 UI tests pass, no regressions.

### 2. Tighten release profile

Cargo's `[profile.release]` defaults are conservative: no LTO, 16 codegen units, no symbol stripping. Added:

- `lto = "thin"` — parallel link-time optimization across the crate graph. ~80% of fat-LTO's benefit at ~30% of the link cost.
- `codegen-units = 1` — pairs with thin LTO so the optimizer can inline across the whole crate.
- `strip = "debuginfo"` — drops DWARF from the Mach-O / ELF output. Function symbols stay intact so backtraces from production nodes remain readable.

`panic` stays at the default `unwind` per AGENTS.md (plugin / MCP error recovery relies on unwinding).

Release build time: ~30 s → ~2m45s on M4 Max. Dev builds (which `just build` uses) are unchanged.

### 3. `web-ui` Cargo feature, default on

Adds a default-on `web-ui` feature that propagates through:

```
mesh-llm (binary)
  → mesh-llm-host-runtime
     → mesh-llm-ui (embed-assets feature)
```

When on (default), the React console is embedded into the binary via `include_dir!` exactly as before. When off, `mesh-llm-ui::asset()` and `::index()` return `None`, the `include_dir!` invocation is elided, and the crate no longer depends on `include_dir`. The asset HTTP responders in `mesh-llm-host-runtime` route 404s for asset paths while every other management-API surface keeps working.

Intended for future lib-style consumers of `mesh-llm-host-runtime` who want the runtime/networking without the embedded web payload.

## Architecture

No mesh wire-protocol changes. No skippy ABI changes. No model-routing or election changes. This is purely build-time / packaging work.

Lib-crate prep: with `default-features = false`, `mesh-llm-host-runtime` and `mesh-llm-ui` now compile to a smaller artifact suitable for embedding in other binaries. Follow-up PRs can feature-gate other heavy optional deps (audit findings below) to push the lib-friendly variant smaller.

## Dep audit (not acted on — separate PRs if pursued)

Top opportunities ranked by size × likelihood of being optional:

| Crate | Size | Notes |
|---|---|---|
| rmcp | 1.1 MB | Plugin/MCP bridge. Could feature-gate. |
| aws_lc_sys | 671 KB | rustls TLS provider. Could swap for ring (smaller, simpler). |
| xet + hf-xet | ~940 KB | HF xet protocol for large model downloads. Could feature-gate. |
| mdns-sd | 297 KB | LAN discovery only. Could feature-gate. |
| opentelemetry stack | ~600 KB | Telemetry. Could feature-gate. |

Each requires careful surgery and is out of scope here.

## Validation

- `cargo fmt --all -- --check` ✓
- `cargo check -p mesh-llm` ✓ (default features)
- `cargo check -p mesh-llm --no-default-features` ✓
- `cargo test -p mesh-llm-host-runtime --lib` → 1416 passed, 0 failed, 6 ignored
- `cargo test -p mesh-llm-ui --lib` → 2 passed (embed-assets) / 1 passed (stub, --no-default-features)
- `npm run typecheck` ✓
- `npm test` → 637 passed, 3 skipped (no regressions in image-describe call sites)
- `cargo build --release -p mesh-llm` → 64 MB binary
- `cargo build --release -p mesh-llm --no-default-features` → 59 MB binary
- Binary `--version` and `--help` smoke OK

## How to consume the lib variant later

```toml
[dependencies]
mesh-llm-host-runtime = { version = "...", default-features = false }
# or
mesh-llm = { version = "...", default-features = false }
```

That's the path forward for publishing `mesh-llm` as a lib crate.
