### PR TITLE
Fix crates.io publish chain for SDK crates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -528,11 +528,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
-      - name: Publish mesh-llm-client
+      - name: Publish crates.io package chain
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked -p mesh-llm-client
-      - name: Publish mesh-api
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --locked -p mesh-api
+        run: scripts/publish-crates.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -68,3 +68,16 @@ Verify:
 ## Publish
 
 Push a `v*` tag to run `.github/workflows/release.yml`.
+
+On non-prerelease tags, the release workflow also publishes the Rust SDK crate
+chain to crates.io in dependency order:
+
+```bash
+scripts/publish-crates.sh --dry-run
+```
+
+Run the dry-run before cutting a GA tag after changing SDK crate manifests or
+workspace-internal SDK dependencies. On the first release that introduces a
+new internal SDK crate, the dry-run validates packages whose registry
+dependencies already exist and reports downstream packages that will be fully
+verified during the real sequential publish after their upstream crates land.

--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -23,11 +23,11 @@ host-io = []
 # tracing, sha2, ed25519-dalek, hex, uuid, url, http, base64, async-trait, httparse
 # (httparse is a transitive dep of iroh; not in forbidden list)
 iroh = "1.0.0-rc.0"
-mesh-llm-identity = { path = "../mesh-llm-identity" }
-mesh-llm-protocol = { path = "../mesh-llm-protocol" }
-mesh-llm-routing = { path = "../mesh-llm-routing" }
-mesh-llm-types = { path = "../mesh-llm-types" }
-model-artifact = { path = "../model-artifact" }
+mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.66.0" }
+mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.66.0" }
+mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.66.0" }
+mesh-llm-types = { path = "../mesh-llm-types", version = "0.66.0" }
+model-artifact = { path = "../model-artifact", version = "0.66.0" }
 async-trait = "0.1"
 httparse = "1"
 tokio = { version = "1", features = ["io-util", "sync", "net", "time", "rt-multi-thread"] }

--- a/crates/model-artifact/Cargo.toml
+++ b/crates/model-artifact/Cargo.toml
@@ -3,11 +3,15 @@ name = "model-artifact"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+description = "Model artifact selection, identity, and GGUF metadata helpers for Mesh LLM"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+readme = "README.md"
 
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-model-ref = { path = "../model-ref" }
+model-ref = { path = "../model-ref", version = "0.66.0" }
 serde.workspace = true
 
 [dev-dependencies]

--- a/crates/model-ref/Cargo.toml
+++ b/crates/model-ref/Cargo.toml
@@ -3,6 +3,10 @@ name = "model-ref"
 edition.workspace = true
 license.workspace = true
 version.workspace = true
+description = "Model reference parsing and normalization helpers for Mesh LLM"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+readme = "README.md"
 
 [dependencies]
 serde.workspace = true

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'USAGE'
+usage: scripts/publish-crates.sh [--dry-run] [--allow-dirty] [--sleep-seconds N]
+
+Publishes the crates.io package chain in dependency order. Use --dry-run for
+local and CI validation without uploading packages. --allow-dirty is accepted
+only with --dry-run so local pre-commit validation can include uncommitted
+manifest changes; real publishing always requires Cargo's clean-tree check.
+USAGE
+}
+
+dry_run=0
+allow_dirty=0
+sleep_seconds=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)
+            dry_run=1
+            shift
+            ;;
+        --allow-dirty)
+            allow_dirty=1
+            shift
+            ;;
+        --sleep-seconds)
+            if [[ $# -lt 2 || ! "$2" =~ ^[0-9]+$ ]]; then
+                usage
+                exit 1
+            fi
+            sleep_seconds="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "$allow_dirty" -eq 1 && "$dry_run" -eq 0 ]]; then
+    echo "--allow-dirty is only supported together with --dry-run" >&2
+    exit 1
+fi
+
+if [[ -z "$sleep_seconds" ]]; then
+    if [[ "$dry_run" -eq 1 ]]; then
+        sleep_seconds=0
+    else
+        sleep_seconds="${CRATES_IO_PUBLISH_SETTLE_SECONDS:-30}"
+    fi
+fi
+
+if [[ "$dry_run" -eq 0 && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+    echo "CARGO_REGISTRY_TOKEN is required for real crates.io publishing" >&2
+    exit 1
+fi
+
+workspace_version="$(
+    perl -ne '
+        $in_workspace_package = 1 if /^\[workspace\.package\]/;
+        $in_workspace_package = 0 if /^\[/ && !/^\[workspace\.package\]/;
+        if ($in_workspace_package && /^\s*version\s*=\s*"([^"]+)"/) {
+            print $1;
+            exit;
+        }
+    ' Cargo.toml
+)"
+
+if [[ -z "$workspace_version" ]]; then
+    echo "failed to read [workspace.package].version from Cargo.toml" >&2
+    exit 1
+fi
+
+crate_version_published() {
+    local crate="$1"
+    local status
+    if ! command -v curl >/dev/null 2>&1; then
+        return 1
+    fi
+    status="$(
+        curl \
+            --fail \
+            --silent \
+            --show-error \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            "https://crates.io/api/v1/crates/${crate}/${workspace_version}" \
+            2>/dev/null || true
+    )"
+    [[ "$status" == "200" ]]
+}
+
+unpublished_registry_deps() {
+    case "$1" in
+        model-artifact)
+            printf '%s\n' model-ref
+            ;;
+        mesh-llm-client)
+            printf '%s\n' \
+                model-artifact \
+                mesh-llm-identity \
+                mesh-llm-protocol \
+                mesh-llm-routing \
+                mesh-llm-types
+            ;;
+        mesh-api)
+            printf '%s\n' mesh-llm-client
+            ;;
+    esac
+}
+
+should_skip_initial_dry_run() {
+    local crate="$1"
+    local dep
+    while IFS= read -r dep; do
+        [[ -n "$dep" ]] || continue
+        if ! crate_version_published "$dep"; then
+            echo "dry-run cannot verify ${crate} until ${dep}@${workspace_version} exists in crates.io"
+            return 0
+        fi
+    done < <(unpublished_registry_deps "$crate")
+    return 1
+}
+
+publish_crates=(
+    model-ref
+    mesh-llm-identity
+    mesh-llm-protocol
+    mesh-llm-routing
+    mesh-llm-types
+    model-artifact
+    mesh-llm-client
+    mesh-api
+)
+
+for index in "${!publish_crates[@]}"; do
+    crate="${publish_crates[$index]}"
+    if [[ "$dry_run" -eq 1 ]] && should_skip_initial_dry_run "$crate"; then
+        continue
+    fi
+
+    args=(publish --locked -p "$crate")
+    if [[ "$dry_run" -eq 1 ]]; then
+        args+=(--dry-run)
+    fi
+    if [[ "$allow_dirty" -eq 1 ]]; then
+        args+=(--allow-dirty)
+    fi
+
+    echo "cargo ${args[*]}"
+    cargo "${args[@]}"
+
+    if [[ "$index" -lt "$((${#publish_crates[@]} - 1))" && "$sleep_seconds" -gt 0 ]]; then
+        echo "waiting ${sleep_seconds}s for crates.io index propagation"
+        sleep "$sleep_seconds"
+    fi
+done

--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -64,13 +64,13 @@ update_workspace_version() {
     printf '%s\n' "$after" >"$file"
 }
 
-update_mesh_client_dependency_version() {
+update_versioned_path_dependency_versions() {
     local file="$1"
     local next="$2"
     local before
     local after
     before="$(cat "$file")"
-    after="$(perl -0777 -pe 's/(mesh-client\s*=\s*\{[^}]*package\s*=\s*"mesh-llm-client"[^}]*version\s*=\s*")[^"]+(")/${1}'"$next"'$2/s' "$file")"
+    after="$(perl -0777 -pe 's/(\{\s*(?=[^}]*\bpath\s*=)(?=[^}]*\bversion\s*=)[^}]*\bversion\s*=\s*")[^"]+(")/${1}'"$next"'$2/gs' "$file")"
     if [[ "$before" == "$after" ]]; then
         return
     fi
@@ -121,7 +121,7 @@ for relative_manifest in "${manifests[@]}"; do
     manifest="$REPO_ROOT/$relative_manifest"
     require_file "$manifest"
     update_manifest_version "$manifest" "$version"
-    update_mesh_client_dependency_version "$manifest" "$version"
+    update_versioned_path_dependency_versions "$manifest" "$version"
     versioned_files+=("$manifest")
 done
 


### PR DESCRIPTION
## Summary

Prepares the Rust SDK crates.io publish path so the next non-prerelease GA tag can publish the full SDK dependency chain instead of failing after GitHub release artifacts are created.

- Adds versioned internal path dependencies for the crates published through `mesh-llm-client` and `mesh-api`.
- Makes `model-ref` and `model-artifact` publishable with crate metadata and versioned internal dependencies.
- Adds `scripts/publish-crates.sh` to publish the SDK crate chain in dependency order.
- Updates the release workflow to use the shared publish script for non-prerelease tags.
- Generalizes `scripts/release-version.sh` so future release bumps keep versioned path dependencies in sync.
- Documents the dry-run path and the first-publish registry constraint in `RELEASE.md`.

## Why

Issue #611 identified that `publish_crates` would fail on the next GA release because `mesh-llm-client` gained workspace-internal path dependencies during crate decomposition, but those dependencies were not publishable registry dependencies. The old release job only published `mesh-llm-client` and then `mesh-api`, which is not enough once the client crate depends on newly split internal crates.

## Publish Order

The publish script uses the dependency order needed by crates.io:

1. `model-ref`
2. `mesh-llm-identity`
3. `mesh-llm-protocol`
4. `mesh-llm-routing`
5. `mesh-llm-types`
6. `model-artifact`
7. `mesh-llm-client`
8. `mesh-api`

Real publishing still requires `CARGO_REGISTRY_TOKEN` and keeps a crates.io propagation wait between packages. The dry-run path avoids uploads and reports downstream crates that cannot be fully dry-run until their new upstream package versions exist in the registry.

## Validation

- `git fetch --no-tags origin main:refs/remotes/origin/main`
- `git diff --check`
- `git diff --cached --check`
- `bash -n scripts/publish-crates.sh`
- `bash -n scripts/release-version.sh`
- `scripts/publish-crates.sh --allow-dirty`: rejected as expected because `--allow-dirty` requires `--dry-run`
- `CARGO_TARGET_DIR=$(mktemp -d /tmp/mesh-llm-publish-target.XXXXXX) scripts/publish-crates.sh --dry-run --allow-dirty`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm-client -p mesh-api`
- `cargo test -p model-ref --lib`: 10 passed
- `cargo test -p model-artifact --lib`: 23 passed

Not run:

- `actionlint`: not installed locally.
- Real `cargo publish` / `just release`: intentionally not run for PR validation.

## Rollback

Revert this PR. No runtime migration, data repair, or protocol rollback is required.

Related: #611
