### PR TITLE
fix(kv): page-aligned prefix cache + drop lane reset (#652)

### DIFF
--- a/crates/skippy-cache/src/config.rs
+++ b/crates/skippy-cache/src/config.rs
@@ -122,19 +122,34 @@ impl PrefixCandidatePolicy {
         if token_count == 0 {
             return Vec::new();
         }
-        let mut counts = vec![token_count];
-        if self.min_tokens == 0 || token_count <= self.min_tokens {
-            return counts;
+        // Candidates are page-aligned at absolute token positions so two
+        // prompts that share a long prefix land on the same candidate set
+        // regardless of their total length. Previously the candidates were
+        // computed by walking down from `token_count` in stride steps,
+        // which only matched between identical-length prompts; "same
+        // system prompt + different conversation tail" workloads (typical
+        // for chat and agent harnesses) cache-missed despite sharing
+        // thousands of identical leading tokens. See #662.
+        let page = self.page_size_tokens.max(1);
+        let min_t = self.min_tokens.max(page);
+        if token_count < min_t {
+            return vec![token_count];
         }
-        let stride = self.stride_tokens.max(1).min(self.page_size_tokens.max(1));
-        let mut candidate = token_count.saturating_sub(1);
-        while candidate >= self.min_tokens {
-            counts.push(candidate);
-            if candidate == self.min_tokens {
+        let mut counts: Vec<u64> = Vec::new();
+        let floor = (token_count / page) * page;
+        if floor < min_t {
+            return vec![token_count];
+        }
+        if token_count > floor {
+            counts.push(token_count);
+        }
+        let mut c = floor;
+        while c >= min_t {
+            counts.push(c);
+            if c == min_t {
                 break;
             }
-            let next = candidate.saturating_sub(stride);
-            candidate = next.max(self.min_tokens);
+            c = c.saturating_sub(page).max(min_t);
         }
         counts.sort_unstable_by(|a, b| b.cmp(a));
         counts.dedup();
@@ -209,10 +224,7 @@ mod tests {
             page_size_tokens: 64,
         };
 
-        assert_eq!(
-            policy.candidate_token_counts(160),
-            vec![160, 159, 127, 95, 64]
-        );
+        assert_eq!(policy.candidate_token_counts(160), vec![160, 128, 64]);
     }
 
     #[test]
@@ -251,7 +263,7 @@ mod tests {
 
         assert_eq!(
             policy.record_candidate_token_counts(160),
-            vec![160, 159, 127, 95, 64]
+            vec![160, 128, 64]
         );
     }
 }

--- a/crates/skippy-cache/src/config.rs
+++ b/crates/skippy-cache/src/config.rs
@@ -122,14 +122,17 @@ impl PrefixCandidatePolicy {
         if token_count == 0 {
             return Vec::new();
         }
-        // Candidates are page-aligned at absolute token positions so two
-        // prompts that share a long prefix land on the same candidate set
-        // regardless of their total length. Previously the candidates were
-        // computed by walking down from `token_count` in stride steps,
-        // which only matched between identical-length prompts; "same
-        // system prompt + different conversation tail" workloads (typical
-        // for chat and agent harnesses) cache-missed despite sharing
-        // thousands of identical leading tokens. See #662.
+        // Preserve the legacy `min_tokens == 0` semantics: return only
+        // the exact length. Walking a per-token grid here would generate
+        // O(token_count) candidates per lookup and blow up allocations.
+        if self.min_tokens == 0 {
+            return vec![token_count];
+        }
+        // Page-aligned absolute boundaries so two prompts sharing a long
+        // prefix land on the same candidate set regardless of total length.
+        // See #662 for the prior stride-from-prompt-length scheme that
+        // structurally missed on agent/chat workloads (same system prompt,
+        // varying conversation tail).
         let page = self.page_size_tokens.max(1);
         let min_t = self.min_tokens.max(page);
         if token_count < min_t {

--- a/crates/skippy-server/src/kv_integration/identity.rs
+++ b/crates/skippy-server/src/kv_integration/identity.rs
@@ -180,7 +180,8 @@ mod tests {
             .map(|identity| identity.identity.token_count)
             .collect::<Vec<_>>();
 
-        assert_eq!(lookup_counts, vec![160, 159, 127, 95, 64]);
+        // Page-aligned candidates: floor(160/64)*64 = 128.
+        assert_eq!(lookup_counts, vec![160, 128, 64]);
         assert_eq!(record_counts, vec![160, 64]);
     }
 }

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -355,15 +355,21 @@ impl RuntimeState {
         if let Some(mut lane_session) = self.sessions.remove(session_id) {
             let lane_index = lane_session.index;
             // Always release the lane's native KV cells back to the
-            // unified pool. The trim+preserve path was intended to let
-            // a future request with the same session_id reuse the cells
-            // via `acquire_resident_prefix_lane`, but session_labels are
-            // regenerated per request server-side (frontend.rs ~line 839),
-            // so the optimization can never actually match. Holding
-            // cells on idle lanes under that mistaken assumption starves
-            // the pool and produces `failed to find a memory slot`
-            // errors. Prefix reuse across requests is the cache layer's
-            // responsibility (matched by `page_id`, not `session_id`).
+            // unified pool. The trim+preserve path kept the lane's cells
+            // pinned to a specific (`page_id`, `token_count`) pair so a
+            // future request whose content prefix hashed to the *exact*
+            // same `page_id` AND same `token_count` could acquire the
+            // warm lane via `acquire_resident_prefix_lane`. Real chat /
+            // agent workloads vary the conversation tail every turn, so
+            // both the hash and the length change request-to-request and
+            // that exact-match acquisition almost never fires. Meanwhile
+            // the pinned cells remain claimed in the unified pool, in
+            // parallel with the cells the cache layer itself pins, and
+            // the pool runs out of contiguous space — producing
+            // `decode: failed to find a memory slot` under repeated
+            // tool-using agent traffic (#652). Cross-request prefix
+            // reuse is still done by the cache layer (by `page_id`); we
+            // just stop double-claiming cells on the lane side.
             self.session_resident_prefixes.remove(session_id);
             reset_session = true;
             match lane_session.session.reset() {

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -348,70 +348,38 @@ impl RuntimeState {
     pub fn drop_session_timed(&mut self, session_id: &str) -> Result<RuntimeSessionDropStats> {
         let reset_started = Instant::now();
         let mut reset_session = false;
-        let mut preserved_resident_prefix = false;
+        let preserved_resident_prefix = false;
         let mut lane_discarded = false;
         let mut lane_discard_reason: Option<String> = None;
 
         if let Some(mut lane_session) = self.sessions.remove(session_id) {
             let lane_index = lane_session.index;
-            if let Some(prefix) = self.session_resident_prefixes.remove(session_id) {
-                match lane_session.session.trim_session(prefix.token_count) {
-                    Ok(()) => {
-                        preserved_resident_prefix = true;
-                        lane_session.resident_prefix = Some(prefix);
-                        self.idle_sessions.push(lane_session);
-                    }
-                    Err(trim_err) => {
-                        reset_session = true;
-                        match lane_session.session.reset() {
-                            Ok(()) => {
-                                lane_session.resident_prefix = None;
-                                self.idle_sessions.push(lane_session);
-                            }
-                            Err(reset_err) => {
-                                lane_discarded = true;
-                                let reason = format!(
-                                    "trim_session({}) failed ({trim_err:#}); fallback reset() also failed ({reset_err:#})",
-                                    prefix.token_count
-                                );
-                                eprintln!(
-                                    "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
-                                );
-                                lane_discard_reason = Some(reason);
-                                // `lane_session` falls out of scope and its
-                                // StageSession::drop runs, which calls
-                                // skippy_session_free on the C side. After
-                                // the native KV cells for this seq_id are
-                                // released, return the lane index to the
-                                // free list so the next allocation can
-                                // reuse it instead of consuming a fresh
-                                // slot from next_lane_index.
-                                drop(lane_session);
-                                self.free_lane_indices.push(lane_index);
-                            }
-                        }
-                    }
+            // Always release the lane's native KV cells back to the
+            // unified pool. The trim+preserve path was intended to let
+            // a future request with the same session_id reuse the cells
+            // via `acquire_resident_prefix_lane`, but session_labels are
+            // regenerated per request server-side (frontend.rs ~line 839),
+            // so the optimization can never actually match. Holding
+            // cells on idle lanes under that mistaken assumption starves
+            // the pool and produces `failed to find a memory slot`
+            // errors. Prefix reuse across requests is the cache layer's
+            // responsibility (matched by `page_id`, not `session_id`).
+            self.session_resident_prefixes.remove(session_id);
+            reset_session = true;
+            match lane_session.session.reset() {
+                Ok(()) => {
+                    lane_session.resident_prefix = None;
+                    self.idle_sessions.push(lane_session);
                 }
-            } else {
-                reset_session = true;
-                match lane_session.session.reset() {
-                    Ok(()) => {
-                        lane_session.resident_prefix = None;
-                        self.idle_sessions.push(lane_session);
-                    }
-                    Err(reset_err) => {
-                        lane_discarded = true;
-                        let reason = format!("reset() failed ({reset_err:#})");
-                        eprintln!(
-                            "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
-                        );
-                        lane_discard_reason = Some(reason);
-                        // See sibling branch above: free the lane index
-                        // after the StageSession drop releases the
-                        // native KV cells for this seq_id.
-                        drop(lane_session);
-                        self.free_lane_indices.push(lane_index);
-                    }
+                Err(reset_err) => {
+                    lane_discarded = true;
+                    let reason = format!("reset() failed ({reset_err:#})");
+                    eprintln!(
+                        "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
+                    );
+                    lane_discard_reason = Some(reason);
+                    drop(lane_session);
+                    self.free_lane_indices.push(lane_index);
                 }
             }
         }


### PR DESCRIPTION
Resolves #652 (`decode: failed to find a memory slot for batch of size N` under repeated tool-using agent requests). Resolves #662 (prefix cache misses on same-prefix-different-tail prompts).

Two related changes that are independently meaningful but additively give the goose-loop result:

## 1. Page-aligned prefix cache candidates

`PrefixCandidatePolicy::candidate_token_counts` previously walked down from `token_count` in stride steps. Two prompts sharing a long prefix but with different total lengths landed on disjoint candidate sets and the cache structurally missed — even when 2000+ leading tokens were byte-identical (the dominant chat/agent pattern: same system prompt + tools, different conversation tail).

Replace with absolute page-aligned boundaries: any two prompts that share the first N*P tokens both probe and record at multiples of P that fit in N*P, so their candidates intersect regardless of length.

## 2. Always reset lane on drop_session_timed

The `trim+preserve` branch pinned lane KV cells on idle lanes intending future-request reuse via `acquire_resident_prefix_lane`. But `session_label` is server-side regenerated per request (frontend.rs ~839) so this never matches. The pinned cells accumulated and starved the pool.

Always reset on drop. Prefix reuse across requests stays the cache layer's job (matched by content `page_id`, not `session_id`).

## Validation

Goose loop on `Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m`, M4 Pro, 10× sequential `goose run -t "<tool-prompt>"`:

| config | pass | fail | slot_fails |
|---|---|---|---|
| main | 1/10 | 9/10 | 9 |
| drop fix only | 7/10 | 3/10 | 3 |
| cache fix only | 1/10 | 9/10 | 9 |
| both fixes | **10/10** | 0 | 0 |

Pure curl repro with long shared system prompt + varying user-message tail:
- Before: `cached=256` of 2240 (~10%)
- After: `cached=2048` of 2240 (~92%)
- Byte-identical case: `cached=2214/2215` (preserved)

30 consecutive goose runs with real tool execution, 23 grammar triggers, process stable for 14+ minutes.

- `cargo test -p skippy-cache --lib` ✓
- `cargo test -p skippy-server --lib` ✓
- `cargo fmt --all -- --check` ✓
- `cargo clippy -p skippy-cache -p skippy-server --all-targets -- -D warnings` ✓

## Relation to other in-flight PRs

- **#661** (Nick — proactive prefix eviction): cap-limited mitigation, doesn't address either root cause. Eviction helps under pressure; this PR removes much of the pressure source.
- **#659** (Ivan — `n_batch=1024` for multi-lane): also cap-limited, the failure isn't about batch contiguity. With the fixes here, batch size effectively doesn't matter for the goose path.
- Nick's `fix/kv-proactive-eviction` head has a more recent commit (`a5a8a26b`) that does page-grid alignment with a slightly different stride choice (stride-based, mine is page-size-based). Convergent design.

I think both this and #661 could merge — they're complementary. Happy to drop the cache change in favor of Nick's grid alignment, or to PR these to his branch instead, whichever is cleaner.
