### PR TITLE
Advertise peer throughput hints for routing

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -640,6 +640,8 @@ fn make_test_state_peer(seed: u8, role: mesh::NodeRole) -> mesh::PeerInfo {
         stage_status_list_supported: false,
         owner_summary: crate::crypto::OwnershipSummary::default(),
         first_joined_mesh_ts: None,
+        advertised_model_throughput: vec![],
+
         display_rtt: None,
         propagated_latency: None,
     }
@@ -1220,6 +1222,8 @@ fn make_test_peer(
         stage_protocol_generation_supported: false,
         stage_status_list_supported: false,
         owner_summary: crate::crypto::OwnershipSummary::default(),
+        advertised_model_throughput: vec![],
+
         display_rtt: None,
         propagated_latency: None,
     }

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -126,6 +126,7 @@ struct LocalAnnouncementData {
     served_model_runtime: Vec<ModelRuntimeDescriptor>,
     owner_attestation: Option<SignedNodeOwnership>,
     artifact_transfer_supported: bool,
+    advertised_model_throughput: Vec<crate::network::metrics::ModelThroughputHint>,
     gpu_mem_bandwidth_gbps: Option<String>,
     gpu_compute_tflops_fp32: Option<String>,
     gpu_compute_tflops_fp16: Option<String>,
@@ -247,6 +248,7 @@ pub(super) fn apply_transitive_ann(
     existing.artifact_transfer_supported = ann.artifact_transfer_supported;
     existing.stage_protocol_generation_supported = ann.stage_protocol_generation_supported;
     existing.stage_status_list_supported = ann.stage_status_list_supported;
+    existing.advertised_model_throughput = ann.advertised_model_throughput.clone();
     if ann.experts_summary.is_some() {
         existing.experts_summary = ann.experts_summary.clone();
     }
@@ -481,6 +483,7 @@ impl Node {
         existing.artifact_transfer_supported = ann.artifact_transfer_supported;
         existing.stage_protocol_generation_supported = ann.stage_protocol_generation_supported;
         existing.stage_status_list_supported = ann.stage_status_list_supported;
+        existing.advertised_model_throughput = ann.advertised_model_throughput.clone();
         if ann.version.is_some() {
             existing.version = ann.version.clone();
         }
@@ -655,13 +658,17 @@ impl Node {
 
     async fn snapshot_local_announcement_data(&self) -> LocalAnnouncementData {
         let owner_summary = self.owner_summary.lock().await.clone();
+        let hosted_models = self.hosted_models.lock().await.clone();
+        let advertised_model_throughput = self
+            .routing_metrics
+            .advertisable_model_throughput(&hosted_models);
         LocalAnnouncementData {
             role: self.role.lock().await.clone(),
             first_joined_mesh_ts: *self.first_joined_mesh_ts.lock().await,
             models: self.models.lock().await.clone(),
             model_source: self.model_source.lock().await.clone(),
             serving_models: self.serving_models.lock().await.clone(),
-            hosted_models: self.hosted_models.lock().await.clone(),
+            hosted_models,
             available_models: self.available_models.lock().await.clone(),
             requested_models: self.requested_models.lock().await.clone(),
             explicit_model_interests: self.explicit_model_interests.lock().await.clone(),
@@ -674,6 +681,7 @@ impl Node {
             owner_attestation: self.owner_attestation.lock().await.clone(),
             artifact_transfer_supported:
                 crate::models::artifact_transfer::artifact_transfer_advertised(&owner_summary),
+            advertised_model_throughput,
             gpu_mem_bandwidth_gbps: Self::format_optional_locked_f32_list(
                 &self.gpu_mem_bandwidth_gbps,
             )
@@ -723,6 +731,7 @@ impl Node {
             artifact_transfer_supported: peer.artifact_transfer_supported,
             stage_protocol_generation_supported: peer.stage_protocol_generation_supported,
             stage_status_list_supported: peer.stage_status_list_supported,
+            advertised_model_throughput: peer.advertised_model_throughput.clone(),
             latency_ms: latency.latency_ms,
             latency_source: Some(match latency.source {
                 DisplayLatencySource::Direct => crate::proto::node::LatencySource::Direct,
@@ -782,6 +791,7 @@ impl Node {
             artifact_transfer_supported: data.artifact_transfer_supported,
             stage_protocol_generation_supported: true,
             stage_status_list_supported: true,
+            advertised_model_throughput: data.advertised_model_throughput,
             latency_ms: None,
             latency_source: None,
             latency_age_ms: None,
@@ -1181,6 +1191,7 @@ mod tests {
             artifact_transfer_supported: true,
             stage_protocol_generation_supported: true,
             stage_status_list_supported: true,
+            advertised_model_throughput: vec![],
             latency_ms: None,
             latency_source: None,
             latency_age_ms: None,
@@ -1361,6 +1372,29 @@ mod tests {
         assert!(existing.stage_protocol_generation_supported);
     }
 
+    #[test]
+    fn test_apply_transitive_ann_refreshes_advertised_model_throughput() {
+        let mut existing = test_peer(Some(100));
+        let mut ann = test_announcement(Some(100));
+        ann.advertised_model_throughput = vec![crate::network::metrics::ModelThroughputHint {
+            model_name: "qwen".to_string(),
+            avg_tokens_per_second_milli: 35_000,
+            throughput_samples: 4,
+        }];
+
+        apply_transitive_ann(
+            &mut existing,
+            &test_addr(0x33),
+            &ann,
+            test_endpoint_id(0xee),
+        );
+
+        assert_eq!(
+            existing.advertised_model_throughput,
+            ann.advertised_model_throughput
+        );
+    }
+
     #[tokio::test]
     async fn test_add_peer_refreshes_stage_status_list_support() {
         let node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
@@ -1393,6 +1427,31 @@ mod tests {
         let state = node.state.lock().await;
         let peer = state.peers.get(&peer_id).expect("peer should be tracked");
         assert!(peer.stage_protocol_generation_supported);
+    }
+
+    #[tokio::test]
+    async fn test_add_peer_refreshes_advertised_model_throughput() {
+        let node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
+        let peer_id = test_endpoint_id(0x46);
+        let addr = test_addr(0x46);
+        let mut ann = test_announcement(Some(100));
+        ann.advertised_model_throughput = vec![crate::network::metrics::ModelThroughputHint {
+            model_name: "qwen".to_string(),
+            avg_tokens_per_second_milli: 20_000,
+            throughput_samples: 2,
+        }];
+
+        node.add_peer(peer_id, addr.clone(), &ann).await;
+        ann.advertised_model_throughput[0].avg_tokens_per_second_milli = 48_000;
+        ann.advertised_model_throughput[0].throughput_samples = 9;
+        node.add_peer(peer_id, addr, &ann).await;
+
+        let state = node.state.lock().await;
+        let peer = state.peers.get(&peer_id).expect("peer should be tracked");
+        assert_eq!(
+            peer.advertised_model_throughput,
+            ann.advertised_model_throughput
+        );
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -977,6 +977,7 @@ pub(crate) struct PeerAnnouncement {
     pub(crate) artifact_transfer_supported: bool,
     pub(crate) stage_protocol_generation_supported: bool,
     pub(crate) stage_status_list_supported: bool,
+    pub(crate) advertised_model_throughput: Vec<crate::network::metrics::ModelThroughputHint>,
     pub(crate) latency_ms: Option<u32>,
     pub(crate) latency_source: Option<crate::proto::node::LatencySource>,
     pub(crate) latency_age_ms: Option<u64>,
@@ -1069,6 +1070,7 @@ pub struct PeerInfo {
     pub artifact_transfer_supported: bool,
     pub stage_protocol_generation_supported: bool,
     pub stage_status_list_supported: bool,
+    pub(crate) advertised_model_throughput: Vec<crate::network::metrics::ModelThroughputHint>,
     /// Most recent direct RTT sample for display purposes (refreshed periodically).
     pub display_rtt: Option<DirectLatencyObservation>,
     /// Latency propagated via transitive gossip.
@@ -1141,6 +1143,7 @@ impl PeerInfo {
             artifact_transfer_supported: ann.artifact_transfer_supported,
             stage_protocol_generation_supported: ann.stage_protocol_generation_supported,
             stage_status_list_supported: ann.stage_status_list_supported,
+            advertised_model_throughput: ann.advertised_model_throughput.clone(),
             display_rtt: None,
             propagated_latency: None,
             owner_summary,
@@ -3254,6 +3257,20 @@ impl Node {
             .peers
             .get(&peer_id)
             .and_then(|peer| peer.advertised_context_length(model_name))
+    }
+
+    pub(crate) async fn peer_model_throughput_hint(
+        &self,
+        peer_id: EndpointId,
+        model_name: &str,
+    ) -> Option<crate::network::metrics::ModelThroughputHint> {
+        let state = self.state.lock().await;
+        state.peers.get(&peer_id).and_then(|peer| {
+            peer.advertised_model_throughput
+                .iter()
+                .find(|hint| hint.model_name == model_name)
+                .cloned()
+        })
     }
 
     pub async fn served_model_descriptors(&self) -> Vec<ServedModelDescriptor> {

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -973,6 +973,8 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
         stage_protocol_generation_supported: false,
         stage_status_list_supported: false,
         owner_summary: OwnershipSummary::default(),
+        advertised_model_throughput: vec![],
+
         display_rtt: None,
         propagated_latency: None,
     }
@@ -3017,6 +3019,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         artifact_transfer_supported: false,
         stage_protocol_generation_supported: false,
         stage_status_list_supported: false,
+        advertised_model_throughput: vec![],
         latency_ms: None,
         latency_source: None,
         latency_age_ms: None,
@@ -3297,6 +3300,7 @@ fn transitive_peer_update_refreshes_metadata_fields() {
         artifact_transfer_supported: true,
         stage_protocol_generation_supported: true,
         stage_status_list_supported: true,
+        advertised_model_throughput: vec![],
         latency_ms: None,
         latency_source: None,
         latency_age_ms: None,
@@ -3382,6 +3386,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
         artifact_transfer_supported: true,
         stage_protocol_generation_supported: true,
         stage_status_list_supported: true,
+        advertised_model_throughput: vec![],
         latency_ms: None,
         latency_source: None,
         latency_age_ms: None,
@@ -3441,6 +3446,7 @@ fn transitive_peer_merge_preserves_richer_direct_address() {
         artifact_transfer_supported: true,
         stage_protocol_generation_supported: true,
         stage_status_list_supported: true,
+        advertised_model_throughput: vec![],
         latency_ms: None,
         latency_source: None,
         latency_age_ms: None,
@@ -4023,6 +4029,7 @@ fn transitive_peer_update_refreshes_last_mentioned() {
         artifact_transfer_supported: true,
         stage_protocol_generation_supported: true,
         stage_status_list_supported: true,
+        advertised_model_throughput: vec![],
         latency_ms: None,
         latency_source: None,
         latency_age_ms: None,
@@ -4775,6 +4782,8 @@ fn make_test_peer(id: EndpointId, rtt_ms: Option<u32>, vram_gb: u64) -> PeerInfo
         stage_protocol_generation_supported: false,
         stage_status_list_supported: false,
         owner_summary: OwnershipSummary::default(),
+        advertised_model_throughput: vec![],
+
         display_rtt: None,
         propagated_latency: None,
     }

--- a/crates/mesh-llm-host-runtime/src/network/metrics.rs
+++ b/crates/mesh-llm-host-runtime/src/network/metrics.rs
@@ -3,7 +3,7 @@
 
 use serde::Serialize;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
@@ -14,6 +14,10 @@ const MAX_TRACKED_MODELS: usize = 128;
 const MAX_TARGETS_PER_MODEL: usize = 16;
 const DEFAULT_MODEL_SHARDS: usize = 32;
 const THROUGHPUT_SCALE_MILLI: u64 = 1000;
+pub(crate) const MAX_ADVERTISED_MODEL_THROUGHPUT_HINTS: usize = 64;
+pub(crate) const MAX_ADVERTISED_MODEL_NAME_BYTES: usize = 256;
+pub(crate) const MAX_ADVERTISED_TPS_MILLI: u64 = 100_000 * THROUGHPUT_SCALE_MILLI;
+pub(crate) const MAX_ADVERTISED_THROUGHPUT_SAMPLES: u64 = 256;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum MetricLayer {
@@ -209,6 +213,48 @@ pub struct ModelRoutingMetricsSnapshot {
 pub(crate) struct RoutingCollectorSnapshot {
     pub status: RoutingMetricsStatusSnapshot,
     pub models: HashMap<String, ModelRoutingMetricsSnapshot>,
+}
+
+/// Soft peer-advertised model throughput hint.
+///
+/// Values are fixed-point milli tokens/second to keep gossip deterministic and
+/// avoid protobuf floating-point edge cases. They are advisory only; routing
+/// clamps and local observations take precedence.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ModelThroughputHint {
+    pub(crate) model_name: String,
+    pub(crate) avg_tokens_per_second_milli: u64,
+    pub(crate) throughput_samples: u64,
+}
+
+pub(crate) fn sanitize_model_throughput_hints<I>(hints: I) -> Vec<ModelThroughputHint>
+where
+    I: IntoIterator<Item = ModelThroughputHint>,
+{
+    let mut seen = HashSet::new();
+    let mut sanitized = Vec::new();
+    for mut hint in hints {
+        hint.model_name = hint.model_name.trim().to_string();
+        if hint.model_name.is_empty()
+            || hint.model_name.len() > MAX_ADVERTISED_MODEL_NAME_BYTES
+            || hint.avg_tokens_per_second_milli == 0
+            || hint.throughput_samples == 0
+            || !seen.insert(hint.model_name.clone())
+        {
+            continue;
+        }
+        hint.avg_tokens_per_second_milli = hint
+            .avg_tokens_per_second_milli
+            .min(MAX_ADVERTISED_TPS_MILLI);
+        hint.throughput_samples = hint
+            .throughput_samples
+            .min(MAX_ADVERTISED_THROUGHPUT_SAMPLES);
+        sanitized.push(hint);
+        if sanitized.len() >= MAX_ADVERTISED_MODEL_THROUGHPUT_HINTS {
+            break;
+        }
+    }
+    sanitized
 }
 
 /// Local-only per-target routing outcome memory exposed on `/api/models`.
@@ -440,6 +486,89 @@ impl RoutingMetrics {
         }
         let tps = average_milli(metrics.throughput_tps_milli_sum, samples)?;
         Some((tps, samples))
+    }
+
+    /// Return bounded local-throughput hints that this node can safely advertise.
+    ///
+    /// Only local targets for currently hosted models are included. Remote and
+    /// endpoint observations are measurements this node made while routing, not
+    /// proof of this node's serving speed, so they are intentionally excluded.
+    pub(crate) fn advertisable_model_throughput(
+        &self,
+        hosted_models: &[String],
+    ) -> Vec<ModelThroughputHint> {
+        let now = Instant::now();
+        let mut seen = HashSet::new();
+        let mut hints = Vec::new();
+
+        for model in hosted_models {
+            let model = model.trim();
+            if model.is_empty() || !seen.insert(model.to_string()) {
+                continue;
+            }
+
+            let shard_index = self.shard_index(model);
+            let mut shard = self.shards[shard_index].lock().unwrap();
+            shard.compact(now, &self.config);
+            let Some(metrics) = shard.models.get(model) else {
+                continue;
+            };
+
+            let mut tps_milli_sum = 0_u64;
+            let mut samples = 0_u64;
+            for (target, target_metrics) in &metrics.targets {
+                if target.kind != TargetKind::Local || target_metrics.throughput_samples == 0 {
+                    continue;
+                }
+                tps_milli_sum =
+                    tps_milli_sum.saturating_add(target_metrics.throughput_tps_milli_sum);
+                samples = samples.saturating_add(target_metrics.throughput_samples);
+            }
+
+            if samples == 0 {
+                continue;
+            }
+            let Some(avg_tokens_per_second_milli) = average_milli_raw(tps_milli_sum, samples)
+            else {
+                continue;
+            };
+            hints.push(ModelThroughputHint {
+                model_name: model.to_string(),
+                avg_tokens_per_second_milli: avg_tokens_per_second_milli
+                    .min(MAX_ADVERTISED_TPS_MILLI),
+                throughput_samples: samples.min(MAX_ADVERTISED_THROUGHPUT_SAMPLES),
+            });
+            if hints.len() >= MAX_ADVERTISED_MODEL_THROUGHPUT_HINTS {
+                break;
+            }
+        }
+
+        sanitize_model_throughput_hints(hints)
+    }
+
+    pub(crate) fn throughput_hint_for_target(
+        &self,
+        model: &str,
+        target: AttemptTarget,
+    ) -> Option<ModelThroughputHint> {
+        let now = Instant::now();
+        let shard_index = self.shard_index(model);
+        let mut shard = self.shards[shard_index].lock().unwrap();
+        shard.compact(now, &self.config);
+        let metrics = shard.models.get(model)?;
+        let target = target.key();
+        let metrics = metrics.targets.get(&target)?;
+        let samples = metrics.throughput_samples;
+        if samples == 0 {
+            return None;
+        }
+        let avg_tokens_per_second_milli =
+            average_milli_raw(metrics.throughput_tps_milli_sum, samples)?;
+        Some(ModelThroughputHint {
+            model_name: model.to_string(),
+            avg_tokens_per_second_milli,
+            throughput_samples: samples,
+        })
     }
 
     fn shard_index(&self, model: &str) -> usize {
@@ -1055,11 +1184,12 @@ fn average(total: u64, count: u64) -> f64 {
 }
 
 fn average_milli(total_milli: u64, count: u64) -> Option<f64> {
-    if count == 0 {
-        None
-    } else {
-        Some(total_milli as f64 / THROUGHPUT_SCALE_MILLI as f64 / count as f64)
-    }
+    average_milli_raw(total_milli, count)
+        .map(|avg_milli| avg_milli as f64 / THROUGHPUT_SCALE_MILLI as f64)
+}
+
+fn average_milli_raw(total_milli: u64, count: u64) -> Option<u64> {
+    (count != 0).then(|| total_milli / count)
 }
 
 fn tokens_per_second_milli(tokens: u64, elapsed: Duration) -> Option<u64> {
@@ -1286,6 +1416,115 @@ mod tests {
         assert_eq!(status.request_count, 1);
         assert_eq!(status.successful_requests, 1);
         assert!(metrics.model_snapshots().is_empty());
+    }
+
+    #[test]
+    fn routing_metrics_advertises_only_local_hosted_model_throughput() {
+        let metrics = RoutingMetrics::new();
+        metrics.record_attempt(
+            Some("qwen"),
+            AttemptTarget::Local("127.0.0.1:9337".into()),
+            Duration::from_millis(2),
+            Duration::from_millis(1_000),
+            AttemptOutcome::Success,
+            Some(42),
+        );
+        metrics.record_attempt(
+            Some("remote-only"),
+            AttemptTarget::Remote("peer-a".into()),
+            Duration::from_millis(2),
+            Duration::from_millis(1_000),
+            AttemptOutcome::Success,
+            Some(200),
+        );
+        metrics.record_attempt(
+            Some("failed-local"),
+            AttemptTarget::Local("127.0.0.1:9338".into()),
+            Duration::from_millis(2),
+            Duration::from_millis(1_000),
+            AttemptOutcome::Timeout,
+            None,
+        );
+
+        let hosted = vec![
+            "qwen".to_string(),
+            "remote-only".to_string(),
+            "failed-local".to_string(),
+        ];
+        let hints = metrics.advertisable_model_throughput(&hosted);
+
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].model_name, "qwen");
+        assert_eq!(hints[0].avg_tokens_per_second_milli, 42_000);
+        assert_eq!(hints[0].throughput_samples, 1);
+    }
+
+    #[test]
+    fn throughput_hint_for_target_ignores_expired_metrics() {
+        let metrics = RoutingMetrics::new();
+        let target = AttemptTarget::Local("127.0.0.1:9337".into());
+        metrics.record_attempt(
+            Some("qwen"),
+            target.clone(),
+            Duration::from_millis(2),
+            Duration::from_millis(1_000),
+            AttemptOutcome::Success,
+            Some(42),
+        );
+
+        assert!(metrics
+            .throughput_hint_for_target("qwen", target.clone())
+            .is_some());
+        metrics.age_model_for_test("qwen", METRICS_TTL + Duration::from_secs(1));
+
+        assert!(metrics.throughput_hint_for_target("qwen", target).is_none());
+    }
+
+    #[test]
+    fn sanitize_model_throughput_hints_drops_invalid_and_clamps_values() {
+        let hints = sanitize_model_throughput_hints([
+            ModelThroughputHint {
+                model_name: "  qwen  ".to_string(),
+                avg_tokens_per_second_milli: MAX_ADVERTISED_TPS_MILLI + 1,
+                throughput_samples: MAX_ADVERTISED_THROUGHPUT_SAMPLES + 1,
+            },
+            ModelThroughputHint {
+                model_name: "qwen".to_string(),
+                avg_tokens_per_second_milli: 42_000,
+                throughput_samples: 7,
+            },
+            ModelThroughputHint {
+                model_name: "".to_string(),
+                avg_tokens_per_second_milli: 42_000,
+                throughput_samples: 7,
+            },
+            ModelThroughputHint {
+                model_name: "x".repeat(MAX_ADVERTISED_MODEL_NAME_BYTES + 1),
+                avg_tokens_per_second_milli: 42_000,
+                throughput_samples: 7,
+            },
+            ModelThroughputHint {
+                model_name: "empty-speed".to_string(),
+                avg_tokens_per_second_milli: 0,
+                throughput_samples: 7,
+            },
+            ModelThroughputHint {
+                model_name: "empty-samples".to_string(),
+                avg_tokens_per_second_milli: 42_000,
+                throughput_samples: 0,
+            },
+        ]);
+
+        assert_eq!(hints.len(), 1);
+        assert_eq!(hints[0].model_name, "qwen");
+        assert_eq!(
+            hints[0].avg_tokens_per_second_milli,
+            MAX_ADVERTISED_TPS_MILLI
+        );
+        assert_eq!(
+            hints[0].throughput_samples,
+            MAX_ADVERTISED_THROUGHPUT_SAMPLES
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -962,36 +962,158 @@ pub(crate) fn request_budget_tokens_from_parts(
     )
 }
 
-fn reorder_candidates_by_context<T: Clone>(
-    candidates: &[(T, Option<u32>)],
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct TargetThroughputRank {
+    avg_tokens_per_second_milli: u64,
+    throughput_samples: u64,
+    local_observation: bool,
+}
+
+#[derive(Clone)]
+struct RankedTarget<T> {
+    index: usize,
+    candidate: T,
+    context_length: Option<u32>,
+    throughput: Option<TargetThroughputRank>,
+}
+
+const LOCAL_THROUGHPUT_PRECEDENCE_SAMPLES: u64 = 3;
+const TARGET_THROUGHPUT_MAX_SCORE_SAMPLES: u64 = 32;
+
+fn target_throughput_rank_key(throughput: Option<TargetThroughputRank>) -> (bool, bool, u64, u64) {
+    let Some(throughput) = throughput else {
+        return (false, false, 0, 0);
+    };
+    if throughput.avg_tokens_per_second_milli == 0 || throughput.throughput_samples == 0 {
+        return (false, false, 0, 0);
+    }
+    let sample_weight = throughput
+        .throughput_samples
+        .min(TARGET_THROUGHPUT_MAX_SCORE_SAMPLES);
+    (
+        true,
+        throughput.local_observation,
+        throughput.avg_tokens_per_second_milli,
+        sample_weight,
+    )
+}
+
+fn sort_ranked_targets<T>(targets: &mut [RankedTarget<T>]) {
+    targets.sort_by(|a, b| {
+        target_throughput_rank_key(b.throughput)
+            .cmp(&target_throughput_rank_key(a.throughput))
+            .then_with(|| a.index.cmp(&b.index))
+    });
+}
+
+fn reorder_candidates_by_context_and_throughput<T: Clone>(
+    candidates: &[(T, Option<u32>, Option<TargetThroughputRank>)],
     required_tokens: Option<u32>,
 ) -> Vec<T> {
+    let ranked = candidates
+        .iter()
+        .enumerate()
+        .map(
+            |(index, (candidate, context_length, throughput))| RankedTarget {
+                index,
+                candidate: candidate.clone(),
+                context_length: *context_length,
+                throughput: *throughput,
+            },
+        )
+        .collect::<Vec<_>>();
+
     let Some(required_tokens) = required_tokens else {
-        return candidates
-            .iter()
-            .map(|(candidate, _)| candidate.clone())
-            .collect();
+        let mut ranked = ranked;
+        sort_ranked_targets(&mut ranked);
+        return ranked.into_iter().map(|ranked| ranked.candidate).collect();
     };
 
     let mut adequate = Vec::new();
     let mut unknown = Vec::new();
-    for (candidate, context_length) in candidates {
-        match context_length {
-            Some(value) if *value >= required_tokens => adequate.push(candidate.clone()),
+    for ranked in ranked {
+        match ranked.context_length {
+            Some(value) if value >= required_tokens => adequate.push(ranked),
             Some(_) => {}
-            None => unknown.push(candidate.clone()),
+            None => unknown.push(ranked),
         }
     }
 
     if adequate.is_empty() && unknown.is_empty() {
-        candidates
+        let mut fallback = candidates
             .iter()
-            .map(|(candidate, _)| candidate.clone())
-            .collect()
-    } else {
-        adequate.extend(unknown);
-        adequate
+            .enumerate()
+            .map(
+                |(index, (candidate, context_length, throughput))| RankedTarget {
+                    index,
+                    candidate: candidate.clone(),
+                    context_length: *context_length,
+                    throughput: *throughput,
+                },
+            )
+            .collect::<Vec<_>>();
+        sort_ranked_targets(&mut fallback);
+        return fallback
+            .into_iter()
+            .map(|ranked| ranked.candidate)
+            .collect();
     }
+
+    sort_ranked_targets(&mut adequate);
+    sort_ranked_targets(&mut unknown);
+    adequate
+        .into_iter()
+        .chain(unknown)
+        .map(|ranked| ranked.candidate)
+        .collect()
+}
+
+fn local_target_throughput_rank(
+    node: &mesh::Node,
+    model: &str,
+    target: &election::InferenceTarget,
+) -> Option<TargetThroughputRank> {
+    let attempt_target = match target {
+        election::InferenceTarget::Local(port) => {
+            crate::network::metrics::AttemptTarget::Local(format!("127.0.0.1:{port}"))
+        }
+        election::InferenceTarget::Remote(peer_id) => {
+            crate::network::metrics::AttemptTarget::Remote(peer_id.fmt_short().to_string())
+        }
+        election::InferenceTarget::None => return None,
+    };
+    node.routing_metrics()
+        .throughput_hint_for_target(model, attempt_target)
+        .map(|hint| TargetThroughputRank {
+            avg_tokens_per_second_milli: hint.avg_tokens_per_second_milli,
+            throughput_samples: hint.throughput_samples,
+            local_observation: true,
+        })
+}
+
+async fn remote_target_throughput_rank(
+    node: &mesh::Node,
+    model: &str,
+    peer_id: iroh::EndpointId,
+) -> Option<TargetThroughputRank> {
+    let target = election::InferenceTarget::Remote(peer_id);
+    let local = local_target_throughput_rank(node, model, &target);
+    if local
+        .map(|hint| hint.throughput_samples >= LOCAL_THROUGHPUT_PRECEDENCE_SAMPLES)
+        .unwrap_or(false)
+    {
+        return local;
+    }
+
+    let gossiped = node
+        .peer_model_throughput_hint(peer_id, model)
+        .await
+        .map(|hint| TargetThroughputRank {
+            avg_tokens_per_second_milli: hint.avg_tokens_per_second_milli,
+            throughput_samples: hint.throughput_samples,
+            local_observation: false,
+        });
+    gossiped.or(local)
 }
 
 async fn order_remote_hosts_by_context(
@@ -1002,9 +1124,13 @@ async fn order_remote_hosts_by_context(
 ) -> Vec<iroh::EndpointId> {
     let mut candidates = Vec::with_capacity(hosts.len());
     for host in hosts {
-        candidates.push((*host, node.peer_model_context_length(*host, model).await));
+        candidates.push((
+            *host,
+            node.peer_model_context_length(*host, model).await,
+            remote_target_throughput_rank(node, model, *host).await,
+        ));
     }
-    reorder_candidates_by_context(&candidates, required_tokens)
+    reorder_candidates_by_context_and_throughput(&candidates, required_tokens)
 }
 
 async fn order_targets_by_context(
@@ -1022,9 +1148,15 @@ async fn order_targets_by_context(
             }
             election::InferenceTarget::None => None,
         };
-        candidates.push((target.clone(), context_length));
+        let throughput = match target {
+            election::InferenceTarget::Remote(peer_id) => {
+                remote_target_throughput_rank(node, model, *peer_id).await
+            }
+            _ => local_target_throughput_rank(node, model, target),
+        };
+        candidates.push((target.clone(), context_length, throughput));
     }
-    reorder_candidates_by_context(&candidates, required_tokens)
+    reorder_candidates_by_context_and_throughput(&candidates, required_tokens)
 }
 
 fn move_target_first<T: PartialEq>(targets: &mut [T], target: &T) -> bool {
@@ -2825,7 +2957,8 @@ async fn order_mesh_target_hosts(
     let Some(name) = effective_model else {
         return target_hosts;
     };
-    let ordered = order_remote_hosts_by_context(node, name, required_tokens, &target_hosts).await;
+    let mut ordered =
+        order_remote_hosts_by_context(node, name, required_tokens, &target_hosts).await;
     if let (Some(prefix_hash), Some(election::InferenceTarget::Remote(cached_host))) =
         (prepared.learn_prefix_hash, prepared.cached_target.as_ref())
     {
@@ -2837,6 +2970,8 @@ async fn order_mesh_target_hosts(
                 prefix_hash,
                 &election::InferenceTarget::Remote(*cached_host),
             );
+        } else {
+            move_target_first(&mut ordered, cached_host);
         }
     }
     ordered
@@ -5068,8 +5203,12 @@ mod tests {
 
     #[test]
     fn test_reorder_candidates_by_context_prefers_known_fit_then_unknown() {
-        let ordered = reorder_candidates_by_context(
-            &[(1u8, Some(4096)), (2u8, None), (3u8, Some(16384))],
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (1u8, Some(4096), None),
+                (2u8, None, None),
+                (3u8, Some(16384), None),
+            ],
             Some(8192),
         );
 
@@ -5078,8 +5217,140 @@ mod tests {
 
     #[test]
     fn test_reorder_candidates_by_context_falls_back_when_all_known_too_small() {
-        let ordered =
-            reorder_candidates_by_context(&[(1u8, Some(4096)), (2u8, Some(6144))], Some(8192));
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[(1u8, Some(4096), None), (2u8, Some(6144), None)],
+            Some(8192),
+        );
+
+        assert_eq!(ordered, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_reorder_candidates_without_throughput_preserves_stable_order() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (1u8, Some(8192), None),
+                (2u8, Some(8192), None),
+                (3u8, None, None),
+            ],
+            Some(4096),
+        );
+
+        assert_eq!(ordered, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_reorder_candidates_by_throughput_prefers_stronger_hint() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (
+                    1u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 10_000,
+                        throughput_samples: 4,
+                        local_observation: false,
+                    }),
+                ),
+                (
+                    2u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 40_000,
+                        throughput_samples: 4,
+                        local_observation: false,
+                    }),
+                ),
+            ],
+            Some(4096),
+        );
+
+        assert_eq!(ordered, vec![2, 1]);
+    }
+
+    #[test]
+    fn test_reorder_candidates_uses_samples_as_tiebreaker_not_multiplier() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (
+                    1u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 20_000,
+                        throughput_samples: 32,
+                        local_observation: false,
+                    }),
+                ),
+                (
+                    2u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 40_000,
+                        throughput_samples: 2,
+                        local_observation: false,
+                    }),
+                ),
+            ],
+            Some(4096),
+        );
+
+        assert_eq!(ordered, vec![2, 1]);
+    }
+
+    #[test]
+    fn test_reorder_candidates_keeps_context_fit_ahead_of_faster_unknown() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (
+                    1u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 10_000,
+                        throughput_samples: 4,
+                        local_observation: false,
+                    }),
+                ),
+                (
+                    2u8,
+                    None,
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 90_000,
+                        throughput_samples: 16,
+                        local_observation: false,
+                    }),
+                ),
+            ],
+            Some(4096),
+        );
+
+        assert_eq!(ordered, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_reorder_candidates_weights_local_observations_above_gossip() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (
+                    1u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 20_000,
+                        throughput_samples: 3,
+                        local_observation: true,
+                    }),
+                ),
+                (
+                    2u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 50_000,
+                        throughput_samples: 4,
+                        local_observation: false,
+                    }),
+                ),
+            ],
+            Some(4096),
+        );
 
         assert_eq!(ordered, vec![1, 2]);
     }

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -3,7 +3,7 @@ use crate::mesh::RouteEntry;
 use crate::mesh::{ModelDemand, NodeRole, PeerAnnouncement, RoutingTable};
 use crate::protocol::NODE_PROTOCOL_GENERATION;
 use iroh::{EndpointAddr, EndpointId};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 fn skippy_stage_subprotocols(
     artifact_transfer_supported: bool,
@@ -414,7 +414,45 @@ pub(crate) fn sanitize_gossip_announcement_for_wire(ann: &PeerAnnouncement) -> P
     sanitized.available_models.clear();
     sanitized.available_model_metadata.clear();
     sanitized.available_model_sizes.clear();
+    sanitized.advertised_model_throughput = sanitize_model_throughput_hints_for_ann(&sanitized);
     sanitized
+}
+
+fn routable_model_names(ann: &PeerAnnouncement) -> HashSet<String> {
+    let mut names = HashSet::new();
+    for model in ann
+        .hosted_models
+        .iter()
+        .flatten()
+        .chain(&ann.serving_models)
+    {
+        let model = model.trim();
+        if !model.is_empty() {
+            names.insert(model.to_string());
+        }
+    }
+    for descriptor in &ann.served_model_descriptors {
+        let model = descriptor.identity.model_name.trim();
+        if !model.is_empty() {
+            names.insert(model.to_string());
+        }
+    }
+    names
+}
+
+fn sanitize_model_throughput_hints_for_ann(
+    ann: &PeerAnnouncement,
+) -> Vec<crate::network::metrics::ModelThroughputHint> {
+    let routable = routable_model_names(ann);
+    if routable.is_empty() {
+        return Vec::new();
+    }
+    crate::network::metrics::sanitize_model_throughput_hints(
+        ann.advertised_model_throughput.clone(),
+    )
+    .into_iter()
+    .filter(|hint| routable.contains(&hint.model_name))
+    .collect()
 }
 
 pub(crate) fn local_role_to_proto(role: &NodeRole) -> (i32, Option<u32>) {
@@ -435,6 +473,26 @@ pub(crate) fn proto_role_to_local(role_int: i32, http_port: Option<u32>) -> Node
         },
         crate::proto::node::NodeRole::Client => NodeRole::Client,
         _ => NodeRole::Worker,
+    }
+}
+
+fn local_throughput_hint_to_proto(
+    hint: &crate::network::metrics::ModelThroughputHint,
+) -> crate::proto::node::AdvertisedModelThroughput {
+    crate::proto::node::AdvertisedModelThroughput {
+        model_name: hint.model_name.clone(),
+        avg_tokens_per_second_milli: hint.avg_tokens_per_second_milli,
+        throughput_samples: hint.throughput_samples,
+    }
+}
+
+fn proto_throughput_hint_to_local(
+    hint: &crate::proto::node::AdvertisedModelThroughput,
+) -> crate::network::metrics::ModelThroughputHint {
+    crate::network::metrics::ModelThroughputHint {
+        model_name: hint.model_name.clone(),
+        avg_tokens_per_second_milli: hint.avg_tokens_per_second_milli,
+        throughput_samples: hint.throughput_samples,
     }
 }
 
@@ -553,6 +611,10 @@ pub(crate) fn local_ann_to_proto_ann(
             .latency_observer_id
             .as_ref()
             .map(|id| id.as_bytes().to_vec()),
+        advertised_model_throughput: sanitize_model_throughput_hints_for_ann(&ann)
+            .iter()
+            .map(local_throughput_hint_to_proto)
+            .collect(),
         subprotocols: skippy_stage_subprotocols(
             ann.artifact_transfer_supported,
             ann.stage_protocol_generation_supported,
@@ -727,6 +789,11 @@ pub(crate) fn proto_ann_to_local(
         artifact_transfer_supported: supports_skippy_artifact_transfer(&pa.subprotocols),
         stage_protocol_generation_supported: supports_skippy_stage_generation(&pa.subprotocols),
         stage_status_list_supported: supports_skippy_status_list(&pa.subprotocols),
+        advertised_model_throughput: pa
+            .advertised_model_throughput
+            .iter()
+            .map(proto_throughput_hint_to_local)
+            .collect(),
         latency_ms: pa.latency_ms,
         latency_source: crate::proto::node::LatencySource::try_from(pa.latency_source).ok(),
         latency_age_ms: pa.latency_age_ms.map(|v| v as u64),
@@ -736,6 +803,7 @@ pub(crate) fn proto_ann_to_local(
         }),
     };
     crate::mesh::backfill_legacy_descriptors(&mut ann);
+    ann.advertised_model_throughput = sanitize_model_throughput_hints_for_ann(&ann);
     Some((addr, ann))
 }
 

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -834,6 +834,8 @@ mod tests {
             stage_protocol_generation_supported: false,
             stage_status_list_supported: false,
             owner_summary: OwnershipSummary::default(),
+            advertised_model_throughput: vec![],
+
             display_rtt: None,
             propagated_latency: None,
         }
@@ -1267,6 +1269,7 @@ mod tests {
             artifact_transfer_supported: true,
             stage_protocol_generation_supported: true,
             stage_status_list_supported: true,
+            advertised_model_throughput: vec![],
             latency_ms: None,
             latency_source: None,
             latency_age_ms: None,
@@ -1311,6 +1314,87 @@ mod tests {
         assert_eq!(roundtripped.claim.owner_id, "owner-abc");
         assert_eq!(roundtripped.claim.cert_id, "cert-123");
         assert_eq!(roundtripped.claim.node_label.as_deref(), Some("studio"));
+    }
+
+    #[test]
+    fn advertised_model_throughput_roundtrips_through_proto_announcement() {
+        let peer_id = EndpointId::from(SecretKey::from_bytes(&[0xAC; 32]).public());
+        let expected_hints = vec![crate::network::metrics::ModelThroughputHint {
+            model_name: "qwen".to_string(),
+            avg_tokens_per_second_milli: 42_000,
+            throughput_samples: 7,
+        }];
+        let ann = super::PeerAnnouncement {
+            addr: iroh::EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            },
+            role: super::NodeRole::Host { http_port: 9337 },
+            first_joined_mesh_ts: None,
+            models: vec![],
+            vram_bytes: 0,
+            model_source: None,
+            serving_models: vec!["qwen".to_string()],
+            hosted_models: Some(vec!["qwen".to_string()]),
+            available_models: vec![],
+            requested_models: vec![],
+            explicit_model_interests: vec![],
+            version: None,
+            model_demand: HashMap::new(),
+            mesh_id: None,
+            gpu_name: None,
+            hostname: None,
+            is_soc: None,
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            available_model_metadata: vec![],
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: vec![],
+            served_model_runtime: vec![],
+            owner_attestation: None,
+            artifact_transfer_supported: false,
+            stage_protocol_generation_supported: false,
+            stage_status_list_supported: false,
+            advertised_model_throughput: vec![
+                expected_hints[0].clone(),
+                crate::network::metrics::ModelThroughputHint {
+                    model_name: "ghost".to_string(),
+                    avg_tokens_per_second_milli: 250_000,
+                    throughput_samples: 99,
+                },
+            ],
+            latency_ms: None,
+            latency_source: None,
+            latency_age_ms: None,
+            latency_observer_id: None,
+        };
+
+        let mut proto_pa = local_ann_to_proto_ann(&ann);
+        assert_eq!(proto_pa.advertised_model_throughput.len(), 1);
+        assert_eq!(proto_pa.advertised_model_throughput[0].model_name, "qwen");
+        assert_eq!(
+            proto_pa.advertised_model_throughput[0].avg_tokens_per_second_milli,
+            42_000
+        );
+        assert_eq!(
+            proto_pa.advertised_model_throughput[0].throughput_samples,
+            7
+        );
+        proto_pa
+            .advertised_model_throughput
+            .push(crate::proto::node::AdvertisedModelThroughput {
+                model_name: "ghost".to_string(),
+                avg_tokens_per_second_milli: 250_000,
+                throughput_samples: 99,
+            });
+
+        let (_, roundtripped) =
+            proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
+        assert_eq!(roundtripped.advertised_model_throughput, expected_hints);
     }
 
     #[test]
@@ -1396,6 +1480,7 @@ mod tests {
             artifact_transfer_supported: true,
             stage_protocol_generation_supported: true,
             stage_status_list_supported: true,
+            advertised_model_throughput: vec![],
             latency_ms: None,
             latency_source: None,
             latency_age_ms: None,
@@ -1959,6 +2044,7 @@ mod tests {
             artifact_transfer_supported: true,
             stage_protocol_generation_supported: true,
             stage_status_list_supported: true,
+            advertised_model_throughput: vec![],
             latency_ms: None,
             latency_source: None,
             latency_age_ms: None,
@@ -2010,6 +2096,7 @@ mod tests {
             artifact_transfer_supported: false,
             stage_protocol_generation_supported: false,
             stage_status_list_supported: false,
+            advertised_model_throughput: vec![],
             latency_ms: None,
             latency_source: None,
             latency_age_ms: None,

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3463,6 +3463,8 @@ mod tests {
             artifact_transfer_supported: false,
             stage_protocol_generation_supported,
             stage_status_list_supported: false,
+            advertised_model_throughput: vec![],
+
             display_rtt: None,
             propagated_latency: None,
             owner_summary: crate::crypto::OwnershipSummary::default(),

--- a/crates/mesh-llm-protocol/proto/node.proto
+++ b/crates/mesh-llm-protocol/proto/node.proto
@@ -51,6 +51,7 @@ message PeerAnnouncement {
   optional LatencySource latency_source = 41;
   optional uint32 latency_age_ms = 42;
   optional bytes latency_observer_id = 43;
+  repeated AdvertisedModelThroughput advertised_model_throughput = 44;
 
 enum LatencySource {
   LATENCY_SOURCE_UNSPECIFIED = 0;
@@ -58,6 +59,12 @@ enum LatencySource {
   LATENCY_SOURCE_ESTIMATED = 2;    // Estimated via transitive gossip
   LATENCY_SOURCE_UNKNOWN = 3;      // Unknown source (e.g. propagated with no origin)
 }
+}
+
+message AdvertisedModelThroughput {
+  string model_name = 1;
+  uint64 avg_tokens_per_second_milli = 2;
+  uint64 throughput_samples = 3;
 }
 
 message MeshSubprotocol {

--- a/crates/mesh-llm-protocol/src/proto/node.rs
+++ b/crates/mesh-llm-protocol/src/proto/node.rs
@@ -116,6 +116,17 @@ pub struct PeerAnnouncement {
     pub latency_age_ms: ::core::option::Option<u32>,
     #[prost(bytes = "vec", optional, tag = "43")]
     pub latency_observer_id: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
+    #[prost(message, repeated, tag = "44")]
+    pub advertised_model_throughput: ::prost::alloc::vec::Vec<AdvertisedModelThroughput>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AdvertisedModelThroughput {
+    #[prost(string, tag = "1")]
+    pub model_name: ::prost::alloc::string::String,
+    #[prost(uint64, tag = "2")]
+    pub avg_tokens_per_second_milli: u64,
+    #[prost(uint64, tag = "3")]
+    pub throughput_samples: u64,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MeshSubprotocol {


### PR DESCRIPTION
## Summary

Mesh peers can now share bounded observed tokens-per-second hints for hosted models through gossip, so routing can make a better choice when multiple targets are otherwise viable.

- Adds an additive `advertised_model_throughput` gossip/protobuf field for per-model throughput hints.
- Publishes only sanitized local serving observations for currently hosted models; remote and endpoint observations are not advertised as this node's own speed.
- Uses peer hints as an advisory routing signal after context-capacity filtering, with local observations weighted ahead of gossip.
- Adds tests for local hint generation, gossip/protobuf round-trip, peer refresh, routing order, and v0 compatibility.

## Why

This addresses #596. Routing already has local outcome memory, but peers could not advertise observed serving speed to the rest of the mesh. The new hint gives the router a bounded, low-risk signal for choosing between otherwise compatible peers without changing the hard routing constraints.

## Protocol / Compatibility

- The protobuf change is additive: `PeerAnnouncement.advertised_model_throughput` uses new tag 44.
- Older protobuf peers should ignore the unknown field, and the legacy v0 JSON compatibility path is unchanged.
- Values are fixed-point milli tokens/sec to avoid floating-point wire edge cases.
- Hints are capped, sanitized, deduplicated by model, and advisory only.
- No ALPN, plugin protocol, or Skippy ABI change is introduced.

## Diff Scope

- Host runtime routing metrics and OpenAI target ordering.
- Mesh gossip peer announcements and peer state refresh.
- Internal protocol conversion plus protobuf mirror for the additive field.
- Focused test fixture updates for the new announcement field.

## Branch Integrity

- Base branch: `main`
- Validated base SHA: `cb9472ee26d2aa356b4c276463a5491be06bb8bf`
- Ahead/behind against fetched `origin/main`: `0 behind / 1 ahead`
- Merge base: `cb9472ee26d2aa356b4c276463a5491be06bb8bf`
- This is now a standalone PR against `main`, not stacked on #566.

## Validation

Local paths in `LLAMA_STAGE_BUILD_DIR` are normalized to `<repo>` below.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm-host-runtime`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal /opt/homebrew/bin/cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime advertised_model_throughput --lib`: PASS, 3 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime routing_metrics_advertises_only_local_hosted_model_throughput --lib`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime reorder_candidates --lib`: PASS, 5 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm --test protocol_convert_matrix`: PASS, 14 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm --test protocol_compat_v0_client`: PASS, 15 passed

## Runtime Safety

- Throughput hints are bounded to 64 entries per announcement.
- Invalid, empty, duplicate, zero-sample, or zero-throughput hints are dropped.
- Advertised values are clamped before wire encoding and after decode.
- Routing still filters by context fit before applying throughput ordering.
- No new background tasks, unbounded queues, or blocking network paths are introduced.
- No invariant regression introduced.

## Rollback

Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known Residual Risks

- I did not run a live two-node mixed-version runtime smoke locally. The additive wire behavior is covered by protocol conversion and v0 compatibility tests, and remote CI should validate the final PR SHA.