### PR TITLE
Add shareable doctor diagnostics bundle

### DIFF
--- a/.agents/skills/diagnose-doctor-bundle/SKILL.md
+++ b/.agents/skills/diagnose-doctor-bundle/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: diagnose-doctor-bundle
+description: Use when diagnosing a mesh-llm doctor zip bundle, support bundle, runtime logs, GPU inventory, plugin inventory, API snapshots, or crash report, and the user wants likely causes, evidence, and suggested fixes.
+---
+
+# Diagnose Doctor Bundle
+
+Use this skill to turn a `mesh-llm doctor` zip into a practical support
+diagnosis. Prefer evidence from the bundle over guesses, and separate facts
+from likely causes.
+
+## Workflow
+
+1. Locate the bundle path from the user or attached files. If no path or file is
+   available, ask for the doctor zip.
+2. Run the bundled helper:
+
+   ```bash
+   python3 .agents/skills/diagnose-doctor-bundle/scripts/summarize_bundle.py /path/to/mesh-llm-doctor.zip
+   ```
+
+   Use `--json` when you need structured output for further processing.
+3. Inspect raw bundle files when the summary points at a problem:
+
+   ```bash
+   unzip -l /path/to/mesh-llm-doctor.zip
+   unzip -p /path/to/mesh-llm-doctor.zip manifest.json
+   unzip -p /path/to/mesh-llm-doctor.zip system.json
+   unzip -p /path/to/mesh-llm-doctor.zip runtime/logs/<name>
+   ```
+
+4. Produce a diagnosis with:
+   - observed facts: version, OS/arch, detected flavor, CPU/memory, GPUs,
+     plugins, selected runtime, API reachability, manifest warnings
+   - likely root cause(s), each tied to evidence from files or log snippets
+   - suggested fixes or next commands, ordered by confidence and impact
+   - what is still unknown and what extra artifact would settle it
+
+## What To Check
+
+- `manifest.json`: warnings, selected runtime, included files, truncated logs.
+- `system.json`: flavor mismatch, low available memory, CPU/OS/arch details,
+  runtime port.
+- `gpus.json` and `gpus.txt`: no GPUs, backend detection mismatch, low VRAM,
+  CUDA/ROCm/Metal/Vulkan errors, unavailable devices.
+- `plugins.json`: installed versions, disabled plugins, inactive runtime plugins,
+  missing commands, unexpected plugin versions.
+- `runtime/owner.json` and `runtime/instances.json`: current vs stale runtime,
+  wrong API port, dead owner, unexpected binary path/version.
+- `api/*.json`: console unreachable, `/v1/models` empty, status errors,
+  model inventory mismatch.
+- `runtime/logs/*`: panics, `ERROR`, OOM, port bind failures, model load
+  failures, GGUF/package errors, skippy stage failures, network join failures,
+  plugin process failures.
+
+## Response Style
+
+Lead with the highest-confidence finding. Do not dump the whole bundle summary.
+Use short evidence snippets with file names. Avoid claiming a root cause when
+the bundle only shows a symptom.
+
+Recommended shape:
+
+```text
+Likely cause: ...
+Evidence:
+- manifest.json: ...
+- runtime/logs/mesh-llm.log: ...
+
+Suggested fix:
+1. ...
+2. ...
+
+Still unknown:
+- ...
+```
+
+## Safety
+
+Doctor bundles are intended to avoid config files and environment variable
+values, but logs can still contain user prompts, local paths, hostnames, model
+names, or tokens emitted by external tools. Do not paste long logs back to the
+user. Quote only the minimal evidence needed for the diagnosis.

--- a/.agents/skills/diagnose-doctor-bundle/SKILL.md
+++ b/.agents/skills/diagnose-doctor-bundle/SKILL.md
@@ -41,7 +41,7 @@ from likely causes.
 - `manifest.json`: warnings, selected runtime, included files, truncated logs.
 - `system.json`: flavor mismatch, low available memory, CPU/OS/arch details,
   runtime port.
-- `gpus.json` and `gpus.txt`: no GPUs, backend detection mismatch, low VRAM,
+- `gpus.json`: no GPUs, backend detection mismatch, low VRAM,
   CUDA/ROCm/Metal/Vulkan errors, unavailable devices.
 - `plugins.json`: installed versions, disabled plugins, inactive runtime plugins,
   missing commands, unexpected plugin versions.
@@ -77,7 +77,8 @@ Still unknown:
 
 ## Safety
 
-Doctor bundles are intended to avoid config files and environment variable
-values, but logs can still contain user prompts, local paths, hostnames, model
-names, or tokens emitted by external tools. Do not paste long logs back to the
-user. Quote only the minimal evidence needed for the diagnosis.
+Doctor bundles include the resolved `config.toml` when available and avoid
+environment variable values, but logs and config can still contain user prompts,
+local paths, hostnames, model names, or tokens emitted by external tools. Do not
+paste long logs back to the user. Quote only the minimal evidence needed for the
+diagnosis.

--- a/.agents/skills/diagnose-doctor-bundle/agents/openai.yaml
+++ b/.agents/skills/diagnose-doctor-bundle/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Diagnose Doctor Bundle"
+  short_description: "Inspect mesh-llm doctor bundles and suggest fixes."
+  default_prompt: "Diagnose this mesh-llm doctor bundle and suggest likely fixes."

--- a/.agents/skills/diagnose-doctor-bundle/scripts/summarize_bundle.py
+++ b/.agents/skills/diagnose-doctor-bundle/scripts/summarize_bundle.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Summarize a mesh-llm doctor bundle for support triage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+from typing import Any
+
+PATTERNS = [
+    ("panic", re.compile(r"\bpanic(?:ked)?\b", re.IGNORECASE)),
+    ("error", re.compile(r"\b(error|failed|failure)\b", re.IGNORECASE)),
+    ("oom", re.compile(r"(out of memory|\boom\b|cannot allocate)", re.IGNORECASE)),
+    ("port", re.compile(r"(address already in use|bind|listen|port \d+)", re.IGNORECASE)),
+    ("gpu", re.compile(r"(cuda|rocm|hip|metal|vulkan|gpu|vram)", re.IGNORECASE)),
+    ("model", re.compile(r"(gguf|model load|tokenizer|tensor|layer package)", re.IGNORECASE)),
+    ("skippy", re.compile(r"(skippy|stage|activation|kv cache)", re.IGNORECASE)),
+    ("network", re.compile(r"(quic|relay|join|peer|mesh|connection refused)", re.IGNORECASE)),
+    ("plugin", re.compile(r"(plugin|mcp|command not found)", re.IGNORECASE)),
+]
+
+MAX_LOG_BYTES = 256_000
+MAX_FINDINGS = 80
+MAX_LINE_CHARS = 240
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("bundle", type=Path, help="mesh-llm doctor zip path")
+    parser.add_argument("--json", action="store_true", help="emit JSON")
+    args = parser.parse_args()
+
+    try:
+        summary = summarize_bundle(args.bundle)
+    except Exception as exc:  # noqa: BLE001 - support helper should be direct.
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print_markdown(summary)
+    return 0
+
+
+def summarize_bundle(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(path)
+    if not zipfile.is_zipfile(path):
+        raise ValueError(f"not a zip file: {path}")
+
+    with zipfile.ZipFile(path) as bundle:
+        names = sorted(info.filename for info in bundle.infolist() if not info.is_dir())
+        json_files = {
+            name: read_json(bundle, name)
+            for name in names
+            if name.endswith(".json") and bundle.getinfo(name).file_size <= 20_000_000
+        }
+        logs = [name for name in names if name.startswith("runtime/logs/")]
+        return {
+            "bundle": str(path),
+            "files": names,
+            "file_count": len(names),
+            "manifest": manifest_summary(json_files.get("manifest.json")),
+            "system": system_summary(json_files.get("system.json")),
+            "gpus": gpu_summary(json_files.get("gpus.json")),
+            "plugins": plugin_summary(json_files.get("plugins.json")),
+            "runtime": runtime_summary(json_files),
+            "api": api_summary(json_files),
+            "log_findings": scan_logs(bundle, logs),
+        }
+
+
+def read_json(bundle: zipfile.ZipFile, name: str) -> Any:
+    try:
+        return json.loads(bundle.read(name).decode("utf-8", errors="replace"))
+    except Exception as exc:  # noqa: BLE001 - keep corrupt JSON visible.
+        return {"_parse_error": str(exc)}
+
+
+def manifest_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"present": False}
+    selected = value.get("selected_instance") or {}
+    return {
+        "present": True,
+        "generated_at": value.get("generated_at"),
+        "target": value.get("target"),
+        "warnings": value.get("warnings") or [],
+        "selected_pid": selected.get("pid"),
+        "selected_live": selected.get("is_live"),
+        "selected_api_port": selected.get("api_port"),
+        "included_files": len(value.get("included_files") or []),
+    }
+
+
+def system_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"present": False}
+    mesh = value.get("mesh_llm") or {}
+    platform = value.get("platform") or {}
+    flavor = value.get("flavor") or {}
+    system = value.get("system") or {}
+    memory = system.get("memory") or {}
+    cpu = system.get("cpu") or {}
+    return {
+        "present": True,
+        "version": mesh.get("version"),
+        "current_exe": mesh.get("current_exe"),
+        "current_dir": mesh.get("current_dir"),
+        "os": platform.get("os"),
+        "arch": platform.get("arch"),
+        "requested_flavor": flavor.get("requested_llama_flavor"),
+        "detected_flavor": flavor.get("detected_host_flavor"),
+        "memory_total_gb": bytes_to_gb(memory.get("total_bytes")),
+        "memory_available_gb": bytes_to_gb(memory.get("available_bytes")),
+        "cpu_logical": cpu.get("logical_count"),
+        "cpu_physical": cpu.get("physical_count"),
+        "cpu_brand": cpu.get("brand"),
+        "api_port": (value.get("runtime") or {}).get("api_port"),
+    }
+
+
+def gpu_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"present": False, "count": 0, "devices": []}
+    devices = value.get("gpus") or value.get("devices") or []
+    if not isinstance(devices, list):
+        devices = []
+    return {
+        "present": True,
+        "count": len(devices),
+        "devices": [compact_gpu(device) for device in devices[:16]],
+    }
+
+
+def compact_gpu(device: Any) -> dict[str, Any]:
+    if not isinstance(device, dict):
+        return {"raw": device}
+    return {
+        key: device.get(key)
+        for key in [
+            "name",
+            "backend_device",
+            "vendor",
+            "total_vram_bytes",
+            "free_vram_bytes",
+            "memory_total_bytes",
+            "memory_available_bytes",
+        ]
+        if key in device
+    }
+
+
+def plugin_summary(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {"present": False}
+    installed = value.get("installed") or []
+    resolved = value.get("resolved") or {}
+    return {
+        "present": True,
+        "installed": compact_plugin_list(installed),
+        "active_runtime": compact_plugin_list(resolved.get("active") or []),
+        "inactive_runtime": compact_plugin_list(resolved.get("inactive") or []),
+    }
+
+
+def compact_plugin_list(items: Any) -> list[dict[str, Any]]:
+    if not isinstance(items, list):
+        return []
+    compacted = []
+    for item in items[:64]:
+        if isinstance(item, dict):
+            compacted.append(
+                {
+                    key: item.get(key)
+                    for key in ["name", "version", "enabled", "kind", "command", "url", "env_keys"]
+                    if key in item
+                }
+            )
+    return compacted
+
+
+def runtime_summary(json_files: dict[str, Any]) -> dict[str, Any]:
+    instances = json_files.get("runtime/instances.json")
+    owner = json_files.get("runtime/owner.json")
+    return {
+        "instances": instances if isinstance(instances, dict) else None,
+        "owner": owner if isinstance(owner, dict) else None,
+    }
+
+
+def api_summary(json_files: dict[str, Any]) -> dict[str, Any]:
+    api = {}
+    for name, value in sorted(json_files.items()):
+        if not name.startswith("api/") or not isinstance(value, dict):
+            continue
+        api[name] = {
+            "ok": value.get("ok"),
+            "status": value.get("status"),
+            "url": value.get("url"),
+            "error": value.get("error"),
+            "body_type": type(value.get("body")).__name__,
+        }
+    return api
+
+
+def scan_logs(bundle: zipfile.ZipFile, logs: list[str]) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for name in logs:
+        data = bundle.read(name)
+        if len(data) > MAX_LOG_BYTES:
+            data = data[-MAX_LOG_BYTES:]
+        text = data.decode("utf-8", errors="replace")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for label, pattern in PATTERNS:
+                if pattern.search(line):
+                    findings.append(
+                        {
+                            "file": name,
+                            "line": line_number,
+                            "pattern": label,
+                            "text": line.strip()[:MAX_LINE_CHARS],
+                        }
+                    )
+                    break
+            if len(findings) >= MAX_FINDINGS:
+                return findings
+    return findings
+
+
+def bytes_to_gb(value: Any) -> float | None:
+    if not isinstance(value, (int, float)):
+        return None
+    return round(float(value) / 1024 / 1024 / 1024, 2)
+
+
+def print_markdown(summary: dict[str, Any]) -> None:
+    print(f"# mesh-llm doctor bundle summary\n")
+    print(f"Bundle: `{summary['bundle']}`")
+    print(f"Files: {summary['file_count']}")
+
+    manifest = summary["manifest"]
+    if manifest.get("present"):
+        print(f"Generated: {manifest.get('generated_at')}")
+        print(f"Selected runtime: pid={manifest.get('selected_pid')} live={manifest.get('selected_live')}")
+        warnings = manifest.get("warnings") or []
+        if warnings:
+            print("\n## Manifest warnings")
+            for warning in warnings:
+                print(f"- {warning}")
+
+    print_section("System", summary["system"])
+    print_section("GPUs", summary["gpus"])
+    print_section("Plugins", summary["plugins"])
+    print_section("API", summary["api"])
+
+    findings = summary["log_findings"]
+    if findings:
+        print("\n## Log findings")
+        for item in findings[:MAX_FINDINGS]:
+            print(
+                f"- `{item['file']}:{item['line']}` [{item['pattern']}]: {item['text']}"
+            )
+    else:
+        print("\n## Log findings\n- No high-signal log patterns found.")
+
+
+def print_section(title: str, value: Any) -> None:
+    print(f"\n## {title}")
+    print("```json")
+    print(json.dumps(value, indent=2, sort_keys=True))
+    print("```")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -12,6 +12,7 @@ use zip::{CompressionMethod, ZipWriter};
 
 use crate::cli::Cli;
 use crate::cli::commands::{gpus, plugin};
+use crate::cli::terminal_progress::start_indeterminate_progress;
 use crate::runtime::instance;
 use crate::system::backend::BinaryFlavor;
 use crate::system::hardware::HardwareSurvey;
@@ -81,6 +82,7 @@ pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -
             .with_context(|| format!("failed to create output directory {}", parent.display()))?;
     }
 
+    let mut progress = start_indeterminate_progress("Building doctor bundle");
     let hw = gpus::collect_gpus_survey();
     let runtime_root = instance::runtime_root().ok();
     let all_instances = runtime_root
@@ -145,6 +147,7 @@ pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -
     manifest.included_files.clone_from(&bundle.included_files);
     add_json(&mut bundle, "manifest.json", &manifest)?;
     bundle.finish()?;
+    progress.finish();
 
     println!("✅ Created doctor bundle");
     println!();

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -154,7 +154,7 @@ pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -
     println!("Path: {}", output_path.display());
     println!(
         "Logs: {}",
-        selected_runtime_label(manifest.selected_instance.as_ref())
+        selected_runtime_label(manifest.selected_instance.as_ref(), &all_instances)
     );
     println!("Files: {}", manifest.included_files.len());
     if !manifest.warnings.is_empty() {
@@ -167,12 +167,23 @@ pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -
     Ok(())
 }
 
-fn selected_runtime_label(info: Option<&RuntimeInstanceInfo>) -> String {
+fn selected_runtime_label(
+    info: Option<&RuntimeInstanceInfo>,
+    instances: &[RuntimeInstanceInfo],
+) -> String {
     let Some(info) = info else {
         return "none selected".to_string();
     };
-    let live = if info.is_live { "running" } else { "previous" };
-    format!("{live} pid {}", info.pid)
+    if info.is_live {
+        return format!("running pid {}", info.pid);
+    }
+    if instances.iter().any(|instance| instance.is_live) {
+        return format!("previous pid {}", info.pid);
+    }
+    format!(
+        "no running mesh-llm process found; using previous pid {}",
+        info.pid
+    )
 }
 
 struct DoctorZip {
@@ -421,7 +432,9 @@ fn read_runtime_instance(runtime_dir: &Path) -> Option<RuntimeInstanceInfo> {
     let pid = value["pid"]
         .as_u64()
         .and_then(|pid| u32::try_from(pid).ok())?;
-    let started_at_unix = value["started_at_unix"].as_i64();
+    let started_at_unix = value["started_at_unix"]
+        .as_i64()
+        .filter(|started_at| *started_at > 0);
     Some(RuntimeInstanceInfo {
         pid,
         api_port: value["api_port"]
@@ -796,6 +809,51 @@ mod tests {
         .expect_err("missing pid should fail");
 
         assert!(err.to_string().contains("pid 11"));
+    }
+
+    #[test]
+    fn runtime_label_explains_stale_fallback() {
+        let previous = instance_info(10, false, 10);
+
+        assert_eq!(
+            selected_runtime_label(Some(&previous), std::slice::from_ref(&previous)),
+            "no running mesh-llm process found; using previous pid 10"
+        );
+    }
+
+    #[test]
+    fn runtime_label_keeps_explicit_previous_when_live_exists() {
+        let previous = instance_info(10, false, 10);
+        let running = instance_info(20, true, 20);
+
+        assert_eq!(
+            selected_runtime_label(Some(&previous), &[previous.clone(), running]),
+            "previous pid 10"
+        );
+    }
+
+    #[test]
+    fn read_runtime_instance_treats_zero_started_at_as_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let runtime_dir = dir.path().join("1234");
+        fs::create_dir(&runtime_dir).expect("runtime dir");
+        fs::write(
+            runtime_dir.join("owner.json"),
+            json!({
+                "pid": 1234,
+                "api_port": 3131,
+                "started_at_unix": 0,
+                "mesh_llm_binary": "/tmp/mesh-llm",
+                "version": "0.0.0-test"
+            })
+            .to_string(),
+        )
+        .expect("owner json");
+
+        let info = read_runtime_instance(&runtime_dir).expect("runtime info");
+
+        assert_eq!(info.started_at_unix, None);
+        assert!(info.sort_time_unix > 0);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -793,6 +793,20 @@ mod tests {
         assert!(err.to_string().contains("pid 11"));
     }
 
+    #[test]
+    fn default_output_path_uses_current_directory() {
+        let cwd = std::env::current_dir().expect("current directory should be available");
+        let path = default_output_path();
+        let file_name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .expect("default output path should have a UTF-8 filename");
+
+        assert!(path.starts_with(cwd));
+        assert!(file_name.starts_with("mesh-llm-doctor-"));
+        assert!(file_name.ends_with(".zip"));
+    }
+
     #[cfg(target_os = "macos")]
     #[test]
     fn parses_macos_available_memory_bytes() {

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -114,7 +114,6 @@ pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -
         &system_report(cli, &hw, api_port),
     )?;
     add_json(&mut bundle, "gpus.json", &gpus::gpus_json(&hw))?;
-    add_text(&mut bundle, "gpus.txt", gpus::gpus_text(&hw))?;
     add_plugin_inventory(&mut bundle, cli, &mut warnings)?;
     add_config_file(&mut bundle, cli, &mut warnings)?;
     add_json(
@@ -864,7 +863,7 @@ fn doctor_readme(max_log_bytes: u64) -> String {
         "mesh-llm doctor bundle\n\n\
          Contents:\n\
          - system.json: mesh-llm version, platform, flavor, CPU, and memory summary\n\
-         - gpus.json / gpus.txt: local GPU facts shown by `mesh-llm gpus`\n\
+         - gpus.json: local GPU facts shown by `mesh-llm gpus --json`\n\
          - plugins.json: installed plugin metadata and resolved runtime plugins\n\
          - config/config.toml: resolved mesh-llm config file when available\n\
          - runtime/instances.json: local runtime process metadata\n\
@@ -1006,6 +1005,8 @@ mod tests {
         let readme = doctor_readme(1024);
 
         assert!(readme.contains("config/config.toml"));
+        assert!(readme.contains("gpus.json"));
+        assert!(!readme.contains("gpus.txt"));
         assert!(readme.contains("Environment variable values are intentionally not included"));
     }
 

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -690,10 +690,12 @@ fn cpu_brand() -> Option<String> {
     None
 }
 
+#[cfg(target_os = "macos")]
 fn command_u64(command: &str, args: &[&str]) -> Option<u64> {
     command_stdout(command, args)?.trim().parse().ok()
 }
 
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new(command)
         .args(args)

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -44,7 +44,9 @@ struct RuntimeInstanceInfo {
     version: Option<String>,
     started_at_unix: Option<i64>,
     mesh_llm_binary: Option<String>,
+    command: Option<String>,
     runtime_dir: PathBuf,
+    runtime_metadata: bool,
     is_live: bool,
     sort_time_unix: i64,
 }
@@ -262,6 +264,14 @@ fn add_runtime_files(
     max_log_bytes: u64,
     warnings: &mut Vec<String>,
 ) -> Result<()> {
+    if !info.runtime_metadata {
+        warnings.push(format!(
+            "selected process has no runtime metadata directory: {}",
+            info.runtime_dir.display()
+        ));
+        return Ok(());
+    }
+
     add_existing_file(
         zip,
         &info.runtime_dir.join("owner.json"),
@@ -396,9 +406,10 @@ async fn fetch_api_snapshot(client: &reqwest::Client, port: u16, endpoint: &str)
 async fn api_response_json(url: String, response: reqwest::Response) -> Value {
     let status = response.status();
     let body = response.text().await.unwrap_or_default();
-    if status == StatusCode::OK
-        && let Ok(json_body) = serde_json::from_str::<Value>(&body)
-    {
+    if status != StatusCode::OK {
+        return json!({"ok": status.is_success(), "url": url, "status": status.as_u16(), "body": body});
+    }
+    if let Ok(json_body) = serde_json::from_str::<Value>(&body) {
         return json!({"ok": true, "url": url, "status": status.as_u16(), "body": json_body});
     }
     json!({"ok": status.is_success(), "url": url, "status": status.as_u16(), "body": body})
@@ -406,18 +417,21 @@ async fn api_response_json(url: String, response: reqwest::Response) -> Value {
 
 fn load_runtime_instances(root: &Path) -> Result<Vec<RuntimeInstanceInfo>> {
     if !root.exists() {
-        return Ok(Vec::new());
+        return Ok(discover_running_mesh_processes(root, &[]));
     }
 
     let mut instances = Vec::new();
     for entry in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
         let path = entry?.path();
-        if path.is_dir()
-            && let Some(info) = read_runtime_instance(&path)
-        {
-            instances.push(info);
+        if !path.is_dir() {
+            continue;
         }
+        let Some(info) = read_runtime_instance(&path) else {
+            continue;
+        };
+        instances.push(info);
     }
+    instances.extend(discover_running_mesh_processes(root, &instances));
     instances.sort_by(|a, b| {
         b.sort_time_unix
             .cmp(&a.sort_time_unix)
@@ -443,9 +457,90 @@ fn read_runtime_instance(runtime_dir: &Path) -> Option<RuntimeInstanceInfo> {
         version: value["version"].as_str().map(str::to_owned),
         started_at_unix,
         mesh_llm_binary: value["mesh_llm_binary"].as_str().map(str::to_owned),
+        command: None,
         runtime_dir: runtime_dir.to_path_buf(),
+        runtime_metadata: true,
         is_live: instance::validate::process_liveness(pid) != instance::validate::Liveness::Dead,
         sort_time_unix: started_at_unix.unwrap_or_else(|| path_modified_unix(runtime_dir)),
+    })
+}
+
+fn discover_running_mesh_processes(
+    runtime_root: &Path,
+    known_instances: &[RuntimeInstanceInfo],
+) -> Vec<RuntimeInstanceInfo> {
+    let known_pids = known_instances
+        .iter()
+        .map(|info| info.pid)
+        .collect::<std::collections::BTreeSet<_>>();
+    parse_running_mesh_processes(
+        &process_table_output().unwrap_or_default(),
+        runtime_root,
+        &known_pids,
+        std::process::id(),
+        chrono::Utc::now().timestamp(),
+    )
+}
+
+#[cfg(unix)]
+fn process_table_output() -> Option<String> {
+    command_stdout("ps", &["-eo", "pid=,command="])
+}
+
+#[cfg(not(unix))]
+fn process_table_output() -> Option<String> {
+    None
+}
+
+fn parse_running_mesh_processes(
+    output: &str,
+    runtime_root: &Path,
+    known_pids: &std::collections::BTreeSet<u32>,
+    current_pid: u32,
+    sort_time_unix: i64,
+) -> Vec<RuntimeInstanceInfo> {
+    output
+        .lines()
+        .filter_map(|line| parse_process_table_row(line))
+        .filter(|(pid, command)| {
+            *pid != current_pid && !known_pids.contains(pid) && is_mesh_llm_runtime_command(command)
+        })
+        .map(|(pid, command)| RuntimeInstanceInfo {
+            pid,
+            api_port: None,
+            version: None,
+            started_at_unix: None,
+            mesh_llm_binary: command.split_whitespace().next().map(str::to_string),
+            command: Some(command.to_string()),
+            runtime_dir: runtime_root.join(pid.to_string()),
+            runtime_metadata: false,
+            is_live: true,
+            sort_time_unix,
+        })
+        .collect()
+}
+
+fn parse_process_table_row(line: &str) -> Option<(u32, &str)> {
+    let trimmed = line.trim_start();
+    let split_at = trimmed.find(char::is_whitespace)?;
+    let pid = trimmed[..split_at].parse().ok()?;
+    let command = trimmed[split_at..].trim();
+    (!command.is_empty()).then_some((pid, command))
+}
+
+fn is_mesh_llm_runtime_command(command: &str) -> bool {
+    if !command.contains("mesh-llm") {
+        return false;
+    }
+    let args = command.split_whitespace().collect::<Vec<_>>();
+    let Some(binary_index) = args.iter().position(|arg| arg.contains("mesh-llm")) else {
+        return false;
+    };
+    args[binary_index + 1..].iter().any(|arg| {
+        matches!(
+            *arg,
+            "client" | "serve" | "--client" | "--auto" | "--model" | "--gguf"
+        )
     })
 }
 
@@ -711,7 +806,6 @@ fn command_u64(command: &str, args: &[&str]) -> Option<u64> {
     command_stdout(command, args)?.trim().parse().ok()
 }
 
-#[cfg(any(target_os = "macos", target_os = "windows"))]
 fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
     let output = std::process::Command::new(command)
         .args(args)
@@ -884,6 +978,38 @@ mod tests {
         );
     }
 
+    #[test]
+    fn parses_running_client_without_runtime_metadata() {
+        let known_pids = std::collections::BTreeSet::new();
+        let processes = parse_running_mesh_processes(
+            "  42 ./target/debug/mesh-llm client --auto\n  43 ./target/debug/mesh-llm doctor\n",
+            Path::new("/tmp/runtime"),
+            &known_pids,
+            99,
+            123,
+        );
+
+        assert_eq!(processes.len(), 1);
+        assert_eq!(processes[0].pid, 42);
+        assert!(processes[0].is_live);
+        assert!(!processes[0].runtime_metadata);
+        assert_eq!(processes[0].runtime_dir, PathBuf::from("/tmp/runtime/42"));
+    }
+
+    #[test]
+    fn process_discovery_skips_current_and_known_pids() {
+        let known_pids = std::collections::BTreeSet::from([42]);
+        let processes = parse_running_mesh_processes(
+            "  42 ./target/debug/mesh-llm serve --model qwen\n  43 ./target/debug/mesh-llm client --auto\n",
+            Path::new("/tmp/runtime"),
+            &known_pids,
+            43,
+            123,
+        );
+
+        assert!(processes.is_empty());
+    }
+
     fn instance_info(pid: u32, is_live: bool, sort_time_unix: i64) -> RuntimeInstanceInfo {
         RuntimeInstanceInfo {
             pid,
@@ -891,7 +1017,9 @@ mod tests {
             version: Some("0.0.0-test".into()),
             started_at_unix: Some(sort_time_unix),
             mesh_llm_binary: Some("/tmp/mesh-llm".into()),
+            command: None,
             runtime_dir: PathBuf::from(format!("/tmp/{pid}")),
+            runtime_metadata: true,
             is_live,
             sort_time_unix,
         }

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -1,0 +1,822 @@
+use anyhow::{Context, Result, bail};
+use clap::ValueEnum;
+use reqwest::StatusCode;
+use serde::Serialize;
+use serde_json::{Value, json};
+use std::fs::{self, File};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+use crate::cli::Cli;
+use crate::cli::commands::{gpus, plugin};
+use crate::runtime::instance;
+use crate::system::backend::BinaryFlavor;
+use crate::system::hardware::HardwareSurvey;
+
+pub(crate) const DEFAULT_MAX_LOG_BYTES: u64 = 20 * 1024 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
+pub(crate) enum DoctorLogTarget {
+    /// Prefer the newest running process; fall back to the newest previous process.
+    Auto,
+    /// Include logs from the newest currently running process.
+    Current,
+    /// Include logs from the newest known process, running or not.
+    Last,
+}
+
+pub(crate) struct DoctorBundleOptions {
+    pub(crate) output: Option<PathBuf>,
+    pub(crate) target: DoctorLogTarget,
+    pub(crate) pid: Option<u32>,
+    pub(crate) port: Option<u16>,
+    pub(crate) max_log_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+struct RuntimeInstanceInfo {
+    pid: u32,
+    api_port: Option<u16>,
+    version: Option<String>,
+    started_at_unix: Option<i64>,
+    mesh_llm_binary: Option<String>,
+    runtime_dir: PathBuf,
+    is_live: bool,
+    sort_time_unix: i64,
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct IncludedFile {
+    zip_path: String,
+    source_path: Option<PathBuf>,
+    bytes_written: u64,
+    truncated: bool,
+    original_bytes: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct DoctorManifest {
+    generated_at: String,
+    output_path: PathBuf,
+    target: String,
+    requested_pid: Option<u32>,
+    requested_port: Option<u16>,
+    max_log_bytes: u64,
+    runtime_root: Option<PathBuf>,
+    selected_instance: Option<RuntimeInstanceInfo>,
+    included_files: Vec<IncludedFile>,
+    warnings: Vec<String>,
+}
+
+pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -> Result<()> {
+    let output_path = options.output.unwrap_or_else(default_output_path);
+    if let Some(parent) = output_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create output directory {}", parent.display()))?;
+    }
+
+    let hw = gpus::collect_gpus_survey();
+    let runtime_root = instance::runtime_root().ok();
+    let all_instances = runtime_root
+        .as_deref()
+        .map(load_runtime_instances)
+        .transpose()?
+        .unwrap_or_default();
+    let selected = select_runtime_instance(&all_instances, options.target, options.pid)?;
+    let api_port = options
+        .port
+        .or_else(|| selected.as_ref().and_then(|info| info.api_port))
+        .unwrap_or(3131);
+
+    let file = File::create(&output_path)
+        .with_context(|| format!("failed to create {}", output_path.display()))?;
+    let mut bundle = DoctorZip::new(file);
+    let mut warnings = Vec::new();
+
+    add_text(
+        &mut bundle,
+        "README.txt",
+        doctor_readme(options.max_log_bytes),
+    )?;
+    add_json(
+        &mut bundle,
+        "system.json",
+        &system_report(cli, &hw, api_port),
+    )?;
+    add_json(&mut bundle, "gpus.json", &gpus::gpus_json(&hw))?;
+    add_text(&mut bundle, "gpus.txt", gpus::gpus_text(&hw))?;
+    add_plugin_inventory(&mut bundle, cli, &mut warnings)?;
+    add_json(
+        &mut bundle,
+        "runtime/instances.json",
+        &json!({
+            "runtime_root": runtime_root,
+            "instances": all_instances,
+        }),
+    )?;
+
+    if let Some(info) = selected.as_ref() {
+        add_runtime_files(&mut bundle, info, options.max_log_bytes, &mut warnings)?;
+    } else {
+        warnings
+            .push("no runtime instance was found; bundle contains system diagnostics only".into());
+    }
+
+    add_api_snapshots(&mut bundle, api_port, &mut warnings).await?;
+
+    let mut manifest = DoctorManifest {
+        generated_at: utc_timestamp(),
+        output_path: output_path.clone(),
+        target: format!("{:?}", options.target).to_ascii_lowercase(),
+        requested_pid: options.pid,
+        requested_port: options.port,
+        max_log_bytes: options.max_log_bytes,
+        runtime_root,
+        selected_instance: selected,
+        included_files: Vec::new(),
+        warnings,
+    };
+    manifest.included_files.clone_from(&bundle.included_files);
+    add_json(&mut bundle, "manifest.json", &manifest)?;
+    bundle.finish()?;
+
+    println!("✅ Created doctor bundle");
+    println!();
+    println!("Path: {}", output_path.display());
+    println!(
+        "Logs: {}",
+        selected_runtime_label(manifest.selected_instance.as_ref())
+    );
+    println!("Files: {}", manifest.included_files.len());
+    if !manifest.warnings.is_empty() {
+        println!();
+        println!("⚠️  Warnings");
+        for warning in &manifest.warnings {
+            println!("  - {warning}");
+        }
+    }
+    Ok(())
+}
+
+fn selected_runtime_label(info: Option<&RuntimeInstanceInfo>) -> String {
+    let Some(info) = info else {
+        return "none selected".to_string();
+    };
+    let live = if info.is_live { "running" } else { "previous" };
+    format!("{live} pid {}", info.pid)
+}
+
+struct DoctorZip {
+    writer: ZipWriter<File>,
+    options: SimpleFileOptions,
+    included_files: Vec<IncludedFile>,
+}
+
+impl DoctorZip {
+    fn new(file: File) -> Self {
+        Self {
+            writer: ZipWriter::new(file),
+            options: SimpleFileOptions::default().compression_method(CompressionMethod::Deflated),
+            included_files: Vec::new(),
+        }
+    }
+
+    fn add_bytes(
+        &mut self,
+        zip_path: &str,
+        source_path: Option<PathBuf>,
+        bytes: &[u8],
+        truncated: bool,
+        original_bytes: Option<u64>,
+    ) -> Result<()> {
+        self.writer
+            .start_file(zip_path, self.options)
+            .with_context(|| format!("failed to start zip entry {zip_path}"))?;
+        self.writer
+            .write_all(bytes)
+            .with_context(|| format!("failed to write zip entry {zip_path}"))?;
+        self.included_files.push(IncludedFile {
+            zip_path: zip_path.to_string(),
+            source_path,
+            bytes_written: bytes.len() as u64,
+            truncated,
+            original_bytes,
+        });
+        Ok(())
+    }
+
+    fn finish(self) -> Result<()> {
+        self.writer
+            .finish()
+            .context("failed to finish doctor zip")?;
+        Ok(())
+    }
+}
+
+fn add_text(zip: &mut DoctorZip, zip_path: &str, contents: impl AsRef<str>) -> Result<()> {
+    zip.add_bytes(zip_path, None, contents.as_ref().as_bytes(), false, None)
+}
+
+fn add_json<T: Serialize>(zip: &mut DoctorZip, zip_path: &str, value: &T) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    zip.add_bytes(zip_path, None, &bytes, false, None)
+}
+
+fn add_plugin_inventory(zip: &mut DoctorZip, cli: &Cli, warnings: &mut Vec<String>) -> Result<()> {
+    match plugin::plugin_inventory_json(cli) {
+        Ok(value) => add_json(zip, "plugins.json", &value),
+        Err(err) => {
+            warnings.push(format!("could not collect plugin inventory: {err:#}"));
+            add_json(
+                zip,
+                "plugins.json",
+                &json!({"ok": false, "error": err.to_string()}),
+            )
+        }
+    }
+}
+
+fn add_runtime_files(
+    zip: &mut DoctorZip,
+    info: &RuntimeInstanceInfo,
+    max_log_bytes: u64,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    add_existing_file(
+        zip,
+        &info.runtime_dir.join("owner.json"),
+        "runtime/owner.json",
+        max_log_bytes,
+        warnings,
+    )?;
+
+    let logs_dir = info.runtime_dir.join("logs");
+    if !logs_dir.exists() {
+        warnings.push(format!(
+            "selected runtime has no logs directory: {}",
+            logs_dir.display()
+        ));
+        return Ok(());
+    }
+    for path in collect_regular_files(&logs_dir)? {
+        let relative = path
+            .strip_prefix(&logs_dir)
+            .unwrap_or(path.as_path())
+            .to_string_lossy()
+            .replace('\\', "/");
+        add_existing_file(
+            zip,
+            &path,
+            &format!("runtime/logs/{relative}"),
+            max_log_bytes,
+            warnings,
+        )?;
+    }
+    Ok(())
+}
+
+fn add_existing_file(
+    zip: &mut DoctorZip,
+    path: &Path,
+    zip_path: &str,
+    max_bytes: u64,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    if !path.exists() {
+        warnings.push(format!("missing diagnostic file: {}", path.display()));
+        return Ok(());
+    }
+
+    let original_bytes = fs::metadata(path)
+        .with_context(|| format!("failed to stat {}", path.display()))?
+        .len();
+    let (bytes, truncated) = read_file_tail(path, max_bytes)?;
+    if truncated {
+        warnings.push(format!(
+            "truncated {} to the last {} bytes",
+            path.display(),
+            bytes.len()
+        ));
+    }
+    zip.add_bytes(
+        zip_path,
+        Some(path.to_path_buf()),
+        &bytes,
+        truncated,
+        Some(original_bytes),
+    )
+}
+
+fn read_file_tail(path: &Path, max_bytes: u64) -> Result<(Vec<u8>, bool)> {
+    let mut file =
+        File::open(path).with_context(|| format!("failed to open {}", path.display()))?;
+    let len = file.metadata()?.len();
+    let truncated = max_bytes > 0 && len > max_bytes;
+    if truncated {
+        file.seek(SeekFrom::Start(len - max_bytes))?;
+    }
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    Ok((bytes, truncated))
+}
+
+fn collect_regular_files(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_regular_files_inner(root, &mut files)?;
+    files.sort();
+    Ok(files)
+}
+
+fn collect_regular_files_inner(root: &Path, files: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_regular_files_inner(&path, files)?;
+        } else if file_type.is_file() {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+async fn add_api_snapshots(
+    zip: &mut DoctorZip,
+    port: u16,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()?;
+    for (zip_path, endpoint) in [
+        ("api/status.json", "/api/status"),
+        ("api/runtime.json", "/api/runtime"),
+        ("api/runtime-processes.json", "/api/runtime/processes"),
+        ("api/models.json", "/api/models"),
+        ("api/v1-models.json", "/v1/models"),
+    ] {
+        let value = fetch_api_snapshot(&client, port, endpoint).await;
+        if value["ok"] == json!(false) {
+            warnings.push(format!("could not fetch http://127.0.0.1:{port}{endpoint}"));
+        }
+        add_json(zip, zip_path, &value)?;
+    }
+    Ok(())
+}
+
+async fn fetch_api_snapshot(client: &reqwest::Client, port: u16, endpoint: &str) -> Value {
+    let url = format!("http://127.0.0.1:{port}{endpoint}");
+    match client.get(&url).send().await {
+        Ok(response) => api_response_json(url, response).await,
+        Err(err) => json!({"ok": false, "url": url, "error": err.to_string()}),
+    }
+}
+
+async fn api_response_json(url: String, response: reqwest::Response) -> Value {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if status == StatusCode::OK
+        && let Ok(json_body) = serde_json::from_str::<Value>(&body)
+    {
+        return json!({"ok": true, "url": url, "status": status.as_u16(), "body": json_body});
+    }
+    json!({"ok": status.is_success(), "url": url, "status": status.as_u16(), "body": body})
+}
+
+fn load_runtime_instances(root: &Path) -> Result<Vec<RuntimeInstanceInfo>> {
+    if !root.exists() {
+        return Ok(Vec::new());
+    }
+
+    let mut instances = Vec::new();
+    for entry in fs::read_dir(root).with_context(|| format!("failed to read {}", root.display()))? {
+        let path = entry?.path();
+        if path.is_dir()
+            && let Some(info) = read_runtime_instance(&path)
+        {
+            instances.push(info);
+        }
+    }
+    instances.sort_by(|a, b| {
+        b.sort_time_unix
+            .cmp(&a.sort_time_unix)
+            .then_with(|| b.pid.cmp(&a.pid))
+    });
+    Ok(instances)
+}
+
+fn read_runtime_instance(runtime_dir: &Path) -> Option<RuntimeInstanceInfo> {
+    let owner_json = fs::read_to_string(runtime_dir.join("owner.json")).ok()?;
+    let value = serde_json::from_str::<Value>(&owner_json).ok()?;
+    let pid = value["pid"]
+        .as_u64()
+        .and_then(|pid| u32::try_from(pid).ok())?;
+    let started_at_unix = value["started_at_unix"].as_i64();
+    Some(RuntimeInstanceInfo {
+        pid,
+        api_port: value["api_port"]
+            .as_u64()
+            .and_then(|port| u16::try_from(port).ok()),
+        version: value["version"].as_str().map(str::to_owned),
+        started_at_unix,
+        mesh_llm_binary: value["mesh_llm_binary"].as_str().map(str::to_owned),
+        runtime_dir: runtime_dir.to_path_buf(),
+        is_live: instance::validate::process_liveness(pid) != instance::validate::Liveness::Dead,
+        sort_time_unix: started_at_unix.unwrap_or_else(|| path_modified_unix(runtime_dir)),
+    })
+}
+
+fn select_runtime_instance(
+    instances: &[RuntimeInstanceInfo],
+    target: DoctorLogTarget,
+    pid: Option<u32>,
+) -> Result<Option<RuntimeInstanceInfo>> {
+    if let Some(pid) = pid {
+        let Some(info) = instances.iter().find(|info| info.pid == pid) else {
+            bail!("no mesh-llm runtime instance found for pid {pid}");
+        };
+        return Ok(Some(info.clone()));
+    }
+
+    let selected = match target {
+        DoctorLogTarget::Auto => instances
+            .iter()
+            .find(|info| info.is_live)
+            .or_else(|| instances.first()),
+        DoctorLogTarget::Current => instances.iter().find(|info| info.is_live),
+        DoctorLogTarget::Last => instances.first(),
+    };
+    Ok(selected.cloned())
+}
+
+fn system_report(cli: &Cli, hw: &HardwareSurvey, api_port: u16) -> Value {
+    json!({
+        "generated_at": utc_timestamp(),
+        "mesh_llm": {
+            "version": crate::VERSION,
+            "current_exe": std::env::current_exe().ok(),
+            "current_dir": std::env::current_dir().ok(),
+        },
+        "platform": {
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "family": std::env::consts::FAMILY,
+        },
+        "flavor": {
+            "requested_llama_flavor": cli.llama_flavor.map(BinaryFlavor::suffix),
+            "detected_host_flavor": detect_host_flavor(hw).map(BinaryFlavor::suffix),
+        },
+        "system": {
+            "memory": collect_memory_info(),
+            "cpu": collect_cpu_info(),
+        },
+        "runtime": {
+            "api_port": api_port,
+            "runtime_root": instance::runtime_root().ok(),
+        },
+    })
+}
+
+fn detect_host_flavor(hw: &HardwareSurvey) -> Option<BinaryFlavor> {
+    if cfg!(target_os = "macos") {
+        return Some(BinaryFlavor::Metal);
+    }
+
+    let backend_devices = hw
+        .gpus
+        .iter()
+        .filter_map(|gpu| gpu.backend_device.as_deref())
+        .collect::<Vec<_>>();
+    if backend_devices
+        .iter()
+        .any(|device| device.starts_with("CUDA"))
+    {
+        return Some(BinaryFlavor::Cuda);
+    }
+    if backend_devices
+        .iter()
+        .any(|device| device.starts_with("ROCm") || device.starts_with("HIP"))
+    {
+        return Some(BinaryFlavor::Rocm);
+    }
+    if backend_devices
+        .iter()
+        .any(|device| device.starts_with("Vulkan"))
+    {
+        return Some(BinaryFlavor::Vulkan);
+    }
+    Some(BinaryFlavor::Cpu)
+}
+
+fn collect_memory_info() -> Value {
+    collect_memory_info_for_platform()
+}
+
+#[cfg(target_os = "linux")]
+fn collect_memory_info_for_platform() -> Value {
+    let meminfo = fs::read_to_string("/proc/meminfo").unwrap_or_default();
+    json!({
+        "total_bytes": parse_linux_meminfo_bytes(&meminfo, "MemTotal"),
+        "available_bytes": parse_linux_meminfo_bytes(&meminfo, "MemAvailable"),
+    })
+}
+
+#[cfg(target_os = "linux")]
+fn parse_linux_meminfo_bytes(meminfo: &str, key: &str) -> Option<u64> {
+    meminfo.lines().find_map(|line| {
+        let (name, rest) = line.split_once(':')?;
+        if name != key {
+            return None;
+        }
+        Some(rest.split_whitespace().next()?.parse::<u64>().ok()? * 1024)
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn collect_memory_info_for_platform() -> Value {
+    json!({
+        "total_bytes": command_u64("sysctl", &["-n", "hw.memsize"]),
+        "available_bytes": macos_available_memory_bytes(),
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn macos_available_memory_bytes() -> Option<u64> {
+    let output = command_stdout("vm_stat", &[])?;
+    parse_macos_vm_stat_available_bytes(&output)
+}
+
+#[cfg(target_os = "macos")]
+fn parse_macos_vm_stat_available_bytes(output: &str) -> Option<u64> {
+    let page_size = output.lines().next().and_then(parse_vm_stat_page_size)?;
+    let pages = ["Pages free", "Pages inactive", "Pages speculative"]
+        .into_iter()
+        .filter_map(|key| parse_vm_stat_pages(output, key))
+        .sum::<u64>();
+    Some(pages * page_size)
+}
+
+#[cfg(target_os = "macos")]
+fn parse_vm_stat_page_size(line: &str) -> Option<u64> {
+    let marker = "page size of ";
+    let rest = &line[line.find(marker)? + marker.len()..];
+    rest.chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .ok()
+}
+
+#[cfg(target_os = "macos")]
+fn parse_vm_stat_pages(output: &str, key: &str) -> Option<u64> {
+    output.lines().find_map(|line| {
+        let (name, rest) = line.split_once(':')?;
+        if name.trim() != key {
+            return None;
+        }
+        rest.chars()
+            .filter(char::is_ascii_digit)
+            .collect::<String>()
+            .parse()
+            .ok()
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn collect_memory_info_for_platform() -> Value {
+    let script = "Get-CimInstance Win32_OperatingSystem | Select-Object TotalVisibleMemorySize,FreePhysicalMemory | ConvertTo-Json -Compress";
+    let Some(output) = command_stdout("powershell", &["-NoProfile", "-Command", script]) else {
+        return json!({"total_bytes": Value::Null, "available_bytes": Value::Null});
+    };
+    let Ok(value) = serde_json::from_str::<Value>(&output) else {
+        return json!({"total_bytes": Value::Null, "available_bytes": Value::Null});
+    };
+    json!({
+        "total_bytes": value["TotalVisibleMemorySize"].as_u64().map(|kb| kb * 1024),
+        "available_bytes": value["FreePhysicalMemory"].as_u64().map(|kb| kb * 1024),
+    })
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn collect_memory_info_for_platform() -> Value {
+    json!({"total_bytes": Value::Null, "available_bytes": Value::Null})
+}
+
+fn collect_cpu_info() -> Value {
+    json!({
+        "logical_count": std::thread::available_parallelism().ok().map(usize::from),
+        "physical_count": physical_cpu_count(),
+        "brand": cpu_brand(),
+    })
+}
+
+fn physical_cpu_count() -> Option<u64> {
+    #[cfg(target_os = "macos")]
+    {
+        return command_u64("sysctl", &["-n", "hw.physicalcpu"]);
+    }
+    #[cfg(target_os = "linux")]
+    {
+        return linux_physical_cpu_count();
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let output = command_stdout(
+            "powershell",
+            &[
+                "-NoProfile",
+                "-Command",
+                "(Get-CimInstance Win32_ComputerSystem).NumberOfProcessors",
+            ],
+        )?;
+        return output.trim().parse().ok();
+    }
+    #[allow(unreachable_code)]
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn linux_physical_cpu_count() -> Option<u64> {
+    let cpuinfo = fs::read_to_string("/proc/cpuinfo").ok()?;
+    let mut physical_ids = std::collections::BTreeSet::new();
+    for block in cpuinfo.split("\n\n") {
+        let physical_id = block.lines().find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            (key.trim() == "physical id").then(|| value.trim().to_string())
+        });
+        if let Some(physical_id) = physical_id {
+            physical_ids.insert(physical_id);
+        }
+    }
+    (!physical_ids.is_empty()).then_some(physical_ids.len() as u64)
+}
+
+fn cpu_brand() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        return command_stdout("sysctl", &["-n", "machdep.cpu.brand_string"])
+            .map(|value| value.trim().to_string())
+            .filter(|value| !value.is_empty());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let cpuinfo = fs::read_to_string("/proc/cpuinfo").ok()?;
+        return cpuinfo.lines().find_map(|line| {
+            let (key, value) = line.split_once(':')?;
+            (key.trim() == "model name").then(|| value.trim().to_string())
+        });
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return command_stdout(
+            "powershell",
+            &[
+                "-NoProfile",
+                "-Command",
+                "(Get-CimInstance Win32_Processor | Select-Object -First 1 -ExpandProperty Name)",
+            ],
+        )
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty());
+    }
+    #[allow(unreachable_code)]
+    None
+}
+
+fn command_u64(command: &str, args: &[&str]) -> Option<u64> {
+    command_stdout(command, args)?.trim().parse().ok()
+}
+
+fn command_stdout(command: &str, args: &[&str]) -> Option<String> {
+    let output = std::process::Command::new(command)
+        .args(args)
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8(output.stdout).ok())?
+}
+
+fn default_output_path() -> PathBuf {
+    std::env::current_dir()
+        .unwrap_or_else(|_| PathBuf::from("."))
+        .join(format!("mesh-llm-doctor-{}.zip", utc_filename_timestamp()))
+}
+
+fn doctor_readme(max_log_bytes: u64) -> String {
+    format!(
+        "mesh-llm doctor bundle\n\n\
+         Contents:\n\
+         - system.json: mesh-llm version, platform, flavor, CPU, and memory summary\n\
+         - gpus.json / gpus.txt: local GPU facts shown by `mesh-llm gpus`\n\
+         - plugins.json: installed plugin metadata and resolved runtime plugins\n\
+         - runtime/instances.json: local runtime process metadata\n\
+         - runtime/owner.json and runtime/logs/: logs from the selected process when available\n\
+         - api/*.json: local management/API snapshots when the console port is reachable\n\
+         - manifest.json: source paths, truncation notes, and warnings\n\n\
+         Config files and environment variables are intentionally not included. \
+         Log files are capped at {max_log_bytes} bytes each and contain the tail when truncated.\n"
+    )
+}
+
+fn utc_timestamp() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+}
+
+fn utc_filename_timestamp() -> String {
+    chrono::Utc::now().format("%Y%m%dT%H%M%SZ").to_string()
+}
+
+fn path_modified_unix(path: &Path) -> i64 {
+    fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .ok()
+        .and_then(system_time_unix)
+        .unwrap_or(0)
+}
+
+fn system_time_unix(time: SystemTime) -> Option<i64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_secs()).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_auto_prefers_newest_live_instance() {
+        let selected = select_runtime_instance(
+            &[
+                instance_info(20, false, 20),
+                instance_info(30, true, 30),
+                instance_info(10, true, 10),
+            ],
+            DoctorLogTarget::Auto,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(selected.map(|info| info.pid), Some(30));
+    }
+
+    #[test]
+    fn select_last_uses_newest_instance_even_when_dead() {
+        let selected = select_runtime_instance(
+            &[instance_info(20, false, 20), instance_info(10, true, 10)],
+            DoctorLogTarget::Last,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(selected.map(|info| info.pid), Some(20));
+    }
+
+    #[test]
+    fn select_pid_requires_matching_instance() {
+        let err = select_runtime_instance(
+            &[instance_info(10, true, 10)],
+            DoctorLogTarget::Auto,
+            Some(11),
+        )
+        .expect_err("missing pid should fail");
+
+        assert!(err.to_string().contains("pid 11"));
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn parses_macos_available_memory_bytes() {
+        let vm_stat = "Mach Virtual Memory Statistics: (page size of 16384 bytes)\n\
+                       Pages free:                               10.\n\
+                       Pages inactive:                           20.\n\
+                       Pages speculative:                        30.\n";
+
+        assert_eq!(
+            parse_macos_vm_stat_available_bytes(vm_stat),
+            Some(60 * 16_384)
+        );
+    }
+
+    fn instance_info(pid: u32, is_live: bool, sort_time_unix: i64) -> RuntimeInstanceInfo {
+        RuntimeInstanceInfo {
+            pid,
+            api_port: Some(3131),
+            version: Some("0.0.0-test".into()),
+            started_at_unix: Some(sort_time_unix),
+            mesh_llm_binary: Some("/tmp/mesh-llm".into()),
+            runtime_dir: PathBuf::from(format!("/tmp/{pid}")),
+            is_live,
+            sort_time_unix,
+        }
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor_bundle.rs
@@ -116,6 +116,7 @@ pub(crate) async fn run_doctor_bundle(cli: &Cli, options: DoctorBundleOptions) -
     add_json(&mut bundle, "gpus.json", &gpus::gpus_json(&hw))?;
     add_text(&mut bundle, "gpus.txt", gpus::gpus_text(&hw))?;
     add_plugin_inventory(&mut bundle, cli, &mut warnings)?;
+    add_config_file(&mut bundle, cli, &mut warnings)?;
     add_json(
         &mut bundle,
         "runtime/instances.json",
@@ -258,6 +259,20 @@ fn add_plugin_inventory(zip: &mut DoctorZip, cli: &Cli, warnings: &mut Vec<Strin
     }
 }
 
+fn add_config_file(zip: &mut DoctorZip, cli: &Cli, warnings: &mut Vec<String>) -> Result<()> {
+    let config_path = match crate::plugin::config_path(cli.config.as_deref()) {
+        Ok(path) => path,
+        Err(err) => {
+            warnings.push(format!("could not resolve config path: {err:#}"));
+            return Ok(());
+        }
+    };
+    if !config_path.exists() {
+        return Ok(());
+    }
+    add_existing_file_full(zip, &config_path, "config/config.toml", warnings)
+}
+
 fn add_runtime_files(
     zip: &mut DoctorZip,
     info: &RuntimeInstanceInfo,
@@ -334,6 +349,27 @@ fn add_existing_file(
         &bytes,
         truncated,
         Some(original_bytes),
+    )
+}
+
+fn add_existing_file_full(
+    zip: &mut DoctorZip,
+    path: &Path,
+    zip_path: &str,
+    warnings: &mut Vec<String>,
+) -> Result<()> {
+    if !path.exists() {
+        warnings.push(format!("missing diagnostic file: {}", path.display()));
+        return Ok(());
+    }
+
+    let bytes = fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
+    zip.add_bytes(
+        zip_path,
+        Some(path.to_path_buf()),
+        &bytes,
+        false,
+        Some(bytes.len() as u64),
     )
 }
 
@@ -830,11 +866,12 @@ fn doctor_readme(max_log_bytes: u64) -> String {
          - system.json: mesh-llm version, platform, flavor, CPU, and memory summary\n\
          - gpus.json / gpus.txt: local GPU facts shown by `mesh-llm gpus`\n\
          - plugins.json: installed plugin metadata and resolved runtime plugins\n\
+         - config/config.toml: resolved mesh-llm config file when available\n\
          - runtime/instances.json: local runtime process metadata\n\
          - runtime/owner.json and runtime/logs/: logs from the selected process when available\n\
          - api/*.json: local management/API snapshots when the console port is reachable\n\
          - manifest.json: source paths, truncation notes, and warnings\n\n\
-         Config files and environment variables are intentionally not included. \
+         Environment variable values are intentionally not included. \
          Log files are capped at {max_log_bytes} bytes each and contain the tail when truncated.\n"
     )
 }
@@ -962,6 +999,39 @@ mod tests {
         assert!(path.starts_with(cwd));
         assert!(file_name.starts_with("mesh-llm-doctor-"));
         assert!(file_name.ends_with(".zip"));
+    }
+
+    #[test]
+    fn doctor_readme_documents_optional_config_file() {
+        let readme = doctor_readme(1024);
+
+        assert!(readme.contains("config/config.toml"));
+        assert!(readme.contains("Environment variable values are intentionally not included"));
+    }
+
+    #[test]
+    fn add_existing_file_full_includes_complete_config() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let config_path = temp.path().join("config.toml");
+        fs::write(&config_path, "[gpu]\nmax_vram = 4\n").expect("write config");
+        let zip_path = temp.path().join("doctor.zip");
+        let file = File::create(&zip_path).expect("create zip");
+        let mut zip = DoctorZip::new(file);
+        let mut warnings = Vec::new();
+
+        add_existing_file_full(&mut zip, &config_path, "config/config.toml", &mut warnings)
+            .expect("add config");
+        zip.finish().expect("finish zip");
+
+        assert!(warnings.is_empty());
+        let file = File::open(&zip_path).expect("open zip");
+        let mut archive = zip::ZipArchive::new(file).expect("read zip");
+        let mut entry = archive.by_name("config/config.toml").expect("config entry");
+        let mut contents = String::new();
+        entry
+            .read_to_string(&mut contents)
+            .expect("read config entry");
+        assert_eq!(contents, "[gpu]\nmax_vram = 4\n");
     }
 
     #[cfg(target_os = "macos")]

--- a/crates/mesh-llm-host-runtime/src/cli/commands/gpus.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/gpus.rs
@@ -16,28 +16,35 @@ pub(crate) fn dispatch_gpu_command(json_output: bool, command: Option<&GpuComman
 }
 
 pub(crate) fn run_gpus(json_output: bool) -> Result<()> {
-    let mut hw = hardware::survey();
-    attach_cached_bandwidth(&mut hw);
+    let hw = collect_gpus_survey();
 
     if json_output {
         return print_json(gpus_json(&hw));
     }
 
+    print!("{}", gpus_text(&hw));
+    Ok(())
+}
+
+pub(crate) fn collect_gpus_survey() -> HardwareSurvey {
+    let mut hw = hardware::survey();
+    attach_cached_bandwidth(&mut hw);
+    hw
+}
+
+pub(crate) fn gpus_text(hw: &HardwareSurvey) -> String {
     if hw.gpus.is_empty() {
-        println!(
-            "⚠️ No runtime-selectable GPUs reported by the embedded inference backend. This node will run CPU-only until the backend exposes a selectable device."
-        );
-        return Ok(());
+        return "⚠️ No runtime-selectable GPUs reported by the embedded inference backend. This node will run CPU-only until the backend exposes a selectable device.\n".to_string();
     }
 
+    let mut output = String::new();
     for (index, gpu) in hw.gpus.iter().enumerate() {
         if index > 0 {
-            println!();
+            output.push('\n');
         }
-        print_gpu(gpu);
+        push_gpu(&mut output, gpu);
     }
-
-    Ok(())
+    output
 }
 
 fn run_gpu_benchmark(json_output: bool) -> Result<()> {
@@ -74,7 +81,7 @@ fn run_gpu_benchmark(json_output: bool) -> Result<()> {
     Ok(())
 }
 
-fn gpus_json(hw: &HardwareSurvey) -> Value {
+pub(crate) fn gpus_json(hw: &HardwareSurvey) -> Value {
     json!({
         "gpu_count": hw.gpus.len(),
         "gpus": hw.gpus.iter().map(gpu_json).collect::<Vec<_>>(),
@@ -192,45 +199,57 @@ fn attach_cached_bandwidth(hw: &mut HardwareSurvey) {
     }
 }
 
-fn print_gpu(gpu: &GpuFacts) {
-    println!("🖥️ GPU {}", gpu.index);
-    println!("  Name: {}", gpu.display_name);
+fn push_gpu(output: &mut String, gpu: &GpuFacts) {
+    push_line(output, format!("🖥️ GPU {}", gpu.index));
+    push_line(output, format!("  Name: {}", gpu.display_name));
     if let Some(stable_id) = gpu.stable_id.as_deref() {
-        println!("  Stable ID: {stable_id}");
+        push_line(output, format!("  Stable ID: {stable_id}"));
     }
     if let Some(backend_device) = gpu.backend_device.as_deref() {
-        println!("  Backend device: {backend_device}");
+        push_line(output, format!("  Backend device: {backend_device}"));
     } else {
-        println!(
-            "  Backend device: unavailable (hardware-visible only; embedded runtime did not report a selectable device)"
+        push_line(
+            output,
+            "  Backend device: unavailable (hardware-visible only; embedded runtime did not report a selectable device)",
         );
     }
-    println!("  VRAM: {}", format_vram(gpu.vram_bytes));
-    println!(
-        "  Bandwidth: {}",
-        gpu.mem_bandwidth_gbps
-            .map(format_bandwidth)
-            .unwrap_or_else(|| "unavailable".to_string())
+    push_line(output, format!("  VRAM: {}", format_vram(gpu.vram_bytes)));
+    push_line(
+        output,
+        format!(
+            "  Bandwidth: {}",
+            gpu.mem_bandwidth_gbps
+                .map(format_bandwidth)
+                .unwrap_or_else(|| "unavailable".to_string())
+        ),
     );
-    println!(
-        "  Unified memory: {}",
-        if gpu.unified_memory { "yes" } else { "no" }
+    push_line(
+        output,
+        format!(
+            "  Unified memory: {}",
+            if gpu.unified_memory { "yes" } else { "no" }
+        ),
     );
     if let Some(pci_bdf) = gpu.pci_bdf.as_deref() {
-        println!("  PCI BDF: {pci_bdf}");
+        push_line(output, format!("  PCI BDF: {pci_bdf}"));
     }
     if let Some(vendor_uuid) = gpu.vendor_uuid.as_deref() {
-        println!("  Vendor UUID: {vendor_uuid}");
+        push_line(output, format!("  Vendor UUID: {vendor_uuid}"));
     }
     if let Some(metal_registry_id) = gpu.metal_registry_id.as_deref() {
-        println!("  Metal registry ID: {metal_registry_id}");
+        push_line(output, format!("  Metal registry ID: {metal_registry_id}"));
     }
     if let Some(dxgi_luid) = gpu.dxgi_luid.as_deref() {
-        println!("  DXGI LUID: {dxgi_luid}");
+        push_line(output, format!("  DXGI LUID: {dxgi_luid}"));
     }
     if let Some(pnp_instance_id) = gpu.pnp_instance_id.as_deref() {
-        println!("  PnP instance ID: {pnp_instance_id}");
+        push_line(output, format!("  PnP instance ID: {pnp_instance_id}"));
     }
+}
+
+fn push_line(output: &mut String, line: impl AsRef<str>) {
+    output.push_str(line.as_ref());
+    output.push('\n');
 }
 
 fn format_vram(bytes: u64) -> String {

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -27,7 +27,7 @@ use crate::cli::commands::plugin::run_plugin_command;
 use crate::cli::commands::plugin_cli::run_external_plugin_command;
 use crate::cli::commands::runtime::{dispatch_runtime_command, run_drop, run_load, run_status};
 use crate::cli::commands::update::run_update;
-use crate::cli::{AuthCommand, Cli, Command};
+use crate::cli::{AuthCommand, Cli, Command, DoctorCommand};
 use crate::network::nostr;
 
 pub(crate) async fn dispatch(cli: &Cli) -> Result<bool> {
@@ -64,21 +64,16 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             port,
             max_log_bytes,
         } => {
-            if let Some(command) = command {
-                dispatch_doctor_command(command).await
-            } else {
-                run_doctor_bundle(
-                    cli,
-                    doctor_bundle::DoctorBundleOptions {
-                        output: output.clone(),
-                        target: *target,
-                        pid: *pid,
-                        port: *port,
-                        max_log_bytes: *max_log_bytes,
-                    },
-                )
-                .await
-            }
+            dispatch_doctor(
+                cli,
+                command.as_ref(),
+                output,
+                *target,
+                *pid,
+                *port,
+                *max_log_bytes,
+            )
+            .await
         }
         Command::Gpus { json, command } => {
             dispatch_gpu_command(*json, command.as_ref())?;
@@ -120,6 +115,32 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
         Command::Auth { command } => dispatch_auth_command(command),
         Command::ExternalPlugin(args) => run_external_plugin_command(cli, args).await,
     }
+}
+
+async fn dispatch_doctor(
+    cli: &Cli,
+    command: Option<&DoctorCommand>,
+    output: &Option<std::path::PathBuf>,
+    target: doctor_bundle::DoctorLogTarget,
+    pid: Option<u32>,
+    port: Option<u16>,
+    max_log_bytes: u64,
+) -> Result<()> {
+    if let Some(command) = command {
+        return dispatch_doctor_command(command).await;
+    }
+
+    run_doctor_bundle(
+        cli,
+        doctor_bundle::DoctorBundleOptions {
+            output: output.clone(),
+            target,
+            pid,
+            port,
+            max_log_bytes,
+        },
+    )
+    .await
 }
 
 async fn dispatch_model_prepare(cmd: &Command) -> Result<()> {

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod benchmark;
 mod discover;
 mod doctor;
+pub(crate) mod doctor_bundle;
 mod download;
 mod gpus;
 mod model_package;
@@ -18,6 +19,7 @@ use crate::cli::commands::agent_cli::{run_claude, run_goose, run_opencode, run_p
 use crate::cli::commands::benchmark::dispatch_benchmark_command;
 use crate::cli::commands::discover::{DiscoverOptions, run_discover, run_stop};
 use crate::cli::commands::doctor::dispatch_doctor_command;
+use crate::cli::commands::doctor_bundle::run_doctor_bundle;
 use crate::cli::commands::download::dispatch_download_command;
 use crate::cli::commands::gpus::dispatch_gpu_command;
 use crate::cli::commands::models::dispatch_models_command;
@@ -54,12 +56,35 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             dispatch_download_command(name.as_deref(), *draft).await
         }
         Command::Update { .. } => run_update(cli).await,
+        Command::Doctor {
+            command,
+            output,
+            target,
+            pid,
+            port,
+            max_log_bytes,
+        } => {
+            if let Some(command) = command {
+                dispatch_doctor_command(command).await
+            } else {
+                run_doctor_bundle(
+                    cli,
+                    doctor_bundle::DoctorBundleOptions {
+                        output: output.clone(),
+                        target: *target,
+                        pid: *pid,
+                        port: *port,
+                        max_log_bytes: *max_log_bytes,
+                    },
+                )
+                .await
+            }
+        }
         Command::Gpus { json, command } => {
             dispatch_gpu_command(*json, command.as_ref())?;
             Ok(())
         }
         Command::Runtime { command } => dispatch_runtime_command(command.as_ref()).await,
-        Command::Doctor { command } => dispatch_doctor_command(command).await,
         Command::Load { name, port } => run_load(name, *port).await,
         Command::Unload { name, port } => run_drop(name, *port).await,
         Command::Status { port } => run_status(*port).await,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/plugin.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/plugin.rs
@@ -6,6 +6,7 @@ use mesh_llm_plugin_manager::{
     default_store_root, install_plugin, update_plugin,
 };
 use reqwest::Client;
+use serde_json::{Value, json};
 
 use crate::cli::terminal_progress::{SpinnerHandle, clear_stderr_line, start_spinner};
 use crate::cli::{Cli, PluginCommand};
@@ -18,9 +19,9 @@ pub(crate) async fn run_plugin_command(command: &PluginCommand, cli: &Cli) -> Re
         PluginCommand::Enable { name } => set_enabled(name, true)?,
         PluginCommand::Disable { name } => set_enabled(name, false)?,
         PluginCommand::Delete { name } => delete(name)?,
-        PluginCommand::Info { name } => info(name)?,
+        PluginCommand::Info { name, json } => info(name, *json)?,
         PluginCommand::Search { query } => search(query.as_deref()).await?,
-        PluginCommand::List => list(cli)?,
+        PluginCommand::List { json } => list(cli, *json)?,
     }
     Ok(())
 }
@@ -71,24 +72,30 @@ fn delete(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn info(name: &str) -> Result<()> {
+fn info(name: &str, json_output: bool) -> Result<()> {
     let store = PluginStore::new(default_store_root()?);
     let metadata = store.load(name)?;
-    println!("name\t{}", metadata.name);
-    println!("version\t{}", metadata.installed_version);
-    println!("enabled\t{}", metadata.enabled);
-    println!("source\t{}", metadata.source_repository);
-    println!("target\t{}", metadata.target_triple);
-    println!("asset\t{}", metadata.downloaded_asset_name);
-    println!("path\t{}", metadata.install_path.display());
+    if json_output {
+        return print_json(&json!({ "plugin": metadata }));
+    }
+
+    println!("🔌 Plugin");
+    println!();
+    println!("Name: {}", metadata.name);
+    println!("Version: {}", metadata.installed_version);
+    println!("State: {}", enabled_label(metadata.enabled));
+    println!("Source: {}", metadata.source_repository);
+    println!("Target: {}", metadata.target_triple);
+    println!("Asset: {}", metadata.downloaded_asset_name);
+    println!("Path: {}", metadata.install_path.display());
     if let Some(protocol) = metadata.last_protocol_version {
-        println!("protocol\t{protocol}");
+        println!("Protocol: {protocol}");
     }
     if let Some(status) = metadata.last_status {
-        println!("status\t{status}");
+        println!("Last status: {status}");
     }
     if let Some(error) = metadata.last_error {
-        println!("error\t{error}");
+        println!("Last error: {error}");
     }
     Ok(())
 }
@@ -113,38 +120,97 @@ async fn search(query: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn list(cli: &Cli) -> Result<()> {
+fn list(cli: &Cli, json_output: bool) -> Result<()> {
+    if json_output {
+        return print_json(&plugin_inventory_json(cli)?);
+    }
+
     let store = PluginStore::new(default_store_root()?);
-    for metadata in store.list()? {
-        let state = if metadata.enabled {
-            "enabled"
-        } else {
-            "disabled"
-        };
+    let installed = store.list()?;
+    let resolved = runtime::load_resolved_plugins(cli)?;
+
+    println!("🔌 Plugins");
+    println!();
+
+    println!("📦 Installed: {}", installed.len());
+    for metadata in installed {
         println!(
-            "{}\tversion={}\tstate={}\tsource={}",
-            metadata.name, metadata.installed_version, state, metadata.source_repository
+            "  {}  version={}  state={}  source={}",
+            metadata.name,
+            metadata.installed_version,
+            enabled_label(metadata.enabled),
+            metadata.source_repository
         );
     }
 
-    let resolved = runtime::load_resolved_plugins(cli)?;
+    println!();
+    println!("⚙️  Runtime: {}", resolved.externals.len());
     for spec in resolved.externals {
         println!(
-            "{}\tkind=runtime\tcommand={}\targs={}",
+            "  {}  command={}  args={}",
             spec.name,
             spec.command,
             spec.args.join(" ")
         );
     }
+
+    if !resolved.inactive.is_empty() {
+        println!();
+        println!("⚠️  Inactive: {}", resolved.inactive.len());
+    }
     for summary in resolved.inactive {
         println!(
-            "{}\tkind={}\tstate={}\terror={}",
+            "  {}  kind={}  state={}  error={}",
             summary.name,
             summary.kind,
             summary.status,
             summary.error.unwrap_or_default()
         );
     }
+    Ok(())
+}
+
+fn enabled_label(enabled: bool) -> &'static str {
+    if enabled {
+        "✅ enabled"
+    } else {
+        "⏸️ disabled"
+    }
+}
+
+pub(crate) fn plugin_inventory_json(cli: &Cli) -> Result<Value> {
+    let store_root = default_store_root()?;
+    let store = PluginStore::new(&store_root);
+    let installed = store.list()?;
+    let resolved = runtime::load_resolved_plugins(cli)?;
+    let active = resolved
+        .externals
+        .into_iter()
+        .map(|spec| {
+            let env_keys = spec.env.keys().cloned().collect::<Vec<_>>();
+            json!({
+                "name": spec.name,
+                "kind": "runtime",
+                "command": spec.command,
+                "args": spec.args,
+                "url": spec.url,
+                "env_keys": env_keys,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    Ok(json!({
+        "store_root": store_root,
+        "installed": installed,
+        "resolved": {
+            "active": active,
+            "inactive": resolved.inactive,
+        },
+    }))
+}
+
+fn print_json(value: &Value) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
 }
 

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -617,6 +617,26 @@ pub(crate) enum Command {
         #[arg(long, conflicts_with = "flavor")]
         detect_flavor: bool,
     },
+    /// Diagnose local mesh, runtime, and split-readiness problems.
+    Doctor {
+        #[command(subcommand)]
+        command: Option<DoctorCommand>,
+        /// Output zip path. Defaults to ./mesh-llm-doctor-<timestamp>.zip.
+        #[arg(long, short)]
+        output: Option<PathBuf>,
+        /// Which runtime process logs to include.
+        #[arg(long, value_enum, default_value_t = commands::doctor_bundle::DoctorLogTarget::Auto)]
+        target: commands::doctor_bundle::DoctorLogTarget,
+        /// Include logs for a specific runtime PID.
+        #[arg(long)]
+        pid: Option<u32>,
+        /// Console/API port to query. Defaults to selected owner.json port or 3131.
+        #[arg(long)]
+        port: Option<u16>,
+        /// Maximum bytes to include from each log file; larger logs include the tail.
+        #[arg(long, default_value_t = commands::doctor_bundle::DEFAULT_MAX_LOG_BYTES)]
+        max_log_bytes: u64,
+    },
     /// Inspect local GPUs, stable IDs, and cached bandwidth.
     #[command(alias = "gpu")]
     Gpus {
@@ -631,11 +651,6 @@ pub(crate) enum Command {
     Runtime {
         #[command(subcommand)]
         command: Option<RuntimeCommand>,
-    },
-    /// Diagnose local mesh, runtime, and split-readiness problems.
-    Doctor {
-        #[command(subcommand)]
-        command: DoctorCommand,
     },
     /// Load a local model into a running mesh-llm instance.
     Load {
@@ -865,6 +880,9 @@ pub(crate) enum PluginCommand {
     Info {
         /// Plugin name.
         name: String,
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
     },
     /// Search the plugin catalog.
     Search {
@@ -872,7 +890,11 @@ pub(crate) enum PluginCommand {
         query: Option<String>,
     },
     /// List installed, auto-registered, and configured plugins.
-    List,
+    List {
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/mesh-llm-host-runtime/src/cli/terminal_progress.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/terminal_progress.rs
@@ -70,6 +70,51 @@ pub(crate) fn start_spinner(message: &str) -> SpinnerHandle {
     }
 }
 
+pub(crate) fn start_indeterminate_progress(message: &str) -> SpinnerHandle {
+    if crate::cli::output::json_mode_enabled() {
+        return SpinnerHandle {
+            done: Arc::new(AtomicBool::new(true)),
+            thread: None,
+        };
+    }
+    let done = Arc::new(AtomicBool::new(false));
+    let done_thread = Arc::clone(&done);
+    let message = message.to_string();
+    let thread = thread::spawn(move || {
+        let mut index = 0usize;
+        while !done_thread.load(Ordering::Relaxed) {
+            eprint!(
+                "\r\x1b[2K🩺 [{}] {}",
+                indeterminate_bar(index, 18, 5),
+                message
+            );
+            let _ = std::io::stderr().flush();
+            index += 1;
+            thread::sleep(Duration::from_millis(100));
+        }
+    });
+    SpinnerHandle {
+        done,
+        thread: Some(thread),
+    }
+}
+
+fn indeterminate_bar(index: usize, width: usize, block_width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    let block_width = block_width.clamp(1, width);
+    let period = width + block_width;
+    let start = (index % period) as isize - block_width as isize;
+    (0..width)
+        .map(|pos| {
+            let pos = pos as isize;
+            let in_block = pos >= start && pos < start + block_width as isize;
+            if in_block { '█' } else { '░' }
+        })
+        .collect()
+}
+
 pub(crate) struct DeterminateProgressLine {
     prefix: String,
 }
@@ -105,5 +150,28 @@ impl DeterminateProgressLine {
             .flush()
             .context("Flush determinate progress")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::indeterminate_bar;
+
+    #[test]
+    fn indeterminate_bar_keeps_stable_width() {
+        for index in 0..32 {
+            assert_eq!(indeterminate_bar(index, 18, 5).chars().count(), 18);
+        }
+    }
+
+    #[test]
+    fn indeterminate_bar_never_exceeds_block_width() {
+        for index in 0..32 {
+            let filled = indeterminate_bar(index, 18, 5)
+                .chars()
+                .filter(|char| *char == '█')
+                .count();
+            assert!(filled <= 5);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Users can now run `mesh-llm doctor` to generate a shareable diagnostics zip with runtime logs when available, GPU inventory, plugin inventory, the resolved `config.toml` when available, flavor, CPU, memory, runtime metadata, and API snapshots. By default the zip is written to the current working directory, callers can still choose a path with `--output`, and the CLI shows an indeterminate progress bar while the bundle is being built.

The bundle is designed for team support handoff without collecting environment variable values. This also adds JSON formatting for plugin CLI data so doctor can collect plugin inventory through the same structured command surface users can run directly.

Doctor now also detects a live `mesh-llm client` or `mesh-llm serve` process from the OS process table when runtime owner metadata is not present. This fixes the case where `mesh-llm client --auto` is running and healthy, but client mode has no `~/.mesh-llm/runtime/<pid>/owner.json`; doctor now reports the running pid and includes live API snapshots instead of falling back to stale runtime metadata.

There is also a repo-local `diagnose-doctor-bundle` skill for future agents. It provides a bundle triage workflow plus a small `summarize_bundle.py` helper that inventories a doctor zip, highlights manifest/API/plugin/GPU/runtime facts, and extracts high-signal log findings for suggested fixes.

## CLI examples

### Create a doctor bundle in the current directory

```console
$ pwd
/Users/alice/project
$ mesh-llm doctor
✨ New version: v0.68.0 -> v0.69.0. Run 'mesh-llm update'.
🩺 [░░█████░░░░░░░░░░] Building doctor bundle
✅ Created doctor bundle

Path: /Users/alice/project/mesh-llm-doctor-20260529T102030Z.zip
Logs: running pid 42142
Files: 13
```

When a config file resolves through `--config`, `MESH_LLM_CONFIG`, or the default `~/.mesh-llm/config.toml`, the bundle includes it as `config/config.toml` and records the source path in `manifest.json`.

### Collect a running client with no runtime metadata directory

```console
$ mesh-llm client --auto
# in another terminal
$ mesh-llm doctor
✅ Created doctor bundle

Path: /Users/alice/project/mesh-llm-doctor-20260529T103000Z.zip
Logs: running pid 74447
Files: 11

⚠️  Warnings
  - selected process has no runtime metadata directory: /Users/alice/.mesh-llm/runtime/74447
  - could not fetch http://127.0.0.1:3131/api/models
```

In this client-only shape, the runtime metadata warning is expected: doctor still includes system, GPU, plugin, config when available, runtime inventory, and API snapshots such as `/api/status`, `/api/runtime`, `/api/runtime/processes`, and `/v1/models`.

### Collect the last known runtime into a chosen file

```console
$ mesh-llm doctor --target last --output /tmp/mesh-doctor.zip
✅ Created doctor bundle

Path: /tmp/mesh-doctor.zip
Logs: previous pid 41008
Files: 12

⚠️  Warnings
  - could not fetch http://127.0.0.1:3131/api/status
```

### Inspect plugins with the human formatter

```console
$ mesh-llm plugins list
🔌 Plugins

📦 Installed
  • openai-endpoint 0.1.0 ✅ enabled
  • telemetry 0.1.0 ⏸️ disabled

⚙️  Runtime
  • openai-endpoint runtime command: mesh-llm-openai-endpoint

⚠️  Inactive
  • telemetry runtime command: mesh-llm-telemetry
```

### Inspect plugins as JSON

```console
$ mesh-llm plugins list --json
{
  "store_root": "/Users/alice/.mesh-llm/plugins",
  "installed": [
    {
      "name": "openai-endpoint",
      "version": "0.1.0",
      "enabled": true
    }
  ],
  "resolved": {
    "active": [
      {
        "name": "openai-endpoint",
        "kind": "runtime",
        "command": "mesh-llm-openai-endpoint",
        "args": [],
        "url": null,
        "env_keys": []
      }
    ],
    "inactive": []
  }
}
```

### Summarize a doctor bundle with the local skill helper

```console
$ python3 .agents/skills/diagnose-doctor-bundle/scripts/summarize_bundle.py mesh-llm-doctor-20260529T102030Z.zip
# mesh-llm doctor bundle summary

Bundle: `mesh-llm-doctor-20260529T102030Z.zip`
Files: 13
Generated: 2026-05-29T10:20:30Z
Selected runtime: pid=42142 live=True
```

## Validation

```console
RUSTC=/Users/jdumay/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc /opt/homebrew/bin/rustup run stable cargo check -p mesh-llm-host-runtime --no-default-features
RUSTC=/Users/jdumay/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc /opt/homebrew/bin/rustup run stable cargo check -p mesh-llm
/opt/homebrew/bin/rustup run stable cargo fmt --all -- --check
RUSTC=/Users/jdumay/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc /opt/homebrew/bin/rustup run stable cargo test -p mesh-llm-host-runtime --no-default-features cli::commands::doctor_bundle::tests --lib
RUSTC=/Users/jdumay/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc /opt/homebrew/bin/rustup run stable cargo test -p mesh-llm-host-runtime --no-default-features cli::commands::doctor::tests --lib
PATH="/Users/jdumay/.rustup/toolchains/stable-aarch64-apple-darwin/bin:$PATH" RUSTC=/Users/jdumay/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc /opt/homebrew/bin/rustup run stable cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings
python3 -m py_compile .agents/skills/diagnose-doctor-bundle/scripts/summarize_bundle.py
tmpvenv=$(mktemp -d /tmp/skill-validate.XXXXXX); python3 -m venv "$tmpvenv"; "$tmpvenv/bin/python" -m pip install --quiet PyYAML; "$tmpvenv/bin/python" /Users/jdumay/.codex/skills/.system/skill-creator/scripts/quick_validate.py .agents/skills/diagnose-doctor-bundle; rm -rf "$tmpvenv"
just build
```

## Live client verification

```console
$ ./target/debug/mesh-llm client --auto
# waited for: client ready, API http://127.0.0.1:9337, console http://127.0.0.1:3131
$ ./target/debug/mesh-llm doctor
✅ Created doctor bundle

Path: /Users/jdumay/code/mesh-llm/mesh-llm-doctor-20260529T023314Z.zip
Logs: running pid 74447
Files: 11

⚠️  Warnings
  - selected process has no runtime metadata directory: /Users/jdumay/.mesh-llm/runtime/74447
  - could not fetch http://127.0.0.1:3131/api/models
```

The generated zip was inspected and contained `system.json`, `gpus.json`, `plugins.json`, `runtime/instances.json`, API snapshots, and `manifest.json`. The manifest selected the live client process with `command: "./target/debug/mesh-llm client --auto"`, `runtime_metadata: false`, and `is_live: true`.

## Private serve verification

```console
$ ./target/debug/mesh-llm serve --gguf ~/.cache/huggingface/hub/models--lmstudio-community--SmolLM2-135M-Instruct-GGUF/blobs/ef7cca8d10447a34aa2aa6fe1c6e876b31b0e449108f0fc211ce27a53f9c11a0 --port 9337 --console 3131 --log-format json
# waited for: node_state=serving, is_host=true, llama_ready=true, peers=0
$ ./target/debug/mesh-llm doctor
✅ Created doctor bundle

Path: /Users/jdumay/code/mesh-llm/mesh-llm-doctor-20260529T024716Z.zip
Logs: running pid 31284
Files: 13
```

The private serve bundle had no warnings. It contained runtime owner metadata, `runtime/logs/skippy-native.log`, all API snapshots with `200 OK`, and the serving model `lmstudio-community/SmolLM2-135M-Instruct-GGUF:Q6_K`.

## Config verification

With `/Users/jdumay/.mesh-llm/config.toml` present, `./target/debug/mesh-llm doctor` produced a bundle containing:

```console
config/config.toml
```

`manifest.json` recorded:

```json
{
  "zip_path": "config/config.toml",
  "source_path": "/Users/jdumay/.mesh-llm/config.toml",
  "bytes_written": 141,
  "truncated": false,
  "original_bytes": 141
}
```

