### PR TITLE
Add plugin host version checks

### DIFF
--- a/.github/workflows/docker-precheck.yml
+++ b/.github/workflows/docker-precheck.yml
@@ -71,6 +71,7 @@ jobs:
             crates/mesh-llm-config/ \
             crates/mesh-llm-console-server/ \
             crates/mesh-llm-plugin/ \
+            crates/mesh-llm-skills/ \
             crates/mesh-llm-plugin-manager/ \
             crates/mesh-client/ \
             crates/mesh-llm-api-client/ \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4031,6 +4031,7 @@ dependencies = [
  "dirs",
  "flate2",
  "futures-util",
+ "mesh-llm-skills",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4056,6 +4057,17 @@ name = "mesh-llm-routing"
 version = "0.68.0"
 dependencies = [
  "iroh",
+]
+
+[[package]]
+name = "mesh-llm-skills"
+version = "0.68.0"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4033,10 +4033,12 @@ dependencies = [
  "futures-util",
  "mesh-llm-skills",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "tar",
  "tempfile",
+ "toml 0.9.12+spec-1.1.0",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/mesh-llm-console-server",
     "crates/mesh-llm-ui",
     "crates/mesh-llm-plugin",
+    "crates/mesh-llm-skills",
     "crates/mesh-llm-plugin-manager",
     "crates/mesh-client",
     "crates/mesh-llm-api-client",

--- a/crates/mesh-llm-host-runtime/src/cli/commands/agent_cli.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/agent_cli.rs
@@ -1,6 +1,8 @@
 use anyhow::{Context, Result};
+use mesh_llm_plugin_manager::SkillAgent;
 use std::process::{Command, Stdio};
 
+use crate::cli::commands::skills::install_skills_for_agent;
 use crate::{cli::shell, runtime};
 use url::Url;
 
@@ -483,6 +485,7 @@ pub(crate) async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
     std::fs::write(&provider_path, serde_json::to_string_pretty(&provider)?)?;
     eprintln!("✅ Wrote {}", provider_path.display());
     write_goose_mcp_config(DEFAULT_MESH_MCP_URL)?;
+    install_skills_for_agent(SkillAgent::Goose);
 
     let goose_app = std::path::Path::new("/Applications/Goose.app");
     if goose_app.exists() {
@@ -560,6 +563,7 @@ pub(crate) async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
     });
     let settings_json = serde_json::to_string(&settings)?;
     let mcp_config_json = mesh_mcp_claude_config_json(DEFAULT_MESH_MCP_URL)?;
+    install_skills_for_agent(SkillAgent::Claude);
 
     eprintln!("🚀 Launching Claude Code with {chosen} → {base_url}\n");
     let mut command = Command::new("claude");
@@ -801,6 +805,7 @@ fn run_pi_with_mesh(
     write: bool,
 ) -> Result<()> {
     write_pi_config_with_limits(model_names, base_url, context_lengths)?;
+    install_skills_for_agent(SkillAgent::Pi);
 
     if write {
         return Ok(());
@@ -843,6 +848,7 @@ pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool)
     };
 
     let result = if write {
+        install_skills_for_agent(SkillAgent::Opencode);
         write_opencode_config(&client, &models, &chosen, &target).await
     } else {
         let spec = build_opencode_launch_spec_with_mcp(
@@ -856,6 +862,7 @@ pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool)
             "🚀 Launching OpenCode with {} → {}\n",
             chosen, target.api_base_url
         );
+        install_skills_for_agent(SkillAgent::Opencode);
         let mut command = Command::new("opencode");
         command
             .args(["-m", &spec.model])

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -9,6 +9,7 @@ mod models;
 mod plugin;
 mod plugin_cli;
 mod runtime;
+mod skills;
 mod update;
 
 use anyhow::Result;
@@ -22,6 +23,7 @@ use crate::cli::commands::models::dispatch_models_command;
 use crate::cli::commands::plugin::run_plugin_command;
 use crate::cli::commands::plugin_cli::run_external_plugin_command;
 use crate::cli::commands::runtime::{dispatch_runtime_command, run_drop, run_load, run_status};
+use crate::cli::commands::skills::run_skills_command;
 use crate::cli::commands::update::run_update;
 use crate::cli::{AuthCommand, Cli, Command};
 use crate::network::nostr;
@@ -86,6 +88,7 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
         Command::Claude { model, port } => run_claude(model.clone(), *port).await,
         Command::Pi { model, host, write } => run_pi(model.clone(), host, *write).await,
         Command::Opencode { model, host, write } => run_opencode(model.clone(), host, *write).await,
+        Command::Skills { command } => run_skills_command(command),
         Command::Plugin { command } => run_plugin_command(command, cli).await,
         Command::Benchmark { command } => dispatch_benchmark_command(command).await,
         Command::ModelPrepare { .. } => dispatch_model_prepare(cmd).await,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/plugin_cli.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/plugin_cli.rs
@@ -2,7 +2,7 @@ use std::ffi::OsString;
 use std::io::Write;
 
 use anyhow::{Context, Result, bail};
-use mesh_llm_plugin_manager::{PluginStore, default_store_root};
+use mesh_llm_plugin_manager::{PluginStore, default_store_root, validate_plugin_compatibility};
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 
@@ -139,6 +139,8 @@ fn resolve_installed_cli_plugin(command: &str) -> Result<Option<plugin::External
     if !metadata.enabled {
         return Ok(None);
     }
+    validate_plugin_compatibility(&metadata.install_path, crate::VERSION)
+        .with_context(|| format!("🚫 Plugin command '{}' is not compatible", metadata.name))?;
     let executable = metadata.executable_path();
     if !executable.exists() {
         bail!(
@@ -272,6 +274,14 @@ mod tests {
         }
     }
 
+    fn write_plugin_toml(install_path: &std::path::Path) {
+        std::fs::write(
+            install_path.join("plugin.toml"),
+            "min_mesh_llm_version = \"0.0.0\"",
+        )
+        .unwrap();
+    }
+
     #[test]
     #[serial]
     fn resolves_installed_cli_plugin_when_not_configured() {
@@ -279,6 +289,7 @@ mod tests {
         let _plugin_dir = EnvGuard::set("MESH_LLM_PLUGIN_DIR", temp.path());
         let install_path = temp.path().join("installed").join("demo");
         std::fs::create_dir_all(&install_path).unwrap();
+        write_plugin_toml(&install_path);
         let executable = install_path.join(format!("demo{}", std::env::consts::EXE_SUFFIX));
         std::fs::write(&executable, "").unwrap();
         PluginStore::new(temp.path())
@@ -300,6 +311,7 @@ mod tests {
         let _plugin_dir = EnvGuard::set("MESH_LLM_PLUGIN_DIR", temp.path());
         let install_path = temp.path().join("installed").join("demo");
         std::fs::create_dir_all(&install_path).unwrap();
+        write_plugin_toml(&install_path);
         PluginStore::new(temp.path())
             .save(&installed_metadata("demo", install_path))
             .unwrap();

--- a/crates/mesh-llm-host-runtime/src/cli/commands/skills.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/skills.rs
@@ -1,0 +1,180 @@
+use anyhow::Result;
+use mesh_llm_plugin_manager::{
+    PluginSkillInstallOptions, SkillAgent, SkillInstallReport, SkillInstallStatus,
+    install_available_skills,
+};
+
+use crate::cli::{SkillAgentArg, SkillCommand};
+
+pub(crate) fn run_skills_command(command: &SkillCommand) -> Result<()> {
+    match command {
+        SkillCommand::Install {
+            agent,
+            all,
+            dry_run,
+            force,
+        } => install(agent, *all, *dry_run, *force),
+    }
+}
+
+pub(crate) fn install_skills_for_agent(agent: SkillAgent) {
+    match PluginSkillInstallOptions::for_agent(agent).and_then(|options| {
+        let report = install_available_skills(&options)?;
+        Ok(report)
+    }) {
+        Ok(report) => print_agent_install_summary(agent, &report),
+        Err(error) => eprintln!(
+            "⚠️  Could not install mesh plugin skills for {}: {error}",
+            agent.as_str()
+        ),
+    }
+}
+
+fn install(agents: &[SkillAgentArg], all: bool, dry_run: bool, force: bool) -> Result<()> {
+    let mut options = PluginSkillInstallOptions::from_env()?;
+    options.skill_options.dry_run = dry_run;
+    options.skill_options.force = force;
+    if all {
+        options.skill_options.detected_only = false;
+    }
+    if !agents.is_empty() {
+        options.skill_options.agents = agents.iter().copied().map(Into::into).collect();
+        options.skill_options.detected_only = false;
+    }
+    let report = install_available_skills(&options)?;
+    print_install_report(&report, dry_run);
+    Ok(())
+}
+
+fn print_agent_install_summary(agent: SkillAgent, report: &SkillInstallReport) {
+    let changed = report
+        .actions
+        .iter()
+        .filter(|action| {
+            matches!(
+                action.status,
+                SkillInstallStatus::Installed | SkillInstallStatus::Updated
+            )
+        })
+        .count();
+    if changed > 0 {
+        eprintln!(
+            "✅ Installed {changed} mesh plugin skill(s) for {}",
+            agent.as_str()
+        );
+    }
+}
+
+fn print_install_report(report: &SkillInstallReport, dry_run: bool) {
+    let heading = if dry_run {
+        "🧪 Mesh plugin skill install preview"
+    } else {
+        "🧠 Installing mesh plugin skills"
+    };
+    eprintln!("{heading}");
+
+    if report.available_skills == 0 {
+        eprintln!("🔎 No plugin skills found in installed plugins.");
+        eprintln!("📦 Plugins can expose skills with skills/<name>/SKILL.md.");
+        return;
+    }
+
+    eprintln!(
+        "📦 Found {}",
+        plural_count(report.available_skills, "plugin skill")
+    );
+
+    if report.targets.is_empty() {
+        eprintln!("🔎 No supported agent skill targets detected.");
+        eprintln!("💡 Use --agent <agent> or --all to install anyway.");
+        return;
+    }
+
+    eprintln!(
+        "🎯 Targeting {}:",
+        plural_count(report.targets.len(), "agent")
+    );
+    for target in &report.targets {
+        let reason = target
+            .detection_reason
+            .as_deref()
+            .unwrap_or("explicit target");
+        eprintln!(
+            "   • {:<8} {} ({reason})",
+            target.agent.as_str(),
+            target.root.display()
+        );
+    }
+
+    eprintln!("🛠️  Applying skills:");
+    for action in &report.actions {
+        let Some(label) = action_status_label(&action.status, dry_run) else {
+            continue;
+        };
+        eprintln!(
+            "   {label:<17} {:<28} -> {:<8} {}",
+            skill_display_name(action),
+            action.agent.as_str(),
+            action.destination_dir.display()
+        );
+    }
+
+    print_install_summary(report, dry_run);
+}
+
+fn print_install_summary(report: &SkillInstallReport, dry_run: bool) {
+    let mut installed = 0;
+    let mut updated = 0;
+    let mut unchanged = 0;
+    let mut conflicts = 0;
+    for action in &report.actions {
+        match action.status {
+            SkillInstallStatus::Installed | SkillInstallStatus::WouldInstall => installed += 1,
+            SkillInstallStatus::Updated | SkillInstallStatus::WouldUpdate => updated += 1,
+            SkillInstallStatus::Unchanged => unchanged += 1,
+            SkillInstallStatus::SkippedConflict | SkillInstallStatus::WouldSkipConflict => {
+                conflicts += 1;
+            }
+        }
+    }
+
+    let verb = if dry_run { "planned" } else { "complete" };
+    let mut parts = vec![
+        format!("{}", plural_count(installed, "install")),
+        format!("{}", plural_count(updated, "update")),
+    ];
+    if unchanged > 0 {
+        parts.push(format!("{}", plural_count(unchanged, "unchanged")));
+    }
+    if conflicts > 0 {
+        parts.push(format!("{}", plural_count(conflicts, "conflict")));
+    }
+    eprintln!("✅ Skill install {verb}: {}", parts.join(", "));
+}
+
+fn action_status_label(status: &SkillInstallStatus, dry_run: bool) -> Option<&'static str> {
+    match status {
+        SkillInstallStatus::Installed => Some("✅ installed"),
+        SkillInstallStatus::Updated => Some("♻️  updated"),
+        SkillInstallStatus::Unchanged if !dry_run => None,
+        SkillInstallStatus::Unchanged => Some("⏭️  unchanged"),
+        SkillInstallStatus::WouldInstall => Some("📝 would install"),
+        SkillInstallStatus::WouldUpdate => Some("📝 would update"),
+        SkillInstallStatus::WouldSkipConflict => Some("⚠️  would skip"),
+        SkillInstallStatus::SkippedConflict => Some("⚠️  skipped"),
+    }
+}
+
+fn skill_display_name(action: &mesh_llm_plugin_manager::SkillInstallAction) -> String {
+    format!("{}/{}", action.provider_name, action.skill_name)
+}
+
+fn plural_count(count: usize, noun: &str) -> String {
+    if count == 1 {
+        format!("{count} {noun}")
+    } else if noun == "unchanged" {
+        format!("{count} unchanged")
+    } else {
+        format!("{count} {noun}s")
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/cli/commands/skills.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/skills.rs
@@ -140,14 +140,14 @@ fn print_install_summary(report: &SkillInstallReport, dry_run: bool) {
 
     let verb = if dry_run { "planned" } else { "complete" };
     let mut parts = vec![
-        format!("{}", plural_count(installed, "install")),
-        format!("{}", plural_count(updated, "update")),
+        plural_count(installed, "install").to_string(),
+        plural_count(updated, "update").to_string(),
     ];
     if unchanged > 0 {
-        parts.push(format!("{}", plural_count(unchanged, "unchanged")));
+        parts.push(plural_count(unchanged, "unchanged").to_string());
     }
     if conflicts > 0 {
-        parts.push(format!("{}", plural_count(conflicts, "conflict")));
+        parts.push(plural_count(conflicts, "conflict").to_string());
     }
     eprintln!("✅ Skill install {verb}: {}", parts.join(", "));
 }

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -742,6 +742,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: PluginCommand,
     },
+    /// Install agent skills exposed by installed plugins.
+    Skills {
+        #[command(subcommand)]
+        command: SkillCommand,
+    },
     /// Benchmark and compare model/runtime strategies.
     #[command(hide = true)]
     Benchmark {
@@ -868,6 +873,46 @@ pub(crate) enum PluginCommand {
     },
     /// List installed, auto-registered, and configured plugins.
     List,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum SkillCommand {
+    /// Install skills exposed by installed plugins into supported agent skill folders.
+    Install {
+        /// Agent to install for. Repeat to install to several agents.
+        #[arg(long, value_enum, conflicts_with = "all")]
+        agent: Vec<SkillAgentArg>,
+        /// Install to all supported agent locations, even if the agent is not detected.
+        #[arg(long)]
+        all: bool,
+        /// Show what would be installed without writing files.
+        #[arg(long)]
+        dry_run: bool,
+        /// Replace an existing non-mesh-managed skill with the same directory name.
+        #[arg(long)]
+        force: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum SkillAgentArg {
+    Goose,
+    Pi,
+    Codex,
+    Opencode,
+    Claude,
+}
+
+impl From<SkillAgentArg> for mesh_llm_plugin_manager::SkillAgent {
+    fn from(value: SkillAgentArg) -> Self {
+        match value {
+            SkillAgentArg::Goose => Self::Goose,
+            SkillAgentArg::Pi => Self::Pi,
+            SkillAgentArg::Codex => Self::Codex,
+            SkillAgentArg::Opencode => Self::Opencode,
+            SkillAgentArg::Claude => Self::Claude,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/mesh-llm-host-runtime/src/plugin/config.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/config.rs
@@ -15,7 +15,9 @@ pub use mesh_llm_config::{
     ThroughputConfig, config_path, config_to_toml, load_config, parse_config_toml, validate_config,
 };
 use mesh_llm_plugin::MeshVisibility;
-use mesh_llm_plugin_manager::{InstalledPluginMetadata, PluginStore, default_store_root};
+use mesh_llm_plugin_manager::{
+    InstalledPluginMetadata, PluginStore, default_store_root, validate_plugin_compatibility,
+};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
@@ -178,6 +180,10 @@ fn append_installed_plugins(
             inactive.push(disabled_installed_plugin_summary(&metadata));
             continue;
         }
+        if let Err(error) = validate_plugin_compatibility(&metadata.install_path, crate::VERSION) {
+            inactive.push(incompatible_installed_plugin_summary(&metadata, error));
+            continue;
+        }
         let command = installed_plugin_command(&metadata);
         if !command.exists() {
             inactive.push(missing_installed_plugin_summary(&metadata, &command));
@@ -214,6 +220,13 @@ fn missing_installed_plugin_summary(
             command.display()
         )),
     )
+}
+
+fn incompatible_installed_plugin_summary(
+    metadata: &InstalledPluginMetadata,
+    error: anyhow::Error,
+) -> PluginSummary {
+    installed_plugin_summary(metadata, "incompatible", Some(error.to_string()))
 }
 
 fn installed_store_error_summary(error: anyhow::Error) -> PluginSummary {

--- a/crates/mesh-llm-plugin-manager/Cargo.toml
+++ b/crates/mesh-llm-plugin-manager/Cargo.toml
@@ -18,10 +18,12 @@ flate2 = "1"
 futures-util = "0.3"
 mesh-llm-skills = { path = "../mesh-llm-skills", version = "0.68.0" }
 reqwest = { version = "0.12", features = ["json", "stream"] }
+semver = "1"
 serde.workspace = true
 serde_json.workspace = true
 tar = "0.4"
 tempfile = "3"
+toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]

--- a/crates/mesh-llm-plugin-manager/Cargo.toml
+++ b/crates/mesh-llm-plugin-manager/Cargo.toml
@@ -16,6 +16,7 @@ anyhow.workspace = true
 dirs = "6"
 flate2 = "1"
 futures-util = "0.3"
+mesh-llm-skills = { path = "../mesh-llm-skills", version = "0.68.0" }
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mesh-llm-plugin-manager/src/archive.rs
+++ b/crates/mesh-llm-plugin-manager/src/archive.rs
@@ -6,7 +6,10 @@ use std::{
 use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
 
-use crate::target::ArchiveExt;
+use crate::{
+    manifest::{CURRENT_MESH_LLM_VERSION, validate_plugin_compatibility},
+    target::ArchiveExt,
+};
 
 pub fn extract_plugin_archive(
     archive_path: &Path,
@@ -118,6 +121,7 @@ fn validate_plugin_root(plugin_dir: &Path, plugin_name: &str) -> Result<()> {
     if !plugin_dir.join("plugin.toml").exists() {
         bail!("installed plugin is missing plugin.toml");
     }
+    validate_plugin_compatibility(plugin_dir, CURRENT_MESH_LLM_VERSION)?;
     let executable = plugin_dir.join(format!("{plugin_name}{}", std::env::consts::EXE_SUFFIX));
     if !executable.exists() {
         bail!(
@@ -209,6 +213,31 @@ mod tests {
         assert_eq!(
             fs::read_to_string(existing.join("old-version.txt")).unwrap(),
             "keep me"
+        );
+    }
+
+    #[test]
+    fn archive_requiring_newer_mesh_llm_is_rejected() {
+        let temp = TempDir::new().unwrap();
+        let install_dir = temp.path().join("installed");
+        let archive_path = temp.path().join("demo.tar.gz");
+        let executable = format!("demo{}", std::env::consts::EXE_SUFFIX);
+        write_tar_gz(
+            &archive_path,
+            "demo",
+            &[
+                ("plugin.toml", b"min_mesh_llm_version = \"999.0.0\""),
+                (&executable, b""),
+            ],
+        )
+        .unwrap();
+
+        let err = extract_plugin_archive(&archive_path, ArchiveExt::TarGz, "demo", &install_dir)
+            .expect_err("archive requiring a newer host should fail validation");
+
+        assert!(
+            err.to_string()
+                .contains("🚫 Plugin requires mesh-llm >= 999.0.0")
         );
     }
 }

--- a/crates/mesh-llm-plugin-manager/src/lib.rs
+++ b/crates/mesh-llm-plugin-manager/src/lib.rs
@@ -3,6 +3,7 @@ pub mod asset;
 pub mod catalog;
 pub mod github;
 pub mod install;
+pub mod manifest;
 pub mod skills;
 pub mod source_ref;
 pub mod store;
@@ -14,6 +15,10 @@ pub use github::{GitHubRelease, GitHubReleaseAsset, GitHubReleaseClient};
 pub use install::{
     InstallOutcome, PluginInstallOptions, PluginProgressEvent, PluginProgressReporter,
     install_plugin, update_plugin,
+};
+pub use manifest::{
+    CURRENT_MESH_LLM_VERSION, PluginTomlManifest, load_plugin_toml, validate_plugin_compatibility,
+    validate_plugin_manifest_compatibility,
 };
 pub use mesh_llm_skills::{
     SkillAgent, SkillInstallAction, SkillInstallReport, SkillInstallStatus, SkillPackage,

--- a/crates/mesh-llm-plugin-manager/src/lib.rs
+++ b/crates/mesh-llm-plugin-manager/src/lib.rs
@@ -3,6 +3,7 @@ pub mod asset;
 pub mod catalog;
 pub mod github;
 pub mod install;
+pub mod skills;
 pub mod source_ref;
 pub mod store;
 pub mod target;
@@ -14,6 +15,11 @@ pub use install::{
     InstallOutcome, PluginInstallOptions, PluginProgressEvent, PluginProgressReporter,
     install_plugin, update_plugin,
 };
+pub use mesh_llm_skills::{
+    SkillAgent, SkillInstallAction, SkillInstallReport, SkillInstallStatus, SkillPackage,
+    SkillTarget,
+};
+pub use skills::{PluginSkillInstallOptions, discover_plugin_skills, install_available_skills};
 pub use source_ref::{GitHubPluginSource, PluginInstallRef, PluginVersion, parse_install_ref};
 pub use store::{InstalledPluginMetadata, PluginStore, default_store_root};
 pub use target::{ArchiveExt, PluginTarget, UnsupportedTarget};

--- a/crates/mesh-llm-plugin-manager/src/manifest.rs
+++ b/crates/mesh-llm-plugin-manager/src/manifest.rs
@@ -1,0 +1,95 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result, bail};
+use semver::Version;
+use serde::Deserialize;
+
+pub const CURRENT_MESH_LLM_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct PluginTomlManifest {
+    #[serde(default, alias = "minimum_mesh_llm_version", alias = "min_version")]
+    pub min_mesh_llm_version: Option<String>,
+}
+
+pub fn load_plugin_toml(plugin_dir: &Path) -> Result<PluginTomlManifest> {
+    let manifest_path = plugin_dir.join("plugin.toml");
+    let contents = fs::read_to_string(&manifest_path)
+        .with_context(|| format!("read plugin manifest {}", manifest_path.display()))?;
+    toml::from_str(&contents)
+        .with_context(|| format!("parse plugin manifest {}", manifest_path.display()))
+}
+
+pub fn validate_plugin_compatibility(plugin_dir: &Path, current_version: &str) -> Result<()> {
+    let manifest = load_plugin_toml(plugin_dir)?;
+    validate_plugin_manifest_compatibility(&manifest, current_version)
+}
+
+pub fn validate_plugin_manifest_compatibility(
+    manifest: &PluginTomlManifest,
+    current_version: &str,
+) -> Result<()> {
+    let Some(required_version) = manifest.min_mesh_llm_version.as_deref() else {
+        return Ok(());
+    };
+
+    let required = parse_version(required_version, "min_mesh_llm_version")?;
+    let current = parse_version(current_version, "current mesh-llm version")?;
+    if current < required {
+        bail!(
+            "🚫 Plugin requires mesh-llm >= {}, current host is {}",
+            required_version,
+            current_version
+        );
+    }
+    Ok(())
+}
+
+fn parse_version(raw: &str, label: &str) -> Result<Version> {
+    let normalized = raw.trim().strip_prefix('v').unwrap_or_else(|| raw.trim());
+    Version::parse(normalized).with_context(|| format!("invalid {label}: {raw}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_missing_min_mesh_llm_version() {
+        let manifest = PluginTomlManifest::default();
+
+        validate_plugin_manifest_compatibility(&manifest, "0.68.0").unwrap();
+    }
+
+    #[test]
+    fn accepts_current_host_at_or_above_minimum() {
+        let manifest = PluginTomlManifest {
+            min_mesh_llm_version: Some("v0.68.0".to_string()),
+        };
+
+        validate_plugin_manifest_compatibility(&manifest, "0.68.0").unwrap();
+        validate_plugin_manifest_compatibility(&manifest, "0.69.0").unwrap();
+    }
+
+    #[test]
+    fn rejects_current_host_below_minimum() {
+        let manifest = PluginTomlManifest {
+            min_mesh_llm_version: Some("0.69.0".to_string()),
+        };
+
+        let err = validate_plugin_manifest_compatibility(&manifest, "0.68.0")
+            .expect_err("host below minimum should fail");
+
+        assert!(
+            err.to_string()
+                .contains("🚫 Plugin requires mesh-llm >= 0.69.0")
+        );
+    }
+
+    #[test]
+    fn parses_aliases() {
+        let manifest: PluginTomlManifest = toml::from_str(r#"min_version = "0.68.0""#).unwrap();
+
+        assert_eq!(manifest.min_mesh_llm_version.as_deref(), Some("0.68.0"));
+    }
+}

--- a/crates/mesh-llm-plugin-manager/src/skills.rs
+++ b/crates/mesh-llm-plugin-manager/src/skills.rs
@@ -1,0 +1,158 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, bail};
+use mesh_llm_skills::{
+    SkillAgent, SkillInstallOptions, SkillInstallReport, SkillPackage, install_skills,
+    is_valid_skill_name,
+};
+
+use crate::store::{InstalledPluginMetadata, PluginStore, default_store_root};
+
+#[derive(Clone, Debug)]
+pub struct PluginSkillInstallOptions {
+    pub store_root: PathBuf,
+    pub skill_options: SkillInstallOptions,
+}
+
+impl PluginSkillInstallOptions {
+    pub fn from_env() -> Result<Self> {
+        Ok(Self {
+            store_root: default_store_root()?,
+            skill_options: SkillInstallOptions::from_env()?,
+        })
+    }
+
+    pub fn for_agent(agent: SkillAgent) -> Result<Self> {
+        Ok(Self {
+            store_root: default_store_root()?,
+            skill_options: SkillInstallOptions::for_agent(agent)?,
+        })
+    }
+}
+
+pub fn install_available_skills(options: &PluginSkillInstallOptions) -> Result<SkillInstallReport> {
+    let store = PluginStore::new(&options.store_root);
+    let skills = discover_plugin_skills(&store)?;
+    install_skills(&skills, &options.skill_options)
+}
+
+pub fn discover_plugin_skills(store: &PluginStore) -> Result<Vec<SkillPackage>> {
+    let mut skills = Vec::new();
+    for plugin in store.list()? {
+        if !plugin.enabled {
+            continue;
+        }
+        append_plugin_root_skill(&mut skills, &plugin);
+        append_plugin_skills_dir(&mut skills, &plugin)?;
+    }
+    skills.sort_by(|left, right| {
+        left.name
+            .cmp(&right.name)
+            .then(left.provider_name.cmp(&right.provider_name))
+    });
+    Ok(skills)
+}
+
+fn append_plugin_root_skill(skills: &mut Vec<SkillPackage>, plugin: &InstalledPluginMetadata) {
+    let source_dir = plugin.install_path.clone();
+    if !source_dir.join("SKILL.md").exists() {
+        return;
+    }
+    skills.push(SkillPackage {
+        provider_name: plugin.name.clone(),
+        provider_version: plugin.installed_version.clone(),
+        name: plugin.name.clone(),
+        source_dir,
+    });
+}
+
+fn append_plugin_skills_dir(
+    skills: &mut Vec<SkillPackage>,
+    plugin: &InstalledPluginMetadata,
+) -> Result<()> {
+    let skills_dir = plugin.install_path.join("skills");
+    if !skills_dir.exists() {
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(&skills_dir)
+        .with_context(|| format!("read plugin skills directory {}", skills_dir.display()))?
+    {
+        let entry =
+            entry.with_context(|| format!("read plugin skill entry {}", skills_dir.display()))?;
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("read file type for {}", entry.path().display()))?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if !is_valid_skill_name(&name) {
+            bail!(
+                "plugin '{}' exposes invalid skill directory '{}'",
+                plugin.name,
+                name
+            );
+        }
+        let source_dir = entry.path();
+        if source_dir.join("SKILL.md").exists() {
+            skills.push(SkillPackage {
+                provider_name: plugin.name.clone(),
+                provider_version: plugin.installed_version.clone(),
+                name,
+                source_dir,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn metadata(name: &str, install_path: PathBuf) -> InstalledPluginMetadata {
+        InstalledPluginMetadata {
+            name: name.to_string(),
+            source_repository: format!("https://github.com/mesh-llm/{name}"),
+            installed_version: "v1.0.0".to_string(),
+            target_triple: "x86_64-unknown-linux-gnu".to_string(),
+            downloaded_asset_name: format!("{name}-x86_64-unknown-linux-gnu.tar.gz"),
+            install_path,
+            enabled: true,
+            last_protocol_version: None,
+            last_status: None,
+            last_error: None,
+        }
+    }
+
+    fn write_skill(root: &Path, name: &str) {
+        let skill_dir = root.join("skills").join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Demo skill\n---\n"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn discovers_enabled_plugin_skills() {
+        let temp = TempDir::new().unwrap();
+        let install_path = temp.path().join("installed").join("demo");
+        write_skill(&install_path, "demo-skill");
+
+        let store = PluginStore::new(temp.path().join("store"));
+        store.save(&metadata("demo", install_path)).unwrap();
+
+        let skills = discover_plugin_skills(&store).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].provider_name, "demo");
+        assert_eq!(skills[0].name, "demo-skill");
+    }
+}

--- a/crates/mesh-llm-skills/Cargo.toml
+++ b/crates/mesh-llm-skills/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mesh-llm-skills"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+description = "Agent skill data model and installer primitives for Mesh LLM"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+dirs = "6"
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/mesh-llm-skills/src/lib.rs
+++ b/crates/mesh-llm-skills/src/lib.rs
@@ -1,0 +1,470 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+const MARKER_FILE: &str = ".mesh-llm-skill.json";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SkillAgent {
+    Goose,
+    Pi,
+    Codex,
+    Opencode,
+    Claude,
+}
+
+impl SkillAgent {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Goose => "goose",
+            Self::Pi => "pi",
+            Self::Codex => "codex",
+            Self::Opencode => "opencode",
+            Self::Claude => "claude",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillTarget {
+    pub agent: SkillAgent,
+    pub root: PathBuf,
+    pub detected: bool,
+    pub detection_reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillPackage {
+    pub provider_name: String,
+    pub provider_version: String,
+    pub name: String,
+    pub source_dir: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+pub struct SkillInstallOptions {
+    pub home_dir: PathBuf,
+    pub agents: Vec<SkillAgent>,
+    pub detected_only: bool,
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+impl SkillInstallOptions {
+    pub fn from_env() -> Result<Self> {
+        let home_dir = dirs::home_dir().context("Cannot determine home directory")?;
+        Ok(Self {
+            home_dir,
+            agents: Vec::new(),
+            detected_only: true,
+            dry_run: false,
+            force: false,
+        })
+    }
+
+    pub fn for_agent(agent: SkillAgent) -> Result<Self> {
+        let mut options = Self::from_env()?;
+        options.agents = vec![agent];
+        options.detected_only = false;
+        Ok(options)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillInstallReport {
+    pub available_skills: usize,
+    pub targets: Vec<SkillTarget>,
+    pub actions: Vec<SkillInstallAction>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillInstallAction {
+    pub agent: SkillAgent,
+    pub skill_name: String,
+    pub provider_name: String,
+    pub source_dir: PathBuf,
+    pub destination_dir: PathBuf,
+    pub status: SkillInstallStatus,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SkillInstallStatus {
+    Installed,
+    Updated,
+    Unchanged,
+    WouldInstall,
+    WouldUpdate,
+    WouldSkipConflict,
+    SkippedConflict,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct ManagedSkillMarker {
+    source_provider: String,
+    source_skill: String,
+    provider_version: String,
+}
+
+pub fn install_skills(
+    skills: &[SkillPackage],
+    options: &SkillInstallOptions,
+) -> Result<SkillInstallReport> {
+    let targets = resolve_targets(options);
+    let mut actions = Vec::new();
+
+    for target in &targets {
+        for skill in skills {
+            actions.push(install_skill_to_target(skill, target, options)?);
+        }
+    }
+
+    Ok(SkillInstallReport {
+        available_skills: skills.len(),
+        targets,
+        actions,
+    })
+}
+
+pub fn resolve_targets(options: &SkillInstallOptions) -> Vec<SkillTarget> {
+    let agents = if options.agents.is_empty() {
+        vec![
+            SkillAgent::Goose,
+            SkillAgent::Pi,
+            SkillAgent::Codex,
+            SkillAgent::Opencode,
+            SkillAgent::Claude,
+        ]
+    } else {
+        options.agents.clone()
+    };
+
+    let mut targets = agents
+        .into_iter()
+        .map(|agent| skill_target(agent, &options.home_dir))
+        .filter(|target| !options.detected_only || target.detected)
+        .collect::<Vec<_>>();
+    targets.sort_by(|left, right| left.agent.as_str().cmp(right.agent.as_str()));
+    targets
+}
+
+pub fn is_valid_skill_name(value: &str) -> bool {
+    let mut previous_hyphen = false;
+    if value.is_empty() || value.len() > 64 || value.starts_with('-') || value.ends_with('-') {
+        return false;
+    }
+    for ch in value.chars() {
+        let valid = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-';
+        if !valid || (ch == '-' && previous_hyphen) {
+            return false;
+        }
+        previous_hyphen = ch == '-';
+    }
+    true
+}
+
+fn install_skill_to_target(
+    skill: &SkillPackage,
+    target: &SkillTarget,
+    options: &SkillInstallOptions,
+) -> Result<SkillInstallAction> {
+    let destination_dir = target.root.join(&skill.name);
+    let marker = ManagedSkillMarker {
+        source_provider: skill.provider_name.clone(),
+        source_skill: skill.name.clone(),
+        provider_version: skill.provider_version.clone(),
+    };
+    let existing_marker = read_marker(&destination_dir)?;
+    let status = classify_install(&destination_dir, existing_marker.as_ref(), &marker, options);
+
+    if !options.dry_run {
+        match status {
+            SkillInstallStatus::Installed | SkillInstallStatus::Updated => {
+                replace_skill_dir(&skill.source_dir, &destination_dir, &marker)?;
+            }
+            SkillInstallStatus::SkippedConflict | SkillInstallStatus::Unchanged => {}
+            SkillInstallStatus::WouldInstall
+            | SkillInstallStatus::WouldUpdate
+            | SkillInstallStatus::WouldSkipConflict => unreachable!("dry-run status in live run"),
+        }
+    }
+
+    Ok(SkillInstallAction {
+        agent: target.agent,
+        skill_name: skill.name.clone(),
+        provider_name: skill.provider_name.clone(),
+        source_dir: skill.source_dir.clone(),
+        destination_dir,
+        status,
+    })
+}
+
+fn classify_install(
+    destination_dir: &Path,
+    existing_marker: Option<&ManagedSkillMarker>,
+    marker: &ManagedSkillMarker,
+    options: &SkillInstallOptions,
+) -> SkillInstallStatus {
+    if !destination_dir.exists() {
+        return if options.dry_run {
+            SkillInstallStatus::WouldInstall
+        } else {
+            SkillInstallStatus::Installed
+        };
+    }
+    if existing_marker == Some(marker) && !options.force {
+        return SkillInstallStatus::Unchanged;
+    }
+    if existing_marker
+        .map(|existing| {
+            existing.source_provider == marker.source_provider
+                && existing.source_skill == marker.source_skill
+        })
+        .unwrap_or(options.force)
+    {
+        return if options.dry_run {
+            SkillInstallStatus::WouldUpdate
+        } else {
+            SkillInstallStatus::Updated
+        };
+    }
+    if options.dry_run {
+        SkillInstallStatus::WouldSkipConflict
+    } else {
+        SkillInstallStatus::SkippedConflict
+    }
+}
+
+fn replace_skill_dir(
+    source_dir: &Path,
+    destination_dir: &Path,
+    marker: &ManagedSkillMarker,
+) -> Result<()> {
+    let parent = destination_dir.parent().with_context(|| {
+        format!(
+            "skill destination has no parent: {}",
+            destination_dir.display()
+        )
+    })?;
+    fs::create_dir_all(parent)
+        .with_context(|| format!("create skills directory {}", parent.display()))?;
+    let temp_dir = parent.join(format!(
+        ".mesh-llm-skill-{}-{}",
+        std::process::id(),
+        marker.source_skill
+    ));
+    if temp_dir.exists() {
+        fs::remove_dir_all(&temp_dir)
+            .with_context(|| format!("remove stale temporary skill dir {}", temp_dir.display()))?;
+    }
+    copy_dir(source_dir, &temp_dir)?;
+    write_marker(&temp_dir, marker)?;
+    if destination_dir.exists() {
+        fs::remove_dir_all(destination_dir)
+            .with_context(|| format!("remove previous skill {}", destination_dir.display()))?;
+    }
+    fs::rename(&temp_dir, destination_dir).with_context(|| {
+        format!(
+            "install skill {} to {}",
+            marker.source_skill,
+            destination_dir.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn copy_dir(source_dir: &Path, destination_dir: &Path) -> Result<()> {
+    fs::create_dir_all(destination_dir)
+        .with_context(|| format!("create directory {}", destination_dir.display()))?;
+    for entry in fs::read_dir(source_dir)
+        .with_context(|| format!("read source directory {}", source_dir.display()))?
+    {
+        let entry = entry.with_context(|| format!("read source entry {}", source_dir.display()))?;
+        let source = entry.path();
+        let destination = destination_dir.join(entry.file_name());
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("read file type for {}", source.display()))?;
+        if file_type.is_dir() {
+            copy_dir(&source, &destination)?;
+        } else if file_type.is_file() {
+            fs::copy(&source, &destination).with_context(|| {
+                format!(
+                    "copy skill file {} to {}",
+                    source.display(),
+                    destination.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn read_marker(skill_dir: &Path) -> Result<Option<ManagedSkillMarker>> {
+    let marker_path = skill_dir.join(MARKER_FILE);
+    if !marker_path.exists() {
+        return Ok(None);
+    }
+    let bytes = fs::read(&marker_path)
+        .with_context(|| format!("read skill marker {}", marker_path.display()))?;
+    Ok(Some(serde_json::from_slice(&bytes).with_context(|| {
+        format!("parse skill marker {}", marker_path.display())
+    })?))
+}
+
+fn write_marker(skill_dir: &Path, marker: &ManagedSkillMarker) -> Result<()> {
+    let marker_path = skill_dir.join(MARKER_FILE);
+    fs::write(&marker_path, serde_json::to_vec_pretty(marker)?)
+        .with_context(|| format!("write skill marker {}", marker_path.display()))?;
+    Ok(())
+}
+
+fn skill_target(agent: SkillAgent, home_dir: &Path) -> SkillTarget {
+    let (root, command, config_dir) = match agent {
+        SkillAgent::Goose => (home_dir.join(".agents").join("skills"), "goose", None),
+        SkillAgent::Pi => (
+            home_dir.join(".pi").join("agent").join("skills"),
+            "pi",
+            Some(home_dir.join(".pi").join("agent")),
+        ),
+        SkillAgent::Codex => (home_dir.join(".agents").join("skills"), "codex", None),
+        SkillAgent::Opencode => (
+            home_dir.join(".config").join("opencode").join("skills"),
+            "opencode",
+            Some(home_dir.join(".config").join("opencode")),
+        ),
+        SkillAgent::Claude => (
+            home_dir.join(".claude").join("skills"),
+            "claude",
+            Some(home_dir.join(".claude")),
+        ),
+    };
+    let command_detected = command_exists(command);
+    let config_detected = config_dir.as_ref().is_some_and(|dir| dir.exists());
+    let detected = command_detected || config_detected || root.exists();
+    let detection_reason = if command_detected {
+        Some(format!("found '{command}' in PATH"))
+    } else if config_detected {
+        config_dir.map(|dir| format!("found {}", dir.display()))
+    } else if root.exists() {
+        Some(format!("found {}", root.display()))
+    } else {
+        None
+    };
+
+    SkillTarget {
+        agent,
+        root,
+        detected,
+        detection_reason,
+    }
+}
+
+fn command_exists(command: &str) -> bool {
+    let Some(paths) = env::var_os("PATH") else {
+        return false;
+    };
+    env::split_paths(&paths)
+        .any(|path| command_candidates(command).any(|candidate| path.join(candidate).is_file()))
+}
+
+fn command_candidates(command: &str) -> impl Iterator<Item = String> + '_ {
+    let suffix = env::consts::EXE_SUFFIX;
+    let mut candidates = vec![command.to_string()];
+    if !suffix.is_empty() {
+        candidates.push(format!("{command}{suffix}"));
+    }
+    if cfg!(windows) {
+        candidates.push(format!("{command}.cmd"));
+        candidates.push(format!("{command}.bat"));
+    }
+    candidates.into_iter()
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn skill(name: &str, source_dir: PathBuf) -> SkillPackage {
+        SkillPackage {
+            provider_name: "demo".to_string(),
+            provider_version: "v1.0.0".to_string(),
+            name: name.to_string(),
+            source_dir,
+        }
+    }
+
+    fn write_skill(root: &Path, name: &str) -> PathBuf {
+        let skill_dir = root.join(name);
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: Demo skill\n---\n"),
+        )
+        .unwrap();
+        skill_dir
+    }
+
+    #[test]
+    fn validates_agent_skill_names() {
+        assert!(is_valid_skill_name("demo-skill-1"));
+        assert!(!is_valid_skill_name("Demo"));
+        assert!(!is_valid_skill_name("-demo"));
+        assert!(!is_valid_skill_name("demo--skill"));
+    }
+
+    #[test]
+    fn installs_skills_to_requested_agent_target() {
+        let temp = TempDir::new().unwrap();
+        let source_dir = write_skill(&temp.path().join("source"), "demo-skill");
+
+        let options = SkillInstallOptions {
+            home_dir: temp.path().join("home"),
+            agents: vec![SkillAgent::Pi],
+            detected_only: false,
+            dry_run: false,
+            force: false,
+        };
+        let report = install_skills(&[skill("demo-skill", source_dir)], &options).unwrap();
+
+        assert_eq!(report.available_skills, 1);
+        assert_eq!(report.actions[0].status, SkillInstallStatus::Installed);
+        assert!(
+            options
+                .home_dir
+                .join(".pi/agent/skills/demo-skill/SKILL.md")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn skips_user_owned_conflicts_without_force() {
+        let temp = TempDir::new().unwrap();
+        let source_dir = write_skill(&temp.path().join("source"), "demo-skill");
+
+        let home_dir = temp.path().join("home");
+        let existing = home_dir.join(".agents/skills/demo-skill");
+        fs::create_dir_all(&existing).unwrap();
+        fs::write(existing.join("SKILL.md"), "---\ndescription: mine\n---\n").unwrap();
+
+        let options = SkillInstallOptions {
+            home_dir,
+            agents: vec![SkillAgent::Codex],
+            detected_only: false,
+            dry_run: false,
+            force: false,
+        };
+        let report = install_skills(&[skill("demo-skill", source_dir)], &options).unwrap();
+
+        assert_eq!(
+            report.actions[0].status,
+            SkillInstallStatus::SkippedConflict
+        );
+    }
+}

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -52,11 +52,13 @@ COPY crates/mesh-llm/Cargo.toml crates/mesh-llm/Cargo.toml
 COPY crates/mesh-llm/build.rs crates/mesh-llm/build.rs
 COPY crates/mesh-llm-plugin/Cargo.toml crates/mesh-llm-plugin/Cargo.toml
 COPY crates/mesh-llm-plugin/build.rs crates/mesh-llm-plugin/build.rs
+COPY crates/mesh-llm-skills/Cargo.toml crates/mesh-llm-skills/Cargo.toml
 COPY crates/mesh-llm-plugin-manager/Cargo.toml crates/mesh-llm-plugin-manager/Cargo.toml
 # Satisfy Cargo workspace member resolution
 COPY crates/mesh-llm-host-runtime/ crates/mesh-llm-host-runtime/
 COPY crates/mesh-llm/ crates/mesh-llm/
 COPY crates/mesh-llm-plugin/ crates/mesh-llm-plugin/
+COPY crates/mesh-llm-skills/ crates/mesh-llm-skills/
 COPY crates/mesh-llm-plugin-manager/ crates/mesh-llm-plugin-manager/
 COPY crates/mesh-client/ crates/mesh-client/
 COPY crates/mesh-llm-api-client/ crates/mesh-llm-api-client/
@@ -121,11 +123,13 @@ COPY crates/mesh-llm/Cargo.toml crates/mesh-llm/Cargo.toml
 COPY crates/mesh-llm/build.rs crates/mesh-llm/build.rs
 COPY crates/mesh-llm-plugin/Cargo.toml crates/mesh-llm-plugin/Cargo.toml
 COPY crates/mesh-llm-plugin/build.rs crates/mesh-llm-plugin/build.rs
+COPY crates/mesh-llm-skills/Cargo.toml crates/mesh-llm-skills/Cargo.toml
 COPY crates/mesh-llm-plugin-manager/Cargo.toml crates/mesh-llm-plugin-manager/Cargo.toml
 # Satisfy Cargo workspace member resolution
 COPY crates/mesh-llm-host-runtime/ crates/mesh-llm-host-runtime/
 COPY crates/mesh-llm/ crates/mesh-llm/
 COPY crates/mesh-llm-plugin/ crates/mesh-llm-plugin/
+COPY crates/mesh-llm-skills/ crates/mesh-llm-skills/
 COPY crates/mesh-llm-plugin-manager/ crates/mesh-llm-plugin-manager/
 COPY crates/mesh-client/ crates/mesh-client/
 COPY crates/mesh-llm-api-client/ crates/mesh-llm-api-client/

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -428,6 +428,16 @@ Switches:
 - `--model <MODEL>`: model id from `/v1/models`.
 - `--port <PORT>`: mesh-llm API port (default `9337`).
 
+### `pi`
+
+Use this to launch Pi already wired to mesh-llm’s OpenAI-compatible endpoint.
+
+Switches:
+
+- `--model <MODEL>`: model id from `/v1/models`.
+- `--host <HOST|HOST:PORT|URL>`: Pi target host or URL (default `127.0.0.1:9337`).
+- `--write`: write the mesh provider config without launching Pi.
+
 ### `opencode`
 
 Use this to launch OpenCode already wired to mesh-llm’s OpenAI-compatible endpoint.
@@ -439,6 +449,30 @@ Switches:
 - `--model <MODEL>`: model id from `/v1/models`.
 - `--host <HOST|HOST:PORT|URL>`: OpenCode target host or URL (default `127.0.0.1:9337`). Bare host forms assume `http`, default inference port `9337`, and default management port `3131`.
 - `--write`: write a merged `~/.config/opencode/opencode.json` that preserves unrelated root keys and sibling providers. If only `opencode.jsonc` exists, mesh-llm errors and tells you to rename or migrate it to `opencode.json` first.
+
+### `skills`
+
+Use this to install Agent Skills exposed by installed mesh plugins.
+
+Usage:
+
+```bash
+mesh-llm skills install
+mesh-llm skills install --agent goose --agent codex
+mesh-llm skills install --all --dry-run
+```
+
+By default, the installer writes only to detected agents. Plugin packages expose
+skills by shipping `skills/<name>/SKILL.md` under the plugin archive root.
+Agent launch commands (`goose`, `pi`, `opencode`, and `claude`) install
+available plugin skills for that agent before starting the session.
+
+Switches:
+
+- `--agent <AGENT>`: install to a specific agent (`goose`, `pi`, `codex`, `opencode`, `claude`); repeatable.
+- `--all`: install to every supported target location even if the agent is not detected.
+- `--dry-run`: print planned writes without changing files.
+- `--force`: overwrite an existing user-owned skill directory with the same name.
 
 ### `stop`
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -160,9 +160,18 @@ cool-plugin/
   cool-plugin.exe
 ```
 
-Only `plugin.toml` and the native executable are required. Documentation,
-license files, and skill folders are optional but recommended when the plugin
-has agent-facing workflows.
+Only `plugin.toml` and the native executable are required. `plugin.toml` should
+declare the minimum compatible host version:
+
+```toml
+min_mesh_llm_version = "0.68.0"
+```
+
+The installer rejects a plugin whose `min_mesh_llm_version` is newer than the
+current `mesh-llm` binary, and installed plugins are checked again at runtime so
+a downgraded host does not launch an incompatible plugin. Documentation, license
+files, and skill folders are optional but recommended when the plugin has
+agent-facing workflows.
 
 ## Plugin Skills
 

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -147,6 +147,9 @@ cool-plugin/
   cool-plugin
   README.md
   LICENSE
+  skills/
+    cool-workflow/
+      SKILL.md
 ```
 
 On Windows, the executable should use `.exe`:
@@ -157,8 +160,47 @@ cool-plugin/
   cool-plugin.exe
 ```
 
-Only `plugin.toml` and the native executable are required. Documentation and
-license files are optional but recommended.
+Only `plugin.toml` and the native executable are required. Documentation,
+license files, and skill folders are optional but recommended when the plugin
+has agent-facing workflows.
+
+## Plugin Skills
+
+Installed plugins may expose Agent Skills by shipping skill directories under
+their extracted plugin root:
+
+```text
+cool-plugin/
+  skills/
+    cool-workflow/
+      SKILL.md
+      references/
+      scripts/
+      assets/
+```
+
+Each skill directory name must use the portable Agent Skills naming convention:
+lowercase ASCII letters, numbers, and single hyphen separators. `SKILL.md`
+should include `name` and `description` YAML frontmatter and should refer to
+supporting files with paths relative to the skill directory. Avoid hard-coded
+home directories, OS-specific absolute paths, and shell-specific commands unless
+the skill documents the required platform in its `compatibility` field.
+
+`mesh-llm skills install` copies plugin skills into detected agent skill
+directories. `mesh-llm goose`, `mesh-llm pi`, `mesh-llm opencode`, and
+`mesh-llm claude` also install available plugin skills for that launched agent
+before starting the session. Existing user-owned skill directories are not
+overwritten unless `--force` is passed to the explicit installer.
+
+Current install targets:
+
+| Agent | Target |
+|---|---|
+| Goose | `~/.agents/skills` |
+| Codex | `~/.agents/skills` |
+| Pi | `~/.pi/agent/skills` |
+| OpenCode | `~/.config/opencode/skills` |
+| Claude Code | `~/.claude/skills` |
 
 Install selection should follow this order:
 

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -45,9 +45,13 @@ COPY crates/mesh-llm/Cargo.toml crates/mesh-llm/Cargo.toml
 COPY crates/mesh-llm/build.rs crates/mesh-llm/build.rs
 COPY crates/mesh-llm-plugin/Cargo.toml crates/mesh-llm-plugin/Cargo.toml
 COPY crates/mesh-llm-plugin/build.rs crates/mesh-llm-plugin/build.rs
+COPY crates/mesh-llm-skills/Cargo.toml crates/mesh-llm-skills/Cargo.toml
+COPY crates/mesh-llm-plugin-manager/Cargo.toml crates/mesh-llm-plugin-manager/Cargo.toml
 COPY crates/mesh-llm-host-runtime/ crates/mesh-llm-host-runtime/
 COPY crates/mesh-llm/ crates/mesh-llm/
 COPY crates/mesh-llm-plugin/ crates/mesh-llm-plugin/
+COPY crates/mesh-llm-skills/ crates/mesh-llm-skills/
+COPY crates/mesh-llm-plugin-manager/ crates/mesh-llm-plugin-manager/
 COPY crates/mesh-client/ crates/mesh-client/
 COPY crates/mesh-llm-api-client/ crates/mesh-llm-api-client/
 COPY crates/mesh-llm-api-server/ crates/mesh-llm-api-server/

--- a/scripts/affected-crates.sh
+++ b/scripts/affected-crates.sh
@@ -21,6 +21,7 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-console-server"
   "mesh-llm-ui"
   "mesh-llm-plugin"
+  "mesh-llm-skills"
   "mesh-llm-plugin-manager"
   "mesh-llm-client"
   "mesh-mixture-of-agents"

--- a/scripts/plan-clippy-batches.sh
+++ b/scripts/plan-clippy-batches.sh
@@ -24,6 +24,7 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-console-server"
   "mesh-llm-ui"
   "mesh-llm-plugin"
+  "mesh-llm-skills"
   "mesh-llm-plugin-manager"
   "mesh-llm-client"
   "mesh-llm-api-client"
@@ -145,6 +146,7 @@ weights = {
     "mesh-llm-console-server": 2,
     "mesh-llm-ui": 2,
     "mesh-llm-plugin": 2,
+    "mesh-llm-skills": 1,
     "mesh-llm-plugin-manager": 1,
     "mesh-llm-node": 2,
     "mesh-llm-nodejs": 2,


### PR DESCRIPTION
## Summary

Adds a `plugin.toml` host compatibility gate so installed plugins can declare the minimum mesh-llm version they require.

## Changes

- Parse `min_mesh_llm_version` from plugin manifests, with aliases for older naming experiments.
- Reject incompatible plugin archives during install before replacing an existing install.
- Re-check installed plugins at runtime and mark incompatible plugins inactive instead of launching them.
- Re-check installed plugin CLI commands before dispatch.
- Document the manifest field in the plugin packaging docs.

## CLI Experience

Install rejects an incompatible archive before replacing any existing plugin install:

```text
$ mesh-llm plugins install mesh-llm/cool-plugin
🚫 Error: 🚫 Plugin requires mesh-llm >= 0.69.0, current host is 0.68.0
```

Listing installed plugins shows an already-installed incompatible plugin as inactive, with the same minimum-version reason:

```text
$ mesh-llm plugins list
cool-plugin	kind=installed	state=incompatible	error=🚫 Plugin requires mesh-llm >= 0.69.0, current host is 0.68.0
```

Running a plugin-provided CLI command fails before launching the plugin process:

```text
$ mesh-llm cool-plugin run
🚫 Error: 🚫 Plugin command 'cool-plugin' is not compatible

Caused by:
    🚫 Plugin requires mesh-llm >= 0.69.0, current host is 0.68.0
```

Configured `[[plugin]] command = "..."` entries are intentionally outside this manifest check because they do not install a `plugin.toml`; those still fail through initialize/protocol compatibility checks.

## Validation

- `cargo test -p mesh-llm-plugin-manager --lib`
- `just build`
- `cargo test -p mesh-llm-host-runtime cli::commands::plugin_cli --lib`
- `cargo check -p mesh-llm`
- `rustfmt --check` on changed Rust files
- `git diff --check`
