### PR TITLE
ci(sdk-smoke): install lld in macOS swift smoke job

### DIFF
--- a/.github/actions/compute-changes/action.yml
+++ b/.github/actions/compute-changes/action.yml
@@ -146,7 +146,7 @@ runs:
         if [[ "${{ inputs.event_name }}" == "workflow_dispatch" ]]; then
           SDK_SMOKE_REQUIRED="true"
         elif [[ -n "$CHANGED_FILES" ]]; then
-          DIRECT_SDK_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^sdk/|^Package\.swift$|^scripts/ci-(native|kotlin|swift)-sdk-smoke\.sh$|^scripts/ci-sdk-fixture\.sh$)' || true)
+          DIRECT_SDK_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^sdk/|^Package\.swift$|^scripts/ci-(native|kotlin|swift)-sdk-smoke\.sh$|^scripts/ci-sdk-fixture\.sh$|^\.github/workflows/sdk-smoke\.yml$)' || true)
           if [[ -n "$DIRECT_SDK_INPUTS" ]]; then
             SDK_SMOKE_REQUIRED="true"
           elif echo "$AFFECTED_CRATES" | jq -e 'index("mesh-llm-client") or index("mesh-api") or index("mesh-api-ffi") or index("mesh-llm-protocol") or index("mesh-llm-routing") or index("mesh-llm-types")' >/dev/null; then

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -603,12 +603,7 @@ jobs:
 
   swift_sdk_smoke:
     needs: [changes, macos_targets]
-    # Disabled on this branch only: macOS runners are rejecting
-    # `-fuse-ld=/opt/homebrew/bin/ld64.lld` with
-    # `clang: error: invalid linker name`. Reproduces on unrelated
-    # branches too (see PR #609). To be fixed on main and re-enabled
-    # there; do not remove this gate without coordinating.
-    if: ${{ false && needs.macos_targets.result == 'success' && needs.changes.outputs.macos_inference_artifact_required == 'true' && needs.changes.outputs.sdk_smoke_required == 'true' && needs.changes.outputs.docs_only != 'true' }}
+    if: ${{ needs.macos_targets.result == 'success' && needs.changes.outputs.macos_inference_artifact_required == 'true' && needs.changes.outputs.sdk_smoke_required == 'true' && needs.changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/sdk-smoke.yml
     with:
       sdk_kind: swift

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -73,7 +73,17 @@ jobs:
 
       - name: Install macOS SDK dependencies
         if: ${{ runner.os == 'macOS' }}
-        run: brew install jq
+        # `lld` is required because the Swift smoke job's transitive
+        # cargo build (via `sdk/swift/scripts/generate-swift-bindings.sh`
+        # in a temp dir) ends up invoking `cc` with
+        # `-fuse-ld=/opt/homebrew/bin/ld64.lld`. Apple clang accepts
+        # that flag only when the binary actually exists on disk;
+        # without `lld` installed the link step fails with
+        # `clang: error: invalid linker name in argument`. The
+        # `macos_targets` job already does `brew install ... lld` for
+        # the same reason — install it here too so the swift smoke
+        # lane matches.
+        run: brew install jq lld
 
       - name: Configure Linux Rust linker
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
## Why

The Swift SDK smoke job has been failing on macOS runners with:

```
clang: error: invalid linker name in argument '-fuse-ld=/opt/homebrew/bin/ld64.lld'
```

This is hitting unrelated PRs (#566, #609) — it is not specific to any one branch.

## What

The transitive cargo build inside `sdk/swift/scripts/generate-swift-bindings.sh` runs in a temp dir and ends up invoking `cc` with `-fuse-ld=/opt/homebrew/bin/ld64.lld`. Apple clang accepts that flag only when the linker binary actually exists on disk; the swift smoke job only installed `jq`, so the link step failed.

The `macos_targets` job (in `pr_builds.yml`) already does `brew install ... lld` for the same reason. This PR mirrors that in the reusable `sdk-smoke.yml` workflow so the swift smoke lane has `lld` available too.

## Follow-up

PR #566 has `swift_sdk_smoke` gated off with a `false &&` while this fix lands. Once this PR is merged and proven green, that gate should be removed (a one-line revert on the affected branch).