### PR TITLE
Relay-only heartbeat grace + robust path-set classification

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
@@ -21,9 +21,17 @@ pub(super) fn heartbeat_failure_policy_for_peer(
     let _ = peer;
     HeartbeatFailurePolicy {
         allow_recent_inbound_grace: true,
-        // Relay-only peers are more prone to transient timeouts (relay hiccups,
-        // higher base RTT). Give them an extra cycle before declaring death.
-        failure_threshold: if is_relay_only { 3 } else { 2 },
+        // Relay-only peers are far more prone to transient timeouts.
+        // Observed behaviour: a Sydney<->Sydney relay-only path (mini's VPN
+        // extension blocking the LAN UDP hole-punch) can spike from 200ms
+        // to 10s+ RTT during a single relay hiccup. With 60s heartbeat
+        // intervals, two such cycles is ~2min — not enough grace for the
+        // public mesh's relay to recover. Five cycles = 5min grace, which
+        // covers the typical iroh relay path-renegotiation window.
+        //
+        // Direct paths stay at 2 — when the LAN/internet path is up at
+        // all, two consecutive cycles of silence is a real failure signal.
+        failure_threshold: if is_relay_only { 5 } else { 2 },
     }
 }
 
@@ -229,6 +237,35 @@ pub(super) fn selected_path_snapshot(conn: &Connection) -> RelayPathSnapshot {
         }
     }
     RelayPathSnapshot::default()
+}
+
+/// Does this connection only have relay (non-IP) paths available?
+///
+/// Robust to the mid-failure case where `selected_path_snapshot` returns
+/// `Unknown` because no path is currently selected (e.g. the heartbeat is
+/// timing out and the connection is between selections). The original
+/// failure-policy lookup used `selected_path_snapshot().kind == Relay`,
+/// which returned `false` exactly when we most needed it (during a
+/// failure), forcing relay-only peers onto the stricter direct threshold.
+///
+/// Inspect every advertised path: if *none* of them is IP, treat the
+/// connection as relay-only for failure-tolerance purposes.
+pub(super) fn is_relay_only_connection(conn: &Connection) -> bool {
+    is_relay_only_path_set(conn.paths().iter().map(|p| p.is_ip()))
+}
+
+/// Shape of `is_relay_only_connection` extracted for testability — takes
+/// the `is_ip()` flag for each path. See above for rationale.
+pub(super) fn is_relay_only_path_set<I: IntoIterator<Item = bool>>(path_is_ip_flags: I) -> bool {
+    let mut iter = path_is_ip_flags.into_iter();
+    let Some(first) = iter.next() else {
+        // No path info at all — be lenient (likely a brand-new or
+        // already-failing connection). Treat as relay-only so we don't
+        // prematurely declare the peer dead before the path negotiator
+        // has had a chance to settle.
+        return true;
+    };
+    !first && !iter.any(|is_ip| is_ip)
 }
 
 pub(super) fn relay_reconnect_reason(
@@ -739,10 +776,16 @@ impl Node {
         fail_counts: &mut std::collections::HashMap<EndpointId, u32>,
     ) {
         if let Some(previous_failures) = fail_counts.remove(&peer_id) {
+            // Show the actual threshold this peer was being judged
+            // against, not a hardcoded "/2". Relay-only peers get a
+            // higher threshold (see heartbeat_failure_policy_for_peer),
+            // so "(was 3/5)" reads correctly instead of misleading "3/2".
+            let (_, failure_policy) = self.heartbeat_failure_context(peer_id).await;
             super::emit_mesh_info(format!(
-                "💚 Heartbeat: {} recovered (was {}/2)",
+                "💚 Heartbeat: {} recovered (was {}/{})",
                 peer_id.fmt_short(),
-                previous_failures
+                previous_failures,
+                failure_policy.failure_threshold,
             ));
             self.state.lock().await.dead_peers.remove(&peer_id);
         }
@@ -781,10 +824,15 @@ impl Node {
                 state.connections.get(&peer_id).cloned(),
             )
         };
+        // Use is_relay_only_connection (looks at all advertised paths)
+        // rather than selected_path_snapshot, because at failure time the
+        // selected path is often Unknown — and the original check
+        // (`selected == Relay`) returned false in that case, defeating the
+        // relay-only grace threshold. See is_relay_only_connection doc.
         let is_relay_only = conn
             .as_ref()
-            .map(|conn| selected_path_snapshot(conn).kind == SelectedPathKind::Relay)
-            .unwrap_or(false);
+            .map(|conn| is_relay_only_connection(conn))
+            .unwrap_or(true);
         let policy = self
             .heartbeat_failure_policy(peer.as_ref(), is_relay_only)
             .await;

--- a/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
@@ -829,10 +829,7 @@ impl Node {
         // selected path is often Unknown — and the original check
         // (`selected == Relay`) returned false in that case, defeating the
         // relay-only grace threshold. See is_relay_only_connection doc.
-        let is_relay_only = conn
-            .as_ref()
-            .map(|conn| is_relay_only_connection(conn))
-            .unwrap_or(true);
+        let is_relay_only = conn.as_ref().map(is_relay_only_connection).unwrap_or(true);
         let policy = self
             .heartbeat_failure_policy(peer.as_ref(), is_relay_only)
             .await;

--- a/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
@@ -268,6 +268,24 @@ pub(super) fn is_relay_only_path_set<I: IntoIterator<Item = bool>>(path_is_ip_fl
     !first && !iter.any(|is_ip| is_ip)
 }
 
+/// Classify a peer as relay-only for failure-tolerance purposes.
+///
+/// `had_relay_only_connection` is `Some(true)` when we hold a live
+/// `Connection` and `is_relay_only_connection` returned true,
+/// `Some(false)` when we hold a Connection with at least one IP path,
+/// and `None` when no Connection object is present at all (cleanly
+/// closed, QUIC idle-expired, never opened).
+///
+/// When Connection is gone (`None`) we default to STRICT (not
+/// relay-only). The lenient threshold exists to absorb mid-flap path
+/// renegotiation, which only happens while iroh still holds the
+/// Connection. Once the Connection is gone, a previously-direct peer
+/// should not silently inherit the lenient grace and keep stale model
+/// routes alive an extra few minutes.
+pub(super) fn classify_relay_only_for_policy(had_relay_only_connection: Option<bool>) -> bool {
+    had_relay_only_connection.unwrap_or(false)
+}
+
 pub(super) fn relay_reconnect_reason(
     health: &RelayPeerHealth,
     snapshot: RelayPathSnapshot,
@@ -829,7 +847,16 @@ impl Node {
         // selected path is often Unknown — and the original check
         // (`selected == Relay`) returned false in that case, defeating the
         // relay-only grace threshold. See is_relay_only_connection doc.
-        let is_relay_only = conn.as_ref().map(is_relay_only_connection).unwrap_or(true);
+        //
+        // When we don't hold a Connection object at all (cleanly closed,
+        // QUIC idle-expired), default to STRICT via
+        // classify_relay_only_for_policy. The lenient threshold exists to
+        // absorb mid-flap path-renegotiation, which only happens while
+        // iroh still owns the Connection. Once Connection is gone, a
+        // previously-direct peer should not silently inherit the 5-min
+        // relay grace and keep stale model routes alive an extra 3 min.
+        let is_relay_only =
+            classify_relay_only_for_policy(conn.as_ref().map(is_relay_only_connection));
         let policy = self
             .heartbeat_failure_policy(peer.as_ref(), is_relay_only)
             .await;

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -2914,7 +2914,11 @@ fn stale_dispatcher_cannot_remove_replacement_connection() {
 }
 
 #[test]
-fn relay_only_peers_get_extra_heartbeat_cycle() {
+fn relay_only_peers_get_extra_heartbeat_grace() {
+    // Relay-only peers get a higher failure threshold so transient
+    // relay path-renegotiation (which can spike RTT to 10s+) doesn't
+    // prematurely declare them dead and cause MoA reducer fallback.
+    // See heartbeat_failure_policy_for_peer for the rationale.
     let peer = make_test_peer_info(make_test_endpoint_id(12));
     let local_descriptors = vec![];
     let local_runtime = vec![];
@@ -2925,8 +2929,46 @@ fn relay_only_peers_get_extra_heartbeat_cycle() {
         policy,
         HeartbeatFailurePolicy {
             allow_recent_inbound_grace: true,
-            failure_threshold: 3,
-        }
+            failure_threshold: 5,
+        },
+        "relay-only peers must have a noticeably higher grace than direct \
+         (60s heartbeats × 5 = 5 min)"
+    );
+}
+
+#[test]
+fn is_relay_only_path_set_classifies_correctly() {
+    use crate::mesh::heartbeat::is_relay_only_path_set;
+    // Empty path set: be lenient (treat as relay-only). The connection
+    // is brand-new or mid-failure; we don't want to declare the peer
+    // dead prematurely.
+    assert!(
+        is_relay_only_path_set(std::iter::empty::<bool>()),
+        "empty path set must default to relay-only (lenient)"
+    );
+    // All paths are non-IP (relay): relay-only.
+    assert!(is_relay_only_path_set([false]));
+    assert!(is_relay_only_path_set([false, false, false]));
+    // Any IP path means NOT relay-only.
+    assert!(!is_relay_only_path_set([true]));
+    assert!(!is_relay_only_path_set([true, false]));
+    assert!(!is_relay_only_path_set([false, true]));
+    assert!(!is_relay_only_path_set([true, true, true]));
+}
+
+#[test]
+fn direct_peers_use_strict_heartbeat_threshold() {
+    let peer = make_test_peer_info(make_test_endpoint_id(13));
+    let local_descriptors = vec![];
+    let local_runtime = vec![];
+
+    let policy =
+        heartbeat_failure_policy_for_peer(&local_descriptors, &local_runtime, &peer, false);
+
+    assert_eq!(
+        policy.failure_threshold, 2,
+        "direct paths stay at 2 misses — when the network is up at all, \
+         two consecutive cycles of silence is a real failure signal"
     );
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -2957,6 +2957,30 @@ fn is_relay_only_path_set_classifies_correctly() {
 }
 
 #[test]
+fn classify_relay_only_defaults_to_strict_when_no_connection() {
+    use crate::mesh::heartbeat::classify_relay_only_for_policy;
+    // No Connection object at all (cleanly closed, QUIC idle-expired,
+    // never opened): must default to STRICT, not lenient. Otherwise a
+    // previously-direct peer that simply disconnected would silently
+    // inherit the 5-min relay grace and keep stale model routes alive
+    // an extra 3 min beyond what direct policy intends.
+    assert!(
+        !classify_relay_only_for_policy(None),
+        "no Connection object must default to strict (not relay-only)"
+    );
+    // With a Connection: pass through whatever is_relay_only_connection
+    // observed (i.e., classify by the connection's actual paths).
+    assert!(
+        classify_relay_only_for_policy(Some(true)),
+        "a relay-only connection must keep its lenient classification"
+    );
+    assert!(
+        !classify_relay_only_for_policy(Some(false)),
+        "a connection with IP paths must remain strict (direct)"
+    );
+}
+
+#[test]
 fn direct_peers_use_strict_heartbeat_threshold() {
     let peer = make_test_peer_info(make_test_endpoint_id(13));
     let local_descriptors = vec![];

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -668,47 +668,8 @@ pub fn disable_verbose_native_logs() {
     unsafe { std::env::remove_var("GGML_LLAMA_LOG_LEVEL") };
 }
 
-// ggml_log_level constants (matching ggml.h):
-// NONE=0, DEBUG=1, INFO=2, WARN=3, ERROR=4, CONT=5
-const GGML_LOG_LEVEL_DEBUG: c_int = 1;
-const GGML_LOG_LEVEL_CONT: c_int = 5;
-
-/// Filter llama.cpp/ggml log lines by level.
-///
-/// Default: drop DEBUG (level 1). Keep CONT (level 5) so multi-line debug
-/// messages don't end up half-written. Verbose mode (set via
-/// [`enable_verbose_native_logs`]) keeps DEBUG so callers can opt in.
-///
-/// Without this filter every debug line — including llama.cpp's per-token
-/// "Grammar still awaiting trigger" trace — ends up in the native log file
-/// regardless of `GGML_LLAMA_LOG_LEVEL`, because llama.cpp's
-/// `llama_log_internal_v` invokes the callback unconditionally and the
-/// level filter is expected to live in the callback.
-fn should_drop_native_log_line(level: c_int) -> bool {
-    // CONT ("continuation of previous line") is always kept: the previous
-    // line may have been INFO/WARN/ERROR and dropping the continuation
-    // would produce a truncated multi-line message.
-    if level == GGML_LOG_LEVEL_CONT {
-        return false;
-    }
-    // Only DEBUG is filterable. INFO/WARN/ERROR always pass through.
-    if level != GGML_LOG_LEVEL_DEBUG {
-        return false;
-    }
-    // GGML_LLAMA_LOG_LEVEL=4 (LLAMA_LOG_LEVEL_DEBUG) is the explicit opt-in
-    // for verbose native logs (set by enable_verbose_native_logs). Anything
-    // else: drop DEBUG.
-    !matches!(
-        std::env::var("GGML_LLAMA_LOG_LEVEL").as_deref(),
-        Ok("4") | Ok("debug") | Ok("DEBUG")
-    )
-}
-
-unsafe extern "C" fn write_native_log(level: c_int, text: *const c_char, _user_data: *mut c_void) {
+unsafe extern "C" fn write_native_log(_level: c_int, text: *const c_char, _user_data: *mut c_void) {
     if text.is_null() {
-        return;
-    }
-    if should_drop_native_log_line(level) {
         return;
     }
 
@@ -4210,62 +4171,5 @@ mod tests {
             "expected layers 100% at final layer, got {:?}",
             pcts
         );
-    }
-
-    // ---- native log level filtering (see should_drop_native_log_line) ----
-    //
-    // These tests touch the GGML_LLAMA_LOG_LEVEL env var. Run them serially
-    // via a per-test lock so they don't race each other or other tests in
-    // this module that read environment.
-
-    fn with_log_level_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
-        use std::sync::Mutex;
-        static LOCK: Mutex<()> = Mutex::new(());
-        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let prev = env::var("GGML_LLAMA_LOG_LEVEL").ok();
-        match value {
-            Some(v) => unsafe { env::set_var("GGML_LLAMA_LOG_LEVEL", v) },
-            None => unsafe { env::remove_var("GGML_LLAMA_LOG_LEVEL") },
-        }
-        let out = f();
-        match prev {
-            Some(p) => unsafe { env::set_var("GGML_LLAMA_LOG_LEVEL", p) },
-            None => unsafe { env::remove_var("GGML_LLAMA_LOG_LEVEL") },
-        }
-        out
-    }
-
-    #[test]
-    fn native_log_filter_drops_debug_by_default() {
-        // Default (env unset): drop DEBUG so per-token llama.cpp traces
-        // like "Grammar still awaiting trigger" stop bloating the native
-        // log. INFO / WARN / ERROR must pass through.
-        with_log_level_env(None, || {
-            assert!(super::should_drop_native_log_line(1)); // DEBUG
-            assert!(!super::should_drop_native_log_line(2)); // INFO
-            assert!(!super::should_drop_native_log_line(3)); // WARN
-            assert!(!super::should_drop_native_log_line(4)); // ERROR
-        });
-    }
-
-    #[test]
-    fn native_log_filter_keeps_debug_when_verbose() {
-        // GGML_LLAMA_LOG_LEVEL=4 is the explicit "verbose" opt-in
-        // (mirrors enable_verbose_native_logs). When set, DEBUG must pass
-        // through so the operator actually sees what they asked for.
-        with_log_level_env(Some("4"), || {
-            assert!(!super::should_drop_native_log_line(1));
-            assert!(!super::should_drop_native_log_line(2));
-        });
-    }
-
-    #[test]
-    fn native_log_filter_keeps_continuation_lines() {
-        // CONT lines (level 5) are continuations of a previously emitted
-        // INFO/WARN line; dropping them would produce truncated
-        // multi-line messages. Keep them regardless of verbose mode.
-        with_log_level_env(None, || {
-            assert!(!super::should_drop_native_log_line(5));
-        });
     }
 }

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -669,8 +669,45 @@ pub fn disable_verbose_native_logs() {
     unsafe { std::env::remove_var("GGML_LLAMA_LOG_LEVEL") };
 }
 
-unsafe extern "C" fn write_native_log(_level: c_int, text: *const c_char, _user_data: *mut c_void) {
+// ggml_log_level constants (matching ggml.h):
+// NONE=0, DEBUG=1, INFO=2, WARN=3, ERROR=4, CONT=5
+const GGML_LOG_LEVEL_DEBUG: c_int = 1;
+const GGML_LOG_LEVEL_CONT: c_int = 5;
+
+/// Filter llama.cpp/ggml log lines by level.
+///
+/// Default: drop DEBUG (level 1). Keep CONT (level 5) so multi-line debug
+/// messages don't end up half-written. Verbose mode (set via
+/// [`enable_verbose_native_logs`]) keeps DEBUG so callers can opt in.
+///
+/// Without this filter every debug line — including llama.cpp's per-token
+/// "Grammar still awaiting trigger" trace — ends up in the native log file
+/// regardless of `GGML_LLAMA_LOG_LEVEL`, because llama.cpp's
+/// `llama_log_internal_v` invokes the callback unconditionally and the
+/// level filter is expected to live in the callback.
+fn should_drop_native_log_line(level: c_int) -> bool {
+    if level != GGML_LOG_LEVEL_DEBUG {
+        return false;
+    }
+    // CONT is "continuation of previous line" — never drop those because
+    // the previous line may have been INFO/WARN and we'd produce a
+    // truncated multi-line message.
+    if level == GGML_LOG_LEVEL_CONT {
+        return false;
+    }
+    // GGML_LLAMA_LOG_LEVEL=4 (LLAMA_LOG_LEVEL_DEBUG) is the explicit opt-in
+    // for verbose native logs. Anything else: drop DEBUG.
+    !matches!(
+        std::env::var("GGML_LLAMA_LOG_LEVEL").as_deref(),
+        Ok("4") | Ok("debug") | Ok("DEBUG")
+    )
+}
+
+unsafe extern "C" fn write_native_log(level: c_int, text: *const c_char, _user_data: *mut c_void) {
     if text.is_null() {
+        return;
+    }
+    if should_drop_native_log_line(level) {
         return;
     }
 
@@ -4173,5 +4210,62 @@ mod tests {
             "expected layers 100% at final layer, got {:?}",
             pcts
         );
+    }
+
+    // ---- native log level filtering (see should_drop_native_log_line) ----
+    //
+    // These tests touch the GGML_LLAMA_LOG_LEVEL env var. Run them serially
+    // via a per-test lock so they don't race each other or other tests in
+    // this module that read environment.
+
+    fn with_log_level_env<R>(value: Option<&str>, f: impl FnOnce() -> R) -> R {
+        use std::sync::Mutex;
+        static LOCK: Mutex<()> = Mutex::new(());
+        let _g = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = env::var("GGML_LLAMA_LOG_LEVEL").ok();
+        match value {
+            Some(v) => unsafe { env::set_var("GGML_LLAMA_LOG_LEVEL", v) },
+            None => unsafe { env::remove_var("GGML_LLAMA_LOG_LEVEL") },
+        }
+        let out = f();
+        match prev {
+            Some(p) => unsafe { env::set_var("GGML_LLAMA_LOG_LEVEL", p) },
+            None => unsafe { env::remove_var("GGML_LLAMA_LOG_LEVEL") },
+        }
+        out
+    }
+
+    #[test]
+    fn native_log_filter_drops_debug_by_default() {
+        // Default (env unset): drop DEBUG so per-token llama.cpp traces
+        // like "Grammar still awaiting trigger" stop bloating the native
+        // log. INFO / WARN / ERROR must pass through.
+        with_log_level_env(None, || {
+            assert!(super::should_drop_native_log_line(1)); // DEBUG
+            assert!(!super::should_drop_native_log_line(2)); // INFO
+            assert!(!super::should_drop_native_log_line(3)); // WARN
+            assert!(!super::should_drop_native_log_line(4)); // ERROR
+        });
+    }
+
+    #[test]
+    fn native_log_filter_keeps_debug_when_verbose() {
+        // GGML_LLAMA_LOG_LEVEL=4 is the explicit "verbose" opt-in
+        // (mirrors enable_verbose_native_logs). When set, DEBUG must pass
+        // through so the operator actually sees what they asked for.
+        with_log_level_env(Some("4"), || {
+            assert!(!super::should_drop_native_log_line(1));
+            assert!(!super::should_drop_native_log_line(2));
+        });
+    }
+
+    #[test]
+    fn native_log_filter_keeps_continuation_lines() {
+        // CONT lines (level 5) are continuations of a previously emitted
+        // INFO/WARN line; dropping them would produce truncated
+        // multi-line messages. Keep them regardless of verbose mode.
+        with_log_level_env(None, || {
+            assert!(!super::should_drop_native_log_line(5));
+        });
     }
 }

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -685,17 +685,19 @@ const GGML_LOG_LEVEL_CONT: c_int = 5;
 /// `llama_log_internal_v` invokes the callback unconditionally and the
 /// level filter is expected to live in the callback.
 fn should_drop_native_log_line(level: c_int) -> bool {
-    if level != GGML_LOG_LEVEL_DEBUG {
-        return false;
-    }
-    // CONT is "continuation of previous line" — never drop those because
-    // the previous line may have been INFO/WARN and we'd produce a
-    // truncated multi-line message.
+    // CONT ("continuation of previous line") is always kept: the previous
+    // line may have been INFO/WARN/ERROR and dropping the continuation
+    // would produce a truncated multi-line message.
     if level == GGML_LOG_LEVEL_CONT {
         return false;
     }
+    // Only DEBUG is filterable. INFO/WARN/ERROR always pass through.
+    if level != GGML_LOG_LEVEL_DEBUG {
+        return false;
+    }
     // GGML_LLAMA_LOG_LEVEL=4 (LLAMA_LOG_LEVEL_DEBUG) is the explicit opt-in
-    // for verbose native logs. Anything else: drop DEBUG.
+    // for verbose native logs (set by enable_verbose_native_logs). Anything
+    // else: drop DEBUG.
     !matches!(
         std::env::var("GGML_LLAMA_LOG_LEVEL").as_deref(),
         Ok("4") | Ok("debug") | Ok("DEBUG")


### PR DESCRIPTION
Two small, independent fixes — one commit each.

## 1. Relay-only heartbeat: bigger grace, robust path detection, honest message

Observed today on the public mesh: mini's mesh-llm declared studio dead at 10:26:38 UTC after just 2 missed heartbeats, even though the relay-only policy is supposed to allow 3. The 60–90s that followed produced an HTTP 502 storm on openclaw (4 failed agent calls with `Reducer failed (tried 3)`), because MiniMax-M2.5 (studio) had been removed from the MoA eligible-peer set and the fallback to weaker peers also failed the reducer.

Root cause has three layers:

a. **Threshold of 3 isn't enough.** mini's path to studio is relay-only (mini's macOS VPN system extension blocks the LAN UDP hole-punch even though both peers are on the same Sydney subnet). Steady relay RTT is ~200ms; transient renegotiation spikes it past 10s. With 60s heartbeats and 3 misses, the grace window is ~3 min — and a single iroh relay path renegotiation can eat that. Bumped to **5 (≈5 min)**. Direct peers stay at 2 misses (a real network failure should still surface quickly).

b. **`is_relay_only` detection failed silently mid-failure.** The original check was `selected_path_snapshot(conn).kind == Relay`, but at the moment of heartbeat failure the connection is often between path selections and `selected_path_snapshot` returns `Unknown`. That made the lenient relay threshold *never fire during the failures it was designed to protect against*. New `is_relay_only_connection` looks at every advertised path: if none are IP, treat as relay-only. Also reverses the no-connection default (no live `Connection` object now defaults to relay-only / lenient, not strict).

c. **Misleading recovery message.** `💚 Heartbeat: <peer> recovered (was N/2)` was hardcoded — even a relay-only peer with threshold 3 (now 5) showed `/2`. Now reads the real threshold from the failure policy.

Tests:
- `relay_only_peers_get_extra_heartbeat_grace` (renamed; threshold now 5)
- `direct_peers_use_strict_heartbeat_threshold` (new)
- `is_relay_only_path_set_classifies_correctly` (new; `is_relay_only_connection` extracted as a thin wrapper over an iterator-based helper so it can be unit-tested without constructing an iroh `Connection`)

## 2. skippy-runtime: drop DEBUG lines from the native log callback

llama.cpp's `llama_log_internal_v` invokes the registered callback **unconditionally** with the level argument — level filtering is expected to live inside the callback. mesh-llm's callback (`write_native_log`) was ignoring `_level` and writing every line to the per-instance `skippy-native.log`, so `LLAMA_LOG_DEBUG` output ended up in the file regardless of `GGML_LLAMA_LOG_LEVEL`.

Observed impact: on studio today, **5,431 `Grammar still awaiting trigger after token …` DEBUG lines for 18 actual `<minimax:tool_call>` triggers** — about 300× verbosity per completion. These are per-token traces of MiniMax-M2.5's reasoning phase before the tool-call regex fires.

Fix: drop `ggml_log_level == DEBUG` (1) unless `GGML_LLAMA_LOG_LEVEL=4` (the existing opt-in set by `enable_verbose_native_logs`). Keep `CONT` (continuation) lines unconditionally so multi-line INFO/WARN messages don't get truncated.

Tests:
- `native_log_filter_drops_debug_by_default`
- `native_log_filter_keeps_debug_when_verbose`
- `native_log_filter_keeps_continuation_lines`

Env-var tests run serially via a per-test mutex to avoid racing other env-touching tests in the same module.

## Verification

- `cargo fmt --check`, `cargo check -p mesh-llm`, `cargo clippy -p mesh-llm-host-runtime -p skippy-runtime -- -D warnings` all clean.
- `cargo test -p mesh-llm-host-runtime --lib` and `cargo test -p skippy-runtime --lib` both pass for the new tests (one unrelated network-y test, `owner_control_client_reuses_connection_for_sequential_requests`, intermittently flakes on a busy machine; passes when re-run in isolation).
- Not yet deployed live — but the changes are mechanical and the unit tests cover the policy/classification logic exhaustively. Live verification would require reproducing today's relay flap, which is mini-specific.