### PR TITLE
Add model metadata to models API

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -7,8 +7,9 @@
 
 pub use mesh_llm_types::mesh::{
     DEMAND_TTL_SECS, MAX_SPLIT_RTT_MS, ModelDemand, ModelRuntimeDescriptor, ModelSourceKind,
-    ServedModelDescriptor, ServedModelIdentity, infer_available_model_descriptors,
-    infer_local_served_model_descriptor, infer_served_model_descriptors, merge_demand,
+    ServedModelDescriptor, ServedModelIdentity, ServedModelMetadata,
+    infer_available_model_descriptors, infer_local_served_model_descriptor,
+    infer_served_model_descriptors, merge_demand,
 };
 
 use anyhow::{Context, Result};
@@ -934,6 +935,7 @@ fn infer_remote_served_descriptors(
                 capabilities_known: false,
                 capabilities: crate::models::ModelCapabilities::default(),
                 topology: None,
+                metadata: None,
             }
         })
         .collect()
@@ -1126,6 +1128,7 @@ fn descriptor_from_identity(
         capabilities_known: true,
         capabilities,
         topology,
+        metadata: crate::models::served_model_metadata_for_path(model_name, &path),
     }
 }
 
@@ -1247,7 +1250,8 @@ fn model_descriptor_score(descriptor: &ServedModelDescriptor) -> u8 {
         + u8::from(descriptor.capabilities.vision != crate::models::CapabilityLevel::None)
         + u8::from(descriptor.capabilities.reasoning != crate::models::CapabilityLevel::None)
         + u8::from(descriptor.capabilities.tool_use != crate::models::CapabilityLevel::None);
-    model_identity_score(identity) + capability_bonus
+    let metadata_bonus = u8::from(descriptor.metadata.is_some());
+    model_identity_score(identity) + capability_bonus + metadata_bonus
 }
 
 fn upsert_mesh_catalog_descriptor(
@@ -3909,6 +3913,34 @@ impl Node {
         self.served_model_descriptors.lock().await.clone()
     }
 
+    pub async fn all_served_model_descriptors(&self) -> Vec<ServedModelDescriptor> {
+        let mut descriptors = self.served_model_descriptors.lock().await.clone();
+        let peer_descriptors = {
+            let state = self.state.lock().await;
+            state
+                .peers
+                .values()
+                .flat_map(|peer| peer.served_model_descriptors.clone())
+                .collect::<Vec<_>>()
+        };
+        descriptors.extend(peer_descriptors);
+        descriptors
+    }
+
+    pub async fn all_model_runtime_descriptors(&self) -> Vec<ModelRuntimeDescriptor> {
+        let mut runtimes = self.model_runtime_descriptors.lock().await.clone();
+        let peer_runtimes = {
+            let state = self.state.lock().await;
+            state
+                .peers
+                .values()
+                .flat_map(|peer| peer.served_model_runtime.clone())
+                .collect::<Vec<_>>()
+        };
+        runtimes.extend(peer_runtimes);
+        runtimes
+    }
+
     pub async fn serving_models(&self) -> Vec<String> {
         self.serving_models.lock().await.clone()
     }
@@ -3943,11 +3975,18 @@ impl Node {
             Vec::new()
         };
         for descriptor in &mut descriptors {
+            if descriptor.metadata.is_none() {
+                descriptor.metadata =
+                    crate::models::served_model_metadata_for_model(&descriptor.identity.model_name);
+            }
             if let Some(existing) = existing_by_name.get(&descriptor.identity.model_name) {
                 descriptor.capabilities = existing.capabilities;
                 descriptor.capabilities_known = existing.capabilities_known;
                 if existing.topology.is_some() {
                     descriptor.topology = existing.topology.clone();
+                }
+                if existing.metadata.is_some() {
+                    descriptor.metadata = existing.metadata.clone();
                 }
             }
         }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -289,6 +289,7 @@ async fn set_serving_models_preserves_existing_known_descriptor_capabilities_whe
             ..Default::default()
         },
         topology: None,
+        metadata: None,
     })
     .await;
 
@@ -3275,6 +3276,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         vocab_size: 151936,
         embedding_size: 4096,
         head_count: 32,
+        kv_head_count: 0,
         layer_count: 36,
         feed_forward_length: 14336,
         key_length: 128,
@@ -3288,6 +3290,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
         expert_count: 0,
         used_expert_count: 0,
         quantization_type: "Q4_K_M".to_string(),
+        parameter_size: None,
     };
 
     let mut model_sizes = HashMap::new();
@@ -3343,6 +3346,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
             capabilities_known: true,
             capabilities: crate::models::ModelCapabilities::default(),
             topology: None,
+            metadata: None,
         }],
         served_model_runtime: vec![ModelRuntimeDescriptor {
             model_name: "Qwen3-8B-Q4_K_M".to_string(),
@@ -3493,6 +3497,7 @@ fn proto_ann_to_local_treats_missing_default_capability_provenance_as_unknown() 
             capabilities: Some(crate::proto::node::ModelCapabilities::default()),
             capabilities_known: None,
             topology: None,
+            metadata: None,
         }],
         ..Default::default()
     };
@@ -3581,6 +3586,7 @@ fn transitive_peer_update_refreshes_metadata_fields() {
         vocab_size: 32000,
         embedding_size: 4096,
         head_count: 32,
+        kv_head_count: 0,
         layer_count: 32,
         feed_forward_length: 11008,
         key_length: 128,
@@ -3594,6 +3600,7 @@ fn transitive_peer_update_refreshes_metadata_fields() {
         expert_count: 0,
         used_expert_count: 0,
         quantization_type: "Q4_K_M".to_string(),
+        parameter_size: None,
     };
 
     let mut new_sizes = HashMap::new();
@@ -4578,6 +4585,7 @@ fn remote_model_scans_are_ignored_after_gossip() {
         vocab_size: 128256,
         embedding_size: 8192,
         head_count: 64,
+        kv_head_count: 0,
         layer_count: 80,
         feed_forward_length: 28672,
         key_length: 128,
@@ -4591,6 +4599,7 @@ fn remote_model_scans_are_ignored_after_gossip() {
         expert_count: 0,
         used_expert_count: 0,
         quantization_type: "Q4_K_M".to_string(),
+        parameter_size: None,
     };
     let mut model_sizes = std::collections::HashMap::new();
     model_sizes.insert("Llama-3.3-70B-Q4_K_M".to_string(), 42_000_000_000u64);

--- a/crates/mesh-llm-host-runtime/src/models/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/models/inventory.rs
@@ -24,10 +24,14 @@ pub struct ModelMetadataCacheProgress {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct CachedCompactModelMetadata {
     model_key: String,
+    #[serde(default)]
+    parameter_size: Option<String>,
     context_length: u32,
     vocab_size: u32,
     embedding_size: u32,
     head_count: u32,
+    #[serde(default)]
+    kv_head_count: u32,
     layer_count: u32,
     feed_forward_length: u32,
     key_length: u32,
@@ -59,6 +63,7 @@ impl CachedCompactModelMetadata {
             vocab_size: self.vocab_size,
             embedding_size: self.embedding_size,
             head_count: self.head_count,
+            kv_head_count: self.kv_head_count,
             layer_count: self.layer_count,
             feed_forward_length: self.feed_forward_length,
             key_length: self.key_length,
@@ -68,20 +73,23 @@ impl CachedCompactModelMetadata {
             special_tokens: vec![],
             rope_scale: self.rope_scale,
             rope_freq_base: self.rope_freq_base,
-            is_moe: false,
-            expert_count: 0,
-            used_expert_count: 0,
+            is_moe: self.expert_count > 0,
+            expert_count: self.expert_count,
+            used_expert_count: self.used_expert_count,
             quantization_type: self.quantization_type,
+            parameter_size: self.parameter_size,
         }
     }
 
     fn from_proto(meta: &crate::proto::node::CompactModelMetadata) -> Self {
         Self {
             model_key: meta.model_key.clone(),
+            parameter_size: meta.parameter_size.clone(),
             context_length: meta.context_length,
             vocab_size: meta.vocab_size,
             embedding_size: meta.embedding_size,
             head_count: meta.head_count,
+            kv_head_count: meta.kv_head_count,
             layer_count: meta.layer_count,
             feed_forward_length: meta.feed_forward_length,
             key_length: meta.key_length,
@@ -90,8 +98,8 @@ impl CachedCompactModelMetadata {
             tokenizer_model_name: meta.tokenizer_model_name.clone(),
             rope_scale: meta.rope_scale,
             rope_freq_base: meta.rope_freq_base,
-            expert_count: 0,
-            used_expert_count: 0,
+            expert_count: meta.expert_count,
+            used_expert_count: meta.used_expert_count,
             quantization_type: meta.quantization_type.clone(),
         }
     }
@@ -199,6 +207,7 @@ fn compact_metadata_from_gguf(
             vocab_size: m.vocab_size,
             embedding_size: m.embedding_size,
             head_count: m.head_count,
+            kv_head_count: m.kv_head_count,
             layer_count: m.layer_count,
             feed_forward_length: m.feed_forward_length,
             key_length: m.key_length,
@@ -208,10 +217,11 @@ fn compact_metadata_from_gguf(
             special_tokens: vec![],
             rope_scale: m.rope_scale,
             rope_freq_base: m.rope_freq_base,
-            is_moe: false,
-            expert_count: 0,
-            used_expert_count: 0,
+            is_moe: m.expert_count > 0,
+            expert_count: m.expert_count,
+            used_expert_count: m.expert_used_count,
             quantization_type,
+            parameter_size: m.parameter_size,
         }
     } else {
         crate::proto::node::CompactModelMetadata {

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -7,6 +7,7 @@ pub mod gguf;
 pub mod inventory;
 pub mod local;
 mod maintenance;
+mod profile;
 pub mod remote_catalog;
 pub mod resolve;
 pub use resolve::ResolvedModel;
@@ -30,6 +31,7 @@ pub use local::{
     model_ref_for_path, scan_installed_models, scan_local_models,
 };
 pub use maintenance::{run_update, warn_about_updates_for_paths};
+pub(crate) use profile::{served_model_metadata_for_model, served_model_metadata_for_path};
 pub use resolve::{
     ModelDetails, ShowVariantsProgress, canonicalize_interest_model_ref,
     download_model_ref_with_progress_details, find_loaded_remote_catalog_model_exact,

--- a/crates/mesh-llm-host-runtime/src/models/profile.rs
+++ b/crates/mesh-llm-host-runtime/src/models/profile.rs
@@ -1,0 +1,165 @@
+use std::path::Path;
+use std::sync::LazyLock;
+
+use regex_lite::Regex;
+
+pub(crate) fn served_model_metadata_for_model(
+    model_name: &str,
+) -> Option<crate::mesh::ServedModelMetadata> {
+    let path = crate::models::find_model_path(model_name);
+    served_model_metadata_for_path(model_name, &path)
+}
+
+pub(crate) fn served_model_metadata_for_path(
+    model_name: &str,
+    path: &Path,
+) -> Option<crate::mesh::ServedModelMetadata> {
+    let compact = path
+        .exists()
+        .then(|| crate::models::gguf::scan_gguf_compact_meta(path))
+        .flatten();
+    let metadata = match compact {
+        Some(meta) => {
+            let parameter_size = meta
+                .parameter_size
+                .clone()
+                .or_else(|| parameter_size_from_text(model_name));
+            let parameter_count_b = parameter_count_b_from_text(&format!(
+                "{} {}",
+                model_name,
+                meta.parameter_size.as_deref().unwrap_or("")
+            ));
+            let kv_head_count = meta.effective_kv_head_count();
+            crate::mesh::ServedModelMetadata {
+                architecture: non_empty(meta.architecture),
+                parameter_size,
+                parameter_count_b,
+                quant: path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .and_then(quant_from_text)
+                    .or_else(|| quant_from_text(model_name)),
+                native_context_length: non_zero(meta.context_length),
+                tokenizer: non_empty(meta.tokenizer_model_name),
+                layer_count: non_zero(meta.layer_count),
+                embedding_size: non_zero(meta.embedding_size),
+                head_count: non_zero(meta.head_count),
+                kv_head_count,
+                expert_count: non_zero(meta.expert_count),
+                active_expert_count: non_zero(meta.expert_used_count),
+            }
+        }
+        None => crate::mesh::ServedModelMetadata {
+            parameter_size: parameter_size_from_text(model_name),
+            parameter_count_b: parameter_count_b_from_text(model_name),
+            quant: quant_from_text(model_name),
+            ..Default::default()
+        },
+    };
+    (!metadata.is_empty()).then_some(metadata)
+}
+
+fn non_empty(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+fn non_zero(value: u32) -> Option<u32> {
+    (value > 0).then_some(value)
+}
+
+fn quant_from_text(value: &str) -> Option<String> {
+    let quant = crate::models::inventory::derive_quantization_type(value)
+        .trim()
+        .trim_end_matches(".gguf")
+        .to_string();
+    (!quant.is_empty()).then_some(quant)
+}
+
+fn parameter_size_from_text(text: &str) -> Option<String> {
+    static MULTIPLIED_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)([bm])").unwrap());
+    static SIMPLE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)([bm])").unwrap());
+
+    MULTIPLIED_RE
+        .captures(text)
+        .map(|captures| {
+            format!(
+                "{}x{}{}",
+                &captures[1],
+                &captures[2],
+                captures[3].to_ascii_uppercase()
+            )
+        })
+        .or_else(|| {
+            SIMPLE_RE
+                .captures(text)
+                .map(|captures| format!("{}{}", &captures[1], captures[2].to_ascii_uppercase()))
+        })
+}
+
+fn parameter_count_b_from_text(text: &str) -> Option<f64> {
+    static MULTIPLIED_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)([bm])").unwrap());
+    static SIMPLE_RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)([bm])").unwrap());
+
+    let mut best: Option<f64> = None;
+    for captures in MULTIPLIED_RE.captures_iter(text) {
+        let Some(left) = captures.get(1).and_then(|m| m.as_str().parse::<f64>().ok()) else {
+            continue;
+        };
+        let Some(right) = captures.get(2).and_then(|m| m.as_str().parse::<f64>().ok()) else {
+            continue;
+        };
+        let Some(unit) = captures.get(3).map(|m| m.as_str().to_ascii_lowercase()) else {
+            continue;
+        };
+        let value = match unit.as_str() {
+            "b" => left * right,
+            "m" => (left * right) / 1000.0,
+            _ => continue,
+        };
+        best = Some(best.map_or(value, |current| current.max(value)));
+    }
+    for captures in SIMPLE_RE.captures_iter(text) {
+        let Some(count) = captures.get(1).and_then(|m| m.as_str().parse::<f64>().ok()) else {
+            continue;
+        };
+        let Some(unit) = captures.get(2).map(|m| m.as_str().to_ascii_lowercase()) else {
+            continue;
+        };
+        let value = match unit.as_str() {
+            "b" => count,
+            "m" => count / 1000.0,
+            _ => continue,
+        };
+        best = Some(best.map_or(value, |current| current.max(value)));
+    }
+    best
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parameter_count_b_from_text, parameter_size_from_text};
+
+    #[test]
+    fn extracts_parameter_size_labels() {
+        assert_eq!(
+            parameter_size_from_text("Qwen3-32B-Q4_K_M").as_deref(),
+            Some("32B")
+        );
+        assert_eq!(
+            parameter_size_from_text("mixtral-8x7b").as_deref(),
+            Some("8x7B")
+        );
+    }
+
+    #[test]
+    fn extracts_total_parameter_count_b() {
+        assert_eq!(parameter_count_b_from_text("Qwen3-32B-Q4_K_M"), Some(32.0));
+        assert_eq!(parameter_count_b_from_text("mixtral-8x7b"), Some(56.0));
+        assert_eq!(parameter_count_b_from_text("235B-A22B"), Some(235.0));
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -154,8 +154,10 @@ async fn handle_models_list_request(
     }
     models.sort();
     models.dedup();
-    let descriptors = node.served_model_descriptors().await;
-    let _ = proxy::send_models_list_with_descriptors(tcp_stream, &models, &descriptors).await;
+    let descriptors = node.all_served_model_descriptors().await;
+    let runtimes = node.all_model_runtime_descriptors().await;
+    let _ = proxy::send_models_list_with_descriptors(tcp_stream, &models, &descriptors, &runtimes)
+        .await;
 }
 
 async fn collect_available_models_for_auto_route(
@@ -219,6 +221,8 @@ async fn resolve_auto_routed_model(
             router::RoutingCandidate {
                 name: name.as_str(),
                 caps,
+                parameter_count_b: proxy::descriptor_metadata_for_model(name, descriptors)
+                    .and_then(|metadata| metadata.parameter_count_b),
                 tps_hint,
                 throughput_samples,
             }
@@ -637,7 +641,7 @@ async fn handle_buffered_api_request(
 
     let local_models = ctx.route.node.models_being_served().await;
     let callable = callable_models_with_local_served(ctx.route.targets, local_models);
-    let descriptors = ctx.route.node.served_model_descriptors().await;
+    let descriptors = ctx.route.node.all_served_model_descriptors().await;
     proxy::rewrite_public_model_alias(&mut request, &callable, &descriptors);
 
     if proxy::is_drop_request(&request.method, &request.path) {

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -2739,6 +2739,13 @@ pub(crate) fn capabilities_for_model(
         .unwrap_or_else(|| crate::models::installed_model_capabilities(model))
 }
 
+pub(crate) fn descriptor_metadata_for_model<'a>(
+    model: &str,
+    descriptors: &'a [mesh::ServedModelDescriptor],
+) -> Option<&'a mesh::ServedModelMetadata> {
+    descriptor_for_model(descriptors, model).and_then(|descriptor| descriptor.metadata.as_ref())
+}
+
 fn capture_path_for_request(request: &BufferedHttpRequest) -> &str {
     &request.client_path
 }
@@ -2785,8 +2792,10 @@ pub async fn handle_mesh_request(
     // Handle /v1/models
     if is_models_list_request(&request.method, &request.path) {
         let served = node.models_being_served().await;
-        let descriptors = node.served_model_descriptors().await;
-        let _ = send_models_list_with_descriptors(tcp_stream, &served, &descriptors).await;
+        let descriptors = node.all_served_model_descriptors().await;
+        let runtimes = node.all_model_runtime_descriptors().await;
+        let _ =
+            send_models_list_with_descriptors(tcp_stream, &served, &descriptors, &runtimes).await;
         return;
     }
 
@@ -2847,7 +2856,7 @@ async fn build_mesh_request_plan(
     affinity: &AffinityRouter,
 ) -> std::result::Result<MeshRequestPlan, MeshRequestFailure> {
     let served = node.models_being_served().await;
-    let descriptors = node.served_model_descriptors().await;
+    let descriptors = node.all_served_model_descriptors().await;
     rewrite_public_model_alias(request, &served, &descriptors);
 
     let is_auto_request =
@@ -3325,6 +3334,8 @@ async fn resolve_auto_model_request(
             router::RoutingCandidate {
                 name: name.as_str(),
                 caps,
+                parameter_count_b: descriptor_metadata_for_model(name, descriptors)
+                    .and_then(|metadata| metadata.parameter_count_b),
                 tps_hint,
                 throughput_samples,
             }
@@ -3959,8 +3970,9 @@ pub async fn send_models_list_with_descriptors(
     mut stream: TcpStream,
     models: &[String],
     descriptors: &[mesh::ServedModelDescriptor],
+    runtimes: &[mesh::ModelRuntimeDescriptor],
 ) -> std::io::Result<()> {
-    let body = models_list_json(models, descriptors).to_string();
+    let body = models_list_json(models, descriptors, runtimes).to_string();
     let resp = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}",
         body.len(),
@@ -3974,6 +3986,7 @@ pub async fn send_models_list_with_descriptors(
 fn models_list_json(
     models: &[String],
     descriptors: &[mesh::ServedModelDescriptor],
+    runtimes: &[mesh::ModelRuntimeDescriptor],
 ) -> serde_json::Value {
     let mut seen = std::collections::HashSet::new();
     let data: Vec<serde_json::Value> = models
@@ -4006,7 +4019,7 @@ fn models_list_json(
             } else {
                 public_id.clone()
             };
-            Some(serde_json::json!({
+            let mut model = serde_json::json!({
                 "id": public_id,
                 "display_name": display_name,
                 "object": "model",
@@ -4016,11 +4029,82 @@ fn models_list_json(
                 "vision_status": capabilities.vision_status(),
                 "audio_status": capabilities.audio_status(),
                 "reasoning_status": capabilities.reasoning_status(),
-            }))
+            });
+            if let Some(metadata) = model_metadata_json(m, descriptor, runtimes) {
+                if let Some(object) = model.as_object_mut() {
+                    object.insert("metadata".to_string(), metadata);
+                }
+            }
+            Some(model)
         })
         .collect();
 
     serde_json::json!({ "object": "list", "data": data })
+}
+
+fn model_metadata_json(
+    model_name: &str,
+    descriptor: Option<&mesh::ServedModelDescriptor>,
+    runtimes: &[mesh::ModelRuntimeDescriptor],
+) -> Option<serde_json::Value> {
+    let mut metadata = serde_json::Map::new();
+    let descriptor_metadata = descriptor.and_then(|descriptor| descriptor.metadata.as_ref());
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.architecture.as_ref()) {
+        metadata.insert("architecture".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.parameter_size.as_ref()) {
+        metadata.insert("parameter_size".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.parameter_count_b) {
+        if value.is_finite() {
+            metadata.insert("parameter_count_b".to_string(), serde_json::json!(value));
+        }
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.quant.as_ref()) {
+        metadata.insert("quant".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = runtime_context_length_for_model(model_name, runtimes) {
+        metadata.insert("context_length".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.native_context_length) {
+        metadata.insert(
+            "native_context_length".to_string(),
+            serde_json::json!(value),
+        );
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.tokenizer.as_ref()) {
+        metadata.insert("tokenizer".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.layer_count) {
+        metadata.insert("layer_count".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.embedding_size) {
+        metadata.insert("embedding_size".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.head_count) {
+        metadata.insert("head_count".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.kv_head_count) {
+        metadata.insert("kv_head_count".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.expert_count) {
+        metadata.insert("expert_count".to_string(), serde_json::json!(value));
+    }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.active_expert_count) {
+        metadata.insert("active_expert_count".to_string(), serde_json::json!(value));
+    }
+    (!metadata.is_empty()).then_some(serde_json::Value::Object(metadata))
+}
+
+fn runtime_context_length_for_model(
+    model_name: &str,
+    runtimes: &[mesh::ModelRuntimeDescriptor],
+) -> Option<u32> {
+    runtimes
+        .iter()
+        .filter(|runtime| runtime.model_name == model_name)
+        .filter_map(mesh::ModelRuntimeDescriptor::advertised_context_length)
+        .max()
 }
 
 pub fn rewrite_public_model_alias(
@@ -4676,7 +4760,7 @@ mod tests {
         let models = vec!["Falcon-H1-1.5B-Instruct-Q4_K_M".to_string()];
         let descriptors = vec![hf_descriptor(&models[0])];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
 
         assert_eq!(
             body["data"][0]["id"],
@@ -4727,7 +4811,7 @@ mod tests {
         };
         let descriptors = vec![descriptor];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
         let public_id = body["data"][0]["id"].as_str().unwrap_or_default();
 
         // The public ID must NOT silently drop the quant suffix that the
@@ -4750,7 +4834,7 @@ mod tests {
         let models = vec!["Falcon-H1-1.5B-Instruct-Q4_K_M".to_string()];
         let descriptors = vec![catalog_model_ref_descriptor(&models[0])];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
 
         assert_eq!(
             body["data"][0]["id"],
@@ -4763,10 +4847,53 @@ mod tests {
         let models = vec!["smollm2-a".to_string()];
         let descriptors = vec![local_gguf_descriptor(&models[0])];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
 
         assert_eq!(body["data"][0]["id"], "smollm2-a");
         assert_eq!(body["data"][0]["display_name"], "smollm2-a");
+    }
+
+    #[test]
+    fn models_list_reports_model_metadata() {
+        let models = vec!["Qwen3-32B-Q4_K_M".to_string()];
+        let mut descriptor = local_gguf_descriptor(&models[0]);
+        descriptor.metadata = Some(mesh::ServedModelMetadata {
+            architecture: Some("qwen3".to_string()),
+            parameter_size: Some("32B".to_string()),
+            parameter_count_b: Some(32.0),
+            quant: Some("Q4_K_M".to_string()),
+            native_context_length: Some(32_768),
+            tokenizer: Some("gpt2".to_string()),
+            layer_count: Some(64),
+            embedding_size: Some(5120),
+            head_count: Some(40),
+            kv_head_count: Some(8),
+            expert_count: Some(128),
+            active_expert_count: Some(8),
+        });
+        let runtimes = vec![mesh::ModelRuntimeDescriptor {
+            model_name: models[0].clone(),
+            identity_hash: None,
+            context_length: Some(65_536),
+            ready: true,
+        }];
+
+        let body = models_list_json(&models, &[descriptor], &runtimes);
+        let metadata = &body["data"][0]["metadata"];
+
+        assert_eq!(metadata["architecture"], "qwen3");
+        assert_eq!(metadata["parameter_size"], "32B");
+        assert_eq!(metadata["parameter_count_b"], 32.0);
+        assert_eq!(metadata["quant"], "Q4_K_M");
+        assert_eq!(metadata["context_length"], 65_536);
+        assert_eq!(metadata["native_context_length"], 32_768);
+        assert_eq!(metadata["tokenizer"], "gpt2");
+        assert_eq!(metadata["layer_count"], 64);
+        assert_eq!(metadata["embedding_size"], 5120);
+        assert_eq!(metadata["head_count"], 40);
+        assert_eq!(metadata["kv_head_count"], 8);
+        assert_eq!(metadata["expert_count"], 128);
+        assert_eq!(metadata["active_expert_count"], 8);
     }
 
     #[test]
@@ -4777,7 +4904,7 @@ mod tests {
             crate::models::ModelCapabilities::default(),
         )];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
 
         assert_eq!(body["data"][0]["capabilities"], serde_json::json!(["text"]));
         assert_eq!(body["data"][0]["vision_status"], "none");
@@ -4789,7 +4916,7 @@ mod tests {
         let models = vec!["Qwen3VL-2B-Instruct-Q4_K_M".to_string()];
         let descriptors = vec![local_gguf_descriptor(&models[0])];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
         let capabilities = body["data"][0]["capabilities"].as_array().unwrap();
 
         assert!(capabilities.iter().any(|cap| cap == "multimodal"));
@@ -4810,7 +4937,7 @@ mod tests {
             },
         )];
 
-        let body = models_list_json(&models, &descriptors);
+        let body = models_list_json(&models, &descriptors, &[]);
         let capabilities = body["data"][0]["capabilities"].as_array().unwrap();
 
         assert!(capabilities.iter().any(|cap| cap == "multimodal"));

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -4030,10 +4030,10 @@ fn models_list_json(
                 "audio_status": capabilities.audio_status(),
                 "reasoning_status": capabilities.reasoning_status(),
             });
-            if let Some(metadata) = model_metadata_json(m, descriptor, runtimes) {
-                if let Some(object) = model.as_object_mut() {
-                    object.insert("metadata".to_string(), metadata);
-                }
+            if let Some(metadata) = model_metadata_json(m, descriptor, runtimes)
+                && let Some(object) = model.as_object_mut()
+            {
+                object.insert("metadata".to_string(), metadata);
             }
             Some(model)
         })
@@ -4055,10 +4055,10 @@ fn model_metadata_json(
     if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.parameter_size.as_ref()) {
         metadata.insert("parameter_size".to_string(), serde_json::json!(value));
     }
-    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.parameter_count_b) {
-        if value.is_finite() {
-            metadata.insert("parameter_count_b".to_string(), serde_json::json!(value));
-        }
+    if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.parameter_count_b)
+        && value.is_finite()
+    {
+        metadata.insert("parameter_count_b".to_string(), serde_json::json!(value));
     }
     if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.quant.as_ref()) {
         metadata.insert("quant".to_string(), serde_json::json!(value));

--- a/crates/mesh-llm-host-runtime/src/network/router.rs
+++ b/crates/mesh-llm-host-runtime/src/network/router.rs
@@ -492,6 +492,8 @@ fn message_text(msg: &Value) -> String {
 pub struct RoutingCandidate<'a> {
     pub name: &'a str,
     pub caps: crate::models::ModelCapabilities,
+    /// Total model parameter count in billions, when advertised.
+    pub parameter_count_b: Option<f64>,
     /// Locally observed throughput in tokens/sec. `None` if no
     /// throughput-bearing attempts have completed for this model yet.
     pub tps_hint: Option<f64>,
@@ -507,6 +509,7 @@ impl<'a> RoutingCandidate<'a> {
         Self {
             name,
             caps,
+            parameter_count_b: None,
             tps_hint: None,
             throughput_samples: 0,
         }
@@ -588,15 +591,12 @@ pub fn pick_model_classified<'a>(
         filtered
     };
 
-    // Bias toward larger models: names that advertise a single-digit
-    // parameter count (e.g. "2B", "9B") go to the bottom. Everything
-    // else — multi-digit billions (31B, 70B) or names that don't encode
-    // a size at all (MiniMax, Coder-Next, fine-tune tags) — stays on
-    // top. The big tier is sampled by tok/s-weighted draw; the small
-    // tier acts only as a fallback when the big tier is empty.
+    // Bias toward larger models: explicit metadata below 10B goes to the
+    // bottom tier. When metadata is absent, fall back to the legacy
+    // single-digit-B name heuristic.
     let (big, small): (Vec<_>, Vec<_>) = candidates
         .into_iter()
-        .partition(|c| !is_single_digit_b_name(c.name));
+        .partition(|c| !is_small_parameter_model(c));
 
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -660,6 +660,13 @@ fn pick_weighted<'a>(candidates: &[&RoutingCandidate<'a>], seed: u64) -> &'a str
     }
     // Numerical tail: pick the last candidate.
     candidates[candidates.len() - 1].name
+}
+
+fn is_small_parameter_model(candidate: &RoutingCandidate<'_>) -> bool {
+    candidate
+        .parameter_count_b
+        .map(|count| count.is_finite() && count < 10.0)
+        .unwrap_or_else(|| is_single_digit_b_name(candidate.name))
 }
 
 /// Small deterministic PRNG so a single seed drives both the
@@ -1271,6 +1278,29 @@ mod tests {
     }
 
     #[test]
+    fn test_pick_uses_parameter_metadata_before_name_heuristic() {
+        use crate::models::ModelCapabilities;
+
+        let no_caps = ModelCapabilities::default();
+        let mut misleading_big_name = RoutingCandidate::unscored("unknown-strong-name", no_caps);
+        misleading_big_name.parameter_count_b = Some(7.0);
+        let mut misleading_small_name = RoutingCandidate::unscored("tiny-looking-7B", no_caps);
+        misleading_small_name.parameter_count_b = Some(32.0);
+        let available = vec![misleading_big_name, misleading_small_name];
+        let cl = Classification {
+            category: Category::Chat,
+            complexity: Complexity::Moderate,
+            needs_tools: false,
+            has_media_inputs: false,
+        };
+
+        for _ in 0..100 {
+            let picked = pick_model_classified(&cl, &available).expect("some pick");
+            assert_eq!(picked, "tiny-looking-7B");
+        }
+    }
+
+    #[test]
     fn test_pick_falls_back_to_small_when_no_big_tier() {
         use crate::models::ModelCapabilities;
 
@@ -1338,6 +1368,7 @@ mod tests {
         RoutingCandidate {
             name,
             caps,
+            parameter_count_b: None,
             tps_hint: Some(tps),
             throughput_samples: samples,
         }

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -261,6 +261,45 @@ fn legacy_descriptor_from_identity(
         capabilities_known: false,
         capabilities: crate::models::ModelCapabilities::default(),
         topology: None,
+        metadata: None,
+    }
+}
+
+fn local_model_metadata_to_proto(
+    metadata: &crate::mesh::ServedModelMetadata,
+) -> crate::proto::node::ServedModelMetadata {
+    crate::proto::node::ServedModelMetadata {
+        architecture: metadata.architecture.clone(),
+        parameter_size: metadata.parameter_size.clone(),
+        parameter_count_b: metadata.parameter_count_b,
+        quant: metadata.quant.clone(),
+        native_context_length: metadata.native_context_length,
+        tokenizer: metadata.tokenizer.clone(),
+        layer_count: metadata.layer_count,
+        embedding_size: metadata.embedding_size,
+        head_count: metadata.head_count,
+        kv_head_count: metadata.kv_head_count,
+        expert_count: metadata.expert_count,
+        active_expert_count: metadata.active_expert_count,
+    }
+}
+
+fn proto_model_metadata_to_local(
+    metadata: &crate::proto::node::ServedModelMetadata,
+) -> crate::mesh::ServedModelMetadata {
+    crate::mesh::ServedModelMetadata {
+        architecture: metadata.architecture.clone(),
+        parameter_size: metadata.parameter_size.clone(),
+        parameter_count_b: metadata.parameter_count_b,
+        quant: metadata.quant.clone(),
+        native_context_length: metadata.native_context_length,
+        tokenizer: metadata.tokenizer.clone(),
+        layer_count: metadata.layer_count,
+        embedding_size: metadata.embedding_size,
+        head_count: metadata.head_count,
+        kv_head_count: metadata.kv_head_count,
+        expert_count: metadata.expert_count,
+        active_expert_count: metadata.active_expert_count,
     }
 }
 
@@ -552,6 +591,10 @@ pub(crate) fn local_ann_to_proto_ann(
                         }),
                 }
             }),
+            metadata: descriptor
+                .metadata
+                .as_ref()
+                .map(local_model_metadata_to_proto),
         })
         .collect();
     let served_model_runtime = ann
@@ -765,6 +808,10 @@ pub(crate) fn proto_ann_to_local(
                                     }),
                                 }
                             }),
+                            metadata: descriptor
+                                .metadata
+                                .as_ref()
+                                .map(proto_model_metadata_to_local),
                         }
                     })
                     .collect();

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -515,6 +515,7 @@ fn runtime_verified_served_model_descriptor(
         capabilities_known: false,
         capabilities: models::ModelCapabilities::default(),
         topology: None,
+        metadata: crate::models::served_model_metadata_for_model(model_name),
     });
     descriptor.identity.model_name = model_name.to_string();
     descriptor.identity.is_primary = model_name == primary_model_name;
@@ -3996,6 +3997,7 @@ max_tokens = 222
             capabilities_known: false,
             capabilities: models::ModelCapabilities::default(),
             topology: None,
+            metadata: None,
         };
         let capabilities = models::ModelCapabilities {
             multimodal: true,

--- a/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
@@ -547,6 +547,7 @@ mod tests {
             capabilities_known: true,
             capabilities: crate::models::ModelCapabilities::default(),
             topology: None,
+            metadata: None,
         };
 
         let snapshot = collector.build_model_view(ModelViewInput {
@@ -595,6 +596,7 @@ mod tests {
             capabilities_known: false,
             capabilities: crate::models::ModelCapabilities::default(),
             topology: None,
+            metadata: None,
         };
 
         let snapshot = collector.build_model_view(ModelViewInput {
@@ -646,6 +648,7 @@ mod tests {
                 ..Default::default()
             },
             topology: None,
+            metadata: None,
         };
 
         let snapshot = collector.build_model_view(ModelViewInput {

--- a/crates/mesh-llm-protocol/proto/node.proto
+++ b/crates/mesh-llm-protocol/proto/node.proto
@@ -115,6 +115,22 @@ message ServedModelDescriptor {
   ModelCapabilities capabilities = 2;
   optional ModelTopology topology = 3;
   optional bool capabilities_known = 4;
+  optional ServedModelMetadata metadata = 5;
+}
+
+message ServedModelMetadata {
+  optional string architecture = 1;
+  optional string parameter_size = 2;
+  optional double parameter_count_b = 3;
+  optional string quant = 4;
+  optional uint32 native_context_length = 5;
+  optional string tokenizer = 6;
+  optional uint32 layer_count = 7;
+  optional uint32 embedding_size = 8;
+  optional uint32 head_count = 9;
+  optional uint32 kv_head_count = 10;
+  optional uint32 expert_count = 11;
+  optional uint32 active_expert_count = 12;
 }
 
 message ServedModelIdentity {
@@ -188,6 +204,8 @@ message CompactModelMetadata {
   uint32 expert_count = 16;
   uint32 used_expert_count = 17;
   string quantization_type = 18;                     // GGUF quantization type string (e.g. "Q4_K_M")
+  uint32 kv_head_count = 19;
+  optional string parameter_size = 20;               // GGUF general.size_label when present (e.g. "32B")
 }
 
 message SpecialToken {

--- a/crates/mesh-llm-protocol/src/proto/node.rs
+++ b/crates/mesh-llm-protocol/src/proto/node.rs
@@ -202,7 +202,7 @@ pub struct SignedNodeOwnership {
     #[prost(bytes = "vec", tag = "10")]
     pub signature: ::prost::alloc::vec::Vec<u8>,
 }
-#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServedModelDescriptor {
     #[prost(message, optional, tag = "1")]
     pub identity: ::core::option::Option<ServedModelIdentity>,
@@ -212,6 +212,35 @@ pub struct ServedModelDescriptor {
     pub topology: ::core::option::Option<ModelTopology>,
     #[prost(bool, optional, tag = "4")]
     pub capabilities_known: ::core::option::Option<bool>,
+    #[prost(message, optional, tag = "5")]
+    pub metadata: ::core::option::Option<ServedModelMetadata>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ServedModelMetadata {
+    #[prost(string, optional, tag = "1")]
+    pub architecture: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "2")]
+    pub parameter_size: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(double, optional, tag = "3")]
+    pub parameter_count_b: ::core::option::Option<f64>,
+    #[prost(string, optional, tag = "4")]
+    pub quant: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint32, optional, tag = "5")]
+    pub native_context_length: ::core::option::Option<u32>,
+    #[prost(string, optional, tag = "6")]
+    pub tokenizer: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint32, optional, tag = "7")]
+    pub layer_count: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "8")]
+    pub embedding_size: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "9")]
+    pub head_count: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "10")]
+    pub kv_head_count: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "11")]
+    pub expert_count: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "12")]
+    pub active_expert_count: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ServedModelIdentity {
@@ -327,6 +356,11 @@ pub struct CompactModelMetadata {
     /// GGUF quantization type string (e.g. "Q4_K_M")
     #[prost(string, tag = "18")]
     pub quantization_type: ::prost::alloc::string::String,
+    #[prost(uint32, tag = "19")]
+    pub kv_head_count: u32,
+    /// GGUF general.size_label when present (e.g. "32B")
+    #[prost(string, optional, tag = "20")]
+    pub parameter_size: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SpecialToken {

--- a/crates/mesh-llm-types/src/mesh/mod.rs
+++ b/crates/mesh-llm-types/src/mesh/mod.rs
@@ -36,7 +36,7 @@ pub struct ServedModelIdentity {
     pub identity_hash: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ServedModelDescriptor {
     pub identity: ServedModelIdentity,
     #[serde(default, skip_serializing_if = "is_false")]
@@ -44,10 +44,57 @@ pub struct ServedModelDescriptor {
     pub capabilities: ModelCapabilities,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topology: Option<ModelTopology>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<ServedModelMetadata>,
 }
 
 fn is_false(value: &bool) -> bool {
     !*value
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ServedModelMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameter_size: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parameter_count_b: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quant: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub native_context_length: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tokenizer: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub layer_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub embedding_size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub head_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kv_head_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expert_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_expert_count: Option<u32>,
+}
+
+impl ServedModelMetadata {
+    pub fn is_empty(&self) -> bool {
+        self.architecture.is_none()
+            && self.parameter_size.is_none()
+            && self.parameter_count_b.is_none()
+            && self.quant.is_none()
+            && self.native_context_length.is_none()
+            && self.tokenizer.is_none()
+            && self.layer_count.is_none()
+            && self.embedding_size.is_none()
+            && self.head_count.is_none()
+            && self.kv_head_count.is_none()
+            && self.expert_count.is_none()
+            && self.active_expert_count.is_none()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -114,6 +161,7 @@ pub fn infer_served_model_descriptors(
                 capabilities_known: false,
                 capabilities: ModelCapabilities::default(),
                 topology: None,
+                metadata: None,
             }
         })
         .collect()

--- a/crates/model-artifact/src/gguf.rs
+++ b/crates/model-artifact/src/gguf.rs
@@ -224,6 +224,7 @@ fn read_gguf_value_as_string_opt(
 #[derive(Clone, Debug, Default)]
 pub struct GgufCompactMeta {
     pub architecture: String,
+    pub parameter_size: Option<String>,
     pub context_length: u32,
     pub vocab_size: u32,
     pub embedding_size: u32,
@@ -432,6 +433,8 @@ pub fn scan_gguf_compact_meta(path: &Path) -> Option<GgufCompactMeta> {
 
         if key == "general.architecture" {
             meta.architecture = read_gguf_value_as_string_opt(&mut f, vtype).ok()??;
+        } else if key == "general.size_label" {
+            meta.parameter_size = read_gguf_value_as_string_opt(&mut f, vtype).ok()?;
         } else if key == "tokenizer.ggml.model" {
             meta.tokenizer_model_name = read_gguf_value_as_string_opt(&mut f, vtype).ok()??;
         } else if key.ends_with(".context_length") {


### PR DESCRIPTION
## Summary

Adds structured model metadata to the served model descriptor and surfaces it through `/v1/models` for routing-aware clients.

- Advertises `architecture`, `parameter_size`, `parameter_count_b`, `quant`, `context_length`, `native_context_length`, tokenizer, layer/head dimensions, and MoE expert counts.
- Carries the metadata over gossip/protobuf as an additive optional field on `ServedModelDescriptor`.
- Reads GGUF `general.size_label`, KV head count, and expert counts into compact metadata.
- Lets `auto` routing use advertised parameter count before falling back to model-name parsing.
- Gives the agents plugin a structured signal for selecting models by capabilities and model strength, including parameter count and available context length.

## Protocol

This is additive: new protobuf fields are optional, and older peers can ignore them. Newer peers treat missing metadata as unknown and fall back to the existing heuristics.

## Validation

- `just build`
- `cargo test -p mesh-llm-host-runtime --lib` -> 1652 passed, 0 failed, 6 ignored
- `cargo test -p model-artifact --lib` -> 23 passed
- `cargo check -p mesh-llm`
- `rustfmt --edition 2024 --check ...`
- `git diff --check`
