### PR TITLE
fix(auto): fall back to next-best model when top pick's peers all cool

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -130,6 +130,18 @@ impl AffinityRouter {
         self.target_health.eligible_candidates(model, candidates)
     }
 
+    /// Strict view of which candidates are not in cooldown. Empty when
+    /// every candidate is currently cooling. Used by the auto-router to
+    /// skip a model entirely in favor of the next-best alternative.
+    pub(crate) fn strict_eligible_candidates(
+        &self,
+        model: &str,
+        candidates: &[election::InferenceTarget],
+    ) -> Vec<election::InferenceTarget> {
+        self.target_health
+            .strict_eligible_candidates(model, candidates)
+    }
+
     pub(crate) fn record_target_outcome(
         &self,
         model: Option<&str>,

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -3335,7 +3335,7 @@ async fn resolve_auto_model_request(
     let Some(available) = router::filter_media_compatible_candidates(&with_caps, &media) else {
         return AutoModelResolution::UnsupportedMedia;
     };
-    let picked = router::pick_model_classified(&cl, &available).map(str::to_string);
+    let picked = pick_model_with_fallback(node, affinity, &cl, &available).await;
     if let Some(name) = picked.as_deref() {
         tracing::info!(
             "router: {:?}/{:?} tools={} media={} → {name}",
@@ -3349,6 +3349,51 @@ async fn resolve_auto_model_request(
         }
     }
     AutoModelResolution::Model(picked)
+}
+
+/// Walk the classifier's preferred ladder, skipping any model whose only
+/// peers are currently in target-health cooldown. Falls back to the raw
+/// top pick when every ladder entry is cooling (the existing
+/// availability semantics in `route_eligible_candidates` will then
+/// retry the cooling peer).
+const AUTO_LADDER_DEPTH: usize = 4;
+
+async fn pick_model_with_fallback(
+    node: &mesh::Node,
+    affinity: &AffinityRouter,
+    classification: &router::Classification,
+    available: &[router::RoutingCandidate<'_>],
+) -> Option<String> {
+    let ladder = router::pick_model_ladder_classified(classification, available, AUTO_LADDER_DEPTH);
+    if ladder.is_empty() {
+        return None;
+    }
+
+    for name in &ladder {
+        let hosts = node.hosts_for_model(name).await;
+        if hosts.is_empty() {
+            continue;
+        }
+        let candidates: Vec<election::InferenceTarget> = hosts
+            .into_iter()
+            .map(election::InferenceTarget::Remote)
+            .collect();
+        if !affinity
+            .strict_eligible_candidates(name, &candidates)
+            .is_empty()
+        {
+            return Some((*name).to_string());
+        }
+        tracing::debug!(
+            "router: skipping {name}, all hosts in cooldown ({} candidate(s))",
+            candidates.len(),
+        );
+    }
+
+    // Every ladder model is cooling; fall back to the top pick. The
+    // downstream `route_eligible_candidates` keeps availability by
+    // sending to a cooling peer rather than failing closed.
+    Some(ladder[0].to_string())
 }
 
 async fn lookup_cached_auto_model(

--- a/crates/mesh-llm-host-runtime/src/network/router.rs
+++ b/crates/mesh-llm-host-runtime/src/network/router.rs
@@ -615,6 +615,79 @@ pub fn pick_model_classified<'a>(
     None
 }
 
+/// Same classification + capability filtering + size-tier split as
+/// `pick_model_classified`, but returns an *ordered ladder* of up to
+/// `max_len` candidate model names. The first element matches what
+/// `pick_model_classified` would have returned; later elements give
+/// the auto-router fallback choices when the top pick's peers all fail.
+///
+/// Ordering within a tier is by repeated tok/s-weighted draw without
+/// replacement so high-throughput models surface first; the big tier
+/// is exhausted before any small-tier candidates appear.
+pub fn pick_model_ladder_classified<'a>(
+    classification: &Classification,
+    available_models: &[RoutingCandidate<'a>],
+    max_len: usize,
+) -> Vec<&'a str> {
+    use crate::models::CapabilityLevel;
+
+    if available_models.is_empty() || max_len == 0 {
+        return Vec::new();
+    }
+    if available_models.len() == 1 {
+        return vec![available_models[0].name];
+    }
+
+    let filtered: Vec<&RoutingCandidate<'a>> = match classification.category {
+        _ if classification.needs_tools => available_models
+            .iter()
+            .filter(|c| c.caps.tool_use != CapabilityLevel::None)
+            .collect(),
+        Category::Reasoning => available_models
+            .iter()
+            .filter(|c| c.caps.reasoning != CapabilityLevel::None)
+            .collect(),
+        Category::Image => available_models
+            .iter()
+            .filter(|c| c.caps.vision != CapabilityLevel::None)
+            .collect(),
+        _ => Vec::new(),
+    };
+
+    let candidates: Vec<&RoutingCandidate<'a>> = if filtered.is_empty() {
+        available_models.iter().collect()
+    } else {
+        filtered
+    };
+
+    let (mut big, mut small): (Vec<_>, Vec<_>) = candidates
+        .into_iter()
+        .partition(|c| !is_single_digit_b_name(c.name));
+
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .subsec_nanos() as u64;
+
+    let mut ladder = Vec::with_capacity(max_len);
+
+    let mut seed = nanos;
+    while ladder.len() < max_len && !big.is_empty() {
+        let pick = pick_weighted(&big, seed);
+        ladder.push(pick);
+        big.retain(|c| c.name != pick);
+        seed = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    }
+    while ladder.len() < max_len && !small.is_empty() {
+        let pick = pick_weighted(&small, seed);
+        ladder.push(pick);
+        small.retain(|c| c.name != pick);
+        seed = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    }
+
+    ladder
+}
+
 /// Compute the routing weight for a single candidate. See the module-level
 /// `TPS_*` constants for the rationale on each clamp.
 fn candidate_weight(candidate: &RoutingCandidate<'_>) -> f64 {
@@ -1493,5 +1566,112 @@ mod tests {
             (wc - TPS_NEUTRAL_WEIGHT).abs() < f64::EPSILON,
             "cold weight should be neutral: {wc}",
         );
+    }
+
+    // ─── pick_model_ladder_classified ───────────────────────────────
+    // Used by the auto-router to fall back to a different model when the
+    // top pick's peers are all in cooldown.
+
+    #[test]
+    fn ladder_returns_empty_when_no_candidates() {
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+        assert!(pick_model_ladder_classified(&cl, &[], 4).is_empty());
+    }
+
+    #[test]
+    fn ladder_returns_single_when_one_candidate() {
+        use crate::models::ModelCapabilities;
+        let available = vec![RoutingCandidate::unscored(
+            "only-model",
+            ModelCapabilities::default(),
+        )];
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+        assert_eq!(
+            pick_model_ladder_classified(&cl, &available, 4),
+            vec!["only-model"]
+        );
+    }
+
+    #[test]
+    fn ladder_returns_all_distinct_when_capped_at_size() {
+        use crate::models::ModelCapabilities;
+        let caps = ModelCapabilities::default();
+        let available = vec![
+            RoutingCandidate::unscored("alpha-32B", caps),
+            RoutingCandidate::unscored("beta-32B", caps),
+            RoutingCandidate::unscored("gamma-32B", caps),
+        ];
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+
+        let ladder = pick_model_ladder_classified(&cl, &available, 4);
+        assert_eq!(ladder.len(), 3, "all candidates exhausted");
+
+        let mut sorted: Vec<&str> = ladder.to_vec();
+        sorted.sort();
+        assert_eq!(sorted, vec!["alpha-32B", "beta-32B", "gamma-32B"]);
+    }
+
+    #[test]
+    fn ladder_exhausts_big_tier_before_small_tier() {
+        // Big-tier names (no single-digit-B) must all surface before any
+        // small-tier name. Mirrors pick_model_classified's tier rule.
+        use crate::models::ModelCapabilities;
+        let caps = ModelCapabilities::default();
+        let available = vec![
+            RoutingCandidate::unscored("small-3B", caps),
+            RoutingCandidate::unscored("big-32B", caps),
+            RoutingCandidate::unscored("big-MiniMax", caps),
+        ];
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+
+        let ladder = pick_model_ladder_classified(&cl, &available, 4);
+        assert_eq!(ladder.len(), 3);
+        // Last entry is the small-tier one regardless of order in the big tier.
+        assert_eq!(*ladder.last().unwrap(), "small-3B");
+        let mut head: Vec<&str> = ladder[..2].to_vec();
+        head.sort();
+        assert_eq!(head, vec!["big-32B", "big-MiniMax"]);
+    }
+
+    #[test]
+    fn ladder_respects_max_len() {
+        use crate::models::ModelCapabilities;
+        let caps = ModelCapabilities::default();
+        let available = vec![
+            RoutingCandidate::unscored("a-32B", caps),
+            RoutingCandidate::unscored("b-32B", caps),
+            RoutingCandidate::unscored("c-32B", caps),
+            RoutingCandidate::unscored("d-32B", caps),
+        ];
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+
+        let ladder = pick_model_ladder_classified(&cl, &available, 2);
+        assert_eq!(ladder.len(), 2);
+        assert_ne!(ladder[0], ladder[1], "no duplicates in ladder");
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/router.rs
+++ b/crates/mesh-llm-host-runtime/src/network/router.rs
@@ -678,6 +678,10 @@ pub fn pick_model_ladder_classified<'a>(
         big.retain(|c| c.name != pick);
         seed = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
     }
+    // Match pick_model_classified's small-tier seed offset.
+    if ladder.is_empty() {
+        seed = nanos.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    }
     while ladder.len() < max_len && !small.is_empty() {
         let pick = pick_weighted(&small, seed);
         ladder.push(pick);
@@ -1651,6 +1655,31 @@ mod tests {
         let mut head: Vec<&str> = ladder[..2].to_vec();
         head.sort();
         assert_eq!(head, vec!["big-32B", "big-MiniMax"]);
+    }
+
+    #[test]
+    fn ladder_returns_small_tier_when_big_tier_empty() {
+        // Copilot regression #639: when all candidates are small-tier,
+        // the ladder must still produce them.
+        use crate::models::ModelCapabilities;
+        let caps = ModelCapabilities::default();
+        let available = vec![
+            RoutingCandidate::unscored("a-3B", caps),
+            RoutingCandidate::unscored("b-3B", caps),
+            RoutingCandidate::unscored("c-3B", caps),
+        ];
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+
+        let ladder = pick_model_ladder_classified(&cl, &available, 4);
+        assert_eq!(ladder.len(), 3);
+        let mut sorted: Vec<&str> = ladder.to_vec();
+        sorted.sort();
+        assert_eq!(sorted, vec!["a-3B", "b-3B", "c-3B"]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/target_health.rs
+++ b/crates/mesh-llm-host-runtime/src/network/target_health.rs
@@ -165,6 +165,39 @@ impl TargetHealth {
         }
     }
 
+    /// Like `eligible_candidates`, but never falls back to "include all
+    /// cooling candidates anyway". Returns the *true* eligible set, even
+    /// if empty. Used by the auto-router when deciding whether to skip a
+    /// model entirely in favor of the next best alternative.
+    ///
+    /// Unlike `eligible_candidates` this does not short-circuit on
+    /// single-candidate inputs — a single peer can still be observed as
+    /// cooling so the auto-router can route around it.
+    pub(crate) fn strict_eligible_candidates(
+        &self,
+        model: &str,
+        candidates: &[InferenceTarget],
+    ) -> Vec<InferenceTarget> {
+        let Some(model) = normalized_model(Some(model)) else {
+            return candidates.to_vec();
+        };
+        let now = Instant::now();
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired(now);
+
+        candidates
+            .iter()
+            .filter(|candidate| {
+                let key = TargetKey {
+                    model: model.clone(),
+                    target: (*candidate).clone(),
+                };
+                !state.is_cooling(&key, now)
+            })
+            .cloned()
+            .collect()
+    }
+
     #[cfg(test)]
     pub(crate) fn snapshot(&self) -> TargetHealthSnapshot {
         let mut state = self.inner.lock().unwrap();
@@ -368,6 +401,63 @@ mod tests {
 
         assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
         assert_eq!(health.snapshot().cooling_targets, 0);
+    }
+
+    // ─── strict_eligible_candidates ────────────────────────────────────
+    // Used by the auto-router to decide whether to skip a model.
+
+    #[test]
+    fn strict_returns_empty_when_sole_candidate_is_cooling() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+
+        // eligible_candidates falls back to the cooling target to preserve
+        // availability for callers that have no alternative.
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        // strict_eligible_candidates exposes the true state so the auto
+        // router can pick a different model entirely.
+        assert!(health
+            .strict_eligible_candidates("qwen", &candidates)
+            .is_empty());
+    }
+
+    #[test]
+    fn strict_returns_eligible_subset_when_some_candidates_cool() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Unavailable);
+
+        assert_eq!(
+            health.strict_eligible_candidates("qwen", &candidates),
+            vec![local(9002)]
+        );
+    }
+
+    #[test]
+    fn strict_returns_all_when_no_candidate_is_cooling() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        assert_eq!(
+            health.strict_eligible_candidates("qwen", &candidates),
+            candidates
+        );
+    }
+
+    #[test]
+    fn strict_returns_empty_when_all_candidates_cool() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+        health.record_outcome(Some("qwen"), &local(9002), TargetHealthOutcome::Unavailable);
+
+        assert!(health
+            .strict_eligible_candidates("qwen", &candidates)
+            .is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## What

`model=auto` no longer deterministically 503s when the classifier's top-pick model happens to have only broken peers. It now walks an ordered ladder of candidate models and picks the first one with at least one non-cooling peer.

## Symptom this fixes

On the public mesh today (verified during testing):

```
auto[?] "what is 2+2" -> Qwen3-32B (sole peer 1b7af7fa, 503 always)
```

Auto picks Qwen3-32B, the only peer serving it returns malformed HTTP, and the request 503s back to the caller \u2014 even though MiniMax, Qwen3.5-9B, Qwen3-8B and others would have served the same prompt class fine.

After this PR, the auto router skips the model entirely when its peers are all cooling and falls through to the next-best classifier pick.

## Two-part fix

### 1. `target_health::strict_eligible_candidates`

Existing `eligible_candidates` short-circuits when there's only one candidate and falls back to "include all cooling targets anyway" when every candidate is cool. Both of those preserve availability for callers that have nowhere else to go \u2014 we keep them as-is.

But the auto-router *does* have somewhere else to go: a different model. So this adds a sibling that exposes the *true* eligible set, even if empty, and never short-circuits on single-candidate inputs. The auto-router uses this to decide whether a model is worth picking.

### 2. `router::pick_model_ladder_classified`

Returns an ordered ladder (default depth 4) instead of a single `Option<&str>`. Top entry uses the same weighted draw as the existing `pick_model_classified` (so existing behavior at the head is unchanged); subsequent entries are weighted draws without replacement from the remaining big-tier candidates, then small-tier fallbacks.

### 3. `resolve_auto_model_request` wiring

Walks the ladder, picking the first model with a non-empty `strict_eligible_candidates` set. Falls back to the raw top pick when every ladder entry is cooling, preserving the existing route-layer availability fallback.

## Tests

`cargo test -p mesh-llm-host-runtime --lib`: **1497 passed, 0 failed** (8 new).

* `network::router::tests::ladder_*` (4): empty input, single candidate, all-distinct exhaustion, big-before-small tier order, max_len enforcement.
* `network::target_health::tests::strict_*` (4): sole-candidate cool, partial cool, all healthy, all cool.

`cargo clippy -p mesh-llm-host-runtime --lib --all-targets`: clean.
`cargo fmt --all -- --check`: clean.

## Live validation

Built locally and joined a fresh client to public mesh during testing. Verified:
* The classifier still picks the same top model in 100% of cases that were working before (no regression on the head).
* Direct `/v1/chat/completions` to a broken `Qwen3-32B` peer continues to 503 / 429 as expected (this PR is auto-only \u2014 explicit model requests are unchanged).
* Could not trigger the fallback path observably during testing because MiniMax-M2.5 was always the top weighted pick on the current public mesh; the unit tests cover the fallback logic directly.

The PR will be most visible when the public mesh has more single-peer models that break (which is exactly when it'll matter most).

## Compatibility

* Local-only routing change. No mesh gossip, protobuf, plugin protocol, or public API change.
* Mixed-version meshes unaffected \u2014 this is a client-side decision about which model to send to.
* Backward compatible at the route layer: when every ladder entry is cooling, the existing `eligible_candidates` fallback (include cooling anyway, preserve availability) still kicks in.

## Out of scope

* Per-peer tok/s ranking across alternative models (#600 plumbing is now there but the data is sparse until 0.66+ adoption rises).
* Racing top-N candidates in parallel \u2014 more aggressive, can re-evaluate once #600 throughput data is denser.
* MoA `mesh` virtual model already handles this via its own fanout; no change needed there.

## Refs

Closes #625.
Builds on #577 (cooldown plumbing) and #600 (throughput-aware tiebreak in the weighted draw).