### PR TITLE
Honor direct chat no-think requests

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -5425,6 +5425,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chat_reasoning_enabled_false_wins_over_nested_effort_before_forwarding() {
+        let body = serde_json::json!({
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning": {"enabled": false, "effort": "low"}
+        })
+        .to_string();
+        let raw = format!(
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let request = read_request_from_parts(vec![raw.into_bytes()]).await;
+        let forwarded = parse_json_body_from_http_request(&request.raw).unwrap();
+
+        assert_eq!(
+            forwarded["chat_template_kwargs"]["enable_thinking"],
+            serde_json::json!(false)
+        );
+        assert_eq!(request.body_json, Some(forwarded));
+    }
+
+    #[tokio::test]
     async fn test_read_http_request_large_body_over_32k() {
         let large = "x".repeat(40_000);
         let body = serde_json::json!({

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -677,12 +677,23 @@ fn request_requires_json_transform(path: &str, body: &[u8], plugin_manager_prese
 
     body_text.contains("\"max_completion_tokens\"")
         || body_text.contains("\"max_output_tokens\"")
+        || body_text_contains_chat_reasoning_template_options(body_text)
         || (plugin_manager_present
             && (body_text.contains("mesh://blob/")
                 || body_text.contains("\"blob_token\"")
                 || body_text.contains("\"mesh_token\"")
                 || body_text.contains("\"input_audio\"")
                 || body_text.contains("\"input_image\"")))
+}
+
+fn body_text_contains_chat_reasoning_template_options(body_text: &str) -> bool {
+    body_text.contains("\"reasoning\"")
+        || body_text.contains("\"reasoning_effort\"")
+        || body_text.contains("\"thinking_budget\"")
+        || body_text.contains("\"chat_template_kwargs\"")
+        || openai_frontend::THINKING_BOOLEAN_ALIASES
+            .iter()
+            .any(|field| body_text.contains(&format!("\"{field}\"")))
 }
 
 fn parse_json_body_from_http_request(raw: &[u8]) -> Option<serde_json::Value> {
@@ -5357,6 +5368,60 @@ mod tests {
         );
 
         assert!(request.body_json.is_none());
+    }
+
+    #[tokio::test]
+    async fn chat_reasoning_effort_none_is_canonicalized_before_forwarding() {
+        let body = serde_json::json!({
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "none"
+        })
+        .to_string();
+        let raw = format!(
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let request = read_request_from_parts(vec![raw.into_bytes()]).await;
+        let forwarded = parse_json_body_from_http_request(&request.raw).unwrap();
+
+        assert_eq!(
+            forwarded["chat_template_kwargs"]["enable_thinking"],
+            serde_json::json!(false)
+        );
+        assert_eq!(request.body_json, Some(forwarded));
+    }
+
+    #[tokio::test]
+    async fn chat_existing_template_kwargs_survive_forwarding_rewrite() {
+        let body = serde_json::json!({
+            "model": "qwen",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_completion_tokens": 32,
+            "reasoning_effort": "low",
+            "chat_template_kwargs": {
+                "enable_thinking": false,
+                "custom": "kept"
+            }
+        })
+        .to_string();
+        let raw = format!(
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+
+        let request = read_request_from_parts(vec![raw.into_bytes()]).await;
+        let forwarded = parse_json_body_from_http_request(&request.raw).unwrap();
+
+        assert_eq!(forwarded["max_tokens"], serde_json::json!(32));
+        assert!(forwarded.get("max_completion_tokens").is_none());
+        assert_eq!(
+            forwarded["chat_template_kwargs"],
+            serde_json::json!({"enable_thinking": false, "custom": "kept"})
+        );
     }
 
     #[tokio::test]

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -3,7 +3,7 @@ use serde_json::{Map, Value};
 
 use crate::{
     chat::{ChatCompletionChunk, ChatCompletionResponse},
-    common::Usage,
+    common::{Usage, THINKING_BOOLEAN_ALIASES},
     errors::OpenAiError,
 };
 
@@ -111,6 +111,149 @@ fn alias_max_tokens(object: &mut Map<String, Value>) -> bool {
         object.entry("max_tokens".to_string()).or_insert(value);
     }
     changed
+}
+
+fn normalize_chat_reasoning_template_options(
+    object: &mut Map<String, Value>,
+) -> Result<bool, OpenAiError> {
+    let mut enable_thinking = reasoning_object_override(object.get("reasoning"))?;
+
+    if let Some(effort) = optional_string_field(object, "reasoning_effort")? {
+        enable_thinking = Some(match effort {
+            "none" => false,
+            "minimal" | "low" | "medium" | "high" | "xhigh" => true,
+            _ => {
+                return Err(OpenAiError::invalid_request(
+                    "reasoning_effort must be one of none, minimal, low, medium, high, xhigh",
+                ));
+            }
+        });
+    }
+
+    for field in THINKING_BOOLEAN_ALIASES {
+        if let Some(enabled) = optional_bool_field(object, field)? {
+            enable_thinking = Some(enabled);
+        }
+    }
+    if optional_u32_field(object, "thinking_budget")? == Some(0) {
+        enable_thinking = Some(false);
+    }
+
+    if chat_template_kwargs_override(object)? {
+        return Ok(false);
+    }
+
+    let Some(enabled) = enable_thinking else {
+        return Ok(false);
+    };
+    let kwargs = ensure_chat_template_kwargs_object(object)?;
+    kwargs.insert("enable_thinking".to_string(), Value::Bool(enabled));
+    Ok(true)
+}
+
+fn reasoning_object_override(value: Option<&Value>) -> Result<Option<bool>, OpenAiError> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    let object = value
+        .as_object()
+        .ok_or_else(|| OpenAiError::invalid_request("reasoning must be an object"))?;
+    let mut enabled = optional_bool_field(object, "enabled")?;
+    if let Some(effort) = optional_string_field(object, "effort")? {
+        enabled = Some(match effort {
+            "none" => false,
+            "minimal" | "low" | "medium" | "high" | "xhigh" => true,
+            _ => {
+                return Err(OpenAiError::invalid_request(
+                    "reasoning.effort must be one of none, minimal, low, medium, high, xhigh",
+                ));
+            }
+        });
+    }
+    if optional_u32_field(object, "max_tokens")? == Some(0) {
+        enabled = Some(false);
+    }
+    Ok(enabled)
+}
+
+fn chat_template_kwargs_override(object: &Map<String, Value>) -> Result<bool, OpenAiError> {
+    let Some(value) = object.get("chat_template_kwargs") else {
+        return Ok(false);
+    };
+    if value.is_null() {
+        return Ok(false);
+    }
+    let kwargs = value
+        .as_object()
+        .ok_or_else(|| OpenAiError::invalid_request("chat_template_kwargs must be an object"))?;
+    for field in THINKING_BOOLEAN_ALIASES {
+        if optional_bool_field(kwargs, field)?.is_some() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+fn ensure_chat_template_kwargs_object(
+    object: &mut Map<String, Value>,
+) -> Result<&mut Map<String, Value>, OpenAiError> {
+    if !object.contains_key("chat_template_kwargs") {
+        object.insert(
+            "chat_template_kwargs".to_string(),
+            Value::Object(Map::new()),
+        );
+    }
+    object
+        .get_mut("chat_template_kwargs")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| OpenAiError::invalid_request("chat_template_kwargs must be an object"))
+}
+
+fn optional_bool_field(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<Option<bool>, OpenAiError> {
+    object
+        .get(field)
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_bool()
+                .ok_or_else(|| OpenAiError::invalid_request(format!("{field} must be a boolean")))
+        })
+        .transpose()
+}
+
+fn optional_string_field<'a>(
+    object: &'a Map<String, Value>,
+    field: &str,
+) -> Result<Option<&'a str>, OpenAiError> {
+    object
+        .get(field)
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| OpenAiError::invalid_request(format!("{field} must be a string")))
+        })
+        .transpose()
+}
+
+fn optional_u32_field(
+    object: &Map<String, Value>,
+    field: &str,
+) -> Result<Option<u32>, OpenAiError> {
+    object
+        .get(field)
+        .filter(|value| !value.is_null())
+        .map(|value| {
+            serde_json::from_value::<u32>(value.clone())
+                .map_err(|_| OpenAiError::invalid_request(format!("{field} must be an integer")))
+        })
+        .transpose()
 }
 
 fn map_response_role(role: &str) -> String {
@@ -406,7 +549,8 @@ pub fn normalize_openai_compat_request(
     let mut rewritten_path = None;
     let mut response_adapter = ResponseAdapterMode::None;
 
-    if path_only(path) == "/v1/responses" {
+    let path_only = path_only(path);
+    if path_only == "/v1/responses" {
         let is_stream = object
             .get("stream")
             .and_then(Value::as_bool)
@@ -418,6 +562,9 @@ pub fn normalize_openai_compat_request(
         } else {
             ResponseAdapterMode::OpenAiResponsesJson
         };
+    }
+    if matches!(path_only, "/v1/chat/completions" | "/v1/responses") {
+        changed |= normalize_chat_reasoning_template_options(object)?;
     }
 
     Ok(NormalizationOutcome {
@@ -1057,6 +1204,44 @@ mod tests {
         assert_eq!(body["response_format"]["type"], "json_schema");
         assert_eq!(body["logprobs"], true);
         assert_eq!(body["top_logprobs"], 3);
+    }
+
+    #[test]
+    fn normalize_chat_reasoning_effort_none_injects_template_kwargs() {
+        let mut body = json!({
+            "model": "direct-model",
+            "messages": [{"role": "user", "content": "What is 2+2?"}],
+            "reasoning_effort": "none"
+        });
+
+        let normalized = normalize_openai_compat_request("/v1/chat/completions", &mut body)
+            .expect("chat request should normalize");
+
+        assert!(normalized.changed);
+        assert_eq!(
+            body["chat_template_kwargs"]["enable_thinking"],
+            json!(false)
+        );
+        assert_eq!(body["reasoning_effort"], json!("none"));
+    }
+
+    #[test]
+    fn normalize_chat_template_kwargs_wins_over_reasoning_effort() {
+        let mut body = json!({
+            "model": "direct-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "low",
+            "chat_template_kwargs": {"enable_thinking": false, "custom": "kept"}
+        });
+
+        let normalized = normalize_openai_compat_request("/v1/chat/completions", &mut body)
+            .expect("chat request should normalize");
+
+        assert!(!normalized.changed);
+        assert_eq!(
+            body["chat_template_kwargs"],
+            json!({"enable_thinking": false, "custom": "kept"})
+        );
     }
 
     #[test]

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -161,22 +161,26 @@ fn reasoning_object_override(value: Option<&Value>) -> Result<Option<bool>, Open
     let object = value
         .as_object()
         .ok_or_else(|| OpenAiError::invalid_request("reasoning must be an object"))?;
-    let mut enabled = optional_bool_field(object, "enabled")?;
-    if let Some(effort) = optional_string_field(object, "effort")? {
-        enabled = Some(match effort {
-            "none" => false,
-            "minimal" | "low" | "medium" | "high" | "xhigh" => true,
-            _ => {
-                return Err(OpenAiError::invalid_request(
-                    "reasoning.effort must be one of none, minimal, low, medium, high, xhigh",
-                ));
-            }
-        });
+    let enabled = optional_bool_field(object, "enabled")?;
+    let effort = optional_string_field(object, "effort")?;
+    let effort_is_valid = match effort {
+        Some("none" | "minimal" | "low" | "medium" | "high" | "xhigh") | None => true,
+        Some(_) => false,
+    };
+    if !effort_is_valid {
+        return Err(OpenAiError::invalid_request(
+            "reasoning.effort must be one of none, minimal, low, medium, high, xhigh",
+        ));
     }
-    if optional_u32_field(object, "max_tokens")? == Some(0) {
-        enabled = Some(false);
+    let max_tokens = optional_u32_field(object, "max_tokens")?;
+
+    if enabled == Some(false) || effort == Some("none") || max_tokens == Some(0) {
+        Ok(Some(false))
+    } else if enabled == Some(true) || effort.is_some() || max_tokens.is_some() {
+        Ok(Some(true))
+    } else {
+        Ok(None)
     }
-    Ok(enabled)
 }
 
 fn chat_template_kwargs_override(object: &Map<String, Value>) -> Result<bool, OpenAiError> {
@@ -1241,6 +1245,24 @@ mod tests {
         assert_eq!(
             body["chat_template_kwargs"],
             json!({"enable_thinking": false, "custom": "kept"})
+        );
+    }
+
+    #[test]
+    fn normalize_chat_reasoning_enabled_false_wins_over_nested_effort() {
+        let mut body = json!({
+            "model": "direct-model",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning": {"enabled": false, "effort": "low"}
+        });
+
+        let normalized = normalize_openai_compat_request("/v1/chat/completions", &mut body)
+            .expect("chat request should normalize");
+
+        assert!(normalized.changed);
+        assert_eq!(
+            body["chat_template_kwargs"]["enable_thinking"],
+            json!(false)
         );
     }
 

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1074,6 +1074,19 @@ fn reasoning_effort_none_turns_off_chat_template_thinking() {
 }
 
 #[test]
+fn top_level_reasoning_effort_none_turns_off_chat_template_thinking() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
+        "messages": [{"role": "user", "content": "hello"}],
+        "reasoning_effort": "none"
+    }))
+    .unwrap();
+
+    let options = chat_template_options(&request).unwrap();
+    assert_eq!(options.enable_thinking, Some(false));
+}
+
+#[test]
 fn provider_enable_thinking_overrides_canonical_reasoning() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",


### PR DESCRIPTION
## Summary

Direct OpenAI-compatible chat requests now preserve explicit no-thinking intent when they are forwarded to downstream model backends.

This canonicalizes caller intent such as `reasoning_effort: "none"`, `reasoning.enabled=false`, provider thinking aliases, and `thinking_budget=0` into `chat_template_kwargs.enable_thinking=false` before forwarding. Existing `chat_template_kwargs` values remain authoritative and are not overwritten.

## Why

Issue #636 showed that direct pinned-model requests could still surface `<think>` content even when the caller explicitly requested no thinking.

The typed Skippy path already understands these options, but the host proxy forwarding path could pass the original request body through without translating the no-thinking intent into the backend-compatible chat-template shape. That meant behavior depended on every downstream backend understanding every caller-specific reasoning knob.

## What changed

- Canonicalizes `/v1/chat/completions` and translated `/v1/responses` bodies into `chat_template_kwargs.enable_thinking` when explicit thinking/no-thinking intent is present.
- Extends host-runtime forwarding detection so reasoning/template knobs trigger JSON body normalization before proxying.
- Preserves existing `chat_template_kwargs` overrides and unrelated request fields.
- Preserves nested no-thinking precedence, so `reasoning.enabled=false` wins over `reasoning.effort="low"` before forwarding.
- Adds regressions for both the normalization layer and the relayed host-runtime forwarding path.
- Adds Skippy-server coverage for the top-level `reasoning_effort: "none"` request shape.

## Scope relative to #645

This PR stays scoped to request-side compatibility normalization before the direct forwarding/proxy path sends a body to a downstream OpenAI-compatible backend.

#645 is the broader guardrail/output-contract layer and should continue to own tool rescue, structured-output retries, and output cleanup. This PR does not try to duplicate that middleware path, and it should remain useful even while #645 settles because it does not depend on opt-in guardrails.

## Compatibility

This is an HTTP-body-only compatibility fix.

No protobuf, gossip, mesh protocol, catalog, or Skippy ABI changes. Older peers and existing model-serving paths should continue to ignore unknown request fields as before.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@c7948d7181f26ed8cf99f9389a7deb8988162a32`
- Branch state: `0 behind / 2 ahead`
- Head commit: `a915c43199bbee9046c1e412ef2e24cf5f1ddeba`

## Validation

- Validation tier: Tier 2R - narrow post-review correction on top of the existing OpenAI-compatible direct chat request normalization PR.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `c7948d7181f26ed8cf99f9389a7deb8988162a32`.
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all`: PASS
- `cargo fmt --all -- --check`: PASS
- `cargo test -p openai-frontend normalize_chat_reasoning_enabled_false_wins_over_nested_effort --lib`: FAIL before fix, reproduced reviewer edge case.
- `cargo test -p openai-frontend normalize_chat --lib`: PASS, 4 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime chat_reasoning_enabled_false_wins_over_nested_effort_before_forwarding --lib`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime chat_reasoning_effort_none_is_canonicalized_before_forwarding --lib`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime chat_existing_template_kwargs_survive_forwarding_rewrite --lib`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo test -p skippy-server top_level_reasoning_effort_none_turns_off_chat_template_thinking --lib`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<repo>/.deps/llama-build/build-stage-abi-metal /opt/homebrew/bin/cargo-clippy clippy -p openai-frontend -p skippy-server -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - post-review compatibility precedence correction only; no release/version sync required.
- Remote CI: PASS on final SHA `a915c43199bbee9046c1e412ef2e24cf5f1ddeba` (PR Builds, PR Docker Build, and PR Quality Checks).
- Not run: live MiniMax/Qwen direct-model smoke - not required for this deterministic precedence correction.
- Not run: two-node mesh or agent harness - not required for selected Tier 2R correction.

## Rollback

Revert this PR.

DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveats: none known.

## Residual risk

The original hosted-model symptom should still be confirmed against the affected live endpoint. This PR proves the deterministic request-normalization and forwarding path locally, but does not claim to solve unrelated `<think>` leakage outside that path.

