### PR TITLE
Add an agent tool-call reliability QA probe

### DIFF
--- a/crates/mesh-llm/tests/qa_agent_tool_call_reliability.rs
+++ b/crates/mesh-llm/tests/qa_agent_tool_call_reliability.rs
@@ -1,0 +1,143 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("mesh-llm crate should live two levels below repo root")
+        .to_path_buf()
+}
+
+fn harness_path() -> PathBuf {
+    repo_root()
+        .join("scripts")
+        .join("qa-agent-tool-call-reliability.py")
+}
+
+fn unique_output_path(test_name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "mesh-llm-{test_name}-{}-{nanos}.jsonl",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn agent_tool_call_harness_exists_and_is_executable() {
+    let path = harness_path();
+    assert!(
+        path.is_file(),
+        "agent tool-call harness is missing at {}",
+        path.display()
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = std::fs::metadata(&path)
+            .expect("harness metadata should be readable")
+            .permissions()
+            .mode();
+        assert_ne!(mode & 0o111, 0, "harness should be executable");
+    }
+}
+
+#[test]
+fn agent_tool_call_harness_help_documents_contract() {
+    let output = Command::new(harness_path())
+        .arg("--help")
+        .output()
+        .expect("harness help should execute");
+
+    assert!(
+        output.status.success(),
+        "harness --help failed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "--base-url",
+        "--models",
+        "--attempts",
+        "--timeout",
+        "--output",
+        "--skip-streaming",
+        "--print-plan",
+        "tool-call",
+        "tool-result",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "harness help should document {expected:?}; stdout was:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn agent_tool_call_harness_print_plan_is_json_and_side_effect_free() {
+    let output_path = unique_output_path("agent-tool-call-print-plan");
+    let output = Command::new(harness_path())
+        .arg("--base-url")
+        .arg("http://127.0.0.1:9337")
+        .arg("--models")
+        .arg("auto,mesh")
+        .arg("--attempts")
+        .arg("2")
+        .arg("--output")
+        .arg(&output_path)
+        .arg("--print-plan")
+        .output()
+        .expect("harness print-plan should execute");
+
+    assert!(
+        output.status.success(),
+        "print-plan failed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let plan: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("print-plan should emit valid JSON");
+    assert_eq!(
+        plan.get("name").and_then(serde_json::Value::as_str),
+        Some("agent-tool-call-reliability")
+    );
+    assert_eq!(
+        plan.get("endpoint").and_then(serde_json::Value::as_str),
+        Some("http://127.0.0.1:9337/v1")
+    );
+    let checks = plan
+        .get("checks")
+        .and_then(serde_json::Value::as_array)
+        .expect("print-plan should include checks");
+    assert_eq!(
+        checks.len(),
+        4,
+        "two models x two attempts should be planned"
+    );
+    assert!(
+        !output_path.exists(),
+        "print-plan must not create result files"
+    );
+}
+
+#[test]
+fn agent_tool_call_harness_rejects_unknown_arguments() {
+    let output = Command::new(harness_path())
+        .arg("--definitely-unknown")
+        .output()
+        .expect("harness argument validation should execute");
+
+    assert!(!output.status.success(), "unknown arguments should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--definitely-unknown"),
+        "unknown-argument error should be explicit; stderr was:\n{stderr}"
+    );
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -201,6 +201,35 @@ pi --model "mesh/Qwen 3.6 27B"
 You can switch models interactively with `Ctrl+M` inside Pi. Pi also supports
 `pi --provider mesh --model <model-id>` and `pi --list-models`.
 
+## Tool-call reliability probe
+
+Use the lightweight QA probe before or after changes that affect agent routing,
+OpenAI chat-completions, tool-call translation, or MoA reducer behavior:
+
+```bash
+scripts/qa-agent-tool-call-reliability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models auto,mesh \
+  --attempts 3 \
+  --output target/agent-tool-call-reliability/results.jsonl
+```
+
+The probe exercises the raw OpenAI-compatible contract directly. For each model
+and attempt it forces a deterministic function call, verifies
+`finish_reason=tool_calls`, sends the matching tool result back, then checks
+that the final answer includes the tool output. Streaming mode is included by
+default and reconstructs `delta.tool_calls[*]` by index before validation.
+
+For a side-effect-free review of the planned checks:
+
+```bash
+scripts/qa-agent-tool-call-reliability.py --models auto,mesh --attempts 2 --print-plan
+```
+
+This complements the heavier Goose, OpenCode, and Pi smoke scripts. Those prove
+real agent CLI behavior; this probe isolates the API contract that those agents
+depend on.
+
 ## curl or any OpenAI client
 
 ```bash

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -101,6 +101,28 @@ For terminal restoration QA:
 - Press `q` and `Ctrl+C`; the cursor should be visible and the shell prompt should not remain in raw mode.
 - A `SIGKILL` (`kill -9`) cannot run in-process cleanup. If a terminal is left corrupted after a hard kill, recover with `reset` or by closing the terminal pane.
 
+### 0d. Agent tool-call reliability
+
+Run the direct tool-call probe when changing OpenAI chat-completions routing,
+agent integrations, MoA reducer behavior, or anything that may affect
+`tools` / `tool_calls` / tool-result continuation:
+
+```bash
+scripts/qa-agent-tool-call-reliability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models auto,mesh \
+  --attempts 3 \
+  --output target/agent-tool-call-reliability/results.jsonl
+```
+
+- `tool_call` and `stream_tool_call` require real OpenAI-style function calls,
+  not prose that says a tool would be used
+- `tool_result` and `stream_tool_result` verify that the assistant can continue
+  after a matching tool result and include the deterministic fixture value
+- `--print-plan` is side-effect-free and emits machine-readable JSON
+- use `--skip-streaming` only when intentionally narrowing a local diagnosis to
+  non-streaming chat-completions
+
 ## Single-model permutations
 
 ### 1. Solo (single node)

--- a/scripts/qa-agent-tool-call-reliability.py
+++ b/scripts/qa-agent-tool-call-reliability.py
@@ -1,0 +1,659 @@
+#!/usr/bin/env python3
+"""Probe mesh-llm's OpenAI tool-call surface for agent reliability."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any, Iterable, NamedTuple
+import urllib.error
+import urllib.request
+
+
+TOOL_NAME = "lookup_fixture_fact"
+FIXTURE_FACTS = {
+    "codeword": "signal-7429",
+    "checksum": "FS-319-DELTA",
+}
+DEFAULT_MODELS = "auto,mesh"
+DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
+DEFAULT_OUTPUT = "target/agent-tool-call-reliability/results.jsonl"
+
+
+class Probe(NamedTuple):
+    model: str
+    attempt: int
+
+
+class ToolCall(NamedTuple):
+    call_id: str
+    key: str
+
+
+class ProbeResult(NamedTuple):
+    model: str
+    attempt: int
+    phase: str
+    ok: bool
+    detail: str
+    elapsed_ms: int
+    status_code: int | None = None
+
+
+def normalize_v1_base(base_url: str) -> str:
+    base = base_url.strip().rstrip("/")
+    if not base:
+        raise ValueError("base URL is empty")
+    if not base.endswith("/v1"):
+        base = f"{base}/v1"
+    return base
+
+
+def parse_models(value: str) -> list[str]:
+    models = [part.strip() for part in value.split(",") if part.strip()]
+    if not models:
+        raise ValueError("at least one model is required")
+    return models
+
+
+def build_plan(models: Iterable[str], attempts: int) -> list[Probe]:
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    return [
+        Probe(model=model, attempt=attempt)
+        for model in models
+        for attempt in range(1, attempts + 1)
+    ]
+
+
+def render_plan(plan: Iterable[Probe], base_url: str) -> str:
+    payload = {
+        "name": "agent-tool-call-reliability",
+        "endpoint": normalize_v1_base(base_url),
+        "checks": [
+            {
+                "model": probe.model,
+                "attempt": probe.attempt,
+                "phases": [
+                    "tool_call",
+                    "tool_result",
+                    "stream_tool_call",
+                    "stream_tool_result",
+                ],
+            }
+            for probe in plan
+        ],
+        "evidence": ["results.jsonl"],
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def tool_schema() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": TOOL_NAME,
+                "description": "Return one deterministic fact from the agent reliability fixture.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "enum": sorted(FIXTURE_FACTS),
+                        },
+                    },
+                    "required": ["key"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+
+def initial_messages(attempt: int) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": "You are a strict OpenAI tool-call compatibility probe.",
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Attempt {attempt}: call the {TOOL_NAME} tool with key=codeword. "
+                "Do not answer directly before the tool call."
+            ),
+        },
+    ]
+
+
+def build_tool_probe_request(model: str, attempt: int) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": initial_messages(attempt),
+        "tools": tool_schema(),
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": TOOL_NAME},
+        },
+        "parallel_tool_calls": False,
+        "stream": False,
+        "max_tokens": 96,
+        "temperature": 0,
+    }
+
+
+def build_stream_tool_probe_request(model: str, attempt: int) -> dict[str, Any]:
+    request = build_tool_probe_request(model, attempt)
+    request["stream"] = True
+    return request
+
+
+def extract_tool_call(response: dict[str, Any]) -> ToolCall:
+    _require_tool_call_finish(response)
+    message = _first_message(response)
+    calls = message.get("tool_calls")
+    if not isinstance(calls, list) or not calls:
+        raise ValueError("response did not contain tool_calls")
+    call = calls[0]
+    if not isinstance(call, dict):
+        raise ValueError("tool call is not an object")
+    call_id = call.get("id")
+    function = call.get("function")
+    if not isinstance(call_id, str) or not call_id:
+        raise ValueError("tool call is missing an id")
+    if not isinstance(function, dict):
+        raise ValueError("tool call is missing a function object")
+    if function.get("name") != TOOL_NAME:
+        raise ValueError(f"unexpected tool name: {function.get('name')!r}")
+    arguments = _decode_tool_arguments(function.get("arguments"))
+    key = arguments.get("key")
+    if key not in FIXTURE_FACTS:
+        raise ValueError(f"unsupported fixture key: {key!r}")
+    return ToolCall(call_id=call_id, key=key)
+
+
+def extract_stream_tool_call(chunks: Iterable[dict[str, Any]]) -> ToolCall:
+    parts: dict[int, dict[str, Any]] = {}
+    saw_tool_finish = False
+    for chunk in chunks:
+        choices = chunk.get("choices")
+        if not isinstance(choices, list):
+            continue
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            delta = choice.get("delta")
+            if choice.get("finish_reason") == "tool_calls":
+                saw_tool_finish = True
+            if not isinstance(delta, dict):
+                continue
+            for call_delta in delta.get("tool_calls") or []:
+                if not isinstance(call_delta, dict):
+                    continue
+                index = call_delta.get("index", 0)
+                if not isinstance(index, int):
+                    raise ValueError(f"tool-call delta index is not an integer: {index!r}")
+                entry = parts.setdefault(index, {"id": "", "name": "", "arguments": []})
+                if isinstance(call_delta.get("id"), str):
+                    entry["id"] = call_delta["id"]
+                function = call_delta.get("function")
+                if isinstance(function, dict):
+                    if isinstance(function.get("name"), str):
+                        entry["name"] += function["name"]
+                    if isinstance(function.get("arguments"), str):
+                        entry["arguments"].append(function["arguments"])
+    if not parts:
+        raise ValueError("stream did not contain tool_call deltas")
+    if not saw_tool_finish:
+        raise ValueError("stream did not finish with tool_calls")
+    first = parts[min(parts)]
+    return _tool_call_from_parts(
+        call_id=first["id"],
+        name=first["name"],
+        arguments="".join(first["arguments"]),
+    )
+
+
+def build_tool_result_request(
+    model: str,
+    attempt: int,
+    assistant_message: dict[str, Any],
+    call: ToolCall,
+) -> dict[str, Any]:
+    expected = FIXTURE_FACTS[call.key]
+    messages = initial_messages(attempt)
+    messages.append(_sanitize_assistant_tool_message(assistant_message))
+    messages.append(
+        {
+            "role": "tool",
+            "tool_call_id": call.call_id,
+            "name": TOOL_NAME,
+            "content": json.dumps(
+                {"key": call.key, "value": expected},
+                separators=(",", ":"),
+            ),
+        }
+    )
+    return {
+        "model": model,
+        "messages": messages,
+        "stream": False,
+        "max_tokens": 64,
+        "temperature": 0,
+    }
+
+
+def build_stream_tool_result_request(
+    model: str,
+    attempt: int,
+    assistant_message: dict[str, Any],
+    call: ToolCall,
+) -> dict[str, Any]:
+    request = build_tool_result_request(model, attempt, assistant_message, call)
+    request["stream"] = True
+    return request
+
+
+def validate_final_answer(response: dict[str, Any], expected: str) -> None:
+    message = _first_message(response)
+    if message.get("tool_calls"):
+        raise ValueError("continuation returned another tool call")
+    content = message.get("content")
+    validate_final_content(content, expected)
+
+
+def validate_final_content(content: Any, expected: str) -> None:
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("continuation returned empty content")
+    if expected not in content:
+        raise ValueError(f"missing expected fixture value: {expected}")
+
+
+def extract_stream_content(chunks: Iterable[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    saw_choice = False
+    for chunk in chunks:
+        choices = chunk.get("choices")
+        if not isinstance(choices, list):
+            continue
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            saw_choice = True
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                continue
+            content = delta.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+    if not saw_choice:
+        raise ValueError("stream returned no choices")
+    return "".join(parts)
+
+
+def write_jsonl(path: Path, results: Iterable[ProbeResult]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for result in results:
+            handle.write(json.dumps(result._asdict(), sort_keys=True) + "\n")
+
+
+def run_probe(
+    base_url: str,
+    probe: Probe,
+    timeout: float,
+    include_streaming: bool = True,
+) -> list[ProbeResult]:
+    results: list[ProbeResult] = []
+    results.extend(run_non_stream_probe(base_url, probe, timeout))
+    if include_streaming:
+        results.extend(run_stream_probe(base_url, probe, timeout))
+    return results
+
+
+def run_non_stream_probe(base_url: str, probe: Probe, timeout: float) -> list[ProbeResult]:
+    results: list[ProbeResult] = []
+    tool_started = time.monotonic()
+    try:
+        request = build_tool_probe_request(probe.model, probe.attempt)
+        response, status_code = post_json(base_url, "/chat/completions", request, timeout)
+        call = extract_tool_call(response)
+        results.append(
+            _result(
+                probe,
+                "tool_call",
+                True,
+                f"{TOOL_NAME} key={call.key}",
+                tool_started,
+                status_code,
+            )
+        )
+    except Exception as exc:
+        results.append(_result(probe, "tool_call", False, str(exc), tool_started))
+        return results
+
+    final_started = time.monotonic()
+    try:
+        assistant_message = _first_message(response)
+        request = build_tool_result_request(probe.model, probe.attempt, assistant_message, call)
+        response, status_code = post_json(base_url, "/chat/completions", request, timeout)
+        validate_final_answer(response, FIXTURE_FACTS[call.key])
+        results.append(
+            _result(
+                probe,
+                "tool_result",
+                True,
+                f"final answer included {FIXTURE_FACTS[call.key]}",
+                final_started,
+                status_code,
+            )
+        )
+    except Exception as exc:
+        results.append(_result(probe, "tool_result", False, str(exc), final_started))
+    return results
+
+
+def run_stream_probe(base_url: str, probe: Probe, timeout: float) -> list[ProbeResult]:
+    results: list[ProbeResult] = []
+    tool_started = time.monotonic()
+    try:
+        request = build_stream_tool_probe_request(probe.model, probe.attempt)
+        chunks, status_code = post_json_stream(base_url, "/chat/completions", request, timeout)
+        call = extract_stream_tool_call(chunks)
+        results.append(
+            _result(
+                probe,
+                "stream_tool_call",
+                True,
+                f"{TOOL_NAME} key={call.key}",
+                tool_started,
+                status_code,
+            )
+        )
+    except Exception as exc:
+        results.append(_result(probe, "stream_tool_call", False, str(exc), tool_started))
+        return results
+
+    final_started = time.monotonic()
+    try:
+        assistant_message = assistant_message_from_tool_call(call)
+        request = build_stream_tool_result_request(probe.model, probe.attempt, assistant_message, call)
+        chunks, status_code = post_json_stream(base_url, "/chat/completions", request, timeout)
+        content = extract_stream_content(chunks)
+        validate_final_content(content, FIXTURE_FACTS[call.key])
+        results.append(
+            _result(
+                probe,
+                "stream_tool_result",
+                True,
+                f"final answer included {FIXTURE_FACTS[call.key]}",
+                final_started,
+                status_code,
+            )
+        )
+    except Exception as exc:
+        results.append(_result(probe, "stream_tool_result", False, str(exc), final_started))
+    return results
+
+
+def assistant_message_from_tool_call(call: ToolCall) -> dict[str, Any]:
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": call.call_id,
+                "type": "function",
+                "function": {
+                    "name": TOOL_NAME,
+                    "arguments": json.dumps({"key": call.key}, separators=(",", ":")),
+                },
+            }
+        ],
+    }
+
+
+def post_json(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float,
+) -> tuple[dict[str, Any], int]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{normalize_v1_base(base_url)}{path}",
+        data=data,
+        headers={
+            "content-type": "application/json",
+            "authorization": "Bearer mesh-llm-agent-probe",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status_code = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {body[:400]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"request failed: {exc}") from exc
+
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError as exc:
+        snippet = body.decode("utf-8", errors="replace")[:400]
+        raise RuntimeError(f"response was not JSON: {snippet}") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError("response JSON was not an object")
+    return decoded, status_code
+
+
+def post_json_stream(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float,
+) -> tuple[list[dict[str, Any]], int]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{normalize_v1_base(base_url)}{path}",
+        data=data,
+        headers={
+            "content-type": "application/json",
+            "authorization": "Bearer mesh-llm-agent-probe",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            chunks = list(
+                parse_sse_lines(line.decode("utf-8", errors="replace") for line in response)
+            )
+            status_code = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {body[:400]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"request failed: {exc}") from exc
+    if not chunks:
+        raise RuntimeError("stream returned no events")
+    return chunks, status_code
+
+
+def parse_sse_lines(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith(":") or not line.startswith("data:"):
+            continue
+        data = line.removeprefix("data:").strip()
+        if data == "[DONE]":
+            break
+        try:
+            decoded = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"stream event was not JSON: {data[:200]}") from exc
+        if not isinstance(decoded, dict):
+            raise RuntimeError("stream event JSON was not an object")
+        yield decoded
+
+
+def default_base_url() -> str:
+    env_base = (
+        os.environ.get("MESH_AGENT_TOOL_BASE_URL")
+        or os.environ.get("MESH_AGENT_BASE_URL")
+        or os.environ.get("MESH_OPENCODE_BASE_URL")
+    )
+    if env_base:
+        return env_base
+    client_base = os.environ.get("MESH_CLIENT_API_BASE")
+    if client_base:
+        return f"{client_base.rstrip('/')}/v1"
+    return DEFAULT_BASE_URL
+
+
+def main() -> int:
+    args = parse_args()
+    base_url = normalize_v1_base(args.base_url)
+    models = parse_models(args.models)
+    plan = build_plan(models, args.attempts)
+    if args.print_plan:
+        print(render_plan(plan, base_url))
+        return 0
+
+    results: list[ProbeResult] = []
+    for probe in plan:
+        results.extend(
+            run_probe(
+                base_url,
+                probe,
+                args.timeout,
+                include_streaming=not args.skip_streaming,
+            )
+        )
+    write_jsonl(Path(args.output), results)
+    print_summary(results, Path(args.output))
+    return 0 if all(result.ok for result in results) else 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Probe OpenAI chat tool-call and tool-result continuation reliability.",
+    )
+    parser.add_argument("--base-url", default=default_base_url())
+    parser.add_argument(
+        "--models",
+        default=os.environ.get("MESH_AGENT_TOOL_MODELS", DEFAULT_MODELS),
+    )
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=int(os.environ.get("MESH_AGENT_TOOL_ATTEMPTS", "1")),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("MESH_AGENT_TOOL_TIMEOUT", "120")),
+    )
+    parser.add_argument("--output", default=os.environ.get("MESH_AGENT_TOOL_OUTPUT", DEFAULT_OUTPUT))
+    parser.add_argument("--skip-streaming", action="store_true")
+    parser.add_argument("--print-plan", action="store_true")
+    return parser.parse_args()
+
+
+def print_summary(results: Iterable[ProbeResult], output: Path) -> None:
+    rows = list(results)
+    passed = sum(1 for row in rows if row.ok)
+    print(f"agent tool-call reliability: {passed}/{len(rows)} phases passed")
+    print(f"results: {output}")
+    for row in rows:
+        status = "PASS" if row.ok else "FAIL"
+        print(f"{status} model={row.model} attempt={row.attempt} phase={row.phase}: {row.detail}")
+
+
+def _first_message(response: dict[str, Any]) -> dict[str, Any]:
+    first = _first_choice(response)
+    message = first.get("message")
+    if not isinstance(message, dict):
+        raise ValueError("first choice did not contain a message object")
+    return message
+
+
+def _first_choice(response: dict[str, Any]) -> dict[str, Any]:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("response had no choices")
+    first = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError("first choice is not an object")
+    return first
+
+
+def _require_tool_call_finish(response: dict[str, Any]) -> None:
+    finish_reason = _first_choice(response).get("finish_reason")
+    if finish_reason != "tool_calls":
+        raise ValueError(f"tool-call turn finish_reason was not tool_calls: {finish_reason!r}")
+
+
+def _decode_tool_arguments(arguments: Any) -> dict[str, Any]:
+    if isinstance(arguments, str):
+        try:
+            decoded = json.loads(arguments)
+        except json.JSONDecodeError as exc:
+            raise ValueError("tool arguments were not valid JSON") from exc
+    elif isinstance(arguments, dict):
+        decoded = arguments
+    else:
+        raise ValueError("tool arguments were neither JSON string nor object")
+    if not isinstance(decoded, dict):
+        raise ValueError("tool arguments were not a JSON object")
+    return decoded
+
+
+def _tool_call_from_parts(call_id: str, name: str, arguments: str) -> ToolCall:
+    if not isinstance(call_id, str) or not call_id:
+        raise ValueError("tool call is missing an id")
+    if name != TOOL_NAME:
+        raise ValueError(f"unexpected tool name: {name!r}")
+    decoded = _decode_tool_arguments(arguments)
+    key = decoded.get("key")
+    if key not in FIXTURE_FACTS:
+        raise ValueError(f"unsupported fixture key: {key!r}")
+    return ToolCall(call_id=call_id, key=key)
+
+
+def _sanitize_assistant_tool_message(message: dict[str, Any]) -> dict[str, Any]:
+    sanitized = {
+        "role": "assistant",
+        "content": message.get("content"),
+        "tool_calls": message.get("tool_calls"),
+    }
+    return {key: value for key, value in sanitized.items() if value is not None}
+
+
+def _result(
+    probe: Probe,
+    phase: str,
+    ok: bool,
+    detail: str,
+    started: float,
+    status_code: int | None = None,
+) -> ProbeResult:
+    elapsed_ms = int((time.monotonic() - started) * 1000)
+    return ProbeResult(
+        model=probe.model,
+        attempt=probe.attempt,
+        phase=phase,
+        ok=ok,
+        detail=detail,
+        elapsed_ms=elapsed_ms,
+        status_code=status_code,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_qa_agent_tool_call_reliability.py
+++ b/scripts/tests/test_qa_agent_tool_call_reliability.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "qa-agent-tool-call-reliability.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("qa_agent_tool_call_reliability", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class AgentToolCallReliabilityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = load_module()
+
+    def test_normalizes_mesh_base_url_to_v1(self) -> None:
+        self.assertEqual(
+            self.harness.normalize_v1_base("http://127.0.0.1:9337"),
+            "http://127.0.0.1:9337/v1",
+        )
+        self.assertEqual(
+            self.harness.normalize_v1_base("http://127.0.0.1:9337/v1/"),
+            "http://127.0.0.1:9337/v1",
+        )
+
+    def test_print_plan_does_not_require_network(self) -> None:
+        plan = self.harness.build_plan(["auto", "mesh"], attempts=2)
+        self.assertEqual(
+            [probe.model for probe in plan],
+            ["auto", "auto", "mesh", "mesh"],
+        )
+        rendered = self.harness.render_plan(plan, "http://127.0.0.1:9337/v1")
+        decoded = json.loads(rendered)
+        self.assertEqual(decoded["name"], "agent-tool-call-reliability")
+        self.assertEqual(decoded["endpoint"], "http://127.0.0.1:9337/v1")
+        self.assertEqual(decoded["checks"][0]["model"], "auto")
+        self.assertEqual(decoded["checks"][3]["attempt"], 2)
+
+    def test_extracts_valid_tool_call(self) -> None:
+        response = {
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "lookup_fixture_fact",
+                                    "arguments": json.dumps({"key": "codeword"}),
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        call = self.harness.extract_tool_call(response)
+        self.assertEqual(call.call_id, "call_1")
+        self.assertEqual(call.key, "codeword")
+
+    def test_rejects_wrong_tool_call_shape(self) -> None:
+        response = {
+            "choices": [
+                {
+                    "finish_reason": "tool_calls",
+                    "message": {
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "lookup_fixture_fact",
+                                    "arguments": json.dumps({"key": "unknown"}),
+                                },
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+        with self.assertRaisesRegex(ValueError, "unsupported fixture key"):
+            self.harness.extract_tool_call(response)
+
+    def test_extracts_streamed_tool_call(self) -> None:
+        chunks = [
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "call_stream",
+                                    "type": "function",
+                                    "function": {
+                                        "name": "lookup_fixture_fact",
+                                        "arguments": '{"key"',
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "choices": [
+                    {
+                        "delta": {
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "function": {"arguments": ':"checksum"}'},
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {"choices": [{"delta": {}, "finish_reason": "tool_calls"}]},
+        ]
+        call = self.harness.extract_stream_tool_call(chunks)
+        self.assertEqual(call.call_id, "call_stream")
+        self.assertEqual(call.key, "checksum")
+
+    def test_validates_tool_result_continuation(self) -> None:
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": "The fixture value is signal-7429.",
+                    }
+                }
+            ]
+        }
+        self.harness.validate_final_answer(response, "signal-7429")
+
+        bad_response = {"choices": [{"message": {"content": "no fixture here"}}]}
+        with self.assertRaisesRegex(ValueError, "missing expected fixture value"):
+            self.harness.validate_final_answer(bad_response, "signal-7429")
+
+    def test_writes_jsonl_probe_results(self) -> None:
+        result = self.harness.ProbeResult(
+            model="auto",
+            attempt=1,
+            phase="tool_call",
+            ok=True,
+            detail="tool call accepted",
+            elapsed_ms=12,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "results.jsonl"
+            self.harness.write_jsonl(path, [result])
+            rows = [
+                json.loads(line)
+                for line in path.read_text(encoding="utf-8").splitlines()
+            ]
+        self.assertEqual(rows[0]["model"], "auto")
+        self.assertEqual(rows[0]["phase"], "tool_call")
+        self.assertTrue(rows[0]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a lightweight QA probe that lets maintainers validate whether a live mesh endpoint can complete agent-style tool-call loops through the OpenAI-compatible chat-completions API.

- Adds `scripts/qa-agent-tool-call-reliability.py` for deterministic tool-call and tool-result continuation checks.
- Covers both non-streaming and streaming chat-completions, including `finish_reason=tool_calls` and streamed `delta.tool_calls[*]` reconstruction.
- Emits JSONL results plus a side-effect-free JSON `--print-plan`.
- Adds Python unit coverage, a Rust contract test for the script surface, and docs for agent/testing workflows.

## Why

Recent agent and MoA testing made tool-call reliability a practical baseline risk. The existing Goose, OpenCode, and Pi smokes are useful end-to-end checks, but they are heavier and can make raw API-contract regressions harder to isolate. This gives a small direct probe for the `tools -> tool_calls -> tool result -> final answer` path those agents depend on.

## Diff Scope

- `scripts/qa-agent-tool-call-reliability.py`
- `scripts/tests/test_qa_agent_tool_call_reliability.py`
- `crates/mesh-llm/tests/qa_agent_tool_call_reliability.rs`
- `docs/AGENTS.md`
- `docs/design/TESTING.md`

## Compatibility

Opt-in verification tooling only. No runtime behavior, mesh protocol, gossip fields, API schema, release artifacts, or CI requirements are changed.

## Branch Integrity

- Base branch: `main`
- Validated base SHA: `27d46a6c4893f6ef0bc9b17591f85179e5e80b0d`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `27d46a6c4893f6ef0bc9b17591f85179e5e80b0d`
- Diff proof computed against freshly fetched `origin/main`.

## Commit Integrity

- `a5ceac7d Add agent tool-call reliability harness`
- One logical tooling/docs commit.
- No forbidden files, build artifacts, caches, secrets, credentials, or local environment files included.

## Diff Hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output before commit

## Validation

Validation tier: Tier 4 - verification tooling plus docs and contract tests for the OpenAI-compatible agent tool-call QA path.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`: PASS, 7 passed
- `python3 -m py_compile scripts/qa-agent-tool-call-reliability.py scripts/tests/test_qa_agent_tool_call_reliability.py`: PASS
- `scripts/qa-agent-tool-call-reliability.py --models auto,mesh --attempts 2 --print-plan >/tmp/mesh-agent-tool-plan.json && python3 -m json.tool /tmp/mesh-agent-tool-plan.json >/dev/null`: PASS
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm --test qa_agent_tool_call_reliability`: PASS, 4 passed
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - not required for selected validation tier/change family.
- Not run: live endpoint probe - not required before opening this opt-in QA harness PR; local parser, plan, and script contract tests cover the new tooling surface.
- Not run: `just build` - not required for selected validation tier; no shipped runtime, UI bundle, or release artifact changed.


## Runtime Safety

Not applicable - no runtime path changed. No invariant regression introduced.

## Documentation Integrity

Updated `docs/AGENTS.md` and `docs/design/TESTING.md` with the probe purpose, commands, streaming behavior, and result interpretation.

## Rollback Plan

Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

