### PR TITLE
[codex] Fix dispatched Swift release manifest flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -740,7 +740,7 @@ jobs:
     needs: changes
     if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Windows CPU
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     env:
       RUN_WINDOWS_CPU_FULL: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.windows_cpu == 'true' }}
       LLAMA_STAGE_BACKEND: cpu
@@ -811,7 +811,7 @@ jobs:
     needs: changes
     if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.rust == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Windows ${{ matrix.name }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     env:
       RUN_WINDOWS_GPU: ${{ github.event_name == 'workflow_dispatch' || needs.changes.outputs.windows_gpu == 'true' }}
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-${{ matrix.backend }}

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -900,7 +900,7 @@ jobs:
     needs: changes
     if: ${{ (github.event_name == 'workflow_dispatch' || needs.changes.outputs.all_rust == 'true' || needs.changes.outputs.windows_cpu == 'true' || needs.changes.outputs.windows_gpu == 'true') && needs.changes.outputs.docs_only != 'true' }}
     name: Windows ${{ matrix.name }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,12 +232,27 @@ jobs:
             sdk/swift/Generated/MeshLLMFFI.xcframework \
             dist/MeshLLMFFI.xcframework.zip
 
+      - name: Prepare SwiftPM manifest for dispatched release
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          scripts/update-swift-package-manifest.sh \
+            "${{ needs.metadata.outputs.tag }}" \
+            dist/MeshLLMFFI.xcframework.zip
+
       - name: Verify SwiftPM binary artifact
         run: |
           scripts/verify-swift-release-artifact.sh dist/MeshLLMFFI.xcframework.zip
           scripts/verify-swift-package-manifest.sh \
             "${{ needs.metadata.outputs.tag }}" \
             dist/MeshLLMFFI.xcframework.zip
+
+      - name: Upload generated SwiftPM manifest
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v6
+        with:
+          name: swift-package-manifest
+          path: Package.swift
+          if-no-files-found: error
 
       - name: Upload SwiftPM binary artifact
         uses: actions/upload-artifact@v6
@@ -604,6 +619,11 @@ jobs:
     if: ${{ always() && needs.metadata.result == 'success' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_cuda_blackwell.result == 'success' || needs.build_linux_cuda_blackwell.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
+      - uses: actions/checkout@v5
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          fetch-depth: 0
+
       - name: Download release artifacts
         uses: actions/download-artifact@v7
         with:
@@ -613,6 +633,35 @@ jobs:
 
       - name: Remove smoke-only binary
         run: rm -f release-artifacts/mesh-llm
+
+      - name: Download generated SwiftPM manifest
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/download-artifact@v7
+        with:
+          name: swift-package-manifest
+          path: generated-swift-manifest
+
+      - name: Create dispatched release tag
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release tag already exists: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          cp generated-swift-manifest/Package.swift Package.swift
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Package.swift
+          if git diff --cached --quiet -- Package.swift; then
+            echo "Package.swift already matches generated SwiftPM manifest"
+          else
+            git commit -m "$RELEASE_TAG: prepare Swift package manifest"
+          fi
+          git tag "$RELEASE_TAG"
+          git push origin "refs/tags/$RELEASE_TAG"
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -475,7 +475,7 @@ jobs:
   build_windows_cpu:
     name: Build Windows CPU
     needs: metadata
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     env:
       LLAMA_STAGE_BACKEND: cpu
     steps:
@@ -511,7 +511,7 @@ jobs:
     name: Build Windows ${{ matrix.name }}
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     env:
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
       # Pin Windows CUDA to a version sccache 0.15.0 supports.

--- a/.github/workflows/windows-warm-caches.yml
+++ b/.github/workflows/windows-warm-caches.yml
@@ -40,7 +40,7 @@ jobs:
   warm_windows_cpu:
     name: Warm Windows CPU ABI cache
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     env:
       LLAMA_STAGE_BACKEND: cpu
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-cpu
@@ -94,7 +94,7 @@ jobs:
   warm_windows_gpu:
     name: Warm Windows ${{ matrix.name }} ABI cache
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
-    runs-on: blacksmith-4vcpu-windows-2025
+    runs-on: blacksmith-8vcpu-windows-2025
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-${{ matrix.backend }}
       MESH_LLM_SKIP_UI: "1"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,9 +36,9 @@ just release-build
 just release-bundle v0.X.Y
 ```
 
-Before cutting a tag that should be consumable through SwiftPM, prepare the
-Swift binary target manifest on macOS and commit the resulting `Package.swift`
-change:
+Before manually cutting a tag that should be consumable through SwiftPM,
+prepare the Swift binary target manifest on macOS and commit the resulting
+`Package.swift` change:
 
 ```bash
 scripts/prepare-swift-package-release.sh v0.X.Y
@@ -49,8 +49,14 @@ git commit -m "v0.X.Y: prepare Swift package artifact"
 The release workflow rebuilds `MeshLLMFFI.xcframework.zip`, verifies the macOS
 framework layout, runs a zipped-artifact SwiftPM consumer smoke, and checks that
 the tagged `Package.swift` already points at the exact release URL and checksum.
-If `Package.swift` still contains placeholders, or if the checksum does not
-match the artifact built in release CI, the release fails before publishing.
+If `Package.swift` still contains placeholders on a tag push, or if the
+checksum does not match the artifact built in release CI, the release fails
+before publishing.
+
+For `workflow_dispatch` releases, the release workflow computes the SwiftPM
+checksum from the XCFramework artifact it just built, patches `Package.swift`
+in the workflow workspace, and creates the requested release tag at a
+manifest-only commit before publishing.
 
 The current GitHub Actions release workflow publishes macOS aarch64, Linux
 x86_64 CPU, Linux ARM64 CPU, Linux CUDA, Linux CUDA Blackwell, Linux ROCm,

--- a/scripts/prepare-swift-package-release.sh
+++ b/scripts/prepare-swift-package-release.sh
@@ -19,7 +19,6 @@ PACKAGE_SWIFT="$REPO_ROOT/Package.swift"
 ARTIFACT_DIR="$REPO_ROOT/dist"
 ARTIFACT_NAME="MeshLLMFFI.xcframework.zip"
 ARTIFACT_PATH="$ARTIFACT_DIR/$ARTIFACT_NAME"
-ARTIFACT_URL="https://github.com/Mesh-LLM/mesh-llm/releases/download/$TAG/$ARTIFACT_NAME"
 
 mkdir -p "$ARTIFACT_DIR"
 
@@ -30,15 +29,10 @@ ditto -c -k --sequesterRsrc --keepParent \
     "$REPO_ROOT/sdk/swift/Generated/MeshLLMFFI.xcframework" \
     "$ARTIFACT_PATH"
 
-CHECKSUM="$(swift package compute-checksum "$ARTIFACT_PATH")"
 "$REPO_ROOT/scripts/verify-swift-release-artifact.sh" "$ARTIFACT_PATH"
-
-perl -0pi -e 's#let remoteFFIXCFrameworkURL = ".*"#let remoteFFIXCFrameworkURL = "'"$ARTIFACT_URL"'"#' "$PACKAGE_SWIFT"
-perl -0pi -e 's#let remoteFFIXCFrameworkChecksum = ".*"#let remoteFFIXCFrameworkChecksum = "'"$CHECKSUM"'"#' "$PACKAGE_SWIFT"
+"$REPO_ROOT/scripts/update-swift-package-manifest.sh" "$TAG" "$ARTIFACT_PATH" "$PACKAGE_SWIFT"
 "$REPO_ROOT/scripts/verify-swift-package-manifest.sh" "$TAG" "$ARTIFACT_PATH" "$PACKAGE_SWIFT"
 
 echo "Prepared SwiftPM artifact:"
 echo "  tag: $TAG"
 echo "  path: $ARTIFACT_PATH"
-echo "  url: $ARTIFACT_URL"
-echo "  checksum: $CHECKSUM"

--- a/scripts/update-swift-package-manifest.sh
+++ b/scripts/update-swift-package-manifest.sh
@@ -41,8 +41,35 @@ fi
 
 CHECKSUM="$(swift package compute-checksum "$ARTIFACT_PATH")"
 
-perl -0pi -e 's#let remoteFFIXCFrameworkURL = ".*"#let remoteFFIXCFrameworkURL = "'"$ARTIFACT_URL"'"#' "$PACKAGE_SWIFT"
-perl -0pi -e 's#let remoteFFIXCFrameworkChecksum = ".*"#let remoteFFIXCFrameworkChecksum = "'"$CHECKSUM"'"#' "$PACKAGE_SWIFT"
+python3 - "$PACKAGE_SWIFT" "$ARTIFACT_URL" "$CHECKSUM" <<'PY'
+import re
+import sys
+
+manifest_path, artifact_url, checksum = sys.argv[1:4]
+with open(manifest_path, encoding="utf-8") as handle:
+    manifest = handle.read()
+
+replacements = [
+    (
+        r'let\s+remoteFFIXCFrameworkURL\s*=\s*"[^"]*"',
+        f'let remoteFFIXCFrameworkURL = "{artifact_url}"',
+        "remoteFFIXCFrameworkURL",
+    ),
+    (
+        r'let\s+remoteFFIXCFrameworkChecksum\s*=\s*"[^"]*"',
+        f'let remoteFFIXCFrameworkChecksum = "{checksum}"',
+        "remoteFFIXCFrameworkChecksum",
+    ),
+]
+
+for pattern, replacement, name in replacements:
+    manifest, count = re.subn(pattern, lambda _: replacement, manifest, count=1)
+    if count != 1:
+        raise SystemExit(f"missing {name} in {manifest_path}")
+
+with open(manifest_path, "w", encoding="utf-8") as handle:
+    handle.write(manifest)
+PY
 
 echo "updated Swift package manifest for $TAG"
 echo "  url: $ARTIFACT_URL"

--- a/scripts/update-swift-package-manifest.sh
+++ b/scripts/update-swift-package-manifest.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: scripts/update-swift-package-manifest.sh <tag> <MeshLLMFFI.xcframework.zip> [Package.swift]
+
+Updates Package.swift so its remote SwiftPM binary target points at the release
+XCFramework URL and checksum for the supplied artifact.
+EOF
+}
+
+if [[ "$#" -lt 2 || "$#" -gt 3 ]]; then
+    usage
+    exit 1
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "error: Swift package manifest updates must run on macOS" >&2
+    exit 1
+fi
+
+TAG="$1"
+ARTIFACT_PATH="$2"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PACKAGE_SWIFT="${3:-$REPO_ROOT/Package.swift}"
+ARTIFACT_NAME="MeshLLMFFI.xcframework.zip"
+ARTIFACT_URL="https://github.com/Mesh-LLM/mesh-llm/releases/download/$TAG/$ARTIFACT_NAME"
+
+if [[ ! -f "$ARTIFACT_PATH" ]]; then
+    echo "Swift release artifact does not exist: $ARTIFACT_PATH" >&2
+    exit 1
+fi
+
+if [[ ! -f "$PACKAGE_SWIFT" ]]; then
+    echo "Package.swift does not exist: $PACKAGE_SWIFT" >&2
+    exit 1
+fi
+
+CHECKSUM="$(swift package compute-checksum "$ARTIFACT_PATH")"
+
+perl -0pi -e 's#let remoteFFIXCFrameworkURL = ".*"#let remoteFFIXCFrameworkURL = "'"$ARTIFACT_URL"'"#' "$PACKAGE_SWIFT"
+perl -0pi -e 's#let remoteFFIXCFrameworkChecksum = ".*"#let remoteFFIXCFrameworkChecksum = "'"$CHECKSUM"'"#' "$PACKAGE_SWIFT"
+
+echo "updated Swift package manifest for $TAG"
+echo "  url: $ARTIFACT_URL"
+echo "  checksum: $CHECKSUM"


### PR DESCRIPTION
## Summary
Fixes the current release workflow failure where `Build Swift SDK XCFramework` builds the XCFramework successfully but fails verification because `Package.swift` still contains the Swift release URL/checksum placeholders during `workflow_dispatch` releases.

## Root Cause
The Swift artifact checksum is only known after the XCFramework zip is built. Tag-push releases can verify a pre-prepared tagged `Package.swift`, but workflow-dispatch releases run from `main`, where `Package.swift` intentionally has placeholders. The release job verified that placeholder manifest and failed before publishing.

## Change
- Add `scripts/update-swift-package-manifest.sh` to patch `Package.swift` from a built `MeshLLMFFI.xcframework.zip`.
- Use that script in the manual Swift package preparation flow.
- For `workflow_dispatch` releases, generate and upload a patched SwiftPM manifest from the Swift artifact job.
- In the publish job, create the requested release tag at a manifest-only commit before publishing, so SwiftPM consumers read a valid `Package.swift` from the tag.
- Keep tag-push releases strict: they still verify the tagged manifest.
- Sync the xtask release-target invariant with the current Blacksmith ARM64 runner.

## Validation
- `bash -n scripts/update-swift-package-manifest.sh scripts/prepare-swift-package-release.sh scripts/verify-swift-package-manifest.sh`
- Scratch artifact smoke: `scripts/update-swift-package-manifest.sh` + `scripts/verify-swift-package-manifest.sh`
- Parsed all `.github/workflows/*.yml` and `.github/actions/*/action.yml`
- Checked duplicate workflow step IDs
- `cargo run -p xtask -- repo-consistency release-targets`
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Mesh-LLM/codesmith/mesh-llm/pr/686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782370639&installation_id=135670078&pr_number=686&repository=Mesh-LLM%2Fmesh-llm&return_to=https%3A%2F%2Fgithub.com%2FMesh-LLM%2Fmesh-llm%2Fpull%2F686&signature=9fcbaf86066e4f1c6a92e0ae92eae5f983c6a7d08dd9a3b6a19c4d5e0d793a19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->