### PR TITLE
[codex] Fix Swift XCFramework release build

### DIFF
--- a/scripts/tests/test_swift_xcframework_env.py
+++ b/scripts/tests/test_swift_xcframework_env.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+import pathlib
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "sdk/swift/scripts/build-xcframework.sh"
+
+
+class SwiftXcframeworkEnvTests(unittest.TestCase):
+    def test_deployment_targets_are_not_globally_exported(self) -> None:
+        script = SCRIPT.read_text()
+
+        self.assertNotIn("export IPHONEOS_DEPLOYMENT_TARGET=", script)
+        self.assertNotIn("export MACOSX_DEPLOYMENT_TARGET=", script)
+        self.assertIn("export -n IPHONEOS_DEPLOYMENT_TARGET MACOSX_DEPLOYMENT_TARGET", script)
+
+    def test_cargo_build_gets_platform_specific_deployment_target(self) -> None:
+        script = SCRIPT.read_text()
+
+        self.assertIn("*-apple-darwin)", script)
+        self.assertIn('CARGO_ENV+=("MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET")', script)
+        self.assertIn("*-apple-ios*)", script)
+        self.assertIn('CARGO_ENV+=("IPHONEOS_DEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET")', script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/swift/scripts/build-xcframework.sh
+++ b/sdk/swift/scripts/build-xcframework.sh
@@ -29,8 +29,9 @@ rustup target add \
   2>/dev/null || true
 
 "$SWIFT_DIR/scripts/generate-swift-bindings.sh"
-export IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-16.0}"
-export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
+IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-16.0}"
+MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-13.0}"
+export -n IPHONEOS_DEPLOYMENT_TARGET MACOSX_DEPLOYMENT_TARGET 2>/dev/null || true
 "$REPO_ROOT/scripts/prepare-llama.sh" "${MESH_LLM_LLAMA_PIN_SHA:-pinned}"
 
 # Resolve stable rustc from rustup (avoids Homebrew rustc shadowing)
@@ -66,11 +67,22 @@ build_rust_target() {
   local LLAMA_BUILD_DIR="$REPO_ROOT/.deps/llama-build/build-stage-abi-$RUST_TARGET-metal"
 
   echo "Building for $RUST_TARGET ($PLATFORM_NAME)..."
-  RUSTC="$RUSTUP_RUSTC" \
-  LLAMA_STAGE_BACKEND=metal \
-  LLAMA_STAGE_BUILD_DIR="$LLAMA_BUILD_DIR" \
-  IPHONEOS_DEPLOYMENT_TARGET="$IPHONEOS_DEPLOYMENT_TARGET" \
-  MACOSX_DEPLOYMENT_TARGET="$MACOSX_DEPLOYMENT_TARGET" \
+  local -a CARGO_ENV=(
+    "RUSTC=$RUSTUP_RUSTC"
+    "LLAMA_STAGE_BACKEND=metal"
+    "LLAMA_STAGE_BUILD_DIR=$LLAMA_BUILD_DIR"
+  )
+
+  case "$RUST_TARGET" in
+    *-apple-darwin)
+      CARGO_ENV+=("MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET")
+      ;;
+    *-apple-ios*)
+      CARGO_ENV+=("IPHONEOS_DEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET")
+      ;;
+  esac
+
+  env "${CARGO_ENV[@]}" \
     cargo build --release -p mesh-llm-ffi --target "$RUST_TARGET" --no-default-features --features "$RUST_FEATURES"
 }
 


### PR DESCRIPTION
The release workflow can now build the Swift SDK XCFramework without leaking the iOS deployment target into the macOS Rust slice builds.

Root cause: `sdk/swift/scripts/build-xcframework.sh` exported both `IPHONEOS_DEPLOYMENT_TARGET` and `MACOSX_DEPLOYMENT_TARGET` globally before invoking Cargo for every Apple target. During the macOS slice, that leaked `IPHONEOS_DEPLOYMENT_TARGET` into the `mesh-llm-gpu-bench` Metal build script, making Apple headers treat the Objective-C compile as iOS while compiling against macOS frameworks.

What changed:
- Keep deployment target variables local to the script instead of globally exported.
- Pass only the platform-specific deployment target into each Cargo build.
- Add a small regression test for the Swift XCFramework environment contract.

Validation:
- `bash -n sdk/swift/scripts/build-xcframework.sh`
- `python3 -m unittest scripts.tests.test_swift_xcframework_env`
- `git diff --check`
