### PR TITLE
Complete Skippy shared-prefix record candidates

### DIFF
--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -2624,57 +2624,81 @@ fn maybe_record_binary_full_prefill(
     if !kv.should_record() || token_ids.is_empty() {
         return result;
     }
-    let base = binary_message_base(config, session_id, message);
-    let identity = kv.prefill_identity(config, &base, 0, token_ids);
+    let identities =
+        binary_full_prefill_record_identities(kv, config, session_id, message, token_ids);
     let mut attrs = binary_message_kv_attrs(config, kv, session_id, message, token_ids.len());
-    attrs.insert("skippy.kv.record_candidates".to_string(), json!(1));
+    attrs.insert(
+        "skippy.kv.record_candidates".to_string(),
+        json!(identities.len()),
+    );
     attrs.insert(
         "skippy.kv.decision".to_string(),
         json!("full_prefill_record"),
     );
     let started = Instant::now();
-    match kv.record_exact_state(runtime, session_id, &identity) {
-        Ok(Some(record)) => {
-            result.recorded_pages = 1;
-            result.recorded_tokens = record.token_count as u64;
-            result.evicted_entries = record.evicted_entries;
-            result.evicted_tokens = record.evicted_logical_bytes;
-            attrs.insert(
-                "skippy.exact_cache.recorded_page_id".to_string(),
-                json!(record.page_id),
-            );
-            attrs.insert(
-                "skippy.exact_cache.payload_kind".to_string(),
-                json!(record.payload_kind.to_string()),
-            );
-            attrs.insert(
-                "skippy.exact_cache.logical_bytes".to_string(),
-                json!(record.logical_bytes),
-            );
-            attrs.insert(
-                "skippy.exact_cache.physical_bytes".to_string(),
-                json!(record.physical_bytes),
-            );
-            attrs.insert(
-                "skippy.exact_cache.entries".to_string(),
-                json!(record.entries),
-            );
+    for identity in identities {
+        let token_count_usize = usize::try_from(identity.identity.token_count)
+            .unwrap_or(usize::MAX)
+            .min(token_ids.len());
+        if token_count_usize == token_ids.len() {
+            match kv.record_exact_state(runtime, session_id, &identity) {
+                Ok(Some(record)) => {
+                    result.recorded_pages = result.recorded_pages.saturating_add(1);
+                    result.recorded_tokens = result
+                        .recorded_tokens
+                        .saturating_add(record.token_count as u64);
+                    result.evicted_entries = result
+                        .evicted_entries
+                        .saturating_add(record.evicted_entries);
+                    result.evicted_tokens = result
+                        .evicted_tokens
+                        .saturating_add(record.evicted_logical_bytes);
+                    attrs.insert(
+                        "skippy.exact_cache.recorded_page_id".to_string(),
+                        json!(record.page_id),
+                    );
+                    attrs.insert(
+                        "skippy.exact_cache.payload_kind".to_string(),
+                        json!(record.payload_kind.to_string()),
+                    );
+                    attrs.insert(
+                        "skippy.exact_cache.logical_bytes".to_string(),
+                        json!(record.logical_bytes),
+                    );
+                    attrs.insert(
+                        "skippy.exact_cache.physical_bytes".to_string(),
+                        json!(record.physical_bytes),
+                    );
+                    attrs.insert(
+                        "skippy.exact_cache.entries".to_string(),
+                        json!(record.entries),
+                    );
+                    continue;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    attrs.insert(
+                        "skippy.exact_cache.record_error".to_string(),
+                        json!(error.to_string()),
+                    );
+                }
+            }
         }
-        Ok(None) => {}
-        Err(error) => {
-            attrs.insert(
-                "skippy.exact_cache.record_error".to_string(),
-                json!(error.to_string()),
-            );
-        }
-    }
-    if result.recorded_pages == 0 {
-        match kv.record_resident_prefix(runtime, session_id, &identity, token_ids) {
+        match kv.record_resident_prefix(
+            runtime,
+            session_id,
+            &identity,
+            &token_ids[..token_count_usize],
+        ) {
             Ok(Some(record)) => {
-                result.recorded_pages = 1;
-                result.recorded_tokens = record.token_count as u64;
-                result.evicted_entries = record.evicted_entries;
-                result.evicted_tokens = record.evicted_tokens;
+                result.recorded_pages = result.recorded_pages.saturating_add(1);
+                result.recorded_tokens = result
+                    .recorded_tokens
+                    .saturating_add(record.token_count as u64);
+                result.evicted_entries = result
+                    .evicted_entries
+                    .saturating_add(record.evicted_entries);
+                result.evicted_tokens = result.evicted_tokens.saturating_add(record.evicted_tokens);
                 attrs.insert(
                     "skippy.kv.recorded_page_id".to_string(),
                     json!(record.page_id),
@@ -2690,6 +2714,7 @@ fn maybe_record_binary_full_prefill(
                     "skippy.kv.record_error".to_string(),
                     json!(error.to_string()),
                 );
+                break;
             }
         }
     }
@@ -2707,6 +2732,17 @@ fn maybe_record_binary_full_prefill(
     );
     telemetry.emit("stage.binary_kv_record_decision", attrs);
     result
+}
+
+fn binary_full_prefill_record_identities(
+    kv: &KvStageIntegration,
+    config: &StageConfig,
+    session_id: &str,
+    message: &StageWireMessage,
+    token_ids: &[i32],
+) -> Vec<PrefillKvIdentity> {
+    let base = binary_message_base(config, session_id, message);
+    kv.record_identities(config, &base, 0, token_ids)
 }
 
 #[derive(Default)]

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -1,4 +1,7 @@
-use super::{prepare_binary_stage_connection, restore_prefill_decode_as_decode_message};
+use super::{
+    binary_full_prefill_record_identities, prepare_binary_stage_connection,
+    restore_prefill_decode_as_decode_message,
+};
 use std::{
     io,
     net::{TcpListener, TcpStream},
@@ -7,8 +10,12 @@ use std::{
     time::Duration,
 };
 
+use crate::kv_integration::KvStageIntegration;
 use skippy_protocol::binary::{
     StageSamplingConfig, StageStateHeader, StageWireMessage, WireActivationDType, WireMessageKind,
+};
+use skippy_protocol::{
+    LoadMode, PeerConfig, StageConfig, StageKvCacheConfig, StageKvCacheMode, StageKvCachePayload,
 };
 
 #[test]
@@ -76,4 +83,118 @@ fn restore_prefill_decode_as_decode_preserves_chat_metadata() {
     assert_eq!(decode.chat_sampling_metadata.as_deref(), Some(metadata));
     assert!(decode.activation.is_empty());
     assert!(decode.positions.is_empty());
+}
+
+fn prefix_cache_test_config() -> StageConfig {
+    StageConfig {
+        run_id: "run".to_string(),
+        topology_id: "topology".to_string(),
+        model_id: "org/model:Q4_K_M".to_string(),
+        package_ref: None,
+        manifest_sha256: None,
+        source_model_path: None,
+        source_model_sha256: None,
+        source_model_bytes: None,
+        materialized_path: None,
+        materialized_pinned: false,
+        model_path: None,
+        projector_path: None,
+        stage_id: "stage-0".to_string(),
+        stage_index: 0,
+        layer_start: 0,
+        layer_end: 4,
+        ctx_size: 8192,
+        lane_count: 2,
+        n_batch: None,
+        n_ubatch: None,
+        n_gpu_layers: 0,
+        cache_type_k: "f16".to_string(),
+        cache_type_v: "f16".to_string(),
+        flash_attn_type: Default::default(),
+        filter_tensors_on_load: false,
+        selected_device: None,
+        kv_cache: Some(StageKvCacheConfig {
+            mode: StageKvCacheMode::LookupRecord,
+            payload: StageKvCachePayload::ResidentKv,
+            max_entries: 8,
+            max_bytes: 0,
+            min_tokens: 256,
+            shared_prefix_stride_tokens: 128,
+            shared_prefix_record_limit: 2,
+        }),
+        load_mode: LoadMode::RuntimeSlice,
+        bind_addr: "127.0.0.1:0".to_string(),
+        upstream: None,
+        downstream: Some(PeerConfig {
+            stage_id: "stage-1".to_string(),
+            stage_index: 1,
+            endpoint: "127.0.0.1:0".to_string(),
+        }),
+    }
+}
+
+fn prefill_message() -> StageWireMessage {
+    StageWireMessage {
+        kind: WireMessageKind::PrefillEmbd,
+        pos_start: 0,
+        token_count: 0,
+        state: StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32),
+        request_id: 11,
+        session_id: 13,
+        sampling: None,
+        chat_sampling_metadata: None,
+        tokens: Vec::new(),
+        positions: Vec::new(),
+        activation: Vec::new(),
+        raw_bytes: Vec::new(),
+    }
+}
+
+#[test]
+fn binary_full_prefill_record_plan_includes_shared_prefix_candidate() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let message = prefill_message();
+    let recorded_tokens = (0..2214).collect::<Vec<_>>();
+    let mut lookup_tokens = recorded_tokens.clone();
+    lookup_tokens.extend(100_000..100_017);
+
+    let record_plan =
+        binary_full_prefill_record_identities(&kv, &config, "session", &message, &recorded_tokens);
+    let base = super::binary_message_base(&config, "session", &message);
+    let lookup_plan = kv.lookup_identities(&config, &base, 0, &lookup_tokens);
+
+    let record_counts = record_plan
+        .iter()
+        .map(|identity| identity.identity.token_count)
+        .collect::<Vec<_>>();
+    let lookup_counts = lookup_plan
+        .iter()
+        .map(|identity| identity.identity.token_count)
+        .collect::<Vec<_>>();
+
+    assert_eq!(record_counts, vec![2214, 2176]);
+    assert!(lookup_counts.contains(&2176));
+
+    let recorded_shared = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("binary full-prefill record plan should include shared grid prefix");
+    let lookup_shared = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("lookup plan should probe shared grid prefix");
+    let recorded_exact = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2214)
+        .expect("binary full-prefill record plan should keep exact first prompt");
+    let lookup_exact = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2231)
+        .expect("lookup plan should probe exact second prompt");
+
+    assert_eq!(recorded_shared.page_id, lookup_shared.page_id);
+    assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
 }

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -1,12 +1,22 @@
 use super::*;
 
+pub(super) fn stage0_prefill_record_identities(
+    kv: &KvStageIntegration,
+    config: &StageConfig,
+    base: &MessageBase,
+    token_start: u64,
+    token_ids: &[i32],
+) -> Vec<crate::kv_integration::PrefillKvIdentity> {
+    kv.record_identities(config, base, token_start, token_ids)
+}
+
 pub(super) fn stage0_full_prefill_record_identities(
     kv: &KvStageIntegration,
     config: &StageConfig,
     base: &MessageBase,
     token_ids: &[i32],
 ) -> Vec<crate::kv_integration::PrefillKvIdentity> {
-    kv.record_identities(config, base, 0, token_ids)
+    stage0_prefill_record_identities(kv, config, base, 0, token_ids)
 }
 
 impl StageOpenAiBackend {
@@ -146,14 +156,32 @@ impl StageOpenAiBackend {
             return Ok(());
         };
         let base = self.local_kv_message_base(session_id, ids);
-        let identity = kv.prefill_identity(&self.config, &base, token_start, token_ids);
-        let resident_record = {
+        let identities =
+            stage0_prefill_record_identities(kv, &self.config, &base, token_start, token_ids);
+        let record_candidate_count = identities.len();
+        let resident_records = {
             let mut runtime = self
                 .runtime
                 .lock()
                 .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
-            kv.record_resident_prefix(&mut runtime, session_id, &identity, token_ids)
-                .map_err(openai_backend_error)?
+            identities
+                .iter()
+                .map(|identity| {
+                    let token_count = identity
+                        .identity
+                        .token_count
+                        .try_into()
+                        .unwrap_or(usize::MAX)
+                        .min(token_ids.len());
+                    kv.record_resident_prefix(
+                        &mut runtime,
+                        session_id,
+                        identity,
+                        &token_ids[..token_count],
+                    )
+                    .map_err(openai_backend_error)
+                })
+                .collect::<OpenAiResult<Vec<_>>>()?
         };
         let activation_record = kv.record_resident_activation(
             &self.config,
@@ -163,11 +191,17 @@ impl StageOpenAiBackend {
             activation_width,
             output,
         );
-        let mut attrs = self.openai_attrs(ids);
-        attrs.insert("skippy.kv.decision".to_string(), json!("stage0_record"));
-        attrs.insert("skippy.kv.token_start".to_string(), json!(token_start));
-        attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
-        if let Some(record) = resident_record {
+        let mut recorded_any = false;
+        for record in resident_records.into_iter().flatten() {
+            recorded_any = true;
+            let mut attrs = self.openai_attrs(ids);
+            attrs.insert("skippy.kv.decision".to_string(), json!("stage0_record"));
+            attrs.insert(
+                "skippy.kv.record_candidates".to_string(),
+                json!(record_candidate_count),
+            );
+            attrs.insert("skippy.kv.token_start".to_string(), json!(token_start));
+            attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
             attrs.insert(
                 "skippy.kv.recorded_page_id".to_string(),
                 json!(record.page_id),
@@ -180,8 +214,21 @@ impl StageOpenAiBackend {
                 "skippy.kv.resident_seq_id".to_string(),
                 json!(record.seq_id),
             );
+            self.telemetry
+                .emit("stage.openai_kv_record_decision", attrs);
         }
         if let Some(record) = activation_record {
+            let mut attrs = self.openai_attrs(ids);
+            attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("stage0_activation_record"),
+            );
+            attrs.insert(
+                "skippy.kv.record_candidates".to_string(),
+                json!(record_candidate_count),
+            );
+            attrs.insert("skippy.kv.token_start".to_string(), json!(token_start));
+            attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
             attrs.insert(
                 "skippy.activation_cache.recorded_page_id".to_string(),
                 json!(record.page_id),
@@ -190,9 +237,20 @@ impl StageOpenAiBackend {
                 "skippy.activation_cache.payload_bytes".to_string(),
                 json!(record.payload_bytes),
             );
+            self.telemetry
+                .emit("stage.openai_kv_record_decision", attrs);
+        } else if !recorded_any {
+            let mut attrs = self.openai_attrs(ids);
+            attrs.insert("skippy.kv.decision".to_string(), json!("stage0_record"));
+            attrs.insert(
+                "skippy.kv.record_candidates".to_string(),
+                json!(record_candidate_count),
+            );
+            attrs.insert("skippy.kv.token_start".to_string(), json!(token_start));
+            attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
+            self.telemetry
+                .emit("stage.openai_kv_record_decision", attrs);
         }
-        self.telemetry
-            .emit("stage.openai_kv_record_decision", attrs);
         Ok(())
     }
 

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -178,6 +178,59 @@ fn stage0_full_prefill_record_plan_includes_shared_prefix_candidate() {
     assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
 }
 
+#[test]
+fn stage0_chunked_prefill_record_plan_includes_shared_prefix_candidate() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let base = prefix_cache_test_base();
+    let recorded_tokens = (0..2214).collect::<Vec<_>>();
+    let mut lookup_tokens = recorded_tokens.clone();
+    lookup_tokens.extend(100_000..100_017);
+
+    let record_plan = super::prefix_cache::stage0_prefill_record_identities(
+        &kv,
+        &config,
+        &base,
+        0,
+        &recorded_tokens,
+    );
+    let lookup_plan = kv.lookup_identities(&config, &base, 0, &lookup_tokens);
+
+    let record_counts = record_plan
+        .iter()
+        .map(|identity| identity.identity.token_count)
+        .collect::<Vec<_>>();
+    let lookup_counts = lookup_plan
+        .iter()
+        .map(|identity| identity.identity.token_count)
+        .collect::<Vec<_>>();
+
+    assert_eq!(record_counts, vec![2214, 2176]);
+    assert!(lookup_counts.contains(&2176));
+
+    let recorded_shared = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("chunked record plan should include shared grid prefix");
+    let lookup_shared = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("lookup plan should probe shared grid prefix");
+    let recorded_exact = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2214)
+        .expect("chunked record plan should keep exact first prompt");
+    let lookup_exact = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2231)
+        .expect("lookup plan should probe exact second prompt");
+
+    assert_eq!(recorded_shared.page_id, lookup_shared.page_id);
+    assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
+}
+
 struct MultimodalSmokeFixture {
     model_path: PathBuf,
     projector_path: PathBuf,

--- a/crates/skippy-server/src/kv_integration/activation.rs
+++ b/crates/skippy-server/src/kv_integration/activation.rs
@@ -49,6 +49,11 @@ impl KvStageIntegration {
         if token_count < self.candidate_policy.min_tokens || frame.payload.is_empty() {
             return None;
         }
+        if u64::from(frame.desc.token_count) != token_count
+            || frame.desc.payload_bytes != frame.payload.len() as u64
+        {
+            return None;
+        }
         let identity = self.prefill_identity(config, base, token_start, token_ids);
         let page_id = activation_page_id(&identity.page_id, activation_width);
         let mut cache = self
@@ -71,5 +76,171 @@ impl KvStageIntegration {
             entries: stats.entries,
             resident_bytes: stats.resident_bytes,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use skippy_protocol::{
+        LoadMode, SCHEMA_VERSION, StageConfig, StageKvCacheConfig, StageKvCacheMode,
+        StageKvCachePayload,
+    };
+    use skippy_runtime::{
+        ActivationDesc, ActivationFrame, RuntimeActivationDType, RuntimeActivationLayout,
+    };
+
+    use super::*;
+
+    fn test_config() -> StageConfig {
+        StageConfig {
+            run_id: "run".to_string(),
+            topology_id: "topology".to_string(),
+            model_id: "org/model:Q4_K_M".to_string(),
+            package_ref: None,
+            manifest_sha256: None,
+            source_model_path: None,
+            source_model_sha256: None,
+            source_model_bytes: None,
+            materialized_path: None,
+            materialized_pinned: false,
+            model_path: None,
+            projector_path: None,
+            stage_id: "stage-0".to_string(),
+            stage_index: 0,
+            layer_start: 0,
+            layer_end: 4,
+            ctx_size: 8192,
+            lane_count: 2,
+            n_batch: None,
+            n_ubatch: None,
+            n_gpu_layers: 0,
+            cache_type_k: "f16".to_string(),
+            cache_type_v: "f16".to_string(),
+            flash_attn_type: Default::default(),
+            filter_tensors_on_load: false,
+            selected_device: None,
+            kv_cache: Some(StageKvCacheConfig {
+                mode: StageKvCacheMode::LookupRecord,
+                payload: StageKvCachePayload::ResidentKv,
+                max_entries: 8,
+                max_bytes: 0,
+                min_tokens: 256,
+                shared_prefix_stride_tokens: 128,
+                shared_prefix_record_limit: 2,
+            }),
+            load_mode: LoadMode::RuntimeSlice,
+            bind_addr: "127.0.0.1:0".to_string(),
+            upstream: None,
+            downstream: None,
+        }
+    }
+
+    fn test_base() -> MessageBase {
+        MessageBase {
+            schema_version: SCHEMA_VERSION,
+            run_id: "run".to_string(),
+            request_id: "request".to_string(),
+            session_id: "session".to_string(),
+            stage_id: "stage-0".to_string(),
+            stage_index: 0,
+            topology_id: "topology".to_string(),
+            model_id: Some("org/model:Q4_K_M".to_string()),
+            tokenizer_id: None,
+            chat_template_id: Some("template".to_string()),
+            seq: Some(1),
+        }
+    }
+
+    fn activation_frame(token_count: u32, payload_bytes: usize) -> ActivationFrame {
+        ActivationFrame {
+            desc: ActivationDesc {
+                version: 1,
+                dtype: RuntimeActivationDType::F32,
+                layout: RuntimeActivationLayout::TokenMajor,
+                producer_stage_index: 0,
+                layer_start: 0,
+                layer_end: 4,
+                token_count,
+                sequence_count: 1,
+                payload_bytes: payload_bytes as u64,
+                flags: 0,
+            },
+            payload: vec![7; payload_bytes],
+        }
+    }
+
+    #[test]
+    fn resident_activation_records_and_restores_exact_frame() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let tokens = (0..300).collect::<Vec<_>>();
+        let frame = activation_frame(tokens.len() as u32, 64);
+
+        let record = kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
+
+        assert!(record.is_some());
+        let restored = kv
+            .restore_resident_activation(&config, &test_base(), 0, &tokens, 4096)
+            .expect("activation frame should restore by exact identity");
+        assert_eq!(restored.frame, frame);
+    }
+
+    #[test]
+    fn resident_activation_rejects_mismatched_frame_token_count() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let tokens = (0..300).collect::<Vec<_>>();
+        let frame = activation_frame(128, 64);
+
+        let record = kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
+
+        assert!(record.is_none());
+        assert!(
+            kv.restore_resident_activation(&config, &test_base(), 0, &tokens, 4096)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resident_activation_stays_exact_for_shared_prefix_candidates() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let recorded_tokens = (0..2214).collect::<Vec<_>>();
+        let mut lookup_tokens = recorded_tokens.clone();
+        lookup_tokens.extend(100_000..100_017);
+        let frame = activation_frame(recorded_tokens.len() as u32, 64);
+
+        let record =
+            kv.record_resident_activation(&config, &test_base(), 0, &recorded_tokens, 4096, &frame);
+
+        assert!(record.is_some());
+        assert!(
+            kv.restore_resident_activation(&config, &test_base(), 0, &lookup_tokens, 4096)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resident_activation_keys_include_activation_width() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let tokens = (0..300).collect::<Vec<_>>();
+        let frame = activation_frame(tokens.len() as u32, 64);
+
+        let record = kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
+
+        assert!(record.is_some());
+        assert!(
+            kv.restore_resident_activation(&config, &test_base(), 0, &tokens, 8192)
+                .is_none()
+        );
     }
 }


### PR DESCRIPTION
## Summary

Completes the remaining Skippy prefix-cache record-site cleanup from #683. The remaining narrow paths now use the same shared-prefix candidate contract as the main LocalRuntime and EmbeddedStageZero full-prefill paths.

This means long shared-prefix agent prompts no longer depend on exact prompt length matches in these record paths: the cache records the exact prefix plus the stable grid-floor candidate that later same-prefix/different-tail prompts can reuse.

## Why

#661 and #681 fixed the dominant cache paths, but three narrower sites still had exact-only behavior or needed an explicit semantic decision:

- EmbeddedStageZero chunked prefill recorded only one exact resident-prefix identity.
- Binary full-prefill recorded one exact identity and therefore missed the shared grid-floor candidate.
- Activation-cache recording used the same exact identity shape, but activation frames are length-specific payloads and should not be recorded under shorter grid candidates without an explicit frame-slicing implementation.

## Diff scope

- Adds a shared stage0 prefill record planner and uses it for chunked EmbeddedStageZero records.
- Updates binary full-prefill recording to plan all record candidates.
- Keeps exact-state recording full-length-only, then records shorter grid candidates through resident-prefix storage.
- Keeps activation-cache lookup/recording exact-only, with guards that reject mismatched frame token counts and payload sizes.
- Adds regression coverage for chunked stage0 planning, binary full-prefill planning, activation exactness, width isolation, and mismatched activation frame rejection.
- Refreshes the branch on current `main` and applies current rustfmt output after rebase.

## Compatibility

No mesh protocol, protobuf, wire-format, Skippy ABI, CLI, or config schema changes.

This only changes local cache record behavior inside Skippy server paths. Existing exact cache entries remain valid; new resident-prefix grid candidates are additive.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@6669b413d253f25994163d1a7de1bf0382f5ce6a`
- Branch state: `0 behind / 1 ahead`
- Head commit: `74ef03175f077253011c0084c9560751ba310c8e`
- Merge-base: `6669b413d253f25994163d1a7de1bf0382f5ce6a`

## Commit integrity

Introduced commit:

- `74ef03175f077253011c0084c9560751ba310c8e Complete Skippy prefix-cache record candidates`

The diff is limited to Skippy server prefix-cache, binary transport, activation-cache logic, and targeted tests.

## Diff hygiene

- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output

## Validation

Validation tier: Tier 2 - narrow Skippy prefix-cache record-site repair for issue #683, refreshed on current main.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `6669b413d253f25994163d1a7de1bf0382f5ce6a`
- `git rebase origin/main`: PASS
- `cargo fmt --all -- --check`: PASS
- `cargo test -p skippy-cache --lib`: PASS, 31 passed
- `LLAMA_STAGE_BUILD_DIR=<local llama stage build dir> cargo test -p skippy-server prefix --lib`: PASS, 7 passed
- `LLAMA_STAGE_BUILD_DIR=<local llama stage build dir> cargo test -p skippy-server resident_activation --lib`: PASS, 4 passed
- `LLAMA_STAGE_BUILD_DIR=<local llama stage build dir> cargo test -p skippy-server --lib`: PASS, 104 passed
- `LLAMA_STAGE_BUILD_DIR=<local llama stage build dir> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<local llama stage build dir> cargo-clippy clippy -p skippy-server --all-targets -- -D warnings`: PASS

Ledger: not applicable - not required for selected validation tier/change family.

Version: not applicable - cache behavior repair only; no release/version sync required.

Not run: live shared-prefix agent smoke - no local model/runtime endpoint was available. The deterministic candidate-planning and cache unit tests cover the changed paths locally; remote CI should still gate merge.

## Runtime safety

- No new blocking locks beyond the existing runtime-lock/cache-lock record paths.
- No new unbounded queues.
- No invariant removal.
- Exact-state cache entries remain full-prefix only; shorter shared-prefix candidates use resident-prefix records instead.
- Activation frames are not reused across shorter candidate identities; token-count and payload-size guards prevent stale or mismatched activation records.

No invariant regression introduced.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

No live model-backed shared-prefix agent smoke was run locally. The remaining proof is deterministic unit coverage plus required remote CI on the final PR SHA.
