### PR TITLE
fix(swift-sdk): produce versioned bundle layout for macOS xcframework

### DIFF
--- a/sdk/swift/scripts/build-host-macos-xcframework.sh
+++ b/sdk/swift/scripts/build-host-macos-xcframework.sh
@@ -96,21 +96,26 @@ PY
 
 FRAMEWORK_DIR="$TARGET_DIR/frameworks/macos-host/$FRAMEWORK_NAME.framework"
 rm -rf "$FRAMEWORK_DIR"
-mkdir -p "$FRAMEWORK_DIR/Headers"
-mkdir -p "$FRAMEWORK_DIR/Modules"
 
-cp "$LIB_PATH" "$FRAMEWORK_DIR/$FRAMEWORK_NAME"
-cp "$FFI_DIR/MeshLLMFFI.h" "$FRAMEWORK_DIR/Headers/MeshLLMFFI.h"
-cp "$FFI_DIR/MeshLLMFFI.modulemap" "$FRAMEWORK_DIR/Modules/module.modulemap"
+# macOS requires a versioned bundle layout (Versions/A/); flat bundles are
+# rejected by the macOS dynamic linker and cause xcframework load failures.
+VERSION_DIR="$FRAMEWORK_DIR/Versions/A"
+mkdir -p "$VERSION_DIR/Headers"
+mkdir -p "$VERSION_DIR/Modules"
+mkdir -p "$VERSION_DIR/Resources"
+
+cp "$LIB_PATH" "$VERSION_DIR/$FRAMEWORK_NAME"
+cp "$FFI_DIR/MeshLLMFFI.h" "$VERSION_DIR/Headers/MeshLLMFFI.h"
+cp "$FFI_DIR/MeshLLMFFI.modulemap" "$VERSION_DIR/Modules/module.modulemap"
 
 if [ -f "$SWIFT_DIR/PrivacyInfo.xcprivacy" ]; then
-  cp "$SWIFT_DIR/PrivacyInfo.xcprivacy" "$FRAMEWORK_DIR/PrivacyInfo.xcprivacy"
+  cp "$SWIFT_DIR/PrivacyInfo.xcprivacy" "$VERSION_DIR/Resources/PrivacyInfo.xcprivacy"
   echo "  Embedded PrivacyInfo.xcprivacy in host macOS framework"
 else
   echo "WARNING: PrivacyInfo.xcprivacy not found at $SWIFT_DIR/PrivacyInfo.xcprivacy"
 fi
 
-cat > "$FRAMEWORK_DIR/Info.plist" << 'PLIST'
+cat > "$VERSION_DIR/Resources/Info.plist" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -129,11 +134,17 @@ cat > "$FRAMEWORK_DIR/Info.plist" << 'PLIST'
 </plist>
 PLIST
 
+ln -sfh A                          "$FRAMEWORK_DIR/Versions/Current"
+ln -sfh "Versions/Current/$FRAMEWORK_NAME" "$FRAMEWORK_DIR/$FRAMEWORK_NAME"
+ln -sfh "Versions/Current/Headers"         "$FRAMEWORK_DIR/Headers"
+ln -sfh "Versions/Current/Modules"         "$FRAMEWORK_DIR/Modules"
+ln -sfh "Versions/Current/Resources"       "$FRAMEWORK_DIR/Resources"
+
 echo "Creating host macOS XCFramework..."
 XCFW_OUT="$XCFRAMEWORK_DIR/$FRAMEWORK_NAME.xcframework"
 rm -rf "$XCFW_OUT"
 mkdir -p "$XCFW_OUT/$XCFRAMEWORK_ID/$FRAMEWORK_NAME.framework"
-cp -R "$FRAMEWORK_DIR/" "$XCFW_OUT/$XCFRAMEWORK_ID/$FRAMEWORK_NAME.framework/"
+cp -RP "$FRAMEWORK_DIR/" "$XCFW_OUT/$XCFRAMEWORK_ID/$FRAMEWORK_NAME.framework/"
 
 cat > "$XCFW_OUT/Info.plist" << XCINFO
 <?xml version="1.0" encoding="UTF-8"?>

--- a/sdk/swift/scripts/build-xcframework.sh
+++ b/sdk/swift/scripts/build-xcframework.sh
@@ -182,24 +182,66 @@ create_framework() {
   local LIB_PATH="$2"
   local FRAMEWORK_DIR="$TARGET_DIR/frameworks/$ARCH/$FRAMEWORK_NAME.framework"
 
-  mkdir -p "$FRAMEWORK_DIR/Headers"
-  mkdir -p "$FRAMEWORK_DIR/Modules"
+  if [ "$ARCH" = "macos" ]; then
+    # macOS requires a versioned bundle layout (Versions/A/); flat bundles are
+    # rejected by the macOS dynamic linker and cause xcframework load failures.
+    local VERSION_DIR="$FRAMEWORK_DIR/Versions/A"
+    mkdir -p "$VERSION_DIR/Headers"
+    mkdir -p "$VERSION_DIR/Modules"
+    mkdir -p "$VERSION_DIR/Resources"
 
-  # Copy static library as the framework binary (no extension)
-  cp "$LIB_PATH" "$FRAMEWORK_DIR/$FRAMEWORK_NAME"
-  cp "$FFI_DIR/MeshLLMFFI.h" "$FRAMEWORK_DIR/Headers/MeshLLMFFI.h"
-  cp "$FFI_DIR/MeshLLMFFI.modulemap" "$FRAMEWORK_DIR/Modules/module.modulemap"
+    cp "$LIB_PATH" "$VERSION_DIR/$FRAMEWORK_NAME"
+    cp "$FFI_DIR/MeshLLMFFI.h" "$VERSION_DIR/Headers/MeshLLMFFI.h"
+    cp "$FFI_DIR/MeshLLMFFI.modulemap" "$VERSION_DIR/Modules/module.modulemap"
 
-  # Embed PrivacyInfo.xcprivacy (required for App Store submission)
-  if [ -f "$SWIFT_DIR/PrivacyInfo.xcprivacy" ]; then
-    cp "$SWIFT_DIR/PrivacyInfo.xcprivacy" "$FRAMEWORK_DIR/PrivacyInfo.xcprivacy"
-    echo "  Embedded PrivacyInfo.xcprivacy in $ARCH framework"
+    if [ -f "$SWIFT_DIR/PrivacyInfo.xcprivacy" ]; then
+      cp "$SWIFT_DIR/PrivacyInfo.xcprivacy" "$VERSION_DIR/Resources/PrivacyInfo.xcprivacy"
+      echo "  Embedded PrivacyInfo.xcprivacy in $ARCH framework"
+    else
+      echo "WARNING: PrivacyInfo.xcprivacy not found at $SWIFT_DIR/PrivacyInfo.xcprivacy"
+    fi
+
+    cat > "$VERSION_DIR/Resources/Info.plist" << 'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>ai.meshllm.MeshLLMFFI</string>
+    <key>CFBundleName</key>
+    <string>MeshLLMFFI</string>
+    <key>CFBundlePackageType</key>
+    <string>FMWK</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>MinimumOSVersion</key>
+    <string>13.0</string>
+</dict>
+</plist>
+PLIST
+
+    ln -sfh A                          "$FRAMEWORK_DIR/Versions/Current"
+    ln -sfh "Versions/Current/$FRAMEWORK_NAME" "$FRAMEWORK_DIR/$FRAMEWORK_NAME"
+    ln -sfh "Versions/Current/Headers"         "$FRAMEWORK_DIR/Headers"
+    ln -sfh "Versions/Current/Modules"         "$FRAMEWORK_DIR/Modules"
+    ln -sfh "Versions/Current/Resources"       "$FRAMEWORK_DIR/Resources"
   else
-    echo "WARNING: PrivacyInfo.xcprivacy not found at $SWIFT_DIR/PrivacyInfo.xcprivacy"
-  fi
+    # iOS, simulator, and Mac Catalyst use flat (non-versioned) framework layout
+    mkdir -p "$FRAMEWORK_DIR/Headers"
+    mkdir -p "$FRAMEWORK_DIR/Modules"
 
-  # Minimal Info.plist (required by xcodebuild -create-xcframework)
-  cat > "$FRAMEWORK_DIR/Info.plist" << 'PLIST'
+    cp "$LIB_PATH" "$FRAMEWORK_DIR/$FRAMEWORK_NAME"
+    cp "$FFI_DIR/MeshLLMFFI.h" "$FRAMEWORK_DIR/Headers/MeshLLMFFI.h"
+    cp "$FFI_DIR/MeshLLMFFI.modulemap" "$FRAMEWORK_DIR/Modules/module.modulemap"
+
+    if [ -f "$SWIFT_DIR/PrivacyInfo.xcprivacy" ]; then
+      cp "$SWIFT_DIR/PrivacyInfo.xcprivacy" "$FRAMEWORK_DIR/PrivacyInfo.xcprivacy"
+      echo "  Embedded PrivacyInfo.xcprivacy in $ARCH framework"
+    else
+      echo "WARNING: PrivacyInfo.xcprivacy not found at $SWIFT_DIR/PrivacyInfo.xcprivacy"
+    fi
+
+    cat > "$FRAMEWORK_DIR/Info.plist" << 'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -217,6 +259,7 @@ create_framework() {
 </dict>
 </plist>
 PLIST
+  fi
 
   echo "  Created framework bundle for $ARCH"
 }
@@ -247,10 +290,10 @@ if [ ! -d "$XCFW_OUT" ]; then
   mkdir -p "$XCFW_OUT/ios-arm64_x86_64-maccatalyst/$FRAMEWORK_NAME.framework"
   mkdir -p "$XCFW_OUT/macos-arm64_x86_64/$FRAMEWORK_NAME.framework"
 
-  cp -R "$TARGET_DIR/frameworks/ios/$FRAMEWORK_NAME.framework/"     "$XCFW_OUT/ios-arm64/$FRAMEWORK_NAME.framework/"
-  cp -R "$TARGET_DIR/frameworks/ios-sim/$FRAMEWORK_NAME.framework/" "$XCFW_OUT/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME.framework/"
-  cp -R "$TARGET_DIR/frameworks/ios-macabi/$FRAMEWORK_NAME.framework/" "$XCFW_OUT/ios-arm64_x86_64-maccatalyst/$FRAMEWORK_NAME.framework/"
-  cp -R "$TARGET_DIR/frameworks/macos/$FRAMEWORK_NAME.framework/"   "$XCFW_OUT/macos-arm64_x86_64/$FRAMEWORK_NAME.framework/"
+  cp -R  "$TARGET_DIR/frameworks/ios/$FRAMEWORK_NAME.framework/"        "$XCFW_OUT/ios-arm64/$FRAMEWORK_NAME.framework/"
+  cp -R  "$TARGET_DIR/frameworks/ios-sim/$FRAMEWORK_NAME.framework/"    "$XCFW_OUT/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME.framework/"
+  cp -R  "$TARGET_DIR/frameworks/ios-macabi/$FRAMEWORK_NAME.framework/" "$XCFW_OUT/ios-arm64_x86_64-maccatalyst/$FRAMEWORK_NAME.framework/"
+  cp -RP "$TARGET_DIR/frameworks/macos/$FRAMEWORK_NAME.framework/"      "$XCFW_OUT/macos-arm64_x86_64/$FRAMEWORK_NAME.framework/"
 
   cat > "$XCFW_OUT/Info.plist" << 'XCINFO'
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
fix(swift-sdk): produce versioned bundle layout for macOS xcframework
 
macOS requires framework bundles to use a Versions/A/ directory structure with top-level symlinks. Flat bundles — where Info.plist sits at the framework root — are rejected by the macOS dynamic linker at load time.

Both build scripts were creating flat bundles for all platforms, which works on iOS/simulator/Catalyst but breaks on macOS. This caused the xcframework to fail when consumed by an Xcode project.

Changes:
 - build-xcframework.sh: split create_framework() into a versioned path for macos and a flat path for iOS/sim/catalyst; Info.plist and PrivacyInfo.xcprivacy move into 
Versions/A/Resources/; add the five canonical Versions/Current symlinks; use cp -RP (not cp -R) in the xcodebuild fallback so symlinks are preserved
- build-host-macos-xcframework.sh: same versioned layout applied to the inline macOS framework construction
