### PR TITLE
Harden layer package stage preparation

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -1040,8 +1040,7 @@ fn download_hf_package_to_local_sync(
             *total_bytes,
             Some(Arc::clone(&package_scope)),
             index + 1,
-        )
-        .with_context(|| format!("download layer package file: {file_name}"))?;
+        )?;
     }
 
     verify_resolved_hf_package_files(

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
@@ -11,7 +11,9 @@ use anyhow::Result;
 use skippy_protocol::LoadMode;
 use tokio::sync::Mutex;
 
-use crate::inference::skippy::materialization::{inspect_stage_package, is_layer_package_ref};
+use crate::inference::skippy::materialization::{
+    inspect_stage_package, is_layer_package_ref, resolve_stage_load_package,
+};
 
 use super::{
     SourceModelKind, StageInventoryRequest, StageLoadRequest, StagePackagePrefetcher,
@@ -129,12 +131,10 @@ pub(super) async fn run_stage_prepare_task(
         Err(error) => {
             let mut status =
                 preparation_status_from_load(&load, StagePreparationState::Failed, None);
-            status.error = Some(match peer_prefetch_error {
-                Some(prefetch_error) => {
-                    format!("{error}; peer artifact prefetch failed: {prefetch_error}")
-                }
-                None => error.to_string(),
-            });
+            status.error = Some(format_stage_prepare_error(
+                &error,
+                peer_prefetch_error.as_deref(),
+            ));
             status
         }
     };
@@ -161,14 +161,25 @@ async fn prefetch_stage_package_if_needed(
     match prefetcher.prefetch_stage_package(request).await {
         Ok(()) => None,
         Err(error) => {
+            let error_message = format!("{error:#}");
             tracing::debug!(
                 topology_id = %load.topology_id,
                 run_id = %load.run_id,
                 stage_id = %load.stage_id,
-                "peer artifact prefetch failed, falling back to local/HF resolver: {error}"
+                "peer artifact prefetch failed, falling back to local/HF resolver: {error_message}"
             );
-            Some(error.to_string())
+            Some(error_message)
         }
+    }
+}
+
+fn format_stage_prepare_error(error: &anyhow::Error, peer_prefetch_error: Option<&str>) -> String {
+    let message = format!("{error:#}");
+    match peer_prefetch_error {
+        Some(prefetch_error) => {
+            format!("{message}; peer artifact prefetch failed: {prefetch_error}")
+        }
+        None => message,
     }
 }
 
@@ -178,9 +189,12 @@ struct PrepareSourceResult {
 
 async fn prepare_stage_source(load: &StageLoadRequest) -> Result<PrepareSourceResult> {
     if load.load_mode == LoadMode::LayerPackage || is_layer_package_ref(&load.package_ref) {
-        let info = inspect_stage_package(&load.package_ref)?;
+        let load = load.clone();
+        let package = tokio::task::spawn_blocking(move || resolve_stage_load_package(&load))
+            .await??
+            .ok_or_else(|| anyhow::anyhow!("layer package load did not resolve a package"))?;
         return Ok(PrepareSourceResult {
-            bytes_total: info.source_model_bytes,
+            bytes_total: package.source_model_bytes,
         });
     }
 
@@ -227,4 +241,33 @@ async fn update_preparation(
     }
     preparations.insert(key.to_string(), status);
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+
+    use super::format_stage_prepare_error;
+
+    #[test]
+    fn stage_prepare_error_preserves_source_chain() {
+        let error = anyhow!("No locks available (os error 77)")
+            .context("download layer package file: shared/embeddings.gguf");
+
+        let message = format_stage_prepare_error(&error, None);
+
+        assert!(message.contains("download layer package file: shared/embeddings.gguf"));
+        assert!(message.contains("No locks available (os error 77)"));
+    }
+
+    #[test]
+    fn stage_prepare_error_includes_prefetch_source_chain() {
+        let error = anyhow!("No locks available (os error 77)")
+            .context("download layer package file: shared/embeddings.gguf");
+
+        let message = format_stage_prepare_error(&error, Some("peer refused package"));
+
+        assert!(message.contains("No locks available (os error 77)"));
+        assert!(message.contains("peer artifact prefetch failed: peer refused package"));
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -5949,7 +5949,32 @@ impl Node {
             self.record_stage_topology(stage_topology_from_load(self.endpoint.id(), load))
                 .await;
         }
-        let response = self.execute_stage_control_request(request).await?;
+        let response = match self.execute_stage_control_request(request.clone()).await {
+            Ok(response) => response,
+            Err(error) => {
+                let crate::inference::skippy::StageControlRequest::Load(load) = request else {
+                    return Err(error);
+                };
+                let error_message = format!("{error:#}");
+                tracing::warn!(
+                    peer = %remote.fmt_short(),
+                    stage_id = %load.stage_id,
+                    "stage load failed: {error_message}"
+                );
+                let mut status = stage_status_from_load(
+                    &load,
+                    crate::inference::skippy::StageRuntimeState::Failed,
+                );
+                status.error = Some(error_message.clone());
+                crate::inference::skippy::StageControlResponse::Ready(
+                    crate::inference::skippy::StageReadyResponse {
+                        accepted: false,
+                        status,
+                        error: Some(error_message),
+                    },
+                )
+            }
+        };
         self.record_stage_control_response(&response).await;
         let status_list_supported = self
             .peer_supports_skippy_subprotocol_feature(

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -5920,6 +5920,43 @@ impl Node {
         }
     }
 
+    async fn execute_stage_control_request_for_peer(
+        &self,
+        remote: EndpointId,
+        request: crate::inference::skippy::StageControlRequest,
+    ) -> anyhow::Result<crate::inference::skippy::StageControlResponse> {
+        match self.execute_stage_control_request(request.clone()).await {
+            Ok(response) => Ok(response),
+            Err(error) => Self::stage_control_load_failure_response(remote, request, error),
+        }
+    }
+
+    fn stage_control_load_failure_response(
+        remote: EndpointId,
+        request: crate::inference::skippy::StageControlRequest,
+        error: anyhow::Error,
+    ) -> anyhow::Result<crate::inference::skippy::StageControlResponse> {
+        let crate::inference::skippy::StageControlRequest::Load(load) = request else {
+            return Err(error);
+        };
+        let error_message = format!("{error:#}");
+        tracing::warn!(
+            peer = %remote.fmt_short(),
+            stage_id = %load.stage_id,
+            "stage load failed: {error_message}"
+        );
+        let mut status =
+            stage_status_from_load(&load, crate::inference::skippy::StageRuntimeState::Failed);
+        status.error = Some(error_message.clone());
+        Ok(crate::inference::skippy::StageControlResponse::Ready(
+            crate::inference::skippy::StageReadyResponse {
+                accepted: false,
+                status,
+                error: Some(error_message),
+            },
+        ))
+    }
+
     async fn handle_stage_control(
         &self,
         remote: EndpointId,
@@ -5949,32 +5986,9 @@ impl Node {
             self.record_stage_topology(stage_topology_from_load(self.endpoint.id(), load))
                 .await;
         }
-        let response = match self.execute_stage_control_request(request.clone()).await {
-            Ok(response) => response,
-            Err(error) => {
-                let crate::inference::skippy::StageControlRequest::Load(load) = request else {
-                    return Err(error);
-                };
-                let error_message = format!("{error:#}");
-                tracing::warn!(
-                    peer = %remote.fmt_short(),
-                    stage_id = %load.stage_id,
-                    "stage load failed: {error_message}"
-                );
-                let mut status = stage_status_from_load(
-                    &load,
-                    crate::inference::skippy::StageRuntimeState::Failed,
-                );
-                status.error = Some(error_message.clone());
-                crate::inference::skippy::StageControlResponse::Ready(
-                    crate::inference::skippy::StageReadyResponse {
-                        accepted: false,
-                        status,
-                        error: Some(error_message),
-                    },
-                )
-            }
-        };
+        let response = self
+            .execute_stage_control_request_for_peer(remote, request)
+            .await?;
         self.record_stage_control_response(&response).await;
         let status_list_supported = self
             .peer_supports_skippy_subprotocol_feature(

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3099,12 +3099,7 @@ async fn wait_for_split_stage_source(
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         let inventory = query_stage_inventory(node, stage_node_id, load).await?;
-        if inventory
-            .available_ranges
-            .iter()
-            .chain(inventory.ready_ranges.iter())
-            .any(|range| range.layer_start <= load.layer_start && range.layer_end >= load.layer_end)
-        {
+        if split_stage_source_is_ready(&inventory, load) {
             tracing::info!(
                 topology_id = %load.topology_id,
                 run_id = %load.run_id,
@@ -3133,6 +3128,44 @@ async fn wait_for_split_stage_source(
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
+}
+
+fn split_stage_source_is_ready(
+    inventory: &skippy::StageLayerInventory,
+    load: &skippy::StageLoadRequest,
+) -> bool {
+    let ready_running_stage = inventory
+        .ready_ranges
+        .iter()
+        .any(|range| split_layer_range_covers(range, load));
+    if ready_running_stage {
+        return true;
+    }
+    if load.load_mode != LoadMode::LayerPackage && !skippy::is_layer_package_ref(&load.package_ref)
+    {
+        return inventory
+            .available_ranges
+            .iter()
+            .any(|range| split_layer_range_covers(range, load));
+    }
+    inventory.preparing_ranges.iter().any(|status| {
+        status.topology_id == load.topology_id
+            && status.run_id == load.run_id
+            && status.stage_id == load.stage_id
+            && status.model_id == load.model_id
+            && status.package_ref == load.package_ref
+            && status.manifest_sha256 == load.manifest_sha256
+            && status.layer_start <= load.layer_start
+            && status.layer_end >= load.layer_end
+            && matches!(
+                status.state,
+                skippy::StagePreparationState::Available | skippy::StagePreparationState::Ready
+            )
+    })
+}
+
+fn split_layer_range_covers(range: &skippy::LayerRange, load: &skippy::StageLoadRequest) -> bool {
+    range.layer_start <= load.layer_start && range.layer_end >= load.layer_end
 }
 
 async fn query_stage_inventory(
@@ -3477,6 +3510,48 @@ mod tests {
             layer_count,
             activation_width: 2048,
             tensor_count: 100,
+        }
+    }
+
+    fn stage_load_request(load_mode: LoadMode) -> skippy::StageLoadRequest {
+        skippy::StageLoadRequest {
+            topology_id: "topology-a".to_string(),
+            run_id: "run-a".to_string(),
+            model_id: "model-a".to_string(),
+            backend: "skippy".to_string(),
+            package_ref: match load_mode {
+                LoadMode::LayerPackage => "hf://meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+                LoadMode::RuntimeSlice | LoadMode::ArtifactSlice => {
+                    "gguf:///models/qwen.gguf".to_string()
+                }
+            },
+            manifest_sha256: "a".repeat(64),
+            stage_id: "stage-1".to_string(),
+            stage_index: 1,
+            layer_start: 18,
+            layer_end: 36,
+            model_path: Some("/models/qwen.gguf".to_string()),
+            source_model_bytes: Some(4_900_000_000),
+            projector_path: None,
+            selected_device: None,
+            bind_addr: "127.0.0.1:0".to_string(),
+            activation_width: 4096,
+            wire_dtype: skippy::StageWireDType::F16,
+            ctx_size: 8192,
+            lane_count: 4,
+            n_batch: Some(2048),
+            n_ubatch: Some(512),
+            n_gpu_layers: -1,
+            cache_type_k: "f16".to_string(),
+            cache_type_v: "f16".to_string(),
+            flash_attn_type: FlashAttentionType::Auto,
+            shutdown_generation: 1,
+            coordinator_term: 1,
+            coordinator_id: None,
+            lease_until_unix_ms: u64::MAX,
+            load_mode,
+            upstream: None,
+            downstream: None,
         }
     }
 
@@ -4305,6 +4380,60 @@ max_tokens = 222
 
         assert!(!signal.can_stage_with(&package, false));
         assert!(signal.can_stage_with(&package, true));
+    }
+
+    #[test]
+    fn layer_package_stage_source_waits_for_exact_prepare_availability() {
+        let load = stage_load_request(LoadMode::LayerPackage);
+        let mut inventory = skippy::StageLayerInventory {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+            layer_count: 36,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 36,
+            }],
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: Some(
+                "/cache/models--meshllm--Qwen3-8B-Q4_K_M-layers/snapshots/main".to_string(),
+            ),
+            source_model_bytes: Some(4_900_000_000),
+            source_model_kind: skippy::SourceModelKind::LayerPackage,
+        };
+
+        assert!(!split_stage_source_is_ready(&inventory, &load));
+
+        inventory
+            .preparing_ranges
+            .push(test_preparation_status_from_load(&load));
+
+        assert!(split_stage_source_is_ready(&inventory, &load));
+    }
+
+    #[test]
+    fn runtime_slice_stage_source_accepts_inventory_availability() {
+        let load = stage_load_request(LoadMode::RuntimeSlice);
+        let inventory = skippy::StageLayerInventory {
+            model_id: load.model_id.clone(),
+            package_ref: load.package_ref.clone(),
+            manifest_sha256: load.manifest_sha256.clone(),
+            layer_count: 36,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 36,
+            }],
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: Some("/models/qwen.gguf".to_string()),
+            source_model_bytes: Some(4_900_000_000),
+            source_model_kind: skippy::SourceModelKind::PlainGguf,
+        };
+
+        assert!(split_stage_source_is_ready(&inventory, &load));
     }
 
     #[test]


### PR DESCRIPTION
This is a small stacked contribution for #705. It keeps the package-ref resolver fix from #705 intact and hardens the split startup path around exact layer-package availability and error reporting.

## Changes
- Make stage preparation for layer-package loads call `resolve_stage_load_package` so the assigned stage artifacts are actually resolved/downloaded before the source is marked available.
- Make the coordinator wait for the exact layer-package preparation status instead of accepting metadata-only `available_ranges`. Direct/runtime GGUF slices still accept inventory availability.
- Return structured failed `StageReadyResponse` values for remote stage-load failures, so callers see the materialization/download error instead of `stream finished early`.
- Preserve full anyhow error chains in preparation status, including peer prefetch fallback errors.

## Validation
- `cargo fmt --all -- --check`
- `just build`
- `cargo test -p mesh-llm-host-runtime stage_prepare_error --lib`
- `cargo test -p mesh-llm-host-runtime stage_source --lib`
- `cargo check -p mesh-llm`