### PR TITLE
Preflight Skippy layer packages before split serving

### DIFF
--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -17,6 +17,8 @@ use sha2::{Digest, Sha256};
 use skippy_ffi::TensorRole;
 use skippy_runtime::{ModelInfo, TensorInfo, write_gguf_from_parts};
 
+mod preflight;
+
 #[derive(Debug, Parser)]
 #[command(name = "skippy-model-package")]
 #[command(about = "Inspect, plan, write, and validate skippy model packages")]
@@ -81,6 +83,13 @@ enum Command {
     ValidatePackage {
         full: PathBuf,
         package: PathBuf,
+    },
+    Preflight {
+        package: PathBuf,
+        #[arg(long)]
+        stages: Option<usize>,
+        #[arg(long)]
+        verify_sha256: bool,
     },
 }
 
@@ -379,6 +388,11 @@ fn main() -> Result<()> {
         ),
         Command::Validate { full, slices } => validate(full, slices),
         Command::ValidatePackage { full, package } => validate_package(full, package),
+        Command::Preflight {
+            package,
+            stages,
+            verify_sha256,
+        } => run_preflight(package, stages, verify_sha256),
     }
 }
 
@@ -944,6 +958,21 @@ fn validate_package(full: PathBuf, package: PathBuf) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(&output)?);
     if !valid {
         bail!("package validation failed");
+    }
+    Ok(())
+}
+
+fn run_preflight(package: PathBuf, stages: Option<usize>, verify_sha256: bool) -> Result<()> {
+    let report = preflight::preflight_package(
+        &package,
+        &preflight::PackagePreflightOptions {
+            stages,
+            verify_sha256,
+        },
+    );
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    if !report.valid {
+        bail!("package preflight failed");
     }
     Ok(())
 }

--- a/crates/skippy-model-package/src/preflight.rs
+++ b/crates/skippy-model-package/src/preflight.rs
@@ -1,0 +1,1030 @@
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct PackagePreflightOptions {
+    pub stages: Option<usize>,
+    pub verify_sha256: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PackagePreflightReport {
+    pub schema_version: u32,
+    pub package_path: String,
+    pub valid: bool,
+    pub model_id: Option<String>,
+    pub layer_count: Option<u32>,
+    pub activation_width: Option<u32>,
+    pub manifest_sha256: Option<String>,
+    pub checked_artifact_count: usize,
+    pub missing_artifact_count: usize,
+    pub issue_count: usize,
+    pub issues: Vec<PreflightIssue>,
+    pub artifacts: Vec<PreflightArtifact>,
+    pub stages: Vec<PreflightStage>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum PreflightSeverity {
+    Error,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub(crate) struct PreflightIssue {
+    pub severity: PreflightSeverity,
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    pub remediation: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PreflightArtifact {
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layer_index: Option<u32>,
+    pub path: String,
+    pub present: bool,
+    pub declared_artifact_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub actual_artifact_bytes: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size_matches_manifest: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256_matches_manifest: Option<bool>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct PreflightStage {
+    pub stage_index: usize,
+    pub layer_start: u32,
+    pub layer_end: u32,
+    pub includes_embeddings: bool,
+    pub includes_output: bool,
+    pub part_count: usize,
+    pub artifact_bytes: u64,
+    pub parts: Vec<String>,
+    pub missing_parts: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageManifest {
+    schema_version: u32,
+    model_id: String,
+    source_model: PackageSourceModel,
+    format: String,
+    layer_count: u32,
+    #[serde(default)]
+    activation_width: Option<u32>,
+    shared: PackageShared,
+    #[serde(default)]
+    projectors: Vec<PackageProjector>,
+    layers: Vec<PackageLayer>,
+    skippy_abi_version: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageSourceModel {
+    path: String,
+    sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageShared {
+    metadata: PackageArtifact,
+    embeddings: PackageArtifact,
+    output: PackageArtifact,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageArtifact {
+    path: String,
+    tensor_count: usize,
+    tensor_bytes: u64,
+    artifact_bytes: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageProjector {
+    kind: String,
+    path: String,
+    tensor_count: usize,
+    tensor_bytes: u64,
+    artifact_bytes: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct PackageLayer {
+    layer_index: u32,
+    path: String,
+    tensor_count: usize,
+    tensor_bytes: u64,
+    artifact_bytes: u64,
+    sha256: String,
+}
+
+#[derive(Debug, Clone)]
+struct ArtifactSpec {
+    role: &'static str,
+    layer_index: Option<u32>,
+    path: String,
+    tensor_count: usize,
+    tensor_bytes: u64,
+    artifact_bytes: u64,
+    sha256: String,
+}
+
+pub(crate) fn preflight_package(
+    package: &Path,
+    options: &PackagePreflightOptions,
+) -> PackagePreflightReport {
+    let mut report = PackagePreflightReport::new(package);
+    let manifest_path = package.join("model-package.json");
+    let manifest_contents = match fs::read(&manifest_path) {
+        Ok(contents) => contents,
+        Err(error) => {
+            report.error(
+                "missing_manifest",
+                format!("cannot read package manifest: {error}"),
+                Some("model-package.json".to_string()),
+                "ensure the package directory contains model-package.json",
+            );
+            return report.finalize();
+        }
+    };
+    report.manifest_sha256 = Some(sha256_bytes(&manifest_contents));
+    let manifest = match serde_json::from_slice::<PackageManifest>(&manifest_contents) {
+        Ok(manifest) => manifest,
+        Err(error) => {
+            report.error(
+                "invalid_manifest_json",
+                format!("cannot parse package manifest: {error}"),
+                Some("model-package.json".to_string()),
+                "rebuild the layer package manifest with skippy-model-package write-package",
+            );
+            return report.finalize();
+        }
+    };
+
+    report.model_id = Some(manifest.model_id.clone());
+    report.layer_count = Some(manifest.layer_count);
+    report.activation_width = manifest.activation_width;
+    validate_manifest_header(&manifest, &mut report);
+    let artifacts = collect_artifacts(&manifest);
+    validate_layer_coverage(&manifest, &mut report);
+    validate_artifacts(package, &artifacts, options.verify_sha256, &mut report);
+    build_stage_reports(&manifest, options.stages, &mut report);
+    report.finalize()
+}
+
+impl PackagePreflightReport {
+    fn new(package: &Path) -> Self {
+        Self {
+            schema_version: 1,
+            package_path: package.display().to_string(),
+            valid: true,
+            model_id: None,
+            layer_count: None,
+            activation_width: None,
+            manifest_sha256: None,
+            checked_artifact_count: 0,
+            missing_artifact_count: 0,
+            issue_count: 0,
+            issues: Vec::new(),
+            artifacts: Vec::new(),
+            stages: Vec::new(),
+        }
+    }
+
+    fn error(
+        &mut self,
+        code: impl Into<String>,
+        message: impl Into<String>,
+        path: Option<String>,
+        remediation: impl Into<String>,
+    ) {
+        self.issues.push(PreflightIssue {
+            severity: PreflightSeverity::Error,
+            code: code.into(),
+            message: message.into(),
+            path,
+            remediation: remediation.into(),
+        });
+    }
+
+    fn finalize(mut self) -> Self {
+        self.issue_count = self.issues.len();
+        self.checked_artifact_count = self.artifacts.len();
+        self.missing_artifact_count = self
+            .artifacts
+            .iter()
+            .filter(|artifact| !artifact.present)
+            .count();
+        self.valid = !self
+            .issues
+            .iter()
+            .any(|issue| issue.severity == PreflightSeverity::Error);
+        self
+    }
+}
+
+fn validate_manifest_header(manifest: &PackageManifest, report: &mut PackagePreflightReport) {
+    if manifest.schema_version != 1 {
+        report.error(
+            "unsupported_schema_version",
+            format!(
+                "unsupported package manifest schema_version {}",
+                manifest.schema_version
+            ),
+            Some("model-package.json".to_string()),
+            "rebuild the package with a compatible skippy-model-package binary",
+        );
+    }
+    if manifest.format != "layer-package" {
+        report.error(
+            "invalid_format",
+            "package manifest format must be layer-package",
+            Some("model-package.json".to_string()),
+            "rebuild the package with skippy-model-package write-package",
+        );
+    }
+    if manifest.model_id.trim().is_empty() {
+        report.error(
+            "empty_model_id",
+            "package manifest model_id must not be empty",
+            Some("model-package.json".to_string()),
+            "rebuild the package with a real model coordinate",
+        );
+    }
+    match manifest.activation_width {
+        Some(0) => report.error(
+            "invalid_activation_width",
+            "package manifest activation_width must be greater than zero",
+            Some("model-package.json".to_string()),
+            "rebuild the package manifest from the source GGUF metadata",
+        ),
+        Some(_) => {}
+        None => report.error(
+            "missing_activation_width",
+            "package manifest is missing activation_width",
+            Some("model-package.json".to_string()),
+            "rebuild the package manifest with a current skippy-model-package write-package",
+        ),
+    }
+    if manifest.source_model.path.trim().is_empty() {
+        report.error(
+            "empty_source_model_path",
+            "package manifest source_model.path must not be empty",
+            Some("model-package.json".to_string()),
+            "rebuild the package manifest with source model provenance",
+        );
+    }
+    if !is_sha256(&manifest.source_model.sha256) {
+        report.error(
+            "invalid_source_model_sha256",
+            "package manifest source_model.sha256 must be a 64-character hex digest",
+            Some("model-package.json".to_string()),
+            "rebuild the package manifest from the source GGUF",
+        );
+    }
+    if manifest.skippy_abi_version.trim().is_empty() {
+        report.error(
+            "missing_skippy_abi_version",
+            "package manifest skippy_abi_version is empty",
+            Some("model-package.json".to_string()),
+            "rebuild the package so runtime compatibility can be checked before serving",
+        );
+    }
+    for projector in &manifest.projectors {
+        if projector.kind.trim().is_empty() {
+            report.error(
+                "empty_projector_kind",
+                "package projector kind must not be empty",
+                Some(projector.path.clone()),
+                "rebuild the package manifest so projector sidecars have a supported kind",
+            );
+        } else if projector.kind != "mmproj" {
+            report.error(
+                "unsupported_projector_kind",
+                format!("unsupported package projector kind {}", projector.kind),
+                Some(projector.path.clone()),
+                "rebuild the package with supported mmproj projector sidecars only",
+            );
+        }
+    }
+}
+
+fn collect_artifacts(manifest: &PackageManifest) -> Vec<ArtifactSpec> {
+    let mut artifacts = vec![
+        artifact_spec("metadata", None, &manifest.shared.metadata),
+        artifact_spec("embeddings", None, &manifest.shared.embeddings),
+        artifact_spec("output", None, &manifest.shared.output),
+    ];
+    artifacts.extend(
+        manifest
+            .layers
+            .iter()
+            .map(|layer| layer_artifact_spec(layer.layer_index, layer)),
+    );
+    artifacts.extend(manifest.projectors.iter().map(projector_artifact_spec));
+    artifacts
+}
+
+fn artifact_spec(
+    role: &'static str,
+    layer_index: Option<u32>,
+    artifact: &PackageArtifact,
+) -> ArtifactSpec {
+    ArtifactSpec {
+        role,
+        layer_index,
+        path: artifact.path.clone(),
+        tensor_count: artifact.tensor_count,
+        tensor_bytes: artifact.tensor_bytes,
+        artifact_bytes: artifact.artifact_bytes,
+        sha256: artifact.sha256.clone(),
+    }
+}
+
+fn layer_artifact_spec(layer_index: u32, layer: &PackageLayer) -> ArtifactSpec {
+    ArtifactSpec {
+        role: "layer",
+        layer_index: Some(layer_index),
+        path: layer.path.clone(),
+        tensor_count: layer.tensor_count,
+        tensor_bytes: layer.tensor_bytes,
+        artifact_bytes: layer.artifact_bytes,
+        sha256: layer.sha256.clone(),
+    }
+}
+
+fn projector_artifact_spec(projector: &PackageProjector) -> ArtifactSpec {
+    ArtifactSpec {
+        role: "projector",
+        layer_index: None,
+        path: projector.path.clone(),
+        tensor_count: projector.tensor_count,
+        tensor_bytes: projector.tensor_bytes,
+        artifact_bytes: projector.artifact_bytes,
+        sha256: projector.sha256.clone(),
+    }
+}
+
+fn validate_layer_coverage(manifest: &PackageManifest, report: &mut PackagePreflightReport) {
+    let mut counts = BTreeMap::<u32, usize>::new();
+    for layer in &manifest.layers {
+        *counts.entry(layer.layer_index).or_default() += 1;
+        if layer.layer_index >= manifest.layer_count {
+            report.error(
+                "layer_index_out_of_range",
+                format!(
+                    "package layer index {} exceeds layer_count {}",
+                    layer.layer_index, manifest.layer_count
+                ),
+                Some(layer.path.clone()),
+                "rebuild the package so layer indexes are contiguous and in range",
+            );
+        }
+    }
+    for layer_index in 0..manifest.layer_count {
+        if !counts.contains_key(&layer_index) {
+            report.error(
+                "missing_layer",
+                format!("package manifest is missing layer {layer_index}"),
+                Some("model-package.json".to_string()),
+                "rebuild the package so every transformer layer has one artifact",
+            );
+        }
+    }
+    for (layer_index, count) in counts {
+        if count > 1 {
+            report.error(
+                "duplicate_layer",
+                format!("package manifest contains layer {layer_index} {count} times"),
+                Some("model-package.json".to_string()),
+                "rebuild the package so each layer appears exactly once",
+            );
+        }
+    }
+}
+
+fn validate_artifacts(
+    package: &Path,
+    artifacts: &[ArtifactSpec],
+    verify_sha256: bool,
+    report: &mut PackagePreflightReport,
+) {
+    for artifact in artifacts {
+        report.artifacts.push(preflight_artifact(
+            package,
+            artifact,
+            verify_sha256,
+            &mut report.issues,
+        ));
+    }
+}
+
+fn preflight_artifact(
+    package: &Path,
+    artifact: &ArtifactSpec,
+    verify_sha256: bool,
+    issues: &mut Vec<PreflightIssue>,
+) -> PreflightArtifact {
+    let path = match safe_relative_path(&artifact.path) {
+        Ok(path) => path,
+        Err(message) => {
+            push_error(
+                issues,
+                "unsafe_artifact_path",
+                format!(
+                    "package {} artifact path is unsafe: {message}",
+                    artifact.role
+                ),
+                Some(artifact.path.clone()),
+                "rebuild the package so artifact paths stay inside the package directory",
+            );
+            return artifact_output(artifact, false, None, None, None);
+        }
+    };
+    validate_artifact_manifest(artifact, issues);
+    let absolute = package.join(&path);
+    let metadata = match fs::metadata(&absolute) {
+        Ok(metadata) if metadata.is_file() => metadata,
+        Ok(_) => {
+            push_error(
+                issues,
+                "artifact_not_file",
+                format!("package artifact {} is not a file", artifact.path),
+                Some(artifact.path.clone()),
+                "replace the artifact path with a regular GGUF file",
+            );
+            return artifact_output(artifact, false, None, None, None);
+        }
+        Err(error) => {
+            push_error(
+                issues,
+                "missing_artifact",
+                format!("package artifact {} is missing: {error}", artifact.path),
+                Some(artifact.path.clone()),
+                "download or rebuild the package artifact before starting split serving",
+            );
+            return artifact_output(artifact, false, None, None, None);
+        }
+    };
+    let actual_len = metadata.len();
+    let size_matches = actual_len == artifact.artifact_bytes;
+    if !size_matches {
+        push_error(
+            issues,
+            "artifact_size_mismatch",
+            format!(
+                "package artifact {} has {} bytes, manifest expects {}",
+                artifact.path, actual_len, artifact.artifact_bytes
+            ),
+            Some(artifact.path.clone()),
+            "redownload or rebuild the package artifact so manifest sizes match",
+        );
+    }
+    let sha_matches = if verify_sha256 {
+        Some(validate_artifact_sha(&absolute, artifact, issues))
+    } else {
+        None
+    };
+    artifact_output(
+        artifact,
+        true,
+        Some(actual_len),
+        Some(size_matches),
+        sha_matches,
+    )
+}
+
+fn validate_artifact_manifest(artifact: &ArtifactSpec, issues: &mut Vec<PreflightIssue>) {
+    if artifact.artifact_bytes == 0 {
+        push_error(
+            issues,
+            "empty_artifact",
+            format!("package {} artifact declares zero bytes", artifact.role),
+            Some(artifact.path.clone()),
+            "rebuild the package; split artifacts must be non-empty files",
+        );
+    }
+    if artifact.tensor_count == 0 && artifact.tensor_bytes > 0 {
+        push_error(
+            issues,
+            "invalid_tensor_bytes",
+            format!(
+                "package {} artifact declares tensor_bytes without tensors",
+                artifact.role
+            ),
+            Some(artifact.path.clone()),
+            "rebuild the package manifest so tensor counts and bytes agree",
+        );
+    }
+    if artifact.tensor_count > 0 && artifact.tensor_bytes == 0 {
+        push_error(
+            issues,
+            "invalid_tensor_bytes",
+            format!(
+                "package {} artifact declares tensors but zero tensor_bytes",
+                artifact.role
+            ),
+            Some(artifact.path.clone()),
+            "rebuild the package manifest so tensor counts and bytes agree",
+        );
+    }
+    if !is_sha256(&artifact.sha256) {
+        push_error(
+            issues,
+            "invalid_artifact_sha256",
+            format!(
+                "package {} artifact sha256 is not a hex digest",
+                artifact.role
+            ),
+            Some(artifact.path.clone()),
+            "rebuild the package manifest so artifact checksums are valid",
+        );
+    }
+}
+
+fn validate_artifact_sha(
+    path: &Path,
+    artifact: &ArtifactSpec,
+    issues: &mut Vec<PreflightIssue>,
+) -> bool {
+    match file_sha256(path) {
+        Ok(actual) if actual == artifact.sha256.to_ascii_lowercase() => true,
+        Ok(actual) => {
+            push_error(
+                issues,
+                "artifact_sha256_mismatch",
+                format!(
+                    "package artifact {} checksum mismatch: expected {}, got {}",
+                    artifact.path, artifact.sha256, actual
+                ),
+                Some(artifact.path.clone()),
+                "redownload or rebuild the package artifact so checksums match",
+            );
+            false
+        }
+        Err(error) => {
+            push_error(
+                issues,
+                "artifact_sha256_unreadable",
+                format!("cannot hash package artifact {}: {error}", artifact.path),
+                Some(artifact.path.clone()),
+                "ensure the artifact is readable before enabling checksum verification",
+            );
+            false
+        }
+    }
+}
+
+fn artifact_output(
+    artifact: &ArtifactSpec,
+    present: bool,
+    actual_artifact_bytes: Option<u64>,
+    size_matches_manifest: Option<bool>,
+    sha256_matches_manifest: Option<bool>,
+) -> PreflightArtifact {
+    PreflightArtifact {
+        role: artifact.role.to_string(),
+        layer_index: artifact.layer_index,
+        path: artifact.path.clone(),
+        present,
+        declared_artifact_bytes: artifact.artifact_bytes,
+        actual_artifact_bytes,
+        size_matches_manifest,
+        sha256_matches_manifest,
+    }
+}
+
+fn build_stage_reports(
+    manifest: &PackageManifest,
+    stages: Option<usize>,
+    report: &mut PackagePreflightReport,
+) {
+    let Some(stage_count) = stages else {
+        return;
+    };
+    if stage_count == 0 {
+        report.error(
+            "invalid_stage_count",
+            "--stages must be greater than zero",
+            Some("model-package.json".to_string()),
+            "choose a positive stage count for split preflight",
+        );
+        return;
+    }
+    if stage_count as u32 > manifest.layer_count {
+        report.error(
+            "stage_count_exceeds_layer_count",
+            format!(
+                "--stages {stage_count} exceeds package layer_count {}",
+                manifest.layer_count
+            ),
+            Some("model-package.json".to_string()),
+            "use at most one split stage per transformer layer",
+        );
+        return;
+    }
+    let artifact_map = stage_artifacts(report);
+    for (stage_index, (layer_start, layer_end)) in
+        partition_layers(manifest.layer_count, stage_count)
+            .into_iter()
+            .enumerate()
+    {
+        report.stages.push(stage_report(
+            stage_index,
+            layer_start,
+            layer_end,
+            stage_count,
+            &artifact_map,
+        ));
+    }
+}
+
+fn stage_report(
+    stage_index: usize,
+    layer_start: u32,
+    layer_end: u32,
+    stage_count: usize,
+    artifact_map: &BTreeMap<String, StageArtifact>,
+) -> PreflightStage {
+    let includes_embeddings = stage_index == 0;
+    let includes_output = stage_index + 1 == stage_count;
+    let mut parts = vec!["metadata".to_string()];
+    if includes_embeddings {
+        parts.push("embeddings".to_string());
+    }
+    for layer_index in layer_start..layer_end {
+        parts.push(format!("layer:{layer_index}"));
+    }
+    if includes_output {
+        parts.push("output".to_string());
+    }
+    let artifact_bytes = parts
+        .iter()
+        .filter_map(|part| artifact_map.get(part))
+        .filter(|artifact| artifact.present)
+        .map(|artifact| artifact.bytes)
+        .sum();
+    let missing_parts = parts
+        .iter()
+        .filter(|part| {
+            !artifact_map
+                .get(*part)
+                .is_some_and(|artifact| artifact.present)
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    PreflightStage {
+        stage_index,
+        layer_start,
+        layer_end,
+        includes_embeddings,
+        includes_output,
+        part_count: parts.len(),
+        artifact_bytes,
+        parts,
+        missing_parts,
+    }
+}
+
+#[derive(Clone, Copy)]
+struct StageArtifact {
+    present: bool,
+    bytes: u64,
+}
+
+fn stage_artifacts(report: &PackagePreflightReport) -> BTreeMap<String, StageArtifact> {
+    report
+        .artifacts
+        .iter()
+        .map(|artifact| {
+            (
+                stage_part_key(artifact),
+                StageArtifact {
+                    present: artifact.present,
+                    bytes: artifact
+                        .actual_artifact_bytes
+                        .unwrap_or(artifact.declared_artifact_bytes),
+                },
+            )
+        })
+        .collect()
+}
+
+fn stage_part_key(artifact: &PreflightArtifact) -> String {
+    match (artifact.role.as_str(), artifact.layer_index) {
+        ("layer", Some(layer)) => format!("layer:{layer}"),
+        (role, _) => role.to_string(),
+    }
+}
+
+fn partition_layers(layer_count: u32, stages: usize) -> Vec<(u32, u32)> {
+    let base = layer_count / stages as u32;
+    let extra = layer_count % stages as u32;
+    let mut start = 0;
+    (0..stages)
+        .map(|stage_index| {
+            let width = base + u32::from((stage_index as u32) < extra);
+            let end = start + width;
+            let range = (start, end);
+            start = end;
+            range
+        })
+        .collect()
+}
+
+fn safe_relative_path(path: &str) -> Result<PathBuf, String> {
+    let path = Path::new(path);
+    if path.as_os_str().is_empty() {
+        return Err("path is empty".to_string());
+    }
+    if path.is_absolute() {
+        return Err("path is absolute".to_string());
+    }
+    if path.components().any(|component| {
+        matches!(
+            component,
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir
+        )
+    }) {
+        return Err("path escapes the package directory".to_string());
+    }
+    Ok(path.to_path_buf())
+}
+
+fn push_error(
+    issues: &mut Vec<PreflightIssue>,
+    code: impl Into<String>,
+    message: impl Into<String>,
+    path: Option<String>,
+    remediation: impl Into<String>,
+) {
+    issues.push(PreflightIssue {
+        severity: PreflightSeverity::Error,
+        code: code.into(),
+        message: message.into(),
+        path,
+        remediation: remediation.into(),
+    });
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64 && value.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
+fn file_sha256(path: &Path) -> anyhow::Result<String> {
+    let mut file = File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 1024 * 1024];
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..read]);
+    }
+    Ok(hex_lower(&hasher.finalize()))
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    hex_lower(&Sha256::digest(bytes))
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn preflight_accepts_complete_package_and_reports_stage_parts() {
+        let dir = unique_test_dir("valid");
+        let package = write_package_fixture(&dir, true);
+
+        let report = preflight_package(
+            &package,
+            &PackagePreflightOptions {
+                stages: Some(2),
+                verify_sha256: true,
+            },
+        );
+
+        assert!(report.valid, "{:?}", report.issues);
+        assert_eq!(report.activation_width, Some(4096));
+        assert_eq!(report.checked_artifact_count, 5);
+        assert_eq!(report.stages.len(), 2);
+        assert_eq!(
+            report.stages[0].parts,
+            ["metadata", "embeddings", "layer:0"]
+        );
+        assert_eq!(report.stages[1].parts, ["metadata", "layer:1", "output"]);
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn preflight_rejects_missing_activation_width() {
+        let dir = unique_test_dir("missing-width");
+        let package = write_package_fixture(&dir, false);
+
+        let report = preflight_package(
+            &package,
+            &PackagePreflightOptions {
+                stages: None,
+                verify_sha256: false,
+            },
+        );
+
+        assert!(!report.valid);
+        assert_issue(&report, "missing_activation_width");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn preflight_reports_missing_shared_embedding_before_split_startup() {
+        let dir = unique_test_dir("missing-embeddings");
+        let package = write_package_fixture(&dir, true);
+        fs::remove_file(package.join("shared/embeddings.gguf")).unwrap();
+
+        let report = preflight_package(
+            &package,
+            &PackagePreflightOptions {
+                stages: Some(2),
+                verify_sha256: false,
+            },
+        );
+
+        assert!(!report.valid);
+        assert_issue(&report, "missing_artifact");
+        assert!(
+            report.stages[0]
+                .missing_parts
+                .contains(&"embeddings".to_string())
+        );
+        assert_eq!(
+            report.stages[0].artifact_bytes,
+            (b"metadata".len() + b"layer0".len()) as u64
+        );
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn preflight_detects_artifact_sha_mismatch_when_requested() {
+        let dir = unique_test_dir("sha-mismatch");
+        let package = write_package_fixture(&dir, true);
+        fs::write(package.join("layers/layer-001.gguf"), b"corrupt1").unwrap();
+
+        let report = preflight_package(
+            &package,
+            &PackagePreflightOptions {
+                stages: None,
+                verify_sha256: true,
+            },
+        );
+
+        assert!(!report.valid);
+        assert_issue(&report, "artifact_sha256_mismatch");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn artifact_sha_verification_uses_resolved_safe_path() {
+        let dir = unique_test_dir("resolved-sha-path");
+        fs::create_dir_all(&dir).unwrap();
+        let resolved = dir.join("resolved.gguf");
+        fs::write(&resolved, b"resolved").unwrap();
+        fs::write(dir.join("manifest-path.gguf"), b"other").unwrap();
+        let artifact = ArtifactSpec {
+            role: "metadata",
+            layer_index: None,
+            path: "manifest-path.gguf".to_string(),
+            tensor_count: 1,
+            tensor_bytes: b"resolved".len() as u64,
+            artifact_bytes: b"resolved".len() as u64,
+            sha256: file_sha256(&resolved).unwrap(),
+        };
+        let mut issues = Vec::new();
+
+        assert!(validate_artifact_sha(&resolved, &artifact, &mut issues));
+        assert!(issues.is_empty(), "{issues:?}");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn preflight_rejects_stage_count_above_layer_count() {
+        let dir = unique_test_dir("too-many-stages");
+        let package = write_package_fixture(&dir, true);
+
+        let report = preflight_package(
+            &package,
+            &PackagePreflightOptions {
+                stages: Some(3),
+                verify_sha256: false,
+            },
+        );
+
+        assert!(!report.valid);
+        assert_issue(&report, "stage_count_exceeds_layer_count");
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    fn assert_issue(report: &PackagePreflightReport, code: &str) {
+        assert!(
+            report.issues.iter().any(|issue| issue.code == code),
+            "missing issue {code}; issues: {:?}",
+            report.issues
+        );
+    }
+
+    fn write_package_fixture(root: &Path, include_activation_width: bool) -> PathBuf {
+        let package = root.join("package");
+        fs::create_dir_all(package.join("shared")).unwrap();
+        fs::create_dir_all(package.join("layers")).unwrap();
+        write_artifact(&package, "shared/metadata.gguf", b"metadata");
+        write_artifact(&package, "shared/embeddings.gguf", b"embeddings");
+        write_artifact(&package, "shared/output.gguf", b"output");
+        write_artifact(&package, "layers/layer-000.gguf", b"layer0");
+        write_artifact(&package, "layers/layer-001.gguf", b"layer1");
+        let mut manifest = serde_json::json!({
+            "schema_version": 1,
+            "model_id": "meshllm/test-model-layers",
+            "source_model": {
+                "path": "test-model.gguf",
+                "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            "format": "layer-package",
+            "layer_count": 2,
+            "shared": {
+                "metadata": artifact_json(&package, "shared/metadata.gguf", b"metadata"),
+                "embeddings": artifact_json(&package, "shared/embeddings.gguf", b"embeddings"),
+                "output": artifact_json(&package, "shared/output.gguf", b"output")
+            },
+            "layers": [
+                layer_json(&package, 0, "layers/layer-000.gguf", b"layer0"),
+                layer_json(&package, 1, "layers/layer-001.gguf", b"layer1")
+            ],
+            "skippy_abi_version": "1.0.0"
+        });
+        if include_activation_width {
+            manifest["activation_width"] = serde_json::json!(4096);
+        }
+        fs::write(
+            package.join("model-package.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        package
+    }
+
+    fn write_artifact(package: &Path, relative_path: &str, bytes: &[u8]) {
+        let path = package.join(relative_path);
+        fs::write(path, bytes).unwrap();
+    }
+
+    fn artifact_json(package: &Path, path: &str, bytes: &[u8]) -> serde_json::Value {
+        serde_json::json!({
+            "path": path,
+            "tensor_count": 1,
+            "tensor_bytes": bytes.len(),
+            "artifact_bytes": bytes.len(),
+            "sha256": file_sha256(&package.join(path)).unwrap()
+        })
+    }
+
+    fn layer_json(package: &Path, layer_index: u32, path: &str, bytes: &[u8]) -> serde_json::Value {
+        let mut value = artifact_json(package, path, bytes);
+        value["layer_index"] = serde_json::json!(layer_index);
+        value
+    }
+
+    fn unique_test_dir(name: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "skippy-model-package-preflight-{name}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+}

--- a/docs/LAYER_PACKAGE_REPOS.md
+++ b/docs/LAYER_PACKAGE_REPOS.md
@@ -42,18 +42,20 @@ subcommands are:
 
 ```bash
 skippy-model-package inspect <model.gguf>
-skippy-model-package plan <model.gguf>
-skippy-model-package write <model.gguf> --out ./package
-skippy-model-package write-stages <model.gguf> --out ./stages
-skippy-model-package write-package <model.gguf> --out ./package
-skippy-model-package validate ./package/model-package.json
-skippy-model-package validate-package ./package
+skippy-model-package plan <model.gguf> --stages 4
+skippy-model-package write <model.gguf> --layers 0..12 --out ./stage-0.gguf
+skippy-model-package write-stages <model.gguf> --stages 4 --out-dir ./stages
+skippy-model-package write-package <model.gguf> --out-dir ./package
+skippy-model-package validate <model.gguf> ./stages/stage-*.gguf
+skippy-model-package validate-package <model.gguf> ./package
+skippy-model-package preflight ./package --stages 4 --verify-sha256
 ```
 
 Validate before publishing:
 
 ```bash
-skippy-model-package validate-package ./package
+skippy-model-package validate-package <model.gguf> ./package
+skippy-model-package preflight ./package --stages 4 --verify-sha256
 ```
 
 ## Queue a Hugging Face package job
@@ -120,6 +122,10 @@ Run package-only certification first:
 ```bash
 mesh-llm models certify hf://namespace/repo@revision --package-only --report-out cert.json
 ```
+
+Use the immutable published ref for certification, not only the local package
+directory. Fix package-local preflight diagnostics and published-ref
+package-only certification failures before moving on to a live endpoint smoke.
 
 Then run a live endpoint smoke once the mesh is serving it:
 

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -142,6 +142,16 @@ materialization:
 mesh-llm models certify hf://meshllm/Qwen3-8B-Q4_K_M-layers --package-only --report-out cert.json
 ```
 
+Use package-only certification as the rollout preflight for published package
+refs. It should fail before a split model becomes routable when package
+resolution, manifest shape, artifact size/SHA, missing stage files,
+tokenizer/projector sidecars, or local materialization are not clean enough for
+serving. For a local package directory, run the package-local preflight first:
+
+```bash
+skippy-model-package preflight ./model-package --stages 2 --verify-sha256
+```
+
 Runtime verification additionally checks a running OpenAI-compatible endpoint:
 
 ```bash

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -325,6 +325,21 @@ mesh-llm serve --model Qwen2.5-32B --split --join <TOKEN>
 - `--listen-all` is not a substitute for this test; it only affects local
   HTTP API/console listeners.
 
+#### Split-package preflight diagnostics
+
+Before starting a package-backed split run, preflight the local package
+directory and then certify the immutable published ref:
+
+```bash
+skippy-model-package preflight ./model-package --stages 2 --verify-sha256
+mesh-llm models certify hf://namespace/repo@revision --package-only --report-out target/skippy-preflight/cert.json
+```
+
+Clean packages should pass with a machine-readable report. Deliberately broken
+packages or refs should fail before the model is advertised through `/v1/models`
+and should name the blocked manifest field, missing artifact, size/SHA mismatch,
+sidecar, or stage part.
+
 ### 4. Two GPU nodes, model too big for one
 
 When the model exceeds host VRAM, split happens automatically without `--split`.

--- a/docs/skippy/NEW_MODEL_ONBOARDING.md
+++ b/docs/skippy/NEW_MODEL_ONBOARDING.md
@@ -14,7 +14,7 @@ Issue #630, Cohere Command A+, is the first model tracked with this flow.
 | --- | --- | --- |
 | Candidate identified | A source model and at least one plausible GGUF or package artifact are known. | No support claim. |
 | Artifact inspected | GGUF metadata or package manifest gives architecture, layer count, activation width, quant, shard layout, and tokenizer sidecars. | May plan a package job. |
-| Package validated | `skippy-model-package` writes and validates a package with no missing, duplicate, or checksum-mismatched owned tensors. | May test staged serving. |
+| Package validated | `skippy-model-package` writes, validates, and preflights a package with no unresolved manifest, artifact, sidecar, materialization, missing, duplicate, or checksum diagnostics. | May test staged serving. |
 | Runtime smoke passed | A package-backed model starts and answers through the OpenAI-compatible surface. | May collect serving evidence. |
 | Family certified | Split correctness, dtype matrix, state handoff/cache policy, and required multimodal sidebands pass. | May promote to reviewed support. |
 | Reviewed support | `docs/skippy/FAMILY_STATUS.md` and reviewed topology records are updated from evidence. | User-visible support claim. |
@@ -71,7 +71,8 @@ After a package exists, validate the package and then run the certification
 surface that matches the evidence you need:
 
 ```bash
-skippy-model-package validate-package /path/to/package
+skippy-model-package validate-package /path/to/model.gguf /path/to/package
+skippy-model-package preflight /path/to/package --stages 2 --verify-sha256
 mesh-llm models certify hf://namespace/repo@revision --package-only --report-out cert.json
 mesh-llm models certify hf://namespace/repo@revision --api-base http://127.0.0.1:9337 --json
 ```


### PR DESCRIPTION
## Summary

Adds a package-local `skippy-model-package preflight` command so layer packages can be checked before they are used for split serving.

The preflight report validates the package manifest, required shared artifacts, layer coverage, projector sidecars, artifact sizes, optional SHA-256 checks, and the exact stage parts that would be required for a requested split topology.

## Issue coverage

Addresses the package-preflight and diagnostics gap behind #630 (`make splits for cohere model`). This gives new-model split onboarding a deterministic package gate before runtime smoke or public support claims.

This intentionally does not use `Closes #630`: Command A+ still needs actual package generation, pinned-model inspection/load proof, and runtime certification before the issue itself should be closed.

## Why

Recent low-VRAM split testing exposed late and hard-to-action failures such as missing `activation_width`, missing shared tensors like `token_embd.weight`, and cases where a worker appeared to receive only `model-package.json` without a clear package-local diagnosis.

Before this change, `validate-package` was useful when the full source GGUF was available, but there was no lightweight package-directory preflight that could answer: is this package complete enough to attempt split serving, and if not, what exactly is missing?

## Diff scope

- Adds `skippy-model-package preflight <package-dir>`.
- Supports `--stages <N>` to report stage ranges, required parts, and missing stage parts.
- Supports `--verify-sha256` for stronger artifact integrity checks.
- Validates manifest shape, `activation_width`, source SHA format, ABI field, required shared artifacts, layer coverage, safe relative paths, projector kind, artifact presence, artifact sizes, and optional checksums.
- Reuses the already validated artifact path for checksum reads instead of rejoining the raw manifest path.
- Computes stage byte totals from artifacts that are actually present, so missing package parts stay visible and do not inflate stage footprint diagnostics.
- Emits a machine-readable JSON report and exits non-zero when preflight has blocking diagnostics.
- Documents how package-local preflight fits before published-ref `mesh-llm models certify --package-only` and live endpoint smoke.

## Compatibility

Tooling-only change in `skippy-model-package` plus documentation updates.

No mesh protocol, runtime serving path, OpenAI surface, workflow, dependency, Cargo manifest, or lockfile changes.

## Branch integrity

- Base branch: `main`
- Validated base: `origin/main@4f52c43b6b4298062243c028cb6d58590101f5df`
- Branch state after rebase: `0 behind / 1 ahead`
- Merge base: `4f52c43b6b4298062243c028cb6d58590101f5df`
- Head commit: `506fe474eb8cbcf675928f330ec91961312b0424`

## Commit integrity

Introduced commit:

- `506fe474eb8cbcf675928f330ec91961312b0424` - `Add Skippy package preflight diagnostics`

This is one logical PR commit. The final diff is limited to `skippy-model-package` preflight CLI code and package/split onboarding docs.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: PASS, 6 intended files.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- Forbidden files: none observed.

## Validation

Validation tier: Tier 2 - narrow `skippy-model-package` CLI diagnostics plus post-review preflight evidence correction, refreshed on current main; no runtime serving, protocol, workflow, dependency, or Cargo manifest change.

Local validation:

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `4f52c43b6b4298062243c028cb6d58590101f5df`.
- `git fetch --no-tags fork codex/skippy-split-package-preflight:refs/remotes/fork/codex/skippy-split-package-preflight`: PASS.
- `git rebase origin/main`: PASS, no conflicts.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p skippy-model-package preflight`: PASS, 6 passed, 10 filtered out.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo test -p skippy-model-package --bin skippy-model-package`: PASS, 16 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo check -p skippy-model-package --bin skippy-model-package`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-abi-build-dir> cargo-clippy clippy -p skippy-model-package --all-targets -- -D warnings`: PASS.

Remote gates on head `506fe474eb8cbcf675928f330ec91961312b0424`:

- Pending - required GitHub checks were triggered by the branch update and have not completed yet.

Ledger: not applicable - not required for selected validation tier/change family.

Version: not applicable - package diagnostics/tooling only; no release/version sync required.

Not run:

- Live HF package/direct split startup smoke - not required for this local package preflight PR; deterministic manifest/artifact/stage diagnostics are covered by targeted unit tests.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

This PR does not certify Cohere Command A+ or any specific live package ref. That should remain a follow-up package/runtime certification step for #630 once the package candidate exists.
