### PR TITLE
Switch Hugging Face client to hf-hub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling 0.20.11",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1530,17 +1555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derivative"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2057,17 +2071,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs4"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
-dependencies = [
- "rustix 1.1.4",
- "tokio",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,10 +2454,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "hf-hub"
+version = "1.0.0"
+source = "git+https://github.com/huggingface/hf-hub.git?branch=main#4cd6d8acd3192021381ff85210be9192b394e0eb"
+dependencies = [
+ "base64",
+ "bon",
+ "bytes",
+ "futures",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "hf-xet"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51abe4fef614e6d944f451ceb9af154efa7e85dff8f2c35e2922cc789e0aa88"
+checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2465,7 +2493,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
+ "uuid",
  "xet-client",
  "xet-core-structures",
  "xet-data",
@@ -2620,33 +2648,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "huggingface-hub"
-version = "0.0.1"
-source = "git+https://github.com/huggingface/huggingface_hub_rust.git?rev=c9749ef76a294d5e97acae6b644071e39854aeb8#c9749ef76a294d5e97acae6b644071e39854aeb8"
-dependencies = [
- "async-trait",
- "base64",
- "bytes",
- "fs4",
- "futures",
- "globset",
- "hf-xet",
- "pathdiff",
- "reqwest 0.13.2",
- "reqwest-middleware",
- "reqwest-retry",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "typed-builder",
- "url",
-]
 
 [[package]]
 name = "humantime"
@@ -3715,8 +3716,8 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "hex",
+ "hf-hub",
  "httparse",
- "huggingface-hub",
  "iroh",
  "keyring",
  "libc",
@@ -3959,7 +3960,7 @@ version = "0.66.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "huggingface-hub",
+ "hf-hub",
  "model-artifact",
  "model-ref",
  "serde",
@@ -3975,7 +3976,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "huggingface-hub",
+ "hf-hub",
  "model-hf",
  "model-ref",
  "reqwest 0.12.28",
@@ -5157,12 +5158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6007,30 +6002,8 @@ dependencies = [
  "async-trait",
  "http",
  "reqwest 0.13.2",
- "serde",
  "thiserror 2.0.18",
  "tower-service",
-]
-
-[[package]]
-name = "reqwest-retry"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
-dependencies = [
- "anyhow",
- "async-trait",
- "futures",
- "getrandom 0.2.17",
- "http",
- "hyper",
- "reqwest 0.13.2",
- "reqwest-middleware",
- "retry-policies",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "wasmtimer",
 ]
 
 [[package]]
@@ -6038,15 +6011,6 @@ name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
-
-[[package]]
-name = "retry-policies"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a4bd6027df676bcb752d3724db0ea3c0c5fc1dd0376fec51ac7dcaf9cc69be"
-dependencies = [
- "rand 0.9.2",
-]
 
 [[package]]
 name = "ring"
@@ -7818,26 +7782,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
-name = "typed-builder"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d30e3a08026c78f246b173243cf07b3696d274debd26680773b6773c2afc7"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c36781cc0e46a83726d9879608e4cf6c2505237e263a8eb8c24502989cfdb28"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7864,16 +7808,6 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "ulid"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
-dependencies = [
- "rand 0.9.2",
- "web-time",
 ]
 
 [[package]]
@@ -8366,20 +8300,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "wasmtimer"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -9093,9 +9013,9 @@ dependencies = [
 
 [[package]]
 name = "xet-client"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9164bc896ccd143b33fd08a8a2c8e3d769e5e0b2c853496694937fcce734bc1a"
+checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9103,17 +9023,15 @@ dependencies = [
  "bytes",
  "clap",
  "crc32fast",
- "derivative",
  "futures",
  "http",
  "hyper",
  "lazy_static",
  "more-asserts",
- "rand 0.9.2",
+ "rand 0.10.1",
  "redb",
  "reqwest 0.13.2",
  "reqwest-middleware",
- "reqwest-retry",
  "serde",
  "serde_json",
  "serde_repr",
@@ -9133,9 +9051,9 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ddd10bc095bdb6539a9ace6bfd9f27c13c8604d2f18d25383169aa948c5c09"
+checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
 dependencies = [
  "async-trait",
  "base64",
@@ -9153,7 +9071,7 @@ dependencies = [
  "lazy_static",
  "lz4_flex",
  "more-asserts",
- "rand 0.9.2",
+ "rand 0.10.1",
  "regex",
  "safe-transmute",
  "serde",
@@ -9170,9 +9088,9 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00516b2aeea170fbed408adf519931f52db71b5fc7365bb6c63055caf5af113a"
+checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9184,7 +9102,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "more-asserts",
- "rand 0.9.2",
+ "rand 0.10.1",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -9193,8 +9111,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "ulid",
  "url",
+ "uuid",
  "walkdir",
  "xet-client",
  "xet-core-structures",
@@ -9203,9 +9121,9 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dfc7acf5e0a8eb33bb6115376126b6776b7c82a043c661816ff070a6408832a"
+checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9224,7 +9142,7 @@ dependencies = [
  "more-asserts",
  "oneshot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.10.1",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,7 +2456,7 @@ dependencies = [
 [[package]]
 name = "hf-hub"
 version = "1.0.0"
-source = "git+https://github.com/huggingface/hf-hub.git?branch=main#4cd6d8acd3192021381ff85210be9192b394e0eb"
+source = "git+https://github.com/huggingface/hf-hub.git?rev=4cd6d8acd3192021381ff85210be9192b394e0eb#4cd6d8acd3192021381ff85210be9192b394e0eb"
 dependencies = [
  "base64",
  "bon",

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -83,7 +83,7 @@ schemars = "1"
 prost = "0.14"
 toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", branch = "main", default-features = false, features = ["blocking"] }
+hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", rev = "4cd6d8acd3192021381ff85210be9192b394e0eb", default-features = false, features = ["blocking"] }
 tabwriter = "1"
 
 [dev-dependencies]

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -83,7 +83,7 @@ schemars = "1"
 prost = "0.14"
 toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-hf_hub = { package = "huggingface-hub", git = "https://github.com/huggingface/huggingface_hub_rust.git", rev = "c9749ef76a294d5e97acae6b644071e39854aeb8", default-features = false, features = ["blocking", "xet"] }
+hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", branch = "main", default-features = false, features = ["blocking"] }
 tabwriter = "1"
 
 [dev-dependencies]

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use hf_hub::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
+use hf_hub::progress::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use skippy_protocol::{LoadMode, StageConfig};
@@ -750,7 +750,7 @@ fn layer_package_progress_label(repo: &str, revision: &str) -> String {
 }
 
 fn download_layer_package_file(
-    model_api: &hf_hub::HFRepositorySync,
+    model_api: &hf_hub::HFRepositorySync<hf_hub::RepoTypeModel>,
     revision: &str,
     label: &str,
     file_name: &str,
@@ -766,15 +766,13 @@ fn download_layer_package_file(
         completed_before,
     ));
     progress.emit_ensuring();
-    let progress_handler: Progress = Some(progress.clone());
+    let progress_handler: Option<Progress> = Some(progress.clone().into());
     let path = model_api
-        .download_file(
-            &hf_hub::RepoDownloadFileParams::builder()
-                .filename(file_name.to_string())
-                .revision(revision.to_string())
-                .progress(progress_handler)
-                .build(),
-        )
+        .download_file()
+        .filename(file_name.to_string())
+        .revision(revision.to_string())
+        .maybe_progress(progress_handler)
+        .send()
         .with_context(|| format!("download layer package file: {file_name}"))?;
     progress.emit_ready(&path);
     Ok(path)

--- a/crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
+++ b/crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
@@ -390,7 +390,7 @@ fn parse_hf_package_ref(package_ref: &str) -> Result<HfPackageRef> {
 
 fn hf_repo_cache_root(repo: &str) -> PathBuf {
     crate::models::huggingface_hub_cache_dir().join(
-        crate::models::local::huggingface_repo_folder_name(repo, hf_hub::RepoType::Model),
+        crate::models::local::huggingface_repo_folder_name(repo, hf_hub::RepoTypeModel),
     )
 }
 

--- a/crates/mesh-llm-host-runtime/src/models/capabilities.rs
+++ b/crates/mesh-llm-host-runtime/src/models/capabilities.rs
@@ -5,7 +5,6 @@ pub use mesh_llm_types::models::capabilities::{
 
 use super::build_hf_tokio_api;
 use super::remote_catalog;
-use hf_hub::{RepoDownloadFileParams, RepoType};
 use serde_json::Value;
 use std::path::Path;
 
@@ -159,13 +158,11 @@ async fn fetch_remote_json_with_api(
 ) -> Option<Value> {
     let (owner, name) = repo.split_once('/').unwrap_or(("", repo.as_str()));
     let path = api
-        .repo(RepoType::Model, owner, name)
-        .download_file(
-            &RepoDownloadFileParams::builder()
-                .filename(file.to_string())
-                .revision(revision)
-                .build(),
-        )
+        .model(owner, name)
+        .download_file()
+        .filename(file.to_string())
+        .revision(revision)
+        .send()
         .await
         .ok()?;
     let text = tokio::fs::read_to_string(path).await.ok()?;

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -4,7 +4,9 @@ use super::track_managed_model_usage;
 use crate::cli::output::{emit_event, interactive_tui_active, ModelProgressStatus, OutputEvent};
 use crate::cli::terminal_progress::{start_spinner, SpinnerHandle};
 use anyhow::{Context, Result};
-use hf_hub::{DownloadEvent, Progress, ProgressEvent, ProgressHandler, RepoDownloadFileParams};
+use hf_hub::progress::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
+#[cfg(test)]
+use hf_hub::progress::{FileProgress, FileStatus};
 #[cfg(test)]
 use std::collections::HashMap;
 use std::io::Write;
@@ -148,12 +150,10 @@ fn parse_safetensors_index_shards(index: &serde_json::Value) -> Result<Vec<Strin
 fn ensure_cached_hf_asset(api: &hf_hub::HFClientSync, asset: &HfAsset) -> Result<PathBuf> {
     let (owner, name) = asset.repo_parts();
     api.model(owner, name)
-        .download_file(
-            &RepoDownloadFileParams::builder()
-                .filename(asset.file.clone())
-                .revision(asset.revision.clone())
-                .build(),
-        )
+        .download_file()
+        .filename(asset.file.clone())
+        .revision(asset.revision.clone())
+        .send()
         .with_context(|| {
             format!(
                 "Cache Hugging Face asset {}/{}@{}",
@@ -564,18 +564,18 @@ fn download_hf_assets_sync(
         } else {
             None
         };
-        let progress_handler: Progress = if let Some(tracker) = &progress_tracker {
-            Some(tracker.clone())
+        let progress_handler: Option<Progress> = if let Some(tracker) = &progress_tracker {
+            Some(tracker.clone().into())
         } else {
             None
         };
-        let path = match api_repo.download_file(
-            &RepoDownloadFileParams::builder()
-                .filename(asset.file.clone())
-                .revision(asset.revision.clone())
-                .progress(progress_handler)
-                .build(),
-        ) {
+        let path = match api_repo
+            .download_file()
+            .filename(asset.file.clone())
+            .revision(asset.revision.clone())
+            .maybe_progress(progress_handler)
+            .send()
+        {
             Ok(path) => {
                 if progress {
                     if required {
@@ -972,22 +972,22 @@ mod tests {
         MeshDownloadProgress::apply_download_event(
             &mut state,
             &DownloadEvent::Progress {
-                files: vec![hf_hub::FileProgress {
+                files: vec![FileProgress {
                     filename: "model.gguf".to_string(),
                     bytes_completed: 250,
                     total_bytes: 1_000,
-                    status: hf_hub::FileStatus::InProgress,
+                    status: FileStatus::InProgress,
                 }],
             },
         );
         MeshDownloadProgress::apply_download_event(
             &mut state,
             &DownloadEvent::Progress {
-                files: vec![hf_hub::FileProgress {
+                files: vec![FileProgress {
                     filename: "model.gguf".to_string(),
                     bytes_completed: 700,
                     total_bytes: 1_000,
-                    status: hf_hub::FileStatus::InProgress,
+                    status: FileStatus::InProgress,
                 }],
             },
         );
@@ -1019,11 +1019,11 @@ mod tests {
         MeshDownloadProgress::apply_download_event(
             &mut state,
             &DownloadEvent::Progress {
-                files: vec![hf_hub::FileProgress {
+                files: vec![FileProgress {
                     filename: "gemma-4-31B-it-Q4_0.gguf".to_string(),
                     bytes_completed: 4_000_000,
                     total_bytes: 17_300_000_000,
-                    status: hf_hub::FileStatus::InProgress,
+                    status: FileStatus::InProgress,
                 }],
             },
         );

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -564,11 +564,9 @@ fn download_hf_assets_sync(
         } else {
             None
         };
-        let progress_handler: Option<Progress> = if let Some(tracker) = &progress_tracker {
-            Some(tracker.clone().into())
-        } else {
-            None
-        };
+        let progress_handler: Option<Progress> = progress_tracker
+            .as_ref()
+            .map(|tracker| tracker.clone().into());
         let path = match api_repo
             .download_file()
             .filename(asset.file.clone())

--- a/crates/mesh-llm-host-runtime/src/models/delete.rs
+++ b/crates/mesh-llm-host-runtime/src/models/delete.rs
@@ -2,7 +2,8 @@ use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use hf_hub::types::cache::{CachedFileInfo, CachedRevisionInfo, HFCacheInfo};
+use hf_hub::cache::{CachedFileInfo, CachedRevisionInfo, HFCacheInfo};
+use hf_hub::{RepoType, RepoTypeModel};
 
 use crate::models::local::{
     gguf_metadata_cache_path, huggingface_hub_cache_dir, huggingface_identity_for_path,
@@ -61,8 +62,7 @@ async fn resolve_cached_hf_ref(
     };
 
     for repo in &cache_info.repos {
-        use hf_hub::RepoType;
-        if repo.repo_type != RepoType::Model || repo.repo_id != repo_id {
+        if repo.repo_type != RepoTypeModel.singular() || repo.repo_id != repo_id {
             continue;
         }
         for cached_revision in &repo.revisions {
@@ -158,8 +158,7 @@ fn find_related_hf_cache_paths(cache_info: &HFCacheInfo, path: &Path) -> Vec<Pat
     let expected = normalized_gguf_stem(file_name);
 
     for repo in &cache_info.repos {
-        use hf_hub::RepoType;
-        if repo.repo_type != RepoType::Model || repo.repo_id != identity.repo_id {
+        if repo.repo_type != RepoTypeModel.singular() || repo.repo_id != identity.repo_id {
             continue;
         }
         for revision in &repo.revisions {

--- a/crates/mesh-llm-host-runtime/src/models/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/models/inventory.rs
@@ -6,6 +6,7 @@ use super::local::{
     direct_hf_cache_root_gguf_paths, gguf_metadata_cache_path, huggingface_hub_cache,
     huggingface_hub_cache_dir, scan_hf_cache_fast, scan_hf_cache_info,
 };
+use hf_hub::{RepoType, RepoTypeModel};
 
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct LocalModelInventorySnapshot {
@@ -116,7 +117,7 @@ fn local_gguf_paths() -> Vec<PathBuf> {
             let cache = huggingface_hub_cache();
             if let Some(cache_info) = scan_hf_cache_info(&cache) {
                 for repo in &cache_info.repos {
-                    if repo.repo_type != "model" {
+                    if repo.repo_type != RepoTypeModel.singular() {
                         continue;
                     }
                     for revision in &repo.revisions {

--- a/crates/mesh-llm-host-runtime/src/models/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/models/inventory.rs
@@ -116,7 +116,7 @@ fn local_gguf_paths() -> Vec<PathBuf> {
             let cache = huggingface_hub_cache();
             if let Some(cache_info) = scan_hf_cache_info(&cache) {
                 for repo in &cache_info.repos {
-                    if repo.repo_type != hf_hub::RepoType::Model {
+                    if repo.repo_type != "model" {
                         continue;
                     }
                     for revision in &repo.revisions {

--- a/crates/mesh-llm-host-runtime/src/models/local.rs
+++ b/crates/mesh-llm-host-runtime/src/models/local.rs
@@ -1,6 +1,5 @@
-use hf_hub::cache::scan_cache_dir;
-use hf_hub::types::cache::{CachedFileInfo, CachedRepoInfo, CachedRevisionInfo, HFCacheInfo};
-use hf_hub::RepoType;
+use hf_hub::cache::{CachedFileInfo, CachedRepoInfo, CachedRevisionInfo, HFCacheInfo};
+use hf_hub::{HFClientBuilder, RepoType, RepoTypeModel};
 use model_ref::{format_model_ref, gguf_matches_quant_selector, normalize_gguf_distribution_id};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
@@ -126,9 +125,9 @@ pub fn huggingface_hub_cache_dir() -> PathBuf {
     huggingface_hub_cache()
 }
 
-pub(crate) fn huggingface_repo_folder_name(repo_id: &str, repo_type: RepoType) -> String {
-    let type_plural = format!("{}s", repo_type);
-    std::iter::once(type_plural.as_str())
+pub(crate) fn huggingface_repo_folder_name(repo_id: &str, repo_type: impl RepoType) -> String {
+    let type_plural = repo_type.plural();
+    std::iter::once(type_plural)
         .chain(repo_id.split('/'))
         .collect::<Vec<_>>()
         .join("--")
@@ -137,7 +136,7 @@ pub(crate) fn huggingface_repo_folder_name(repo_id: &str, repo_type: RepoType) -
 #[cfg(test)]
 pub(crate) fn huggingface_snapshot_path(
     repo_id: &str,
-    repo_type: RepoType,
+    repo_type: impl RepoType,
     revision: &str,
 ) -> PathBuf {
     huggingface_hub_cache_dir()
@@ -153,7 +152,16 @@ pub(crate) fn scan_hf_cache_info(cache_root: &Path) -> Option<HFCacheInfo> {
             .enable_all()
             .build()
             .ok()?;
-        runtime.block_on(scan_cache_dir(&cache_root)).ok()
+        runtime
+            .block_on(
+                HFClientBuilder::new()
+                    .cache_dir(cache_root)
+                    .build()
+                    .ok()?
+                    .scan_cache()
+                    .send(),
+            )
+            .ok()
     };
 
     if tokio::runtime::Handle::try_current().is_ok() {
@@ -164,7 +172,7 @@ pub(crate) fn scan_hf_cache_info(cache_root: &Path) -> Option<HFCacheInfo> {
 }
 
 fn cache_repo_id(repo: &CachedRepoInfo) -> Option<&str> {
-    (repo.repo_type == RepoType::Model).then_some(repo.repo_id.as_str())
+    (repo.repo_type == RepoTypeModel.singular()).then_some(repo.repo_id.as_str())
 }
 
 pub fn mesh_llm_cache_dir() -> PathBuf {
@@ -404,8 +412,12 @@ fn cache_scanned_file_path(
         .file_path
         .strip_prefix(&revision.snapshot_path)
         .unwrap_or(file.file_path.as_path());
-    cache_root
-        .join(huggingface_repo_folder_name(&repo.repo_id, repo.repo_type))
+    repo.repo_path
+        .strip_prefix(cache_root)
+        .map_or_else(
+            |_| repo.repo_path.clone(),
+            |relative| cache_root.join(relative),
+        )
         .join("snapshots")
         .join(&revision.commit_hash)
         .join(relative)
@@ -486,7 +498,7 @@ fn scan_hf_cache_models(names: &mut Vec<String>, seen: &mut HashSet<String>, min
             return;
         };
         for repo in &cache_info.repos {
-            if repo.repo_type != RepoType::Model {
+            if repo.repo_type != RepoTypeModel.singular() {
                 continue;
             }
             for revision in &repo.revisions {
@@ -702,7 +714,7 @@ fn find_hf_cache_model_ref_path(root: &Path, model: &model_ref::ModelRef) -> Opt
     let cache_info = scan_hf_cache_info(root)?;
     let mut candidates = Vec::new();
     for repo in &cache_info.repos {
-        if repo.repo_type != RepoType::Model || repo.repo_id != model.repo {
+        if repo.repo_type != RepoTypeModel.singular() || repo.repo_id != model.repo {
             continue;
         }
         for revision in &repo.revisions {
@@ -739,7 +751,7 @@ fn find_synthetic_local_gguf_path(root: &Path, model: &model_ref::ModelRef) -> O
     let cache_info = scan_hf_cache_info(root);
     if let Some(cache_info) = cache_info {
         for repo in &cache_info.repos {
-            if repo.repo_type != RepoType::Model {
+            if repo.repo_type != RepoTypeModel.singular() {
                 continue;
             }
             for revision in &repo.revisions {
@@ -768,7 +780,7 @@ fn find_hf_cache_model_path(root: &Path, stem: &str) -> Option<PathBuf> {
     let cache_root = huggingface_hub_cache_dir();
     let cache_info = scan_hf_cache_info(&cache_root)?;
     for repo in &cache_info.repos {
-        if repo.repo_type != RepoType::Model {
+        if repo.repo_type != RepoTypeModel.singular() {
             continue;
         }
         for revision in &repo.revisions {

--- a/crates/mesh-llm-host-runtime/src/models/maintenance.rs
+++ b/crates/mesh-llm-host-runtime/src/models/maintenance.rs
@@ -1,7 +1,7 @@
 use super::{build_hf_api, huggingface_hub_cache_dir, run_hf_sync, short_revision};
 use crate::cli::terminal_progress::{clear_stderr_line, DeterminateProgressLine};
 use anyhow::{Context, Result};
-use hf_hub::{RepoDownloadFileParams, RepoInfo, RepoInfoParams, RepoType};
+use hf_hub::{repository::ModelInfo, RepoTypeModel};
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
@@ -310,23 +310,21 @@ fn collect_ref_files(root: &Path, dir: &Path, refs: &mut Vec<(String, String)>) 
     Ok(())
 }
 
-fn remote_repo_info(api: &hf_hub::HFClientSync, repo_id: &str, ref_name: &str) -> Result<RepoInfo> {
+fn remote_repo_info(
+    api: &hf_hub::HFClientSync,
+    repo_id: &str,
+    ref_name: &str,
+) -> Result<ModelInfo> {
     let (owner, name) = repo_id.split_once('/').unwrap_or(("", repo_id));
     api.model(owner, name)
-        .info(
-            &RepoInfoParams::builder()
-                .revision(ref_name.to_string())
-                .build(),
-        )
+        .info()
+        .revision(ref_name.to_string())
+        .send()
         .with_context(|| format!("Fetch repo info for {repo_id}@{ref_name}"))
 }
 
-fn repo_info_sha(info: &RepoInfo) -> String {
-    match info {
-        RepoInfo::Model(info) => info.sha.clone().unwrap_or_default(),
-        RepoInfo::Dataset(info) => info.sha.clone().unwrap_or_default(),
-        RepoInfo::Space(info) => info.sha.clone().unwrap_or_default(),
-    }
+fn repo_info_sha(info: &ModelInfo) -> String {
+    info.sha.clone().unwrap_or_default()
 }
 
 fn check_repo_update(api: &hf_hub::HFClientSync, repo: &CachedRepo) -> Result<Option<String>> {
@@ -366,12 +364,12 @@ fn update_cached_repo(api: &hf_hub::HFClientSync, repo: &CachedRepo) -> Result<U
         }
         position += 1;
         eprintln!("   ↻ [{}/{}] {}", position, total_files, file);
-        match api_repo.download_file(
-            &RepoDownloadFileParams::builder()
-                .filename(file.clone())
-                .revision(repo.ref_name.clone())
-                .build(),
-        ) {
+        match api_repo
+            .download_file()
+            .filename(file.clone())
+            .revision(repo.ref_name.clone())
+            .send()
+        {
             Ok(path) => {
                 eprintln!("   ✅ {}", path.display());
                 counts.refreshed += 1;
@@ -402,7 +400,7 @@ fn cached_repo_files(repo: &CachedRepo) -> Result<Vec<String>> {
     let snapshots_dir = huggingface_hub_cache_dir()
         .join(super::local::huggingface_repo_folder_name(
             &repo.repo_id,
-            RepoType::Model,
+            RepoTypeModel,
         ))
         .join("snapshots");
     if !snapshots_dir.is_dir() {

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -60,7 +60,7 @@ pub(crate) fn build_hf_api(_progress: bool) -> Result<HFClientSync> {
     if let Some(token) = hf_token_override() {
         builder = builder.token(token);
     }
-    HFClientSync::from_api(builder.build().context("Build Hugging Face API client")?)
+    HFClientSync::from_inner(builder.build().context("Build Hugging Face API client")?)
         .context("Build Hugging Face sync API client")
 }
 

--- a/crates/mesh-llm-host-runtime/src/models/remote_catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/remote_catalog.rs
@@ -18,8 +18,6 @@ use std::sync::{
     Arc, LazyLock,
 };
 
-use hf_hub::{RepoDownloadFileParams, RepoInfo, RepoInfoParams};
-
 use anyhow::{bail, Context, Result};
 use model_resolver::{
     CatalogProvider, CatalogSidecarAsset, CatalogSidecarRef,
@@ -153,17 +151,12 @@ fn refresh_catalog_sync() -> Result<()> {
 
     // List all files in the dataset repo
     let info = dataset
-        .info(
-            &RepoInfoParams::builder()
-                .revision("main".to_string())
-                .build(),
-        )
+        .info()
+        .revision("main".to_string())
+        .send()
         .context("fetch meshllm/catalog dataset info")?;
 
-    let siblings = match info {
-        RepoInfo::Dataset(ref d) => d.siblings.as_ref(),
-        _ => None,
-    };
+    let siblings = info.siblings.as_ref();
     let Some(siblings) = siblings else {
         bail!("meshllm/catalog dataset info has no file listing");
     };
@@ -190,12 +183,10 @@ fn refresh_catalog_sync() -> Result<()> {
     // Download each entry file
     for entry_file in &entry_files {
         let downloaded = dataset
-            .download_file(
-                &RepoDownloadFileParams::builder()
-                    .filename(entry_file.clone())
-                    .revision("main".to_string())
-                    .build(),
-            )
+            .download_file()
+            .filename(entry_file.clone())
+            .revision("main".to_string())
+            .send()
             .with_context(|| format!("download catalog entry {entry_file}"))?;
 
         // Copy to our cache dir structure if needed
@@ -372,12 +363,11 @@ fn hf_model_repo_has_file(repo: &str, revision: &str, file: &str) -> Result<bool
         let (owner, name) = repo.split_once('/').unwrap_or(("", repo.as_str()));
         let info = api
             .model(owner, name)
-            .info(&RepoInfoParams::builder().revision(revision.clone()).build())
+            .info()
+            .revision(revision.clone())
+            .send()
             .with_context(|| format!("fetch Hugging Face model repo {repo}@{revision}"))?;
-        let RepoInfo::Model(detail) = info else {
-            bail!("expected Hugging Face model repo info for {repo}@{revision}");
-        };
-        Ok(detail
+        Ok(info
             .siblings
             .unwrap_or_default()
             .iter()

--- a/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
@@ -7,7 +7,6 @@ use super::{
 use crate::cli::terminal_progress::start_spinner;
 use crate::models::usage::ModelUsageRecord;
 use anyhow::{bail, Context, Result};
-use hf_hub::{ListModelsParams, RepoInfo, RepoInfoParams};
 use model_artifact::{select_primary_artifact_file, ModelArtifactFile};
 use serde::Deserialize;
 use std::cmp::Ordering;
@@ -610,13 +609,12 @@ fn select_strong_repo_hit(query: &str, repo_ids: &[String]) -> Option<String> {
 
 async fn discover_hf_repo_for_bare_name(name: &str) -> Result<Option<String>> {
     let api = super::build_hf_tokio_api(false)?;
-    let params = ListModelsParams::builder()
+    let stream = api
+        .list_models()
         .search(name.to_string())
         .filter("gguf".to_string())
         .limit(20_usize)
-        .build();
-    let stream = api
-        .list_models(&params)
+        .send()
         .with_context(|| format!("Search Hugging Face for '{name}'"))?;
     tokio::pin!(stream);
     let mut repo_ids = Vec::new();
@@ -992,16 +990,11 @@ async fn fetch_repo_sibling_entries(
     let (owner, name) = repo.split_once('/').unwrap_or(("", repo));
     let detail = api
         .model(owner, name)
-        .info(
-            &RepoInfoParams::builder()
-                .revision(revision.to_string())
-                .build(),
-        )
+        .info()
+        .revision(revision.to_string())
+        .send()
         .await
         .with_context(|| format!("Fetch Hugging Face repo {repo}@{revision}"))?;
-    let RepoInfo::Model(detail) = detail else {
-        bail!("Expected model repo info for {repo}@{revision}");
-    };
     let siblings = detail
         .siblings
         .unwrap_or_default()

--- a/crates/mesh-llm-host-runtime/src/models/search.rs
+++ b/crates/mesh-llm-host-runtime/src/models/search.rs
@@ -8,7 +8,7 @@ use super::ModelCapabilities;
 use super::{build_hf_tokio_api, capabilities, catalog, remote_catalog};
 use crate::system::hardware;
 use anyhow::{Context, Result};
-use hf_hub::{ListModelsParams, ModelInfo};
+use hf_hub::repository::ModelInfo;
 use regex_lite::Regex;
 use serde_json::{json, Value};
 use std::collections::HashSet;
@@ -189,26 +189,38 @@ where
     };
     progress(SearchProgress::SearchingHub);
     let api = build_hf_tokio_api(false)?;
-    let base_builder = ListModelsParams::builder()
-        .search(query.to_string())
-        .filter(
-            match filter {
-                SearchArtifactFilter::Gguf => "gguf",
-                SearchArtifactFilter::Mlx => "mlx",
-            }
-            .to_string(),
-        )
-        .full(true)
-        .limit(repo_limit);
-    let params = match api_sort_key(sort) {
-        Some(api_sort) => base_builder.sort(api_sort.to_string()).build(),
-        None => base_builder.build(),
-    };
-    let stream = api.list_models(&params).context("Search Hugging Face")?;
-    tokio::pin!(stream);
     let mut repos = Vec::new();
-    while let Some(repo) = stream.next().await {
-        repos.push(repo.context("Search Hugging Face repo summary")?);
+    let artifact_filter = match filter {
+        SearchArtifactFilter::Gguf => "gguf",
+        SearchArtifactFilter::Mlx => "mlx",
+    };
+    if let Some(api_sort) = api_sort_key(sort) {
+        let stream = api
+            .list_models()
+            .search(query.to_string())
+            .filter(artifact_filter.to_string())
+            .sort(api_sort.to_string())
+            .full(true)
+            .limit(repo_limit)
+            .send()
+            .context("Search Hugging Face")?;
+        tokio::pin!(stream);
+        while let Some(repo) = stream.next().await {
+            repos.push(repo.context("Search Hugging Face repo summary")?);
+        }
+    } else {
+        let stream = api
+            .list_models()
+            .search(query.to_string())
+            .filter(artifact_filter.to_string())
+            .full(true)
+            .limit(repo_limit)
+            .send()
+            .context("Search Hugging Face")?;
+        tokio::pin!(stream);
+        while let Some(repo) = stream.next().await {
+            repos.push(repo.context("Search Hugging Face repo summary")?);
+        }
     }
 
     let total = repos.len();
@@ -262,7 +274,7 @@ async fn build_search_hit(
     let repo_downloads = repo.downloads;
     let repo_likes = repo.likes;
     let detail = repo;
-    let repo_id = detail.model_id.clone().unwrap_or(detail.id.clone());
+    let repo_id = detail.id.clone();
     let siblings = detail.siblings.clone().unwrap_or_default();
     let sibling_names: Vec<String> = siblings
         .iter()

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -7773,7 +7773,7 @@ mod tests {
     use crate::models::local::{huggingface_repo_folder_name, huggingface_snapshot_path};
     use crate::plugin::{GpuAssignment, GpuConfig, ModelConfigEntry};
     use crate::system::hardware::GpuFacts;
-    use hf_hub::RepoType;
+    use hf_hub::RepoTypeModel;
     use serial_test::serial;
     use std::path::Path;
     use std::path::PathBuf;
@@ -8525,10 +8525,10 @@ mod tests {
         std::env::remove_var("XDG_CACHE_HOME");
 
         let repo_id = "bartowski/Llama-3.2-1B-Instruct-GGUF";
-        let repo_dir = cache_root.join(huggingface_repo_folder_name(repo_id, RepoType::Model));
+        let repo_dir = cache_root.join(huggingface_repo_folder_name(repo_id, RepoTypeModel));
         std::fs::create_dir_all(repo_dir.join("refs")).unwrap();
         std::fs::write(repo_dir.join("refs").join("main"), "test-commit").unwrap();
-        let model_path = huggingface_snapshot_path(repo_id, RepoType::Model, "test-commit")
+        let model_path = huggingface_snapshot_path(repo_id, RepoTypeModel, "test-commit")
             .join("Llama-3.2-1B-Instruct-Q4_K_M.gguf");
         std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
         std::fs::write(&model_path, b"gguf").unwrap();
@@ -8564,10 +8564,10 @@ mod tests {
         std::env::remove_var("XDG_CACHE_HOME");
 
         let repo_id = "someone/Custom-GGUF";
-        let repo_dir = cache_root.join(huggingface_repo_folder_name(repo_id, RepoType::Model));
+        let repo_dir = cache_root.join(huggingface_repo_folder_name(repo_id, RepoTypeModel));
         std::fs::create_dir_all(repo_dir.join("refs")).unwrap();
         std::fs::write(repo_dir.join("refs").join("main"), "test-commit").unwrap();
-        let model_path = huggingface_snapshot_path(repo_id, RepoType::Model, "test-commit")
+        let model_path = huggingface_snapshot_path(repo_id, RepoTypeModel, "test-commit")
             .join("Custom-Model-Q4_K_M.gguf");
         std::fs::create_dir_all(model_path.parent().unwrap()).unwrap();
         std::fs::write(&model_path, b"gguf").unwrap();

--- a/crates/model-hf/Cargo.toml
+++ b/crates/model-hf/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-hf_hub = { package = "huggingface-hub", git = "https://github.com/huggingface/huggingface_hub_rust.git", rev = "c9749ef76a294d5e97acae6b644071e39854aeb8", default-features = false, features = ["blocking", "xet"] }
+hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", branch = "main", default-features = false, features = ["blocking"] }
 model-artifact = { path = "../model-artifact" }
 model-ref = { path = "../model-ref" }
 serde.workspace = true

--- a/crates/model-hf/Cargo.toml
+++ b/crates/model-hf/Cargo.toml
@@ -7,7 +7,7 @@ version.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", branch = "main", default-features = false, features = ["blocking"] }
+hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", rev = "4cd6d8acd3192021381ff85210be9192b394e0eb", default-features = false, features = ["blocking"] }
 model-artifact = { path = "../model-artifact" }
 model-ref = { path = "../model-ref" }
 serde.workspace = true

--- a/crates/model-hf/src/lib.rs
+++ b/crates/model-hf/src/lib.rs
@@ -3,13 +3,12 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use hf_hub::{
-    cache::scan_cache_dir,
-    types::cache::{CachedRepoInfo, HFCacheInfo},
-    types::repo::ModelInfo,
-    HFClient, HFClientBuilder, RepoDownloadFileParams, RepoInfo, RepoInfoParams, RepoType,
+    cache::{CachedRepoInfo, HFCacheInfo},
+    repository::ModelInfo,
+    HFClient, HFClientBuilder, RepoType, RepoTypeModel,
 };
 use model_artifact::{ModelArtifactFile, ModelIdentity, ModelRepository, ResolvedModelArtifact};
 use model_ref::{
@@ -40,13 +39,11 @@ impl HfModelRepository {
     pub async fn download_file(&self, repo: &str, revision: &str, file: &str) -> Result<PathBuf> {
         let (owner, name) = repo_parts(repo);
         self.api
-            .repo(RepoType::Model, owner, name)
-            .download_file(
-                &RepoDownloadFileParams::builder()
-                    .filename(file.to_string())
-                    .revision(revision.to_string())
-                    .build(),
-            )
+            .model(owner, name)
+            .download_file()
+            .filename(file.to_string())
+            .revision(revision.to_string())
+            .send()
             .await
             .with_context(|| format!("download Hugging Face model file {repo}@{revision}/{file}"))
     }
@@ -144,20 +141,13 @@ impl ModelRepository for HfModelRepository {
 impl HfModelRepository {
     async fn repo_info(&self, repo: &str, revision: &str) -> Result<ModelInfo> {
         let (owner, name) = repo_parts(repo);
-        let detail = self
-            .api
+        self.api
             .model(owner, name)
-            .info(
-                &RepoInfoParams::builder()
-                    .revision(revision.to_string())
-                    .build(),
-            )
+            .info()
+            .revision(revision.to_string())
+            .send()
             .await
-            .with_context(|| format!("fetch Hugging Face model repo {repo}@{revision}"))?;
-        let RepoInfo::Model(detail) = detail else {
-            bail!("expected Hugging Face model repo info for {repo}@{revision}");
-        };
-        Ok(detail)
+            .with_context(|| format!("fetch Hugging Face model repo {repo}@{revision}"))
     }
 }
 
@@ -225,15 +215,19 @@ pub fn hf_token_override() -> Option<String> {
     None
 }
 
-pub fn huggingface_repo_folder_name(repo_id: &str, repo_type: RepoType) -> String {
-    let type_plural = format!("{}s", repo_type);
-    std::iter::once(type_plural.as_str())
+pub fn huggingface_repo_folder_name(repo_id: &str, repo_type: impl RepoType) -> String {
+    let type_plural = repo_type.plural();
+    std::iter::once(type_plural)
         .chain(repo_id.split('/'))
         .collect::<Vec<_>>()
         .join("--")
 }
 
-pub fn huggingface_snapshot_path(repo_id: &str, repo_type: RepoType, revision: &str) -> PathBuf {
+pub fn huggingface_snapshot_path(
+    repo_id: &str,
+    repo_type: impl RepoType,
+    revision: &str,
+) -> PathBuf {
     huggingface_hub_cache_dir()
         .join(huggingface_repo_folder_name(repo_id, repo_type))
         .join("snapshots")
@@ -371,7 +365,16 @@ fn scan_hf_cache_info(cache_root: &Path) -> Option<HFCacheInfo> {
             .enable_all()
             .build()
             .ok()?;
-        runtime.block_on(scan_cache_dir(&cache_root)).ok()
+        runtime
+            .block_on(
+                HFClientBuilder::new()
+                    .cache_dir(cache_root)
+                    .build()
+                    .ok()?
+                    .scan_cache()
+                    .send(),
+            )
+            .ok()
     };
 
     if tokio::runtime::Handle::try_current().is_ok() {
@@ -398,7 +401,7 @@ fn identity_from_parts(repo_id: String, revision: String, file: String) -> HfMod
 }
 
 fn cache_repo_id(repo: &CachedRepoInfo) -> Option<&str> {
-    (repo.repo_type == RepoType::Model).then_some(repo.repo_id.as_str())
+    (repo.repo_type == RepoTypeModel.singular()).then_some(repo.repo_id.as_str())
 }
 
 fn parse_model_repo_folder_name(folder: &str) -> Option<String> {
@@ -487,7 +490,7 @@ mod tests {
     #[test]
     fn repo_folder_name_matches_huggingface_cache_layout() {
         assert_eq!(
-            huggingface_repo_folder_name("org/repo", RepoType::Model),
+            huggingface_repo_folder_name("org/repo", RepoTypeModel),
             "models--org--repo"
         );
     }

--- a/crates/model-package/Cargo.toml
+++ b/crates/model-package/Cargo.toml
@@ -11,7 +11,7 @@ sha2.workspace = true
 anyhow.workspace = true
 bytes = "1"
 chrono = "0.4"
-hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", branch = "main", default-features = false, features = ["blocking"] }
+hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", rev = "4cd6d8acd3192021381ff85210be9192b394e0eb", default-features = false, features = ["blocking"] }
 model-hf = { path = "../model-hf" }
 model-ref = { path = "../model-ref" }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/model-package/Cargo.toml
+++ b/crates/model-package/Cargo.toml
@@ -11,7 +11,7 @@ sha2.workspace = true
 anyhow.workspace = true
 bytes = "1"
 chrono = "0.4"
-hf_hub = { package = "huggingface-hub", git = "https://github.com/huggingface/huggingface_hub_rust.git", rev = "c9749ef76a294d5e97acae6b644071e39854aeb8", default-features = false, features = ["blocking", "xet", "buckets"] }
+hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", branch = "main", default-features = false, features = ["blocking"] }
 model-hf = { path = "../model-hf" }
 model-ref = { path = "../model-ref" }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
+++ b/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
@@ -4,13 +4,10 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Utc};
 use futures::StreamExt;
-use hf_hub::error::HFError;
-use hf_hub::types::commit::AddSource;
-use hf_hub::types::{
-    CreateRepoParams, ListModelsParams, RepoDownloadFileToBytesParams, RepoInfo, RepoInfoParams,
-    RepoType, RepoUploadFileParams,
+use hf_hub::{
+    repository::{AddSource, ModelInfo},
+    HFClient, HFError, HFRepository, RepoTypeModel,
 };
-use hf_hub::{HFClient, HFRepository};
 use model_package::jobs::{CpuJobPlan, HfJobsClient, JobInfo, JobSpec, JobStage, JobVolume};
 use model_package::prepare::{self, DiscoveredQuant};
 use model_package::script;
@@ -541,15 +538,14 @@ async fn list_ranked_models(
     sort: &str,
     limit: usize,
 ) -> Result<Vec<RankedModel>> {
-    let params = ListModelsParams::builder()
+    let stream = client
+        .list_models()
         .author(author.to_string())
         .search(search.to_string())
         .sort(sort.to_string())
         .full(false)
         .limit(limit)
-        .build();
-    let stream = client
-        .list_models(&params)
+        .send()
         .with_context(|| format!("list {author} models sorted by {sort}"))?;
     tokio::pin!(stream);
 
@@ -735,24 +731,13 @@ async fn candidate_status(
     Ok(QueueStatus::Missing)
 }
 
-async fn model_repo_info(
-    client: &HFClient,
-    repo_id: &str,
-) -> Result<Option<hf_hub::types::repo::ModelInfo>> {
+async fn model_repo_info(client: &HFClient, repo_id: &str) -> Result<Option<ModelInfo>> {
     let (owner, name) = parse_repo(repo_id)?;
     let repo = client.model(owner, name);
-    match repo
-        .info(
-            &RepoInfoParams::builder()
-                .revision("main".to_string())
-                .build(),
-        )
-        .await
-    {
-        Ok(RepoInfo::Model(info)) => Ok(Some(info)),
-        Ok(_) => bail!("{repo_id} is not a model repo"),
+    match repo.info().revision("main".to_string()).send().await {
+        Ok(info) => Ok(Some(info)),
         Err(HFError::RepoNotFound { .. }) | Err(HFError::RevisionNotFound { .. }) => Ok(None),
-        Err(HFError::Http { status, .. }) if status.as_u16() == 404 => Ok(None),
+        Err(HFError::Http { context }) if context.status.as_u16() == 404 => Ok(None),
         Err(err) => Err(err).with_context(|| format!("fetch target repo info for {repo_id}")),
     }
 }
@@ -761,19 +746,17 @@ async fn catalog_has_package(client: &HFClient, candidate: &Candidate) -> Result
     let entry_path = catalog_entry_path(&candidate.model.repo_id)?;
     let dataset = client.dataset("meshllm", "catalog");
     let bytes = match dataset
-        .download_file_to_bytes(
-            &RepoDownloadFileToBytesParams::builder()
-                .filename(entry_path.clone())
-                .revision("main".to_string())
-                .build(),
-        )
+        .download_file_to_bytes()
+        .filename(entry_path.clone())
+        .revision("main".to_string())
+        .send()
         .await
     {
         Ok(bytes) => bytes,
         Err(HFError::EntryNotFound { .. }) | Err(HFError::RepoNotFound { .. }) => {
             return Ok(false);
         }
-        Err(HFError::Http { status, .. }) if status.as_u16() == 404 => return Ok(false),
+        Err(HFError::Http { context }) if context.status.as_u16() == 404 => return Ok(false),
         Err(err) => {
             return Err(err).with_context(|| format!("download catalog entry {entry_path}"))
         }
@@ -806,13 +789,11 @@ fn json_contains_package_repo(value: &Value, target_repo: &str) -> bool {
 
 async fn write_queue_marker(client: &HFClient, candidate: &Candidate, args: &Args) -> Result<()> {
     client
-        .create_repo(
-            &CreateRepoParams::builder()
-                .repo_id(candidate.target_repo.clone())
-                .repo_type(RepoType::Model)
-                .exist_ok(true)
-                .build(),
-        )
+        .create_repository()
+        .repo_id(candidate.target_repo.clone())
+        .repo_type(RepoTypeModel)
+        .exist_ok(true)
+        .send()
         .await
         .with_context(|| format!("create target repo {}", candidate.target_repo))?;
 
@@ -831,15 +812,13 @@ async fn write_queue_marker(client: &HFClient, candidate: &Candidate, args: &Arg
     };
     let bytes = serde_json::to_vec_pretty(&marker)?;
     let repo = model_repo(client, &candidate.target_repo)?;
-    repo.upload_file(
-        &RepoUploadFileParams::builder()
-            .source(AddSource::Bytes(bytes))
-            .path_in_repo("automation/queue.json")
-            .commit_message(format!("Queue layer package for {}", candidate.model_id))
-            .build(),
-    )
-    .await
-    .with_context(|| format!("upload queue marker to {}", candidate.target_repo))?;
+    repo.upload_file()
+        .source(AddSource::bytes(bytes))
+        .path_in_repo("automation/queue.json")
+        .commit_message(format!("Queue layer package for {}", candidate.model_id))
+        .send()
+        .await
+        .with_context(|| format!("upload queue marker to {}", candidate.target_repo))?;
     Ok(())
 }
 
@@ -935,7 +914,7 @@ fn parse_repo(repo_id: &str) -> Result<(&str, &str)> {
         .with_context(|| format!("invalid Hugging Face repo id: {repo_id}"))
 }
 
-fn model_repo(client: &HFClient, repo_id: &str) -> Result<HFRepository> {
+fn model_repo(client: &HFClient, repo_id: &str) -> Result<HFRepository<RepoTypeModel>> {
     let (owner, name) = parse_repo(repo_id)?;
     Ok(client.model(owner, name))
 }

--- a/crates/model-package/src/permissions.rs
+++ b/crates/model-package/src/permissions.rs
@@ -21,6 +21,7 @@ pub struct PermissionCheck {
 pub async fn check_permissions(client: &HFClient) -> Result<PermissionCheck> {
     let user = client
         .whoami()
+        .send()
         .await
         .context("HF whoami failed — is your token valid?")?;
 

--- a/crates/model-package/src/prepare.rs
+++ b/crates/model-package/src/prepare.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use futures::StreamExt;
-use hf_hub::types::{RepoListTreeParams, RepoTreeEntry};
+use hf_hub::repository::RepoTreeEntry;
 use hf_hub::HFClient;
 use model_ref::{
     gguf_matches_quant_selector, normalize_gguf_distribution_id, quant_selector_from_gguf_file,
@@ -55,9 +55,11 @@ pub async fn list_quants(client: &HFClient, repo: &str) -> Result<Vec<Discovered
     let (owner, name) = parse_repo(repo)?;
     let hf_repo = client.model(&owner, &name);
 
-    let params = RepoListTreeParams::builder().recursive(true).build();
-
-    let stream = hf_repo.list_tree(&params).context("list repo tree")?;
+    let stream = hf_repo
+        .list_tree()
+        .recursive(true)
+        .send()
+        .context("list repo tree")?;
 
     futures::pin_mut!(stream);
 

--- a/crates/model-package/src/script.rs
+++ b/crates/model-package/src/script.rs
@@ -1,5 +1,8 @@
 use anyhow::{Context, Result};
-use hf_hub::{BucketTreeEntry, HFClient};
+use hf_hub::{
+    buckets::{BucketDownload, BucketTreeEntry, BucketUpload},
+    HFClient,
+};
 use sha2::{Digest, Sha256};
 
 /// The embedded canonical job script.
@@ -29,7 +32,9 @@ pub async fn check_bucket_script(client: &HFClient) -> Result<ScriptFreshness> {
     let paths = vec!["split-model-job.sh".to_string()];
 
     let entries = bucket
-        .get_paths_info(&paths)
+        .get_paths_info()
+        .paths(paths)
+        .send()
         .await
         .context("check bucket script metadata")?;
 
@@ -57,12 +62,13 @@ pub async fn check_bucket_script(client: &HFClient) -> Result<ScriptFreshness> {
     let tmp_dir = tempfile::tempdir().context("create bucket script check temp dir")?;
     let tmp_path = tmp_dir.path().join("split-model-job.sh");
 
-    let download_params = hf_hub::BucketDownloadFilesParams {
-        files: vec![("split-model-job.sh".to_string(), tmp_path.clone())],
-    };
-
     bucket
-        .download_files(&download_params, &Default::default())
+        .download_files()
+        .files(vec![BucketDownload::new(
+            "split-model-job.sh",
+            tmp_path.clone(),
+        )])
+        .send()
         .await
         .context("download bucket script for hash verification")?;
 
@@ -96,9 +102,13 @@ pub async fn update_bucket_script(client: &HFClient) -> Result<()> {
     let tmp_path = tmp_dir.path().join("split-model-job.sh");
     std::fs::write(&tmp_path, EMBEDDED_SCRIPT)?;
 
-    let files = vec![(tmp_path.clone(), "split-model-job.sh".to_string())];
     bucket
-        .upload_files(&files, &Default::default())
+        .upload_files()
+        .files(vec![BucketUpload::new(
+            tmp_path.clone(),
+            "split-model-job.sh",
+        )])
+        .send()
         .await
         .context("upload script to meshllm/layer-split-output bucket")?;
 


### PR DESCRIPTION
## Summary
- Switch Hugging Face dependencies from `huggingface-hub` / `huggingface_hub_rust` to `hf-hub` from the current main branch.
- Migrate model download, search, cache scan, bucket, and repository management call sites to hf-hub's new builder and typed repo APIs.
- Keep the lockfile focused on the required hf-hub, bon, and Xet dependency changes.

## Validation
- `cargo fmt --all -- --check`
- `cargo check -p model-package`
- `cargo check -p mesh-llm`
- `cargo test -p model-hf --lib`
- `cargo test -p model-package --lib`