### PR TITLE
[codex] Fix native SDK runtime crate packaging

### DIFF
--- a/scripts/package-native-sdk-crate.sh
+++ b/scripts/package-native-sdk-crate.sh
@@ -112,6 +112,8 @@ cp "$manifest" "$crate_dir/native/manifest.json"
 cp -R "$artifact_dir/lib" "$crate_dir/native/lib"
 
 cat > "$crate_dir/Cargo.toml" <<EOF
+[workspace]
+
 [package]
 name = "$crate_name"
 version = "$version"


### PR DESCRIPTION
Generated native SDK runtime crates now declare their own empty workspace, so `cargo package` treats them as standalone crates even when they are emitted under the mesh-llm checkout.

## Root Cause

The release workflow writes generated runtime crates under `dist/native-sdk-crates/...`. Because that path is inside the repository, Cargo found the parent `Cargo.toml` workspace and failed with:

```text
current package believes it's in a workspace when it's not
```

The generated crates are publishable artifacts rather than workspace members, so the manifest template needs to opt out of the parent workspace.

## Validation

- `bash -n scripts/package-native-sdk-crate.sh`
- `git diff --check`
- Repo-local smoke packaging of a fake `meshllm-native-linux-x86_64-cpu` artifact under `target/native-sdk-crate-smoke/...`, matching the CI condition where Cargo can see the parent workspace
