### PR TITLE
Harden Skippy binary frame allocation bounds

### DIFF
--- a/crates/skippy-protocol/src/binary/activation.rs
+++ b/crates/skippy-protocol/src/binary/activation.rs
@@ -1,6 +1,8 @@
 use std::io;
 
-use super::{invalid_data, state_flags, WireActivationDType};
+use super::{
+    invalid_data, state_flags, types::MAX_STAGE_DECODED_ACTIVATION_BYTES, WireActivationDType,
+};
 
 pub fn activation_wire_bytes(
     dtype: WireActivationDType,
@@ -42,6 +44,19 @@ pub fn activation_wire_bytes_with_state_flags(
     }
 }
 
+pub(crate) fn activation_decoded_f32_bytes_with_state_flags(
+    token_count: i32,
+    n_embd: i32,
+    state_flag_bits: i32,
+) -> io::Result<usize> {
+    activation_wire_bytes_with_state_flags(
+        WireActivationDType::F32,
+        token_count,
+        n_embd,
+        state_flag_bits,
+    )
+}
+
 pub fn encode_f32_activation_payload(
     dtype: WireActivationDType,
     token_count: i32,
@@ -64,6 +79,11 @@ pub fn encode_f32_activation_payload_with_state_flags(
         n_embd,
         state_flag_bits,
     )?;
+    if expected_f32_bytes > MAX_STAGE_DECODED_ACTIVATION_BYTES {
+        return Err(invalid_data(
+            "decoded activation payload byte count exceeds maximum",
+        ));
+    }
     if f32_payload.len() != expected_f32_bytes {
         return Err(invalid_data("F32 activation payload size mismatch"));
     }
@@ -90,10 +110,19 @@ pub fn activation_payload_multiplier_from_state_flags(state_flag_bits: i32) -> u
 }
 
 pub(crate) fn decode_f16_to_f32_bytes(input: &[u8]) -> io::Result<Vec<u8>> {
-    if !input.len().is_multiple_of(2) {
+    if input.len() & 1 != 0 {
         return Err(invalid_data("F16 activation payload has odd byte length"));
     }
-    let mut out = Vec::with_capacity((input.len() / 2) * 4);
+    let decoded_bytes = input
+        .len()
+        .checked_mul(2)
+        .ok_or_else(|| invalid_data("decoded activation byte count overflow"))?;
+    if decoded_bytes > MAX_STAGE_DECODED_ACTIVATION_BYTES {
+        return Err(invalid_data(
+            "decoded activation payload byte count exceeds maximum",
+        ));
+    }
+    let mut out = Vec::with_capacity(decoded_bytes);
     for chunk in input.chunks_exact(2) {
         let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
         out.extend_from_slice(&f16_bits_to_f32(bits).to_le_bytes());
@@ -102,7 +131,7 @@ pub(crate) fn decode_f16_to_f32_bytes(input: &[u8]) -> io::Result<Vec<u8>> {
 }
 
 fn encode_f32_to_f16_bytes(input: &[u8]) -> io::Result<Vec<u8>> {
-    if !input.len().is_multiple_of(4) {
+    if input.len() & 3 != 0 {
         return Err(invalid_data("F32 activation payload size is not aligned"));
     }
     let mut out = Vec::with_capacity(input.len() / 2);
@@ -134,10 +163,21 @@ pub(crate) fn decode_q8_to_f32_bytes_with_state_flags(
     let value_bytes = token_count
         .checked_mul(n_embd)
         .ok_or_else(|| invalid_data("Q8 value byte count overflow"))?;
-    if input.len() != scale_bytes + value_bytes {
+    let expected_bytes = scale_bytes
+        .checked_add(value_bytes)
+        .ok_or_else(|| invalid_data("Q8 activation payload byte count overflow"))?;
+    if input.len() != expected_bytes {
         return Err(invalid_data("Q8 activation payload size mismatch"));
     }
-    let mut out = Vec::with_capacity(value_bytes * 4);
+    let decoded_bytes = value_bytes
+        .checked_mul(4)
+        .ok_or_else(|| invalid_data("decoded activation byte count overflow"))?;
+    if decoded_bytes > MAX_STAGE_DECODED_ACTIVATION_BYTES {
+        return Err(invalid_data(
+            "decoded activation payload byte count exceeds maximum",
+        ));
+    }
+    let mut out = Vec::with_capacity(decoded_bytes);
     for token_index in 0..token_count {
         let scale_offset = token_index * 4;
         let scale = f32::from_le_bytes([

--- a/crates/skippy-protocol/src/binary/codec.rs
+++ b/crates/skippy-protocol/src/binary/codec.rs
@@ -1,10 +1,14 @@
 use std::io::{self, Read, Write};
 
 use super::{
-    activation::activation_wire_bytes_with_state_flags, invalid_data, invalid_input,
-    StageLogitBias, StageReply, StageReplyStats, StageSamplingConfig, StageStateHeader,
-    StageWireMessage, WireActivationDType, WireMessageKind, WireReplyKind, MAX_STAGE_LOGIT_BIAS,
-    READY_MAGIC, STAGE_STATE_VERSION,
+    activation::{
+        activation_decoded_f32_bytes_with_state_flags, activation_wire_bytes_with_state_flags,
+    },
+    invalid_data, invalid_input, StageLogitBias, StageReply, StageReplyStats, StageSamplingConfig,
+    StageStateHeader, StageWireMessage, WireActivationDType, WireMessageKind, WireReplyKind,
+    MAX_STAGE_ACTIVATION_BYTES, MAX_STAGE_CHAT_SAMPLING_METADATA_BYTES,
+    MAX_STAGE_DECODED_ACTIVATION_BYTES, MAX_STAGE_LOGIT_BIAS, MAX_STAGE_PREDICTED_TOKENS,
+    MAX_STAGE_SIDEBAND_VALUES, MAX_STAGE_STATE_IMPORT_BYTES, READY_MAGIC, STAGE_STATE_VERSION,
 };
 
 pub fn send_ready(mut writer: impl Write) -> io::Result<()> {
@@ -51,6 +55,9 @@ pub fn send_reply_predicted_tokens_with_stats(
     predicted_tokens: &[i32],
     stats: StageReplyStats,
 ) -> io::Result<()> {
+    if predicted_tokens.len() > MAX_STAGE_PREDICTED_TOKENS {
+        return Err(invalid_input("too many predicted tokens"));
+    }
     let predicted = predicted_tokens.first().copied().unwrap_or(0);
     write_i32(&mut writer, WireReplyKind::PredictedTokens as i32)?;
     write_i32(&mut writer, predicted)?;
@@ -68,11 +75,13 @@ pub fn send_reply_predicted_tokens_with_stats(
 pub fn recv_reply(mut reader: impl Read) -> io::Result<StageReply> {
     let kind = WireReplyKind::try_from(read_i32(&mut reader)?)?;
     let predicted = read_i32(&mut reader)?;
-    let predicted_count = read_i32(&mut reader)?;
-    if predicted_count < 0 {
-        return Err(invalid_data("negative predicted token count"));
-    }
-    let mut predicted_tokens = Vec::with_capacity(predicted_count as usize);
+    let predicted_count = checked_i32_len(
+        read_i32(&mut reader)?,
+        MAX_STAGE_PREDICTED_TOKENS,
+        "negative predicted token count",
+        "predicted token count exceeds maximum",
+    )?;
+    let mut predicted_tokens = Vec::with_capacity(predicted_count);
     for _ in 0..predicted_count {
         predicted_tokens.push(read_i32(&mut reader)?);
     }
@@ -99,10 +108,16 @@ pub fn write_stage_message(
     write_i32(&mut writer, message.kind as i32)?;
     write_i32(&mut writer, message.pos_start)?;
     write_i32(&mut writer, message.token_count)?;
+    if message.tokens.len() > MAX_STAGE_SIDEBAND_VALUES {
+        return Err(invalid_input("too many tokens"));
+    }
     write_i32(
         &mut writer,
         i32::try_from(message.tokens.len()).map_err(|_| invalid_input("too many tokens"))?,
     )?;
+    if message.positions.len() > MAX_STAGE_SIDEBAND_VALUES {
+        return Err(invalid_input("too many position sideband values"));
+    }
     write_i32(
         &mut writer,
         i32::try_from(message.positions.len())
@@ -129,6 +144,9 @@ pub fn write_stage_message(
     }
     if let Some(metadata) = message.chat_sampling_metadata.as_ref() {
         let bytes = metadata.as_bytes();
+        if bytes.len() > MAX_STAGE_CHAT_SAMPLING_METADATA_BYTES {
+            return Err(invalid_input("chat sampling metadata is too large"));
+        }
         write_u32(
             &mut writer,
             u32::try_from(bytes.len())
@@ -138,6 +156,14 @@ pub fn write_stage_message(
     }
 
     if message.kind == WireMessageKind::StateImport {
+        let raw_byte_count = usize::try_from(message.token_count)
+            .map_err(|_| invalid_input("state import raw byte count mismatch"))?;
+        if raw_byte_count != message.raw_bytes.len() {
+            return Err(invalid_input("state import raw byte count mismatch"));
+        }
+        if raw_byte_count > MAX_STAGE_STATE_IMPORT_BYTES {
+            return Err(invalid_input("state import raw byte count exceeds maximum"));
+        }
         writer.write_all(&message.raw_bytes)?;
         return Ok(());
     }
@@ -170,8 +196,11 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
     };
     let chat_sampling_metadata = if (state.flags & super::state_flags::CHAT_SAMPLING_METADATA) != 0
     {
-        let len = usize::try_from(read_u32(&mut reader)?)
-            .map_err(|_| invalid_data("chat sampling metadata length overflows usize"))?;
+        let len = checked_u32_len(
+            read_u32(&mut reader)?,
+            MAX_STAGE_CHAT_SAMPLING_METADATA_BYTES,
+            "chat sampling metadata length exceeds maximum",
+        )?;
         let mut bytes = vec![0_u8; len];
         reader.read_exact(&mut bytes)?;
         Some(
@@ -201,8 +230,26 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
     if token_count < 0 || token_sideband_count < 0 || position_sideband_count < 0 {
         return Err(invalid_data("negative wire count"));
     }
+    let token_sideband_count = checked_i32_len(
+        token_sideband_count,
+        MAX_STAGE_SIDEBAND_VALUES,
+        "negative wire count",
+        "token sideband count exceeds maximum",
+    )?;
+    let position_sideband_count = checked_i32_len(
+        position_sideband_count,
+        MAX_STAGE_SIDEBAND_VALUES,
+        "negative wire count",
+        "position sideband count exceeds maximum",
+    )?;
     if kind == WireMessageKind::StateImport {
-        let mut raw_bytes = vec![0; token_count as usize];
+        let raw_byte_count = checked_i32_len(
+            token_count,
+            MAX_STAGE_STATE_IMPORT_BYTES,
+            "negative wire count",
+            "state import byte count exceeds maximum",
+        )?;
+        let mut raw_bytes = vec![0; raw_byte_count];
         reader.read_exact(&mut raw_bytes)?;
         return Ok(StageWireMessage {
             kind,
@@ -220,11 +267,11 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
         });
     }
 
-    let mut tokens = Vec::with_capacity(token_sideband_count as usize);
+    let mut tokens = Vec::with_capacity(token_sideband_count);
     for _ in 0..token_sideband_count {
         tokens.push(read_i32(&mut reader)?);
     }
-    let mut positions = Vec::with_capacity(position_sideband_count as usize);
+    let mut positions = Vec::with_capacity(position_sideband_count);
     for _ in 0..position_sideband_count {
         positions.push(read_i32(&mut reader)?);
     }
@@ -234,6 +281,20 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
         } else {
             activation_wire_bytes_with_state_flags(dtype, token_count, n_embd, state.flags)?
         };
+    if activation_bytes > MAX_STAGE_ACTIVATION_BYTES {
+        return Err(invalid_data(
+            "activation payload byte count exceeds maximum",
+        ));
+    }
+    if activation_bytes > 0 {
+        let decoded_activation_bytes =
+            activation_decoded_f32_bytes_with_state_flags(token_count, n_embd, state.flags)?;
+        if decoded_activation_bytes > MAX_STAGE_DECODED_ACTIVATION_BYTES {
+            return Err(invalid_data(
+                "decoded activation payload byte count exceeds maximum",
+            ));
+        }
+    }
     let mut activation = vec![0; activation_bytes];
     if activation_bytes > 0 {
         reader.read_exact(&mut activation)?;
@@ -252,6 +313,30 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
         activation,
         raw_bytes: Vec::new(),
     })
+}
+
+fn checked_i32_len(
+    value: i32,
+    max: usize,
+    negative_message: &'static str,
+    too_large_message: &'static str,
+) -> io::Result<usize> {
+    if value < 0 {
+        return Err(invalid_data(negative_message));
+    }
+    let value = usize::try_from(value).map_err(|_| invalid_data(too_large_message))?;
+    if value > max {
+        return Err(invalid_data(too_large_message));
+    }
+    Ok(value)
+}
+
+fn checked_u32_len(value: u32, max: usize, too_large_message: &'static str) -> io::Result<usize> {
+    let value = usize::try_from(value).map_err(|_| invalid_data(too_large_message))?;
+    if value > max {
+        return Err(invalid_data(too_large_message));
+    }
+    Ok(value)
 }
 
 fn write_state_header(mut writer: impl Write, state: StageStateHeader) -> io::Result<()> {

--- a/crates/skippy-protocol/src/binary/mod.rs
+++ b/crates/skippy-protocol/src/binary/mod.rs
@@ -17,9 +17,11 @@ pub use types::{
     StageLogitBias, StageReply, StageReplyStats, StageSamplingConfig, StageStateHeader,
     StageWireMessage, WireActivationDType, WireMessageKind, WireReplyKind, WireStagePhase,
     ACTIVATION_FLAG_GEMMA3N_ALTUP, ACTIVATION_FLAG_RWKV7_V_FIRST, LLAMA_TOKEN_NULL,
-    MAX_STAGE_LOGIT_BIAS, READY_MAGIC, STAGE_LOGIT_BIAS_WIRE_BYTES,
-    STAGE_SAMPLING_CONFIG_BASE_BYTES, STAGE_STATE_HEADER_BYTES, STAGE_STATE_VERSION,
-    STAGE_WIRE_FIXED_HEADER_BYTES,
+    MAX_STAGE_ACTIVATION_BYTES, MAX_STAGE_CHAT_SAMPLING_METADATA_BYTES,
+    MAX_STAGE_DECODED_ACTIVATION_BYTES, MAX_STAGE_LOGIT_BIAS, MAX_STAGE_PREDICTED_TOKENS,
+    MAX_STAGE_SIDEBAND_VALUES, MAX_STAGE_STATE_IMPORT_BYTES, READY_MAGIC,
+    STAGE_LOGIT_BIAS_WIRE_BYTES, STAGE_SAMPLING_CONFIG_BASE_BYTES, STAGE_STATE_HEADER_BYTES,
+    STAGE_STATE_VERSION, STAGE_WIRE_FIXED_HEADER_BYTES,
 };
 
 pub(crate) fn invalid_data(message: &'static str) -> std::io::Error {
@@ -34,6 +36,56 @@ pub(crate) fn invalid_input(message: &'static str) -> std::io::Error {
 mod tests {
     use super::*;
     use std::io::Cursor;
+
+    fn push_i32(bytes: &mut Vec<u8>, value: i32) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u32(bytes: &mut Vec<u8>, value: u32) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_u64(bytes: &mut Vec<u8>, value: u64) {
+        bytes.extend_from_slice(&value.to_le_bytes());
+    }
+
+    fn push_state_header(bytes: &mut Vec<u8>, state: StageStateHeader) {
+        push_i32(bytes, state.version);
+        push_i32(bytes, state.seq_id);
+        push_i32(bytes, state.phase);
+        push_i32(bytes, state.flags);
+        push_i32(bytes, state.checkpoint_generation);
+        push_i32(bytes, state.prompt_token_count);
+        push_i32(bytes, state.decode_step);
+        push_i32(bytes, state.current_token);
+        push_i32(bytes, state.source_stage_index);
+        push_i32(bytes, state.reserved);
+    }
+
+    fn stage_frame_prefix(
+        kind: WireMessageKind,
+        token_count: i32,
+        token_sideband_count: i32,
+        position_sideband_count: i32,
+        state: StageStateHeader,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        push_i32(&mut bytes, kind as i32);
+        push_i32(&mut bytes, 0);
+        push_i32(&mut bytes, token_count);
+        push_i32(&mut bytes, token_sideband_count);
+        push_i32(&mut bytes, position_sideband_count);
+        push_state_header(&mut bytes, state);
+        push_u64(&mut bytes, 7);
+        push_u64(&mut bytes, 11);
+        bytes
+    }
+
+    fn assert_invalid_data<T: std::fmt::Debug>(result: std::io::Result<T>, expected: &str) {
+        let error = result.unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(error.to_string(), expected);
+    }
 
     #[test]
     fn ready_round_trips() {
@@ -61,6 +113,22 @@ mod tests {
         assert_eq!(reply.kind, WireReplyKind::PredictedTokens);
         assert_eq!(reply.predicted, 1);
         assert_eq!(reply.predicted_tokens, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn reply_rejects_predicted_token_count_over_limit() {
+        let mut bytes = Vec::new();
+        push_i32(&mut bytes, WireReplyKind::PredictedTokens as i32);
+        push_i32(&mut bytes, 1);
+        push_i32(
+            &mut bytes,
+            i32::try_from(MAX_STAGE_PREDICTED_TOKENS + 1).unwrap(),
+        );
+
+        assert_invalid_data(
+            recv_reply(Cursor::new(bytes)),
+            "predicted token count exceeds maximum",
+        );
     }
 
     #[test]
@@ -156,6 +224,25 @@ mod tests {
     }
 
     #[test]
+    fn stage_message_rejects_sampling_metadata_length_over_limit() {
+        let mut state = StageStateHeader::new(
+            WireMessageKind::ConfigureGeneration,
+            WireActivationDType::F32,
+        );
+        state.flags |= state_flags::CHAT_SAMPLING_METADATA;
+        let mut bytes = stage_frame_prefix(WireMessageKind::ConfigureGeneration, 0, 0, 0, state);
+        push_u32(
+            &mut bytes,
+            u32::try_from(MAX_STAGE_CHAT_SAMPLING_METADATA_BYTES + 1).unwrap(),
+        );
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), 2048),
+            "chat sampling metadata length exceeds maximum",
+        );
+    }
+
+    #[test]
     fn driver_origin_message_round_trips_without_activation() {
         let mut state =
             StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32);
@@ -186,6 +273,44 @@ mod tests {
         assert_eq!(decoded.session_id, 17);
         assert_eq!(decoded.state.flags & state_flags::SAMPLING, 0);
         assert!(decoded.sampling.is_none());
+    }
+
+    #[test]
+    fn stage_message_rejects_token_sideband_count_over_limit() {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32);
+        state.source_stage_index = -1;
+        let bytes = stage_frame_prefix(
+            WireMessageKind::PrefillEmbd,
+            0,
+            i32::try_from(MAX_STAGE_SIDEBAND_VALUES + 1).unwrap(),
+            0,
+            state,
+        );
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), 2048),
+            "token sideband count exceeds maximum",
+        );
+    }
+
+    #[test]
+    fn stage_message_rejects_position_sideband_count_over_limit() {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32);
+        state.source_stage_index = -1;
+        let bytes = stage_frame_prefix(
+            WireMessageKind::PrefillEmbd,
+            0,
+            0,
+            i32::try_from(MAX_STAGE_SIDEBAND_VALUES + 1).unwrap(),
+            state,
+        );
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), 2048),
+            "position sideband count exceeds maximum",
+        );
     }
 
     #[test]
@@ -283,6 +408,47 @@ mod tests {
     }
 
     #[test]
+    fn state_import_rejects_raw_byte_count_over_limit() {
+        let state = StageStateHeader::new(WireMessageKind::StateImport, WireActivationDType::F32);
+        let bytes = stage_frame_prefix(
+            WireMessageKind::StateImport,
+            i32::try_from(MAX_STAGE_STATE_IMPORT_BYTES + 1).unwrap(),
+            0,
+            0,
+            state,
+        );
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), 2048),
+            "state import byte count exceeds maximum",
+        );
+    }
+
+    #[test]
+    fn state_import_writer_rejects_raw_byte_count_mismatch() {
+        let state = StageStateHeader::new(WireMessageKind::StateImport, WireActivationDType::F32);
+        let message = StageWireMessage {
+            kind: WireMessageKind::StateImport,
+            pos_start: 0,
+            token_count: 8,
+            state,
+            request_id: 31,
+            session_id: 37,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: Vec::new(),
+            positions: Vec::new(),
+            activation: Vec::new(),
+            raw_bytes: vec![1, 2, 3, 4],
+        };
+        let mut bytes = Vec::new();
+        let error = write_stage_message(&mut bytes, &message, WireActivationDType::F32)
+            .expect_err("mismatched state import byte count should fail");
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+        assert_eq!(error.to_string(), "state import raw byte count mismatch");
+    }
+
+    #[test]
     fn state_export_message_round_trips_without_payload() {
         let state = StageStateHeader::new(WireMessageKind::StateExport, WireActivationDType::F32);
         let message = StageWireMessage {
@@ -306,6 +472,101 @@ mod tests {
         assert!(decoded.raw_bytes.is_empty());
         assert!(decoded.tokens.is_empty());
         assert!(decoded.activation.is_empty());
+    }
+
+    #[test]
+    fn stage_message_rejects_activation_payload_over_limit() {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F32);
+        state.source_stage_index = 0;
+        state.flags |= state_flags::GEMMA3N_ALTUP_SIDEBAND;
+        let token_count = i32::try_from(MAX_STAGE_ACTIVATION_BYTES / 4 / 4 / 1024 + 1).unwrap();
+        let bytes = stage_frame_prefix(WireMessageKind::DecodeEmbd, token_count, 0, 0, state);
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), 1024),
+            "activation payload byte count exceeds maximum",
+        );
+    }
+
+    #[test]
+    fn stage_message_rejects_f16_activation_when_decoded_payload_exceeds_limit() {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F16);
+        state.source_stage_index = 0;
+        let n_embd = 65_536;
+        let token_count =
+            i32::try_from(MAX_STAGE_DECODED_ACTIVATION_BYTES / 4 / n_embd as usize + 1).unwrap();
+        let wire_bytes = activation_wire_bytes_with_state_flags(
+            WireActivationDType::F16,
+            token_count,
+            n_embd,
+            0,
+        )
+        .unwrap();
+        assert!(wire_bytes <= MAX_STAGE_ACTIVATION_BYTES);
+        let bytes = stage_frame_prefix(WireMessageKind::DecodeEmbd, token_count, 0, 0, state);
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), n_embd),
+            "decoded activation payload byte count exceeds maximum",
+        );
+    }
+
+    #[test]
+    fn stage_message_rejects_q8_activation_when_decoded_payload_exceeds_limit() {
+        let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::Q8);
+        state.source_stage_index = 0;
+        let n_embd = 65_536;
+        let token_count =
+            i32::try_from(MAX_STAGE_DECODED_ACTIVATION_BYTES / 4 / n_embd as usize + 1).unwrap();
+        let wire_bytes =
+            activation_wire_bytes_with_state_flags(WireActivationDType::Q8, token_count, n_embd, 0)
+                .unwrap();
+        assert!(wire_bytes <= MAX_STAGE_ACTIVATION_BYTES);
+        let bytes = stage_frame_prefix(WireMessageKind::DecodeEmbd, token_count, 0, 0, state);
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), n_embd),
+            "decoded activation payload byte count exceeds maximum",
+        );
+    }
+
+    #[test]
+    fn stage_message_rejects_q8_sideband_activation_when_decoded_payload_exceeds_limit() {
+        let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::Q8);
+        state.source_stage_index = 0;
+        state.flags |= state_flags::GEMMA3N_ALTUP_SIDEBAND;
+        let n_embd = 65_536;
+        let token_count =
+            i32::try_from(MAX_STAGE_DECODED_ACTIVATION_BYTES / 4 / 4 / n_embd as usize + 1)
+                .unwrap();
+        let wire_bytes = activation_wire_bytes_with_state_flags(
+            WireActivationDType::Q8,
+            token_count,
+            n_embd,
+            state.flags,
+        )
+        .unwrap();
+        assert!(wire_bytes <= MAX_STAGE_ACTIVATION_BYTES);
+        let bytes = stage_frame_prefix(WireMessageKind::DecodeEmbd, token_count, 0, 0, state);
+
+        assert_invalid_data(
+            read_stage_message(Cursor::new(bytes), n_embd),
+            "decoded activation payload byte count exceeds maximum",
+        );
+    }
+
+    #[test]
+    fn activation_encoding_rejects_decoded_payload_over_limit_before_compression() {
+        let n_embd = 65_536;
+        let token_count =
+            i32::try_from(MAX_STAGE_DECODED_ACTIVATION_BYTES / 4 / n_embd as usize + 1).unwrap();
+
+        assert_invalid_data(
+            encode_f32_activation_payload(WireActivationDType::F16, token_count, n_embd, &[]),
+            "decoded activation payload byte count exceeds maximum",
+        );
     }
 
     #[test]

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -7,6 +7,12 @@ use super::{
 
 pub const STAGE_STATE_VERSION: i32 = 6;
 pub const MAX_STAGE_LOGIT_BIAS: usize = 256;
+pub const MAX_STAGE_PREDICTED_TOKENS: usize = 262_144;
+pub const MAX_STAGE_SIDEBAND_VALUES: usize = 1_048_576;
+pub const MAX_STAGE_CHAT_SAMPLING_METADATA_BYTES: usize = 8 * 1024 * 1024;
+pub const MAX_STAGE_STATE_IMPORT_BYTES: usize = 512 * 1024 * 1024;
+pub const MAX_STAGE_ACTIVATION_BYTES: usize = 512 * 1024 * 1024;
+pub const MAX_STAGE_DECODED_ACTIVATION_BYTES: usize = 512 * 1024 * 1024;
 pub const READY_MAGIC: i32 = 0x5352_4459; // "SRDY"
 pub const LLAMA_TOKEN_NULL: i32 = -1;
 pub const STAGE_STATE_HEADER_BYTES: usize = 10 * 4;
@@ -408,7 +414,14 @@ impl StageWireMessage {
             return Ok(Vec::new());
         }
         match self.state.dtype()? {
-            WireActivationDType::F32 => Ok(self.activation.clone()),
+            WireActivationDType::F32 => {
+                if self.activation.len() > MAX_STAGE_DECODED_ACTIVATION_BYTES {
+                    return Err(invalid_data(
+                        "decoded activation payload byte count exceeds maximum",
+                    ));
+                }
+                Ok(self.activation.clone())
+            }
             WireActivationDType::F16 => decode_f16_to_f32_bytes(&self.activation),
             WireActivationDType::Q8 => decode_q8_to_f32_bytes_with_state_flags(
                 &self.activation,


### PR DESCRIPTION
## Summary

Skippy binary stage transport now rejects malformed or oversized peer frames before allocating payload buffers.

- Adds explicit upper bounds for predicted-token replies, sideband counts, chat sampling metadata, state-import bytes, activation payload bytes, and decoded activation payloads.
- Validates outbound state-import and large metadata/sideband frames so local writers do not emit frames the reader would reject.
- Keeps the caps conservative for long-context prefix-cache restore and large ALTUP/RWKV activation frames.
- Adds regression tests that construct oversized wire frames and assert InvalidData before payload allocation.

## Why

The binary codec trusted peer-controlled counts and lengths before allocating Vec buffers. A malformed or incompatible peer could advertise a huge count and force a large reservation/allocation before the codec reached EOF or rejected the frame.

This is a local stage transport hardening change; it does not change the Skippy ALPN, protobuf stage-control generation, mesh gossip, or plugin protocols.

## Compatibility

The wire format is unchanged. Valid existing frames continue to decode. The new limits are intentionally above current long-context prefix-cache and large activation use cases, while rejecting clearly unreasonable allocation requests.

## Validation

- git fetch --no-tags origin main:refs/remotes/origin/main
- git diff --check
- git diff --cached --check
- cargo fmt --all -- --check
- cargo clippy -p skippy-protocol --all-targets -- -D warnings
- cargo test -p skippy-protocol --lib (26 passed)
- LLAMA_STAGE_BUILD_DIR=<local stage ABI build dir> cargo test -p skippy-server --lib (81 passed)
- LLAMA_STAGE_BUILD_DIR=<local stage ABI build dir> cargo check -p skippy-runtime -p skippy-ffi -p skippy-prompt -p skippy-bench -p skippy-correctness -p mesh-llm

## Rollback

Revert this PR.