### PR TITLE
Add split onboarding flow for Command A+ candidates

### DIFF
--- a/.github/workflows/queue-unsloth-layer-packages.yml
+++ b/.github/workflows/queue-unsloth-layer-packages.yml
@@ -5,10 +5,22 @@ on:
     - cron: "23 17 * * *"
   workflow_dispatch:
     inputs:
+      author:
+        description: "Hugging Face author or organization to scan"
+        required: false
+        default: "unsloth"
+      search:
+        description: "Hugging Face model search query"
+        required: false
+        default: "GGUF"
       max_jobs:
         description: "Maximum HF Jobs to submit"
         required: false
         default: "5"
+      max_per_family:
+        description: "Maximum queued model(s) per inferred family"
+        required: false
+        default: "1"
       confirm:
         description: "Actually submit HF Jobs and wait for completion"
         required: false
@@ -22,6 +34,10 @@ on:
         description: "Comma-separated 4-bit quant preference"
         required: false
         default: "UD-Q4_K_XL,UD-Q4_K_M,Q4_K_XL,Q4_K_M"
+      split_candidate_vram_gib:
+        description: "Minimum selected-quant size in GiB for split-job candidates"
+        required: false
+        default: "8"
 
 permissions:
   contents: read
@@ -37,10 +53,14 @@ jobs:
     env:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
       GITHUB_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      AUTHOR: ${{ github.event.inputs.author || 'unsloth' }}
+      SEARCH: ${{ github.event.inputs.search || 'GGUF' }}
       MAX_JOBS: ${{ github.event.inputs.max_jobs || '5' }}
+      MAX_PER_FAMILY: ${{ github.event.inputs.max_per_family || '1' }}
       CONFIRM: ${{ github.event.inputs.confirm || 'false' }}
       MESH_LLM_REF: ${{ github.event.inputs.mesh_llm_ref || 'main' }}
       QUANT_PREFERENCE: ${{ github.event.inputs.quant_preference || 'UD-Q4_K_XL,UD-Q4_K_M,Q4_K_XL,Q4_K_M' }}
+      SPLIT_CANDIDATE_VRAM_GIB: ${{ github.event.inputs.split_candidate_vram_gib || '8' }}
 
     steps:
       - uses: actions/checkout@v5
@@ -57,9 +77,13 @@ jobs:
           set -euo pipefail
 
           args=(
+            --author "$AUTHOR"
+            --search "$SEARCH"
             --max-jobs "$MAX_JOBS"
+            --max-per-family "$MAX_PER_FAMILY"
             --mesh-llm-ref "$MESH_LLM_REF"
             --quant-preference "$QUANT_PREFERENCE"
+            --split-candidate-vram-gib "$SPLIT_CANDIDATE_VRAM_GIB"
           )
 
           if [[ "$CONFIRM" == "true" ]]; then

--- a/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
+++ b/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
@@ -410,7 +410,9 @@ where
 fn print_help() {
     println!(
         "queue-unsloth-layer-packages\n\n\
-         Options:\n\
+           Options:\n\
+           --author HF_AUTHOR_OR_ORG\n\
+           --search QUERY\n\
            --max-jobs N\n\
            --max-per-family N\n\
            --confirm\n\

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Use this hub to find project guides that are not owned by a single Rust crate.
 | Doc | What it covers |
 |---|---|
 | [skippy/FAMILY_STATUS.md](skippy/FAMILY_STATUS.md) | Certified family/split/wire-dtype status |
+| [skippy/NEW_MODEL_ONBOARDING.md](skippy/NEW_MODEL_ONBOARDING.md) | New-model split/certification intake checklist |
 | [skippy/FAMILY_CERTIFY.md](skippy/FAMILY_CERTIFY.md) | Certification workflow for new families |
 | [skippy/TOPOLOGY_PLANNER.md](skippy/TOPOLOGY_PLANNER.md) | Stage topology planning behavior |
 | [skippy/DATA_FLOW.md](skippy/DATA_FLOW.md) | Stage data flow and transport details |

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -90,6 +90,10 @@ eligible derived cache entries.
 
 ## Verify a package before rollout
 
+For a brand-new model family or a large sharded GGUF candidate, start with the
+[new model onboarding checklist](skippy/NEW_MODEL_ONBOARDING.md) before adding a
+support-matrix entry.
+
 Package-only verification checks resolution, artifact integrity, and local stage
 materialization:
 

--- a/docs/skippy/FAMILY_CERTIFY.md
+++ b/docs/skippy/FAMILY_CERTIFY.md
@@ -4,7 +4,11 @@ Use this runbook to certify a model family for the stage-split runtime. Keep it
 operator-facing; the customer-facing support matrix lives elsewhere.
 
 Current supported families, recommended artifacts, and shipping settings live in
-`docs/FAMILY_STATUS.md`.
+`docs/skippy/FAMILY_STATUS.md`.
+
+For a new model that is not already in the support matrix, start with
+`docs/skippy/NEW_MODEL_ONBOARDING.md` before adding reviewed family policy or a
+customer-facing support row.
 
 ## What Certified Means
 
@@ -70,8 +74,9 @@ just family-certify FAMILY /path/to/target.gguf \
 
 Before promoting neural draft support, run a target/draft preflight with the
 `spec-bench` workflow to prove tokenizer compatibility and useful acceptance.
-Do not list neural draft as a shipping feature in `docs/FAMILY_STATUS.md` until
-that preflight and staged prompt/spec lane pass.
+Do not list neural draft as a shipping feature in
+`docs/skippy/FAMILY_STATUS.md` until that preflight and staged prompt/spec lane
+pass.
 
 ## Large Model Lifecycle
 
@@ -92,8 +97,8 @@ shortcut.
 
 After a meaningful run:
 
-1. Update `docs/FAMILY_STATUS.md` first. This is the source of truth for what a
-   customer can run and with which settings.
+1. Update `docs/skippy/FAMILY_STATUS.md` first. This is the source of truth for
+   what a customer can run and with which settings.
 2. Promote the reviewed capability record in
    `crates/skippy-topology/capabilities/reviewed-family-capabilities.json`
    when the run should drive planner policy.

--- a/docs/skippy/LLAMA_PARITY.md
+++ b/docs/skippy/LLAMA_PARITY.md
@@ -9,6 +9,11 @@ that family is certified. It means the family has at least one reviewed artifact
 that proves the stage ABI, activation handoff, topology policy, and cache policy
 work together.
 
+For new large-model requests that do not already have a cheap representative,
+start with [NEW_MODEL_ONBOARDING.md](NEW_MODEL_ONBOARDING.md). Keep those models
+as onboarding candidates until package, runtime, and family evidence is strong
+enough to promote.
+
 ## Workflow
 
 1. Join the pinned llama.cpp inventory with the candidate manifest:

--- a/docs/skippy/NEW_MODEL_ONBOARDING.md
+++ b/docs/skippy/NEW_MODEL_ONBOARDING.md
@@ -1,0 +1,127 @@
+# New Model Split Onboarding
+
+Use this checklist for new-model requests before adding a family to the
+customer-facing Skippy support matrix. The goal is to make split onboarding
+repeatable without accidentally advertising a model before the current
+llama.cpp pin, package writer, staged runtime, cache policy, and serving path
+have real evidence.
+
+Issue #630, Cohere Command A+, is the first model tracked with this flow.
+
+## Evidence Levels
+
+| Level | Meaning | Promotion effect |
+| --- | --- | --- |
+| Candidate identified | A source model and at least one plausible GGUF or package artifact are known. | No support claim. |
+| Artifact inspected | GGUF metadata or package manifest gives architecture, layer count, activation width, quant, shard layout, and tokenizer sidecars. | May plan a package job. |
+| Package validated | `skippy-model-package` writes and validates a package with no missing, duplicate, or checksum-mismatched owned tensors. | May test staged serving. |
+| Runtime smoke passed | A package-backed model starts and answers through the OpenAI-compatible surface. | May collect serving evidence. |
+| Family certified | Split correctness, dtype matrix, state handoff/cache policy, and required multimodal sidebands pass. | May promote to reviewed support. |
+| Reviewed support | `docs/skippy/FAMILY_STATUS.md` and reviewed topology records are updated from evidence. | User-visible support claim. |
+
+Do not skip from candidate to reviewed support. A big or popular model is still
+only a candidate until the evidence exists.
+
+## Decision Tree
+
+1. Start from the source model and record the exact Hugging Face repo, revision,
+   license, architecture, model type, modality, and file layout.
+2. If the source repo is safetensors-only, find or produce a GGUF before any
+   Skippy split claim. The staged runtime cannot certify a safetensors source
+   directly.
+3. If the GGUF is sharded, inspect the first shard and keep the full shard set
+   available for package writing or runtime loading.
+4. If the model is MoE, recurrent, hybrid, multimodal, or uses custom
+   llama.cpp support, treat it as high risk until the pinned llama.cpp tree can
+   load and inspect it.
+5. Run package validation before runtime certification for models too large for
+   a local full-model parity pass.
+6. Promote only after the evidence maps cleanly to both
+   `docs/skippy/FAMILY_STATUS.md` and
+   `crates/skippy-topology/capabilities/reviewed-family-capabilities.json`.
+
+## Standard Checks
+
+Validate the parity manifest and current llama.cpp family inventory:
+
+```bash
+python3 scripts/skippy-llama-parity.py validate
+python3 scripts/skippy-llama-parity.py inventory --priority p0
+```
+
+List a candidate package job without spending HF Jobs credits:
+
+```bash
+cargo run -p model-package --bin queue-unsloth-layer-packages -- \
+  --author DevQuasar \
+  --search command-a-plus \
+  --max-jobs 1 \
+  --max-per-family 1 \
+  --quant-preference Q4_K_M,Q3_K_M \
+  --dry-run
+```
+
+For a selected GGUF repo and quant, use the normal package CLI in dry-run mode:
+
+```bash
+mesh-llm models package DevQuasar/CohereLabs.command-a-plus-05-2026-bf16-GGUF:Q4_K_M --dry-run
+```
+
+After a package exists, validate the package and then run the certification
+surface that matches the evidence you need:
+
+```bash
+skippy-model-package validate-package /path/to/package
+mesh-llm models certify hf://namespace/repo@revision --package-only --report-out cert.json
+mesh-llm models certify hf://namespace/repo@revision --api-base http://127.0.0.1:9337 --json
+```
+
+Full family promotion still uses the family certification runbook:
+
+```bash
+just family-certify FAMILY /path/to/model.gguf ...
+```
+
+## Cohere Command A+ Starter Record
+
+Current request:
+
+- Issue: `#630`
+- Source model: `CohereLabs/command-a-plus-05-2026-bf16`
+- Current source shape: safetensors-only, `model_type=cohere2_vision`,
+  `pipeline_tag=image-text-to-text`, 9 safetensors shards.
+- Candidate GGUF: `DevQuasar/CohereLabs.command-a-plus-05-2026-bf16-GGUF`
+- Candidate GGUF shape: third-party Q3_K_M and Q4_K_M sharded GGUF artifacts.
+- Known risk: the candidate GGUF model card marks support as experimental and
+  points at a custom llama.cpp branch for `cohere2-moe-support`.
+
+Treat this as a candidate, not support. Do not add Command A+ to
+`FAMILY_STATUS.md`, `reviewed-family-capabilities.json`, or the catalog until:
+
+1. The pinned mesh-llm llama.cpp tree can inspect/load the selected GGUF.
+2. Package writing and `validate-package` pass for the selected quant.
+3. The package-backed runtime smoke passes through `/v1/models`,
+   `/v1/chat/completions`, and `/v1/responses`.
+4. Text split evidence passes for the selected topology.
+5. Vision/projector/media sideband evidence passes before any multimodal
+   support claim.
+6. MoE/cache policy is explicitly reviewed instead of inheriting the older
+   Command-R7B `cohere2` evidence.
+
+The existing `Cohere2` support row covers a Command-R7B-style text GGUF. It is
+not proof that Command A+ / `cohere2_vision` / `cohere2_moe` can be split by
+the current runtime.
+
+## Promotion Rule
+
+Every promotion PR must state:
+
+- exact source and package artifact refs;
+- selected quant and shard layout;
+- package validation result;
+- runtime certification result;
+- family certification result or explicit package-only rationale;
+- cache/state policy decision;
+- whether multimodal support was tested or intentionally left unsupported.
+
+If any of those are unknown, keep the model in candidate/onboarding state.

--- a/docs/skippy/NEW_MODEL_ONBOARDING.md
+++ b/docs/skippy/NEW_MODEL_ONBOARDING.md
@@ -95,6 +95,19 @@ Current request:
 - Known risk: the candidate GGUF model card marks support as experimental and
   points at a custom llama.cpp branch for `cohere2-moe-support`.
 
+Current certification status:
+
+| Gate | Command A+ candidate status |
+| --- | --- |
+| Pinned mesh-llm llama.cpp inspect/load | Not run |
+| Package write and `validate-package` | Not run |
+| `/v1/models` runtime smoke | Not run |
+| `/v1/chat/completions` runtime smoke | Not run |
+| `/v1/responses` runtime smoke | Not run |
+| Text split evidence | Not run |
+| Vision/projector/media sideband evidence | Not run |
+| MoE and cache-policy review | Not run |
+
 Treat this as a candidate, not support. Do not add Command A+ to
 `FAMILY_STATUS.md`, `reviewed-family-capabilities.json`, or the catalog until:
 

--- a/scripts/skippy-llama-parity.py
+++ b/scripts/skippy-llama-parity.py
@@ -26,6 +26,7 @@ from typing import Any
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MANIFEST = ROOT / "docs/skippy/llama-parity-candidates.json"
 DEFAULT_UPSTREAM_PIN = ROOT / "third_party/llama.cpp/upstream.txt"
+SHARDED_GGUF_RE = re.compile(r"-0*(\d+)-of-0*\d+\.gguf$", re.IGNORECASE)
 
 
 def repo_cache_dir(repo: str) -> Path:
@@ -137,6 +138,16 @@ def filter_priority(
     return [row for row in rows if str(row.get("priority", "p2")).lower() in requested]
 
 
+def candidate_file_rank(path: Path) -> int:
+    name = path.name.lower()
+    if "mmproj" in name:
+        return 3
+    shard = SHARDED_GGUF_RE.search(name)
+    if shard:
+        return 0 if int(shard.group(1)) == 1 else 2
+    return 1
+
+
 def resolve_candidate_file(candidate: dict[str, Any]) -> Path | None:
     repo = candidate.get("repo")
     include = candidate.get("include", "*.gguf")
@@ -152,7 +163,7 @@ def resolve_candidate_file(candidate: dict[str, Any]) -> Path | None:
         return None
     matches.sort(
         key=lambda path: (
-            "mmproj" in path.name.lower(),
+            candidate_file_rank(path),
             path.stat().st_size,
             str(path),
         )

--- a/scripts/tests/test_skippy_llama_parity.py
+++ b/scripts/tests/test_skippy_llama_parity.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "skippy-llama-parity.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("skippy_llama_parity", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class SkippyLlamaParityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parity = load_module()
+
+    def test_resolves_first_gguf_shard_for_split_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            previous_cache = os.environ.get("HF_HUB_CACHE")
+            cache_root = Path(tmp) / "hub"
+            snapshot = (
+                cache_root
+                / "models--DevQuasar--CohereLabs.command-a-plus-05-2026-bf16-GGUF"
+                / "snapshots"
+                / "abc123"
+            )
+            snapshot.mkdir(parents=True)
+            first_shard = (
+                snapshot
+                / "CohereLabs.command-a-plus-05-2026-bf16-Q4_K_M-00001-of-00009.gguf"
+            )
+            last_shard = (
+                snapshot
+                / "CohereLabs.command-a-plus-05-2026-bf16-Q4_K_M-00009-of-00009.gguf"
+            )
+            mmproj = snapshot / "mmproj-CohereLabs.command-a-plus-05-2026-bf16.gguf"
+            first_shard.write_bytes(b"larger-first-shard")
+            last_shard.write_bytes(b"x")
+            mmproj.write_bytes(b"")
+            os.environ["HF_HUB_CACHE"] = str(cache_root)
+            try:
+                resolved = self.parity.resolve_candidate_file(
+                    {
+                        "repo": "DevQuasar/CohereLabs.command-a-plus-05-2026-bf16-GGUF",
+                        "include": "*Q4_K_M*.gguf",
+                    }
+                )
+            finally:
+                if previous_cache is None:
+                    os.environ.pop("HF_HUB_CACHE", None)
+                else:
+                    os.environ["HF_HUB_CACHE"] = previous_cache
+
+        self.assertEqual(resolved, first_shard)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Refs #630.

Adds an evidence-gated Skippy split/certification onboarding path for new-model requests, with Cohere Command A+ as the first tracked candidate.

This is intentionally not a Command A+ support claim. Command A+ certification has not been run in this PR. The model remains candidate-level until the selected GGUF/package can be inspected by the pinned mesh-llm llama.cpp tree, package validation passes, runtime smoke passes, and the relevant split, multimodal, MoE, and cache-policy evidence is collected.

## Why

Issue #630 asks whether Cohere Command A+ can be split and tested for mesh. The current evidence is not strong enough for a support-matrix promotion: the source model is safetensors-only, the available public GGUF candidate is third-party and sharded, and its model card describes experimental support that may depend on custom llama.cpp work.

This PR creates the repeatable, reviewable path to evaluate that kind of model honestly before making any user-visible support claim.

The existing `cohere2` certification evidence is useful context only. It is not treated as proof for Command A+ / `cohere2_vision` / `cohere2_moe`.

## Diff scope

- Adds `docs/skippy/NEW_MODEL_ONBOARDING.md` with evidence levels, a decision tree, standard checks, promotion rules, and a Cohere Command A+ starter record.
- Clarifies that Command A+ certification has not been run yet by marking pinned llama.cpp inspection/load, package write + `validate-package`, `/v1/models`, `/v1/chat/completions`, `/v1/responses`, text split, multimodal sideband, and MoE/cache-policy gates as `Not run`.
- Links the onboarding checklist from the docs hub, Skippy split guide, family-certification runbook, and llama parity guide.
- Fixes `scripts/skippy-llama-parity.py` so sharded GGUF candidates resolve the first `00001-of-...` shard before later shards or mmproj files.
- Adds regression coverage for the sharded GGUF resolver behavior.
- Extends the layer-package queue workflow dispatch inputs with `author`, `search`, `max_per_family`, and `split_candidate_vram_gib`, so maintainers can dry-run non-Unsloth candidates without code changes.
- Updates queue CLI help to show the already-supported `--author` and `--search` options.

## Compatibility

No mesh protocol, protobuf, gossip, Skippy ABI, catalog, or runtime serving behavior changes.

The workflow changes are additive. Real HF Jobs submission remains opt-in through `confirm`; the Command A+ path documented here stays dry-run/package-validation first.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@73d91355b8f975b524065a83d4b5b30d070cf23c`
- Rebase onto current `origin/main`: PASS
- Branch state: `0 behind / 2 ahead`
- Head commit: `54a44c7d3c16108bf4894352946f07cb1756a228`

## Validation

- Validation tier: Tier 4 - verification tooling, workflow dispatch inputs, and Skippy split-certification onboarding docs for issue #630.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `73d91355b8f975b524065a83d4b5b30d070cf23c`.
- `git fetch --no-tags fork codex/cohere-command-a-split-onboarding:refs/remotes/fork/codex/cohere-command-a-split-onboarding`: PASS, remote branch was `d43cceeca22d3c203e994a1e4bd3665ab002eabb` before rebase.
- `git rebase origin/main`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `python3 -m unittest discover -s scripts/tests`: PASS, 17 passed
- `python3 scripts/skippy-llama-parity.py validate`: PASS, no output
- `ruby -ryaml -e 'YAML.load_file(ARGV.fetch(0)); puts "ok"' .github/workflows/queue-unsloth-layer-packages.yml`: PASS, ok
- `cargo fmt --all -- --check`: PASS
- `cargo check -p model-package --bin queue-unsloth-layer-packages`: PASS
- `cargo test -p model-package --lib`: PASS, 8 passed
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - onboarding/tooling/docs clarification only; no release/version sync required.
- Remote CI: PASS on final SHA `54a44c7d3c16108bf4894352946f07cb1756a228` (PR Builds, PR Docker Build, and PR Quality Checks completed successfully; workflow-skipped optional SDK/UI/live-smoke jobs remained skipped by repository conditions).
- Not run: `actionlint` - not installed locally.
- Not run: real HF Jobs submission or package publication - intentionally avoided for PR validation.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

Command A+ is still not certified by this PR, and #630 should remain open until the actual promotion checks pass.

The next proof step is to confirm whether the pinned mesh-llm llama.cpp tree can inspect/load the selected GGUF candidate, then run package validation, runtime certification through `/v1/models`, `/v1/chat/completions`, and `/v1/responses`, and only then consider support-matrix or reviewed-topology promotion.