### PR TITLE
Restore main CI for OpenAI transport tests

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -4803,6 +4803,7 @@ mod tests {
             stage_status_list_supported: false,
             advertised_model_throughput: vec![],
             display_rtt: None,
+            selected_path: None,
             propagated_latency: None,
             owner_summary: crate::crypto::OwnershipSummary::default(),
         }


### PR DESCRIPTION
## Summary
- Add the new PeerInfo selected_path field to the OpenAI transport test peer fixture.
- Keeps the fixture aligned with the required mesh PeerInfo shape after the latest main merge.

## Validation
- rustup run stable cargo fmt --all -- --check
- rustup run stable cargo check -p mesh-llm
- rustup run stable cargo test -p mesh-llm-host-runtime --lib