### PR TITLE
Make auto routing fall back to healthy models

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -130,6 +130,15 @@ impl AffinityRouter {
         self.target_health.eligible_candidates(model, candidates)
     }
 
+    pub(crate) fn route_strict_eligible_candidates(
+        &self,
+        model: &str,
+        candidates: &[election::InferenceTarget],
+    ) -> Vec<election::InferenceTarget> {
+        self.target_health
+            .strict_eligible_candidates(model, candidates)
+    }
+
     pub(crate) fn record_target_outcome(
         &self,
         model: Option<&str>,
@@ -888,6 +897,25 @@ mod tests {
         assert_eq!(prepared.ordered.len(), 1);
         assert_eq!(prepared.learn_prefix_hash, None);
         assert_eq!(prepared.cached_target, None);
+    }
+
+    #[test]
+    fn strict_eligible_candidates_drop_single_cooling_auto_target() {
+        let id = make_id(1);
+        let target = election::InferenceTarget::Remote(id);
+        let affinity = AffinityRouter::with_config(true, true);
+
+        affinity.record_target_outcome(Some("qwen"), &target, TargetHealthOutcome::Unavailable);
+
+        assert_eq!(
+            affinity.route_eligible_candidates("qwen", std::slice::from_ref(&target)),
+            vec![target.clone()]
+        );
+        assert!(
+            affinity
+                .route_strict_eligible_candidates("qwen", std::slice::from_ref(&target))
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/auto_route.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/auto_route.rs
@@ -1,0 +1,149 @@
+//! Auto-route model admission helpers.
+//!
+//! Explicit model routing keeps an availability-preserving fallback when every
+//! target is cooling. Auto routing can be stricter before it chooses a model:
+//! if another model has a healthy target that can fit the request context, it
+//! should use that model instead of spending an agent turn on a target we just
+//! proved unhealthy or too small.
+
+use crate::inference::election;
+use crate::mesh;
+use crate::network::affinity::AffinityRouter;
+use crate::network::router;
+
+fn has_routable_candidate(candidates: &[election::InferenceTarget]) -> bool {
+    candidates
+        .iter()
+        .any(|target| !matches!(target, election::InferenceTarget::None))
+}
+
+async fn target_context_satisfies_request(
+    node: &mesh::Node,
+    model: &str,
+    required_tokens: Option<u32>,
+    target: &election::InferenceTarget,
+) -> bool {
+    let Some(required_tokens) = required_tokens else {
+        return !matches!(target, election::InferenceTarget::None);
+    };
+    let context_length = match target {
+        election::InferenceTarget::Local(_) => node.local_model_context_length(model).await,
+        election::InferenceTarget::Remote(peer_id) => {
+            node.peer_model_context_length(*peer_id, model).await
+        }
+        election::InferenceTarget::None => return false,
+    };
+    context_length
+        .map(|context| context >= required_tokens)
+        .unwrap_or(true)
+}
+
+async fn context_compatible_targets(
+    node: &mesh::Node,
+    model: &str,
+    required_tokens: Option<u32>,
+    candidates: &[election::InferenceTarget],
+) -> Vec<election::InferenceTarget> {
+    let mut compatible = Vec::new();
+    for candidate in candidates {
+        if target_context_satisfies_request(node, model, required_tokens, candidate).await {
+            compatible.push(candidate.clone());
+        }
+    }
+    compatible
+}
+
+pub(crate) async fn model_has_eligible_target(
+    node: &mesh::Node,
+    model: &str,
+    required_tokens: Option<u32>,
+    candidates: &[election::InferenceTarget],
+    affinity: &AffinityRouter,
+) -> bool {
+    let context_compatible =
+        context_compatible_targets(node, model, required_tokens, candidates).await;
+    if !has_routable_candidate(&context_compatible) {
+        return false;
+    }
+    has_routable_candidate(&affinity.route_strict_eligible_candidates(model, &context_compatible))
+}
+
+pub(crate) async fn model_has_eligible_remote_host(
+    node: &mesh::Node,
+    model: &str,
+    required_tokens: Option<u32>,
+    affinity: &AffinityRouter,
+) -> bool {
+    let targets: Vec<election::InferenceTarget> = node
+        .hosts_for_model(model)
+        .await
+        .into_iter()
+        .map(election::InferenceTarget::Remote)
+        .collect();
+    model_has_eligible_target(node, model, required_tokens, &targets, affinity).await
+}
+
+pub(crate) fn pool_for_ready_models<'a>(
+    available: &[router::RoutingCandidate<'a>],
+    ready_models: &[&str],
+) -> Vec<router::RoutingCandidate<'a>> {
+    let ready = available
+        .iter()
+        .filter(|candidate| ready_models.contains(&candidate.name))
+        .cloned()
+        .collect::<Vec<_>>();
+    if ready.is_empty() {
+        available.to_vec()
+    } else {
+        ready
+    }
+}
+
+pub(crate) async fn ready_remote_models<'a>(
+    node: &mesh::Node,
+    required_tokens: Option<u32>,
+    available: &[router::RoutingCandidate<'a>],
+    affinity: &AffinityRouter,
+) -> Vec<&'a str> {
+    let mut ready_models = Vec::new();
+    for candidate in available {
+        if model_has_eligible_remote_host(node, candidate.name, required_tokens, affinity).await {
+            ready_models.push(candidate.name);
+        }
+    }
+    ready_models
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_route_pool_prefers_ready_models_when_any_ready() {
+        let caps = crate::models::ModelCapabilities::default();
+        let available = vec![
+            router::RoutingCandidate::unscored("cooling-model", caps),
+            router::RoutingCandidate::unscored("ready-model", caps),
+        ];
+
+        let pool = pool_for_ready_models(&available, &["ready-model"]);
+
+        assert_eq!(pool.len(), 1);
+        assert_eq!(pool[0].name, "ready-model");
+    }
+
+    #[test]
+    fn auto_route_pool_preserves_availability_when_none_ready() {
+        let caps = crate::models::ModelCapabilities::default();
+        let available = vec![
+            router::RoutingCandidate::unscored("cooling-a", caps),
+            router::RoutingCandidate::unscored("cooling-b", caps),
+        ];
+
+        let pool = pool_for_ready_models(&available, &[]);
+
+        assert_eq!(pool.len(), available.len());
+        assert_eq!(pool[0].name, "cooling-a");
+        assert_eq!(pool[1].name, "cooling-b");
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -3,6 +3,7 @@ use crate::cli::output::{OutputEvent, emit_event};
 use crate::inference::{election, pipeline};
 use crate::mesh;
 use crate::network::affinity;
+use crate::network::openai::auto_route;
 use crate::network::openai::transport as proxy;
 use crate::network::router;
 use mesh_llm_node::serving::{UnloadOptions, UnloadTarget};
@@ -189,6 +190,8 @@ async fn resolve_auto_routed_model(
     targets: &election::ModelTargets,
     plugin_manager: Option<&crate::plugin::PluginManager>,
     descriptors: &[crate::mesh::ServedModelDescriptor],
+    required_tokens: Option<u32>,
+    affinity: &affinity::AffinityRouter,
 ) -> AutoRouteResolution {
     if request.model_name.is_some() && request.model_name.as_deref() != Some("auto") {
         return AutoRouteResolution::Continue {
@@ -232,6 +235,9 @@ async fn resolve_auto_routed_model(
         proxy::release_request_objects(node, &request.request_object_request_ids).await;
         return AutoRouteResolution::MediaUnsupported;
     };
+    let available =
+        auto_route_pool_for_ready_models(node, targets, required_tokens, &available, affinity)
+            .await;
 
     let effective_model = router::pick_model_classified(&classification, &available).map(|name| {
         tracing::info!(
@@ -247,6 +253,69 @@ async fn resolve_auto_routed_model(
         effective_model,
         classification: Some(classification),
     }
+}
+
+async fn auto_route_pool_for_ready_models<'a>(
+    node: &mesh::Node,
+    targets: &election::ModelTargets,
+    required_tokens: Option<u32>,
+    available: &[router::RoutingCandidate<'a>],
+    affinity: &affinity::AffinityRouter,
+) -> Vec<router::RoutingCandidate<'a>> {
+    let mut ready_models = Vec::new();
+    for candidate in available {
+        if auto_route_model_has_ready_ingress_target(
+            node,
+            targets,
+            candidate.name,
+            required_tokens,
+            affinity,
+        )
+        .await
+        {
+            ready_models.push(candidate.name);
+        }
+    }
+    auto_route::pool_for_ready_models(available, &ready_models)
+}
+
+async fn auto_route_model_has_ready_ingress_target(
+    node: &mesh::Node,
+    targets: &election::ModelTargets,
+    model: &str,
+    required_tokens: Option<u32>,
+    affinity: &affinity::AffinityRouter,
+) -> bool {
+    let local_candidates = targets.candidates(model);
+    if contains_routable_candidate(&local_candidates) {
+        return auto_route::model_has_eligible_target(
+            node,
+            model,
+            required_tokens,
+            &local_candidates,
+            affinity,
+        )
+        .await;
+    }
+
+    let remote_candidates = node
+        .hosts_for_model(model)
+        .await
+        .into_iter()
+        .map(election::InferenceTarget::Remote)
+        .collect::<Vec<_>>();
+    if !remote_candidates.is_empty() {
+        return auto_route::model_has_eligible_target(
+            node,
+            model,
+            required_tokens,
+            &remote_candidates,
+            affinity,
+        )
+        .await;
+    }
+
+    true
 }
 
 fn maybe_enable_auto_route_hooks(
@@ -490,12 +559,16 @@ async fn prepare_auto_route_decision(
     ctx: &IngressRouteContext<'_>,
     descriptors: &[crate::mesh::ServedModelDescriptor],
 ) -> Result<AutoRouteDecision, ()> {
+    let required_tokens =
+        proxy::request_budget_tokens_from_parts(request.body_len_bytes, request.completion_tokens);
     match resolve_auto_routed_model(
         ctx.node,
         request,
         ctx.targets,
         ctx.plugin_manager,
         descriptors,
+        required_tokens,
+        ctx.affinity,
     )
     .await
     {
@@ -504,10 +577,6 @@ async fn prepare_auto_route_decision(
             classification,
         } => {
             maybe_enable_auto_route_hooks(request, effective_model.as_deref());
-            let required_tokens = proxy::request_budget_tokens_from_parts(
-                request.body_len_bytes,
-                request.completion_tokens,
-            );
             if let Some(name) = effective_model.as_ref() {
                 ctx.node.record_request(name);
             }
@@ -811,8 +880,11 @@ fn first_available_target(targets: &election::ModelTargets) -> election::Inferen
 }
 
 fn has_available_candidates(targets: &election::ModelTargets, model: &str) -> bool {
-    targets
-        .candidates(model)
+    contains_routable_candidate(&targets.candidates(model))
+}
+
+fn contains_routable_candidate(candidates: &[election::InferenceTarget]) -> bool {
+    candidates
         .iter()
         .any(|target| !matches!(target, election::InferenceTarget::None))
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod auto_route;
 pub(crate) mod ingress;
 pub(crate) mod moa_gateway;
 pub(crate) mod response_adapter;

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -8,6 +8,7 @@ use crate::mesh;
 use crate::network::affinity::{
     AffinityRouter, PreparedTargets, TargetSelection, prepare_remote_targets_for_request,
 };
+use crate::network::openai::auto_route;
 use crate::network::openai::response_adapter;
 use crate::network::openai::tool_call_ids::{
     ChatStreamNormalizationState, normalize_chat_completion_json_body,
@@ -2862,15 +2863,18 @@ async fn build_mesh_request_plan(
     let is_auto_request =
         request.model_name.is_none() || request.model_name.as_deref() == Some("auto");
     let auto_session_key = auto_session_key_for_request(request, is_auto_request);
-    let effective_model = match resolve_auto_model_request(
+    let required_tokens =
+        request_budget_tokens_from_parts(request.body_len_bytes, request.completion_tokens);
+    let effective_model = match resolve_auto_model_request(AutoModelRequestArgs {
         node,
         request,
-        &served,
-        &descriptors,
+        served: &served,
+        descriptors: &descriptors,
         is_auto_request,
         auto_session_key,
+        required_tokens,
         affinity,
-    )
+    })
     .await
     {
         AutoModelResolution::Model(model) => model.or(request.model_name.clone()),
@@ -2892,8 +2896,6 @@ async fn build_mesh_request_plan(
         MeshTargetResolution::NoHostsAvailable => return Err(MeshRequestFailure::NoHostsAvailable),
     };
 
-    let required_tokens =
-        request_budget_tokens_from_parts(request.body_len_bytes, request.completion_tokens);
     let prepared = prepare_mesh_targets(
         request,
         effective_model.as_deref(),
@@ -3296,15 +3298,28 @@ fn auto_session_key_for_request(
         .and_then(|body| crate::network::affinity::auto_model_session_key(Some(body)))
 }
 
-async fn resolve_auto_model_request(
-    node: &mesh::Node,
-    request: &mut BufferedHttpRequest,
-    served: &[String],
-    descriptors: &[mesh::ServedModelDescriptor],
+struct AutoModelRequestArgs<'a> {
+    node: &'a mesh::Node,
+    request: &'a mut BufferedHttpRequest,
+    served: &'a [String],
+    descriptors: &'a [mesh::ServedModelDescriptor],
     is_auto_request: bool,
     auto_session_key: Option<u64>,
-    affinity: &AffinityRouter,
-) -> AutoModelResolution {
+    required_tokens: Option<u32>,
+    affinity: &'a AffinityRouter,
+}
+
+async fn resolve_auto_model_request(args: AutoModelRequestArgs<'_>) -> AutoModelResolution {
+    let AutoModelRequestArgs {
+        node,
+        request,
+        served,
+        descriptors,
+        is_auto_request,
+        auto_session_key,
+        required_tokens,
+        affinity,
+    } = args;
     if !is_auto_request {
         return AutoModelResolution::Model(None);
     }
@@ -3313,13 +3328,6 @@ async fn resolve_auto_model_request(
         return AutoModelResolution::Model(None);
     };
     let media = router::media_requirements(body_json);
-    if let Some(model) =
-        lookup_cached_auto_model(node, descriptors, affinity, auto_session_key, &media).await
-    {
-        return AutoModelResolution::Model(Some(model));
-    }
-
-    let cl = router::classify(body_json);
     // Build candidates with observed throughput so pick_model_classified
     // can weight by locally-measured tok/s where samples exist.
     let routing_metrics = node.routing_metrics();
@@ -3341,9 +3349,30 @@ async fn resolve_auto_model_request(
             }
         })
         .collect();
-    let Some(available) = router::filter_media_compatible_candidates(&with_caps, &media) else {
+    let available = router::filter_media_compatible_candidates(&with_caps, &media);
+    let ready_models = if let Some(available) = available.as_ref() {
+        auto_route::ready_remote_models(node, required_tokens, available, affinity).await
+    } else {
+        Vec::new()
+    };
+    if let Some(model) = lookup_cached_auto_model(
+        node,
+        descriptors,
+        affinity,
+        auto_session_key,
+        &media,
+        &ready_models,
+    )
+    .await
+    {
+        return AutoModelResolution::Model(Some(model));
+    }
+
+    let Some(available) = available else {
         return AutoModelResolution::UnsupportedMedia;
     };
+    let available = auto_route::pool_for_ready_models(&available, &ready_models);
+    let cl = router::classify(body_json);
     let picked = router::pick_model_classified(&cl, &available).map(str::to_string);
     if let Some(name) = picked.as_deref() {
         tracing::info!(
@@ -3366,11 +3395,12 @@ async fn lookup_cached_auto_model(
     affinity: &AffinityRouter,
     auto_session_key: Option<u64>,
     media: &router::MediaRequirements,
+    ready_models: &[&str],
 ) -> Option<String> {
     let key = auto_session_key?;
     let model = affinity.lookup_auto_model(key)?;
     if let Some(reason) =
-        cached_auto_model_reclassify_reason(node, &model, media, descriptors).await
+        cached_auto_model_reclassify_reason(node, &model, media, descriptors, ready_models).await
     {
         tracing::debug!("auto: cached model {model} {reason}, reclassifying");
         affinity.forget_auto_model(key);
@@ -3385,12 +3415,18 @@ async fn cached_auto_model_reclassify_reason(
     model: &str,
     media: &router::MediaRequirements,
     descriptors: &[mesh::ServedModelDescriptor],
+    ready_models: &[&str],
 ) -> Option<&'static str> {
     if cached_auto_model_missing(node, model).await {
         return Some("no longer served");
     }
-    cached_auto_model_needs_reclassify(model, media, descriptors)
-        .then_some("cannot satisfy media requirements")
+    if cached_auto_model_needs_reclassify(model, media, descriptors) {
+        return Some("cannot satisfy media requirements");
+    }
+    if !ready_models.is_empty() && !ready_models.contains(&model) {
+        return Some("has no eligible target for this request");
+    }
+    None
 }
 
 async fn cached_auto_model_missing(node: &mesh::Node, model: &str) -> bool {
@@ -4726,6 +4762,86 @@ mod tests {
         }
     }
 
+    fn test_peer_serving_model(peer_id: iroh::EndpointId, model: &str) -> mesh::PeerInfo {
+        mesh::PeerInfo {
+            id: peer_id,
+            addr: iroh::EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            },
+            role: mesh::NodeRole::Host { http_port: 9337 },
+            first_joined_mesh_ts: None,
+            models: vec![model.to_string()],
+            vram_bytes: 16 * 1024 * 1024 * 1024,
+            rtt_ms: None,
+            model_source: None,
+            serving_models: vec![model.to_string()],
+            hosted_models: vec![model.to_string()],
+            hosted_models_known: true,
+            available_models: vec![],
+            requested_models: vec![],
+            explicit_model_interests: vec![],
+            last_seen: std::time::Instant::now(),
+            last_mentioned: std::time::Instant::now(),
+            version: None,
+            gpu_name: None,
+            hostname: None,
+            is_soc: None,
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            available_model_metadata: vec![],
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: vec![local_gguf_descriptor(model)],
+            served_model_runtime: vec![],
+            owner_attestation: None,
+            artifact_transfer_supported: false,
+            stage_protocol_generation_supported: false,
+            stage_status_list_supported: false,
+            advertised_model_throughput: vec![],
+            display_rtt: None,
+            propagated_latency: None,
+            owner_summary: crate::crypto::OwnershipSummary::default(),
+        }
+    }
+
+    async fn test_node_with_remote_models(models: &[(&str, iroh::EndpointId)]) -> mesh::Node {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Client)
+            .await
+            .expect("test node should start");
+        for (model, peer_id) in models {
+            node.insert_test_peer(test_peer_serving_model(*peer_id, model))
+                .await;
+        }
+        node
+    }
+
+    fn text_auto_request() -> BufferedHttpRequest {
+        let body = serde_json::json!({
+            "model": "auto",
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let body_bytes = serde_json::to_vec(&body).expect("request body should serialize");
+        BufferedHttpRequest {
+            raw: Vec::new(),
+            method: "POST".to_string(),
+            path: "/v1/chat/completions".to_string(),
+            client_path: "/v1/chat/completions".to_string(),
+            body_json: Some(body),
+            body_json_attempted: true,
+            body_bytes: Some(body_bytes),
+            body_len_bytes: 0,
+            completion_tokens: None,
+            model_name: Some("auto".to_string()),
+            stream: None,
+            request_object_request_ids: Vec::new(),
+            response_adapter: ResponseAdapter::None,
+        }
+    }
+
     async fn read_request_from_parts_with_limits(
         parts: Vec<Vec<u8>>,
         limits: HttpReadLimits,
@@ -5159,6 +5275,111 @@ mod tests {
             &media,
             &descriptors
         ));
+    }
+
+    #[tokio::test]
+    async fn cached_auto_model_stays_sticky_when_no_ready_remote_model_exists() -> Result<()> {
+        let cached_model = "cached-cooling-model-31B";
+        let alternate_model = "alternate-cooling-model-31B";
+        let cached_peer = iroh::EndpointId::from(iroh::SecretKey::generate().public());
+        let alternate_peer = iroh::EndpointId::from(iroh::SecretKey::generate().public());
+        let node = test_node_with_remote_models(&[
+            (cached_model, cached_peer),
+            (alternate_model, alternate_peer),
+        ])
+        .await;
+        let affinity = AffinityRouter::new();
+        let key = 0xA11CE;
+        affinity.remember_auto_model(key, cached_model);
+        affinity.record_target_outcome(
+            Some(cached_model),
+            &election::InferenceTarget::Remote(cached_peer),
+            TargetHealthOutcome::Unavailable,
+        );
+        affinity.record_target_outcome(
+            Some(alternate_model),
+            &election::InferenceTarget::Remote(alternate_peer),
+            TargetHealthOutcome::Unavailable,
+        );
+        let descriptors = vec![
+            local_gguf_descriptor(cached_model),
+            local_gguf_descriptor(alternate_model),
+        ];
+        let media = router::MediaRequirements::default();
+        let caps = crate::models::ModelCapabilities::default();
+        let available = vec![
+            router::RoutingCandidate::unscored(cached_model, caps),
+            router::RoutingCandidate::unscored(alternate_model, caps),
+        ];
+        let ready_models =
+            auto_route::ready_remote_models(&node, None, &available, &affinity).await;
+        assert!(ready_models.is_empty());
+
+        let cached = lookup_cached_auto_model(
+            &node,
+            &descriptors,
+            &affinity,
+            Some(key),
+            &media,
+            &ready_models,
+        )
+        .await;
+
+        assert_eq!(cached.as_deref(), Some(cached_model));
+        assert_eq!(
+            affinity.lookup_auto_model(key).as_deref(),
+            Some(cached_model)
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn auto_model_cache_switches_when_ready_alternate_exists() -> Result<()> {
+        let cached_model = "cached-cooling-model-31B";
+        let alternate_model = "ready-alternate-model-31B";
+        let cached_peer = iroh::EndpointId::from(iroh::SecretKey::generate().public());
+        let alternate_peer = iroh::EndpointId::from(iroh::SecretKey::generate().public());
+        let node = test_node_with_remote_models(&[
+            (cached_model, cached_peer),
+            (alternate_model, alternate_peer),
+        ])
+        .await;
+        let affinity = AffinityRouter::new();
+        let key = 0xB0B;
+        affinity.remember_auto_model(key, cached_model);
+        affinity.record_target_outcome(
+            Some(cached_model),
+            &election::InferenceTarget::Remote(cached_peer),
+            TargetHealthOutcome::Unavailable,
+        );
+        let served = vec![cached_model.to_string(), alternate_model.to_string()];
+        let descriptors = vec![
+            local_gguf_descriptor(cached_model),
+            local_gguf_descriptor(alternate_model),
+        ];
+        let mut request = text_auto_request();
+
+        let resolved = resolve_auto_model_request(AutoModelRequestArgs {
+            node: &node,
+            request: &mut request,
+            served: &served,
+            descriptors: &descriptors,
+            is_auto_request: true,
+            auto_session_key: Some(key),
+            required_tokens: None,
+            affinity: &affinity,
+        })
+        .await;
+
+        assert!(matches!(
+            resolved,
+            AutoModelResolution::Model(Some(model)) if model == alternate_model
+        ));
+        assert_eq!(
+            affinity.lookup_auto_model(key).as_deref(),
+            Some(alternate_model)
+        );
+        Ok(())
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/target_health.rs
+++ b/crates/mesh-llm-host-runtime/src/network/target_health.rs
@@ -133,7 +133,24 @@ impl TargetHealth {
         model: &str,
         candidates: &[InferenceTarget],
     ) -> Vec<InferenceTarget> {
-        if candidates.len() <= 1 {
+        self.eligible_candidates_inner(model, candidates, true)
+    }
+
+    pub(crate) fn strict_eligible_candidates(
+        &self,
+        model: &str,
+        candidates: &[InferenceTarget],
+    ) -> Vec<InferenceTarget> {
+        self.eligible_candidates_inner(model, candidates, false)
+    }
+
+    fn eligible_candidates_inner(
+        &self,
+        model: &str,
+        candidates: &[InferenceTarget],
+        preserve_availability: bool,
+    ) -> Vec<InferenceTarget> {
+        if preserve_availability && candidates.len() <= 1 {
             return candidates.to_vec();
         }
         let Some(model) = normalized_model(Some(model)) else {
@@ -157,7 +174,7 @@ impl TargetHealth {
             }
         }
 
-        if cooling == 0 || !has_routable_candidate(&eligible) {
+        if cooling == 0 || (preserve_availability && !has_routable_candidate(&eligible)) {
             candidates.to_vec()
         } else {
             state.routes_avoided = state.routes_avoided.saturating_add(cooling as u64);
@@ -337,6 +354,51 @@ mod tests {
             TargetHealthSnapshot {
                 cooling_targets: 1,
                 routes_avoided: 0,
+            }
+        );
+    }
+
+    #[test]
+    fn strict_candidates_exclude_single_cooling_target_for_auto_fallback() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert!(
+            health
+                .strict_eligible_candidates("qwen", &candidates)
+                .is_empty()
+        );
+        assert_eq!(
+            health.snapshot(),
+            TargetHealthSnapshot {
+                cooling_targets: 1,
+                routes_avoided: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn strict_candidates_exclude_all_cooling_targets_for_auto_fallback() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
+        health.record_outcome(Some("qwen"), &local(9002), TargetHealthOutcome::Unavailable);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert!(
+            health
+                .strict_eligible_candidates("qwen", &candidates)
+                .is_empty()
+        );
+        assert_eq!(
+            health.snapshot(),
+            TargetHealthSnapshot {
+                cooling_targets: 2,
+                routes_avoided: 2,
             }
         );
     }


### PR DESCRIPTION
## Summary

`model=auto` now avoids choosing a model whose only available targets are cooling, unavailable, or too small for the request context when another suitable model can serve the prompt. Explicit requests for a named model keep the existing availability-preserving behavior, but auto routing gets a stricter pre-selection path so agent/chat traffic can fall through to a healthier model instead of repeatedly spending turns on a known-bad top pick.

Fixes #625.

## Why

#625 describes the public-mesh failure mode directly: auto could classify a prompt, pick the preferred model, and then keep routing to that model even when its only peer had just failed. The existing target-health filter intentionally preserved availability for explicit model requests, but auto routing needed model-level admission before it committed to a model.

The review pass also caught an important stickiness edge: a cached `model=auto` session should not abandon its current model merely because that model is cooling if every alternative is cooling too. In that case switching models does not buy a healthier route and can break agent/tool-loop KV locality.

## Diff scope

- Adds a strict target-health path for auto routing while keeping the existing lenient path for explicit model routes.
- Adds an auto-route admission module that checks both request context budget and target health before a model participates in auto selection.
- Applies the same ready-model pool to both passive mesh OpenAI routing and local API ingress routing.
- Reclassifies cached auto-model sessions only when the cached model is missing, cannot satisfy media requirements, or a non-empty ready-model pool excludes it.
- Preserves cached auto-model stickiness when no ready alternate model exists.
- Adds regression coverage for single-candidate cooldown, all-cooling fallback behavior, ready-model pool selection, cached all-cooling stickiness, and switching to a ready alternate.

## Behavior notes

- If at least one auto candidate has a healthy/context-compatible target, auto selects from that ready pool.
- If every candidate is cooling or otherwise ineligible, auto preserves availability by falling back to the original candidate pool instead of manufacturing an immediate empty-route failure.
- Cached auto sessions keep their model when the ready pool is empty; they switch only when another compatible model has a proven eligible target.
- Missing cached models and media-incompatible cached models are still hard reclassification reasons.
- `ContextOverflow`, 4xx rejections, and client disconnects still do not poison target health; only retryable timeout/unavailable outcomes cool targets.

## Compatibility

No mesh protocol, Skippy ABI, package format, release metadata, or CLI contract changes. This is process-local routing behavior only; no new gossip fields or mixed-version incompatibility.

## Validation

Validation tier: Tier 3 - shared OpenAI routing behavior for agent/model auto selection, refreshed on current main and updated for the cached auto-model stickiness review fix.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `6d2f6b104f0ebc63f933fced1d840bacbdc15b34`
- `git rebase origin/main`: PASS, no conflicts
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime openai::transport --lib -- --test-threads=1`: PASS, 63 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime auto_route --lib -- --test-threads=1`: PASS, 2 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime target_health --lib -- --test-threads=1`: PASS, 11 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime strict_eligible --lib -- --test-threads=1`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS

Ledger: not applicable - not required for selected validation tier/change family.
Version: not applicable - no release/version sync required for this non-release routing behavior change.

Not run: live multi-node agent smoke. I did not have a local model/runtime mesh endpoint available; deterministic routing-health and auto-route unit coverage plus shipped-binary check/clippy cover the changed paths.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risk

This should still get normal PR CI and one real public/private mesh smoke with `model=auto` after opening: force one preferred model target into cooldown/unavailable state, confirm auto falls through to another compatible model, then confirm the preferred model can participate again after health recovers.
