### PR TITLE
Add split readiness diagnostics and Windows capture bundle

### DIFF
--- a/contrib/windows/CollectSplitDiagnostics.ps1
+++ b/contrib/windows/CollectSplitDiagnostics.ps1
@@ -1,0 +1,252 @@
+param(
+    [string[]]$ConsoleUrls = @("http://127.0.0.1:3131"),
+    [string[]]$ApiUrls = @("http://127.0.0.1:9337/v1"),
+    [string]$Model = "auto",
+    [string]$OutputDir = $env:TEMP,
+    [string]$MeshLlm = "",
+    [switch]$RunProbe,
+    [switch]$SkipHttp,
+    [switch]$Help
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Show-Usage {
+    @"
+CollectSplitDiagnostics.ps1 - capture split-readiness diagnostics for maintainers.
+
+Usage:
+  .\contrib\windows\CollectSplitDiagnostics.ps1 -Model meshllm/Qwen3-8B-Q4_K_M-layers
+
+Options:
+  -ConsoleUrls  Management API URLs, default http://127.0.0.1:3131
+  -ApiUrls      OpenAI API base URLs, default http://127.0.0.1:9337/v1
+  -Model        Model id/ref for split doctor and optional chat probe
+  -OutputDir    Parent output directory, default TEMP
+  -MeshLlm      mesh-llm.exe path, default target\release\mesh-llm.exe or PATH
+  -RunProbe     Run a tiny /chat/completions probe through each API URL
+  -SkipHttp     Capture local system/process facts only
+  -Help         Print this help
+"@
+}
+
+if ($Help) {
+    Show-Usage
+    exit 0
+}
+
+function Resolve-MeshBinary {
+    param([string]$Preferred)
+
+    if ($Preferred -and (Test-Path -LiteralPath $Preferred)) {
+        return (Resolve-Path -LiteralPath $Preferred).Path
+    }
+
+    $ReleaseBinary = Join-Path (Get-Location) "target\release\mesh-llm.exe"
+    if (Test-Path -LiteralPath $ReleaseBinary) {
+        return (Resolve-Path -LiteralPath $ReleaseBinary).Path
+    }
+
+    $Command = Get-Command "mesh-llm" -ErrorAction SilentlyContinue
+    if ($Command) {
+        return $Command.Source
+    }
+
+    return $null
+}
+
+function New-DiagnosticDirectory {
+    param([string]$Parent)
+
+    $Stamp = Get-Date -Format "yyyyMMdd-HHmmss"
+    $Base = Join-Path $Parent "mesh-split-diagnostics-$Stamp"
+    New-Item -ItemType Directory -Force -Path $Base | Out-Null
+    return $Base
+}
+
+function Write-TextFile {
+    param(
+        [string]$Path,
+        [string]$Content
+    )
+
+    Set-Content -LiteralPath $Path -Value $Content -Encoding UTF8
+}
+
+function Invoke-CaptureCommand {
+    param(
+        [string]$Path,
+        [string]$FileName,
+        [string]$Command,
+        [string[]]$Arguments
+    )
+
+    $Target = Join-Path $Path $FileName
+    try {
+        $Output = & $Command @Arguments 2>&1 | Out-String
+        Write-TextFile -Path $Target -Content $Output
+    } catch {
+        Write-TextFile -Path $Target -Content "command failed: $($_.Exception.Message)"
+    }
+}
+
+function Redact-Text {
+    param([string]$Text)
+
+    if (-not $Text) {
+        return $Text
+    }
+
+    $Redacted = $Text
+    $Redacted = [regex]::Replace($Redacted, '("token"\s*:\s*")[^"]+(")', '$1<redacted>$2')
+    $Redacted = [regex]::Replace($Redacted, '(Authorization:\s*Bearer\s+)[^\s"]+', '$1<redacted>', 'IgnoreCase')
+    $Redacted = [regex]::Replace($Redacted, '([A-Za-z0-9_]*(?:TOKEN|KEY)\s*=\s*)[^\s"]+', '$1<redacted>', 'IgnoreCase')
+    $Redacted = [regex]::Replace($Redacted, '("--join"\s*,\s*")[^"]+(")', '$1<redacted>$2')
+    return $Redacted
+}
+
+function Invoke-HttpCapture {
+    param(
+        [string]$Path,
+        [string]$Name,
+        [string]$Url
+    )
+
+    $RedactedPath = Join-Path $Path "$Name.json"
+    try {
+        $Response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 10 -Uri $Url
+        $Content = [string]$Response.Content
+        Write-TextFile -Path $RedactedPath -Content (Redact-Text $Content)
+    } catch {
+        Write-TextFile -Path $RedactedPath -Content "request failed: $($_.Exception.Message)"
+    }
+}
+
+function Invoke-ChatProbe {
+    param(
+        [string]$Path,
+        [string]$Name,
+        [string]$ApiBase,
+        [string]$Model
+    )
+
+    $ProbePath = Join-Path $Path "$Name.chat-probe.json"
+    $Body = @{
+        model = $Model
+        messages = @(@{ role = "user"; content = "Reply with mesh split diagnostic probe." })
+        max_tokens = 16
+        stream = $false
+    } | ConvertTo-Json -Depth 8
+
+    try {
+        $Url = ($ApiBase.TrimEnd('/')) + "/chat/completions"
+        $Response = Invoke-WebRequest -UseBasicParsing -TimeoutSec 30 -Method Post -Uri $Url -ContentType "application/json" -Body $Body
+        Write-TextFile -Path $ProbePath -Content (Redact-Text ([string]$Response.Content))
+    } catch {
+        Write-TextFile -Path $ProbePath -Content "probe failed: $($_.Exception.Message)"
+    }
+}
+
+function Copy-RuntimeLogTails {
+    param([string]$Path)
+
+    $RuntimeRoot = Join-Path $HOME ".mesh-llm\runtime"
+    if (-not (Test-Path -LiteralPath $RuntimeRoot)) {
+        return
+    }
+
+    $LogsDir = Join-Path $Path "logs"
+    New-Item -ItemType Directory -Force -Path $LogsDir | Out-Null
+    Get-ChildItem -LiteralPath $RuntimeRoot -Recurse -Filter "skippy-native.log" -ErrorAction SilentlyContinue |
+        ForEach-Object {
+            $SafeName = ($_.FullName -replace '[\\/:*?"<>| ]', '_')
+            $Target = Join-Path $LogsDir $SafeName
+            try {
+                $Tail = Get-Content -LiteralPath $_.FullName -Tail 400 -ErrorAction Stop | Out-String
+                Write-TextFile -Path $Target -Content $Tail
+            } catch {
+                Write-TextFile -Path $Target -Content "log read failed: $($_.Exception.Message)"
+            }
+        }
+}
+
+$MeshBinary = Resolve-MeshBinary -Preferred $MeshLlm
+$CaptureDir = New-DiagnosticDirectory -Parent $OutputDir
+
+$Manifest = [ordered]@{
+    created_at = (Get-Date).ToString("o")
+    model = $Model
+    console_urls = $ConsoleUrls
+    api_urls = $ApiUrls
+    mesh_llm = $MeshBinary
+    run_probe = [bool]$RunProbe
+    skip_http = [bool]$SkipHttp
+    os = [System.Environment]::OSVersion.VersionString
+    powershell = $PSVersionTable.PSVersion.ToString()
+}
+Write-TextFile -Path (Join-Path $CaptureDir "manifest.json") -Content ($Manifest | ConvertTo-Json -Depth 6)
+
+if ($MeshBinary) {
+    Invoke-CaptureCommand -Path $CaptureDir -FileName "mesh-llm.version.txt" -Command $MeshBinary -Arguments @("--version")
+    Invoke-CaptureCommand -Path $CaptureDir -FileName "mesh-llm.gpus.json" -Command $MeshBinary -Arguments @("gpus", "--json")
+} else {
+    Write-TextFile -Path (Join-Path $CaptureDir "mesh-llm.version.txt") -Content "mesh-llm binary not found"
+}
+
+try {
+    Get-CimInstance Win32_OperatingSystem | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $CaptureDir "windows.os.json") -Encoding UTF8
+    Get-CimInstance Win32_VideoController | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $CaptureDir "windows.gpus.json") -Encoding UTF8
+} catch {
+    Write-TextFile -Path (Join-Path $CaptureDir "windows.cim-error.txt") -Content $_.Exception.Message
+}
+
+Get-Process | Select-Object Id, ProcessName, Path | ConvertTo-Json -Depth 4 |
+    Set-Content -LiteralPath (Join-Path $CaptureDir "processes.json") -Encoding UTF8
+
+Invoke-CaptureCommand -Path $CaptureDir -FileName "netstat.txt" -Command "netstat" -Arguments @("-ano")
+
+foreach ($OptionalCommand in @("nvidia-smi", "vulkaninfo", "rocminfo")) {
+    $Command = Get-Command $OptionalCommand -ErrorAction SilentlyContinue
+    if ($Command) {
+        Invoke-CaptureCommand -Path $CaptureDir -FileName "$OptionalCommand.txt" -Command $Command.Source -Arguments @()
+    }
+}
+
+if (-not $SkipHttp) {
+    $Index = 0
+    foreach ($ConsoleUrl in $ConsoleUrls) {
+        $Name = "console-$Index"
+        $Base = $ConsoleUrl.TrimEnd('/')
+        Invoke-HttpCapture -Path $CaptureDir -Name "$Name.status" -Url "$Base/api/status"
+        Invoke-HttpCapture -Path $CaptureDir -Name "$Name.runtime-stages" -Url "$Base/api/runtime/stages"
+        if ($Model -and $Model -ne "auto") {
+            $Encoded = [System.Uri]::EscapeDataString($Model)
+            Invoke-HttpCapture -Path $CaptureDir -Name "$Name.split-readiness" -Url "$Base/api/diagnostics/split-readiness?model_ref=$Encoded"
+        }
+        $Index += 1
+    }
+
+    $Index = 0
+    foreach ($ApiUrl in $ApiUrls) {
+        $Name = "api-$Index"
+        $Base = $ApiUrl.TrimEnd('/')
+        Invoke-HttpCapture -Path $CaptureDir -Name "$Name.models" -Url "$Base/models"
+        if ($RunProbe) {
+            Invoke-ChatProbe -Path $CaptureDir -Name $Name -ApiBase $Base -Model $Model
+        }
+        $Index += 1
+    }
+}
+
+Copy-RuntimeLogTails -Path $CaptureDir
+
+$ZipPath = "$CaptureDir.zip"
+if (Test-Path -LiteralPath $ZipPath) {
+    Remove-Item -LiteralPath $ZipPath -Force
+}
+Compress-Archive -Path (Join-Path $CaptureDir "*") -DestinationPath $ZipPath -Force
+
+Write-Host "Split diagnostics written to:"
+Write-Host "  $CaptureDir"
+Write-Host "  $ZipPath"

--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -20,5 +20,19 @@ Chat with that server:
 .\contrib\windows\StartChat.ps1 -Model Qwen2.5-3B-Instruct-Q4_K_M
 ```
 
+Collect split diagnostics from one or more already-running nodes:
+
+```powershell
+.\contrib\windows\CollectSplitDiagnostics.ps1 `
+  -Model meshllm/Qwen3-8B-Q4_K_M-layers `
+  -ConsoleUrls http://127.0.0.1:3131 `
+  -ApiUrls http://127.0.0.1:9337/v1
+```
+
+The collector writes a timestamped folder and zip containing redacted
+management API payloads, `/v1/models`, GPU/process facts, optional probe
+results, and recent `skippy-native.log` tails. It attaches to running nodes; it
+does not start or stop mesh processes.
+
 The scripts default to `target\release\mesh-llm.exe` when it exists, otherwise
 they fall back to `mesh-llm` on `PATH`.

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -8,6 +8,7 @@
 //!   POST /api/model-interests — register local explicit interest for a canonical model ref
 //!   DELETE /api/model-interests/{model_ref} — clear local explicit interest
 //!   GET  /api/model-targets — ranked model targets from explicit interest and demand
+//!   GET  /api/diagnostics/split-readiness — split peer eligibility and operator guidance
 //!   GET  /api/runtime   — local model state (JSON)
 //!   GET  /api/runtime/llama — local llama.cpp runtime metrics + slots snapshots (JSON)
 //!   GET  /api/runtime/events — SSE stream of llama.cpp runtime metrics + slots snapshots
@@ -45,6 +46,7 @@ mod model_target_capacity;
 mod model_targets;
 mod routes;
 mod server;
+mod split_readiness;
 mod state;
 pub(crate) mod status;
 

--- a/crates/mesh-llm-host-runtime/src/api/routes/diagnostics.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/diagnostics.rs
@@ -1,0 +1,58 @@
+use super::super::{
+    MeshApi,
+    http::{respond_error, respond_json},
+};
+use tokio::net::TcpStream;
+use url::form_urlencoded;
+
+pub(super) async fn handle(
+    stream: &mut TcpStream,
+    state: &MeshApi,
+    path: &str,
+) -> anyhow::Result<()> {
+    let model_ref = match split_readiness_model_ref(path) {
+        Some(model_ref) => model_ref,
+        None => {
+            return respond_error(stream, 400, "Missing required 'model_ref' query parameter")
+                .await;
+        }
+    };
+    let report = state.split_readiness_report(&model_ref).await;
+    respond_json(stream, 200, &report).await
+}
+
+fn split_readiness_model_ref(path: &str) -> Option<String> {
+    let (_, raw_query) = path.split_once('?')?;
+    for (key, value) in form_urlencoded::parse(raw_query.as_bytes()) {
+        if matches!(key.as_ref(), "model_ref" | "model") {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_readiness_model_ref;
+
+    #[test]
+    fn split_readiness_query_accepts_percent_encoded_model_ref() {
+        assert_eq!(
+            split_readiness_model_ref(
+                "/api/diagnostics/split-readiness?model_ref=meshllm%2FQwen3-8B-Q4_K_M-layers"
+            ),
+            Some("meshllm/Qwen3-8B-Q4_K_M-layers".to_string())
+        );
+    }
+
+    #[test]
+    fn split_readiness_query_rejects_blank_model_ref() {
+        assert_eq!(
+            split_readiness_model_ref("/api/diagnostics/split-readiness?model_ref=%20"),
+            None
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
@@ -1,4 +1,5 @@
 mod chat;
+mod diagnostics;
 mod discover;
 mod mcp;
 mod mesh_hook;
@@ -32,6 +33,10 @@ pub(super) const DISPATCH_REQUEST: DispatchRequestFn =
             match (method, path_only) {
                 ("GET", "/api/discover") => {
                     discover::handle(stream, state).await?;
+                    Ok(true)
+                }
+                ("GET", "/api/diagnostics/split-readiness") => {
+                    diagnostics::handle(stream, state, path).await?;
                     Ok(true)
                 }
                 ("GET" | "POST" | "DELETE", "/mcp") => {

--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -1,0 +1,740 @@
+use super::MeshApi;
+use super::status::{ModelTargetCapacityAdvicePayload, ModelTargetCapacityAdviceState};
+use crate::mesh::{NodeRole, PeerInfo};
+use serde::Serialize;
+
+const MIN_SPLIT_PARTICIPANTS: usize = 2;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct SplitReadinessInput {
+    pub(crate) model_ref: String,
+    pub(crate) local: SplitReadinessNodeInput,
+    pub(crate) peers: Vec<SplitReadinessNodeInput>,
+    pub(crate) capacity_advice: Option<ModelTargetCapacityAdvicePayload>,
+    pub(crate) active_topology_count: usize,
+    pub(crate) active_stage_count: usize,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SplitReadinessNodeInput {
+    pub(crate) node_id: String,
+    pub(crate) short_node_id: String,
+    pub(crate) source: SplitReadinessNodeSource,
+    pub(crate) role: SplitReadinessNodeRole,
+    pub(crate) vram_bytes: u64,
+    pub(crate) requested_models: Vec<String>,
+    pub(crate) explicit_model_interests: Vec<String>,
+    pub(crate) serving_models: Vec<String>,
+    pub(crate) hosted_models: Vec<String>,
+    pub(crate) available_models: Vec<String>,
+    pub(crate) model_source: Option<String>,
+    pub(crate) stage_protocol_generation_supported: bool,
+    pub(crate) artifact_transfer_supported: bool,
+    pub(crate) rtt_ms: Option<u32>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SplitReadinessNodeSource {
+    Local,
+    Peer,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SplitReadinessNodeRole {
+    Worker,
+    Host,
+    Client,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SplitReadinessVerdict {
+    Ready,
+    WaitingForPeers,
+    InsufficientCapacity,
+    UnknownModelSize,
+    NoModel,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize)]
+pub(crate) struct SplitReadinessReport {
+    pub(crate) model_ref: String,
+    pub(crate) verdict: SplitReadinessVerdict,
+    pub(crate) participant_count: usize,
+    pub(crate) exclusion_count: usize,
+    pub(crate) active_topology_count: usize,
+    pub(crate) active_stage_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) capacity_advice: Option<ModelTargetCapacityAdvicePayload>,
+    pub(crate) participants: Vec<SplitReadinessParticipant>,
+    pub(crate) exclusions: Vec<SplitReadinessExclusion>,
+    pub(crate) recommendations: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct SplitReadinessParticipant {
+    pub(crate) node_id: String,
+    pub(crate) short_node_id: String,
+    pub(crate) source: SplitReadinessNodeSource,
+    pub(crate) role: SplitReadinessNodeRole,
+    pub(crate) vram_bytes: u64,
+    pub(crate) artifact_transfer_supported: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) rtt_ms: Option<u32>,
+    pub(crate) model_source_state: &'static str,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct SplitReadinessExclusion {
+    pub(crate) node_id: String,
+    pub(crate) short_node_id: String,
+    pub(crate) source: SplitReadinessNodeSource,
+    pub(crate) role: SplitReadinessNodeRole,
+    pub(crate) reason: &'static str,
+    pub(crate) recommendation: &'static str,
+    pub(crate) vram_bytes: u64,
+}
+
+impl MeshApi {
+    pub(crate) async fn split_readiness_report(&self, model_ref: &str) -> SplitReadinessReport {
+        let node = self.inner.lock().await.node.clone();
+        let model_target_lookup = self.model_target_lookup().await;
+        let capacity_advice = model_target_lookup
+            .by_model_ref
+            .get(model_ref)
+            .or_else(|| model_target_lookup.by_model_name.get(model_ref))
+            .map(|target| target.capacity_advice.clone());
+
+        let role = node.role().await;
+        let local = SplitReadinessNodeInput {
+            node_id: node.id().to_string(),
+            short_node_id: node.id().fmt_short().to_string(),
+            source: SplitReadinessNodeSource::Local,
+            role: split_node_role(&role),
+            vram_bytes: node.vram_bytes(),
+            requested_models: node.requested_models().await,
+            explicit_model_interests: node.explicit_model_interests().await,
+            serving_models: node.serving_models().await,
+            hosted_models: node.hosted_models().await,
+            available_models: node.available_models().await,
+            model_source: None,
+            stage_protocol_generation_supported: true,
+            artifact_transfer_supported: true,
+            rtt_ms: None,
+        };
+        let peers = node
+            .peers()
+            .await
+            .into_iter()
+            .map(peer_readiness_input)
+            .collect();
+        let active_topology_count = node.stage_topologies().await.len();
+        let active_stage_count = node
+            .stage_runtime_statuses()
+            .await
+            .into_iter()
+            .filter(|status| status.model_id == model_ref)
+            .count();
+
+        build_split_readiness_report(SplitReadinessInput {
+            model_ref: model_ref.to_string(),
+            local,
+            peers,
+            capacity_advice,
+            active_topology_count,
+            active_stage_count,
+        })
+    }
+}
+
+pub(crate) fn build_split_readiness_report(input: SplitReadinessInput) -> SplitReadinessReport {
+    let mut participants = Vec::new();
+    let mut exclusions = Vec::new();
+    for node in std::iter::once(input.local).chain(input.peers) {
+        match split_node_exclusion_reason(&input.model_ref, &node) {
+            Some(reason) => exclusions.push(split_exclusion(node, reason)),
+            None => participants.push(split_participant(&input.model_ref, node)),
+        }
+    }
+    let capacity_advice =
+        participant_capacity_advice(input.capacity_advice, participants.as_slice());
+    let verdict = split_readiness_verdict(
+        &input.model_ref,
+        participants.len(),
+        capacity_advice.as_ref(),
+    );
+    let recommendations = split_readiness_recommendations(&input.model_ref, verdict, &exclusions);
+    SplitReadinessReport {
+        model_ref: input.model_ref,
+        verdict,
+        participant_count: participants.len(),
+        exclusion_count: exclusions.len(),
+        active_topology_count: input.active_topology_count,
+        active_stage_count: input.active_stage_count,
+        capacity_advice,
+        participants,
+        exclusions,
+        recommendations,
+    }
+}
+
+fn peer_readiness_input(peer: PeerInfo) -> SplitReadinessNodeInput {
+    let rtt_ms = peer.current_direct_rtt_ms();
+    SplitReadinessNodeInput {
+        node_id: peer.id.to_string(),
+        short_node_id: peer.id.fmt_short().to_string(),
+        source: SplitReadinessNodeSource::Peer,
+        role: split_node_role(&peer.role),
+        vram_bytes: peer.vram_bytes,
+        requested_models: peer.requested_models,
+        explicit_model_interests: peer.explicit_model_interests,
+        serving_models: peer.serving_models,
+        hosted_models: peer.hosted_models,
+        available_models: peer.available_models,
+        model_source: peer.model_source,
+        stage_protocol_generation_supported: peer.stage_protocol_generation_supported,
+        artifact_transfer_supported: peer.artifact_transfer_supported,
+        rtt_ms,
+    }
+}
+
+fn split_node_role(role: &NodeRole) -> SplitReadinessNodeRole {
+    match role {
+        NodeRole::Worker => SplitReadinessNodeRole::Worker,
+        NodeRole::Host { .. } => SplitReadinessNodeRole::Host,
+        NodeRole::Client => SplitReadinessNodeRole::Client,
+    }
+}
+
+fn split_node_exclusion_reason(
+    model_ref: &str,
+    node: &SplitReadinessNodeInput,
+) -> Option<SplitReadinessExclusionReason> {
+    if node.role == SplitReadinessNodeRole::Client {
+        return Some(SplitReadinessExclusionReason::Client);
+    }
+    if node.vram_bytes == 0 {
+        return Some(SplitReadinessExclusionReason::MissingVram);
+    }
+    if !node_wants_model(model_ref, node) {
+        return Some(SplitReadinessExclusionReason::MissingModelInterest);
+    }
+    if !node.stage_protocol_generation_supported {
+        return Some(SplitReadinessExclusionReason::StageProtocolGeneration);
+    }
+    if node.source == SplitReadinessNodeSource::Peer && !node_has_stage_source(model_ref, node) {
+        return Some(SplitReadinessExclusionReason::MissingModelSource);
+    }
+    None
+}
+
+fn split_participant(model_ref: &str, node: SplitReadinessNodeInput) -> SplitReadinessParticipant {
+    let model_source_state = model_source_state(model_ref, &node);
+    SplitReadinessParticipant {
+        node_id: node.node_id,
+        short_node_id: node.short_node_id,
+        source: node.source,
+        role: node.role,
+        vram_bytes: node.vram_bytes,
+        artifact_transfer_supported: node.artifact_transfer_supported,
+        rtt_ms: node.rtt_ms,
+        model_source_state,
+    }
+}
+
+fn split_exclusion(
+    node: SplitReadinessNodeInput,
+    reason: SplitReadinessExclusionReason,
+) -> SplitReadinessExclusion {
+    SplitReadinessExclusion {
+        node_id: node.node_id,
+        short_node_id: node.short_node_id,
+        source: node.source,
+        role: node.role,
+        reason: reason.as_str(),
+        recommendation: reason.recommendation(),
+        vram_bytes: node.vram_bytes,
+    }
+}
+
+fn split_readiness_verdict(
+    model_ref: &str,
+    participant_count: usize,
+    capacity_advice: Option<&ModelTargetCapacityAdvicePayload>,
+) -> SplitReadinessVerdict {
+    if model_ref.trim().is_empty() {
+        return SplitReadinessVerdict::NoModel;
+    }
+    if participant_count < MIN_SPLIT_PARTICIPANTS {
+        return SplitReadinessVerdict::WaitingForPeers;
+    }
+    let Some(capacity_advice) = capacity_advice else {
+        return SplitReadinessVerdict::UnknownModelSize;
+    };
+    match capacity_advice.state {
+        ModelTargetCapacityAdviceState::InsufficientCapacity
+        | ModelTargetCapacityAdviceState::UnknownCapacity
+        | ModelTargetCapacityAdviceState::NoEligibleHosts => {
+            SplitReadinessVerdict::InsufficientCapacity
+        }
+        ModelTargetCapacityAdviceState::UnknownModelSize => SplitReadinessVerdict::UnknownModelSize,
+        _ => SplitReadinessVerdict::Ready,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SplitReadinessCapacitySummary {
+    best_single_node_capacity_bytes: Option<u64>,
+    aggregate_capacity_bytes: u64,
+    eligible_node_count: usize,
+}
+
+fn participant_capacity_advice(
+    capacity_advice: Option<ModelTargetCapacityAdvicePayload>,
+    participants: &[SplitReadinessParticipant],
+) -> Option<ModelTargetCapacityAdvicePayload> {
+    let mut advice = capacity_advice?;
+    let summary = participant_capacity_summary(participants);
+    advice.best_single_node_capacity_bytes = summary.best_single_node_capacity_bytes;
+    advice.aggregate_capacity_bytes = summary.aggregate_capacity_bytes;
+    advice.eligible_node_count = summary.eligible_node_count;
+    advice.excluded_client_node_count = 0;
+    advice.missing_capacity_node_count = 0;
+
+    if advice.state == ModelTargetCapacityAdviceState::AlreadyServing {
+        return Some(advice);
+    }
+
+    let Some(required_bytes) = advice.required_bytes else {
+        advice.state = ModelTargetCapacityAdviceState::UnknownModelSize;
+        advice.reason = "model_size_unknown";
+        advice.shortfall_bytes = None;
+        return Some(advice);
+    };
+
+    advice.state = participant_capacity_state(required_bytes, advice.split_capable, summary);
+    advice.reason = participant_capacity_reason(advice.state);
+    advice.shortfall_bytes =
+        participant_capacity_shortfall(required_bytes, advice.split_capable, summary);
+    Some(advice)
+}
+
+fn participant_capacity_summary(
+    participants: &[SplitReadinessParticipant],
+) -> SplitReadinessCapacitySummary {
+    let mut aggregate_capacity_bytes = 0_u64;
+    let mut best_single_node_capacity_bytes: Option<u64> = None;
+    for participant in participants {
+        aggregate_capacity_bytes = aggregate_capacity_bytes.saturating_add(participant.vram_bytes);
+        best_single_node_capacity_bytes = Some(
+            best_single_node_capacity_bytes
+                .unwrap_or_default()
+                .max(participant.vram_bytes),
+        );
+    }
+    SplitReadinessCapacitySummary {
+        best_single_node_capacity_bytes,
+        aggregate_capacity_bytes,
+        eligible_node_count: participants.len(),
+    }
+}
+
+fn participant_capacity_state(
+    required_bytes: u64,
+    split_capable: bool,
+    summary: SplitReadinessCapacitySummary,
+) -> ModelTargetCapacityAdviceState {
+    if summary.eligible_node_count == 0 {
+        return ModelTargetCapacityAdviceState::NoEligibleHosts;
+    }
+    if summary
+        .best_single_node_capacity_bytes
+        .is_some_and(|capacity| capacity >= required_bytes)
+    {
+        return ModelTargetCapacityAdviceState::SingleNodeFit;
+    }
+    if split_capable
+        && summary.eligible_node_count >= MIN_SPLIT_PARTICIPANTS
+        && summary.aggregate_capacity_bytes >= required_bytes
+    {
+        return ModelTargetCapacityAdviceState::SplitCandidate;
+    }
+    ModelTargetCapacityAdviceState::InsufficientCapacity
+}
+
+const fn participant_capacity_reason(state: ModelTargetCapacityAdviceState) -> &'static str {
+    match state {
+        ModelTargetCapacityAdviceState::AlreadyServing => "already_serving",
+        ModelTargetCapacityAdviceState::SingleNodeFit => "single_node_capacity_available",
+        ModelTargetCapacityAdviceState::SplitCandidate => "aggregate_split_capacity_available",
+        ModelTargetCapacityAdviceState::InsufficientCapacity => {
+            "participant_split_capacity_insufficient"
+        }
+        ModelTargetCapacityAdviceState::UnknownModelSize => "model_size_unknown",
+        ModelTargetCapacityAdviceState::UnknownCapacity => "capacity_unknown",
+        ModelTargetCapacityAdviceState::NoEligibleHosts => "no_worker_or_host_capacity",
+    }
+}
+
+fn participant_capacity_shortfall(
+    required_bytes: u64,
+    split_capable: bool,
+    summary: SplitReadinessCapacitySummary,
+) -> Option<u64> {
+    let comparable_capacity = if split_capable && summary.eligible_node_count >= 2 {
+        summary.aggregate_capacity_bytes
+    } else {
+        summary.best_single_node_capacity_bytes.unwrap_or_default()
+    };
+    let shortfall = required_bytes.saturating_sub(comparable_capacity);
+    (shortfall > 0).then_some(shortfall)
+}
+
+fn split_readiness_recommendations(
+    model_ref: &str,
+    verdict: SplitReadinessVerdict,
+    exclusions: &[SplitReadinessExclusion],
+) -> Vec<String> {
+    let mut recommendations = Vec::new();
+    if verdict == SplitReadinessVerdict::WaitingForPeers {
+        recommendations.push(format!(
+            "Start at least one more worker/host with --model {model_ref} --split and join it to this mesh."
+        ));
+        recommendations.push(
+            "When testing multiple nodes on one machine, use distinct --port, --console, and --bind-port values for every process."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::StageProtocolGeneration.as_str())
+    {
+        recommendations.push(
+            "Upgrade excluded peers so they advertise current stage protocol support.".to_string(),
+        );
+    }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::MissingVram.as_str())
+    {
+        recommendations.push(
+            "Run mesh-llm gpus on excluded peers and check backend/device visibility before attempting split serving."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::MissingModelSource.as_str())
+    {
+        recommendations.push(
+            "Start excluded peers with a resolvable package source or wait until stage inventory can prove the package is available before retrying split serving."
+                .to_string(),
+        );
+    }
+    recommendations
+}
+
+fn node_wants_model(model_ref: &str, node: &SplitReadinessNodeInput) -> bool {
+    [
+        node.requested_models.as_slice(),
+        node.explicit_model_interests.as_slice(),
+        node.serving_models.as_slice(),
+        node.hosted_models.as_slice(),
+        node.available_models.as_slice(),
+    ]
+    .into_iter()
+    .flatten()
+    .any(|candidate| model_matches(candidate, model_ref))
+        || node
+            .model_source
+            .as_deref()
+            .is_some_and(|candidate| model_matches(candidate, model_ref))
+}
+
+fn model_source_state(model_ref: &str, node: &SplitReadinessNodeInput) -> &'static str {
+    if node
+        .model_source
+        .as_deref()
+        .is_some_and(|source| !source.trim().is_empty())
+    {
+        return "declared";
+    }
+    if node
+        .serving_models
+        .iter()
+        .chain(node.hosted_models.iter())
+        .any(|candidate| model_matches(candidate, model_ref))
+    {
+        return "serving";
+    }
+    if node
+        .available_models
+        .iter()
+        .any(|candidate| model_matches(candidate, model_ref))
+    {
+        return "available";
+    }
+    if node.artifact_transfer_supported {
+        return "transfer_supported";
+    }
+    "unknown"
+}
+
+fn node_has_stage_source(model_ref: &str, node: &SplitReadinessNodeInput) -> bool {
+    matches!(
+        model_source_state(model_ref, node),
+        "declared" | "serving" | "available"
+    )
+}
+
+fn model_matches(candidate: &str, model_ref: &str) -> bool {
+    let candidate = candidate.trim();
+    let model_ref = model_ref.trim();
+    if candidate.eq_ignore_ascii_case(model_ref) {
+        return true;
+    }
+    let candidate_base = candidate.rsplit('/').next().unwrap_or(candidate);
+    let model_base = model_ref.rsplit('/').next().unwrap_or(model_ref);
+    candidate_base.eq_ignore_ascii_case(model_base)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SplitReadinessExclusionReason {
+    Client,
+    MissingVram,
+    MissingModelInterest,
+    StageProtocolGeneration,
+    MissingModelSource,
+}
+
+impl SplitReadinessExclusionReason {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Client => "client",
+            Self::MissingVram => "missing_vram",
+            Self::MissingModelInterest => "missing_model_interest",
+            Self::StageProtocolGeneration => "stage_protocol_generation",
+            Self::MissingModelSource => "missing_model_source",
+        }
+    }
+
+    const fn recommendation(self) -> &'static str {
+        match self {
+            Self::Client => "Run this peer in serve mode if it should contribute compute.",
+            Self::MissingVram => {
+                "Check GPU visibility or pass a lower --max-vram only after confirming the backend is detected."
+            }
+            Self::MissingModelInterest => {
+                "Start the peer with the same --model value or add explicit model interest."
+            }
+            Self::StageProtocolGeneration => {
+                "Upgrade this peer; its stage protocol generation is too old for split serving."
+            }
+            Self::MissingModelSource => {
+                "Ensure this peer can resolve or inventory the layer package before split serving."
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::api::status::{ModelTargetCapacityAdvicePayload, ModelTargetCapacityAdviceState};
+
+    fn advice(state: ModelTargetCapacityAdviceState) -> ModelTargetCapacityAdvicePayload {
+        ModelTargetCapacityAdvicePayload {
+            state,
+            reason: "test",
+            required_bytes: Some(10_000_000_000),
+            best_single_node_capacity_bytes: Some(6_000_000_000),
+            aggregate_capacity_bytes: 12_000_000_000,
+            shortfall_bytes: None,
+            eligible_node_count: 2,
+            missing_capacity_node_count: 0,
+            excluded_client_node_count: 0,
+            split_capable: true,
+        }
+    }
+
+    fn node(
+        id: &str,
+        role: SplitReadinessNodeRole,
+        requested_models: &[&str],
+    ) -> SplitReadinessNodeInput {
+        SplitReadinessNodeInput {
+            node_id: id.to_string(),
+            short_node_id: id.chars().take(8).collect(),
+            source: SplitReadinessNodeSource::Peer,
+            role,
+            vram_bytes: 8_000_000_000,
+            requested_models: requested_models
+                .iter()
+                .map(|value| value.to_string())
+                .collect(),
+            explicit_model_interests: Vec::new(),
+            serving_models: Vec::new(),
+            hosted_models: Vec::new(),
+            available_models: Vec::new(),
+            model_source: None,
+            stage_protocol_generation_supported: true,
+            artifact_transfer_supported: true,
+            rtt_ms: Some(4),
+        }
+    }
+
+    fn local_node(requested_models: &[&str]) -> SplitReadinessNodeInput {
+        let mut local = node(
+            "local00000000000000000000000000000000",
+            SplitReadinessNodeRole::Host,
+            requested_models,
+        );
+        local.source = SplitReadinessNodeSource::Local;
+        local.rtt_ms = None;
+        local
+    }
+
+    #[test]
+    fn split_readiness_waits_when_only_local_node_wants_model() {
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![node(
+                "peer000000000000000000000000000000000",
+                SplitReadinessNodeRole::Worker,
+                &[],
+            )],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.participants.len(), 1);
+        assert_eq!(report.exclusions[0].reason, "missing_model_interest");
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|item| item.contains("--model meshllm/Qwen3-8B-Q4_K_M-layers"))
+        );
+    }
+
+    #[test]
+    fn split_readiness_is_ready_with_two_interested_stage_hosts() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::Ready);
+        assert_eq!(report.participants.len(), 2);
+        assert!(report.exclusions.is_empty());
+    }
+
+    #[test]
+    fn split_readiness_does_not_borrow_capacity_from_excluded_peer() {
+        let mut local = local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]);
+        local.vram_bytes = 4_000_000_000;
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        peer.vram_bytes = 4_000_000_000;
+        let mut excluded = node(
+            "excluded000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &[],
+        );
+        excluded.vram_bytes = 40_000_000_000;
+        let mut stale_advice = advice(ModelTargetCapacityAdviceState::SplitCandidate);
+        stale_advice.aggregate_capacity_bytes = 48_000_000_000;
+        stale_advice.best_single_node_capacity_bytes = Some(40_000_000_000);
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local,
+            peers: vec![peer, excluded],
+            capacity_advice: Some(stale_advice),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        let capacity = report.capacity_advice.as_ref().expect("capacity advice");
+        assert_eq!(report.verdict, SplitReadinessVerdict::InsufficientCapacity);
+        assert_eq!(report.participant_count, 2);
+        assert_eq!(report.exclusions[0].reason, "missing_model_interest");
+        assert_eq!(capacity.aggregate_capacity_bytes, 8_000_000_000);
+        assert_eq!(
+            capacity.state,
+            ModelTargetCapacityAdviceState::InsufficientCapacity
+        );
+        assert_eq!(capacity.shortfall_bytes, Some(2_000_000_000));
+    }
+
+    #[test]
+    fn split_readiness_counts_peer_with_available_model_as_participant() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &[],
+        );
+        peer.available_models = vec!["Qwen3-8B-Q4_K_M-layers".to_string()];
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::Ready);
+        assert_eq!(report.participants.len(), 2);
+        assert!(report.exclusions.is_empty());
+    }
+
+    #[test]
+    fn split_readiness_excludes_interested_peer_with_unknown_model_source() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.artifact_transfer_supported = false;
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.participant_count, 1);
+        assert_eq!(report.exclusions[0].reason, "missing_model_source");
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|item| item.contains("resolvable package source"))
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use crate::cli::DoctorCommand;
+
+pub(crate) async fn dispatch_doctor_command(command: &DoctorCommand) -> Result<()> {
+    match command {
+        DoctorCommand::Split {
+            model_ref,
+            port,
+            json,
+            output_dir,
+        } => run_split_doctor(model_ref, *port, *json, output_dir.as_deref()).await,
+    }
+}
+
+async fn run_split_doctor(
+    model_ref: &str,
+    port: u16,
+    json_output: bool,
+    output_dir: Option<&Path>,
+) -> Result<()> {
+    let report = fetch_split_readiness_report(model_ref, port).await?;
+    if let Some(output_dir) = output_dir {
+        write_split_readiness_report(output_dir, &report)?;
+    }
+    if json_output {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        for line in split_readiness_lines(&report) {
+            println!("{line}");
+        }
+    }
+    Ok(())
+}
+
+async fn fetch_split_readiness_report(model_ref: &str, port: u16) -> Result<serde_json::Value> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()?;
+    let encoded = urlencoding::encode(model_ref);
+    let url =
+        format!("http://127.0.0.1:{port}/api/diagnostics/split-readiness?model_ref={encoded}");
+    client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| {
+            format!("Can't connect to mesh-llm console on port {port}. Is it running?")
+        })?
+        .error_for_status()?
+        .json::<serde_json::Value>()
+        .await
+        .map_err(Into::into)
+}
+
+fn write_split_readiness_report(output_dir: &Path, report: &serde_json::Value) -> Result<PathBuf> {
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("create split doctor output dir {}", output_dir.display()))?;
+    let path = output_dir.join("split-readiness.json");
+    let json = serde_json::to_string_pretty(report)?;
+    std::fs::write(&path, json)
+        .with_context(|| format!("write split readiness report {}", path.display()))?;
+    Ok(path)
+}
+
+fn split_readiness_lines(report: &serde_json::Value) -> Vec<String> {
+    let model = report["model_ref"].as_str().unwrap_or("unknown");
+    let verdict = report["verdict"].as_str().unwrap_or("unknown");
+    let participants = report["participant_count"].as_u64().unwrap_or_default();
+    let exclusions = report["exclusion_count"].as_u64().unwrap_or_default();
+
+    let mut lines = vec![
+        format!("🩺 Split readiness: {verdict}"),
+        String::new(),
+        format!("Model: {model}"),
+        format!("Eligible participants: {participants}"),
+        format!("Excluded peers: {exclusions}"),
+    ];
+
+    if let Some(items) = report["recommendations"].as_array() {
+        let recommendations = items
+            .iter()
+            .filter_map(serde_json::Value::as_str)
+            .filter(|value| !value.trim().is_empty())
+            .collect::<Vec<_>>();
+        if !recommendations.is_empty() {
+            lines.push(String::new());
+            lines.push("Recommended next steps:".to_string());
+            lines.extend(
+                recommendations
+                    .into_iter()
+                    .map(|item| format!("  - {item}")),
+            );
+        }
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{split_readiness_lines, write_split_readiness_report};
+    use serde_json::json;
+
+    #[test]
+    fn split_readiness_lines_show_waiting_guidance() {
+        let report = json!({
+            "model_ref": "meshllm/Qwen3-8B-Q4_K_M-layers",
+            "verdict": "waiting_for_peers",
+            "participant_count": 1,
+            "exclusion_count": 1,
+            "recommendations": [
+                "Start at least one more worker/host with --model meshllm/Qwen3-8B-Q4_K_M-layers --split and join it to this mesh."
+            ]
+        });
+
+        let lines = split_readiness_lines(&report);
+
+        assert!(lines.iter().any(|line| line.contains("waiting_for_peers")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("Eligible participants: 1"))
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("--model meshllm/Qwen3-8B-Q4_K_M-layers"))
+        );
+    }
+
+    #[test]
+    fn split_readiness_capture_writes_report_json() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let report = json!({"verdict": "ready"});
+
+        let path = write_split_readiness_report(dir.path(), &report).expect("write report");
+
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("split-readiness.json")
+        );
+        let written = std::fs::read_to_string(path).expect("read report");
+        assert!(written.contains("\"verdict\": \"ready\""));
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -2,6 +2,7 @@ mod agent_cli;
 mod auth;
 mod benchmark;
 mod discover;
+mod doctor;
 mod download;
 mod gpus;
 mod model_package;
@@ -16,6 +17,7 @@ use anyhow::Result;
 use crate::cli::commands::agent_cli::{run_claude, run_goose, run_opencode, run_pi};
 use crate::cli::commands::benchmark::dispatch_benchmark_command;
 use crate::cli::commands::discover::{DiscoverOptions, run_discover, run_stop};
+use crate::cli::commands::doctor::dispatch_doctor_command;
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
 use crate::cli::commands::models::dispatch_models_command;
@@ -57,6 +59,7 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             Ok(())
         }
         Command::Runtime { command } => dispatch_runtime_command(command.as_ref()).await,
+        Command::Doctor { command } => dispatch_doctor_command(command).await,
         Command::Load { name, port } => run_load(name, *port).await,
         Command::Unload { name, port } => run_drop(name, *port).await,
         Command::Status { port } => run_status(*port).await,

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -632,6 +632,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: Option<RuntimeCommand>,
     },
+    /// Diagnose local mesh, runtime, and split-readiness problems.
+    Doctor {
+        #[command(subcommand)]
+        command: DoctorCommand,
+    },
     /// Load a local model into a running mesh-llm instance.
     Load {
         /// Model name/path/url to load
@@ -868,6 +873,25 @@ pub(crate) enum PluginCommand {
     },
     /// List installed, auto-registered, and configured plugins.
     List,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum DoctorCommand {
+    /// Diagnose split-readiness for a model on a running local mesh node.
+    Split {
+        /// Model ref/name to diagnose.
+        #[arg(long, visible_alias = "model")]
+        model_ref: String,
+        /// Console/API port of the running mesh-llm instance.
+        #[arg(long, default_value = "3131")]
+        port: u16,
+        /// Print machine-readable JSON.
+        #[arg(long)]
+        json: bool,
+        /// Write split-readiness.json to this directory for sharing with maintainers.
+        #[arg(long)]
+        output_dir: Option<PathBuf>,
+    },
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -97,10 +97,23 @@ consistent without requiring you to publish a package repository first.
 ```bash
 curl -s http://localhost:3131/api/status | jq .
 curl -s http://localhost:9337/v1/models | jq '.data[].id'
+mesh-llm doctor split --model-ref meshllm/Qwen3-8B-Q4_K_M-layers --port 3131
 ```
 
 The stage runtime status is exposed through the management API and web console.
 The OpenAI model list should include the full model id once stage 0 is ready.
+The split doctor explains which peers are eligible, which peers were excluded,
+and the exact next step when the coordinator sees only itself as a valid split
+participant.
+
+On Windows, collect a shareable diagnostic bundle from already-running nodes:
+
+```powershell
+.\contrib\windows\CollectSplitDiagnostics.ps1 `
+  -Model meshllm/Qwen3-8B-Q4_K_M-layers `
+  -ConsoleUrls http://127.0.0.1:3131 `
+  -ApiUrls http://127.0.0.1:9337/v1
+```
 
 ## Cache behavior
 


### PR DESCRIPTION
## Summary

This PR adds a repeatable split-readiness diagnostic path for operators who are trying to bring up Skippy split serving across multiple nodes.

Users can now:

- Ask a running node why a model is or is not split-ready through `GET /api/diagnostics/split-readiness?model_ref=...`.
- Run `mesh-llm doctor split --model-ref <model>` for terminal-readable guidance and optional JSON capture.
- Collect a redacted Windows diagnostic bundle from already-running nodes with `contrib/windows/CollectSplitDiagnostics.ps1`.
- Follow the documented split doctor flow from `docs/SKIPPY_SPLITS.md` and the Windows helper README.

## Why

Recent split setup debugging showed that users can hit symptoms like "only one valid node", repeated manifest transfer, missing stage source, or unclear GPU/backend eligibility without a compact way to prove which node was excluded and why.

This keeps the fix operational and low-risk: it does not change split placement, routing, gossip, protocol payloads, model loading, or artifact transfer behavior. It only exposes the already-known readiness signals in a focused diagnostic surface and adds a shareable capture path for Windows repros.

## Diff scope

- Adds a read-only split-readiness report that classifies local and peer nodes as eligible participants or exclusions.
- Computes readiness verdicts and capacity evidence from the same participant set shown in the report, so excluded high-capacity peers cannot make the diagnostic report `ready`.
- Reports peers with missing stage/package source proof as excluded with `missing_model_source` instead of treating unknown source state as ready.
- Adds exclusion reasons for client role, missing VRAM, missing model interest/source signal, and missing stage protocol generation support.
- Adds recommendations for common operator mistakes, including starting another worker/host with the same model and using distinct ports when testing multiple local processes.
- Adds `mesh-llm doctor split` with human-readable output, `--json`, and `--output-dir` support.
- Adds a Windows collector that captures redacted status/runtime/models/split-readiness payloads, GPU/process facts, optional probe output, and recent Skippy native log tails without starting or stopping mesh processes.
- Updates split and Windows docs to point users at the new flow.

## Compatibility and safety

No mesh wire protocol change.
No plugin protocol change.
No Skippy ABI change.
No routing or model-load behavior change.
The management endpoint is read-only.
The Windows collector redacts token/auth/join-like values before writing captured HTTP payloads.

## Validation

Validation tier: Tier 4 - split-readiness verification tooling, read-only management diagnostics, Windows capture helper, and post-review diagnostic correctness repair; no routing, wire protocol, or model-load behavior change.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `6f6d606c6191fafce68973eff56fe7aa3e035533`.
- `git rebase origin/main`: PASS, no conflicts.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS, no output.
- `cargo test -p mesh-llm-host-runtime split_readiness --lib -- --test-threads=1`: PASS, 9 passed.
- `cargo check -p mesh-llm`: PASS.
- `cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.

Ledger: not applicable - not required for selected validation tier/change family.
Version: not applicable - diagnostics/tooling/docs only; no release/version sync required.

Not run:

- PowerShell syntax/help validation - `pwsh` is not installed in this environment.
- Live two-node split smoke - no local split-capable multi-node runtime/model endpoint was available; deterministic split-readiness tests cover the diagnostic classification and capture path.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

The Windows collector should still be exercised on an actual Windows machine with `pwsh` and a running mesh setup before treating it as fully field-proven. The Rust-side diagnostic classification and CLI output are covered locally.
