### PR TITLE
feat(embed): mesh_llm::embed — in-process NodeBuilder/NodeHandle for Rust consumers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if 1.0.4",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,6 +260,45 @@ dependencies = [
  "serde",
  "serde_derive",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "asn1-rs"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1473,6 +1525,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if 1.0.4",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1543,6 +1609,20 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom 7.1.3",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2382,6 +2462,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -3059,6 +3145,7 @@ version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
 dependencies = [
+ "axum",
  "backon",
  "blake3",
  "bytes",
@@ -3158,12 +3245,20 @@ version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
 dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
  "portable-atomic",
+ "reqwest 0.13.2",
+ "rustls",
+ "rustls-platform-verifier 0.7.0",
  "ryu",
  "serde",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3185,9 +3280,12 @@ version = "1.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
 dependencies = [
+ "ahash",
  "blake3",
  "bytes",
  "cfg_aliases",
+ "clap",
+ "dashmap",
  "data-encoding",
  "derive_more",
  "getrandom 0.4.2",
@@ -3208,17 +3306,28 @@ dependencies = [
  "pin-project",
  "postcard",
  "rand 0.10.1",
+ "rcgen",
+ "reloadable-state",
  "reqwest 0.13.2",
  "rustls",
+ "rustls-cert-file-reader",
+ "rustls-cert-reloadable-resolver",
  "rustls-pki-types",
  "serde",
  "serde_bytes",
+ "serde_json",
+ "sha1 0.11.0",
+ "simdutf8",
  "strum 0.28.0",
+ "time",
  "tokio",
  "tokio-rustls",
+ "tokio-rustls-acme",
  "tokio-util",
  "tokio-websockets",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
+ "tracing-subscriber",
  "url",
  "vergen-gitcl",
  "webpki-roots 1.0.6",
@@ -3715,10 +3824,12 @@ dependencies = [
  "crypto_box",
  "dirs",
  "ed25519-dalek",
+ "futures-util",
  "hex",
  "hf-hub",
  "httparse",
  "iroh",
+ "iroh-relay",
  "keyring",
  "libc",
  "mdns-sd",
@@ -3764,7 +3875,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -4341,6 +4452,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "sorted-index-buffer",
  "thiserror 2.0.18",
@@ -4715,6 +4827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4998,6 +5119,16 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
 ]
 
 [[package]]
@@ -5816,6 +5947,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redb"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5900,6 +6045,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reloadable-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dc20ac1418988b60072d783c9f68e28a173fb63493c127952f6face3b40c6e0"
+
+[[package]]
+name = "reloadable-state"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3853ef78d45b50f8b989896304a85239539d39b7f866a000e8846b9b72d74ce8"
+dependencies = [
+ "arc-swap",
+ "reloadable-core",
+ "tokio",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5974,7 +6136,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6112,6 +6274,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6151,6 +6322,40 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-cert-file-reader"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb47c2a50fdfdaf95b0ac8b12620fc327da1fd4adbb30d0c56d866b005873ff"
+dependencies = [
+ "rustls-cert-read",
+ "rustls-pki-types",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "rustls-cert-read"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd46e8c5ae4de3345c4786a83f99ec7aff287209b9e26fa883c473aeb28f19d5"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-cert-reloadable-resolver"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1baa8a3a1f05eaa9fc55aed4342867f70e5c170ea3bfed1b38c51a4857c0c8"
+dependencies = [
+ "futures-util",
+ "reloadable-state",
+ "rustls",
+ "rustls-cert-read",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6194,6 +6399,27 @@ dependencies = [
  "security-framework-sys",
  "webpki-root-certs",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6618,6 +6844,17 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -7438,6 +7675,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls-acme"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af8573b15fdad8d66da116198cd8fd8d87ff62a67c1c6c3df7f62da1170793f"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "log",
+ "num-bigint",
+ "pem",
+ "proc-macro2",
+ "rcgen",
+ "reqwest 0.13.2",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 1.0.6",
+ "x509-parser",
+]
+
+[[package]]
 name = "tokio-socks"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7527,6 +7792,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -7770,7 +8050,7 @@ dependencies = [
  "rand 0.9.2",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -7900,7 +8180,7 @@ dependencies = [
  "serde",
  "tempfile",
  "textwrap",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_internal_macros",
  "uniffi_meta",
  "uniffi_pipeline",
@@ -7956,7 +8236,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.117",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "uniffi_meta",
 ]
 
@@ -9002,6 +9282,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom 7.1.3",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9182,6 +9480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9225,7 +9532,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "serde_repr",
- "sha1",
+ "sha1 0.10.6",
  "static_assertions",
  "tracing",
  "uds_windows",

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -91,3 +91,10 @@ axum = "0.8"
 serial_test = "3"
 mesh-client = { package = "mesh-llm-client", path = "../mesh-client" }
 tempfile = "3"
+# Used by the gated-relay regression test to spawn an in-process iroh-relay
+# with AccessConfig::Restricted, then build a real iroh::Endpoint from our
+# relay_map_from_urls output and verify --relay-auth tokens reach the relay
+# on the WebSocket upgrade (and that the wrong token is rejected).
+iroh = { version = "1.0.0-rc.0", features = ["test-utils"] }
+iroh-relay = { version = "1.0.0-rc.0", features = ["server", "test-utils"] }
+futures-util = "0.3"

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -8,6 +8,58 @@ use crate::cli::runtime::RuntimeCommand;
 use crate::crypto::TrustPolicy;
 use crate::network::discovery::MeshDiscoveryMode;
 
+/// Parse a `URL=TOKEN` pair for `--relay-auth`. Splits on the first `=` only,
+/// so tokens may contain `=` (base64 padding, JWTs).
+fn parse_relay_auth_pair(s: &str) -> Result<(String, String), String> {
+    let Some((url, token)) = s.split_once('=') else {
+        return Err(format!(
+            "expected URL=TOKEN, got {s:?} (no '=' separator found)"
+        ));
+    };
+    if url.is_empty() {
+        return Err(format!("expected URL=TOKEN, got empty URL in {s:?}"));
+    }
+    if token.is_empty() {
+        return Err(format!("expected URL=TOKEN, got empty token in {s:?}"));
+    }
+    Ok((url.to_string(), token.to_string()))
+}
+
+#[cfg(test)]
+mod relay_auth_parser_tests {
+    use super::parse_relay_auth_pair;
+
+    #[test]
+    fn parses_simple_pair() {
+        let (url, token) = parse_relay_auth_pair("https://r.example/=abc123").unwrap();
+        assert_eq!(url, "https://r.example/");
+        assert_eq!(token, "abc123");
+    }
+
+    #[test]
+    fn preserves_equals_in_token() {
+        // Base64-padded tokens and NIP-98-style payloads often contain `=`.
+        let (_, token) = parse_relay_auth_pair("https://r/=eyJhbGciOiJFZERTQSJ9.payload==")
+            .expect("token with '=' must parse");
+        assert_eq!(token, "eyJhbGciOiJFZERTQSJ9.payload==");
+    }
+
+    #[test]
+    fn rejects_missing_separator() {
+        assert!(parse_relay_auth_pair("no-separator").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_url() {
+        assert!(parse_relay_auth_pair("=token").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_token() {
+        assert!(parse_relay_auth_pair("https://r/=").is_err());
+    }
+}
+
 #[derive(Subcommand, Debug)]
 pub(crate) enum TrustCommand {
     /// Add an owner to the local trust store allowlist.
@@ -379,6 +431,17 @@ pub(crate) struct Cli {
     /// Override iroh relay URLs.
     #[arg(long, hide = true)]
     pub(crate) relay: Vec<String>,
+
+    /// Per-relay bearer token for gated iroh relays, formatted as
+    /// `URL=TOKEN`. Repeatable. The token is sent as
+    /// `Authorization: Bearer <TOKEN>` on the WebSocket upgrade to the
+    /// matching `--relay` URL. Relays not listed here register without
+    /// authentication (the correct behavior for public relays).
+    ///
+    /// Splits on the first `=` only, so tokens may contain `=` (base64
+    /// padding, JWTs, etc.).
+    #[arg(long = "relay-auth", value_parser = parse_relay_auth_pair, hide = true)]
+    pub(crate) relay_auth: Vec<(String, String)>,
 
     /// Bind QUIC to a fixed UDP port (for NAT port forwarding).
     #[arg(long, hide = true)]

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -850,6 +850,7 @@ where
         "--draft",
         "--bin-dir",
         "--relay",
+        "--relay-auth",
         "--nostr-relay",
         "--config",
         "--owner-key",
@@ -1108,6 +1109,72 @@ mod tests {
                 .into_iter()
                 .map(OsString::from)
                 .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn normalize_runtime_surface_args_treats_relay_auth_as_value_taking_before_serve() {
+        // Regression: --relay-auth carries a `URL=TOKEN` value, so the
+        // pseudo-subcommand scanner must skip the value and still discover
+        // `serve` (or `client`) as the runtime surface. If --relay-auth is not
+        // in the value-taking list the scanner stops at the token and Clap
+        // sees a malformed command.
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "--relay-auth",
+            "https://gated.example/=token",
+            "serve",
+            "--relay",
+            "https://gated.example/",
+            "--auto",
+        ]);
+
+        assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Serve));
+        assert_eq!(
+            normalized.normalized,
+            vec![
+                "mesh-llm",
+                "--relay-auth",
+                "https://gated.example/=token",
+                "--relay",
+                "https://gated.example/",
+                "--auto",
+            ]
+            .into_iter()
+            .map(OsString::from)
+            .collect::<Vec<_>>()
+        );
+
+        // And the resulting argv must actually parse cleanly through Clap so
+        // the relay-auth value reaches `Cli::relay_auth`.
+        let cli = Cli::try_parse_from(&normalized.normalized).expect("clap parse");
+        assert_eq!(
+            cli.relay_auth,
+            vec![("https://gated.example/".to_string(), "token".to_string())],
+        );
+    }
+
+    #[test]
+    fn normalize_runtime_surface_args_relay_auth_before_client_invocation() {
+        // Same regression but for the `client` surface, including a token
+        // containing `=` (NIP-98-style base64 padding).
+        let normalized = normalize_runtime_surface_args([
+            "mesh-llm",
+            "--relay-auth",
+            "https://gated.example/=eyJhbGciOiJFZERTQSJ9.payload==",
+            "client",
+            "--auto",
+        ]);
+
+        assert_eq!(normalized.explicit_surface, Some(RuntimeSurface::Client));
+        let cli = Cli::try_parse_from(&normalized.normalized).expect("clap parse");
+        assert!(cli.client, "client surface flag should be set");
+        assert_eq!(
+            cli.relay_auth,
+            vec![(
+                "https://gated.example/".to_string(),
+                "eyJhbGciOiJFZERTQSJ9.payload==".to_string()
+            )],
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/embed.rs
+++ b/crates/mesh-llm-host-runtime/src/embed.rs
@@ -1,0 +1,314 @@
+//! Embed mesh-llm in a Rust application.
+//!
+//! This module is the **public, stable** Rust API for running a mesh-llm node
+//! in-process. Use it when you want to ship mesh-llm as part of your own
+//! binary instead of shelling out to the `mesh-llm` CLI.
+//!
+//! Everything else in this crate is `pub(crate)` or `pub` only because Rust
+//! doesn't have a smaller visibility — those modules are internal and may
+//! change in any release. Build against `mesh_llm::embed::*` and you get a
+//! curated, documented surface.
+//!
+//! # Quickstart
+//!
+//! ```no_run
+//! use std::collections::HashMap;
+//! use mesh_llm::embed::{NodeBuilder, NodeRole, QuicBindSelection};
+//!
+//! # async fn run() -> anyhow::Result<()> {
+//! let mut relay_auths = HashMap::new();
+//! relay_auths.insert(
+//!     "https://gated.example/".to_string(),
+//!     "<nip98-bearer-or-static-token>".to_string(),
+//! );
+//!
+//! let handle = NodeBuilder::new()
+//!     .role(NodeRole::Client)
+//!     .relays(["https://gated.example/"])
+//!     .relay_auths(relay_auths)
+//!     .bind(QuicBindSelection::default())
+//!     .max_vram_gb(0.0)
+//!     .enumerate_host(true)
+//!     .start()
+//!     .await?;
+//!
+//! handle.start_accepting();
+//! handle.set_display_name("my-app".to_string()).await;
+//!
+//! let invite = handle.invite_token();
+//! println!("share this with peers: {invite}");
+//!
+//! // ... later, when your application is done with the mesh:
+//! drop(handle);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Scope
+//!
+//! `NodeBuilder` + `NodeHandle` give you the in-process equivalent of the
+//! `mesh-llm` CLI's mesh layer: peer membership, gossip, invite tokens,
+//! relay registration (including [`--relay-auth`][relay-auth] for gated
+//! iroh relays), and model advertisement.
+//!
+//! It does **not** start the HTTP proxy, the management console, the TUI,
+//! local inference, or the auto-discovery / auto-mode loops. Those are
+//! orchestrated by the CLI's `runtime::run` and would need their own
+//! embed surface; we'll add one if there is demand.
+//!
+//! [relay-auth]: https://github.com/Mesh-LLM/mesh-llm/pull/641
+
+use crate::mesh;
+use anyhow::Result;
+use std::collections::HashMap;
+
+pub use crate::mesh::{NodeRole, QuicBindSelection, RelayConfig};
+
+/// Builder for an in-process mesh-llm [`NodeHandle`].
+///
+/// All fields are optional and have CLI-equivalent defaults:
+/// - `role`: [`NodeRole::Client`]
+/// - `relays`: empty (mesh-llm's bundled default iroh relays are used)
+/// - `relay_auths`: empty (no gated relays)
+/// - `bind`: ephemeral port, OS-chosen bind IP
+/// - `max_vram_gb`: `None` (use all available VRAM)
+/// - `enumerate_host`: `true` (publish hardware survey to gossip)
+#[derive(Debug, Default)]
+pub struct NodeBuilder {
+    role: NodeRole,
+    relays: Vec<String>,
+    relay_auths: HashMap<String, String>,
+    bind: QuicBindSelection,
+    max_vram_gb: Option<f64>,
+    enumerate_host: bool,
+}
+
+impl NodeBuilder {
+    /// Start with all defaults. Equivalent to `NodeBuilder::default()` plus
+    /// `enumerate_host = true`, which matches the CLI's default behaviour.
+    pub fn new() -> Self {
+        Self {
+            enumerate_host: true,
+            ..Default::default()
+        }
+    }
+
+    /// Set the role this node plays in the mesh.
+    pub fn role(mut self, role: NodeRole) -> Self {
+        self.role = role;
+        self
+    }
+
+    /// Set the iroh relay URLs this node will register with. Pass an empty
+    /// iterator (or skip the call) to use the bundled default relays.
+    pub fn relays<I, S>(mut self, relays: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.relays = relays.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the full per-relay auth-token map. Keys must exactly match the
+    /// relay URLs in [`Self::relays`] (or the bundled defaults, if you
+    /// didn't override). Relays not present in this map register
+    /// unauthenticated, which is correct for public relays.
+    ///
+    /// Tokens are forwarded verbatim to `iroh::RelayConfig::with_auth_token`
+    /// and sent as `Authorization: Bearer <token>` on the relay WebSocket
+    /// upgrade. For relays running `AccessConfig::Restricted` with NIP-98
+    /// admission this should be a base64-encoded signed kind:27235 event;
+    /// for relays with a custom static token, just the static token.
+    pub fn relay_auths(mut self, relay_auths: HashMap<String, String>) -> Self {
+        self.relay_auths = relay_auths;
+        self
+    }
+
+    /// Add or replace a single relay-auth entry.
+    pub fn relay_auth(mut self, relay_url: impl Into<String>, token: impl Into<String>) -> Self {
+        self.relay_auths.insert(relay_url.into(), token.into());
+        self
+    }
+
+    /// Set the QUIC bind selection (IP and/or port).
+    pub fn bind(mut self, bind: QuicBindSelection) -> Self {
+        self.bind = bind;
+        self
+    }
+
+    /// Set the VRAM cap in gigabytes. `None` means "use whatever the hardware
+    /// reports". Pass `Some(0.0)` for a client-only node that should not
+    /// advertise any VRAM.
+    pub fn max_vram_gb(mut self, max_vram_gb: Option<f64>) -> Self {
+        self.max_vram_gb = max_vram_gb;
+        self
+    }
+
+    /// Whether to publish a hardware survey (GPU name, VRAM, hostname, etc.)
+    /// to gossip. Defaults to `true`. Set to `false` to keep the node
+    /// hardware profile private.
+    pub fn enumerate_host(mut self, enumerate_host: bool) -> Self {
+        self.enumerate_host = enumerate_host;
+        self
+    }
+
+    /// Bring the node online. Returns a [`NodeHandle`] once the iroh
+    /// endpoint has been bound and (best-effort) the home relay has been
+    /// reached.
+    pub async fn start(self) -> Result<NodeHandle> {
+        let relay = RelayConfig {
+            urls: &self.relays,
+            auths: &self.relay_auths,
+        };
+        let (node, _channels) = mesh::Node::start(
+            self.role,
+            relay,
+            self.bind,
+            self.max_vram_gb,
+            self.enumerate_host,
+            // OwnerRuntimeConfig is for owner-control endpoints, which the
+            // embed surface doesn't expose yet. None ⇒ no control listener.
+            None,
+            // Embedders don't have a `mesh-llm` config file; pass None to
+            // skip config-driven model defaults.
+            None,
+        )
+        .await?;
+        Ok(NodeHandle { inner: node })
+    }
+}
+
+/// A running in-process mesh-llm node.
+///
+/// Drop the handle to stop accepting new mesh traffic (in-flight tasks may
+/// continue briefly). A graceful `shutdown()` API may be added later.
+#[derive(Clone)]
+pub struct NodeHandle {
+    inner: mesh::Node,
+}
+
+impl NodeHandle {
+    /// Start accepting incoming mesh connections.
+    ///
+    /// The bind happens in [`NodeBuilder::start`], but the accept loop waits
+    /// until you call this. That lets you finish wiring listeners (display
+    /// name, models) before the node is reachable.
+    pub fn start_accepting(&self) {
+        self.inner.start_accepting();
+    }
+
+    /// The stable endpoint ID of this node (derived from its iroh secret key).
+    pub fn id(&self) -> String {
+        format!("{:?}", self.inner.id())
+    }
+
+    /// An invite token that lets another node join this one with
+    /// [`NodeHandle::join`].
+    pub fn invite_token(&self) -> String {
+        self.inner.invite_token()
+    }
+
+    /// Join an existing mesh via an invite token produced by another node's
+    /// [`Self::invite_token`].
+    pub async fn join(&self, invite_token: &str) -> Result<()> {
+        self.inner.join(invite_token).await
+    }
+
+    /// Set a human-readable display name advertised to peers.
+    pub async fn set_display_name(&self, name: String) {
+        self.inner.set_display_name(name).await;
+    }
+
+    /// Replace the set of models this node advertises as available.
+    pub async fn set_models(&self, models: Vec<String>) {
+        self.inner.set_models(models).await;
+    }
+
+    /// Get the current set of advertised models.
+    pub async fn models(&self) -> Vec<String> {
+        self.inner.models().await
+    }
+
+    /// Read the current role.
+    pub async fn role(&self) -> NodeRole {
+        self.inner.role().await
+    }
+
+    /// A simplified view of currently-known peers. Each entry is one peer's
+    /// `(endpoint_id, role, models)`. This is intentionally narrow — if you
+    /// need the full peer record, build it from gossip yourself or open an
+    /// issue describing your use case.
+    pub async fn peers(&self) -> Vec<EmbedPeer> {
+        self.inner
+            .peers()
+            .await
+            .into_iter()
+            .map(|peer| EmbedPeer {
+                id: format!("{:?}", peer.id),
+                role: peer.role,
+                models: peer.models,
+                rtt_ms: peer.rtt_ms,
+            })
+            .collect()
+    }
+}
+
+/// Public peer summary exposed by [`NodeHandle::peers`]. Stable subset of
+/// the internal `PeerInfo`.
+#[derive(Debug, Clone)]
+pub struct EmbedPeer {
+    /// Hex-formatted endpoint ID, suitable for logging and display.
+    pub id: String,
+    /// Role this peer advertises in gossip.
+    pub role: NodeRole,
+    /// Models the peer advertises as available.
+    pub models: Vec<String>,
+    /// Last observed round-trip-time in milliseconds, if known.
+    pub rtt_ms: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_defaults_match_cli_intent() {
+        let b = NodeBuilder::new();
+        assert!(b.enumerate_host, "enumerate_host defaults to true");
+        assert_eq!(b.role, NodeRole::Worker);
+        assert!(b.relays.is_empty());
+        assert!(b.relay_auths.is_empty());
+        assert_eq!(b.max_vram_gb, None);
+    }
+
+    #[test]
+    fn builder_threads_relay_auths_through() {
+        let b = NodeBuilder::new()
+            .relays(["https://gated.example/"])
+            .relay_auth("https://gated.example/", "bearer-token");
+        assert_eq!(b.relays, vec!["https://gated.example/".to_string()]);
+        assert_eq!(
+            b.relay_auths
+                .get("https://gated.example/")
+                .map(String::as_str),
+            Some("bearer-token"),
+        );
+    }
+
+    #[test]
+    fn builder_relay_auths_replaces_full_map() {
+        let mut map = HashMap::new();
+        map.insert("https://a/".to_string(), "ta".to_string());
+        map.insert("https://b/".to_string(), "tb".to_string());
+        let b = NodeBuilder::new()
+            .relay_auth("https://stale/", "stale") // should be replaced
+            .relay_auths(map);
+        assert_eq!(b.relay_auths.len(), 2);
+        assert!(!b.relay_auths.contains_key("https://stale/"));
+        assert_eq!(
+            b.relay_auths.get("https://a/").map(String::as_str),
+            Some("ta")
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 mod api;
 mod cli;
 pub mod crypto;
+pub mod embed;
 mod inference;
 mod mesh;
 mod models;

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -270,11 +270,104 @@ fn effective_relay_urls(relay_urls: &[String]) -> Vec<String> {
     }
 }
 
-fn relay_map_from_urls(urls: &[String]) -> iroh::RelayMap {
-    let configs = urls
-        .iter()
-        .map(|url| iroh::RelayConfig::new(url.parse().expect("invalid relay URL"), None));
+/// Build a [`RelayMap`] from URLs, attaching per-relay auth tokens where
+/// configured.
+///
+/// `auths` maps relay URLs (as they appear in `urls`) to bearer tokens. Tokens
+/// are passed to [`iroh::RelayConfig::with_auth_token`] which sends them as
+/// `Authorization: Bearer <token>` on the WebSocket upgrade. Relays not present
+/// in the map register unauthenticated, which is the correct behavior for
+/// public (`AccessConfig::Everyone`) relays.
+///
+/// This is the wire-up that lets a gated iroh-relay (e.g. one running
+/// `AccessConfig::Restricted` with NIP-98 admission) admit this node while
+/// public relays in the same map continue to work normally.
+fn relay_map_from_urls(
+    urls: &[String],
+    auths: &std::collections::HashMap<String, String>,
+) -> iroh::RelayMap {
+    let configs = urls.iter().map(|url| {
+        let parsed = url.parse().expect("invalid relay URL");
+        let cfg = iroh::RelayConfig::new(parsed, None);
+        match auths.get(url) {
+            Some(token) => cfg.with_auth_token(token.clone()),
+            None => cfg,
+        }
+    });
     iroh::RelayMap::from_iter(configs)
+}
+
+#[cfg(test)]
+mod relay_map_tests {
+    use super::relay_map_from_urls;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    fn configs(map: &iroh::RelayMap) -> Vec<Arc<iroh::RelayConfig>> {
+        map.relays::<Vec<_>>()
+    }
+
+    #[test]
+    fn builds_map_without_auth_when_empty() {
+        let urls = vec!["https://r1.example/".to_string()];
+        let map = relay_map_from_urls(&urls, &HashMap::new());
+        let cfgs = configs(&map);
+        assert_eq!(cfgs.len(), 1);
+        assert!(
+            cfgs[0].auth_token.is_none(),
+            "no auth supplied → no auth_token set"
+        );
+    }
+
+    #[test]
+    fn attaches_auth_token_for_matching_url() {
+        let urls = vec!["https://gated.example/".to_string()];
+        let mut auths = HashMap::new();
+        auths.insert("https://gated.example/".to_string(), "nip98-bearer".into());
+        let map = relay_map_from_urls(&urls, &auths);
+        let cfgs = configs(&map);
+        assert_eq!(cfgs.len(), 1);
+        assert_eq!(cfgs[0].auth_token.as_deref(), Some("nip98-bearer"));
+    }
+
+    #[test]
+    fn leaves_other_relays_unauthenticated_in_mixed_map() {
+        // The whole point: gated relay gets a token, public relays don't.
+        let urls = vec![
+            "https://gated.example/".to_string(),
+            "https://public.iroh/".to_string(),
+        ];
+        let mut auths = HashMap::new();
+        auths.insert("https://gated.example/".to_string(), "bearer-xyz".into());
+
+        let map = relay_map_from_urls(&urls, &auths);
+        let by_url: HashMap<String, Option<String>> = configs(&map)
+            .into_iter()
+            .map(|cfg| (cfg.url.to_string(), cfg.auth_token.clone()))
+            .collect();
+
+        // Find the entries by matching on host substring, since iroh-relay may
+        // canonicalise the URL form (e.g. trailing dot on the host).
+        let gated = by_url
+            .iter()
+            .find(|(u, _)| u.contains("gated.example"))
+            .expect("gated relay should be in the map");
+        let public = by_url
+            .iter()
+            .find(|(u, _)| u.contains("public.iroh"))
+            .expect("public relay should be in the map");
+
+        assert_eq!(
+            gated.1.as_deref(),
+            Some("bearer-xyz"),
+            "gated relay must carry its token"
+        );
+        assert!(
+            public.1.is_none(),
+            "public relay must register without a token, got {:?}",
+            public.1
+        );
+    }
 }
 
 fn encode_endpoint_addr_token(addr: &EndpointAddr) -> String {
@@ -1420,6 +1513,7 @@ fn startup_transport_config() -> iroh::endpoint::QuicTransportConfig {
 async fn bind_mesh_endpoint(
     secret_key: SecretKey,
     relay_urls: &[String],
+    relay_auths: &std::collections::HashMap<String, String>,
     quic_bind: QuicBindSelection,
 ) -> Result<Endpoint> {
     let mut builder = Endpoint::builder(iroh::endpoint::presets::Minimal)
@@ -1434,6 +1528,7 @@ async fn bind_mesh_endpoint(
     tracing::info!("Relay: {:?}", urls);
     builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map_from_urls(
         &urls,
+        relay_auths,
     )));
 
     if let Some(addr) = quic_bind_addr(quic_bind) {
@@ -1569,12 +1664,14 @@ fn init_owner_runtime(
 fn configure_control_relay(
     mut builder: iroh::endpoint::Builder,
     relay_urls: Option<&[String]>,
+    relay_auths: &std::collections::HashMap<String, String>,
 ) -> iroh::endpoint::Builder {
     if let Some(relay_urls) = relay_urls {
         let urls = effective_relay_urls(relay_urls);
         tracing::info!("Owner-control relay: {:?}", urls);
         builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map_from_urls(
             &urls,
+            relay_auths,
         )));
     } else {
         builder = builder.relay_mode(iroh::endpoint::RelayMode::Disabled);
@@ -2628,6 +2725,7 @@ impl Node {
     pub async fn start(
         role: NodeRole,
         relay_urls: &[String],
+        relay_auths: &std::collections::HashMap<String, String>,
         quic_bind: QuicBindSelection,
         max_vram_gb: Option<f64>,
         enumerate_host: bool,
@@ -2635,7 +2733,8 @@ impl Node {
         config_path: Option<&std::path::Path>,
     ) -> Result<(Self, TunnelChannels)> {
         let secret_key = startup_secret_key(&role).await?;
-        let endpoint = bind_mesh_endpoint(secret_key.clone(), relay_urls, quic_bind).await?;
+        let endpoint =
+            bind_mesh_endpoint(secret_key.clone(), relay_urls, relay_auths, quic_bind).await?;
         // Wait briefly for relay connection so the invite token includes the relay URL.
         // On sinkholed networks this times out and we proceed without relay (direct UDP only).
         wait_for_endpoint_online(
@@ -2764,6 +2863,7 @@ impl Node {
                 .as_ref()
                 .and_then(|config| config.control_advertise_addr),
             Some(relay_urls),
+            relay_auths,
         )
         .await?;
 
@@ -2907,6 +3007,7 @@ impl Node {
         bind_addr: Option<std::net::SocketAddr>,
         advertise_addr: Option<std::net::SocketAddr>,
         relay_urls: Option<&[String]>,
+        relay_auths: &std::collections::HashMap<String, String>,
     ) -> Result<()> {
         if self.local_verified_owner_id().await.is_none() {
             return Ok(());
@@ -2916,7 +3017,7 @@ impl Node {
             .secret_key(secret_key)
             .alpns(vec![ALPN_CONTROL_V1.to_vec()])
             .bind_addr(bind_addr.unwrap_or_else(default_control_bind_addr))?;
-        builder = configure_control_relay(builder, relay_urls);
+        builder = configure_control_relay(builder, relay_urls, relay_auths);
         let endpoint = builder.bind().await?;
         if relay_urls.is_some() {
             wait_for_endpoint_online(

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -116,6 +116,17 @@ pub struct QuicBindSelection {
     pub port: Option<u16>,
 }
 
+/// Relay map plus per-relay bearer tokens for gated iroh-relays.
+///
+/// `urls` is the relay map; `auths` is a sparse map of relay URL -> bearer
+/// token used when registering with relays running `AccessConfig::Restricted`.
+/// Public relays in the same map continue to register without auth.
+#[derive(Clone, Copy, Debug)]
+pub struct RelayConfig<'a> {
+    pub urls: &'a [String],
+    pub auths: &'a std::collections::HashMap<String, String>,
+}
+
 fn quic_bind_addr(bind: QuicBindSelection) -> Option<SocketAddr> {
     if let Some(ip) = bind.ip {
         return Some(SocketAddr::new(
@@ -2724,14 +2735,15 @@ impl Node {
 
     pub async fn start(
         role: NodeRole,
-        relay_urls: &[String],
-        relay_auths: &std::collections::HashMap<String, String>,
+        relay: RelayConfig<'_>,
         quic_bind: QuicBindSelection,
         max_vram_gb: Option<f64>,
         enumerate_host: bool,
         owner_config: Option<OwnerRuntimeConfig>,
         config_path: Option<&std::path::Path>,
     ) -> Result<(Self, TunnelChannels)> {
+        let relay_urls = relay.urls;
+        let relay_auths = relay.auths;
         let secret_key = startup_secret_key(&role).await?;
         let endpoint =
             bind_mesh_endpoint(secret_key.clone(), relay_urls, relay_auths, quic_bind).await?;

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -281,11 +281,11 @@ fn effective_relay_urls(relay_urls: &[String]) -> Vec<String> {
     }
 }
 
-/// Build a [`RelayMap`] from URLs, attaching per-relay auth tokens where
-/// configured.
+/// Build an [`iroh::RelayMap`] from URLs, attaching per-relay auth tokens
+/// where configured.
 ///
 /// `auths` maps relay URLs (as they appear in `urls`) to bearer tokens. Tokens
-/// are passed to [`iroh::RelayConfig::with_auth_token`] which sends them as
+/// are passed to `iroh::RelayConfig::with_auth_token` which sends them as
 /// `Authorization: Bearer <token>` on the WebSocket upgrade. Relays not present
 /// in the map register unauthenticated, which is the correct behavior for
 /// public (`AccessConfig::Everyone`) relays.
@@ -378,6 +378,170 @@ mod relay_map_tests {
             "public relay must register without a token, got {:?}",
             public.1
         );
+    }
+}
+
+/// End-to-end regression tests for `--relay-auth` against a real in-process
+/// iroh-relay running [`iroh_relay::server::AccessConfig::Restricted`].
+///
+/// These tests do not go through the full `Node::start` path — they exercise
+/// `relay_map_from_urls` (the new wiring) plus the iroh `Endpoint` builder
+/// the same way `bind_mesh_endpoint` does, with `ca_roots_config` overridden
+/// for the relay's self-signed test cert. The contract being defended is:
+///
+///  1. A token configured for a gated relay URL reaches iroh as
+///     `RelayConfig::with_auth_token`, gets sent as `Authorization: Bearer`
+///     on the WebSocket upgrade, and the relay admits the endpoint.
+///  2. The wrong token (or no token) is rejected with `not authorized` and
+///     the endpoint never reaches `online()`.
+///  3. Mixed maps work: a gated relay with the right token coexists with a
+///     public relay (no token) in the same `RelayMap`.
+#[cfg(test)]
+mod gated_relay_e2e_tests {
+    use super::relay_map_from_urls;
+    use futures_util::StreamExt;
+    use iroh::endpoint::{presets, Endpoint, RelayMode};
+    use iroh::test_utils::run_relay_server_with_access;
+    use iroh::SecretKey;
+    use iroh::Watcher;
+    use iroh_relay::server::{Access, AccessConfig};
+    use iroh_relay::tls::CaRootsConfig;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    /// Spawn an in-process iroh-relay that only admits `expected_token`.
+    /// Returns (relay_url_string, drop-guard server).
+    async fn spawn_gated_relay(
+        expected_token: &'static str,
+    ) -> (String, iroh_relay::server::Server) {
+        let access = AccessConfig::Restricted(Box::new(move |request| {
+            Box::pin(async move {
+                if request.auth_token().as_deref() == Some(expected_token) {
+                    Access::Allow
+                } else {
+                    Access::Deny
+                }
+            })
+        }));
+        let (_relay_map, relay_url, server) = run_relay_server_with_access(false, access)
+            .await
+            .expect("spawn gated relay");
+        (relay_url.to_string(), server)
+    }
+
+    /// Build an `Endpoint` configured the same way `bind_mesh_endpoint` does,
+    /// but using `relay_map_from_urls` for the relay map and accepting the
+    /// relay's self-signed test cert via `insecure_skip_verify`.
+    async fn build_endpoint(
+        relay_urls: &[String],
+        relay_auths: &HashMap<String, String>,
+    ) -> Endpoint {
+        Endpoint::builder(presets::Minimal)
+            .secret_key(SecretKey::generate())
+            .relay_mode(RelayMode::Custom(relay_map_from_urls(
+                relay_urls,
+                relay_auths,
+            )))
+            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .bind()
+            .await
+            .expect("endpoint bind")
+    }
+
+    #[tokio::test]
+    async fn matching_token_admits_endpoint_to_gated_relay() {
+        const TOKEN: &str = "secret-token";
+        let (relay_url, _server) = spawn_gated_relay(TOKEN).await;
+
+        let urls = vec![relay_url.clone()];
+        let mut auths = HashMap::new();
+        auths.insert(relay_url, TOKEN.to_string());
+
+        let ep = build_endpoint(&urls, &auths).await;
+        tokio::time::timeout(Duration::from_secs(5), ep.online())
+            .await
+            .expect("endpoint with matching token should come online");
+    }
+
+    #[tokio::test]
+    async fn wrong_token_is_rejected_by_gated_relay() {
+        const TOKEN: &str = "secret-token";
+        let (relay_url, _server) = spawn_gated_relay(TOKEN).await;
+
+        let urls = vec![relay_url.clone()];
+        let mut auths = HashMap::new();
+        auths.insert(relay_url, "wrong-token".to_string());
+
+        let ep = build_endpoint(&urls, &auths).await;
+
+        // Observe the relay-side denial via home_relay_status before falling
+        // back to the timeout. We must see `not authorized` to prove the
+        // token actually reached the relay (rather than e.g. silently being
+        // dropped before the WebSocket upgrade).
+        let mut stream = ep.home_relay_status().stream();
+        let auth_err = tokio::time::timeout(Duration::from_secs(5), async {
+            while let Some(status) = stream.next().await {
+                if let Some(err) = status.iter().filter_map(|s| s.last_error()).next() {
+                    return Some(format!("{err:#}"));
+                }
+            }
+            None
+        })
+        .await
+        .expect("home relay status should report an error within 5s")
+        .expect("home relay status should yield an error");
+        assert!(
+            auth_err.contains("not authorized"),
+            "expected 'not authorized' in error, got: {auth_err}"
+        );
+
+        // And the endpoint must NOT come online.
+        let online = tokio::time::timeout(Duration::from_millis(500), ep.online()).await;
+        assert!(
+            online.is_err(),
+            "endpoint with wrong token must not reach online() within 500ms"
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_token_for_gated_relay_is_rejected() {
+        const TOKEN: &str = "secret-token";
+        let (relay_url, _server) = spawn_gated_relay(TOKEN).await;
+
+        // No auth in the map at all → relay must deny.
+        let urls = vec![relay_url];
+        let auths = HashMap::new();
+        let ep = build_endpoint(&urls, &auths).await;
+
+        let online = tokio::time::timeout(Duration::from_millis(500), ep.online()).await;
+        assert!(
+            online.is_err(),
+            "endpoint without a token must not be admitted by a gated relay"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_map_authenticates_only_the_gated_relay() {
+        const TOKEN: &str = "secret-token";
+        let (gated_url, _gated) = spawn_gated_relay(TOKEN).await;
+
+        // Spin up a second, fully-open relay to stand in for a public iroh
+        // relay sharing the same map.
+        let (_public_map, public_url, _public) =
+            run_relay_server_with_access(false, AccessConfig::Everyone)
+                .await
+                .expect("spawn public relay");
+        let public_url = public_url.to_string();
+
+        let urls = vec![gated_url.clone(), public_url.clone()];
+        let mut auths = HashMap::new();
+        auths.insert(gated_url, TOKEN.to_string());
+        // Public relay intentionally absent from `auths`.
+
+        let ep = build_endpoint(&urls, &auths).await;
+        tokio::time::timeout(Duration::from_secs(5), ep.online())
+            .await
+            .expect("endpoint should come online via the mixed relay map");
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1121,8 +1121,14 @@ async fn control_plane_listener_starts_with_owner() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
 
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
 
     let endpoint = node
         .control_endpoint()
@@ -1146,8 +1152,14 @@ async fn control_plane_listener_uses_explicit_advertised_address() -> anyhow::Re
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
     let advertised_addr = std::net::SocketAddr::from(([203, 0, 113, 10], 18443));
 
-    node.maybe_start_control_listener(secret_key, None, Some(advertised_addr), None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        Some(advertised_addr),
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
 
     let endpoint = node
         .control_endpoint()
@@ -1173,6 +1185,7 @@ async fn control_plane_listener_disabled_without_owner() -> anyhow::Result<()> {
         Some("127.0.0.1:7447".parse().unwrap()),
         None,
         None,
+        &std::collections::HashMap::new(),
     )
     .await?;
 
@@ -1184,8 +1197,14 @@ async fn control_plane_listener_disabled_without_owner() -> anyhow::Result<()> {
 async fn control_plane_listener_accepts_only_control_alpn() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     let endpoint = Node::decode_invite_token(
         &node
             .control_endpoint()
@@ -1214,8 +1233,14 @@ async fn control_plane_listener_accepts_only_control_alpn() -> anyhow::Result<()
 async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     let control_endpoint = node
         .control_endpoint()
         .await
@@ -1245,8 +1270,14 @@ async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> 
 async fn control_plane_listener_shutdown_stops_listener_task() -> anyhow::Result<()> {
     let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key,
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     let endpoint = Node::decode_invite_token(
         &node
             .control_endpoint()
@@ -5128,8 +5159,14 @@ async fn start_owner_control_test_server(
     *node.owner_attestation.lock().await = Some(ownership);
     *node.owner_summary.lock().await = owner_summary;
     *node.trust_store.lock().await = trust_store;
-    node.maybe_start_control_listener(secret_key.clone(), None, None, None)
-        .await?;
+    node.maybe_start_control_listener(
+        secret_key.clone(),
+        None,
+        None,
+        None,
+        &std::collections::HashMap::new(),
+    )
+    .await?;
     Ok((node, secret_key, config_path))
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -4976,9 +4976,12 @@ pub(crate) async fn run_plugin_mcp(cli: &Cli) -> Result<()> {
     let resolved_plugins = load_resolved_plugins(cli)?;
     let config = plugin::load_config(cli.config.as_deref())?;
     let owner_config = owner_runtime_config(cli, &config)?;
+    let relay_auths: std::collections::HashMap<String, String> =
+        cli.relay_auth.iter().cloned().collect();
     let (node, _channels) = mesh::Node::start(
         NodeRole::Client,
         &cli.relay,
+        &relay_auths,
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
             port: cli.bind_port,
@@ -5143,9 +5146,12 @@ async fn start_run_auto_node_and_plugins(
     };
     let owner_config = owner_runtime_config(cli, config)?;
     let max_vram = if cli.client { Some(0.0) } else { cli.max_vram };
+    let relay_auths: std::collections::HashMap<String, String> =
+        cli.relay_auth.iter().cloned().collect();
     let (node, channels) = mesh::Node::start(
         role,
         &cli.relay,
+        &relay_auths,
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
             port: cli.bind_port,

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -4980,8 +4980,10 @@ pub(crate) async fn run_plugin_mcp(cli: &Cli) -> Result<()> {
         cli.relay_auth.iter().cloned().collect();
     let (node, _channels) = mesh::Node::start(
         NodeRole::Client,
-        &cli.relay,
-        &relay_auths,
+        mesh::RelayConfig {
+            urls: &cli.relay,
+            auths: &relay_auths,
+        },
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
             port: cli.bind_port,
@@ -5150,8 +5152,10 @@ async fn start_run_auto_node_and_plugins(
         cli.relay_auth.iter().cloned().collect();
     let (node, channels) = mesh::Node::start(
         role,
-        &cli.relay,
-        &relay_auths,
+        mesh::RelayConfig {
+            urls: &cli.relay,
+            auths: &relay_auths,
+        },
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
             port: cli.bind_port,

--- a/crates/mesh-llm/tests/embed_api_surface.rs
+++ b/crates/mesh-llm/tests/embed_api_surface.rs
@@ -1,0 +1,59 @@
+//! Embed API surface tests.
+//!
+//! These tests pin the `mesh_llm::embed::*` API as seen by an external
+//! consumer. Regressions in method signatures, default values, or the
+//! visibility of re-exported types will fail at compile time here.
+//!
+//! Live-network behaviour (actual relay registration) is covered separately
+//! by `embed_gated_relay.rs` (gated behind `#[ignore]`).
+
+use std::collections::HashMap;
+
+use mesh_llm::embed::{NodeBuilder, NodeRole, QuicBindSelection};
+
+#[test]
+fn node_builder_is_chainable_and_owns_its_state() {
+    let mut auths = HashMap::new();
+    auths.insert("https://gated.example/".to_string(), "tok".to_string());
+
+    // The whole point: an embedder can configure a node end-to-end with
+    // chained calls and no awaits. The builder is fully synchronous up to
+    // `.start()`.
+    let _builder = NodeBuilder::new()
+        .role(NodeRole::Client)
+        .relays(["https://gated.example/", "https://public.iroh/"])
+        .relay_auths(auths)
+        .relay_auth("https://another-gated.example/", "tok2")
+        .bind(QuicBindSelection {
+            ip: None,
+            port: None,
+        })
+        .max_vram_gb(Some(0.0))
+        .enumerate_host(false);
+}
+
+#[test]
+fn node_role_default_is_worker() {
+    assert_eq!(NodeRole::default(), NodeRole::Worker);
+}
+
+#[test]
+fn node_role_serializes_for_external_consumers() {
+    // The embed surface re-exports NodeRole. External consumers commonly
+    // round-trip it through serde for config files; pin that behaviour.
+    let role = NodeRole::Host { http_port: 9337 };
+    let json = serde_json::to_string(&role).expect("NodeRole should serialize");
+    assert!(
+        json.contains("Host"),
+        "NodeRole::Host should serialize with a `Host` variant tag: {json}"
+    );
+    let back: NodeRole = serde_json::from_str(&json).expect("NodeRole should round-trip");
+    assert_eq!(back, role);
+}
+
+#[test]
+fn quic_bind_selection_is_default_constructible() {
+    let q = QuicBindSelection::default();
+    assert!(q.ip.is_none());
+    assert!(q.port.is_none());
+}

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,93 @@
+# Embedding mesh-llm in a Rust application
+
+mesh-llm exposes a small, curated Rust API for running an in-process mesh
+node from your own binary. Use it when you want to ship mesh-llm as part of
+a larger Rust application rather than shelling out to the `mesh-llm` CLI.
+
+The full surface lives at [`mesh_llm::embed`][embed-module]. Everything
+else in the `mesh-llm` crate (and the underlying `mesh-llm-host-runtime`
+crate) is implementation detail and may change in any release.
+
+[embed-module]: https://docs.rs/mesh-llm/latest/mesh_llm/embed/index.html
+
+## What's in scope
+
+`NodeBuilder` and `NodeHandle` cover the mesh layer:
+
+- iroh endpoint binding
+- peer membership and gossip
+- invite-token generation and joining
+- relay registration (including [`--relay-auth`][relay-auth-pr] for gated
+  iroh relays)
+- model advertisement
+
+[relay-auth-pr]: https://github.com/Mesh-LLM/mesh-llm/pull/641
+
+## What's not in scope (yet)
+
+The embed surface deliberately does **not** start:
+
+- the HTTP proxy (`/v1/*` OpenAI-compatible API)
+- the management console (`/api/*`)
+- the TUI
+- local llama.cpp / skippy inference
+- auto-discovery / auto-mode loops
+- model downloads
+
+If you want the full runtime, including those, run the `mesh-llm` binary as
+a subprocess. Open an issue with your use case if you need an embed surface
+for any of them.
+
+## Quickstart
+
+```rust,no_run
+use std::collections::HashMap;
+use mesh_llm::embed::{NodeBuilder, NodeRole, QuicBindSelection};
+
+# async fn run() -> anyhow::Result<()> {
+let mut relay_auths = HashMap::new();
+relay_auths.insert(
+    "https://gated.example/".to_string(),
+    "<nip98-bearer-or-static-token>".to_string(),
+);
+
+let handle = NodeBuilder::new()
+    .role(NodeRole::Client)
+    .relays(["https://gated.example/"])
+    .relay_auths(relay_auths)
+    .bind(QuicBindSelection::default())
+    .max_vram_gb(Some(0.0))
+    .enumerate_host(true)
+    .start()
+    .await?;
+
+handle.start_accepting();
+handle.set_display_name("my-app".to_string()).await;
+
+let invite = handle.invite_token();
+println!("share with peers: {invite}");
+
+// later
+drop(handle);
+# Ok(())
+# }
+```
+
+## Stability
+
+`mesh_llm::embed::*` is the stable Rust embed surface. Internal modules
+(everything else in the crate) may change without notice. If you find
+yourself reaching into internals, please open an issue so we can surface
+the missing capability on the embed module.
+
+## Relationship to `mesh-llm-client`
+
+- `mesh-llm-client` is a thin **client-only** crate: it speaks the mesh
+  protocol to an existing mesh-llm host and exposes chat / completions /
+  responses APIs. It does not run a mesh node.
+- `mesh_llm::embed` runs a real mesh node in-process: it joins the gossip
+  mesh, advertises models, accepts inbound peers, and can produce invite
+  tokens.
+
+Pick `mesh-llm-client` if you only need to *talk to* a mesh; pick
+`mesh_llm::embed` if you need to *be part of* the mesh.


### PR DESCRIPTION
## What you can now do

Run a mesh-llm node from a Rust app without shelling out to the CLI:

```rust
use mesh_llm::embed::{NodeBuilder, NodeRole, QuicBindSelection};

let handle = NodeBuilder::new()
    .role(NodeRole::Client)
    .relays(["https://gated.example/"])
    .relay_auth("https://gated.example/", "<nip98-bearer>")
    .max_vram_gb(Some(0.0))
    .start()
    .await?;

handle.start_accepting();
handle.set_display_name("my-app".to_string()).await;
let invite = handle.invite_token();
```

The full surface is at `mesh_llm::embed`. Builder methods cover role, relays, per-relay auth tokens (works with the new `--relay-auth` feature from #641), QUIC bind, VRAM cap, and hardware enumeration. `NodeHandle` forwards a curated subset of `mesh::Node`: `start_accepting`, `id`, `invite_token`, `join`, `set_display_name`, `set_models`, `models`, `role`, `peers`.

## Scope

**In:** mesh layer only — peer membership, gossip, invite tokens, relay registration, model advertisement.

**Out (deliberately, for now):** HTTP proxy, management console, TUI, local inference, auto-discovery, model downloads. Those stay behind the `mesh-llm` CLI. Open an issue if you need an embed surface for any of them.

## Architecture

- The new module is `crates/mesh-llm-host-runtime/src/embed.rs`, re-exported from the shipped `mesh-llm` crate as `mesh_llm::embed`.
- `NodeHandle` wraps `mesh::Node` (kept `pub(crate)`) so we can keep refactoring internal mesh code without breaking embedders. Likewise, `PeerInfo` is reduced to an `EmbedPeer` view (`id`, `role`, `models`, `rtt_ms`).
- The embed module is documented as the **only stable Rust API** in this crate. Everything else may change in any release.
- See `docs/embedding.md` for the embedder-facing doc, including the relationship to `mesh-llm-client` (which is the *client-only* talk-to-a-mesh crate; embed is for *being part of* a mesh).

## Validation

- `cargo test -p mesh-llm-host-runtime --lib embed::` — unit tests pin builder defaults, chainability, and that `relay_auths(map)` replaces prior `relay_auth(url, token)` entries.
- `cargo test -p mesh-llm --test embed_api_surface` — external-consumer compile/runtime test for the public surface (chains, `NodeRole` default + serde round-trip, `QuicBindSelection` default). Future signature regressions fail this test, which is what an external embedder would feel.
- `cargo clippy --all-targets -- -D warnings` clean on `-p mesh-llm` and `-p mesh-llm-host-runtime`.
- `cargo fmt --all -- --check` clean.

## Follow-ups (not in this PR)

- `NodeHandle::shutdown()` for graceful drop of the endpoint + background tasks. v1 ships with implicit drop only.
- Embed surface for the OpenAI HTTP proxy if there's demand.
- Embed surface for skippy / local inference once the stage-runtime API stabilises further.

Depends on #641 (the `RelayConfig` struct from --relay-auth).