### PR TITLE
Add repeatable nightly stability benchmark harness

### DIFF
--- a/.github/workflows/nightly-stability-run.yml
+++ b/.github/workflows/nightly-stability-run.yml
@@ -1,0 +1,156 @@
+name: Reusable Nightly Stability Run
+
+on:
+  workflow_call:
+    inputs:
+      base_url:
+        required: false
+        default: ""
+        type: string
+      models:
+        required: false
+        default: "auto,mesh"
+        type: string
+      attempts:
+        required: false
+        default: "5"
+        type: string
+      agent_smokes:
+        required: false
+        default: ""
+        type: string
+      skip_streaming:
+        required: false
+        default: false
+        type: boolean
+      timeout:
+        required: false
+        default: "180"
+        type: string
+      runs_on:
+        required: false
+        default: '"self-hosted"'
+        type: string
+      output_dir:
+        required: false
+        default: nightly-artifacts/stability/latest
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  stability:
+    name: Run stability harness
+    runs-on: ${{ fromJson(inputs.runs_on) }}
+    timeout-minutes: 120
+    env:
+      MESH_STABILITY_BASE_URL: ${{ inputs.base_url }}
+      MESH_STABILITY_MODELS: ${{ inputs.models }}
+      MESH_STABILITY_ATTEMPTS: ${{ inputs.attempts }}
+      MESH_STABILITY_AGENT_SMOKES: ${{ inputs.agent_smokes }}
+      MESH_STABILITY_TIMEOUT: ${{ inputs.timeout }}
+      MESH_STABILITY_OUTPUT_DIR: ${{ inputs.output_dir }}
+      MESH_STABILITY_SKIP_STREAMING: ${{ inputs.skip_streaming && 'true' || 'false' }}
+      OPENCODE_DISABLE_AUTOUPDATE: "true"
+      OPENCODE_DISABLE_PRUNE: "true"
+      OPENCODE_DISABLE_LSP_DOWNLOAD: "true"
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Preflight configuration
+        id: preflight
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${MESH_STABILITY_BASE_URL:-}" ]]; then
+            {
+              echo "## Nightly stability"
+              echo
+              echo "No mesh endpoint configured. Set MESH_NIGHTLY_STABILITY_BASE_URL, MESH_AGENT_BASE_URL, or pass base_url manually."
+            } >> "$GITHUB_STEP_SUMMARY"
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              exit 1
+            fi
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-node@v5
+        if: ${{ steps.preflight.outputs.run == 'true' && inputs.agent_smokes != '' }}
+        with:
+          node-version: 24
+
+      - name: Install requested agent CLIs
+        if: ${{ steps.preflight.outputs.run == 'true' && inputs.agent_smokes != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          corepack enable
+          corepack prepare pnpm@10 --activate
+          export PNPM_HOME="$HOME/.local/share/pnpm"
+          mkdir -p "$PNPM_HOME"
+          echo "PNPM_HOME=$PNPM_HOME" >> "$GITHUB_ENV"
+          echo "$PNPM_HOME" >> "$GITHUB_PATH"
+
+          if [[ ",${MESH_STABILITY_AGENT_SMOKES}," == *",opencode,"* ]]; then
+            pnpm add --global opencode-ai@latest
+            opencode --version
+          fi
+
+          if [[ ",${MESH_STABILITY_AGENT_SMOKES}," == *",pi,"* ]]; then
+            pnpm add --global @earendil-works/pi-coding-agent@latest
+            pi --version
+          fi
+
+          if [[ ",${MESH_STABILITY_AGENT_SMOKES}," == *",goose,"* ]]; then
+            curl -fsSL https://github.com/aaif-goose/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+            "$HOME/.local/bin/goose" --version
+          fi
+
+      - name: Run stability harness
+        if: ${{ steps.preflight.outputs.run == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(
+            --base-url "$MESH_STABILITY_BASE_URL"
+            --models "$MESH_STABILITY_MODELS"
+            --attempts "$MESH_STABILITY_ATTEMPTS"
+            --timeout "$MESH_STABILITY_TIMEOUT"
+            --agent-smokes "$MESH_STABILITY_AGENT_SMOKES"
+            --output-dir "$MESH_STABILITY_OUTPUT_DIR"
+          )
+          if [[ "$MESH_STABILITY_SKIP_STREAMING" == "true" ]]; then
+            args+=(--skip-streaming)
+          fi
+          scripts/qa-nightly-stability.py "${args[@]}"
+
+      - name: Publish run summary
+        if: ${{ always() && steps.preflight.outputs.run == 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f "$MESH_STABILITY_OUTPUT_DIR/summary.md" ]]; then
+            cat "$MESH_STABILITY_OUTPUT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Nightly stability"
+              echo
+              echo "No summary.md was produced by the stability harness."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload stability evidence
+        if: ${{ always() && steps.preflight.outputs.run == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: nightly-stability-${{ github.run_number }}-${{ github.sha }}
+          path: ${{ inputs.output_dir }}/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/nightly-stability.yml
+++ b/.github/workflows/nightly-stability.yml
@@ -1,0 +1,60 @@
+name: Nightly Stability
+
+on:
+  schedule:
+    - cron: "37 9 * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "OpenAI-compatible mesh /v1 endpoint. Falls back to repo vars."
+        required: false
+      models:
+        description: "Comma-separated model IDs to probe."
+        required: false
+        default: "auto,mesh"
+      attempts:
+        description: "Attempts per model."
+        required: false
+        default: "5"
+      agent_smokes:
+        description: "Optional agent CLI smokes: opencode,pi,goose."
+        required: false
+        default: ""
+      skip_streaming:
+        description: "Skip streaming chat/tool-call phases."
+        required: false
+        type: boolean
+        default: false
+      timeout:
+        description: "Request timeout in seconds for each probe."
+        required: false
+        default: "180"
+      runs_on:
+        description: "JSON runner label string/array for the reusable workflow."
+        required: false
+        default: '"self-hosted"'
+      output_dir:
+        description: "Evidence output directory. Defaults to nightly-artifacts/stability/<run_id>."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-stability
+  cancel-in-progress: false
+
+jobs:
+  stability:
+    if: ${{ github.event_name == 'workflow_dispatch' || vars.MESH_NIGHTLY_STABILITY_ENABLED == '1' }}
+    uses: ./.github/workflows/nightly-stability-run.yml
+    with:
+      base_url: ${{ github.event.inputs.base_url || vars.MESH_NIGHTLY_STABILITY_BASE_URL || vars.MESH_AGENT_BASE_URL || vars.MESH_OPENCODE_BASE_URL }}
+      models: ${{ github.event.inputs.models || vars.MESH_NIGHTLY_STABILITY_MODELS || 'auto,mesh' }}
+      attempts: ${{ github.event.inputs.attempts || vars.MESH_NIGHTLY_STABILITY_ATTEMPTS || '5' }}
+      agent_smokes: ${{ github.event.inputs.agent_smokes || vars.MESH_NIGHTLY_STABILITY_AGENT_SMOKES || '' }}
+      skip_streaming: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_streaming || false }}
+      timeout: ${{ github.event.inputs.timeout || vars.MESH_NIGHTLY_STABILITY_TIMEOUT || '180' }}
+      runs_on: ${{ github.event.inputs.runs_on || vars.MESH_NIGHTLY_STABILITY_RUNS_ON || '"self-hosted"' }}
+      output_dir: ${{ github.event.inputs.output_dir || format('nightly-artifacts/stability/{0}', github.run_id) }}

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -24,6 +24,10 @@ This is the best way to show what mesh-llm does: zero setup, zero config, just s
 
 Relay connections degrade over hours on some nodes (Studio pattern: fresh=250ms, 10h=isolated). Need relay health monitoring, periodic reconnect, and better understanding of iroh's relay lifecycle. See [crates/mesh-llm/TODO.md](crates/mesh-llm/TODO.md) for investigation notes.
 
+Short-term stabilization should be evidence-led: use the opt-in nightly
+stability harness to trend `/v1/models`, chat, streaming, tool-call, and agent
+smoke behavior across repeated runs before promoting fixes as release-quality.
+
 ## Production relay infrastructure
 
 mesh-llm uses managed iroh relays via [services.iroh.computer](https://services.iroh.computer) as the default:

--- a/crates/mesh-llm/tests/qa_nightly_stability.rs
+++ b/crates/mesh-llm/tests/qa_nightly_stability.rs
@@ -1,0 +1,194 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("mesh-llm crate should live two levels below repo root")
+        .to_path_buf()
+}
+
+fn harness_path() -> PathBuf {
+    repo_root().join("scripts").join("qa-nightly-stability.py")
+}
+
+fn workflow_path(name: &str) -> PathBuf {
+    repo_root().join(".github").join("workflows").join(name)
+}
+
+fn unique_output_dir(test_name: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should be after unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "mesh-llm-{test_name}-{}-{nanos}",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn nightly_stability_harness_exists_and_is_executable() {
+    let path = harness_path();
+    assert!(
+        path.is_file(),
+        "nightly stability harness is missing at {}",
+        path.display()
+    );
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+
+        let mode = std::fs::metadata(&path)
+            .expect("harness metadata should be readable")
+            .permissions()
+            .mode();
+        assert_ne!(mode & 0o111, 0, "harness should be executable");
+    }
+}
+
+#[test]
+fn nightly_stability_wrapper_calls_reusable_workflow() {
+    let wrapper = std::fs::read_to_string(workflow_path("nightly-stability.yml"))
+        .expect("nightly stability workflow should be readable");
+    assert!(
+        wrapper.contains("uses: ./.github/workflows/nightly-stability-run.yml"),
+        "scheduled/manual wrapper should delegate execution to the reusable workflow"
+    );
+    for expected in [
+        "workflow_dispatch:",
+        "base_url:",
+        "models:",
+        "attempts:",
+        "agent_smokes:",
+        "skip_streaming:",
+        "timeout:",
+        "runs_on:",
+        "output_dir:",
+    ] {
+        assert!(
+            wrapper.contains(expected),
+            "wrapper should expose {expected:?}; workflow was:\n{wrapper}"
+        );
+    }
+}
+
+#[test]
+fn nightly_stability_reusable_workflow_owns_execution() {
+    let reusable = std::fs::read_to_string(workflow_path("nightly-stability-run.yml"))
+        .expect("reusable nightly stability workflow should be readable");
+    for expected in [
+        "workflow_call:",
+        "runs-on: ${{ fromJson(inputs.runs_on) }}",
+        "scripts/qa-nightly-stability.py",
+        "Publish run summary",
+        "$GITHUB_STEP_SUMMARY",
+        "actions/upload-artifact@v6",
+    ] {
+        assert!(
+            reusable.contains(expected),
+            "reusable workflow should contain {expected:?}; workflow was:\n{reusable}"
+        );
+    }
+}
+
+#[test]
+fn nightly_stability_harness_print_plan_is_json_and_side_effect_free() {
+    let output_dir = unique_output_dir("nightly-stability-print-plan");
+    let output = Command::new(harness_path())
+        .arg("--base-url")
+        .arg("http://127.0.0.1:9337")
+        .arg("--models")
+        .arg("auto,mesh")
+        .arg("--attempts")
+        .arg("2")
+        .arg("--agent-smokes")
+        .arg("opencode,pi,goose")
+        .arg("--output-dir")
+        .arg(&output_dir)
+        .arg("--print-plan")
+        .output()
+        .expect("harness print-plan should execute");
+
+    assert!(
+        output.status.success(),
+        "print-plan failed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let plan: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("print-plan should emit valid JSON");
+    assert_eq!(
+        plan.get("name").and_then(serde_json::Value::as_str),
+        Some("nightly-stability")
+    );
+    assert_eq!(
+        plan.get("endpoint").and_then(serde_json::Value::as_str),
+        Some("http://127.0.0.1:9337/v1")
+    );
+    let steps = plan
+        .get("steps")
+        .and_then(serde_json::Value::as_array)
+        .expect("print-plan should include steps");
+    assert_eq!(
+        steps.len(),
+        5,
+        "OpenAI surface probe, tool-call probe, and three agent smokes"
+    );
+    assert!(
+        !output_dir.exists(),
+        "print-plan must not create evidence directories"
+    );
+}
+
+#[test]
+fn nightly_stability_harness_help_documents_contract() {
+    let output = Command::new(harness_path())
+        .arg("--help")
+        .output()
+        .expect("harness help should execute");
+
+    assert!(
+        output.status.success(),
+        "harness --help failed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for expected in [
+        "--base-url",
+        "--models",
+        "--attempts",
+        "--agent-smokes",
+        "--output-dir",
+        "--print-plan",
+        "commands.jsonl",
+        "results.jsonl",
+        "summary.json",
+    ] {
+        assert!(
+            stdout.contains(expected),
+            "harness help should document {expected:?}; stdout was:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn nightly_stability_harness_rejects_unknown_agent_smokes() {
+    let output = Command::new(harness_path())
+        .arg("--agent-smokes")
+        .arg("unknown")
+        .arg("--print-plan")
+        .output()
+        .expect("harness argument validation should execute");
+
+    assert!(!output.status.success(), "unknown agent smoke should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown agent smoke"),
+        "unknown agent smoke error should be explicit; stderr was:\n{stderr}"
+    );
+}

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -230,6 +230,33 @@ This complements the heavier Goose, OpenCode, and Pi smoke scripts. Those prove
 real agent CLI behavior; this probe isolates the API contract that those agents
 depend on.
 
+## Nightly stability harness
+
+Use the repeatable stability harness when a branch needs broader live-mesh
+evidence without changing the mesh under test:
+
+```bash
+scripts/qa-nightly-stability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models auto,mesh \
+  --attempts 5 \
+  --agent-smokes opencode,pi,goose \
+  --output-dir target/nightly-stability/local
+```
+
+The harness attaches to an existing `/v1` endpoint, probes `/v1/models`, normal
+chat, streaming chat, the direct tool-call reliability probe, and optionally the
+OpenCode/Pi/Goose agent smokes. It writes `manifest.json`, `commands.jsonl`,
+`results.jsonl`, `summary.json`, `summary.md`, and logs under the output
+directory. Use `--print-plan` before long runs to inspect the exact check list
+without touching the endpoint or creating artifacts.
+
+Scheduled GitHub runs are opt-in via `MESH_NIGHTLY_STABILITY_ENABLED=1` plus a
+configured endpoint. The scheduled/manual wrapper delegates execution to the
+reusable `nightly-stability-run.yml` workflow, which owns the harness run,
+artifact upload, and timing summary. Treat this as a trend/evidence harness,
+not a required PR gate.
+
 ## curl or any OpenAI client
 
 ```bash

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -123,6 +123,47 @@ scripts/qa-agent-tool-call-reliability.py \
 - use `--skip-streaming` only when intentionally narrowing a local diagnosis to
   non-streaming chat-completions
 
+### 0e. Nightly stability harness
+
+Use the repeatable stability harness when you want black-box evidence that a
+live mesh endpoint stays usable across repeated chat, streaming, tool-call, and
+optional agent-client checks:
+
+```bash
+scripts/qa-nightly-stability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models auto,mesh \
+  --attempts 5 \
+  --agent-smokes opencode,pi,goose \
+  --output-dir target/nightly-stability/local
+```
+
+- the harness attaches to an existing OpenAI-compatible `/v1` endpoint; it does
+  not start nodes, load models, publish to the public mesh, or change routing
+  policy
+- direct OpenAI surface probes write `results.jsonl` with `/v1/models`,
+  non-streaming chat, streaming chat, HTTP status, elapsed time, and TTFT where
+  applicable
+- the merged tool-call probe remains the canonical tool-call validator; this
+  harness invokes it and records its command/log path instead of reimplementing
+  tool-call parsing
+- optional OpenCode, Pi, and Goose smokes reuse the existing CI agent fixtures;
+  missing optional CLIs are recorded as `PREREQ` rather than a stability failure
+- every run writes `manifest.json`, `commands.jsonl`, `results.jsonl`,
+  `summary.json`, `summary.md`, and `logs/`
+- `--print-plan` is side-effect-free and shows the exact checks/artifacts that
+  would run
+
+The scheduled GitHub workflow is opt-in through
+`MESH_NIGHTLY_STABILITY_ENABLED=1` and a configured
+`MESH_NIGHTLY_STABILITY_BASE_URL` (or the existing agent endpoint variables).
+The scheduled/manual wrapper calls the reusable `nightly-stability-run.yml`
+workflow so maintainers can reuse the same harness execution from other
+workflows or lab jobs. The job summary includes the timing snapshot from
+`summary.md`, so day-over-day drift can be checked without opening JSONL
+artifacts. It is intentionally evidence-producing and non-required: failed
+nightlies should guide stabilization work, not block unrelated pull requests.
+
 ## Single-model permutations
 
 ### 1. Solo (single node)

--- a/scripts/qa-nightly-stability.py
+++ b/scripts/qa-nightly-stability.py
@@ -1,0 +1,809 @@
+#!/usr/bin/env python3
+"""Run repeatable mesh-llm stability checks and write evidence artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any, Iterable, NamedTuple
+import urllib.error
+import urllib.request
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
+DEFAULT_MODELS = "auto,mesh"
+DEFAULT_ATTEMPTS = 3
+DEFAULT_TIMEOUT = 120.0
+DEFAULT_OUTPUT_DIR = "target/nightly-stability/latest"
+VALID_AGENT_SMOKES = ("opencode", "pi", "goose")
+
+
+class CommandSpec(NamedTuple):
+    name: str
+    command: list[str]
+    env: dict[str, str]
+    log: str
+    prerequisite: str | None = None
+
+
+class CommandResult(NamedTuple):
+    name: str
+    status: str
+    exit_code: int
+    elapsed_ms: int
+    log: str
+
+
+class ProbeResult(NamedTuple):
+    model: str | None
+    attempt: int | None
+    phase: str
+    ok: bool
+    detail: str
+    elapsed_ms: int
+    status_code: int | None = None
+    ttft_ms: int | None = None
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def normalize_v1_base(base_url: str) -> str:
+    base = base_url.strip().rstrip("/")
+    if not base:
+        raise ValueError("base URL is empty")
+    if not base.endswith("/v1"):
+        base = f"{base}/v1"
+    return base
+
+
+def parse_csv(value: str) -> list[str]:
+    return [part.strip() for part in value.split(",") if part.strip()]
+
+
+def parse_models(value: str) -> list[str]:
+    models = parse_csv(value)
+    if not models:
+        raise ValueError("at least one model is required")
+    return models
+
+
+def parse_agent_smokes(value: str) -> list[str]:
+    requested = parse_csv(value)
+    unknown = sorted(set(requested) - set(VALID_AGENT_SMOKES))
+    if unknown:
+        joined = ", ".join(unknown)
+        allowed = ", ".join(VALID_AGENT_SMOKES)
+        raise ValueError(f"unknown agent smoke: {joined}; expected one of {allowed}")
+    return requested
+
+
+def build_plan(
+    base_url: str,
+    models: list[str],
+    attempts: int,
+    output_dir: Path,
+    agent_smokes: list[str],
+    skip_streaming: bool,
+    timeout: float,
+) -> dict[str, Any]:
+    specs = build_command_specs(
+        base_url=base_url,
+        models=models,
+        attempts=attempts,
+        output_dir=output_dir,
+        agent_smokes=agent_smokes,
+        skip_streaming=skip_streaming,
+        timeout=timeout,
+    )
+    steps: list[dict[str, Any]] = [
+        {
+            "name": "openai-surface-probe",
+            "models": models,
+            "attempts": attempts,
+            "phases": ["models", "chat", *([] if skip_streaming else ["stream_chat"])],
+            "output": str(output_dir / "results.jsonl"),
+        }
+    ]
+    steps.extend(
+        {
+            "name": spec.name,
+            "command": spec.command,
+            "env": spec.env,
+            "log": spec.log,
+            "prerequisite": spec.prerequisite,
+        }
+        for spec in specs
+    )
+    return {
+        "name": "nightly-stability",
+        "endpoint": normalize_v1_base(base_url),
+        "models": models,
+        "attempts": attempts,
+        "output_dir": str(output_dir),
+        "evidence": [
+            "manifest.json",
+            "commands.jsonl",
+            "results.jsonl",
+            "summary.json",
+            "summary.md",
+            "logs/",
+        ],
+        "steps": steps,
+    }
+
+
+def build_command_specs(
+    base_url: str,
+    models: list[str],
+    attempts: int,
+    output_dir: Path,
+    agent_smokes: list[str],
+    skip_streaming: bool,
+    timeout: float,
+) -> list[CommandSpec]:
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    base = normalize_v1_base(base_url)
+    logs_dir = Path("logs")
+    specs = [
+        CommandSpec(
+            name="tool-call-reliability",
+            command=_tool_call_command(base, models, attempts, output_dir, skip_streaming, timeout),
+            env={},
+            log=str(logs_dir / "tool-call-reliability.log"),
+        )
+    ]
+    for smoke in agent_smokes:
+        specs.append(_agent_smoke_spec(smoke, base, output_dir))
+    return specs
+
+
+def _tool_call_command(
+    base_url: str,
+    models: list[str],
+    attempts: int,
+    output_dir: Path,
+    skip_streaming: bool,
+    timeout: float,
+) -> list[str]:
+    command = [
+        sys.executable,
+        str(repo_root() / "scripts" / "qa-agent-tool-call-reliability.py"),
+        "--base-url",
+        base_url,
+        "--models",
+        ",".join(models),
+        "--attempts",
+        str(attempts),
+        "--timeout",
+        _format_float(timeout),
+        "--output",
+        str(output_dir / "tool-call-results.jsonl"),
+    ]
+    if skip_streaming:
+        command.append("--skip-streaming")
+    return command
+
+
+def _agent_smoke_spec(smoke: str, base_url: str, output_dir: Path) -> CommandSpec:
+    logs_dir = Path("logs")
+    work_dir = output_dir / "agent-smokes" / smoke
+    env = {
+        "MESH_AGENT_BASE_URL": base_url,
+        "MESH_OPENCODE_BASE_URL": base_url,
+    }
+    if smoke == "opencode":
+        script = "ci-opencode-smoke.sh"
+        prerequisite = "opencode"
+        env.update(
+            {
+                "OPENCODE_SMOKE_WORK_DIR": str(work_dir),
+                "OPENCODE_SMOKE_OUTPUT": str(work_dir / "opencode-output.jsonl"),
+                "OPENCODE_SMOKE_TURN1_OUTPUT": str(work_dir / "opencode-turn1.jsonl"),
+                "OPENCODE_SMOKE_TURN2_OUTPUT": str(work_dir / "opencode-turn2.jsonl"),
+                "OPENCODE_SMOKE_ERROR_LOG": str(work_dir / "opencode-stderr.log"),
+                "OPENCODE_SMOKE_SURFACE_LOG": str(work_dir / "openai-surface.jsonl"),
+                "OPENCODE_SMOKE_SURFACE_PROXY_LOG": str(work_dir / "openai-surface-proxy.log"),
+            }
+        )
+    elif smoke == "pi":
+        script = "ci-pi-smoke.sh"
+        prerequisite = "pi"
+        env.update(
+            {
+                "PI_SMOKE_WORK_DIR": str(work_dir),
+                "PI_SMOKE_OUTPUT": str(work_dir / "pi-output.jsonl"),
+                "PI_SMOKE_ERROR_LOG": str(work_dir / "pi-stderr.log"),
+            }
+        )
+    elif smoke == "goose":
+        script = "ci-goose-smoke.sh"
+        prerequisite = "goose"
+        env.update(
+            {
+                "GOOSE_SMOKE_WORK_DIR": str(work_dir),
+                "GOOSE_SMOKE_OUTPUT": str(work_dir / "goose-output.jsonl"),
+                "GOOSE_SMOKE_ERROR_LOG": str(work_dir / "goose-stderr.log"),
+            }
+        )
+    else:
+        raise ValueError(f"unknown agent smoke: {smoke}")
+    return CommandSpec(
+        name=f"{smoke}-agent-smoke",
+        command=[str(repo_root() / "scripts" / script)],
+        env=env,
+        log=str(logs_dir / f"{smoke}-agent-smoke.log"),
+        prerequisite=prerequisite,
+    )
+
+
+def run_commands(specs: Iterable[CommandSpec], output_dir: Path) -> list[CommandResult]:
+    results: list[CommandResult] = []
+    for spec in specs:
+        results.append(run_command(spec, output_dir))
+    return results
+
+
+def run_command(spec: CommandSpec, output_dir: Path) -> CommandResult:
+    log_path = output_dir / spec.log
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    if spec.prerequisite and shutil.which(spec.prerequisite) is None:
+        log_path.write_text(
+            f"Prerequisite command not found on PATH: {spec.prerequisite}\n",
+            encoding="utf-8",
+        )
+        return CommandResult(
+            name=spec.name,
+            status="PREREQ",
+            exit_code=0,
+            elapsed_ms=0,
+            log=spec.log,
+        )
+    env = os.environ.copy()
+    env.update(spec.env)
+    start = time.monotonic()
+    with log_path.open("w", encoding="utf-8") as log:
+        log.write(f"$ {shell_join(spec.command)}\n\n")
+        process = subprocess.run(
+            spec.command,
+            cwd=repo_root(),
+            env=env,
+            stdout=log,
+            stderr=subprocess.STDOUT,
+            text=True,
+            check=False,
+        )
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+    status = "PASS" if process.returncode == 0 else "FAIL"
+    return CommandResult(
+        name=spec.name,
+        status=status,
+        exit_code=process.returncode,
+        elapsed_ms=elapsed_ms,
+        log=spec.log,
+    )
+
+
+def run_surface_probes(
+    base_url: str,
+    models: list[str],
+    attempts: int,
+    timeout: float,
+    include_streaming: bool,
+) -> list[ProbeResult]:
+    base = normalize_v1_base(base_url)
+    results: list[ProbeResult] = [run_models_probe(base, timeout)]
+    for model in models:
+        for attempt in range(1, attempts + 1):
+            results.append(run_chat_probe(base, model, attempt, timeout))
+            if include_streaming:
+                results.append(run_stream_chat_probe(base, model, attempt, timeout))
+    return results
+
+
+def run_models_probe(base_url: str, timeout: float) -> ProbeResult:
+    started = time.monotonic()
+    try:
+        response, status_code = get_json(base_url, "/models", timeout)
+        data = response.get("data")
+        if not isinstance(data, list) or not data:
+            raise ValueError("models response did not contain any models")
+        return _probe_result(None, None, "models", True, f"{len(data)} models", started, status_code)
+    except Exception as exc:
+        return _probe_result(None, None, "models", False, str(exc), started)
+
+
+def run_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> ProbeResult:
+    started = time.monotonic()
+    try:
+        response, status_code = post_json(
+            base_url,
+            "/chat/completions",
+            build_chat_request(model, attempt, stream=False),
+            timeout,
+        )
+        validate_sentinel(first_message_content(response), "STABILITY_OK")
+        return _probe_result(model, attempt, "chat", True, "matched STABILITY_OK", started, status_code)
+    except Exception as exc:
+        return _probe_result(model, attempt, "chat", False, str(exc), started)
+
+
+def run_stream_chat_probe(base_url: str, model: str, attempt: int, timeout: float) -> ProbeResult:
+    started = time.monotonic()
+    try:
+        chunks, status_code, ttft_ms = post_json_stream(
+            base_url,
+            "/chat/completions",
+            build_chat_request(model, attempt, stream=True),
+            timeout,
+        )
+        validate_sentinel(stream_content(chunks), "STREAM_OK")
+        return _probe_result(
+            model,
+            attempt,
+            "stream_chat",
+            True,
+            "matched STREAM_OK",
+            started,
+            status_code,
+            ttft_ms,
+        )
+    except Exception as exc:
+        return _probe_result(model, attempt, "stream_chat", False, str(exc), started)
+
+
+def build_chat_request(model: str, attempt: int, stream: bool) -> dict[str, Any]:
+    sentinel = "STREAM_OK" if stream else "STABILITY_OK"
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a deterministic mesh-llm stability probe.",
+            },
+            {
+                "role": "user",
+                "content": f"Attempt {attempt}: reply with exactly {sentinel} and no extra text.",
+            },
+        ],
+        "stream": stream,
+        "max_tokens": 32,
+        "temperature": 0,
+    }
+
+
+def get_json(base_url: str, path: str, timeout: float) -> tuple[dict[str, Any], int]:
+    request = urllib.request.Request(f"{base_url}{path}", method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status_code = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {body[:400]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"request failed: {exc}") from exc
+    return decode_json_object(body), status_code
+
+
+def post_json(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float,
+) -> tuple[dict[str, Any], int]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"content-type": "application/json", "authorization": "Bearer mesh-llm-stability"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status_code = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {body[:400]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"request failed: {exc}") from exc
+    return decode_json_object(body), status_code
+
+
+def post_json_stream(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float,
+) -> tuple[list[dict[str, Any]], int, int | None]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{base_url}{path}",
+        data=data,
+        headers={"content-type": "application/json", "authorization": "Bearer mesh-llm-stability"},
+        method="POST",
+    )
+    started = time.monotonic()
+    first_event_ms: int | None = None
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            chunks: list[dict[str, Any]] = []
+            for chunk in parse_sse_lines(line.decode("utf-8", errors="replace") for line in response):
+                if first_event_ms is None:
+                    first_event_ms = int((time.monotonic() - started) * 1000)
+                chunks.append(chunk)
+            status_code = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {body[:400]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"request failed: {exc}") from exc
+    if not chunks:
+        raise RuntimeError("stream returned no events")
+    return chunks, status_code, first_event_ms
+
+
+def decode_json_object(body: bytes) -> dict[str, Any]:
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError as exc:
+        snippet = body.decode("utf-8", errors="replace")[:400]
+        raise RuntimeError(f"response was not JSON: {snippet}") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError("response JSON was not an object")
+    return decoded
+
+
+def parse_sse_lines(lines: Iterable[str]) -> Iterable[dict[str, Any]]:
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not line or line.startswith(":") or not line.startswith("data:"):
+            continue
+        data = line.removeprefix("data:").strip()
+        if data == "[DONE]":
+            break
+        try:
+            decoded = json.loads(data)
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(f"stream event was not JSON: {data[:200]}") from exc
+        if not isinstance(decoded, dict):
+            raise RuntimeError("stream event JSON was not an object")
+        yield decoded
+
+
+def first_message_content(response: dict[str, Any]) -> str:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("response had no choices")
+    first = choices[0]
+    if not isinstance(first, dict):
+        raise ValueError("first choice is not an object")
+    message = first.get("message")
+    if not isinstance(message, dict):
+        raise ValueError("first choice did not contain a message object")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("message content was not a string")
+    return content
+
+
+def stream_content(chunks: Iterable[dict[str, Any]]) -> str:
+    parts: list[str] = []
+    saw_choice = False
+    for chunk in chunks:
+        choices = chunk.get("choices")
+        if not isinstance(choices, list):
+            continue
+        for choice in choices:
+            if not isinstance(choice, dict):
+                continue
+            saw_choice = True
+            delta = choice.get("delta")
+            if not isinstance(delta, dict):
+                continue
+            content = delta.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+    if not saw_choice:
+        raise ValueError("stream returned no choices")
+    return "".join(parts)
+
+
+def validate_sentinel(content: str, sentinel: str) -> None:
+    if content.strip() != sentinel:
+        raise ValueError(f"expected exactly {sentinel}, got {content!r}")
+
+
+def _probe_result(
+    model: str | None,
+    attempt: int | None,
+    phase: str,
+    ok: bool,
+    detail: str,
+    started: float,
+    status_code: int | None = None,
+    ttft_ms: int | None = None,
+) -> ProbeResult:
+    return ProbeResult(
+        model=model,
+        attempt=attempt,
+        phase=phase,
+        ok=ok,
+        detail=detail,
+        elapsed_ms=int((time.monotonic() - started) * 1000),
+        status_code=status_code,
+        ttft_ms=ttft_ms,
+    )
+
+
+def write_evidence(
+    output_dir: Path,
+    plan: dict[str, Any],
+    results: list[CommandResult],
+    probe_results: list[ProbeResult] | None = None,
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    manifest = dict(plan)
+    manifest["created_at"] = datetime.now(timezone.utc).isoformat()
+    _write_json(output_dir / "manifest.json", manifest)
+    _write_jsonl(output_dir / "commands.jsonl", [result._asdict() for result in results])
+    _write_jsonl(output_dir / "results.jsonl", [result._asdict() for result in (probe_results or [])])
+    summary = summarize_evidence(results, probe_results or [])
+    _write_json(output_dir / "summary.json", summary)
+    (output_dir / "summary.md").write_text(
+        render_summary_markdown(summary, results, probe_results or []),
+        encoding="utf-8",
+    )
+
+
+def summarize_results(results: Iterable[CommandResult]) -> dict[str, Any]:
+    rows = list(results)
+    passed = sum(1 for row in rows if row.status == "PASS")
+    failed = sum(1 for row in rows if row.status == "FAIL")
+    prereq = sum(1 for row in rows if row.status == "PREREQ")
+    elapsed_ms = sum(row.elapsed_ms for row in rows)
+    return {
+        "ok": failed == 0,
+        "total": len(rows),
+        "passed": passed,
+        "failed": failed,
+        "prereq": prereq,
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def summarize_probe_results(results: Iterable[ProbeResult]) -> dict[str, Any]:
+    rows = list(results)
+    passed = sum(1 for row in rows if row.ok)
+    failed = sum(1 for row in rows if not row.ok)
+    elapsed_ms = sum(row.elapsed_ms for row in rows)
+    return {
+        "ok": failed == 0,
+        "total": len(rows),
+        "passed": passed,
+        "failed": failed,
+        "prereq": 0,
+        "elapsed_ms": elapsed_ms,
+    }
+
+
+def summarize_evidence(
+    command_results: Iterable[CommandResult],
+    probe_results: Iterable[ProbeResult],
+) -> dict[str, Any]:
+    commands = summarize_results(command_results)
+    probes = summarize_probe_results(probe_results)
+    failed = commands["failed"] + probes["failed"]
+    total = commands["total"] + probes["total"]
+    return {
+        "ok": failed == 0,
+        "total": total,
+        "passed": commands["passed"] + probes["passed"],
+        "failed": failed,
+        "prereq": commands["prereq"] + probes["prereq"],
+        "elapsed_ms": commands["elapsed_ms"] + probes["elapsed_ms"],
+        "commands": commands,
+        "probes": probes,
+    }
+
+
+def render_summary_markdown(
+    summary: dict[str, Any],
+    results: Iterable[CommandResult],
+    probe_results: Iterable[ProbeResult],
+) -> str:
+    commands = summary.get("commands", {})
+    probes = summary.get("probes", {})
+    lines = [
+        "# Nightly Stability Summary",
+        "",
+        f"- Overall: {'PASS' if summary['ok'] else 'FAIL'}",
+        f"- Passed: {summary['passed']}/{summary['total']}",
+        f"- Prereq: {summary['prereq']}",
+        f"- Elapsed: {summary['elapsed_ms']} ms",
+        "",
+        "## Timing Snapshot",
+        "",
+        "| Area | Passed | Failed | Prereq | Elapsed ms |",
+        "|---|---:|---:|---:|---:|",
+        _summary_timing_row("OpenAI surface probes", probes),
+        _summary_timing_row("Command probes", commands),
+        "",
+        "## OpenAI Surface Probes",
+        "",
+        "| Phase | Model | Attempt | Status | HTTP | TTFT ms | Elapsed ms | Detail |",
+        "|---|---|---:|---:|---:|---:|---:|---|",
+    ]
+    for result in probe_results:
+        lines.append(
+            f"| `{result.phase}` | `{result.model or ''}` | {result.attempt or ''} | "
+            f"{'PASS' if result.ok else 'FAIL'} | {result.status_code or ''} | "
+            f"{result.ttft_ms or ''} | {result.elapsed_ms} | {result.detail} |"
+        )
+    lines.extend([
+        "",
+        "## Command Probes",
+        "",
+        "| Step | Status | Exit | Elapsed ms | Log |",
+        "|---|---:|---:|---:|---|",
+    ])
+    for result in results:
+        lines.append(
+            f"| `{result.name}` | {result.status} | {result.exit_code} | "
+            f"{result.elapsed_ms} | `{result.log}` |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _summary_timing_row(label: str, summary: dict[str, Any]) -> str:
+    return (
+        f"| {label} | {summary.get('passed', 0)} | {summary.get('failed', 0)} | "
+        f"{summary.get('prereq', 0)} | {summary.get('elapsed_ms', 0)} |"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run repeatable mesh-llm stability checks and write manifest.json, "
+            "commands.jsonl, results.jsonl, summary.json, and summary.md evidence."
+        )
+    )
+    parser.add_argument("--base-url", default=default_base_url())
+    parser.add_argument("--models", default=os.environ.get("MESH_STABILITY_MODELS", DEFAULT_MODELS))
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=int(os.environ.get("MESH_STABILITY_ATTEMPTS", str(DEFAULT_ATTEMPTS))),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("MESH_STABILITY_TIMEOUT", str(DEFAULT_TIMEOUT))),
+    )
+    parser.add_argument(
+        "--agent-smokes",
+        default=os.environ.get("MESH_STABILITY_AGENT_SMOKES", ""),
+        help="Comma-separated optional agent CLI smokes: opencode,pi,goose.",
+    )
+    parser.add_argument("--output-dir", default=os.environ.get("MESH_STABILITY_OUTPUT_DIR", DEFAULT_OUTPUT_DIR))
+    parser.add_argument("--skip-streaming", action="store_true")
+    parser.add_argument("--print-plan", action="store_true")
+    return parser.parse_args()
+
+
+def default_base_url() -> str:
+    for name in ("MESH_STABILITY_BASE_URL", "MESH_AGENT_BASE_URL", "MESH_OPENCODE_BASE_URL"):
+        value = os.environ.get(name)
+        if value:
+            return value
+    client_base = os.environ.get("MESH_CLIENT_API_BASE")
+    if client_base:
+        return f"{client_base.rstrip('/')}/v1"
+    return DEFAULT_BASE_URL
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        models = parse_models(args.models)
+        agent_smokes = parse_agent_smokes(args.agent_smokes)
+        output_dir = Path(args.output_dir)
+        plan = build_plan(
+            base_url=args.base_url,
+            models=models,
+            attempts=args.attempts,
+            output_dir=output_dir,
+            agent_smokes=agent_smokes,
+            skip_streaming=args.skip_streaming,
+            timeout=args.timeout,
+        )
+        if args.print_plan:
+            print(json.dumps(plan, indent=2, sort_keys=True))
+            return 0
+        specs = build_command_specs(
+            base_url=args.base_url,
+            models=models,
+            attempts=args.attempts,
+            output_dir=output_dir,
+            agent_smokes=agent_smokes,
+            skip_streaming=args.skip_streaming,
+            timeout=args.timeout,
+        )
+        probe_results = run_surface_probes(
+            base_url=args.base_url,
+            models=models,
+            attempts=args.attempts,
+            timeout=args.timeout,
+            include_streaming=not args.skip_streaming,
+        )
+        results = run_commands(specs, output_dir)
+        write_evidence(output_dir, plan, results, probe_results)
+        summary = summarize_evidence(results, probe_results)
+        print_human_summary(output_dir, summary, results, probe_results)
+        return 0 if summary["ok"] else 1
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+def print_human_summary(
+    output_dir: Path,
+    summary: dict[str, Any],
+    results: Iterable[CommandResult],
+    probe_results: Iterable[ProbeResult],
+) -> None:
+    print(f"nightly stability: {summary['passed']}/{summary['total']} steps passed")
+    print(f"results: {output_dir}")
+    for result in probe_results:
+        status = "PASS" if result.ok else "FAIL"
+        print(
+            f"{status} {result.phase} model={result.model or '-'} "
+            f"attempt={result.attempt or '-'} elapsed_ms={result.elapsed_ms}: {result.detail}"
+        )
+    for result in results:
+        print(
+            f"{result.status} {result.name}: exit={result.exit_code} "
+            f"elapsed_ms={result.elapsed_ms} log={result.log}"
+        )
+
+
+def shell_join(command: Iterable[str]) -> str:
+    return " ".join(_shell_quote(part) for part in command)
+
+
+def _shell_quote(value: str) -> str:
+    if value and all(ch.isalnum() or ch in "/._-:=," for ch in value):
+        return value
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_jsonl(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def _format_float(value: float) -> str:
+    if value.is_integer():
+        return str(int(value))
+    return str(value)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_qa_nightly_stability.py
+++ b/scripts/tests/test_qa_nightly_stability.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "qa-nightly-stability.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("qa_nightly_stability", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class NightlyStabilityHarnessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.harness = load_module()
+
+    def test_parses_models_and_agent_smokes(self) -> None:
+        self.assertEqual(self.harness.parse_csv("auto, mesh"), ["auto", "mesh"])
+        self.assertEqual(self.harness.parse_csv(""), [])
+        self.assertEqual(self.harness.parse_agent_smokes("opencode, goose"), ["opencode", "goose"])
+
+        with self.assertRaisesRegex(ValueError, "unknown agent smoke"):
+            self.harness.parse_agent_smokes("opencode,unknown")
+
+    def test_build_plan_is_side_effect_free_and_repeatable(self) -> None:
+        plan = self.harness.build_plan(
+            base_url="http://127.0.0.1:9337",
+            models=["auto", "mesh"],
+            attempts=2,
+            output_dir=Path("target/nightly-stability/example"),
+            agent_smokes=["opencode", "pi", "goose"],
+            skip_streaming=False,
+            timeout=120.0,
+        )
+
+        self.assertEqual(plan["name"], "nightly-stability")
+        self.assertEqual(plan["endpoint"], "http://127.0.0.1:9337/v1")
+        self.assertEqual(plan["models"], ["auto", "mesh"])
+        self.assertEqual(plan["attempts"], 2)
+        self.assertEqual([step["name"] for step in plan["steps"]], [
+            "openai-surface-probe",
+            "tool-call-reliability",
+            "opencode-agent-smoke",
+            "pi-agent-smoke",
+            "goose-agent-smoke",
+        ])
+        self.assertNotIn("--skip-streaming", json.dumps(plan), "streaming should not be skipped")
+
+    def test_build_plan_can_skip_streaming(self) -> None:
+        plan = self.harness.build_plan(
+            base_url="http://127.0.0.1:9337/v1",
+            models=["auto"],
+            attempts=1,
+            output_dir=Path("target/nightly-stability/example"),
+            agent_smokes=[],
+            skip_streaming=True,
+            timeout=30.0,
+        )
+        command = plan["steps"][1]["command"]
+        self.assertIn("--skip-streaming", command)
+
+    def test_command_specs_keep_logs_relative_to_output_dir(self) -> None:
+        output_dir = Path("nightly-artifacts/stability/12345")
+        specs = self.harness.build_command_specs(
+            base_url="http://127.0.0.1:9337",
+            models=["auto"],
+            attempts=1,
+            output_dir=output_dir,
+            agent_smokes=["opencode"],
+            skip_streaming=False,
+            timeout=30.0,
+        )
+
+        self.assertEqual(
+            [spec.log for spec in specs],
+            [
+                "logs/tool-call-reliability.log",
+                "logs/opencode-agent-smoke.log",
+            ],
+        )
+
+    def test_summarizes_command_results(self) -> None:
+        rows = [
+            self.harness.CommandResult(
+                name="tool-call-reliability",
+                status="PASS",
+                exit_code=0,
+                elapsed_ms=25,
+                log="logs/tool.log",
+            ),
+            self.harness.CommandResult(
+                name="opencode-agent-smoke",
+                status="FAIL",
+                exit_code=1,
+                elapsed_ms=50,
+                log="logs/opencode.log",
+            ),
+        ]
+        summary = self.harness.summarize_results(rows)
+        self.assertFalse(summary["ok"])
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["total"], 2)
+
+    def test_missing_optional_agent_cli_records_prereq(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            result = self.harness.run_command(
+                self.harness.CommandSpec(
+                    name="missing-agent-smoke",
+                    command=["/definitely/missing"],
+                    env={},
+                    log=str(Path("logs") / "missing-agent-smoke.log"),
+                    prerequisite="mesh-llm-definitely-missing-agent-cli",
+                ),
+                out,
+            )
+            log = out / "logs" / "missing-agent-smoke.log"
+            self.assertTrue(log.exists())
+
+        self.assertEqual(result.status, "PREREQ")
+        self.assertEqual(result.exit_code, 0)
+
+    def test_summarizes_probe_results(self) -> None:
+        rows = [
+            self.harness.ProbeResult(
+                model="auto",
+                attempt=1,
+                phase="chat",
+                ok=True,
+                detail="matched sentinel",
+                elapsed_ms=20,
+                status_code=200,
+                ttft_ms=None,
+            ),
+            self.harness.ProbeResult(
+                model="mesh",
+                attempt=1,
+                phase="stream_chat",
+                ok=False,
+                detail="stream returned no choices",
+                elapsed_ms=40,
+                status_code=None,
+                ttft_ms=None,
+            ),
+        ]
+        summary = self.harness.summarize_probe_results(rows)
+        self.assertFalse(summary["ok"])
+        self.assertEqual(summary["passed"], 1)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(summary["total"], 2)
+
+    def test_write_evidence_outputs_machine_readable_files(self) -> None:
+        rows = [
+            self.harness.CommandResult(
+                name="tool-call-reliability",
+                status="PASS",
+                exit_code=0,
+                elapsed_ms=25,
+                log="logs/tool.log",
+            )
+        ]
+        plan = self.harness.build_plan(
+            base_url="http://127.0.0.1:9337",
+            models=["auto"],
+            attempts=1,
+            output_dir=Path("target/nightly-stability/example"),
+            agent_smokes=[],
+            skip_streaming=False,
+            timeout=30.0,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            probe_rows = [
+                self.harness.ProbeResult(
+                    model=None,
+                    attempt=None,
+                    phase="models",
+                    ok=True,
+                    detail="1 models",
+                    elapsed_ms=10,
+                    status_code=200,
+                    ttft_ms=None,
+                )
+            ]
+            self.harness.write_evidence(out, plan, rows, probe_rows)
+            manifest = json.loads((out / "manifest.json").read_text(encoding="utf-8"))
+            summary = json.loads((out / "summary.json").read_text(encoding="utf-8"))
+            commands = [
+                json.loads(line)
+                for line in (out / "commands.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+            results = [
+                json.loads(line)
+                for line in (out / "results.jsonl").read_text(encoding="utf-8").splitlines()
+            ]
+
+        self.assertEqual(manifest["name"], "nightly-stability")
+        self.assertTrue(summary["ok"])
+        self.assertEqual(commands[0]["name"], "tool-call-reliability")
+        self.assertEqual(results[0]["phase"], "models")
+
+    def test_summary_markdown_includes_timing_snapshot(self) -> None:
+        summary = {
+            "ok": True,
+            "total": 2,
+            "passed": 2,
+            "failed": 0,
+            "prereq": 0,
+            "elapsed_ms": 35,
+            "commands": {
+                "passed": 1,
+                "failed": 0,
+                "prereq": 0,
+                "elapsed_ms": 25,
+            },
+            "probes": {
+                "passed": 1,
+                "failed": 0,
+                "prereq": 0,
+                "elapsed_ms": 10,
+            },
+        }
+        rendered = self.harness.render_summary_markdown(summary, [], [])
+
+        self.assertIn("## Timing Snapshot", rendered)
+        self.assertIn("| OpenAI surface probes | 1 | 0 | 0 | 10 |", rendered)
+        self.assertIn("| Command probes | 1 | 0 | 0 | 25 |", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds an opt-in nightly/repeatable stability harness for live mesh endpoints, so maintainers can run the same OpenAI-compatible surface, tool-call, streaming, and optional agent-smoke checks and keep structured evidence artifacts from each run.

## Why
Recent public-mesh, MoA, and agent-tool stability work needs a repeatable signal rather than one-off lab commands. This builds on #623 by composing the deterministic tool-call reliability probe into a broader stability run without making it a required PR gate.

## Diff scope
* Adds `scripts/qa-nightly-stability.py`, which probes `/v1/models`, non-stream chat, streaming chat/TTFT, the existing tool-call reliability probe, and optional `opencode`, `pi`, and `goose` smokes.
* Writes `manifest.json`, `commands.jsonl`, `results.jsonl`, `summary.json`, `summary.md`, and `logs/` under the selected output directory.
* Splits the GitHub Actions integration into a scheduled/manual wrapper (`nightly-stability.yml`) and a reusable `workflow_call` execution workflow (`nightly-stability-run.yml`).
* Keeps command log references relative to the evidence directory (`logs/*.log`) so relative workflow output paths do not duplicate the output directory in generated artifacts.
* Adds Python unit coverage, a Rust CLI/workflow contract test, and docs in `docs/AGENTS.md`, `docs/design/TESTING.md`, and `ROADMAP.md`.

## Operational notes
* Scheduled runs are gated by `vars.MESH_NIGHTLY_STABILITY_ENABLED == '1'`; manual dispatch can run the harness on demand.
* The workflow requires a configured base URL from dispatch input or repository variables.
* Optional agent CLIs are treated as prerequisites: missing CLIs are recorded as `PREREQ` evidence instead of being hidden as success.
* No protocol, runtime routing, release, or UI behavior changes.

## Validation
* Validation tier: Tier 4 - opt-in scheduled/reusable verification tooling plus post-review correction for repeatable live mesh stability evidence.
* git fetch --no-tags origin main:refs/remotes/origin/main: PASS
* git diff --check: PASS, no output
* git diff --cached --check: PASS, no output
* python3 -m unittest scripts.tests.test_qa_nightly_stability.NightlyStabilityHarnessTests.test_command_specs_keep_logs_relative_to_output_dir: PASS, 1 passed after reproducing the duplicated relative-output log path failure.
* python3 -m unittest discover -s scripts/tests -p 'test_*.py': PASS, 16 passed
* python3 -m py_compile scripts/qa-nightly-stability.py scripts/tests/test_qa_nightly_stability.py: PASS
* scripts/qa-nightly-stability.py --base-url http://127.0.0.1:9337 --models auto,mesh --attempts 2 --agent-smokes opencode,pi,goose --output-dir nightly-artifacts/stability/12345 --print-plan | python3 -m json.tool >/tmp/mesh-nightly-plan.json: PASS
* python3 inline plan-log assertion for /tmp/mesh-nightly-plan.json: PASS, command logs are relative logs/*.log paths with no duplicated output directory.
* ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "yaml ok #{path}" }' .github/workflows/nightly-stability.yml .github/workflows/nightly-stability-run.yml: PASS
* cargo fmt --all -- --check: PASS
* LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm --test qa_nightly_stability: PASS, 6 passed
* LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm: PASS
* Ledger: not applicable - not required for selected validation tier/change family.
* Version: not applicable - verification tooling/docs/test-only change; no release/version sync required.
* Not run: actionlint - not installed locally.
* Not run: live public mesh nightly - not required for selected validation tier; fake/contract tests and opt-in workflow coverage validate the harness without requiring an external lab endpoint.
* Not run: just build - not required for selected validation tier; no UI or bundle artifact changed.

## Rollback
Revert this PR. No runtime migration, data repair, protocol rollback, or release rollback is required.

## Known residual risks
* The workflow only produces live stability signal after maintainers provide a real lab/public-mesh endpoint and enable the scheduled run.
* Full live public-mesh nightly evidence is intentionally left to the opt-in workflow rather than simulated inside this PR validation.
