### PR TITLE
fix(justfile): drop default on bench-corpus tier before *ARGS

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -204,7 +204,7 @@ skippy-wan-lab-build-bins:
     cargo build --release --locked -p skippy-server -p skippy-prompt -p metrics-server -p skippy-model-package
 
 # Generate a reproducible benchmark corpus for skippy bench tooling.
-bench-corpus tier="smoke" *ARGS:
+bench-corpus tier *ARGS:
     scripts/generate-bench-corpus.py "{{ tier }}" {{ ARGS }}
 
 # Run skippy family certification checks.


### PR DESCRIPTION
## What this fixes

Running any `just` recipe currently fails to parse:

```
error: Non-default parameter `ARGS` follows default parameter
   ——▶ Justfile:207:28
    │
207 │ bench-corpus tier="smoke" *ARGS:
    │                            ^^^^
```

This blocks **every** `just` invocation on machines with a current `just` — `just build`, `just release-build-vulkan`, `just bundle`, etc. — not just `bench-corpus`.

## Why

Newer `just` versions reject a defaulted positional parameter that precedes a variadic. Older `just` accepted it, so it slipped through review and CI (which has an older pinned `just`).

Introduced in #422 (`5454baac`, "Replace llama-server with skippy runtime").

## Fix

Drop the default on `tier`. `*ARGS` already accepts zero args, and callers that want the smoke tier just pass it explicitly:

```
just bench-corpus smoke
```

## Validation

```
$ just --list | head -3
Available recipes:
    auto                                              # Build and auto-join a mesh ...
    bench-corpus tier *ARGS                           # Generate a reproducible benchmark corpus ...
```