### PR TITLE
Require healthy direct paths for split serving

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -224,6 +224,17 @@ fn split_node_exclusion_reason(
     if !node.stage_protocol_generation_supported {
         return Some(SplitReadinessExclusionReason::StageProtocolGeneration);
     }
+    if node.source == SplitReadinessNodeSource::Peer {
+        if node.rtt_ms.is_none() {
+            return Some(SplitReadinessExclusionReason::MissingStagePath);
+        }
+        if node
+            .rtt_ms
+            .is_some_and(|rtt_ms| rtt_ms > crate::mesh::MAX_SPLIT_RTT_MS)
+        {
+            return Some(SplitReadinessExclusionReason::StagePathTooSlow);
+        }
+    }
     if node.source == SplitReadinessNodeSource::Peer && !node_has_stage_source(model_ref, node) {
         return Some(SplitReadinessExclusionReason::MissingModelSource);
     }
@@ -433,6 +444,24 @@ fn split_readiness_recommendations(
                 .to_string(),
         );
     }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::MissingStagePath.as_str())
+    {
+        recommendations.push(
+            "Wait for direct peer latency to be measured before split serving, or check that the nodes can establish a direct QUIC path."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::StagePathTooSlow.as_str())
+    {
+        recommendations.push(format!(
+            "Use lower-latency peers for split serving; direct stage RTT must be at or below {}ms.",
+            crate::mesh::MAX_SPLIT_RTT_MS
+        ));
+    }
     recommendations
 }
 
@@ -506,6 +535,8 @@ enum SplitReadinessExclusionReason {
     MissingVram,
     MissingModelInterest,
     StageProtocolGeneration,
+    MissingStagePath,
+    StagePathTooSlow,
     MissingModelSource,
 }
 
@@ -516,6 +547,8 @@ impl SplitReadinessExclusionReason {
             Self::MissingVram => "missing_vram",
             Self::MissingModelInterest => "missing_model_interest",
             Self::StageProtocolGeneration => "stage_protocol_generation",
+            Self::MissingStagePath => "missing_stage_path",
+            Self::StagePathTooSlow => "stage_path_too_slow",
             Self::MissingModelSource => "missing_model_source",
         }
     }
@@ -531,6 +564,12 @@ impl SplitReadinessExclusionReason {
             }
             Self::StageProtocolGeneration => {
                 "Upgrade this peer; its stage protocol generation is too old for split serving."
+            }
+            Self::MissingStagePath => {
+                "Wait for a measured direct path before admitting this peer to split serving."
+            }
+            Self::StagePathTooSlow => {
+                "Use a lower-latency path or peer before admitting this peer to split serving."
             }
             Self::MissingModelSource => {
                 "Ensure this peer can resolve or inventory the layer package before split serving."
@@ -735,6 +774,66 @@ mod tests {
                 .recommendations
                 .iter()
                 .any(|item| item.contains("resolvable package source"))
+        );
+    }
+
+    #[test]
+    fn split_readiness_excludes_peer_without_measured_stage_path() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        peer.rtt_ms = None;
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.participant_count, 1);
+        assert_eq!(report.exclusions[0].reason, "missing_stage_path");
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|item| item.contains("direct peer latency"))
+        );
+    }
+
+    #[test]
+    fn split_readiness_excludes_peer_with_slow_stage_path() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        peer.rtt_ms = Some(crate::mesh::MAX_SPLIT_RTT_MS + 1);
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.participant_count, 1);
+        assert_eq!(report.exclusions[0].reason, "stage_path_too_slow");
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|item| item.contains("80ms"))
         );
     }
 }

--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -1,6 +1,6 @@
 use super::MeshApi;
 use super::status::{ModelTargetCapacityAdvicePayload, ModelTargetCapacityAdviceState};
-use crate::mesh::{NodeRole, PeerInfo};
+use crate::mesh::{NodeRole, PeerInfo, SplitStagePathRejection, SplitStagePathSnapshot};
 use serde::Serialize;
 
 const MIN_SPLIT_PARTICIPANTS: usize = 2;
@@ -30,7 +30,7 @@ pub(crate) struct SplitReadinessNodeInput {
     pub(crate) model_source: Option<String>,
     pub(crate) stage_protocol_generation_supported: bool,
     pub(crate) artifact_transfer_supported: bool,
-    pub(crate) rtt_ms: Option<u32>,
+    pub(crate) stage_path: SplitStagePathSnapshot,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
@@ -122,14 +122,13 @@ impl MeshApi {
             model_source: None,
             stage_protocol_generation_supported: true,
             artifact_transfer_supported: true,
-            rtt_ms: None,
+            stage_path: SplitStagePathSnapshot::unknown(),
         };
-        let peers = node
-            .peers()
-            .await
-            .into_iter()
-            .map(peer_readiness_input)
-            .collect();
+        let mut peers = Vec::new();
+        for peer in node.peers().await {
+            let stage_path = node.split_stage_path_snapshot(peer.id).await;
+            peers.push(peer_readiness_input(peer, stage_path));
+        }
         let active_topology_count = node.stage_topologies().await.len();
         let active_stage_count = node
             .stage_runtime_statuses()
@@ -180,8 +179,10 @@ pub(crate) fn build_split_readiness_report(input: SplitReadinessInput) -> SplitR
     }
 }
 
-fn peer_readiness_input(peer: PeerInfo) -> SplitReadinessNodeInput {
-    let rtt_ms = peer.current_direct_rtt_ms();
+fn peer_readiness_input(
+    peer: PeerInfo,
+    stage_path: SplitStagePathSnapshot,
+) -> SplitReadinessNodeInput {
     SplitReadinessNodeInput {
         node_id: peer.id.to_string(),
         short_node_id: peer.id.fmt_short().to_string(),
@@ -196,7 +197,7 @@ fn peer_readiness_input(peer: PeerInfo) -> SplitReadinessNodeInput {
         model_source: peer.model_source,
         stage_protocol_generation_supported: peer.stage_protocol_generation_supported,
         artifact_transfer_supported: peer.artifact_transfer_supported,
-        rtt_ms,
+        stage_path,
     }
 }
 
@@ -224,16 +225,10 @@ fn split_node_exclusion_reason(
     if !node.stage_protocol_generation_supported {
         return Some(SplitReadinessExclusionReason::StageProtocolGeneration);
     }
-    if node.source == SplitReadinessNodeSource::Peer {
-        if node.rtt_ms.is_none() {
-            return Some(SplitReadinessExclusionReason::MissingStagePath);
-        }
-        if node
-            .rtt_ms
-            .is_some_and(|rtt_ms| rtt_ms > crate::mesh::MAX_SPLIT_RTT_MS)
-        {
-            return Some(SplitReadinessExclusionReason::StagePathTooSlow);
-        }
+    if node.source == SplitReadinessNodeSource::Peer
+        && let Some(rejection) = node.stage_path.stage_path_rejection()
+    {
+        return Some(split_readiness_stage_path_rejection(rejection));
     }
     if node.source == SplitReadinessNodeSource::Peer && !node_has_stage_source(model_ref, node) {
         return Some(SplitReadinessExclusionReason::MissingModelSource);
@@ -250,8 +245,24 @@ fn split_participant(model_ref: &str, node: SplitReadinessNodeInput) -> SplitRea
         role: node.role,
         vram_bytes: node.vram_bytes,
         artifact_transfer_supported: node.artifact_transfer_supported,
-        rtt_ms: node.rtt_ms,
+        rtt_ms: node.stage_path.rtt_ms,
         model_source_state,
+    }
+}
+
+const fn split_readiness_stage_path_rejection(
+    rejection: SplitStagePathRejection,
+) -> SplitReadinessExclusionReason {
+    match rejection {
+        SplitStagePathRejection::MissingStagePath => {
+            SplitReadinessExclusionReason::MissingStagePath
+        }
+        SplitStagePathRejection::StagePathRelayOnly => {
+            SplitReadinessExclusionReason::StagePathRelayOnly
+        }
+        SplitStagePathRejection::StagePathTooSlow => {
+            SplitReadinessExclusionReason::StagePathTooSlow
+        }
     }
 }
 
@@ -455,6 +466,15 @@ fn split_readiness_recommendations(
     }
     if exclusions
         .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::StagePathRelayOnly.as_str())
+    {
+        recommendations.push(
+            "Relay-only peers are not admitted for split serving; check firewall/NAT settings so the stage connection can use a direct QUIC path."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
         .any(|item| item.reason == SplitReadinessExclusionReason::StagePathTooSlow.as_str())
     {
         recommendations.push(format!(
@@ -536,6 +556,7 @@ enum SplitReadinessExclusionReason {
     MissingModelInterest,
     StageProtocolGeneration,
     MissingStagePath,
+    StagePathRelayOnly,
     StagePathTooSlow,
     MissingModelSource,
 }
@@ -548,6 +569,7 @@ impl SplitReadinessExclusionReason {
             Self::MissingModelInterest => "missing_model_interest",
             Self::StageProtocolGeneration => "stage_protocol_generation",
             Self::MissingStagePath => "missing_stage_path",
+            Self::StagePathRelayOnly => "stage_path_relay_only",
             Self::StagePathTooSlow => "stage_path_too_slow",
             Self::MissingModelSource => "missing_model_source",
         }
@@ -567,6 +589,9 @@ impl SplitReadinessExclusionReason {
             }
             Self::MissingStagePath => {
                 "Wait for a measured direct path before admitting this peer to split serving."
+            }
+            Self::StagePathRelayOnly => {
+                "Establish a direct QUIC path before admitting this peer to split serving."
             }
             Self::StagePathTooSlow => {
                 "Use a lower-latency path or peer before admitting this peer to split serving."
@@ -620,7 +645,7 @@ mod tests {
             model_source: None,
             stage_protocol_generation_supported: true,
             artifact_transfer_supported: true,
-            rtt_ms: Some(4),
+            stage_path: crate::mesh::SplitStagePathSnapshot::direct(Some(4)),
         }
     }
 
@@ -631,7 +656,7 @@ mod tests {
             requested_models,
         );
         local.source = SplitReadinessNodeSource::Local;
-        local.rtt_ms = None;
+        local.stage_path = crate::mesh::SplitStagePathSnapshot::unknown();
         local
     }
 
@@ -785,7 +810,7 @@ mod tests {
             &["meshllm/Qwen3-8B-Q4_K_M-layers"],
         );
         peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
-        peer.rtt_ms = None;
+        peer.stage_path = crate::mesh::SplitStagePathSnapshot::unknown();
 
         let report = build_split_readiness_report(SplitReadinessInput {
             model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
@@ -815,7 +840,8 @@ mod tests {
             &["meshllm/Qwen3-8B-Q4_K_M-layers"],
         );
         peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
-        peer.rtt_ms = Some(crate::mesh::MAX_SPLIT_RTT_MS + 1);
+        peer.stage_path =
+            crate::mesh::SplitStagePathSnapshot::direct(Some(crate::mesh::MAX_SPLIT_RTT_MS + 1));
 
         let report = build_split_readiness_report(SplitReadinessInput {
             model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
@@ -835,5 +861,29 @@ mod tests {
                 .iter()
                 .any(|item| item.contains("80ms"))
         );
+    }
+
+    #[test]
+    fn split_readiness_excludes_relay_only_peer() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        peer.stage_path = crate::mesh::SplitStagePathSnapshot::relay(Some(5));
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.participant_count, 1);
+        assert_eq!(report.exclusions[0].reason, "stage_path_relay_only");
     }
 }

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -647,6 +647,7 @@ fn make_test_state_peer(seed: u8, role: mesh::NodeRole) -> mesh::PeerInfo {
         advertised_model_throughput: vec![],
 
         display_rtt: None,
+        selected_path: None,
         propagated_latency: None,
     }
 }
@@ -1682,6 +1683,7 @@ fn make_test_peer(
         advertised_model_throughput: vec![],
 
         display_rtt: None,
+        selected_path: None,
         propagated_latency: None,
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -327,34 +327,29 @@ impl Node {
         } else {
             "inbound_gossip_path"
         };
-        self.capture_selected_connection_path(remote, &conn, capture_source);
-        let path_list = conn.paths();
-        for path_info in &path_list {
-            if !path_info.is_selected() {
-                continue;
-            }
-            let path_rtt_ms = path_info.rtt().as_millis() as u32;
-            if path_rtt_ms == 0 {
-                continue;
-            }
+        let Some(observation) =
+            self.capture_selected_connection_path(remote, &conn, capture_source)
+        else {
+            return;
+        };
+        if let Some(path_rtt_ms) = observation.rtt_ms {
             if ceiling_rtt_ms.is_some_and(|ceiling| path_rtt_ms >= ceiling) {
-                break;
+                self.update_peer_selected_path(remote, observation).await;
+                return;
             }
-            let path_type = if path_info.is_ip() { "direct" } else { "relay" };
             super::emit_mesh_info(format!(
                 "📡 Peer {} RTT: {}ms ({}){}",
                 remote.fmt_short(),
                 path_rtt_ms,
-                path_type,
+                observation.path_type,
                 if ceiling_rtt_ms.is_some() {
                     " [path info]"
                 } else {
                     ""
                 }
             ));
-            self.update_peer_rtt(remote, path_rtt_ms).await;
-            break;
         }
+        self.update_peer_selected_path(remote, observation).await;
     }
 
     async fn maybe_connect_discovered_peer(

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -117,6 +117,42 @@ pub(crate) struct HttpCaptureEvent<'a> {
     pub(crate) stream: Option<bool>,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SplitStagePathKind {
+    Direct,
+    Relay,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct SplitStagePathSnapshot {
+    pub(crate) kind: SplitStagePathKind,
+    pub(crate) rtt_ms: Option<u32>,
+}
+
+impl SplitStagePathSnapshot {
+    pub(crate) const fn direct(rtt_ms: Option<u32>) -> Self {
+        Self {
+            kind: SplitStagePathKind::Direct,
+            rtt_ms,
+        }
+    }
+
+    pub(crate) const fn relay(rtt_ms: Option<u32>) -> Self {
+        Self {
+            kind: SplitStagePathKind::Relay,
+            rtt_ms,
+        }
+    }
+
+    pub(crate) const fn unknown() -> Self {
+        Self {
+            kind: SplitStagePathKind::Unknown,
+            rtt_ms: None,
+        }
+    }
+}
+
 fn selected_path_observation(conn: &Connection) -> Option<SelectedPathObservation> {
     let path_list = conn.paths();
     for path_info in &path_list {
@@ -144,6 +180,17 @@ fn selected_path_observation(conn: &Connection) -> Option<SelectedPathObservatio
     }
 
     None
+}
+
+fn split_stage_path_snapshot_from_connection(conn: &Connection) -> SplitStagePathSnapshot {
+    let Some(observation) = selected_path_observation(conn) else {
+        return SplitStagePathSnapshot::unknown();
+    };
+    match observation.path_type {
+        "direct" => SplitStagePathSnapshot::direct(observation.rtt_ms),
+        "relay" => SplitStagePathSnapshot::relay(observation.rtt_ms),
+        _ => SplitStagePathSnapshot::unknown(),
+    }
 }
 
 fn endpoint_id_capture_fields(id: EndpointId) -> serde_json::Value {
@@ -4889,6 +4936,23 @@ impl Node {
                     );
                 }
                 Ok(conn)
+            }
+        }
+    }
+
+    pub(crate) async fn split_stage_path_snapshot(
+        &self,
+        peer_id: EndpointId,
+    ) -> SplitStagePathSnapshot {
+        match self.connection_to_peer(peer_id).await {
+            Ok(conn) => split_stage_path_snapshot_from_connection(&conn),
+            Err(error) => {
+                tracing::debug!(
+                    peer = %peer_id.fmt_short(),
+                    error = %error,
+                    "split stage path probe could not open mesh connection"
+                );
+                SplitStagePathSnapshot::unknown()
             }
         }
     }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -125,6 +125,23 @@ pub(crate) enum SplitStagePathKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SplitStagePathRejection {
+    MissingStagePath,
+    StagePathRelayOnly,
+    StagePathTooSlow,
+}
+
+impl SplitStagePathRejection {
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::MissingStagePath => "missing_stage_path",
+            Self::StagePathRelayOnly => "stage_path_relay_only",
+            Self::StagePathTooSlow => "stage_path_too_slow",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct SplitStagePathSnapshot {
     pub(crate) kind: SplitStagePathKind,
     pub(crate) rtt_ms: Option<u32>,
@@ -149,6 +166,37 @@ impl SplitStagePathSnapshot {
         Self {
             kind: SplitStagePathKind::Unknown,
             rtt_ms: None,
+        }
+    }
+
+    pub(crate) const fn with_direct_rtt_fallback(self, fallback_rtt_ms: Option<u32>) -> Self {
+        match (self.kind, self.rtt_ms, fallback_rtt_ms) {
+            (SplitStagePathKind::Direct, None, Some(rtt_ms)) => Self::direct(Some(rtt_ms)),
+            _ => self,
+        }
+    }
+
+    pub(crate) fn with_peer_path_fallback(self, fallback: Option<SelectedPathObservation>) -> Self {
+        match (self.kind, fallback) {
+            (SplitStagePathKind::Direct, Some(observation)) => {
+                self.with_direct_rtt_fallback(observation.rtt_ms)
+            }
+            (SplitStagePathKind::Unknown, Some(observation)) => {
+                split_stage_path_snapshot_from_observation(observation)
+            }
+            _ => self,
+        }
+    }
+
+    pub(crate) const fn stage_path_rejection(self) -> Option<SplitStagePathRejection> {
+        match self.kind {
+            SplitStagePathKind::Direct => match self.rtt_ms {
+                Some(rtt_ms) if rtt_ms <= MAX_SPLIT_RTT_MS => None,
+                Some(_) => Some(SplitStagePathRejection::StagePathTooSlow),
+                None => Some(SplitStagePathRejection::MissingStagePath),
+            },
+            SplitStagePathKind::Relay => Some(SplitStagePathRejection::StagePathRelayOnly),
+            SplitStagePathKind::Unknown => Some(SplitStagePathRejection::MissingStagePath),
         }
     }
 }
@@ -182,15 +230,34 @@ fn selected_path_observation(conn: &Connection) -> Option<SelectedPathObservatio
     None
 }
 
-fn split_stage_path_snapshot_from_connection(conn: &Connection) -> SplitStagePathSnapshot {
-    let Some(observation) = selected_path_observation(conn) else {
-        return SplitStagePathSnapshot::unknown();
-    };
+fn split_stage_path_snapshot_from_observation(
+    observation: SelectedPathObservation,
+) -> SplitStagePathSnapshot {
     match observation.path_type {
         "direct" => SplitStagePathSnapshot::direct(observation.rtt_ms),
         "relay" => SplitStagePathSnapshot::relay(observation.rtt_ms),
         _ => SplitStagePathSnapshot::unknown(),
     }
+}
+
+fn split_stage_path_snapshot_from_connection(conn: &Connection) -> SplitStagePathSnapshot {
+    let Some(observation) = selected_path_observation(conn) else {
+        return SplitStagePathSnapshot::unknown();
+    };
+    split_stage_path_snapshot_from_observation(observation)
+}
+
+fn stage_transport_path_rejection(
+    conn: &Connection,
+    stream_type: u8,
+    fallback: Option<SelectedPathObservation>,
+) -> Option<SplitStagePathRejection> {
+    if stream_type != skippy_protocol::STAGE_STREAM_TRANSPORT {
+        return None;
+    }
+    split_stage_path_snapshot_from_connection(conn)
+        .with_peer_path_fallback(fallback)
+        .stage_path_rejection()
 }
 
 fn endpoint_id_capture_fields(id: EndpointId) -> serde_json::Value {
@@ -257,6 +324,12 @@ const ARTIFACT_TRANSFER_BUFFER_BYTES: usize = 1024 * 1024;
 const ARTIFACT_TRANSFER_INVALID_OFFSET_ERROR: &str = "invalid transfer offset";
 
 type MeshBiStream = (iroh::endpoint::SendStream, iroh::endpoint::RecvStream);
+
+enum StageBiAccept {
+    Streams(MeshBiStream),
+    Continue,
+    Closed,
+}
 
 enum StageStreamAccept {
     Dispatch(MeshBiStream, u8),
@@ -1471,6 +1544,8 @@ pub struct PeerInfo {
     pub(crate) advertised_model_throughput: Vec<crate::network::metrics::ModelThroughputHint>,
     /// Most recent direct RTT sample for display purposes (refreshed periodically).
     pub display_rtt: Option<DirectLatencyObservation>,
+    /// Last selected path observed on the mesh control connection to this peer.
+    pub(crate) selected_path: Option<SelectedPathObservation>,
     /// Latency propagated via transitive gossip.
     pub propagated_latency: Option<PropagatedLatencyObservation>,
     pub owner_summary: OwnershipSummary,
@@ -1543,6 +1618,7 @@ impl PeerInfo {
             stage_status_list_supported: ann.stage_status_list_supported,
             advertised_model_throughput: ann.advertised_model_throughput.clone(),
             display_rtt: None,
+            selected_path: None,
             propagated_latency: None,
             owner_summary,
         }
@@ -1551,6 +1627,17 @@ impl PeerInfo {
     /// Return the most recent direct RTT sample for display, falling back to best-seen RTT.
     pub fn current_direct_rtt_ms(&self) -> Option<u32> {
         self.display_rtt.as_ref().map(|d| d.rtt_ms).or(self.rtt_ms)
+    }
+
+    pub(crate) fn split_stage_path_fallback(&self) -> Option<SelectedPathObservation> {
+        let observation = self.selected_path?;
+        if observation.path_type != "direct" {
+            return Some(observation);
+        }
+        Some(SelectedPathObservation {
+            rtt_ms: self.rtt_ms.or(observation.rtt_ms),
+            ..observation
+        })
     }
 
     /// Compute display latency from direct sample or propagated data.
@@ -3122,6 +3209,15 @@ impl Node {
         skippy_protocol::validate_stage_transport_open(&open)
             .map_err(|e| anyhow::anyhow!("StageTransportOpen validation error: {e}"))?;
         let conn = self.stage_connection_to_peer(peer_id).await?;
+        let snapshot = split_stage_path_snapshot_from_connection(&conn)
+            .with_peer_path_fallback(self.peer_stage_path_fallback(peer_id).await);
+        if let Some(rejection) = snapshot.stage_path_rejection() {
+            anyhow::bail!(
+                "stage transport path to {} is not eligible for split serving: {}",
+                peer_id.fmt_short(),
+                rejection.as_str()
+            );
+        }
         let (mut send, recv) = conn.open_bi().await?;
         send.write_all(&[skippy_protocol::STAGE_STREAM_TRANSPORT])
             .await?;
@@ -4156,6 +4252,27 @@ impl Node {
         }
     }
 
+    async fn update_peer_selected_path(
+        &self,
+        id: EndpointId,
+        observation: SelectedPathObservation,
+    ) {
+        let direct_rtt_ms = if observation.path_type == "direct" {
+            observation.rtt_ms
+        } else {
+            None
+        };
+        {
+            let mut state = self.state.lock().await;
+            if let Some(peer) = state.peers.get_mut(&id) {
+                peer.selected_path = Some(observation);
+            }
+        }
+        if let Some(rtt_ms) = direct_rtt_ms {
+            self.update_peer_rtt(id, rtt_ms).await;
+        }
+    }
+
     /// Re-gossip our state to all connected peers.
     /// Call after changing assigned/hosted state, role, or configured models.
     pub async fn regossip(&self) {
@@ -4944,17 +5061,31 @@ impl Node {
         &self,
         peer_id: EndpointId,
     ) -> SplitStagePathSnapshot {
-        match self.connection_to_peer(peer_id).await {
-            Ok(conn) => split_stage_path_snapshot_from_connection(&conn),
+        let fallback = self.peer_stage_path_fallback(peer_id).await;
+        match self.stage_connection_to_peer(peer_id).await {
+            Ok(conn) => {
+                split_stage_path_snapshot_from_connection(&conn).with_peer_path_fallback(fallback)
+            }
             Err(error) => {
                 tracing::debug!(
                     peer = %peer_id.fmt_short(),
                     error = %error,
-                    "split stage path probe could not open mesh connection"
+                    "split stage path probe could not open stage connection"
                 );
-                SplitStagePathSnapshot::unknown()
+                SplitStagePathSnapshot::unknown().with_peer_path_fallback(fallback)
             }
         }
+    }
+
+    async fn peer_stage_path_fallback(
+        &self,
+        peer_id: EndpointId,
+    ) -> Option<SelectedPathObservation> {
+        let state = self.state.lock().await;
+        state
+            .peers
+            .get(&peer_id)
+            .and_then(PeerInfo::split_stage_path_fallback)
     }
 
     async fn open_mesh_subprotocol_stream(
@@ -5446,19 +5577,19 @@ impl Node {
         }
     }
 
-    async fn accept_stage_stream(
+    async fn accept_admitted_stage_bi(
         &self,
         conn: &Connection,
         remote: EndpointId,
-    ) -> StageStreamAccept {
-        let (send, mut recv) = match conn.accept_bi().await {
+    ) -> StageBiAccept {
+        let (send, recv) = match conn.accept_bi().await {
             Ok(streams) => streams,
             Err(e) => {
                 tracing::info!(
                     "Skippy stage connection to {} closed: {e}",
                     remote.fmt_short()
                 );
-                return StageStreamAccept::Closed;
+                return StageBiAccept::Closed;
             }
         };
         if !self.stage_stream_admitted(remote).await {
@@ -5467,10 +5598,36 @@ impl Node {
                 remote.fmt_short()
             );
             drop((send, recv));
-            return StageStreamAccept::Continue;
+            return StageBiAccept::Continue;
         }
+        StageBiAccept::Streams((send, recv))
+    }
+
+    async fn accept_stage_stream(
+        &self,
+        conn: &Connection,
+        remote: EndpointId,
+    ) -> StageStreamAccept {
+        let (send, mut recv) = match self.accept_admitted_stage_bi(conn, remote).await {
+            StageBiAccept::Streams(streams) => streams,
+            StageBiAccept::Continue => return StageStreamAccept::Continue,
+            StageBiAccept::Closed => return StageStreamAccept::Closed,
+        };
         let mut type_buf = [0u8; 1];
         if recv.read_exact(&mut type_buf).await.is_err() {
+            return StageStreamAccept::Continue;
+        }
+        if let Some(rejection) = stage_transport_path_rejection(
+            conn,
+            type_buf[0],
+            self.peer_stage_path_fallback(remote).await,
+        ) {
+            tracing::warn!(
+                "Rejected skippy stage transport stream from {}: {}",
+                remote.fmt_short(),
+                rejection.as_str()
+            );
+            drop((send, recv));
             return StageStreamAccept::Continue;
         }
         StageStreamAccept::Dispatch((send, recv), type_buf[0])
@@ -7689,19 +7846,29 @@ impl Node {
                 for path_info in &path_list {
                     if path_info.is_selected() {
                         let rtt_ms = path_info.rtt().as_millis() as u32;
-                        if rtt_ms == 0 {
-                            continue;
-                        }
+                        let rtt_ms = (rtt_ms != 0).then_some(rtt_ms);
                         let path_type = if path_info.is_ip() { "direct" } else { "relay" };
-                        if rtt_ms > 0 {
+                        if let Some(rtt_ms) = rtt_ms {
                             emit_mesh_info(format!(
                                 "📡 Peer {} RTT recheck: {}ms ({})",
                                 peer_id.fmt_short(),
                                 rtt_ms,
                                 path_type
                             ));
-                            node_for_recheck.update_peer_rtt(peer_id, rtt_ms).await;
                         }
+                        node_for_recheck
+                            .update_peer_selected_path(
+                                peer_id,
+                                SelectedPathObservation {
+                                    path_type,
+                                    rtt_ms,
+                                    observed_direct_remote_addr: match path_info.remote_addr() {
+                                        TransportAddr::Ip(addr) => Some(*addr),
+                                        _ => None,
+                                    },
+                                },
+                            )
+                            .await;
                         break;
                     }
                 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -73,6 +73,144 @@ fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
 }
 
 #[test]
+fn split_stage_path_allows_fast_direct_path() {
+    assert_eq!(
+        SplitStagePathSnapshot::direct(Some(MAX_SPLIT_RTT_MS)).stage_path_rejection(),
+        None
+    );
+}
+
+#[test]
+fn split_stage_path_rejects_missing_rtt() {
+    assert_eq!(
+        SplitStagePathSnapshot::direct(None).stage_path_rejection(),
+        Some(SplitStagePathRejection::MissingStagePath)
+    );
+}
+
+#[test]
+fn split_stage_path_accepts_direct_path_with_peer_rtt_fallback() {
+    assert_eq!(
+        SplitStagePathSnapshot::direct(None)
+            .with_direct_rtt_fallback(Some(MAX_SPLIT_RTT_MS))
+            .stage_path_rejection(),
+        None
+    );
+}
+
+#[test]
+fn split_stage_path_keeps_relay_rejection_with_peer_rtt_fallback() {
+    assert_eq!(
+        SplitStagePathSnapshot::relay(None)
+            .with_direct_rtt_fallback(Some(1))
+            .stage_path_rejection(),
+        Some(SplitStagePathRejection::StagePathRelayOnly)
+    );
+}
+
+#[test]
+fn split_stage_path_rejects_slow_peer_rtt_fallback() {
+    assert_eq!(
+        SplitStagePathSnapshot::direct(None)
+            .with_direct_rtt_fallback(Some(MAX_SPLIT_RTT_MS + 1))
+            .stage_path_rejection(),
+        Some(SplitStagePathRejection::StagePathTooSlow)
+    );
+}
+
+#[test]
+fn split_stage_path_rejects_relay_path() {
+    assert_eq!(
+        SplitStagePathSnapshot::relay(Some(1)).stage_path_rejection(),
+        Some(SplitStagePathRejection::StagePathRelayOnly)
+    );
+}
+
+#[test]
+fn split_stage_path_rejects_slow_direct_path() {
+    assert_eq!(
+        SplitStagePathSnapshot::direct(Some(MAX_SPLIT_RTT_MS + 1)).stage_path_rejection(),
+        Some(SplitStagePathRejection::StagePathTooSlow)
+    );
+}
+
+#[test]
+fn split_stage_path_rejects_unknown_path() {
+    assert_eq!(
+        SplitStagePathSnapshot::unknown().stage_path_rejection(),
+        Some(SplitStagePathRejection::MissingStagePath)
+    );
+}
+
+#[test]
+fn split_stage_path_uses_direct_peer_path_fallback_for_unknown_stage_path() {
+    let fallback = SelectedPathObservation {
+        path_type: "direct",
+        rtt_ms: Some(MAX_SPLIT_RTT_MS),
+        observed_direct_remote_addr: None,
+    };
+
+    assert_eq!(
+        SplitStagePathSnapshot::unknown()
+            .with_peer_path_fallback(Some(fallback))
+            .stage_path_rejection(),
+        None
+    );
+}
+
+#[test]
+fn split_stage_path_keeps_relay_peer_path_fallback_rejected() {
+    let fallback = SelectedPathObservation {
+        path_type: "relay",
+        rtt_ms: Some(1),
+        observed_direct_remote_addr: None,
+    };
+
+    assert_eq!(
+        SplitStagePathSnapshot::unknown()
+            .with_peer_path_fallback(Some(fallback))
+            .stage_path_rejection(),
+        Some(SplitStagePathRejection::StagePathRelayOnly)
+    );
+}
+
+#[test]
+fn split_stage_path_peer_fallback_does_not_convert_relay_rtt_to_direct() {
+    let mut peer = make_test_peer_info(make_test_endpoint_id(0x4a));
+    peer.rtt_ms = Some(1);
+    peer.selected_path = Some(SelectedPathObservation {
+        path_type: "relay",
+        rtt_ms: Some(1),
+        observed_direct_remote_addr: None,
+    });
+
+    assert_eq!(
+        SplitStagePathSnapshot::unknown()
+            .with_peer_path_fallback(peer.split_stage_path_fallback())
+            .stage_path_rejection(),
+        Some(SplitStagePathRejection::StagePathRelayOnly)
+    );
+}
+
+#[test]
+fn split_stage_path_peer_fallback_uses_best_direct_rtt() {
+    let mut peer = make_test_peer_info(make_test_endpoint_id(0x4b));
+    peer.rtt_ms = Some(MAX_SPLIT_RTT_MS);
+    peer.selected_path = Some(SelectedPathObservation {
+        path_type: "direct",
+        rtt_ms: None,
+        observed_direct_remote_addr: None,
+    });
+
+    assert_eq!(
+        SplitStagePathSnapshot::unknown()
+            .with_peer_path_fallback(peer.split_stage_path_fallback())
+            .stage_path_rejection(),
+        None
+    );
+}
+
+#[test]
 fn endpoint_addr_filter_for_bind_ip_keeps_selected_ip_relay_and_public_candidates() {
     let mut addr = EndpointAddr {
         id: make_test_endpoint_id(0x42),
@@ -990,6 +1128,7 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
         advertised_model_throughput: vec![],
 
         display_rtt: None,
+        selected_path: None,
         propagated_latency: None,
     }
 }
@@ -5129,6 +5268,7 @@ fn make_test_peer(id: EndpointId, rtt_ms: Option<u32>, vram_gb: u64) -> PeerInfo
         advertised_model_throughput: vec![],
 
         display_rtt: None,
+        selected_path: None,
         propagated_latency: None,
     }
 }

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -906,6 +906,7 @@ alias = "model-alias"
             advertised_model_throughput: vec![],
 
             display_rtt: None,
+            selected_path: None,
             propagated_latency: None,
         }
     }

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -2815,17 +2815,15 @@ fn split_peer_preflight_exclusion_reason(
 fn split_peer_stage_path_exclusion_reason(
     snapshot: mesh::SplitStagePathSnapshot,
 ) -> Option<SplitParticipantExclusionReason> {
-    match snapshot.kind {
-        mesh::SplitStagePathKind::Direct => match snapshot.rtt_ms {
-            Some(rtt_ms) if rtt_ms <= mesh::MAX_SPLIT_RTT_MS => None,
-            Some(_) => Some(SplitParticipantExclusionReason::StagePathTooSlow),
-            None => Some(SplitParticipantExclusionReason::MissingStagePath),
-        },
-        mesh::SplitStagePathKind::Relay => {
+    match snapshot.stage_path_rejection()? {
+        mesh::SplitStagePathRejection::MissingStagePath => {
+            Some(SplitParticipantExclusionReason::MissingStagePath)
+        }
+        mesh::SplitStagePathRejection::StagePathRelayOnly => {
             Some(SplitParticipantExclusionReason::StagePathRelayOnly)
         }
-        mesh::SplitStagePathKind::Unknown => {
-            Some(SplitParticipantExclusionReason::MissingStagePath)
+        mesh::SplitStagePathRejection::StagePathTooSlow => {
+            Some(SplitParticipantExclusionReason::StagePathTooSlow)
         }
     }
 }
@@ -3636,6 +3634,7 @@ mod tests {
             advertised_model_throughput: vec![],
 
             display_rtt: None,
+            selected_path: None,
             propagated_latency: None,
             owner_summary: crate::crypto::OwnershipSummary::default(),
         }

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1070,6 +1070,9 @@ pub(super) enum SplitParticipantExclusionReason {
     MissingVram,
     MissingModelInterest,
     StageProtocolGeneration,
+    MissingStagePath,
+    StagePathRelayOnly,
+    StagePathTooSlow,
     MissingModelSource,
 }
 
@@ -1080,6 +1083,9 @@ impl SplitParticipantExclusionReason {
             Self::MissingVram => "missing_vram",
             Self::MissingModelInterest => "missing_model_interest",
             Self::StageProtocolGeneration => "stage_protocol_generation",
+            Self::MissingStagePath => "missing_stage_path",
+            Self::StagePathRelayOnly => "stage_path_relay_only",
+            Self::StagePathTooSlow => "stage_path_too_slow",
             Self::MissingModelSource => "missing_model_source",
         }
     }
@@ -2743,6 +2749,15 @@ async fn collect_split_participants(
             });
             continue;
         }
+        if let Some(reason) =
+            split_peer_stage_path_exclusion_reason(node.split_stage_path_snapshot(peer.id).await)
+        {
+            excluded.push(SplitParticipantExclusion {
+                node_id: peer.id,
+                reason,
+            });
+            continue;
+        }
 
         if let Some(package_signal) =
             split_peer_package_signal(node, peer.id, model_ref, package).await
@@ -2795,6 +2810,24 @@ fn split_peer_preflight_exclusion_reason(
         return Some(SplitParticipantExclusionReason::StageProtocolGeneration);
     }
     None
+}
+
+fn split_peer_stage_path_exclusion_reason(
+    snapshot: mesh::SplitStagePathSnapshot,
+) -> Option<SplitParticipantExclusionReason> {
+    match snapshot.kind {
+        mesh::SplitStagePathKind::Direct => match snapshot.rtt_ms {
+            Some(rtt_ms) if rtt_ms <= mesh::MAX_SPLIT_RTT_MS => None,
+            Some(_) => Some(SplitParticipantExclusionReason::StagePathTooSlow),
+            None => Some(SplitParticipantExclusionReason::MissingStagePath),
+        },
+        mesh::SplitStagePathKind::Relay => {
+            Some(SplitParticipantExclusionReason::StagePathRelayOnly)
+        }
+        mesh::SplitStagePathKind::Unknown => {
+            Some(SplitParticipantExclusionReason::MissingStagePath)
+        }
+    }
 }
 
 fn split_peer_stage_host_exclusion_reason(
@@ -4322,6 +4355,7 @@ max_tokens = 222
     #[test]
     fn split_peer_preflight_requires_current_stage_protocol_generation() {
         let mut peer = split_test_peer(0x61, "Qwen3-Coder", false);
+        peer.rtt_ms = Some(crate::mesh::MAX_SPLIT_RTT_MS);
 
         assert_eq!(
             split_peer_preflight_exclusion_reason(
@@ -4333,6 +4367,67 @@ max_tokens = 222
         );
 
         peer.stage_protocol_generation_supported = true;
+        assert_eq!(
+            split_peer_preflight_exclusion_reason(
+                &peer,
+                "Qwen3-Coder",
+                "meshllm/Qwen3-Coder-layers"
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn split_peer_preflight_requires_measured_stage_path() {
+        assert_eq!(
+            split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::unknown()),
+            Some(SplitParticipantExclusionReason::MissingStagePath)
+        );
+    }
+
+    #[test]
+    fn split_peer_preflight_rejects_slow_stage_path() {
+        assert_eq!(
+            split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::direct(Some(
+                crate::mesh::MAX_SPLIT_RTT_MS + 1,
+            ))),
+            Some(SplitParticipantExclusionReason::StagePathTooSlow)
+        );
+    }
+
+    #[test]
+    fn split_peer_preflight_rejects_relay_only_stage_path() {
+        assert_eq!(
+            split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::relay(Some(
+                crate::mesh::MAX_SPLIT_RTT_MS,
+            ))),
+            Some(SplitParticipantExclusionReason::StagePathRelayOnly)
+        );
+    }
+
+    #[test]
+    fn split_peer_preflight_rejects_direct_stage_path_without_rtt() {
+        assert_eq!(
+            split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::direct(None)),
+            Some(SplitParticipantExclusionReason::MissingStagePath)
+        );
+    }
+
+    #[test]
+    fn split_peer_preflight_allows_fast_stage_path() {
+        assert_eq!(
+            split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::direct(Some(
+                crate::mesh::MAX_SPLIT_RTT_MS,
+            ))),
+            None
+        );
+    }
+
+    #[test]
+    fn split_peer_preflight_keeps_host_eligibility_separate_from_stage_path() {
+        let mut peer = split_test_peer(0x66, "Qwen3-Coder", true);
+        peer.rtt_ms = Some(crate::mesh::MAX_SPLIT_RTT_MS + 1);
+
         assert_eq!(
             split_peer_preflight_exclusion_reason(
                 &peer,


### PR DESCRIPTION
## Summary

Split serving now refuses to plan or open a stage transport participant unless the peer has path-kind-aware evidence for a direct split-capable route. The split-readiness report uses the same stage-path policy, so operators get an honest preflight signal before a split load reaches stage assignment.

## Why

#723 made split readiness observable. This follow-up closes the runtime admission gap behind the recent split-bringup reports: a peer could look capacity-eligible while the stage path was missing, relay-only, or too slow for split traffic. Review also caught that checking only the mesh control connection was not enough, because actual activation opens a separate Skippy stage connection.

I am not marking this as closing a GitHub issue because I did not find a dedicated open issue for this exact admission gap. This is a focused follow-up to #723 and the current Discord split-debugging thread.

## Diff scope

- Adds a shared split-stage path policy for direct, relay-only, slow, and unknown stage paths.
- Uses the actual `skippy-stage/1` connection for split admission probes and for outbound/inbound activation transport guards.
- Persists the selected mesh-control path kind separately from numeric RTT, so a fast relay RTT cannot be treated as direct-path evidence.
- Allows unknown freshly opened stage-path snapshots to fall back only to previously observed direct selected-path evidence; relay-only fallback evidence remains rejected.
- Rejects outbound and inbound stage transport streams when the actual stage connection is relay-only, missing latency/path evidence, or above `MAX_SPLIT_RTT_MS`.
- Mirrors the same path-aware exclusions in `/api/diagnostics/split-readiness`, including a relay-only reason and operator recommendation.
- Keeps local host eligibility separate from remote stage-path checks.
- Adds regression coverage for fast direct paths, direct selected-path fallback, relay fallback rejection, missing path/RTT, slow direct paths, host eligibility, and readiness reporting.

## Compatibility

No mesh protocol, Skippy ABI, package format, release metadata, or CLI contract changes. This tightens runtime split admission and diagnostics using already-available connection/path evidence.

## Validation

Validation tier: Tier 2R - post-review split-serving path admission correction for #733.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `dd0be6043f7be56dd4e477f94f9201cb1bf301b3`
- `git rebase origin/main`: PASS, no conflicts
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime split_stage_path --lib -- --test-threads=1`: PASS, 12 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime split_readiness --lib -- --test-threads=1`: PASS, 12 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime split_peer_preflight --lib -- --test-threads=1`: PASS, 7 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS

Ledger: not applicable - not required for selected validation tier/change family.
Version: not applicable - no release/version sync required for this post-review runtime correction.

Not run locally: live two-node split activation smoke. The mandatory PR `two_node_split_smoke` is the final full split proof for the pushed SHA.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risk

The local proof covers the admission and diagnostics logic deterministically. The full network/runtime proof is intentionally left to PR CI, especially `two_node_split_smoke`, because this change is specifically about live two-node split activation behavior.
