### PR TITLE
[codex] Move hf-hub dependency to 1.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2499,31 +2499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hf-hub"
-version = "1.0.0"
-source = "git+https://github.com/huggingface/hf-hub.git?rev=4cd6d8acd3192021381ff85210be9192b394e0eb#4cd6d8acd3192021381ff85210be9192b394e0eb"
-dependencies = [
- "base64",
- "bon",
- "bytes",
- "futures",
- "globset",
- "hf-xet",
- "hyper",
- "pathdiff",
- "reqwest 0.13.2",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tokio-retry",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hf-xet"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,7 +3753,7 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "hex",
- "hf-hub 1.0.0",
+ "hf-hub",
  "httparse",
  "iroh",
  "keyring",
@@ -4051,7 +4026,7 @@ version = "0.66.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "hf-hub 1.0.0-rc.1",
+ "hf-hub",
  "model-artifact",
  "model-ref",
  "serde",
@@ -4067,7 +4042,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hf-hub 1.0.0",
+ "hf-hub",
  "model-hf",
  "model-ref",
  "reqwest 0.12.28",

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -85,7 +85,7 @@ schemars = "1"
 prost = "0.14"
 toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", rev = "4cd6d8acd3192021381ff85210be9192b394e0eb", default-features = false, features = ["blocking"] }
+hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
 tabwriter = "1"
 
 [dev-dependencies]

--- a/crates/model-package/Cargo.toml
+++ b/crates/model-package/Cargo.toml
@@ -11,7 +11,7 @@ sha2.workspace = true
 anyhow.workspace = true
 bytes = "1"
 chrono = "0.4"
-hf_hub = { package = "hf-hub", git = "https://github.com/huggingface/hf-hub.git", rev = "4cd6d8acd3192021381ff85210be9192b394e0eb", default-features = false, features = ["blocking"] }
+hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
 model-hf = { path = "../model-hf" }
 model-ref = { path = "../model-ref" }
 reqwest = { version = "0.12", features = ["json", "stream"] }


### PR DESCRIPTION
## Summary

Move the remaining `hf-hub` dependency declarations off the pinned Git revision and onto the published `1.0.0-rc.1` crate.

This makes `mesh-llm-host-runtime`, `model-package`, and `model-hf` resolve the same registry package and removes the duplicate Git-sourced `hf-hub 1.0.0` entry from `Cargo.lock`.

## Validation

- `cargo check -p model-package`
- `cargo check -p mesh-llm`
- `git diff --check`
