### PR TITLE
Reject context-incompatible OpenAI route targets

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -979,11 +979,21 @@ pub(crate) fn request_budget_tokens_from_parts(
         return None;
     }
     let prompt_tokens = ceil_div_u32(saturating_u32(body_len_bytes), 4);
+    let completion_tokens = completion_tokens.unwrap_or(0);
+    let requested_tokens = prompt_tokens.saturating_add(completion_tokens);
     Some(
         prompt_tokens
-            .saturating_add(completion_tokens.unwrap_or(0))
-            .saturating_add(REQUEST_TOKEN_MARGIN),
+            .saturating_add(completion_tokens)
+            .saturating_add(request_token_margin(requested_tokens)),
     )
+}
+
+fn request_token_margin(requested_tokens: u32) -> u32 {
+    const MIN_REQUEST_TOKEN_MARGIN: u32 = 16;
+    if requested_tokens == 0 {
+        return 0;
+    }
+    ceil_div_u32(requested_tokens, 4).clamp(MIN_REQUEST_TOKEN_MARGIN, REQUEST_TOKEN_MARGIN)
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -1064,23 +1074,7 @@ fn reorder_candidates_by_context_and_throughput<T: Clone>(
     }
 
     if adequate.is_empty() && unknown.is_empty() {
-        let mut fallback = candidates
-            .iter()
-            .enumerate()
-            .map(
-                |(index, (candidate, context_length, throughput))| RankedTarget {
-                    index,
-                    candidate: candidate.clone(),
-                    context_length: *context_length,
-                    throughput: *throughput,
-                },
-            )
-            .collect::<Vec<_>>();
-        sort_ranked_targets(&mut fallback);
-        return fallback
-            .into_iter()
-            .map(|ranked| ranked.candidate)
-            .collect();
+        return Vec::new();
     }
 
     sort_ranked_targets(&mut adequate);
@@ -3588,6 +3582,15 @@ enum RouteModelDisposition {
     Return(bool),
 }
 
+fn no_context_eligible_target_reason(model: &str, required_tokens: Option<u32>) -> String {
+    match required_tokens {
+        Some(tokens) => format!(
+            "no context-compatible target for model '{model}' can fit approximately {tokens} tokens"
+        ),
+        None => format!("no eligible target for model '{model}'"),
+    }
+}
+
 async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> bool {
     let RouteModelRequestArgs {
         node,
@@ -3605,7 +3608,9 @@ async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> bool {
     let ordered_candidates = affinity.route_eligible_candidates(model, &ordered_candidates);
     if ordered_candidates.is_empty() {
         record_route_model_unavailable(&node, model, 0);
-        return false;
+        let reason = no_context_eligible_target_reason(model, required_tokens);
+        let _ = send_503(tcp_stream, &reason).await;
+        return true;
     }
 
     let selection = crate::network::affinity::select_model_target_from_candidates(
@@ -5601,7 +5606,7 @@ mod tests {
     }
 
     #[test]
-    fn test_request_budget_tokens_includes_output_budget_and_margin() {
+    fn test_request_budget_tokens_includes_output_budget_and_scaled_margin() {
         let body = serde_json::json!({
             "model": "qwen",
             "max_tokens": 512,
@@ -5609,7 +5614,28 @@ mod tests {
         });
 
         let budget = request_budget_tokens(&body).unwrap();
-        assert!(budget >= 512 + REQUEST_TOKEN_MARGIN);
+        let prompt_tokens = ceil_div_u32(serde_json::to_vec(&body).unwrap().len() as u32, 4);
+        assert_eq!(
+            budget,
+            prompt_tokens + 512 + request_token_margin(prompt_tokens + 512)
+        );
+    }
+
+    #[test]
+    fn test_request_budget_tokens_uses_bounded_margin_for_small_requests() {
+        let budget = request_budget_tokens_from_parts(128, Some(4)).unwrap();
+
+        assert!(
+            budget <= 256,
+            "small smoke requests should fit a tiny CI context: {budget}"
+        );
+    }
+
+    #[test]
+    fn test_request_budget_tokens_keeps_full_margin_for_large_requests() {
+        let budget = request_budget_tokens_from_parts(10_000, Some(512)).unwrap();
+
+        assert_eq!(budget, 2_500 + 512 + REQUEST_TOKEN_MARGIN);
     }
 
     #[test]
@@ -5640,13 +5666,23 @@ mod tests {
     }
 
     #[test]
-    fn test_reorder_candidates_by_context_falls_back_when_all_known_too_small() {
+    fn test_reorder_candidates_by_context_rejects_all_known_too_small() {
         let ordered = reorder_candidates_by_context_and_throughput(
             &[(1u8, Some(4096), None), (2u8, Some(6144), None)],
             Some(8192),
         );
 
-        assert_eq!(ordered, vec![1, 2]);
+        assert!(ordered.is_empty());
+    }
+
+    #[test]
+    fn test_reorder_candidates_by_context_keeps_unknown_when_known_too_small() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[(1u8, Some(4096), None), (2u8, None, None)],
+            Some(8192),
+        );
+
+        assert_eq!(ordered, vec![2]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs
@@ -36,6 +36,33 @@ async fn spawn_api_proxy_test_harness(
     (addr, handle)
 }
 
+async fn spawn_api_proxy_test_harness_with_contexts(
+    targets: election::ModelTargets,
+    contexts: &[(&str, u32)],
+) -> (SocketAddr, tokio::task::JoinHandle<()>) {
+    let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
+        .await
+        .unwrap();
+    for (model, context_length) in contexts {
+        node.set_model_runtime_context_length(model, Some(*context_length))
+            .await;
+    }
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (_target_tx, target_rx) = watch::channel(targets);
+    let (drop_tx, _drop_rx) = mpsc::unbounded_channel();
+    let handle = tokio::spawn(api_proxy(
+        node,
+        addr.port(),
+        target_rx,
+        drop_tx,
+        Some(listener),
+        false,
+        affinity::AffinityRouter::default(),
+    ));
+    (addr, handle)
+}
+
 async fn spawn_api_proxy_test_harness_with_plugin_manager(
     targets: election::ModelTargets,
     plugin_manager: plugin::PluginManager,
@@ -1611,6 +1638,52 @@ async fn test_api_proxy_returns_last_context_overflow_bad_request_when_all_targe
     proxy_handle.abort();
     let _ = first_handle.await;
     let _ = second_handle.await;
+}
+
+#[tokio::test]
+async fn test_api_proxy_rejects_request_when_all_known_contexts_too_small() {
+    let (first_port, first_rx, first_handle) = spawn_capturing_upstream(r#"{"ok":"first"}"#).await;
+    let (second_port, second_rx, second_handle) =
+        spawn_capturing_upstream(r#"{"ok":"second"}"#).await;
+    let (proxy_addr, proxy_handle) = spawn_api_proxy_test_harness_with_contexts(
+        single_model_targets("test", &[first_port, second_port]),
+        &[("test", 4096)],
+    )
+    .await;
+
+    let body = json!({
+        "model": "test",
+        "max_tokens": 512,
+        "messages": [{"role": "user", "content": "x".repeat(20_000)}],
+    })
+    .to_string();
+    let request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+
+    let response = send_request_and_read_response(proxy_addr, vec![request.into_bytes()]).await;
+    let first_seen = tokio::time::timeout(Duration::from_millis(100), first_rx).await;
+    let second_seen = tokio::time::timeout(Duration::from_millis(100), second_rx).await;
+
+    proxy_handle.abort();
+    first_handle.abort();
+    second_handle.abort();
+
+    assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+    assert!(
+        response.contains("context") || response.contains("target"),
+        "response should explain why no target was eligible: {response}"
+    );
+    assert!(
+        first_seen.is_err(),
+        "proxy should not contact a known-too-small target"
+    );
+    assert!(
+        second_seen.is_err(),
+        "proxy should not contact any known-too-small fallback target"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
OpenAI routing now stops sending oversized requests to peers that have already advertised a runtime context window too small for the request.

If every known target is too small, the proxy returns a clear OpenAI-style 503 instead of falling back to a guaranteed-bad upstream. Peers without runtime context metadata remain eligible so mixed-version meshes and legacy peers keep working.

This refresh also bounds the request-budget safety margin proportionally for tiny OpenAI requests, so strict context admission does not reject the CI smoke path purely because of a fixed reserve while larger requests keep the existing conservative margin cap.

## Why
Context-aware target ordering already preferred peers that could fit the estimated request budget, but the all-known-too-small case fell back to the original candidate list. That made route admission knowingly try targets that could not fit the request, producing slower retries or confusing upstream failures instead of an immediate, actionable response.

The first CI pass also exposed an important edge case: a tiny `--ctx-size 256` smoke request could be over-budgeted by the fixed 256-token margin alone. The fix keeps strict admission, but makes the margin scale with the estimated request size and caps it at the previous maximum.

## Diff scope
- Tightens context-aware candidate ordering so all-known-too-small targets produce no eligible candidate.
- Preserves unknown-context peers as fallback candidates for mixed-version compatibility.
- Returns a controlled 503 from the OpenAI proxy when no context-compatible target remains.
- Uses a bounded proportional request margin so small smoke requests fit tiny contexts while large requests keep the full safety cap.
- Adds unit and proxy regression coverage proving known-too-small upstreams are not contacted and small request budgets remain admissible.

## Branch integrity
- Base branch: `main`
- Validated base: `3be3869d3dd3642b40e7cff1765810b5e105a991`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `3be3869d3dd3642b40e7cff1765810b5e105a991`
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity
- `639decdb979b22702f2f30d43989b361be0588fe` — Reject known-too-small context targets
- One logical commit.
- Final diff is limited to OpenAI transport routing and proxy regression tests.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — no release/version sync required for this non-release routing admission fix.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: PASS, intended files only.
  - `crates/mesh-llm-host-runtime/src/network/openai/transport.rs`
  - `crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs`
- `git diff --check origin/main...HEAD`: PASS, no output.
- No env files, secrets, generated artifacts, caches, or unrelated files are included.

## Validation mode and proof
Validation mode: Mode 2 — narrow runtime routing admission fix.

Local validation:
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `3be3869d3dd3642b40e7cff1765810b5e105a991`.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime test_request_budget_tokens --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime reorder_candidates_by_context --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime test_api_proxy_rejects_request_when_all_known_contexts_too_small --lib -- --test-threads=1`: PASS, 1 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo check -p mesh-llm`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.
- `just build`: PASS.
- `MESH_CI_API_PORT=9537 MESH_CI_CONSOLE_PORT=3331 MESH_CI_HEADLESS_API_PORT=9538 MESH_CI_HEADLESS_CONSOLE_PORT=3332 scripts/ci-smoke-test.sh target/debug/mesh-llm ci-artifacts/linux <cached-smollm2-gguf>`: PASS, Skippy smoke passed.

Not run:
- Live multi-node OpenAI routing smoke — not required for selected validation mode; targeted admission/proxy tests plus the CI smoke reproduction cover the changed local route-admission path.

## CI context confirmation
PASS — required GitHub CI completed successfully on final SHA `639decdb979b22702f2f30d43989b361be0588fe`. CI context names unchanged.

## Runtime safety
- No protocol, schema, gossip, plugin protocol, or Skippy ABI change.
- No new locks, queues, background loops, or retry paths.
- No invariant regression introduced.
- Known-too-small targets are rejected before route attempts; unknown-context peers remain available for compatibility.
- Request-budget admission remains conservative for large requests and no longer over-rejects tiny CI smoke requests solely from a fixed margin.

## Documentation integrity
Not applicable — no docs, runbooks, or commands changed.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
Required remote CI passed on SHA `639decdb979b22702f2f30d43989b361be0588fe`. Local live mixed-node routing was not run in this workspace; CI covered two-node client serving, two-node split smoke, Skippy inference smoke, and the relevant Linux/macOS test surfaces.
