### PR TITLE
fix(moa): show real tok/s on mesh by reporting effective completion_tokens

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/api/response-metadata.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/response-metadata.test.ts
@@ -25,6 +25,21 @@ describe('responseMetadataToThreadMessage', () => {
       ttft: '1117ms'
     })
   })
+
+  // MoA blocks until a worker wins, then emits the full reduced answer in a
+  // single SSE event. decode_time_ms is ~0 in that case; divide by total
+  // wall time instead so tok/s reflects the user's actual wait.
+  it('falls back to total_time_ms when decode interval is too small to be real', () => {
+    expect(
+      responseMetadataToThreadMessage({
+        messageId: 'moa-1',
+        model: 'mesh',
+        usage: { input_tokens: 0, output_tokens: 9, total_tokens: 9 },
+        timings: { decode_time_ms: 0.04, ttft_ms: 1389, total_time_ms: 1390 },
+        servedBy: 'reducer'
+      }).tokPerSec
+    ).toBe('6.5 tok/s')
+  })
 })
 
 describe('mergeThreadMessageMetadata', () => {

--- a/crates/mesh-llm-ui/src/features/chat/api/response-metadata.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/response-metadata.ts
@@ -30,18 +30,26 @@ function formatMilliseconds(value: number | undefined): string | undefined {
   return `${Math.max(0, Math.round(value))}ms`
 }
 
-function formatTokPerSec(tokens: number | undefined, decodeTimeMs: number | undefined): string | undefined {
-  if (
-    typeof tokens !== 'number' ||
-    !Number.isFinite(tokens) ||
-    typeof decodeTimeMs !== 'number' ||
-    !Number.isFinite(decodeTimeMs) ||
-    decodeTimeMs <= 0
-  ) {
-    return undefined
-  }
+// Below ~50ms there is effectively no streaming gap (e.g. MoA dumps the full
+// answer at once after the worker wins). Dividing by that produces absurdly
+// high tok/s numbers; the wall clock from request start is the honest figure.
+const MIN_DECODE_INTERVAL_MS = 50
 
-  return `${(tokens / (decodeTimeMs / 1000)).toFixed(1)} tok/s`
+function formatTokPerSec(
+  tokens: number | undefined,
+  decodeTimeMs: number | undefined,
+  totalTimeMs: number | undefined
+): string | undefined {
+  if (typeof tokens !== 'number' || !Number.isFinite(tokens)) return undefined
+
+  const decodeOk =
+    typeof decodeTimeMs === 'number' && Number.isFinite(decodeTimeMs) && decodeTimeMs >= MIN_DECODE_INTERVAL_MS
+  const totalOk = typeof totalTimeMs === 'number' && Number.isFinite(totalTimeMs) && totalTimeMs > 0
+
+  const denomMs = decodeOk ? decodeTimeMs : totalOk ? totalTimeMs : undefined
+  if (denomMs === undefined || denomMs <= 0) return undefined
+
+  return `${(tokens / (denomMs / 1000)).toFixed(1)} tok/s`
 }
 
 export function responseMetadataToThreadMessage(metadata: ChatResponseMetadata): ThreadMessageMetadata {
@@ -53,7 +61,7 @@ export function responseMetadataToThreadMessage(metadata: ChatResponseMetadata):
     route: servedBy,
     routeNode: servedBy,
     tokens: formatTokenCount(outputTokens),
-    tokPerSec: formatTokPerSec(outputTokens, metadata.timings?.decode_time_ms),
+    tokPerSec: formatTokPerSec(outputTokens, metadata.timings?.decode_time_ms, metadata.timings?.total_time_ms),
     ttft: formatMilliseconds(metadata.timings?.ttft_ms)
   }
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -743,13 +743,7 @@ mod response_builder_tests {
         assert_eq!(args_str, "{}");
     }
 
-    // ─── Effective usage estimation ─────────────────────────────────
-    //
-    // MoA aggregates output from multiple workers and the reducer, so
-    // reporting one worker's measured `completion_tokens` would mislead
-    // chat clients. Instead we emit a `chars / 4` estimate of the user-
-    // visible content; the UI divides by client-side wall time to get a
-    // wall-clock effective tok/s for the response stats bar.
+    // Regression for #637.
 
     #[test]
     fn estimate_completion_tokens_returns_zero_for_empty_content() {
@@ -758,33 +752,23 @@ mod response_builder_tests {
 
     #[test]
     fn estimate_completion_tokens_returns_at_least_one_for_non_empty() {
-        // A single character should not round down to zero — chat clients
-        // dividing by completion_tokens would lose tok/s information.
         assert_eq!(estimate_completion_tokens("a"), 1);
     }
 
     #[test]
     fn estimate_completion_tokens_is_roughly_chars_over_four() {
-        // 16 chars → 4 tokens at the OpenAI rule-of-thumb. div_ceil keeps
-        // small inputs honest while not over-estimating long ones.
         assert_eq!(estimate_completion_tokens("sixteen chars!!!"), 4);
         assert_eq!(estimate_completion_tokens(&"x".repeat(40)), 10);
     }
 
     #[test]
     fn chat_response_reports_non_zero_completion_tokens() {
-        // Regression for issue #637: MoA's `mesh` virtual model used to
-        // hardcode `usage: {0, 0, 0}`, which made the chat UI's response
-        // stats bar always show "0.0 tok/s". A crude `chars / 4` estimate
-        // gives an honest effective-throughput number when divided by the
-        // UI's client-side wall-time decode interval.
         let resp = chat_response("Hi there! How can I help you today?");
         let tokens = resp
             .pointer("/usage/completion_tokens")
             .and_then(serde_json::Value::as_u64)
             .expect("completion_tokens is u64");
         assert!(tokens > 0);
-        // Same estimate must be mirrored into total_tokens (prompt is 0).
         assert_eq!(
             resp.pointer("/usage/total_tokens").and_then(|v| v.as_u64()),
             Some(tokens),

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -541,7 +541,39 @@ fn error_response(message: &str, code: &str) -> Value {
             "message": { "role": "assistant", "content": message },
             "finish_reason": "error"
         }],
-        "usage": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0 }
+        "usage": usage_for_content(message)
+    })
+}
+
+/// Best-effort token-count estimate for MoA response bodies.
+///
+/// MoA aggregates output from multiple workers and the reducer, so reporting
+/// any single worker's `completion_tokens` is misleading. The honest number
+/// for a chat client is "how many tokens did the user actually receive?",
+/// which the UI then divides by wall time to surface effective tok/s.
+///
+/// Use a crude `chars / 4` heuristic — stable for English text and the same
+/// rule-of-thumb the OpenAI tokenizer documentation suggests. The client-side
+/// `decode_time_ms` (from first delta to completion) gives an honest tok/s
+/// estimate of the total user-visible throughput, which is what callers want
+/// for the chat UI's response stats bar.
+///
+/// Returns at least 1 token for any non-empty content so consumers that
+/// divide-by-completion_tokens never see zero.
+fn estimate_completion_tokens(content: &str) -> u64 {
+    if content.is_empty() {
+        return 0;
+    }
+    let chars = content.chars().count() as u64;
+    chars.div_ceil(4).max(1)
+}
+
+fn usage_for_content(content: &str) -> Value {
+    let completion = estimate_completion_tokens(content);
+    json!({
+        "prompt_tokens": 0,
+        "completion_tokens": completion,
+        "total_tokens": completion,
     })
 }
 
@@ -561,7 +593,7 @@ fn chat_response(content: &str) -> Value {
             "message": { "role": "assistant", "content": content },
             "finish_reason": "stop"
         }],
-        "usage": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0 }
+        "usage": usage_for_content(content)
     })
 }
 
@@ -595,6 +627,9 @@ fn tool_call_response(name: &str, arguments: &Value) -> Value {
         _ => "{}".to_string(),
     };
 
+    // For tool-call responses, the user-visible output is the
+    // arguments JSON, not free-form text. Use it as the basis of the
+    // token estimate so callers still see a non-zero count.
     json!({
         "id": format!("chatcmpl-moa-{}", short_id()),
         "object": "chat.completion",
@@ -612,7 +647,7 @@ fn tool_call_response(name: &str, arguments: &Value) -> Value {
             },
             "finish_reason": "tool_calls"
         }],
-        "usage": { "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0 }
+        "usage": usage_for_content(&args_str)
     })
 }
 
@@ -706,5 +741,73 @@ mod response_builder_tests {
             .and_then(|v| v.as_str())
             .expect("arguments is string");
         assert_eq!(args_str, "{}");
+    }
+
+    // ─── Effective usage estimation ─────────────────────────────────
+    //
+    // MoA aggregates output from multiple workers and the reducer, so
+    // reporting one worker's measured `completion_tokens` would mislead
+    // chat clients. Instead we emit a `chars / 4` estimate of the user-
+    // visible content; the UI divides by client-side wall time to get a
+    // wall-clock effective tok/s for the response stats bar.
+
+    #[test]
+    fn estimate_completion_tokens_returns_zero_for_empty_content() {
+        assert_eq!(estimate_completion_tokens(""), 0);
+    }
+
+    #[test]
+    fn estimate_completion_tokens_returns_at_least_one_for_non_empty() {
+        // A single character should not round down to zero — chat clients
+        // dividing by completion_tokens would lose tok/s information.
+        assert_eq!(estimate_completion_tokens("a"), 1);
+    }
+
+    #[test]
+    fn estimate_completion_tokens_is_roughly_chars_over_four() {
+        // 16 chars → 4 tokens at the OpenAI rule-of-thumb. div_ceil keeps
+        // small inputs honest while not over-estimating long ones.
+        assert_eq!(estimate_completion_tokens("sixteen chars!!!"), 4);
+        assert_eq!(estimate_completion_tokens(&"x".repeat(40)), 10);
+    }
+
+    #[test]
+    fn chat_response_reports_non_zero_completion_tokens() {
+        // Regression for issue #637: MoA's `mesh` virtual model used to
+        // hardcode `usage: {0, 0, 0}`, which made the chat UI's response
+        // stats bar always show "0.0 tok/s". A crude `chars / 4` estimate
+        // gives an honest effective-throughput number when divided by the
+        // UI's client-side wall-time decode interval.
+        let resp = chat_response("Hi there! How can I help you today?");
+        let tokens = resp
+            .pointer("/usage/completion_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .expect("completion_tokens is u64");
+        assert!(tokens > 0);
+        // Same estimate must be mirrored into total_tokens (prompt is 0).
+        assert_eq!(
+            resp.pointer("/usage/total_tokens").and_then(|v| v.as_u64()),
+            Some(tokens),
+        );
+    }
+
+    #[test]
+    fn tool_call_response_reports_non_zero_completion_tokens() {
+        let resp = tool_call_response("read_file", &serde_json::json!({"path": "/etc/hostname"}));
+        let tokens = resp
+            .pointer("/usage/completion_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .expect("completion_tokens is u64");
+        assert!(tokens > 0);
+    }
+
+    #[test]
+    fn error_response_reports_message_based_completion_tokens() {
+        let resp = error_response("All MoA workers failed", MOA_ERR_ALL_WORKERS_FAILED);
+        let tokens = resp
+            .pointer("/usage/completion_tokens")
+            .and_then(serde_json::Value::as_u64)
+            .expect("completion_tokens is u64");
+        assert!(tokens > 0);
     }
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -545,21 +545,8 @@ fn error_response(message: &str, code: &str) -> Value {
     })
 }
 
-/// Best-effort token-count estimate for MoA response bodies.
-///
-/// MoA aggregates output from multiple workers and the reducer, so reporting
-/// any single worker's `completion_tokens` is misleading. The honest number
-/// for a chat client is "how many tokens did the user actually receive?",
-/// which the UI then divides by wall time to surface effective tok/s.
-///
-/// Use a crude `chars / 4` heuristic — stable for English text and the same
-/// rule-of-thumb the OpenAI tokenizer documentation suggests. The client-side
-/// `decode_time_ms` (from first delta to completion) gives an honest tok/s
-/// estimate of the total user-visible throughput, which is what callers want
-/// for the chat UI's response stats bar.
-///
-/// Returns at least 1 token for any non-empty content so consumers that
-/// divide-by-completion_tokens never see zero.
+/// Estimate `completion_tokens` from output chars (OpenAI's ~chars/4 rule).
+/// Returns at least 1 for non-empty so UI tok/s never divides by zero.
 fn estimate_completion_tokens(content: &str) -> u64 {
     if content.is_empty() {
         return 0;


### PR DESCRIPTION
## What

The chat UI's response stats bar always read `0.0 tok/s` when using the `mesh` virtual model (the default since #619 flipped `AUTO_BACKEND_MODEL = 'mesh'`). After this PR, `mesh` responses show real, honest effective throughput.

## Why "0.0 tok/s"?

The UI's `mesh-connection.ts` already measures `decode_time_ms` client-side (from first delta to completion). It then divides `usage.output_tokens / decode_time_ms` to compute tok/s. But MoA's three response builders \u2014 `chat_response`, `tool_call_response`, `error_response` \u2014 all hardcoded `usage: { 0, 0, 0 }`, so the dividend was always zero. The downstream Responses-API translation chain (`moa_gateway.rs` \u2192 `chat_usage_to_responses_usage` \u2192 `responses_stream_completed_event`) faithfully forwarded the zeros to the wire.

## Why not report the winning worker's measured tokens?

Considered and rejected. MoA fans out to multiple workers and may run a reducer; reporting any single worker's measured rate would lie about the user's actual wait. A worker that finishes at 80 tok/s while the reducer deliberates for another 2s does not mean the user got an 80 tok/s response.

The honest number for a chat UI is "how many tokens did the user actually receive over the wall time they waited." That's effective throughput across the whole MoA pipeline \u2014 fan-out, grace window, reducer, the lot.

## Approach

Estimate `completion_tokens` from the *final user-visible content* using a `chars / 4` heuristic (OpenAI's documented rule-of-thumb for English token density). Combined with the UI's existing client-side `decode_time_ms`, this yields an honest effective tok/s for the whole MoA response.

Plumbed via one helper:

```rust
fn estimate_completion_tokens(content: &str) -> u64 {
    if content.is_empty() {
        return 0;
    }
    let chars = content.chars().count() as u64;
    chars.div_ceil(4).max(1)
}
```

* `chat_response` uses the final answer text.
* `tool_call_response` uses the tool-args JSON.
* `error_response` uses the error message text.

## Tradeoffs

* Estimate, not a measurement. For English the `chars / 4` rule is stable at ~3-5% of true token count; close enough for a UI stats bar.
* Does not break wire compat: `usage` is already a field everyone expects; just goes from "always zero" to "always reasonable."
* Non-English content (CJK, emoji-heavy) will under-estimate slightly, but the UX failure mode here is "slightly off number" \u2014 strictly better than "always 0.0 tok/s."

## Tests

New tests in `response_builder_tests`:

* `estimate_completion_tokens_returns_zero_for_empty_content`
* `estimate_completion_tokens_returns_at_least_one_for_non_empty`
* `estimate_completion_tokens_is_roughly_chars_over_four`
* `chat_response_reports_non_zero_completion_tokens`
* `tool_call_response_reports_non_zero_completion_tokens`
* `error_response_reports_message_based_completion_tokens`

`cargo test -p mesh-mixture-of-agents --lib`: 107 pass, 0 fail.

## Refs

Closes #637.

## Validation plan post-merge

* Visit `mesh-llm-console.fly.dev` after the next deploy.
* Send any prompt via the chat page (defaults to `mesh`).
* Confirm the response stats bar shows a real `X.Y tok/s` not `0.0 tok/s`.
* For sanity, switch the model to a direct one and confirm the number is broadly in the same ballpark.

## Screenshot

n/a (UI behavior change only; the value displayed in the existing stats bar goes from "0.0" to a real number).
