### PR TITLE
Harden crates.io publish preflight

### DIFF
--- a/.github/workflows/pr_quality.yml
+++ b/.github/workflows/pr_quality.yml
@@ -37,6 +37,8 @@ jobs:
           fetch-depth: 0
       - name: Check CI crate-list drift
         run: cargo run -p xtask -- repo-consistency ci-crate-lists
+      - name: Check publish crate-chain drift
+        run: cargo run -p xtask -- repo-consistency publish-crates
       - uses: ./.github/actions/compute-changes
         id: compute
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -801,9 +801,27 @@ jobs:
           overwrite_files: true
           files: release-artifacts/*
 
+  publish_crates_preflight:
+    name: Preflight crates.io packages
+    needs: [metadata, publish]
+    if: ${{ needs.metadata.outputs.prerelease != 'true' && needs.metadata.outputs.canary != 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Check crates.io publish-chain consistency
+        run: cargo run -p xtask -- repo-consistency publish-crates
+      - name: Dry-run crates.io package chain
+        run: scripts/publish-crates.sh --dry-run --allow-dirty --sleep-seconds 0
+
   publish_crates:
     name: Publish crates.io packages
-    needs: [metadata, publish]
+    needs: [metadata, publish, publish_crates_preflight]
     if: ${{ needs.metadata.outputs.prerelease != 'true' && needs.metadata.outputs.canary != 'true' }}
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,6 +109,7 @@ On non-prerelease tags, the release workflow also publishes the Rust SDK crate
 chain to crates.io in dependency order:
 
 ```bash
+cargo run -p xtask -- repo-consistency publish-crates
 scripts/publish-crates.sh --dry-run
 ```
 
@@ -126,11 +127,14 @@ The chain currently publishes:
 10. `mesh-llm-node`
 11. `mesh-llm-api-server`
 
-Run the dry-run before cutting a GA tag after changing SDK crate manifests or
-workspace-internal SDK dependencies. On the first release that introduces a
-new internal SDK crate, the dry-run validates packages whose registry
-dependencies already exist and reports downstream packages that will be fully
-verified during the real sequential publish after their upstream crates land.
+Run the consistency check and dry-run before cutting a GA tag after changing
+SDK crate manifests or workspace-internal SDK dependencies. The consistency
+check keeps the scripted publish order, workspace path dependency versions,
+publish metadata, bundled file includes, and CI release preflight in sync. On
+the first release that introduces a new internal SDK crate, the dry-run
+validates packages whose registry dependencies already exist and reports
+downstream packages that will be fully verified during the real sequential
+publish after their upstream crates land.
 
 If crates.io rate-limits the non-prerelease publish chain after some crates
 have already uploaded, rerun `scripts/publish-crates.sh` for the same checked

--- a/crates/mesh-llm-gpu-bench/src/runner.rs
+++ b/crates/mesh-llm-gpu-bench/src/runner.rs
@@ -85,9 +85,14 @@ pub fn parse_benchmark_output(stdout: &[u8]) -> Option<Vec<BenchmarkOutput>> {
             None
         }
         Err(err) => {
-            if let Ok(val) = serde_json::from_slice::<serde_json::Value>(stdout)
-                && let Some(msg) = val.get("error").and_then(|v| v.as_str())
-            {
+            let error_message = serde_json::from_slice::<serde_json::Value>(stdout)
+                .ok()
+                .and_then(|val| {
+                    val.get("error")
+                        .and_then(|v| v.as_str())
+                        .map(ToOwned::to_owned)
+                });
+            if let Some(msg) = error_message {
                 tracing::warn!("benchmark reported error: {msg}");
                 return None;
             }

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -1,0 +1,430 @@
+[
+  {
+    "name": "Qwen3-4B-Q4_K_M",
+    "file": "Qwen3-4B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf",
+    "size": "2.5GB",
+    "description": "Qwen3 starter, thinking/non-thinking modes",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-3B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-3B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/main/qwen2.5-3b-instruct-q4_k_m.gguf",
+    "size": "2.1GB",
+    "description": "Small & fast general chat",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Llama-3.2-3B-Instruct-Q4_K_M",
+    "file": "Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf",
+    "size": "2.0GB",
+    "description": "Meta Llama 3.2, goose default, good tool calling",
+    "draft": "Llama-3.2-1B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-8B-Q4_K_M",
+    "file": "Qwen3-8B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf",
+    "size": "5.0GB",
+    "description": "Qwen3 mid-tier, strong for its size",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",
+    "size": "4.4GB",
+    "description": "Code generation & completion",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Gemma-3-12B-it-Q4_K_M",
+    "file": "Gemma-3-12B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-3-12b-it-GGUF/resolve/main/gemma-3-12b-it-Q4_K_M.gguf",
+    "size": "7.3GB",
+    "description": "Google Gemma 3 12B, punches above weight",
+    "draft": "Gemma-3-1B-it-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Hermes-2-Pro-Mistral-7B-Q4_K_M",
+    "file": "Hermes-2-Pro-Mistral-7B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/Hermes-2-Pro-Mistral-7B-GGUF/resolve/main/Hermes-2-Pro-Mistral-7B-Q4_K_M.gguf",
+    "size": "4.4GB",
+    "description": "Goose default, strong tool calling for agents",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-14B-Q4_K_M",
+    "file": "Qwen3-14B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf",
+    "size": "9.0GB",
+    "description": "Qwen3 strong chat, thinking modes",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-14B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-14B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/Qwen2.5-14B-Instruct-GGUF/resolve/main/Qwen2.5-14B-Instruct-Q4_K_M.gguf",
+    "size": "9.0GB",
+    "description": "Solid general chat",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-Coder-14B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/Qwen2.5-Coder-14B-Instruct-GGUF/resolve/main/Qwen2.5-Coder-14B-Instruct-Q4_K_M.gguf",
+    "size": "9.0GB",
+    "description": "Strong code gen, fills gap between 7B and 32B",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "DeepSeek-R1-Distill-Qwen-14B-Q4_K_M",
+    "file": "DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+    "size": "9.0GB",
+    "description": "DeepSeek R1 reasoning distilled into Qwen 14B",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Devstral-Small-2505-Q4_K_M",
+    "file": "Devstral-Small-2505-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Devstral-Small-2505-GGUF/resolve/main/Devstral-Small-2505-Q4_K_M.gguf",
+    "size": "14.3GB",
+    "description": "Mistral agentic coding, tool use",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Mistral-Small-3.1-24B-Instruct-Q4_K_M",
+    "file": "Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Mistral-Small-3.1-24B-Instruct-2503-GGUF/resolve/main/Mistral-Small-3.1-24B-Instruct-2503-Q4_K_M.gguf",
+    "size": "14.3GB",
+    "description": "Mistral general chat, good tool calling",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "GLM-4.7-Flash-Q4_K_M",
+    "file": "GLM-4.7-Flash-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/GLM-4.7-Flash-GGUF/resolve/main/GLM-4.7-Flash-Q4_K_M.gguf",
+    "size": "18GB",
+    "description": "30B/3B, fast inference, tool calling",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-30B-A3B-Q4_K_M",
+    "file": "Qwen3-30B-A3B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf",
+    "size": "17.3GB",
+    "description": "general chat, thinking/non-thinking",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M",
+    "file": "Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-Coder-30B-A3B-Instruct-GGUF/resolve/main/Qwen3-Coder-30B-A3B-Instruct-Q4_K_M.gguf",
+    "size": "18.6GB",
+    "description": "agentic coding, tool use",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "GLM-4-32B-0414-Q4_K_M",
+    "file": "GLM-4-32B-0414-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/GLM-4-32B-0414-GGUF/resolve/main/GLM-4-32B-0414-Q4_K_M.gguf",
+    "size": "19.7GB",
+    "description": "Strong 32B, good tool calling",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-32B-Q4_K_M",
+    "file": "Qwen3-32B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-32B-GGUF/resolve/main/Qwen3-32B-Q4_K_M.gguf",
+    "size": "19.8GB",
+    "description": "Best Qwen3 dense, thinking/non-thinking modes",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M",
+    "file": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+    "size": "19.9GB",
+    "description": "DeepSeek R1 reasoning distilled into Qwen 32B",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-32B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-32B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/Qwen2.5-32B-Instruct-GGUF/resolve/main/Qwen2.5-32B-Instruct-Q4_K_M.gguf",
+    "size": "20GB",
+    "description": "Proven general chat",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-Coder-32B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-Coder-32B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct-GGUF/resolve/main/qwen2.5-coder-32b-instruct-q4_k_m.gguf",
+    "size": "20GB",
+    "description": "Top-tier code gen, matches GPT-4o on code",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Llama-4-Scout-Q4_K_M",
+    "file": "Llama-4-Scout-4bit-Q4_K_M.gguf",
+    "url": "https://huggingface.co/glogwa68/Llama-4-scout-GGUF/resolve/main/Llama-4-Scout-4bit-Q4_K_M.gguf",
+    "size": "22.5GB",
+    "description": "109B/17B, Meta latest, tool calling",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Gemma-3-27B-it-Q4_K_M",
+    "file": "Gemma-3-27B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/google_gemma-3-27b-it-GGUF/resolve/main/google_gemma-3-27b-it-Q4_K_M.gguf",
+    "size": "17GB",
+    "description": "Google Gemma 3 27B, strong reasoning",
+    "draft": "Gemma-3-1B-it-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3.5-27B-Q4_K_M",
+    "file": "Qwen3.5-27B-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/qwen3.5/blobs/sha256:d4b8b4f4c350f5d322dc8235175eeae02d32c6f3fd70bdb9ea481e3abb7d7fc4",
+    "size": "17GB",
+    "description": "Qwen3.5 27B, vision + text, strong reasoning and coding",
+    "draft": "Qwen3-0.6B-Q4_K_M",
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.5-27B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-27B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3-Coder-Next-Q4_K_M",
+    "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
+    "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
+    "size": "48GB",
+    "description": "Qwen3 Coder Next ~85B dense, frontier coding model",
+    "draft": null,
+    "extra_files": [
+      {
+        "file": "Qwen3-Coder-Next-Q4_K_M-00002-of-00004.gguf",
+        "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00002-of-00004.gguf"
+      },
+      {
+        "file": "Qwen3-Coder-Next-Q4_K_M-00003-of-00004.gguf",
+        "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00003-of-00004.gguf"
+      },
+      {
+        "file": "Qwen3-Coder-Next-Q4_K_M-00004-of-00004.gguf",
+        "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00004-of-00004.gguf"
+      }
+    ],
+    "mmproj": null
+  },
+  {
+    "name": "Llama-3.3-70B-Instruct-Q4_K_M",
+    "file": "Llama-3.3-70B-Instruct-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/llama3.3/blobs/sha256:4824460d29f2058aaf6e1118a63a7a197a09bed509f0e7d4e2efb1ee273b447d",
+    "size": "43GB",
+    "description": "Meta Llama 3.3 70B, strong all-around",
+    "draft": "Llama-3.2-1B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen2.5-72B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-72B-Instruct-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/qwen2.5/blobs/sha256:6e7fdda508e91cb0f63de5c15ff79ac63a1584ccafd751c07ca12b7f442101b8",
+    "size": "47GB",
+    "description": "Flagship Qwen2.5, great tensor split showcase",
+    "draft": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "DeepSeek-R1-Distill-70B-Q4_K_M",
+    "file": "DeepSeek-R1-Distill-70B-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/deepseek-r1/blobs/sha256:4cd576d9aa16961244012223abf01445567b061f1814b57dfef699e4cf8df339",
+    "size": "43GB",
+    "description": "DeepSeek R1 distilled to 70B (Qwen2.5-based), strong reasoning",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Mixtral-8x22B-Instruct-Q4_K_M",
+    "file": "Mixtral-8x22B-Instruct-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/mixtral/blobs/sha256:f3329ad0c787f4f73cab99e8c877bb76403060561dd0caa318127683c87bbcb4",
+    "size": "86GB",
+    "description": "Mixtral 8x22B",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-235B-A22B-Q4_K_M",
+    "file": "Qwen3-235B-A22B-Q4_K_M.gguf",
+    "url": "https://registry.ollama.ai/v2/library/qwen3/blobs/sha256:aeacdadecbed8a07e42026d1a1d3cd30715bb2994ebe4e4ca4009e1a4abe8d5d",
+    "size": "142GB",
+    "description": "Qwen3 235B A22B",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Llama-3.1-405B-Instruct-Q2_K",
+    "file": "Llama-3.1-405B-Instruct-Q2_K.gguf",
+    "url": "https://registry.ollama.ai/v2/library/llama3.1/blobs/sha256:e7e1972e5b13caead8a8dd9c94f4a0dec59ac2d9dd52e0cd1c067e6077eb4677",
+    "size": "149GB",
+    "description": "Llama 3.1 405B Instruct Q2_K, largest dense model",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "MiniMax-M2.5-Q4_K_M",
+    "file": "MiniMax-M2.5-Q4_K_M-00001-of-00004.gguf",
+    "url": "https://huggingface.co/unsloth/MiniMax-M2.5-GGUF/resolve/main/Q4_K_M/MiniMax-M2.5-Q4_K_M-00001-of-00004.gguf",
+    "size": "138GB",
+    "description": "MiniMax-M2.5 456B/46B, Q4_K_M",
+    "draft": null,
+    "extra_files": [
+      {
+        "file": "MiniMax-M2.5-Q4_K_M-00002-of-00004.gguf",
+        "url": "https://huggingface.co/unsloth/MiniMax-M2.5-GGUF/resolve/main/Q4_K_M/MiniMax-M2.5-Q4_K_M-00002-of-00004.gguf"
+      },
+      {
+        "file": "MiniMax-M2.5-Q4_K_M-00003-of-00004.gguf",
+        "url": "https://huggingface.co/unsloth/MiniMax-M2.5-GGUF/resolve/main/Q4_K_M/MiniMax-M2.5-Q4_K_M-00003-of-00004.gguf"
+      },
+      {
+        "file": "MiniMax-M2.5-Q4_K_M-00004-of-00004.gguf",
+        "url": "https://huggingface.co/unsloth/MiniMax-M2.5-GGUF/resolve/main/Q4_K_M/MiniMax-M2.5-Q4_K_M-00004-of-00004.gguf"
+      }
+    ],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3.5-0.8B-Vision-Q4_K_M",
+    "file": "Qwen3.5-0.8B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf",
+    "size": "508MB",
+    "description": "Tiny vision model, OCR, screenshots, runs anywhere",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.5-0.8B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3.5-4B-Vision-Q4_K_M",
+    "file": "Qwen3.5-4B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf",
+    "size": "2.7GB",
+    "description": "Small vision model, good quality/size balance",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.5-4B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3.5-9B-Vision-Q4_K_M",
+    "file": "Qwen3.5-9B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf",
+    "size": "5.8GB",
+    "description": "Vision + text, replaces Qwen3-8B with image understanding",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.5-9B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
+    "name": "Qwen2.5-0.5B-Instruct-Q4_K_M",
+    "file": "Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q4_k_m.gguf",
+    "size": "491MB",
+    "description": "Draft for Qwen2.5 and DeepSeek-R1-Distill models",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Qwen3-0.6B-Q4_K_M",
+    "file": "Qwen3-0.6B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf",
+    "size": "397MB",
+    "description": "Draft for Qwen3 models",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Llama-3.2-1B-Instruct-Q4_K_M",
+    "file": "Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/Llama-3.2-1B-Instruct-GGUF/resolve/main/Llama-3.2-1B-Instruct-Q4_K_M.gguf",
+    "size": "760MB",
+    "description": "Draft for Llama 3.x and Llama 4 models",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
+    "name": "Gemma-3-1B-it-Q4_K_M",
+    "file": "Gemma-3-1B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/bartowski/google_gemma-3-1b-it-GGUF/resolve/main/google_gemma-3-1b-it-Q4_K_M.gguf",
+    "size": "780MB",
+    "description": "Draft for Gemma 3 models",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  }
+]

--- a/crates/mesh-llm-node/src/models.rs
+++ b/crates/mesh-llm-node/src/models.rs
@@ -564,8 +564,7 @@ fn is_layer_package_file(relative_file: &str) -> bool {
 }
 
 fn catalog_models() -> Vec<CatalogModel> {
-    serde_json::from_str(include_str!("../../mesh-client/src/models/catalog.json"))
-        .expect("parse bundled mesh client model catalog")
+    serde_json::from_str(include_str!("catalog.json")).expect("parse bundled model catalog")
 }
 
 fn find_catalog_model(query: &str) -> Option<CatalogModel> {

--- a/crates/mesh-llm-system/src/benchmark.rs
+++ b/crates/mesh-llm-system/src/benchmark.rs
@@ -180,10 +180,14 @@ fn per_gpu_names(hw: &HardwareSurvey) -> Vec<String> {
         }
 
         // Handle summarized "N× name" form (e.g., "8× NVIDIA A100").
-        if let Some((count_str, name)) = part_trimmed.split_once('×')
-            && let Ok(count) = count_str.trim().parse::<usize>()
-        {
-            let name_trimmed = name.trim();
+        let counted_name = part_trimmed.split_once('×').and_then(|(count_str, name)| {
+            count_str
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .map(|count| (count, name.trim()))
+        });
+        if let Some((count, name_trimmed)) = counted_name {
             for _ in 0..count {
                 names.push(name_trimmed.to_string());
             }
@@ -336,30 +340,31 @@ pub fn run_or_load(
     let path = fingerprint_path();
 
     // Cache-hit path
-    if let Some(ref cached) = load_fingerprint(&path)
-        && !hardware_changed(cached, hw)
-    {
-        let mem_bandwidth: Vec<f64> = cached.gpus.iter().map(|g| g.p90_gbps).collect();
-        let compute_tflops_fp32 = cached
-            .gpus
-            .iter()
-            .map(|g| g.compute_tflops_fp32)
-            .collect::<Option<Vec<f64>>>();
-        let compute_tflops_fp16 = cached
-            .gpus
-            .iter()
-            .map(|g| g.compute_tflops_fp16)
-            .collect::<Option<Vec<f64>>>();
-        let result = BenchmarkResult {
-            mem_bandwidth_gbps: mem_bandwidth,
-            compute_tflops_fp32,
-            compute_tflops_fp16,
-        };
-        tracing::info!(
-            "Using cached bandwidth fingerprint: {} GPUs",
-            result.mem_bandwidth_gbps.len()
-        );
-        return Some(result);
+    match load_fingerprint(&path) {
+        Some(ref cached) if !hardware_changed(cached, hw) => {
+            let mem_bandwidth: Vec<f64> = cached.gpus.iter().map(|g| g.p90_gbps).collect();
+            let compute_tflops_fp32 = cached
+                .gpus
+                .iter()
+                .map(|g| g.compute_tflops_fp32)
+                .collect::<Option<Vec<f64>>>();
+            let compute_tflops_fp16 = cached
+                .gpus
+                .iter()
+                .map(|g| g.compute_tflops_fp16)
+                .collect::<Option<Vec<f64>>>();
+            let result = BenchmarkResult {
+                mem_bandwidth_gbps: mem_bandwidth,
+                compute_tflops_fp32,
+                compute_tflops_fp16,
+            };
+            tracing::info!(
+                "Using cached bandwidth fingerprint: {} GPUs",
+                result.mem_bandwidth_gbps.len()
+            );
+            return Some(result);
+        }
+        _ => {}
     }
 
     tracing::info!("Hardware changed or no cache — running memory bandwidth benchmark");

--- a/crates/mesh-llm-system/src/hardware/enrichers.rs
+++ b/crates/mesh-llm-system/src/hardware/enrichers.rs
@@ -138,11 +138,16 @@ mod linux {
             return None;
         }
 
-        if let Some(pci_bdf) = gpu.pci_bdf.as_deref().and_then(normalize_pci_bdf)
-            && let Some(info) = infos
-                .iter()
-                .find(|info| info.pci_bdf.as_deref() == Some(pci_bdf.as_str()))
-        {
+        let pci_match = gpu
+            .pci_bdf
+            .as_deref()
+            .and_then(normalize_pci_bdf)
+            .and_then(|pci_bdf| {
+                infos
+                    .iter()
+                    .find(|info| info.pci_bdf.as_deref() == Some(pci_bdf.as_str()))
+            });
+        if let Some(info) = pci_match {
             return Some(info);
         }
 

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -372,8 +372,8 @@ impl Collector for DefaultCollector {
                         ])
                         .output()
                         .ok();
-                    if let Some(out) = out {
-                        if out.status.success() {
+                    match out {
+                        Some(out) if out.status.success() => {
                             let s = String::from_utf8(out.stdout).ok()?;
                             let parsed = parse_nvidia_gpu_memory_and_reserved(&s);
                             if !parsed.is_empty() {
@@ -387,6 +387,7 @@ impl Collector for DefaultCollector {
                                 }
                             }
                         }
+                        Some(_) | None => {}
                     }
                     let out = std::process::Command::new("nvidia-smi")
                         .args(["--query-gpu=memory.total", "--format=csv,noheader,nounits"])
@@ -539,8 +540,8 @@ impl Collector for DefaultCollector {
                         .args(["--showproductname"])
                         .output()
                         .ok();
-                    if let Some(out) = out {
-                        if out.status.success() {
+                    match out {
+                        Some(out) if out.status.success() => {
                             if let Ok(s) = String::from_utf8(out.stdout) {
                                 let names = parse_rocm_gpu_names(&s);
                                 if metrics.contains(&Metric::GpuName) {
@@ -551,34 +552,36 @@ impl Collector for DefaultCollector {
                                 }
                             }
                         }
-                    } else {
-                        for args in [["discovery", "--json"], ["discovery", "-j"]] {
-                            let out = std::process::Command::new("xpu-smi")
-                                .args(args)
-                                .output()
-                                .ok();
-                            if let Some(out) = out {
-                                if !out.status.success() {
-                                    continue;
-                                }
-                                let Ok(stdout) = String::from_utf8(out.stdout) else {
-                                    continue;
-                                };
-                                let gpus = parse_xpu_smi_discovery_json(&stdout);
-                                if !gpus.is_empty() {
-                                    let names: Vec<String> =
-                                        gpus.iter().map(|gpu| gpu.name.clone()).collect();
-                                    if metrics.contains(&Metric::GpuName) {
-                                        survey.gpu_name = summarize_gpu_name(&names);
+                        None => {
+                            for args in [["discovery", "--json"], ["discovery", "-j"]] {
+                                let out = std::process::Command::new("xpu-smi")
+                                    .args(args)
+                                    .output()
+                                    .ok();
+                                if let Some(out) = out {
+                                    if !out.status.success() {
+                                        continue;
                                     }
-                                    if metrics.contains(&Metric::GpuCount) {
-                                        survey.gpu_count =
-                                            u8::try_from(names.len()).unwrap_or(u8::MAX);
+                                    let Ok(stdout) = String::from_utf8(out.stdout) else {
+                                        continue;
+                                    };
+                                    let gpus = parse_xpu_smi_discovery_json(&stdout);
+                                    if !gpus.is_empty() {
+                                        let names: Vec<String> =
+                                            gpus.iter().map(|gpu| gpu.name.clone()).collect();
+                                        if metrics.contains(&Metric::GpuName) {
+                                            survey.gpu_name = summarize_gpu_name(&names);
+                                        }
+                                        if metrics.contains(&Metric::GpuCount) {
+                                            survey.gpu_count =
+                                                u8::try_from(names.len()).unwrap_or(u8::MAX);
+                                        }
+                                        break;
                                     }
-                                    break;
                                 }
                             }
                         }
+                        Some(_) => {}
                     }
                 }
             }
@@ -695,9 +698,9 @@ impl Collector for TegraCollector {
         }
 
         if metrics.contains(&Metric::GpuName) {
-            if let Ok(model) = std::fs::read_to_string("/sys/firmware/devicetree/base/model") {
-                survey.gpu_name = parse_tegra_model_name(&model);
-            }
+            survey.gpu_name = std::fs::read_to_string("/sys/firmware/devicetree/base/model")
+                .ok()
+                .and_then(|model| parse_tegra_model_name(&model));
         }
 
         if metrics.contains(&Metric::VramBytes) {
@@ -738,14 +741,21 @@ fn detect_collector_impl() -> Box<dyn Collector> {
 
 #[cfg(all(target_os = "linux", not(feature = "skippy-devices")))]
 fn detect_collector_impl() -> Box<dyn Collector> {
-    if cfg!(target_arch = "aarch64") {
-        if let Ok(compat) = std::fs::read_to_string("/proc/device-tree/compatible") {
-            if is_tegra(&compat) {
-                return Box::new(TegraCollector);
-            }
-        }
+    if is_tegra_host() {
+        return Box::new(TegraCollector);
     }
     Box::new(DefaultCollector)
+}
+
+#[cfg(all(target_os = "linux", not(feature = "skippy-devices")))]
+fn is_tegra_host() -> bool {
+    if !cfg!(target_arch = "aarch64") {
+        return false;
+    }
+    match std::fs::read_to_string("/proc/device-tree/compatible") {
+        Ok(compat) => is_tegra(&compat),
+        Err(_) => false,
+    }
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -333,23 +333,24 @@ impl Collector for DefaultCollector {
             if metrics.contains(&Metric::IsSoc) {
                 survey.is_soc = true;
             }
-            if metrics.contains(&Metric::VramBytes)
-                && let Some((vram_bytes, reserved_bytes)) =
+            if metrics.contains(&Metric::VramBytes) {
+                if let Some((vram_bytes, reserved_bytes)) =
                     macos_metal_gpu_budget(query_metal_recommended_working_set_bytes())
-            {
-                survey.vram_bytes = vram_bytes;
-                survey.gpu_vram = vec![vram_bytes];
-                survey.gpu_reserved = vec![reserved_bytes];
+                {
+                    survey.vram_bytes = vram_bytes;
+                    survey.gpu_vram = vec![vram_bytes];
+                    survey.gpu_reserved = vec![reserved_bytes];
+                }
             }
             if metrics.contains(&Metric::GpuName) {
                 let out = std::process::Command::new("sysctl")
                     .args(["-n", "machdep.cpu.brand_string"])
                     .output()
                     .ok();
-                if let Some(out) = out
-                    && let Ok(s) = String::from_utf8(out.stdout)
-                {
-                    survey.gpu_name = parse_macos_cpu_brand(&s);
+                if let Some(out) = out {
+                    if let Ok(s) = String::from_utf8(out.stdout) {
+                        survey.gpu_name = parse_macos_cpu_brand(&s);
+                    }
                 }
             }
             if metrics.contains(&Metric::GpuCount) {
@@ -371,19 +372,19 @@ impl Collector for DefaultCollector {
                         ])
                         .output()
                         .ok();
-                    if let Some(out) = out
-                        && out.status.success()
-                    {
-                        let s = String::from_utf8(out.stdout).ok()?;
-                        let parsed = parse_nvidia_gpu_memory_and_reserved(&s);
-                        if !parsed.is_empty() {
-                            survey.gpu_reserved =
-                                parsed.iter().map(|(_, reserved)| *reserved).collect();
-                            let per_gpu: Vec<u64> =
-                                parsed.iter().map(|(total, _)| *total).collect();
-                            let total: u64 = per_gpu.iter().sum();
-                            if total > 0 {
-                                return Some((total, per_gpu));
+                    if let Some(out) = out {
+                        if out.status.success() {
+                            let s = String::from_utf8(out.stdout).ok()?;
+                            let parsed = parse_nvidia_gpu_memory_and_reserved(&s);
+                            if !parsed.is_empty() {
+                                survey.gpu_reserved =
+                                    parsed.iter().map(|(_, reserved)| *reserved).collect();
+                                let per_gpu: Vec<u64> =
+                                    parsed.iter().map(|(total, _)| *total).collect();
+                                let total: u64 = per_gpu.iter().sum();
+                                if total > 0 {
+                                    return Some((total, per_gpu));
+                                }
                             }
                         }
                     }
@@ -539,15 +540,15 @@ impl Collector for DefaultCollector {
                         .output()
                         .ok();
                     if let Some(out) = out {
-                        if out.status.success()
-                            && let Ok(s) = String::from_utf8(out.stdout)
-                        {
-                            let names = parse_rocm_gpu_names(&s);
-                            if metrics.contains(&Metric::GpuName) {
-                                survey.gpu_name = summarize_gpu_name(&names);
-                            }
-                            if metrics.contains(&Metric::GpuCount) {
-                                survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
+                        if out.status.success() {
+                            if let Ok(s) = String::from_utf8(out.stdout) {
+                                let names = parse_rocm_gpu_names(&s);
+                                if metrics.contains(&Metric::GpuName) {
+                                    survey.gpu_name = summarize_gpu_name(&names);
+                                }
+                                if metrics.contains(&Metric::GpuCount) {
+                                    survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
+                                }
                             }
                         }
                     } else {
@@ -556,10 +557,13 @@ impl Collector for DefaultCollector {
                                 .args(args)
                                 .output()
                                 .ok();
-                            if let Some(out) = out
-                                && out.status.success()
-                                && let Ok(stdout) = String::from_utf8(out.stdout)
-                            {
+                            if let Some(out) = out {
+                                if !out.status.success() {
+                                    continue;
+                                }
+                                let Ok(stdout) = String::from_utf8(out.stdout) else {
+                                    continue;
+                                };
                                 let gpus = parse_xpu_smi_discovery_json(&stdout);
                                 if !gpus.is_empty() {
                                     let names: Vec<String> =
@@ -690,10 +694,10 @@ impl Collector for TegraCollector {
             survey.is_soc = true;
         }
 
-        if metrics.contains(&Metric::GpuName)
-            && let Ok(model) = std::fs::read_to_string("/sys/firmware/devicetree/base/model")
-        {
-            survey.gpu_name = parse_tegra_model_name(&model);
+        if metrics.contains(&Metric::GpuName) {
+            if let Ok(model) = std::fs::read_to_string("/sys/firmware/devicetree/base/model") {
+                survey.gpu_name = parse_tegra_model_name(&model);
+            }
         }
 
         if metrics.contains(&Metric::VramBytes) {
@@ -734,11 +738,12 @@ fn detect_collector_impl() -> Box<dyn Collector> {
 
 #[cfg(all(target_os = "linux", not(feature = "skippy-devices")))]
 fn detect_collector_impl() -> Box<dyn Collector> {
-    if cfg!(target_arch = "aarch64")
-        && let Ok(compat) = std::fs::read_to_string("/proc/device-tree/compatible")
-        && is_tegra(&compat)
-    {
-        return Box::new(TegraCollector);
+    if cfg!(target_arch = "aarch64") {
+        if let Ok(compat) = std::fs::read_to_string("/proc/device-tree/compatible") {
+            if is_tegra(&compat) {
+                return Box::new(TegraCollector);
+            }
+        }
     }
     Box::new(DefaultCollector)
 }
@@ -930,7 +935,10 @@ fn resolve_pinned_gpu_with_compatibility<'a>(
                 .iter()
                 .filter(|gpu| !gpu_pinnable_ids(gpu).is_empty())
                 .collect::<Vec<_>>();
-            if accept_single_pinnable_gpu_fallback && let [gpu] = pinnable_gpus.as_slice() {
+            if let (true, [gpu]) = (
+                accept_single_pinnable_gpu_fallback,
+                pinnable_gpus.as_slice(),
+            ) {
                 tracing::warn!(
                     "configured gpu_id '{}' did not match the single available pinnable GPU; accepting '{}' for compatibility",
                     configured_id,

--- a/crates/mesh-llm-system/src/hardware/parsers.rs
+++ b/crates/mesh-llm-system/src/hardware/parsers.rs
@@ -254,16 +254,22 @@ pub fn expand_gpu_names(summary: Option<&str>, expected_count: usize) -> Vec<Str
         if part.is_empty() {
             continue;
         }
-        if let Some((count_str, name)) = part.split_once('×')
-            && let Ok(count) = count_str.trim().parse::<usize>()
-        {
+        let counted_name = part.split_once('×').and_then(|(count_str, name)| {
             let name = name.trim();
-            if !name.is_empty() {
-                for _ in 0..count {
-                    names.push(name.to_string());
-                }
-                continue;
+            if name.is_empty() {
+                return None;
             }
+            count_str
+                .trim()
+                .parse::<usize>()
+                .ok()
+                .map(|count| (count, name))
+        });
+        if let Some((count, name)) = counted_name {
+            for _ in 0..count {
+                names.push(name.to_string());
+            }
+            continue;
         }
         names.push(part.to_string());
     }

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -15,6 +15,7 @@ Environment:
   CRATES_IO_PUBLISH_MAX_ATTEMPTS        Real-publish retry attempts for crates.io 429s (default: 6)
   CRATES_IO_PUBLISH_RETRY_BASE_SECONDS Fallback retry base when crates.io gives no timestamp (default: 60)
   CRATES_IO_PUBLISH_RETRY_MAX_SECONDS  Fallback retry cap when crates.io gives no timestamp (default: 900)
+  CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS Set to 1 to allow publish when crates.io status cannot be verified (default: 0)
 USAGE
 }
 
@@ -40,6 +41,15 @@ require_nonnegative_int() {
     local value="$2"
     if [[ ! "$value" =~ ^[0-9]+$ ]]; then
         echo "${name} must be a non-negative integer" >&2
+        exit 1
+    fi
+}
+
+require_binary_flag() {
+    local name="$1"
+    local value="$2"
+    if [[ "$value" != "0" && "$value" != "1" ]]; then
+        echo "${name} must be 0 or 1" >&2
         exit 1
     fi
 }
@@ -93,11 +103,13 @@ fi
 max_attempts="${CRATES_IO_PUBLISH_MAX_ATTEMPTS:-6}"
 retry_base_seconds="${CRATES_IO_PUBLISH_RETRY_BASE_SECONDS:-60}"
 retry_max_seconds="${CRATES_IO_PUBLISH_RETRY_MAX_SECONDS:-900}"
+allow_unknown_status="${CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS:-0}"
 
 require_nonnegative_int CRATES_IO_PUBLISH_SETTLE_SECONDS "$sleep_seconds"
 require_positive_int CRATES_IO_PUBLISH_MAX_ATTEMPTS "$max_attempts"
 require_positive_int CRATES_IO_PUBLISH_RETRY_BASE_SECONDS "$retry_base_seconds"
 require_positive_int CRATES_IO_PUBLISH_RETRY_MAX_SECONDS "$retry_max_seconds"
+require_binary_flag CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS "$allow_unknown_status"
 
 if [[ "$dry_run" -eq 0 && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
     echo "CARGO_REGISTRY_TOKEN is required for real crates.io publishing" >&2
@@ -259,7 +271,12 @@ publish_crate_with_retry() {
             return 0
         fi
         if [[ "$status" == "unknown" ]]; then
-            warn "[${index}/${total}] could not verify ${crate}@${workspace_version} on crates.io; trying cargo publish"
+            if [[ "$allow_unknown_status" -ne 1 ]]; then
+                warn "[${index}/${total}] could not verify ${crate}@${workspace_version} on crates.io; aborting before publish"
+                warn "set CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1 to continue when registry status cannot be verified"
+                return 101
+            fi
+            warn "[${index}/${total}] could not verify ${crate}@${workspace_version} on crates.io; trying cargo publish because CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1"
         fi
     fi
 

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -140,6 +140,49 @@ class PublishCratesScriptTests(unittest.TestCase):
             )
             self.assertFalse((fixture.tmp_path / "cargo.log").exists())
 
+    def test_real_publish_can_opt_into_unknown_registry_status(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({"model-ref": 500})
+            fixture.write_fake_cargo()
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+
+            result = fixture.run(
+                env={
+                    "CARGO_REGISTRY_TOKEN": "test-token",
+                    "CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS": "1",
+                    "CRATES_IO_PUBLISH_SETTLE_SECONDS": "0",
+                }
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn(
+                "trying cargo publish because CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1",
+                result.stderr,
+            )
+            self.assertIn("-p model-ref", fixture.read_log("cargo.log"))
+
+    def test_real_publish_rejects_invalid_unknown_status_opt_in(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({})
+            fixture.write_fake_cargo()
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+
+            result = fixture.run(
+                env={
+                    "CARGO_REGISTRY_TOKEN": "test-token",
+                    "CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS": "yes",
+                }
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS must be 0 or 1",
+                result.stderr,
+            )
+            self.assertFalse((fixture.tmp_path / "cargo.log").exists())
+
     def test_cargo_failure_output_redacts_registry_token(self) -> None:
         with PublishCratesFixture() as fixture:
             fixture.write_curl_statuses({})

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -6,7 +6,7 @@ use mesh_llm_system::embedded_release_footer::{
     verify_embedded_release_footer,
 };
 use serde::Deserialize;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -82,12 +82,14 @@ impl ReleaseBuildAttestationClaims {
         {
             return Err("invalid release build attestation shape".into());
         }
-        if let (Some(min), Some(max)) = (
+        match (
             self.supported_protocol_generation_min,
             self.supported_protocol_generation_max,
-        ) && min > max
-        {
-            return Err("invalid release build attestation protocol bounds".into());
+        ) {
+            (Some(min), Some(max)) if min > max => {
+                return Err("invalid release build attestation protocol bounds".into());
+            }
+            _ => {}
         }
         if !self.artifact_digest.starts_with("sha256:") {
             return Err("release build attestation artifact digest must start with sha256:".into());
@@ -369,6 +371,12 @@ fn run() -> DynResult<()> {
             println!("repo consistency checks passed: ci-crate-lists");
             Ok(())
         }
+        [command, scope] if command == "repo-consistency" && scope == "publish-crates" => {
+            let repo_root = repo_root()?;
+            check_publish_crates_consistency(&repo_root)?;
+            println!("repo consistency checks passed: publish-crates");
+            Ok(())
+        }
         [command, scope, rest @ ..]
             if command == "release-attestation" && scope == "generate-keypair" =>
         {
@@ -383,7 +391,7 @@ fn run() -> DynResult<()> {
             inspect_release_attestation(rest)
         }
         _ => Err(
-            "usage:\n  cargo run -p xtask -- repo-consistency release-targets\n  cargo run -p xtask -- repo-consistency ci-crate-lists\n  cargo run -p xtask -- release-attestation generate-keypair --private-key-out <path> --public-key-out <path>\n  cargo run -p xtask -- release-attestation stamp --binary <path> --signing-key-file <path> [--node-version <semver>] [--build-id <id>] [--commit <sha>] [--target-triple <triple>] [--protocol-min <n>] [--protocol-max <n>]\n  cargo run -p xtask -- release-attestation inspect --binary <path> [--public-key-file <path>] [--json]"
+            "usage:\n  cargo run -p xtask -- repo-consistency release-targets\n  cargo run -p xtask -- repo-consistency ci-crate-lists\n  cargo run -p xtask -- repo-consistency publish-crates\n  cargo run -p xtask -- release-attestation generate-keypair --private-key-out <path> --public-key-out <path>\n  cargo run -p xtask -- release-attestation stamp --binary <path> --signing-key-file <path> [--node-version <semver>] [--build-id <id>] [--commit <sha>] [--target-triple <triple>] [--protocol-min <n>] [--protocol-max <n>]\n  cargo run -p xtask -- release-attestation inspect --binary <path> [--public-key-file <path>] [--json]"
                 .to_string()
                 .into(),
         ),
@@ -701,6 +709,7 @@ fn check_release_targets() -> DynResult<()> {
     check_windows_name_invariance(&fixture_rows, &fixture_version)?;
     check_ci_script_workspace_members(&repo_root)?;
     check_attestation_default_version(&repo_root)?;
+    check_publish_crates_consistency(&repo_root)?;
     check_docs_and_workflow_invariants(&repo_root)?;
 
     println!("repo consistency checks passed: release-targets");
@@ -822,6 +831,24 @@ struct CargoMetadata {
 struct CargoPackage {
     id: String,
     name: String,
+    version: String,
+    manifest_path: PathBuf,
+    #[serde(default)]
+    dependencies: Vec<CargoDependency>,
+    description: Option<String>,
+    license: Option<String>,
+    license_file: Option<String>,
+    repository: Option<String>,
+    readme: Option<String>,
+    publish: Option<Vec<String>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoDependency {
+    name: String,
+    req: String,
+    kind: Option<String>,
+    path: Option<PathBuf>,
 }
 
 fn fixture_rows(repo_root: &Path) -> DynResult<Vec<FixtureRow>> {
@@ -1534,7 +1561,28 @@ fn check_ci_script_workspace_members(repo_root: &Path) -> DynResult<()> {
     Ok(())
 }
 
-fn workspace_package_names(repo_root: &Path) -> DynResult<BTreeSet<String>> {
+fn check_publish_crates_consistency(repo_root: &Path) -> DynResult<()> {
+    let metadata = workspace_metadata(repo_root, "publish crate consistency")?;
+    let publish_crates = publish_script_crates(repo_root)?;
+    let workspace_members = metadata
+        .workspace_members
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let packages_by_name = workspace_packages_by_name(&metadata, &workspace_members);
+    let packages_by_dir = workspace_packages_by_dir(&metadata, &workspace_members)?;
+    let publish_order = publish_order(&publish_crates)?;
+
+    check_publish_crate_metadata(repo_root, &publish_crates, &packages_by_name)?;
+    check_publish_crate_dependencies(&publish_order, &packages_by_name, &packages_by_dir)?;
+    check_publish_literal_includes(&publish_crates, &packages_by_name)?;
+    check_publish_catalog_sync(repo_root)?;
+    check_publish_workflow_invariants(repo_root)?;
+
+    Ok(())
+}
+
+fn workspace_metadata(repo_root: &Path, context: &str) -> DynResult<CargoMetadata> {
     let mut cargo = Command::new("cargo");
     cargo
         .current_dir(repo_root)
@@ -1544,13 +1592,384 @@ fn workspace_package_names(repo_root: &Path) -> DynResult<BTreeSet<String>> {
     let output = run_command(&mut cargo)?;
     if !output.status.success() {
         return Err(format!(
-            "cargo metadata failed while checking CI crate lists: {}",
+            "cargo metadata failed while checking {context}: {}",
             trimmed_stderr_or_stdout(&output)
         )
         .into());
     }
+    Ok(serde_json::from_slice(&output.stdout)?)
+}
 
-    let metadata: CargoMetadata = serde_json::from_slice(&output.stdout)?;
+fn publish_script_crates(repo_root: &Path) -> DynResult<Vec<String>> {
+    let relative_path = "scripts/publish-crates.sh";
+    let contents = fs::read_to_string(repo_root.join(relative_path))?;
+    let mut in_array = false;
+    let mut crates = Vec::new();
+    let mut seen = BTreeSet::new();
+
+    for line in contents.lines() {
+        let trimmed = line.trim();
+        if !in_array {
+            if trimmed == "publish_crates=(" {
+                in_array = true;
+            }
+            continue;
+        }
+
+        if trimmed == ")" {
+            if crates.is_empty() {
+                return Err(format!("{relative_path}: publish_crates array is empty").into());
+            }
+            return Ok(crates);
+        }
+
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let crate_name = trimmed.trim_matches('"').to_string();
+        if !seen.insert(crate_name.clone()) {
+            return Err(
+                format!("{relative_path}: duplicate publish_crates entry `{crate_name}`").into(),
+            );
+        }
+        crates.push(crate_name);
+    }
+
+    Err(format!("{relative_path}: missing publish_crates array").into())
+}
+
+fn workspace_packages_by_name<'a>(
+    metadata: &'a CargoMetadata,
+    workspace_members: &BTreeSet<String>,
+) -> BTreeMap<String, &'a CargoPackage> {
+    metadata
+        .packages
+        .iter()
+        .filter(|package| workspace_members.contains(&package.id))
+        .map(|package| (package.name.clone(), package))
+        .collect()
+}
+
+fn workspace_packages_by_dir<'a>(
+    metadata: &'a CargoMetadata,
+    workspace_members: &BTreeSet<String>,
+) -> DynResult<BTreeMap<PathBuf, &'a CargoPackage>> {
+    let mut packages = BTreeMap::new();
+    for package in metadata
+        .packages
+        .iter()
+        .filter(|package| workspace_members.contains(&package.id))
+    {
+        let dir = package
+            .manifest_path
+            .parent()
+            .ok_or_else(|| format!("{}: manifest path has no parent", package.name))?
+            .to_path_buf();
+        packages.insert(dir, package);
+    }
+    Ok(packages)
+}
+
+fn publish_order(crates: &[String]) -> DynResult<BTreeMap<String, usize>> {
+    let mut order = BTreeMap::new();
+    for (index, crate_name) in crates.iter().enumerate() {
+        if order.insert(crate_name.clone(), index).is_some() {
+            return Err(format!("duplicate publish crate `{crate_name}`").into());
+        }
+    }
+    Ok(order)
+}
+
+fn check_publish_crate_metadata(
+    repo_root: &Path,
+    publish_crates: &[String],
+    packages_by_name: &BTreeMap<String, &CargoPackage>,
+) -> DynResult<()> {
+    for crate_name in publish_crates {
+        let package = packages_by_name
+            .get(crate_name)
+            .ok_or_else(|| format!("publish crate `{crate_name}` is not a workspace package"))?;
+        if !package_is_publishable(package) {
+            return Err(format!("publish crate `{crate_name}` is marked publish=false").into());
+        }
+        ensure_nonempty_option(&package.description, &format!("{crate_name} description"))?;
+        if package.license.as_deref().unwrap_or("").is_empty()
+            && package.license_file.as_deref().unwrap_or("").is_empty()
+        {
+            return Err(format!("{crate_name}: missing license or license-file").into());
+        }
+        ensure_nonempty_option(&package.repository, &format!("{crate_name} repository"))?;
+        check_publish_readme(repo_root, package)?;
+    }
+
+    Ok(())
+}
+
+fn check_publish_readme(repo_root: &Path, package: &CargoPackage) -> DynResult<()> {
+    let manifest_dir = package
+        .manifest_path
+        .parent()
+        .ok_or_else(|| format!("{}: manifest path has no parent", package.name))?;
+    let readme = package.readme.as_deref().unwrap_or("README.md");
+    let readme_path = manifest_dir.join(readme);
+    if readme_path.exists() {
+        return Ok(());
+    }
+
+    let relative = readme_path
+        .strip_prefix(repo_root)
+        .unwrap_or(readme_path.as_path())
+        .display();
+    Err(format!("{}: missing publish readme `{relative}`", package.name).into())
+}
+
+fn check_publish_crate_dependencies(
+    publish_order: &BTreeMap<String, usize>,
+    packages_by_name: &BTreeMap<String, &CargoPackage>,
+    packages_by_dir: &BTreeMap<PathBuf, &CargoPackage>,
+) -> DynResult<()> {
+    for (crate_name, package) in packages_by_name {
+        let Some(package_index) = publish_order.get(crate_name) else {
+            continue;
+        };
+        for dependency in package
+            .dependencies
+            .iter()
+            .filter(|dep| dep.kind.as_deref() != Some("dev"))
+        {
+            let Some(path) = dependency.path.as_ref() else {
+                continue;
+            };
+            let Some(target) = packages_by_dir.get(path) else {
+                return Err(format!(
+                    "{crate_name}: workspace path dependency `{}` has no package at {}",
+                    dependency.name,
+                    path.display()
+                )
+                .into());
+            };
+            if !package_is_publishable(target) {
+                return Err(format!(
+                    "{crate_name}: publishable crate depends on non-publishable workspace crate `{}`",
+                    target.name
+                )
+                .into());
+            }
+            check_publish_dependency_version(crate_name, target, dependency)?;
+            let Some(dep_index) = publish_order.get(&target.name) else {
+                return Err(format!(
+                    "{crate_name}: publishable dependency `{}` is missing from scripts/publish-crates.sh",
+                    target.name
+                )
+                .into());
+            };
+            if dep_index >= package_index {
+                return Err(format!(
+                    "{crate_name}: dependency `{}` must appear earlier in scripts/publish-crates.sh",
+                    target.name
+                )
+                .into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn check_publish_dependency_version(
+    crate_name: &str,
+    target: &CargoPackage,
+    dependency: &CargoDependency,
+) -> DynResult<()> {
+    let caret = format!("^{}", target.version);
+    if dependency.req == target.version || dependency.req == caret {
+        return Ok(());
+    }
+    Err(format!(
+        "{crate_name}: dependency `{}` uses version requirement `{}`, expected `{}`",
+        target.name, dependency.req, caret
+    )
+    .into())
+}
+
+fn package_is_publishable(package: &CargoPackage) -> bool {
+    package
+        .publish
+        .as_ref()
+        .map(|registries| !registries.is_empty())
+        .unwrap_or(true)
+}
+
+fn check_publish_literal_includes(
+    publish_crates: &[String],
+    packages_by_name: &BTreeMap<String, &CargoPackage>,
+) -> DynResult<()> {
+    for crate_name in publish_crates {
+        let package = packages_by_name
+            .get(crate_name)
+            .ok_or_else(|| format!("publish crate `{crate_name}` is not a workspace package"))?;
+        check_package_literal_includes(package)?;
+    }
+    Ok(())
+}
+
+fn check_package_literal_includes(package: &CargoPackage) -> DynResult<()> {
+    let package_dir = package
+        .manifest_path
+        .parent()
+        .ok_or_else(|| format!("{}: manifest path has no parent", package.name))?;
+    let src_dir = package_dir.join("src");
+    if !src_dir.exists() {
+        return Ok(());
+    }
+
+    let package_root = package_dir.canonicalize()?;
+    for rust_file in rust_files_under(&src_dir)? {
+        let source = fs::read_to_string(&rust_file)?;
+        for include_path in literal_include_paths(&source) {
+            let resolved = rust_file
+                .parent()
+                .ok_or_else(|| format!("{}: source path has no parent", rust_file.display()))?
+                .join(&include_path);
+            if !resolved.exists() {
+                return Err(format!(
+                    "{}: literal include `{}` does not exist",
+                    rust_file.display(),
+                    include_path
+                )
+                .into());
+            }
+            let resolved = resolved.canonicalize()?;
+            if !resolved.starts_with(&package_root) {
+                return Err(format!(
+                    "{}: literal include `{}` points outside publish package root",
+                    rust_file.display(),
+                    include_path
+                )
+                .into());
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn rust_files_under(root: &Path) -> DynResult<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    collect_rust_files(root, &mut files)?;
+    Ok(files)
+}
+
+fn collect_rust_files(dir: &Path, files: &mut Vec<PathBuf>) -> DynResult<()> {
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_rust_files(&path, files)?;
+        } else if path.extension().and_then(|value| value.to_str()) == Some("rs") {
+            files.push(path);
+        }
+    }
+    Ok(())
+}
+
+fn literal_include_paths(source: &str) -> Vec<String> {
+    let mut paths = Vec::new();
+    for line in source.lines() {
+        for pattern in ["include_str!(\"", "include_bytes!(\""] {
+            let Some(start) = line.find(pattern) else {
+                continue;
+            };
+            let tail = &line[start + pattern.len()..];
+            if let Some(end) = tail.find('"') {
+                paths.push(tail[..end].to_string());
+            }
+        }
+    }
+    paths
+}
+
+fn check_publish_catalog_sync(repo_root: &Path) -> DynResult<()> {
+    let client_catalog = fs::read_to_string(
+        repo_root
+            .join("crates")
+            .join("mesh-client")
+            .join("src")
+            .join("models")
+            .join("catalog.json"),
+    )?;
+    let node_catalog = fs::read_to_string(
+        repo_root
+            .join("crates")
+            .join("mesh-llm-node")
+            .join("src")
+            .join("catalog.json"),
+    )?;
+    ensure_eq(
+        &client_catalog,
+        &node_catalog,
+        "mesh-llm-node packaged catalog copy",
+    )
+}
+
+fn check_publish_workflow_invariants(repo_root: &Path) -> DynResult<()> {
+    let release = fs::read_to_string(repo_root.join("RELEASE.md"))?;
+    let release_workflow = fs::read_to_string(repo_root.join(".github/workflows/release.yml"))?;
+    let pr_quality_workflow =
+        fs::read_to_string(repo_root.join(".github/workflows/pr_quality.yml"))?;
+
+    ensure_contains(
+        &release,
+        "cargo run -p xtask -- repo-consistency publish-crates",
+        "RELEASE publish-chain consistency command",
+    )?;
+    ensure_contains(
+        &release_workflow,
+        "publish_crates_preflight:",
+        "release workflow crates.io preflight job",
+    )?;
+    ensure_contains(
+        &release_workflow,
+        "cargo run -p xtask -- repo-consistency publish-crates",
+        "release workflow publish-chain consistency check",
+    )?;
+    ensure_contains(
+        &release_workflow,
+        "scripts/publish-crates.sh --dry-run --allow-dirty --sleep-seconds 0",
+        "release workflow publish-chain dry-run",
+    )?;
+    ensure_contains_normalized(
+        &release_workflow,
+        "publish_crates_preflight:
+          name: Preflight crates.io packages
+          needs: [metadata, publish]
+          if: ${{ needs.metadata.outputs.prerelease != 'true' && needs.metadata.outputs.canary != 'true' }}
+          runs-on: blacksmith-4vcpu-ubuntu-2404
+          steps:
+            - uses: actions/checkout@v5
+            - uses: dtolnay/rust-toolchain@stable
+            - name: Prepare dispatched release version
+              if: github.event_name == 'workflow_dispatch'
+              env:
+                RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+              run: scripts/release-version.sh \"$RELEASE_TAG\"",
+        "release workflow publish preflight dispatched version preparation",
+    )?;
+    ensure_contains(
+        &release_workflow,
+        "needs: [metadata, publish, publish_crates_preflight]",
+        "release workflow real publish preflight dependency",
+    )?;
+    ensure_contains(
+        &pr_quality_workflow,
+        "cargo run -p xtask -- repo-consistency publish-crates",
+        "PR quality publish-chain drift check",
+    )?;
+
+    Ok(())
+}
+
+fn workspace_package_names(repo_root: &Path) -> DynResult<BTreeSet<String>> {
+    let metadata = workspace_metadata(repo_root, "CI crate lists")?;
     let workspace_members = metadata
         .workspace_members
         .into_iter()
@@ -1678,6 +2097,13 @@ fn ensure_eq_option(expected: Option<&str>, actual: Option<&str>, context: &str)
         Ok(())
     } else {
         Err(format!("{context}: expected {:?}, got {:?}", expected, actual).into())
+    }
+}
+
+fn ensure_nonempty_option(value: &Option<String>, context: &str) -> DynResult<()> {
+    match value.as_deref() {
+        Some(value) if !value.is_empty() => Ok(()),
+        _ => Err(format!("{context}: missing value").into()),
     }
 }
 


### PR DESCRIPTION
## Summary

This hardens the crates.io publish path before the next release by making publish-chain drift visible in CI and by preventing the release job from blindly publishing when registry status cannot be verified.

Users and maintainers now get an earlier, deterministic failure when the SDK/API publish chain is not packageable, when publish order drifts, or when a packaged crate accidentally depends on files outside its package boundary.

## Issues

Closes #691.
Closes #611.

- #691: the publish script now fails closed when crates.io status is unknown unless the release operator explicitly sets `CRATES_IO_PUBLISH_ALLOW_UNKNOWN_STATUS=1`, while preserving the existing retry behavior for real 429 publish responses.
- #611: the release and PR quality paths now validate the crates.io publish chain before GA, including package metadata, path dependency version requirements, publish order, workflow wiring, and package include boundaries.

## Diff scope

- Adds `xtask repo-consistency publish-crates` and wires it into both release-target consistency and PR quality.
- Adds a dedicated release preflight job that validates publish-chain consistency and runs `scripts/publish-crates.sh --dry-run --allow-dirty --sleep-seconds 0` before real publish.
- Applies the same workflow_dispatch release-version preparation step to the preflight job before the consistency check and dry-run publish chain.
- Hardens `scripts/publish-crates.sh` so unknown registry status is an explicit operator decision, not the default path.
- Adds publish-script unit coverage for the fail-closed status check and the explicit opt-in path.
- Makes `mesh-llm-node` package self-contained by shipping its catalog under the crate instead of including a sibling crate file at publish time.
- Updates `RELEASE.md` with the new preflight and recovery behavior.

## Compatibility

No runtime, mesh protocol, Skippy ABI, SDK API, or user-facing CLI behavior changes. This is release tooling and packageability hardening only.

## Branch integrity

- Base branch: `main`
- Validated base SHA: `95695f9f7d82160c78154bb9a95d97a3e049875e`
- Current head SHA: `f743be85b587ea9b34037ae4d52b210665ffbe3a`
- Ahead/behind after rebase: `2 / 0`
- Merge status: `CLEAN`

## Validation

Validation tier: Tier 4 for release/publish workflow hardening, with a Tier 2R same-PR compile hygiene correction retained in the branch history. This refresh only rebased the branch onto current `main` and revalidated the touched release/tooling crates and affected hardware/packageability paths.

Local validation on final pushed SHA `f743be85b587ea9b34037ae4d52b210665ffbe3a`:

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `95695f9f7d82160c78154bb9a95d97a3e049875e`.
- `git rebase origin/main`: PASS, no conflicts.
- `git rev-list --left-right --count origin/main...HEAD`: PASS, `0 / 2`.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS.
- `cargo check -p xtask`: PASS.
- `cargo run -p xtask -- repo-consistency publish-crates`: PASS.
- `cargo run -p xtask -- repo-consistency release-targets`: PASS.
- `cargo run -p xtask -- repo-consistency ci-crate-lists`: PASS.
- `python3 -m unittest scripts.tests.test_publish_crates`: PASS, 9 passed.
- `cargo test -p mesh-llm-system hardware:: --lib`: PASS, 67 passed.
- `cargo test -p mesh-llm-gpu-bench --lib`: PASS, 0 passed.
- `cargo test -p mesh-llm-node --lib`: PASS, 9 passed.
- `cargo clippy -p mesh-llm-system -p mesh-llm-gpu-bench -p xtask --all-targets -- -D warnings`: PASS.
- `cargo publish --dry-run --locked --allow-dirty -p mesh-llm-node`: PASS.
- `scripts/publish-crates.sh --dry-run --allow-dirty --sleep-seconds 0`: PASS, first five crates verified; downstream crates reported expected local dry-run dependency availability limits and the script exited 0.

Remote gates on final pushed SHA `f743be85b587ea9b34037ae4d52b210665ffbe3a`:

- PR Quality Checks: PASS (`changes`, `rust-fmt`, `rust-clippy (0)`, `rust-clippy (1)`, `rust-clippy (2)`, `summary`; `ui-quality` skipped because no UI path changed).
- PR Builds: PASS (`Linux CPU`, `Linux CUDA slim`, `Linux ROCm slim`, `Linux Vulkan`, `macOS CPU`, `macOS CUDA`, `macOS ROCm`, `macOS Vulkan`, `Linux tests (unit)`, `Linux tests (protocol)`, `Linux tests (sdk-api)`, `Linux tests (skippy)`, `Linux tests (skippy-smoke)`, `Linux client-auto boot test`, `macOS unit tests`, `inference_smoke_tests`, `two_node_split_smoke`, `two_node_client_serving_smoke`, `native_sdk_smoke`, `kotlin_sdk_smoke`, `swift_sdk_smoke`, `HuggingFace download smoke`; expected skips: Windows matrix, `agent_live_smokes`).

Ledger: not applicable - not required for selected validation tier/change family.
Version: not applicable - release tooling/packageability guard and compile-hygiene correction only; no release/version sync required.

Not run: full release workflow locally - not required for selected validation tier; targeted xtask/script/package dry-run checks cover the changed release path and mandatory PR CI is green on the final SHA.

## Review status

The prior requested-change item has been addressed in code: `publish_crates_preflight` now prepares the workflow_dispatch release version before the consistency check and dry-run publish chain. GitHub still shows the earlier `CHANGES_REQUESTED` review decision, so final merge still needs re-review/approval.

## Rollback

Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks

The dry-run proves local packageability and release-script behavior, but it does not upload crates or fully emulate crates.io propagation timing. The real release workflow remains the final publish gate after merge.
