### PR TITLE
Fix Skippy smoke build directory

### DIFF
--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LLAMA_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-.deps/llama-build/build-stage-abi-static}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+resolve_llama_build_dir() {
+  if [[ -n "${LLAMA_STAGE_BUILD_DIR:-}" ]]; then
+    printf '%s\n' "$LLAMA_STAGE_BUILD_DIR"
+  elif [[ -n "${SKIPPY_LLAMA_BUILD_DIR:-}" ]]; then
+    printf '%s\n' "$SKIPPY_LLAMA_BUILD_DIR"
+  else
+    "$ROOT/scripts/build-llama.sh" --print-build-dir
+  fi
+}
+
+LLAMA_BUILD_DIR="$(resolve_llama_build_dir)"
 WORK_DIR="${WORK_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/skippy-ci-smoke}"
 REPORT_DIR="${WORK_DIR}/reports"
 MODEL_DIR="${WORK_DIR}/models"


### PR DESCRIPTION
## Summary
- fix `scripts/skippy-ci-smoke.sh` so it resolves the llama.cpp ABI build directory through `scripts/build-llama.sh --print-build-dir` when no explicit build directory is provided
- preserve existing `LLAMA_STAGE_BUILD_DIR` and `SKIPPY_LLAMA_BUILD_DIR` overrides for CI jobs that set them explicitly

## Root Cause
The `llama.cpp Upstream Canary` workflow builds the ABI with `scripts/build-llama.sh`, which now defaults to `.deps/llama-build/build-stage-abi-cpu` on Linux CPU. The smoke test script still defaulted to the stale `.deps/llama-build/build-stage-abi-static` path, so it failed before running any Skippy checks.

## Validation
- `bash -n scripts/skippy-ci-smoke.sh`
- `scripts/build-llama.sh --print-build-dir`
- `bash -o pipefail -c 'scripts/skippy-ci-smoke.sh 2>&1 | sed -n "1,8p"'` verified the unset-env path now points at `.deps/llama-build/build-stage-abi-cpu`
