### PR TITLE
Fix OpenCode launcher config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serde_yaml",
  "serial_test",
  "sha2 0.10.9",
  "skippy-coordinator",
@@ -6948,6 +6949,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serdect"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8435,6 +8449,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -48,6 +48,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.9"
 anyhow = "1"
 async-trait = "0.1"
 arboard = "3"

--- a/crates/mesh-llm-host-runtime/src/cli/commands/agent_cli.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/agent_cli.rs
@@ -5,10 +5,12 @@ use crate::{cli::shell, runtime};
 use url::Url;
 
 const OPENCODE_PROVIDER_ID: &str = "mesh";
-const OPENCODE_CONFIG_ENV: &str = "OPENCODE_CONFIG_CONTENT";
 const OPENCODE_API_KEY_ENV: &str = "OPENAI_API_KEY";
 const OPENCODE_API_KEY_VALUE: &str = "dummy";
 const OPENCODE_INSTALL_HINT: &str = "curl -fsSL https://opencode.ai/install | bash";
+const MESH_MCP_SERVER_ID: &str = "mesh";
+const MESH_MCP_DISPLAY_NAME: &str = "Mesh LLM";
+const DEFAULT_MESH_MCP_URL: &str = "http://127.0.0.1:3131/mcp";
 
 fn configure_interactive_stdio(command: &mut Command) {
     #[cfg(unix)]
@@ -33,6 +35,15 @@ fn configure_interactive_stdio(command: &mut Command) {
         .stderr(Stdio::inherit());
 }
 
+fn configure_opencode_launch_command(command: &mut Command, spec: &OpenCodeLaunchSpec) {
+    command
+        .args(["-m", &spec.model])
+        .env(spec.api_key_env, spec.api_key_value);
+    // OpenCode runs on Bun, which expects the original terminal file
+    // descriptors. Reopening /dev/tty here can make Bun fail while
+    // initializing its TTY write streams.
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct OpenCodeLaunchSpec {
     provider_id: &'static str,
@@ -49,8 +60,124 @@ struct OpenCodeTarget {
     api_base_url: String,
     api_models_url: String,
     management_models_url: String,
+    mcp_url: String,
     auto_start_local_mesh: bool,
     local_port: Option<u16>,
+}
+
+fn mesh_mcp_opencode_config(mcp_url: &str) -> serde_json::Value {
+    serde_json::json!({
+        "type": "remote",
+        "url": mcp_url,
+        "enabled": true,
+        "timeout": 300000,
+    })
+}
+
+fn mesh_mcp_claude_config_json(mcp_url: &str) -> Result<String> {
+    serde_json::to_string(&serde_json::json!({
+        "mcpServers": {
+            MESH_MCP_SERVER_ID: {
+                "type": "http",
+                "url": mcp_url,
+            }
+        }
+    }))
+    .context("serialize Claude MCP config")
+}
+
+fn mesh_mcp_goose_extension(mcp_url: &str) -> Result<serde_yaml::Value> {
+    serde_yaml::to_value(serde_json::json!({
+        "enabled": true,
+        "type": "streamable_http",
+        "name": MESH_MCP_DISPLAY_NAME,
+        "description": "Expose mesh-llm plugin MCP tools.",
+        "uri": mcp_url,
+        "timeout": 300,
+        "bundled": null,
+        "available_tools": [],
+    }))
+    .context("build Goose MCP extension config")
+}
+
+fn yaml_key(key: &str) -> serde_yaml::Value {
+    serde_yaml::Value::String(key.to_string())
+}
+
+fn empty_yaml_mapping() -> serde_yaml::Value {
+    serde_yaml::Value::Mapping(serde_yaml::Mapping::new())
+}
+
+fn ensure_yaml_mapping<'a>(
+    parent: &'a mut serde_yaml::Mapping,
+    key: &str,
+    path: &std::path::Path,
+) -> Result<&'a mut serde_yaml::Mapping> {
+    let key_value = yaml_key(key);
+    parent
+        .entry(key_value.clone())
+        .or_insert_with(empty_yaml_mapping);
+    parent
+        .get_mut(&key_value)
+        .and_then(serde_yaml::Value::as_mapping_mut)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Expected '{}' in {} to be a YAML mapping",
+                key,
+                path.display()
+            )
+        })
+}
+
+fn read_goose_config(path: &std::path::Path) -> Result<serde_yaml::Value> {
+    if !path.exists() {
+        return Ok(empty_yaml_mapping());
+    }
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read {}", path.display()))?;
+    if content.trim().is_empty() {
+        return Ok(empty_yaml_mapping());
+    }
+    let value: serde_yaml::Value = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse {} as YAML", path.display()))?;
+    if value.as_mapping().is_none() {
+        anyhow::bail!("Expected {} to contain a YAML mapping", path.display());
+    }
+    Ok(value)
+}
+
+fn merge_goose_mcp_config(
+    config: &mut serde_yaml::Value,
+    mcp_url: &str,
+    path: &std::path::Path,
+) -> Result<()> {
+    let root = config
+        .as_mapping_mut()
+        .ok_or_else(|| anyhow::anyhow!("Expected {} to contain a YAML mapping", path.display()))?;
+    let extensions = ensure_yaml_mapping(root, "extensions", path)?;
+    extensions.insert(
+        yaml_key(MESH_MCP_SERVER_ID),
+        mesh_mcp_goose_extension(mcp_url)?,
+    );
+    Ok(())
+}
+
+fn write_goose_mcp_config_to_path(path: &std::path::Path, mcp_url: &str) -> Result<()> {
+    std::fs::create_dir_all(path.parent().expect("Goose config path must have parent"))?;
+    let mut config = read_goose_config(path)?;
+    merge_goose_mcp_config(&mut config, mcp_url, path)?;
+    std::fs::write(path, serde_yaml::to_string(&config)?)?;
+    eprintln!("✅ Wrote mesh MCP extension to {}", path.display());
+    Ok(())
+}
+
+fn write_goose_mcp_config(mcp_url: &str) -> Result<()> {
+    let config_path = dirs::home_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".config")
+        .join("goose")
+        .join("config.yaml");
+    write_goose_mcp_config_to_path(&config_path, mcp_url)
 }
 
 fn is_loopback_or_localhost(host: &str) -> bool {
@@ -122,6 +249,9 @@ fn normalize_mesh_host_with_label(host: &str, label: &str) -> Result<OpenCodeTar
     }
     management.set_path("/api/models");
 
+    let mut mcp = management.clone();
+    mcp.set_path("/mcp");
+
     let auto_start_local_mesh = is_local_host && parsed.scheme() == "http";
 
     Ok(OpenCodeTarget {
@@ -129,6 +259,7 @@ fn normalize_mesh_host_with_label(host: &str, label: &str) -> Result<OpenCodeTar
         api_base_url: api_base.to_string(),
         api_models_url: api_models.to_string(),
         management_models_url: management.to_string(),
+        mcp_url: mcp.to_string(),
         auto_start_local_mesh,
         local_port: api_base.port_or_known_default(),
     })
@@ -144,10 +275,25 @@ fn build_opencode_launch_spec(
     resolved_model: &str,
     api_base_url: &str,
 ) -> OpenCodeLaunchSpec {
+    build_opencode_launch_spec_with_mcp(
+        model_names,
+        resolved_model,
+        api_base_url,
+        DEFAULT_MESH_MCP_URL,
+    )
+}
+
+fn build_opencode_launch_spec_with_mcp(
+    model_names: &[String],
+    resolved_model: &str,
+    api_base_url: &str,
+    mcp_url: &str,
+) -> OpenCodeLaunchSpec {
     build_opencode_launch_spec_with_limits(
         model_names,
         resolved_model,
         api_base_url,
+        mcp_url,
         &std::collections::HashMap::new(),
     )
 }
@@ -156,6 +302,7 @@ fn build_opencode_launch_spec_with_limits(
     model_names: &[String],
     resolved_model: &str,
     api_base_url: &str,
+    mcp_url: &str,
     context_lengths: &std::collections::HashMap<String, Option<u32>>,
 ) -> OpenCodeLaunchSpec {
     let mut models = serde_json::Map::new();
@@ -193,6 +340,9 @@ fn build_opencode_launch_spec_with_limits(
         "$schema": "https://opencode.ai/config.json",
         "provider": {
             OPENCODE_PROVIDER_ID: serde_json::Value::Object(mesh_provider),
+        },
+        "mcp": {
+            MESH_MCP_SERVER_ID: mesh_mcp_opencode_config(mcp_url),
         }
     });
 
@@ -216,8 +366,7 @@ fn opencode_missing_binary_guidance(
         spec.install_hint.to_string(),
         "Then rerun through mesh-llm:".to_string(),
         format!("  mesh-llm opencode --host {host} --model {chosen}"),
-        "mesh-llm injects OPENCODE_CONFIG_CONTENT automatically when launching OpenCode."
-            .to_string(),
+        "mesh-llm writes the mesh provider into your OpenCode config before launching.".to_string(),
     ]
 }
 
@@ -340,6 +489,7 @@ pub(crate) async fn run_goose(model: Option<String>, port: u16) -> Result<()> {
     let provider_path = goose_config_dir.join("mesh.json");
     std::fs::write(&provider_path, serde_json::to_string_pretty(&provider)?)?;
     eprintln!("✅ Wrote {}", provider_path.display());
+    write_goose_mcp_config(DEFAULT_MESH_MCP_URL)?;
 
     let goose_app = std::path::Path::new("/Applications/Goose.app");
     if goose_app.exists() {
@@ -416,10 +566,18 @@ pub(crate) async fn run_claude(model: Option<String>, port: u16) -> Result<()> {
         "terminalProgressBarEnabled": false
     });
     let settings_json = serde_json::to_string(&settings)?;
+    let mcp_config_json = mesh_mcp_claude_config_json(DEFAULT_MESH_MCP_URL)?;
 
     eprintln!("🚀 Launching Claude Code with {chosen} → {base_url}\n");
     let mut command = Command::new("claude");
-    command.args(["--model", &chosen, "--settings", &settings_json]);
+    command.args([
+        "--model",
+        &chosen,
+        "--settings",
+        &settings_json,
+        "--mcp-config",
+        &mcp_config_json,
+    ]);
     configure_interactive_stdio(&mut command);
     let status = command.status();
     match status {
@@ -694,13 +852,12 @@ pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool)
     let result = if write {
         write_opencode_config(&client, &models, &chosen, &target).await
     } else {
-        let context_lengths =
-            fetch_model_context_lengths(&client, &target.management_models_url).await;
-        let spec = build_opencode_launch_spec_with_limits(
+        write_opencode_config(&client, &models, &chosen, &target).await?;
+        let spec = build_opencode_launch_spec_with_mcp(
             &models,
             &chosen,
             &target.api_base_url,
-            &context_lengths,
+            &target.mcp_url,
         );
 
         eprintln!(
@@ -708,11 +865,7 @@ pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool)
             chosen, target.api_base_url
         );
         let mut command = Command::new("opencode");
-        command
-            .args(["-m", &spec.model])
-            .env(OPENCODE_CONFIG_ENV, &spec.config_content)
-            .env(spec.api_key_env, spec.api_key_value);
-        configure_interactive_stdio(&mut command);
+        configure_opencode_launch_command(&mut command, &spec);
         let status = command.status();
         match status {
             Ok(s) if s.success() => {}
@@ -849,10 +1002,12 @@ async fn write_opencode_config_to_path(
         model_names,
         resolved_model,
         &target.api_base_url,
+        &target.mcp_url,
         &context_lengths,
     );
     let config_value: serde_json::Value = serde_json::from_str(&spec.config_content)?;
     let mesh_provider = config_value["provider"]["mesh"].clone();
+    let mesh_mcp = config_value["mcp"]["mesh"].clone();
 
     // Merge schema if needed (for display in ordered format)
     let mut merged_config = existing_config.clone();
@@ -871,6 +1026,7 @@ async fn write_opencode_config_to_path(
     }
 
     merge_mesh_provider(&mut merged_config, mesh_provider.clone(), config_path)?;
+    merge_provider(&mut merged_config, "mcp", "mesh", mesh_mcp, config_path)?;
 
     let formatted_json = serde_json::to_string_pretty(&merged_config)?;
     std::fs::write(config_path, &formatted_json)?;
@@ -923,12 +1079,13 @@ pub(crate) fn build_mesh_provider_spec_for_test(
 #[cfg(test)]
 mod tests {
     use super::{
-        OPENCODE_INSTALL_HINT, build_mesh_provider_spec_for_test, build_opencode_launch_spec,
-        build_opencode_launch_spec_with_limits, build_pi_provider_config,
-        build_pi_provider_config_with_limits, cleanup_mesh_child, merge_context_lengths,
-        normalize_opencode_host, opencode_missing_binary_guidance, pi_missing_binary_guidance,
-        resolve_opencode_config_path_from_home, write_opencode_config_for_test,
-        write_pi_config_for_test, write_pi_config_to_path,
+        DEFAULT_MESH_MCP_URL, OPENCODE_INSTALL_HINT, build_mesh_provider_spec_for_test,
+        build_opencode_launch_spec, build_opencode_launch_spec_with_limits,
+        build_pi_provider_config, build_pi_provider_config_with_limits, cleanup_mesh_child,
+        configure_opencode_launch_command, merge_context_lengths, merge_goose_mcp_config,
+        mesh_mcp_claude_config_json, normalize_opencode_host, opencode_missing_binary_guidance,
+        pi_missing_binary_guidance, resolve_opencode_config_path_from_home,
+        write_opencode_config_for_test, write_pi_config_for_test, write_pi_config_to_path,
     };
 
     const LOCAL_OPENCODE_HOST: &str = "127.0.0.1:9337";
@@ -990,6 +1147,58 @@ mod tests {
                 .map(|m| m.len()),
             Some(2)
         );
+        assert_eq!(config["mcp"]["mesh"]["type"], "remote");
+        assert_eq!(config["mcp"]["mesh"]["enabled"], true);
+        assert_eq!(config["mcp"]["mesh"]["url"], DEFAULT_MESH_MCP_URL);
+    }
+
+    #[test]
+    fn claude_mcp_config_points_at_mesh_mcp_http_endpoint() {
+        let config = mesh_mcp_claude_config_json("http://127.0.0.1:3131/mcp").unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&config).unwrap();
+
+        assert_eq!(
+            parsed["mcpServers"]["mesh"]["type"],
+            serde_json::json!("http")
+        );
+        assert_eq!(
+            parsed["mcpServers"]["mesh"]["url"],
+            serde_json::json!("http://127.0.0.1:3131/mcp")
+        );
+    }
+
+    #[test]
+    fn goose_mcp_merge_preserves_existing_extensions() {
+        let mut config: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+extensions:
+  developer:
+    enabled: true
+GOOSE_PROVIDER: mesh
+"#,
+        )
+        .unwrap();
+        let path = std::path::Path::new("/tmp/goose/config.yaml");
+
+        merge_goose_mcp_config(&mut config, "http://127.0.0.1:3131/mcp", path).unwrap();
+        let extensions = config
+            .get("extensions")
+            .and_then(serde_yaml::Value::as_mapping)
+            .unwrap();
+
+        assert!(extensions.contains_key("developer"));
+        let mesh = extensions
+            .get("mesh")
+            .and_then(serde_yaml::Value::as_mapping)
+            .unwrap();
+        assert_eq!(
+            mesh.get("type").and_then(serde_yaml::Value::as_str),
+            Some("streamable_http")
+        );
+        assert_eq!(
+            mesh.get("uri").and_then(serde_yaml::Value::as_str),
+            Some("http://127.0.0.1:3131/mcp")
+        );
     }
 
     #[test]
@@ -1005,6 +1214,44 @@ mod tests {
 
         assert_eq!(spec.provider_id, "mesh");
         assert_eq!(spec.model, "mesh/bartowski/DeepSeek-R1.gguf");
+    }
+
+    #[test]
+    fn opencode_launch_command_uses_persisted_config_instead_of_env_blob() {
+        let spec = build_opencode_launch_spec(
+            &["GLM-4.7-Flash-Q4_K_M".to_string()],
+            "GLM-4.7-Flash-Q4_K_M",
+            "http://127.0.0.1:9337/v1",
+        );
+        let mut command = std::process::Command::new("opencode");
+
+        configure_opencode_launch_command(&mut command, &spec);
+
+        let args = command
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        let envs = command
+            .get_envs()
+            .filter_map(|(key, value)| {
+                value.map(|value| {
+                    (
+                        key.to_string_lossy().into_owned(),
+                        value.to_string_lossy().into_owned(),
+                    )
+                })
+            })
+            .collect::<std::collections::BTreeMap<_, _>>();
+
+        assert_eq!(args, vec!["-m", "mesh/GLM-4.7-Flash-Q4_K_M"]);
+        assert_eq!(
+            envs.get("OPENAI_API_KEY").map(String::as_str),
+            Some("dummy")
+        );
+        assert!(
+            !envs.contains_key("OPENCODE_CONFIG_CONTENT"),
+            "interactive launch should use the persisted opencode config"
+        );
     }
 
     #[test]
@@ -1038,7 +1285,7 @@ mod tests {
         );
         assert_eq!(
             lines[4],
-            "mesh-llm injects OPENCODE_CONFIG_CONTENT automatically when launching OpenCode."
+            "mesh-llm writes the mesh provider into your OpenCode config before launching."
         );
     }
 
@@ -1077,6 +1324,9 @@ mod tests {
 
         assert_eq!(parsed["$schema"], "https://opencode.ai/config.json");
         assert!(parsed["provider"]["mesh"].is_object());
+        assert_eq!(parsed["mcp"]["mesh"]["type"], "remote");
+        assert_eq!(parsed["mcp"]["mesh"]["url"], "http://127.0.0.1:3131/mcp");
+        assert_eq!(parsed["mcp"]["mesh"]["enabled"], true);
     }
 
     #[test]
@@ -1559,6 +1809,7 @@ mod tests {
             &models,
             "Qwen3.5-27B",
             "http://127.0.0.1:9337/v1",
+            DEFAULT_MESH_MCP_URL,
             &context_lengths,
         );
         let config: serde_json::Value =
@@ -1613,6 +1864,7 @@ mod tests {
             target.management_models_url,
             "http://mesh.example.com:3131/api/models"
         );
+        assert_eq!(target.mcp_url, "http://mesh.example.com:3131/mcp");
         assert!(!target.auto_start_local_mesh);
     }
 
@@ -1626,6 +1878,7 @@ mod tests {
             target.management_models_url,
             "http://127.0.0.1:3131/api/models"
         );
+        assert_eq!(target.mcp_url, "http://127.0.0.1:3131/mcp");
         assert!(target.auto_start_local_mesh);
         assert_eq!(target.local_port, Some(9443));
     }
@@ -1696,6 +1949,96 @@ mod tests {
         );
         assert!(!target.auto_start_local_mesh);
         assert_eq!(target.local_port, Some(9337));
+    }
+
+    #[test]
+    fn merge_context_lengths_uses_runtime_process_when_api_models_missing() {
+        let models = serde_json::json!({
+            "mesh_models": [
+                { "name": "ModelA", "context_length": null },
+                { "name": "ModelB", "context_length": 8192 },
+            ]
+        });
+        let processes = serde_json::json!({
+            "processes": [
+                { "name": "ModelA", "context_length": 16384 },
+                { "name": "ModelB", "context_length": null },
+                { "name": "ModelC", "context_length": 32768 },
+            ]
+        });
+
+        let result = merge_context_lengths(&models, &processes);
+
+        assert_eq!(result.get("ModelA"), Some(&Some(16384)));
+        assert_eq!(result.get("ModelB"), Some(&Some(8192)));
+        assert_eq!(result.get("ModelC"), Some(&Some(32768)));
+    }
+
+    #[test]
+    fn merge_context_lengths_api_models_only() {
+        let models = serde_json::json!({
+            "mesh_models": [
+                { "name": "ModelA", "context_length": 4096 },
+                { "name": "ModelB", "context_length": 8192 },
+            ]
+        });
+        let processes = serde_json::json!({ "processes": [] });
+
+        let result = merge_context_lengths(&models, &processes);
+
+        assert_eq!(result.get("ModelA"), Some(&Some(4096)));
+        assert_eq!(result.get("ModelB"), Some(&Some(8192)));
+        assert_eq!(result.get("ModelC"), None);
+    }
+
+    #[test]
+    fn merge_context_lengths_runtime_process_only() {
+        let models = serde_json::json!({ "mesh_models": [] });
+        let processes = serde_json::json!({
+            "processes": [
+                { "name": "ModelX", "context_length": 65536 },
+            ]
+        });
+
+        let result = merge_context_lengths(&models, &processes);
+
+        assert_eq!(result.get("ModelX"), Some(&Some(65536)));
+    }
+
+    #[test]
+    fn merge_context_lengths_runtime_process_trumps_api_models() {
+        let models = serde_json::json!({
+            "mesh_models": [
+                { "name": "Qwen3-8B", "context_length": 32768 },
+            ]
+        });
+        let processes = serde_json::json!({
+            "processes": [
+                { "name": "Qwen3-8B", "context_length": 16384 },
+            ]
+        });
+
+        let result = merge_context_lengths(&models, &processes);
+
+        assert_eq!(result.get("Qwen3-8B"), Some(&Some(16384)));
+    }
+
+    #[test]
+    fn merge_context_lengths_falls_back_to_metadata_when_runtime_null() {
+        let models = serde_json::json!({
+            "mesh_models": [
+                { "name": "ModelA", "context_length": 4096 },
+            ]
+        });
+        let processes = serde_json::json!({
+            "processes": [
+                { "name": "ModelA", "context_length": null },
+            ]
+        });
+
+        let result = merge_context_lengths(&models, &processes);
+
+        assert_eq!(result.get("ModelA"), Some(&Some(4096)));
     }
 
     #[test]
@@ -1797,100 +2140,5 @@ mod tests {
             .try_wait()
             .expect("wait should succeed");
         assert!(status.is_some(), "child should be exited after cleanup");
-    }
-
-    #[test]
-    fn merge_context_lengths_uses_runtime_process_when_api_models_missing() {
-        let models = serde_json::json!({
-            "mesh_models": [
-                { "name": "ModelA", "context_length": null },
-                { "name": "ModelB", "context_length": 8192 },
-            ]
-        });
-        let processes = serde_json::json!({
-            "processes": [
-                { "name": "ModelA", "context_length": 16384 },
-                { "name": "ModelB", "context_length": null },
-                { "name": "ModelC", "context_length": 32768 },
-            ]
-        });
-
-        let result = merge_context_lengths(&models, &processes);
-
-        // ModelA has null in /api/models but 16384 in runtime processes -> use 16384
-        assert_eq!(result.get("ModelA"), Some(&Some(16384)));
-        // ModelB has 8192 in /api/models but null in runtime processes -> keep 8192
-        assert_eq!(result.get("ModelB"), Some(&Some(8192)));
-        // ModelC is only in runtime processes -> use 32768
-        assert_eq!(result.get("ModelC"), Some(&Some(32768)));
-    }
-
-    #[test]
-    fn merge_context_lengths_api_models_only() {
-        let models = serde_json::json!({
-            "mesh_models": [
-                { "name": "ModelA", "context_length": 4096 },
-                { "name": "ModelB", "context_length": 8192 },
-            ]
-        });
-        let processes = serde_json::json!({ "processes": [] });
-
-        let result = merge_context_lengths(&models, &processes);
-
-        assert_eq!(result.get("ModelA"), Some(&Some(4096)));
-        assert_eq!(result.get("ModelB"), Some(&Some(8192)));
-        assert_eq!(result.get("ModelC"), None);
-    }
-
-    #[test]
-    fn merge_context_lengths_runtime_process_only() {
-        let models = serde_json::json!({ "mesh_models": [] });
-        let processes = serde_json::json!({
-            "processes": [
-                { "name": "ModelX", "context_length": 65536 },
-            ]
-        });
-
-        let result = merge_context_lengths(&models, &processes);
-
-        assert_eq!(result.get("ModelX"), Some(&Some(65536)));
-    }
-
-    #[test]
-    fn merge_context_lengths_runtime_process_trumps_api_models() {
-        let models = serde_json::json!({
-            "mesh_models": [
-                { "name": "Qwen3-8B", "context_length": 32768 },
-            ]
-        });
-        let processes = serde_json::json!({
-            "processes": [
-                { "name": "Qwen3-8B", "context_length": 16384 },
-            ]
-        });
-
-        let result = merge_context_lengths(&models, &processes);
-
-        // Runtime value (16384) overrides metadata value (32768)
-        assert_eq!(result.get("Qwen3-8B"), Some(&Some(16384)));
-    }
-
-    #[test]
-    fn merge_context_lengths_falls_back_to_metadata_when_runtime_null() {
-        let models = serde_json::json!({
-            "mesh_models": [
-                { "name": "ModelA", "context_length": 4096 },
-            ]
-        });
-        let processes = serde_json::json!({
-            "processes": [
-                { "name": "ModelA", "context_length": null },
-            ]
-        });
-
-        let result = merge_context_lengths(&models, &processes);
-
-        // Runtime has ModelA with null -> fall back to metadata (4096)
-        assert_eq!(result.get("ModelA"), Some(&Some(4096)));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/cli/commands/agent_cli.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/agent_cli.rs
@@ -8,6 +8,8 @@ const OPENCODE_PROVIDER_ID: &str = "mesh";
 const OPENCODE_API_KEY_ENV: &str = "OPENAI_API_KEY";
 const OPENCODE_API_KEY_VALUE: &str = "dummy";
 const OPENCODE_INSTALL_HINT: &str = "curl -fsSL https://opencode.ai/install | bash";
+const OPENCODE_DEFAULT_CONTEXT_LIMIT: u32 = 32_768;
+const OPENCODE_OUTPUT_LIMIT: u32 = 4_096;
 const MESH_MCP_SERVER_ID: &str = "mesh";
 const MESH_MCP_DISPLAY_NAME: &str = "Mesh LLM";
 const DEFAULT_MESH_MCP_URL: &str = "http://127.0.0.1:3131/mcp";
@@ -310,13 +312,15 @@ fn build_opencode_launch_spec_with_limits(
         let mut model_obj = serde_json::Map::new();
         model_obj.insert("name".to_string(), serde_json::json!(model));
 
-        if let Some(&Some(ctx_len)) = context_lengths.get(model) {
-            let limit = serde_json::json!({
-                "context": ctx_len,
-                "output": ctx_len,
-            });
-            model_obj.insert("limit".to_string(), limit);
-        }
+        let ctx_len = context_lengths
+            .get(model)
+            .and_then(|ctx_len| *ctx_len)
+            .unwrap_or(OPENCODE_DEFAULT_CONTEXT_LIMIT);
+        let limit = serde_json::json!({
+            "context": ctx_len,
+            "output": OPENCODE_OUTPUT_LIMIT.min(ctx_len),
+        });
+        model_obj.insert("limit".to_string(), limit);
 
         models.insert(model.clone(), serde_json::Value::Object(model_obj));
     }
@@ -852,31 +856,36 @@ pub(crate) async fn run_opencode(model: Option<String>, host: &str, write: bool)
     let result = if write {
         write_opencode_config(&client, &models, &chosen, &target).await
     } else {
-        write_opencode_config(&client, &models, &chosen, &target).await?;
-        let spec = build_opencode_launch_spec_with_mcp(
-            &models,
-            &chosen,
-            &target.api_base_url,
-            &target.mcp_url,
-        );
+        match write_opencode_config(&client, &models, &chosen, &target).await {
+            Ok(()) => {
+                let spec = build_opencode_launch_spec_with_mcp(
+                    &models,
+                    &chosen,
+                    &target.api_base_url,
+                    &target.mcp_url,
+                );
 
-        eprintln!(
-            "🚀 Launching OpenCode with {} → {}\n",
-            chosen, target.api_base_url
-        );
-        let mut command = Command::new("opencode");
-        configure_opencode_launch_command(&mut command, &spec);
-        let status = command.status();
-        match status {
-            Ok(s) if s.success() => {}
-            Ok(s) => eprintln!("opencode exited with {s}"),
-            Err(_) => {
-                for line in opencode_missing_binary_guidance(&chosen, &target.input, &spec) {
-                    eprintln!("{line}");
+                eprintln!(
+                    "🚀 Launching OpenCode with {} → {}\n",
+                    chosen, target.api_base_url
+                );
+                let mut command = Command::new("opencode");
+                configure_opencode_launch_command(&mut command, &spec);
+                let status = command.status();
+                match status {
+                    Ok(s) if s.success() => {}
+                    Ok(s) => eprintln!("opencode exited with {s}"),
+                    Err(_) => {
+                        for line in opencode_missing_binary_guidance(&chosen, &target.input, &spec)
+                        {
+                            eprintln!("{line}");
+                        }
+                    }
                 }
+                Ok(())
             }
+            Err(error) => Err(error),
         }
-        Ok(())
     };
 
     cleanup_mesh_child(&mut mesh_child);
@@ -1079,9 +1088,10 @@ pub(crate) fn build_mesh_provider_spec_for_test(
 #[cfg(test)]
 mod tests {
     use super::{
-        DEFAULT_MESH_MCP_URL, OPENCODE_INSTALL_HINT, build_mesh_provider_spec_for_test,
-        build_opencode_launch_spec, build_opencode_launch_spec_with_limits,
-        build_pi_provider_config, build_pi_provider_config_with_limits, cleanup_mesh_child,
+        DEFAULT_MESH_MCP_URL, OPENCODE_DEFAULT_CONTEXT_LIMIT, OPENCODE_INSTALL_HINT,
+        OPENCODE_OUTPUT_LIMIT, build_mesh_provider_spec_for_test, build_opencode_launch_spec,
+        build_opencode_launch_spec_with_limits, build_pi_provider_config,
+        build_pi_provider_config_with_limits, cleanup_mesh_child,
         configure_opencode_launch_command, merge_context_lengths, merge_goose_mcp_config,
         mesh_mcp_claude_config_json, normalize_opencode_host, opencode_missing_binary_guidance,
         pi_missing_binary_guidance, resolve_opencode_config_path_from_home,
@@ -1825,7 +1835,7 @@ GOOSE_PROVIDER: mesh
         );
         assert_eq!(
             config["provider"]["mesh"]["models"]["Qwen3.5-27B"]["limit"]["output"],
-            262144
+            OPENCODE_OUTPUT_LIMIT
         );
 
         assert_eq!(
@@ -1838,16 +1848,20 @@ GOOSE_PROVIDER: mesh
         );
         assert_eq!(
             config["provider"]["mesh"]["models"]["Gemma-7B"]["limit"]["output"],
-            8192
+            OPENCODE_OUTPUT_LIMIT
         );
 
         assert_eq!(
             config["provider"]["mesh"]["models"]["Llama-3B"]["name"],
             "Llama-3B"
         );
-        assert!(
-            config["provider"]["mesh"]["models"]["Llama-3B"]["limit"].is_null(),
-            "model with None context_length should not have limit field"
+        assert_eq!(
+            config["provider"]["mesh"]["models"]["Llama-3B"]["limit"]["context"],
+            OPENCODE_DEFAULT_CONTEXT_LIMIT
+        );
+        assert_eq!(
+            config["provider"]["mesh"]["models"]["Llama-3B"]["limit"]["output"],
+            OPENCODE_OUTPUT_LIMIT
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/plugin/mcp.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/mcp.rs
@@ -48,6 +48,37 @@ struct ToolRef {
     tool: rmcp::model::Tool,
 }
 
+fn normalize_tool_schema(mut tool: rmcp::model::Tool) -> rmcp::model::Tool {
+    tool.input_schema = Arc::new(normalize_input_schema((*tool.input_schema).clone()));
+    if tool
+        .output_schema
+        .as_deref()
+        .is_some_and(|schema| schema.get("type").and_then(Value::as_str) != Some("object"))
+    {
+        tool.output_schema = None;
+    }
+    tool
+}
+
+fn normalize_input_schema(
+    mut schema: serde_json::Map<String, serde_json::Value>,
+) -> serde_json::Map<String, serde_json::Value> {
+    if schema.get("type").and_then(Value::as_str) == Some("object") {
+        return schema;
+    }
+    if schema.contains_key("properties") {
+        schema.insert("type".to_string(), serde_json::json!("object"));
+        return schema;
+    }
+    serde_json::json!({
+        "type": "object",
+        "additionalProperties": true,
+    })
+    .as_object()
+    .cloned()
+    .expect("object schema")
+}
+
 #[derive(Clone)]
 enum PromptTarget {
     Plugin {
@@ -598,7 +629,7 @@ impl PluginMcpServer {
                                 plugin_name: plugin_name.clone(),
                                 tool_name: raw_name.clone(),
                             },
-                            tool: stapler::operation(mcp_name, operation),
+                            tool: normalize_tool_schema(stapler::operation(mcp_name, operation)),
                         },
                     );
                 }
@@ -621,7 +652,7 @@ impl PluginMcpServer {
             for tool in listed {
                 let raw_name = tool.name.to_string();
                 let canonical_name = endpoint.canonical_name(&raw_name);
-                let mut namespaced = tool.clone();
+                let mut namespaced = normalize_tool_schema(tool.clone());
                 namespaced.name = canonical_name.clone().into();
                 tools.insert(
                     canonical_name,
@@ -804,7 +835,11 @@ impl ServerHandler for PluginMcpServer {
                     .unwrap_or_else(|| serde_json::json!({}));
                 let result = self
                     .plugin_manager
-                    .invoke_operation(plugin_name, tool_name, &arguments.to_string())
+                    .invoke_operation_without_timeout(
+                        plugin_name,
+                        tool_name,
+                        &arguments.to_string(),
+                    )
                     .await
                     .map_err(internal_error)?;
                 Ok(operation_result_to_call_tool_result(result))
@@ -1449,6 +1484,38 @@ mod tests {
     };
     use serde_json::json;
     use std::path::PathBuf;
+
+    #[test]
+    fn normalize_tool_schema_makes_empty_input_schema_object() {
+        let mut tool = Tool::new("bad", "Bad schema", Arc::new(Default::default()));
+        tool.output_schema = Some(Arc::new(
+            json!({
+                "type": "array",
+                "items": { "type": "string" }
+            })
+            .as_object()
+            .cloned()
+            .unwrap(),
+        ));
+
+        let normalized = normalize_tool_schema(tool);
+
+        assert_eq!(
+            normalized.input_schema.get("type").and_then(Value::as_str),
+            Some("object")
+        );
+        assert_eq!(
+            normalized
+                .input_schema
+                .get("additionalProperties")
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+        assert!(
+            normalized.output_schema.is_none(),
+            "non-object output schemas should be omitted for strict MCP clients"
+        );
+    }
 
     struct NoopBridge;
 


### PR DESCRIPTION
## Summary

Fixes `mesh-llm opencode` so interactive launches use OpenCode's persisted config instead of injecting `OPENCODE_CONFIG_CONTENT`.

The launcher now writes the mesh provider and mesh MCP endpoint to the normal OpenCode config before starting OpenCode, then launches with `-m mesh/<model>` and `OPENAI_API_KEY=dummy`.

It also avoids reopening `/dev/tty` for OpenCode specifically. OpenCode runs on Bun, and Bun can fail while initializing TTY write streams when the child process receives reopened terminal file descriptors from the launcher.

## MCP / Agents

This also tightens the `/mcp` endpoint for OpenCode and other strict MCP clients:

- normalizes plugin MCP tool input schemas so empty schemas become valid object schemas
- drops non-object output schemas when a strict MCP client cannot accept them
- lets MCP client timeouts own long-running plugin tool calls instead of applying the host's short plugin operation timeout

That lets `agents.get_agents` / `agents.send_message` load through OpenCode's MCP client and allows long A2A agent tasks such as `pr-review` to run through the mesh MCP endpoint.

## Why

OpenCode/Bun can crash during interactive startup when launched through the env-config path or with launcher-managed TTY file descriptors. Persisting the config first and inheriting the shell's original stdio matches the working manual path and keeps MCP available through `http://127.0.0.1:3131/mcp`.

## Validation

- `cargo test -p mesh-llm-host-runtime opencode --lib`
- `cargo test -p mesh-llm-host-runtime normalize_tool_schema_makes_empty_input_schema_object --lib`
- `just build`
- Verified `opencode mcp list` connects to `http://127.0.0.1:3131/mcp`
- Ran the `pr-review` A2A agent through `agents mcp` with OpenCode ACP and reviewed this PR
