### PR TITLE
[codex] Fix duplicate selected path test field

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -4859,7 +4859,6 @@ mod tests {
             display_rtt: None,
             selected_path: None,
             propagated_latency: None,
-            selected_path: None,
             owner_summary: crate::crypto::OwnershipSummary::default(),
         }
     }


### PR DESCRIPTION
## Summary

Fixes the main-branch PR Quality Checks failure for commit `13eb13dafc1269c950f2ad9f6d2beda53e9eccdf` by removing a duplicated `selected_path` initializer from the OpenAI transport test fixture.

## Root Cause

`cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings` compiles test targets and failed with `E0062` because the `PeerInfo` test fixture specified `selected_path` twice.

## Validation

- `rustup run stable cargo fmt --all -- --check`
- `rustup run stable cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `rustup run stable cargo check -p mesh-llm`
- `rustup run stable cargo clippy -p mesh-llm --all-targets -- -D warnings`
