### PR TITLE
Add Linux ARM64 CUDA release flavor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,7 @@ jobs:
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
-      image: nvidia/cuda:13.1.2-devel-ubuntu24.04
+      image: nvidia/cuda:12.9.2-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
     steps:
@@ -567,7 +567,7 @@ jobs:
       # pulls latest = CUDA 13.2, which deterministically crashes sccache
       # on nvcc output (see mozilla/sccache#2470). CI pins to the same
       # version via Jimver/cuda-toolkit; mirror that here.
-      WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '13.1.2' }}
+      WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '12.9.2' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,15 +297,20 @@ jobs:
           if-no-files-found: error
 
   build_linux_aarch64_cuda:
-    name: Build Linux aarch64 CUDA
+    name: Build Linux aarch64 CUDA (${{ matrix.cuda_version }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda_version: ['12.9.2', '13.1.2']
     container:
-      image: nvidia/cuda:13.1.2-devel-ubuntu24.04
+      image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
       MESH_RELEASE_ARCH: aarch64
+      MESH_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
       - name: Install base packages
         run: |
@@ -332,7 +337,7 @@ jobs:
             crates/mesh-llm-ui/pnpm-lock.yaml
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@just
-      - name: Build ARM64 CUDA release bundle
+      - name: Build aarch64 CUDA release bundle
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
@@ -340,19 +345,24 @@ jobs:
           just --shell bash --shell-arg -c release-bundle-aarch64-cuda "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
-          name: release-linux-aarch64-cuda
+          name: release-linux-aarch64-cuda-${{ matrix.cuda_version }}
           path: dist/*
           if-no-files-found: error
 
   build_linux_cuda:
-    name: Build Linux CUDA
+    name: Build Linux CUDA (${{ matrix.cuda_version }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda_version: ['12.9.2', '13.1.2']
     container:
-      image: nvidia/cuda:12.9.2-devel-ubuntu24.04
+      image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
+      MESH_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
       - name: Install base packages
         run: |
@@ -387,19 +397,24 @@ jobs:
           just --shell bash --shell-arg -c release-bundle-cuda "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
-          name: release-linux-cuda
+          name: release-linux-cuda-${{ matrix.cuda_version }}
           path: dist/*
           if-no-files-found: error
 
   build_linux_cuda_blackwell:
-    name: Build Linux CUDA (Blackwell)
+    name: Build Linux CUDA Blackwell (${{ matrix.cuda_version }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda_version: ['12.9.2', '13.1.2']
     container:
-      image: nvidia/cuda:13.1.2-devel-ubuntu24.04
+      image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
+      MESH_CUDA_VERSION: ${{ matrix.cuda_version }}
     steps:
       - name: Install base packages
         run: |
@@ -434,7 +449,7 @@ jobs:
           just --shell bash --shell-arg -c release-bundle-cuda-blackwell "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
-          name: release-linux-cuda-blackwell
+          name: release-linux-cuda-blackwell-${{ matrix.cuda_version }}
           path: dist/*
           if-no-files-found: error
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     container:
-      image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.6.3' }}-devel-ubuntu22.04
+      image: nvidia/cuda:13.1.2-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
       MESH_RELEASE_ARCH: aarch64
@@ -350,7 +350,7 @@ jobs:
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
-      image: nvidia/cuda:${{ vars.CUDA_VERSION || '12.6.3' }}-devel-ubuntu22.04
+      image: nvidia/cuda:13.1.2-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
     steps:
@@ -397,7 +397,7 @@ jobs:
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     container:
-      image: nvidia/cuda:${{ vars.CUDA_BLACKWELL_VERSION || '12.8.0' }}-devel-ubuntu22.04
+      image: nvidia/cuda:13.1.2-devel-ubuntu24.04
     env:
       LLAMA_STAGE_BACKEND: cuda
     steps:
@@ -567,7 +567,7 @@ jobs:
       # pulls latest = CUDA 13.2, which deterministically crashes sccache
       # on nvcc output (see mozilla/sccache#2470). CI pins to the same
       # version via Jimver/cuda-toolkit; mirror that here.
-      WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '12.6.3' }}
+      WINDOWS_CUDA_VERSION: ${{ vars.CUDA_VERSION || '13.1.2' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,58 +401,6 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  build_linux_cuda_blackwell:
-    name: Build Linux CUDA Blackwell (${{ matrix.cuda_version }})
-    needs: metadata
-    if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
-    runs-on: blacksmith-4vcpu-ubuntu-2404
-    strategy:
-      fail-fast: false
-      matrix:
-        cuda_version: ['12.9.2', '13.1.2']
-    container:
-      image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
-    env:
-      LLAMA_STAGE_BACKEND: cuda
-      MESH_CUDA_VERSION: ${{ matrix.cuda_version }}
-    steps:
-      - name: Install base packages
-        run: |
-          for attempt in 1 2 3; do
-            apt-get -o Acquire::Retries=5 update &&
-              DEBIAN_FRONTEND=noninteractive apt-get -o Acquire::Retries=5 install -y --fix-missing ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential lld &&
-              break
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep $((attempt * 10))
-          done
-          rm -rf /var/lib/apt/lists/*
-      - uses: actions/checkout@v5
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: |
-            .github/cache-version.txt
-            crates/mesh-llm-ui/pnpm-lock.yaml
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@just
-      - name: Build CUDA Blackwell release bundle
-        env:
-          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
-        run: |
-          just --shell bash --shell-arg -c release-build-cuda-blackwell
-          just --shell bash --shell-arg -c release-bundle-cuda-blackwell "$RELEASE_TAG" dist
-      - uses: actions/upload-artifact@v6
-        with:
-          name: release-linux-cuda-blackwell-${{ matrix.cuda_version }}
-          path: dist/*
-          if-no-files-found: error
-
   build_linux_rocm:
     name: Build Linux ROCm
     needs: metadata
@@ -675,12 +623,11 @@ jobs:
       - build_linux_arm64
       - build_linux_aarch64_cuda
       - build_linux_cuda
-      - build_linux_cuda_blackwell
       - build_linux_rocm
       - build_linux_vulkan
       - build_windows_cpu
       - build_windows_gpu
-    if: ${{ always() && needs.metadata.result == 'success' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_aarch64_cuda.result == 'success' || needs.build_linux_aarch64_cuda.result == 'skipped') && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_cuda_blackwell.result == 'success' || needs.build_linux_cuda_blackwell.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') }}
+    if: ${{ always() && needs.metadata.result == 'success' && needs.build.result == 'success' && needs.inference_smoke_tests.result == 'success' && needs.build_native_sdk_runtime.result == 'success' && needs.build_swift_sdk_artifact.result == 'success' && needs.build_linux_arm64.result == 'success' && (needs.build_linux_aarch64_cuda.result == 'success' || needs.build_linux_aarch64_cuda.result == 'skipped') && (needs.build_linux_cuda.result == 'success' || needs.build_linux_cuda.result == 'skipped') && (needs.build_linux_rocm.result == 'success' || needs.build_linux_rocm.result == 'skipped') && (needs.build_linux_vulkan.result == 'success' || needs.build_linux_vulkan.result == 'skipped') && needs.build_windows_cpu.result == 'success' && (needs.build_windows_gpu.result == 'success' || needs.build_windows_gpu.result == 'skipped') }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -297,7 +297,7 @@ jobs:
           if-no-files-found: error
 
   build_linux_aarch64_cuda:
-    name: Build Linux ARM64 CUDA
+    name: Build Linux aarch64 CUDA
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
@@ -336,11 +336,11 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: |
-          just --shell bash --shell-arg -c release-build-arm64-cuda
-          just --shell bash --shell-arg -c release-bundle-arm64-cuda "$RELEASE_TAG" dist
+          just --shell bash --shell-arg -c release-build-aarch64-cuda
+          just --shell bash --shell-arg -c release-bundle-aarch64-cuda "$RELEASE_TAG" dist
       - uses: actions/upload-artifact@v6
         with:
-          name: release-linux-arm64-cuda
+          name: release-linux-aarch64-cuda
           path: dist/*
           if-no-files-found: error
 

--- a/Justfile
+++ b/Justfile
@@ -148,8 +148,10 @@ release-build-aarch64:
     @scripts/build-release.sh
 
 # Build a Linux aarch64 CUDA release artifact (Jetson/Orin).
-release-build-aarch64-cuda cuda_arch="75;80;86;87;89;90;110":
-    @MESH_LLM_BUILD_PROFILE=release MESH_RELEASE_ARCH=aarch64 scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
+# SM arches selected by MESH_CUDA_VERSION env (set by CI matrix).
+release-build-aarch64-cuda:
+    @MESH_LLM_BUILD_PROFILE=release MESH_RELEASE_ARCH=aarch64 scripts/build-linux.sh --backend cuda \
+      --cuda-arch "$(if [[ "${MESH_CUDA_VERSION:-}" == 13.* ]]; then echo '75;80;86;87;89;90;110'; else echo '75;80;86;87;89;90'; fi)"
 
 # Prepare the pinned llama.cpp checkout and apply the Mesh-LLM ABI patch queue.
 llama-prepare:
@@ -166,12 +168,17 @@ llama-build: llama-prepare
 release-build-windows:
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cpu -BuildProfile release
 
-# Build a Linux CUDA release artifact (primary / R535-compatible lane).
-release-build-cuda cuda_arch="75;80;86;87;89;90":
-    @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
+# Build a Linux CUDA release artifact (primary lane).
+# SM arches selected by MESH_CUDA_VERSION env (set by CI matrix).
+release-build-cuda:
+    @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda \
+      --cuda-arch "$(if [[ "${MESH_CUDA_VERSION:-}" == 13.* ]]; then echo '75;80;86;87;89;90'; else echo '75;80;86;87;89;90'; fi)"
 
-release-build-cuda-blackwell cuda_arch="75;80;86;87;89;90;100;103;120;121":
-    @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
+# Build a Linux CUDA release artifact (Blackwell lane).
+# SM arches selected by MESH_CUDA_VERSION env (set by CI matrix).
+release-build-cuda-blackwell:
+    @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda \
+      --cuda-arch "$(if [[ "${MESH_CUDA_VERSION:-}" == 13.* ]]; then echo '75;80;86;87;89;90;100;103;120;121'; else echo '75;80;86;87;89;90;100;120'; fi)"
 
 release-build-cuda-windows cuda_arch="75;80;86;87;89;90":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}" -BuildProfile release

--- a/Justfile
+++ b/Justfile
@@ -168,22 +168,13 @@ llama-build: llama-prepare
 release-build-windows:
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cpu -BuildProfile release
 
-# Build a Linux CUDA release artifact (primary lane).
+# Build a Linux CUDA release artifact.
 # SM arches selected by MESH_CUDA_VERSION env (set by CI matrix).
 release-build-cuda:
     @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda \
-      --cuda-arch "$(if [[ "${MESH_CUDA_VERSION:-}" == 13.* ]]; then echo '75;80;86;87;89;90'; else echo '75;80;86;87;89;90'; fi)"
-
-# Build a Linux CUDA release artifact (Blackwell lane).
-# SM arches selected by MESH_CUDA_VERSION env (set by CI matrix).
-release-build-cuda-blackwell:
-    @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda \
-      --cuda-arch "$(if [[ "${MESH_CUDA_VERSION:-}" == 13.* ]]; then echo '75;80;86;87;89;90;100;103;120;121'; else echo '75;80;86;87;89;90;100;120'; fi)"
+      --cuda-arch "$(if [[ "${MESH_CUDA_VERSION:-}" == 13.* ]]; then echo '75;80;86;87;89;90;100;103;120;121'; else echo '75;80;86;87;89;90'; fi)"
 
 release-build-cuda-windows cuda_arch="75;80;86;87;89;90":
-    @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}" -BuildProfile release
-
-release-build-cuda-blackwell-windows cuda_arch="75;80;86;87;89;90;100;120":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}" -BuildProfile release
 
 # Build a Linux ROCm ABI release artifact with an explicit architecture list.
@@ -316,14 +307,8 @@ release-bundle-windows version output="dist":
 release-bundle-cuda version output="dist":
     MESH_RELEASE_FLAVOR=cuda scripts/package-release.sh "{{ version }}" "{{ output }}"
 
-release-bundle-cuda-blackwell version output="dist":
-    MESH_RELEASE_FLAVOR=cuda-blackwell scripts/package-release.sh "{{ version }}" "{{ output }}"
-
 release-bundle-cuda-windows version output="dist":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1 -Version "{{version}}" -OutputDir "{{output}}" -Flavor cuda
-
-release-bundle-cuda-blackwell-windows version output="dist":
-    @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/package-release.ps1 -Version "{{version}}" -OutputDir "{{output}}" -Flavor cuda-blackwell
 
 # Create Linux ROCm release archive(s).
 release-bundle-rocm version output="dist":

--- a/Justfile
+++ b/Justfile
@@ -148,7 +148,7 @@ release-build-aarch64:
     @scripts/build-release.sh
 
 # Build a Linux aarch64 CUDA release artifact (Jetson/Orin).
-release-build-aarch64-cuda cuda_arch="75;80;86;87;89;90":
+release-build-aarch64-cuda cuda_arch="75;80;86;87;89;90;110":
     @MESH_LLM_BUILD_PROFILE=release MESH_RELEASE_ARCH=aarch64 scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
 # Prepare the pinned llama.cpp checkout and apply the Mesh-LLM ABI patch queue.
@@ -170,7 +170,7 @@ release-build-windows:
 release-build-cuda cuda_arch="75;80;86;87;89;90":
     @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
-release-build-cuda-blackwell cuda_arch="75;80;86;87;89;90;100;120":
+release-build-cuda-blackwell cuda_arch="75;80;86;87;89;90;100;103;120;121":
     @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
 release-build-cuda-windows cuda_arch="75;80;86;87;89;90":

--- a/Justfile
+++ b/Justfile
@@ -143,13 +143,13 @@ build-runtime backend="" cuda_arch="" rocm_arch="":
 release-build:
     @scripts/build-release.sh
 
-# Build a Linux ARM64 CPU release artifact on a native ARM64 runner.
-release-build-arm64:
+# Build a Linux aarch64 CPU release artifact on a native aarch64 runner.
+release-build-aarch64:
     @scripts/build-release.sh
 
-# Build a Linux ARM64 CUDA release artifact (Jetson/Orin).
-release-build-arm64-cuda cuda_arch="75;80;86;87;89;90":
-    @MESH_LLM_BUILD_PROFILE=release scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
+# Build a Linux aarch64 CUDA release artifact (Jetson/Orin).
+release-build-aarch64-cuda cuda_arch="75;80;86;87;89;90":
+    @MESH_LLM_BUILD_PROFILE=release MESH_RELEASE_ARCH=aarch64 scripts/build-linux.sh --backend cuda --cuda-arch "{{ cuda_arch }}"
 
 # Prepare the pinned llama.cpp checkout and apply the Mesh-LLM ABI patch queue.
 llama-prepare:
@@ -285,13 +285,13 @@ bundle output="/tmp/mesh-bundle.tar.gz":
 release-bundle version output="dist":
     @scripts/package-release.sh "{{ version }}" "{{ output }}"
 
-# Create a Linux ARM64 CPU release archive on a native ARM64 runner.
-release-bundle-arm64 version output="dist":
+# Create a Linux aarch64 CPU release archive on a native aarch64 runner.
+release-bundle-aarch64 version output="dist":
     @scripts/package-release.sh "{{ version }}" "{{ output }}"
 
-# Create a Linux ARM64 CUDA release archive on a native ARM64 runner.
-release-bundle-arm64-cuda version output="dist":
-    MESH_RELEASE_FLAVOR=cuda scripts/package-release.sh "{{ version }}" "{{ output }}"
+# Create a Linux aarch64 CUDA release archive on a native aarch64 runner.
+release-bundle-aarch64-cuda version output="dist":
+    MESH_RELEASE_ARCH=aarch64 MESH_RELEASE_FLAVOR=cuda scripts/package-release.sh "{{ version }}" "{{ output }}"
 
 # Run repo-level release-target consistency checks.
 [unix]

--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ llama.cpp parity queue.
 ## Install and build notes
 
 Tagged releases publish macOS bundles plus Linux CPU, Linux ARM64 CPU, Linux
-CUDA, Linux CUDA Blackwell, Linux ROCm, Linux Vulkan, Windows CPU, Windows
-CUDA, Windows ROCm, and Windows Vulkan bundles. Metal is macOS-only. The Linux
-ARM64 artifact is `mesh-llm-aarch64-unknown-linux-gnu.tar.gz`; in install and
-release contexts, `arm64` and `aarch64` mean the same 64-bit ARM target.
+ARM64 CUDA, Linux CUDA, Linux CUDA Blackwell, Linux ROCm, Linux Vulkan, Windows
+CPU, Windows CUDA, Windows ROCm, and Windows Vulkan bundles. Metal is
+macOS-only. The Linux ARM64 CPU artifact is
+`mesh-llm-aarch64-unknown-linux-gnu.tar.gz`; the Linux ARM64 CUDA artifact is
+`mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz`. In install and release
+contexts, `arm64` and `aarch64` mean the same 64-bit ARM target.
 
 Build from source with `just`:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -59,12 +59,13 @@ in the workflow workspace, and creates the requested release tag at a
 manifest-only commit before publishing.
 
 The current GitHub Actions release workflow publishes macOS aarch64, Linux
-x86_64 CPU, Linux ARM64 CPU, Linux CUDA, Linux CUDA Blackwell, Linux ROCm,
-Linux Vulkan, Windows CPU, Windows CUDA, Windows ROCm, and Windows Vulkan
-bundles, plus the SwiftPM `MeshLLMFFI.xcframework.zip` binary artifact. The
-Linux ARM64 artifact is named
-`mesh-llm-aarch64-unknown-linux-gnu.tar.gz`; CUDA lanes are named
-`mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz` and
+x86_64 CPU, Linux ARM64 CPU, Linux ARM64 CUDA, Linux CUDA, Linux CUDA
+Blackwell, Linux ROCm, Linux Vulkan, Windows CPU, Windows CUDA, Windows ROCm,
+and Windows Vulkan bundles, plus the SwiftPM `MeshLLMFFI.xcframework.zip`
+binary artifact. The Linux ARM64 CPU artifact is named
+`mesh-llm-aarch64-unknown-linux-gnu.tar.gz`; the Linux ARM64 CUDA artifact is
+named `mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz`. x86_64 CUDA lanes are
+named `mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz` and
 `mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz`.
 
 Windows release artifacts use the `x86_64-pc-windows-msvc` target triple and

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -431,10 +431,16 @@ fn release_asset_candidates(
     match preference {
         ReleaseAssetPreference::StableFirst => {
             push_release_asset_candidate(&mut candidates, target.stable_asset_name());
+            for name in target.stable_cuda_versioned_names() {
+                push_release_asset_candidate(&mut candidates, Some(name));
+            }
             push_release_asset_candidate(&mut candidates, target.versioned_asset_name(release_tag));
         }
         ReleaseAssetPreference::VersionedFirst => {
             push_release_asset_candidate(&mut candidates, target.versioned_asset_name(release_tag));
+            for name in target.stable_cuda_versioned_names() {
+                push_release_asset_candidate(&mut candidates, Some(name));
+            }
             push_release_asset_candidate(&mut candidates, target.stable_asset_name());
         }
     }

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -1918,12 +1918,16 @@ mod tests {
 
     #[test]
     fn test_is_tegra_nvidia_model_positive_orin_agx() {
-        assert!(is_tegra_nvidia_model("NVIDIA Jetson AGX Orin Developer Kit"));
+        assert!(is_tegra_nvidia_model(
+            "NVIDIA Jetson AGX Orin Developer Kit"
+        ));
     }
 
     #[test]
     fn test_is_tegra_nvidia_model_positive_orin_nano() {
-        assert!(is_tegra_nvidia_model("NVIDIA Jetson Orin Nano Developer Kit"));
+        assert!(is_tegra_nvidia_model(
+            "NVIDIA Jetson Orin Nano Developer Kit"
+        ));
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -558,26 +558,11 @@ fn probe_nvidia_backend() -> bool {
         || command_exists("nvcc")
         || Path::new("/dev/nvidiactl").exists()
         || Path::new("/proc/driver/nvidia/gpus").is_dir()
-        || probe_tegra_backend()
-}
-
-/// Detect NVIDIA Tegra / Jetson SoC accelerators (Orin AGX, Orin NX, Xavier, etc.).
-/// These expose an integrated NVIDIA GPU but have no nvidia-smi or /dev/nvidiactl — only a
-/// device-tree model string containing "tegra" or "jetson".
-fn probe_tegra_backend() -> bool {
-    let dt_model = Path::new("/proc/device-tree/model");
-    if !dt_model.exists() {
-        return false;
-    }
-    std::fs::read_to_string(dt_model)
-        .map(|s| is_tegra_model(&s))
-        .unwrap_or(false)
-}
-
-/// Check whether a device-tree model string identifies an NVIDIA Tegra/Jetson SoC.
-fn is_tegra_model(content: &str) -> bool {
-    let lower = content.to_ascii_lowercase();
-    lower.contains("tegra") || lower.contains("jetson")
+        || Path::new("/dev/nvhost-gpu").exists()
+        || Path::new("/dev/nvhost-ctrl-gpu").exists()
+        || nvidia_device_tree_models()
+            .iter()
+            .any(|model| is_tegra_nvidia_model(model))
 }
 
 fn nvidia_compute_caps() -> Vec<String> {
@@ -627,6 +612,34 @@ fn nvidia_proc_models() -> Vec<String> {
             })
         })
         .collect()
+}
+
+fn nvidia_device_tree_models() -> Vec<String> {
+    [
+        "/proc/device-tree/model",
+        "/proc/device-tree/compatible",
+        "/sys/firmware/devicetree/base/model",
+        "/sys/firmware/devicetree/base/compatible",
+    ]
+    .iter()
+    .filter_map(|path| std::fs::read(path).ok())
+    .map(|bytes| {
+        String::from_utf8_lossy(&bytes)
+            .replace('\0', "\n")
+            .trim()
+            .to_string()
+    })
+    .filter(|model| !model.is_empty())
+    .collect()
+}
+
+fn is_tegra_nvidia_model(model: &str) -> bool {
+    const TEGRA_MODEL_MARKERS: [&str; 5] = ["JETSON", "TEGRA", "ORIN", "NVGPU", "THOR"];
+
+    let upper = model.to_ascii_uppercase();
+    TEGRA_MODEL_MARKERS
+        .iter()
+        .any(|marker| upper.contains(marker))
 }
 
 fn is_blackwell_nvidia_model(model: &str) -> bool {
@@ -1851,6 +1864,18 @@ mod tests {
             preferred_bundle_flavor_for_platform("linux", "aarch64", probe),
             Some(backend::BinaryFlavor::Cuda)
         );
+
+        let probe = HostBackendProbe {
+            cuda_blackwell: false,
+            cuda: false,
+            rocm: true,
+            vulkan: true,
+            metal: true,
+        };
+        assert_eq!(
+            preferred_bundle_flavor_for_platform("linux", "aarch64", probe),
+            Some(backend::BinaryFlavor::Cpu)
+        );
         assert_eq!(
             preferred_bundle_flavor_for_platform("linux", "armv7l", probe),
             None
@@ -1896,6 +1921,24 @@ mod tests {
     }
 
     #[test]
+    fn test_tegra_nvidia_detection_from_model_name() {
+        for model in [
+            "NVIDIA Jetson AGX Orin",
+            "Orin (nvgpu)",
+            "nvidia,tegra234",
+            "Jetson Thor",
+        ] {
+            assert!(is_tegra_nvidia_model(model), "{model} should select cuda");
+        }
+        for model in ["Raspberry Pi 5", "Apple M4", "AMD Radeon"] {
+            assert!(
+                !is_tegra_nvidia_model(model),
+                "{model} should not select cuda"
+            );
+        }
+    }
+
+    #[test]
     fn test_update_flavor_preference_falls_back_to_cpu() {
         assert_eq!(
             preferred_bundle_flavor_for_platform("windows", "x86_64", HostBackendProbe::default()),
@@ -1935,38 +1978,38 @@ mod tests {
     }
 
     #[test]
-    fn test_is_tegra_model_positive_orin_agx() {
-        assert!(is_tegra_model("NVIDIA Jetson AGX Orin Developer Kit"));
+    fn test_is_tegra_nvidia_model_positive_orin_agx() {
+        assert!(is_tegra_nvidia_model("NVIDIA Jetson AGX Orin Developer Kit"));
     }
 
     #[test]
-    fn test_is_tegra_model_positive_orin_nano() {
-        assert!(is_tegra_model("NVIDIA Jetson Orin Nano Developer Kit"));
+    fn test_is_tegra_nvidia_model_positive_orin_nano() {
+        assert!(is_tegra_nvidia_model("NVIDIA Jetson Orin Nano Developer Kit"));
     }
 
     #[test]
-    fn test_is_tegra_model_positive_xavier() {
-        assert!(is_tegra_model("NVIDIA Jetson Xavier NX"));
+    fn test_is_tegra_nvidia_model_positive_xavier() {
+        assert!(is_tegra_nvidia_model("NVIDIA Jetson Xavier NX"));
     }
 
     #[test]
-    fn test_is_tegra_model_positive_lowercase() {
-        assert!(is_tegra_model("nvidia tegra234"));
+    fn test_is_tegra_nvidia_model_positive_lowercase() {
+        assert!(is_tegra_nvidia_model("nvidia tegra234"));
     }
 
     #[test]
-    fn test_is_tegra_model_negative_raspberry_pi() {
-        assert!(!is_tegra_model("Raspberry Pi 4 Model B Rev 1.5"));
+    fn test_is_tegra_nvidia_model_negative_raspberry_pi() {
+        assert!(!is_tegra_nvidia_model("Raspberry Pi 4 Model B Rev 1.5"));
     }
 
     #[test]
-    fn test_is_tegra_model_negative_amd() {
-        assert!(!is_tegra_model("AMD EPYC Server"));
+    fn test_is_tegra_nvidia_model_negative_amd() {
+        assert!(!is_tegra_nvidia_model("AMD EPYC Server"));
     }
 
     #[test]
-    fn test_is_tegra_model_empty() {
-        assert!(!is_tegra_model(""));
+    fn test_is_tegra_nvidia_model_empty() {
+        assert!(!is_tegra_nvidia_model(""));
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -47,7 +47,6 @@ struct UpdateTarget {
 
 #[derive(Clone, Copy, Debug, Default)]
 struct HostBackendProbe {
-    cuda_blackwell: bool,
     cuda: bool,
     rocm: bool,
     vulkan: bool,
@@ -503,8 +502,7 @@ fn preferred_bundle_flavor_for_platform(
     probe: HostBackendProbe,
 ) -> Option<backend::BinaryFlavor> {
     // Keep this detection order and the probes below in sync with install.sh.
-    const UPDATE_FLAVOR_PREFERENCE: [backend::BinaryFlavor; 6] = [
-        backend::BinaryFlavor::CudaBlackwell,
+    const UPDATE_FLAVOR_PREFERENCE: [backend::BinaryFlavor; 5] = [
         backend::BinaryFlavor::Cuda,
         backend::BinaryFlavor::Rocm,
         backend::BinaryFlavor::Vulkan,
@@ -531,7 +529,6 @@ fn flavor_supported_for_update(
     }
 
     match flavor {
-        backend::BinaryFlavor::CudaBlackwell => probe.cuda_blackwell,
         backend::BinaryFlavor::Cuda => probe.cuda,
         backend::BinaryFlavor::Rocm => probe.rocm,
         backend::BinaryFlavor::Vulkan => probe.vulkan,
@@ -542,21 +539,11 @@ fn flavor_supported_for_update(
 
 fn current_host_backend_probe() -> HostBackendProbe {
     HostBackendProbe {
-        cuda_blackwell: probe_cuda_blackwell_backend(),
         cuda: probe_nvidia_backend(),
         rocm: probe_rocm_backend(),
         vulkan: probe_vulkan_backend(),
         metal: cfg!(target_os = "macos"),
     }
-}
-
-fn probe_cuda_blackwell_backend() -> bool {
-    nvidia_compute_caps()
-        .iter()
-        .any(|capability| is_blackwell_compute_capability(capability))
-        || nvidia_proc_models()
-            .iter()
-            .any(|model| is_blackwell_nvidia_model(model))
 }
 
 fn probe_nvidia_backend() -> bool {
@@ -571,25 +558,7 @@ fn probe_nvidia_backend() -> bool {
             .any(|model| is_tegra_nvidia_model(model))
 }
 
-fn nvidia_compute_caps() -> Vec<String> {
-    let Ok(output) = std::process::Command::new("nvidia-smi")
-        .args(["--query-gpu=compute_cap", "--format=csv,noheader"])
-        .output()
-    else {
-        return Vec::new();
-    };
-    if !output.status.success() {
-        return Vec::new();
-    }
-
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .map(ToString::to_string)
-        .collect()
-}
-
+#[cfg(test)]
 fn is_blackwell_compute_capability(capability: &str) -> bool {
     let normalized = capability
         .chars()
@@ -598,26 +567,6 @@ fn is_blackwell_compute_capability(capability: &str) -> bool {
     normalized
         .parse::<u16>()
         .is_ok_and(|sm| (100..200).contains(&sm))
-}
-
-fn nvidia_proc_models() -> Vec<String> {
-    let Ok(entries) = std::fs::read_dir("/proc/driver/nvidia/gpus") else {
-        return Vec::new();
-    };
-
-    entries
-        .filter_map(Result::ok)
-        .map(|entry| entry.path().join("information"))
-        .filter_map(|path| std::fs::read_to_string(path).ok())
-        .filter_map(|contents| {
-            contents.lines().find_map(|line| {
-                line.strip_prefix("Model:")
-                    .map(str::trim)
-                    .filter(|model| !model.is_empty())
-                    .map(ToString::to_string)
-            })
-        })
-        .collect()
 }
 
 fn nvidia_device_tree_models() -> Vec<String> {
@@ -648,6 +597,7 @@ fn is_tegra_nvidia_model(model: &str) -> bool {
         .any(|marker| upper.contains(marker))
 }
 
+#[cfg(test)]
 fn is_blackwell_nvidia_model(model: &str) -> bool {
     const BLACKWELL_MODEL_MARKERS: [&str; 14] = [
         "BLACKWELL",
@@ -1805,19 +1755,6 @@ mod tests {
     #[test]
     fn test_update_flavor_preference_uses_backend_order() {
         let probe = HostBackendProbe {
-            cuda_blackwell: true,
-            cuda: true,
-            rocm: true,
-            vulkan: true,
-            metal: false,
-        };
-        assert_eq!(
-            preferred_bundle_flavor_for_platform("linux", "x86_64", probe),
-            Some(backend::BinaryFlavor::CudaBlackwell)
-        );
-
-        let probe = HostBackendProbe {
-            cuda_blackwell: false,
             cuda: true,
             rocm: true,
             vulkan: true,
@@ -1829,7 +1766,6 @@ mod tests {
         );
 
         let probe = HostBackendProbe {
-            cuda_blackwell: false,
             cuda: false,
             rocm: true,
             vulkan: true,
@@ -1841,7 +1777,6 @@ mod tests {
         );
 
         let probe = HostBackendProbe {
-            cuda_blackwell: false,
             cuda: false,
             rocm: false,
             vulkan: true,
@@ -1856,7 +1791,6 @@ mod tests {
     #[test]
     fn test_update_flavor_preference_filters_by_published_platform() {
         let probe = HostBackendProbe {
-            cuda_blackwell: true,
             cuda: true,
             rocm: true,
             vulkan: true,
@@ -1872,7 +1806,6 @@ mod tests {
         );
 
         let probe = HostBackendProbe {
-            cuda_blackwell: false,
             cuda: false,
             rocm: true,
             vulkan: true,
@@ -1893,7 +1826,7 @@ mod tests {
         for capability in ["10.0", "10.3", "12.0", "12.1", "100", "103", "120", "121"] {
             assert!(
                 is_blackwell_compute_capability(capability),
-                "{capability} should select cuda-blackwell"
+                "{capability} requires CUDA 13.x"
             );
         }
         for capability in ["7.5", "8.0", "8.9", "9.0", "75", "80", "89", "90"] {
@@ -1915,7 +1848,7 @@ mod tests {
         ] {
             assert!(
                 is_blackwell_nvidia_model(model),
-                "{model} should select cuda-blackwell"
+                "{model} requires CUDA 13.x"
             );
         }
         for model in ["NVIDIA H100", "NVIDIA A100", "NVIDIA RTX 4090"] {
@@ -2022,7 +1955,6 @@ mod tests {
     fn test_tegra_selects_cuda_on_linux_aarch64() {
         // Simulate a Tegra/Jetson probe: cuda=true (set by tegra), everything else false.
         let probe = HostBackendProbe {
-            cuda_blackwell: false,
             cuda: true,
             rocm: false,
             vulkan: false,
@@ -2036,40 +1968,9 @@ mod tests {
     }
 
     #[test]
-    fn test_tegra_cuda_not_blackwell() {
-        // Tegra SoCs are not Blackwell — cuda is true, cuda_blackwell is false.
-        let probe = HostBackendProbe {
-            cuda_blackwell: false,
-            cuda: true,
-            rocm: false,
-            vulkan: false,
-            metal: false,
-        };
-        assert!(
-            !flavor_supported_for_update(
-                backend::BinaryFlavor::CudaBlackwell,
-                "linux",
-                "aarch64",
-                probe
-            ),
-            "Tegra should NOT select Blackwell"
-        );
-        assert!(
-            flavor_supported_for_update(
-                backend::BinaryFlavor::Cuda,
-                "linux",
-                "aarch64",
-                probe
-            ),
-            "Tegra MUST select standard CUDA"
-        );
-    }
-
-    #[test]
     fn test_tegra_falls_back_to_cpu_when_cuda_unsupported() {
         // If the release has no CUDA asset for aarch64, CPU is the fallback.
         let probe = HostBackendProbe {
-            cuda_blackwell: false,
             cuda: true,
             rocm: false,
             vulkan: false,

--- a/crates/mesh-llm-system/src/backend.rs
+++ b/crates/mesh-llm-system/src/backend.rs
@@ -10,17 +10,15 @@ use std::time::Duration;
 pub enum BinaryFlavor {
     Cpu,
     Cuda,
-    CudaBlackwell,
     Rocm,
     Vulkan,
     Metal,
 }
 
 impl BinaryFlavor {
-    pub const ALL: [BinaryFlavor; 6] = [
+    pub const ALL: [BinaryFlavor; 5] = [
         BinaryFlavor::Cpu,
         BinaryFlavor::Cuda,
-        BinaryFlavor::CudaBlackwell,
         BinaryFlavor::Rocm,
         BinaryFlavor::Vulkan,
         BinaryFlavor::Metal,
@@ -30,7 +28,6 @@ impl BinaryFlavor {
         match self {
             BinaryFlavor::Cpu => "cpu",
             BinaryFlavor::Cuda => "cuda",
-            BinaryFlavor::CudaBlackwell => "cuda-blackwell",
             BinaryFlavor::Rocm => "rocm",
             BinaryFlavor::Vulkan => "vulkan",
             BinaryFlavor::Metal => "metal",
@@ -78,7 +75,7 @@ pub fn platform_bin_name(name: &str) -> String {
 pub fn backend_device_for_flavor(index: usize, binary_flavor: BinaryFlavor) -> Option<String> {
     match binary_flavor {
         BinaryFlavor::Cpu => None,
-        BinaryFlavor::Cuda | BinaryFlavor::CudaBlackwell => Some(format!("CUDA{index}")),
+        BinaryFlavor::Cuda => Some(format!("CUDA{index}")),
         BinaryFlavor::Rocm => Some(format!("ROCm{index}")),
         BinaryFlavor::Vulkan => Some(format!("Vulkan{index}")),
         BinaryFlavor::Metal => Some(format!("MTL{index}")),

--- a/crates/mesh-llm-system/src/release_target.rs
+++ b/crates/mesh-llm-system/src/release_target.rs
@@ -157,6 +157,30 @@ impl ReleaseTarget {
         self.asset_name(Some(release_tag))
     }
 
+    /// Return CUDA-versioned asset names (e.g. `-cuda-12`, `-cuda-13`) for cuda flavors.
+    /// Returns empty vec for non-cuda flavors or unsupported targets.
+    pub fn stable_cuda_versioned_names(self) -> Vec<String> {
+        if self.support_status() != SupportStatus::Supported {
+            return Vec::new();
+        }
+
+        let triple = match self.target_triple() {
+            Some(t) => t,
+            None => return Vec::new(),
+        };
+        let archive = self.archive_kind().extension();
+        let base_flavor = match self.flavor {
+            BinaryFlavor::Cuda => "cuda",
+            BinaryFlavor::CudaBlackwell => "cuda-blackwell",
+            _ => return Vec::new(),
+        };
+
+        vec![
+            format!("mesh-llm-{triple}-{base_flavor}-12.{archive}"),
+            format!("mesh-llm-{triple}-{base_flavor}-13.{archive}"),
+        ]
+    }
+
     fn asset_name(self, release_tag: Option<&str>) -> Option<String> {
         if self.support_status() != SupportStatus::Supported {
             return None;
@@ -307,6 +331,19 @@ mod tests {
             cuda_arm64.stable_asset_name(),
             Some("mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz".to_string())
         );
+
+        // CUDA versioned names for matrix artifacts.
+        let cuda_names = cuda_aarch64.stable_cuda_versioned_names();
+        assert_eq!(
+            cuda_names,
+            vec![
+                "mesh-llm-aarch64-unknown-linux-gnu-cuda-12.tar.gz",
+                "mesh-llm-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
+            ]
+        );
+
+        // Non-CUDA flavors return empty.
+        assert!(arm64.stable_cuda_versioned_names().is_empty());
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/release_target.rs
+++ b/crates/mesh-llm-system/src/release_target.rs
@@ -285,6 +285,8 @@ mod tests {
     fn release_target_arm64_aliases_have_identical_linux_assets() {
         let arm64 = ReleaseTarget::from_raw("linux", "arm64", BinaryFlavor::Cpu).unwrap();
         let aarch64 = ReleaseTarget::from_raw("linux", "aarch64", BinaryFlavor::Cpu).unwrap();
+        let cuda_arm64 = ReleaseTarget::from_raw("linux", "arm64", BinaryFlavor::Cuda).unwrap();
+        let cuda_aarch64 = ReleaseTarget::from_raw("linux", "aarch64", BinaryFlavor::Cuda).unwrap();
 
         assert_eq!(arm64.support_status(), aarch64.support_status());
         assert_eq!(arm64.stable_asset_name(), aarch64.stable_asset_name());
@@ -295,6 +297,15 @@ mod tests {
         assert_eq!(
             arm64.stable_asset_name(),
             Some("mesh-llm-aarch64-unknown-linux-gnu.tar.gz".to_string())
+        );
+        assert_eq!(cuda_arm64.support_status(), cuda_aarch64.support_status());
+        assert_eq!(
+            cuda_arm64.stable_asset_name(),
+            cuda_aarch64.stable_asset_name()
+        );
+        assert_eq!(
+            cuda_arm64.stable_asset_name(),
+            Some("mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz".to_string())
         );
     }
 

--- a/crates/mesh-llm-system/src/release_target.rs
+++ b/crates/mesh-llm-system/src/release_target.rs
@@ -114,14 +114,12 @@ impl ReleaseTarget {
             (CanonicalOs::Macos, CanonicalArch::Aarch64, BinaryFlavor::Metal)
             | (CanonicalOs::Linux, CanonicalArch::X86_64, BinaryFlavor::Cpu)
             | (CanonicalOs::Linux, CanonicalArch::X86_64, BinaryFlavor::Cuda)
-            | (CanonicalOs::Linux, CanonicalArch::X86_64, BinaryFlavor::CudaBlackwell)
             | (CanonicalOs::Linux, CanonicalArch::X86_64, BinaryFlavor::Rocm)
             | (CanonicalOs::Linux, CanonicalArch::X86_64, BinaryFlavor::Vulkan)
             | (CanonicalOs::Linux, CanonicalArch::Aarch64, BinaryFlavor::Cpu)
             | (CanonicalOs::Linux, CanonicalArch::Aarch64, BinaryFlavor::Cuda)
             | (CanonicalOs::Windows, CanonicalArch::X86_64, BinaryFlavor::Cpu)
             | (CanonicalOs::Windows, CanonicalArch::X86_64, BinaryFlavor::Cuda)
-            | (CanonicalOs::Windows, CanonicalArch::X86_64, BinaryFlavor::CudaBlackwell)
             | (CanonicalOs::Windows, CanonicalArch::X86_64, BinaryFlavor::Rocm)
             | (CanonicalOs::Windows, CanonicalArch::X86_64, BinaryFlavor::Vulkan) => {
                 SupportStatus::Supported
@@ -171,7 +169,6 @@ impl ReleaseTarget {
         let archive = self.archive_kind().extension();
         let base_flavor = match self.flavor {
             BinaryFlavor::Cuda => "cuda",
-            BinaryFlavor::CudaBlackwell => "cuda-blackwell",
             _ => return Vec::new(),
         };
 
@@ -191,7 +188,6 @@ impl ReleaseTarget {
         let flavor_suffix = match self.flavor {
             BinaryFlavor::Cpu | BinaryFlavor::Metal => "",
             BinaryFlavor::Cuda => "-cuda",
-            BinaryFlavor::CudaBlackwell => "-cuda-blackwell",
             BinaryFlavor::Rocm => "-rocm",
             BinaryFlavor::Vulkan => "-vulkan",
         };
@@ -233,7 +229,6 @@ mod tests {
         match name {
             "cpu" => BinaryFlavor::Cpu,
             "cuda" => BinaryFlavor::Cuda,
-            "cuda-blackwell" => BinaryFlavor::CudaBlackwell,
             "rocm" => BinaryFlavor::Rocm,
             "vulkan" => BinaryFlavor::Vulkan,
             "metal" => BinaryFlavor::Metal,

--- a/crates/mesh-llm-system/tests/fixtures/release-target-matrix.json
+++ b/crates/mesh-llm-system/tests/fixtures/release-target-matrix.json
@@ -26,14 +26,6 @@
   {
     "os": "linux",
     "arch": "x86_64",
-    "flavor": "cuda-blackwell",
-    "support": "supported",
-    "stable_asset": "mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz",
-    "versioned_asset": "mesh-llm-v0.60.0-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz"
-  },
-  {
-    "os": "linux",
-    "arch": "x86_64",
     "flavor": "rocm",
     "support": "supported",
     "stable_asset": "mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz",
@@ -66,14 +58,6 @@
   {
     "os": "linux",
     "arch": "aarch64",
-    "flavor": "cuda-blackwell",
-    "support": "unknown",
-    "stable_asset": null,
-    "versioned_asset": null
-  },
-  {
-    "os": "linux",
-    "arch": "aarch64",
     "flavor": "rocm",
     "support": "unknown",
     "stable_asset": null,
@@ -99,14 +83,6 @@
     "os": "macos",
     "arch": "aarch64",
     "flavor": "cuda",
-    "support": "unknown",
-    "stable_asset": null,
-    "versioned_asset": null
-  },
-  {
-    "os": "macos",
-    "arch": "aarch64",
-    "flavor": "cuda-blackwell",
     "support": "unknown",
     "stable_asset": null,
     "versioned_asset": null
@@ -142,14 +118,6 @@
     "support": "supported",
     "stable_asset": "mesh-llm-x86_64-pc-windows-msvc-cuda.zip",
     "versioned_asset": "mesh-llm-v0.60.0-x86_64-pc-windows-msvc-cuda.zip"
-  },
-  {
-    "os": "windows",
-    "arch": "x86_64",
-    "flavor": "cuda-blackwell",
-    "support": "supported",
-    "stable_asset": "mesh-llm-x86_64-pc-windows-msvc-cuda-blackwell.zip",
-    "versioned_asset": "mesh-llm-v0.60.0-x86_64-pc-windows-msvc-cuda-blackwell.zip"
   },
   {
     "os": "windows",

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -31,9 +31,9 @@ Release bundles install the `mesh-llm` host binary plus the flavor-specific
 native runtime libraries it embeds. Normal serving runs inside the `mesh-llm`
 host process, which loads the Skippy/llama.cpp stage runtime directly.
 
-Published bundle flavors include macOS, Linux CPU, Linux ARM64 CPU, Linux CUDA,
-Linux CUDA Blackwell, Linux ROCm, Linux Vulkan, Windows CPU, Windows CUDA,
-Windows ROCm, and Windows Vulkan. Metal remains macOS-only.
+Published bundle flavors include macOS, Linux CPU, Linux ARM64 CPU, Linux ARM64
+CUDA, Linux CUDA, Linux CUDA Blackwell, Linux ROCm, Linux Vulkan, Windows CPU,
+Windows CUDA, Windows ROCm, and Windows Vulkan. Metal remains macOS-only.
 
 If you keep more than one flavor in the same `bin` directory, choose one explicitly:
 

--- a/install.sh
+++ b/install.sh
@@ -453,6 +453,29 @@ choose_flavor() {
     echo "$reply"
 }
 
+detect_cuda_major() {
+    # Detect host CUDA major version from nvcc or libcudart.
+    local ver=""
+    if command -v nvcc >/dev/null 2>&1; then
+        ver="$(nvcc --version 2>/dev/null | grep -oP 'release \K[0-9]+')"
+    fi
+    if [[ -z "$ver" ]]; then
+        # Try to find libcudart.so and extract version from filename.
+        local lib
+        for lib in /usr/local/cuda*/targets/*/lib/libcudart.so.* /usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
+            if [[ -f "$lib" ]]; then
+                ver="$(basename "$lib" | grep -oP 'libcudart\.so\.\K[0-9]+' | head -n 1)"
+                break
+            fi
+        done
+    fi
+    if [[ -z "$ver" ]]; then
+        # Fallback: check ldconfig for libcudart.
+        ver="$(ldconfig -p 2>/dev/null | grep -oP 'libcudart\.so\.\K[0-9]+' | sort -rn | head -n 1)"
+    fi
+    echo "${ver:-}"
+}
+
 asset_name() {
     local flavor="$1"
     case "$(platform_support_status)" in
@@ -464,7 +487,15 @@ asset_name() {
         Linux/aarch64)
             case "$flavor" in
                 cpu) echo "mesh-llm-aarch64-unknown-linux-gnu.tar.gz" ;;
-                cuda) echo "mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz" ;;
+                cuda)
+                    local cuda_major="$(detect_cuda_major)"
+                    if [[ -n "$cuda_major" ]]; then
+                        echo "mesh-llm-aarch64-unknown-linux-gnu-cuda-${cuda_major}.tar.gz"
+                    else
+                        # Fallback: try to match any cuda artifact.
+                        echo "mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz"
+                    fi
+                    ;;
                 *)
                     echo "error: unsupported aarch64 flavor '$flavor'" >&2
                     exit 1
@@ -474,8 +505,14 @@ asset_name() {
         Linux/x86_64)
             case "$flavor" in
                 cpu) echo "mesh-llm-x86_64-unknown-linux-gnu.tar.gz" ;;
-                cuda) echo "mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz" ;;
-                cuda-blackwell) echo "mesh-llm-x86_64-unknown-linux-gnu-cuda-blackwell.tar.gz" ;;
+                cuda|cuda-blackwell)
+                    local cuda_major="$(detect_cuda_major)"
+                    if [[ -n "$cuda_major" ]]; then
+                        echo "mesh-llm-x86_64-unknown-linux-gnu-${flavor}-${cuda_major}.tar.gz"
+                    else
+                        echo "mesh-llm-x86_64-unknown-linux-gnu-${flavor}.tar.gz"
+                    fi
+                    ;;
                 rocm) echo "mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz" ;;
                 vulkan) echo "mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz" ;;
                 *)

--- a/install.sh
+++ b/install.sh
@@ -424,6 +424,7 @@ choose_flavor() {
 
 detect_cuda_major() {
     # Detect host CUDA major version from nvcc or libcudart.
+    # Only return versions we publish artifacts for (12, 13).
     local ver=""
     if command -v nvcc >/dev/null 2>&1; then
         ver="$(nvcc --version 2>/dev/null | grep -oP 'release \K[0-9]+')"
@@ -442,7 +443,11 @@ detect_cuda_major() {
         # Fallback: check ldconfig for libcudart.
         ver="$(ldconfig -p 2>/dev/null | grep -oP 'libcudart\.so\.\K[0-9]+' | sort -rn | head -n 1)"
     fi
-    echo "${ver:-}"
+    # Only return versions we publish artifacts for (12, 13).
+    case "$ver" in
+        12|13) echo "$ver" ;;
+        *)     echo "" ;;
+    esac
 }
 
 asset_name() {

--- a/install.sh
+++ b/install.sh
@@ -232,31 +232,6 @@ nvidia_model_is_blackwell() {
     esac
 }
 
-probe_cuda_blackwell() {
-    if command -v nvidia-smi >/dev/null 2>&1; then
-        local raw
-        while IFS= read -r raw; do
-            if is_blackwell_cuda_sm "$raw"; then
-                return 0
-            fi
-        done < <(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null || true)
-    fi
-
-    if [[ -d /proc/driver/nvidia/gpus ]]; then
-        local info
-        for info in /proc/driver/nvidia/gpus/*/information; do
-            [[ -f "$info" ]] || continue
-            local model
-            model="$(sed -n 's/^Model:[[:space:]]*//p' "$info" | head -n 1)"
-            if [[ -n "$model" ]] && nvidia_model_is_blackwell "$model"; then
-                return 0
-            fi
-        done
-    fi
-
-    return 1
-}
-
 probe_rocm() {
     command -v rocm-smi >/dev/null 2>&1 ||
         command -v rocminfo >/dev/null 2>&1 ||
@@ -299,7 +274,7 @@ supported_flavors() {
             echo "cuda cpu"
             ;;
         Linux/x86_64)
-            echo "cuda-blackwell cuda rocm vulkan cpu"
+            echo "cuda rocm vulkan cpu"
             ;;
         *)
                 platform_error_message >&2
@@ -314,9 +289,7 @@ supported_flavors() {
     esac
 }
 
-# Keep this detection order and the probes above (probe_nvidia, probe_cuda_blackwell,
-# probe_rocm, probe_vulkan, probe_tegra) in sync with the Rust updater flavor
-# selection in crates/mesh-llm-system/src/autoupdate.rs.
+# Keep this detection order and the probes above (probe_nvidia, probe_rocm, probe_vulkan, probe_tegra) in sync with the Rust updater flavor selection in crates/mesh-llm-system/src/autoupdate.rs.
 recommended_flavor() {
     case "$(platform_support_status)" in
         supported)
@@ -332,9 +305,7 @@ recommended_flavor() {
             fi
             ;;
         Linux/x86_64)
-            if probe_cuda_blackwell; then
-                echo "cuda-blackwell"
-            elif probe_nvidia; then
+            if probe_nvidia; then
                 echo "cuda"
             elif probe_rocm; then
                 echo "rocm"
@@ -369,9 +340,7 @@ recommendation_reason() {
                 echo "NVIDIA tooling or devices were detected."
             fi
             ;;
-        cuda-blackwell)
-            echo "Blackwell NVIDIA hardware was detected."
-            ;;
+
         rocm)
             echo "ROCm/HIP tooling was detected."
             ;;
@@ -505,12 +474,12 @@ asset_name() {
         Linux/x86_64)
             case "$flavor" in
                 cpu) echo "mesh-llm-x86_64-unknown-linux-gnu.tar.gz" ;;
-                cuda|cuda-blackwell)
+                cuda)
                     local cuda_major="$(detect_cuda_major)"
                     if [[ -n "$cuda_major" ]]; then
-                        echo "mesh-llm-x86_64-unknown-linux-gnu-${flavor}-${cuda_major}.tar.gz"
+                        echo "mesh-llm-x86_64-unknown-linux-gnu-cuda-${cuda_major}.tar.gz"
                     else
-                        echo "mesh-llm-x86_64-unknown-linux-gnu-${flavor}.tar.gz"
+                        echo "mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz"
                     fi
                     ;;
                 rocm) echo "mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz" ;;

--- a/install.sh
+++ b/install.sh
@@ -172,7 +172,38 @@ probe_nvidia() {
     command -v nvidia-smi >/dev/null 2>&1 ||
         command -v nvcc >/dev/null 2>&1 ||
         [[ -e /dev/nvidiactl ]] ||
-        [[ -d /proc/driver/nvidia/gpus ]]
+        [[ -d /proc/driver/nvidia/gpus ]] ||
+        probe_tegra_nvidia
+}
+
+tegra_model_text() {
+    if [[ -n "${MESH_LLM_TEST_TEGRA_MODEL:-}" ]]; then
+        printf '%s\n' "$MESH_LLM_TEST_TEGRA_MODEL"
+        return 0
+    fi
+
+    local path
+    for path in \
+        /proc/device-tree/model \
+        /proc/device-tree/compatible \
+        /sys/firmware/devicetree/base/model \
+        /sys/firmware/devicetree/base/compatible; do
+        [[ -r "$path" ]] || continue
+        tr '\0' '\n' <"$path" 2>/dev/null || true
+        printf '\n'
+    done
+}
+
+probe_tegra_nvidia() {
+    local model
+    model="$(tegra_model_text | tr '[:lower:]' '[:upper:]')"
+    case "$model" in
+        *JETSON*|*TEGRA*|*ORIN*|*NVGPU*|*THOR*)
+            return 0
+            ;;
+    esac
+
+    [[ -e /dev/nvhost-gpu ]] || [[ -e /dev/nvhost-ctrl-gpu ]]
 }
 
 normalize_cuda_sm() {
@@ -294,7 +325,7 @@ recommended_flavor() {
             echo "metal"
             ;;
         Linux/aarch64)
-            if probe_tegra; then
+            if probe_nvidia; then
                 echo "cuda"
             else
                 echo "cpu"

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -73,8 +73,7 @@ function Get-BinaryFlavor {
 
     # The "release flavor" (outer archive name) and the "binary flavor"
     # (inner executable suffix / runtime BinaryFlavor lookup) are not
-    # always the same. hip archives contain -rocm binaries, while
-    # cuda-blackwell keeps its distinct runtime flavor suffix.
+    # always the same. hip archives contain -rocm binaries.
     if ($RequestedFlavor) {
         switch ($RequestedFlavor.ToLowerInvariant()) {
             "hip" { return "rocm" }
@@ -162,8 +161,8 @@ $releaseFlavor = Get-ReleaseFlavor $Flavor
 $binaryFlavor = Get-BinaryFlavor $Flavor
 $targetTriple = "x86_64-pc-windows-msvc"
 $archiveExt = "zip"
-# Outer archive names use the release flavor (e.g. cuda-blackwell); inner
-# binary names use the binary flavor (e.g. cuda) so the runtime finds them.
+# Outer archive names use the release flavor; inner
+# binary names use the binary flavor so the runtime finds them.
 $stableAsset = New-ReleaseAssetName -Prefix "mesh-llm" -TargetTriple $targetTriple -ArchiveExt $archiveExt -BinaryFlavor $releaseFlavor
 $versionedAsset = New-ReleaseAssetName -Prefix "mesh-llm-$Version" -TargetTriple $targetTriple -ArchiveExt $archiveExt -BinaryFlavor $releaseFlavor
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -61,6 +61,15 @@ flavor_suffix() {
         ""|cpu|metal)
             printf '\n'
             ;;
+        cuda|cuda-blackwell)
+            # When MESH_CUDA_VERSION is set (CI matrix), include major version.
+            if [[ -n "${MESH_CUDA_VERSION:-}" ]]; then
+                local major="${MESH_CUDA_VERSION%%.*}"
+                printf -- '-%s-%s\n' "$1" "$major"
+            else
+                printf -- '-%s\n' "$1"
+            fi
+            ;;
         *)
             printf -- '-%s\n' "$1"
             ;;

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -61,7 +61,7 @@ flavor_suffix() {
         ""|cpu|metal)
             printf '\n'
             ;;
-        cuda|cuda-blackwell)
+        cuda)
             # When MESH_CUDA_VERSION is set (CI matrix), include major version.
             if [[ -n "${MESH_CUDA_VERSION:-}" ]]; then
                 local major="${MESH_CUDA_VERSION%%.*}"
@@ -189,7 +189,7 @@ supported_release_flavors() {
             printf 'metal\n'
             ;;
         linux/x86_64)
-            printf 'cpu cuda cuda-blackwell rocm vulkan\n'
+            printf 'cpu cuda rocm vulkan\n'
             ;;
         linux/aarch64)
             printf 'cpu cuda\n'

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -594,8 +594,8 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
     )?;
     ensure_contains(
         &release_workflow,
-        "name: release-linux-aarch64-cuda",
-        "release workflow aarch64 CUDA artifact",
+        "name: release-linux-aarch64-cuda-${{ matrix.cuda_version }}",
+        "release workflow aarch64 CUDA artifact (matrix)",
     )?;
     ensure_contains(
         &release_workflow,

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -144,6 +144,10 @@ fn check_installer_outcomes(repo_root: &Path, rows: &[FixtureRow]) -> DynResult<
         .stable_asset
         .clone()
         .ok_or("linux/aarch64/cpu stable asset missing")?;
+    let linux_arm64_cuda_asset = fixture_row(rows, "linux", "aarch64", "cuda")?
+        .stable_asset
+        .clone()
+        .ok_or("linux/aarch64/cuda stable asset missing")?;
     let macos_arm64_asset = fixture_row(rows, "macos", "aarch64", "metal")?
         .stable_asset
         .clone()
@@ -213,6 +217,36 @@ fn check_installer_outcomes(repo_root: &Path, rows: &[FixtureRow]) -> DynResult<
             &format!("{} asset parity", case.label),
         )?;
     }
+
+    let orin_envs = [
+        ("MESH_LLM_TEST_UNAME_S", "Linux"),
+        ("MESH_LLM_TEST_UNAME_M", "aarch64"),
+        ("MESH_LLM_TEST_TEGRA_MODEL", "NVIDIA Jetson AGX Orin"),
+    ];
+    let recommended = sourced_script_stdout(
+        repo_root,
+        "install.sh",
+        "recommended_flavor",
+        &orin_envs,
+        &[],
+    )?;
+    ensure_eq(
+        "cuda",
+        &recommended,
+        "Linux/aarch64 Orin recommended flavor",
+    )?;
+    let actual_cuda_asset = sourced_script_stdout(
+        repo_root,
+        "install.sh",
+        "asset_name \"$2\"",
+        &orin_envs,
+        &["cuda"],
+    )?;
+    ensure_eq(
+        linux_arm64_cuda_asset.as_str(),
+        &actual_cuda_asset,
+        "Linux/aarch64 Orin CUDA asset parity",
+    )?;
 
     let arm_fixture = fixture_row(rows, "linux", "arm", "cpu")?;
     let arm_envs = [
@@ -524,9 +558,19 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
         "README Linux ARM64 asset note",
     )?;
     ensure_contains(
+        &readme,
+        "mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz",
+        "README Linux ARM64 CUDA asset note",
+    )?;
+    ensure_contains(
         &release,
         "mesh-llm-aarch64-unknown-linux-gnu.tar.gz",
         "RELEASE Linux ARM64 asset note",
+    )?;
+    ensure_contains(
+        &release,
+        "mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz",
+        "RELEASE Linux ARM64 CUDA asset note",
     )?;
     ensure_contains_normalized(
         &readme,
@@ -550,8 +594,13 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
     )?;
     ensure_contains(
         &release_workflow,
-        "name: release-linux-arm64-cuda",
-        "release workflow ARM64 CUDA artifact",
+        "name: release-linux-aarch64-cuda",
+        "release workflow aarch64 CUDA artifact",
+    )?;
+    ensure_contains(
+        &release_workflow,
+        "- build_linux_aarch64_cuda",
+        "release workflow aarch64 CUDA publish need",
     )?;
     ensure_contains(
         &release_workflow,
@@ -580,13 +629,13 @@ fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<()> {
     )?;
     ensure_contains(
         &justfile,
-        "release-build-arm64-cuda",
-        "Justfile ARM64 CUDA build recipe",
+        "release-build-aarch64-cuda",
+        "Justfile aarch64 CUDA build recipe",
     )?;
     ensure_contains(
         &justfile,
-        "release-bundle-arm64-cuda",
-        "Justfile ARM64 CUDA bundle recipe",
+        "release-bundle-aarch64-cuda",
+        "Justfile aarch64 CUDA bundle recipe",
     )?;
     ensure_contains(
         &justfile,


### PR DESCRIPTION
## Summary

Adds a Linux ARM64 CUDA release flavor so Jetson/Orin-class hosts can install a GPU-capable Mesh bundle instead of always falling back to the ARM64 CPU bundle.

## Changes

- Add `linux/aarch64 + cuda` to the release target matrix and package-release support.
- Update `install.sh` to offer `cuda cpu` on Linux ARM64 and recommend CUDA when Jetson/Orin/Tegra/NVGPU/Thor hardware is detected.
- Mirror the NVIDIA SoC detection in Rust autoupdate flavor selection.
- Add ARM64 CUDA release build and bundle Just recipes plus a GitHub release job.
- Update release docs and repo-consistency checks for the new ARM64 CUDA artifact.

## Validation

- `bash -n install.sh scripts/package-release.sh scripts/build-linux.sh`
- Simulated Orin installer selection resolves `mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz`.
- Simulated `Linux/aarch64 + cuda` package release resolves stable and versioned ARM64 CUDA assets.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'`
- `git diff --check`
- Parsed `crates/mesh-llm-system/tests/fixtures/release-target-matrix.json`

Could not run `just check-release` or Rust tests locally because the shell's Rust toolchain is broken: `~/.cargo/bin/cargo` points through `rustup` to missing `/opt/homebrew/bin/rustup-init`.
