### PR TITLE
Guard release version mismatches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,12 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install cmake ninja lld
 
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+
       - name: Build release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -183,6 +189,12 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install cmake ninja lld
 
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+
       - name: Package native SDK runtime
         run: |
           scripts/package-native-sdk.sh \
@@ -222,6 +234,12 @@ jobs:
 
       - name: Install macOS dependencies
         run: brew install cmake ninja lld
+
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
 
       - name: Build SwiftPM binary artifact
         run: |
@@ -284,6 +302,11 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl lld
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build ARM64 CPU release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -331,6 +354,11 @@ jobs:
             crates/mesh-llm-ui/pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build CUDA release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -378,6 +406,11 @@ jobs:
             crates/mesh-llm-ui/pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build CUDA Blackwell release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -425,6 +458,11 @@ jobs:
             crates/mesh-llm-ui/pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build ROCm release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -460,6 +498,11 @@ jobs:
       - uses: taiki-e/install-action@just
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl glslc libvulkan-dev spirv-headers lld
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build Vulkan release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -493,6 +536,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Build Windows CPU release bundle
         shell: pwsh
         env:
@@ -554,6 +603,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
       - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Cache Windows SDK installers
         if: ${{ matrix.backend != 'cuda' }}
         uses: actions/cache@v5
@@ -624,6 +679,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - uses: dtolnay/rust-toolchain@stable
+        if: github.event_name == 'workflow_dispatch'
+
       - name: Download release artifacts
         uses: actions/download-artifact@v7
         with:
@@ -651,14 +709,15 @@ jobs:
             echo "Release tag already exists: $RELEASE_TAG" >&2
             exit 1
           fi
+          scripts/release-version.sh "$RELEASE_TAG"
           cp generated-swift-manifest/Package.swift Package.swift
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Package.swift
-          if git diff --cached --quiet -- Package.swift; then
-            echo "Package.swift already matches generated SwiftPM manifest"
+          git add Cargo.toml Cargo.lock crates/*/Cargo.toml tools/*/Cargo.toml sdk/kotlin/build.gradle.kts Package.swift
+          if git diff --cached --quiet; then
+            echo "Release source files already match $RELEASE_TAG"
           else
-            git commit -m "$RELEASE_TAG: prepare Swift package manifest"
+            git commit -m "$RELEASE_TAG: prepare release source"
           fi
           git tag "$RELEASE_TAG"
           git push origin "refs/tags/$RELEASE_TAG"

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -892,6 +892,7 @@ async fn install_latest_bundle(
         download_url(&release_asset_url(&release.tag, asset_name), &archive).await?;
         extract_bundle_archive(&archive, &extracted)?;
         let staged_files = collect_bundle_files(&extracted, expected_flavor)?;
+        verify_staged_mesh_binary_version(&extracted, &release.version)?;
         finish_bundle_install(
             exe,
             install_dir,
@@ -1091,6 +1092,34 @@ fn collect_bundle_files(
     );
     files.sort_by_key(|name| (name == &mesh_binary_name(), name.clone()));
     Ok(files)
+}
+
+fn verify_staged_mesh_binary_version(extracted: &Path, expected_version: &str) -> Result<()> {
+    let binary = extracted.join(mesh_binary_name());
+    let output = std::process::Command::new(&binary)
+        .arg("--version")
+        .output()
+        .with_context(|| format!("Failed to run staged binary {}", binary.display()))?;
+
+    anyhow::ensure!(
+        output.status.success(),
+        "Staged binary {} failed --version with status {}",
+        binary.display(),
+        output.status
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let actual_version = stdout
+        .split_whitespace()
+        .last()
+        .context("Staged binary --version output was empty")?;
+    anyhow::ensure!(
+        actual_version == expected_version,
+        "Downloaded release v{} contains mesh-llm v{}; refusing to install mismatched bundle.",
+        expected_version,
+        actual_version
+    );
+    Ok(())
 }
 
 #[cfg(not(windows))]
@@ -1714,6 +1743,27 @@ mod tests {
         let path = dir.join("mesh-llm");
         std::fs::write(&path, b"binary").unwrap();
         assert!(path_is_writable(&path));
+        let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_staged_binary_version_must_match_release() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = temp_dir("self-update-version-check");
+        let binary = dir.join(mesh_binary_name());
+        std::fs::write(&binary, "#!/bin/sh\necho 'mesh-llm 0.68.0'\n").unwrap();
+        let mut permissions = std::fs::metadata(&binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&binary, permissions).unwrap();
+
+        verify_staged_mesh_binary_version(&dir, "0.68.0").unwrap();
+        let err = verify_staged_mesh_binary_version(&dir, "0.69.0").unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("contains mesh-llm v0.68.0; refusing to install")
+        );
         let _ = std::fs::remove_dir_all(dir);
     }
 

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -154,6 +154,25 @@ function Require-File {
     }
 }
 
+function Assert-MeshBinaryVersion {
+    param(
+        [string]$Path,
+        [string]$ExpectedVersion
+    )
+
+    $expected = $ExpectedVersion.TrimStart("v")
+    $output = & $Path --version
+    if ($LASTEXITCODE -ne 0) {
+        throw "Release binary failed --version with exit code ${LASTEXITCODE}: $Path"
+    }
+
+    $parts = "$output".Trim() -split '\s+'
+    $actual = if ($parts.Count -gt 0) { $parts[$parts.Count - 1] } else { "" }
+    if ($actual -ne $expected) {
+        throw "Release binary version mismatch: expected $expected, got ${actual}. Binary: $Path. Output: $output"
+    }
+}
+
 $Version = Normalize-RecipeArgument $Version @("version")
 $OutputDir = Normalize-RecipeArgument $OutputDir @("output", "output_dir", "outputdir")
 $Flavor = Normalize-RecipeArgument $Flavor @("flavor", "backend")
@@ -183,7 +202,10 @@ $bundleDir = Join-Path $stagingRoot "mesh-bundle"
 New-Item -ItemType Directory -Path $bundleDir -Force | Out-Null
 
 try {
-    Copy-Item $meshBinary -Destination (Join-Path $bundleDir (Get-BundleBinaryName "mesh-llm" $binaryFlavor)) -Force
+    $bundleBinary = Join-Path $bundleDir (Get-BundleBinaryName "mesh-llm" $binaryFlavor)
+    Copy-Item $meshBinary -Destination $bundleBinary -Force
+    Assert-MeshBinaryVersion -Path $bundleBinary -ExpectedVersion $Version
+
     $versionedPath = Join-Path $resolvedOutputDir $versionedAsset
     $stablePath = Join-Path $resolvedOutputDir $stableAsset
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -307,6 +307,28 @@ usage() {
     echo "usage: scripts/package-release.sh <version> [output_dir]" >&2
 }
 
+verify_mesh_binary_version() {
+    local binary="$1"
+    local expected="$2"
+    local output
+    local actual
+
+    expected="${expected#v}"
+    if [[ ! -x "$binary" ]]; then
+        echo "Release binary is not executable: $binary" >&2
+        exit 1
+    fi
+
+    output="$("$binary" --version)"
+    actual="$(awk '{print $NF}' <<<"$output")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "Release binary version mismatch: expected $expected, got ${actual:-<empty>}" >&2
+        echo "Binary: $binary" >&2
+        echo "Output: $output" >&2
+        exit 1
+    fi
+}
+
 main() {
     if [[ $# -lt 1 || -z "${1:-}" ]]; then
         usage
@@ -334,6 +356,7 @@ main() {
     mkdir -p "$bundle_dir"
 
     cp "$RELEASE_BIN_DIR/mesh-llm${BIN_EXT}" "$bundle_dir/$(bundle_bin_name mesh-llm)"
+    verify_mesh_binary_version "$bundle_dir/$(bundle_bin_name mesh-llm)" "$version"
 
     if [[ "$os_name" == "Darwin" ]]; then
         for bin in "$bundle_dir/$(bundle_bin_name mesh-llm)"; do


### PR DESCRIPTION
## Summary

This prevents release artifacts and self-updates from silently accepting a bundle whose embedded `mesh-llm --version` does not match the release tag.

## Root Cause

The `v0.69.0` workflow-dispatched release built artifacts from a checkout whose Cargo workspace version was still `0.68.0`. The publish job then created a `v0.69.0` tag that only updated `Package.swift`, so the GitHub release metadata said `v0.69.0` while the macOS arm64 bundle still contained a `0.68.0` binary.

## Changes

- Run `scripts/release-version.sh "$RELEASE_TAG"` before each workflow-dispatched release build, including native SDK and Swift artifact jobs.
- Include Cargo/Kotlin version bumps in the workflow-dispatched release tag commit.
- Make Unix and Windows release packagers fail if the bundled `mesh-llm --version` does not match the requested release version.
- Make self-update verify the staged downloaded binary version before replacing the installed executable.

## Validation

- `rustfmt --edition 2024 --check crates/mesh-llm-system/src/autoupdate.rs`
- `cargo test -p mesh-llm-system test_staged_binary_version_must_match_release`
- `cargo check -p mesh-llm-system`
- `bash -n scripts/package-release.sh scripts/release-version.sh`
- YAML parse for `.github/workflows/release.yml`
- `git diff --check`
- `cargo run -p xtask -- repo-consistency release-targets`
- `cargo run -p xtask -- repo-consistency ci-crate-lists`
- Manual packaging smoke: matching fake binary succeeds; mismatched fake binary fails with the expected version mismatch error.