### PR TITLE
Reduce Skippy unified KV pressure

### DIFF
--- a/crates/skippy-cache/src/resident/prefix.rs
+++ b/crates/skippy-cache/src/resident/prefix.rs
@@ -47,6 +47,36 @@ pub struct ResidentPrefixAllocation {
     pub seq_id: i32,
     pub evictions: Vec<ResidentPrefixEviction>,
     pub should_save: bool,
+    pub should_retain: bool,
+}
+
+impl ResidentPrefixAllocation {
+    fn existing(seq_id: i32) -> Self {
+        Self {
+            seq_id,
+            evictions: Vec::new(),
+            should_save: false,
+            should_retain: true,
+        }
+    }
+
+    fn new_record(seq_id: i32, evictions: Vec<ResidentPrefixEviction>) -> Self {
+        Self {
+            seq_id,
+            evictions,
+            should_save: true,
+            should_retain: true,
+        }
+    }
+
+    fn uncacheable() -> Self {
+        Self {
+            seq_id: -1,
+            evictions: Vec::new(),
+            should_save: false,
+            should_retain: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -124,21 +154,16 @@ impl ResidentPrefixCache {
         }
         self.clock = self.clock.saturating_add(1);
         if let Some(entry) = self.entries.get(page_id) {
-            return Ok(ResidentPrefixAllocation {
-                seq_id: entry.seq_id,
-                evictions: Vec::new(),
-                should_save: false,
-            });
+            return Ok(ResidentPrefixAllocation::existing(entry.seq_id));
+        }
+        if self.candidate_exceeds_single_record_budget(estimated_bytes, token_count) {
+            return Ok(ResidentPrefixAllocation::uncacheable());
         }
 
         let evictions =
             self.evict_until_room_for(estimated_bytes, token_count, &mut drop_evicted)?;
         let seq_id = self.next_sequence_id()?;
-        Ok(ResidentPrefixAllocation {
-            seq_id,
-            evictions,
-            should_save: true,
-        })
+        Ok(ResidentPrefixAllocation::new_record(seq_id, evictions))
     }
 
     pub fn commit_record(
@@ -226,6 +251,16 @@ impl ResidentPrefixCache {
         Ok(evictions)
     }
 
+    fn candidate_exceeds_single_record_budget(
+        &self,
+        estimated_bytes: u64,
+        token_count: u64,
+    ) -> bool {
+        let over_bytes = self.max_bytes > 0 && estimated_bytes > self.max_bytes;
+        let over_tokens = self.max_resident_tokens > 0 && token_count > self.max_resident_tokens;
+        over_bytes || over_tokens
+    }
+
     fn next_sequence_id(&mut self) -> Result<i32> {
         if let Some(seq_id) = self.free_seq_ids.pop() {
             return Ok(seq_id);
@@ -308,6 +343,29 @@ mod tests {
         assert_eq!(dropped, vec![alloc1.seq_id], "LRU should evict oldest");
         assert_eq!(cache.stats().entries, 2);
         assert_eq!(cache.stats().resident_tokens, 3000);
+    }
+
+    #[test]
+    fn oversized_resident_prefix_candidate_is_nonfatal() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 4096));
+        let small = cache
+            .allocate_for_record("small", 1000, 100, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("small".to_string(), small.seq_id, 1000, 100);
+
+        let allocation = cache
+            .allocate_for_record("huge", 5000, 100, |_| {
+                panic!("oversized candidates should not evict existing entries")
+            })
+            .expect("oversized candidates should be treated as uncacheable, not fatal");
+
+        assert!(!allocation.should_save);
+        assert!(!allocation.should_retain);
+        assert!(allocation.evictions.is_empty());
+        let stats = cache.stats();
+        assert_eq!(stats.entries, 1);
+        assert_eq!(stats.resident_tokens, 1000);
+        assert!(cache.lookup("small").is_some());
     }
 
     #[test]

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -32,6 +32,13 @@ pub const GGML_TYPE_Q4_0: u32 = 2;
 pub const GGML_TYPE_Q8_0: u32 = 8;
 pub const LLAMA_SERVER_DEFAULT_N_BATCH: u32 = 2048;
 pub const LLAMA_SERVER_DEFAULT_N_UBATCH: u32 = 512;
+/// Smaller default prefill batch for multi-lane skippy serving.
+///
+/// When `lane_count > 1`, skippy enables llama.cpp unified KV mode: every
+/// lane shares one `n_ctx` cell pool. A smaller default batch reduces the
+/// amount of KV space each prefill asks the shared pool to reserve at once
+/// after other lanes reset or preserve resident prefixes.
+pub const SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH: u32 = 1024;
 
 /// GGML_LLAMA_LOG_LEVEL values (set before llama_backend_init).
 /// 0=silent, 1=error, 2=warn, 3=info (default), 4=debug.
@@ -757,6 +764,10 @@ impl RuntimeConfig {
 
     fn as_raw(&self) -> Result<RawRuntimeConfigParts> {
         self.validate().map_err(anyhow::Error::msg)?;
+        let n_batch = self
+            .n_batch
+            .unwrap_or_else(|| default_n_batch_for_lane_count(self.lane_count));
+        let n_ubatch = self.n_ubatch.unwrap_or(LLAMA_SERVER_DEFAULT_N_UBATCH);
         let selected_backend_device = self
             .selected_backend_device
             .as_ref()
@@ -776,20 +787,8 @@ impl RuntimeConfig {
                 layer_end: i32::try_from(self.layer_end).context("layer_end exceeds i32")?,
                 ctx_size: i32::try_from(self.ctx_size).context("ctx_size exceeds i32")?,
                 lane_count: i32::try_from(self.lane_count).context("lane_count exceeds i32")?,
-                n_batch: self
-                    .n_batch
-                    .or(Some(LLAMA_SERVER_DEFAULT_N_BATCH))
-                    .map(i32::try_from)
-                    .transpose()
-                    .context("n_batch exceeds i32")?
-                    .unwrap_or(0),
-                n_ubatch: self
-                    .n_ubatch
-                    .or(Some(LLAMA_SERVER_DEFAULT_N_UBATCH))
-                    .map(i32::try_from)
-                    .transpose()
-                    .context("n_ubatch exceeds i32")?
-                    .unwrap_or(0),
+                n_batch: i32::try_from(n_batch).context("n_batch exceeds i32")?,
+                n_ubatch: i32::try_from(n_ubatch).context("n_ubatch exceeds i32")?,
                 n_threads: self
                     .n_threads
                     .map(i32::try_from)
@@ -818,6 +817,14 @@ impl RuntimeConfig {
             },
             _selected_backend_device: selected_backend_device,
         })
+    }
+}
+
+fn default_n_batch_for_lane_count(lane_count: u32) -> u32 {
+    if lane_count > 1 {
+        SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH
+    } else {
+        LLAMA_SERVER_DEFAULT_N_BATCH
     }
 }
 
@@ -3493,7 +3500,8 @@ mod tests {
         set_filtered_native_logs_enabled, unregister_filtered_native_logs, write_native_log,
         ChatTemplateMessage, FlashAttentionType, ModelInfo, NativeLogAggregator, NativeLogEvent,
         RuntimeConfig, RuntimeLoadMode, StageModel, TensorRole, GGML_TYPE_F16, GGML_TYPE_Q4_0,
-        GGML_TYPE_Q8_0,
+        GGML_TYPE_Q8_0, LLAMA_SERVER_DEFAULT_N_BATCH, LLAMA_SERVER_DEFAULT_N_UBATCH,
+        SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH,
     };
 
     static NATIVE_LOG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -3638,6 +3646,54 @@ mod tests {
             unsafe { std::ffi::CStr::from_ptr(raw.raw.selected_backend_device).to_string_lossy() };
 
         assert_eq!(device, "MTL0");
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_uses_smaller_batch_for_unified_kv_defaults() -> anyhow::Result<()> {
+        let config = RuntimeConfig {
+            lane_count: 4,
+            n_batch: None,
+            n_ubatch: None,
+            ..RuntimeConfig::default()
+        };
+
+        let raw = config.as_raw()?;
+
+        assert_eq!(raw.raw.n_batch, SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH as i32);
+        assert_eq!(raw.raw.n_ubatch, LLAMA_SERVER_DEFAULT_N_UBATCH as i32);
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_keeps_llama_batch_default_for_single_lane() -> anyhow::Result<()> {
+        let config = RuntimeConfig {
+            lane_count: 1,
+            n_batch: None,
+            n_ubatch: None,
+            ..RuntimeConfig::default()
+        };
+
+        let raw = config.as_raw()?;
+
+        assert_eq!(raw.raw.n_batch, LLAMA_SERVER_DEFAULT_N_BATCH as i32);
+        assert_eq!(raw.raw.n_ubatch, LLAMA_SERVER_DEFAULT_N_UBATCH as i32);
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_preserves_explicit_unified_kv_batch() -> anyhow::Result<()> {
+        let config = RuntimeConfig {
+            lane_count: 4,
+            n_batch: Some(2048),
+            n_ubatch: Some(256),
+            ..RuntimeConfig::default()
+        };
+
+        let raw = config.as_raw()?;
+
+        assert_eq!(raw.raw.n_batch, 2048);
+        assert_eq!(raw.raw.n_ubatch, 256);
         Ok(())
     }
 

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -184,6 +184,9 @@ impl KvStageIntegration {
             estimated_bytes,
             |seq_id| runtime.drop_resident_prefix_sequence(session_id, seq_id),
         )?;
+        if !allocation.should_retain {
+            return Ok(None);
+        }
         if allocation.should_save {
             runtime.save_resident_prefix(session_id, allocation.seq_id, token_count as u64)?;
             cache.commit_record(


### PR DESCRIPTION
## Summary

Reduces Skippy unified-KV pressure for multi-lane serving by lowering the default raw runtime `n_batch` used when `lane_count > 1`, while preserving single-lane behavior and explicit model/config overrides.

The PR also makes oversized resident-prefix cache candidates nonfatal. If one candidate cannot fit within the resident-prefix token/byte budget, Skippy now treats that candidate as uncacheable instead of failing the record path, so smaller shared-prefix candidates can still be attempted.

## Why

Issue #652 diagnosed `decode: failed to find a memory slot for batch of size 2048` under Goose/Pi-style tool traffic against Skippy unified KV. In that mode, several lanes share one KV cell pool, and upstream llama.cpp no longer performs the old defrag path when a large contiguous slot cannot be found.

This is a conservative mitigation, not a claim that the long-term defrag/root-cause work is finished. It directly reduces the contiguous batch pressure that triggers the reported failure and keeps resident-prefix cache recording from turning an oversized candidate into a hard error.

Refs #652.

## Diff scope

- Adds a Skippy multi-lane unified-KV default `n_batch` of `1024`.
- Keeps single-lane default behavior at the existing llama-server-compatible `2048`.
- Preserves explicit `batch` / `n_batch` and `ubatch` / `n_ubatch` overrides.
- Treats resident-prefix candidates larger than the configured token/byte budget as uncacheable rather than fatal.
- Prevents uncacheable resident-prefix candidates from being saved or retained with a placeholder sequence id.
- Adds regression coverage for both the runtime default and the resident-prefix cache edge case.

## Compatibility

No protobuf, gossip, mesh wire protocol, plugin protocol, or Skippy ABI changes.

This changes only default runtime/cache behavior for Skippy serving. Existing explicit model/config batch overrides remain authoritative.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@c36132fd3d9f693cac6b9ceafd976db38545656e`
- Branch state during validation: `0 behind / 1 ahead`
- Head commit: `675576bf8b85527b8a58c557d9568375b65348cd`

## Commit integrity

One logical commit:

- `675576bf8b85527b8a58c557d9568375b65348cd` - Reduce Skippy unified KV pressure

Final diff contains only Skippy runtime/cache/server changes.

## Validation

Validation tier: Tier 2 - narrow Skippy unified-KV pressure mitigation for issue #652; no protocol, ABI, gossip, UI, or release tooling changes.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, validated base `c36132fd3d9f693cac6b9ceafd976db38545656e`
- `git rev-list --left-right --count origin/main...HEAD`: PASS, `0 behind / 1 ahead`
- `cargo fmt --all -- --check`: PASS
- `cargo test -p skippy-cache oversized_resident_prefix_candidate_is_nonfatal --lib`: FAIL before cache guard, red test expected nonfatal oversized resident-prefix allocation
- `cargo test -p skippy-cache oversized_resident_prefix_candidate_is_nonfatal --lib`: PASS, 1 passed
- `cargo test -p skippy-cache --lib`: PASS, 14 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build> cargo test -p skippy-runtime runtime_config_raw_ --lib`: PASS, 4 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build> cargo test -p skippy-runtime --lib`: PASS, 39 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build> cargo test -p skippy-server --lib`: PASS, 81 passed outside the restricted sandbox; the restricted-sandbox run failed only on a socket/listener test with `Operation not permitted`
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build> cargo test -p mesh-llm-host-runtime runtime::context_planning --lib`: PASS, 9 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build> cargo-clippy clippy -p skippy-cache -p skippy-runtime -p skippy-server --all-targets -- -D warnings`: PASS
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `git diff --check origin/main...HEAD`: PASS, no output
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - runtime/cache mitigation inside existing Skippy config defaults; no release/version sync required.

Not run:

- Live Goose/Pi Qwen2.5-3B reproduction - no affected live direct-model endpoint was available during local validation. The deterministic runtime-default and resident-prefix cache regressions cover the local failure paths changed by this PR.

## Runtime safety

No new locks, queues, network paths, wire formats, or background tasks are introduced.

The resident-prefix cache now exits early for candidates that cannot fit within a single-record budget, avoiding futile eviction attempts and avoiding invalid save/retain behavior for uncacheable candidates.

No invariant regression introduced.

## Rollback

Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

This PR mitigates the reported pressure path; it does not restore llama.cpp defrag or claim complete root-cause closure for all unified-KV fragmentation cases.

The live Goose/Pi reproduction should still be re-run by someone with the affected Skippy direct-model endpoint available.
