### PR TITLE
Cover asymmetric KV cache width pricing

### DIFF
--- a/crates/model-artifact/src/gguf.rs
+++ b/crates/model-artifact/src/gguf.rs
@@ -817,6 +817,23 @@ mod tests {
     }
 
     #[test]
+    fn kv_cache_quant_prices_key_and_value_widths_independently() {
+        let meta = GgufCompactMeta {
+            head_count: 32,
+            kv_head_count: 8,
+            layer_count: 24,
+            key_length: 64,
+            value_length: 256,
+            ..Default::default()
+        };
+        let quant = GgufKvCacheQuant::new(GgufKvCacheType::Q8_0, GgufKvCacheType::Q4_0);
+
+        assert_eq!(quant.k_cache_bytes_per_token(&meta), Some(13_056));
+        assert_eq!(quant.v_cache_bytes_per_token(&meta), Some(27_648));
+        assert_eq!(quant.kv_cache_bytes_per_token(&meta), Some(40_704));
+    }
+
+    #[test]
     fn kv_cache_bytes_per_token_returns_none_when_required_fields_are_missing() {
         let meta = GgufCompactMeta {
             head_count: 32,


### PR DESCRIPTION
## Summary

This is now a narrow regression-test follow-up after current `main` absorbed and simplified the runtime auto-planning work from the original branch.

- Keeps current `main` runtime planning behavior, including the conservative unified-KV auto slot ceiling from the recent multi-node fixes.
- Drops the stale `RuntimePlanningProfile` / public-mesh lane escalation from this branch instead of fighting the newer runtime work.
- Adds coverage that GGUF KV-cache pricing handles asymmetric key/value widths independently.

## Why

The maintainer feedback was to update against current `main` and re-check the shape after the multi-node runtime changes. After rebasing, the right professional scope was not to reintroduce the older runtime planning profile. The remaining useful piece is the model-artifact regression coverage for asymmetric K/V metadata, which protects the capacity math used by the planner without changing runtime behavior.

## Diff scope

- `crates/model-artifact/src/gguf.rs`
  - Adds a regression test for independent K/V cache width pricing.

## Compatibility

- Test-only change.
- No runtime behavior change.
- No mesh wire protocol, gossip, protobuf, Skippy ABI, or plugin protocol compatibility change.

## Validation

Local validation:

- `git fetch --no-tags origin main:refs/remotes/origin/main codex/kv-context-slot-auto-planning:refs/remotes/origin/codex/kv-context-slot-auto-planning` - PASS
- `git rebase origin/main` - PASS
- `git diff --check origin/main...HEAD` - PASS, no output
- `git diff --check` - PASS, no output
- `git diff --cached --check` - PASS, no output
- `cargo fmt --all -- --check` - PASS
- `cargo test -p model-artifact gguf --lib` - PASS, 16 passed
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime runtime::context_planning --lib` - PASS, 9 passed
- `cargo check -p model-artifact` - PASS
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm` - PASS
- `/opt/homebrew/bin/cargo-clippy clippy -p model-artifact --all-targets -- -D warnings` - PASS

Remote validation:

- PR Quality Checks - PASS
- PR Builds - PASS
- PR Docker Build - PASS

Not run:

- Live performance smoke - not required after the final diff no longer changes runtime planning behavior. Current `main` runtime planning remains covered by targeted `runtime::context_planning` tests and remote CI.

## Rollback

Revert this PR.

Related: #359
