### PR TITLE
Reconcile model targets into local runtime loads

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
@@ -570,6 +570,7 @@ mod tests {
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             extra: Default::default(),
         };
 

--- a/crates/mesh-llm-host-runtime/src/plugin/config.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/config.rs
@@ -26,6 +26,8 @@ pub struct MeshConfig {
     #[serde(default)]
     pub defaults: Option<ModelConfigDefaults>,
     #[serde(default)]
+    pub runtime: RuntimeConfig,
+    #[serde(default)]
     pub models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     pub plugins: Vec<PluginConfigEntry>,
@@ -47,6 +49,12 @@ pub struct GpuConfig {
     pub assignment: GpuAssignment,
     #[serde(default)]
     pub parallel: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct RuntimeConfig {
+    #[serde(default)]
+    pub reconcile_model_targets: bool,
 }
 
 #[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
@@ -548,6 +556,8 @@ struct RawMeshConfig {
     #[serde(default)]
     defaults: Option<ModelConfigDefaults>,
     #[serde(default)]
+    runtime: RuntimeConfig,
+    #[serde(default)]
     models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     plugins: Vec<PluginConfigEntry>,
@@ -644,6 +654,7 @@ impl<'de> Deserialize<'de> for MeshConfig {
             owner_control: raw.owner_control,
             telemetry: raw.telemetry,
             defaults: raw.defaults,
+            runtime: raw.runtime,
             models: raw.models,
             plugins: raw.plugins,
             extra: raw.extra,
@@ -2737,6 +2748,22 @@ flash_attention = "enabled"
             config.models[0].flash_attention,
             Some(FlashAttentionType::Enabled)
         );
+    }
+
+    #[test]
+    fn runtime_model_target_reconciliation_deserializes_from_toml() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+
+[runtime]
+reconcile_model_targets = true
+"#,
+        )
+        .unwrap();
+
+        assert!(config.runtime.reconcile_model_targets);
+        validate_config(&config).unwrap();
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -967,6 +967,7 @@ fn legacy_proto_config_to_mesh(
         owner_control: Default::default(),
         telemetry: Default::default(),
         defaults: None,
+        runtime: Default::default(),
         models,
         plugins,
         extra: Default::default(),

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -1946,6 +1946,7 @@ alias = "model-alias"
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B.gguf".to_string(),
                 mmproj: Some("mm.gguf".to_string()),
@@ -2071,6 +2072,7 @@ reasoning_format = "qwen"
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "test.gguf".to_string(),
                 mmproj: None,
@@ -2102,6 +2104,7 @@ reasoning_format = "qwen"
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "other.gguf".to_string(),
                 mmproj: None,
@@ -2165,6 +2168,7 @@ reasoning_format = "qwen"
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![ModelConfigEntry {
                 model: "Qwen3-8B-Q4_K_M".to_string(),
                 mmproj: Some("mmproj-f16.gguf".to_string()),

--- a/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
@@ -250,6 +250,7 @@ mod tests {
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![],
             plugins: vec![],
             extra: Default::default(),
@@ -563,6 +564,7 @@ reasoning_format = "qwen"
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![crate::plugin::ModelConfigEntry {
                 model: model.to_string(),
                 mmproj: None,
@@ -607,6 +609,7 @@ reasoning_format = "qwen"
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![crate::plugin::ModelConfigEntry {
                 model: "test.gguf".to_string(),
                 mmproj: None,
@@ -764,6 +767,7 @@ temperature = 0.2
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,
+            runtime: Default::default(),
             models: vec![crate::plugin::ModelConfigEntry {
                 model: "noop-test.gguf".to_string(),
                 mmproj: None,

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -57,6 +57,10 @@ pub(super) enum RuntimeEvent {
         model: String,
         port: u16,
     },
+    ModelTargetReconciliationLoadFinished {
+        model_ref: String,
+        result: std::result::Result<api::RuntimeLoadResponse, String>,
+    },
 }
 
 pub(super) enum LocalRuntimeBackendHandle {

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -5,6 +5,7 @@ mod discovery;
 pub mod instance;
 mod interactive;
 mod local;
+mod model_target_reconciliation;
 mod proxy;
 mod split_planning;
 pub(crate) mod survey;
@@ -27,6 +28,11 @@ use self::local::{
     LocalRuntimeModelStartSpec, ManagedModelController, OpenAiGuardrailPolicyHandle, RuntimeEvent,
     SplitCoordinatorAck, SplitCoordinatorEvent, SplitRuntimeReason, SplitRuntimeStart,
     StartupRuntimePlan,
+};
+use self::model_target_reconciliation::{
+    plan_model_target_reconciliation, ModelTargetReconciliationCandidate,
+    ModelTargetReconciliationCapacityState, ModelTargetReconciliationInput,
+    ModelTargetReconciliationPolicy, ModelTargetReconciliationState,
 };
 use self::proxy::{api_proxy, bootstrap_proxy};
 use crate::api;
@@ -53,14 +59,14 @@ use clap::{CommandFactory, Parser};
 use mesh_llm_node::serving::{UnloadOptions, UnloadTarget};
 use skippy_protocol::FlashAttentionType;
 use std::cell::Cell;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc, Mutex,
 };
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tracing_subscriber::fmt::MakeWriter;
 use zeroize::Zeroizing;
 
@@ -68,6 +74,7 @@ const PRETTY_DASHBOARD_INVENTORY_CACHE_TTL: Duration = Duration::from_secs(5);
 const DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL: Duration = Duration::from_millis(250);
 const DASHBOARD_FIRST_PAINT_TIMEOUT: Duration = Duration::from_secs(2);
 const SPLIT_STANDBY_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+const MODEL_TARGET_RECONCILIATION_INTERVAL: Duration = Duration::from_secs(15);
 
 type DashboardContextUsage =
     Arc<tokio::sync::Mutex<HashMap<String, HashMap<DashboardContextUsageSource, u64>>>>;
@@ -3275,6 +3282,181 @@ async fn resolve_model(input: &std::path::Path) -> Result<PathBuf> {
     models::resolve_model_spec(input).await
 }
 
+fn model_target_reconciliation_policy(
+    config: &plugin::MeshConfig,
+) -> ModelTargetReconciliationPolicy {
+    ModelTargetReconciliationPolicy {
+        enabled: config.runtime.reconcile_model_targets,
+        ..ModelTargetReconciliationPolicy::default()
+    }
+}
+
+struct ReconcileModelTargetsContext<'a> {
+    policy: &'a ModelTargetReconciliationPolicy,
+    state: &'a mut ModelTargetReconciliationState,
+    node: &'a mesh::Node,
+    console_state: Option<&'a api::MeshApi>,
+    runtime_models: &'a HashMap<String, RuntimeModelHandleEntry>,
+    managed_models: &'a HashMap<String, ManagedModelController>,
+    control_tx: &'a tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
+    runtime_event_tx: &'a tokio::sync::mpsc::UnboundedSender<RuntimeEvent>,
+}
+
+async fn reconcile_model_targets_once(ctx: ReconcileModelTargetsContext<'_>) {
+    let ReconcileModelTargetsContext {
+        policy,
+        state,
+        node,
+        console_state,
+        runtime_models,
+        managed_models,
+        control_tx,
+        runtime_event_tx,
+    } = ctx;
+    if !policy.enabled {
+        return;
+    }
+    let Some(console_state) = console_state else {
+        return;
+    };
+    let local_interest_model_refs = node
+        .explicit_model_interests()
+        .await
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    if local_interest_model_refs.is_empty() {
+        state.prune_expired(runtime_unix_secs());
+        return;
+    }
+
+    let target_lookup = console_state.model_target_lookup().await;
+    let loaded_model_refs = runtime_loaded_model_refs(runtime_models, managed_models);
+    let local_vram_bytes = node.vram_bytes();
+    let targets = target_lookup
+        .targets
+        .into_iter()
+        .map(|target| {
+            let local_path = if target.wanted
+                && target.serving_node_count == 0
+                && local_interest_model_refs.contains(&target.model_ref)
+                && target.capacity_advice.state
+                    == api::status::ModelTargetCapacityAdviceState::SingleNodeFit
+                && model_target_reconciliation_local_fit(&target, local_vram_bytes)
+            {
+                local_model_path_for_reconciliation_target(&target)
+            } else {
+                None
+            };
+            ModelTargetReconciliationCandidate {
+                model_ref: target.model_ref,
+                model_name: target.model_name,
+                wanted: target.wanted,
+                serving_node_count: target.serving_node_count,
+                capacity_state: ModelTargetReconciliationCapacityState::from(
+                    target.capacity_advice.state,
+                ),
+                local_path,
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let now_secs = runtime_unix_secs();
+    let actions = plan_model_target_reconciliation(
+        policy,
+        state,
+        ModelTargetReconciliationInput {
+            now_secs,
+            local_role: node.role().await,
+            local_interest_model_refs: &local_interest_model_refs,
+            loaded_model_refs: &loaded_model_refs,
+            targets: &targets,
+        },
+    );
+
+    for action in actions {
+        let load_spec = action.load_spec.to_string_lossy().to_string();
+        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        if control_tx
+            .send(api::RuntimeControlRequest::Load {
+                spec: load_spec.clone(),
+                resp: resp_tx,
+            })
+            .is_err()
+        {
+            state.record_load_failure(&action.model_ref, now_secs, policy);
+            let _ = emit_event(OutputEvent::Warning {
+                message: format!(
+                    "Model target reconciliation could not queue '{}'",
+                    action.model_ref
+                ),
+                context: Some("runtime control channel closed".to_string()),
+            });
+            continue;
+        }
+
+        state.mark_load_started(&action.model_ref);
+        let event_tx = runtime_event_tx.clone();
+        let model_ref = action.model_ref.clone();
+        tokio::spawn(async move {
+            let result = match resp_rx.await {
+                Ok(result) => result.map_err(|err| err.to_string()),
+                Err(err) => Err(format!("runtime load response channel closed: {err}")),
+            };
+            let _ = event_tx
+                .send(RuntimeEvent::ModelTargetReconciliationLoadFinished { model_ref, result });
+        });
+        let _ = emit_event(OutputEvent::Info {
+            message: format!("Model target reconciliation loading '{}'", action.model_ref),
+            context: Some(format!("path={load_spec}")),
+        });
+    }
+}
+
+fn runtime_loaded_model_refs(
+    runtime_models: &HashMap<String, RuntimeModelHandleEntry>,
+    managed_models: &HashMap<String, ManagedModelController>,
+) -> BTreeSet<String> {
+    runtime_models
+        .values()
+        .map(|entry| entry.model_name.clone())
+        .chain(
+            managed_models
+                .values()
+                .map(|controller| controller.model_name.clone()),
+        )
+        .collect()
+}
+
+fn local_model_path_for_reconciliation_target(
+    target: &api::status::ModelTargetPayload,
+) -> Option<PathBuf> {
+    [
+        Some(target.model_ref.as_str()),
+        target.model_name.as_deref(),
+    ]
+    .into_iter()
+    .flatten()
+    .map(models::find_model_path)
+    .find(|path| path.exists())
+}
+
+fn model_target_reconciliation_local_fit(
+    target: &api::status::ModelTargetPayload,
+    local_vram_bytes: u64,
+) -> bool {
+    target
+        .capacity_advice
+        .required_bytes
+        .is_some_and(|required| local_vram_bytes >= required)
+}
+
+fn runtime_unix_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or_default()
+}
+
 fn cli_has_explicit_models(cli: &Cli) -> bool {
     !cli.model.is_empty() || !cli.gguf.is_empty()
 }
@@ -5673,6 +5855,7 @@ struct RunAutoRuntimeLifecycleContext<'a> {
     primary_model_name: &'a str,
     target_tx: &'a Arc<tokio::sync::watch::Sender<election::ModelTargets>>,
     control_rx: &'a mut tokio::sync::mpsc::UnboundedReceiver<api::RuntimeControlRequest>,
+    control_tx: &'a tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
     runtime_event_rx: &'a mut tokio::sync::mpsc::UnboundedReceiver<RuntimeEvent>,
     runtime_state: &'a mut RunAutoRuntimeState,
     console_state: Option<&'a api::MeshApi>,
@@ -5769,6 +5952,7 @@ struct RunAutoRuntimeLoopContext<'a> {
     node: &'a mesh::Node,
     primary_model_name: &'a str,
     target_tx: &'a Arc<tokio::sync::watch::Sender<election::ModelTargets>>,
+    control_tx: &'a tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
     runtime_models: &'a mut HashMap<String, RuntimeModelHandleEntry>,
     runtime_survey_models: &'a mut HashMap<String, survey::SurveyLoadedModel>,
     managed_models: &'a mut HashMap<String, ManagedModelController>,
@@ -5783,6 +5967,8 @@ struct RunAutoRuntimeLoopContext<'a> {
     survey_telemetry: &'a survey::SurveyTelemetry,
     startup_ready_reporter: &'a StartupReadyReporter,
     openai_guardrail_policy: &'a OpenAiGuardrailPolicyHandle,
+    model_target_reconciliation_policy: ModelTargetReconciliationPolicy,
+    model_target_reconciliation_state: ModelTargetReconciliationState,
 }
 
 struct RunAutoRuntimeState {
@@ -5982,6 +6168,7 @@ async fn run_auto_runtime_loop_and_shutdown(ctx: RunAutoRuntimeLifecycleContext<
         primary_model_name,
         target_tx,
         control_rx,
+        control_tx,
         runtime_event_rx,
         runtime_state,
         console_state,
@@ -6001,6 +6188,7 @@ async fn run_auto_runtime_loop_and_shutdown(ctx: RunAutoRuntimeLifecycleContext<
         node,
         primary_model_name,
         target_tx,
+        control_tx,
         runtime_models: &mut runtime_state.runtime_models,
         runtime_survey_models: &mut runtime_state.runtime_survey_models,
         managed_models: &mut runtime_state.managed_models,
@@ -6015,6 +6203,8 @@ async fn run_auto_runtime_loop_and_shutdown(ctx: RunAutoRuntimeLifecycleContext<
         survey_telemetry,
         startup_ready_reporter,
         openai_guardrail_policy: &runtime_state.openai_guardrail_policy,
+        model_target_reconciliation_policy: model_target_reconciliation_policy(config),
+        model_target_reconciliation_state: ModelTargetReconciliationState::default(),
     };
     run_auto_runtime_event_loop(&mut loop_ctx, control_rx, runtime_event_rx).await;
 
@@ -6193,7 +6383,7 @@ async fn run_auto_load_runtime_model(
         ctx.node.vram_bytes(),
         model_bytes,
     )?;
-    add_serving_assignment(ctx.node, ctx.primary_model_name, &requested_model).await;
+    add_serving_assignment(ctx.node, ctx.primary_model_name, &runtime_model_name).await;
     let launch_started = Instant::now();
     let capacity_budget_bytes = capacity_reservation.capacity_budget_bytes();
     let (loaded_name, handle, death_rx) = match start_runtime_local_model(
@@ -6226,7 +6416,7 @@ async fn run_auto_load_runtime_model(
         Ok(result) => result,
         Err(err) => {
             drop(capacity_reservation);
-            remove_serving_assignment(ctx.node, &requested_model).await;
+            remove_serving_assignment(ctx.node, &runtime_model_name).await;
             ctx.survey_telemetry.record_launch_failure(
                 survey::SurveyModelSpec {
                     model: &requested_model,
@@ -6554,6 +6744,74 @@ async fn run_auto_handle_runtime_exit(
     });
 }
 
+async fn run_auto_reconcile_model_targets(ctx: &mut RunAutoRuntimeLoopContext<'_>) {
+    reconcile_model_targets_once(ReconcileModelTargetsContext {
+        policy: &ctx.model_target_reconciliation_policy,
+        state: &mut ctx.model_target_reconciliation_state,
+        node: ctx.node,
+        console_state: ctx.console_state,
+        runtime_models: ctx.runtime_models,
+        managed_models: ctx.managed_models,
+        control_tx: ctx.control_tx,
+        runtime_event_tx: ctx.runtime_event_tx,
+    })
+    .await;
+}
+
+fn run_auto_record_model_target_manual_unload(
+    ctx: &mut RunAutoRuntimeLoopContext<'_>,
+    requested_target: &str,
+    result: &Result<api::RuntimeUnloadResponse>,
+) {
+    let Ok(response) = result else {
+        return;
+    };
+    let now_secs = runtime_unix_secs();
+    ctx.model_target_reconciliation_state.record_manual_unload(
+        requested_target,
+        now_secs,
+        &ctx.model_target_reconciliation_policy,
+    );
+    if response.model != requested_target {
+        ctx.model_target_reconciliation_state.record_manual_unload(
+            &response.model,
+            now_secs,
+            &ctx.model_target_reconciliation_policy,
+        );
+    }
+}
+
+fn run_auto_handle_model_target_reconciliation_result(
+    ctx: &mut RunAutoRuntimeLoopContext<'_>,
+    model_ref: String,
+    result: std::result::Result<api::RuntimeLoadResponse, String>,
+) {
+    match result {
+        Ok(response) => {
+            ctx.model_target_reconciliation_state
+                .record_load_success(&model_ref);
+            let _ = emit_event(OutputEvent::Info {
+                message: format!("Model target reconciliation loaded '{}'", response.model),
+                context: Some(format!(
+                    "model_ref={} instance={}",
+                    model_ref, response.instance_id
+                )),
+            });
+        }
+        Err(error) => {
+            ctx.model_target_reconciliation_state.record_load_failure(
+                &model_ref,
+                runtime_unix_secs(),
+                &ctx.model_target_reconciliation_policy,
+            );
+            let _ = emit_event(OutputEvent::Warning {
+                message: format!("Model target reconciliation failed for '{model_ref}'"),
+                context: Some(error),
+            });
+        }
+    }
+}
+
 async fn run_auto_handle_control_request(
     ctx: &mut RunAutoRuntimeLoopContext<'_>,
     cmd: api::RuntimeControlRequest,
@@ -6569,7 +6827,8 @@ async fn run_auto_handle_control_request(
             options,
             resp,
         } => {
-            let result = run_auto_unload_runtime_model(ctx, target, options).await;
+            let result = run_auto_unload_runtime_model(ctx, target.clone(), options).await;
+            run_auto_record_model_target_manual_unload(ctx, target.as_runtime_target(), &result);
             let _ = resp.send(result);
             false
         }
@@ -6656,6 +6915,10 @@ async fn run_auto_runtime_event_loop(
     let mut dashboard_context_usage_tick =
         tokio::time::interval(DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL);
     dashboard_context_usage_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut model_target_reconciliation_tick =
+        tokio::time::interval(MODEL_TARGET_RECONCILIATION_INTERVAL);
+    model_target_reconciliation_tick
+        .set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         tokio::select! {
             _ = dashboard_context_usage_tick.tick() => {
@@ -6677,6 +6940,9 @@ async fn run_auto_runtime_event_loop(
                     .collect();
                 refresh_dashboard_context_usage_batch(ctx.dashboard_context_usage, updates).await;
             }
+            _ = model_target_reconciliation_tick.tick() => {
+                run_auto_reconcile_model_targets(ctx).await;
+            }
             signal = wait_shutdown_signal() => {
                 let _ = emit_event(OutputEvent::ShutdownRequested { signal });
                 ctx.startup_ready_reporter.mark_shutdown_requested();
@@ -6691,6 +6957,9 @@ async fn run_auto_runtime_event_loop(
             }
             Some(event) = runtime_event_rx.recv() => {
                 match event {
+                    RuntimeEvent::ModelTargetReconciliationLoadFinished { model_ref, result } => {
+                        run_auto_handle_model_target_reconciliation_result(ctx, model_ref, result);
+                    }
                     RuntimeEvent::Exited { instance_id, model, port } => {
                         run_auto_handle_runtime_exit(ctx, instance_id, model, port).await;
                     }
@@ -7403,6 +7672,7 @@ async fn run_auto(
         primary_model_name: &model_name,
         target_tx: &target_tx,
         control_rx: &mut control_rx,
+        control_tx: &control_tx,
         runtime_event_rx: &mut runtime_event_rx,
         runtime_state: &mut runtime_state,
         console_state: console_state.as_ref(),
@@ -8018,6 +8288,51 @@ mod tests {
         } else {
             std::env::remove_var(key);
         }
+    }
+
+    fn reconciliation_target_with_required_bytes(
+        required_bytes: Option<u64>,
+    ) -> api::status::ModelTargetPayload {
+        api::status::ModelTargetPayload {
+            rank: 1,
+            model_ref: "org/model@main:model.gguf".to_string(),
+            display_name: "Model".to_string(),
+            model_name: Some("Model".to_string()),
+            explicit_interest_count: 1,
+            request_count: 0,
+            last_active_secs_ago: None,
+            serving_node_count: 0,
+            requested: false,
+            wanted: true,
+            wanted_reason: Some("explicit_interest"),
+            capacity_advice: api::status::ModelTargetCapacityAdvicePayload {
+                state: api::status::ModelTargetCapacityAdviceState::SingleNodeFit,
+                reason: "single_node_capacity_available",
+                required_bytes,
+                best_single_node_capacity_bytes: required_bytes,
+                aggregate_capacity_bytes: required_bytes.unwrap_or_default(),
+                shortfall_bytes: None,
+                eligible_node_count: 1,
+                missing_capacity_node_count: 0,
+                excluded_client_node_count: 0,
+                split_capable: false,
+            },
+        }
+    }
+
+    #[test]
+    fn model_target_reconciliation_local_fit_requires_current_node_capacity() {
+        let target = reconciliation_target_with_required_bytes(Some(10));
+
+        assert!(model_target_reconciliation_local_fit(&target, 10));
+        assert!(!model_target_reconciliation_local_fit(&target, 9));
+    }
+
+    #[test]
+    fn model_target_reconciliation_local_fit_rejects_unknown_required_bytes() {
+        let target = reconciliation_target_with_required_bytes(None);
+
+        assert!(!model_target_reconciliation_local_fit(&target, u64::MAX));
     }
 
     fn remote_catalog_layer_entry(

--- a/crates/mesh-llm-host-runtime/src/runtime/model_target_reconciliation.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/model_target_reconciliation.rs
@@ -1,0 +1,561 @@
+use crate::api::status::ModelTargetCapacityAdviceState;
+use crate::mesh::NodeRole;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct ModelTargetReconciliationPolicy {
+    pub(crate) enabled: bool,
+    pub(crate) max_loads_per_tick: usize,
+    pub(crate) failure_cooldown_secs: u64,
+    pub(crate) manual_unload_cooldown_secs: u64,
+}
+
+impl Default for ModelTargetReconciliationPolicy {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            max_loads_per_tick: 1,
+            failure_cooldown_secs: 5 * 60,
+            manual_unload_cooldown_secs: 5 * 60,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ModelTargetReconciliationState {
+    in_flight_model_refs: BTreeSet<String>,
+    failed_until_secs: BTreeMap<String, u64>,
+    manual_unload_until_secs: BTreeMap<String, u64>,
+}
+
+impl ModelTargetReconciliationState {
+    pub(crate) fn mark_load_started(&mut self, model_ref: &str) {
+        self.in_flight_model_refs.insert(model_ref.to_string());
+    }
+
+    pub(crate) fn record_load_success(&mut self, model_ref: &str) {
+        self.in_flight_model_refs.remove(model_ref);
+        self.failed_until_secs.remove(model_ref);
+    }
+
+    pub(crate) fn record_load_failure(
+        &mut self,
+        model_ref: &str,
+        now_secs: u64,
+        policy: &ModelTargetReconciliationPolicy,
+    ) {
+        self.in_flight_model_refs.remove(model_ref);
+        if policy.failure_cooldown_secs > 0 {
+            self.failed_until_secs.insert(
+                model_ref.to_string(),
+                now_secs.saturating_add(policy.failure_cooldown_secs),
+            );
+        }
+    }
+
+    pub(crate) fn record_manual_unload(
+        &mut self,
+        model_ref: &str,
+        now_secs: u64,
+        policy: &ModelTargetReconciliationPolicy,
+    ) {
+        self.in_flight_model_refs.remove(model_ref);
+        if policy.manual_unload_cooldown_secs > 0 {
+            self.manual_unload_until_secs.insert(
+                model_ref.to_string(),
+                now_secs.saturating_add(policy.manual_unload_cooldown_secs),
+            );
+        }
+    }
+
+    pub(crate) fn prune_expired(&mut self, now_secs: u64) {
+        self.failed_until_secs.retain(|_, until| *until > now_secs);
+        self.manual_unload_until_secs
+            .retain(|_, until| *until > now_secs);
+    }
+
+    fn suppressed(&self, model_ref: &str, model_name: Option<&str>, now_secs: u64) -> bool {
+        self.in_flight_model_refs
+            .iter()
+            .any(|in_flight| model_identity_matches(in_flight, model_ref))
+            || self.cooldown_active(&self.failed_until_secs, model_ref, model_name, now_secs)
+            || self.cooldown_active(
+                &self.manual_unload_until_secs,
+                model_ref,
+                model_name,
+                now_secs,
+            )
+    }
+
+    fn cooldown_active(
+        &self,
+        cooldowns: &BTreeMap<String, u64>,
+        model_ref: &str,
+        model_name: Option<&str>,
+        now_secs: u64,
+    ) -> bool {
+        cooldowns.iter().any(|(key, until)| {
+            *until > now_secs
+                && (model_identity_matches(key, model_ref)
+                    || model_name.is_some_and(|name| model_identity_matches(key, name)))
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ModelTargetReconciliationInput<'a> {
+    pub(crate) now_secs: u64,
+    pub(crate) local_role: NodeRole,
+    pub(crate) local_interest_model_refs: &'a BTreeSet<String>,
+    pub(crate) loaded_model_refs: &'a BTreeSet<String>,
+    pub(crate) targets: &'a [ModelTargetReconciliationCandidate],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ModelTargetReconciliationCandidate {
+    pub(crate) model_ref: String,
+    pub(crate) model_name: Option<String>,
+    pub(crate) wanted: bool,
+    pub(crate) serving_node_count: usize,
+    pub(crate) capacity_state: ModelTargetReconciliationCapacityState,
+    pub(crate) local_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ModelTargetReconciliationCapacityState {
+    AlreadyServing,
+    SingleNodeFit,
+    SplitCandidate,
+    InsufficientCapacity,
+    UnknownModelSize,
+    UnknownCapacity,
+    NoEligibleHosts,
+}
+
+impl From<ModelTargetCapacityAdviceState> for ModelTargetReconciliationCapacityState {
+    fn from(value: ModelTargetCapacityAdviceState) -> Self {
+        match value {
+            ModelTargetCapacityAdviceState::AlreadyServing => Self::AlreadyServing,
+            ModelTargetCapacityAdviceState::SingleNodeFit => Self::SingleNodeFit,
+            ModelTargetCapacityAdviceState::SplitCandidate => Self::SplitCandidate,
+            ModelTargetCapacityAdviceState::InsufficientCapacity => Self::InsufficientCapacity,
+            ModelTargetCapacityAdviceState::UnknownModelSize => Self::UnknownModelSize,
+            ModelTargetCapacityAdviceState::UnknownCapacity => Self::UnknownCapacity,
+            ModelTargetCapacityAdviceState::NoEligibleHosts => Self::NoEligibleHosts,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ModelTargetReconciliationAction {
+    pub(crate) model_ref: String,
+    pub(crate) model_name: Option<String>,
+    pub(crate) load_spec: PathBuf,
+}
+
+pub(crate) fn plan_model_target_reconciliation(
+    policy: &ModelTargetReconciliationPolicy,
+    state: &mut ModelTargetReconciliationState,
+    input: ModelTargetReconciliationInput<'_>,
+) -> Vec<ModelTargetReconciliationAction> {
+    state.prune_expired(input.now_secs);
+    if !policy.enabled
+        || policy.max_loads_per_tick == 0
+        || matches!(input.local_role, NodeRole::Client)
+    {
+        return Vec::new();
+    }
+
+    let mut actions = Vec::new();
+    for target in input.targets {
+        if actions.len() >= policy.max_loads_per_tick {
+            break;
+        }
+        let Some(load_spec) = target.local_path.clone() else {
+            continue;
+        };
+        if !target.wanted
+            || target.serving_node_count > 0
+            || target.capacity_state != ModelTargetReconciliationCapacityState::SingleNodeFit
+            || !input.local_interest_model_refs.contains(&target.model_ref)
+            || loaded_target(input.loaded_model_refs, target)
+            || state.suppressed(
+                &target.model_ref,
+                target.model_name.as_deref(),
+                input.now_secs,
+            )
+        {
+            continue;
+        }
+
+        actions.push(ModelTargetReconciliationAction {
+            model_ref: target.model_ref.clone(),
+            model_name: target.model_name.clone(),
+            load_spec,
+        });
+    }
+    actions
+}
+
+fn loaded_target(
+    loaded_model_refs: &BTreeSet<String>,
+    target: &ModelTargetReconciliationCandidate,
+) -> bool {
+    loaded_model_refs.iter().any(|loaded| {
+        model_identity_matches(loaded, &target.model_ref)
+            || target
+                .model_name
+                .as_deref()
+                .is_some_and(|name| model_identity_matches(loaded, name))
+    })
+}
+
+fn model_identity_matches(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let (Ok(left), Ok(right)) = (
+        model_ref::ModelRef::parse(left),
+        model_ref::ModelRef::parse(right),
+    ) else {
+        return false;
+    };
+    left.repo == right.repo
+        && left.selector == right.selector
+        && revisions_match_for_reconciliation(left.revision.as_deref(), right.revision.as_deref())
+}
+
+fn revisions_match_for_reconciliation(left: Option<&str>, right: Option<&str>) -> bool {
+    left == right || matches!((left, right), (None, Some("main")) | (Some("main"), None))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NOW: u64 = 1_764_000_000;
+
+    fn enabled_policy() -> ModelTargetReconciliationPolicy {
+        ModelTargetReconciliationPolicy {
+            enabled: true,
+            ..ModelTargetReconciliationPolicy::default()
+        }
+    }
+
+    fn target(model_ref: &str) -> ModelTargetReconciliationCandidate {
+        ModelTargetReconciliationCandidate {
+            model_ref: model_ref.to_string(),
+            model_name: Some("Qwen3-8B-Q4_K_M".to_string()),
+            wanted: true,
+            serving_node_count: 0,
+            capacity_state: ModelTargetReconciliationCapacityState::SingleNodeFit,
+            local_path: Some(PathBuf::from("/models/qwen.gguf")),
+        }
+    }
+
+    fn input<'a>(
+        local_interests: &'a BTreeSet<String>,
+        loaded: &'a BTreeSet<String>,
+        targets: &'a [ModelTargetReconciliationCandidate],
+    ) -> ModelTargetReconciliationInput<'a> {
+        ModelTargetReconciliationInput {
+            now_secs: NOW,
+            local_role: NodeRole::Host { http_port: 9337 },
+            local_interest_model_refs: local_interests,
+            loaded_model_refs: loaded,
+            targets,
+        }
+    }
+
+    #[test]
+    fn planner_is_disabled_by_default() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &ModelTargetReconciliationPolicy::default(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn plans_single_local_load_for_wanted_single_node_fit_interest() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert_eq!(
+            actions,
+            vec![ModelTargetReconciliationAction {
+                model_ref: "org/model@main:file.gguf".to_string(),
+                model_name: Some("Qwen3-8B-Q4_K_M".to_string()),
+                load_spec: PathBuf::from("/models/qwen.gguf"),
+            }]
+        );
+    }
+
+    #[test]
+    fn skips_peer_only_or_requested_targets_without_local_interest() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::new();
+        let loaded = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn skips_non_single_node_or_already_available_targets() {
+        let mut split = target("org/split@main:file.gguf");
+        split.capacity_state = ModelTargetReconciliationCapacityState::SplitCandidate;
+        let mut served = target("org/served@main:file.gguf");
+        served.serving_node_count = 1;
+        let mut missing_path = target("org/missing@main:file.gguf");
+        missing_path.local_path = None;
+        let targets = vec![split, served, missing_path];
+        let local_interests = BTreeSet::from([
+            "org/split@main:file.gguf".to_string(),
+            "org/served@main:file.gguf".to_string(),
+            "org/missing@main:file.gguf".to_string(),
+        ]);
+        let loaded = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn cooldowns_and_in_flight_entries_suppress_until_expired() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::new();
+        let policy = enabled_policy();
+        let mut state = ModelTargetReconciliationState::default();
+        state.record_load_failure("org/model@main:file.gguf", NOW, &policy);
+
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+        assert!(actions.is_empty());
+
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            ModelTargetReconciliationInput {
+                now_secs: NOW + policy.failure_cooldown_secs + 1,
+                ..input(&local_interests, &loaded, &targets)
+            },
+        );
+        assert_eq!(actions.len(), 1);
+    }
+
+    #[test]
+    fn loaded_model_name_suppresses_duplicate_action() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::from(["Qwen3-8B-Q4_K_M".to_string()]);
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn client_role_never_reconciles_local_loads() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            ModelTargetReconciliationInput {
+                local_role: NodeRole::Client,
+                ..input(&local_interests, &loaded, &targets)
+            },
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn max_loads_per_tick_caps_eligible_targets() {
+        let mut first = target("org/first@main:file.gguf");
+        first.model_name = Some("First".to_string());
+        let mut second = target("org/second@main:file.gguf");
+        second.model_name = Some("Second".to_string());
+        let targets = vec![first, second];
+        let local_interests = BTreeSet::from([
+            "org/first@main:file.gguf".to_string(),
+            "org/second@main:file.gguf".to_string(),
+        ]);
+        let loaded = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert_eq!(actions.len(), 1);
+        assert_eq!(actions[0].model_ref, "org/first@main:file.gguf");
+    }
+
+    #[test]
+    fn loaded_model_ref_suppresses_duplicate_action() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn loaded_hf_selector_without_revision_suppresses_main_revision_target() {
+        let mut target = target("unsloth/Qwen3-8B-GGUF@main:Q4_K_M");
+        target.model_name = None;
+        let targets = vec![target];
+        let local_interests = BTreeSet::from(["unsloth/Qwen3-8B-GGUF@main:Q4_K_M".to_string()]);
+        let loaded = BTreeSet::from(["unsloth/Qwen3-8B-GGUF:Q4_K_M".to_string()]);
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn loaded_hf_selector_without_revision_does_not_suppress_non_main_revision_target() {
+        let mut target = target("unsloth/Qwen3-8B-GGUF@feature:Q4_K_M");
+        target.model_name = None;
+        let targets = vec![target];
+        let local_interests = BTreeSet::from(["unsloth/Qwen3-8B-GGUF@feature:Q4_K_M".to_string()]);
+        let loaded = BTreeSet::from(["unsloth/Qwen3-8B-GGUF:Q4_K_M".to_string()]);
+        let mut state = ModelTargetReconciliationState::default();
+
+        let actions = plan_model_target_reconciliation(
+            &enabled_policy(),
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert_eq!(actions.len(), 1);
+    }
+
+    #[test]
+    fn in_flight_load_suppresses_until_completion() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::new();
+        let policy = enabled_policy();
+        let mut state = ModelTargetReconciliationState::default();
+        state.mark_load_started("org/model@main:file.gguf");
+
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+        assert!(actions.is_empty());
+
+        state.record_load_success("org/model@main:file.gguf");
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+        assert_eq!(actions.len(), 1);
+    }
+
+    #[test]
+    fn manual_unload_cooldown_suppresses_main_revision_target_by_loaded_alias() {
+        let mut target = target("unsloth/Qwen3-8B-GGUF@main:Q4_K_M");
+        target.model_name = None;
+        let targets = vec![target];
+        let local_interests = BTreeSet::from(["unsloth/Qwen3-8B-GGUF@main:Q4_K_M".to_string()]);
+        let loaded = BTreeSet::new();
+        let policy = enabled_policy();
+        let mut state = ModelTargetReconciliationState::default();
+        state.record_manual_unload("unsloth/Qwen3-8B-GGUF:Q4_K_M", NOW, &policy);
+
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+
+        assert!(actions.is_empty());
+    }
+
+    #[test]
+    fn manual_unload_cooldown_suppresses_by_model_ref_or_name() {
+        let targets = vec![target("org/model@main:file.gguf")];
+        let local_interests = BTreeSet::from(["org/model@main:file.gguf".to_string()]);
+        let loaded = BTreeSet::new();
+        let policy = enabled_policy();
+        let mut state = ModelTargetReconciliationState::default();
+        state.record_manual_unload("Qwen3-8B-Q4_K_M", NOW, &policy);
+
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            input(&local_interests, &loaded, &targets),
+        );
+        assert!(actions.is_empty());
+
+        let actions = plan_model_target_reconciliation(
+            &policy,
+            &mut state,
+            ModelTargetReconciliationInput {
+                now_secs: NOW + policy.manual_unload_cooldown_secs + 1,
+                ..input(&local_interests, &loaded, &targets)
+            },
+        );
+        assert_eq!(actions.len(), 1);
+    }
+}

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -228,6 +228,12 @@ visibility; it does not launch, unload, or auto-assign models by itself. Entries
 should use canonical refs such as `org/repo@rev:variant`. Mesh management works
 without the HTML via curl/scripts.
 
+Runtime reconciliation is opt-in. When `[runtime] reconcile_model_targets = true`
+is set, the local runtime may load an already-present local GGUF for a locally
+registered explicit interest, but only when `/api/model-targets` says the target
+is wanted, unserved, and a single-node capacity fit for the current node. It
+does not download models, start split serving, or act on peer-only interest.
+
 `/api/model-targets` keeps raw inputs and computed hints separate. Each target
 reports `signals` from observed mesh state (`explicit_interest_count`,
 `request_count`, `last_active_secs_ago`, `serving_node_count`, and `requested`)

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -461,6 +461,7 @@ curl localhost:3131/api/discover # Nostr meshes (current mesh marked by mesh_id)
 - `/api/search` returns 200 JSON with canonical model refs for matching results
 - `/api/model-interests` stores and returns local explicit-interest entries keyed by canonical model refs
 - `/api/model-targets` returns ranked targets with explicit-interest counts, request counts, serving-node counts, `wanted` for targets not currently served, and derived `capacity_advice` without changing ranking or routing behavior
+- If `[runtime] reconcile_model_targets = true` is enabled, unserved local explicit interests that are already present on disk and fit the current node may be runtime-loaded automatically. Leave it unset for read-only advisory checks.
 - Discover results can be matched to current mesh by `mesh_id`
 
 ### 24. HTTP proxy single-request connection contract


### PR DESCRIPTION
## Summary

This makes model-target advice actionable for local runtimes, while keeping the behavior explicit and opt-in.

When `[runtime] reconcile_model_targets = true` is set, a node can automatically runtime-load a model that is already present on local disk when that model is:

- registered as a local explicit interest,
- currently wanted by `/api/model-targets`,
- not already served by the mesh,
- advised as a single-node fit,
- small enough for the current node's local capacity.

## Why

#579 added advisory capacity evaluation for model targets. This follow-up closes the next local-only step: a node that already has a wanted model on disk can act on that advice without requiring manual runtime load calls.

The guardrails are intentionally narrow. This does not download models, start split serving, act on peer-only demand, or change gossip/protocol compatibility.

## Implementation

- Adds `[runtime] reconcile_model_targets = true` as an opt-in local runtime config flag.
- Adds a small reconciliation planner with in-flight, failure, and manual-unload cooldown tracking.
- Wires a periodic reconciliation tick into the current runtime event loop shape.
- Queues normal runtime `Load` requests rather than introducing a separate launch path.
- Records reconciliation load completion/failure through runtime events.
- Reconciles Hugging Face model identities conservatively, so `repo@main:selector` and `repo:selector` match while non-main revisions remain distinct.
- Preserves current main's typed runtime unload flow and records manual-unload cooldowns through the canonical runtime target identity.
- Preserves current main's expanded configuration UI/runtime config and OpenAI guardrail runtime-loop surfaces while carrying the runtime reconciliation config through TOML deserialization, owner-control apply payloads, and the runtime event loop.
- Documents the behavior in the design/testing notes.

## Compatibility

- Disabled by default.
- Local config only; no mesh gossip, peer protocol, protobuf, or plugin protocol changes.
- No model downloads or split-serving automation.
- Existing manual runtime load/unload behavior remains supported.
- Manual unload suppresses immediate auto-reload by model ref/name cooldown, including equivalent Hugging Face main-revision aliases.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@148fffde031b4b1005c1d209e109eacd86a8581e`
- Branch state after rebase: `0 behind / 1 ahead`
- Merge base: `148fffde031b4b1005c1d209e109eacd86a8581e`
- Head commit: `edf3e5f0905706fd35a60fbdc5d8cd40167438fd`

## Validation

- Validation tier: Tier 3 - opt-in shared runtime reconciliation from advisory model targets into local runtime loads, with post-review alias/cooldown repair and post-main conflict repair after the configuration UI/runtime config and guardrail surfaces landed on main.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `148fffde031b4b1005c1d209e109eacd86a8581e`.
- `git rebase origin/main`: PASS, resolved the runtime CLI `MeshConfig` initializer conflict by preserving both current main's `extra` config field and PR #607's `runtime` reconciliation config; resolved the runtime loop context conflict by preserving current main's OpenAI guardrail policy handle plus PR #607's model-target reconciliation policy/state.
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime control_plane_api_cli_builds_apply_request_body --lib -- --test-threads=1`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime model_target_reconciliation --lib -- --test-threads=1`: PASS, 17 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime config_sync --lib -- --test-threads=1`: PASS, 22 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime plugin::config --lib -- --test-threads=1`: PASS, 45 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal /opt/homebrew/bin/cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS
- Remote CI on `edf3e5f0905706fd35a60fbdc5d8cd40167438fd`: PASS, including PR Quality Checks, PR Docker Build, PR Builds, Skippy Inference Smoke Tests, and two-node client/serving smoke.
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - no release/version sync required for this non-release PR branch.
- Not run: `just build` - not required for selected validation tier; no UI or bundle artifact changed.
- Not run: live multi-node inference smoke - not required for local PR-ready proof; feature is opt-in and remote CI/reviewer runtime validation should gate merge.

## CI context confirmation

Remote CI passed on `edf3e5f0905706fd35a60fbdc5d8cd40167438fd`.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

Live multi-node behavior still deserves maintainer/runtime validation before enabling the opt-in flag broadly.
