### PR TITLE
fix(justfile): default optional args to empty string

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -204,7 +204,7 @@ skippy-wan-lab-build-bins:
     cargo build --release --locked -p skippy-server -p skippy-prompt -p metrics-server -p skippy-model-package
 
 # Generate a reproducible benchmark corpus for skippy bench tooling.
-bench-corpus tier="smoke" *ARGS:
+bench-corpus tier="smoke" *ARGS="":
     scripts/generate-bench-corpus.py "{{ tier }}" {{ ARGS }}
 
 # Run skippy family certification checks.
@@ -221,7 +221,7 @@ skippy-openai-smoke *ARGS:
     just with-lld scripts/skippy-openai-smoke.sh {{ ARGS }}
 
 # Run the skippy benchmark/debug telemetry collector.
-metrics-server db="/tmp/mesh-metrics.duckdb" http_addr="127.0.0.1:18080" otlp_addr="127.0.0.1:14317" *ARGS: metrics-server-build
+metrics-server db="/tmp/mesh-metrics.duckdb" http_addr="127.0.0.1:18080" otlp_addr="127.0.0.1:14317" *ARGS="": metrics-server-build
     target/debug/metrics-server serve --db "{{ db }}" --http-addr "{{ http_addr }}" --otlp-grpc-addr "{{ otlp_addr }}" {{ ARGS }}
 
 # Download the default model (GLM-4.7-Flash Q4_K_M, 17GB)


### PR DESCRIPTION
## Summary
Fixes default variadic argument handling in the `Justfile` for two recipes:
- `bench-corpus`
- `metrics-server`

Both recipes now default `*ARGS` to an empty string, allowing them to run without requiring extra arguments.

## Changes
- Updated `bench-corpus` from `*ARGS` to `*ARGS=""`
- Updated `metrics-server` from `*ARGS` to `*ARGS=""`

## Why
This prevents `just` recipe invocation failures when no additional arguments are provided, while preserving support for passing optional extra arguments when needed.

## Testing
`just build` now runs without errors on Linux