### PR TITLE
Use combined hf-hub fork for model downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,7 +718,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1514,7 +1514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2475,7 +2475,7 @@ dependencies = [
 [[package]]
 name = "hf-hub"
 version = "1.0.0"
-source = "git+https://github.com/Mesh-LLM/hf-hub?branch=mesh%2Fresumable-downloads#fb94355171f2125b4cda86fb42ccad87563816cc"
+source = "git+https://github.com/Mesh-LLM/hf-hub?branch=mesh-llm#e8fb7ac4e4ed982650f65738c54f661ed83aeddf"
 dependencies = [
  "base64",
  "bon",
@@ -6249,7 +6249,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7309,7 +7309,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8605,7 +8605,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,8 @@ dependencies = [
 
 [[package]]
 name = "hf-hub"
-version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89305dc8fe34e165eaf0eb12b6e294e12381d9df9a431bcc52a5809bab4319"
+version = "1.0.0"
+source = "git+https://github.com/Mesh-LLM/hf-hub?branch=mesh%2Fresumable-downloads#fb94355171f2125b4cda86fb42ccad87563816cc"
 dependencies = [
  "base64",
  "bon",
@@ -6250,7 +6249,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7310,7 +7309,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8606,7 +8605,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ serde_json = "1"
 sha2 = "0.10"
 
 [patch.crates-io]
-hf-hub = { git = "https://github.com/Mesh-LLM/hf-hub", branch = "mesh/resumable-downloads" }
+hf-hub = { git = "https://github.com/Mesh-LLM/hf-hub", branch = "mesh-llm" }
 
 [workspace.lints.clippy]
 cognitive_complexity = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
 
+[patch.crates-io]
+hf-hub = { git = "https://github.com/Mesh-LLM/hf-hub", branch = "mesh/resumable-downloads" }
+
 [workspace.lints.clippy]
 cognitive_complexity = "warn"
 too_many_lines = "warn"

--- a/crates/model-hf/src/lib.rs
+++ b/crates/model-hf/src/lib.rs
@@ -423,6 +423,7 @@ fn env_path(key: &str) -> Option<PathBuf> {
 mod tests {
     use super::*;
     use std::path::Path;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn cache_path_identity_matches_mesh_snapshot_layout() {
@@ -492,5 +493,125 @@ mod tests {
             huggingface_repo_folder_name("org/repo", RepoTypeModel),
             "models--org--repo"
         );
+    }
+
+    #[tokio::test]
+    async fn download_file_resumes_existing_incomplete_cache_blob() {
+        let body = Arc::new(b"abcdefghij".to_vec());
+        let ranges = Arc::new(Mutex::new(Vec::new()));
+        let endpoint = start_http_resume_server(Arc::clone(&body), Arc::clone(&ranges));
+
+        let cache_dir = tempfile::tempdir().unwrap();
+        let incomplete = cache_dir
+            .path()
+            .join("models--owner--repo")
+            .join("blobs")
+            .join(format!("{TEST_ETAG}.incomplete"));
+        std::fs::create_dir_all(incomplete.parent().unwrap()).unwrap();
+        std::fs::write(&incomplete, b"abcd").unwrap();
+
+        let repo = HfModelRepository::builder()
+            .endpoint(endpoint)
+            .cache_dir(cache_dir.path())
+            .build()
+            .unwrap();
+
+        let path = repo
+            .download_file("owner/repo", "main", "model.bin")
+            .await
+            .unwrap();
+
+        assert_eq!(std::fs::read(path).unwrap(), body.as_slice());
+        assert!(
+            ranges
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|range| range == "bytes=4-")
+        );
+    }
+
+    const TEST_COMMIT: &str = "0123456789012345678901234567890123456789";
+    const TEST_ETAG: &str = "etag-http";
+
+    fn start_http_resume_server(body: Arc<Vec<u8>>, ranges: Arc<Mutex<Vec<String>>>) -> String {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for connection in listener.incoming() {
+                let Ok(mut stream) = connection else {
+                    return;
+                };
+                let body = Arc::clone(&body);
+                let ranges = Arc::clone(&ranges);
+                std::thread::spawn(move || handle_resume_request(&mut stream, &body, &ranges));
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    fn handle_resume_request(
+        stream: &mut std::net::TcpStream,
+        body: &[u8],
+        ranges: &Mutex<Vec<String>>,
+    ) {
+        use std::io::{Read, Write};
+
+        let mut request = vec![0; 4096];
+        let Ok(read) = stream.read(&mut request) else {
+            return;
+        };
+        let request = String::from_utf8_lossy(&request[..read]);
+        let is_head = request.starts_with("HEAD ");
+        let range = request.lines().find_map(range_header_value);
+        if !is_head && let Some(range) = range {
+            ranges.lock().unwrap().push(range.to_string());
+        }
+        let response = http_resume_response(body, is_head, range);
+        let _ = stream.write_all(&response);
+    }
+
+    fn range_header_value(line: &str) -> Option<&str> {
+        let (name, value) = line.split_once(':')?;
+        name.eq_ignore_ascii_case("range").then(|| value.trim())
+    }
+
+    fn http_resume_response(body: &[u8], is_head: bool, range: Option<&str>) -> Vec<u8> {
+        if is_head {
+            return response_bytes("200 OK", body.len(), None, &[]);
+        }
+        if range == Some("bytes=4-") {
+            return response_bytes(
+                "206 Partial Content",
+                body.len() - 4,
+                Some("bytes 4-9/10"),
+                &body[4..],
+            );
+        }
+        response_bytes("200 OK", body.len(), None, body)
+    }
+
+    fn response_bytes(
+        status: &str,
+        content_length: usize,
+        content_range: Option<&str>,
+        body: &[u8],
+    ) -> Vec<u8> {
+        let content_range = content_range
+            .map(|value| format!("Content-Range: {value}\r\n"))
+            .unwrap_or_default();
+        format!(
+            "HTTP/1.1 {status}\r\n\
+             ETag: \"{TEST_ETAG}\"\r\n\
+             X-Repo-Commit: {TEST_COMMIT}\r\n\
+             Content-Length: {content_length}\r\n\
+             {content_range}\
+             Connection: close\r\n\
+             \r\n"
+        )
+        .into_bytes()
+        .into_iter()
+        .chain(body.iter().copied())
+        .collect()
     }
 }


### PR DESCRIPTION
## Merge dependency

This branch temporarily patches `hf-hub` to the Mesh-LLM fork branch `mesh-llm` so mesh-llm can consume and test resumable downloads plus Windows cache fallback behavior before the upstream fixes land.

- https://github.com/huggingface/hf-hub/pull/170
- https://github.com/huggingface/hf-hub/pull/172

## Summary

- Patch `hf-hub` to `https://github.com/Mesh-LLM/hf-hub`, branch `mesh-llm`.
- Lock the dependency to `e8fb7ac4`, which combines HTTP/LFS and Xet resume support with the Windows symlink fallback behavior.
- Keep the `model-hf` regression test that seeds an existing `.incomplete` cache blob and verifies the Mesh HF wrapper resumes with `Range: bytes=4-`.

## Validation

- `cargo test -p model-hf --lib --locked`
- `cargo fmt --all -- --check`
- `cargo check -p mesh-llm`
- `cargo clippy -p model-hf --all-targets -- -D warnings`
- `git diff --check`
