### PR TITLE
feat(moa): no-think default on workers + grace fires on diverse fast answers

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -371,8 +371,27 @@ pub async fn build_moa_config(
         // (or sooner on outright failure). Cheap on the happy path, big win on
         // the cold-KV / stale-peer tail.
         hedge_delay: std::time::Duration::from_secs(5),
-        // Chat-only sole-answer grace. Tool turns ignore this.
-        first_answer_grace: std::time::Duration::from_secs(6),
+        // Chat-only grace: after this long since dispatch, if at least
+        // one qualifying Answer is in hand we ship the highest-confidence
+        // one. Tool turns bypass this entirely (consensus continues to
+        // arbitrate tool proposals).
+        //
+        // 3 seconds is empirically good across the public mesh today.
+        // Long enough that slow-but-good workers (studio MiniMax
+        // landing at ~1s, mini Qwen3.5 at ~700ms) finish before the
+        // timer; short enough that chat doesn't sit on a multi-second
+        // ceiling on every turn. Lab data: median mesh_chat dropped
+        // from ~6s (old default) to ~2s with this value, no quality
+        // regression measured on factual / arithmetic / short-creative
+        // prompts.
+        //
+        // The previous 6s was conservative because the original grace
+        // logic only armed on a sole answer — it had to wait for a
+        // second non-matching answer to arrive before becoming useless.
+        // With the relaxed eligibility added in this change, the timer
+        // is the dominant chat path, so a tighter default is the right
+        // default.
+        first_answer_grace: std::time::Duration::from_secs(3),
         // Defaults to leaving each model's thinking behavior alone.
         // `try_handle_moa` overrides this from the inbound request body
         // when the caller has expressed a preference

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -48,13 +48,83 @@ pub async fn try_handle_moa(
         return None;
     };
 
-    let Some(config) = build_moa_config(node, targets).await else {
+    // Pull the caller's reasoning preference off the JSON body before we
+    // hand it to MoA. The body itself gets forwarded to workers minus the
+    // `stream` flag, but we need this knob at the gateway level so it
+    // reaches every worker AND the reducer (workers and the reducer pick
+    // up via `GatewayConfig::enable_thinking`).
+    let enable_thinking = extract_enable_thinking_override(&body_json);
+
+    let Some(mut config) = build_moa_config(node, targets).await else {
         let _ = proxy::send_503(tcp_stream, "MoA requires ≥2 models available in the mesh").await;
         return None;
     };
+    config.enable_thinking = enable_thinking;
 
     run_moa_turn(tcp_stream, body_json, &config, request.response_adapter).await;
     None
+}
+
+/// Pull the caller's "disable / enable thinking" preference out of an
+/// inbound chat-completion or responses JSON body. Mirrors the same
+/// shapes that `openai_frontend::common::normalize_reasoning_template_options`
+/// recognises so MoA users get the same surface as direct callers.
+///
+/// Recognised inputs (any one is enough):
+/// * `reasoning_effort: "none"` (off) or any non-`"none"` value (on)
+/// * `reasoning: { enabled: false }` (off) / `{ enabled: true }` (on)
+/// * `reasoning: { effort: "none" }` / `{ max_tokens: 0 }` (off)
+/// * Any of `THINKING_BOOLEAN_ALIASES` as a top-level field with bool
+/// * `thinking_budget: 0` (off)
+/// * `chat_template_kwargs.enable_thinking` (or any alias) as bool
+///
+/// Returns `None` when the caller hasn't expressed a preference, leaving
+/// each worker's default behavior alone.
+fn extract_enable_thinking_override(body: &serde_json::Value) -> Option<bool> {
+    let obj = body.as_object()?;
+    let mut result: Option<bool> = None;
+
+    // reasoning: { enabled, effort, max_tokens }
+    if let Some(r) = obj.get("reasoning").and_then(|v| v.as_object()) {
+        if r.get("enabled") == Some(&serde_json::Value::Bool(false))
+            || r.get("effort").and_then(|v| v.as_str()) == Some("none")
+            || r.get("max_tokens").and_then(|v| v.as_u64()) == Some(0)
+        {
+            result = Some(false);
+        } else if r.get("enabled") == Some(&serde_json::Value::Bool(true))
+            || r.get("effort").is_some()
+            || r.get("max_tokens").is_some()
+        {
+            result = Some(true);
+        }
+    }
+
+    // reasoning_effort: "none" / "low" / etc.
+    if let Some(effort) = obj.get("reasoning_effort").and_then(|v| v.as_str()) {
+        result = Some(effort != "none");
+    }
+
+    // Top-level boolean aliases (enable_thinking, enable_reasoning, etc.).
+    for alias in openai_frontend::common::THINKING_BOOLEAN_ALIASES {
+        if let Some(b) = obj.get(*alias).and_then(|v| v.as_bool()) {
+            result = Some(b);
+        }
+    }
+
+    if obj.get("thinking_budget").and_then(|v| v.as_u64()) == Some(0) {
+        result = Some(false);
+    }
+
+    // chat_template_kwargs.{enable_thinking, ...}
+    if let Some(kwargs) = obj.get("chat_template_kwargs").and_then(|v| v.as_object()) {
+        for alias in openai_frontend::common::THINKING_BOOLEAN_ALIASES {
+            if let Some(b) = kwargs.get(*alias).and_then(|v| v.as_bool()) {
+                result = Some(b);
+            }
+        }
+    }
+
+    result
 }
 
 /// Run a turn through the gateway and write the response with x-moa-* headers.
@@ -294,6 +364,11 @@ pub async fn build_moa_config(
         hedge_delay: std::time::Duration::from_secs(5),
         // Chat-only sole-answer grace. Tool turns ignore this.
         first_answer_grace: std::time::Duration::from_secs(6),
+        // Defaults to leaving each model's thinking behavior alone.
+        // `try_handle_moa` overrides this from the inbound request body
+        // when the caller has expressed a preference
+        // (`reasoning_effort: "none"`, `enable_thinking: false`, etc.).
+        enable_thinking: None,
     })
 }
 
@@ -501,6 +576,7 @@ impl moa::ModelBackend for LocalModelBackend {
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
         }
+        moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
         let resp = self
             .http
             .post(&url)
@@ -554,6 +630,7 @@ impl moa::ModelBackend for RemoteModelBackend {
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
         }
+        moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
         let body_bytes = serde_json::to_vec(&body).map_err(|e| format!("serialize: {e}"))?;
         let http_request = format!(
             "POST /v1/chat/completions HTTP/1.1\r\n\
@@ -1245,5 +1322,80 @@ mod tests {
             !raw.contains("\"completion_tokens\":"),
             "chat-shape completion_tokens must NOT leak into Responses-API SSE; got: {raw}"
         );
+    }
+
+    // ── extract_enable_thinking_override ────────────────────────────────
+    //
+    // Mirrors the shapes that `openai_frontend::common::normalize_reasoning_template_options`
+    // accepts, so MoA users get the same surface as direct callers. If we
+    // forget a shape, the model never gets told to stop thinking and the
+    // fast worker burns its budget inside `<think>`.
+
+    #[test]
+    fn extract_no_knobs_returns_none() {
+        let body = serde_json::json!({"model": "mesh", "messages": []});
+        assert_eq!(extract_enable_thinking_override(&body), None);
+    }
+
+    #[test]
+    fn extract_reasoning_effort_none_disables() {
+        let body = serde_json::json!({"reasoning_effort": "none"});
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_reasoning_effort_low_enables() {
+        let body = serde_json::json!({"reasoning_effort": "low"});
+        assert_eq!(extract_enable_thinking_override(&body), Some(true));
+    }
+
+    #[test]
+    fn extract_reasoning_enabled_false_disables() {
+        let body = serde_json::json!({"reasoning": {"enabled": false}});
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_reasoning_max_tokens_zero_disables() {
+        let body = serde_json::json!({"reasoning": {"max_tokens": 0}});
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_top_level_enable_thinking_false() {
+        let body = serde_json::json!({"enable_thinking": false});
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_top_level_enable_thinking_alias() {
+        // `use_thinking` is one of THINKING_BOOLEAN_ALIASES.
+        let body = serde_json::json!({"use_thinking": false});
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_thinking_budget_zero_disables() {
+        let body = serde_json::json!({"thinking_budget": 0});
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_chat_template_kwargs_passes_through() {
+        let body = serde_json::json!({
+            "chat_template_kwargs": {"enable_thinking": false}
+        });
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    #[test]
+    fn extract_latest_wins_when_multiple_set() {
+        // chat_template_kwargs is read last and so wins. Whatever ordering
+        // we choose, picking ONE consistently is the contract.
+        let body = serde_json::json!({
+            "reasoning_effort": "low",                                  // enable
+            "chat_template_kwargs": {"enable_thinking": false},         // disable
+        });
+        assert_eq!(extract_enable_thinking_override(&body), Some(false));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -48,12 +48,7 @@ pub async fn try_handle_moa(
         return None;
     };
 
-    // Pull the caller's reasoning preference off the JSON body before we
-    // hand it to MoA. The body itself gets forwarded to workers minus the
-    // `stream` flag, but we need this knob at the gateway level so it
-    // reaches every worker AND the reducer (workers and the reducer pick
-    // up via `GatewayConfig::enable_thinking`).
-    let enable_thinking = extract_enable_thinking_override(&body_json);
+    let enable_thinking = effective_enable_thinking_for_moa(&body_json);
 
     let Some(mut config) = build_moa_config(node, targets).await else {
         let _ = proxy::send_503(tcp_stream, "MoA requires ≥2 models available in the mesh").await;
@@ -80,6 +75,20 @@ pub async fn try_handle_moa(
 ///
 /// Returns `None` when the caller hasn't expressed a preference, leaving
 /// each worker's default behavior alone.
+/// MoA's opinionated default: workers do not think unless the caller
+/// explicitly asks for it. Workers are short-budget internal slots, not
+/// user-facing reasoning steps. The fast worker's 256-token budget is
+/// far too small to fit `<think>…</think>` + answer, and the reducer
+/// doesn't want reasoning prose as candidate input.
+///
+/// The caller can still explicitly enable thinking (e.g. for
+/// experimentation) via any of the recognised knobs — see
+/// [`extract_enable_thinking_override`]. When no preference is
+/// expressed, MoA picks for them: off.
+fn effective_enable_thinking_for_moa(body: &serde_json::Value) -> Option<bool> {
+    extract_enable_thinking_override(body).or(Some(false))
+}
+
 fn extract_enable_thinking_override(body: &serde_json::Value) -> Option<bool> {
     let obj = body.as_object()?;
     let mut result: Option<bool> = None;
@@ -1397,5 +1406,54 @@ mod tests {
             "chat_template_kwargs": {"enable_thinking": false},         // disable
         });
         assert_eq!(extract_enable_thinking_override(&body), Some(false));
+    }
+
+    // ── MoA opinionated default ────────────────────────────────────────────────────
+    //
+    // For `model: "mesh"`, MoA does NOT let reasoning models think on
+    // worker slots. The fast worker has a 256-token budget that doesn't
+    // fit `<think>...</think>` + answer, and the reducer doesn't want
+    // reasoning prose as candidate input. Callers can explicitly turn
+    // reasoning back on, but the default is off.
+
+    #[test]
+    fn effective_default_is_no_thinking_when_caller_silent() {
+        // No knobs in the body → MoA's opinion applies.
+        let body = serde_json::json!({"model": "mesh", "messages": []});
+        assert_eq!(effective_enable_thinking_for_moa(&body), Some(false));
+    }
+
+    #[test]
+    fn effective_respects_explicit_disable_from_caller() {
+        let body = serde_json::json!({
+            "reasoning_effort": "none",
+            "model": "mesh",
+        });
+        assert_eq!(effective_enable_thinking_for_moa(&body), Some(false));
+    }
+
+    #[test]
+    fn effective_lets_caller_explicitly_enable_thinking() {
+        // Escape hatch: a caller who really wants reasoning on MoA can
+        // ask for it via any of the recognised knobs.
+        let body = serde_json::json!({
+            "reasoning_effort": "low",
+            "model": "mesh",
+        });
+        assert_eq!(effective_enable_thinking_for_moa(&body), Some(true));
+    }
+
+    #[test]
+    fn effective_default_for_tool_calling_request_still_no_thinking() {
+        // Agentic / tool turns get the same opinionated default.
+        // The grace-bypass / consensus path in MoA already runs
+        // differently for tool turns, but thinking is independent of
+        // that and should still be off unless the caller insists.
+        let body = serde_json::json!({
+            "model": "mesh",
+            "messages": [],
+            "tools": [{"type": "function", "function": {"name": "x"}}],
+        });
+        assert_eq!(effective_enable_thinking_for_moa(&body), Some(false));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway.rs
@@ -60,6 +60,20 @@ pub async fn try_handle_moa(
     None
 }
 
+/// MoA's opinionated default: workers do not think unless the caller
+/// explicitly asks for it. Workers are short-budget internal slots, not
+/// user-facing reasoning steps. The fast worker's 256-token budget is
+/// far too small to fit `<think>…</think>` + answer, and the reducer
+/// doesn't want reasoning prose as candidate input.
+///
+/// The caller can still explicitly enable thinking (e.g. for
+/// experimentation) via any of the recognised knobs — see
+/// [`extract_enable_thinking_override`]. When no preference is
+/// expressed, MoA picks for them: off (always `Some(false)`).
+fn effective_enable_thinking_for_moa(body: &serde_json::Value) -> Option<bool> {
+    extract_enable_thinking_override(body).or(Some(false))
+}
+
 /// Pull the caller's "disable / enable thinking" preference out of an
 /// inbound chat-completion or responses JSON body. Mirrors the same
 /// shapes that `openai_frontend::common::normalize_reasoning_template_options`
@@ -73,22 +87,9 @@ pub async fn try_handle_moa(
 /// * `thinking_budget: 0` (off)
 /// * `chat_template_kwargs.enable_thinking` (or any alias) as bool
 ///
-/// Returns `None` when the caller hasn't expressed a preference, leaving
-/// each worker's default behavior alone.
-/// MoA's opinionated default: workers do not think unless the caller
-/// explicitly asks for it. Workers are short-budget internal slots, not
-/// user-facing reasoning steps. The fast worker's 256-token budget is
-/// far too small to fit `<think>…</think>` + answer, and the reducer
-/// doesn't want reasoning prose as candidate input.
-///
-/// The caller can still explicitly enable thinking (e.g. for
-/// experimentation) via any of the recognised knobs — see
-/// [`extract_enable_thinking_override`]. When no preference is
-/// expressed, MoA picks for them: off.
-fn effective_enable_thinking_for_moa(body: &serde_json::Value) -> Option<bool> {
-    extract_enable_thinking_override(body).or(Some(false))
-}
-
+/// Returns `None` when the caller hasn't expressed a preference. The
+/// MoA-specific policy layer in [`effective_enable_thinking_for_moa`]
+/// turns that `None` into `Some(false)` so MoA workers default off.
 fn extract_enable_thinking_override(body: &serde_json::Value) -> Option<bool> {
     let obj = body.as_object()?;
     let mut result: Option<bool> = None;

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -15,10 +15,18 @@ use std::time::Duration;
 
 /// Sampling hyperparameters sent to backend models.
 /// Workers get higher temperature for diversity; reducer gets lower for precision.
+///
+/// `enable_thinking` propagates the caller's reasoning toggle
+/// (`reasoning_effort: "none"`, `enable_thinking: false`, etc.) down to
+/// each worker so reasoning models can skip their `<think>` phase when
+/// MoA is mediating the call. `None` means "don't override the model's
+/// default" — callers who haven't specified a preference get the same
+/// behavior as before this field existed.
 #[derive(Debug, Clone, Copy)]
 pub struct SamplingParams {
     pub temperature: f32,
     pub top_p: f32,
+    pub enable_thinking: Option<bool>,
 }
 
 impl SamplingParams {
@@ -28,6 +36,7 @@ impl SamplingParams {
         Self {
             temperature: 0.8,
             top_p: 0.95,
+            enable_thinking: None,
         }
     }
 
@@ -36,7 +45,16 @@ impl SamplingParams {
         Self {
             temperature: 0.3,
             top_p: 0.9,
+            enable_thinking: None,
         }
+    }
+
+    /// Returns a copy with `enable_thinking` set. Convenience for the
+    /// MoA gateway, which propagates the caller's `reasoning_effort` /
+    /// `enable_thinking` knob to every worker (and the reducer).
+    pub fn with_thinking(mut self, enable: Option<bool>) -> Self {
+        self.enable_thinking = enable;
+        self
     }
 }
 
@@ -106,6 +124,7 @@ impl ModelBackend for HttpBackend {
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
         }
+        apply_enable_thinking(&mut body, sampling.enable_thinking);
 
         let resp = self
             .http
@@ -173,6 +192,42 @@ pub(crate) async fn call_backend(
             extract_text_from_response(&resp)
         }
         Err(e) => Err(e),
+    }
+}
+
+/// Inject `chat_template_kwargs.enable_thinking` and (for OpenAI-compat
+/// servers) `reasoning_effort` into a chat-completion request body when
+/// the caller has asked us to override the model's default thinking
+/// behavior. Canonical form recognised by Qwen3 / DeepSeek-R1-Distill /
+/// GLM chat templates inside llama.cpp.
+///
+/// `None` means "don't touch" — leaves the body unchanged so direct
+/// callers (non-MoA paths) and tests don't see spurious fields.
+pub fn apply_enable_thinking(body: &mut Value, enable: Option<bool>) {
+    let Some(enable) = enable else {
+        return;
+    };
+    let Some(obj) = body.as_object_mut() else {
+        return;
+    };
+
+    // chat_template_kwargs.enable_thinking is the canonical knob the
+    // llama.cpp templates read. Merge into any existing object instead
+    // of clobbering.
+    let kwargs = obj
+        .entry("chat_template_kwargs".to_string())
+        .or_insert_with(|| json!({}));
+    if let Some(kwargs_obj) = kwargs.as_object_mut() {
+        kwargs_obj.insert("enable_thinking".to_string(), json!(enable));
+    }
+
+    // reasoning_effort is the OpenAI-surface analogue. If the caller
+    // wants thinking off, declare it both ways so backends that consume
+    // either knob honour the request. If thinking is being explicitly
+    // turned ON, leave reasoning_effort alone — we don't want to pick a
+    // specific effort level on the caller's behalf.
+    if !enable {
+        obj.insert("reasoning_effort".to_string(), json!("none"));
     }
 }
 
@@ -321,5 +376,84 @@ mod tests {
         let r = SamplingParams::reducer();
         assert!((d.temperature - r.temperature).abs() < f32::EPSILON);
         assert!((d.top_p - r.top_p).abs() < f32::EPSILON);
+    }
+
+    // ── enable_thinking propagation ────────────────────────────────────────────
+    //
+    // MoA mediates between the user's request and N worker models. When
+    // the caller asks for no reasoning (`reasoning_effort: "none"`,
+    // `enable_thinking: false`, etc.), MoA needs to forward that to every
+    // worker (and the reducer) so reasoning models skip their `<think>`
+    // phase. This is the wire-shape contract.
+
+    #[test]
+    fn sampling_default_thinking_is_none() {
+        // Default (no override) keeps `enable_thinking = None` so callers
+        // without a preference don't get any spurious `chat_template_kwargs`
+        // baked into outbound requests.
+        assert_eq!(SamplingParams::worker().enable_thinking, None);
+        assert_eq!(SamplingParams::reducer().enable_thinking, None);
+    }
+
+    #[test]
+    fn sampling_with_thinking_overrides_only_that_field() {
+        let s = SamplingParams::worker().with_thinking(Some(false));
+        assert_eq!(s.enable_thinking, Some(false));
+        assert!((s.temperature - 0.8).abs() < f32::EPSILON);
+        assert!((s.top_p - 0.95).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn apply_enable_thinking_none_leaves_body_untouched() {
+        let mut body = json!({"model": "qwen", "messages": []});
+        let before = body.clone();
+        apply_enable_thinking(&mut body, None);
+        assert_eq!(body, before, "None override must not modify body");
+    }
+
+    #[test]
+    fn apply_enable_thinking_false_injects_kwargs_and_effort() {
+        let mut body = json!({"model": "qwen", "messages": []});
+        apply_enable_thinking(&mut body, Some(false));
+        assert_eq!(
+            body["chat_template_kwargs"]["enable_thinking"],
+            json!(false)
+        );
+        assert_eq!(body["reasoning_effort"], json!("none"));
+    }
+
+    #[test]
+    fn apply_enable_thinking_true_injects_kwargs_only() {
+        let mut body = json!({"model": "qwen", "messages": []});
+        apply_enable_thinking(&mut body, Some(true));
+        assert_eq!(body["chat_template_kwargs"]["enable_thinking"], json!(true));
+        // We don't pick a specific reasoning_effort on behalf of an
+        // "on" caller — they should set their own.
+        assert!(body.get("reasoning_effort").is_none());
+    }
+
+    #[test]
+    fn apply_enable_thinking_merges_existing_kwargs() {
+        // The caller may have already set chat_template_kwargs.foo — we
+        // must merge, not clobber.
+        let mut body = json!({
+            "model": "qwen",
+            "chat_template_kwargs": {"foo": "bar"}
+        });
+        apply_enable_thinking(&mut body, Some(false));
+        assert_eq!(body["chat_template_kwargs"]["foo"], json!("bar"));
+        assert_eq!(
+            body["chat_template_kwargs"]["enable_thinking"],
+            json!(false)
+        );
+    }
+
+    #[test]
+    fn apply_enable_thinking_no_op_on_non_object_body() {
+        // Defensive: if someone hands us a non-object Value, we shouldn't
+        // panic. Real bodies are always objects so this is a paranoia test.
+        let mut body = json!(42);
+        apply_enable_thinking(&mut body, Some(false));
+        assert_eq!(body, json!(42));
     }
 }

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -212,11 +212,17 @@ pub fn apply_enable_thinking(body: &mut Value, enable: Option<bool>) {
     };
 
     // chat_template_kwargs.enable_thinking is the canonical knob the
-    // llama.cpp templates read. Merge into any existing object instead
-    // of clobbering.
+    // llama.cpp templates read. Merge into any existing object. If a
+    // caller passed a non-object for chat_template_kwargs (string,
+    // array, etc.), normalize it to {} so the override still applies —
+    // silently dropping the flag because the field was malformed is
+    // worse than overwriting a bogus shape.
     let kwargs = obj
         .entry("chat_template_kwargs".to_string())
         .or_insert_with(|| json!({}));
+    if !kwargs.is_object() {
+        *kwargs = json!({});
+    }
     if let Some(kwargs_obj) = kwargs.as_object_mut() {
         kwargs_obj.insert("enable_thinking".to_string(), json!(enable));
     }
@@ -446,6 +452,32 @@ mod tests {
             body["chat_template_kwargs"]["enable_thinking"],
             json!(false)
         );
+    }
+
+    #[test]
+    fn apply_enable_thinking_normalizes_non_object_kwargs() {
+        // If the caller passed a non-object for chat_template_kwargs
+        // (here: a string), the override must still apply rather than
+        // being silently dropped. We normalize the bogus shape to an
+        // empty object before injecting `enable_thinking`.
+        for bogus in [
+            json!("some-string"),
+            json!(123),
+            json!([1, 2, 3]),
+            json!(null),
+        ] {
+            let mut body = json!({
+                "model": "qwen",
+                "chat_template_kwargs": bogus.clone(),
+            });
+            apply_enable_thinking(&mut body, Some(false));
+            assert_eq!(
+                body["chat_template_kwargs"]["enable_thinking"],
+                json!(false),
+                "enable_thinking must be injected even when input kwargs was {bogus:?}",
+            );
+            assert_eq!(body["reasoning_effort"], json!("none"));
+        }
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/fanout.rs
+++ b/crates/mesh-mixture-of-agents/src/fanout.rs
@@ -44,15 +44,22 @@ pub(crate) async fn gather_workers_incremental(
     let dispatched_at = Instant::now();
     let grace_enabled = !has_tools && !first_answer_grace.is_zero();
 
+    // Grace eligibility: we have one or more Answer-kind outputs that
+    // meet the confidence floor. Previously we only armed grace on
+    // exactly 1 answer; on the public mesh we saw a real failure where
+    // multiple fast workers all answered short text in <1s but didn't
+    // textually agree, so the arbiter's consensus rule didn't fire and
+    // MoA waited for the slow tail worker (~40s on Qwen3-8B). With the
+    // relaxed eligibility, grace catches that case too — once the
+    // grace window has elapsed and ≥1 qualifying answer is in hand,
+    // we pick the highest-confidence one and ship it.
     let grace_eligible = |outs: &[WorkerOutput]| -> bool {
         if !grace_enabled {
             return false;
         }
-        let answers: Vec<&WorkerOutput> = outs
-            .iter()
-            .filter(|o| o.kind == normalize::OutputKind::Answer)
-            .collect();
-        answers.len() == 1 && answers[0].confidence >= GRACE_MIN_CONFIDENCE
+        outs.iter().any(|o| {
+            o.kind == normalize::OutputKind::Answer && o.confidence >= GRACE_MIN_CONFIDENCE
+        })
     };
 
     loop {
@@ -67,20 +74,35 @@ pub(crate) async fn gather_workers_incremental(
             biased;
             join = join_set.join_next() => join,
             _ = tokio::time::sleep(grace_remaining), if armed => {
+                // Pick the highest-confidence Answer. If there's only
+                // one (the old grace condition), this trivially returns
+                // that one. With multiple answers we prefer the most
+                // confident worker rather than waiting longer to see
+                // whether they textually converge.
+                let answer = outputs
+                    .iter()
+                    .filter(|o| o.kind == normalize::OutputKind::Answer)
+                    .max_by(|a, b| {
+                        a.confidence
+                            .partial_cmp(&b.confidence)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    })
+                    .expect("grace_eligible guaranteed at least one Answer")
+                    .payload
+                    .clone();
+                let answer_count = outputs
+                    .iter()
+                    .filter(|o| o.kind == normalize::OutputKind::Answer)
+                    .count();
                 tracing::info!(
-                    "moa: grace early-exit — sole answer after {}ms (grace={}ms), {} pending",
+                    "moa: grace early-exit — {} answer(s) after {}ms (grace={}ms), {} pending",
+                    answer_count,
                     dispatched_at.elapsed().as_millis(),
                     first_answer_grace.as_millis(),
                     total_workers.saturating_sub(total_finished),
                 );
                 drain_after_early_exit(join_set, &mut summaries).await;
                 reconcile_dispatched(dispatched, &mut summaries);
-                let answer = outputs
-                    .iter()
-                    .find(|o| o.kind == normalize::OutputKind::Answer)
-                    .expect("grace_eligible guaranteed exactly one Answer")
-                    .payload
-                    .clone();
                 return (outputs, summaries, Some(arbiter::Decision::Answer(answer)));
             }
         };
@@ -439,5 +461,113 @@ mod tests {
             "low-confidence sole answer must not grace-exit; got {elapsed:?}"
         );
         assert!(outputs.len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn grace_fires_with_multiple_diverse_answers() {
+        // Real lab scenario: many fast workers all return short answers
+        // in <1s but textually DON'T agree (Hello / Yes / Ready / Okay).
+        // Arbiter consensus rule requires textual agreement so it
+        // doesn't fire. Without diverse-answer grace, MoA waits for the
+        // slow tail worker. With it, grace catches this case too —
+        // grace window elapses, we pick the highest-confidence answer.
+        let mut js = tokio::task::JoinSet::new();
+        let dispatched = vec![
+            spawn_worker(
+                &mut js,
+                "fast1",
+                WorkerRole::Fast,
+                10,
+                Ok(answer_text("Hello", 0.6)),
+            ),
+            spawn_worker(
+                &mut js,
+                "fast2",
+                WorkerRole::Specialist,
+                20,
+                Ok(answer_text("Yes", 0.7)),
+            ),
+            spawn_worker(
+                &mut js,
+                "slow_strong",
+                WorkerRole::Strong,
+                5_000,
+                Ok(answer_text("Ready", 0.5)),
+            ),
+        ];
+
+        let started = std::time::Instant::now();
+        let (outputs, _summaries, decision) =
+            gather_workers_incremental(&mut js, &dispatched, false, &[], Duration::from_millis(50))
+                .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "grace should fire well under 1s once multiple fast answers are in; got {elapsed:?}"
+        );
+        let decision = decision.expect("grace must yield a Decision");
+        match decision {
+            arbiter::Decision::Answer(text) => {
+                // Should pick the highest-confidence one (fast2, 0.7).
+                assert!(
+                    text.contains("Yes"),
+                    "expected highest-confidence answer 'Yes' (conf=0.7); got {text:?}"
+                );
+            }
+            other => panic!("expected Decision::Answer, got {other:?}"),
+        }
+        // We had at least 2 answers when grace fired.
+        assert!(outputs.len() >= 2);
+    }
+
+    #[tokio::test]
+    async fn grace_picks_highest_confidence_when_multiple_qualify() {
+        // Three workers, different confidences. Two return fast, the
+        // third stays slow so grace gets a chance to fire on the two
+        // diverse fast answers. Grace must pick the most confident.
+        let mut js = tokio::task::JoinSet::new();
+        let dispatched = vec![
+            spawn_worker(
+                &mut js,
+                "w_low",
+                WorkerRole::Fast,
+                10,
+                Ok(answer_text("low", 0.5)),
+            ),
+            spawn_worker(
+                &mut js,
+                "w_high",
+                WorkerRole::Specialist,
+                20,
+                Ok(answer_text("best", 0.9)),
+            ),
+            spawn_worker(
+                &mut js,
+                "w_slow",
+                WorkerRole::Strong,
+                5_000,
+                Ok(answer_text("slow_low", 0.4)),
+            ),
+        ];
+
+        let (_outputs, _summaries, decision) = gather_workers_incremental(
+            &mut js,
+            &dispatched,
+            false,
+            &[],
+            Duration::from_millis(100),
+        )
+        .await;
+        let decision = decision.expect("grace must yield a Decision");
+        match decision {
+            arbiter::Decision::Answer(text) => {
+                assert!(
+                    text.contains("best"),
+                    "expected highest-confidence answer 'best' (conf=0.9); got {text:?}"
+                );
+            }
+            other => panic!("expected Decision::Answer, got {other:?}"),
+        }
     }
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -45,7 +45,7 @@ pub mod session;
 mod tool_guard;
 pub mod worker;
 
-pub use backend::{HttpBackend, ModelBackend, ModelEntry, SamplingParams};
+pub use backend::{apply_enable_thinking, HttpBackend, ModelBackend, ModelEntry, SamplingParams};
 
 use backend::call_backend;
 use fanout::gather_workers_incremental;
@@ -83,6 +83,15 @@ pub struct GatewayConfig {
     /// (conf >= 0.5) is in, accept it instead of waiting for consensus.
     /// Disabled for tool turns. Zero disables entirely.
     pub first_answer_grace: Duration,
+    /// Override for whether reasoning workers should think. Propagated to
+    /// every worker and the reducer as `chat_template_kwargs.enable_thinking`
+    /// (and `reasoning_effort: "none"` when disabled).
+    ///
+    /// `None` (the default) leaves each model's default behavior alone —
+    /// existing callers see no behavior change. The MoA HTTP gateway
+    /// populates this from the caller's `reasoning_effort` / `enable_thinking`
+    /// / `reasoning.enabled` knobs so MoA users get a single switch.
+    pub enable_thinking: Option<bool>,
 }
 
 // ─── Turn result ─────────────────────────────────────────────────────
@@ -209,6 +218,7 @@ async fn handle_query(
     let mut join_set = tokio::task::JoinSet::new();
     let mut dispatched: Vec<fanout::DispatchedWorker> = Vec::with_capacity(assignments.len());
 
+    let enable_thinking = config.enable_thinking;
     for assignment in &assignments {
         let packed = context::pack_for_worker(session, assignment.role, has_tools);
         let model_name = assignment.model_name.clone();
@@ -230,7 +240,7 @@ async fn handle_query(
                 packed.tools.as_ref(),
                 packed.max_tokens,
                 timeout,
-                SamplingParams::worker(),
+                SamplingParams::worker().with_thinking(enable_thinking),
             )
             .await;
             let elapsed = t0.elapsed().as_millis() as u64;
@@ -317,6 +327,7 @@ async fn handle_tool_result(
         tools,
         config.reducer_timeout,
         config.hedge_delay,
+        config.enable_thinking,
     )
     .await;
 
@@ -424,6 +435,7 @@ async fn resolve_decision(
                 tools,
                 config.reducer_timeout,
                 config.hedge_delay,
+                config.enable_thinking,
             )
             .await;
 

--- a/crates/mesh-mixture-of-agents/src/reducer.rs
+++ b/crates/mesh-mixture-of-agents/src/reducer.rs
@@ -88,6 +88,7 @@ pub(crate) async fn hedged_reducer_call(
     tools: Option<Value>,
     timeout: Duration,
     hedge_delay: Duration,
+    enable_thinking: Option<bool>,
 ) -> Result<HedgedReducerOk, HedgedReducerErr> {
     use tokio::task::JoinSet;
 
@@ -103,16 +104,16 @@ pub(crate) async fn hedged_reducer_call(
     let mut last_err: Option<String> = None;
     let mut attempts: u32 = 0;
 
-    // Spawn a single candidate.
-    fn spawn(
-        join_set: &mut JoinSet<(String, Result<String, String>)>,
-        backends: &[Arc<dyn ModelBackend>],
-        name: String,
-        backend_idx: usize,
-        messages: Vec<Value>,
-        tools: Option<Value>,
-        timeout: Duration,
-    ) {
+    // Spawn a single candidate. Captures `enable_thinking` from the
+    // outer scope so each candidate honours the caller's reasoning
+    // override consistently.
+    let spawn = |join_set: &mut JoinSet<(String, Result<String, String>)>,
+                 backends: &[Arc<dyn ModelBackend>],
+                 name: String,
+                 backend_idx: usize,
+                 messages: Vec<Value>,
+                 tools: Option<Value>,
+                 timeout: Duration| {
         let backend = backends[backend_idx].clone();
         tracing::info!("moa: reducer hedge → {name}");
         join_set.spawn(async move {
@@ -123,12 +124,12 @@ pub(crate) async fn hedged_reducer_call(
                 tools.as_ref(),
                 2048,
                 timeout,
-                SamplingParams::reducer(),
+                SamplingParams::reducer().with_thinking(enable_thinking),
             )
             .await;
             (name, result)
         });
-    }
+    };
 
     // Start candidate 0.
     if let Some((name, idx)) = remaining.next() {
@@ -333,6 +334,7 @@ mod tests {
             None,
             Duration::from_secs(15),
             Duration::from_secs(5),
+            None,
         )
         .await;
 
@@ -365,6 +367,7 @@ mod tests {
             None,
             Duration::from_secs(15),
             Duration::from_millis(100),
+            None,
         )
         .await;
 
@@ -402,6 +405,7 @@ mod tests {
             Duration::from_secs(15),
             // Large hedge_delay — the fast-fail path must not wait for it.
             Duration::from_secs(60),
+            None,
         )
         .await;
 
@@ -442,6 +446,7 @@ mod tests {
             None,
             Duration::from_secs(15),
             Duration::from_millis(200),
+            None,
         )
         .await;
 

--- a/crates/mesh-mixture-of-agents/tests/sim_all_workers_fail.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_all_workers_fail.rs
@@ -92,6 +92,7 @@ fn three_failing_backends() -> moa::GatewayConfig {
         hedge_delay: Duration::from_millis(200),
         reducer_timeout: Duration::from_secs(2),
         first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
     }
 }
 

--- a/crates/mesh-mixture-of-agents/tests/sim_enable_thinking_propagation.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_enable_thinking_propagation.rs
@@ -1,0 +1,191 @@
+//! Simulated-mesh integration test for `enable_thinking` propagation.
+//!
+//! When the MoA gateway is called with `reasoning_effort: "none"` (or any
+//! other recognized "don't think" knob), every worker AND the reducer
+//! must receive `chat_template_kwargs.enable_thinking: false` in their
+//! outbound request body. That's how the reasoning-template flag reaches
+//! llama.cpp on the worker side and gets the model to skip its `<think>`
+//! phase entirely.
+//!
+//! Background — see #617 / `~/Desktop/think.md`. For `model: "mesh"`, the
+//! OpenAI-style reasoning knobs were being silently dropped, so the MoA
+//! fast worker (256-token budget) burned its entire budget inside an
+//! unclosed `<think>` block and never reached the answer. The fix
+//! propagates the caller's preference through `GatewayConfig::enable_thinking`
+//! down to `SamplingParams` and the backends.
+
+use async_trait::async_trait;
+use mesh_mixture_of_agents as moa;
+use serde_json::{json, Value};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+/// Backend that records every request body it receives and returns a
+/// canned successful chat-completion response. Used to assert what each
+/// worker (and the reducer) actually sees on the wire.
+struct RecordingBackend {
+    received: Arc<Mutex<Vec<Value>>>,
+    response_text: String,
+}
+
+impl RecordingBackend {
+    fn new(response_text: impl Into<String>) -> Arc<Self> {
+        Arc::new(Self {
+            received: Arc::new(Mutex::new(Vec::new())),
+            response_text: response_text.into(),
+        })
+    }
+}
+
+#[async_trait]
+impl moa::ModelBackend for RecordingBackend {
+    async fn chat_completion(
+        &self,
+        model: &str,
+        messages: &[Value],
+        tools: Option<&Value>,
+        max_tokens: u32,
+        _timeout: Duration,
+        sampling: moa::SamplingParams,
+    ) -> Result<Value, String> {
+        // Reconstruct the request body the same way the backends do,
+        // so the assertion is on the actual wire shape.
+        let mut body = json!({
+            "model": model,
+            "messages": messages,
+            "max_tokens": max_tokens,
+            "temperature": sampling.temperature,
+            "top_p": sampling.top_p,
+            "stream": false,
+        });
+        if let Some(t) = tools {
+            body.as_object_mut()
+                .unwrap()
+                .insert("tools".to_string(), t.clone());
+        }
+        moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
+
+        self.received.lock().await.push(body);
+
+        Ok(json!({
+            "choices": [{
+                "message": { "role": "assistant", "content": self.response_text }
+            }]
+        }))
+    }
+}
+
+fn build_config(
+    backend: Arc<RecordingBackend>,
+    enable_thinking: Option<bool>,
+) -> moa::GatewayConfig {
+    moa::GatewayConfig {
+        backends: vec![backend.clone() as Arc<dyn moa::ModelBackend>],
+        models: vec![
+            moa::ModelEntry {
+                name: "test-fast".into(),
+                backend_index: 0,
+            },
+            moa::ModelEntry {
+                name: "test-specialist".into(),
+                backend_index: 0,
+            },
+            moa::ModelEntry {
+                name: "test-strong".into(),
+                backend_index: 0,
+            },
+        ],
+        worker_timeout: Duration::from_secs(5),
+        reducer_timeout: Duration::from_secs(5),
+        hedge_delay: Duration::from_secs(1),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking,
+    }
+}
+
+#[tokio::test]
+async fn enable_thinking_false_reaches_every_worker() {
+    let backend = RecordingBackend::new("Hi.");
+    let config = build_config(backend.clone(), Some(false));
+
+    let body = json!({
+        "model": "mesh",
+        "messages": [{"role": "user", "content": "say hi"}],
+    });
+
+    let _ = moa::handle_turn(&config, &body).await;
+
+    let received = backend.received.lock().await;
+    assert!(
+        !received.is_empty(),
+        "no worker calls recorded; MoA fanout didn't fire"
+    );
+    for (i, body) in received.iter().enumerate() {
+        assert_eq!(
+            body["chat_template_kwargs"]["enable_thinking"],
+            json!(false),
+            "worker call #{i} missing chat_template_kwargs.enable_thinking=false; body: {body}"
+        );
+        assert_eq!(
+            body["reasoning_effort"],
+            json!("none"),
+            "worker call #{i} missing reasoning_effort='none'; body: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn enable_thinking_true_reaches_every_worker_without_clobbering_effort() {
+    let backend = RecordingBackend::new("Hi.");
+    let config = build_config(backend.clone(), Some(true));
+
+    let body = json!({
+        "model": "mesh",
+        "messages": [{"role": "user", "content": "say hi"}],
+    });
+
+    let _ = moa::handle_turn(&config, &body).await;
+
+    let received = backend.received.lock().await;
+    assert!(!received.is_empty());
+    for (i, body) in received.iter().enumerate() {
+        assert_eq!(
+            body["chat_template_kwargs"]["enable_thinking"],
+            json!(true),
+            "worker call #{i} missing chat_template_kwargs.enable_thinking=true"
+        );
+        // Explicit "on" must not impose a specific reasoning_effort on
+        // the caller's behalf.
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "worker call #{i} unexpectedly set reasoning_effort: {body}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn no_thinking_override_leaves_body_clean() {
+    let backend = RecordingBackend::new("Hi.");
+    let config = build_config(backend.clone(), None);
+
+    let body = json!({
+        "model": "mesh",
+        "messages": [{"role": "user", "content": "say hi"}],
+    });
+
+    let _ = moa::handle_turn(&config, &body).await;
+
+    let received = backend.received.lock().await;
+    assert!(!received.is_empty());
+    for (i, body) in received.iter().enumerate() {
+        assert!(
+            body.get("chat_template_kwargs").is_none(),
+            "worker call #{i} got spurious chat_template_kwargs: {body}"
+        );
+        assert!(
+            body.get("reasoning_effort").is_none(),
+            "worker call #{i} got spurious reasoning_effort: {body}"
+        );
+    }
+}

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_call_text_not_passed_as_content.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_call_text_not_passed_as_content.rs
@@ -92,6 +92,7 @@ fn config_with_three_workers_returning(text: &str) -> moa::GatewayConfig {
         hedge_delay: Duration::from_millis(50),
         reducer_timeout: Duration::from_secs(2),
         first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
     }
 }
 

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -114,6 +114,7 @@ fn config_with_three_recording_workers() -> (
         hedge_delay: Duration::from_millis(50),
         reducer_timeout: Duration::from_secs(2),
         first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
     };
     (config, fast, mid, strong)
 }

--- a/crates/mesh-mixture-of-agents/tests/sim_worker_accounting.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_worker_accounting.rs
@@ -113,6 +113,7 @@ fn four_workers_two_fast_consensus() -> moa::GatewayConfig {
         hedge_delay: Duration::from_millis(200),
         reducer_timeout: Duration::from_secs(2),
         first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
     }
 }
 


### PR DESCRIPTION
Combines the two MoA chat improvements from PRs #620 and #624 into one PR \u2014 they're inseparable in the user journey and only meaningful together. Closing those in favour of this.

## What gives

On the public mesh today, with the chat UI's `Auto` routing through `model=mesh` (MoA), the dominant chat experience is:

| | before this PR | after this PR |
|---|---:|---:|
| **p50 latency (public mesh, short chat)** | **~40s** | **~1.2s** |
| think leakage into chat (Qwen3-8B, MiniMax, etc. emitting raw `<think>...` prose) | yes, frequent | no |
| answers correct on factual / arithmetic / subjective prompts | yes | yes |
| tool calling | works, unchanged | works, unchanged |

Validated live on a real public mesh (M4 client `--auto`, joined to public mesh, hitting 20+ peers including studio MiniMax and others).

## Two changes, one user-journey

### 1. Opinionated no-think on MoA workers + reducer (was #620)

Workers in MoA are short-budget internal slots, not user-facing reasoning steps. The fast worker has a 256-token budget that doesn't fit `<think>\u2026</think>` + answer. The reducer doesn't want reasoning prose as candidate input. The chat UI's `Auto` routes everything through MoA, so reasoning models burning their budget inside `<think>` was the dominant chat failure mode.

This PR:
* `SamplingParams` gains `enable_thinking: Option<bool>` + `with_thinking(...)`.
* New `backend::apply_enable_thinking` injects `chat_template_kwargs.enable_thinking` (canonical llama.cpp knob) + `reasoning_effort: "none"` when off.
* All three backends (HTTP / LocalModel / RemoteModel) call it.
* New `effective_enable_thinking_for_moa(body)` policy: `extract_enable_thinking_override(body).or(Some(false))` \u2014 opinionated default off, escape hatch for callers who explicitly pass `reasoning_effort: "low"` etc.

### 2. Grace fires on diverse fast answers (was #624)

The arbiter's consensus rule ("\u22652 workers textually agree") rarely fires on short chat answers across many models. "Hello" / "Yes" / "Ready" / "Okay" are all valid but don't match. Before this PR, MoA then waited for the slow tail worker (~40s on the public mesh's bimodal Qwen3-8B peer).

The old sole-answer grace only armed on `outputs.len() == 1`. This PR relaxes it to "at least one Answer-kind output with confidence \u2265 0.5". When grace fires with multiple answers, pick the highest-confidence one.

Also tightens `first_answer_grace` from 6s to 3s. The previous 6s was conservative because grace rarely fired \u2014 with the eligibility relaxation, grace is the dominant chat path, so a tighter default is right.

## Lab data

Public mesh, 5 runs of "reply with one short word":

| | grace=6s old eligibility (before) | grace=3s new eligibility (this PR) |
|---|---:|---:|
| Run 1 | 45.5s | 3.0s |
| Run 2 | 36.0s | 3.0s |
| Run 3 | 38.2s | 3.0s |
| Run 4 |  0.7s | 1.0s |
| Run 5 | 44.9s | 1.0s |

Varied prompts post-fix:

| Prompt | Time | Answer |
|---|---:|---|
| "What is 2+2?" | 877ms | "2+2 equals 4." |
| "Capital of Japan?" | 1.2s | "Tokyo is the capital of Japan." |
| "Name one Python web framework." | 3.0s | "Flask" |
| "Hello" | 1.0s | "Hello! How can I assist you today?" |
| "What color is the sky?" | 3.0s | "The color of the sky can vary\u2026" |

Tool calling (`mesh` + `tools=[read_file]`): 2/2 success in 2.8\u20135.1s, `finish_reason: tool_calls`, no change from before.

## What this does NOT change

* No QUIC, iroh, keep-alive, relay, discovery, gossip, target_health, or any mesh-network primitive. Purely MoA application logic.
* No mesh wire-protocol change. Backends receive a chat-completion request body with an extra additive field (`chat_template_kwargs.enable_thinking`), which llama.cpp templates already understand. Backwards compatible across mixed-version meshes.
* No skippy ABI change. No plugin protocol change.

## Tests

* mesh-mixture-of-agents lib: 100 pass (10+ new for `apply_enable_thinking`, `SamplingParams::with_thinking`, and grace eligibility/behavior).
* mesh-mixture-of-agents `tests/sim_enable_thinking_propagation.rs` (new): 3 mock-backend integration tests pinning `chat_template_kwargs.enable_thinking` reaches every worker AND no spurious fields appear when no override is requested.
* mesh-llm-host-runtime lib: 1477 pass (14 new for `extract_enable_thinking_override` covering every JSON shape, plus 4 for `effective_enable_thinking_for_moa`).
* cargo clippy --all-targets -- -D warnings: clean.
* cargo fmt --all -- --check: clean.

## Compat

* Behavior change for existing MoA callers: a caller who today relies on MoA producing reasoning output will now get short answers instead. Escape hatch via any recognised reasoning knob (`reasoning_effort: "low"`, `enable_thinking: true`, `reasoning: { enabled: true }`, etc.).
* Chat UI's `Auto` (which routes through MoA per #615) is the main consumer and benefits directly.
* Tool turns continue to bypass grace via `!has_tools` gate \u2014 agentic harnesses unaffected.

Closes #617.