### PR TITLE
[codex] Fix Swift XCFramework Metal target gating

### DIFF
--- a/crates/mesh-llm-gpu-bench/build.rs
+++ b/crates/mesh-llm-gpu-bench/build.rs
@@ -1,24 +1,6 @@
 fn main() {
-    #[cfg(target_os = "macos")]
-    {
-        let object = out_path("mesh_llm_gpu_bench_metal.o");
-        run_or_panic({
-            let mut command = std::process::Command::new("clang");
-            command
-                .arg("-O3")
-                .arg("-fobjc-arc")
-                .arg("-fPIC")
-                .arg("-c")
-                .arg("native/metal/membench_metal.m")
-                .arg("-o")
-                .arg(&object);
-            command
-        });
-        archive_static_lib(&object, "mesh_llm_gpu_bench_metal");
-
-        println!("cargo:rerun-if-changed=native/metal/membench_metal.m");
-        println!("cargo:rustc-link-lib=framework=Foundation");
-        println!("cargo:rustc-link-lib=framework=Metal");
+    if target_os_is("macos") {
+        build_metal();
     }
 
     if std::env::var_os("CARGO_FEATURE_CUDA").is_some() {
@@ -32,6 +14,31 @@ fn main() {
     if std::env::var_os("CARGO_FEATURE_INTEL").is_some() {
         build_intel();
     }
+}
+
+fn target_os_is(os: &str) -> bool {
+    std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok(os)
+}
+
+fn build_metal() {
+    let object = out_path("mesh_llm_gpu_bench_metal.o");
+    run_or_panic({
+        let mut command = std::process::Command::new("clang");
+        command
+            .arg("-O3")
+            .arg("-fobjc-arc")
+            .arg("-fPIC")
+            .arg("-c")
+            .arg("native/metal/membench_metal.m")
+            .arg("-o")
+            .arg(&object);
+        command
+    });
+    archive_static_lib(&object, "mesh_llm_gpu_bench_metal");
+
+    println!("cargo:rerun-if-changed=native/metal/membench_metal.m");
+    println!("cargo:rustc-link-lib=framework=Foundation");
+    println!("cargo:rustc-link-lib=framework=Metal");
 }
 
 fn native_source(dir: &str, name: &str) -> String {


### PR DESCRIPTION
## Summary
Fixes the release job failure in `Build Swift SDK XCFramework` by gating the Metal GPU benchmark build on Cargo target OS instead of build-script host OS.

## Root Cause
`crates/mesh-llm-gpu-bench/build.rs` used `#[cfg(target_os = "macos")]`, which describes the macOS GitHub Actions runner compiling the build script. During the Swift XCFramework build, that caused the Metal Objective-C source to compile even for iOS slices such as `aarch64-apple-ios`, mixing macOS SDK headers into an iOS target and failing on unavailable Security/Foundation APIs.

## Change
The build script now checks `CARGO_CFG_TARGET_OS` at runtime and only builds/links the Metal benchmark when the Cargo target is actually macOS. The Metal build path was moved into a small helper while leaving CUDA/HIP/Intel feature handling unchanged.

## Validation
- `cargo check -p mesh-llm-gpu-bench --target aarch64-apple-ios`
- `cargo check -p mesh-llm-gpu-bench --target aarch64-apple-darwin`
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- `git diff --check`