### PR TITLE
moa: harden gateway from PR #566 review (panic surface, error propagation, dedup race, dead code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,13 @@ mesh-llm serve --auto --headless
 For a deeper operator guide, see [docs/USAGE.md](docs/USAGE.md). For every CLI
 command and switch, see [docs/CLI.md](docs/CLI.md).
 
-## Mixture-of-Agents (`model: "mesh"`)
+## Mixture-of-Agents (`model: "mesh"`) — experimental
+
+> ⚠️ **Experimental.** The MoA gateway is new in this release. Behavior,
+> routing heuristics, error shapes, and tuning knobs may change between
+> versions while we tune it. Treat `model: "mesh"` as a preview feature
+> rather than a stable production path; use a specific model id when you
+> need stable semantics.
 
 Send a request with `"model": "mesh"` and the proxy fans it out to every
 model available in the mesh in parallel, arbitrates their responses with

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/family_policy.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/family_policy.rs
@@ -260,14 +260,15 @@ fn resident_kv_policy(activation_wire_dtype: StageWireDType) -> FamilyPolicy {
             // prefixes are recorded, so cache hit rate for the
             // recent workload is preserved.
             //
-            // Live observation: even at 16, sustained Goose `auto`
-            // traffic eventually starves the lanes — see the
-            // `prefix cache leak under sustained agent traffic`
-            // section in `docs/design/MOA_BRANCH_REPORT.md`. The
-            // 16-entry cap pushes the failure point from ~6 to ~16+
-            // requests but does not fully eliminate it. The proper
-            // fix is more invasive in `skippy-server` and out of
-            // scope for PR #566.
+            // The entry-count cap is the *coarse* lever: it bounds
+            // how many distinct prefixes the cache can hold, but with
+            // `kv_unified = true` even 16 long prefixes can pin the
+            // full cell pool. The complementary fine-grained cell
+            // budget (`max_resident_tokens` in
+            // `ResidentCacheConfig::from_stage`, landed in PR #566)
+            // closes the remaining gap by evicting on token pressure
+            // before the cell pool runs out. The 16-entry cap is
+            // still useful as a structural ceiling.
             max_entries: 16,
         },
     }

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -604,20 +604,21 @@ async fn try_handle_moa_intercept(
     if decision.effective_model.as_deref() != Some(moa::VIRTUAL_MODEL_NAME) {
         return MoaInterceptResult::NotMoa(tcp_stream);
     }
-    // try_handle_moa self-gates on the model name; the Some(_) return path
-    // means it declined to handle despite our outer gate — log and treat as
-    // handled (we can't reliably re-use the stream after the handoff).
-    if let Some(_unused_stream) = crate::network::openai::moa_gateway::try_handle_moa(
+    // `try_handle_moa` self-gates on the model name and consumes the
+    // stream when it accepts. The outer gate above guarantees the gate
+    // matches, so the inner call always returns `None` here — the stream
+    // is gone, either with the MoA response, a 503, or a 400. Discard
+    // the return value explicitly. The previous shape kept an
+    // `if let Some(_) = … { tracing::error!(...) }` branch that could
+    // never fire and made the control flow confusing to read.
+    let _ = crate::network::openai::moa_gateway::try_handle_moa(
         ctx.route.node,
         tcp_stream,
         request,
         decision.effective_model.as_deref(),
         Some(ctx.route.targets),
     )
-    .await
-    {
-        tracing::error!("moa: try_handle_moa returned unused stream despite outer model gate");
-    }
+    .await;
     proxy::release_request_objects(ctx.route.node, &request.request_object_request_ids).await;
     MoaInterceptResult::Handled
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -72,12 +72,34 @@ async fn run_moa_turn(
 /// Write the MoA response on the chosen transport (JSON or SSE), logging
 /// (but not propagating) any I/O error.
 ///
-/// When the gateway reports `TurnKind::Failed` we send an HTTP 502 (Bad
-/// Gateway) with the structured error body, rather than HTTP 200. The
-/// crate's `error_response` already carries an OpenAI-shape top-level
-/// `error` object and `finish_reason: "error"`, but unsophisticated
-/// clients that only check the HTTP status need that status to actually
-/// reflect failure.
+/// Detect whether a MoA response body is signalling failure.
+///
+/// Two signals, either of which means "failure":
+///
+///   * Top-level `error` object — OpenAI-shape error envelope produced
+///     by `moa::error_response`.
+///   * `choices[0].finish_reason == "error"` — same convention applied
+///     by the crate's response builder for in-band failure signalling.
+///
+/// Previously the HTTP-status decision was based on `TurnKind == Failed`,
+/// but the tool-result reducer path can produce an error_response with
+/// `TurnKind::ToolResult` when every reducer candidate fails. Tying the
+/// status to the body's failure signal instead means *all* error-shaped
+/// MoA responses get a non-200 status, regardless of which sub-flow
+/// produced them.
+fn is_moa_failure_body(body: &serde_json::Value) -> bool {
+    if body.get("error").is_some() {
+        return true;
+    }
+    body.pointer("/choices/0/finish_reason")
+        .and_then(|v| v.as_str())
+        == Some("error")
+}
+
+/// When the response body signals MoA failure (top-level `error` field or
+/// `choices[0].finish_reason == "error"`) we send an HTTP 502 (Bad
+/// Gateway), not HTTP 200. Unsophisticated clients that only check the
+/// HTTP status need that status to actually reflect failure.
 async fn write_moa_response(
     tcp_stream: TcpStream,
     moa_result: &moa::TurnResult,
@@ -85,12 +107,14 @@ async fn write_moa_response(
     was_streaming: bool,
 ) {
     let body = &moa_result.response_body;
+    let is_failure = is_moa_failure_body(body);
     let result = if was_streaming {
-        // SSE always uses 200: the failure signal rides in the streamed
-        // chunks (the body includes `error` and `finish_reason: "error"`).
-        // Once the headers are sent we cannot change the status code.
+        // SSE always uses 200: once the headers are flushed we cannot
+        // change the status code. The failure signal rides inside the
+        // emitted SSE chunks (`finish_reason: "error"`) — see
+        // `send_moa_as_sse` for the propagation.
         send_moa_as_sse(tcp_stream, body, extra_headers).await
-    } else if moa_result.turn_kind == moa::TurnKind::Failed {
+    } else if is_failure {
         proxy::send_json_with_status_and_headers(tcp_stream, 502, body, extra_headers).await
     } else {
         proxy::send_json_ok_with_headers(tcp_stream, body, extra_headers).await
@@ -494,11 +518,22 @@ async fn send_moa_as_sse(
         .and_then(|v| v.as_array())
         .cloned();
 
-    let finish_reason = if tool_calls.is_some() {
-        "tool_calls"
-    } else {
-        "stop"
+    // Propagate the actual finish_reason rather than always emitting `stop`.
+    // For failure-shaped bodies the inner `finish_reason` is `"error"` and
+    // the body carries a top-level `error` object — SSE clients keyed on
+    // `finish_reason` (Goose, OpenAI SDKs) need that signal to detect
+    // failure. Previously the SSE adapter hard-coded `"stop"`, which made
+    // MoA failures look like successful completions to streaming consumers.
+    let inner_finish_reason = response
+        .pointer("/choices/0/finish_reason")
+        .and_then(|v| v.as_str());
+    let finish_reason: &str = match inner_finish_reason {
+        Some("error") => "error",
+        _ if tool_calls.is_some() => "tool_calls",
+        Some(other) => other,
+        None => "stop",
     };
+    let is_failure = is_moa_failure_body(response);
 
     let delta = if let Some(ref tcs) = tool_calls {
         serde_json::json!({
@@ -529,6 +564,27 @@ async fn send_moa_as_sse(
     let data = format!("data: {}\n\n", chunk);
     let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
     stream.write_all(framed.as_bytes()).await?;
+
+    // For failure-shaped bodies, emit an explicit error chunk before the
+    // final `finish_reason` chunk so SSE clients that scan deltas for an
+    // `error` field can see the failure signal even if they ignore the
+    // finish_reason itself. This mirrors the OpenAI-compatible shape used
+    // by some upstream servers (an in-stream chunk carrying a structured
+    // `error` payload).
+    if is_failure {
+        if let Some(err) = response.get("error") {
+            let err_chunk = serde_json::json!({
+                "id": id,
+                "object": "chat.completion.chunk",
+                "model": model,
+                "choices": [],
+                "error": err,
+            });
+            let data = format!("data: {}\n\n", err_chunk);
+            let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
+            stream.write_all(framed.as_bytes()).await?;
+        }
+    }
 
     let stop = serde_json::json!({
         "id": id,
@@ -610,5 +666,49 @@ mod tests {
             strip_think_from_content("answer prefix<think>never closed"),
             "answer prefix"
         );
+    }
+
+    #[test]
+    fn is_moa_failure_body_detects_top_level_error() {
+        // Regression for PR #566 review (item #7): the HTTP status was
+        // gated on `TurnKind == Failed`, but reducer-failure tool-result
+        // turns produce an error_response with `TurnKind::ToolResult`.
+        // The body still carries the canonical failure signals, so
+        // status now follows the body.
+        let body = serde_json::json!({
+            "error": { "message": "reducer failed", "type": "moa_failure" },
+            "choices": [{ "finish_reason": "error", "message": { "content": "oops" } }],
+        });
+        assert!(is_moa_failure_body(&body));
+    }
+
+    #[test]
+    fn is_moa_failure_body_detects_finish_reason_error() {
+        let body = serde_json::json!({
+            "choices": [{ "finish_reason": "error", "message": { "content": "oops" } }],
+        });
+        assert!(is_moa_failure_body(&body));
+    }
+
+    #[test]
+    fn is_moa_failure_body_returns_false_for_success() {
+        let body = serde_json::json!({
+            "choices": [{ "finish_reason": "stop", "message": { "content": "hello" } }],
+        });
+        assert!(!is_moa_failure_body(&body));
+    }
+
+    #[test]
+    fn is_moa_failure_body_returns_false_for_tool_calls() {
+        let body = serde_json::json!({
+            "choices": [{
+                "finish_reason": "tool_calls",
+                "message": {
+                    "role": "assistant",
+                    "tool_calls": [{"id": "x", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+                },
+            }],
+        });
+        assert!(!is_moa_failure_body(&body));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -18,12 +18,19 @@ use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
 /// Detect `model: "mesh"`, build a mesh-wide MoA config, run the turn,
-/// send the HTTP response (JSON or SSE), and return `true` if the request
-/// was handled. Returns `false` if the request is not for MoA, so the
-/// caller can fall through to normal routing.
+/// and write the HTTP response (JSON or SSE) directly to the stream.
 ///
-/// On MoA failure (e.g. <2 models in the mesh) sends a 503 and still
-/// returns `true` — the caller must not also try to respond.
+/// Return value carries the un-consumed `TcpStream` so the caller knows
+/// what to do next:
+///
+/// * `Some(stream)` — the request is *not* MoA-shaped (effective model
+///   is not the virtual `"mesh"` name). The stream is returned unused
+///   and the caller should fall through to normal routing.
+///
+/// * `None` — MoA owns the response. The stream has been consumed: a
+///   successful MoA response, a 503 (when fewer than 2 models are
+///   reachable), or a 400 (when the request body wasn't JSON) was
+///   already written. The caller must *not* attempt to respond again.
 pub async fn try_handle_moa(
     node: &mesh::Node,
     tcp_stream: TcpStream,

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -577,12 +577,7 @@ async fn send_moa_as_sse(
         "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\nCache-Control: no-cache\r\nConnection: close\r\n",
     );
     for (name, value) in extra_headers {
-        // Strip CR/LF defensively against header-injection bugs creeping in later.
-        let safe_value: String = value.chars().filter(|c| *c != '\r' && *c != '\n').collect();
-        header.push_str(name);
-        header.push_str(": ");
-        header.push_str(&safe_value);
-        header.push_str("\r\n");
+        crate::network::openai::transport::append_safe_header(&mut header, name, value);
     }
     header.push_str("\r\n");
     stream.write_all(header.as_bytes()).await?;

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -115,22 +115,32 @@ async fn write_moa_response(
 ) {
     let body = &moa_result.response_body;
     let is_failure = is_moa_failure_body(body);
-    let result = if was_streaming {
-        // SSE always uses 200: once the headers are flushed we cannot
-        // change the status code. The failure signal rides inside the
-        // emitted SSE chunks (`finish_reason: "error"`) — see
-        // `send_moa_as_sse` for the propagation.
-        send_moa_as_sse(tcp_stream, body, extra_headers).await
+    // Streaming + failure: respond as non-streaming HTTP 502 with the
+    // structured error body instead of streaming a 200 SSE that happens
+    // to carry `finish_reason: "error"`. The OpenAI API behaves this
+    // way (failures on streaming endpoints come back as a single
+    // non-streaming JSON error response with the right HTTP status), so
+    // stream=true MoA failures now match non-stream failures at the
+    // HTTP layer. SSE clients see a clean connection-level error
+    // (5xx + JSON) instead of a misleading 200 with an in-band signal.
+    let (mode, result) = if was_streaming && !is_failure {
+        (
+            "SSE",
+            send_moa_as_sse(tcp_stream, body, extra_headers).await,
+        )
     } else if is_failure {
-        proxy::send_json_with_status_and_headers(tcp_stream, 502, body, extra_headers).await
+        (
+            "JSON-502",
+            proxy::send_json_with_status_and_headers(tcp_stream, 502, body, extra_headers).await,
+        )
     } else {
-        proxy::send_json_ok_with_headers(tcp_stream, body, extra_headers).await
+        (
+            "JSON",
+            proxy::send_json_ok_with_headers(tcp_stream, body, extra_headers).await,
+        )
     };
     if let Err(e) = result {
-        tracing::warn!(
-            "MoA: response write failed ({}): {e}",
-            if was_streaming { "SSE" } else { "JSON" }
-        );
+        tracing::warn!("MoA: response write failed ({mode}): {e}");
     }
 }
 
@@ -608,22 +618,19 @@ async fn send_moa_as_sse(
         .and_then(|v| v.as_array())
         .cloned();
 
-    // Propagate the actual finish_reason rather than always emitting `stop`.
-    // For failure-shaped bodies the inner `finish_reason` is `"error"` and
-    // the body carries a top-level `error` object — SSE clients keyed on
-    // `finish_reason` (Goose, OpenAI SDKs) need that signal to detect
-    // failure. Previously the SSE adapter hard-coded `"stop"`, which made
-    // MoA failures look like successful completions to streaming consumers.
-    let inner_finish_reason = response
-        .pointer("/choices/0/finish_reason")
-        .and_then(|v| v.as_str());
-    let finish_reason: &str = match inner_finish_reason {
-        Some("error") => "error",
-        _ if tool_calls.is_some() => "tool_calls",
-        Some(other) => other,
-        None => "stop",
+    // Caller (`write_moa_response`) routes failure-shaped bodies to a
+    // non-streaming 502 JSON response, so this function only ever sees a
+    // successful turn. The only choice the SSE adapter still has to make
+    // is `tool_calls` vs `stop`.
+    let finish_reason: &str = if tool_calls.is_some() {
+        "tool_calls"
+    } else {
+        "stop"
     };
-    let is_failure = is_moa_failure_body(response);
+    debug_assert!(
+        !is_moa_failure_body(response),
+        "send_moa_as_sse received a failure body; should have routed to 502"
+    );
 
     let delta = if let Some(ref tcs) = tool_calls {
         serde_json::json!({
@@ -654,27 +661,6 @@ async fn send_moa_as_sse(
     let data = format!("data: {}\n\n", chunk);
     let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
     stream.write_all(framed.as_bytes()).await?;
-
-    // For failure-shaped bodies, emit an explicit error chunk before the
-    // final `finish_reason` chunk so SSE clients that scan deltas for an
-    // `error` field can see the failure signal even if they ignore the
-    // finish_reason itself. This mirrors the OpenAI-compatible shape used
-    // by some upstream servers (an in-stream chunk carrying a structured
-    // `error` payload).
-    if is_failure {
-        if let Some(err) = response.get("error") {
-            let err_chunk = serde_json::json!({
-                "id": id,
-                "object": "chat.completion.chunk",
-                "model": model,
-                "choices": [],
-                "error": err,
-            });
-            let data = format!("data: {}\n\n", err_chunk);
-            let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
-            stream.write_all(framed.as_bytes()).await?;
-        }
-    }
 
     let stop = serde_json::json!({
         "id": id,
@@ -882,5 +868,55 @@ mod tests {
             }],
         });
         assert!(!is_moa_failure_body(&body));
+    }
+
+    // ── Streaming + failure routing ────────────────────────────────────
+    //
+    // The actual write path (`write_moa_response`) writes to a real
+    // `TcpStream`, so we test the *decision* it makes by extracting the
+    // failure detection into `is_moa_failure_body` and proving the
+    // routing logic with the same booleans the writer uses.
+    //
+    // The contract is:
+    //   was_streaming=false, is_failure=false  -> JSON 200
+    //   was_streaming=false, is_failure=true   -> JSON 502
+    //   was_streaming=true,  is_failure=false  -> SSE
+    //   was_streaming=true,  is_failure=true   -> JSON 502 (NOT SSE 200)
+    // The last row is the PR #612 review finding: streaming MoA failures
+    // must surface as a real 502 at the HTTP layer instead of streaming
+    // a 200 SSE carrying an in-band error.
+
+    fn route_decision(was_streaming: bool, is_failure: bool) -> &'static str {
+        if was_streaming && !is_failure {
+            "sse"
+        } else if is_failure {
+            "json-502"
+        } else {
+            "json-200"
+        }
+    }
+
+    #[test]
+    fn streaming_success_routes_to_sse() {
+        assert_eq!(route_decision(true, false), "sse");
+    }
+
+    #[test]
+    fn streaming_failure_routes_to_json_502_not_sse() {
+        // Regression for PR #612 review: streaming failures previously
+        // went out as `SSE 200` + in-band `finish_reason: "error"`.
+        // Now they collapse to a non-streaming JSON 502, matching the
+        // OpenAI API and the non-streaming MoA failure path.
+        assert_eq!(route_decision(true, true), "json-502");
+    }
+
+    #[test]
+    fn non_streaming_success_routes_to_json_200() {
+        assert_eq!(route_decision(false, false), "json-200");
+    }
+
+    #[test]
+    fn non_streaming_failure_routes_to_json_502() {
+        assert_eq!(route_decision(false, true), "json-502");
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -181,26 +181,33 @@ pub async fn build_moa_config(
     targets: Option<&election::ModelTargets>,
 ) -> Option<moa::GatewayConfig> {
     let http = reqwest::Client::new();
-    let mut seen_bases = std::collections::HashSet::new();
     let mut backends: Vec<std::sync::Arc<dyn moa::ModelBackend>> = Vec::new();
     let mut models: Vec<moa::ModelEntry> = Vec::new();
     let mut local_count = 0usize;
 
     // Full mesh-wide model list (local + every peer's advertised
-    // routable models). Sorted by name length so the shorter (canonical)
-    // form wins dedup.
-    let mut all_models: Vec<String> = node.models_being_served().await;
-    all_models.sort_by_key(|n| n.len());
+    // routable models).
+    let all_models: Vec<String> = node
+        .models_being_served()
+        .await
+        .into_iter()
+        .filter(|n| n != moa::VIRTUAL_MODEL_NAME)
+        .collect();
 
-    for name in all_models {
-        if !accept_for_dedup(&name, &mut seen_bases) {
-            continue;
-        }
-        add_worker_backend(
+    // Group aliases by canonical base. The old shape sorted by name
+    // length, took the *first* alias per base, and dropped the rest —
+    // which silently dropped the model from the worker pool whenever the
+    // shortest-named peer was unreachable (regression flagged by PR #566
+    // review). Now we keep every alias per base and try them in order so
+    // a longer-named reachable alias can still resolve when the shortest
+    // one is offline.
+    let groups = group_aliases_by_canonical_base(all_models, targets);
+    for aliases in groups {
+        resolve_one_worker_from_aliases(
             node,
             targets,
             &http,
-            &name,
+            &aliases,
             &mut backends,
             &mut models,
             &mut local_count,
@@ -246,13 +253,94 @@ pub async fn build_moa_config(
     })
 }
 
-/// Filter out the virtual `"mesh"` name and de-dup by canonical base.
-/// Returns true if `name` is a fresh model that should be considered.
-fn accept_for_dedup(name: &str, seen_bases: &mut std::collections::HashSet<String>) -> bool {
-    if name == moa::VIRTUAL_MODEL_NAME {
-        return false;
+/// Try each alias in `aliases` until one resolves to a backend, then stop.
+///
+/// Aliases are pre-sorted by `group_aliases_by_canonical_base` so the most
+/// preferred (locally-served first, then shortest) is tried first. Falls
+/// back to longer aliases when the preferred one's peer is unreachable.
+#[allow(clippy::too_many_arguments)]
+async fn resolve_one_worker_from_aliases(
+    node: &mesh::Node,
+    targets: Option<&election::ModelTargets>,
+    http: &reqwest::Client,
+    aliases: &[String],
+    backends: &mut Vec<std::sync::Arc<dyn moa::ModelBackend>>,
+    models: &mut Vec<moa::ModelEntry>,
+    local_count: &mut usize,
+) {
+    for name in aliases {
+        if add_worker_backend(node, targets, http, name, backends, models, local_count).await {
+            return;
+        }
     }
-    seen_bases.insert(canonical_base_name(name))
+}
+
+/// Group all advertised model names by their canonical base so each
+/// canonical model contributes exactly one worker, but the resolver gets
+/// to pick the alias that actually has a reachable backend.
+///
+/// The earlier shape committed to a single alias per base *before* trying
+/// to resolve a backend. Two failure modes:
+///
+///   1. The chosen alias is advertised only by a peer that drops between
+///      gossip refresh and orchestration — `hosts_for_model` returns
+///      empty, the worker is dropped, and longer-form aliases for the
+///      same canonical model from still-reachable peers are rejected as
+///      duplicates.
+///   2. The local node advertises a longer convention
+///      (e.g. `unsloth/Qwen3-8B-GGUF:Q4_K_M`) while a peer advertises a
+///      shorter variant (e.g. `Qwen3-8B-Q4_K_M`). The shortest-name rule
+///      picks the peer alias, `add_worker_backend` looks for a local port
+///      under that specific string, finds nothing, and forces a
+///      QUIC-tunnel backend even though the model is right here.
+///
+/// Both failure modes are fixed by grouping first and resolving second.
+/// Within each group the aliases are ordered so the most likely
+/// optimization wins first try: locally-served name (skippy-port fast
+/// path) before remote names, then shortest first as a tiebreaker.
+fn group_aliases_by_canonical_base(
+    names: Vec<String>,
+    targets: Option<&election::ModelTargets>,
+) -> Vec<Vec<String>> {
+    let mut by_base: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for name in names {
+        by_base
+            .entry(canonical_base_name(&name))
+            .or_default()
+            .push(name);
+    }
+    // Deterministic group order so the worker list is stable across
+    // builds even though HashMap iteration is not. Sort group entries
+    // (locally-served first, then shortest), then sort groups by their
+    // first ("best") alias.
+    let mut groups: Vec<Vec<String>> = by_base
+        .into_values()
+        .map(|mut aliases| {
+            aliases.sort_by(|a, b| {
+                let la = is_locally_served(a, targets);
+                let lb = is_locally_served(b, targets);
+                lb.cmp(&la) // local (true) before remote (false)
+                    .then_with(|| a.len().cmp(&b.len()))
+                    .then_with(|| a.cmp(b))
+            });
+            aliases
+        })
+        .collect();
+    groups.sort_by(|a, b| a[0].cmp(&b[0]));
+    groups
+}
+
+/// Does the local routing table have a backend port for this exact name?
+fn is_locally_served(name: &str, targets: Option<&election::ModelTargets>) -> bool {
+    targets
+        .and_then(|t| {
+            t.targets.get(name).map(|tv| {
+                tv.iter()
+                    .any(|t| matches!(t, election::InferenceTarget::Local(_)))
+            })
+        })
+        .unwrap_or(false)
 }
 
 /// Resolve `name` to a backend (local skippy port if available, else first
@@ -696,6 +784,88 @@ mod tests {
             "choices": [{ "finish_reason": "stop", "message": { "content": "hello" } }],
         });
         assert!(!is_moa_failure_body(&body));
+    }
+
+    fn make_targets(local_names: &[&str]) -> election::ModelTargets {
+        let mut t = election::ModelTargets::default();
+        for (i, name) in local_names.iter().enumerate() {
+            t.targets.insert(
+                (*name).to_string(),
+                vec![election::InferenceTarget::Local(50000 + i as u16)],
+            );
+        }
+        t
+    }
+
+    #[test]
+    fn group_aliases_keeps_all_aliases_per_canonical_base() {
+        // Regression for PR #566 review (item #10): the dedup-then-resolve
+        // shape committed to a single alias per base before checking
+        // backend reachability. Now every alias is retained so the
+        // resolver can fall back if the preferred alias is unreachable.
+        let groups = group_aliases_by_canonical_base(
+            vec![
+                "Qwen3-8B-Q4_K_M".to_string(),
+                "unsloth/Qwen3-8B-GGUF:Q4_K_M".to_string(),
+            ],
+            None,
+        );
+        assert_eq!(groups.len(), 1, "both names share a canonical base");
+        assert_eq!(groups[0].len(), 2, "both aliases retained");
+    }
+
+    #[test]
+    fn group_aliases_prefers_locally_served_alias_even_when_longer() {
+        // Without a targets table, length-order wins and the shorter peer
+        // alias would be tried first — forcing an unnecessary QUIC hop
+        // when the model is right here under a different alias.
+        // With targets, the local-served alias must come first.
+        let local = "unsloth/Qwen3-8B-GGUF:Q4_K_M";
+        let peer = "Qwen3-8B-Q4_K_M";
+        let targets = make_targets(&[local]);
+        let groups = group_aliases_by_canonical_base(
+            vec![peer.to_string(), local.to_string()],
+            Some(&targets),
+        );
+        assert_eq!(groups.len(), 1);
+        assert_eq!(
+            groups[0].first().map(String::as_str),
+            Some(local),
+            "locally-served alias must win even though it's longer"
+        );
+    }
+
+    #[test]
+    fn group_aliases_falls_back_to_shortest_when_no_local() {
+        // No targets table at all (pure --client --auto node) — shortest
+        // alias should win, but the longer alias is still in the group so
+        // it can be tried if the shortest one is unreachable.
+        let groups = group_aliases_by_canonical_base(
+            vec![
+                "unsloth/Qwen3-8B-GGUF:Q4_K_M".to_string(),
+                "Qwen3-8B-Q4_K_M".to_string(),
+            ],
+            None,
+        );
+        assert_eq!(groups.len(), 1);
+        assert_eq!(
+            groups[0].first().map(String::as_str),
+            Some("Qwen3-8B-Q4_K_M")
+        );
+        assert_eq!(groups[0].len(), 2, "longer alias kept as fallback");
+    }
+
+    #[test]
+    fn group_aliases_distinct_models_stay_in_separate_groups() {
+        let groups = group_aliases_by_canonical_base(
+            vec![
+                "unsloth/Qwen3-8B-GGUF:Q4_K_M".to_string(),
+                "unsloth/Qwen3-32B-GGUF:Q4_K_M".to_string(),
+                "unsloth/MiniMax-M2.5-GGUF:Q4_K_M".to_string(),
+            ],
+            None,
+        );
+        assert_eq!(groups.len(), 3);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -4030,9 +4030,58 @@ pub async fn send_json_ok(mut stream: TcpStream, data: &serde_json::Value) -> st
     Ok(())
 }
 
+/// RFC 7230 tchar set for header field names: ASCII alphanumeric plus
+/// `!#$%&'*+-.^_`|~`. We additionally forbid `:` because it terminates
+/// the field-name in the wire grammar. Used to reject caller-provided
+/// header names that could carry CR/LF or other injection bytes.
+pub(crate) fn is_valid_header_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.bytes().all(|b| {
+            b.is_ascii_alphanumeric()
+                || matches!(
+                    b,
+                    b'!' | b'#'
+                        | b'$'
+                        | b'%'
+                        | b'&'
+                        | b'\''
+                        | b'*'
+                        | b'+'
+                        | b'-'
+                        | b'.'
+                        | b'^'
+                        | b'_'
+                        | b'`'
+                        | b'|'
+                        | b'~'
+                )
+        })
+}
+
+/// Append a single `name: value` header line if `name` is a valid HTTP
+/// header field name. CR/LF in `value` is stripped defensively. Used by
+/// the `*_with_headers` writers below so a malformed header from a
+/// future caller can't inject extra headers / smuggle a response.
+pub(crate) fn append_safe_header(headers: &mut String, name: &str, value: &str) {
+    if !is_valid_header_name(name) {
+        tracing::warn!(
+            "openai transport: dropping header with invalid name `{name}` (RFC 7230 tchar required)"
+        );
+        return;
+    }
+    let safe_value: String = value.chars().filter(|c| *c != '\r' && *c != '\n').collect();
+    headers.push_str(name);
+    headers.push_str(": ");
+    headers.push_str(&safe_value);
+    headers.push_str("\r\n");
+}
+
 /// Like `send_json_ok` but allows the caller to append arbitrary response
-/// headers (e.g. `x-moa-*` observability headers). Header names and values
-/// must be plain ASCII without CR/LF; values are not validated further.
+/// headers (e.g. `x-moa-*` observability headers).
+///
+/// Header names must satisfy the RFC 7230 tchar grammar (ASCII
+/// alphanumeric + a small symbol set); invalid names are dropped with a
+/// warning rather than written verbatim. Values are stripped of CR/LF.
 pub async fn send_json_ok_with_headers(
     mut stream: TcpStream,
     data: &serde_json::Value,
@@ -4041,12 +4090,7 @@ pub async fn send_json_ok_with_headers(
     let body = data.to_string();
     let mut headers = String::from("HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n");
     for (name, value) in extra_headers {
-        // Strip CR/LF defensively against header-injection bugs creeping in later.
-        let safe_value: String = value.chars().filter(|c| *c != '\r' && *c != '\n').collect();
-        headers.push_str(name);
-        headers.push_str(": ");
-        headers.push_str(&safe_value);
-        headers.push_str("\r\n");
+        append_safe_header(&mut headers, name, value);
     }
     headers.push_str(&format!("Content-Length: {}\r\n\r\n", body.len()));
     stream.write_all(headers.as_bytes()).await?;
@@ -4082,12 +4126,7 @@ pub async fn send_json_with_status_and_headers(
     let body = data.to_string();
     let mut headers = format!("HTTP/1.1 {code} {status}\r\nContent-Type: application/json\r\n");
     for (name, value) in extra_headers {
-        // Strip CR/LF defensively against header-injection.
-        let safe_value: String = value.chars().filter(|c| *c != '\r' && *c != '\n').collect();
-        headers.push_str(name);
-        headers.push_str(": ");
-        headers.push_str(&safe_value);
-        headers.push_str("\r\n");
+        append_safe_header(&mut headers, name, value);
     }
     headers.push_str(&format!("Content-Length: {}\r\n\r\n", body.len()));
     stream.write_all(headers.as_bytes()).await?;
@@ -4326,6 +4365,46 @@ async fn relay_pipeline_non_streaming_response(
 mod tests {
     use super::*;
     use tokio::net::TcpListener;
+
+    // ── Header-name validation ──────────────────────────────────────
+
+    #[test]
+    fn is_valid_header_name_accepts_normal_observability_headers() {
+        assert!(is_valid_header_name("x-moa-elapsed-ms"));
+        assert!(is_valid_header_name("X-MoA-Workers"));
+        assert!(is_valid_header_name("Content-Type"));
+        assert!(is_valid_header_name("x-request-id"));
+    }
+
+    #[test]
+    fn is_valid_header_name_rejects_injection_attempts() {
+        // Regression for PR #566 review item #5c: header NAMES were not
+        // sanitized, only values. A name carrying CR/LF or a colon would
+        // smuggle extra headers / split the response.
+        assert!(!is_valid_header_name("x-evil\r\nSet-Cookie"));
+        assert!(!is_valid_header_name("x-evil\nSet-Cookie"));
+        assert!(!is_valid_header_name("x-evil: hijacked"));
+        assert!(!is_valid_header_name("x evil")); // space inside name
+        assert!(!is_valid_header_name(""));
+    }
+
+    #[test]
+    fn append_safe_header_drops_invalid_name() {
+        let mut buf = String::new();
+        append_safe_header(&mut buf, "x-evil\r\nSet-Cookie", "bad");
+        assert!(buf.is_empty(), "invalid name must be dropped, got {buf:?}");
+    }
+
+    #[test]
+    fn append_safe_header_strips_crlf_from_value() {
+        let mut buf = String::new();
+        append_safe_header(&mut buf, "x-ok", "ok\r\nSet-Cookie: hijack");
+        assert!(
+            buf.starts_with("x-ok: okSet-Cookie: hijack\r\n"),
+            "value CRLF must be stripped; got {buf:?}"
+        );
+        assert_eq!(buf.matches("\r\n").count(), 1);
+    }
 
     fn hf_descriptor(model_name: &str) -> mesh::ServedModelDescriptor {
         mesh::ServedModelDescriptor {

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -177,18 +177,34 @@ pub(crate) async fn call_backend(
 }
 
 /// Extract retry-after seconds from an error message containing "retry-after: N".
+///
+/// The earlier shape called `err.to_lowercase()` (Unicode-aware) and then
+/// sliced the *original* `err` using the byte offset from the lowercased
+/// string. For non-ASCII inputs, `to_lowercase()` can change UTF-8 byte
+/// length, so the offset could land mid-codepoint and either panic or
+/// produce garbage. Use `to_ascii_lowercase()` which is a 1:1 byte mapping
+/// so the offset stays valid in the original string.
 fn parse_retry_after(err: &str) -> Option<u64> {
-    let lower = err.to_lowercase();
-    lower
-        .find("retry-after:")
-        .map(|i| &err[i + 12..])
-        .and_then(|s| s.split_whitespace().next())
+    let lower = err.to_ascii_lowercase();
+    let i = lower.find("retry-after:")?;
+    let tail = err.get(i + "retry-after:".len()..)?;
+    tail.split_whitespace()
+        .next()
         .and_then(|s| s.trim().parse::<u64>().ok())
 }
 
 /// Extract assistant text from a chat completion response body.
+///
+/// The response comes from an untrusted backend (peer node, local skippy,
+/// or in tests a mock). Direct indexing like `resp["choices"][0]["message"]`
+/// returns `Value::Null` on missing fields, which then silently produces
+/// an empty string — or worse, panics in `.unwrap()` chains. Use
+/// `.pointer()` so a malformed response surfaces as a structured `Err`
+/// rather than a hidden empty answer.
 fn extract_text_from_response(resp: &Value) -> Result<String, String> {
-    let message = &resp["choices"][0]["message"];
+    let message = resp
+        .pointer("/choices/0/message")
+        .ok_or_else(|| "malformed response: missing choices[0].message".to_string())?;
 
     // Native tool_calls → KV format for normalizer
     if let Some(tool_calls) = message.get("tool_calls").and_then(|tc| tc.as_array()) {
@@ -254,6 +270,35 @@ mod tests {
     fn parse_retry_after_case_insensitive() {
         let err = "Retry-After: 5";
         assert_eq!(parse_retry_after(err), Some(5));
+    }
+
+    #[test]
+    fn parse_retry_after_handles_non_ascii_prefix_without_panic() {
+        // Regression for PR #566 review: the prior shape used
+        // `to_lowercase()` (Unicode-aware, can change byte length) and
+        // sliced the original `err` with that offset. For inputs with
+        // non-ASCII before the marker, the slice could land mid-codepoint
+        // and panic. With `to_ascii_lowercase()` the offset is byte-stable.
+        let err = "über-error: retry-after: 7";
+        assert_eq!(parse_retry_after(err), Some(7));
+    }
+
+    #[test]
+    fn extract_text_returns_err_on_missing_choices() {
+        // Regression for PR #566 review: direct-indexing
+        // `resp["choices"][0]["message"]` returns `Value::Null` on
+        // malformed responses; downstream `.unwrap()` chains then panicked.
+        // Now a structured error surfaces instead.
+        let resp: Value = serde_json::json!({"id": "x"});
+        let err = extract_text_from_response(&resp).unwrap_err();
+        assert!(err.contains("missing choices"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn extract_text_returns_err_on_empty_choices() {
+        let resp: Value = serde_json::json!({"choices": []});
+        let err = extract_text_from_response(&resp).unwrap_err();
+        assert!(err.contains("missing choices"));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -85,18 +85,13 @@ fn pack_fast(session: &Session) -> PackedContext {
     let system = system_with_tool_names(session);
     let user_text = session.last_user_text();
 
-    // Include running summary for multi-turn context
-    let mut system_full = system;
-    if session.turn_count() > 1 {
-        let summary = session.running_summary();
-        if !summary.is_empty() {
-            system_full.push_str(&format!("\n\nConversation so far:\n{summary}"));
-        }
-    }
-
+    // Per-request sessions: the caller owns the multi-turn loop and
+    // sends the full history each request. Continuation context lives
+    // in `session.messages()`; this path intentionally trims to just
+    // the last user message to keep the fast worker's context small.
     PackedContext {
         messages: vec![
-            json!({"role": "system", "content": system_full}),
+            json!({"role": "system", "content": system}),
             json!({"role": "user", "content": user_text}),
         ],
         max_tokens: 256,

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -239,7 +239,7 @@ async fn handle_query(
 
     if outputs.is_empty() {
         return TurnResult {
-            response_body: error_response("All MoA workers failed"),
+            response_body: error_response("All MoA workers failed", MOA_ERR_ALL_WORKERS_FAILED),
             worker_summaries: summaries,
             reducer_used: false,
             reducer_attempts: 0,
@@ -360,7 +360,10 @@ async fn handle_tool_result(
             (
                 candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
                 false,
-                error_response(&format!("Reducer failed (tried {attempts}): {err}")),
+                error_response(
+                    &format!("Reducer failed (tried {attempts}): {err}"),
+                    MOA_ERR_ALL_REDUCERS_FAILED,
+                ),
             )
         }
     };
@@ -493,9 +496,15 @@ fn best_answer(outputs: &[WorkerOutput]) -> String {
 ///     so unstructured clients still surface a useful string to the
 ///     human, just not as a successful assistant reply.
 ///
+/// `code` is the machine-parseable failure mode that clients can branch
+/// on. Callers pass one of the [`MOA_ERR_*`] constants so distinct
+/// failure modes (all-workers-failed vs all-reducers-failed vs future
+/// kinds) surface accurately to the caller rather than being collapsed
+/// to a single string.
+///
 /// The ingress layer is responsible for choosing the HTTP status; this
 /// body is the in-band signal.
-fn error_response(message: &str) -> Value {
+fn error_response(message: &str, code: &str) -> Value {
     json!({
         "id": format!("chatcmpl-moa-{}", short_id()),
         "object": "chat.completion",
@@ -503,7 +512,7 @@ fn error_response(message: &str) -> Value {
         "error": {
             "message": message,
             "type": "moa_failure",
-            "code": "all_workers_failed",
+            "code": code,
         },
         "choices": [{
             "index": 0,
@@ -513,6 +522,12 @@ fn error_response(message: &str) -> Value {
         "usage": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0 }
     })
 }
+
+/// All fanned-out workers failed before the arbiter could pick a winner.
+pub const MOA_ERR_ALL_WORKERS_FAILED: &str = "all_workers_failed";
+/// Every reducer candidate failed (in both the tool-result and the
+/// arbiter-escalated paths).
+pub const MOA_ERR_ALL_REDUCERS_FAILED: &str = "all_reducers_failed";
 
 fn chat_response(content: &str) -> Value {
     json!({

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -333,11 +333,18 @@ async fn handle_tool_result(
 
     let (reducer_name, succeeded, response_body) = match chosen {
         Some((name, reduced)) => {
+            // Be consistent with the fanout/arbiter path: emit a real
+            // `tool_calls` response whenever the reducer named a tool,
+            // even if `arguments` is missing. The fanout path emits `{}`
+            // for empty arguments; this path used to fall back to a
+            // chat_response carrying the reducer's prose, which broke
+            // agent harnesses (Goose, OpenCode) that only act on
+            // `tool_calls`. `tool_call_response` already collapses
+            // missing / non-object arguments to `"{}"`.
             let body = match reduced.kind {
                 normalize::OutputKind::ToolProposal => {
-                    if let (Some(tname), Some(args)) =
-                        (reduced.tool_name.as_ref(), reduced.tool_arguments.as_ref())
-                    {
+                    if let Some(tname) = reduced.tool_name.as_ref() {
+                        let args = reduced.tool_arguments.as_ref().unwrap_or(&Value::Null);
                         tool_call_response(tname, args)
                     } else {
                         chat_response(&reduced.payload)
@@ -427,9 +434,16 @@ async fn resolve_decision(
             match chosen {
                 Some(reduced) => match reduced.kind {
                     normalize::OutputKind::ToolProposal => {
-                        if let (Some(name), Some(args)) =
-                            (reduced.tool_name.as_ref(), reduced.tool_arguments.as_ref())
-                        {
+                        // See the matching block in `handle_tool_result`:
+                        // emit `tool_calls` whenever `tool_name` is present,
+                        // defaulting `arguments` to `{}` via
+                        // `tool_call_response`. Agent harnesses key on
+                        // `tool_calls` rather than scanning prose, so the
+                        // previous "both name AND args required" gate would
+                        // silently fall back to a chat_response and break
+                        // the calling agent's tool loop.
+                        if let Some(name) = reduced.tool_name.as_ref() {
+                            let args = reduced.tool_arguments.as_ref().unwrap_or(&Value::Null);
                             (tool_call_response(name, args), true, attempts)
                         } else {
                             (chat_response(&reduced.payload), true, attempts)

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -175,7 +175,7 @@ pub async fn handle_turn(config: &GatewayConfig, body: &Value) -> TurnResult {
         session::TurnType::ToolResult => {
             handle_tool_result(config, &session, has_tools, &allowed_tools, start).await
         }
-        session::TurnType::Fresh | session::TurnType::Continuation => {
+        session::TurnType::Fresh => {
             handle_query(config, &session, has_tools, &allowed_tools, start).await
         }
     }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -456,7 +456,12 @@ fn best_answer(outputs: &[WorkerOutput]) -> String {
     outputs
         .iter()
         .filter(|o| matches!(o.kind, normalize::OutputKind::Answer))
-        .max_by(|a, b| a.confidence.partial_cmp(&b.confidence).unwrap())
+        // `total_cmp` is total over all f32 (including NaN/Inf); `partial_cmp`
+        // can return `None` on NaN, which would panic on `unwrap`.
+        // `normalize_worker_output` now sanitizes non-finite confidences
+        // before they reach here, but using `total_cmp` keeps this site
+        // panic-free even if a future caller skips the normalizer.
+        .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
         .or(outputs.first())
         .map(|o| o.payload.clone())
         .unwrap_or_default()
@@ -510,10 +515,33 @@ fn chat_response(content: &str) -> Value {
 }
 
 fn tool_call_response(name: &str, arguments: &Value) -> Value {
-    let args_str = if arguments.is_string() {
-        arguments.as_str().unwrap_or("{}").to_string()
-    } else {
-        serde_json::to_string(arguments).unwrap_or_else(|_| "{}".to_string())
+    // OpenAI tool-call `arguments` is a JSON-object *string*. Three input
+    // shapes have to collapse to a valid object string here:
+    //
+    //   * String form: trust the caller's JSON (worker already passed
+    //     through `extract_tool_arguments` so the inner shape is sane).
+    //   * Null / non-object: emit `"{}"` rather than `"null"` or
+    //     `"\"foo\""`. The previous shape would serialize `Value::Null`
+    //     to the literal four-char string `"null"`, which downstream
+    //     OpenAI tool-call consumers reject.
+    //   * Object: serialize as JSON.
+    let args_str = match arguments {
+        Value::String(s) => {
+            // Validate that the string is itself a JSON object; if not,
+            // fall back to `{}` to keep wire-shape sane.
+            if serde_json::from_str::<Value>(s)
+                .map(|v| v.is_object())
+                .unwrap_or(false)
+            {
+                s.clone()
+            } else {
+                "{}".to_string()
+            }
+        }
+        Value::Null => "{}".to_string(),
+        v if v.is_object() => serde_json::to_string(v).unwrap_or_else(|_| "{}".to_string()),
+        // Bare primitives / arrays — not a valid tool-call arguments object.
+        _ => "{}".to_string(),
     };
 
     json!({
@@ -544,4 +572,88 @@ fn short_id() -> String {
         .unwrap_or_default()
         .as_nanos();
     format!("{:x}", t)
+}
+
+#[cfg(test)]
+mod response_builder_tests {
+    use super::*;
+    use crate::normalize::{OutputKind, WorkerOutput};
+    use crate::worker::WorkerRole;
+
+    fn answer(model: &str, confidence: f32, payload: &str) -> WorkerOutput {
+        WorkerOutput {
+            kind: OutputKind::Answer,
+            confidence,
+            tool_name: None,
+            tool_arguments: None,
+            payload: payload.to_string(),
+            model: model.to_string(),
+            role: WorkerRole::Fast,
+            elapsed_ms: 1,
+        }
+    }
+
+    #[test]
+    fn best_answer_does_not_panic_on_nan_confidence() {
+        // Regression for PR #566 review: `partial_cmp(...).unwrap()` could
+        // panic if any confidence reached this site as NaN. After switching
+        // to `total_cmp`, this is safe even if normalize is bypassed.
+        let outputs = vec![
+            answer("a", f32::NAN, "nan-answer"),
+            answer("b", 0.7, "good-answer"),
+            answer("c", f32::NAN, "another-nan"),
+        ];
+        let picked = best_answer(&outputs);
+        // `total_cmp` treats NaN as greater than any finite; the assertion
+        // here is *not* about which specific answer wins, only that we do
+        // not panic and we return *some* answer.
+        assert!(!picked.is_empty());
+    }
+
+    #[test]
+    fn tool_call_response_emits_object_args_for_null() {
+        // Regression: `Value::Null` previously serialized to the literal
+        // string "null", which downstream OpenAI tool-call consumers reject.
+        let resp = tool_call_response("list", &Value::Null);
+        let args_str = resp
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(|v| v.as_str())
+            .expect("arguments is string");
+        assert_eq!(args_str, "{}");
+    }
+
+    #[test]
+    fn tool_call_response_emits_object_args_for_primitive() {
+        let resp = tool_call_response("list", &Value::from(42));
+        let args_str = resp
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(|v| v.as_str())
+            .expect("arguments is string");
+        assert_eq!(args_str, "{}");
+    }
+
+    #[test]
+    fn tool_call_response_passes_through_string_form_when_valid() {
+        let resp = tool_call_response(
+            "read_file",
+            &Value::String("{\"path\":\"README.md\"}".to_string()),
+        );
+        let args_str = resp
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(|v| v.as_str())
+            .expect("arguments is string");
+        let parsed: Value = serde_json::from_str(args_str).unwrap();
+        assert_eq!(parsed["path"], "README.md");
+    }
+
+    #[test]
+    fn tool_call_response_rejects_invalid_string_form() {
+        // If the caller hands us a bare non-JSON string, fall back to `{}`.
+        let resp = tool_call_response("x", &Value::String("not json at all".to_string()));
+        let args_str = resp
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(|v| v.as_str())
+            .expect("arguments is string");
+        assert_eq!(args_str, "{}");
+    }
 }

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -247,9 +247,14 @@ fn try_json_parse(
 /// which is logically dead: `.cloned()` on a `Some(Value::String("…"))` is
 /// already `Some`, so the `or_else` branch never ran and string-encoded
 /// arguments leaked through unparsed. We branch explicitly here so each
-/// shape gets the right handling, and missing/null `arguments` collapses to
-/// `Some({})` so the OpenAI tool-call serializer never emits the literal
-/// string `"null"`.
+/// shape gets the right handling.
+///
+/// Missing or `Value::Null` arguments return `None` from this helper;
+/// downstream `tool_call_response` substitutes `"{}"` when serializing
+/// the OpenAI tool-call wire shape, so the literal string `"null"`
+/// never reaches the client. The `WorkerOutput::tool_arguments`
+/// invariant is therefore "`None` or an object", with `None` meaning
+/// "emit empty-object args at wire time".
 fn extract_tool_arguments(value: Option<&Value>) -> Option<Value> {
     match value {
         Some(Value::String(s)) => {

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -44,28 +44,50 @@ pub fn normalize_worker_output(
     let text = if cleaned.is_empty() { raw } else { &cleaned };
 
     // Strategy 1: try JSON parse
-    if let Some(output) = try_json_parse(text, model, role, elapsed_ms) {
-        return output;
-    }
-
     // Strategy 2: try line-based key:value extraction
-    if let Some(output) = try_kv_parse(text, model, role, elapsed_ms) {
-        return output;
-    }
-
     // Strategy 3: heuristic classification
-    let mut output = heuristic_classify(text, model, role, elapsed_ms);
+    //
+    // Whichever strategy wins, we then run a single sanitize pass over the
+    // result so the invariants hold regardless of parse path. The previous
+    // shape returned early on Strategy 1 / 2 and only sanitized Strategy 3,
+    // which let non-finite confidences (e.g. KV `confidence: NaN` parsed via
+    // `parse::<f32>()`) escape into the arbiter where `partial_cmp/total_cmp`
+    // can panic on `unwrap`.
+    let output = try_json_parse(text, model, role, elapsed_ms)
+        .or_else(|| try_kv_parse(text, model, role, elapsed_ms))
+        .unwrap_or_else(|| {
+            let mut heuristic = heuristic_classify(text, model, role, elapsed_ms);
+            // Heuristic path can leak stray KV envelope lines into the payload
+            // when the model output contains a partial `kind:/confidence:/`
+            // block; structured parsers already isolate the payload field.
+            heuristic.payload = strip_kv_envelope(&heuristic.payload);
+            heuristic
+        });
 
-    // Final cleanup: strip any KV envelope lines that leaked into the payload
-    // (e.g. when KV parse fails but the text ends with kind:/confidence:/payload:
-    // lines from truncated model output).
-    output.payload = strip_kv_envelope(&output.payload);
+    sanitize_worker_output(output)
+}
 
-    // Sanitize confidence: clamp NaN/Inf to 0.5 so comparisons never panic.
+/// Enforce the invariants every arbiter / reducer call site assumes.
+///
+/// * `confidence` is finite (NaN/Inf clamp to 0.5 so comparisons never panic).
+/// * `tool_arguments`, when `Some`, is an object — callers serialize it as a
+///   JSON object string; `Value::Null` collapses to an empty object, and bare
+///   primitives collapse to `{}` rather than producing invalid `arguments`.
+fn sanitize_worker_output(mut output: WorkerOutput) -> WorkerOutput {
     if !output.confidence.is_finite() {
         output.confidence = 0.5;
     }
-
+    if let Some(args) = output.tool_arguments.as_ref() {
+        if args.is_null() {
+            output.tool_arguments = Some(serde_json::json!({}));
+        } else if !args.is_object() {
+            // Primitive or array payloads cannot be re-serialized as a valid
+            // OpenAI tool-call `arguments` object string. Replace with an
+            // empty object so downstream callers always see a well-formed
+            // structure rather than `"null"` / `"\"foo\""`.
+            output.tool_arguments = Some(serde_json::json!({}));
+        }
+    }
     output
 }
 
@@ -154,11 +176,7 @@ fn try_json_parse(
             .or_else(|| obj.get("name").and_then(|v| v.as_str()))
             .or_else(|| obj.get("tool").and_then(|v| v.as_str()));
         if let Some(tname) = openai_tool_name {
-            let args = obj.get("arguments").cloned().or_else(|| {
-                obj.get("arguments")
-                    .and_then(|a| a.as_str())
-                    .and_then(|s| serde_json::from_str(s).ok())
-            });
+            let args = extract_tool_arguments(obj.get("arguments"));
             return Some(WorkerOutput {
                 kind: OutputKind::ToolProposal,
                 // OpenAI-shape tool calls have no native confidence
@@ -195,12 +213,7 @@ fn try_json_parse(
         .and_then(|t| t.as_str())
         .map(|s| s.to_string());
 
-    let tool_arguments = obj.get("arguments").cloned().or_else(|| {
-        // Sometimes models put args as a string
-        obj.get("arguments")
-            .and_then(|a| a.as_str())
-            .and_then(|s| serde_json::from_str(s).ok())
-    });
+    let tool_arguments = extract_tool_arguments(obj.get("arguments"));
 
     let payload = obj
         .get("payload")
@@ -218,6 +231,41 @@ fn try_json_parse(
         role,
         elapsed_ms,
     })
+}
+
+/// Pull a tool-call `arguments` value out of a parsed JSON envelope.
+///
+/// Models emit `arguments` in two shapes:
+///
+/// 1. As a JSON object: `"arguments": {"path": "README.md"}` — use as-is.
+/// 2. As a JSON-encoded string: `"arguments": "{\"path\":\"README.md\"}"`
+///    — the OpenAI wire shape. We need to `from_str` the inner string so
+///    the downstream `Value::Object` invariant holds.
+///
+/// The original code wrote
+///     obj.get("arguments").cloned().or_else(|| obj.get("arguments").and_then(as_str)...)
+/// which is logically dead: `.cloned()` on a `Some(Value::String("…"))` is
+/// already `Some`, so the `or_else` branch never ran and string-encoded
+/// arguments leaked through unparsed. We branch explicitly here so each
+/// shape gets the right handling, and missing/null `arguments` collapses to
+/// `Some({})` so the OpenAI tool-call serializer never emits the literal
+/// string `"null"`.
+fn extract_tool_arguments(value: Option<&Value>) -> Option<Value> {
+    match value {
+        Some(Value::String(s)) => {
+            // String form: parse the inner JSON. If it doesn't parse,
+            // fall through to `{}` rather than carrying a bare string.
+            serde_json::from_str(s)
+                .ok()
+                .or_else(|| Some(serde_json::json!({})))
+        }
+        Some(Value::Null) | None => None,
+        Some(other) if other.is_object() => Some(other.clone()),
+        // Bare arrays / numbers / bools cannot be a valid OpenAI tool-call
+        // arguments object — collapse to `{}`. The sanitize pass in
+        // `normalize_worker_output` also enforces this defensively.
+        Some(_) => Some(serde_json::json!({})),
+    }
 }
 
 /// Try line-based `key: value` extraction.
@@ -670,5 +718,69 @@ mod tests {
         let raw = r#"{"kind": "answer", "confidence": "NaN", "payload": "hello"}"#;
         let out = normalize_worker_output(raw, "test-model", WorkerRole::Fast, 100);
         assert!(out.confidence.is_finite());
+    }
+
+    #[test]
+    fn kv_path_clamps_nan_confidence() {
+        // Regression for PR #566 review: the JSON path was being clamped
+        // but the KV path was not, so `confidence: NaN` in the KV envelope
+        // returned `f32::NAN` straight to the arbiter where `partial_cmp`
+        // panicked. After the refactor, sanitize runs on every parse path.
+        let raw = "kind: answer\nconfidence: NaN\npayload: hello";
+        let out = normalize_worker_output(raw, "test-model", WorkerRole::Fast, 100);
+        assert!(
+            out.confidence.is_finite(),
+            "KV NaN must be sanitized; got {}",
+            out.confidence
+        );
+        assert_eq!(out.confidence, 0.5);
+    }
+
+    #[test]
+    fn kv_path_clamps_inf_confidence() {
+        // `parse::<f32>()` happily accepts `inf` / `-inf` too.
+        let raw = "kind: answer\nconfidence: inf\npayload: hello";
+        let out = normalize_worker_output(raw, "test-model", WorkerRole::Fast, 100);
+        assert!(out.confidence.is_finite());
+        assert_eq!(out.confidence, 0.5);
+    }
+
+    #[test]
+    fn json_string_encoded_arguments_are_parsed_to_object() {
+        // Regression: the original `obj.get("arguments").cloned().or_else(…)`
+        // chain had a dead `or_else` branch — string-encoded JSON arguments
+        // never made it through the inner `from_str` and leaked as a bare
+        // string into the tool-call wire shape. With `extract_tool_arguments`,
+        // the string is parsed into a real JSON object.
+        let raw = r#"{"function": "read_file", "arguments": "{\"path\": \"README.md\"}"}"#;
+        let out = normalize_worker_output(raw, "test-model", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("read_file"));
+        let args = out.tool_arguments.expect("args parsed");
+        assert!(args.is_object(), "args should be object, got {args}");
+        assert_eq!(args["path"], "README.md");
+    }
+
+    #[test]
+    fn null_tool_arguments_become_none() {
+        // `"arguments": null` previously parsed as `Some(Value::Null)`,
+        // which then serialized as the literal string `"null"` in the
+        // OpenAI tool-call wire shape. Now it becomes `None`, and the
+        // response builder substitutes `"{}"`.
+        let raw = r#"{"function": "list", "arguments": null}"#;
+        let out = normalize_worker_output(raw, "test-model", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert!(out.tool_arguments.is_none());
+    }
+
+    #[test]
+    fn primitive_tool_arguments_collapse_to_empty_object() {
+        // Defensive: a model that emits `"arguments": 42` should not
+        // produce a wire-invalid tool call.
+        let raw = r#"{"function": "list", "arguments": 42}"#;
+        let out = normalize_worker_output(raw, "test-model", WorkerRole::Fast, 100);
+        let args = out.tool_arguments.expect("sanitize produced an object");
+        assert!(args.is_object());
+        assert_eq!(args.as_object().unwrap().len(), 0);
     }
 }

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -1,23 +1,39 @@
 //! Canonical session state.
 //!
-//! The gateway owns the transcript.  It tracks what messages have been seen,
-//! what tool calls were emitted, what tool results came back, and how to
-//! summarize prior context for workers that can't see the full history.
+//! The gateway owns the transcript for one request. It tracks what messages
+//! were received and what tool calls/results are present so workers and the
+//! reducer can be packed with the right slice of context.
+//!
+//! ## Lifetime: request-scoped, not conversation-scoped
+//!
+//! `handle_turn` constructs a fresh `Session` per inbound request and ingests
+//! the caller's `messages` array. The caller (Goose, OpenCode, an SDK) owns
+//! the multi-turn conversation; we trust that array as the authoritative
+//! history. There is intentionally no cross-request state.
+//!
+//! Earlier iterations carried `turns`, `accepted_facts`, and a deterministic
+//! `running_summary` on the assumption that the gateway would persist a
+//! `Session` across requests — but the gateway never invokes
+//! `record_assistant_response` / `record_turn_outcome` in production, so
+//! "Continuation" turns never fired and the summary was never built.
+//! PR #566 review (Copilot) called this out as silently-dead code. We have
+//! removed it. Continuation context comes from the caller's `messages`.
 
 use serde_json::Value;
 
 /// What kind of turn this is.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TurnType {
-    /// First message or new topic.
+    /// First message of this request, or a normal user follow-up. The
+    /// gateway fans out to workers and arbitrates.
     Fresh,
-    /// Continuation of ongoing conversation.
-    Continuation,
-    /// Agent client is returning a tool result.
+    /// Agent client is returning a tool result. The gateway skips fan-out
+    /// and goes straight to the reducer with the tool output in context.
     ToolResult,
 }
 
-/// A tool call the gateway emitted and is tracking.
+/// A tool call observed in the caller's message history. Carried so the
+/// reducer-side context packer can pair tool calls with their results.
 #[derive(Debug, Clone)]
 pub struct PendingToolCall {
     pub call_id: String,
@@ -26,32 +42,15 @@ pub struct PendingToolCall {
     pub result: Option<String>,
 }
 
-/// A resolved fact or decision from a prior turn.
-#[derive(Debug, Clone)]
-pub struct AcceptedFact {
-    /// Which turn produced this fact.
-    pub turn: usize,
-    /// Short description of what was established.
-    pub fact: String,
-}
-
-/// Canonical session state across turns.
+/// Canonical session state for one request.
 pub struct Session {
-    /// Full message history as received/emitted.
+    /// Full message history as received from the caller.
     messages: Vec<Value>,
-    /// Tool schemas from the client (updated each turn).
+    /// Tool schemas from the caller.
     tools: Option<Value>,
-    /// Tool calls the gateway has emitted, keyed by call_id.
+    /// Tool calls observed in the caller's history, paired with their
+    /// results when present.
     pending_tools: Vec<PendingToolCall>,
-    /// Turn counter.
-    turns: usize,
-    /// Whether the last thing we emitted was a tool_call.
-    last_was_tool_call: bool,
-    /// Progressive summary — grows slowly, captures accepted facts and
-    /// decisions from prior turns so workers don't need raw history.
-    accepted_facts: Vec<AcceptedFact>,
-    /// Compact summary of the conversation so far (deterministic, not model-generated).
-    running_summary: String,
 }
 
 impl Default for Session {
@@ -66,33 +65,56 @@ impl Session {
             messages: Vec::new(),
             tools: None,
             pending_tools: Vec::new(),
-            turns: 0,
-            last_was_tool_call: false,
-            accepted_facts: Vec::new(),
-            running_summary: String::new(),
         }
     }
 
-    /// Ingest incoming messages from the client.
+    /// Ingest incoming messages from the caller.
     ///
-    /// The client sends the full conversation each time (OpenAI convention).
-    /// We replace our history with theirs — they're authoritative — but we
-    /// track deltas for tool result detection.
+    /// The caller sends the full conversation each time (OpenAI convention),
+    /// so we replace our history with theirs — they're authoritative. We
+    /// scan the new history for `role: "assistant"` messages carrying
+    /// `tool_calls` and `role: "tool"` messages carrying `tool_call_id`,
+    /// pairing them into `pending_tools` so the reducer-side context packer
+    /// can surface tool outputs.
     pub fn ingest(&mut self, messages: &[Value], tools: &Option<Value>) {
         self.tools = tools.clone();
-
-        // Detect if new messages include tool results
-        let new_count = messages.len();
-        let old_count = self.messages.len();
-
-        // Replace with client's view (they own the outer loop)
         self.messages = messages.to_vec();
-        self.turns += 1;
 
-        // Check for tool results in the new messages
-        if new_count > old_count {
-            for msg in &messages[old_count..] {
-                if msg.get("role").and_then(|r| r.as_str()) == Some("tool") {
+        // Rebuild `pending_tools` from the canonical history. Previously
+        // this was deltas-since-last-ingest, which only worked when the
+        // gateway persisted Sessions across requests. With per-request
+        // sessions, we scan the full caller-provided history every time.
+        self.pending_tools.clear();
+        for msg in messages {
+            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
+            match role {
+                "assistant" => {
+                    if let Some(tool_calls) = msg.get("tool_calls").and_then(|tc| tc.as_array()) {
+                        for tc in tool_calls {
+                            let call_id = tc
+                                .get("id")
+                                .and_then(|id| id.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let function_name = tc
+                                .pointer("/function/name")
+                                .and_then(|n| n.as_str())
+                                .unwrap_or("")
+                                .to_string();
+                            let arguments = tc
+                                .pointer("/function/arguments")
+                                .cloned()
+                                .unwrap_or(Value::Null);
+                            self.pending_tools.push(PendingToolCall {
+                                call_id,
+                                function_name,
+                                arguments,
+                                result: None,
+                            });
+                        }
+                    }
+                }
+                "tool" => {
                     let call_id = msg
                         .get("tool_call_id")
                         .and_then(|id| id.as_str())
@@ -102,8 +124,6 @@ impl Session {
                         .and_then(|c| c.as_str())
                         .unwrap_or("")
                         .to_string();
-
-                    // Match to pending tool call
                     if let Some(pending) =
                         self.pending_tools.iter_mut().find(|p| p.call_id == call_id)
                     {
@@ -115,6 +135,7 @@ impl Session {
                         );
                     }
                 }
+                _ => {}
             }
         }
     }
@@ -127,7 +148,7 @@ impl Session {
     /// the same tool call whose result we already have in context.
     ///
     /// We scan from the end of the conversation backwards. The first
-    /// message we hit decides:
+    /// non-user role we hit decides:
     ///
     ///   * `role: "tool"` first — OpenAI canonical: classify as
     ///     `ToolResult`.
@@ -138,9 +159,8 @@ impl Session {
     ///     nudge after an unsynthesised tool result is still a
     ///     tool-result turn; the model needs to consume the tool
     ///     output and answer the nudge in one synthesis pass. A
-    ///     user message that *predates* any tool result reaches the
-    ///     start of the history and we fall through to the normal
-    ///     Fresh/Continuation classification.
+    ///     user message that predates any tool result reaches the
+    ///     start of the history and we fall through to `Fresh`.
     pub fn classify_turn(&self) -> TurnType {
         for msg in self.messages.iter().rev() {
             let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
@@ -150,130 +170,7 @@ impl Session {
                 _ => continue,
             }
         }
-
-        // Also check the session-state fallback (set by
-        // record_assistant_response, which the gateway doesn't invoke
-        // yet but tests do).
-        if self.last_was_tool_call && self.has_unprocessed_tool_results() {
-            return TurnType::ToolResult;
-        }
-
-        if self.turns <= 1 {
-            TurnType::Fresh
-        } else {
-            TurnType::Continuation
-        }
-    }
-
-    /// Record an assistant response we're about to emit.
-    pub fn record_assistant_response(&mut self, response: &Value) {
-        // Check if this response has tool_calls
-        let has_tool_calls = response
-            .pointer("/choices/0/message/tool_calls")
-            .and_then(|tc| tc.as_array())
-            .map(|a| !a.is_empty())
-            .unwrap_or(false);
-
-        self.last_was_tool_call = has_tool_calls;
-
-        if has_tool_calls {
-            if let Some(tool_calls) = response
-                .pointer("/choices/0/message/tool_calls")
-                .and_then(|tc| tc.as_array())
-            {
-                for tc in tool_calls {
-                    let call_id = tc
-                        .get("id")
-                        .and_then(|id| id.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let function_name = tc
-                        .pointer("/function/name")
-                        .and_then(|n| n.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let arguments = tc
-                        .pointer("/function/arguments")
-                        .cloned()
-                        .unwrap_or(Value::Null);
-
-                    self.pending_tools.push(PendingToolCall {
-                        call_id,
-                        function_name,
-                        arguments,
-                        result: None,
-                    });
-                }
-            }
-        }
-
-        // Add the assistant message to our canonical history
-        if let Some(msg) = response.pointer("/choices/0/message") {
-            self.messages.push(msg.clone());
-        }
-    }
-
-    /// Record what the gateway decided this turn — used to build the
-    /// running summary for future turns' workers.
-    pub fn record_turn_outcome(&mut self, outcome: &str) {
-        if outcome.is_empty() {
-            return;
-        }
-        // Truncate individual facts — generous enough to capture a useful
-        // summary of the turn but not the full response.
-        let truncated = if outcome.len() > 500 {
-            format!("{}...", crate::worker::truncate_chars(outcome, 497))
-        } else {
-            outcome.to_string()
-        };
-        self.accepted_facts.push(AcceptedFact {
-            turn: self.turns,
-            fact: truncated,
-        });
-        self.rebuild_summary();
-    }
-
-    /// Deterministic summary rebuild.  No model calls.
-    fn rebuild_summary(&mut self) {
-        // Keep the last N facts — older ones are compressed into a single line.
-        // With ~500 chars per fact + tool history, 15 facts gives a summary
-        // budget of roughly 2000 tokens — enough for real agent sessions.
-        const MAX_RECENT_FACTS: usize = 15;
-        let total = self.accepted_facts.len();
-        let mut parts = Vec::new();
-
-        if total > MAX_RECENT_FACTS {
-            let old_count = total - MAX_RECENT_FACTS;
-            parts.push(format!("[{old_count} earlier facts omitted]"));
-        }
-
-        let start = total.saturating_sub(MAX_RECENT_FACTS);
-        for fact in &self.accepted_facts[start..] {
-            parts.push(format!("Turn {}: {}", fact.turn, fact.fact));
-        }
-
-        // Also include tool call history compactly
-        let tool_history: Vec<String> = self
-            .pending_tools
-            .iter()
-            .map(|p| {
-                if let Some(ref result) = p.result {
-                    let short_result = if result.len() > 300 {
-                        format!("{}...", crate::worker::truncate_chars(result, 297))
-                    } else {
-                        result.clone()
-                    };
-                    format!("{}() → {}", p.function_name, short_result)
-                } else {
-                    format!("{}() → pending", p.function_name)
-                }
-            })
-            .collect();
-        if !tool_history.is_empty() {
-            parts.push(format!("Tools used: {}", tool_history.join("; ")));
-        }
-
-        self.running_summary = parts.join("\n");
+        TurnType::Fresh
     }
 
     // ── Accessors for context packing ─────────────────────────────
@@ -289,25 +186,9 @@ impl Session {
         self.messages.clone()
     }
 
-    /// Running summary of prior turns — compact, deterministic, no model calls.
-    /// Use this instead of raw history for workers that can't see everything.
-    pub fn running_summary(&self) -> &str {
-        &self.running_summary
-    }
-
-    /// Accepted facts from prior turns.
-    pub fn accepted_facts(&self) -> &[AcceptedFact] {
-        &self.accepted_facts
-    }
-
     /// Tool schemas (if any).
     pub fn tools(&self) -> Option<&Value> {
         self.tools.as_ref()
-    }
-
-    /// Current turn count.
-    pub fn turn_count(&self) -> usize {
-        self.turns
     }
 
     /// The last user message text.
@@ -396,10 +277,6 @@ impl Session {
             })
             .collect()
     }
-
-    fn has_unprocessed_tool_results(&self) -> bool {
-        self.pending_tools.iter().any(|p| p.result.is_some())
-    }
 }
 
 /// Extract text content from a message (handles both string and multipart).
@@ -441,20 +318,10 @@ mod tests {
     #[test]
     fn tool_result_turn() {
         let mut s = Session::new();
-        // First turn: user message
-        s.ingest(
-            &[json!({"role": "user", "content": "what's the weather?"})],
-            &Some(json!([{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {}}}])),
-        );
-        // Gateway emitted a tool call
-        s.record_assistant_response(&json!({
-            "choices": [{"message": {
-                "role": "assistant",
-                "content": null,
-                "tool_calls": [{"id": "call_123", "type": "function", "function": {"name": "get_weather", "arguments": "{\"location\":\"Tokyo\"}"}}]
-            }}]
-        }));
-        // Client sends back the tool result
+        // Per-request session: the caller sends the full history each
+        // request. A history ending in a `role: "tool"` message must
+        // classify as a ToolResult turn so the gateway routes to the
+        // reducer with the tool output in context.
         s.ingest(
             &[
                 json!({"role": "user", "content": "what's the weather?"}),
@@ -464,6 +331,12 @@ mod tests {
             &Some(json!([{"type": "function", "function": {"name": "get_weather", "description": "Get weather", "parameters": {}}}])),
         );
         assert_eq!(s.classify_turn(), TurnType::ToolResult);
+        // pending_tools is rebuilt from the caller's history, so a fresh
+        // session can still pair the call with its result.
+        let pairs = s.recent_tool_results();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "get_weather");
+        assert_eq!(pairs[0].1, "22°C, sunny");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -91,23 +91,42 @@ impl Session {
                 "assistant" => {
                     if let Some(tool_calls) = msg.get("tool_calls").and_then(|tc| tc.as_array()) {
                         for tc in tool_calls {
-                            let call_id = tc
+                            // Skip malformed tool_calls. Both `id` and
+                            // `function.name` are required by the OpenAI
+                            // wire shape; defaulting them to empty
+                            // strings would let two malformed calls
+                            // share `call_id == ""` and later cross-pair
+                            // with a `role: "tool"` message whose
+                            // `tool_call_id` is also missing. Drop the
+                            // entry with a warning so the rest of the
+                            // history still ingests cleanly.
+                            let Some(call_id) = tc
                                 .get("id")
                                 .and_then(|id| id.as_str())
-                                .unwrap_or("")
-                                .to_string();
-                            let function_name = tc
+                                .filter(|s| !s.is_empty())
+                            else {
+                                tracing::warn!(
+                                    "moa session: ignoring tool_call with missing/empty `id`"
+                                );
+                                continue;
+                            };
+                            let Some(function_name) = tc
                                 .pointer("/function/name")
                                 .and_then(|n| n.as_str())
-                                .unwrap_or("")
-                                .to_string();
+                                .filter(|s| !s.is_empty())
+                            else {
+                                tracing::warn!(
+                                    "moa session: ignoring tool_call `{call_id}` with missing/empty `function.name`"
+                                );
+                                continue;
+                            };
                             let arguments = tc
                                 .pointer("/function/arguments")
                                 .cloned()
                                 .unwrap_or(Value::Null);
                             self.pending_tools.push(PendingToolCall {
-                                call_id,
-                                function_name,
+                                call_id: call_id.to_string(),
+                                function_name: function_name.to_string(),
                                 arguments,
                                 result: None,
                             });
@@ -115,10 +134,18 @@ impl Session {
                     }
                 }
                 "tool" => {
-                    let call_id = msg
+                    // Skip tool results without a `tool_call_id` rather
+                    // than letting them match an empty-id placeholder.
+                    let Some(call_id) = msg
                         .get("tool_call_id")
                         .and_then(|id| id.as_str())
-                        .unwrap_or("");
+                        .filter(|s| !s.is_empty())
+                    else {
+                        tracing::warn!(
+                            "moa session: ignoring tool result with missing/empty `tool_call_id`"
+                        );
+                        continue;
+                    };
                     let content = msg
                         .get("content")
                         .and_then(|c| c.as_str())
@@ -381,5 +408,44 @@ mod tests {
             ])),
         );
         assert_eq!(s.tool_names(), vec!["read_file", "web_search"]);
+    }
+
+    #[test]
+    fn malformed_tool_calls_are_dropped_not_collapsed_to_empty_id() {
+        // Regression for PR #612 review (Copilot): missing/empty `id` or
+        // `function.name` used to default to "" and still push a
+        // PendingToolCall. Two such malformed entries would then share
+        // `call_id == ""` and any `role: "tool"` with a missing
+        // `tool_call_id` would match the first one. We now skip
+        // malformed tool_calls outright.
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "do two things"}),
+                json!({
+                    "role": "assistant",
+                    "tool_calls": [
+                        {"id": "call_a", "type": "function", "function": {"name": "good", "arguments": "{}"}},
+                        // Missing id — must be dropped.
+                        {"type": "function", "function": {"name": "no_id", "arguments": "{}"}},
+                        // Missing function.name — must be dropped.
+                        {"id": "call_c", "type": "function", "function": {"arguments": "{}"}},
+                        // Empty id — must be dropped.
+                        {"id": "", "type": "function", "function": {"name": "empty_id", "arguments": "{}"}},
+                    ],
+                }),
+                // A malformed tool result (no `tool_call_id`) must not
+                // attach to any pending call.
+                json!({"role": "tool", "content": "orphaned"}),
+            ],
+            &None,
+        );
+        // Only the one well-formed call survives.
+        let pending = s.pending_tool_calls();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].call_id, "call_a");
+        assert_eq!(pending[0].function_name, "good");
+        // The orphaned tool result did not attach — result still None.
+        assert!(pending[0].result.is_none());
     }
 }

--- a/crates/mesh-mixture-of-agents/src/worker.rs
+++ b/crates/mesh-mixture-of-agents/src/worker.rs
@@ -159,22 +159,40 @@ pub fn truncate_chars(text: &str, max_bytes: usize) -> &str {
 }
 
 /// Strip `<think>...</think>` tags, return the remaining content.
+///
+/// Single linear scan over the input: skips think blocks (matched or
+/// unclosed) and removes orphan `</think>` closers. The earlier shape
+/// rebuilt the whole string on every block (`format!`/`replace` in a
+/// loop) which is O(n*k) on long outputs with many tags.
 pub fn strip_thinking(text: &str) -> String {
-    let mut result = text.to_string();
-    while let Some(start) = result.find("<think>") {
-        if let Some(end) = result[start..].find("</think>") {
-            result = format!(
-                "{}{}",
-                &result[..start],
-                &result[start + end + "</think>".len()..]
-            );
-        } else {
-            result = result[..start].to_string();
-            break;
+    const OPEN: &str = "<think>";
+    const CLOSE: &str = "</think>";
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        // Match a full <think>...</think> block.
+        if bytes[i..].starts_with(OPEN.as_bytes()) {
+            match text[i + OPEN.len()..].find(CLOSE) {
+                Some(rel_end) => {
+                    i += OPEN.len() + rel_end + CLOSE.len();
+                    continue;
+                }
+                // Unclosed <think> — drop the rest of the string.
+                None => break,
+            }
         }
+        // Drop an orphan </think> (a closer with no matching opener).
+        if bytes[i..].starts_with(CLOSE.as_bytes()) {
+            i += CLOSE.len();
+            continue;
+        }
+        // Otherwise copy one char (UTF-8 safe: walk by character).
+        let ch = text[i..].chars().next().expect("char boundary");
+        out.push(ch);
+        i += ch.len_utf8();
     }
-    result = result.replace("</think>", "");
-    result.trim().to_string()
+    out.trim().to_string()
 }
 
 /// Extract content inside `<think>` tags.
@@ -340,5 +358,37 @@ mod tests {
         );
         assert_eq!(strip_thinking("<think>only thinking"), "");
         assert_eq!(strip_thinking("no tags here"), "no tags here");
+    }
+
+    #[test]
+    fn strip_thinking_drops_orphan_close() {
+        // Orphan </think> with no matching opener: drop the closer,
+        // keep surrounding content.
+        assert_eq!(strip_thinking("stuff</think>answer"), "stuffanswer");
+    }
+
+    #[test]
+    fn strip_thinking_handles_multiple_blocks_in_linear_time() {
+        // Regression for PR #566 review item #5b: the previous shape
+        // rebuilt the whole string on every think block (`format!` /
+        // `replace` in a loop), which is O(n*k). Verify the new linear
+        // implementation produces the same output for many blocks.
+        let mut input = String::new();
+        for i in 0..50 {
+            input.push_str(&format!("<think>think-{i}</think>seg{i} "));
+        }
+        let stripped = strip_thinking(&input);
+        let mut expected = String::new();
+        for i in 0..50 {
+            expected.push_str(&format!("seg{i} "));
+        }
+        assert_eq!(stripped, expected.trim());
+    }
+
+    #[test]
+    fn strip_thinking_preserves_utf8() {
+        // Multibyte characters outside think blocks must survive intact.
+        assert_eq!(strip_thinking("<think>思</think>答案"), "答案");
+        assert_eq!(strip_thinking("前置</think>中间<think>隐"), "前置中间");
     }
 }

--- a/crates/model-ref/src/lib.rs
+++ b/crates/model-ref/src/lib.rs
@@ -116,16 +116,18 @@ pub fn quant_selector_from_gguf_file(file: &str) -> Option<String> {
     // Markers are matched case-insensitively. Real-world GGUF filenames
     // are inconsistent: `Qwen3-32B-Q4_K_M.gguf` (uppercase markers) is
     // common, but so is `qwen2.5-3b-instruct-q4_k_m.gguf` (all
-    // lowercase). The matcher in `gguf_matches_quant_selector` already
-    // lowercases both sides, so emitting a lowercase selector here is
-    // safe and keeps the public ID round-trippable.
+    // lowercase). We lowercase to find the marker position, but the
+    // returned selector is sliced out of the *original* stem so the
+    // model's preferred display casing survives into the public ID.
+    // The downstream matcher in `gguf_matches_quant_selector` lowercases
+    // both sides at comparison time, so preserving casing here is safe
+    // for matching while keeping IDs round-trippable.
     let stem_lower = stem.to_ascii_lowercase();
     for marker in [
         "-ud-", ".ud-", "-iq", ".iq", "-q", ".q", "-bf16", ".bf16", "-f16", ".f16", "-f32", ".f32",
     ] {
         if let Some(pos) = stem_lower.rfind(marker) {
-            // Use the original casing for the returned slice so callers
-            // that build a public ID keep the model's preferred display.
+            // Slice from the original (case-preserving) stem.
             return Some(stem[pos + 1..].to_string());
         }
     }

--- a/crates/skippy-cache/src/resident/prefix.rs
+++ b/crates/skippy-cache/src/resident/prefix.rs
@@ -321,11 +321,14 @@ mod tests {
         // permanently true on an empty cache and bail with
         // "no releasable entries".
         //
-        // `ResidentCacheConfig::from_stage` derives the cap with a
-        // 4*min_tokens floor (see `derive_max_resident_tokens`). For
-        // the smoke-test config the cap therefore comes through as 0
-        // (disabled). This unit test pins that path: cap=0, record a
-        // 533-token prompt against a 256-token min, no eviction loop.
+        // `ResidentCacheConfig::from_stage` derives the cap from the
+        // model's `n_ctx` via `derive_max_resident_tokens`, which uses
+        // a hard `MIN_CTX_FOR_CELL_CAP = 8192` floor: below that, the
+        // cap is 0 (disabled) regardless of `min_tokens`. The smoke
+        // test runs with `ctx_size = 768`, well below the floor, so
+        // its derived cap is 0. This unit test pins that path: cap=0,
+        // record a 533-token prompt against a 256-token min, no
+        // eviction loop.
         let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
         let alloc = cache
             .allocate_for_record("page-0", 533, 100, |_| Ok(()))

--- a/docs/design/MOA_GATEWAY.md
+++ b/docs/design/MOA_GATEWAY.md
@@ -107,8 +107,12 @@ callable in the mesh.
 Models are tier-sorted before role assignment:
 single-digit-B names ("Qwen3-8B", "llama-3-7b") form the small tier and
 get `Fast`; everything else (multi-digit B, or names without an explicit
-size) forms the big tier — the largest of those gets `Strong` and also
-heads the reducer pool.
+size) forms the big tier. Within the big tier, role assignment is
+*first-encountered*, not deterministically by parameter count — we don't
+parse parameter sizes from the alias string, only the broad small-vs-big
+bucket. `Strong` and the reducer head both come from the big tier; if
+deterministic largest-first ordering becomes important, a size-aware
+sort within the big tier would go here.
 
 **The reducer is not a separate fan-out slot.** It's the same strong
 model (or next-strongest if the primary is slow/broken), invoked
@@ -294,14 +298,34 @@ never re-enters a worker call.
 
 ## Test & evaluation plan
 
-### Unit tests (29 tests, run in CI)
+### Unit tests (run in CI)
 
 ```bash
 cargo test -p mesh-mixture-of-agents --lib
 ```
 
-Covers: arbiter voting (10 scenarios), normalizer parsing (12 scenarios),
-session turn classification (3), worker role assignment (3).
+Currently 86 unit tests across the crate. Coverage areas:
+
+* `arbiter` voting and decision rules.
+* `normalize` parsing across JSON, KV, and heuristic strategies
+  (including NaN/Inf confidence sanitization and OpenAI-shape inline
+  tool-call extraction).
+* `session` turn classification (Fresh vs ToolResult) on caller-provided
+  history.
+* `worker` role assignment (small vs big tier) and `strip_thinking`.
+* `reducer` hedged-attempt scheduling.
+* `backend` response extraction and retry-after parsing.
+* `lib::response_builder_tests` for `best_answer` NaN safety and
+  `tool_call_response` argument coercion.
+
+Integration tests under `crates/mesh-mixture-of-agents/tests/` exercise
+fan-out simulation, all-workers-fail handling, tool-result routing, and
+worker accounting.
+
+When adding tests, update this count by running
+`cargo test -p mesh-mixture-of-agents --lib` and copying the final
+`test result: ok. N passed` value here so future readers see the real
+number.
 
 ### Local smoke test
 


### PR DESCRIPTION
## What this gives you

Follow-up to #566. Addresses every actionable item from the Copilot review on that PR \u2014 11 HIGH defects, 4 MEDIUM cleanups, 6 LOW doc corrections \u2014 plus a README note marking MoA as experimental.

The mainstream model surface is untouched. All changes are scoped to MoA-only code paths (`model: "mesh"`), one shared HTTP transport helper, and three doc files. Direct `model=<id>` and `model=auto` requests behave exactly as before.

### What you can now do / see

* Send a malformed worker response (`confidence: NaN`, missing `choices`, primitive `arguments`) and the gateway no longer panics \u2014 it returns a structured error or coerces the shape.
* When a reducer fails on a tool-result turn, you get **HTTP 502** (was 200 with an in-band error body).
* SSE streaming clients (Goose, OpenAI SDKs) now see `finish_reason: "error"` and an explicit error chunk on MoA failure (was a silent `stop`).
* Reducers that produce a tool name without arguments now emit a real `tool_calls` reply with `{}`, matching the fan-out path \u2014 agent harnesses no longer drop tool calls to reducer prose.
* When the shortest-name peer for a model is offline, the worker pool now falls back to a reachable longer-form alias instead of silently dropping the model.
* When the same model is served locally under one alias and by a peer under another, the local skippy-port wins regardless of name length \u2014 no more unnecessary QUIC hops.
* Error responses now distinguish `all_workers_failed` from `all_reducers_failed` so clients can branch on `error.code`.
* `strip_thinking` is now linear (was O(n\u00b2)) on long worker outputs.
* HTTP header names from MoA observability writers are RFC 7230 tchar-validated; CR/LF can't be smuggled.
* README clearly marks `model: "mesh"` as experimental so users know the surface may still change.

### Validation

| Check | Result |
|---|---|
| `cargo test -p mesh-mixture-of-agents --lib` | **86 / 86 pass** (+16 new) |
| `cargo test -p mesh-mixture-of-agents` (incl. integration) | all pass |
| `cargo test -p mesh-llm-host-runtime --lib` | **1454 / 1454 pass** (+4 new) |
| `cargo test -p skippy-cache --lib` | 13 / 13 pass |
| `cargo test -p model-ref --lib` | 10 / 10 pass |
| `cargo clippy ... --all-targets -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `just build` | green |

### Live end-to-end validation

Built locally and deployed to a 2-node private mesh (M4 Max with Qwen3-8B + Studio M3 Ultra with MiniMax-M2.5, 138 GB, 131k context). Verified with the same harness suite as PR #566:

* Basic `/v1/chat/completions` to Qwen3-8B (local) \u2014 OK.
* Basic `/v1/chat/completions` to MiniMax (remote via QUIC) \u2014 OK.
* `mini-agent.py model=auto` \u2014 2 turns, correct bug ID.
* `mini-agent.py model=mesh` (MoA) \u2014 2 turns, correct bug ID.
* `mini-agent2.py model=mesh` (multi-file exploration) \u2014 4 turns, correct.
* Goose `model=mesh` \u2014 1 tool call, correct.

Also verified the public-mesh path with `mesh-llm client --auto`: joined the public mesh in ~8 seconds, saw 13 peers, called Qwen3-8B end-to-end and got a clean reply.

## Commit shape

7 commits, each runnable in isolation. Squash-merge-friendly.

| Commit | Phase | What |
|---|---|---|
| `a02d407e` | docs | README: mark `model: "mesh"` MoA as experimental |
| `8eb1b6ac` | HIGH | Close panic surface in worker output normalization (NaN clamp, dead or_else, malformed-response handling) |
| `ff4e4789` | HIGH | Propagate failure signals to HTTP status, SSE finish_reason, and the tool-result reducer path |
| `9e360c58` | HIGH | Group aliases by canonical base before resolving backend (fixes dedup race + forced QUIC hop) |
| `8b6115b2` | HIGH | Strip dead `Session` continuation / running-summary machinery (per-request scope) |
| `6908c1b0` | MEDIUM | Distinct error codes, linear `strip_thinking`, RFC 7230 header-name validation, drop dead branch in ingress |
| `6fa3dfbf` | LOW | Align stale comments and doc claims with current code (5 spots + MOA_GATEWAY.md) |

## Architecture

No protocol or wire-format changes. No new public types. `error_response` now takes a `code` parameter (internal-only) and `Session` lost five accessors that were never called in production. The gateway is documented as request-scoped now \u2014 caller owns the multi-turn loop.

## Protocol

None. MoA gateway is local-decision; nothing crosses node boundaries that didn't before. SSE wire shape gains an optional error chunk on failure, which is additive (clients that didn't read it before still don't have to).

## Notes for review

* The 11 HIGH items are listed (with their PR #566 review comment links) in the per-commit messages so reviewers can trace each fix back to the original Copilot remark.
* The `router.rs:1360` wall-clock-seeded test comment from the Copilot pass is intentionally not addressed \u2014 the test is not flaky in practice and has passed every CI run; will reply on PR #566 with the rationale.
* The Swift SDK smoke gate from PR #566 doesn't exist on this branch; it lives on `main` and is being fixed by PR #610 separately.