### PR TITLE
fix(release): pin Windows CUDA to sccache-compatible version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,6 +400,12 @@ jobs:
     runs-on: windows-2022
     env:
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
+      # Pin Windows CUDA to a version sccache 0.15.0 supports.
+      # `choco install cuda` (used previously via install-windows-sdk.ps1)
+      # pulls latest = CUDA 13.2, which deterministically crashes sccache
+      # on nvcc output (see mozilla/sccache#2470). CI pins to the same
+      # version via Jimver/cuda-toolkit; mirror that here.
+      WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '12.6.3' }}
     strategy:
       fail-fast: false
       matrix:
@@ -435,11 +441,31 @@ jobs:
       - uses: taiki-e/install-action@just
       - uses: mozilla-actions/sccache-action@v0.0.9
       - name: Cache Windows SDK installers
+        if: ${{ matrix.backend != 'cuda' }}
         uses: actions/cache@v5
         with:
           path: ~/sdk-installer-cache/${{ matrix.backend }}
           key: windows-sdk-installers-${{ matrix.backend }}-${{ env.ROCM_HIP_SDK_FILENAME }}-${{ hashFiles('scripts/install-windows-sdk.ps1') }}
+      - name: Install CUDA toolkit
+        if: ${{ matrix.backend == 'cuda' }}
+        uses: Jimver/cuda-toolkit@v0.2.35
+        with:
+          cuda: ${{ env.WINDOWS_CUDA_VERSION }}
+          method: network
+          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "visual_studio_integration"]'
+          use-github-cache: true
+          use-local-cache: true
+          log-file-suffix: windows-cuda-release
+      - name: Verify CUDA toolkit
+        if: ${{ matrix.backend == 'cuda' }}
+        shell: pwsh
+        run: |
+          if (-not $env:CUDA_PATH -or -not (Test-Path $env:CUDA_PATH)) {
+            throw "CUDA_PATH was not configured by Jimver/cuda-toolkit."
+          }
+          & nvcc --version
       - name: Install backend SDK
+        if: ${{ matrix.backend != 'cuda' }}
         shell: pwsh
         run: |
           .\scripts\install-windows-sdk.ps1 `


### PR DESCRIPTION
## What

The Windows CUDA release lane now pins CUDA via `Jimver/cuda-toolkit@v0.2.35` to `vars.CUDA_VERSION || '12.6.3'` (currently 12.8.0 in repo variables), matching the CI lane. The previous `choco install cuda` path in `scripts/install-windows-sdk.ps1` pulled the latest CUDA Toolkit (13.2) which is incompatible with sccache 0.15.0.

The rocm and vulkan branches of `install-windows-sdk.ps1` are unchanged — only the cuda matrix entry is rewired.

## Why

Both v0.66.0-rc5 and v0.66.0-rc6 release runs failed on Build Windows CUDA with:

```
sccache: error: failed to execute compile
sccache: caused by: error reading compile response from server
sccache: caused by: An existing connection was forcibly closed by the remote host. (os error 10054)
ninja: build stopped: subcommand failed.
```

This is the documented incompatibility in [mozilla/sccache#2470](https://github.com/mozilla/sccache/issues/2470) (CUDA + MSVC + Ninja Multi-Config). sccache 0.15.0 cannot parse the shell line nvcc 13.x emits on Windows. The crash is on the same file (`argsort.cu`) every run.

PR #604 made the in-script retry actually run by tolerating a dead sccache server during cleanup. That fix is correct on its own — without it, the retry path crashed before the second cmake invocation. But with #604 merged, the retry still hits the same deterministic crash because the underlying nvcc/sccache incompatibility is unfixable in the script.

The CI Windows CUDA lane (`.github/workflows/ci.yml:864`) has been working throughout because it already uses `Jimver/cuda-toolkit@v0.2.35` with `WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '12.6.3' }}`. PR #604's PR CI Windows CUDA succeeded against the same code that failed in the release lane — only difference was the CUDA version. This PR mirrors the CI setup in release.

## Risk

- Adds `Jimver/cuda-toolkit@v0.2.35` as a new dep in release.yml. Same action+SHA CI already uses, so no new surface area.
- The `Cache Windows SDK installers` step now skips on `matrix.backend == 'cuda'`. Cache there was tied to `install-windows-sdk.ps1` hash, and that script is no longer called for cuda — caching is now handled by Jimver's `use-github-cache: true` + `use-local-cache: true` instead.
- ROCm and Vulkan paths unchanged.

## Validation

The PR's own CI will exercise the Windows CUDA lane on this change. If that goes green, retry v0.66.0-rc6 (or cut rc7) — should produce the missing Windows CUDA bundle and unblock the release publish gate.