### PR TITLE
Resume and harden trusted Skippy package artifact transfer

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/artifact_transfer_io.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/artifact_transfer_io.rs
@@ -1,0 +1,293 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use tokio::io::{AsyncRead, AsyncWriteExt};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct PartialArtifactSelection {
+    pub(super) path: PathBuf,
+    pub(super) offset: u64,
+}
+
+pub(super) struct PartialArtifactGuard {
+    path: PathBuf,
+    cleanup_on_drop: bool,
+}
+
+impl PartialArtifactGuard {
+    #[cfg(test)]
+    pub(super) fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup_on_drop: true,
+        }
+    }
+
+    pub(super) fn preserve_on_error(path: PathBuf) -> Self {
+        Self {
+            path,
+            cleanup_on_drop: false,
+        }
+    }
+
+    pub(super) fn disarm(&mut self) {
+        self.cleanup_on_drop = false;
+    }
+
+    pub(super) fn remove_now(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+        self.disarm();
+    }
+}
+
+impl Drop for PartialArtifactGuard {
+    fn drop(&mut self) {
+        if self.cleanup_on_drop {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+pub(super) fn partial_artifact_path(destination: &Path) -> PathBuf {
+    let file_name = artifact_file_name(destination);
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or(0);
+    destination.with_file_name(format!(
+        ".{file_name}.{}.{}.part",
+        std::process::id(),
+        unique
+    ))
+}
+
+pub(super) fn select_partial_artifact(
+    destination: &Path,
+    max_resume_size: u64,
+) -> Result<PartialArtifactSelection> {
+    if let Some((path, offset)) = largest_resumable_partial(destination, max_resume_size)? {
+        return Ok(PartialArtifactSelection { path, offset });
+    }
+    Ok(PartialArtifactSelection {
+        path: partial_artifact_path(destination),
+        offset: 0,
+    })
+}
+
+pub(super) async fn read_artifact_transfer_chunk<R>(
+    reader: &mut R,
+    buffer: &mut [u8],
+    idle_timeout: std::time::Duration,
+) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+{
+    let read = tokio::time::timeout(idle_timeout, tokio::io::AsyncReadExt::read(reader, buffer))
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("artifact transfer body read idle timeout after {idle_timeout:?}")
+        })?
+        .context("read artifact transfer bytes")?;
+    anyhow::ensure!(
+        read > 0,
+        "artifact transfer ended before expected byte count"
+    );
+    Ok(read)
+}
+
+pub(super) async fn append_artifact_transfer_body<R>(
+    reader: &mut R,
+    partial_path: &Path,
+    offset: u64,
+    total_size: u64,
+    buffer_bytes: usize,
+    idle_timeout: std::time::Duration,
+) -> Result<()>
+where
+    R: AsyncRead + Unpin,
+{
+    let actual_offset = match tokio::fs::metadata(partial_path).await {
+        Ok(metadata) => {
+            anyhow::ensure!(metadata.is_file(), "partial artifact is not a file");
+            metadata.len()
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => 0,
+        Err(error) => return Err(error).context("stat partial artifact"),
+    };
+    anyhow::ensure!(
+        actual_offset == offset,
+        "partial artifact changed while opening transfer"
+    );
+
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(partial_path)
+        .await
+        .context("open partial artifact")?;
+    let mut remaining = total_size.saturating_sub(offset);
+    let mut buffer = vec![0u8; buffer_bytes];
+    while remaining > 0 {
+        let limit = buffer.len().min(remaining as usize);
+        let read = read_artifact_transfer_chunk(reader, &mut buffer[..limit], idle_timeout).await?;
+        file.write_all(&buffer[..read])
+            .await
+            .context("write partial artifact")?;
+        remaining -= read as u64;
+    }
+    file.flush().await.context("flush partial artifact")?;
+    Ok(())
+}
+
+fn largest_resumable_partial(
+    destination: &Path,
+    max_resume_size: u64,
+) -> Result<Option<(PathBuf, u64)>> {
+    let Some(parent) = destination.parent() else {
+        return Ok(None);
+    };
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).context("read package artifact directory"),
+    };
+    let prefix = partial_file_prefix(destination);
+    let mut best: Option<(PathBuf, u64)> = None;
+    for entry in entries {
+        let entry = entry.context("read package artifact directory entry")?;
+        let path = entry.path();
+        if !is_partial_for_destination(&path, &prefix) {
+            continue;
+        }
+        let metadata = match entry.metadata() {
+            Ok(metadata) => metadata,
+            Err(_) => continue,
+        };
+        if !metadata.is_file() {
+            continue;
+        }
+        let size = metadata.len();
+        if size > max_resume_size {
+            let _ = std::fs::remove_file(&path);
+            continue;
+        }
+        let replace = best.as_ref().is_none_or(|(_, best_size)| size > *best_size);
+        if replace {
+            best = Some((path, size));
+        }
+    }
+    Ok(best)
+}
+
+fn is_partial_for_destination(path: &Path, prefix: &str) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with(prefix) && name.ends_with(".part"))
+}
+
+fn partial_file_prefix(destination: &Path) -> String {
+    format!(".{}.", artifact_file_name(destination))
+}
+
+fn artifact_file_name(destination: &Path) -> String {
+    destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("artifact")
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn append_artifact_transfer_body_resumes_existing_partial() {
+        let temp = tempfile::tempdir().unwrap();
+        let partial = temp.path().join(".artifact.gguf.123.part");
+        std::fs::write(&partial, b"layer").unwrap();
+        let (mut writer, mut reader) = tokio::io::duplex(3);
+        tokio::spawn(async move {
+            writer.write_all(b"000").await.unwrap();
+        });
+
+        append_artifact_transfer_body(
+            &mut reader,
+            &partial,
+            5,
+            8,
+            2,
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(std::fs::read(partial).unwrap(), b"layer000");
+    }
+
+    #[test]
+    fn partial_artifact_guard_removes_armed_partial_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".artifact.part");
+        std::fs::write(&path, b"partial").unwrap();
+
+        {
+            let _guard = PartialArtifactGuard::new(path.clone());
+        }
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn partial_artifact_guard_preserves_disarmed_installed_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".artifact.part");
+        std::fs::write(&path, b"partial").unwrap();
+
+        {
+            let mut guard = PartialArtifactGuard::new(path.clone());
+            guard.disarm();
+        }
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn partial_artifact_guard_can_preserve_partial_after_transfer_error() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join(".artifact.part");
+        std::fs::write(&path, b"partial").unwrap();
+
+        {
+            let _guard = PartialArtifactGuard::preserve_on_error(path.clone());
+        }
+
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn select_partial_artifact_reuses_largest_valid_partial() {
+        let temp = tempfile::tempdir().unwrap();
+        let destination = temp.path().join("layer-000.gguf");
+        let small = temp.path().join(".layer-000.gguf.small.part");
+        let large = temp.path().join(".layer-000.gguf.large.part");
+        let oversized = temp.path().join(".layer-000.gguf.oversized.part");
+        let unrelated = temp.path().join(".layer-001.gguf.large.part");
+        std::fs::write(&small, b"la").unwrap();
+        std::fs::write(&large, b"layer").unwrap();
+        std::fs::write(&oversized, b"layer0000").unwrap();
+        std::fs::write(&unrelated, b"layer000").unwrap();
+
+        let selected = select_partial_artifact(&destination, 8).unwrap();
+
+        assert_eq!(
+            selected,
+            PartialArtifactSelection {
+                path: large,
+                offset: 5
+            }
+        );
+        assert!(!oversized.exists());
+        assert!(unrelated.exists());
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -30,6 +30,13 @@ use crate::crypto::{
 };
 use crate::protocol::*;
 
+use self::artifact_transfer_io::{
+    append_artifact_transfer_body, select_partial_artifact, PartialArtifactGuard,
+};
+
+#[cfg(test)]
+use self::artifact_transfer_io::read_artifact_transfer_chunk;
+
 use skippy_protocol::proto::stage as skippy_stage_proto;
 
 const PRETTY_LOCAL_REQUEST_WINDOW_SECS: u64 = 24 * 60 * 60;
@@ -68,6 +75,7 @@ pub(super) const PEER_CONNECT_AND_GOSSIP_TIMEOUT: std::time::Duration =
 const ARTIFACT_TRANSFER_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const ARTIFACT_TRANSFER_READ_IDLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 const ARTIFACT_TRANSFER_BUFFER_BYTES: usize = 1024 * 1024;
+const ARTIFACT_TRANSFER_INVALID_OFFSET_ERROR: &str = "invalid transfer offset";
 
 type MeshBiStream = (iroh::endpoint::SendStream, iroh::endpoint::RecvStream);
 
@@ -293,66 +301,6 @@ fn control_endpoint_addr(
         addr.addrs.insert(TransportAddr::Ip(advertise_addr));
     }
     addr
-}
-
-fn partial_artifact_path(destination: &std::path::Path) -> std::path::PathBuf {
-    let file_name = destination
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("artifact");
-    let unique = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|duration| duration.as_nanos())
-        .unwrap_or(0);
-    destination.with_file_name(format!(
-        ".{file_name}.{}.{}.part",
-        std::process::id(),
-        unique
-    ))
-}
-
-struct PartialArtifactGuard {
-    path: std::path::PathBuf,
-    armed: bool,
-}
-
-impl PartialArtifactGuard {
-    fn new(path: std::path::PathBuf) -> Self {
-        Self { path, armed: true }
-    }
-
-    fn disarm(&mut self) {
-        self.armed = false;
-    }
-}
-
-impl Drop for PartialArtifactGuard {
-    fn drop(&mut self) {
-        if self.armed {
-            let _ = std::fs::remove_file(&self.path);
-        }
-    }
-}
-
-async fn read_artifact_transfer_chunk<R>(
-    reader: &mut R,
-    buffer: &mut [u8],
-    idle_timeout: std::time::Duration,
-) -> Result<usize>
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    let read = tokio::time::timeout(idle_timeout, tokio::io::AsyncReadExt::read(reader, buffer))
-        .await
-        .map_err(|_| {
-            anyhow::anyhow!("artifact transfer body read idle timeout after {idle_timeout:?}")
-        })?
-        .context("read artifact transfer bytes")?;
-    anyhow::ensure!(
-        read > 0,
-        "artifact transfer ended before expected byte count"
-    );
-    Ok(read)
 }
 
 async fn write_artifact_transfer_response(
@@ -5734,8 +5682,6 @@ impl Node {
         artifact: &crate::models::artifact_transfer::PackageArtifactRequest,
         destination: &std::path::Path,
     ) -> Result<()> {
-        use tokio::io::AsyncWriteExt;
-
         if let Some(parent) = destination.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -5745,9 +5691,11 @@ impl Node {
             &artifact.package_ref,
             destination,
         )?;
-        let temp_path = partial_artifact_path(destination);
-        let mut partial_guard = PartialArtifactGuard::new(temp_path.clone());
-        let offset = 0;
+        let resume_limit = Self::artifact_transfer_resume_limit(artifact)?;
+        let partial = select_partial_artifact(destination, resume_limit)?;
+        let temp_path = partial.path;
+        let offset = partial.offset;
+        let mut partial_guard = PartialArtifactGuard::preserve_on_error(temp_path.clone());
 
         let frame = skippy_stage_proto::StageArtifactTransferRequest {
             gen: skippy_protocol::STAGE_PROTOCOL_GENERATION,
@@ -5788,6 +5736,7 @@ impl Node {
         .await
         .map_err(|_| anyhow::anyhow!("timeout opening artifact transfer stream"))??;
         let (mut recv, response) = response;
+        Self::remove_invalid_resume_partial(&mut partial_guard, offset, &response);
         if !response.accepted {
             anyhow::bail!(
                 "peer artifact transfer rejected: {}",
@@ -5826,29 +5775,15 @@ impl Node {
         );
 
         let transfer_result = async {
-            let mut file = tokio::fs::OpenOptions::new()
-                .create_new(true)
-                .write(true)
-                .open(&temp_path)
-                .await
-                .context("open partial artifact")?;
-            let mut remaining = response.total_size.saturating_sub(offset);
-            let mut buffer = vec![0u8; ARTIFACT_TRANSFER_BUFFER_BYTES];
-            while remaining > 0 {
-                let limit = buffer.len().min(remaining as usize);
-                let read = read_artifact_transfer_chunk(
-                    &mut recv,
-                    &mut buffer[..limit],
-                    ARTIFACT_TRANSFER_READ_IDLE_TIMEOUT,
-                )
-                .await?;
-                file.write_all(&buffer[..read])
-                    .await
-                    .context("write partial artifact")?;
-                remaining -= read as u64;
-            }
-            file.flush().await.context("flush partial artifact")?;
-            drop(file);
+            append_artifact_transfer_body(
+                &mut recv,
+                &temp_path,
+                offset,
+                response.total_size,
+                ARTIFACT_TRANSFER_BUFFER_BYTES,
+                ARTIFACT_TRANSFER_READ_IDLE_TIMEOUT,
+            )
+            .await?;
 
             let actual_size = tokio::fs::metadata(&temp_path)
                 .await
@@ -5883,11 +5818,53 @@ impl Node {
         }
         .await;
         if let Err(error) = transfer_result {
-            let _ = tokio::fs::remove_file(&temp_path).await;
+            let error_message = error.to_string();
+            if error_message.contains("transferred artifact sha256 mismatch")
+                || error_message.contains("partial artifact size mismatch after transfer")
+            {
+                partial_guard.remove_now();
+            }
             return Err(error);
         }
         partial_guard.disarm();
         Ok(())
+    }
+
+    fn remove_invalid_resume_partial(
+        partial_guard: &mut PartialArtifactGuard,
+        offset: u64,
+        response: &skippy_stage_proto::StageArtifactTransferResponse,
+    ) {
+        if Self::artifact_transfer_response_invalidates_resume_offset(offset, response) {
+            partial_guard.remove_now();
+        }
+    }
+
+    fn artifact_transfer_response_invalidates_resume_offset(
+        offset: u64,
+        response: &skippy_stage_proto::StageArtifactTransferResponse,
+    ) -> bool {
+        if offset == 0 {
+            return false;
+        }
+        if response.accepted {
+            return offset > response.total_size;
+        }
+        response.error.as_deref() == Some(ARTIFACT_TRANSFER_INVALID_OFFSET_ERROR)
+    }
+
+    fn artifact_transfer_resume_limit(
+        artifact: &crate::models::artifact_transfer::PackageArtifactRequest,
+    ) -> Result<u64> {
+        if let Some(expected_size) = artifact.expected_size {
+            return Ok(expected_size);
+        }
+        if artifact.relative_path.as_path()
+            == std::path::Path::new(crate::models::artifact_transfer::PACKAGE_MANIFEST_FILE)
+        {
+            return Ok(crate::models::artifact_transfer::MAX_PACKAGE_MANIFEST_BYTES);
+        }
+        anyhow::bail!("artifact transfer resume requires an expected artifact size")
     }
 
     async fn artifact_transfer_rejected(
@@ -5993,25 +5970,32 @@ impl Node {
         send: &mut iroh::endpoint::SendStream,
         request: &skippy_stage_proto::StageArtifactTransferRequest,
     ) -> anyhow::Result<Option<crate::models::artifact_transfer::ServableArtifact>> {
-        let artifact =
-            match crate::models::artifact_transfer::servable_artifact_from_request(request) {
-                Ok(artifact) => artifact,
-                Err(error) => {
-                    tracing::debug!(
-                        peer = %remote.fmt_short(),
-                        path = %request.relative_path,
-                        "artifact transfer request cannot be served: {error}"
-                    );
-                    Self::artifact_transfer_rejected(send, 0, None, "artifact unavailable").await?;
-                    return Ok(None);
-                }
-            };
+        let request_for_resolution = request.clone();
+        let artifact = match tokio::task::spawn_blocking(move || {
+            crate::models::artifact_transfer::servable_artifact_from_request(
+                &request_for_resolution,
+            )
+        })
+        .await
+        .context("join artifact transfer resolution task")?
+        {
+            Ok(artifact) => artifact,
+            Err(error) => {
+                tracing::debug!(
+                    peer = %remote.fmt_short(),
+                    path = %request.relative_path,
+                    "artifact transfer request cannot be served: {error}"
+                );
+                Self::artifact_transfer_rejected(send, 0, None, "artifact unavailable").await?;
+                return Ok(None);
+            }
+        };
         if request.offset > artifact.size {
             Self::artifact_transfer_rejected(
                 send,
                 artifact.size,
                 Some(&artifact.sha256),
-                "invalid transfer offset",
+                ARTIFACT_TRANSFER_INVALID_OFFSET_ERROR,
             )
             .await?;
             return Ok(None);
@@ -8323,6 +8307,7 @@ fn ensure_private_node_key_file(path: &std::path::Path) -> Result<()> {
     Ok(())
 }
 
+mod artifact_transfer_io;
 mod gossip;
 mod heartbeat;
 pub use gossip::backfill_legacy_descriptors;

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -2189,6 +2189,31 @@ async fn artifact_transfer_stream_serves_authorized_stage_artifact() -> Result<(
     recv.read_exact(&mut bytes).await?;
     assert_eq!(bytes, b"layer000");
 
+    let mut resume_request = request.clone();
+    resume_request.offset = 5;
+    let (mut resume_send, mut resume_recv) = client
+        .open_skippy_stage_mesh_stream(server_id, skippy_protocol::STAGE_STREAM_ARTIFACT_TRANSFER)
+        .await?;
+    write_len_prefixed(&mut resume_send, &resume_request.encode_to_vec()).await?;
+    resume_send.finish()?;
+    let resume_response_buf = read_len_prefixed(&mut resume_recv).await?;
+    let resume_response =
+        skippy_stage_proto::StageArtifactTransferResponse::decode(resume_response_buf.as_slice())?;
+    assert!(
+        resume_response.accepted,
+        "resume artifact response: {:?}",
+        resume_response.error
+    );
+    assert_eq!(resume_response.total_size, 8);
+    assert_eq!(
+        resume_response.sha256.as_deref(),
+        Some(expected_sha.as_str())
+    );
+    let mut resumed_bytes =
+        vec![0u8; (resume_response.total_size - resume_request.offset) as usize];
+    resume_recv.read_exact(&mut resumed_bytes).await?;
+    assert_eq!(resumed_bytes, b"000");
+
     let conn = client.stage_connection_to_peer(server_id).await?;
     let (mut legacy_send, mut legacy_recv) = conn.open_bi().await?;
     legacy_send
@@ -2213,6 +2238,85 @@ async fn artifact_transfer_stream_serves_authorized_stage_artifact() -> Result<(
     legacy_recv.read_exact(&mut legacy_bytes).await?;
     assert_eq!(legacy_bytes, b"layer000");
     assert!(package_dir.join("model-package.json").is_file());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn artifact_transfer_stream_rejects_corrupt_same_size_cached_artifact() -> Result<()> {
+    use crate::protocol::{read_len_prefixed, write_len_prefixed};
+    use base64::Engine as _;
+    use prost::Message as _;
+
+    let cache = tempfile::tempdir().unwrap();
+    let _cache_guard = EnvVarGuard::set("HF_HUB_CACHE", cache.path());
+    let _transfer_guard = EnvVarGuard::set_str("MESH_LLM_ARTIFACT_TRANSFER", "1");
+    let (package_dir, package_ref, manifest_sha256) =
+        write_hf_artifact_stream_package(cache.path());
+    std::fs::write(package_dir.join("layers/layer-000.gguf"), b"corrupt!").unwrap();
+    let server = make_test_node(super::NodeRole::Host { http_port: 9337 }).await?;
+    let client = make_test_node(super::NodeRole::Worker).await?;
+    server
+        .set_mesh_id("artifact-transfer-corrupt-mesh".to_string())
+        .await;
+    client
+        .set_mesh_id("artifact-transfer-corrupt-mesh".to_string())
+        .await;
+    server.start_accepting();
+    client.start_accepting();
+
+    let server_id = server.id();
+    let client_id = client.id();
+    let invite = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(&server.endpoint.addr())?);
+    client.join(&invite).await?;
+    wait_for_peer(&client, server_id).await;
+    wait_for_peer(&server, client_id).await;
+    server
+        .record_stage_topology(StageTopologyInstance {
+            topology_id: "topology-artifact-corrupt".to_string(),
+            run_id: "run-artifact-corrupt".to_string(),
+            model_id: "model-artifact".to_string(),
+            package_ref: package_ref.clone(),
+            manifest_sha256: manifest_sha256.clone(),
+            stages: vec![StageAssignment {
+                stage_id: "stage-0".to_string(),
+                stage_index: 0,
+                node_id: client_id,
+                layer_start: 0,
+                layer_end: 1,
+                endpoint: StageEndpoint {
+                    bind_addr: String::new(),
+                },
+            }],
+        })
+        .await;
+
+    let request = skippy_stage_proto::StageArtifactTransferRequest {
+        gen: skippy_protocol::STAGE_PROTOCOL_GENERATION,
+        requester_id: client_id.as_bytes().to_vec(),
+        topology_id: "topology-artifact-corrupt".to_string(),
+        run_id: "run-artifact-corrupt".to_string(),
+        stage_id: "stage-0".to_string(),
+        package_ref,
+        manifest_sha256,
+        relative_path: "layers/layer-000.gguf".to_string(),
+        offset: 0,
+        expected_size: Some(8),
+        expected_sha256: Some(sha256_hex(b"layer000")),
+    };
+
+    let (mut send, mut recv) = client
+        .open_skippy_stage_mesh_stream(server_id, skippy_protocol::STAGE_STREAM_ARTIFACT_TRANSFER)
+        .await?;
+    write_len_prefixed(&mut send, &request.encode_to_vec()).await?;
+    send.finish()?;
+    let response_buf = read_len_prefixed(&mut recv).await?;
+    let response =
+        skippy_stage_proto::StageArtifactTransferResponse::decode(response_buf.as_slice())?;
+    assert!(!response.accepted);
+    assert_eq!(response.error.as_deref(), Some("artifact unavailable"));
 
     Ok(())
 }
@@ -2314,6 +2418,44 @@ async fn artifact_transfer_body_read_has_idle_timeout() {
     assert!(error
         .to_string()
         .contains("artifact transfer body read idle timeout"));
+}
+
+#[test]
+fn artifact_transfer_invalid_resume_offset_removes_preserved_partial() {
+    let temp = tempfile::tempdir().unwrap();
+    let partial = temp.path().join(".model-package.json.stale.part");
+    std::fs::write(&partial, b"stale manifest bytes").unwrap();
+    let mut guard = PartialArtifactGuard::preserve_on_error(partial.clone());
+    let response = skippy_stage_proto::StageArtifactTransferResponse {
+        gen: skippy_protocol::STAGE_PROTOCOL_GENERATION,
+        accepted: false,
+        total_size: 8,
+        sha256: Some(sha256_hex(b"manifest")),
+        error: Some(ARTIFACT_TRANSFER_INVALID_OFFSET_ERROR.to_string()),
+    };
+
+    Node::remove_invalid_resume_partial(&mut guard, 128, &response);
+
+    assert!(!partial.exists());
+}
+
+#[test]
+fn artifact_transfer_smaller_resume_response_removes_preserved_partial() {
+    let temp = tempfile::tempdir().unwrap();
+    let partial = temp.path().join(".model-package.json.oversized.part");
+    std::fs::write(&partial, b"stale manifest bytes").unwrap();
+    let mut guard = PartialArtifactGuard::preserve_on_error(partial.clone());
+    let response = skippy_stage_proto::StageArtifactTransferResponse {
+        gen: skippy_protocol::STAGE_PROTOCOL_GENERATION,
+        accepted: true,
+        total_size: 8,
+        sha256: Some(sha256_hex(b"manifest")),
+        error: None,
+    };
+
+    Node::remove_invalid_resume_partial(&mut guard, 128, &response);
+
+    assert!(!partial.exists());
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
+++ b/crates/mesh-llm-host-runtime/src/models/artifact_transfer.rs
@@ -337,6 +337,11 @@ pub(crate) fn servable_artifact_from_request(
         metadata.len() == declared.artifact_bytes,
         "cached artifact size mismatch"
     );
+    let actual_sha = file_sha256_hex(&path)?;
+    anyhow::ensure!(
+        actual_sha.eq_ignore_ascii_case(&declared.sha256),
+        "cached artifact sha256 mismatch"
+    );
     Ok(ServableArtifact {
         path,
         size: declared.artifact_bytes,
@@ -370,22 +375,30 @@ fn parse_hf_package_ref(package_ref: &str) -> Result<HfPackageRef> {
     let rest = package_ref
         .strip_prefix("hf://")
         .context("artifact transfer only supports hf:// package refs")?;
-    let (repo, revision) = if let Some((repo, revision)) = rest.split_once('@') {
-        (repo, revision)
-    } else if let Some(index) = rest.rfind(':') {
-        (&rest[..index], &rest[index + 1..])
-    } else {
-        (rest, "main")
-    };
+    let (repo, revision) = rest
+        .split_once('@')
+        .context("artifact transfer requires an explicit immutable hf://namespace/repo@revision")?;
     anyhow::ensure!(
         repo.split('/').count() == 2 && !repo.contains(':') && !repo.contains('@'),
         "HF package repo id must look like namespace/repo"
     );
-    anyhow::ensure!(!revision.trim().is_empty(), "HF package revision is empty");
+    let revision = revision.trim();
+    anyhow::ensure!(!revision.is_empty(), "HF package revision is empty");
+    anyhow::ensure!(
+        is_immutable_revision_hint(revision),
+        "artifact transfer requires an immutable HF package revision"
+    );
     Ok(HfPackageRef {
         repo: repo.to_string(),
         revision: revision.to_string(),
     })
+}
+
+fn is_immutable_revision_hint(revision: &str) -> bool {
+    !matches!(
+        revision.trim().to_ascii_lowercase().as_str(),
+        "main" | "master" | "latest" | "dev" | "develop" | "development"
+    )
 }
 
 fn hf_repo_cache_root(repo: &str) -> PathBuf {
@@ -797,6 +810,58 @@ mod tests {
         assert!(servable_artifact_from_request(&undeclared).is_err());
 
         restore_env("HF_HUB_CACHE", prev);
+    }
+
+    #[test]
+    #[serial]
+    fn servable_artifact_rejects_same_size_corrupt_cached_bytes() {
+        let prev = std::env::var_os("HF_HUB_CACHE");
+        let temp = tempfile::tempdir().unwrap();
+        std::env::set_var("HF_HUB_CACHE", temp.path());
+        let (package_dir, package_ref, manifest_sha) = write_package_fixture(temp.path());
+        fs::write(package_dir.join("layers/layer-000.gguf"), b"corrupt!").unwrap();
+
+        let request = skippy_protocol::proto::stage::StageArtifactTransferRequest {
+            gen: skippy_protocol::STAGE_PROTOCOL_GENERATION,
+            requester_id: vec![1; 32],
+            topology_id: "topology-a".to_string(),
+            run_id: "run-a".to_string(),
+            stage_id: "stage-0".to_string(),
+            package_ref,
+            manifest_sha256: manifest_sha,
+            relative_path: "layers/layer-000.gguf".to_string(),
+            offset: 0,
+            expected_size: Some(8),
+            expected_sha256: Some(sha256_hex(b"layer000")),
+        };
+
+        let error = servable_artifact_from_request(&request).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("cached artifact sha256 mismatch"),
+            "unexpected error: {error}"
+        );
+
+        restore_env("HF_HUB_CACHE", prev);
+    }
+
+    #[test]
+    fn peer_artifact_transfer_requires_explicit_non_mutable_revision() {
+        for package_ref in [
+            "hf://meshllm/demo-layers",
+            "hf://meshllm/demo-layers:abc123",
+            "hf://meshllm/demo-layers@main",
+            "hf://meshllm/demo-layers@master",
+            "hf://meshllm/demo-layers@latest",
+        ] {
+            assert!(
+                package_cache_dir_for_ref(package_ref).is_err(),
+                "{package_ref} must not be eligible for peer transfer"
+            );
+        }
+
+        assert!(package_cache_dir_for_ref("hf://meshllm/demo-layers@abc123").is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Workers can now resume trusted Skippy layer-package artifact prefetches from an existing partial file instead of restarting every peer transfer from byte 0.

This also tightens the serving side: peer transfer now requires explicit pinned `hf://namespace/repo@revision` package refs, verifies cached artifact bytes against the package manifest before serving, and keeps partial files only when they are safe to resume.

## Why

The Skippy artifact-transfer protocol already had an `offset` field and the docs describe resume support, but the requester always sent `offset = 0` and wrote to a fresh hidden partial file. Interrupted transfers therefore lost useful progress, which matters for large layer-package artifacts on LAN/private mesh deployments.

While reviewing that path, I also found an integrity gap: a same-size corrupted cached artifact could satisfy manifest-declared size checks and be served with the manifest SHA without hashing local bytes first.

## Diff scope

- Moves partial artifact file handling into a dedicated mesh artifact-transfer IO helper.
- Reuses the largest valid hidden partial for the destination and sends its length as the transfer offset.
- Appends only the missing suffix, then verifies final size/SHA before atomic install.
- Preserves partials after resumable transfer interruptions, but removes them after final size/SHA failure.
- Rejects mutable or implicit package refs for peer transfer; only explicit `hf://namespace/repo@revision` refs are eligible.
- Hash-verifies non-manifest cached artifacts before serving them to a peer.
- Adds regression coverage for resume selection/body append, nonzero stream offset, pinned-ref eligibility, and same-size corrupted cache rejection.

## Protocol / compatibility

No protobuf, stream-byte, ALPN, gossip, or Skippy ABI change.

This continues to use the existing `skippy-stage/1` artifact-transfer stream and the existing `offset` field. Mixed-version behavior remains feature-gated by the existing subprotocol advertisement; peers without artifact-transfer support are skipped by the existing fallback path.

No package inventory, cache paths, or artifact filenames are gossiped.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@c36132fd`
- Branch state: `0 behind / 1 ahead`
- Head commit: `e1bd221d`

## Validation

- Validation tier: Tier 3 - mesh/skippy runtime transport hardening for trusted layer-package artifact transfer; no proto/schema change.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, validated `origin/main@c36132fd`.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS.
- `cargo test -p skippy-protocol stage_artifact_transfer --lib`: PASS, 1 passed.
- `cargo test -p skippy-topology --lib`: PASS, 26 passed.
- `LLAMA_STAGE_BUILD_DIR=<prepared llama-stage ABI build> cargo test -p mesh-llm-host-runtime artifact_transfer --lib`: PASS, 23 passed.
- `LLAMA_STAGE_BUILD_DIR=<prepared llama-stage ABI build> cargo check -p mesh-llm`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<prepared llama-stage ABI build> cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - no release metadata/version sync required; release flow owns version bumps.
- Remote CI: pending after PR creation.
- Not run: live two-node artifact-transfer smoke - no local multi-machine package cache setup was available; targeted mesh stream tests cover the protocol path, and remote CI should run before merge.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

The live multi-machine benefit should still be confirmed on a private mesh with a large pinned HF layer package already cached on the coordinator. The local tests prove the deterministic transfer, resume, integrity, and policy paths.