### PR TITLE
fix(swift-sdk): inherit caller QoS in runBlocking to eliminate hang-risk warnings

### DIFF
--- a/sdk/swift/Sources/MeshLLM/Node.swift
+++ b/sdk/swift/Sources/MeshLLM/Node.swift
@@ -469,7 +469,7 @@ public final class Node: @unchecked Sendable {
 
 private func runBlocking<T>(_ work: @escaping () throws -> T) async throws -> T {
     try await withCheckedThrowingContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global().async(flags: .inheritQoS) {
             do {
                 continuation.resume(returning: try work())
             } catch {
@@ -481,7 +481,7 @@ private func runBlocking<T>(_ work: @escaping () throws -> T) async throws -> T 
 
 private func runNonThrowing<T>(_ work: @escaping () -> T) async -> T {
     await withCheckedContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global().async(flags: .inheritQoS) {
             continuation.resume(returning: work())
         }
     }
@@ -489,7 +489,7 @@ private func runNonThrowing<T>(_ work: @escaping () -> T) async -> T {
 
 private func runBlocking<T>(_ work: @escaping () -> T) async -> T {
     await withCheckedContinuation { continuation in
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global().async(flags: .inheritQoS) {
             continuation.resume(returning: work())
         }
     }


### PR DESCRIPTION
## Problem

The Swift SDK's private `runBlocking` helpers (three overloads in `Node.swift`) dispatch FFI work to a hardcoded `DispatchQueue.global(qos: .userInitiated)` queue. When these are called from a higher-priority context — for example, from an `@MainActor`-isolated method (`.userInteractive` QoS) — the OS scheduler sees a higher-priority thread suspended waiting on a lower-priority queue. Xcode's Thread Performance Checker flags this as a **Hang Risk** (QoS inversion).

## Fix

Replace the hardcoded QoS with `DispatchQueue.global().async(flags: .inheritQoS)`. The `.inheritQoS` flag causes the dispatched block to run at the submitting thread's QoS class rather than the queue's default, eliminating the inversion without changing any other behaviour.

```swift
// Before
DispatchQueue.global(qos: .userInitiated).async { ... }

// After
DispatchQueue.global().async(flags: .inheritQoS) { ... }
```

Three occurrences changed — one per `runBlocking`/`runNonThrowing` overload.

## Testing

Verified in [Orbit](https://github.com/keranm/orbit-release), which integrates the Swift SDK. Hang Risk warnings no longer appear in Xcode's Thread Performance Checker after this change.