### PR TITLE
fix(cuda-crash): add preventitive crash framework for skippy allocation OOMs

### DIFF
--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(has_cuda)");
     println!("cargo:rerun-if-env-changed=LLAMA_STAGE_BUILD_DIR");
     println!("cargo:rerun-if-env-changed=LLAMA_STAGE_LIB_DIR");
     println!("cargo:rerun-if-env-changed=LLAMA_STAGE_LINK_MODE");
@@ -134,6 +135,7 @@ fn main() {
     );
     if has_cuda {
         println!("cargo:rustc-link-lib=static=ggml-cuda");
+        println!("cargo:rustc-cfg=has_cuda");
     }
     let has_hip = static_archive_exists(
         &build_dir,

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -576,6 +576,13 @@ unsafe extern "C" {
         out_error: *mut *mut Error,
     ) -> Status;
 
+    pub fn skippy_backend_device_check_memory(
+        device_index: usize,
+        headroom_bytes: usize,
+        out_sufficient: *mut bool,
+        out_error: *mut *mut Error,
+    ) -> Status;
+
     pub fn skippy_model_open(
         path: *const c_char,
         config: *const RuntimeConfig,
@@ -1138,6 +1145,26 @@ unsafe extern "C" {
         logits_last: bool,
         new_n_past: *mut i32,
     ) -> c_int;
+
+    pub fn skippy_alloc_tracker_init();
+    pub fn skippy_alloc_tracker_reset();
+    pub fn skippy_alloc_tracker_get_max_seen() -> u64;
+}
+
+#[cfg(has_cuda)]
+extern "C" {
+    pub fn ggml_backend_cuda_set_alloc_hook(
+        hook: Option<
+            unsafe extern "C" fn(
+                device: usize,
+                alloc_size: usize,
+                pool_used: usize,
+                user_data: *mut c_void,
+            ) -> bool,
+        >,
+        user_data: *mut c_void,
+    );
+    pub fn ggml_backend_cuda_clear_alloc_hook();
 }
 
 pub type Opaque = c_void;

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -1152,7 +1152,7 @@ unsafe extern "C" {
 }
 
 #[cfg(has_cuda)]
-extern "C" {
+unsafe extern "C" {
     pub fn ggml_backend_cuda_set_alloc_hook(
         hook: Option<
             unsafe extern "C" fn(

--- a/crates/skippy-runtime/Cargo.toml
+++ b/crates/skippy-runtime/Cargo.toml
@@ -22,3 +22,6 @@ tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_cuda)'] }

--- a/crates/skippy-runtime/src/devices.rs
+++ b/crates/skippy-runtime/src/devices.rs
@@ -93,3 +93,161 @@ fn c_string_optional(ptr: *const c_char) -> Result<Option<String>> {
         .into_owned();
     Ok((!value.is_empty()).then_some(value))
 }
+
+/// Checks whether a backend device has at least `headroom_bytes` of free memory.
+///
+/// Returns `Ok(true)` if the device exists and `free >= headroom_bytes`.
+/// Returns `Ok(false)` if the device exists but free memory is below the threshold,
+/// or if the device index is out of range.
+/// Returns `Err` on ABI error.
+///
+/// # Backend coverage
+///
+/// The underlying C API (`skippy_backend_device_check_memory`) delegates to
+/// `ggml_backend_dev_memory()` which queries the backend's `get_memory()`.
+/// This is accurate for CUDA and ROCm. For other backends (Intel, Vulkan,
+/// Metal) where `get_memory` may return 0 or stale values, extend the C
+/// function with a backend-specific fallback before calling
+/// `ggml_backend_dev_memory()` — see the switch-case skeleton in skippy.cpp.
+pub fn check_device_memory(device_index: usize, headroom_bytes: u64) -> Result<bool> {
+    let mut sufficient = false;
+    let mut error = ptr::null_mut();
+    let status = unsafe {
+        skippy_ffi::skippy_backend_device_check_memory(
+            device_index,
+            headroom_bytes as usize,
+            &mut sufficient,
+            &mut error,
+        )
+    };
+    super::ensure_ok(status, error)?;
+    Ok(sufficient)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_device_memory;
+
+    #[test]
+    fn out_of_range_device_index_returns_false() {
+        let result = check_device_memory(usize::MAX, 0).unwrap();
+        assert!(
+            !result,
+            "out-of-range device index should indicate insufficient memory"
+        );
+    }
+
+    #[test]
+    fn impossible_headroom_returns_false() {
+        let result = check_device_memory(0, u64::MAX).unwrap();
+        assert!(
+            !result,
+            "impossible headroom should indicate insufficient memory"
+        );
+    }
+
+    #[test]
+    fn zero_headroom_does_not_crash() {
+        // This may return true (if a device exists) or false (if no devices).
+        // Either is valid — the important thing is it doesn't error or crash.
+        let result = check_device_memory(0, 0);
+        assert!(
+            result.is_ok(),
+            "zero headroom query should not fail: {:?}",
+            result.err()
+        );
+    }
+}
+
+/// Dynamic GPU allocation tracker — replaces static VRAM headroom with max-seen tracking.
+///
+/// Uses the C-side `skippy_alloc_tracker_*` API which tracks VMM pool allocations
+/// via the CUDA alloc hook from patch 0083.
+///
+/// # Multi-session limitation
+///
+/// The underlying CUDA alloc hook (`g_ggml_cuda_alloc_hook`) is a process-global
+/// static pointer — when multiple sessions are created, the last `session_create`
+/// wins and overwrites any prior hook registration. Currently the callback always
+/// returns `true` (tracking-only), so worst-case impact across overlapping sessions
+/// is noisy `max_seen` tracking (the atomic counter accumulates allocations from all
+/// active sessions). Always call [`reset`] before loading a new model to clear stale
+/// values, or headroom computation will be based on outdated allocation patterns.
+pub mod alloc_tracker {
+    use super::*;
+
+    /// Initialize/reset the allocation tracker at session startup.
+    pub fn init() {
+        unsafe {
+            skippy_ffi::skippy_alloc_tracker_init();
+        }
+    }
+
+    /// Reset max-seen counter (called on model reload / full lifecycle restart).
+    pub fn reset() {
+        unsafe {
+            skippy_ffi::skippy_alloc_tracker_reset();
+        }
+    }
+
+    /// Returns the maximum VMM pool allocation size seen so far.
+    /// Used to compute dynamic headroom: `headroom = max_seen * 1.05`.
+    pub fn get_max_seen() -> u64 {
+        unsafe { skippy_ffi::skippy_alloc_tracker_get_max_seen() }
+    }
+
+    /// Compute dynamic headroom based on max-seen allocation.
+    /// Returns 5% of max_seen, clamped to [min_headroom, max_headroom].
+    pub fn compute_dynamic_headroom(max_seen: u64) -> u64 {
+        let min_headroom = 256 * 1024 * 1024;
+        let dynamic = (max_seen as f64 * 0.05) as u64;
+        std::cmp::max(min_headroom, dynamic)
+    }
+
+    /// Check device memory using the new tracker-based approach.
+    ///
+    /// If max_seen > 0 and current free >= computed headroom → OK.
+    /// Falls back to static check_device_memory if no data yet.
+    pub fn check_device_memory_with_tracker(device_index: usize, total_vram: u64) -> Result<bool> {
+        let max_seen = get_max_seen();
+
+        if max_seen > 0 {
+            let headroom = compute_dynamic_headroom(max_seen);
+            check_device_memory(device_index, headroom)
+        } else {
+            let static_headroom = std::cmp::max(256 * 1024 * 1024, total_vram / 20);
+            check_device_memory(device_index, static_headroom)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn compute_dynamic_headroom_clamps_minimum() {
+            let headroom = compute_dynamic_headroom(1_000_000);
+            assert!(
+                headroom >= 256 * 1024 * 1024,
+                "should clamp to 256MB minimum"
+            );
+        }
+
+        #[test]
+        fn compute_dynamic_headroom_scales() {
+            let headroom = compute_dynamic_headroom(8_000_000_000u64);
+            assert!(headroom == 400_000_000, "5% of 8GB should be 400MB");
+        }
+
+        #[test]
+        fn fallback_check_does_not_crash() {
+            let result = check_device_memory_with_tracker(usize::MAX, 0);
+            assert!(
+                result.is_ok(),
+                "out-of-range device should not error: {:?}",
+                result.err()
+            );
+            assert!(!result.unwrap(), "should return false for missing device");
+        }
+    }
+}

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -53,7 +53,9 @@ pub enum FlashAttentionType {
     Enabled = 1,
 }
 
-pub use devices::{BackendDevice, BackendDeviceType, backend_devices};
+pub use devices::{
+    BackendDevice, BackendDeviceType, alloc_tracker, backend_devices, check_device_memory,
+};
 pub use skippy_ffi::LoadMode as RuntimeLoadMode;
 pub use skippy_ffi::{
     ActivationDType as RuntimeActivationDType, ActivationLayout as RuntimeActivationLayout,

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -10,7 +10,7 @@ use skippy_runtime::{
     ActivationFrame, FlashAttentionType as RuntimeFlashAttentionType, GenerationSignalWindow,
     MediaInput, MediaPrefill, MediaPrefillFrame, RuntimeConfig, RuntimeKvPage, RuntimeKvPageDesc,
     RuntimeLoadMode, SamplingConfig, StageModel, StageSession, StageSessionCheckpoint, TokenSignal,
-    parse_cache_type,
+    alloc_tracker, parse_cache_type,
 };
 
 use crate::package::select_package_parts;
@@ -23,6 +23,8 @@ pub struct RuntimeLaunchOverrides {
 
 pub struct RuntimeState {
     pub model: StageModel,
+    device_index: usize,
+    total_vram: Option<u64>,
     layer_start: u32,
     layer_end: u32,
     lane_count: u32,
@@ -97,7 +99,31 @@ struct ResidentLanePrefix {
 }
 
 impl RuntimeState {
+    /// Check that the backend device has sufficient free memory for
+    /// inference.  Returns an error when free memory has dropped below
+    /// the configured headroom, which prevents a hard `abort()` in the
+    /// CUDA VMM pool (`cuMemCreate` OOM inside ggml).
+    /// Pre-inference memory check. For backends where `ggml_backend_dev_memory()`
+    /// doesn't report accurate free memory (Intel, Vulkan, Metal), either:
+    ///   - Bypass this check by returning `Ok(())` early based on device type, or
+    ///   - Add a backend-specific query in `skippy_backend_device_check_memory` (see skippy.cpp).
+    fn check_memory(&self) -> Result<()> {
+        if let Some(total_vram) = self.total_vram {
+            let sufficient =
+                alloc_tracker::check_device_memory_with_tracker(self.device_index, total_vram)
+                    .context("failed to query backend device memory")?;
+            if !sufficient {
+                bail!(
+                    "backend device {} has insufficient free memory",
+                    self.device_index,
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub fn prefill(&mut self, session_id: &str, token_ids: &[i32]) -> Result<()> {
+        self.check_memory()?;
         let session = self.session(session_id)?;
         session.prefill_chunked(token_ids)?;
         self.add_session_tokens(session_id, token_ids.len() as u64);
@@ -119,6 +145,7 @@ impl RuntimeState {
         media: &[MediaInput],
         sampling: Option<&SamplingConfig>,
     ) -> Result<MediaPrefill> {
+        self.check_memory()?;
         let model = &self.model as *const StageModel;
         let session = self.session(session_id)?;
         // `session()` mutably borrows the session map, while the projector lives
@@ -136,6 +163,7 @@ impl RuntimeState {
         prompt: &str,
         media: &[MediaInput],
     ) -> Result<MediaPrefillFrame> {
+        self.check_memory()?;
         let model = &self.model as *const StageModel;
         let session = self.session(session_id)?;
         // `session()` mutably borrows the session map, while the projector lives
@@ -867,8 +895,23 @@ pub fn load_runtime_with_overrides(
         }
     };
 
+    let device_index = config
+        .selected_device
+        .as_ref()
+        .and_then(|d| d.index)
+        .unwrap_or(0);
+    let total_vram = config.selected_device.as_ref().and_then(|d| d.vram_bytes);
+
+    // Reset max-seen counter before model load so stale values from a previous
+    // runtime instance don't inflate headroom computation on reload. Then init
+    // the tracker fresh for this lifecycle.
+    alloc_tracker::reset();
+    alloc_tracker::init();
+
     Ok(Some(Arc::new(Mutex::new(RuntimeState {
         model,
+        device_index,
+        total_vram,
         layer_start: config.layer_start,
         layer_end: config.layer_end,
         lane_count: config.lane_count,

--- a/third_party/llama.cpp/patches/0082-Expose-skippy-backend-device-memory-check-ABI.patch
+++ b/third_party/llama.cpp/patches/0082-Expose-skippy-backend-device-memory-check-ABI.patch
@@ -1,0 +1,69 @@
+From 449cf7edefc85b4007c594ae55c6decbb75ef28f Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 28 May 2026 01:18:56 -0400
+Subject: [PATCH] Expose skippy backend device memory check ABI
+
+Add skippy_backend_device_check_memory() - a public C function that queries a
+backend device's free memory via ggml_backend_dev_memory() and returns whether
+free >= headroom_bytes. This lets the Rust runtime pre-check GPU free memory
+before inference to avoid the cuMemCreate OOM path that leads to GGML_ABORT.
+
+---
+ src/skippy.cpp | 41 +++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 41 insertions(+)
+
+
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index f9e657181..5f619a586 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -1859,11 +1859,45 @@ enum skippy_status skippy_backend_device_at(
+     return skippy_success(out_error);
+ }
+ 
+-static enum skippy_status skippy_finish_model_open(
+-        llama_model * model,
+-        const struct skippy_runtime_config * config,
+-        struct skippy_model ** out_model,
++enum skippy_status skippy_backend_device_check_memory(
++        size_t device_index,
++        size_t headroom_bytes,
++        bool * out_sufficient,
+         struct skippy_error ** out_error) {
++    if (out_sufficient == nullptr) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "out_sufficient is required");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++
++    skippy_load_backends_for_device_query();
++    const size_t device_count = ggml_backend_dev_count();
++    if (device_index >= device_count) {
++        *out_sufficient = false;
++        return skippy_success(out_error);
++    }
++
++    // NOTE: ggml_backend_dev_memory delegates to the backend's get_memory().
++    //   - CUDA (NVIDIA):  cuMemGetInfo          - accurate live query
++    //   - ROCm (AMD):     hipMemGetInfo          - accurate live query
++    //   - Intel GPU:      depends on Level Zero  - may return 0/stale
++    //   - Vulkan:         shared memory model    - no unified free pool
++    //   - Metal:          unified memory         - no separate GPU pool
++    //
++    // If extending to a backend where ggml_backend_dev_memory() returns 0
++    // for free/total, add a backend-specific fallback query here.
++    ggml_backend_dev_t device = ggml_backend_dev_get(device_index);
++    size_t free = 0, total = 0;
++    ggml_backend_dev_memory(device, &free, &total);
++
++    *out_sufficient = (free >= headroom_bytes);
++    return skippy_success(out_error);
++}
++
++ static enum skippy_status skippy_finish_model_open(
++         llama_model * model,
++         const struct skippy_runtime_config * config,
++         struct skippy_model ** out_model,
++         struct skippy_error ** out_error) {
+     if (config != nullptr && config->filter_tensors_on_load) {
+         const int32_t n_layer = llama_model_n_layer(model);
+         if (model->arch != LLM_ARCH_LLAMA &&

--- a/third_party/llama.cpp/patches/0083-cuda-alloc-hook.patch
+++ b/third_party/llama.cpp/patches/0083-cuda-alloc-hook.patch
@@ -1,0 +1,75 @@
+From 72168ff4c19cf17b49a0090d4bd9c10a2825716c Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 28 May 2026 20:13:24 -0400
+Subject: [PATCH] Add CUDA VMM pool allocation hook
+
+Add an allocation hook callback to ggml-cuda.cu VMM pool that fires before cuMemCreate, allowing callers to decide whether to allow or abort the allocation.
+---
+ ggml/include/ggml-cuda.h        |  5 +++++
+ ggml/src/ggml-cuda/ggml-cuda.cu | 27 +++++++++++++++++++++++++++
+ 2 files changed, 32 insertions(+)
+
+diff --git a/ggml/include/ggml-cuda.h b/ggml/include/ggml-cuda.h
+index 5436c7ef5..dbfe4ddae 100644
+--- a/ggml/include/ggml-cuda.h
++++ b/ggml/include/ggml-cuda.h
+@@ -45,6 +45,11 @@ GGML_BACKEND_API void ggml_backend_cuda_unregister_host_buffer(void * buffer);
+ 
+ GGML_BACKEND_API ggml_backend_reg_t ggml_backend_cuda_reg(void);
+ 
++typedef bool (*ggml_cuda_alloc_hook_t)(size_t device, size_t alloc_size, size_t pool_used, void *user_data);
++
++GGML_BACKEND_API void ggml_backend_cuda_set_alloc_hook(ggml_cuda_alloc_hook_t hook, void *user_data);
++GGML_BACKEND_API void ggml_backend_cuda_clear_alloc_hook(void);
++
+ #ifdef  __cplusplus
+ }
+ #endif
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index 23d1c0692..c14e28f54 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -86,6 +86,25 @@
+ #include <string>
+ #include <vector>
+ 
++// Allocation hook callback — returns true to proceed, false to abort (return nullptr)
++typedef bool (*ggml_cuda_alloc_hook_t)(size_t device, size_t alloc_size, size_t pool_used, void *user_data);
++static ggml_cuda_alloc_hook_t g_ggml_cuda_alloc_hook = nullptr;
++static void * g_ggml_cuda_alloc_hook_user_data = nullptr;
++
++static std::mutex g_ggml_cuda_alloc_hook_mutex;
++
++GGML_API void ggml_backend_cuda_set_alloc_hook(ggml_cuda_alloc_hook_t hook, void *user_data) {
++    std::lock_guard<std::mutex> lock(g_ggml_cuda_alloc_hook_mutex);
++    g_ggml_cuda_alloc_hook = hook;
++    g_ggml_cuda_alloc_hook_user_data = user_data;
++}
++
++GGML_API void ggml_backend_cuda_clear_alloc_hook(void) {
++    std::lock_guard<std::mutex> lock(g_ggml_cuda_alloc_hook_mutex);
++    g_ggml_cuda_alloc_hook = nullptr;
++    g_ggml_cuda_alloc_hook_user_data = nullptr;
++}
++
+ static_assert(sizeof(half) == sizeof(ggml_fp16_t), "wrong fp16 size");
+ 
+ #define GGML_LOG_WARN_ONCE(str) \
+@@ -512,6 +531,14 @@ struct ggml_cuda_pool_vmm : public ggml_cuda_pool {
+ 
+         size_t avail = pool_size - pool_used;
+ 
++        // Call allocation hook before attempting cuMemCreate
++        if (g_ggml_cuda_alloc_hook != nullptr) {
++            bool proceed = g_ggml_cuda_alloc_hook(static_cast<size_t>(device), size, pool_used, g_ggml_cuda_alloc_hook_user_data);
++            if (!proceed) {
++                return nullptr;
++            }
++        }
++
+         if (size > avail) {
+             // round up to the next multiple of the granularity
+             size_t reserve_size = size - avail;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0084-alloc-tracker-api.patch
+++ b/third_party/llama.cpp/patches/0084-alloc-tracker-api.patch
@@ -1,0 +1,104 @@
+From 342611c041f20525bbb1571b27c6c82e3e8827a0 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 28 May 2026 21:51:05 -0400
+Subject: [PATCH] Add GPU allocation tracker C API for dynamic VRAM headroom
+
+---
+ include/skippy.h |  5 +++++
+ src/skippy.cpp   | 50 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 55 insertions(+)
+
+diff --git a/include/skippy.h b/include/skippy.h
+index 84173c028..7c4da4f03 100644
+--- a/include/skippy.h
++++ b/include/skippy.h
+@@ -573,6 +573,11 @@ LLAMA_API enum skippy_status skippy_write_gguf_from_parts(
+         const char * output_path,
+         struct skippy_error ** out_error);
+ 
++/* GPU allocation tracker — replaces static VRAM headroom with max-seen tracking. */
++LLAMA_API void skippy_alloc_tracker_init(void);
++LLAMA_API void skippy_alloc_tracker_reset(void);
++LLAMA_API uint64_t skippy_alloc_tracker_get_max_seen(void);
++
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index 5f619a586..428ba87f2 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -42,6 +42,38 @@
+ 
+ using json = nlohmann::ordered_json;
+ 
++/* GPU allocation tracker — atomic max-seen for dynamic VRAM headroom. */
++#include <atomic>
++static std::atomic<uint64_t> g_skippy_alloc_max_seen{0};
++
++void skippy_alloc_tracker_init(void) {
++    g_skippy_alloc_max_seen.store(0, std::memory_order_relaxed);
++}
++
++void skippy_alloc_tracker_reset(void) {
++    g_skippy_alloc_max_seen.store(0, std::memory_order_relaxed);
++}
++
++uint64_t skippy_alloc_tracker_get_max_seen(void) {
++    return g_skippy_alloc_max_seen.load(std::memory_order_relaxed);
++}
++
++/* CUDA alloc hook callback — updates max-seen before cuMemCreate. */
++static bool skippy_alloc_hook_callback(
++        size_t /*device*/,
++        size_t alloc_size,
++        size_t /*pool_used*/,
++        void * /*user_data*/) {
++    uint64_t current = g_skippy_alloc_max_seen.load(std::memory_order_relaxed);
++    while (alloc_size > current) {
++        if (g_skippy_alloc_max_seen.compare_exchange_weak(current, static_cast<uint64_t>(alloc_size),
++                std::memory_order_relaxed, std::memory_order_relaxed)) {
++            break;
++        }
++    }
++    return true; /* always proceed — caller handles OOM */
++}
++
+ struct skippy_model {
+     llama_model * model = nullptr;
+     llama_context * ctx = nullptr;
+@@ -2242,6 +2274,15 @@ enum skippy_status skippy_session_create(
+     if (llama_memory_t memory = model->ctx->get_memory()) {
+         llama_memory_seq_rm(memory, seq_id, -1, -1);
+     }
++#ifdef GGML_USE_CUDA
++    {
++        extern "C" {
++            void ggml_backend_cuda_set_alloc_hook(ggml_cuda_alloc_hook_t hook, void *user_data);
++        }
++        ggml_backend_cuda_set_alloc_hook(skippy_alloc_hook_callback, nullptr);
++    }
++#endif
++
+     return skippy_success(out_error);
+ }
+ 
+@@ -2449,6 +2490,15 @@ enum skippy_status skippy_session_free(
+                 session->stage_model->lane_in_use[lane] = false;
+             }
+         }
++#ifdef GGML_USE_CUDA
++        {
++            extern "C" {
++                void ggml_backend_cuda_clear_alloc_hook(void);
++            }
++            ggml_backend_cuda_clear_alloc_hook();
++        }
++#endif
++
+         delete session;
+     }
+     return skippy_success(out_error);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0084-alloc-tracker-api.patch
+++ b/third_party/llama.cpp/patches/0084-alloc-tracker-api.patch
@@ -5,8 +5,8 @@ Subject: [PATCH] Add GPU allocation tracker C API for dynamic VRAM headroom
 
 ---
  include/skippy.h |  5 +++++
- src/skippy.cpp   | 50 ++++++++++++++++++++++++++++++++++++++++++++++++
- 2 files changed, 55 insertions(+)
+ src/skippy.cpp   | 41 +++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 46 insertions(+)
 
 diff --git a/include/skippy.h b/include/skippy.h
 index 84173c028..7c4da4f03 100644
@@ -25,10 +25,10 @@ index 84173c028..7c4da4f03 100644
  }
  #endif
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index 5f619a586..428ba87f2 100644
+index dd858fbd2..bfc062f1e 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -42,6 +42,38 @@
+@@ -42,6 +42,46 @@
  
  using json = nlohmann::ordered_json;
  
@@ -64,41 +64,36 @@ index 5f619a586..428ba87f2 100644
 +    return true; /* always proceed — caller handles OOM */
 +}
 +
++#ifdef GGML_USE_CUDA
++extern "C" {
++typedef bool (*ggml_cuda_alloc_hook_t)(size_t device, size_t alloc_size, size_t pool_used, void *user_data);
++void ggml_backend_cuda_set_alloc_hook(ggml_cuda_alloc_hook_t hook, void *user_data);
++void ggml_backend_cuda_clear_alloc_hook(void);
++}
++#endif
++
  struct skippy_model {
      llama_model * model = nullptr;
      llama_context * ctx = nullptr;
-@@ -2242,6 +2274,15 @@ enum skippy_status skippy_session_create(
+@@ -2242,6 +2282,9 @@ enum skippy_status skippy_session_create(
      if (llama_memory_t memory = model->ctx->get_memory()) {
          llama_memory_seq_rm(memory, seq_id, -1, -1);
      }
 +#ifdef GGML_USE_CUDA
-+    {
-+        extern "C" {
-+            void ggml_backend_cuda_set_alloc_hook(ggml_cuda_alloc_hook_t hook, void *user_data);
-+        }
-+        ggml_backend_cuda_set_alloc_hook(skippy_alloc_hook_callback, nullptr);
-+    }
++    ggml_backend_cuda_set_alloc_hook(skippy_alloc_hook_callback, nullptr);
 +#endif
-+
      return skippy_success(out_error);
  }
  
-@@ -2449,6 +2490,15 @@ enum skippy_status skippy_session_free(
+@@ -2447,6 +2490,9 @@ enum skippy_status skippy_session_free(
                  session->stage_model->lane_in_use[lane] = false;
              }
          }
 +#ifdef GGML_USE_CUDA
-+        {
-+            extern "C" {
-+                void ggml_backend_cuda_clear_alloc_hook(void);
-+            }
-+            ggml_backend_cuda_clear_alloc_hook();
-+        }
++        ggml_backend_cuda_clear_alloc_hook();
 +#endif
-+
          delete session;
      }
      return skippy_success(out_error);
 -- 
 2.50.1 (Apple Git-155)
-


### PR DESCRIPTION
I've been battling crashes pretty often and had an idea to try and track allocation sizes, and cowardly skipping the `alloc` to prevent the entire process from getting an `abort()` (other models might be loaded). 

We can evolve this to clean up the offending model, or print some kind of warning. 

Next thing we do might be to gate behind an option, or (less usefully) a debug flag.