### PR TITLE
Make GPU inventory backend-authoritative with ROCm diagnostics

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/commands/gpus.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/gpus.rs
@@ -24,7 +24,9 @@ pub(crate) fn run_gpus(json_output: bool) -> Result<()> {
     }
 
     if hw.gpus.is_empty() {
-        println!("⚠️ No GPUs detected on this node.");
+        println!(
+            "⚠️ No runtime-selectable GPUs reported by the embedded inference backend. This node will run CPU-only until the backend exposes a selectable device."
+        );
         return Ok(());
     }
 
@@ -96,6 +98,20 @@ fn gpu_json(gpu: &GpuFacts) -> Value {
         "metal_registry_id": gpu.metal_registry_id,
         "dxgi_luid": gpu.dxgi_luid,
         "pnp_instance_id": gpu.pnp_instance_id,
+        "runtime_offload": runtime_offload_json(gpu),
+    })
+}
+
+fn runtime_offload_json(gpu: &GpuFacts) -> Value {
+    let backend_device_visible = gpu.backend_device.is_some();
+    json!({
+        "backend_device_visible": backend_device_visible,
+        "selectable": backend_device_visible,
+        "diagnostic": if backend_device_visible {
+            "embedded_backend_device_available"
+        } else {
+            "hardware_detected_without_embedded_backend_device"
+        },
     })
 }
 
@@ -184,6 +200,10 @@ fn print_gpu(gpu: &GpuFacts) {
     }
     if let Some(backend_device) = gpu.backend_device.as_deref() {
         println!("  Backend device: {backend_device}");
+    } else {
+        println!(
+            "  Backend device: unavailable (hardware-visible only; embedded runtime did not report a selectable device)"
+        );
     }
     println!("  VRAM: {}", format_vram(gpu.vram_bytes));
     println!(
@@ -278,6 +298,14 @@ mod tests {
         assert_eq!(value["gpus"][0]["name"], json!("GPU 0"));
         assert_eq!(value["gpus"][0]["mem_bandwidth_gbps"], json!(1008.0));
         assert_eq!(value["gpus"][0]["stable_id"], json!("stable-0"));
+        assert_eq!(
+            value["gpus"][0]["runtime_offload"],
+            json!({
+                "backend_device_visible": true,
+                "selectable": true,
+                "diagnostic": "embedded_backend_device_available",
+            })
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/hardware/enrichers.rs
+++ b/crates/mesh-llm-system/src/hardware/enrichers.rs
@@ -89,12 +89,14 @@ mod linux {
     pub(crate) fn enrich_gpu_facts(gpus: &mut [GpuFacts]) {
         let mut infos = cuda_device_infos();
         merge_nvml_device_infos(&mut infos);
-        if infos.is_empty() {
-            return;
+        if !infos.is_empty() {
+            enrich_nvidia_gpu_facts(gpus, &infos);
         }
+    }
 
+    fn enrich_nvidia_gpu_facts(gpus: &mut [GpuFacts], infos: &[NvidiaDeviceInfo]) {
         for gpu in gpus {
-            let Some(info) = match_nvidia_device(gpu, &infos) else {
+            let Some(info) = match_nvidia_device(gpu, infos) else {
                 continue;
             };
             if let Some(total_bytes) = info.total_bytes {
@@ -120,17 +122,6 @@ mod linux {
                 }
             }
         }
-    }
-
-    pub(crate) fn discover_gpu_facts() -> Vec<GpuFacts> {
-        let mut infos = cuda_device_infos();
-        merge_nvml_device_infos(&mut infos);
-
-        infos
-            .into_iter()
-            .enumerate()
-            .filter_map(|(index, info)| gpu_fact_from_nvidia_info(index, info))
-            .collect()
     }
 
     fn match_nvidia_device<'a>(
@@ -339,41 +330,10 @@ mod linux {
         const MIB: u64 = 1024 * 1024;
         bytes.div_ceil(MIB) * MIB
     }
-
-    fn gpu_fact_from_nvidia_info(index: usize, info: NvidiaDeviceInfo) -> Option<GpuFacts> {
-        let display_name = info.name?;
-        let stable_id = info
-            .pci_bdf
-            .as_ref()
-            .filter(|pci_bdf| !super::super::is_placeholder_pci_bdf(pci_bdf))
-            .map(|pci_bdf| format!("pci:{pci_bdf}"));
-        Some(GpuFacts {
-            index,
-            display_name,
-            backend_device: Some(format!("CUDA{index}")),
-            vram_bytes: info.total_bytes.unwrap_or(0),
-            reserved_bytes: info.reserved_bytes,
-            mem_bandwidth_gbps: None,
-            compute_tflops_fp32: None,
-            compute_tflops_fp16: None,
-            unified_memory: false,
-            stable_id,
-            pci_bdf: info.pci_bdf,
-            vendor_uuid: info.uuid,
-            metal_registry_id: None,
-            dxgi_luid: None,
-            pnp_instance_id: None,
-        })
-    }
 }
 
 #[cfg(target_os = "linux")]
-pub(super) use linux::{discover_gpu_facts, enrich_gpu_facts};
+pub(super) use linux::enrich_gpu_facts;
 
 #[cfg(not(target_os = "linux"))]
 pub(super) fn enrich_gpu_facts(_gpus: &mut [GpuFacts]) {}
-
-#[cfg(not(target_os = "linux"))]
-pub(super) fn discover_gpu_facts() -> Vec<GpuFacts> {
-    Vec::new()
-}

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -272,8 +272,13 @@ fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: 
         return false;
     }
 
-    let Ok(gpus) = skippy_devices::gpu_facts() else {
-        return false;
+    let gpus = match skippy_devices::gpu_facts() {
+        Ok(gpus) => gpus,
+        Err(_) => {
+            #[cfg(target_os = "linux")]
+            apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
+            return true;
+        }
     };
     if gpus.is_empty() {
         #[cfg(target_os = "linux")]

--- a/crates/mesh-llm-system/src/hardware/parsers.rs
+++ b/crates/mesh-llm-system/src/hardware/parsers.rs
@@ -79,17 +79,20 @@ pub fn parse_rocm_gpu_names(output: &str) -> Vec<String> {
 /// `reserved_bytes`.
 #[cfg(any(target_os = "linux", test))]
 pub fn parse_rocm_gpu_memory_and_used(output: &str) -> Vec<(u64, Option<u64>)> {
-    output
-        .lines()
-        .skip(1)
-        .filter_map(|line| {
-            let mut columns = line.split(',').map(str::trim);
-            let _device = columns.next()?;
-            let total = columns.next()?.parse::<u64>().ok()?;
-            let used = columns.next().and_then(|value| value.parse::<u64>().ok());
-            Some((total, used))
-        })
-        .collect()
+    let mut rows = output.lines();
+    let _header = rows.find(|line| {
+        let lower = line.to_ascii_lowercase();
+        lower.contains("total") && lower.contains("memory")
+    });
+
+    rows.filter_map(|line| {
+        let mut columns = line.split(',').map(str::trim);
+        let _device = columns.next()?;
+        let total = columns.next()?.parse::<u64>().ok()?;
+        let used = columns.next().and_then(|value| value.parse::<u64>().ok());
+        Some((total, used))
+    })
+    .collect()
 }
 
 #[cfg(all(

--- a/crates/mesh-llm-system/src/hardware/skippy_devices.rs
+++ b/crates/mesh-llm-system/src/hardware/skippy_devices.rs
@@ -33,15 +33,22 @@ pub fn gpu_facts() -> anyhow::Result<Vec<GpuFacts>> {
         return result.map_err(anyhow::Error::msg);
     }
 
+    let mut facts = gpu_facts_from_backend_devices(skippy_runtime::backend_devices()?);
+    if !facts.is_empty() {
+        super::enrichers::enrich_gpu_facts(&mut facts);
+    }
+
+    Ok(facts)
+}
+
+fn gpu_facts_from_backend_devices(
+    backend_devices: Vec<skippy_runtime::BackendDevice>,
+) -> Vec<GpuFacts> {
     let mut accelerator_index = 0usize;
     let mut facts = Vec::new();
 
-    for device in skippy_runtime::backend_devices()? {
-        if !matches!(
-            device.device_type,
-            skippy_runtime::BackendDeviceType::Gpu
-                | skippy_runtime::BackendDeviceType::IntegratedGpu
-        ) {
+    for device in backend_devices {
+        if !is_runtime_accelerator(&device) {
             continue;
         }
 
@@ -94,10 +101,87 @@ pub fn gpu_facts() -> anyhow::Result<Vec<GpuFacts>> {
         });
     }
 
-    if facts.is_empty() {
-        facts = super::enrichers::discover_gpu_facts();
-    }
-    super::enrichers::enrich_gpu_facts(&mut facts);
+    facts
+}
 
-    Ok(facts)
+fn is_runtime_accelerator(device: &skippy_runtime::BackendDevice) -> bool {
+    match device.device_type {
+        skippy_runtime::BackendDeviceType::Gpu
+        | skippy_runtime::BackendDeviceType::IntegratedGpu => true,
+        skippy_runtime::BackendDeviceType::Accelerator => {
+            device.memory_total > 0 || looks_like_known_gpu_backend(device)
+        }
+        skippy_runtime::BackendDeviceType::Cpu | skippy_runtime::BackendDeviceType::Meta => false,
+    }
+}
+
+fn looks_like_known_gpu_backend(device: &skippy_runtime::BackendDevice) -> bool {
+    let text = format!(
+        "{} {}",
+        device.name,
+        device.description.as_deref().unwrap_or_default()
+    )
+    .to_ascii_uppercase();
+    [
+        "CUDA", "HIP", "ROCM", "VULKAN", "SYCL", "METAL", "MTL", "GPU",
+    ]
+    .iter()
+    .any(|needle| text.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skippy_runtime::{BackendDevice, BackendDeviceType};
+
+    fn backend_device(
+        name: &str,
+        device_type: BackendDeviceType,
+        memory_total: u64,
+    ) -> BackendDevice {
+        BackendDevice {
+            name: name.to_string(),
+            description: Some(name.to_string()),
+            device_id: None,
+            memory_free: memory_total,
+            memory_total,
+            device_type,
+            caps: 0,
+        }
+    }
+
+    #[test]
+    fn empty_backend_inventory_does_not_synthesize_platform_gpu_facts() {
+        assert!(gpu_facts_from_backend_devices(Vec::new()).is_empty());
+    }
+
+    #[test]
+    fn cpu_backend_inventory_does_not_synthesize_platform_gpu_facts() {
+        let facts = gpu_facts_from_backend_devices(vec![backend_device(
+            "CPU",
+            BackendDeviceType::Cpu,
+            64 * 1024 * 1024 * 1024,
+        )]);
+
+        assert!(facts.is_empty());
+    }
+
+    #[test]
+    fn hip_backend_device_is_runtime_selectable_gpu_fact() {
+        let facts = gpu_facts_from_backend_devices(vec![BackendDevice {
+            name: "HIP0".to_string(),
+            description: Some("AMD Instinct MI300X".to_string()),
+            device_id: Some("0000:65:00.0".to_string()),
+            memory_free: 200_000_000_000,
+            memory_total: 206_158_430_208,
+            device_type: BackendDeviceType::Accelerator,
+            caps: 0,
+        }]);
+
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].display_name, "AMD Instinct MI300X");
+        assert_eq!(facts[0].backend_device.as_deref(), Some("HIP0"));
+        assert_eq!(facts[0].vram_bytes, 206_158_430_208);
+        assert_eq!(facts[0].stable_id.as_deref(), Some("pci:0000:65:00.0"));
+    }
 }

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -212,6 +212,19 @@ card1,25753026560,512000000";
 }
 
 #[test]
+fn test_parse_rocm_gpu_memory_and_used_ignores_warning_preamble() {
+    let fixture = "\
+WARNING: AMD GPU device(s) is/are in a low-power state. Check power control/runtime_status
+
+device,VRAM Total Memory (B),VRAM Total Used Memory (B)
+card0,206158430208,0";
+    assert_eq!(
+        parse_rocm_gpu_memory_and_used(fixture),
+        vec![(206_158_430_208, Some(0))]
+    );
+}
+
+#[test]
 fn test_parse_xpu_smi_discovery_json() {
     let fixture = r#"{
           "devices": [
@@ -652,7 +665,7 @@ fn test_cpu_only_runtime_budget_respects_requested_metrics() {
 
 #[cfg(all(target_os = "linux", feature = "skippy-devices"))]
 #[test]
-fn test_skippy_backend_error_falls_through_to_legacy_collectors() {
+fn test_skippy_backend_error_uses_cpu_only_budget_without_legacy_fallback() {
     skippy_devices::set_test_gpu_facts_result(Err(anyhow::anyhow!("boom")));
 
     let mut survey = HardwareSurvey::default();
@@ -663,23 +676,35 @@ fn test_skippy_backend_error_falls_through_to_legacy_collectors() {
 
     skippy_devices::clear_test_gpu_facts_result();
 
-    assert!(!handled);
+    assert!(handled);
     assert_eq!(survey.gpu_name, None);
     assert_eq!(survey.gpu_count, 0);
-    assert_eq!(survey.vram_bytes, 0);
+    assert!(survey.gpu_vram.is_empty());
+    assert!(survey.gpus.is_empty());
+    assert!(survey.vram_bytes > 0);
 }
 
 #[cfg(all(target_os = "linux", feature = "skippy-devices"))]
 #[test]
-fn test_skippy_backend_empty_result_uses_cpu_only_budget() {
+fn test_skippy_backend_empty_result_uses_cpu_only_budget_without_legacy_fallback() {
     skippy_devices::set_test_gpu_facts_result(Ok(vec![]));
 
     let mut survey = HardwareSurvey::default();
-    let handled = apply_skippy_backend_devices_to_survey(&mut survey, &[Metric::VramBytes]);
+    let handled = apply_skippy_backend_devices_to_survey(
+        &mut survey,
+        &[
+            Metric::GpuName,
+            Metric::GpuCount,
+            Metric::VramBytes,
+            Metric::GpuFacts,
+        ],
+    );
 
     skippy_devices::clear_test_gpu_facts_result();
 
     assert!(handled);
+    assert_eq!(survey.gpu_name, None);
+    assert_eq!(survey.gpu_count, 0);
     assert!(survey.gpu_vram.is_empty());
     assert!(survey.gpus.is_empty());
     assert!(survey.vram_bytes > 0);

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -463,11 +463,25 @@ fn should_suppress_native_log_line(line: &str) -> bool {
 }
 
 fn summarize_native_log_line(line: &str) -> Option<NativeLogEvent> {
+    if let Some((category, params)) = cpu_offload_diagnostic_params(line) {
+        return Some(NativeLogEvent {
+            message: line.to_string(),
+            category,
+            params,
+        });
+    }
+
+    let lower = line.to_ascii_lowercase();
     if line.contains("backend_init")
         || line.contains("llama_backend_init")
         || line.contains("GGML_CUDA")
-        || (line.contains("CUDA") && (line.contains("init") || line.contains("device")))
-        || (line.contains("metal") && (line.contains("init") || line.contains("device")))
+        || line.contains("GGML_HIP")
+        || line.contains("GGML_ROCM")
+        || ((lower.contains("cuda")
+            || lower.contains("hip")
+            || lower.contains("rocm")
+            || lower.contains("metal"))
+            && (lower.contains("init") || lower.contains("device") || lower.contains("backend")))
     {
         return Some(NativeLogEvent {
             message: line.to_string(),
@@ -526,6 +540,32 @@ fn summarize_native_log_line(line: &str) -> Option<NativeLogEvent> {
     }
 
     None
+}
+
+fn cpu_offload_diagnostic_params(line: &str) -> Option<(&'static str, Vec<(String, Value)>)> {
+    let lower = line.to_ascii_lowercase();
+    let (category, surface) = if lower.contains("cpu_mapped model buffer size") {
+        ("memory", "model_buffer")
+    } else if lower.contains("cpu kv buffer size") {
+        ("kv_cache", "kv_buffer")
+    } else if lower.contains("cpu compute buffer size") {
+        ("memory", "compute_buffer")
+    } else {
+        return None;
+    };
+    Some((
+        category,
+        vec![
+            (
+                "offload_device".to_string(),
+                Value::String("CPU".to_string()),
+            ),
+            (
+                "offload_surface".to_string(),
+                Value::String(surface.to_string()),
+            ),
+        ],
+    ))
 }
 
 fn parse_loaded_metadata_counts(line: &str) -> Option<(usize, usize)> {
@@ -3818,6 +3858,22 @@ mod tests {
                 params: Vec::new(),
             }]
         );
+        assert_eq!(
+            aggregator.process_line("llama_backend_init: GGML_HIP backend initialized"),
+            vec![NativeLogEvent {
+                message: "llama_backend_init: GGML_HIP backend initialized".to_string(),
+                category: "backend",
+                params: Vec::new(),
+            }]
+        );
+        assert_eq!(
+            aggregator.process_line("llama_backend_init: GGML_ROCM backend initialized"),
+            vec![NativeLogEvent {
+                message: "llama_backend_init: GGML_ROCM backend initialized".to_string(),
+                category: "backend",
+                params: Vec::new(),
+            }]
+        );
     }
 
     #[test]
@@ -3938,6 +3994,82 @@ mod tests {
                 params: Vec::new(),
             }]
         );
+    }
+
+    #[test]
+    fn aggregator_tags_cpu_offload_evidence_without_capacity_facts() {
+        let mut aggregator = NativeLogAggregator::default();
+        let model_buffer =
+            aggregator.process_line("load_tensors:   CPU_Mapped model buffer size = 47492.37 MiB");
+        assert_eq!(
+            model_buffer,
+            vec![NativeLogEvent {
+                message: "load_tensors:   CPU_Mapped model buffer size = 47492.37 MiB".to_string(),
+                category: "memory",
+                params: vec![
+                    (
+                        "offload_device".to_string(),
+                        Value::String("CPU".to_string())
+                    ),
+                    (
+                        "offload_surface".to_string(),
+                        Value::String("model_buffer".to_string())
+                    ),
+                ],
+            }]
+        );
+        assert_no_capacity_params(&model_buffer);
+
+        assert_eq!(
+            aggregator.process_line("llama_kv_cache:        CPU KV buffer size =  3264.00 MiB"),
+            vec![NativeLogEvent {
+                message: "llama_kv_cache:        CPU KV buffer size =  3264.00 MiB".to_string(),
+                category: "kv_cache",
+                params: vec![
+                    (
+                        "offload_device".to_string(),
+                        Value::String("CPU".to_string())
+                    ),
+                    (
+                        "offload_surface".to_string(),
+                        Value::String("kv_buffer".to_string())
+                    ),
+                ],
+            }]
+        );
+        assert_eq!(
+            aggregator.process_line("sched_reserve:        CPU compute buffer size =   856.29 MiB"),
+            vec![NativeLogEvent {
+                message: "sched_reserve:        CPU compute buffer size =   856.29 MiB".to_string(),
+                category: "memory",
+                params: vec![
+                    (
+                        "offload_device".to_string(),
+                        Value::String("CPU".to_string())
+                    ),
+                    (
+                        "offload_surface".to_string(),
+                        Value::String("compute_buffer".to_string())
+                    ),
+                ],
+            }]
+        );
+    }
+
+    fn assert_no_capacity_params(events: &[NativeLogEvent]) {
+        const CAPACITY_KEYS: &[&str] = &[
+            "backend_device",
+            "capacity_gb",
+            "gpu_count",
+            "gpu_vram",
+            "vram_bytes",
+        ];
+        assert!(events.iter().all(|event| {
+            event
+                .params
+                .iter()
+                .all(|(key, _)| !CAPACITY_KEYS.contains(&key.as_str()))
+        }));
     }
 
     #[test]

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -734,7 +734,7 @@ mesh-llm gpus --json
 mesh-llm gpu benchmark --json
 ```
 
-This prints the local GPU inventory with stable IDs, backend device names, VRAM, unified-memory status, and cached bandwidth when a benchmark fingerprint is already present. Add `--json` for machine-readable inventory output, or run `mesh-llm gpu benchmark --json` to refresh the cached fingerprint and print the benchmark summary as JSON.
+This prints the local runtime-selectable GPU inventory with stable IDs, backend device names, VRAM, unified-memory status, and cached bandwidth when a benchmark fingerprint is already present. In the shipped Skippy-enabled binary, a GPU appears here only when the embedded backend reports it as selectable. Add `--json` for machine-readable inventory output, or run `mesh-llm gpu benchmark --json` to refresh the cached fingerprint and print the benchmark summary as JSON.
 
 ## Local runtime control
 

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -305,6 +305,13 @@ trait Collector {
 | `DefaultCollector` | Linux AMD | `/sys/class/drm`, `rocm-smi` |
 | `TegraCollector` | Jetson / Tegra | sysfs + `tegrastats` |
 
+The shipped `mesh-llm` binary builds `mesh-llm-system` with `skippy-devices`.
+In that mode, runtime-selectable GPU inventory is authoritative from the
+embedded Skippy/llama backend device API. Platform collectors remain legacy
+fallbacks for non-Skippy builds and diagnostic surfaces, but they must not
+invent GPU count, backend identity, or usable runtime capacity when the embedded
+backend reports no selectable GPU.
+
 `survey()` calls all applicable collectors and returns a `HardwareSurvey` with `gpu_name`, `gpu_vram` (per-GPU bytes), `gpu_reserved` (per-GPU reserved or unavailable bytes when the platform reports a true reserved/unavailable metric), `vram_bytes` (total), `hostname`, `is_soc`, and per-device `GpuFacts` entries. Benchmark-derived memory-bandwidth and compute-throughput hints are attached later when cached or freshly measured results are available. ROCm `rocm-smi --showmeminfo` and Intel `xpu-smi` discovery expose live used-memory counters, so mesh-llm intentionally omits `gpu_reserved` for those backends instead of reinterpreting used bytes as reserved memory.
 
 ### Gossip Fields

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -10,7 +10,8 @@ mesh-llm gpus --json | jq .
 mesh-llm gpu benchmark --json | jq .
 ```
 
-- Prints local GPU entries with stable IDs, backend devices, VRAM, unified-memory status, and cached bandwidth when a fingerprint is available
+- Prints local runtime-selectable GPU entries with stable IDs, backend devices, VRAM, unified-memory status, and cached bandwidth when a fingerprint is available
+- In the shipped Skippy-enabled binary, platform tools alone are not enough: if the embedded backend does not enumerate a GPU, the node should report CPU-only rather than advertising probe-visible GPU capacity
 - `--json` emits machine-readable inventory and benchmark payloads suitable for automation
 
 ### 0a. Startup config smoke

--- a/docs/design/message_protocol.md
+++ b/docs/design/message_protocol.md
@@ -113,7 +113,7 @@ Each `PeerAnnouncement` describes one node's state. Fields:
 | `available_model_sizes` | File sizes in bytes per model name |
 | `serialized_addr` | JSON-serialized `EndpointAddr` for peer discovery |
 
-These GPU telemetry fields are additive and optional. Older peers continue to interoperate by ignoring unknown `/1` protobuf fields, and the richer hardware reporting does not replace the existing model-metadata flow. For clarity, `gpu_mem_bandwidth_gbps` values are serialized in GB/s (gigabytes/sec), matching benchmark output and CLI formatting; only the field name still carries the older `gbps` suffix for backward compatibility. ROCm `rocm-smi --showmeminfo` and Intel `xpu-smi` discovery expose used-memory counters rather than a true reserved/system-memory value, so `gpu_reserved_bytes` is intentionally omitted for those backends.
+These GPU telemetry fields are additive and optional. Older peers continue to interoperate by ignoring unknown `/1` protobuf fields, and the richer hardware reporting does not replace the existing model-metadata flow. For the shipped Skippy-enabled binary, GPU telemetry represents devices the embedded backend reports as runtime-selectable; platform probes are not a fallback source for advertised GPU count or usable capacity when Skippy reports no backend GPU. For clarity, `gpu_mem_bandwidth_gbps` values are serialized in GB/s (gigabytes/sec), matching benchmark output and CLI formatting; only the field name still carries the older `gbps` suffix for backward compatibility. ROCm `rocm-smi --showmeminfo` and Intel `xpu-smi` discovery expose used-memory counters rather than a true reserved/system-memory value, so `gpu_reserved_bytes` is intentionally omitted for those backends.
 
 #### ExpertsSummary
 


### PR DESCRIPTION
## Summary

This refreshes the ROCm/MI300 GPU inventory work onto current `main` while preserving the review direction from #677: the shipped Skippy-enabled `mesh-llm` binary treats embedded backend enumeration as the source of truth for runtime-selectable GPU capacity.

A GPU is advertised as mesh runtime capacity only when the embedded Skippy/llama backend reports it through `skippy_runtime::backend_devices()`. Platform tools remain diagnostic only and do not synthesize runtime capacity that the embedded inference backend cannot select.

## Why

Review correctly called out the source-of-truth boundary: `rocm-smi`, `nvidia-smi`, `xpu-smi`, `tegrastats`, and similar platform probes can see hardware that the embedded runtime may not be able to use.

This PR keeps runtime planning honest. If Skippy reports no usable backend GPU, the shipped runtime reports CPU-only capacity instead of promoting platform-visible devices into mesh-serving capacity.

## Diff scope

- Keeps Skippy backend device enumeration authoritative for runtime-selectable GPU facts.
- Keeps legacy platform CLI collection out of the Skippy-enabled runtime capacity path.
- Preserves diagnostic native-log evidence for CPU/offload surfaces without turning those logs into GPU capacity facts.
- Updates `mesh-llm gpus` JSON/output expectations around backend visibility and runtime offload diagnostics.
- Updates docs to make the platform-diagnostics-vs-runtime-capacity distinction explicit.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@6669b413d253f25994163d1a7de1bf0382f5ce6a`
- Branch state after rebase: `0 behind / 1 ahead`
- Merge base: `6669b413d253f25994163d1a7de1bf0382f5ce6a`
- Head commit: `d75d14209ab45bac20a09cddc636f9e2f7c6f229`

## Commit integrity

Introduced commit:

- `d75d14209ab45bac20a09cddc636f9e2f7c6f229` — `Make GPU inventory backend-authoritative with ROCm diagnostics`

This is one logical PR commit. The final diff is limited to the intended GPU inventory/runtime diagnostic files.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: PASS, 11 intended files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- Forbidden files: none observed.

## Validation

Validation tier: Tier 3 — hardware inventory/runtime diagnostics affecting runtime capacity semantics and CLI/API-visible GPU facts.

Local validation:

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, updated `origin/main` to `6669b413d253f25994163d1a7de1bf0382f5ce6a`.
- `git rebase origin/main`: PASS, no conflicts.
- `cargo fmt --all -- --check`: PASS.
- `cargo test -p mesh-llm-system hardware:: --lib`: PASS, 67 passed.
- `cargo test -p mesh-llm-system --features skippy-devices hardware:: --lib`: PASS, 70 passed.
- `cargo test -p mesh-llm-system --features skippy-devices rocm --lib`: PASS, 7 passed.
- `cargo test -p mesh-llm-host-runtime gpus --lib`: PASS, 26 passed.
- `cargo test -p skippy-runtime aggregator --lib`: PASS, 12 passed.
- `cargo check -p mesh-llm`: PASS.
- `cargo clippy -p mesh-llm-system -p skippy-runtime -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.

Remote gates on head `d75d14209ab45bac20a09cddc636f9e2f7c6f229`:

- `gh pr checks 677 --repo Mesh-LLM/mesh-llm`: PASS, required PR Quality and PR Builds checks passed on final head.
- Rerun note: transient GitHub Actions toolchain/cache failures were rerun; the final rerun passed.

Ledger: not applicable — not required for selected validation tier/change family.

Version: not applicable — runtime diagnostics/inventory semantics only; no release/version sync required.

Not run:

- `just build` — not required for selected validation tier; no UI assets or release bundle changed.
- Live MI300/gfx942 ROCm smoke — no local ROCm/MI300 host is available; this remains the residual hardware validation for a maintainer or ROCm host.

## Runtime safety

No protobuf, gossip schema, Skippy ABI, workflow, or release metadata change.

The change intentionally keeps advertised runtime GPU capacity coupled to embedded backend-selectable devices. Platform-visible-only hardware is not promoted into mesh-serving capacity for the shipped Skippy-enabled binary.

No invariant regression introduced.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

A real MI300/gfx942 ROCm host should still confirm that the embedded llama/Skippy build enumerates the device through `skippy_runtime::backend_devices()`. This PR keeps runtime-capacity reporting honest; it does not replace that hardware smoke.

