### PR TITLE
fix(kv-eviction): proactive prefix cache eviction before decode

### DIFF
--- a/crates/skippy-cache/src/config.rs
+++ b/crates/skippy-cache/src/config.rs
@@ -127,7 +127,13 @@ impl PrefixCandidatePolicy {
             return counts;
         }
         let stride = self.stride_tokens.max(1).min(self.page_size_tokens.max(1));
-        let mut candidate = token_count.saturating_sub(1);
+        let mut candidate = stable_grid_floor(token_count, stride);
+        if candidate == token_count {
+            candidate = candidate.saturating_sub(stride);
+        }
+        if candidate < self.min_tokens {
+            candidate = self.min_tokens;
+        }
         while candidate >= self.min_tokens {
             counts.push(candidate);
             if candidate == self.min_tokens {
@@ -151,32 +157,15 @@ impl PrefixCandidatePolicy {
         let mut selected = Vec::with_capacity(limit);
         selected.push(token_count);
 
-        let lower_bound = candidates
-            .iter()
-            .copied()
-            .filter(|candidate| *candidate != token_count)
-            .min()
-            .unwrap_or(token_count);
         let shared_slots = limit.saturating_sub(1);
         if shared_slots == 0 {
             return selected;
         }
-        for slot in 0..shared_slots {
-            let target = if shared_slots == 1 {
-                lower_bound
-            } else {
-                let span = token_count.saturating_sub(lower_bound);
-                token_count
-                    .saturating_sub(span.saturating_mul((slot + 1) as u64) / shared_slots as u64)
+        for candidate in candidates.iter().copied() {
+            if selected.len() >= limit {
+                break;
             }
-            .max(self.min_tokens)
-            .min(token_count);
-            if let Some(candidate) = candidates
-                .iter()
-                .copied()
-                .filter(|candidate| *candidate <= target && *candidate != token_count)
-                .max()
-            {
+            if candidate != token_count {
                 selected.push(candidate);
             }
         }
@@ -196,6 +185,10 @@ impl PrefixCandidatePolicy {
     }
 }
 
+fn stable_grid_floor(token_count: u64, stride: u64) -> u64 {
+    token_count.saturating_sub(token_count % stride.max(1))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -209,10 +202,7 @@ mod tests {
             page_size_tokens: 64,
         };
 
-        assert_eq!(
-            policy.candidate_token_counts(160),
-            vec![160, 159, 127, 95, 64]
-        );
+        assert_eq!(policy.candidate_token_counts(160), vec![160, 128, 96, 64]);
     }
 
     #[test]
@@ -224,7 +214,7 @@ mod tests {
             page_size_tokens: 64,
         };
 
-        assert_eq!(policy.record_candidate_token_counts(160), vec![160, 64]);
+        assert_eq!(policy.record_candidate_token_counts(160), vec![160, 128]);
     }
 
     #[test]
@@ -251,7 +241,40 @@ mod tests {
 
         assert_eq!(
             policy.record_candidate_token_counts(160),
-            vec![160, 159, 127, 95, 64]
+            vec![160, 128, 96, 64]
         );
+    }
+
+    #[test]
+    fn same_prefix_different_tail_prompts_share_near_tail_candidate() {
+        let policy = PrefixCandidatePolicy {
+            min_tokens: 256,
+            stride_tokens: 128,
+            record_limit: 2,
+            page_size_tokens: 256,
+        };
+
+        let recorded = policy.record_candidate_token_counts(2214);
+        let lookup = policy.candidate_token_counts(2231);
+        let shared = recorded
+            .iter()
+            .copied()
+            .find(|candidate| lookup.contains(candidate));
+
+        assert_eq!(recorded, vec![2214, 2176]);
+        assert_eq!(shared, Some(2176));
+    }
+
+    #[test]
+    fn non_aligned_min_tokens_still_provides_shared_floor_candidate() {
+        let policy = PrefixCandidatePolicy {
+            min_tokens: 300,
+            stride_tokens: 128,
+            record_limit: 2,
+            page_size_tokens: 300,
+        };
+
+        assert_eq!(policy.candidate_token_counts(350), vec![350, 300]);
+        assert_eq!(policy.record_candidate_token_counts(350), vec![350, 300]);
     }
 }

--- a/crates/skippy-cache/src/resident/prefix.rs
+++ b/crates/skippy-cache/src/resident/prefix.rs
@@ -47,6 +47,36 @@ pub struct ResidentPrefixAllocation {
     pub seq_id: i32,
     pub evictions: Vec<ResidentPrefixEviction>,
     pub should_save: bool,
+    pub should_retain: bool,
+}
+
+impl ResidentPrefixAllocation {
+    fn existing(seq_id: i32) -> Self {
+        Self {
+            seq_id,
+            evictions: Vec::new(),
+            should_save: false,
+            should_retain: true,
+        }
+    }
+
+    fn new_record(seq_id: i32, evictions: Vec<ResidentPrefixEviction>) -> Self {
+        Self {
+            seq_id,
+            evictions,
+            should_save: true,
+            should_retain: true,
+        }
+    }
+
+    fn uncacheable() -> Self {
+        Self {
+            seq_id: -1,
+            evictions: Vec::new(),
+            should_save: false,
+            should_retain: false,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -124,21 +154,16 @@ impl ResidentPrefixCache {
         }
         self.clock = self.clock.saturating_add(1);
         if let Some(entry) = self.entries.get(page_id) {
-            return Ok(ResidentPrefixAllocation {
-                seq_id: entry.seq_id,
-                evictions: Vec::new(),
-                should_save: false,
-            });
+            return Ok(ResidentPrefixAllocation::existing(entry.seq_id));
+        }
+        if self.candidate_exceeds_single_record_budget(estimated_bytes, token_count) {
+            return Ok(ResidentPrefixAllocation::uncacheable());
         }
 
         let evictions =
             self.evict_until_room_for(estimated_bytes, token_count, &mut drop_evicted)?;
         let seq_id = self.next_sequence_id()?;
-        Ok(ResidentPrefixAllocation {
-            seq_id,
-            evictions,
-            should_save: true,
-        })
+        Ok(ResidentPrefixAllocation::new_record(seq_id, evictions))
     }
 
     pub fn commit_record(
@@ -261,6 +286,16 @@ impl ResidentPrefixCache {
         Ok(evictions)
     }
 
+    fn candidate_exceeds_single_record_budget(
+        &self,
+        estimated_bytes: u64,
+        token_count: u64,
+    ) -> bool {
+        let over_bytes = self.max_bytes > 0 && estimated_bytes > self.max_bytes;
+        let over_tokens = self.max_resident_tokens > 0 && token_count > self.max_resident_tokens;
+        over_bytes || over_tokens
+    }
+
     fn next_sequence_id(&mut self) -> Result<i32> {
         if let Some(seq_id) = self.free_seq_ids.pop() {
             return Ok(seq_id);
@@ -343,6 +378,29 @@ mod tests {
         assert_eq!(dropped, vec![alloc1.seq_id], "LRU should evict oldest");
         assert_eq!(cache.stats().entries, 2);
         assert_eq!(cache.stats().resident_tokens, 3000);
+    }
+
+    #[test]
+    fn oversized_resident_prefix_candidate_is_nonfatal() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 4096));
+        let small = cache
+            .allocate_for_record("small", 1000, 100, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("small".to_string(), small.seq_id, 1000, 100);
+
+        let allocation = cache
+            .allocate_for_record("huge", 5000, 100, |_| {
+                panic!("oversized candidates should not evict existing entries")
+            })
+            .expect("oversized candidates should be treated as uncacheable, not fatal");
+
+        assert!(!allocation.should_save);
+        assert!(!allocation.should_retain);
+        assert!(allocation.evictions.is_empty());
+        let stats = cache.stats();
+        assert_eq!(stats.entries, 1);
+        assert_eq!(stats.resident_tokens, 1000);
+        assert!(cache.lookup("small").is_some());
     }
 
     #[test]

--- a/crates/skippy-cache/src/resident/prefix.rs
+++ b/crates/skippy-cache/src/resident/prefix.rs
@@ -205,6 +205,33 @@ impl ResidentPrefixCache {
         &mut self,
         drop_evicted: &mut impl FnMut(i32) -> Result<()>,
     ) -> Result<Option<ResidentPrefixEviction>> {
+        self.evict_lru_entry(drop_evicted)
+    }
+
+    /// Evict LRU entries until at least `min_tokens` have been released,
+    /// or until no non-borrowed entry remains. Returns the entries that
+    /// were actually evicted.
+    pub fn evict_lru_until_tokens(
+        &mut self,
+        min_tokens: u64,
+        drop_evicted: &mut impl FnMut(i32) -> Result<()>,
+    ) -> Result<Vec<ResidentPrefixEviction>> {
+        let mut evictions = Vec::new();
+        let mut evicted_tokens = 0_u64;
+        while evicted_tokens < min_tokens {
+            let Some(eviction) = self.evict_lru_entry(drop_evicted)? else {
+                break;
+            };
+            evicted_tokens = evicted_tokens.saturating_add(eviction.token_count);
+            evictions.push(eviction);
+        }
+        Ok(evictions)
+    }
+
+    fn evict_lru_entry(
+        &mut self,
+        drop_evicted: &mut impl FnMut(i32) -> Result<()>,
+    ) -> Result<Option<ResidentPrefixEviction>> {
         let victim = self
             .entries
             .iter()
@@ -214,19 +241,23 @@ impl ResidentPrefixCache {
         let Some(victim) = victim else {
             return Ok(None);
         };
-        if let Some(entry) = self.entries.remove(&victim) {
-            drop_evicted(entry.seq_id)?;
-            self.free_seq_ids.push(entry.seq_id);
-            self.resident_tokens = self.resident_tokens.saturating_sub(entry.token_count);
-            self.estimated_bytes = self.estimated_bytes.saturating_sub(entry.estimated_bytes);
-            Ok(Some(ResidentPrefixEviction {
-                page_id: victim,
-                seq_id: entry.seq_id,
-                token_count: entry.token_count,
-            }))
-        } else {
-            Ok(None)
-        }
+        let entry = self
+            .entries
+            .get(&victim)
+            .expect("selected resident prefix victim should exist");
+        drop_evicted(entry.seq_id)?;
+        let entry = self
+            .entries
+            .remove(&victim)
+            .expect("selected resident prefix victim should still exist after native drop");
+        self.free_seq_ids.push(entry.seq_id);
+        self.resident_tokens = self.resident_tokens.saturating_sub(entry.token_count);
+        self.estimated_bytes = self.estimated_bytes.saturating_sub(entry.estimated_bytes);
+        Ok(Some(ResidentPrefixEviction {
+            page_id: victim,
+            seq_id: entry.seq_id,
+            token_count: entry.token_count,
+        }))
     }
 
     pub fn stats(&self) -> ResidentPrefixCacheStats {
@@ -262,26 +293,10 @@ impl ResidentPrefixCache {
             if !over_entries && !over_bytes && !over_tokens {
                 break;
             }
-            let Some(victim) = self
-                .entries
-                .iter()
-                .filter(|(_, entry)| !entry.borrowed)
-                .min_by_key(|(_, entry)| entry.last_used)
-                .map(|(key, _)| key.clone())
-            else {
+            let Some(eviction) = self.evict_lru_entry(drop_evicted)? else {
                 bail!("resident prefix cache has no releasable entries");
             };
-            if let Some(entry) = self.entries.remove(&victim) {
-                drop_evicted(entry.seq_id)?;
-                self.free_seq_ids.push(entry.seq_id);
-                self.resident_tokens = self.resident_tokens.saturating_sub(entry.token_count);
-                self.estimated_bytes = self.estimated_bytes.saturating_sub(entry.estimated_bytes);
-                evictions.push(ResidentPrefixEviction {
-                    page_id: victim,
-                    seq_id: entry.seq_id,
-                    token_count: entry.token_count,
-                });
-            }
+            evictions.push(eviction);
         }
         Ok(evictions)
     }
@@ -644,6 +659,94 @@ mod tests {
             cache.free_seq_ids.contains(&alloc.seq_id),
             "evicted seq_id should be reusable"
         );
+    }
+
+    #[test]
+    fn evict_one_lru_drop_failure_preserves_cache_state() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let alloc = cache
+            .allocate_for_record("page-0", 1000, 200, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc.seq_id, 1000, 200);
+
+        let error = cache.evict_one_lru_entry(&mut |_| Err(anyhow::anyhow!("native drop failed")));
+
+        assert!(error.is_err());
+        assert_eq!(cache.stats().entries, 1);
+        assert_eq!(cache.stats().resident_tokens, 1000);
+        assert_eq!(cache.stats().estimated_bytes, 200);
+        assert!(cache.lookup("page-0").is_some());
+        assert!(cache.free_seq_ids.is_empty());
+    }
+
+    #[test]
+    fn allocate_for_record_drop_failure_preserves_existing_cache_state() {
+        let mut cache = ResidentPrefixCache::new(cfg(1, 0, 0));
+        let alloc = cache
+            .allocate_for_record("page-0", 1000, 200, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc.seq_id, 1000, 200);
+
+        let error = cache.allocate_for_record("page-1", 1000, 200, |_| {
+            Err(anyhow::anyhow!("native drop failed"))
+        });
+
+        assert!(error.is_err());
+        assert_eq!(cache.stats().entries, 1);
+        assert_eq!(cache.stats().resident_tokens, 1000);
+        assert_eq!(cache.stats().estimated_bytes, 200);
+        assert!(cache.lookup("page-0").is_some());
+        assert!(cache.lookup("page-1").is_none());
+        assert!(cache.free_seq_ids.is_empty());
+    }
+
+    #[test]
+    fn evict_lru_until_tokens_evicts_multiple_entries_until_target() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let mut seq_ids = Vec::new();
+        for (index, token_count) in [300, 400, 500].into_iter().enumerate() {
+            let alloc = cache
+                .allocate_for_record(&format!("page-{index}"), token_count, 100, |_| Ok(()))
+                .unwrap();
+            seq_ids.push(alloc.seq_id);
+            cache.commit_record(format!("page-{index}"), alloc.seq_id, token_count, 100);
+        }
+
+        let mut dropped = Vec::new();
+        let evictions = cache
+            .evict_lru_until_tokens(700, &mut |seq_id| {
+                dropped.push(seq_id);
+                Ok(())
+            })
+            .unwrap();
+
+        assert_eq!(evictions.len(), 2);
+        assert_eq!(evictions[0].page_id, "page-0");
+        assert_eq!(evictions[1].page_id, "page-1");
+        assert_eq!(dropped, vec![seq_ids[0], seq_ids[1]]);
+        assert_eq!(cache.stats().entries, 1);
+        assert_eq!(cache.stats().resident_tokens, 500);
+        assert!(cache.lookup("page-2").is_some());
+    }
+
+    #[test]
+    fn evict_lru_until_tokens_stops_when_no_releasable_entries_remain() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        for (index, token_count) in [300, 400].into_iter().enumerate() {
+            let alloc = cache
+                .allocate_for_record(&format!("page-{index}"), token_count, 100, |_| Ok(()))
+                .unwrap();
+            cache.commit_record(format!("page-{index}"), alloc.seq_id, token_count, 100);
+        }
+        cache.acquire("page-1");
+
+        let evictions = cache.evict_lru_until_tokens(1024, &mut |_| Ok(())).unwrap();
+
+        assert_eq!(evictions.len(), 1);
+        assert_eq!(evictions[0].page_id, "page-0");
+        assert_eq!(cache.stats().entries, 1);
+        assert_eq!(cache.stats().resident_tokens, 400);
+        assert!(cache.lookup("page-1").is_none());
     }
 
     #[test]

--- a/crates/skippy-cache/src/resident/prefix.rs
+++ b/crates/skippy-cache/src/resident/prefix.rs
@@ -169,6 +169,41 @@ impl ResidentPrefixCache {
         );
     }
 
+    /// Evict one LRU entry (the entry with the smallest `last_used`
+    /// that is not currently borrowed). Returns the evicted entry
+    /// metadata, or `None` if there is nothing to evict.
+    ///
+    /// This is the **proactive eviction** path: it runs outside the
+    /// normal `allocate_for_record` flow so that the decode loop can
+    /// free KV cells before grammar-triggered retries need them.
+    pub fn evict_one_lru_entry(
+        &mut self,
+        drop_evicted: &mut impl FnMut(i32) -> Result<()>,
+    ) -> Result<Option<ResidentPrefixEviction>> {
+        let victim = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| !entry.borrowed)
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(key, _)| key.clone());
+        let Some(victim) = victim else {
+            return Ok(None);
+        };
+        if let Some(entry) = self.entries.remove(&victim) {
+            drop_evicted(entry.seq_id)?;
+            self.free_seq_ids.push(entry.seq_id);
+            self.resident_tokens = self.resident_tokens.saturating_sub(entry.token_count);
+            self.estimated_bytes = self.estimated_bytes.saturating_sub(entry.estimated_bytes);
+            Ok(Some(ResidentPrefixEviction {
+                page_id: victim,
+                seq_id: entry.seq_id,
+                token_count: entry.token_count,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
     pub fn stats(&self) -> ResidentPrefixCacheStats {
         ResidentPrefixCacheStats {
             entries: self.entries.len(),
@@ -361,5 +396,329 @@ mod tests {
         );
         assert_eq!(cache.stats().entries, 12);
         assert_eq!(cache.stats().resident_tokens, 120_000);
+    }
+
+    #[test]
+    fn evict_one_lru_evicts_least_recently_used() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let mut dropped: Vec<i32> = Vec::new();
+
+        // Insert 3 entries.
+        for i in 0..3 {
+            let alloc = cache
+                .allocate_for_record(&format!("page-{i}"), 500, 100, |sid| {
+                    dropped.push(sid);
+                    Ok(())
+                })
+                .unwrap();
+            cache.commit_record(format!("page-{i}"), alloc.seq_id, 500, 100);
+        }
+        assert_eq!(cache.stats().entries, 3);
+        assert_eq!(cache.stats().resident_tokens, 1500);
+
+        // Touch page-1 and page-2 (LRU should now be page-0).
+        cache.lookup("page-1");
+        cache.lookup("page-2");
+
+        let evicted = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("should have evicted one entry");
+
+        assert_eq!(evicted.page_id, "page-0", "LRU should be page-0");
+        assert_eq!(evicted.token_count, 500);
+        assert_eq!(cache.stats().entries, 2);
+        assert_eq!(cache.stats().resident_tokens, 1000);
+    }
+
+    #[test]
+    fn evict_one_lru_skips_borrowed_entries() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let mut dropped: Vec<i32> = Vec::new();
+
+        let alloc0 = cache
+            .allocate_for_record("page-0", 500, 100, |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc0.seq_id, 500, 100);
+
+        let alloc1 = cache
+            .allocate_for_record("page-1", 500, 100, |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap();
+        cache.commit_record("page-1".to_string(), alloc1.seq_id, 500, 100);
+
+        // Borrow page-0 (the oldest entry).
+        cache.acquire("page-0");
+
+        let evicted = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("should have evicted one entry");
+
+        // page-0 is borrowed, so LRU should skip it and evict page-1.
+        assert_eq!(evicted.page_id, "page-1", "should skip borrowed entry");
+        assert_eq!(cache.stats().entries, 1);
+    }
+
+    #[test]
+    fn evict_one_lru_empty_cache_returns_none() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let result = cache.evict_one_lru_entry(&mut |_| Ok(())).unwrap();
+        assert!(result.is_none(), "empty cache should return None");
+    }
+
+    #[test]
+    fn evict_one_lru_all_borrowed_returns_none() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let mut dropped: Vec<i32> = Vec::new();
+
+        let alloc = cache
+            .allocate_for_record("page-0", 500, 100, |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc.seq_id, 500, 100);
+        cache.acquire("page-0");
+
+        let result = cache.evict_one_lru_entry(&mut |_| Ok(())).unwrap();
+        assert!(
+            result.is_none(),
+            "cache with only borrowed entries should return None"
+        );
+        assert_eq!(cache.stats().entries, 1);
+    }
+
+    #[test]
+    fn evict_one_lru_multiple_calls_drain_all_non_borrowed() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let mut dropped: Vec<i32> = Vec::new();
+
+        let mut seq_ids = Vec::new();
+        for i in 0..4 {
+            let alloc = cache
+                .allocate_for_record(&format!("page-{i}"), 300, 50, |_| Ok(()))
+                .unwrap();
+            seq_ids.push(alloc.seq_id);
+            cache.commit_record(format!("page-{i}"), alloc.seq_id, 300, 50);
+        }
+        assert_eq!(cache.stats().entries, 4);
+
+        // Touch two to shift LRU ordering.
+        cache.lookup("page-2");
+        cache.lookup("page-3");
+
+        cache.acquire("page-2");
+
+        let e1 = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("first eviction");
+        assert_eq!(e1.page_id, "page-0");
+        assert_eq!(cache.stats().entries, 3);
+
+        let e2 = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("second eviction");
+        assert_eq!(e2.page_id, "page-1");
+        assert_eq!(cache.stats().entries, 2);
+
+        let e3 = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("third eviction");
+        assert_eq!(e3.page_id, "page-3");
+        assert_eq!(cache.stats().entries, 1);
+
+        let e4 = cache.evict_one_lru_entry(&mut |_| Ok(())).unwrap();
+        assert!(e4.is_none(), "only borrowed remains");
+        assert_eq!(cache.stats().entries, 1);
+
+        assert!(dropped.contains(&seq_ids[0]), "page-0 seq_id dropped");
+        assert!(dropped.contains(&seq_ids[1]), "page-1 seq_id dropped");
+        assert!(dropped.contains(&seq_ids[3]), "page-3 seq_id dropped");
+    }
+
+    #[test]
+    fn evict_one_lru_updates_internal_accounting() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let alloc = cache
+            .allocate_for_record("page-0", 1000, 200, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc.seq_id, 1000, 200);
+
+        assert_eq!(cache.stats().resident_tokens, 1000);
+        assert_eq!(cache.stats().estimated_bytes, 200);
+        assert_eq!(cache.stats().entries, 1);
+
+        let evicted = cache
+            .evict_one_lru_entry(&mut |_| Ok(()))
+            .unwrap()
+            .expect("should evict");
+
+        assert_eq!(cache.stats().resident_tokens, 0);
+        assert_eq!(cache.stats().estimated_bytes, 0);
+        assert_eq!(cache.stats().entries, 0);
+        assert_eq!(evicted.token_count, 1000);
+        assert_eq!(evicted.seq_id, alloc.seq_id);
+        assert!(
+            cache.free_seq_ids.contains(&alloc.seq_id),
+            "evicted seq_id should be reusable"
+        );
+    }
+
+    #[test]
+    fn evict_one_lru_seq_id_reused_on_subsequent_allocation() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let alloc = cache
+            .allocate_for_record("page-0", 500, 100, |_| Ok(()))
+            .unwrap();
+        let orig_seq_id = alloc.seq_id;
+        cache.commit_record("page-0".to_string(), orig_seq_id, 500, 100);
+
+        cache.evict_one_lru_entry(&mut |_| Ok(())).unwrap();
+
+        let alloc2 = cache
+            .allocate_for_record("page-1", 500, 100, |_| Ok(()))
+            .unwrap();
+        assert_eq!(
+            alloc2.seq_id, orig_seq_id,
+            "should reuse evicted seq_id before allocating new one"
+        );
+    }
+
+    #[test]
+    fn evict_one_lru_then_recommit_same_page_id() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let alloc = cache
+            .allocate_for_record("page-0", 500, 100, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc.seq_id, 500, 100);
+
+        cache.evict_one_lru_entry(&mut |_| Ok(())).unwrap();
+
+        assert_eq!(cache.stats().entries, 0);
+        assert_eq!(cache.stats().resident_tokens, 0);
+
+        let alloc2 = cache
+            .allocate_for_record("page-0", 800, 150, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc2.seq_id, 800, 150);
+
+        assert_eq!(cache.stats().entries, 1);
+        assert_eq!(cache.stats().resident_tokens, 800);
+        assert_eq!(cache.stats().estimated_bytes, 150);
+    }
+
+    #[test]
+    fn evict_one_lru_preserves_allocate_for_record_eviction_logic() {
+        let mut cache = ResidentPrefixCache::new(cfg(4, 0, 4096));
+        let mut dropped: Vec<i32> = Vec::new();
+
+        for i in 0..4 {
+            let alloc = cache
+                .allocate_for_record(&format!("page-{i}"), 500, 100, |_| Ok(()))
+                .unwrap();
+            cache.commit_record(format!("page-{i}"), alloc.seq_id, 500, 100);
+        }
+        assert_eq!(cache.stats().entries, 4);
+
+        cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("should evict");
+        assert_eq!(cache.stats().entries, 3);
+
+        let alloc = cache
+            .allocate_for_record("page-4", 500, 100, |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap();
+        assert!(
+            alloc.evictions.is_empty(),
+            "allocate after proactive eviction should not need more evictions"
+        );
+        cache.commit_record("page-4".to_string(), alloc.seq_id, 500, 100);
+        assert_eq!(cache.stats().entries, 4);
+    }
+
+    #[test]
+    fn evict_one_lru_after_release_shifts_lru_ordering() {
+        let mut cache = ResidentPrefixCache::new(cfg(16, 0, 0));
+        let mut dropped: Vec<i32> = Vec::new();
+
+        let alloc0 = cache
+            .allocate_for_record("page-0", 500, 100, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-0".to_string(), alloc0.seq_id, 500, 100);
+
+        let alloc1 = cache
+            .allocate_for_record("page-1", 500, 100, |_| Ok(()))
+            .unwrap();
+        cache.commit_record("page-1".to_string(), alloc1.seq_id, 500, 100);
+
+        // Release bumps last_used, so page-0 becomes strictly newer.
+        cache.acquire("page-0");
+        cache.release("page-0");
+
+        let evicted = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("should evict");
+        assert_eq!(
+            evicted.page_id, "page-1",
+            "recently released entry should not be LRU immediately"
+        );
+    }
+
+    #[test]
+    fn evict_one_lru_from_cache_at_entry_cap_does_not_panic() {
+        let mut cache = ResidentPrefixCache::new(cfg(4, 0, 0));
+        let mut dropped: Vec<i32> = Vec::new();
+        for i in 0..4 {
+            let alloc = cache
+                .allocate_for_record(&format!("page-{i}"), 500, 100, |_| Ok(()))
+                .unwrap();
+            cache.commit_record(format!("page-{i}"), alloc.seq_id, 500, 100);
+        }
+        assert_eq!(cache.stats().entries, 4);
+
+        let evicted = cache
+            .evict_one_lru_entry(&mut |sid| {
+                dropped.push(sid);
+                Ok(())
+            })
+            .unwrap()
+            .expect("should evict at cap");
+        assert_eq!(evicted.page_id, "page-0");
+        assert_eq!(cache.stats().entries, 3);
     }
 }

--- a/crates/skippy-metrics/src/lib.rs
+++ b/crates/skippy-metrics/src/lib.rs
@@ -11,6 +11,12 @@ pub mod attr {
     pub const LAYER_START: &str = "skippy.layer_start";
     pub const LAYER_END: &str = "skippy.layer_end";
     pub const LOAD_MODE: &str = "skippy.load_mode";
+    pub const KV_PROACTIVE_EVICTION_STATUS: &str = "skippy.kv.proactive_eviction_status";
+    pub const KV_PROACTIVE_EVICTION_ERROR_KIND: &str = "skippy.kv.proactive_eviction_error_kind";
+    pub const KV_PROACTIVE_EVICTION_TARGET_TOKENS: &str =
+        "skippy.kv.proactive_eviction_target_tokens";
+    pub const KV_PROACTIVE_EVICTED_ENTRIES: &str = "skippy.kv.proactive_evicted_entries";
+    pub const KV_PROACTIVE_EVICTED_TOKENS: &str = "skippy.kv.proactive_evicted_tokens";
 }
 
 pub mod metric {

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -32,6 +32,13 @@ pub const GGML_TYPE_Q4_0: u32 = 2;
 pub const GGML_TYPE_Q8_0: u32 = 8;
 pub const LLAMA_SERVER_DEFAULT_N_BATCH: u32 = 2048;
 pub const LLAMA_SERVER_DEFAULT_N_UBATCH: u32 = 512;
+/// Smaller default prefill batch for multi-lane skippy serving.
+///
+/// When `lane_count > 1`, skippy enables llama.cpp unified KV mode: every
+/// lane shares one `n_ctx` cell pool. A smaller default batch reduces the
+/// amount of KV space each prefill asks the shared pool to reserve at once
+/// after other lanes reset or preserve resident prefixes.
+pub const SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH: u32 = 1024;
 
 /// GGML_LLAMA_LOG_LEVEL values (set before llama_backend_init).
 /// 0=silent, 1=error, 2=warn, 3=info (default), 4=debug.
@@ -757,6 +764,10 @@ impl RuntimeConfig {
 
     fn as_raw(&self) -> Result<RawRuntimeConfigParts> {
         self.validate().map_err(anyhow::Error::msg)?;
+        let n_batch = self
+            .n_batch
+            .unwrap_or_else(|| default_n_batch_for_lane_count(self.lane_count));
+        let n_ubatch = self.n_ubatch.unwrap_or(LLAMA_SERVER_DEFAULT_N_UBATCH);
         let selected_backend_device = self
             .selected_backend_device
             .as_ref()
@@ -776,20 +787,8 @@ impl RuntimeConfig {
                 layer_end: i32::try_from(self.layer_end).context("layer_end exceeds i32")?,
                 ctx_size: i32::try_from(self.ctx_size).context("ctx_size exceeds i32")?,
                 lane_count: i32::try_from(self.lane_count).context("lane_count exceeds i32")?,
-                n_batch: self
-                    .n_batch
-                    .or(Some(LLAMA_SERVER_DEFAULT_N_BATCH))
-                    .map(i32::try_from)
-                    .transpose()
-                    .context("n_batch exceeds i32")?
-                    .unwrap_or(0),
-                n_ubatch: self
-                    .n_ubatch
-                    .or(Some(LLAMA_SERVER_DEFAULT_N_UBATCH))
-                    .map(i32::try_from)
-                    .transpose()
-                    .context("n_ubatch exceeds i32")?
-                    .unwrap_or(0),
+                n_batch: i32::try_from(n_batch).context("n_batch exceeds i32")?,
+                n_ubatch: i32::try_from(n_ubatch).context("n_ubatch exceeds i32")?,
                 n_threads: self
                     .n_threads
                     .map(i32::try_from)
@@ -818,6 +817,14 @@ impl RuntimeConfig {
             },
             _selected_backend_device: selected_backend_device,
         })
+    }
+}
+
+fn default_n_batch_for_lane_count(lane_count: u32) -> u32 {
+    if lane_count > 1 {
+        SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH
+    } else {
+        LLAMA_SERVER_DEFAULT_N_BATCH
     }
 }
 
@@ -3493,7 +3500,8 @@ mod tests {
         set_filtered_native_logs_enabled, unregister_filtered_native_logs, write_native_log,
         ChatTemplateMessage, FlashAttentionType, ModelInfo, NativeLogAggregator, NativeLogEvent,
         RuntimeConfig, RuntimeLoadMode, StageModel, TensorRole, GGML_TYPE_F16, GGML_TYPE_Q4_0,
-        GGML_TYPE_Q8_0,
+        GGML_TYPE_Q8_0, LLAMA_SERVER_DEFAULT_N_BATCH, LLAMA_SERVER_DEFAULT_N_UBATCH,
+        SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH,
     };
 
     static NATIVE_LOG_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
@@ -3638,6 +3646,54 @@ mod tests {
             unsafe { std::ffi::CStr::from_ptr(raw.raw.selected_backend_device).to_string_lossy() };
 
         assert_eq!(device, "MTL0");
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_uses_smaller_batch_for_unified_kv_defaults() -> anyhow::Result<()> {
+        let config = RuntimeConfig {
+            lane_count: 4,
+            n_batch: None,
+            n_ubatch: None,
+            ..RuntimeConfig::default()
+        };
+
+        let raw = config.as_raw()?;
+
+        assert_eq!(raw.raw.n_batch, SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH as i32);
+        assert_eq!(raw.raw.n_ubatch, LLAMA_SERVER_DEFAULT_N_UBATCH as i32);
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_keeps_llama_batch_default_for_single_lane() -> anyhow::Result<()> {
+        let config = RuntimeConfig {
+            lane_count: 1,
+            n_batch: None,
+            n_ubatch: None,
+            ..RuntimeConfig::default()
+        };
+
+        let raw = config.as_raw()?;
+
+        assert_eq!(raw.raw.n_batch, LLAMA_SERVER_DEFAULT_N_BATCH as i32);
+        assert_eq!(raw.raw.n_ubatch, LLAMA_SERVER_DEFAULT_N_UBATCH as i32);
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_preserves_explicit_unified_kv_batch() -> anyhow::Result<()> {
+        let config = RuntimeConfig {
+            lane_count: 4,
+            n_batch: Some(2048),
+            n_ubatch: Some(256),
+            ..RuntimeConfig::default()
+        };
+
+        let raw = config.as_raw()?;
+
+        assert_eq!(raw.raw.n_batch, 2048);
+        assert_eq!(raw.raw.n_ubatch, 256);
         Ok(())
     }
 

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1919,6 +1919,55 @@ fn openai_io_error(error: std::io::Error) -> OpenAiError {
     OpenAiError::backend(error.to_string())
 }
 
+fn proactive_eviction_error_kind(error: &anyhow::Error) -> &'static str {
+    let message = error.to_string();
+    if message.contains("is not active") {
+        "inactive_session"
+    } else if message.contains("batch size") {
+        "invalid_batch_size"
+    } else {
+        "native_drop_failed"
+    }
+}
+
+fn proactive_eviction_attrs(
+    status: &str,
+    error_kind: Option<&str>,
+    target_tokens: u64,
+    evicted_entries: usize,
+    evicted_tokens: u64,
+) -> BTreeMap<String, Value> {
+    let mut attrs = BTreeMap::from([
+        (
+            "skippy.kv.decision".to_string(),
+            json!("proactive_eviction"),
+        ),
+        (
+            attr_key::KV_PROACTIVE_EVICTION_STATUS.to_string(),
+            json!(status),
+        ),
+        (
+            attr_key::KV_PROACTIVE_EVICTION_TARGET_TOKENS.to_string(),
+            json!(target_tokens),
+        ),
+        (
+            attr_key::KV_PROACTIVE_EVICTED_ENTRIES.to_string(),
+            json!(evicted_entries),
+        ),
+        (
+            attr_key::KV_PROACTIVE_EVICTED_TOKENS.to_string(),
+            json!(evicted_tokens),
+        ),
+    ]);
+    if let Some(error_kind) = error_kind {
+        attrs.insert(
+            attr_key::KV_PROACTIVE_EVICTION_ERROR_KIND.to_string(),
+            json!(error_kind),
+        );
+    }
+    attrs
+}
+
 fn parse_wire_dtype(value: &str) -> Result<WireActivationDType> {
     match value {
         "fp32" | "f32" => Ok(WireActivationDType::F32),

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -287,13 +287,51 @@ impl StageOpenAiBackend {
         };
         let max_tokens = max_tokens.resolve(prefill.position as usize, self.ctx_size)?;
 
-        // Proactive eviction: free one resident prefix KV slot for
-        // grammar-triggered retries during the coming decode loop.
+        // Proactive eviction: free one native decode batch worth of resident
+        // prefix KV cells for grammar-triggered retries during the coming
+        // decode loop.
+        let mut proactive_eviction_status = "disabled";
+        let mut proactive_eviction_error_kind_attr = None;
+        let mut proactive_eviction_target_tokens = 0_u64;
+        let mut proactive_evicted_entries = 0_usize;
+        let mut proactive_evicted_tokens = 0_u64;
         if let Some(kv) = self.kv.as_ref() {
-            if let Ok(mut runtime) = self.runtime.lock() {
-                let _ = kv.evict_one_resident_prefix(&mut runtime, &session_id);
+            match self.runtime.lock() {
+                Ok(mut runtime) => {
+                    match kv.evict_resident_prefix_for_decode_batch(&mut runtime, &session_id) {
+                        Ok(eviction) => {
+                            proactive_eviction_status = if eviction.evicted_entries > 0 {
+                                "evicted"
+                            } else {
+                                "noop"
+                            };
+                            proactive_eviction_target_tokens = eviction.target_tokens;
+                            proactive_evicted_entries = eviction.evicted_entries;
+                            proactive_evicted_tokens = eviction.evicted_tokens;
+                        }
+                        Err(error) => {
+                            proactive_eviction_status = "error";
+                            proactive_eviction_error_kind_attr =
+                                Some(proactive_eviction_error_kind(&error));
+                        }
+                    }
+                }
+                Err(_) => {
+                    proactive_eviction_status = "error";
+                    proactive_eviction_error_kind_attr = Some("runtime_lock_poisoned");
+                }
             }
         }
+        self.telemetry.emit(
+            "stage.openai_kv_record_decision",
+            proactive_eviction_attrs(
+                proactive_eviction_status,
+                proactive_eviction_error_kind_attr,
+                proactive_eviction_target_tokens,
+                proactive_evicted_entries,
+                proactive_evicted_tokens,
+            ),
+        );
 
         let mut collector =
             TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk);

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -287,6 +287,14 @@ impl StageOpenAiBackend {
         };
         let max_tokens = max_tokens.resolve(prefill.position as usize, self.ctx_size)?;
 
+        // Proactive eviction: free one resident prefix KV slot for
+        // grammar-triggered retries during the coming decode loop.
+        if let Some(kv) = self.kv.as_ref() {
+            if let Ok(mut runtime) = self.runtime.lock() {
+                let _ = kv.evict_one_resident_prefix(&mut runtime, &session_id);
+            }
+        }
+
         let mut collector =
             TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk);
         let result = (|| {

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -285,6 +285,12 @@ impl StageOpenAiBackend {
                         }
                     }
                 }
+                // Proactive eviction: after prefill recording, evict one
+                // LRU resident prefix entry to free KV cells for
+                // grammar-triggered retries during the decode loop.
+                if let Some(kv) = self.kv.as_ref() {
+                    let _ = kv.evict_one_resident_prefix(&mut runtime, &session_id);
+                }
                 let runtime_sessions_after = runtime.session_stats();
                 let runtime_lock_hold_ms = runtime_lock_hold_timer.elapsed_ms();
                 let mut attrs = self.openai_attrs(request.ids);

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -285,11 +285,32 @@ impl StageOpenAiBackend {
                         }
                     }
                 }
-                // Proactive eviction: after prefill recording, evict one
-                // LRU resident prefix entry to free KV cells for
-                // grammar-triggered retries during the decode loop.
+                // Proactive eviction: after prefill recording, evict enough
+                // LRU resident-prefix entries to free one native decode batch
+                // for grammar-triggered retries during the decode loop.
+                let mut proactive_eviction_status = "disabled";
+                let mut proactive_eviction_error_kind_attr = None;
+                let mut proactive_eviction_target_tokens = 0_u64;
+                let mut proactive_evicted_entries = 0_usize;
+                let mut proactive_evicted_tokens = 0_u64;
                 if let Some(kv) = self.kv.as_ref() {
-                    let _ = kv.evict_one_resident_prefix(&mut runtime, &session_id);
+                    match kv.evict_resident_prefix_for_decode_batch(&mut runtime, &session_id) {
+                        Ok(eviction) => {
+                            proactive_eviction_status = if eviction.evicted_entries > 0 {
+                                "evicted"
+                            } else {
+                                "noop"
+                            };
+                            proactive_eviction_target_tokens = eviction.target_tokens;
+                            proactive_evicted_entries = eviction.evicted_entries;
+                            proactive_evicted_tokens = eviction.evicted_tokens;
+                        }
+                        Err(error) => {
+                            proactive_eviction_status = "error";
+                            proactive_eviction_error_kind_attr =
+                                Some(proactive_eviction_error_kind(&error));
+                        }
+                    }
                 }
                 let runtime_sessions_after = runtime.session_stats();
                 let runtime_lock_hold_ms = runtime_lock_hold_timer.elapsed_ms();
@@ -335,6 +356,16 @@ impl StageOpenAiBackend {
                     &runtime_sessions_after,
                 );
                 self.emit_openai_phase("stage.openai_prefill", prefill_timer, attrs);
+                self.telemetry.emit(
+                    "stage.openai_kv_record_decision",
+                    proactive_eviction_attrs(
+                        proactive_eviction_status,
+                        proactive_eviction_error_kind_attr,
+                        proactive_eviction_target_tokens,
+                        proactive_evicted_entries,
+                        proactive_evicted_tokens,
+                    ),
+                );
             }
             if let Some(metadata) = request.chat_sampling_metadata {
                 let mut runtime = self

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -23,6 +23,40 @@ const MM_CTX_SIZE_ENV: &str = "SKIPPY_MM_CTX_SIZE";
 const MM_MAX_TOKENS_ENV: &str = "SKIPPY_MM_MAX_TOKENS";
 const MM_N_GPU_LAYERS_ENV: &str = "SKIPPY_MM_N_GPU_LAYERS";
 
+#[test]
+fn proactive_eviction_attrs_are_bounded_and_request_free() {
+    let attrs = proactive_eviction_attrs("error", Some("inactive_session"), 1024, 2, 768);
+
+    assert_eq!(
+        attrs.get("skippy.kv.decision"),
+        Some(&json!("proactive_eviction"))
+    );
+    assert_eq!(
+        attrs.get(attr_key::KV_PROACTIVE_EVICTION_STATUS),
+        Some(&json!("error"))
+    );
+    assert_eq!(
+        attrs.get(attr_key::KV_PROACTIVE_EVICTION_ERROR_KIND),
+        Some(&json!("inactive_session"))
+    );
+    assert_eq!(
+        attrs.get(attr_key::KV_PROACTIVE_EVICTION_TARGET_TOKENS),
+        Some(&json!(1024))
+    );
+    assert_eq!(
+        attrs.get(attr_key::KV_PROACTIVE_EVICTED_ENTRIES),
+        Some(&json!(2))
+    );
+    assert_eq!(
+        attrs.get(attr_key::KV_PROACTIVE_EVICTED_TOKENS),
+        Some(&json!(768))
+    );
+    assert!(!attrs.contains_key(attr_key::REQUEST_ID));
+    assert!(!attrs.contains_key(attr_key::SESSION_ID));
+    assert!(!attrs.contains_key("openai.prompt_cache_key"));
+    assert!(!attrs.contains_key("openai.prompt_cache_retention"));
+}
+
 struct MultimodalSmokeFixture {
     model_path: PathBuf,
     projector_path: PathBuf,

--- a/crates/skippy-server/src/kv_integration/identity.rs
+++ b/crates/skippy-server/src/kv_integration/identity.rs
@@ -180,7 +180,7 @@ mod tests {
             .map(|identity| identity.identity.token_count)
             .collect::<Vec<_>>();
 
-        assert_eq!(lookup_counts, vec![160, 159, 127, 95, 64]);
-        assert_eq!(record_counts, vec![160, 64]);
+        assert_eq!(lookup_counts, vec![160, 128, 96, 64]);
+        assert_eq!(record_counts, vec![160, 128]);
     }
 }

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -208,6 +208,9 @@ impl KvStageIntegration {
             estimated_bytes,
             |seq_id| runtime.drop_resident_prefix_sequence(session_id, seq_id),
         )?;
+        if !allocation.should_retain {
+            return Ok(None);
+        }
         if allocation.should_save {
             runtime.save_resident_prefix(session_id, allocation.seq_id, token_count as u64)?;
             cache.commit_record(

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -142,6 +142,30 @@ impl KvStageIntegration {
         Ok(None)
     }
 
+    /// Evict one LRU resident prefix entry. This is the **proactive
+    /// eviction** path: it runs outside the normal
+    /// `allocate_for_record` flow so the decode loop can free KV cells
+    /// before grammar-triggered retries need them.
+    ///
+    /// Returns whether an entry was actually evicted. Errors from the
+    /// C-side drop callback are propagated.
+    pub fn evict_one_resident_prefix(
+        &self,
+        runtime: &mut RuntimeState,
+        session_id: &str,
+    ) -> Result<bool> {
+        if self.payload != StagePrefixCachePayload::ResidentKv {
+            return Ok(false);
+        }
+        let mut cache = self
+            .resident
+            .lock()
+            .expect("resident prefix cache lock poisoned");
+        let mut drop_fn = |seq_id: i32| runtime.drop_resident_prefix_sequence(session_id, seq_id);
+        let evicted = cache.evict_one_lru_entry(&mut drop_fn)?;
+        Ok(evicted.is_some())
+    }
+
     pub fn release_resident_prefix(&self, page_id: &str) {
         self.resident
             .lock()

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -7,6 +7,13 @@ use super::{
     StagePrefixCachePayload,
 };
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResidentPrefixDecodeEviction {
+    pub target_tokens: u64,
+    pub evicted_entries: usize,
+    pub evicted_tokens: u64,
+}
+
 impl KvStageIntegration {
     pub fn probe_resident_prefix(
         &self,
@@ -142,28 +149,34 @@ impl KvStageIntegration {
         Ok(None)
     }
 
-    /// Evict one LRU resident prefix entry. This is the **proactive
-    /// eviction** path: it runs outside the normal
-    /// `allocate_for_record` flow so the decode loop can free KV cells
-    /// before grammar-triggered retries need them.
+    /// Evict enough resident-prefix entries to free at least one native
+    /// decode batch worth of KV cells, or all currently releasable entries.
     ///
-    /// Returns whether an entry was actually evicted. Errors from the
-    /// C-side drop callback are propagated.
-    pub fn evict_one_resident_prefix(
+    /// The single-entry eviction path is not enough when the LRU entry is
+    /// smaller than `n_batch`; tool/grammar retries need a contiguous decode
+    /// batch, so the proactive path uses the active session batch size as its
+    /// concrete budget.
+    pub fn evict_resident_prefix_for_decode_batch(
         &self,
         runtime: &mut RuntimeState,
         session_id: &str,
-    ) -> Result<bool> {
+    ) -> Result<ResidentPrefixDecodeEviction> {
         if self.payload != StagePrefixCachePayload::ResidentKv {
-            return Ok(false);
+            return Ok(ResidentPrefixDecodeEviction::default());
         }
+        let target_tokens = runtime.session_batch_size(session_id)? as u64;
         let mut cache = self
             .resident
             .lock()
             .expect("resident prefix cache lock poisoned");
         let mut drop_fn = |seq_id: i32| runtime.drop_resident_prefix_sequence(session_id, seq_id);
-        let evicted = cache.evict_one_lru_entry(&mut drop_fn)?;
-        Ok(evicted.is_some())
+        let evictions = cache.evict_lru_until_tokens(target_tokens, &mut drop_fn)?;
+        let evicted_tokens = evictions.iter().map(|eviction| eviction.token_count).sum();
+        Ok(ResidentPrefixDecodeEviction {
+            target_tokens,
+            evicted_entries: evictions.len(),
+            evicted_tokens,
+        })
     }
 
     pub fn release_resident_prefix(&self, page_id: &str) {

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -359,70 +359,44 @@ impl RuntimeState {
     pub fn drop_session_timed(&mut self, session_id: &str) -> Result<RuntimeSessionDropStats> {
         let reset_started = Instant::now();
         let mut reset_session = false;
-        let mut preserved_resident_prefix = false;
+        let preserved_resident_prefix = false;
         let mut lane_discarded = false;
         let mut lane_discard_reason: Option<String> = None;
 
         if let Some(mut lane_session) = self.sessions.remove(session_id) {
             let lane_index = lane_session.index;
-            if let Some(prefix) = self.session_resident_prefixes.remove(session_id) {
-                match lane_session.session.trim_session(prefix.token_count) {
-                    Ok(()) => {
-                        preserved_resident_prefix = true;
-                        lane_session.resident_prefix = Some(prefix);
-                        self.idle_sessions.push(lane_session);
-                    }
-                    Err(trim_err) => {
-                        reset_session = true;
-                        match lane_session.session.reset() {
-                            Ok(()) => {
-                                lane_session.resident_prefix = None;
-                                self.idle_sessions.push(lane_session);
-                            }
-                            Err(reset_err) => {
-                                lane_discarded = true;
-                                let reason = format!(
-                                    "trim_session({}) failed ({trim_err:#}); fallback reset() also failed ({reset_err:#})",
-                                    prefix.token_count
-                                );
-                                eprintln!(
-                                    "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
-                                );
-                                lane_discard_reason = Some(reason);
-                                // `lane_session` falls out of scope and its
-                                // StageSession::drop runs, which calls
-                                // skippy_session_free on the C side. After
-                                // the native KV cells for this seq_id are
-                                // released, return the lane index to the
-                                // free list so the next allocation can
-                                // reuse it instead of consuming a fresh
-                                // slot from next_lane_index.
-                                drop(lane_session);
-                                self.free_lane_indices.push(lane_index);
-                            }
-                        }
-                    }
+            // Always release the lane's native KV cells back to the
+            // unified pool. The trim+preserve path kept the lane's cells
+            // pinned to a specific (`page_id`, `token_count`) pair so a
+            // future request whose content prefix hashed to the *exact*
+            // same `page_id` AND same `token_count` could acquire the
+            // warm lane via `acquire_resident_prefix_lane`. Real chat /
+            // agent workloads vary the conversation tail every turn, so
+            // both the hash and the length change request-to-request and
+            // that exact-match acquisition almost never fires. Meanwhile
+            // the pinned cells remain claimed in the unified pool, in
+            // parallel with the cells the cache layer itself pins, and
+            // the pool runs out of contiguous space — producing
+            // `decode: failed to find a memory slot` under repeated
+            // tool-using agent traffic (#652). Cross-request prefix
+            // reuse is still done by the cache layer (by `page_id`); we
+            // just stop double-claiming cells on the lane side.
+            self.session_resident_prefixes.remove(session_id);
+            reset_session = true;
+            match lane_session.session.reset() {
+                Ok(()) => {
+                    lane_session.resident_prefix = None;
+                    self.idle_sessions.push(lane_session);
                 }
-            } else {
-                reset_session = true;
-                match lane_session.session.reset() {
-                    Ok(()) => {
-                        lane_session.resident_prefix = None;
-                        self.idle_sessions.push(lane_session);
-                    }
-                    Err(reset_err) => {
-                        lane_discarded = true;
-                        let reason = format!("reset() failed ({reset_err:#})");
-                        eprintln!(
-                            "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
-                        );
-                        lane_discard_reason = Some(reason);
-                        // See sibling branch above: free the lane index
-                        // after the StageSession drop releases the
-                        // native KV cells for this seq_id.
-                        drop(lane_session);
-                        self.free_lane_indices.push(lane_index);
-                    }
+                Err(reset_err) => {
+                    lane_discarded = true;
+                    let reason = format!("reset() failed ({reset_err:#})");
+                    eprintln!(
+                        "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
+                    );
+                    lane_discard_reason = Some(reason);
+                    drop(lane_session);
+                    self.free_lane_indices.push(lane_index);
                 }
             }
         }

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -157,6 +157,10 @@ impl RuntimeState {
         Ok(token)
     }
 
+    pub fn session_batch_size(&mut self, session_id: &str) -> Result<usize> {
+        self.active_session(session_id)?.batch_size()
+    }
+
     pub fn configure_chat_sampling(
         &mut self,
         session_id: &str,
@@ -301,6 +305,13 @@ impl RuntimeState {
             .get_mut(session_id)
             .expect("session inserted above")
             .session)
+    }
+
+    fn active_session(&mut self, session_id: &str) -> Result<&mut StageSession> {
+        self.sessions
+            .get_mut(session_id)
+            .map(|lane_session| &mut lane_session.session)
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} is not active"))
     }
 
     pub fn prewarm_idle_sessions(
@@ -742,7 +753,7 @@ impl RuntimeState {
         session_id: &str,
         cache_seq_id: i32,
     ) -> Result<()> {
-        self.session(session_id)?.drop_sequence(cache_seq_id)
+        self.active_session(session_id)?.drop_sequence(cache_seq_id)
     }
 
     fn add_session_tokens(&mut self, session_id: &str, count: u64) {


### PR DESCRIPTION
## Summary

When the resident prefix cache is at capacity and a grammar-triggered retry needs an extra KV cache slot mid-generation, the decode loop can fail with `"failed to find a memory slot"`. This is especially visible under agent harness tool loops where prefix cache entries pin KV cells across turns while the active lane needs more room for grammar retries.

This PR adds a single proactive eviction step before the decode loop starts: one LRU entry from the resident prefix cache is evicted right after prefill recording, while the runtime lock is still held. This frees KV cells before the decode loop begins, so grammar-triggered retries can use them.

The change is small (one `evict_one_lru_entry()` call per generation) and complementary to the existing `allocate_for_record` eviction path. It fires at a different point in the lifecycle and does not change the cache's own capacity-based eviction behavior.

### What #659 did

1. **Reduced `n_batch` from 2048 to 1024** in multi-lane unified KV mode. Smaller batches mean each `llama_decode` call touches fewer KV cells at once, so the peak cell demand per decode step is lower. This reduces how often the pool is over-committed during the decode loop.

2. **Made oversized prefix cache candidates nonfatal**. Previously if a candidate prefix exceeded the token budget, the cache would hard-error (`bail!`). After #659 it soft-rejects instead, keeping the existing prefix cache intact rather than crashing the lane.

### Why we want this too

Both #659 changes only reduce *how often* the failure triggers. They don't remove the failure mode itself:

- **Grammar retries still consume multiple KV slots** within a single generation. With `MAX_AUTO_PARALLEL_SLOTS=4`, each grammar trigger forks a new sequence in the KV cache. A generation with 5+ grammar triggers still exhausts 4 slots, regardless of batch size. The batch size reduction just means each of those 4 slots needs slightly less headroom per decode, but on turn 3 of an agent loop, the prefix cache pins enough KV cells from the same unified pool that even reduced batch demand can exceed what's left.

- **The prefix cache still pins KV cells across turns**. Each cached prefix occupies KV cells from the unified pool (`n_ctx` total cells shared between active lanes and cached prefixes). After 2-3 agent-harness turns, accumulated cached prefixes pin enough cells that the active lane's remaining pool is small. When grammar triggers then need 4 parallel sequences, the available pool may be too small even with `n_batch=1024`.

- **Session reset bookkeeping drift is not addressed**. The `drop_session_timed` path in `runtime_state.rs` (lines 347-353) can leave C-side KV slots allocated when the Rust-side cleanup fails under KV pressure. This drift accumulates across multiple generation cycles in a tool loop. Neither #659 change affects this path.

## Changes

- **`skippy-cache`**: Added `evict_one_lru_entry` to `ResidentPrefixCache`. Scans entries in LRU order (skipping borrowed entries) and evicts the least-recently-used one. 7 new unit tests cover empty cache, all-borrowed, LRU ordering, seq-id recycling, internal accounting, and interaction with `allocate_for_record`.

- **`skippy-server`**: Added `evict_one_resident_prefix` to `KvStageIntegration`. Bridges the cache eviction to the C-side drop callback.

- **`local_generation.rs`**: Calls `evict_one_resident_prefix` after prefill recording, before entering the decode loop.

- **`generation_flow.rs`**: Same eviction point for the multimodal path.

## Verification

- `cargo test -p skippy-cache --lib`: 24 tests pass
- `cargo test -p skippy-server --lib`: 81 tests pass
- `cargo check -p mesh-llm`: zero warnings
- `just test-all`: all 7 stages pass (fmt, clippy, Rust tests, ESLint/Prettier, tsc, vitest 658/661, Playwright smoke)
