### PR TITLE
Fix Skippy prefix-cache reuse for shared-prefix agent prompts

### DIFF
--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -1,5 +1,14 @@
 use super::*;
 
+pub(super) fn stage0_full_prefill_record_identities(
+    kv: &KvStageIntegration,
+    config: &StageConfig,
+    base: &MessageBase,
+    token_ids: &[i32],
+) -> Vec<crate::kv_integration::PrefillKvIdentity> {
+    kv.record_identities(config, base, 0, token_ids)
+}
+
 impl StageOpenAiBackend {
     pub(super) fn local_kv_message_base(
         &self,
@@ -200,22 +209,34 @@ impl StageOpenAiBackend {
             return Ok(false);
         }
         let base = self.local_kv_message_base(session_id, ids);
-        let identity = kv.prefill_identity(&self.config, &base, 0, token_ids);
-        let record = {
+        let identities = stage0_full_prefill_record_identities(kv, &self.config, &base, token_ids);
+        let record_candidate_count = identities.len();
+        let records = {
             let mut runtime = self
                 .runtime
                 .lock()
                 .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
-            kv.record_resident_prefix(&mut runtime, session_id, &identity, token_ids)
-                .map_err(openai_backend_error)?
+            identities
+                .iter()
+                .map(|identity| {
+                    kv.record_resident_prefix(&mut runtime, session_id, identity, token_ids)
+                        .map_err(openai_backend_error)
+                })
+                .collect::<OpenAiResult<Vec<_>>>()?
         };
-        let mut attrs = self.openai_attrs(ids);
-        attrs.insert(
-            "skippy.kv.decision".to_string(),
-            json!("stage0_full_prefill_record"),
-        );
-        attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
-        if let Some(record) = record {
+        let mut recorded_any = false;
+        for record in records.into_iter().flatten() {
+            recorded_any = true;
+            let mut attrs = self.openai_attrs(ids);
+            attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("stage0_full_prefill_record"),
+            );
+            attrs.insert(
+                "skippy.kv.record_candidates".to_string(),
+                json!(record_candidate_count),
+            );
+            attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
             attrs.insert(
                 "skippy.kv.recorded_page_id".to_string(),
                 json!(record.page_id),
@@ -230,11 +251,22 @@ impl StageOpenAiBackend {
             );
             self.telemetry
                 .emit("stage.openai_kv_record_decision", attrs);
-            return Ok(true);
         }
-        self.telemetry
-            .emit("stage.openai_kv_record_decision", attrs);
-        Ok(false)
+        if !recorded_any {
+            let mut attrs = self.openai_attrs(ids);
+            attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("stage0_full_prefill_record"),
+            );
+            attrs.insert(
+                "skippy.kv.record_candidates".to_string(),
+                json!(record_candidate_count),
+            );
+            attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
+            self.telemetry
+                .emit("stage.openai_kv_record_decision", attrs);
+        }
+        Ok(recorded_any)
     }
 
     pub(super) fn try_restore_embedded_split_prefill(

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -14,6 +14,9 @@ use std::{
 use axum::{http::StatusCode, response::IntoResponse};
 use openai_frontend::{AssistantMessage, ChatCompletionChoice};
 use serde_json::json;
+use skippy_protocol::{
+    LoadMode, PeerConfig, StageKvCacheConfig, StageKvCacheMode, StageKvCachePayload, SCHEMA_VERSION,
+};
 use tokio::sync::Semaphore;
 
 const MM_MODEL_ENV: &str = "SKIPPY_MM_MODEL";
@@ -57,6 +60,122 @@ fn proactive_eviction_attrs_are_bounded_and_request_free() {
     assert!(!attrs.contains_key(attr_key::SESSION_ID));
     assert!(!attrs.contains_key("openai.prompt_cache_key"));
     assert!(!attrs.contains_key("openai.prompt_cache_retention"));
+}
+
+fn prefix_cache_test_config() -> StageConfig {
+    StageConfig {
+        run_id: "run".to_string(),
+        topology_id: "topology".to_string(),
+        model_id: "org/model:Q4_K_M".to_string(),
+        package_ref: None,
+        manifest_sha256: None,
+        source_model_path: None,
+        source_model_sha256: None,
+        source_model_bytes: None,
+        materialized_path: None,
+        materialized_pinned: false,
+        model_path: None,
+        projector_path: None,
+        stage_id: "stage-0".to_string(),
+        stage_index: 0,
+        layer_start: 0,
+        layer_end: 4,
+        ctx_size: 8192,
+        lane_count: 2,
+        n_batch: None,
+        n_ubatch: None,
+        n_gpu_layers: 0,
+        cache_type_k: "f16".to_string(),
+        cache_type_v: "f16".to_string(),
+        flash_attn_type: Default::default(),
+        filter_tensors_on_load: false,
+        selected_device: None,
+        kv_cache: Some(StageKvCacheConfig {
+            mode: StageKvCacheMode::LookupRecord,
+            payload: StageKvCachePayload::ResidentKv,
+            max_entries: 8,
+            max_bytes: 0,
+            min_tokens: 256,
+            shared_prefix_stride_tokens: 128,
+            shared_prefix_record_limit: 2,
+        }),
+        load_mode: LoadMode::RuntimeSlice,
+        bind_addr: "127.0.0.1:0".to_string(),
+        upstream: None,
+        downstream: Some(PeerConfig {
+            stage_id: "stage-1".to_string(),
+            stage_index: 1,
+            endpoint: "127.0.0.1:0".to_string(),
+        }),
+    }
+}
+
+fn prefix_cache_test_base() -> MessageBase {
+    MessageBase {
+        schema_version: SCHEMA_VERSION,
+        run_id: "run".to_string(),
+        request_id: "request".to_string(),
+        session_id: "session".to_string(),
+        stage_id: "stage-0".to_string(),
+        stage_index: 0,
+        topology_id: "topology".to_string(),
+        model_id: Some("org/model:Q4_K_M".to_string()),
+        tokenizer_id: None,
+        chat_template_id: Some("template".to_string()),
+        seq: Some(1),
+    }
+}
+
+#[test]
+fn stage0_full_prefill_record_plan_includes_shared_prefix_candidate() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let base = prefix_cache_test_base();
+    let recorded_tokens = (0..2214).collect::<Vec<_>>();
+    let mut lookup_tokens = recorded_tokens.clone();
+    lookup_tokens.extend(100_000..100_017);
+
+    let record_plan = super::prefix_cache::stage0_full_prefill_record_identities(
+        &kv,
+        &config,
+        &base,
+        &recorded_tokens,
+    );
+    let lookup_plan = kv.lookup_identities(&config, &base, 0, &lookup_tokens);
+
+    let record_counts = record_plan
+        .iter()
+        .map(|identity| identity.identity.token_count)
+        .collect::<Vec<_>>();
+    let lookup_counts = lookup_plan
+        .iter()
+        .map(|identity| identity.identity.token_count)
+        .collect::<Vec<_>>();
+
+    assert_eq!(record_counts, vec![2214, 2176]);
+    assert!(lookup_counts.contains(&2176));
+
+    let recorded_shared = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("record plan should include shared grid prefix");
+    let lookup_shared = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("lookup plan should probe shared grid prefix");
+    let recorded_exact = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2214)
+        .expect("record plan should keep exact first prompt");
+    let lookup_exact = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2231)
+        .expect("lookup plan should probe exact second prompt");
+
+    assert_eq!(recorded_shared.page_id, lookup_shared.page_id);
+    assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
 }
 
 struct MultimodalSmokeFixture {

--- a/crates/skippy-server/src/kv_integration/identity.rs
+++ b/crates/skippy-server/src/kv_integration/identity.rs
@@ -183,4 +183,53 @@ mod tests {
         assert_eq!(lookup_counts, vec![160, 128, 96, 64]);
         assert_eq!(record_counts, vec![160, 128]);
     }
+
+    #[test]
+    fn same_prefix_different_tail_identities_share_recorded_grid_page() {
+        let config = StageConfig {
+            ctx_size: 8192,
+            kv_cache: Some(StageKvCacheConfig {
+                min_tokens: 256,
+                shared_prefix_stride_tokens: 128,
+                ..test_config().kv_cache.expect("test cache config")
+            }),
+            ..test_config()
+        };
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("cache enabled");
+        let base = test_base();
+        let recorded_tokens = (0..2214).collect::<Vec<_>>();
+        let mut lookup_tokens = recorded_tokens.clone();
+        lookup_tokens.extend(100_000..100_017);
+
+        let record_identities = kv.record_identities(&config, &base, 0, &recorded_tokens);
+        let lookup_identities = kv.lookup_identities(&config, &base, 0, &lookup_tokens);
+
+        let record_counts = record_identities
+            .iter()
+            .map(|identity| identity.identity.token_count)
+            .collect::<Vec<_>>();
+        assert_eq!(record_counts, vec![2214, 2176]);
+
+        let recorded_shared = record_identities
+            .iter()
+            .find(|identity| identity.identity.token_count == 2176)
+            .expect("record identities should include shared grid prefix");
+        let lookup_shared = lookup_identities
+            .iter()
+            .find(|identity| identity.identity.token_count == 2176)
+            .expect("lookup identities should probe shared grid prefix");
+        let recorded_exact = record_identities
+            .iter()
+            .find(|identity| identity.identity.token_count == 2214)
+            .expect("record identities should include exact first prompt");
+        let lookup_exact = lookup_identities
+            .iter()
+            .find(|identity| identity.identity.token_count == 2231)
+            .expect("lookup identities should include exact second prompt");
+
+        assert_eq!(recorded_shared.page_id, lookup_shared.page_id);
+        assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
+    }
 }


### PR DESCRIPTION
## Summary

Skippy split prefill now records the same bounded shared-prefix cache candidates that lookup already probes, so repeated tool/agent requests with a stable long prefix and changing tail can actually reuse the resident prefix cache.

This keeps exact prompt records intact while adding the near-tail grid candidate needed for the dominant chat/agent shape: same system prompt and tools, different conversation tail.

## Why

The cache candidate policy could already probe shared-prefix lengths for same-prefix/different-tail prompts, but the embedded stage0 full-prefill record path still recorded only the exact first prompt identity.

That meant the next request could ask for the reusable shared-prefix page and find nothing, leaving prefix-cache reuse ineffective for the agent workload shape called out in #662.

## Diff scope

- Reuses `KvStageIntegration::record_identities` for embedded stage0 full-prefill recording instead of recording a single exact identity.
- Records each bounded candidate into the resident prefix cache and emits record telemetry for retained candidates.
- Preserves exact prompt identities and existing candidate limits; no unbounded cache growth.
- Adds identity-level and server-level regressions proving same-prefix/different-tail prompts share the recorded grid page while exact prompt identities remain distinct.

## Compatibility

Skippy server behavior only.

No protobuf, mesh gossip, plugin protocol, llama.cpp ABI, package format, CLI, or UI changes.

## Runtime safety

The change keeps candidate generation bounded by the existing cache policy and does not add unbounded queues, background tasks, or protocol state. Runtime mutation still goes through the existing resident-prefix recording path under the existing runtime lock.

No invariant regression introduced.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@9b51d0106a3d826dd00882c441e80b5c501017c7`
- Branch state after rebase: `0 behind / 1 ahead`
- Merge base: `9b51d0106a3d826dd00882c441e80b5c501017c7`
- Head commit: `93cd44686c88efaac9de297566f08587deada0fe`

## Commit integrity

- `93cd44686c88efaac9de297566f08587deada0fe Record shared-prefix candidates for split prefill`

The PR contains one logical change and touches only the Skippy prefix-cache recording/tests surface.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: PASS, 3 intended files under `crates/skippy-server`.
- `git diff --check origin/main...HEAD`: PASS, no output
- Forbidden files/artifacts: not present

## Validation

- Validation tier: Tier 2 - narrow Skippy prefix-cache record/lookup repair for shared-prefix agent prompts.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `9b51d0106a3d826dd00882c441e80b5c501017c7`.
- `git rebase origin/main`: PASS
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `cargo test -p skippy-cache --lib`: PASS, 31 passed
- `LLAMA_STAGE_BUILD_DIR=<prepared llama stage build> cargo test -p skippy-server prefix --lib`: PASS, 4 passed
- `LLAMA_STAGE_BUILD_DIR=<prepared llama stage build> cargo test -p skippy-server --lib`: PASS, 98 passed
- `LLAMA_STAGE_BUILD_DIR=<prepared llama stage build> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<prepared llama stage build> cargo-clippy clippy -p skippy-server --all-targets -- -D warnings`: PASS
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - cache behavior repair only; no release/version sync required.
- Remote CI: Pending - will run after PR creation/update.
- Not run: live shared-prefix agent smoke - no local model/runtime endpoint was available in this isolated worktree; deterministic identity/server tests cover the record/lookup path.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

A live agent harness with an actual Skippy model should still confirm the user-visible cached-token behavior after this lands, but the deterministic tests cover the previously missing record/lookup candidate path.
