### PR TITLE
Add KV/tool-loop stability certification harness

### DIFF
--- a/.agents/skills/kv-tool-loop-stability/SKILL.md
+++ b/.agents/skills/kv-tool-loop-stability/SKILL.md
@@ -62,7 +62,7 @@ scripts/qa-kv-tool-loop-stability.py \
 ## Reporting Rules
 
 - Report the model list, attempts, pressure turns, timeout, cache thresholds,
-  native log paths, and output directory.
+  success rate, native log paths, and output directory.
 - Include the summary verdict and failing phase details from `summary.md` or
   `summary.json`.
 - Do not paste full prompts, auth headers, huge stable prefixes, or private

--- a/.agents/skills/kv-tool-loop-stability/SKILL.md
+++ b/.agents/skills/kv-tool-loop-stability/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: kv-tool-loop-stability
+description: Use this skill when certifying mesh-llm KV/cache stability under repeated OpenAI tool-call loops, same-prefix cache reuse, suffix-prefill limits, or native Skippy slot/decode/eviction failures.
+metadata:
+  short-description: Certify KV/tool-loop stability
+---
+
+# KV Tool-Loop Stability
+
+Use this skill when changing Skippy KV slot cleanup, prefix-cache lookup,
+OpenAI tool-loop behavior, agent harnesses, or any runtime path related to
+`llama_decode failed`, `failed to find a memory slot`, low same-prefix cache
+reuse, or proactive eviction failures.
+
+## Workflow
+
+1. Attach to an existing OpenAI-compatible `/v1` endpoint. This harness does
+   not start nodes, load models, join meshes, or change routing policy.
+2. Prefer a direct model when reproducing Skippy KV/cache issues. Use `auto`
+   only when intentionally validating routed behavior.
+3. Run `--print-plan` first and confirm the models, attempts,
+   `pressure_turns`, timeout, cache thresholds, output directory, and native
+   logs.
+4. Pass the active Skippy native log when available. The harness checkpoints
+   native logs at run start and scans only appended bytes.
+5. Preserve the evidence directory: `manifest.json`, `results.jsonl`,
+   `summary.json`, `summary.md`, and `transcripts/*.jsonl`.
+
+## Commands
+
+Preview the run without touching the endpoint:
+
+```bash
+scripts/qa-kv-tool-loop-stability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m \
+  --attempts 5 \
+  --pressure-turns 8 \
+  --timeout 180 \
+  --min-cached-tokens 2048 \
+  --suffix-prefill-limit 256 \
+  --native-log ~/.mesh-llm/runtime/<pid>/logs/skippy-native.log \
+  --output-dir target/kv-tool-loop-stability/local \
+  --print-plan
+```
+
+Run the certification:
+
+```bash
+scripts/qa-kv-tool-loop-stability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m \
+  --attempts 5 \
+  --pressure-turns 8 \
+  --timeout 180 \
+  --min-cached-tokens 2048 \
+  --suffix-prefill-limit 256 \
+  --native-log ~/.mesh-llm/runtime/<pid>/logs/skippy-native.log \
+  --output-dir target/kv-tool-loop-stability/local
+```
+
+## Reporting Rules
+
+- Report the model list, attempts, pressure turns, timeout, cache thresholds,
+  native log paths, and output directory.
+- Include the summary verdict and failing phase details from `summary.md` or
+  `summary.json`.
+- Do not paste full prompts, auth headers, huge stable prefixes, or private
+  endpoint data.
+- If no native log is available, say that native-log scanning was not run.
+
+## Validation
+
+When changing this harness, run:
+
+```bash
+python3 -m unittest scripts.tests.test_qa_kv_tool_loop_stability
+python3 -m py_compile scripts/qa-kv-tool-loop-stability.py scripts/tests/test_qa_kv_tool_loop_stability.py
+```

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -177,7 +177,9 @@ scripts/qa-kv-tool-loop-stability.py \
   --models Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m \
   --attempts 5 \
   --pressure-turns 8 \
+  --timeout 180 \
   --min-cached-tokens 2048 \
+  --suffix-prefill-limit 256 \
   --native-log ~/.mesh-llm/runtime/<pid>/logs/skippy-native.log \
   --output-dir target/kv-tool-loop-stability/local
 ```
@@ -193,11 +195,15 @@ scripts/qa-kv-tool-loop-stability.py \
 - `--min-cached-tokens 2048` matches the known Qwen 3B reproduction shape where
   healthy same-prefix reuse is near the shared prefix, not the 256-token floor
 - `--native-log` scans Skippy native logs for `failed to find a memory slot`,
-  `llama_decode failed`, and proactive eviction errors after the run
+  `llama_decode failed`, and proactive eviction errors appended after the
+  certification starts, so stale failures in long-lived logs do not fail a
+  clean run
 - every run writes `manifest.json`, `results.jsonl`, `summary.json`,
-  `summary.md`, and sanitized transcript JSONL under `transcripts/`
+  `summary.md`, and sanitized transcript JSONL under `transcripts/`; the
+  transcript directory is reset at run start to keep repeated `latest` runs
+  auditable
 - `--print-plan` is side-effect-free and emits the exact models, thresholds,
-  checks, and evidence files that would be produced
+  runtime options, checks, and evidence files that would be produced
 
 This certification is deliberately a lab/release-confidence check, not a
 required PR gate. Use it to prove KV/cache stability on a real direct-model

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -164,6 +164,46 @@ workflows or lab jobs. The job summary includes the timing snapshot from
 artifacts. It is intentionally evidence-producing and non-required: failed
 nightlies should guide stabilization work, not block unrelated pull requests.
 
+### 0f. KV/tool-loop stability certification
+
+Run the KV/tool-loop certification probe when changing Skippy KV slot cleanup,
+prefix-cache lookup, agent tool-loop behavior, or any runtime path related to
+issues where repeated tool calls eventually hit `llama_decode failed` or low
+same-prefix cache reuse.
+
+```bash
+scripts/qa-kv-tool-loop-stability.py \
+  --base-url http://127.0.0.1:9337/v1 \
+  --models Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m \
+  --attempts 5 \
+  --pressure-turns 8 \
+  --min-cached-tokens 2048 \
+  --native-log ~/.mesh-llm/runtime/<pid>/logs/skippy-native.log \
+  --output-dir target/kv-tool-loop-stability/local
+```
+
+- the probe attaches to an existing `/v1/chat/completions` endpoint; it does
+  not start nodes, load models, join a mesh, or change routing policy
+- each attempt runs a growing non-streaming tool-result conversation with a
+  long stable system prefix, repeated pressure turns, a second forced tool
+  call, and final recall of both deterministic tool facts
+- `same_prefix_cache` warms the same long prefix with one tail and measures a
+  different tail; `exact_prefix_cache` verifies the identical-body cache path
+  still works
+- `--min-cached-tokens 2048` matches the known Qwen 3B reproduction shape where
+  healthy same-prefix reuse is near the shared prefix, not the 256-token floor
+- `--native-log` scans Skippy native logs for `failed to find a memory slot`,
+  `llama_decode failed`, and proactive eviction errors after the run
+- every run writes `manifest.json`, `results.jsonl`, `summary.json`,
+  `summary.md`, and sanitized transcript JSONL under `transcripts/`
+- `--print-plan` is side-effect-free and emits the exact models, thresholds,
+  checks, and evidence files that would be produced
+
+This certification is deliberately a lab/release-confidence check, not a
+required PR gate. Use it to prove KV/cache stability on a real direct-model
+endpoint after local unit tests and before relying on agent workloads such as
+Goose, Pi, or OpenCode for broad smoke coverage.
+
 ## Single-model permutations
 
 ### 1. Solo (single node)

--- a/scripts/qa-kv-tool-loop-stability.py
+++ b/scripts/qa-kv-tool-loop-stability.py
@@ -8,6 +8,7 @@ import datetime as dt
 import json
 import os
 from pathlib import Path
+import shutil
 import time
 from typing import Any, Iterable, NamedTuple
 import urllib.error
@@ -28,6 +29,7 @@ DEFAULT_TIMEOUT = 180.0
 DEFAULT_MIN_CACHED_TOKENS = 2048
 DEFAULT_SUFFIX_PREFILL_LIMIT = 256
 DEFAULT_OUTPUT_DIR = "target/kv-tool-loop-stability/latest"
+NATIVE_LOG_CHECKPOINT_TAIL_BYTES = 4096
 FAILURE_PATTERNS = (
     "failed to find a memory slot",
     "RuntimeError: llama_decode failed",
@@ -50,6 +52,13 @@ class LogFinding(NamedTuple):
     line_number: int
     pattern: str
     text: str
+
+
+class NativeLogCheckpoint(NamedTuple):
+    path: Path
+    offset: int
+    identity: tuple[int, int] | None
+    tail: bytes
 
 
 class ProbeResult(NamedTuple):
@@ -84,42 +93,73 @@ def parse_native_logs(values: Iterable[str] | None) -> list[Path]:
     logs: list[Path] = []
     env_value = os.environ.get("MESH_KV_TOOL_LOOP_NATIVE_LOGS")
     if env_value:
-        logs.extend(Path(part.strip()) for part in env_value.split(",") if part.strip())
+        logs.extend(
+            Path(part.strip()).expanduser()
+            for part in env_value.split(",")
+            if part.strip()
+        )
     for value in values or []:
-        logs.append(Path(value))
-    return logs
+        logs.append(Path(value).expanduser())
+    return dedupe_paths(logs)
+
+
+def dedupe_paths(paths: Iterable[Path]) -> list[Path]:
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for path in paths:
+        key = os.fspath(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(path)
+    return deduped
 
 
 def build_plan(
     base_url: str,
     models: Iterable[str],
     attempts: int,
+    pressure_turns: int,
+    timeout: float,
     output_dir: Path,
     min_cached_tokens: int,
+    suffix_prefill_limit: int,
     native_logs: Iterable[Path],
 ) -> dict[str, Any]:
     model_list = list(models)
     if attempts < 1:
         raise ValueError("attempts must be at least 1")
+    if pressure_turns < 0:
+        raise ValueError("pressure_turns cannot be negative")
+    if timeout <= 0:
+        raise ValueError("timeout must be positive")
     if min_cached_tokens < 0:
         raise ValueError("min_cached_tokens cannot be negative")
+    if suffix_prefill_limit < 0:
+        raise ValueError("suffix_prefill_limit cannot be negative")
     checks = [
         {
             "phase": "tool_loop",
             "models": model_list,
             "attempts": attempts,
+            "pressure_turns": pressure_turns,
+            "timeout_seconds": timeout,
             "description": "Growing tool-result conversation with a stable long prefix.",
         },
         {
             "phase": "same_prefix_cache",
             "models": model_list,
             "min_cached_tokens": min_cached_tokens,
+            "suffix_prefill_limit": suffix_prefill_limit,
+            "timeout_seconds": timeout,
             "description": "Same long prefix with a different tiny tail should reuse cached tokens.",
         },
         {
             "phase": "exact_prefix_cache",
             "models": model_list,
             "min_cached_tokens": min_cached_tokens,
+            "suffix_prefill_limit": suffix_prefill_limit,
+            "timeout_seconds": timeout,
             "description": "Identical body warm request should still reuse cached tokens.",
         },
     ]
@@ -129,6 +169,7 @@ def build_plan(
             {
                 "phase": "native_log_scan",
                 "paths": log_paths,
+                "scan_mode": "appended_since_run_start",
                 "fatal_patterns": list(FAILURE_PATTERNS)
                 + ["proactive_eviction status=error"],
             }
@@ -138,8 +179,12 @@ def build_plan(
         "base_url": normalize_v1_base(base_url),
         "models": model_list,
         "attempts": attempts,
+        "pressure_turns": pressure_turns,
+        "timeout_seconds": timeout,
         "output_dir": str(output_dir),
         "min_cached_tokens": min_cached_tokens,
+        "suffix_prefill_limit": suffix_prefill_limit,
+        "native_log_scan_mode": "appended_since_run_start" if log_paths else None,
         "native_logs": log_paths,
         "checks": checks,
         "evidence_files": [
@@ -392,6 +437,98 @@ def scan_failure_logs(paths: Iterable[Path]) -> list[LogFinding]:
     return findings
 
 
+def capture_native_log_checkpoints(paths: Iterable[Path]) -> list[NativeLogCheckpoint]:
+    checkpoints: list[NativeLogCheckpoint] = []
+    for path in paths:
+        try:
+            stat = path.stat()
+        except FileNotFoundError:
+            checkpoints.append(NativeLogCheckpoint(path=path, offset=0, identity=None, tail=b""))
+            continue
+        checkpoints.append(
+            NativeLogCheckpoint(
+                path=path,
+                offset=stat.st_size,
+                identity=file_identity(stat),
+                tail=read_checkpoint_tail(path, stat.st_size),
+            )
+        )
+    return checkpoints
+
+
+def scan_failure_logs_since(
+    checkpoints: Iterable[NativeLogCheckpoint],
+) -> list[LogFinding]:
+    findings: list[LogFinding] = []
+    for checkpoint in checkpoints:
+        findings.extend(scan_one_log_since(checkpoint))
+    return findings
+
+
+def scan_one_log_since(checkpoint: NativeLogCheckpoint) -> list[LogFinding]:
+    path = checkpoint.path
+    try:
+        stat = path.stat()
+    except FileNotFoundError:
+        return [
+            LogFinding(
+                path=str(path),
+                line_number=0,
+                pattern="missing log",
+                text="native log path did not exist",
+            )
+        ]
+    offset = checkpoint.offset
+    if (
+        checkpoint.identity != file_identity(stat)
+        or stat.st_size < checkpoint.offset
+        or not checkpoint_tail_matches(checkpoint)
+    ):
+        offset = 0
+    with path.open("rb") as handle:
+        handle.seek(offset)
+        return scan_failure_lines(path, handle)
+
+
+def scan_failure_lines(path: Path, handle: Iterable[bytes]) -> list[LogFinding]:
+    findings: list[LogFinding] = []
+    for line_number, raw_line in enumerate(handle, start=1):
+        line = raw_line.decode("utf-8", errors="replace").strip()
+        pattern = matched_failure_pattern(line)
+        if pattern:
+            findings.append(
+                LogFinding(
+                    path=str(path),
+                    line_number=line_number,
+                    pattern=pattern,
+                    text=line[:500],
+                )
+            )
+    return findings
+
+
+def file_identity(stat: os.stat_result) -> tuple[int, int]:
+    return (int(stat.st_dev), int(stat.st_ino))
+
+
+def read_checkpoint_tail(path: Path, offset: int) -> bytes:
+    if offset <= 0:
+        return b""
+    start = max(offset - NATIVE_LOG_CHECKPOINT_TAIL_BYTES, 0)
+    with path.open("rb") as handle:
+        handle.seek(start)
+        return handle.read(offset - start)
+
+
+def checkpoint_tail_matches(checkpoint: NativeLogCheckpoint) -> bool:
+    if checkpoint.offset <= 0:
+        return True
+    try:
+        return read_checkpoint_tail(checkpoint.path, checkpoint.offset) == checkpoint.tail
+    except OSError:
+        return False
+
+
 def matched_failure_pattern(line: str) -> str | None:
     for pattern in FAILURE_PATTERNS:
         if pattern in line:
@@ -583,9 +720,9 @@ def run_cache_probe(
         return _result(model, 0, phase, False, str(exc), started)
 
 
-def run_native_log_scan(paths: Iterable[Path]) -> ProbeResult:
+def run_native_log_scan(checkpoints: Iterable[NativeLogCheckpoint]) -> ProbeResult:
     started = time.monotonic()
-    findings = scan_failure_logs(paths)
+    findings = scan_failure_logs_since(checkpoints)
     if findings:
         detail = "; ".join(
             f"{finding.path}:{finding.line_number} {finding.pattern}: {finding.text[:160]}"
@@ -609,6 +746,8 @@ def run_certification(
     output_dir: Path,
 ) -> list[ProbeResult]:
     transcript_dir = output_dir / "transcripts"
+    prepare_transcript_dir(transcript_dir)
+    log_checkpoints = capture_native_log_checkpoints(native_logs)
     results: list[ProbeResult] = []
     for model in models:
         for attempt in range(1, attempts + 1):
@@ -644,8 +783,16 @@ def run_certification(
         )
     log_paths = list(native_logs)
     if log_paths:
-        results.append(run_native_log_scan(log_paths))
+        results.append(run_native_log_scan(log_checkpoints))
     return results
+
+
+def prepare_transcript_dir(transcript_dir: Path) -> None:
+    if transcript_dir.is_symlink() or transcript_dir.is_file():
+        transcript_dir.unlink()
+    elif transcript_dir.exists():
+        shutil.rmtree(transcript_dir)
+    transcript_dir.mkdir(parents=True, exist_ok=True)
 
 
 def write_evidence(output_dir: Path, plan: dict[str, Any], results: Iterable[ProbeResult]) -> None:
@@ -866,8 +1013,11 @@ def main() -> int:
         base_url=base_url,
         models=models,
         attempts=args.attempts,
+        pressure_turns=args.pressure_turns,
+        timeout=args.timeout,
         output_dir=output_dir,
         min_cached_tokens=args.min_cached_tokens,
+        suffix_prefill_limit=args.suffix_prefill_limit,
         native_logs=native_logs,
     )
     if args.print_plan:

--- a/scripts/qa-kv-tool-loop-stability.py
+++ b/scripts/qa-kv-tool-loop-stability.py
@@ -1,0 +1,986 @@
+#!/usr/bin/env python3
+"""Certify KV/cache stability under repeated OpenAI tool-loop pressure."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any, Iterable, NamedTuple
+import urllib.error
+import urllib.request
+
+
+TOOL_NAME = "lookup_probe_fact"
+FIXTURE_FACTS = {
+    "primary": "KV-STABILITY-PRIMARY-7429",
+    "secondary": "KV-STABILITY-SECONDARY-319",
+}
+KV_PIN = "KV-PIN-8842"
+DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
+DEFAULT_MODELS = "auto"
+DEFAULT_ATTEMPTS = 3
+DEFAULT_PRESSURE_TURNS = 6
+DEFAULT_TIMEOUT = 180.0
+DEFAULT_MIN_CACHED_TOKENS = 2048
+DEFAULT_SUFFIX_PREFILL_LIMIT = 256
+DEFAULT_OUTPUT_DIR = "target/kv-tool-loop-stability/latest"
+FAILURE_PATTERNS = (
+    "failed to find a memory slot",
+    "RuntimeError: llama_decode failed",
+    "llama_decode failed",
+)
+
+
+class ToolCall(NamedTuple):
+    call_id: str
+    key: str
+
+
+class CacheMetrics(NamedTuple):
+    prompt_tokens: int
+    cached_tokens: int
+
+
+class LogFinding(NamedTuple):
+    path: str
+    line_number: int
+    pattern: str
+    text: str
+
+
+class ProbeResult(NamedTuple):
+    model: str
+    attempt: int
+    phase: str
+    ok: bool
+    detail: str
+    elapsed_ms: int
+    status_code: int | None = None
+    prompt_tokens: int | None = None
+    cached_tokens: int | None = None
+
+
+def normalize_v1_base(base_url: str) -> str:
+    base = base_url.strip().rstrip("/")
+    if not base:
+        raise ValueError("base URL is empty")
+    if not base.endswith("/v1"):
+        base = f"{base}/v1"
+    return base
+
+
+def parse_models(value: str) -> list[str]:
+    models = [part.strip() for part in value.split(",") if part.strip()]
+    if not models:
+        raise ValueError("at least one model is required")
+    return models
+
+
+def parse_native_logs(values: Iterable[str] | None) -> list[Path]:
+    logs: list[Path] = []
+    env_value = os.environ.get("MESH_KV_TOOL_LOOP_NATIVE_LOGS")
+    if env_value:
+        logs.extend(Path(part.strip()) for part in env_value.split(",") if part.strip())
+    for value in values or []:
+        logs.append(Path(value))
+    return logs
+
+
+def build_plan(
+    base_url: str,
+    models: Iterable[str],
+    attempts: int,
+    output_dir: Path,
+    min_cached_tokens: int,
+    native_logs: Iterable[Path],
+) -> dict[str, Any]:
+    model_list = list(models)
+    if attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    if min_cached_tokens < 0:
+        raise ValueError("min_cached_tokens cannot be negative")
+    checks = [
+        {
+            "phase": "tool_loop",
+            "models": model_list,
+            "attempts": attempts,
+            "description": "Growing tool-result conversation with a stable long prefix.",
+        },
+        {
+            "phase": "same_prefix_cache",
+            "models": model_list,
+            "min_cached_tokens": min_cached_tokens,
+            "description": "Same long prefix with a different tiny tail should reuse cached tokens.",
+        },
+        {
+            "phase": "exact_prefix_cache",
+            "models": model_list,
+            "min_cached_tokens": min_cached_tokens,
+            "description": "Identical body warm request should still reuse cached tokens.",
+        },
+    ]
+    log_paths = [str(path) for path in native_logs]
+    if log_paths:
+        checks.append(
+            {
+                "phase": "native_log_scan",
+                "paths": log_paths,
+                "fatal_patterns": list(FAILURE_PATTERNS)
+                + ["proactive_eviction status=error"],
+            }
+        )
+    return {
+        "name": "kv-tool-loop-stability",
+        "base_url": normalize_v1_base(base_url),
+        "models": model_list,
+        "attempts": attempts,
+        "output_dir": str(output_dir),
+        "min_cached_tokens": min_cached_tokens,
+        "native_logs": log_paths,
+        "checks": checks,
+        "evidence_files": [
+            "manifest.json",
+            "results.jsonl",
+            "summary.json",
+            "summary.md",
+            "transcripts/*.jsonl",
+        ],
+    }
+
+
+def render_plan(plan: dict[str, Any]) -> str:
+    return json.dumps(plan, indent=2, sort_keys=True)
+
+
+def tool_schema() -> list[dict[str, Any]]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": TOOL_NAME,
+                "description": "Return one deterministic KV/tool-loop probe fact.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "key": {
+                            "type": "string",
+                            "enum": sorted(FIXTURE_FACTS),
+                        }
+                    },
+                    "required": ["key"],
+                    "additionalProperties": False,
+                },
+            },
+        }
+    ]
+
+
+def build_tool_call_request(
+    model: str,
+    attempt: int,
+    key: str = "primary",
+    messages: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    request_messages = list(messages) if messages is not None else initial_messages(attempt, key)
+    return {
+        "model": model,
+        "messages": request_messages,
+        "tools": tool_schema(),
+        "tool_choice": {
+            "type": "function",
+            "function": {"name": TOOL_NAME},
+        },
+        "parallel_tool_calls": False,
+        "stream": False,
+        "temperature": 0,
+        "max_tokens": 128,
+        "reasoning_effort": "none",
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def initial_messages(attempt: int, key: str) -> list[dict[str, str]]:
+    return [
+        {
+            "role": "system",
+            "content": stable_system_prefix(),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Attempt {attempt}: call {TOOL_NAME} with key={key}. "
+                f"Keep the pinned context value {KV_PIN} in memory for the final answer. "
+                "Do not answer directly before the tool call."
+            ),
+        },
+    ]
+
+
+def build_tool_result_request(
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int = 128,
+) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": messages,
+        "stream": False,
+        "temperature": 0,
+        "max_tokens": max_tokens,
+        "reasoning_effort": "none",
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def build_cache_request(model: str, tail: str) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": stable_system_prefix(),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"{tail}\nReturn exactly this pinned value in one sentence: {KV_PIN}."
+                ),
+            },
+        ],
+        "stream": False,
+        "temperature": 0,
+        "max_tokens": 32,
+        "reasoning_effort": "none",
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def stable_system_prefix() -> str:
+    lines = [
+        "You are a deterministic KV/cache stability certification endpoint.",
+        f"Pinned recall token: {KV_PIN}.",
+        "When a tool is requested, call exactly the requested tool and never invent facts.",
+    ]
+    for index in range(192):
+        lines.append(
+            "stable-prefix-block-"
+            f"{index:03d}: preserve tool schema, conversation state, and cached prompt geometry."
+        )
+    return "\n".join(lines)
+
+
+def extract_tool_call(response: dict[str, Any]) -> ToolCall:
+    finish_reason = _first_choice(response).get("finish_reason")
+    if finish_reason != "tool_calls":
+        raise ValueError(f"tool-call turn finish_reason was not tool_calls: {finish_reason!r}")
+    message = _first_message(response)
+    calls = message.get("tool_calls")
+    if not isinstance(calls, list) or not calls:
+        raise ValueError("response did not contain tool_calls")
+    call = calls[0]
+    if not isinstance(call, dict):
+        raise ValueError("tool call is not an object")
+    call_id = call.get("id")
+    function = call.get("function")
+    if not isinstance(call_id, str) or not call_id.strip():
+        raise ValueError("tool call is missing a non-empty id")
+    if not isinstance(function, dict) or function.get("name") != TOOL_NAME:
+        raise ValueError(f"unexpected tool name: {function!r}")
+    arguments = _decode_tool_arguments(function.get("arguments"))
+    key = arguments.get("key")
+    if key not in FIXTURE_FACTS:
+        raise ValueError(f"unsupported fixture key: {key!r}")
+    return ToolCall(call_id=call_id, key=key)
+
+
+def assistant_tool_message(response: dict[str, Any]) -> dict[str, Any]:
+    message = dict(_first_message(response))
+    return {
+        "role": "assistant",
+        "content": message.get("content"),
+        "tool_calls": message.get("tool_calls"),
+    }
+
+
+def tool_result_message(call: ToolCall) -> dict[str, Any]:
+    return {
+        "role": "tool",
+        "tool_call_id": call.call_id,
+        "name": TOOL_NAME,
+        "content": json.dumps(
+            {"key": call.key, "value": FIXTURE_FACTS[call.key]},
+            separators=(",", ":"),
+        ),
+    }
+
+
+def extract_cache_metrics(response: dict[str, Any]) -> CacheMetrics:
+    usage = response.get("usage")
+    if not isinstance(usage, dict):
+        return CacheMetrics(prompt_tokens=0, cached_tokens=0)
+    prompt_tokens = _as_non_negative_int(usage.get("prompt_tokens"))
+    details = usage.get("prompt_tokens_details")
+    cached_tokens = 0
+    if isinstance(details, dict):
+        cached_tokens = _as_non_negative_int(details.get("cached_tokens"))
+    return CacheMetrics(prompt_tokens=prompt_tokens, cached_tokens=cached_tokens)
+
+
+def evaluate_cache_threshold(
+    metrics: CacheMetrics,
+    min_cached_tokens: int,
+    suffix_prefill_limit: int,
+) -> tuple[bool, str]:
+    if metrics.cached_tokens < min_cached_tokens:
+        return (
+            False,
+            (
+                f"cached_tokens={metrics.cached_tokens} below required minimum "
+                f"{min_cached_tokens}; prompt_tokens={metrics.prompt_tokens}"
+            ),
+        )
+    if metrics.prompt_tokens > 0:
+        suffix_prefill_tokens = max(metrics.prompt_tokens - metrics.cached_tokens, 0)
+        if suffix_prefill_tokens > suffix_prefill_limit:
+            return (
+                False,
+                (
+                    f"suffix_prefill_tokens={suffix_prefill_tokens} above limit "
+                    f"{suffix_prefill_limit}; prompt_tokens={metrics.prompt_tokens} "
+                    f"cached_tokens={metrics.cached_tokens}"
+                ),
+            )
+    return (
+        True,
+        (
+            f"prompt_tokens={metrics.prompt_tokens} cached_tokens={metrics.cached_tokens} "
+            f"min_cached_tokens={min_cached_tokens}"
+        ),
+    )
+
+
+def scan_failure_logs(paths: Iterable[Path]) -> list[LogFinding]:
+    findings: list[LogFinding] = []
+    for path in paths:
+        if not path.exists():
+            findings.append(
+                LogFinding(
+                    path=str(path),
+                    line_number=0,
+                    pattern="missing log",
+                    text="native log path did not exist",
+                )
+            )
+            continue
+        with path.open("rb") as handle:
+            for line_number, raw_line in enumerate(handle, start=1):
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                pattern = matched_failure_pattern(line)
+                if pattern:
+                    findings.append(
+                        LogFinding(
+                            path=str(path),
+                            line_number=line_number,
+                            pattern=pattern,
+                            text=line[:500],
+                        )
+                    )
+    return findings
+
+
+def matched_failure_pattern(line: str) -> str | None:
+    for pattern in FAILURE_PATTERNS:
+        if pattern in line:
+            return pattern
+    if "proactive_eviction" in line and "status=error" in line:
+        return "proactive_eviction status=error"
+    return None
+
+
+def run_tool_loop_probe(
+    base_url: str,
+    model: str,
+    attempt: int,
+    timeout: float,
+    pressure_turns: int,
+    transcript_dir: Path,
+) -> ProbeResult:
+    started = time.monotonic()
+    transcript_path = transcript_dir / safe_name(f"{model}-attempt-{attempt}.jsonl")
+    messages = initial_messages(attempt, "primary")
+    try:
+        response, status_code = post_json(
+            base_url,
+            "/chat/completions",
+            build_tool_call_request(model, attempt, messages=messages),
+            timeout,
+        )
+        first_call = extract_tool_call(response)
+        record_transcript(transcript_path, "first_tool_call", status_code, first_call.call_id)
+        messages.extend([assistant_tool_message(response), tool_result_message(first_call)])
+        run_final_after_tool(base_url, model, messages, timeout, [FIXTURE_FACTS[first_call.key]])
+        run_pressure_turns(base_url, model, messages, timeout, pressure_turns, transcript_path)
+        run_second_tool_loop(base_url, model, messages, timeout, transcript_path)
+        run_final_recall(base_url, model, messages, timeout, transcript_path)
+        return _result(
+            model,
+            attempt,
+            "tool_loop",
+            True,
+            f"completed {pressure_turns} pressure turns and two tool calls",
+            started,
+            status_code,
+        )
+    except Exception as exc:
+        record_transcript(transcript_path, "failure", None, detail=str(exc))
+        return _result(model, attempt, "tool_loop", False, str(exc), started)
+
+
+def run_final_after_tool(
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    timeout: float,
+    expected_values: Iterable[str],
+) -> None:
+    messages.append(
+        {
+            "role": "user",
+            "content": f"Answer with the tool fact and include {KV_PIN}.",
+        }
+    )
+    response, _status_code = post_json(
+        base_url,
+        "/chat/completions",
+        build_tool_result_request(model, messages),
+        timeout,
+    )
+    validate_message(response, [*expected_values, KV_PIN])
+    messages.append(_assistant_text_message(response))
+
+
+def run_pressure_turns(
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    timeout: float,
+    pressure_turns: int,
+    transcript_path: Path,
+) -> None:
+    for turn in range(1, pressure_turns + 1):
+        messages.append(
+            {
+                "role": "user",
+                "content": (
+                    f"Pressure turn {turn}: keep the pinned value stable. "
+                    f"Return {KV_PIN} and a short confirmation."
+                ),
+            }
+        )
+        response, status_code = post_json(
+            base_url,
+            "/chat/completions",
+            build_tool_result_request(model, messages, max_tokens=64),
+            timeout,
+        )
+        validate_message(response, [KV_PIN])
+        record_transcript(transcript_path, f"pressure_turn_{turn}", status_code)
+        messages.append(_assistant_text_message(response))
+
+
+def run_second_tool_loop(
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    timeout: float,
+    transcript_path: Path,
+) -> None:
+    messages.append(
+        {
+            "role": "user",
+            "content": (
+                f"Now call {TOOL_NAME} with key=secondary. "
+                "Do not answer directly before the tool call."
+            ),
+        }
+    )
+    response, status_code = post_json(
+        base_url,
+        "/chat/completions",
+        build_tool_call_request(model, attempt=1, key="secondary", messages=messages),
+        timeout,
+    )
+    call = extract_tool_call(response)
+    record_transcript(transcript_path, "second_tool_call", status_code, call.call_id)
+    messages.extend([assistant_tool_message(response), tool_result_message(call)])
+
+
+def run_final_recall(
+    base_url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    timeout: float,
+    transcript_path: Path,
+) -> None:
+    expected = [KV_PIN, FIXTURE_FACTS["primary"], FIXTURE_FACTS["secondary"]]
+    messages.append(
+        {
+            "role": "user",
+            "content": "Final recall: include both tool facts and the pinned KV value.",
+        }
+    )
+    response, status_code = post_json(
+        base_url,
+        "/chat/completions",
+        build_tool_result_request(model, messages, max_tokens=128),
+        timeout,
+    )
+    validate_message(response, expected)
+    record_transcript(transcript_path, "final_recall", status_code)
+    messages.append(_assistant_text_message(response))
+
+
+def run_cache_probe(
+    base_url: str,
+    model: str,
+    phase: str,
+    timeout: float,
+    min_cached_tokens: int,
+    suffix_prefill_limit: int,
+) -> ProbeResult:
+    started = time.monotonic()
+    try:
+        if phase == "exact_prefix_cache":
+            warm = build_cache_request(model, "Exact-prefix warmup tail.")
+            measured = dict(warm)
+        else:
+            warm = build_cache_request(model, "Same-prefix warmup tail alpha.")
+            measured = build_cache_request(model, "Same-prefix measured tail beta.")
+        post_json(base_url, "/chat/completions", warm, timeout)
+        response, status_code = post_json(base_url, "/chat/completions", measured, timeout)
+        metrics = extract_cache_metrics(response)
+        ok, detail = evaluate_cache_threshold(
+            metrics,
+            min_cached_tokens=min_cached_tokens,
+            suffix_prefill_limit=suffix_prefill_limit,
+        )
+        return _result(
+            model,
+            0,
+            phase,
+            ok,
+            detail,
+            started,
+            status_code,
+            metrics.prompt_tokens,
+            metrics.cached_tokens,
+        )
+    except Exception as exc:
+        return _result(model, 0, phase, False, str(exc), started)
+
+
+def run_native_log_scan(paths: Iterable[Path]) -> ProbeResult:
+    started = time.monotonic()
+    findings = scan_failure_logs(paths)
+    if findings:
+        detail = "; ".join(
+            f"{finding.path}:{finding.line_number} {finding.pattern}: {finding.text[:160]}"
+            for finding in findings[:5]
+        )
+        if len(findings) > 5:
+            detail += f"; +{len(findings) - 5} more"
+        return _result("native-log", 0, "native_log_scan", False, detail, started)
+    return _result("native-log", 0, "native_log_scan", True, "no fatal KV log patterns", started)
+
+
+def run_certification(
+    base_url: str,
+    models: Iterable[str],
+    attempts: int,
+    timeout: float,
+    pressure_turns: int,
+    min_cached_tokens: int,
+    suffix_prefill_limit: int,
+    native_logs: Iterable[Path],
+    output_dir: Path,
+) -> list[ProbeResult]:
+    transcript_dir = output_dir / "transcripts"
+    results: list[ProbeResult] = []
+    for model in models:
+        for attempt in range(1, attempts + 1):
+            results.append(
+                run_tool_loop_probe(
+                    base_url,
+                    model,
+                    attempt,
+                    timeout,
+                    pressure_turns,
+                    transcript_dir,
+                )
+            )
+        results.append(
+            run_cache_probe(
+                base_url,
+                model,
+                "same_prefix_cache",
+                timeout,
+                min_cached_tokens,
+                suffix_prefill_limit,
+            )
+        )
+        results.append(
+            run_cache_probe(
+                base_url,
+                model,
+                "exact_prefix_cache",
+                timeout,
+                min_cached_tokens,
+                suffix_prefill_limit,
+            )
+        )
+    log_paths = list(native_logs)
+    if log_paths:
+        results.append(run_native_log_scan(log_paths))
+    return results
+
+
+def write_evidence(output_dir: Path, plan: dict[str, Any], results: Iterable[ProbeResult]) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    rows = list(results)
+    manifest = dict(plan)
+    manifest["created_at"] = utc_now()
+    (output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    with (output_dir / "results.jsonl").open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row._asdict(), sort_keys=True) + "\n")
+    summary = summarize_results(rows)
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "summary.md").write_text(
+        render_summary_markdown(summary, rows),
+        encoding="utf-8",
+    )
+
+
+def summarize_results(results: Iterable[ProbeResult]) -> dict[str, Any]:
+    rows = list(results)
+    passed = sum(1 for row in rows if row.ok)
+    failed = len(rows) - passed
+    phases: dict[str, dict[str, int]] = {}
+    for row in rows:
+        bucket = phases.setdefault(row.phase, {"passed": 0, "failed": 0, "total": 0})
+        bucket["total"] += 1
+        bucket["passed" if row.ok else "failed"] += 1
+    return {
+        "ok": failed == 0,
+        "total": len(rows),
+        "passed": passed,
+        "failed": failed,
+        "phases": phases,
+    }
+
+
+def render_summary_markdown(summary: dict[str, Any], results: Iterable[ProbeResult]) -> str:
+    rows = list(results)
+    status = "PASS" if summary["ok"] else "FAIL"
+    lines = [
+        "# KV Tool-Loop Stability Summary",
+        "",
+        f"Status: **{status}**",
+        "",
+        "| Phase | Passed | Failed | Total |",
+        "|---|---:|---:|---:|",
+    ]
+    for phase, counts in sorted(summary["phases"].items()):
+        lines.append(
+            f"| {phase} | {counts['passed']} | {counts['failed']} | {counts['total']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "| Result | Model | Attempt | Phase | Detail |",
+            "|---|---|---:|---|---|",
+        ]
+    )
+    for row in rows:
+        result = "PASS" if row.ok else "FAIL"
+        detail = row.detail.replace("|", "\\|")
+        lines.append(f"| {result} | {row.model} | {row.attempt} | {row.phase} | {detail} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def post_json(
+    base_url: str,
+    path: str,
+    payload: dict[str, Any],
+    timeout: float,
+) -> tuple[dict[str, Any], int]:
+    data = json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        f"{normalize_v1_base(base_url)}{path}",
+        data=data,
+        headers={
+            "content-type": "application/json",
+            "authorization": "Bearer mesh-llm-kv-tool-loop-probe",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read()
+            status_code = response.status
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {exc.code}: {body[:400]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"request failed: {exc}") from exc
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError as exc:
+        snippet = body.decode("utf-8", errors="replace")[:400]
+        raise RuntimeError(f"response was not JSON: {snippet}") from exc
+    if not isinstance(decoded, dict):
+        raise RuntimeError("response JSON was not an object")
+    return decoded, status_code
+
+
+def validate_message(response: dict[str, Any], expected_values: Iterable[str]) -> None:
+    message = _first_message(response)
+    if message.get("tool_calls"):
+        raise ValueError("expected final text, got another tool call")
+    content = message.get("content")
+    if not isinstance(content, str) or not content.strip():
+        raise ValueError("response content was empty")
+    missing = [value for value in expected_values if value not in content]
+    if missing:
+        raise ValueError(f"response missing expected values: {', '.join(missing)}")
+
+
+def record_transcript(
+    path: Path,
+    phase: str,
+    status_code: int | None,
+    tool_call_id: str | None = None,
+    detail: str | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "phase": phase,
+        "status_code": status_code,
+        "tool_call_id": tool_call_id,
+        "detail": detail,
+        "recorded_at": utc_now(),
+    }
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def print_summary(results: Iterable[ProbeResult], output_dir: Path) -> None:
+    rows = list(results)
+    passed = sum(1 for row in rows if row.ok)
+    print(f"kv/tool-loop stability: {passed}/{len(rows)} phases passed")
+    print(f"evidence: {output_dir}")
+    for row in rows:
+        status = "PASS" if row.ok else "FAIL"
+        print(f"{status} model={row.model} attempt={row.attempt} phase={row.phase}: {row.detail}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Certify live mesh-llm KV/cache stability under OpenAI tool-loop pressure.",
+    )
+    parser.add_argument("--base-url", default=default_base_url())
+    parser.add_argument(
+        "--models",
+        default=os.environ.get("MESH_KV_TOOL_LOOP_MODELS", DEFAULT_MODELS),
+    )
+    parser.add_argument(
+        "--attempts",
+        type=int,
+        default=int(os.environ.get("MESH_KV_TOOL_LOOP_ATTEMPTS", str(DEFAULT_ATTEMPTS))),
+    )
+    parser.add_argument(
+        "--pressure-turns",
+        type=int,
+        default=int(os.environ.get("MESH_KV_TOOL_LOOP_PRESSURE_TURNS", str(DEFAULT_PRESSURE_TURNS))),
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=float(os.environ.get("MESH_KV_TOOL_LOOP_TIMEOUT", str(DEFAULT_TIMEOUT))),
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=os.environ.get("MESH_KV_TOOL_LOOP_OUTPUT_DIR", DEFAULT_OUTPUT_DIR),
+    )
+    parser.add_argument(
+        "--min-cached-tokens",
+        type=int,
+        default=int(
+            os.environ.get("MESH_KV_TOOL_LOOP_MIN_CACHED_TOKENS", str(DEFAULT_MIN_CACHED_TOKENS))
+        ),
+    )
+    parser.add_argument(
+        "--suffix-prefill-limit",
+        type=int,
+        default=int(
+            os.environ.get(
+                "MESH_KV_TOOL_LOOP_SUFFIX_PREFILL_LIMIT",
+                str(DEFAULT_SUFFIX_PREFILL_LIMIT),
+            )
+        ),
+    )
+    parser.add_argument("--native-log", action="append", default=[])
+    parser.add_argument("--print-plan", action="store_true")
+    return parser.parse_args()
+
+
+def default_base_url() -> str:
+    env_base = os.environ.get("MESH_KV_TOOL_LOOP_BASE_URL")
+    if env_base:
+        return env_base
+    client_base = os.environ.get("MESH_CLIENT_API_BASE")
+    if client_base:
+        return f"{client_base.rstrip('/')}/v1"
+    return DEFAULT_BASE_URL
+
+
+def main() -> int:
+    args = parse_args()
+    base_url = normalize_v1_base(args.base_url)
+    models = parse_models(args.models)
+    validate_runtime_options(args)
+    output_dir = Path(args.output_dir)
+    native_logs = parse_native_logs(args.native_log)
+    plan = build_plan(
+        base_url=base_url,
+        models=models,
+        attempts=args.attempts,
+        output_dir=output_dir,
+        min_cached_tokens=args.min_cached_tokens,
+        native_logs=native_logs,
+    )
+    if args.print_plan:
+        print(render_plan(plan))
+        return 0
+    results = run_certification(
+        base_url=base_url,
+        models=models,
+        attempts=args.attempts,
+        timeout=args.timeout,
+        pressure_turns=args.pressure_turns,
+        min_cached_tokens=args.min_cached_tokens,
+        suffix_prefill_limit=args.suffix_prefill_limit,
+        native_logs=native_logs,
+        output_dir=output_dir,
+    )
+    write_evidence(output_dir, plan, results)
+    print_summary(results, output_dir)
+    return 0 if all(row.ok for row in results) else 1
+
+
+def validate_runtime_options(args: argparse.Namespace) -> None:
+    if args.attempts < 1:
+        raise ValueError("attempts must be at least 1")
+    if args.pressure_turns < 0:
+        raise ValueError("pressure-turns cannot be negative")
+    if args.min_cached_tokens < 0:
+        raise ValueError("min-cached-tokens cannot be negative")
+    if args.suffix_prefill_limit < 0:
+        raise ValueError("suffix-prefill-limit cannot be negative")
+
+
+def _first_message(response: dict[str, Any]) -> dict[str, Any]:
+    choice = _first_choice(response)
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        raise ValueError("first choice did not contain a message object")
+    return message
+
+
+def _first_choice(response: dict[str, Any]) -> dict[str, Any]:
+    choices = response.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("response had no choices")
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        raise ValueError("first choice is not an object")
+    return choice
+
+
+def _decode_tool_arguments(arguments: Any) -> dict[str, Any]:
+    if isinstance(arguments, str):
+        try:
+            decoded = json.loads(arguments)
+        except json.JSONDecodeError as exc:
+            raise ValueError("tool arguments were not valid JSON") from exc
+    elif isinstance(arguments, dict):
+        decoded = arguments
+    else:
+        raise ValueError("tool arguments were neither JSON string nor object")
+    if not isinstance(decoded, dict):
+        raise ValueError("tool arguments were not a JSON object")
+    return decoded
+
+
+def _assistant_text_message(response: dict[str, Any]) -> dict[str, Any]:
+    message = _first_message(response)
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("assistant message content was not text")
+    return {"role": "assistant", "content": content}
+
+
+def _as_non_negative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int) and value > 0:
+        return value
+    return 0
+
+
+def _result(
+    model: str,
+    attempt: int,
+    phase: str,
+    ok: bool,
+    detail: str,
+    started: float,
+    status_code: int | None = None,
+    prompt_tokens: int | None = None,
+    cached_tokens: int | None = None,
+) -> ProbeResult:
+    return ProbeResult(
+        model=model,
+        attempt=attempt,
+        phase=phase,
+        ok=ok,
+        detail=detail,
+        elapsed_ms=int((time.monotonic() - started) * 1000),
+        status_code=status_code,
+        prompt_tokens=prompt_tokens,
+        cached_tokens=cached_tokens,
+    )
+
+
+def safe_name(value: str) -> str:
+    safe = "".join(char if char.isalnum() or char in "._-" else "_" for char in value)
+    return f"{safe}.jsonl"
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/qa-kv-tool-loop-stability.py
+++ b/scripts/qa-kv-tool-loop-stability.py
@@ -486,13 +486,18 @@ def scan_one_log_since(checkpoint: NativeLogCheckpoint) -> list[LogFinding]:
     ):
         offset = 0
     with path.open("rb") as handle:
+        start_line_number = line_number_start_for_offset(handle, offset)
         handle.seek(offset)
-        return scan_failure_lines(path, handle)
+        return scan_failure_lines(path, handle, start_line_number)
 
 
-def scan_failure_lines(path: Path, handle: Iterable[bytes]) -> list[LogFinding]:
+def scan_failure_lines(
+    path: Path,
+    handle: Iterable[bytes],
+    start_line_number: int = 1,
+) -> list[LogFinding]:
     findings: list[LogFinding] = []
-    for line_number, raw_line in enumerate(handle, start=1):
+    for line_number, raw_line in enumerate(handle, start=start_line_number):
         line = raw_line.decode("utf-8", errors="replace").strip()
         pattern = matched_failure_pattern(line)
         if pattern:
@@ -505,6 +510,21 @@ def scan_failure_lines(path: Path, handle: Iterable[bytes]) -> list[LogFinding]:
                 )
             )
     return findings
+
+
+def line_number_start_for_offset(handle: Any, offset: int) -> int:
+    if offset <= 0:
+        return 1
+    handle.seek(0)
+    remaining = offset
+    newline_count = 0
+    while remaining > 0:
+        chunk = handle.read(min(remaining, 1024 * 1024))
+        if not chunk:
+            break
+        remaining -= len(chunk)
+        newline_count += chunk.count(b"\n")
+    return newline_count + 1
 
 
 def file_identity(stat: os.stat_result) -> tuple[int, int]:
@@ -699,6 +719,7 @@ def run_cache_probe(
             measured = build_cache_request(model, "Same-prefix measured tail beta.")
         post_json(base_url, "/chat/completions", warm, timeout)
         response, status_code = post_json(base_url, "/chat/completions", measured, timeout)
+        validate_message(response, [KV_PIN])
         metrics = extract_cache_metrics(response)
         ok, detail = evaluate_cache_threshold(
             metrics,

--- a/scripts/tests/test_qa_kv_tool_loop_stability.py
+++ b/scripts/tests/test_qa_kv_tool_loop_stability.py
@@ -120,6 +120,47 @@ class KvToolLoopStabilityTests(unittest.TestCase):
         self.assertFalse(ok)
         self.assertIn("below required minimum", detail)
 
+    def test_cache_probe_fails_wrong_completion_even_with_cached_tokens(self):
+        harness = load_module()
+        original_post_json = harness.post_json
+        responses = [
+            {
+                "choices": [{"message": {"content": f"warmup includes {harness.KV_PIN}"}}],
+                "usage": {
+                    "prompt_tokens": 2240,
+                    "prompt_tokens_details": {"cached_tokens": 2176},
+                },
+            },
+            {
+                "choices": [{"message": {"content": "wrong cached completion"}}],
+                "usage": {
+                    "prompt_tokens": 2240,
+                    "prompt_tokens_details": {"cached_tokens": 2176},
+                },
+            },
+        ]
+
+        def fake_post_json(base_url, path, payload, timeout):
+            del base_url, path, payload, timeout
+            return responses.pop(0), 200
+
+        harness.post_json = fake_post_json
+        try:
+            result = harness.run_cache_probe(
+                base_url="http://localhost:9337/v1",
+                model="direct-model",
+                phase="same_prefix_cache",
+                timeout=180.0,
+                min_cached_tokens=2048,
+                suffix_prefill_limit=256,
+            )
+        finally:
+            harness.post_json = original_post_json
+
+        self.assertFalse(result.ok)
+        self.assertIn("response missing expected values", result.detail)
+        self.assertEqual(responses, [])
+
     def test_log_scan_detects_memory_slot_and_eviction_errors(self):
         harness = load_module()
         with tempfile.TemporaryDirectory() as tmp:
@@ -167,8 +208,29 @@ class KvToolLoopStabilityTests(unittest.TestCase):
             findings = harness.scan_failure_logs_since(checkpoints)
 
         self.assertEqual(len(findings), 1)
-        self.assertEqual(findings[0].line_number, 1)
+        self.assertEqual(findings[0].line_number, 2)
         self.assertEqual(findings[0].pattern, "failed to find a memory slot")
+
+    def test_native_log_scan_preserves_file_line_number_after_checkpoint(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "skippy-native.log"
+            log_path.write_text(
+                "old benign line 1\n"
+                "old llama_decode failed before this certification\n"
+                "old benign line 3\n",
+                encoding="utf-8",
+            )
+            checkpoints = harness.capture_native_log_checkpoints([log_path])
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write("new benign line 4\n")
+                handle.write("RuntimeError: llama_decode failed\n")
+
+            findings = harness.scan_failure_logs_since(checkpoints)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].line_number, 5)
+        self.assertEqual(findings[0].pattern, "RuntimeError: llama_decode failed")
 
     def test_native_log_scan_reports_new_log_created_after_checkpoint(self):
         harness = load_module()

--- a/scripts/tests/test_qa_kv_tool_loop_stability.py
+++ b/scripts/tests/test_qa_kv_tool_loop_stability.py
@@ -1,0 +1,165 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "qa-kv-tool-loop-stability.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("qa_kv_tool_loop_stability", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class KvToolLoopStabilityTests(unittest.TestCase):
+    def test_plan_declares_tool_loop_cache_and_log_scan(self):
+        harness = load_module()
+        plan = harness.build_plan(
+            base_url="http://localhost:9337",
+            models=["Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m"],
+            attempts=3,
+            output_dir=Path("target/kv-tool-loop-stability/latest"),
+            min_cached_tokens=2048,
+            native_logs=[Path("skippy-native.log")],
+        )
+
+        self.assertEqual(plan["name"], "kv-tool-loop-stability")
+        self.assertEqual(plan["base_url"], "http://localhost:9337/v1")
+        self.assertEqual(plan["attempts"], 3)
+        self.assertEqual(plan["min_cached_tokens"], 2048)
+        self.assertIn("manifest.json", plan["evidence_files"])
+        self.assertIn("results.jsonl", plan["evidence_files"])
+        self.assertIn("summary.md", plan["evidence_files"])
+        self.assertEqual(
+            [check["phase"] for check in plan["checks"]],
+            ["tool_loop", "same_prefix_cache", "exact_prefix_cache", "native_log_scan"],
+        )
+
+    def test_tool_loop_requests_keep_stable_prefix_and_vary_tail(self):
+        harness = load_module()
+        first = harness.build_tool_call_request("direct-model", attempt=1)
+        second = harness.build_tool_call_request("direct-model", attempt=2)
+
+        self.assertEqual(first["model"], "direct-model")
+        self.assertEqual(first["messages"][0]["content"], second["messages"][0]["content"])
+        self.assertNotEqual(first["messages"][1]["content"], second["messages"][1]["content"])
+        self.assertEqual(
+            first["tool_choice"],
+            {"type": "function", "function": {"name": "lookup_probe_fact"}},
+        )
+        self.assertFalse(first["parallel_tool_calls"])
+        self.assertEqual(first["tools"][0]["function"]["name"], "lookup_probe_fact")
+
+    def test_cache_metrics_extract_openai_usage_tokens(self):
+        harness = load_module()
+        metrics = harness.extract_cache_metrics(
+            {
+                "usage": {
+                    "prompt_tokens": 2240,
+                    "prompt_tokens_details": {"cached_tokens": 2176},
+                }
+            }
+        )
+        self.assertEqual(metrics.prompt_tokens, 2240)
+        self.assertEqual(metrics.cached_tokens, 2176)
+
+        missing = harness.extract_cache_metrics({"usage": {"prompt_tokens": 12}})
+        self.assertEqual(missing.prompt_tokens, 12)
+        self.assertEqual(missing.cached_tokens, 0)
+
+    def test_cache_threshold_reports_shortfall(self):
+        harness = load_module()
+
+        ok, detail = harness.evaluate_cache_threshold(
+            harness.CacheMetrics(prompt_tokens=2240, cached_tokens=2176),
+            min_cached_tokens=2048,
+            suffix_prefill_limit=256,
+        )
+        self.assertTrue(ok)
+        self.assertIn("cached_tokens=2176", detail)
+
+        ok, detail = harness.evaluate_cache_threshold(
+            harness.CacheMetrics(prompt_tokens=2240, cached_tokens=256),
+            min_cached_tokens=2048,
+            suffix_prefill_limit=256,
+        )
+        self.assertFalse(ok)
+        self.assertIn("below required minimum", detail)
+
+    def test_log_scan_detects_memory_slot_and_eviction_errors(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "skippy-native.log"
+            log_path.write_text(
+                "Grammar triggered on regex: '<tool_call>'\n"
+                "decode: failed to find a memory slot for batch of size 2048\n"
+                "skippy.kv.decision proactive_eviction status=error\n",
+                encoding="utf-8",
+            )
+
+            findings = harness.scan_failure_logs([log_path])
+
+        self.assertEqual(len(findings), 2)
+        self.assertEqual(findings[0].pattern, "failed to find a memory slot")
+        self.assertEqual(findings[1].pattern, "proactive_eviction status=error")
+
+    def test_write_evidence_outputs_manifest_results_and_summary(self):
+        harness = load_module()
+        plan = harness.build_plan(
+            base_url="http://localhost:9337/v1",
+            models=["direct-model"],
+            attempts=1,
+            output_dir=Path("target/kv-tool-loop-stability/latest"),
+            min_cached_tokens=2048,
+            native_logs=[],
+        )
+        results = [
+            harness.ProbeResult(
+                model="direct-model",
+                attempt=1,
+                phase="tool_loop",
+                ok=True,
+                detail="tool loop completed",
+                elapsed_ms=25,
+                status_code=200,
+                prompt_tokens=None,
+                cached_tokens=None,
+            ),
+            harness.ProbeResult(
+                model="direct-model",
+                attempt=1,
+                phase="same_prefix_cache",
+                ok=False,
+                detail="cached_tokens=256 below required minimum 2048",
+                elapsed_ms=12,
+                status_code=200,
+                prompt_tokens=2240,
+                cached_tokens=256,
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            harness.write_evidence(output_dir, plan, results)
+
+            manifest = json.loads((output_dir / "manifest.json").read_text(encoding="utf-8"))
+            summary = json.loads((output_dir / "summary.json").read_text(encoding="utf-8"))
+            result_lines = (output_dir / "results.jsonl").read_text(encoding="utf-8").splitlines()
+            summary_md = (output_dir / "summary.md").read_text(encoding="utf-8")
+
+        self.assertEqual(manifest["name"], "kv-tool-loop-stability")
+        self.assertFalse(summary["ok"])
+        self.assertEqual(summary["total"], 2)
+        self.assertEqual(summary["failed"], 1)
+        self.assertEqual(len(result_lines), 2)
+        self.assertIn("KV Tool-Loop Stability Summary", summary_md)
+        self.assertIn("same_prefix_cache", summary_md)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_qa_kv_tool_loop_stability.py
+++ b/scripts/tests/test_qa_kv_tool_loop_stability.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -23,21 +24,49 @@ class KvToolLoopStabilityTests(unittest.TestCase):
             base_url="http://localhost:9337",
             models=["Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m"],
             attempts=3,
+            pressure_turns=8,
+            timeout=90.0,
             output_dir=Path("target/kv-tool-loop-stability/latest"),
             min_cached_tokens=2048,
+            suffix_prefill_limit=256,
             native_logs=[Path("skippy-native.log")],
         )
 
         self.assertEqual(plan["name"], "kv-tool-loop-stability")
         self.assertEqual(plan["base_url"], "http://localhost:9337/v1")
         self.assertEqual(plan["attempts"], 3)
+        self.assertEqual(plan["pressure_turns"], 8)
+        self.assertEqual(plan["timeout_seconds"], 90.0)
         self.assertEqual(plan["min_cached_tokens"], 2048)
+        self.assertEqual(plan["suffix_prefill_limit"], 256)
+        self.assertEqual(plan["native_log_scan_mode"], "appended_since_run_start")
         self.assertIn("manifest.json", plan["evidence_files"])
         self.assertIn("results.jsonl", plan["evidence_files"])
         self.assertIn("summary.md", plan["evidence_files"])
         self.assertEqual(
             [check["phase"] for check in plan["checks"]],
             ["tool_loop", "same_prefix_cache", "exact_prefix_cache", "native_log_scan"],
+        )
+        self.assertEqual(plan["checks"][0]["pressure_turns"], 8)
+        self.assertEqual(plan["checks"][1]["suffix_prefill_limit"], 256)
+        self.assertEqual(plan["checks"][2]["timeout_seconds"], 90.0)
+        self.assertEqual(plan["checks"][3]["scan_mode"], "appended_since_run_start")
+
+    def test_parse_native_logs_dedupes_env_and_cli_paths(self):
+        harness = load_module()
+        original = os.environ.get("MESH_KV_TOOL_LOOP_NATIVE_LOGS")
+        os.environ["MESH_KV_TOOL_LOOP_NATIVE_LOGS"] = "skippy-native.log, other.log"
+        try:
+            logs = harness.parse_native_logs(["skippy-native.log", "third.log"])
+        finally:
+            if original is None:
+                os.environ.pop("MESH_KV_TOOL_LOOP_NATIVE_LOGS", None)
+            else:
+                os.environ["MESH_KV_TOOL_LOOP_NATIVE_LOGS"] = original
+
+        self.assertEqual(
+            [str(path) for path in logs],
+            ["skippy-native.log", "other.log", "third.log"],
         )
 
     def test_tool_loop_requests_keep_stable_prefix_and_vary_tail(self):
@@ -108,14 +137,185 @@ class KvToolLoopStabilityTests(unittest.TestCase):
         self.assertEqual(findings[0].pattern, "failed to find a memory slot")
         self.assertEqual(findings[1].pattern, "proactive_eviction status=error")
 
+    def test_native_log_scan_ignores_preexisting_failures_after_checkpoint(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "skippy-native.log"
+            log_path.write_text(
+                "old llama_decode failed before this certification\n",
+                encoding="utf-8",
+            )
+            checkpoints = harness.capture_native_log_checkpoints([log_path])
+            log_path.write_text(
+                log_path.read_text(encoding="utf-8") + "new benign line\n",
+                encoding="utf-8",
+            )
+
+            findings = harness.scan_failure_logs_since(checkpoints)
+
+        self.assertEqual(findings, [])
+
+    def test_native_log_scan_reports_failures_appended_after_checkpoint(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "skippy-native.log"
+            log_path.write_text("old benign line\n", encoding="utf-8")
+            checkpoints = harness.capture_native_log_checkpoints([log_path])
+            with log_path.open("a", encoding="utf-8") as handle:
+                handle.write("decode: failed to find a memory slot for batch of size 2048\n")
+
+            findings = harness.scan_failure_logs_since(checkpoints)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].line_number, 1)
+        self.assertEqual(findings[0].pattern, "failed to find a memory slot")
+
+    def test_native_log_scan_reports_new_log_created_after_checkpoint(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "skippy-native.log"
+            checkpoints = harness.capture_native_log_checkpoints([log_path])
+            log_path.write_text("RuntimeError: llama_decode failed\n", encoding="utf-8")
+
+            findings = harness.scan_failure_logs_since(checkpoints)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, "RuntimeError: llama_decode failed")
+
+    def test_native_log_scan_rescans_truncated_log_after_checkpoint(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            log_path = Path(tmp) / "skippy-native.log"
+            log_path.write_text("old benign line that makes the file long\n", encoding="utf-8")
+            checkpoints = harness.capture_native_log_checkpoints([log_path])
+            log_path.write_text(
+                "skippy.kv.decision proactive_eviction status=error\n",
+                encoding="utf-8",
+            )
+
+            findings = harness.scan_failure_logs_since(checkpoints)
+
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].pattern, "proactive_eviction status=error")
+
+    def test_prepare_transcript_dir_removes_stale_attempt_files(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript_dir = Path(tmp) / "transcripts"
+            transcript_dir.mkdir()
+            stale = transcript_dir / "direct-model-attempt-1.jsonl"
+            stale.write_text('{"phase":"old"}\n', encoding="utf-8")
+
+            harness.prepare_transcript_dir(transcript_dir)
+
+            self.assertTrue(transcript_dir.is_dir())
+            self.assertFalse(stale.exists())
+
+    def test_run_certification_resets_transcripts_before_writing(self):
+        harness = load_module()
+        original_tool_loop = harness.run_tool_loop_probe
+        original_cache_probe = harness.run_cache_probe
+
+        def fake_tool_loop(
+            base_url,
+            model,
+            attempt,
+            timeout,
+            pressure_turns,
+            transcript_dir,
+        ):
+            del base_url, timeout, pressure_turns
+            harness.record_transcript(
+                transcript_dir / f"{model}-attempt-{attempt}.jsonl",
+                "fresh",
+                200,
+            )
+            return harness.ProbeResult(
+                model=model,
+                attempt=attempt,
+                phase="tool_loop",
+                ok=True,
+                detail="fresh transcript",
+                elapsed_ms=1,
+            )
+
+        def fake_cache_probe(
+            base_url,
+            model,
+            phase,
+            timeout,
+            min_cached_tokens,
+            suffix_prefill_limit,
+        ):
+            del base_url, timeout, min_cached_tokens, suffix_prefill_limit
+            return harness.ProbeResult(
+                model=model,
+                attempt=0,
+                phase=phase,
+                ok=True,
+                detail="cache ok",
+                elapsed_ms=1,
+            )
+
+        harness.run_tool_loop_probe = fake_tool_loop
+        harness.run_cache_probe = fake_cache_probe
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                output_dir = Path(tmp)
+                transcript_dir = output_dir / "transcripts"
+                transcript_dir.mkdir()
+                stale = transcript_dir / "direct-model-attempt-1.jsonl"
+                obsolete = transcript_dir / "old-model-attempt-3.jsonl"
+                stale.write_text('{"phase":"old"}\n', encoding="utf-8")
+                obsolete.write_text('{"phase":"obsolete"}\n', encoding="utf-8")
+
+                harness.run_certification(
+                    base_url="http://localhost:9337/v1",
+                    models=["direct-model"],
+                    attempts=1,
+                    timeout=180.0,
+                    pressure_turns=8,
+                    min_cached_tokens=2048,
+                    suffix_prefill_limit=256,
+                    native_logs=[],
+                    output_dir=output_dir,
+                )
+
+                lines = stale.read_text(encoding="utf-8").splitlines()
+                payload = json.loads(lines[0])
+
+            self.assertEqual(len(lines), 1)
+            self.assertEqual(payload["phase"], "fresh")
+            self.assertFalse(obsolete.exists())
+        finally:
+            harness.run_tool_loop_probe = original_tool_loop
+            harness.run_cache_probe = original_cache_probe
+
+    def test_record_transcript_appends_within_attempt(self):
+        harness = load_module()
+        with tempfile.TemporaryDirectory() as tmp:
+            transcript_path = Path(tmp) / "transcripts" / "direct-model-attempt-1.jsonl"
+            harness.record_transcript(transcript_path, "first_tool_call", 200)
+            harness.record_transcript(transcript_path, "pressure_turn_1", 200)
+
+            phases = [
+                json.loads(line)["phase"]
+                for line in transcript_path.read_text(encoding="utf-8").splitlines()
+            ]
+
+        self.assertEqual(phases, ["first_tool_call", "pressure_turn_1"])
+
     def test_write_evidence_outputs_manifest_results_and_summary(self):
         harness = load_module()
         plan = harness.build_plan(
             base_url="http://localhost:9337/v1",
             models=["direct-model"],
             attempts=1,
+            pressure_turns=8,
+            timeout=180.0,
             output_dir=Path("target/kv-tool-loop-stability/latest"),
             min_cached_tokens=2048,
+            suffix_prefill_limit=256,
             native_logs=[],
         )
         results = [
@@ -153,6 +353,9 @@ class KvToolLoopStabilityTests(unittest.TestCase):
             summary_md = (output_dir / "summary.md").read_text(encoding="utf-8")
 
         self.assertEqual(manifest["name"], "kv-tool-loop-stability")
+        self.assertEqual(manifest["pressure_turns"], 8)
+        self.assertEqual(manifest["suffix_prefill_limit"], 256)
+        self.assertEqual(manifest["timeout_seconds"], 180.0)
         self.assertFalse(summary["ok"])
         self.assertEqual(summary["total"], 2)
         self.assertEqual(summary["failed"], 1)


### PR DESCRIPTION
## Summary

Adds a standalone KV/tool-loop stability certification harness for live OpenAI-compatible mesh endpoints.

The harness exercises the specific failure shape from recent Skippy KV/tool-loop work: repeated non-streaming tool-result continuations against a long stable prefix, same-prefix/different-tail cache reuse, exact-prefix cache reuse, and optional Skippy native-log scanning for fatal KV/decode signals.

## Why

The broad nightly stability harness is useful for trend and endpoint health, but it does not give a focused lab proof for the KV/cache failure modes behind repeated agent tool loops. This PR adds a narrow certification tool maintainers can run against a real direct-model Skippy endpoint before relying on Goose, Pi, OpenCode, or release-candidate agent workloads.

The target regressions are concrete: `llama_decode failed`, `failed to find a memory slot`, unexpectedly low `usage.prompt_tokens_details.cached_tokens` on same-prefix/different-tail prompts, proactive eviction errors in native logs, and cached responses that report good cache metrics while returning the wrong completion.

## Diff scope

- Adds `scripts/qa-kv-tool-loop-stability.py`, a stdlib-only importable CLI probe with `--print-plan` support.
- Runs a growing two-tool-call conversation with pressure turns and final recall of deterministic fixture values.
- Adds `same_prefix_cache` and `exact_prefix_cache` checks using OpenAI usage cache metrics.
- Validates cache-probe completion text as well as cache metrics, so high `cached_tokens` cannot hide an incorrect cached answer.
- Adds optional `--native-log` scanning for slot exhaustion, decode failures, and proactive eviction errors appended after the certification starts.
- Preserves physical native-log file line numbers when scanning from a checkpoint offset.
- Writes repeatable evidence: `manifest.json`, `results.jsonl`, `summary.json`, `summary.md`, and sanitized transcript JSONL.
- Resets `transcripts/` at run start so repeated `latest` runs do not mix stale attempt records into fresh evidence.
- Includes execution-affecting options in `--print-plan` / `manifest.json`: `pressure_turns`, `timeout_seconds`, `suffix_prefill_limit`, and native-log scan mode.
- Adds repo-local agent guidance in `.agents/skills/kv-tool-loop-stability/SKILL.md`.
- Documents the certification flow in `docs/design/TESTING.md`.

## How to run

```bash
scripts/qa-kv-tool-loop-stability.py \
  --base-url http://127.0.0.1:9337/v1 \
  --models Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m \
  --attempts 5 \
  --pressure-turns 8 \
  --timeout 180 \
  --min-cached-tokens 2048 \
  --suffix-prefill-limit 256 \
  --native-log ~/.mesh-llm/runtime/<pid>/logs/skippy-native.log \
  --output-dir target/kv-tool-loop-stability/local
```

`--print-plan` is side-effect-free and emits the exact checks, models, thresholds, runtime options, native-log scan mode, and evidence files before running a live endpoint.

## Compatibility

Verification tooling and docs only. No runtime behavior, protobuf, gossip, mesh protocol, Skippy ABI, workflow, or required CI gate changes.

This intentionally avoids workflow YAML so it does not collide with active CI optimization work and remains a lab/release-confidence check rather than a new PR blocker.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@d50a4683`
- Branch state after rebase/update: `0 behind / 3 ahead`
- Head commit: `affa268fb3652711f0e7dbba0041d142ae006efa`

## Validation

- Validation tier: Tier 4 - verification tooling and testing documentation for KV/tool-loop stability certification, with post-review correctness/log-line evidence repairs; no runtime, protocol, workflow, or CI gate change.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `d50a4683`.
- `git rebase origin/main`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `python3 -m unittest scripts.tests.test_qa_kv_tool_loop_stability`: PASS, 16 passed
- `python3 -m unittest discover -s scripts/tests`: PASS, 36 passed
- `python3 -m py_compile scripts/qa-kv-tool-loop-stability.py scripts/tests/test_qa_kv_tool_loop_stability.py`: PASS
- `python3 scripts/qa-kv-tool-loop-stability.py --models auto,mesh --attempts 1 --pressure-turns 2 --timeout 30 --min-cached-tokens 128 --suffix-prefill-limit 64 --output-dir target/kv-tool-loop-stability/review-smoke --print-plan > /tmp/kv-tool-loop-plan.json && python3 -m json.tool /tmp/kv-tool-loop-plan.json >/dev/null`: PASS
- Remote PR Build/Quality checks on `affa268fb3652711f0e7dbba0041d142ae006efa`: PASS for `changes` and PR Quality `summary`; Rust/build/live-smoke contexts were skipped by workflow path selection for this scripts/docs-only update.
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - verification tooling/docs only; no release/version sync required.
- Not run: cargo check/tests - not required for selected validation tier; no Rust/runtime code changed.
- Not run: live direct-model Skippy certification run - no local loaded direct-model endpoint was available; this PR adds and hardens the reproducible harness and local unit/plan proof.

## Review status

Pending reviewer re-review after the earlier `CHANGES_REQUESTED` review. All known actionable review comments have code/test coverage in the updated head.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

The live certification should still be run by a maintainer or lab host with the affected direct-model Skippy endpoint and native log path available. Local validation proves the harness behavior, evidence contract, side-effect-free plan output, and post-review evidence repeatability; it does not claim a specific live model endpoint is now stable.
