### PR TITLE
Return OpenAI-shaped runtime errors for failed model loads

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -4268,8 +4268,7 @@ pub async fn send_json_with_status_and_headers(
 }
 
 pub async fn send_400(mut stream: TcpStream, msg: &str) -> std::io::Result<()> {
-    let body = serde_json::to_vec(&serde_json::json!({ "error": msg }))
-        .expect("serializing JSON error response should not fail");
+    let body = openai_error_body(400, msg);
     let headers = format!(
         "HTTP/1.1 400 Bad Request\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
         body.len()
@@ -4282,13 +4281,20 @@ pub async fn send_400(mut stream: TcpStream, msg: &str) -> std::io::Result<()> {
 
 pub async fn send_error(mut stream: TcpStream, code: u16, msg: &str) -> std::io::Result<()> {
     let status = match code {
+        401 => "Unauthorized",
+        403 => "Forbidden",
         404 => "Not Found",
         409 => "Conflict",
+        413 => "Payload Too Large",
         422 => "Unprocessable Content",
         429 => "Too Many Requests",
+        500 => "Internal Server Error",
+        502 => "Bad Gateway",
+        503 => "Service Unavailable",
+        504 => "Gateway Timeout",
         _ => "Bad Request",
     };
-    let body = serde_json::json!({"error": msg}).to_string();
+    let body = openai_error_body(code, msg);
     let retry_after = if code == 429 {
         "Retry-After: 5\r\n"
     } else {
@@ -4297,7 +4303,7 @@ pub async fn send_error(mut stream: TcpStream, code: u16, msg: &str) -> std::io:
     let resp = format!(
         "HTTP/1.1 {code} {status}\r\nContent-Type: application/json\r\n{retry_after}Content-Length: {}\r\n\r\n{}",
         body.len(),
-        body
+        String::from_utf8_lossy(&body)
     );
     stream.write_all(resp.as_bytes()).await?;
     stream.shutdown().await?;
@@ -4310,15 +4316,57 @@ pub async fn send_503(stream: TcpStream, reason: &str) -> std::io::Result<()> {
 }
 
 async fn send_503_inner(mut stream: TcpStream, reason: &str) -> std::io::Result<()> {
-    let body = serde_json::json!({"error": reason}).to_string();
+    let body = openai_error_body(503, reason);
     let resp = format!(
         "HTTP/1.1 503 Service Unavailable\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
         body.len(),
-        body
+        String::from_utf8_lossy(&body)
     );
     stream.write_all(resp.as_bytes()).await?;
     stream.shutdown().await?;
     Ok(())
+}
+
+fn openai_error_body(status_code: u16, message: &str) -> Vec<u8> {
+    let status =
+        http::StatusCode::from_u16(status_code).unwrap_or(http::StatusCode::INTERNAL_SERVER_ERROR);
+    let kind = openai_error_kind_for_status(status_code);
+    let error = openai_frontend::OpenAiError::from_kind(status, kind, message)
+        .with_code(openai_error_code_for_status(status_code));
+    serde_json::to_vec(&error.body()).expect("serializing JSON error response should not fail")
+}
+
+const fn openai_error_kind_for_status(status_code: u16) -> openai_frontend::OpenAiErrorKind {
+    match status_code {
+        401 => openai_frontend::OpenAiErrorKind::Authentication,
+        403 => openai_frontend::OpenAiErrorKind::Permission,
+        404 => openai_frontend::OpenAiErrorKind::NotFound,
+        413 => openai_frontend::OpenAiErrorKind::PayloadTooLarge,
+        429 => openai_frontend::OpenAiErrorKind::RateLimit,
+        500 => openai_frontend::OpenAiErrorKind::Internal,
+        502 => openai_frontend::OpenAiErrorKind::ServiceUnavailable,
+        503 => openai_frontend::OpenAiErrorKind::ServiceUnavailable,
+        504 => openai_frontend::OpenAiErrorKind::Timeout,
+        _ => openai_frontend::OpenAiErrorKind::InvalidRequest,
+    }
+}
+
+const fn openai_error_code_for_status(status_code: u16) -> &'static str {
+    match status_code {
+        400 => "bad_request",
+        401 => "invalid_api_key",
+        403 => "permission_denied",
+        404 => "model_not_found",
+        409 => "conflict",
+        413 => "payload_too_large",
+        422 => "unprocessable_content",
+        429 => "rate_limit_exceeded",
+        500 => "internal_server_error",
+        502 => "service_unavailable",
+        503 => "service_unavailable",
+        504 => "timeout",
+        _ => "invalid_request",
+    }
 }
 
 /// Pipeline-aware HTTP proxy for local targets.
@@ -4498,6 +4546,7 @@ async fn relay_pipeline_non_streaming_response(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::Future;
     use tokio::net::TcpListener;
 
     // ── Header-name validation ──────────────────────────────────────
@@ -5728,36 +5777,63 @@ mod tests {
 
     #[tokio::test]
     async fn test_send_error_429_includes_retry_after() {
-        use tokio::io::AsyncReadExt;
-        use tokio::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let server = tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.unwrap();
-            super::send_error(stream, 429, "model not available")
-                .await
-                .unwrap();
-        });
-
-        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let mut buf = vec![0u8; 4096];
-        let mut total = 0;
-        loop {
-            let n = client.read(&mut buf[total..]).await.unwrap();
-            if n == 0 {
-                break;
-            }
-            total += n;
-        }
-        let response = String::from_utf8_lossy(&buf[..total]);
+        let response = capture_proxy_error_response(|stream| async move {
+            super::send_error(stream, 429, "model not available").await
+        })
+        .await;
+        let body = response_json_body(&response);
 
         assert!(response.starts_with("HTTP/1.1 429 Too Many Requests\r\n"));
         assert!(response.contains("Retry-After: 5\r\n"));
-        assert!(response.contains("model not available"));
+        assert_eq!(body["error"]["message"], "model not available");
+        assert_eq!(body["error"]["type"], "rate_limit_error");
+        assert_eq!(body["error"]["code"], "rate_limit_exceeded");
+    }
 
+    #[tokio::test]
+    async fn test_send_503_uses_openai_error_shape() {
+        let response = capture_proxy_error_response(|stream| async move {
+            super::send_503(stream, "skippy ABI call failed: Unsupported").await
+        })
+        .await;
+        let body = response_json_body(&response);
+
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable\r\n"));
+        assert_eq!(
+            body["error"]["message"],
+            "skippy ABI call failed: Unsupported"
+        );
+        assert_eq!(body["error"]["type"], "server_error");
+        assert_eq!(body["error"]["code"], "service_unavailable");
+    }
+
+    async fn capture_proxy_error_response<F, Fut>(send: F) -> String
+    where
+        F: FnOnce(tokio::net::TcpStream) -> Fut + Send + 'static,
+        Fut: Future<Output = std::io::Result<()>> + Send + 'static,
+    {
+        use tokio::io::AsyncReadExt;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            send(stream).await.unwrap();
+        });
+
+        let mut client = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let mut output = Vec::new();
+        client.read_to_end(&mut output).await.unwrap();
         server.await.unwrap();
+        String::from_utf8(output).unwrap()
+    }
+
+    fn response_json_body(response: &str) -> serde_json::Value {
+        let body_start = response
+            .find("\r\n\r\n")
+            .map(|index| index + 4)
+            .expect("response contains header terminator");
+        serde_json::from_str(&response[body_start..]).unwrap()
     }
 
     #[test]

--- a/crates/openai-frontend/src/errors.rs
+++ b/crates/openai-frontend/src/errors.rs
@@ -178,7 +178,9 @@ fn map_upstream_kind(status_code: u16, upstream_type: &str) -> OpenAiErrorKind {
         (403, _) => OpenAiErrorKind::Permission,
         (404, _) => OpenAiErrorKind::NotFound,
         (429, _) => OpenAiErrorKind::RateLimit,
+        (502, _) => OpenAiErrorKind::ServiceUnavailable,
         (503, _) => OpenAiErrorKind::ServiceUnavailable,
+        (504, _) => OpenAiErrorKind::Timeout,
         _ => OpenAiErrorKind::Internal,
     }
 }

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -1135,6 +1135,7 @@ pub struct ResponseSseState {
     pub usage: Option<Value>,
     pub created_emitted: bool,
     pub output_item_emitted: bool,
+    pub failed: bool,
 }
 
 impl ResponseSseState {
@@ -1150,6 +1151,7 @@ impl ResponseSseState {
             usage: None,
             created_emitted: false,
             output_item_emitted: false,
+            failed: false,
         }
     }
 

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -214,6 +214,9 @@ async fn responses(
                 let mut state_machine = body_state
                     .lock()
                     .expect("responses stream state lock poisoned");
+                if state_machine.failed {
+                    return stream::iter(out.into_iter().map(Ok::<_, Infallible>));
+                }
                 match item {
                     Ok(chunk) => {
                         if !state_machine.created_emitted {
@@ -280,6 +283,7 @@ async fn responses(
                         }
                     }
                     Err(error) => {
+                        state_machine.failed = true;
                         out.push(
                             Event::default()
                                 .event("error")
@@ -295,6 +299,9 @@ async fn responses(
                     .lock()
                     .expect("responses stream state lock poisoned");
                 let mut out = Vec::new();
+                if state_machine.failed {
+                    return out;
+                }
                 if !state_machine.created_emitted {
                     let sequence_number = state_machine.next_sequence_number();
                     out.push(
@@ -913,6 +920,19 @@ mod tests {
     }
 
     #[test]
+    fn upstream_error_body_maps_legacy_string_error_shape() {
+        let body = br#"{"error":"skippy ABI call failed: Unsupported"}"#;
+        let mapped = map_upstream_error_body(503, body).unwrap();
+        let value: Value = serde_json::from_slice(&mapped).unwrap();
+        assert_eq!(
+            value["error"]["message"],
+            "skippy ABI call failed: Unsupported"
+        );
+        assert_eq!(value["error"]["type"], "server_error");
+        assert_eq!(value["error"]["code"], "service_unavailable");
+    }
+
+    #[test]
     fn already_openai_error_passthrough_is_detected() {
         let value = json!({
             "error": {
@@ -1143,6 +1163,26 @@ mod tests {
         let body = response_body_text(response).await;
         assert!(body.contains(r#""error":{"#));
         assert!(body.contains(r#""code":"service_unavailable""#));
+        assert!(body.contains("data: [DONE]"));
+    }
+
+    #[tokio::test]
+    async fn responses_stream_frames_backend_errors_without_completed_tail() {
+        let response = post_json(
+            "/v1/responses",
+            json!({
+                "model": "stream-error",
+                "input": "hi",
+                "stream": true
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_body_text(response).await;
+        assert!(body.contains("event: error"));
+        assert!(body.contains(r#""message":"stream backend failed""#));
+        assert!(body.contains(r#""code":"service_unavailable""#));
+        assert!(!body.contains("event: response.completed"));
         assert!(body.contains("data: [DONE]"));
     }
 

--- a/crates/openai-frontend/src/sse.rs
+++ b/crates/openai-frontend/src/sse.rs
@@ -5,7 +5,9 @@ use serde::Serialize;
 
 pub fn json_event(value: &impl Serialize) -> Result<Event, Infallible> {
     Ok(Event::default().json_data(value).unwrap_or_else(|_| {
-        Event::default().data(r#"{"error":{"message":"failed to serialize SSE event"}}"#)
+        Event::default().data(
+            r#"{"error":{"message":"failed to serialize SSE event","type":"server_error","param":null,"code":"internal_server_error"}}"#,
+        )
     }))
 }
 


### PR DESCRIPTION
## Summary

Fixes #715.

This PR makes runtime/model-load failures visible to OpenAI-compatible clients in the standard OpenAI error envelope instead of returning legacy string-shaped bodies such as `{"error":"..."}`.

Users and agent harnesses can now reliably read:

- `error.message` with the original backend/runtime failure text.
- `error.type` with a compatible OpenAI error category.
- `error.code` with a stable machine-readable code.

## Why

OpenCode and similar SDK clients expect OpenAI-compatible errors to use `{"error":{"message":...,"type":...,"param":...,"code":...}}`. When a Skippy/model-load failure surfaced through the host-runtime proxy as a raw string error, clients could not parse the useful backend message even though the runtime had the right diagnostic text.

This keeps the backend message intact while normalizing the transport contract at the OpenAI boundary.

## Diff scope

- Normalizes host-runtime proxy helper errors for 400/429/503-style responses into OpenAI-compatible error bodies.
- Preserves retry behavior, including `Retry-After` for rate-limit style responses.
- Extends upstream error mapping so legacy string errors and 502/503/504 upstream failures map into stable OpenAI-compatible kinds.
- Prevents `/v1/responses` streaming from emitting a misleading `response.completed` tail after a backend stream error.
- Ensures fallback SSE serialization errors also use a complete OpenAI error body shape.
- Adds regression tests for legacy string error mapping, proxy error helpers, and Responses streaming error tails.

## Compatibility and safety

No mesh wire protocol change.
No plugin protocol change.
No Skippy ABI change.
No release metadata change.
The change is limited to OpenAI-compatible HTTP error formatting and Responses-stream error termination semantics.
The original backend/runtime error text remains available in `error.message`.

## Validation

Validation tier: Tier 3 - shared OpenAI-compatible error contract across host-runtime proxy helpers and openai-frontend Responses streaming for issue #715; no protocol/schema or release metadata change.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `a8537718183fa714a56af169177b4767ec23f186`.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS, no output.
- `cargo test -p openai-frontend error --lib`: PASS, 17 passed.
- `cargo test -p openai-frontend --lib`: PASS, 156 passed.
- `cargo test -p mesh-llm-host-runtime send_ --lib -- --test-threads=1`: PASS, 2 passed.
- `cargo check -p mesh-llm`: PASS.
- `cargo-clippy clippy -p openai-frontend -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.

Ledger: not applicable - not required for selected validation tier/change family.
Version: not applicable - no release/version sync required for this non-release runtime compatibility fix.

Not run:

- Live OpenCode/opencode smoke against the failing GGUF models - no local loaded model/runtime endpoint for those models was available; deterministic proxy/frontend tests prove the OpenAI error envelope and streaming failure branches.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

The exact OpenCode symptom should still be confirmed with one of the originally failing models once a maintainer has that model loaded locally. The error-shape contract and streaming failure branches are covered deterministically in this PR.
