### PR TITLE
feat(cli): --relay-auth URL=TOKEN for gated iroh-relays

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -8,6 +8,58 @@ use crate::cli::runtime::RuntimeCommand;
 use crate::crypto::TrustPolicy;
 use crate::network::discovery::MeshDiscoveryMode;
 
+/// Parse a `URL=TOKEN` pair for `--relay-auth`. Splits on the first `=` only,
+/// so tokens may contain `=` (base64 padding, JWTs).
+fn parse_relay_auth_pair(s: &str) -> Result<(String, String), String> {
+    let Some((url, token)) = s.split_once('=') else {
+        return Err(format!(
+            "expected URL=TOKEN, got {s:?} (no '=' separator found)"
+        ));
+    };
+    if url.is_empty() {
+        return Err(format!("expected URL=TOKEN, got empty URL in {s:?}"));
+    }
+    if token.is_empty() {
+        return Err(format!("expected URL=TOKEN, got empty token in {s:?}"));
+    }
+    Ok((url.to_string(), token.to_string()))
+}
+
+#[cfg(test)]
+mod relay_auth_parser_tests {
+    use super::parse_relay_auth_pair;
+
+    #[test]
+    fn parses_simple_pair() {
+        let (url, token) = parse_relay_auth_pair("https://r.example/=abc123").unwrap();
+        assert_eq!(url, "https://r.example/");
+        assert_eq!(token, "abc123");
+    }
+
+    #[test]
+    fn preserves_equals_in_token() {
+        // Base64-padded tokens and NIP-98-style payloads often contain `=`.
+        let (_, token) = parse_relay_auth_pair("https://r/=eyJhbGciOiJFZERTQSJ9.payload==")
+            .expect("token with '=' must parse");
+        assert_eq!(token, "eyJhbGciOiJFZERTQSJ9.payload==");
+    }
+
+    #[test]
+    fn rejects_missing_separator() {
+        assert!(parse_relay_auth_pair("no-separator").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_url() {
+        assert!(parse_relay_auth_pair("=token").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_token() {
+        assert!(parse_relay_auth_pair("https://r/=").is_err());
+    }
+}
+
 #[derive(Subcommand, Debug)]
 pub(crate) enum TrustCommand {
     /// Add an owner to the local trust store allowlist.
@@ -379,6 +431,17 @@ pub(crate) struct Cli {
     /// Override iroh relay URLs.
     #[arg(long, hide = true)]
     pub(crate) relay: Vec<String>,
+
+    /// Per-relay bearer token for gated iroh relays, formatted as
+    /// `URL=TOKEN`. Repeatable. The token is sent as
+    /// `Authorization: Bearer <TOKEN>` on the WebSocket upgrade to the
+    /// matching `--relay` URL. Relays not listed here register without
+    /// authentication (the correct behavior for public relays).
+    ///
+    /// Splits on the first `=` only, so tokens may contain `=` (base64
+    /// padding, JWTs, etc.).
+    #[arg(long = "relay-auth", value_parser = parse_relay_auth_pair, hide = true)]
+    pub(crate) relay_auth: Vec<(String, String)>,
 
     /// Bind QUIC to a fixed UDP port (for NAT port forwarding).
     #[arg(long, hide = true)]

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -270,11 +270,104 @@ fn effective_relay_urls(relay_urls: &[String]) -> Vec<String> {
     }
 }
 
-fn relay_map_from_urls(urls: &[String]) -> iroh::RelayMap {
-    let configs = urls
-        .iter()
-        .map(|url| iroh::RelayConfig::new(url.parse().expect("invalid relay URL"), None));
+/// Build a [`RelayMap`] from URLs, attaching per-relay auth tokens where
+/// configured.
+///
+/// `auths` maps relay URLs (as they appear in `urls`) to bearer tokens. Tokens
+/// are passed to [`iroh::RelayConfig::with_auth_token`] which sends them as
+/// `Authorization: Bearer <token>` on the WebSocket upgrade. Relays not present
+/// in the map register unauthenticated, which is the correct behavior for
+/// public (`AccessConfig::Everyone`) relays.
+///
+/// This is the wire-up that lets a gated iroh-relay (e.g. one running
+/// `AccessConfig::Restricted` with NIP-98 admission) admit this node while
+/// public relays in the same map continue to work normally.
+fn relay_map_from_urls(
+    urls: &[String],
+    auths: &std::collections::HashMap<String, String>,
+) -> iroh::RelayMap {
+    let configs = urls.iter().map(|url| {
+        let parsed = url.parse().expect("invalid relay URL");
+        let cfg = iroh::RelayConfig::new(parsed, None);
+        match auths.get(url) {
+            Some(token) => cfg.with_auth_token(token.clone()),
+            None => cfg,
+        }
+    });
     iroh::RelayMap::from_iter(configs)
+}
+
+#[cfg(test)]
+mod relay_map_tests {
+    use super::relay_map_from_urls;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn configs(map: &iroh::RelayMap) -> Vec<Arc<iroh::RelayConfig>> {
+        map.relays::<Vec<_>>()
+    }
+
+    #[test]
+    fn builds_map_without_auth_when_empty() {
+        let urls = vec!["https://r1.example/".to_string()];
+        let map = relay_map_from_urls(&urls, &HashMap::new());
+        let cfgs = configs(&map);
+        assert_eq!(cfgs.len(), 1);
+        assert!(
+            cfgs[0].auth_token.is_none(),
+            "no auth supplied → no auth_token set"
+        );
+    }
+
+    #[test]
+    fn attaches_auth_token_for_matching_url() {
+        let urls = vec!["https://gated.example/".to_string()];
+        let mut auths = HashMap::new();
+        auths.insert("https://gated.example/".to_string(), "nip98-bearer".into());
+        let map = relay_map_from_urls(&urls, &auths);
+        let cfgs = configs(&map);
+        assert_eq!(cfgs.len(), 1);
+        assert_eq!(cfgs[0].auth_token.as_deref(), Some("nip98-bearer"));
+    }
+
+    #[test]
+    fn leaves_other_relays_unauthenticated_in_mixed_map() {
+        // The whole point: gated relay gets a token, public relays don't.
+        let urls = vec![
+            "https://gated.example/".to_string(),
+            "https://public.iroh/".to_string(),
+        ];
+        let mut auths = HashMap::new();
+        auths.insert("https://gated.example/".to_string(), "bearer-xyz".into());
+
+        let map = relay_map_from_urls(&urls, &auths);
+        let by_url: HashMap<String, Option<String>> = configs(&map)
+            .into_iter()
+            .map(|cfg| (cfg.url.to_string(), cfg.auth_token.clone()))
+            .collect();
+
+        // Find the entries by matching on host substring, since iroh-relay may
+        // canonicalise the URL form (e.g. trailing dot on the host).
+        let gated = by_url
+            .iter()
+            .find(|(u, _)| u.contains("gated.example"))
+            .expect("gated relay should be in the map");
+        let public = by_url
+            .iter()
+            .find(|(u, _)| u.contains("public.iroh"))
+            .expect("public relay should be in the map");
+
+        assert_eq!(
+            gated.1.as_deref(),
+            Some("bearer-xyz"),
+            "gated relay must carry its token"
+        );
+        assert!(
+            public.1.is_none(),
+            "public relay must register without a token, got {:?}",
+            public.1
+        );
+    }
 }
 
 fn encode_endpoint_addr_token(addr: &EndpointAddr) -> String {
@@ -1420,6 +1513,7 @@ fn startup_transport_config() -> iroh::endpoint::QuicTransportConfig {
 async fn bind_mesh_endpoint(
     secret_key: SecretKey,
     relay_urls: &[String],
+    relay_auths: &std::collections::HashMap<String, String>,
     quic_bind: QuicBindSelection,
 ) -> Result<Endpoint> {
     let mut builder = Endpoint::builder(iroh::endpoint::presets::Minimal)
@@ -1434,6 +1528,7 @@ async fn bind_mesh_endpoint(
     tracing::info!("Relay: {:?}", urls);
     builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map_from_urls(
         &urls,
+        relay_auths,
     )));
 
     if let Some(addr) = quic_bind_addr(quic_bind) {
@@ -1569,12 +1664,14 @@ fn init_owner_runtime(
 fn configure_control_relay(
     mut builder: iroh::endpoint::Builder,
     relay_urls: Option<&[String]>,
+    relay_auths: &std::collections::HashMap<String, String>,
 ) -> iroh::endpoint::Builder {
     if let Some(relay_urls) = relay_urls {
         let urls = effective_relay_urls(relay_urls);
         tracing::info!("Owner-control relay: {:?}", urls);
         builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map_from_urls(
             &urls,
+            relay_auths,
         )));
     } else {
         builder = builder.relay_mode(iroh::endpoint::RelayMode::Disabled);
@@ -2628,6 +2725,7 @@ impl Node {
     pub async fn start(
         role: NodeRole,
         relay_urls: &[String],
+        relay_auths: &std::collections::HashMap<String, String>,
         quic_bind: QuicBindSelection,
         max_vram_gb: Option<f64>,
         enumerate_host: bool,
@@ -2635,7 +2733,8 @@ impl Node {
         config_path: Option<&std::path::Path>,
     ) -> Result<(Self, TunnelChannels)> {
         let secret_key = startup_secret_key(&role).await?;
-        let endpoint = bind_mesh_endpoint(secret_key.clone(), relay_urls, quic_bind).await?;
+        let endpoint =
+            bind_mesh_endpoint(secret_key.clone(), relay_urls, relay_auths, quic_bind).await?;
         // Wait briefly for relay connection so the invite token includes the relay URL.
         // On sinkholed networks this times out and we proceed without relay (direct UDP only).
         wait_for_endpoint_online(
@@ -2764,6 +2863,7 @@ impl Node {
                 .as_ref()
                 .and_then(|config| config.control_advertise_addr),
             Some(relay_urls),
+            relay_auths,
         )
         .await?;
 
@@ -2907,6 +3007,7 @@ impl Node {
         bind_addr: Option<std::net::SocketAddr>,
         advertise_addr: Option<std::net::SocketAddr>,
         relay_urls: Option<&[String]>,
+        relay_auths: &std::collections::HashMap<String, String>,
     ) -> Result<()> {
         if self.local_verified_owner_id().await.is_none() {
             return Ok(());
@@ -2916,7 +3017,7 @@ impl Node {
             .secret_key(secret_key)
             .alpns(vec![ALPN_CONTROL_V1.to_vec()])
             .bind_addr(bind_addr.unwrap_or_else(default_control_bind_addr))?;
-        builder = configure_control_relay(builder, relay_urls);
+        builder = configure_control_relay(builder, relay_urls, relay_auths);
         let endpoint = builder.bind().await?;
         if relay_urls.is_some() {
             wait_for_endpoint_online(

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1121,8 +1121,14 @@ async fn control_plane_listener_starts_with_owner() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
 
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
 
     let endpoint = node
         .control_endpoint()
@@ -1146,8 +1152,14 @@ async fn control_plane_listener_uses_explicit_advertised_address() -> anyhow::Re
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
     let advertised_addr = std::net::SocketAddr::from(([203, 0, 113, 10], 18443));
 
-    node.maybe_start_control_listener(secret_key, None, Some(advertised_addr), None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        Some(advertised_addr),
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
 
     let endpoint = node
         .control_endpoint()
@@ -1173,6 +1185,7 @@ async fn control_plane_listener_disabled_without_owner() -> anyhow::Result<()> {
         Some("127.0.0.1:7447".parse().unwrap()),
         None,
         None,
+        &std::collections::HashMap::new(),
     )
     .await?;
 
@@ -1184,8 +1197,14 @@ async fn control_plane_listener_disabled_without_owner() -> anyhow::Result<()> {
 async fn control_plane_listener_accepts_only_control_alpn() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     let endpoint = Node::decode_invite_token(
         &node
             .control_endpoint()
@@ -1214,8 +1233,14 @@ async fn control_plane_listener_accepts_only_control_alpn() -> anyhow::Result<()
 async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     let control_endpoint = node
         .control_endpoint()
         .await
@@ -1245,8 +1270,14 @@ async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> 
 async fn control_plane_listener_shutdown_stops_listener_task() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     let endpoint = Node::decode_invite_token(
         &node
             .control_endpoint()
@@ -5128,8 +5159,14 @@ async fn start_owner_control_test_server(
     *node.owner_attestation.lock().await = Some(ownership);
     *node.owner_summary.lock().await = owner_summary;
     *node.trust_store.lock().await = trust_store;
-    node.maybe_start_control_listener(secret_key.clone(), None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key.clone(),
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     Ok((node, secret_key, config_path))
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -4976,9 +4976,12 @@ pub(crate) async fn run_plugin_mcp(cli: &Cli) -> Result<()> {
     let resolved_plugins = load_resolved_plugins(cli)?;
     let config = plugin::load_config(cli.config.as_deref())?;
     let owner_config = owner_runtime_config(cli, &config)?;
+    let relay_auths: std::collections::HashMap<String, String> =
+        cli.relay_auth.iter().cloned().collect();
     let (node, _channels) = mesh::Node::start(
         NodeRole::Client,
         &cli.relay,
+        &relay_auths,
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
             port: cli.bind_port,
@@ -5143,9 +5146,12 @@ async fn start_run_auto_node_and_plugins(
     };
     let owner_config = owner_runtime_config(cli, config)?;
     let max_vram = if cli.client { Some(0.0) } else { cli.max_vram };
+    let relay_auths: std::collections::HashMap<String, String> =
+        cli.relay_auth.iter().cloned().collect();
     let (node, channels) = mesh::Node::start(
         role,
         &cli.relay,
+        &relay_auths,
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
             port: cli.bind_port,


### PR DESCRIPTION
Adds a per-relay bearer token to the iroh relay map so mesh-llm can register with a gated iroh-relay (one running AccessConfig::Restricted) while public relays in the same map continue to register without auth.

This is a standard iroh feature so really this should just be exposing it.