### PR TITLE
chore(github): Add lightweight issue templates to repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Report something broken or unexpectedly failing
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Problem
+
+What happened, and what did you expect instead?
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Diagnostics
+
+Include the command you ran, platform/backend, relevant logs, `/api/status` output if available, and whether this was a private mesh, published mesh, or `--auto` join.
+
+## Extra context
+
+Add screenshots, videos, links, or notes that may help us understand the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest a new capability or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Feature
+
+What would you like mesh-llm to do?
+
+## Problem or use case
+
+What problem does this solve, and who is it for?
+
+## Desired behavior
+
+What should happen when this works well?
+
+## Extra context
+
+Add examples, screenshots, links, or constraints that may help maintainers evaluate the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Title
+
+Use an accurate title that describes the user-visible change or fix.
+
+## Original problem
+
+What was broken, missing, confusing, or risky before this PR?
+
+## Diagnostics
+
+How did you verify the problem? Include commands, logs, screenshots, or links when useful.
+
+## Fix
+
+How does this PR fix the problem? Call out compatibility, protocol, or migration concerns if any.
+
+## Validation
+
+- [ ] I ran the relevant local checks, or explained why they do not apply.
+- [ ] UI changes include screenshots or video, or explain why visual aids are not needed.


### PR DESCRIPTION
## Summary
This PR adds issue templates for contributors to provide a guide for providing baseline minimum of information to reviewers.

Automatic bug / feature selection for new issues