### PR TITLE
Keep plugin runtime responsive during long operations

### DIFF
--- a/crates/mesh-llm-plugin/src/context.rs
+++ b/crates/mesh-llm-plugin/src/context.rs
@@ -146,15 +146,11 @@ impl<'a> PluginContext<'a> {
         let mut pending_guard =
             PendingHostResponseGuard::new(request_id, self.pending_host_responses.clone());
 
-        if let Err(err) = self
-            .send_payload(
-                proto::envelope::Payload::OpenMeshStreamRequest(request),
-                request_id,
-            )
-            .await
-        {
-            return Err(err);
-        }
+        self.send_payload(
+            proto::envelope::Payload::OpenMeshStreamRequest(request),
+            request_id,
+        )
+        .await?;
 
         let response = rx.await??;
         pending_guard.disarm();

--- a/crates/mesh-llm-plugin/src/context.rs
+++ b/crates/mesh-llm-plugin/src/context.rs
@@ -1,31 +1,52 @@
 use anyhow::{Result, bail};
 use serde::Serialize;
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::{Mutex, mpsc, oneshot};
 
 use crate::{
     PROTOCOL_VERSION,
     helpers::{channel_message, json_channel_message},
-    io::{
-        LocalStream, connect_side_stream, read_envelope, send_bulk_transfer_message,
-        send_channel_message, write_envelope,
-    },
+    io::{LocalStream, connect_side_stream},
     proto,
 };
 
 static NEXT_HOST_REQUEST_ID: AtomicU64 = AtomicU64::new(1);
+const PLUGIN_ORIGINATED_REQUEST_BIT: u64 = 1 << 63;
+
+pub(crate) type PendingHostResponses =
+    Arc<Mutex<HashMap<u64, oneshot::Sender<Result<proto::Envelope>>>>>;
 
 pub struct PluginContext<'a> {
-    pub(crate) stream: &'a mut LocalStream,
-    pub(crate) plugin_id: &'a str,
+    pub(crate) outbound_tx: mpsc::Sender<proto::Envelope>,
+    pub(crate) pending_host_responses: PendingHostResponses,
+    pub(crate) plugin_id: String,
+    pub(crate) _marker: PhantomData<&'a mut ()>,
 }
 
 impl<'a> PluginContext<'a> {
+    pub(crate) fn new(
+        plugin_id: String,
+        outbound_tx: mpsc::Sender<proto::Envelope>,
+        pending_host_responses: PendingHostResponses,
+    ) -> Self {
+        Self {
+            outbound_tx,
+            pending_host_responses,
+            plugin_id,
+            _marker: PhantomData,
+        }
+    }
+
     pub async fn send_channel(&mut self, message: proto::ChannelMessage) -> Result<()> {
         self.send_channel_message(message).await
     }
 
     pub async fn send_channel_message(&mut self, message: proto::ChannelMessage) -> Result<()> {
-        send_channel_message(self.stream, self.plugin_id, message).await
+        self.send_payload(proto::envelope::Payload::ChannelMessage(message), 0)
+            .await
     }
 
     pub async fn send_text_channel(
@@ -69,26 +90,20 @@ impl<'a> PluginContext<'a> {
         &mut self,
         message: proto::BulkTransferMessage,
     ) -> Result<()> {
-        send_bulk_transfer_message(self.stream, self.plugin_id, message).await
+        self.send_payload(proto::envelope::Payload::BulkTransferMessage(message), 0)
+            .await
     }
 
     pub async fn notify_host<P>(&mut self, method: &str, params: P) -> Result<()>
     where
         P: Serialize,
     {
-        write_envelope(
-            self.stream,
-            &proto::Envelope {
-                protocol_version: PROTOCOL_VERSION,
-                plugin_id: self.plugin_id.to_string(),
-                request_id: 0,
-                payload: Some(proto::envelope::Payload::RpcNotification(
-                    proto::RpcNotification {
-                        method: method.to_string(),
-                        params_json: serde_json::to_string(&params)?,
-                    },
-                )),
-            },
+        self.send_payload(
+            proto::envelope::Payload::RpcNotification(proto::RpcNotification {
+                method: method.to_string(),
+                params_json: serde_json::to_string(&params)?,
+            }),
+            0,
         )
         .await
     }
@@ -97,26 +112,25 @@ impl<'a> PluginContext<'a> {
         &mut self,
         request: proto::OpenMeshStreamRequest,
     ) -> Result<proto::OpenMeshStreamResponse> {
-        let request_id = NEXT_HOST_REQUEST_ID.fetch_add(1, Ordering::Relaxed);
-        write_envelope(
-            self.stream,
-            &proto::Envelope {
-                protocol_version: PROTOCOL_VERSION,
-                plugin_id: self.plugin_id.to_string(),
-                request_id,
-                payload: Some(proto::envelope::Payload::OpenMeshStreamRequest(request)),
-            },
-        )
-        .await?;
+        let request_id = next_host_request_id();
+        let (tx, rx) = oneshot::channel();
+        self.pending_host_responses
+            .lock()
+            .await
+            .insert(request_id, tx);
 
-        let response = read_envelope(self.stream).await?;
-        if response.request_id != request_id {
-            bail!(
-                "Received host response id {} while waiting for {}",
-                response.request_id,
-                request_id
-            );
+        if let Err(err) = self
+            .send_payload(
+                proto::envelope::Payload::OpenMeshStreamRequest(request),
+                request_id,
+            )
+            .await
+        {
+            self.pending_host_responses.lock().await.remove(&request_id);
+            return Err(err);
         }
+
+        let response = rx.await??;
         match response.payload {
             Some(proto::envelope::Payload::OpenMeshStreamResponse(response)) => Ok(response),
             Some(proto::envelope::Payload::ErrorResponse(error)) => bail!(error.message),
@@ -143,4 +157,20 @@ impl<'a> PluginContext<'a> {
             .ok_or_else(|| anyhow::anyhow!("Host accepted mesh stream without an endpoint"))?;
         connect_side_stream(endpoint, response.transport_kind).await
     }
+
+    async fn send_payload(&self, payload: proto::envelope::Payload, request_id: u64) -> Result<()> {
+        self.outbound_tx
+            .send(proto::Envelope {
+                protocol_version: PROTOCOL_VERSION,
+                plugin_id: self.plugin_id.clone(),
+                request_id,
+                payload: Some(payload),
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("plugin host connection is closed"))
+    }
+}
+
+pub(crate) fn next_host_request_id() -> u64 {
+    PLUGIN_ORIGINATED_REQUEST_BIT | NEXT_HOST_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
 }

--- a/crates/mesh-llm-plugin/src/context.rs
+++ b/crates/mesh-llm-plugin/src/context.rs
@@ -2,9 +2,9 @@ use anyhow::{Result, bail};
 use serde::Serialize;
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::sync::{Mutex, mpsc, oneshot};
+use std::sync::{Arc, Mutex};
+use tokio::sync::{mpsc, oneshot};
 
 use crate::{
     PROTOCOL_VERSION,
@@ -18,6 +18,34 @@ const PLUGIN_ORIGINATED_REQUEST_BIT: u64 = 1 << 63;
 
 pub(crate) type PendingHostResponses =
     Arc<Mutex<HashMap<u64, oneshot::Sender<Result<proto::Envelope>>>>>;
+
+struct PendingHostResponseGuard {
+    request_id: u64,
+    pending_host_responses: PendingHostResponses,
+    active: bool,
+}
+
+impl PendingHostResponseGuard {
+    fn new(request_id: u64, pending_host_responses: PendingHostResponses) -> Self {
+        Self {
+            request_id,
+            pending_host_responses,
+            active: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for PendingHostResponseGuard {
+    fn drop(&mut self) {
+        if self.active {
+            remove_pending_host_response(&self.pending_host_responses, self.request_id);
+        }
+    }
+}
 
 pub struct PluginContext<'a> {
     pub(crate) outbound_tx: mpsc::Sender<proto::Envelope>,
@@ -114,10 +142,9 @@ impl<'a> PluginContext<'a> {
     ) -> Result<proto::OpenMeshStreamResponse> {
         let request_id = next_host_request_id();
         let (tx, rx) = oneshot::channel();
-        self.pending_host_responses
-            .lock()
-            .await
-            .insert(request_id, tx);
+        insert_pending_host_response(&self.pending_host_responses, request_id, tx);
+        let mut pending_guard =
+            PendingHostResponseGuard::new(request_id, self.pending_host_responses.clone());
 
         if let Err(err) = self
             .send_payload(
@@ -126,11 +153,11 @@ impl<'a> PluginContext<'a> {
             )
             .await
         {
-            self.pending_host_responses.lock().await.remove(&request_id);
             return Err(err);
         }
 
         let response = rx.await??;
+        pending_guard.disarm();
         match response.payload {
             Some(proto::envelope::Payload::OpenMeshStreamResponse(response)) => Ok(response),
             Some(proto::envelope::Payload::ErrorResponse(error)) => bail!(error.message),
@@ -173,4 +200,36 @@ impl<'a> PluginContext<'a> {
 
 pub(crate) fn next_host_request_id() -> u64 {
     PLUGIN_ORIGINATED_REQUEST_BIT | NEXT_HOST_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(crate) fn insert_pending_host_response(
+    pending_host_responses: &PendingHostResponses,
+    request_id: u64,
+    sender: oneshot::Sender<Result<proto::Envelope>>,
+) {
+    pending_host_responses
+        .lock()
+        .expect("pending host response map poisoned")
+        .insert(request_id, sender);
+}
+
+pub(crate) fn remove_pending_host_response(
+    pending_host_responses: &PendingHostResponses,
+    request_id: u64,
+) -> Option<oneshot::Sender<Result<proto::Envelope>>> {
+    pending_host_responses
+        .lock()
+        .expect("pending host response map poisoned")
+        .remove(&request_id)
+}
+
+pub(crate) fn drain_pending_host_responses(
+    pending_host_responses: &PendingHostResponses,
+) -> Vec<oneshot::Sender<Result<proto::Envelope>>> {
+    pending_host_responses
+        .lock()
+        .expect("pending host response map poisoned")
+        .drain()
+        .map(|(_, sender)| sender)
+        .collect()
 }

--- a/crates/mesh-llm-plugin/src/helpers.rs
+++ b/crates/mesh-llm-plugin/src/helpers.rs
@@ -533,6 +533,7 @@ type ToolHandler = Arc<
         + Sync,
 >;
 
+#[derive(Clone)]
 pub struct ToolRouter {
     tools: Vec<Tool>,
     handlers: HashMap<String, ToolHandler>,
@@ -636,6 +637,7 @@ type PromptHandler = Arc<
         + Sync,
 >;
 
+#[derive(Clone)]
 pub struct PromptRouter {
     prompts: Vec<Prompt>,
     handlers: HashMap<String, PromptHandler>,
@@ -689,6 +691,7 @@ impl Default for PromptRouter {
     }
 }
 
+#[derive(Clone)]
 enum ResourceReadMatcher {
     Exact(String),
     Prefix(String),
@@ -712,6 +715,7 @@ type ResourceHandler = Arc<
         + Sync,
 >;
 
+#[derive(Clone)]
 pub struct ResourceRouter {
     resources: Vec<Resource>,
     resource_templates: Vec<ResourceTemplate>,
@@ -797,6 +801,7 @@ impl Default for ResourceRouter {
     }
 }
 
+#[derive(Clone)]
 enum CompletionMatcher {
     PromptArgument {
         prompt_name: String,
@@ -841,6 +846,7 @@ type CompletionHandler = Arc<
         + Sync,
 >;
 
+#[derive(Clone)]
 pub struct CompletionRouter {
     handlers: Vec<(CompletionMatcher, CompletionHandler)>,
 }
@@ -1008,6 +1014,7 @@ type TaskCancelHandler = Arc<
         + Sync,
 >;
 
+#[derive(Clone)]
 pub struct TaskRouter {
     list_handler: Option<TaskListHandler>,
     info_handler: Option<TaskInfoHandler>,

--- a/crates/mesh-llm-plugin/src/io.rs
+++ b/crates/mesh-llm-plugin/src/io.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result, bail};
 use prost::Message;
 #[cfg(unix)]
 use std::path::PathBuf;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 use crate::{PROTOCOL_VERSION, proto};
 
@@ -15,7 +15,30 @@ pub enum LocalStream {
     PipeServer(tokio::net::windows::named_pipe::NamedPipeServer),
 }
 
+pub type LocalReadHalf = Box<dyn AsyncRead + Send + Unpin>;
+pub type LocalWriteHalf = Box<dyn AsyncWrite + Send + Unpin>;
+
 impl LocalStream {
+    pub fn into_split(self) -> (LocalReadHalf, LocalWriteHalf) {
+        match self {
+            #[cfg(unix)]
+            LocalStream::Unix(stream) => {
+                let (read, write) = stream.into_split();
+                (Box::new(read), Box::new(write))
+            }
+            #[cfg(windows)]
+            LocalStream::PipeClient(stream) => {
+                let (read, write) = tokio::io::split(stream);
+                (Box::new(read), Box::new(write))
+            }
+            #[cfg(windows)]
+            LocalStream::PipeServer(stream) => {
+                let (read, write) = tokio::io::split(stream);
+                (Box::new(read), Box::new(write))
+            }
+        }
+    }
+
     async fn write_all(&mut self, bytes: &[u8]) -> Result<()> {
         match self {
             #[cfg(unix)]
@@ -183,12 +206,38 @@ pub async fn bind_side_stream(plugin_id: &str, stream_id: &str) -> Result<LocalL
     }
 }
 
+pub async fn write_envelope_to<W>(stream: &mut W, envelope: &proto::Envelope) -> Result<()>
+where
+    W: AsyncWrite + Unpin + ?Sized,
+{
+    let mut body = Vec::new();
+    envelope.encode(&mut body)?;
+    stream.write_all(&(body.len() as u32).to_le_bytes()).await?;
+    stream.write_all(&body).await?;
+    Ok(())
+}
+
 pub async fn write_envelope(stream: &mut LocalStream, envelope: &proto::Envelope) -> Result<()> {
     let mut body = Vec::new();
     envelope.encode(&mut body)?;
     stream.write_all(&(body.len() as u32).to_le_bytes()).await?;
     stream.write_all(&body).await?;
     Ok(())
+}
+
+pub async fn read_envelope_from<R>(stream: &mut R) -> Result<proto::Envelope>
+where
+    R: AsyncRead + Unpin + ?Sized,
+{
+    let mut len_buf = [0u8; 4];
+    stream.read_exact(&mut len_buf).await?;
+    let len = u32::from_le_bytes(len_buf) as usize;
+    if len > 16 * 1024 * 1024 {
+        bail!("Plugin frame too large");
+    }
+    let mut body = vec![0u8; len];
+    stream.read_exact(&mut body).await?;
+    Ok(proto::Envelope::decode(body.as_slice())?)
 }
 
 pub async fn read_envelope(stream: &mut LocalStream) -> Result<proto::Envelope> {

--- a/crates/mesh-llm-plugin/src/runtime.rs
+++ b/crates/mesh-llm-plugin/src/runtime.rs
@@ -11,13 +11,16 @@ use serde::de::DeserializeOwned;
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use tokio::sync::{Mutex, RwLock, mpsc};
+use tokio::sync::{RwLock, mpsc, watch};
 
 use crate::{
     PROTOCOL_VERSION,
-    context::{PendingHostResponses, PluginContext},
+    context::{
+        PendingHostResponses, PluginContext, drain_pending_host_responses,
+        remove_pending_host_response,
+    },
     error::{PluginError, PluginResult, PluginRpcResult},
     helpers::{
         CompletionRouter, PromptRouter, ResourceRouter, TaskRouter, ToolCallRequest, ToolRouter,
@@ -1348,6 +1351,11 @@ struct RuntimeState<P> {
     pending_host_responses: PendingHostResponses,
 }
 
+struct OrderedPayload {
+    request_id: u64,
+    payload: proto::envelope::Payload,
+}
+
 impl PluginRuntime {
     pub async fn run<P: Plugin + Clone + Sync + 'static>(plugin: P) -> Result<()> {
         let stream = connect_from_env().await?;
@@ -1361,19 +1369,92 @@ impl PluginRuntime {
         let plugin_id = plugin.plugin_id().to_string();
         let (read, write) = stream.into_split();
         let (outbound_tx, outbound_rx) = mpsc::channel(256);
-        let writer = tokio::spawn(Self::write_loop(write, outbound_rx));
+        let (ordered_tx, ordered_rx) = mpsc::channel(256);
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
         let state = Arc::new(RuntimeState {
             plugin: Arc::new(RwLock::new(plugin)),
             plugin_id,
             outbound_tx,
             pending_host_responses: Arc::new(Mutex::new(HashMap::new())),
         });
+        let mut writer = tokio::spawn(Self::write_loop(
+            write,
+            outbound_rx,
+            state.pending_host_responses.clone(),
+            shutdown_tx.clone(),
+            shutdown_rx.clone(),
+        ));
+        let ordered_handlers = tokio::spawn(Self::ordered_handler_loop(
+            state.clone(),
+            ordered_rx,
+            shutdown_rx,
+        ));
 
-        match Self::read_loop(state, read).await {
-            Ok(()) => Ok(writer.await??),
-            Err(err) => {
-                writer.abort();
-                Err(err)
+        let read_result = Self::read_loop(state.clone(), read, ordered_tx);
+        tokio::pin!(read_result);
+
+        let result = tokio::select! {
+            read_result = &mut read_result => read_result,
+            writer_result = &mut writer => match writer_result {
+                Ok(Ok(())) => Ok(()),
+                Ok(Err(err)) => Err(err),
+                Err(err) => Err(err.into()),
+            },
+        };
+
+        let shutdown_reason = match &result {
+            Ok(()) => "plugin host connection is closed".to_string(),
+            Err(err) => format!("plugin host connection is closed: {err}"),
+        };
+        Self::shutdown_runtime(&shutdown_tx, &state.pending_host_responses, shutdown_reason);
+        if !writer.is_finished() {
+            let _ = writer.await;
+        }
+        if !ordered_handlers.is_finished() {
+            ordered_handlers.abort();
+        }
+
+        match ordered_handlers.await {
+            Ok(()) => result,
+            Err(err) if err.is_cancelled() => result,
+            Err(err) if result.is_ok() => Err(err.into()),
+            Err(_) => result,
+        }
+    }
+
+    fn shutdown_runtime(
+        shutdown_tx: &watch::Sender<bool>,
+        pending_host_responses: &PendingHostResponses,
+        reason: String,
+    ) {
+        let _ = shutdown_tx.send(true);
+        Self::fail_pending_host_responses(pending_host_responses, reason);
+    }
+
+    fn fail_pending_host_responses(pending_host_responses: &PendingHostResponses, reason: String) {
+        for sender in drain_pending_host_responses(pending_host_responses) {
+            let _ = sender.send(Err(anyhow::anyhow!(reason.clone())));
+        }
+    }
+
+    async fn ordered_handler_loop<P: Plugin + Clone + Sync + 'static>(
+        state: Arc<RuntimeState<P>>,
+        mut ordered_rx: mpsc::Receiver<OrderedPayload>,
+        mut shutdown_rx: watch::Receiver<bool>,
+    ) {
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        break;
+                    }
+                }
+                payload = ordered_rx.recv() => {
+                    let Some(payload) = payload else {
+                        break;
+                    };
+                    let _ = Self::handle_payload(state.clone(), payload.request_id, payload.payload).await;
+                }
             }
         }
     }
@@ -1381,13 +1462,14 @@ impl PluginRuntime {
     async fn read_loop<P: Plugin + Clone + Sync + 'static>(
         state: Arc<RuntimeState<P>>,
         mut read: LocalReadHalf,
+        ordered_tx: mpsc::Sender<OrderedPayload>,
     ) -> Result<()> {
         loop {
             let envelope = read_envelope_from(&mut *read).await?;
             if Self::complete_pending_host_response(&state, &envelope).await {
                 continue;
             }
-            if !Self::handle_envelope(state.clone(), envelope).await? {
+            if !Self::handle_envelope(state.clone(), &ordered_tx, envelope).await? {
                 break;
             }
         }
@@ -1397,9 +1479,38 @@ impl PluginRuntime {
     async fn write_loop(
         mut write: LocalWriteHalf,
         mut outbound_rx: mpsc::Receiver<proto::Envelope>,
+        pending_host_responses: PendingHostResponses,
+        shutdown_tx: watch::Sender<bool>,
+        mut shutdown_rx: watch::Receiver<bool>,
     ) -> Result<()> {
-        while let Some(envelope) = outbound_rx.recv().await {
-            write_envelope_to(&mut *write, &envelope).await?;
+        loop {
+            tokio::select! {
+                _ = shutdown_rx.changed() => {
+                    if *shutdown_rx.borrow() {
+                        Self::drain_outbound_before_shutdown(&mut write, &mut outbound_rx).await?;
+                        return Ok(());
+                    }
+                }
+                envelope = outbound_rx.recv() => {
+                    let Some(envelope) = envelope else {
+                        return Ok(());
+                    };
+                    if let Err(err) = write_envelope_to(&mut *write, &envelope).await {
+                        let reason = format!("plugin host write failed: {err}");
+                        Self::shutdown_runtime(&shutdown_tx, &pending_host_responses, reason);
+                        return Err(err);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn drain_outbound_before_shutdown(
+        write: &mut LocalWriteHalf,
+        outbound_rx: &mut mpsc::Receiver<proto::Envelope>,
+    ) -> Result<()> {
+        while let Ok(envelope) = outbound_rx.try_recv() {
+            write_envelope_to(&mut **write, &envelope).await?;
         }
         Ok(())
     }
@@ -1408,11 +1519,8 @@ impl PluginRuntime {
         state: &RuntimeState<P>,
         envelope: &proto::Envelope,
     ) -> bool {
-        let Some(sender) = state
-            .pending_host_responses
-            .lock()
-            .await
-            .remove(&envelope.request_id)
+        let Some(sender) =
+            remove_pending_host_response(&state.pending_host_responses, envelope.request_id)
         else {
             return false;
         };
@@ -1422,6 +1530,7 @@ impl PluginRuntime {
 
     async fn handle_envelope<P: Plugin + Clone + Sync + 'static>(
         state: Arc<RuntimeState<P>>,
+        ordered_tx: &mpsc::Sender<OrderedPayload>,
         envelope: proto::Envelope,
     ) -> Result<bool> {
         let request_id = envelope.request_id;
@@ -1443,8 +1552,40 @@ impl PluginRuntime {
                 .await?;
                 Ok(false)
             }
+            payload if Self::is_ordered_payload(&payload) => {
+                Self::enqueue_ordered_payload(ordered_tx, request_id, payload).await
+            }
             payload => Self::spawn_payload_handler(state, request_id, payload),
         }
+    }
+
+    fn is_ordered_payload(payload: &proto::envelope::Payload) -> bool {
+        matches!(
+            payload,
+            proto::envelope::Payload::RpcNotification(_)
+                | proto::envelope::Payload::ChannelMessage(_)
+                | proto::envelope::Payload::BulkTransferMessage(_)
+                | proto::envelope::Payload::MeshEvent(_)
+                | proto::envelope::Payload::CancelStreamNotification(_)
+                | proto::envelope::Payload::CloseStreamNotification(_)
+                | proto::envelope::Payload::StreamError(_)
+                | proto::envelope::Payload::ErrorResponse(_)
+        )
+    }
+
+    async fn enqueue_ordered_payload(
+        ordered_tx: &mpsc::Sender<OrderedPayload>,
+        request_id: u64,
+        payload: proto::envelope::Payload,
+    ) -> Result<bool> {
+        ordered_tx
+            .send(OrderedPayload {
+                request_id,
+                payload,
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("plugin ordered handler is closed"))?;
+        Ok(true)
     }
 
     fn spawn_payload_handler<P: Plugin + Clone + Sync + 'static>(
@@ -1786,6 +1927,19 @@ mod tests {
         )
     }
 
+    fn test_channel_message(message_kind: &str) -> proto::ChannelMessage {
+        proto::ChannelMessage {
+            channel: "events".into(),
+            source_peer_id: "peer-a".into(),
+            target_peer_id: "peer-b".into(),
+            content_type: "text/plain".into(),
+            body: Vec::new(),
+            message_kind: message_kind.into(),
+            correlation_id: String::new(),
+            metadata_json: String::new(),
+        }
+    }
+
     #[tokio::test]
     async fn invoke_service_dispatches_operation_prompt_resource_and_completion() {
         let mut plugin = plugin! {
@@ -2057,6 +2211,135 @@ mod tests {
         let mut request_ids = vec![first.request_id, second.request_id];
         request_ids.sort_unstable();
         assert_eq!(request_ids, vec![1, 2]);
+
+        runtime.abort();
+    }
+
+    #[tokio::test]
+    async fn dropped_open_mesh_stream_request_removes_pending_response() {
+        let (outbound_tx, mut outbound_rx) = mpsc::channel(8);
+        let pending_host_responses = Arc::new(Mutex::new(HashMap::new()));
+        let mut context =
+            PluginContext::new("demo".into(), outbound_tx, pending_host_responses.clone());
+
+        let request = tokio::spawn(async move {
+            let _ = context
+                .open_mesh_stream(proto::OpenMeshStreamRequest::default())
+                .await;
+        });
+
+        let outbound = outbound_rx
+            .recv()
+            .await
+            .expect("request should be sent before awaiting host response");
+        assert_ne!(outbound.request_id, 0);
+        assert_eq!(
+            pending_host_responses
+                .lock()
+                .expect("pending map should not be poisoned")
+                .len(),
+            1
+        );
+
+        request.abort();
+        let _ = request.await;
+
+        assert!(
+            pending_host_responses
+                .lock()
+                .expect("pending map should not be poisoned")
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn ordered_notifications_do_not_overtake_each_other() {
+        let first_started = Arc::new(Notify::new());
+        let release_first = Arc::new(Notify::new());
+        let handled = Arc::new(Mutex::new(Vec::<String>::new()));
+        let first_started_for_handler = first_started.clone();
+        let release_first_for_handler = release_first.clone();
+        let handled_for_handler = handled.clone();
+        let plugin = SimplePlugin::new(PluginMetadata::new(
+            "demo",
+            "1.0.0",
+            plugin_server_info("demo", "1.0.0", "Demo", "Demo plugin", None::<String>),
+        ))
+        .on_channel_message(move |message, _context| {
+            let first_started = first_started_for_handler.clone();
+            let release_first = release_first_for_handler.clone();
+            let handled = handled_for_handler.clone();
+            Box::pin(async move {
+                if message.message_kind == "first" {
+                    first_started.notify_one();
+                    release_first.notified().await;
+                }
+                handled
+                    .lock()
+                    .expect("handled list should not be poisoned")
+                    .push(message.message_kind);
+                Ok(())
+            })
+        });
+
+        #[cfg(unix)]
+        let (plugin_stream, host_stream) = tokio::net::UnixStream::pair().unwrap();
+        #[cfg(not(unix))]
+        panic!("runtime stream tests are only implemented for unix");
+
+        let runtime = tokio::spawn(PluginRuntime::run_with_stream(
+            plugin,
+            LocalStream::Unix(plugin_stream),
+        ));
+        let mut host_stream = LocalStream::Unix(host_stream);
+
+        for (request_id, message_kind) in [(1, "first"), (2, "second")] {
+            write_envelope(
+                &mut host_stream,
+                &proto::Envelope {
+                    protocol_version: PROTOCOL_VERSION,
+                    plugin_id: "demo".into(),
+                    request_id,
+                    payload: Some(proto::envelope::Payload::ChannelMessage(
+                        test_channel_message(message_kind),
+                    )),
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        first_started.notified().await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            handled
+                .lock()
+                .expect("handled list should not be poisoned")
+                .is_empty(),
+            "second message should wait behind the first ordered handler"
+        );
+
+        release_first.notify_one();
+        timeout(Duration::from_secs(1), async {
+            loop {
+                if handled
+                    .lock()
+                    .expect("handled list should not be poisoned")
+                    .len()
+                    == 2
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("ordered handlers should finish");
+
+        assert_eq!(
+            *handled.lock().expect("handled list should not be poisoned"),
+            vec![String::from("first"), String::from("second")]
+        );
 
         runtime.abort();
     }

--- a/crates/mesh-llm-plugin/src/runtime.rs
+++ b/crates/mesh-llm-plugin/src/runtime.rs
@@ -8,21 +8,26 @@ use rmcp::model::{
     SubscribeRequestParams, UnsubscribeRequestParams,
 };
 use serde::de::DeserializeOwned;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use tokio::sync::{Mutex, RwLock, mpsc};
+
 use crate::{
     PROTOCOL_VERSION,
-    context::PluginContext,
+    context::{PendingHostResponses, PluginContext},
     error::{PluginError, PluginResult, PluginRpcResult},
     helpers::{
         CompletionRouter, PromptRouter, ResourceRouter, TaskRouter, ToolCallRequest, ToolRouter,
         json_response, parse_get_prompt_request, parse_read_resource_request, parse_rpc_params,
         parse_tool_call_request,
     },
-    io::{LocalStream, connect_from_env, read_envelope, write_envelope},
+    io::{
+        LocalReadHalf, LocalStream, LocalWriteHalf, connect_from_env, read_envelope_from,
+        write_envelope_to,
+    },
     proto,
 };
 use serde::{Deserialize, Serialize};
@@ -630,6 +635,7 @@ pub trait Plugin: Send {
     }
 }
 
+#[derive(Clone)]
 pub struct SimplePlugin {
     metadata: PluginMetadata,
     operation_router: Option<ToolRouter>,
@@ -953,6 +959,7 @@ impl InternalRpcPluginBuilder {
     }
 }
 
+#[derive(Clone)]
 pub struct InternalRpcPlugin {
     plugin: SimplePlugin,
     rpc_handlers: BTreeMap<String, RpcMethodHandler>,
@@ -1334,105 +1341,193 @@ impl Plugin for SimplePlugin {
 
 pub struct PluginRuntime;
 
+struct RuntimeState<P> {
+    plugin: Arc<RwLock<P>>,
+    plugin_id: String,
+    outbound_tx: mpsc::Sender<proto::Envelope>,
+    pending_host_responses: PendingHostResponses,
+}
+
 impl PluginRuntime {
-    pub async fn run<P: Plugin>(plugin: P) -> Result<()> {
+    pub async fn run<P: Plugin + Clone + Sync + 'static>(plugin: P) -> Result<()> {
         let stream = connect_from_env().await?;
         Self::run_with_stream(plugin, stream).await
     }
 
-    pub async fn run_with_stream<P: Plugin>(mut plugin: P, mut stream: LocalStream) -> Result<()> {
+    pub async fn run_with_stream<P: Plugin + Clone + Sync + 'static>(
+        plugin: P,
+        stream: LocalStream,
+    ) -> Result<()> {
+        let plugin_id = plugin.plugin_id().to_string();
+        let (read, write) = stream.into_split();
+        let (outbound_tx, outbound_rx) = mpsc::channel(256);
+        let writer = tokio::spawn(Self::write_loop(write, outbound_rx));
+        let state = Arc::new(RuntimeState {
+            plugin: Arc::new(RwLock::new(plugin)),
+            plugin_id,
+            outbound_tx,
+            pending_host_responses: Arc::new(Mutex::new(HashMap::new())),
+        });
+
+        match Self::read_loop(state, read).await {
+            Ok(()) => Ok(writer.await??),
+            Err(err) => {
+                writer.abort();
+                Err(err)
+            }
+        }
+    }
+
+    async fn read_loop<P: Plugin + Clone + Sync + 'static>(
+        state: Arc<RuntimeState<P>>,
+        mut read: LocalReadHalf,
+    ) -> Result<()> {
         loop {
-            let envelope = read_envelope(&mut stream).await?;
-            if !Self::handle_envelope(&mut plugin, &mut stream, envelope).await? {
+            let envelope = read_envelope_from(&mut *read).await?;
+            if Self::complete_pending_host_response(&state, &envelope).await {
+                continue;
+            }
+            if !Self::handle_envelope(state.clone(), envelope).await? {
                 break;
             }
         }
-
         Ok(())
     }
 
-    async fn handle_envelope<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
+    async fn write_loop(
+        mut write: LocalWriteHalf,
+        mut outbound_rx: mpsc::Receiver<proto::Envelope>,
+    ) -> Result<()> {
+        while let Some(envelope) = outbound_rx.recv().await {
+            write_envelope_to(&mut *write, &envelope).await?;
+        }
+        Ok(())
+    }
+
+    async fn complete_pending_host_response<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
+        envelope: &proto::Envelope,
+    ) -> bool {
+        let Some(sender) = state
+            .pending_host_responses
+            .lock()
+            .await
+            .remove(&envelope.request_id)
+        else {
+            return false;
+        };
+        let _ = sender.send(Ok(envelope.clone()));
+        true
+    }
+
+    async fn handle_envelope<P: Plugin + Clone + Sync + 'static>(
+        state: Arc<RuntimeState<P>>,
         envelope: proto::Envelope,
     ) -> Result<bool> {
         let request_id = envelope.request_id;
-        let plugin_id = plugin.plugin_id().to_string();
         let Some(payload) = envelope.payload else {
             return Ok(true);
         };
 
         match payload {
             proto::envelope::Payload::InitializeRequest(request) => {
-                Self::handle_initialize(plugin, stream, &plugin_id, request_id, request).await
+                Self::handle_initialize(state, request_id, request).await
             }
-            proto::envelope::Payload::HealthRequest(_) => {
-                Self::handle_health(plugin, stream, &plugin_id, request_id).await
-            }
+            proto::envelope::Payload::HealthRequest(_) => Self::handle_health(state, request_id),
             proto::envelope::Payload::ShutdownRequest(_) => {
                 Self::write_payload(
-                    stream,
-                    &plugin_id,
+                    &state,
                     request_id,
                     proto::envelope::Payload::ShutdownResponse(proto::ShutdownResponse {}),
                 )
                 .await?;
                 Ok(false)
             }
-            proto::envelope::Payload::RpcRequest(request) => {
-                Self::handle_rpc(plugin, stream, &plugin_id, request_id, request).await
-            }
-            proto::envelope::Payload::InvokeServiceRequest(request) => {
-                Self::handle_invoke_service(plugin, stream, &plugin_id, request_id, request).await
-            }
-            proto::envelope::Payload::OpenStreamRequest(request) => {
-                Self::handle_open_stream(plugin, stream, &plugin_id, request_id, request).await
-            }
-            proto::envelope::Payload::RpcNotification(notification) => {
-                Self::handle_rpc_notification(plugin, stream, &plugin_id, notification).await
-            }
-            proto::envelope::Payload::ChannelMessage(message) => {
-                Self::handle_channel_message(plugin, stream, &plugin_id, message).await
-            }
-            proto::envelope::Payload::BulkTransferMessage(message) => {
-                Self::handle_bulk_transfer_message(plugin, stream, &plugin_id, message).await
-            }
-            proto::envelope::Payload::MeshEvent(event) => {
-                Self::handle_mesh_event(plugin, stream, &plugin_id, event).await
-            }
-            proto::envelope::Payload::CancelStreamNotification(notification) => {
-                Self::handle_cancel_stream(plugin, stream, &plugin_id, notification).await
-            }
-            proto::envelope::Payload::CloseStreamNotification(notification) => {
-                Self::handle_close_stream(plugin, stream, &plugin_id, notification).await
-            }
-            proto::envelope::Payload::StreamError(error) => {
-                Self::handle_stream_error(plugin, stream, &plugin_id, error).await
-            }
-            proto::envelope::Payload::ErrorResponse(error) => {
-                Self::handle_host_error(plugin, stream, &plugin_id, error).await
-            }
-            _ => Ok(true),
+            payload => Self::spawn_payload_handler(state, request_id, payload),
         }
     }
 
-    async fn handle_initialize<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    fn spawn_payload_handler<P: Plugin + Clone + Sync + 'static>(
+        state: Arc<RuntimeState<P>>,
+        request_id: u64,
+        payload: proto::envelope::Payload,
+    ) -> Result<bool> {
+        tokio::spawn(async move {
+            let _ = Self::handle_payload(state, request_id, payload).await;
+        });
+        Ok(true)
+    }
+
+    async fn handle_payload<P: Plugin + Clone + Sync>(
+        state: Arc<RuntimeState<P>>,
+        request_id: u64,
+        payload: proto::envelope::Payload,
+    ) -> Result<()> {
+        match payload {
+            proto::envelope::Payload::RpcRequest(request) => {
+                let payload = Self::rpc_payload(&state, request).await;
+                Self::write_payload(&state, request_id, payload).await
+            }
+            proto::envelope::Payload::InvokeServiceRequest(request) => {
+                let payload = Self::invoke_service_payload(&state, request).await;
+                Self::write_payload(&state, request_id, payload).await
+            }
+            proto::envelope::Payload::OpenStreamRequest(request) => {
+                let payload = Self::open_stream_payload(&state, request).await;
+                Self::write_payload(&state, request_id, payload).await
+            }
+            proto::envelope::Payload::RpcNotification(notification) => {
+                Self::handle_rpc_notification(&state, notification)
+                    .await
+                    .map(|_| ())
+            }
+            proto::envelope::Payload::ChannelMessage(message) => {
+                Self::handle_channel_message(&state, message)
+                    .await
+                    .map(|_| ())
+            }
+            proto::envelope::Payload::BulkTransferMessage(message) => {
+                Self::handle_bulk_transfer_message(&state, message)
+                    .await
+                    .map(|_| ())
+            }
+            proto::envelope::Payload::MeshEvent(event) => {
+                Self::handle_mesh_event(&state, event).await.map(|_| ())
+            }
+            proto::envelope::Payload::CancelStreamNotification(notification) => {
+                Self::handle_cancel_stream(&state, notification)
+                    .await
+                    .map(|_| ())
+            }
+            proto::envelope::Payload::CloseStreamNotification(notification) => {
+                Self::handle_close_stream(&state, notification)
+                    .await
+                    .map(|_| ())
+            }
+            proto::envelope::Payload::StreamError(error) => {
+                Self::handle_stream_error(&state, error).await.map(|_| ())
+            }
+            proto::envelope::Payload::ErrorResponse(error) => {
+                Self::handle_host_error(&state, error).await.map(|_| ())
+            }
+            _ => Ok(()),
+        }?;
+        Ok(())
+    }
+
+    async fn handle_initialize<P: Plugin + Clone + Sync>(
+        state: Arc<RuntimeState<P>>,
         request_id: u64,
         request: proto::InitializeRequest,
     ) -> Result<bool> {
-        let init_result = {
-            let mut context = PluginContext { stream, plugin_id };
-            plugin
-                .initialize(PluginInitializeRequest::from(request), &mut context)
-                .await
-        };
+        let mut plugin = state.plugin.write().await;
+        let mut context = Self::context(&state);
+        let init_result = plugin
+            .initialize(PluginInitializeRequest::from(request), &mut context)
+            .await;
         if let Err(err) = init_result {
             Self::write_payload(
-                stream,
-                plugin_id,
+                &state,
                 request_id,
                 proto::envelope::Payload::ErrorResponse(err.into_error_response()),
             )
@@ -1441,11 +1536,10 @@ impl PluginRuntime {
         }
 
         Self::write_payload(
-            stream,
-            plugin_id,
+            &state,
             request_id,
             proto::envelope::Payload::InitializeResponse(proto::InitializeResponse {
-                plugin_id: plugin_id.to_string(),
+                plugin_id: state.plugin_id.clone(),
                 plugin_protocol_version: PROTOCOL_VERSION,
                 plugin_version: plugin.plugin_version(),
                 server_info_json: serde_json::to_string(&plugin.server_info())?,
@@ -1455,206 +1549,188 @@ impl PluginRuntime {
         )
         .await?;
 
-        let mut context = PluginContext { stream, plugin_id };
+        let mut context = Self::context(&state);
         plugin.on_initialized(&mut context).await?;
         Ok(true)
     }
 
-    async fn handle_health<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    fn handle_health<P: Plugin + Clone + Sync + 'static>(
+        state: Arc<RuntimeState<P>>,
         request_id: u64,
     ) -> Result<bool> {
-        let detail = {
-            let mut context = PluginContext { stream, plugin_id };
-            plugin.health(&mut context).await?
-        };
-        Self::write_payload(
-            stream,
-            plugin_id,
-            request_id,
-            proto::envelope::Payload::HealthResponse(proto::HealthResponse {
-                status: proto::health_response::Status::Ok as i32,
-                detail,
-            }),
-        )
-        .await?;
-        Ok(true)
-    }
-
-    async fn handle_rpc<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
-        request_id: u64,
-        request: proto::RpcRequest,
-    ) -> Result<bool> {
-        let payload = {
-            let mut context = PluginContext { stream, plugin_id };
-            match plugin.handle_rpc(request, &mut context).await {
-                Ok(payload) => payload,
-                Err(err) => proto::envelope::Payload::ErrorResponse(err.into_error_response()),
-            }
-        };
-        Self::write_payload(stream, plugin_id, request_id, payload).await?;
-        Ok(true)
-    }
-
-    async fn handle_invoke_service<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
-        request_id: u64,
-        request: proto::InvokeServiceRequest,
-    ) -> Result<bool> {
-        let payload = {
-            let mut context = PluginContext { stream, plugin_id };
-            match plugin.invoke_service(request, &mut context).await {
-                Ok(Some(response)) => proto::envelope::Payload::InvokeServiceResponse(response),
-                Ok(None) => proto::envelope::Payload::ErrorResponse(
-                    PluginError::method_not_found("Unsupported service invocation")
+        tokio::spawn(async move {
+            let mut plugin = Self::plugin_for_request(&state).await;
+            let mut context = Self::context(&state);
+            let payload = match plugin.health(&mut context).await {
+                Ok(detail) => proto::envelope::Payload::HealthResponse(proto::HealthResponse {
+                    status: proto::health_response::Status::Ok as i32,
+                    detail,
+                }),
+                Err(err) => proto::envelope::Payload::ErrorResponse(
+                    PluginError::internal(format!("health check failed: {err}"))
                         .into_error_response(),
                 ),
-                Err(err) => proto::envelope::Payload::ErrorResponse(err.into_error_response()),
-            }
-        };
-        Self::write_payload(stream, plugin_id, request_id, payload).await?;
+            };
+            let _ = Self::write_payload(&state, request_id, payload).await;
+        });
         Ok(true)
     }
 
-    async fn handle_open_stream<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
-        request_id: u64,
-        request: proto::OpenStreamRequest,
-    ) -> Result<bool> {
-        let payload = {
-            let mut context = PluginContext { stream, plugin_id };
-            match plugin.open_stream(request, &mut context).await {
-                Ok(Some(response)) => proto::envelope::Payload::OpenStreamResponse(response),
-                Ok(None) => proto::envelope::Payload::ErrorResponse(
-                    PluginError::method_not_found(
-                        "Unsupported stream control message 'open_stream'",
-                    )
+    async fn plugin_for_request<P: Plugin + Clone + Sync>(state: &RuntimeState<P>) -> P {
+        state.plugin.read().await.clone()
+    }
+
+    async fn rpc_payload<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
+        request: proto::RpcRequest,
+    ) -> proto::envelope::Payload {
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
+        match plugin.handle_rpc(request, &mut context).await {
+            Ok(payload) => payload,
+            Err(err) => proto::envelope::Payload::ErrorResponse(err.into_error_response()),
+        }
+    }
+
+    async fn invoke_service_payload<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
+        request: proto::InvokeServiceRequest,
+    ) -> proto::envelope::Payload {
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
+        match plugin.invoke_service(request, &mut context).await {
+            Ok(Some(response)) => proto::envelope::Payload::InvokeServiceResponse(response),
+            Ok(None) => proto::envelope::Payload::ErrorResponse(
+                PluginError::method_not_found("Unsupported service invocation")
                     .into_error_response(),
-                ),
-                Err(err) => proto::envelope::Payload::ErrorResponse(err.into_error_response()),
-            }
-        };
-        Self::write_payload(stream, plugin_id, request_id, payload).await?;
-        Ok(true)
+            ),
+            Err(err) => proto::envelope::Payload::ErrorResponse(err.into_error_response()),
+        }
     }
 
-    async fn handle_rpc_notification<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn open_stream_payload<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
+        request: proto::OpenStreamRequest,
+    ) -> proto::envelope::Payload {
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
+        match plugin.open_stream(request, &mut context).await {
+            Ok(Some(response)) => proto::envelope::Payload::OpenStreamResponse(response),
+            Ok(None) => proto::envelope::Payload::ErrorResponse(
+                PluginError::method_not_found("Unsupported stream control message 'open_stream'")
+                    .into_error_response(),
+            ),
+            Err(err) => proto::envelope::Payload::ErrorResponse(err.into_error_response()),
+        }
+    }
+
+    async fn handle_rpc_notification<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         notification: proto::RpcNotification,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin
             .on_rpc_notification(notification, &mut context)
             .await?;
         Ok(true)
     }
 
-    async fn handle_channel_message<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_channel_message<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         message: proto::ChannelMessage,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin.on_channel_message(message, &mut context).await?;
         Ok(true)
     }
 
-    async fn handle_bulk_transfer_message<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_bulk_transfer_message<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         message: proto::BulkTransferMessage,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin
             .on_bulk_transfer_message(message, &mut context)
             .await?;
         Ok(true)
     }
 
-    async fn handle_mesh_event<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_mesh_event<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         event: proto::MeshEvent,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin.on_mesh_event(event, &mut context).await?;
         Ok(true)
     }
 
-    async fn handle_cancel_stream<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_cancel_stream<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         notification: proto::CancelStreamNotification,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin.on_cancel_stream(notification, &mut context).await?;
         Ok(true)
     }
 
-    async fn handle_close_stream<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_close_stream<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         notification: proto::CloseStreamNotification,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin.on_close_stream(notification, &mut context).await?;
         Ok(true)
     }
 
-    async fn handle_stream_error<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_stream_error<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         error: proto::StreamError,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin.on_stream_error(error, &mut context).await?;
         Ok(true)
     }
 
-    async fn handle_host_error<P: Plugin>(
-        plugin: &mut P,
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    async fn handle_host_error<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         error: proto::ErrorResponse,
     ) -> Result<bool> {
-        let mut context = PluginContext { stream, plugin_id };
+        let mut plugin = Self::plugin_for_request(state).await;
+        let mut context = Self::context(state);
         plugin.on_host_error(error, &mut context).await?;
         Ok(true)
     }
 
-    async fn write_payload(
-        stream: &mut LocalStream,
-        plugin_id: &str,
+    fn context<P: Plugin + Clone + Sync>(state: &RuntimeState<P>) -> PluginContext<'static> {
+        PluginContext::new(
+            state.plugin_id.clone(),
+            state.outbound_tx.clone(),
+            state.pending_host_responses.clone(),
+        )
+    }
+
+    async fn write_payload<P: Plugin + Clone + Sync>(
+        state: &RuntimeState<P>,
         request_id: u64,
         payload: proto::envelope::Payload,
     ) -> Result<()> {
-        write_envelope(
-            stream,
-            &proto::Envelope {
+        state
+            .outbound_tx
+            .send(proto::Envelope {
                 protocol_version: PROTOCOL_VERSION,
-                plugin_id: plugin_id.to_string(),
+                plugin_id: state.plugin_id.clone(),
                 request_id,
                 payload: Some(payload),
-            },
-        )
-        .await
+            })
+            .await
+            .map_err(|_| anyhow::anyhow!("plugin host connection is closed"))
     }
 }
 
@@ -1687,10 +1763,13 @@ fn normalize_call_tool_output(result: &CallToolResult) -> PluginResult<String> {
 mod tests {
     use super::*;
     use crate::{mcp, plugin, plugin_server_info};
+    use crate::{read_envelope, write_envelope};
     use rmcp::model::{
         ArgumentInfo, PromptMessage, PromptMessageContent, PromptMessageRole, Reference,
     };
     use serde_json::json;
+    use tokio::sync::{Barrier, Notify};
+    use tokio::time::{Duration, timeout};
 
     #[derive(Clone, Debug, Default, Deserialize, Serialize, schemars::JsonSchema)]
     struct DemoArgs {
@@ -1698,16 +1777,13 @@ mod tests {
         message: String,
     }
 
-    async fn disconnected_stream() -> LocalStream {
-        #[cfg(unix)]
-        {
-            let (client, _server) = tokio::net::UnixStream::pair().unwrap();
-            LocalStream::Unix(client)
-        }
-        #[cfg(windows)]
-        {
-            panic!("runtime tests are only implemented for unix");
-        }
+    fn test_context() -> PluginContext<'static> {
+        let (outbound_tx, _outbound_rx) = mpsc::channel(8);
+        PluginContext::new(
+            "demo".into(),
+            outbound_tx,
+            Arc::new(Mutex::new(HashMap::new())),
+        )
     }
 
     #[tokio::test]
@@ -1747,11 +1823,7 @@ mod tests {
             ],
         };
 
-        let mut stream = disconnected_stream().await;
-        let mut context = PluginContext {
-            stream: &mut stream,
-            plugin_id: "demo",
-        };
+        let mut context = test_context();
 
         let op = plugin
             .invoke_service(
@@ -1830,5 +1902,162 @@ mod tests {
             completion_result.completion.values,
             vec![String::from("alpha")]
         );
+    }
+
+    #[tokio::test]
+    async fn health_request_returns_while_operation_is_running() {
+        let started = Arc::new(Notify::new());
+        let started_for_tool = started.clone();
+        let plugin = plugin! {
+            metadata: PluginMetadata::new(
+                "demo",
+                "1.0.0",
+                plugin_server_info("demo", "1.0.0", "Demo", "Demo plugin", None::<String>),
+            ),
+            mcp: [
+                mcp::tool("slow")
+                    .description("Slow operation")
+                    .input::<DemoArgs>()
+                    .handle(move |_args, _context| {
+                        let started = started_for_tool.clone();
+                        Box::pin(async move {
+                            started.notify_one();
+                            tokio::time::sleep(Duration::from_millis(300)).await;
+                            Ok(json!({ "done": true }))
+                        })
+                    }),
+            ],
+        };
+
+        #[cfg(unix)]
+        let (plugin_stream, host_stream) = tokio::net::UnixStream::pair().unwrap();
+        #[cfg(not(unix))]
+        panic!("runtime stream tests are only implemented for unix");
+
+        let runtime = tokio::spawn(PluginRuntime::run_with_stream(
+            plugin,
+            LocalStream::Unix(plugin_stream),
+        ));
+        let mut host_stream = LocalStream::Unix(host_stream);
+        write_envelope(
+            &mut host_stream,
+            &proto::Envelope {
+                protocol_version: PROTOCOL_VERSION,
+                plugin_id: "demo".into(),
+                request_id: 1,
+                payload: Some(proto::envelope::Payload::InvokeServiceRequest(
+                    proto::InvokeServiceRequest {
+                        kind: proto::ServiceKind::Operation as i32,
+                        service_name: "slow".into(),
+                        input_json: "{}".into(),
+                    },
+                )),
+            },
+        )
+        .await
+        .unwrap();
+
+        started.notified().await;
+        write_envelope(
+            &mut host_stream,
+            &proto::Envelope {
+                protocol_version: PROTOCOL_VERSION,
+                plugin_id: "demo".into(),
+                request_id: 2,
+                payload: Some(proto::envelope::Payload::HealthRequest(
+                    proto::HealthRequest {},
+                )),
+            },
+        )
+        .await
+        .unwrap();
+
+        let health = timeout(Duration::from_millis(150), read_envelope(&mut host_stream))
+            .await
+            .expect("health response should not wait for slow operation")
+            .unwrap();
+        assert_eq!(health.request_id, 2);
+        assert!(matches!(
+            health.payload,
+            Some(proto::envelope::Payload::HealthResponse(_))
+        ));
+
+        let invoke = timeout(Duration::from_secs(1), read_envelope(&mut host_stream))
+            .await
+            .expect("slow operation should still complete")
+            .unwrap();
+        assert_eq!(invoke.request_id, 1);
+
+        runtime.abort();
+    }
+
+    #[tokio::test]
+    async fn invokes_service_requests_concurrently() {
+        let barrier = Arc::new(Barrier::new(2));
+        let barrier_for_tool = barrier.clone();
+        let plugin = plugin! {
+            metadata: PluginMetadata::new(
+                "demo",
+                "1.0.0",
+                plugin_server_info("demo", "1.0.0", "Demo", "Demo plugin", None::<String>),
+            ),
+            mcp: [
+                mcp::tool("barrier")
+                    .description("Waits for another request")
+                    .input::<DemoArgs>()
+                    .handle(move |_args, _context| {
+                        let barrier = barrier_for_tool.clone();
+                        Box::pin(async move {
+                            barrier.wait().await;
+                            Ok(json!({ "done": true }))
+                        })
+                    }),
+            ],
+        };
+
+        #[cfg(unix)]
+        let (plugin_stream, host_stream) = tokio::net::UnixStream::pair().unwrap();
+        #[cfg(not(unix))]
+        panic!("runtime stream tests are only implemented for unix");
+
+        let runtime = tokio::spawn(PluginRuntime::run_with_stream(
+            plugin,
+            LocalStream::Unix(plugin_stream),
+        ));
+        let mut host_stream = LocalStream::Unix(host_stream);
+
+        for request_id in [1, 2] {
+            write_envelope(
+                &mut host_stream,
+                &proto::Envelope {
+                    protocol_version: PROTOCOL_VERSION,
+                    plugin_id: "demo".into(),
+                    request_id,
+                    payload: Some(proto::envelope::Payload::InvokeServiceRequest(
+                        proto::InvokeServiceRequest {
+                            kind: proto::ServiceKind::Operation as i32,
+                            service_name: "barrier".into(),
+                            input_json: "{}".into(),
+                        },
+                    )),
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let first = timeout(Duration::from_secs(1), read_envelope(&mut host_stream))
+            .await
+            .expect("first invoke response should not block behind another request")
+            .unwrap();
+        let second = timeout(Duration::from_secs(1), read_envelope(&mut host_stream))
+            .await
+            .expect("second invoke response should not block behind another request")
+            .unwrap();
+        let mut request_ids = vec![first.request_id, second.request_id];
+        request_ids.sort_unstable();
+        assert_eq!(request_ids, vec![1, 2]);
+
+        runtime.abort();
     }
 }


### PR DESCRIPTION
## Summary

Makes plugin runtimes accept and execute concurrent host requests instead of serializing the entire plugin process behind one long-running handler.

This fixes the class of failure we hit while testing A2A agents through the mesh MCP endpoint: `agents.send_message` started a long ACP-backed PR review task, then the plugin process stopped responding to host traffic because the runtime was blocked inside that single operation. The host supervisor interpreted that as a dead plugin, restarted it, and the original MCP call failed with:

```text
MCP error -32603: Plugin 'agents' disconnected
```

## Problem

The old runtime processed envelopes serially:

1. read one envelope from the host
2. await the handler to completion
3. write the response
4. read the next envelope

That meant a slow `tools/call`, service invocation, stream open, or plugin event handler blocked every later envelope, including health checks. Async handlers could yield to Tokio, but the runtime read loop still awaited the active handler before accepting the next host message.

The first version of this PR made the read/write loops concurrent, but still held a plugin mutex while each handler executed. That kept the process responsive to envelope reads, but still imposed a runtime-level plugin concurrency limit. That is not what agent plugins need: A2A, ACP-backed tasks, long MCP tools, and remote mesh streams must be able to run concurrently unless the plugin itself chooses to limit them.

## Changes

- Splits plugin connection IO into an independent read loop and serialized write loop.
- Routes all plugin writes through an outbound channel instead of giving handlers direct `&mut LocalStream` access.
- Dispatches host requests into independent tasks so one long operation does not block later host messages.
- Stores the initialized plugin behind an `RwLock`, then clones the plugin handle for each inbound request and drops the lock before invoking the handler.
- Removes the runtime-level handler mutex and the synthetic `busy` health response.
- Routes plugin-originated host responses, such as `open_mesh_stream`, through a pending response map instead of directly reading from the shared stream.
- Adds a regression test that sends two service invocations which must rendezvous with each other; the test times out if handlers are still serialized.
- Keeps the health regression test that verifies health can respond while a slow operation is still running.

## Plugin Concurrency Contract

`PluginRuntime::run` and `PluginRuntime::run_with_stream` now require plugin handles to be `Clone + Sync`.

The runtime does not impose a request concurrency limit. Plugin implementations that need shared state should put that state behind their own `Arc`, `Mutex`, `RwLock`, database pool, queue, or semaphore. Plugin implementations that need a concurrency limit should enforce that limit inside the plugin where the policy belongs.

The built-in `SimplePlugin`, routers, and `InternalRpcPlugin` are cloneable, so macro-built plugins and the in-tree plugins continue to work.

## Compatibility

This changes the source-level bound for custom plugin types passed directly to `PluginRuntime::run`: they now need to be cloneable and sync-safe. The wire protocol is unchanged.

Existing plugins built with the public builders/macros should not need handler rewrites. Custom plugins with internal mutable fields should move those fields into shared interior state, for example `Arc<Mutex<State>>`, if they need mutations to be visible across concurrent request clones.

## Validation

- `cargo test -p mesh-llm-plugin --lib`
- `cargo check -p mesh-llm`