### PR TITLE
fix(build-windows): tolerate dead sccache server in CUDA retry path

### DIFF
--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -339,7 +339,17 @@ function Invoke-CmakeBuild {
         }
 
         Write-Warning "CUDA ABI build failed while using sccache; restarting sccache and retrying once."
-        & $compilerCacheBin --stop-server 2>&1 | Out-Null
+        # `sccache --stop-server` exits non-zero when the server is already dead
+        # (which is precisely the case this retry path exists to handle). Tolerate
+        # that instead of letting $ErrorActionPreference='Stop' turn it into a
+        # terminating error that aborts the retry before cmake runs again.
+        $previousErrorActionPreference = $ErrorActionPreference
+        try {
+            $ErrorActionPreference = "Continue"
+            & $compilerCacheBin --stop-server 2>&1 | Out-Null
+        } finally {
+            $ErrorActionPreference = $previousErrorActionPreference
+        }
         Start-Sleep -Seconds 2
         Reset-SccacheStats
         Invoke-NativeCommand "cmake" $arguments


### PR DESCRIPTION
The CUDA ABI build has a retry-once-after-sccache-restart path in `Invoke-CmakeBuild`. It calls `sccache --stop-server` to clean up before retrying cmake. When the sccache server has already crashed (which is precisely the case this retry path exists to handle), `sccache --stop-server` exits non-zero with 'couldn't connect to server'.

Because the script runs under `$ErrorActionPreference = 'Stop'`, the non-zero native exit is promoted to a terminating PowerShell error and the catch block re-throws before the retry cmake invocation ever runs. `mesh-llm.exe` is therefore never produced and the downstream `package-release.ps1` fails with 'Required file not found'.

Wrap the `--stop-server` call in a localized
`$ErrorActionPreference = 'Continue'` block (and restore the prior value) so a dead server is silently ignored and the retry proceeds. `Reset-SccacheStats` further down already uses this exact pattern for the same reason.

Observed in the v0.66.0-rc5 release run on Build Windows CUDA:
  sccache: error: failed to execute compile
  sccache: caused by: An existing connection was forcibly closed
    by the remote host. (os error 10054)
  WARNING: CUDA ABI build failed while using sccache; restarting
    sccache and retrying once.
  sccache: error: couldn't connect to server
  error: recipe `release-build-cuda-windows` failed on line 173