### PR TITLE
Drop deprecated mesh-bundle release asset

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -260,8 +260,8 @@ mesh-join join="" port="9337" gguf=model split="":
     fi
     exec {{ mesh_bin }} $ARGS
 
-# Create a portable tarball with all binaries for deployment to another machine
-bundle output="/tmp/mesh-bundle.tar.gz":
+# Create a portable tarball with all binaries for deployment to another machine.
+bundle output="/tmp/mesh-llm-bundle.tar.gz":
     #!/usr/bin/env bash
     set -euo pipefail
     DIR=$(mktemp -d)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,10 +27,10 @@ The release bundle is now a single `mesh-llm` runtime binary. External
 just bundle
 ```
 
-This creates `/tmp/mesh-bundle.tar.gz` containing the packaged `mesh-llm`
-executable. That packaged binary is the release-attestation source of truth.
-Local and dev builds from `just build` stay unstamped by default, so `missing`
-is expected there.
+This creates `/tmp/mesh-llm-bundle.tar.gz` containing the packaged `mesh-llm`
+executable for local deployment. Platform release archives are named by target,
+such as `mesh-llm-aarch64-apple-darwin.tar.gz`; the deprecated
+`mesh-bundle.tar.gz` release asset is no longer published.
 
 Verify the packaged executable with `cargo run -p xtask -- release-attestation inspect --binary /tmp/test-bundle/mesh-llm --public-key-file /tmp/mesh-release-key.pub`.
 `valid` means the packaged binary matches a trusted release signer, `missing`
@@ -89,7 +89,7 @@ On native Windows, `just check-release` still runs the Rust/docs/workflow invari
 
 ```bash
 mkdir /tmp/test-bundle
-tar xzf /tmp/mesh-bundle.tar.gz -C /tmp/test-bundle --strip-components=1
+tar xzf /tmp/mesh-llm-bundle.tar.gz -C /tmp/test-bundle --strip-components=1
 /tmp/test-bundle/mesh-llm --model Qwen2.5-3B
 rm -rf /tmp/test-bundle
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,8 +29,7 @@ just bundle
 
 This creates `/tmp/mesh-llm-bundle.tar.gz` containing the packaged `mesh-llm`
 executable for local deployment. Platform release archives are named by target,
-such as `mesh-llm-aarch64-apple-darwin.tar.gz`; the deprecated
-`mesh-bundle.tar.gz` release asset is no longer published.
+such as `mesh-llm-aarch64-apple-darwin.tar.gz`.
 
 Verify the packaged executable with `cargo run -p xtask -- release-attestation inspect --binary /tmp/test-bundle/mesh-llm --public-key-file /tmp/mesh-release-key.pub`.
 `valid` means the packaged binary matches a trusted release signer, `missing`

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -7,7 +7,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
 
 use crate::backend;
-use crate::release_target::{CanonicalArch, CanonicalOs, ReleaseTarget};
+use crate::release_target::ReleaseTarget;
 
 const DEFAULT_RELEASE_REPO: &str = "Mesh-LLM/mesh-llm";
 #[cfg(not(windows))]
@@ -402,16 +402,6 @@ fn stable_release_asset_name_for(
         .and_then(ReleaseTarget::stable_asset_name)
 }
 
-fn legacy_release_asset_name(target: ReleaseTarget) -> Option<String> {
-    (target
-        == ReleaseTarget::new(
-            CanonicalOs::Macos,
-            CanonicalArch::Aarch64,
-            backend::BinaryFlavor::Metal,
-        ))
-    .then_some("mesh-bundle.tar.gz".to_string())
-}
-
 fn push_release_asset_candidate(candidates: &mut Vec<String>, asset_name: Option<String>) {
     let Some(asset_name) = asset_name else {
         return;
@@ -443,7 +433,6 @@ fn release_asset_candidates(
             push_release_asset_candidate(&mut candidates, target.stable_asset_name());
         }
     }
-    push_release_asset_candidate(&mut candidates, legacy_release_asset_name(target));
     candidates
 }
 
@@ -1701,28 +1690,6 @@ mod tests {
                 ReleaseAssetPreference::VersionedFirst,
             ),
             Some("mesh-llm-aarch64-unknown-linux-gnu.tar.gz".to_string())
-        );
-    }
-
-    #[test]
-    fn test_macos_legacy_bundle_asset_remains_compatible() {
-        let release = ReleaseInfo {
-            tag: "v0.60.0".to_string(),
-            version: "0.60.0".to_string(),
-            assets: vec!["mesh-bundle.tar.gz".to_string()],
-        };
-
-        assert_eq!(
-            resolve_release_asset_name(
-                &release,
-                ReleaseTarget::new(
-                    CanonicalOs::Macos,
-                    CanonicalArch::Aarch64,
-                    backend::BinaryFlavor::Metal,
-                ),
-                ReleaseAssetPreference::StableFirst,
-            ),
-            Some("mesh-bundle.tar.gz".to_string())
         );
     }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,8 +206,8 @@
         <p class="section-lead">macOS or Linux. One command to install, one to run.</p>
 
         <div class="code-block">
-            <span class="comment"># Install on macOS (downloads ~18MB bundle)</span><br>
-            <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="val">https://github.com/Mesh-LLM/mesh-llm/releases/latest/download/mesh-bundle.tar.gz</span> | <span class="cmd">tar</span> xz &amp;&amp; mkdir -p ~/.local/bin &amp;&amp; mv mesh-bundle/* ~/.local/bin/<br><br>
+            <span class="comment"># Install the latest platform bundle</span><br>
+            <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="val">https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.sh</span> | <span class="cmd">bash</span><br><br>
             <span class="comment"># Install on Linux (build from source — needs just, cmake, nvcc, Rust, Node.js)</span><br>
             <span class="cmd">git clone</span> <span class="val">https://github.com/Mesh-LLM/mesh-llm</span> &amp;&amp; <span class="cmd">cd</span> mesh-llm &amp;&amp; <span class="cmd">just</span> build<br><br>
             <span class="comment"># Join the public mesh — instant chat, zero config</span><br>

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -327,7 +327,6 @@ resolve_release_target() {
     effective_flavor="$(effective_release_flavor)"
     BIN_EXT=""
     ARCHIVE_EXT="tar.gz"
-    LEGACY_ASSET=""
 
     case "$support" in
         recognized-unsupported)
@@ -341,7 +340,6 @@ resolve_release_target() {
     case "$normalized" in
         macos/aarch64)
             TARGET_TRIPLE="aarch64-apple-darwin"
-            LEGACY_ASSET="mesh-bundle.tar.gz"
             ;;
         linux/x86_64)
             TARGET_TRIPLE="x86_64-unknown-linux-gnu"
@@ -485,9 +483,8 @@ main() {
     bundle_dir="$_STAGING_DIR/mesh-bundle"
     mkdir -p "$bundle_dir"
 
-bundle_binary="$bundle_dir/$(bundle_bin_name mesh-llm)"
+    bundle_binary="$bundle_dir/$(bundle_bin_name mesh-llm)"
     cp "$RELEASE_BIN_DIR/mesh-llm${BIN_EXT}" "$bundle_binary"
-
 
     if [[ "$os_name" == "Darwin" && -f "$bundle_binary" ]]; then
         install_name_tool -add_rpath @executable_path/ "$bundle_binary" 2>/dev/null || true
@@ -497,10 +494,6 @@ bundle_binary="$bundle_dir/$(bundle_bin_name mesh-llm)"
 
     create_archive "$bundle_dir" "$output_dir/$versioned_asset" "$ARCHIVE_EXT"
     create_archive "$bundle_dir" "$output_dir/$STABLE_ASSET" "$ARCHIVE_EXT"
-
-    if [[ -n "$LEGACY_ASSET" ]]; then
-        cp "$output_dir/$STABLE_ASSET" "$output_dir/$LEGACY_ASSET"
-    fi
 
     echo "Created release archives:"
     find "$output_dir" -maxdepth 1 -type f -print | sort


### PR DESCRIPTION
## Summary

Stop publishing the deprecated generic release asset from the macOS packaging path. Platform releases now rely on the target-named stable and versioned archives.

This also updates the local `just bundle` default output and docs/install snippets so new workflows no longer point people at the deprecated asset name. The updater asset selection now uses only the target-named stable/versioned candidates.

## Validation

- `cargo run -p xtask -- repo-consistency release-targets`
- `bash -n scripts/package-release.sh`
- macOS packaging name probe returns `mesh-llm-aarch64-apple-darwin.tar.gz` and `mesh-llm-v0.68.0-aarch64-apple-darwin.tar.gz`
- `cargo fmt --all -- --check`
- `just with-lld cargo check -p mesh-llm-system`
- `just with-lld cargo test -p mesh-llm-system --lib release_asset`
- `just with-lld cargo check -p mesh-llm`
- `just with-lld cargo clippy -p mesh-llm-system --all-targets -- -D warnings`
- `just with-lld cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `git diff --check`
