### PR TITLE
Fix HF layer-package split serving

### DIFF
--- a/.agents/skills/skippy-bench/SKILL.md
+++ b/.agents/skills/skippy-bench/SKILL.md
@@ -23,7 +23,7 @@ Useful current checks:
 
 ```bash
 cargo test -p skippy-server --lib
-cargo test -p mesh-llm inference::skippy --lib
+cargo test -p mesh-llm-host-runtime --lib inference::skippy
 ```
 
 When benchmark harnesses are imported, keep reporting separate from request-path

--- a/.agents/skills/skippy-correctness/SKILL.md
+++ b/.agents/skills/skippy-correctness/SKILL.md
@@ -33,8 +33,8 @@ Current mesh-level checks:
 ```bash
 cargo test -p skippy-runtime --lib
 cargo test -p skippy-server --lib
-cargo test -p mesh-llm inference::skippy --lib
-cargo test -p mesh-llm --lib
+cargo test -p mesh-llm-host-runtime --lib inference::skippy
+cargo test -p mesh-llm-host-runtime --lib
 ```
 
 If `skippy-correctness` is imported later, prefer that harness for model-backed

--- a/.agents/skills/skippy-model-package/SKILL.md
+++ b/.agents/skills/skippy-model-package/SKILL.md
@@ -33,11 +33,16 @@ Useful current checks in this repo:
 ```bash
 cargo test -p skippy-runtime --lib
 cargo test -p skippy-topology --lib
-cargo test -p mesh-llm inference::skippy --lib
+cargo test -p mesh-llm-host-runtime --lib inference::skippy
 ```
 
-If standalone slicer/package CLI crates are imported later, prefer those
-repo-native commands over ad hoc scripts.
+For a published layer package, prefer package-local diagnostics before a live
+split smoke:
+
+```bash
+cargo test -p skippy-model-package --bin skippy-model-package
+skippy-model-package preflight <package-dir> --stages 2
+```
 
 ## Cache Policy
 

--- a/.agents/skills/skippy-server/SKILL.md
+++ b/.agents/skills/skippy-server/SKILL.md
@@ -34,13 +34,13 @@ Run cargo commands serially:
 cargo check -p mesh-llm
 cargo test -p skippy-server --lib
 cargo test -p skippy-protocol --lib
-cargo test -p mesh-llm inference::skippy --lib
+cargo test -p mesh-llm-host-runtime --lib inference::skippy
 ```
 
 For lifecycle/status changes, also run:
 
 ```bash
-cargo test -p mesh-llm --lib
+cargo test -p mesh-llm-host-runtime --lib
 ```
 
 ## Rules

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -674,6 +674,18 @@ jobs:
       smoke_script: scripts/ci-two-node-client-serving-smoke.sh
       timeout_minutes: 20
 
+  two_node_split_smoke:
+    needs: [changes, linux_cpu_artifact]
+    if: ${{ needs.linux_cpu_artifact.result == 'success' && needs.changes.outputs.linux_inference_artifact_required == 'true' && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.all_rust == 'true' || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'skippy-server') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'skippy-runtime') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'model-artifact')) && needs.changes.outputs.docs_only != 'true' }}
+    uses: ./.github/workflows/scripted-binary-smoke.yml
+    with:
+      artifact_name: ci-linux-inference-binaries
+      artifact_path: ci-artifacts/linux
+      staged_binary_path: target/debug/mesh-llm
+      model_cache_scope: two-node-split-smoke-model
+      smoke_script: scripts/ci-two-node-split-smoke.sh
+      timeout_minutes: 25
+
   native_sdk_smoke:
     needs: [changes, linux_cpu_artifact]
     if: ${{ needs.linux_cpu_artifact.result == 'success' && needs.changes.outputs.linux_inference_artifact_required == 'true' && needs.changes.outputs.sdk_smoke_required == 'true' && needs.changes.outputs.docs_only != 'true' }}

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -1040,8 +1040,7 @@ fn download_hf_package_to_local_sync(
             *total_bytes,
             Some(Arc::clone(&package_scope)),
             index + 1,
-        )
-        .with_context(|| format!("download layer package file: {file_name}"))?;
+        )?;
     }
 
     verify_resolved_hf_package_files(

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -31,6 +31,12 @@ fn fake_package_identity(layer_count: u32) -> SkippyPackageIdentity {
     }
 }
 
+fn fake_hf_package_identity(layer_count: u32) -> SkippyPackageIdentity {
+    let mut package = fake_package_identity(layer_count);
+    package.package_ref = "hf://meshllm/Qwen3-8B-Q4_K_M-layers".to_string();
+    package
+}
+
 fn parse_config(toml: &str) -> MeshConfig {
     toml::from_str(toml).expect("config should parse")
 }
@@ -685,6 +691,32 @@ draft_max_tokens = 8
         openai.wire_dtype,
         skippy_protocol::binary::WireActivationDType::Q8
     );
+}
+
+#[test]
+fn layer_package_translation_does_not_treat_hf_ref_as_direct_gguf() {
+    let config = MeshConfig::default();
+    let package_ref = "hf://meshllm/Qwen3-8B-Q4_K_M-layers";
+    let resolved = resolve_skippy_config(SkippyConfigResolveRequest {
+        mesh_config: &config,
+        model_id: "meshllm/Qwen3-8B-Q4_K_M-layers",
+        model_path: Path::new(package_ref),
+        model_bytes: 5 * 1024 * 1024 * 1024,
+        allocatable_memory_bytes: None,
+        request_defaults: None,
+    })
+    .unwrap();
+
+    let options = resolved
+        .to_embedded_runtime_options(
+            &SkippyTelemetryOptions::off(),
+            Some(fake_hf_package_identity(36)),
+            LoadMode::LayerPackage,
+        )
+        .unwrap();
+
+    assert_eq!(options.config.load_mode, LoadMode::LayerPackage);
+    assert_eq!(options.config.model_path.as_deref(), Some(package_ref));
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/translation.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/translation.rs
@@ -45,6 +45,16 @@ impl ResolvedSkippyConfig {
         } else {
             self.ensure_embedded_openai_safe(true)?;
         }
+        let options = self.base_model_load_options(telemetry);
+        let stage_config = single_stage_config(&options)?;
+        let family_policy =
+            family_policy_for_model_path(&self.hardware.resolved_model_path, Some(&self.model_id));
+        let kv_cache = self
+            .resolve_stage_kv_cache(family_policy.stage_kv_cache_config_for_stage(&stage_config))?;
+        Ok(options.with_kv_cache(kv_cache))
+    }
+
+    fn base_model_load_options(&self, telemetry: SkippyTelemetryOptions) -> SkippyModelLoadOptions {
         let mut options = SkippyModelLoadOptions::for_direct_gguf(
             self.model_id.clone(),
             self.hardware.resolved_model_path.clone(),
@@ -76,12 +86,7 @@ impl ResolvedSkippyConfig {
                 vram_bytes: None,
             });
         }
-        let stage_config = single_stage_config(&options)?;
-        let family_policy =
-            family_policy_for_model_path(&self.hardware.resolved_model_path, Some(&self.model_id));
-        let kv_cache = self
-            .resolve_stage_kv_cache(family_policy.stage_kv_cache_config_for_stage(&stage_config))?;
-        Ok(options.with_kv_cache(kv_cache))
+        options
     }
 
     pub(crate) fn to_stage_config(
@@ -89,8 +94,8 @@ impl ResolvedSkippyConfig {
         package_identity: Option<SkippyPackageIdentity>,
         load_mode: LoadMode,
     ) -> Result<StageConfig> {
-        let mut load_options =
-            self.build_model_load_options(SkippyTelemetryOptions::off(), true)?;
+        self.ensure_embedded_openai_safe(true)?;
+        let mut load_options = self.base_model_load_options(SkippyTelemetryOptions::off());
         if let Some(package_identity) = package_identity {
             load_options.package_identity = Some(package_identity.clone());
             if self.hardware.stage_layer_end.is_none() {

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
@@ -11,7 +11,9 @@ use anyhow::Result;
 use skippy_protocol::LoadMode;
 use tokio::sync::Mutex;
 
-use crate::inference::skippy::materialization::{inspect_stage_package, is_layer_package_ref};
+use crate::inference::skippy::materialization::{
+    inspect_stage_package, is_layer_package_ref, resolve_stage_load_package,
+};
 
 use super::{
     SourceModelKind, StageInventoryRequest, StageLoadRequest, StagePackagePrefetcher,
@@ -129,12 +131,10 @@ pub(super) async fn run_stage_prepare_task(
         Err(error) => {
             let mut status =
                 preparation_status_from_load(&load, StagePreparationState::Failed, None);
-            status.error = Some(match peer_prefetch_error {
-                Some(prefetch_error) => {
-                    format!("{error}; peer artifact prefetch failed: {prefetch_error}")
-                }
-                None => error.to_string(),
-            });
+            status.error = Some(format_stage_prepare_error(
+                &error,
+                peer_prefetch_error.as_deref(),
+            ));
             status
         }
     };
@@ -161,14 +161,25 @@ async fn prefetch_stage_package_if_needed(
     match prefetcher.prefetch_stage_package(request).await {
         Ok(()) => None,
         Err(error) => {
+            let error_message = format!("{error:#}");
             tracing::debug!(
                 topology_id = %load.topology_id,
                 run_id = %load.run_id,
                 stage_id = %load.stage_id,
-                "peer artifact prefetch failed, falling back to local/HF resolver: {error}"
+                "peer artifact prefetch failed, falling back to local/HF resolver: {error_message}"
             );
-            Some(error.to_string())
+            Some(error_message)
         }
+    }
+}
+
+fn format_stage_prepare_error(error: &anyhow::Error, peer_prefetch_error: Option<&str>) -> String {
+    let message = format!("{error:#}");
+    match peer_prefetch_error {
+        Some(prefetch_error) => {
+            format!("{message}; peer artifact prefetch failed: {prefetch_error}")
+        }
+        None => message,
     }
 }
 
@@ -178,9 +189,12 @@ struct PrepareSourceResult {
 
 async fn prepare_stage_source(load: &StageLoadRequest) -> Result<PrepareSourceResult> {
     if load.load_mode == LoadMode::LayerPackage || is_layer_package_ref(&load.package_ref) {
-        let info = inspect_stage_package(&load.package_ref)?;
+        let load = load.clone();
+        let package = tokio::task::spawn_blocking(move || resolve_stage_load_package(&load))
+            .await??
+            .ok_or_else(|| anyhow::anyhow!("layer package load did not resolve a package"))?;
         return Ok(PrepareSourceResult {
-            bytes_total: info.source_model_bytes,
+            bytes_total: package.source_model_bytes,
         });
     }
 
@@ -227,4 +241,33 @@ async fn update_preparation(
     }
     preparations.insert(key.to_string(), status);
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::format_stage_prepare_error;
+
+    #[test]
+    fn stage_prepare_error_preserves_source_chain() {
+        let error = anyhow!("No locks available (os error 77)")
+            .context("download layer package file: shared/embeddings.gguf");
+
+        let message = format_stage_prepare_error(&error, None);
+
+        assert!(message.contains("download layer package file: shared/embeddings.gguf"));
+        assert!(message.contains("No locks available (os error 77)"));
+    }
+
+    #[test]
+    fn stage_prepare_error_includes_prefetch_source_chain() {
+        let error = anyhow!("No locks available (os error 77)")
+            .context("download layer package file: shared/embeddings.gguf");
+
+        let message = format_stage_prepare_error(&error, Some("peer refused package"));
+
+        assert!(message.contains("No locks available (os error 77)"));
+        assert!(message.contains("peer artifact prefetch failed: peer refused package"));
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -5920,6 +5920,43 @@ impl Node {
         }
     }
 
+    async fn execute_stage_control_request_for_peer(
+        &self,
+        remote: EndpointId,
+        request: crate::inference::skippy::StageControlRequest,
+    ) -> anyhow::Result<crate::inference::skippy::StageControlResponse> {
+        match self.execute_stage_control_request(request.clone()).await {
+            Ok(response) => Ok(response),
+            Err(error) => Self::stage_control_load_failure_response(remote, request, error),
+        }
+    }
+
+    fn stage_control_load_failure_response(
+        remote: EndpointId,
+        request: crate::inference::skippy::StageControlRequest,
+        error: anyhow::Error,
+    ) -> anyhow::Result<crate::inference::skippy::StageControlResponse> {
+        let crate::inference::skippy::StageControlRequest::Load(load) = request else {
+            return Err(error);
+        };
+        let error_message = format!("{error:#}");
+        tracing::warn!(
+            peer = %remote.fmt_short(),
+            stage_id = %load.stage_id,
+            "stage load failed: {error_message}"
+        );
+        let mut status =
+            stage_status_from_load(&load, crate::inference::skippy::StageRuntimeState::Failed);
+        status.error = Some(error_message.clone());
+        Ok(crate::inference::skippy::StageControlResponse::Ready(
+            crate::inference::skippy::StageReadyResponse {
+                accepted: false,
+                status,
+                error: Some(error_message),
+            },
+        ))
+    }
+
     async fn handle_stage_control(
         &self,
         remote: EndpointId,
@@ -5949,7 +5986,9 @@ impl Node {
             self.record_stage_topology(stage_topology_from_load(self.endpoint.id(), load))
                 .await;
         }
-        let response = self.execute_stage_control_request(request).await?;
+        let response = self
+            .execute_stage_control_request_for_peer(remote, request)
+            .await?;
         self.record_stage_control_response(&response).await;
         let status_list_supported = self
             .peer_supports_skippy_subprotocol_feature(

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3099,12 +3099,7 @@ async fn wait_for_split_stage_source(
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         let inventory = query_stage_inventory(node, stage_node_id, load).await?;
-        if inventory
-            .available_ranges
-            .iter()
-            .chain(inventory.ready_ranges.iter())
-            .any(|range| range.layer_start <= load.layer_start && range.layer_end >= load.layer_end)
-        {
+        if split_stage_source_is_ready(&inventory, load) {
             tracing::info!(
                 topology_id = %load.topology_id,
                 run_id = %load.run_id,
@@ -3133,6 +3128,44 @@ async fn wait_for_split_stage_source(
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
+}
+
+fn split_stage_source_is_ready(
+    inventory: &skippy::StageLayerInventory,
+    load: &skippy::StageLoadRequest,
+) -> bool {
+    let ready_running_stage = inventory
+        .ready_ranges
+        .iter()
+        .any(|range| split_layer_range_covers(range, load));
+    if ready_running_stage {
+        return true;
+    }
+    if load.load_mode != LoadMode::LayerPackage && !skippy::is_layer_package_ref(&load.package_ref)
+    {
+        return inventory
+            .available_ranges
+            .iter()
+            .any(|range| split_layer_range_covers(range, load));
+    }
+    inventory.preparing_ranges.iter().any(|status| {
+        status.topology_id == load.topology_id
+            && status.run_id == load.run_id
+            && status.stage_id == load.stage_id
+            && status.model_id == load.model_id
+            && status.package_ref == load.package_ref
+            && status.manifest_sha256 == load.manifest_sha256
+            && status.layer_start <= load.layer_start
+            && status.layer_end >= load.layer_end
+            && matches!(
+                status.state,
+                skippy::StagePreparationState::Available | skippy::StagePreparationState::Ready
+            )
+    })
+}
+
+fn split_layer_range_covers(range: &skippy::LayerRange, load: &skippy::StageLoadRequest) -> bool {
+    range.layer_start <= load.layer_start && range.layer_end >= load.layer_end
 }
 
 async fn query_stage_inventory(
@@ -3477,6 +3510,48 @@ mod tests {
             layer_count,
             activation_width: 2048,
             tensor_count: 100,
+        }
+    }
+
+    fn stage_load_request(load_mode: LoadMode) -> skippy::StageLoadRequest {
+        skippy::StageLoadRequest {
+            topology_id: "topology-a".to_string(),
+            run_id: "run-a".to_string(),
+            model_id: "model-a".to_string(),
+            backend: "skippy".to_string(),
+            package_ref: match load_mode {
+                LoadMode::LayerPackage => "hf://meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+                LoadMode::RuntimeSlice | LoadMode::ArtifactSlice => {
+                    "gguf:///models/qwen.gguf".to_string()
+                }
+            },
+            manifest_sha256: "a".repeat(64),
+            stage_id: "stage-1".to_string(),
+            stage_index: 1,
+            layer_start: 18,
+            layer_end: 36,
+            model_path: Some("/models/qwen.gguf".to_string()),
+            source_model_bytes: Some(4_900_000_000),
+            projector_path: None,
+            selected_device: None,
+            bind_addr: "127.0.0.1:0".to_string(),
+            activation_width: 4096,
+            wire_dtype: skippy::StageWireDType::F16,
+            ctx_size: 8192,
+            lane_count: 4,
+            n_batch: Some(2048),
+            n_ubatch: Some(512),
+            n_gpu_layers: -1,
+            cache_type_k: "f16".to_string(),
+            cache_type_v: "f16".to_string(),
+            flash_attn_type: FlashAttentionType::Auto,
+            shutdown_generation: 1,
+            coordinator_term: 1,
+            coordinator_id: None,
+            lease_until_unix_ms: u64::MAX,
+            load_mode,
+            upstream: None,
+            downstream: None,
         }
     }
 
@@ -4305,6 +4380,60 @@ max_tokens = 222
 
         assert!(!signal.can_stage_with(&package, false));
         assert!(signal.can_stage_with(&package, true));
+    }
+
+    #[test]
+    fn layer_package_stage_source_waits_for_exact_prepare_availability() {
+        let load = stage_load_request(LoadMode::LayerPackage);
+        let mut inventory = skippy::StageLayerInventory {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+            layer_count: 36,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 36,
+            }],
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: Some(
+                "/cache/models--meshllm--Qwen3-8B-Q4_K_M-layers/snapshots/main".to_string(),
+            ),
+            source_model_bytes: Some(4_900_000_000),
+            source_model_kind: skippy::SourceModelKind::LayerPackage,
+        };
+
+        assert!(!split_stage_source_is_ready(&inventory, &load));
+
+        inventory
+            .preparing_ranges
+            .push(test_preparation_status_from_load(&load));
+
+        assert!(split_stage_source_is_ready(&inventory, &load));
+    }
+
+    #[test]
+    fn runtime_slice_stage_source_accepts_inventory_availability() {
+        let load = stage_load_request(LoadMode::RuntimeSlice);
+        let inventory = skippy::StageLayerInventory {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+            layer_count: 36,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 36,
+            }],
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: Some("/models/qwen.gguf".to_string()),
+            source_model_bytes: Some(4_900_000_000),
+            source_model_kind: skippy::SourceModelKind::PlainGguf,
+        };
+
+        assert!(split_stage_source_is_ready(&inventory, &load));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -4820,7 +4820,9 @@ max_tokens = 222
         node.set_stage_control_sender(control_tx).await;
 
         let requests = Arc::new(StdMutex::new(Vec::new()));
+        let preparations = Arc::new(StdMutex::new(Vec::<skippy::StagePreparationStatus>::new()));
         let captured_requests = Arc::clone(&requests);
+        let captured_preparations = Arc::clone(&preparations);
         tokio::spawn(async move {
             while let Some(command) = control_rx.recv().await {
                 captured_requests
@@ -4829,18 +4831,30 @@ max_tokens = 222
                     .push(command.request.clone());
                 let response = match &command.request {
                     skippy::StageControlRequest::Prepare(prepare) => {
+                        let status = test_preparation_status_from_load(&prepare.load);
+                        captured_preparations.lock().unwrap().push(status.clone());
                         Ok(skippy::StageControlResponse::PrepareAccepted(
                             skippy::StagePrepareAcceptedResponse {
                                 accepted: true,
-                                status: test_preparation_status_from_load(&prepare.load),
+                                status,
                                 error: None,
                             },
                         ))
                     }
                     skippy::StageControlRequest::Inventory(inventory) => {
-                        Ok(skippy::StageControlResponse::Inventory(
-                            test_inventory_from_request(inventory),
-                        ))
+                        let mut response = test_inventory_from_request(inventory);
+                        response.preparing_ranges = captured_preparations
+                            .lock()
+                            .unwrap()
+                            .iter()
+                            .filter(|status| {
+                                status.model_id == inventory.model_id
+                                    && status.package_ref == inventory.package_ref
+                                    && status.manifest_sha256 == inventory.manifest_sha256
+                            })
+                            .cloned()
+                            .collect();
+                        Ok(skippy::StageControlResponse::Inventory(response))
                     }
                     skippy::StageControlRequest::Claim(claim) => {
                         Ok(skippy::StageControlResponse::ClaimAccepted(

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -619,8 +619,8 @@ Local burn-in checklist:
 - `cargo test -p openai-frontend --lib`
 - `cargo test -p metrics-server`
 - `cargo check -p mesh-llm`
-- `cargo test -p mesh-llm inference::skippy --lib`
-- `cargo test -p mesh-llm --lib`
+- `cargo test -p mesh-llm-host-runtime --lib inference::skippy`
+- `cargo test -p mesh-llm-host-runtime --lib`
 - metrics-server fixture ingest/finalize/report export
 
 ## Stage Failure Recovery

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -39,6 +39,47 @@ Other peers join the mesh normally:
 mesh-llm serve --join <token>
 ```
 
+## Two-node split smoke test
+
+Use the same layer-package model on every serving node. Each node resolves the
+package and downloads only the shared artifacts plus the layer files needed for
+its assigned stage.
+
+```bash
+# node A: starts the private mesh and becomes the coordinator
+mesh-llm serve \
+  --model meshllm/Qwen3-8B-Q4_K_M-layers \
+  --split \
+  --max-vram 5 \
+  --bind-port 7842 \
+  --port 9447 \
+  --console 3232
+
+# node B: joins with the token printed by node A
+mesh-llm serve \
+  --model meshllm/Qwen3-8B-Q4_K_M-layers \
+  --split \
+  --max-vram 5 \
+  --join <token> \
+  --bind-port 7843 \
+  --port 9447 \
+  --console 3232
+```
+
+For hosts with more than one network interface, add `--bind-ip <lan-ip>` on
+each node so the invite token and gossip advertise the routable address.
+
+Once both stages are ready:
+
+```bash
+curl -sS http://127.0.0.1:3232/api/status | jq '{state:.node_state, ready:.llama_ready, peers:(.peers|length), stages:.runtime.stages}'
+curl -sS http://127.0.0.1:9447/v1/models | jq '.data[].id'
+curl -sS http://127.0.0.1:9447/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer mesh' \
+  -d '{"model":"meshllm/Qwen3-8B-Q4_K_M-layers","messages":[{"role":"user","content":"Reply with OK"}],"max_tokens":16}'
+```
+
 ## Use a local GGUF
 
 Direct GGUFs still work:

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -215,7 +215,7 @@ Goose, Pi, or OpenCode for broad smoke coverage.
 ### 1. Solo (single node)
 
 ```bash
-mesh-llm serve --model Qwen2.5-3B --console
+mesh-llm serve --model Qwen2.5-3B --console 3131
 ```
 
 - API on `:9337`, console on `:3131`
@@ -251,16 +251,66 @@ mesh-llm serve --model Qwen2.5-32B --join <TOKEN>
 ### 3. Two GPU nodes, forced split
 
 ```bash
-# host with --split
-mesh-llm serve --model Qwen2.5-32B --bind-port 7842 --split
-# worker joins
-mesh-llm serve --model Qwen2.5-32B --join <TOKEN>
+# node A (coordinator)
+mesh-llm serve \
+  --model meshllm/Qwen3-8B-Q4_K_M-layers \
+  --split \
+  --max-vram 5 \
+  --bind-port 7842 \
+  --port 9447 \
+  --console 3232
+
+# node B (worker)
+mesh-llm serve \
+  --model meshllm/Qwen3-8B-Q4_K_M-layers \
+  --split \
+  --max-vram 5 \
+  --join <TOKEN> \
+  --bind-port 7843 \
+  --port 9447 \
+  --console 3232
 ```
 
 - `--split` forces staged execution even when the model fits on the host
-- Embedded runtime assigns two participating stage routes
+- Use a published layer package (`*-layers`) so each node downloads only the
+  shared artifacts and layer files assigned to its stage.
+- Embedded runtime assigns participating stage routes
 - Stage placement is proportional to available VRAM (e.g. `0.67,0.33`)
-- Draft model auto-detected and used
+- If `--max-vram` is too low, planning should fail before startup with the
+  required memory estimate. In lab testing, `3` GB was too low for this Qwen3
+  8B package at the default context, while `5` GB per node reached readiness.
+- Wait for `/api/status` on the coordinator to show `node_state="serving"`,
+  `llama_ready=true`, a ready runtime stage, and one peer.
+- `GET /v1/models` should list the full layer-package model id.
+- A short `/v1/chat/completions` request should return an OpenAI-shaped
+  response from the layer-package model.
+
+> **CI gap (TODO):** There is no CI test for this scenario. The closest CI
+> coverage today is:
+>
+> - `scripts/ci-two-node-client-serving-smoke.sh` — two nodes, but only tests
+>   `client` -> `serve` routing. The model is held entirely on one node.
+> - `scripts/skippy-ci-smoke.sh` — exercises 3-stage layer splits via
+>   `skippy-correctness chain`, but all stages run on `127.0.0.1` in a single
+>   runner. It validates the staged-runtime ABI, not mesh-llm node-to-node
+>   split serving over QUIC.
+>
+> Cross-node split via `--split` / `--join` / `--max-vram` is currently only
+> validated manually (lab nodes, `mic-lab` skill). A future CI smoke should:
+>
+> 1. Start node A: `mesh-llm serve --model <tiny-gguf> --split --max-vram <small> --bind-port <p>`
+> 2. Start node B: `mesh-llm serve --model <tiny-gguf> --split --max-vram <small> --join <TOKEN>`
+>    — pick `--max-vram` low enough on both sides that neither node can hold
+>    the model alone, so the runtime is forced to actually split across the
+>    mesh rather than fall back to single-host serving.
+> 3. Wait for `/api/status` on both nodes to show `peers >= 1` and
+>    `/v1/models` to become non-empty.
+> 4. Send a short `/v1/chat/completions` against either node and assert a
+>    valid OpenAI-shaped response.
+>
+> Use real flags only: `--split`, `--max-vram`, `--join`, `--bind-port`,
+> `--port`, `--console`. There is no `--layer-range` flag — layer placement
+> is decided by the runtime from advertised VRAM, not pinned by CLI.
 
 #### Multi-interface Docker/Linux bind-IP validation
 
@@ -304,7 +354,7 @@ mesh-llm client --join <TOKEN> --port 9555
 
 ```bash
 # node A: seeds mesh with two models, serves 3B
-mesh-llm serve --model Qwen2.5-3B --model GLM-4.7-Flash --console
+mesh-llm serve --model Qwen2.5-3B --model GLM-4.7-Flash --console 3131
 # node B: joins, auto-assigned to GLM (needed, on disk)
 mesh-llm serve --join <TOKEN>
 ```
@@ -359,7 +409,7 @@ mesh-llm unload GLM-4.7-Flash-Q4_K_M
 
 ```bash
 # Running node
-mesh-llm serve --model Qwen2.5-0.5B-Instruct-Q4_K_M --console
+mesh-llm serve --model Qwen2.5-0.5B-Instruct-Q4_K_M --console 3131
 
 # Operator surface
 mesh-llm load Llama-3.2-1B-Instruct-Q4_K_M
@@ -731,10 +781,10 @@ Without this, both processes share `~/.mesh-llm/key` and appear as the same node
 
 ```bash
 # Terminal 1: host with --split
-mesh-llm serve --model Qwen2.5-3B --port 9337 --split --console
+mesh-llm serve --model Qwen2.5-3B --port 9337 --console 3131 --split
 
 # Terminal 2: worker with ephemeral key
-MESH_LLM_EPHEMERAL_KEY=1 mesh-llm serve --model Qwen2.5-3B --join <TOKEN> --port 9338 --split --max-vram 1
+MESH_LLM_EPHEMERAL_KEY=1 mesh-llm serve --model Qwen2.5-3B --join <TOKEN> --port 9338 --console 3145 --split --max-vram 1
 ```
 
 - Host starts solo, then re-elects with split when worker joins

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -285,8 +285,13 @@ mesh-llm serve \
 - A short `/v1/chat/completions` request should return an OpenAI-shaped
   response from the layer-package model.
 
-> **CI gap (TODO):** There is no CI test for this scenario. The closest CI
-> coverage today is:
+> **CI coverage:** `two_node_split_smoke` runs
+> `scripts/ci-two-node-split-smoke.sh` against the Linux inference binary and a
+> tiny GGUF. It starts two serving nodes, waits for a topology with stages on
+> two distinct nodes, checks `/v1/models`, and sends a short
+> `/v1/chat/completions` request through stage 0.
+>
+> Other nearby CI coverage:
 >
 > - `scripts/ci-two-node-client-serving-smoke.sh` — two nodes, but only tests
 >   `client` -> `serve` routing. The model is held entirely on one node.
@@ -294,19 +299,6 @@ mesh-llm serve \
 >   `skippy-correctness chain`, but all stages run on `127.0.0.1` in a single
 >   runner. It validates the staged-runtime ABI, not mesh-llm node-to-node
 >   split serving over QUIC.
->
-> Cross-node split via `--split` / `--join` / `--max-vram` is currently only
-> validated manually (lab nodes, `mic-lab` skill). A future CI smoke should:
->
-> 1. Start node A: `mesh-llm serve --model <tiny-gguf> --split --max-vram <small> --bind-port <p>`
-> 2. Start node B: `mesh-llm serve --model <tiny-gguf> --split --max-vram <small> --join <TOKEN>`
->    — pick `--max-vram` low enough on both sides that neither node can hold
->    the model alone, so the runtime is forced to actually split across the
->    mesh rather than fall back to single-host serving.
-> 3. Wait for `/api/status` on both nodes to show `peers >= 1` and
->    `/v1/models` to become non-empty.
-> 4. Send a short `/v1/chat/completions` against either node and assert a
->    valid OpenAI-shaped response.
 >
 > Use real flags only: `--split`, `--max-vram`, `--join`, `--bind-port`,
 > `--port`, `--console`. There is no `--layer-range` flag — layer placement

--- a/docs/index.html
+++ b/docs/index.html
@@ -58,6 +58,7 @@
         <div class="links">
             <a href="#install">Quick start</a>
             <a href="#models">Models</a>
+            <a href="#splits">Splits</a>
             <a href="#agents">Agents</a>
             <a href="#blackboard">Blackboard</a>
             <a href="#features">Features</a>
@@ -328,6 +329,37 @@
         </table>
         </div>
         <p style="font-size:0.75rem; color:var(--text3); margin-top:0.8rem;">Full catalog: <code>mesh-llm download</code> · Not in the catalog? Use a HuggingFace URL — any GGUF works.</p>
+    </section>
+
+    <section id="splits">
+        <div class="section-tag">Split serving</div>
+        <h2>Run one model across two nodes</h2>
+        <p class="section-lead">Use a published layer package and start every serving node with the same model id. The coordinator picks layer ranges; each node downloads the shared artifacts and layer files it needs for its assigned stage.</p>
+
+        <div class="code-block">
+            <span class="comment"># Node A: coordinator. Copy the printed token.</span><br>
+            <span class="cmd">mesh-llm</span> serve \<br>
+            &nbsp;&nbsp;<span class="flag">--model</span> <span class="val">meshllm/Qwen3-8B-Q4_K_M-layers</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--split</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--max-vram</span> <span class="val">5</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--bind-port</span> <span class="val">7842</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--port</span> <span class="val">9447</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--console</span> <span class="val">3232</span><br><br>
+            <span class="comment"># Node B: worker. Use the token from node A.</span><br>
+            <span class="cmd">mesh-llm</span> serve \<br>
+            &nbsp;&nbsp;<span class="flag">--model</span> <span class="val">meshllm/Qwen3-8B-Q4_K_M-layers</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--split</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--max-vram</span> <span class="val">5</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--join</span> <span class="val">&lt;token&gt;</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--bind-port</span> <span class="val">7843</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--port</span> <span class="val">9447</span> \<br>
+            &nbsp;&nbsp;<span class="flag">--console</span> <span class="val">3232</span><br><br>
+            <span class="comment"># Verify from node A</span><br>
+            <span class="cmd">curl</span> <span class="val">http://127.0.0.1:9447/v1/models</span><br>
+            <span class="cmd">curl</span> <span class="val">http://127.0.0.1:3232/api/status</span>
+        </div>
+
+        <p style="font-size:0.82rem; color:var(--text2); margin-top:1rem;">On multi-interface hosts, add <code>--bind-ip &lt;lan-ip&gt;</code> on each node so peers advertise a reachable address. If planning says the model needs more memory, increase <code>--max-vram</code> or use a smaller context/model.</p>
     </section>
 
     <section id="blackboard">

--- a/docs/index.html
+++ b/docs/index.html
@@ -341,25 +341,19 @@
             <span class="cmd">mesh-llm</span> serve \<br>
             &nbsp;&nbsp;<span class="flag">--model</span> <span class="val">meshllm/Qwen3-8B-Q4_K_M-layers</span> \<br>
             &nbsp;&nbsp;<span class="flag">--split</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--max-vram</span> <span class="val">5</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--bind-port</span> <span class="val">7842</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--port</span> <span class="val">9447</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--console</span> <span class="val">3232</span><br><br>
+            &nbsp;&nbsp;<span class="flag">--max-vram</span> <span class="val">5</span><br><br>
             <span class="comment"># Node B: worker. Use the token from node A.</span><br>
             <span class="cmd">mesh-llm</span> serve \<br>
             &nbsp;&nbsp;<span class="flag">--model</span> <span class="val">meshllm/Qwen3-8B-Q4_K_M-layers</span> \<br>
             &nbsp;&nbsp;<span class="flag">--split</span> \<br>
             &nbsp;&nbsp;<span class="flag">--max-vram</span> <span class="val">5</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--join</span> <span class="val">&lt;token&gt;</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--bind-port</span> <span class="val">7843</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--port</span> <span class="val">9447</span> \<br>
-            &nbsp;&nbsp;<span class="flag">--console</span> <span class="val">3232</span><br><br>
+            &nbsp;&nbsp;<span class="flag">--join</span> <span class="val">&lt;token&gt;</span><br><br>
             <span class="comment"># Verify from node A</span><br>
-            <span class="cmd">curl</span> <span class="val">http://127.0.0.1:9447/v1/models</span><br>
-            <span class="cmd">curl</span> <span class="val">http://127.0.0.1:3232/api/status</span>
+            <span class="cmd">curl</span> <span class="val">http://127.0.0.1:9337/v1/models</span><br>
+            <span class="cmd">curl</span> <span class="val">http://127.0.0.1:3131/api/status</span>
         </div>
 
-        <p style="font-size:0.82rem; color:var(--text2); margin-top:1rem;">On multi-interface hosts, add <code>--bind-ip &lt;lan-ip&gt;</code> on each node so peers advertise a reachable address. If planning says the model needs more memory, increase <code>--max-vram</code> or use a smaller context/model.</p>
+        <p style="font-size:0.82rem; color:var(--text2); margin-top:1rem;">Defaults are API <code>:9337</code> and console <code>:3131</code>. On multi-interface hosts, add <code>--bind-ip &lt;lan-ip&gt;</code> so peers advertise a reachable address. If planning says the model needs more memory, increase <code>--max-vram</code> or use a smaller context/model.</p>
     </section>
 
     <section id="blackboard">

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# ci-two-node-split-smoke.sh - verify real two-node split serving.
+#
+# Usage: scripts/ci-two-node-split-smoke.sh <mesh-llm-binary> <bin-dir> <model-path-or-ref>
+#
+# Unlike ci-two-node-client-serving-smoke.sh, both processes are serving nodes.
+# The smoke requires the runtime to publish a topology with stages on at least
+# two distinct nodes before it sends an OpenAI chat request through stage 0.
+
+set -euo pipefail
+
+MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path-or-ref>}"
+BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path-or-ref>}"
+MODEL="${MESH_TWO_NODE_SPLIT_MODEL:-${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path-or-ref>}}"
+
+SEED_API_PORT="${MESH_TWO_NODE_SPLIT_SEED_API_PORT:-9367}"
+SEED_CONSOLE_PORT="${MESH_TWO_NODE_SPLIT_SEED_CONSOLE_PORT:-3161}"
+SEED_BIND_PORT="${MESH_TWO_NODE_SPLIT_SEED_BIND_PORT:-53647}"
+WORKER_API_PORT="${MESH_TWO_NODE_SPLIT_WORKER_API_PORT:-9368}"
+WORKER_CONSOLE_PORT="${MESH_TWO_NODE_SPLIT_WORKER_CONSOLE_PORT:-3162}"
+WORKER_BIND_PORT="${MESH_TWO_NODE_SPLIT_WORKER_BIND_PORT:-53648}"
+MAX_WAIT="${MESH_TWO_NODE_SPLIT_MAX_WAIT:-300}"
+CTX_SIZE="${MESH_TWO_NODE_SPLIT_CTX_SIZE:-}"
+MAX_VRAM="${MESH_TWO_NODE_SPLIT_MAX_VRAM:-1}"
+DEVICE="${MESH_TWO_NODE_SPLIT_DEVICE:-CPU}"
+WORK_DIR="${MESH_TWO_NODE_SPLIT_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/mesh-two-node-split.XXXXXX")}"
+# Keep this under /tmp with a short prefix because plugin Unix socket paths
+# must fit platform SUN_LEN limits, especially on macOS where TMPDIR is long.
+PROCESS_ROOT="${MESH_TWO_NODE_SPLIT_PROCESS_ROOT:-$(mktemp -d "/tmp/m2split.XXXXXX")}"
+SEED_LOG="${WORK_DIR}/seed.log"
+WORKER_LOG="${WORK_DIR}/worker.log"
+
+echo "=== CI Two-Node Split Smoke ==="
+echo "  mesh-llm:       $MESH_LLM"
+echo "  bin-dir:        $BIN_DIR (compatibility placeholder)"
+echo "  model:          $MODEL"
+echo "  seed api:       $SEED_API_PORT"
+echo "  seed console:   $SEED_CONSOLE_PORT"
+echo "  seed bind:      $SEED_BIND_PORT"
+echo "  worker api:     $WORKER_API_PORT"
+echo "  worker console: $WORKER_CONSOLE_PORT"
+echo "  worker bind:    $WORKER_BIND_PORT"
+echo "  ctx size:       ${CTX_SIZE:-model default}"
+echo "  max vram:       ${MAX_VRAM}GB"
+echo "  device:         $DEVICE"
+
+if [[ ! -x "$MESH_LLM" ]]; then
+    echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
+    exit 1
+fi
+
+descendant_pids() {
+    local pid="$1"
+    local children
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    for child in $children; do
+        descendant_pids "$child"
+        printf '%s\n' "$child"
+    done
+}
+
+kill_tree() {
+    local pid="${1:-}"
+    [[ -n "$pid" ]] || return 0
+    local children
+    children="$(descendant_pids "$pid" | sort -u || true)"
+    kill "$pid" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill 2>/dev/null || true
+    fi
+    sleep 1
+    kill -9 "$pid" 2>/dev/null || true
+    if [[ -n "$children" ]]; then
+        printf '%s\n' "$children" | xargs kill -9 2>/dev/null || true
+    fi
+    wait "$pid" 2>/dev/null || true
+}
+
+SEED_PID=""
+WORKER_PID=""
+cleanup() {
+    kill_tree "$WORKER_PID"
+    kill_tree "$SEED_PID"
+    echo "--- seed log tail ---"
+    tail -160 "$SEED_LOG" 2>/dev/null || true
+    echo "--- worker log tail ---"
+    tail -160 "$WORKER_LOG" 2>/dev/null || true
+    echo "--- end logs ---"
+    if [[ -z "${MESH_TWO_NODE_SPLIT_WORK_DIR:-}" ]]; then
+        rm -rf "$WORK_DIR"
+    fi
+    if [[ -z "${MESH_TWO_NODE_SPLIT_PROCESS_ROOT:-}" ]]; then
+        rm -rf "$PROCESS_ROOT"
+    fi
+}
+trap cleanup EXIT
+
+status_json() {
+    local console_port="$1"
+    curl -fsS --max-time 5 "http://127.0.0.1:${console_port}/api/status" 2>/dev/null || true
+}
+
+stages_json() {
+    local console_port="$1"
+    curl -fsS --max-time 5 "http://127.0.0.1:${console_port}/api/runtime/stages" 2>/dev/null || true
+}
+
+query_token() {
+    STATUS_JSON="$1" python3 - <<'PY'
+import json
+import os
+
+try:
+    status = json.loads(os.environ.get("STATUS_JSON", "") or "{}")
+except Exception:
+    status = {}
+print(status.get("token") or "")
+PY
+}
+
+query_peer_count() {
+    STATUS_JSON="$1" python3 - <<'PY'
+import json
+import os
+
+try:
+    status = json.loads(os.environ.get("STATUS_JSON", "") or "{}")
+except Exception:
+    status = {}
+print(len(status.get("peers") or []))
+PY
+}
+
+query_split_ready() {
+    STAGES_JSON="$1" MODELS_JSON="$2" python3 - <<'PY'
+import json
+import os
+
+try:
+    stages = json.loads(os.environ.get("STAGES_JSON", "") or "{}")
+except Exception:
+    stages = {}
+try:
+    models = json.loads(os.environ.get("MODELS_JSON", "") or "{}")
+except Exception:
+    models = {}
+
+nodes = []
+stage_count = 0
+for topology in stages.get("topologies") or []:
+    for stage in topology.get("stages") or []:
+        stage_count += 1
+        node = stage.get("node_id")
+        if node and node not in nodes:
+            nodes.append(node)
+
+model_count = len(models.get("data") or [])
+ready = stage_count >= 2 and len(nodes) >= 2 and model_count >= 1
+print(
+    f"ready={str(ready).lower()} stages={stage_count} "
+    f"nodes={len(nodes)} models={model_count}"
+)
+raise SystemExit(0 if ready else 1)
+PY
+}
+
+start_node() {
+    local label="$1"
+    local join_token="$2"
+    local api_port="$3"
+    local console_port="$4"
+    local bind_port="$5"
+    local log_file="$6"
+    local home="${PROCESS_ROOT}/${label}/h"
+    local runtime="${PROCESS_ROOT}/${label}/r"
+    mkdir -p "$home" "$runtime"
+
+    local -a args=(
+        --log-format json
+        serve
+        --model "$MODEL"
+        --split
+        --no-draft
+        --device "$DEVICE"
+        --max-vram "$MAX_VRAM"
+        --port "$api_port"
+        --console "$console_port"
+        --bind-port "$bind_port"
+        --headless
+    )
+    if [[ -n "$join_token" ]]; then
+        args+=(--join "$join_token")
+    fi
+    if [[ -n "$CTX_SIZE" ]]; then
+        args+=(--ctx-size "$CTX_SIZE")
+    fi
+
+    HOME="$home" \
+        MESH_LLM_RUNTIME_ROOT="$runtime" \
+        MESH_LLM_EPHEMERAL_KEY=1 \
+        "$MESH_LLM" "${args[@]}" >"$log_file" 2>&1 &
+    printf '%s\n' "$!"
+}
+
+SEED_PID="$(start_node seed "" "$SEED_API_PORT" "$SEED_CONSOLE_PORT" "$SEED_BIND_PORT" "$SEED_LOG")"
+
+TOKEN=""
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$SEED_PID" 2>/dev/null; then
+        echo "seed exited unexpectedly" >&2
+        tail -160 "$SEED_LOG" >&2 || true
+        exit 1
+    fi
+    TOKEN="$(query_token "$(status_json "$SEED_CONSOLE_PORT")")"
+    if [[ -n "$TOKEN" ]]; then
+        echo "Seed produced invite token after ${i}s"
+        break
+    fi
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for seed invite token" >&2
+        tail -160 "$SEED_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+WORKER_PID="$(start_node worker "$TOKEN" "$WORKER_API_PORT" "$WORKER_CONSOLE_PORT" "$WORKER_BIND_PORT" "$WORKER_LOG")"
+
+for i in $(seq 1 "$MAX_WAIT"); do
+    if ! kill -0 "$SEED_PID" 2>/dev/null; then
+        echo "seed exited unexpectedly" >&2
+        tail -160 "$SEED_LOG" >&2 || true
+        exit 1
+    fi
+    if ! kill -0 "$WORKER_PID" 2>/dev/null; then
+        echo "worker exited unexpectedly" >&2
+        tail -160 "$WORKER_LOG" >&2 || true
+        exit 1
+    fi
+
+    PEERS="$(query_peer_count "$(status_json "$SEED_CONSOLE_PORT")")"
+    if [[ "$PEERS" -ge 1 ]]; then
+        MODELS_JSON="$(curl -fsS --max-time 5 "http://127.0.0.1:${SEED_API_PORT}/v1/models" 2>/dev/null || true)"
+        READY_SUMMARY="$(query_split_ready "$(stages_json "$SEED_CONSOLE_PORT")" "$MODELS_JSON" 2>/dev/null || true)"
+        if [[ "$READY_SUMMARY" == ready=true* ]]; then
+            echo "Split topology ready after ${i}s: ${READY_SUMMARY}"
+            break
+        fi
+    fi
+
+    if [[ "$i" -eq "$MAX_WAIT" ]]; then
+        echo "timed out waiting for real split topology" >&2
+        echo "last peer count: ${PEERS:-unknown}" >&2
+        echo "last split summary: ${READY_SUMMARY:-unknown}" >&2
+        tail -160 "$SEED_LOG" >&2 || true
+        tail -160 "$WORKER_LOG" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+WORK_PAYLOAD="${WORK_DIR}/chat-payload.json"
+CHAT_RESPONSE="${WORK_DIR}/chat-response.json"
+MODEL_ID="$(
+    curl -fsS --max-time 5 "http://127.0.0.1:${SEED_API_PORT}/v1/models" |
+        python3 -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0].get("id", "") if data else "")'
+)"
+if [[ -z "$MODEL_ID" ]]; then
+    echo "seed /v1/models did not return a model id" >&2
+    exit 1
+fi
+
+python3 - "$MODEL_ID" "$WORK_PAYLOAD" <<'PY'
+import json
+import sys
+
+model, path = sys.argv[1:3]
+payload = {
+    "model": model,
+    "messages": [{"role": "user", "content": "Reply with one word."}],
+    "stream": False,
+    "max_tokens": 8,
+    "temperature": 0,
+}
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump(payload, fh)
+PY
+
+curl -fsS --max-time 180 \
+    "http://127.0.0.1:${SEED_API_PORT}/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d @"$WORK_PAYLOAD" \
+    -o "$CHAT_RESPONSE"
+
+python3 - "$CHAT_RESPONSE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    body = json.load(fh)
+if body.get("object") != "chat.completion":
+    raise SystemExit(f"unexpected chat object: {body.get('object')!r}")
+if not body.get("choices"):
+    raise SystemExit("chat response had no choices")
+print("Split chat response validated")
+PY
+
+echo "Two-node split smoke passed"

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -226,6 +226,8 @@ done
 
 WORKER_PID="$(start_node worker "$TOKEN" "$WORKER_API_PORT" "$WORKER_CONSOLE_PORT" "$WORKER_BIND_PORT" "$WORKER_LOG")"
 
+DRIVER_LABEL=""
+DRIVER_API_PORT=""
 for i in $(seq 1 "$MAX_WAIT"); do
     if ! kill -0 "$SEED_PID" 2>/dev/null; then
         echo "seed exited unexpectedly" >&2
@@ -238,18 +240,27 @@ for i in $(seq 1 "$MAX_WAIT"); do
         exit 1
     fi
 
-    PEERS="$(query_peer_count "$(status_json "$SEED_CONSOLE_PORT")")"
-    if [[ "$PEERS" -ge 1 ]]; then
-        MODELS_JSON="$(curl -fsS --max-time 5 "http://127.0.0.1:${SEED_API_PORT}/v1/models" 2>/dev/null || true)"
-        READY_SUMMARY="$(query_split_ready "$(stages_json "$SEED_CONSOLE_PORT")" "$MODELS_JSON" 2>/dev/null || true)"
-        if [[ "$READY_SUMMARY" == ready=true* ]]; then
-            echo "Split topology ready after ${i}s: ${READY_SUMMARY}"
-            break
+    for endpoint in \
+        "seed:${SEED_API_PORT}:${SEED_CONSOLE_PORT}" \
+        "worker:${WORKER_API_PORT}:${WORKER_CONSOLE_PORT}"; do
+        IFS=: read -r label api_port console_port <<<"$endpoint"
+        PEERS="$(query_peer_count "$(status_json "$console_port")")"
+        if [[ "$PEERS" -lt 1 ]]; then
+            continue
         fi
-    fi
+        MODELS_JSON="$(curl -fsS --max-time 5 "http://127.0.0.1:${api_port}/v1/models" 2>/dev/null || true)"
+        READY_SUMMARY="$(query_split_ready "$(stages_json "$console_port")" "$MODELS_JSON" 2>/dev/null || true)"
+        if [[ "$READY_SUMMARY" == ready=true* ]]; then
+            DRIVER_LABEL="$label"
+            DRIVER_API_PORT="$api_port"
+            echo "Split topology ready after ${i}s on ${label}: ${READY_SUMMARY}"
+            break 2
+        fi
+    done
 
     if [[ "$i" -eq "$MAX_WAIT" ]]; then
         echo "timed out waiting for real split topology" >&2
+        echo "last checked endpoint: ${label:-unknown}" >&2
         echo "last peer count: ${PEERS:-unknown}" >&2
         echo "last split summary: ${READY_SUMMARY:-unknown}" >&2
         tail -160 "$SEED_LOG" >&2 || true
@@ -261,12 +272,16 @@ done
 
 WORK_PAYLOAD="${WORK_DIR}/chat-payload.json"
 CHAT_RESPONSE="${WORK_DIR}/chat-response.json"
+if [[ -z "$DRIVER_API_PORT" ]]; then
+    echo "no split driver API port was selected" >&2
+    exit 1
+fi
 MODEL_ID="$(
-    curl -fsS --max-time 5 "http://127.0.0.1:${SEED_API_PORT}/v1/models" |
+    curl -fsS --max-time 5 "http://127.0.0.1:${DRIVER_API_PORT}/v1/models" |
         python3 -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0].get("id", "") if data else "")'
 )"
 if [[ -z "$MODEL_ID" ]]; then
-    echo "seed /v1/models did not return a model id" >&2
+    echo "${DRIVER_LABEL:-selected driver} /v1/models did not return a model id" >&2
     exit 1
 fi
 
@@ -287,7 +302,7 @@ with open(path, "w", encoding="utf-8") as fh:
 PY
 
 curl -fsS --max-time 180 \
-    "http://127.0.0.1:${SEED_API_PORT}/v1/chat/completions" \
+    "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
     -H 'content-type: application/json' \
     -d @"$WORK_PAYLOAD" \
     -o "$CHAT_RESPONSE"


### PR DESCRIPTION
🤖 AI-authored update.

## Summary

Fixes split serving for Hugging Face layer-package refs such as `meshllm/Qwen3-8B-Q4_K_M-layers` by keeping package refs out of the direct-GGUF canonicalization path.

Operators can now start a two-node split where each node resolves the published layer package and downloads only the artifacts needed for its assigned stage.

## What changed

- Build base Skippy model-load options without immediately constructing a single-stage direct-GGUF package.
- Attach layer-package identity before stage config construction for package-backed split serving.
- Add a regression test for `hf://meshllm/Qwen3-8B-Q4_K_M-layers` translation.
- Document the two-node split smoke flow in the testing playbook, Skippy split guide, and docs landing page.
- Correct stale Skippy skill validation commands to target `mesh-llm-host-runtime`.
- Add CI coverage for a real two-node split smoke using the scripted binary smoke pipeline.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mesh-llm-host-runtime --lib layer_package_translation_does_not_treat_hf_ref_as_direct_gguf`
- `cargo test -p mesh-llm-host-runtime --lib inference::skippy -- --list`
- `cargo check -p mesh-llm`
- `bash -n scripts/ci-two-node-split-smoke.sh`
- `git diff --check`
- `cargo run -p xtask -- repo-consistency ci-crate-lists`
- Local two-node split smoke: `MESH_TWO_NODE_SPLIT_DEVICE=Metal MESH_TWO_NODE_SPLIT_MAX_VRAM=5 MESH_TWO_NODE_SPLIT_MAX_WAIT=420 scripts/ci-two-node-split-smoke.sh ./target/debug/mesh-llm ./target/debug /tmp/Qwen3-8B-Q4_K_M.gguf`
- Manual two-node lab smoke: local M4 coordinator + Studio worker using `meshllm/Qwen3-8B-Q4_K_M-layers --split --max-vram 5`; `/api/status` showed the split stage ready, `/v1/models` listed the layer-package model, and `/v1/chat/completions` returned an OpenAI-shaped response.
- GitHub Actions: PR Builds and PR Quality Checks passed for `a7ba4b43`, including `two_node_split_smoke / Scripted Binary Smoke`.

## Notes

`--max-vram 3` correctly failed planning for this package/context in the lab. `--max-vram 5` reached readiness.