### PR TITLE
Add overlapping KV tool-loop certification

### DIFF
--- a/scripts/qa-kv-tool-loop-stability.py
+++ b/scripts/qa-kv-tool-loop-stability.py
@@ -4,11 +4,13 @@
 from __future__ import annotations
 
 import argparse
+import concurrent.futures
 import datetime as dt
 import json
 import os
 from pathlib import Path
 import shutil
+import threading
 import time
 from typing import Any, Iterable, NamedTuple
 import urllib.error
@@ -25,6 +27,7 @@ DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
 DEFAULT_MODELS = "auto"
 DEFAULT_ATTEMPTS = 3
 DEFAULT_PRESSURE_TURNS = 6
+DEFAULT_OVERLAP_REQUESTS = 2
 DEFAULT_TIMEOUT = 180.0
 DEFAULT_MIN_CACHED_TOKENS = 2048
 DEFAULT_SUFFIX_PREFILL_LIMIT = 256
@@ -71,6 +74,13 @@ class ProbeResult(NamedTuple):
     status_code: int | None = None
     prompt_tokens: int | None = None
     cached_tokens: int | None = None
+
+
+class OverlapRequest(NamedTuple):
+    label: str
+    payload: dict[str, Any]
+    expects_tool_call: bool
+    expected_values: tuple[str, ...]
 
 
 def normalize_v1_base(base_url: str) -> str:
@@ -125,6 +135,7 @@ def build_plan(
     min_cached_tokens: int,
     suffix_prefill_limit: int,
     native_logs: Iterable[Path],
+    overlap_requests: int = DEFAULT_OVERLAP_REQUESTS,
 ) -> dict[str, Any]:
     model_list = list(models)
     if attempts < 1:
@@ -137,6 +148,8 @@ def build_plan(
         raise ValueError("min_cached_tokens cannot be negative")
     if suffix_prefill_limit < 0:
         raise ValueError("suffix_prefill_limit cannot be negative")
+    if overlap_requests < 2:
+        raise ValueError("overlap_requests must be at least 2")
     checks = [
         {
             "phase": "tool_loop",
@@ -145,6 +158,19 @@ def build_plan(
             "pressure_turns": pressure_turns,
             "timeout_seconds": timeout,
             "description": "Growing tool-result conversation with a stable long prefix.",
+        },
+        {
+            "phase": "overlap_tool_loop",
+            "models": model_list,
+            "attempts": attempts,
+            "overlap_requests": overlap_requests,
+            "min_cached_tokens": min_cached_tokens,
+            "suffix_prefill_limit": suffix_prefill_limit,
+            "timeout_seconds": timeout,
+            "description": (
+                "Goose/Pi-shaped overlapping title and tool requests followed by "
+                "tool-result continuation and same-prefix cache proof."
+            ),
         },
         {
             "phase": "same_prefix_cache",
@@ -180,6 +206,7 @@ def build_plan(
         "models": model_list,
         "attempts": attempts,
         "pressure_turns": pressure_turns,
+        "overlap_requests": overlap_requests,
         "timeout_seconds": timeout,
         "output_dir": str(output_dir),
         "min_cached_tokens": min_cached_tokens,
@@ -246,6 +273,88 @@ def build_tool_call_request(
         "reasoning_effort": "none",
         "chat_template_kwargs": {"enable_thinking": False},
     }
+
+
+def build_overlap_requests(
+    model: str,
+    attempt: int,
+    overlap_requests: int,
+) -> list[OverlapRequest]:
+    if overlap_requests < 2:
+        raise ValueError("overlap_requests must be at least 2")
+    requests = [
+        OverlapRequest(
+            label="title",
+            payload=build_overlap_title_request(model, attempt),
+            expects_tool_call=False,
+            expected_values=(KV_PIN,),
+        ),
+        OverlapRequest(
+            label="tool_primary",
+            payload=build_overlap_tool_request(model, attempt, "tool_primary", "primary"),
+            expects_tool_call=True,
+            expected_values=(),
+        ),
+    ]
+    for index in range(2, overlap_requests):
+        key = "secondary" if index % 2 else "primary"
+        label = f"tool_{index}"
+        requests.append(
+            OverlapRequest(
+                label=label,
+                payload=build_overlap_tool_request(model, attempt, label, key),
+                expects_tool_call=True,
+                expected_values=(),
+            )
+        )
+    return requests
+
+
+def build_overlap_title_request(model: str, attempt: int) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {
+                "role": "system",
+                "content": stable_system_prefix(),
+            },
+            {
+                "role": "user",
+                "content": (
+                    f"Concurrent title probe attempt {attempt}. "
+                    f"Return a short title that includes {KV_PIN}."
+                ),
+            },
+        ],
+        "stream": False,
+        "temperature": 0,
+        "max_tokens": 48,
+        "reasoning_effort": "none",
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+
+def build_overlap_tool_request(
+    model: str,
+    attempt: int,
+    label: str,
+    key: str,
+) -> dict[str, Any]:
+    messages = [
+        {
+            "role": "system",
+            "content": stable_system_prefix(),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Concurrent tool probe {label} attempt {attempt}: call {TOOL_NAME} "
+                f"with key={key}. Keep {KV_PIN} in memory. "
+                "Do not answer directly before the tool call."
+            ),
+        },
+    ]
+    return build_tool_call_request(model, attempt, key=key, messages=messages)
 
 
 def initial_messages(attempt: int, key: str) -> list[dict[str, str]]:
@@ -712,15 +821,21 @@ def run_cache_probe(
     started = time.monotonic()
     try:
         if phase == "exact_prefix_cache":
-            warm = build_cache_request(model, "Exact-prefix warmup tail.")
-            measured = dict(warm)
+            status_code, metrics = measure_cache_reuse(
+                base_url,
+                model,
+                timeout,
+                warm_tail="Exact-prefix warmup tail.",
+                measured_tail="Exact-prefix warmup tail.",
+            )
         else:
-            warm = build_cache_request(model, "Same-prefix warmup tail alpha.")
-            measured = build_cache_request(model, "Same-prefix measured tail beta.")
-        post_json(base_url, "/chat/completions", warm, timeout)
-        response, status_code = post_json(base_url, "/chat/completions", measured, timeout)
-        validate_message(response, [KV_PIN])
-        metrics = extract_cache_metrics(response)
+            status_code, metrics = measure_cache_reuse(
+                base_url,
+                model,
+                timeout,
+                warm_tail="Same-prefix warmup tail alpha.",
+                measured_tail="Same-prefix measured tail beta.",
+            )
         ok, detail = evaluate_cache_threshold(
             metrics,
             min_cached_tokens=min_cached_tokens,
@@ -739,6 +854,138 @@ def run_cache_probe(
         )
     except Exception as exc:
         return _result(model, 0, phase, False, str(exc), started)
+
+
+def measure_cache_reuse(
+    base_url: str,
+    model: str,
+    timeout: float,
+    warm_tail: str,
+    measured_tail: str,
+) -> tuple[int, CacheMetrics]:
+    warm = build_cache_request(model, warm_tail)
+    measured = build_cache_request(model, measured_tail)
+    post_json(base_url, "/chat/completions", warm, timeout)
+    response, status_code = post_json(base_url, "/chat/completions", measured, timeout)
+    validate_message(response, [KV_PIN])
+    return status_code, extract_cache_metrics(response)
+
+
+def run_overlap_tool_loop_probe(
+    base_url: str,
+    model: str,
+    attempt: int,
+    timeout: float,
+    overlap_requests: int,
+    min_cached_tokens: int,
+    suffix_prefill_limit: int,
+    transcript_dir: Path,
+) -> ProbeResult:
+    started = time.monotonic()
+    transcript_path = transcript_dir / safe_name(f"{model}-attempt-{attempt}-overlap")
+    try:
+        contexts = build_overlap_requests(model, attempt, overlap_requests)
+        responses = run_initial_overlap_requests(base_url, contexts, timeout)
+        for context, response, status_code in responses:
+            record_transcript(transcript_path, f"overlap_{context.label}", status_code)
+            if context.expects_tool_call:
+                complete_overlap_tool_loop(
+                    base_url,
+                    model,
+                    context,
+                    response,
+                    status_code,
+                    timeout,
+                    transcript_path,
+                )
+            else:
+                validate_message(response, context.expected_values)
+        status_code, metrics = measure_cache_reuse(
+            base_url,
+            model,
+            timeout,
+            warm_tail="Overlap warmup tail alpha.",
+            measured_tail="Overlap measured tail beta.",
+        )
+        ok, detail = evaluate_cache_threshold(
+            metrics,
+            min_cached_tokens=min_cached_tokens,
+            suffix_prefill_limit=suffix_prefill_limit,
+        )
+        if not ok:
+            return _result(
+                model,
+                attempt,
+                "overlap_tool_loop",
+                False,
+                detail,
+                started,
+                status_code,
+                metrics.prompt_tokens,
+                metrics.cached_tokens,
+            )
+        return _result(
+            model,
+            attempt,
+            "overlap_tool_loop",
+            True,
+            f"completed {len(contexts)} overlapping starts and cache proof; {detail}",
+            started,
+            status_code,
+            metrics.prompt_tokens,
+            metrics.cached_tokens,
+        )
+    except Exception as exc:
+        record_transcript(transcript_path, "failure", None, detail=str(exc))
+        return _result(model, attempt, "overlap_tool_loop", False, str(exc), started)
+
+
+def run_initial_overlap_requests(
+    base_url: str,
+    contexts: list[OverlapRequest],
+    timeout: float,
+) -> list[tuple[OverlapRequest, dict[str, Any], int]]:
+    barrier = threading.Barrier(len(contexts))
+
+    def send(context: OverlapRequest) -> tuple[OverlapRequest, dict[str, Any], int]:
+        try:
+            barrier.wait(timeout=min(max(timeout, 1.0), 30.0))
+        except threading.BrokenBarrierError as exc:
+            raise RuntimeError("overlap request barrier broke before dispatch") from exc
+        response, status_code = post_json(
+            base_url,
+            "/chat/completions",
+            context.payload,
+            timeout,
+        )
+        return context, response, status_code
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=len(contexts)) as executor:
+        futures = [executor.submit(send, context) for context in contexts]
+        return [future.result(timeout=timeout + 30.0) for future in futures]
+
+
+def complete_overlap_tool_loop(
+    base_url: str,
+    model: str,
+    context: OverlapRequest,
+    response: dict[str, Any],
+    status_code: int,
+    timeout: float,
+    transcript_path: Path,
+) -> None:
+    messages = [dict(message) for message in context.payload["messages"]]
+    first_call = extract_tool_call(response)
+    record_transcript(
+        transcript_path,
+        f"{context.label}_tool_call",
+        status_code,
+        first_call.call_id,
+    )
+    messages.extend([assistant_tool_message(response), tool_result_message(first_call)])
+    run_final_after_tool(base_url, model, messages, timeout, [FIXTURE_FACTS[first_call.key]])
+    run_second_tool_loop(base_url, model, messages, timeout, transcript_path)
+    run_final_recall(base_url, model, messages, timeout, transcript_path)
 
 
 def run_native_log_scan(checkpoints: Iterable[NativeLogCheckpoint]) -> ProbeResult:
@@ -765,6 +1012,7 @@ def run_certification(
     suffix_prefill_limit: int,
     native_logs: Iterable[Path],
     output_dir: Path,
+    overlap_requests: int = DEFAULT_OVERLAP_REQUESTS,
 ) -> list[ProbeResult]:
     transcript_dir = output_dir / "transcripts"
     prepare_transcript_dir(transcript_dir)
@@ -779,6 +1027,18 @@ def run_certification(
                     attempt,
                     timeout,
                     pressure_turns,
+                    transcript_dir,
+                )
+            )
+            results.append(
+                run_overlap_tool_loop_probe(
+                    base_url,
+                    model,
+                    attempt,
+                    timeout,
+                    overlap_requests,
+                    min_cached_tokens,
+                    suffix_prefill_limit,
                     transcript_dir,
                 )
             )
@@ -983,6 +1243,12 @@ def parse_args() -> argparse.Namespace:
         default=int(os.environ.get("MESH_KV_TOOL_LOOP_PRESSURE_TURNS", str(DEFAULT_PRESSURE_TURNS))),
     )
     parser.add_argument(
+        "--overlap-requests",
+        type=int,
+        default=int(os.environ.get("MESH_KV_TOOL_LOOP_OVERLAP_REQUESTS", str(DEFAULT_OVERLAP_REQUESTS))),
+        help="Number of simultaneous title/tool requests to launch for the overlap probe.",
+    )
+    parser.add_argument(
         "--timeout",
         type=float,
         default=float(os.environ.get("MESH_KV_TOOL_LOOP_TIMEOUT", str(DEFAULT_TIMEOUT))),
@@ -1040,6 +1306,7 @@ def main() -> int:
         min_cached_tokens=args.min_cached_tokens,
         suffix_prefill_limit=args.suffix_prefill_limit,
         native_logs=native_logs,
+        overlap_requests=args.overlap_requests,
     )
     if args.print_plan:
         print(render_plan(plan))
@@ -1054,6 +1321,7 @@ def main() -> int:
         suffix_prefill_limit=args.suffix_prefill_limit,
         native_logs=native_logs,
         output_dir=output_dir,
+        overlap_requests=args.overlap_requests,
     )
     write_evidence(output_dir, plan, results)
     print_summary(results, output_dir)
@@ -1065,6 +1333,8 @@ def validate_runtime_options(args: argparse.Namespace) -> None:
         raise ValueError("attempts must be at least 1")
     if args.pressure_turns < 0:
         raise ValueError("pressure-turns cannot be negative")
+    if args.overlap_requests < 2:
+        raise ValueError("overlap-requests must be at least 2")
     if args.min_cached_tokens < 0:
         raise ValueError("min-cached-tokens cannot be negative")
     if args.suffix_prefill_limit < 0:

--- a/scripts/tests/test_qa_kv_tool_loop_stability.py
+++ b/scripts/tests/test_qa_kv_tool_loop_stability.py
@@ -45,12 +45,20 @@ class KvToolLoopStabilityTests(unittest.TestCase):
         self.assertIn("summary.md", plan["evidence_files"])
         self.assertEqual(
             [check["phase"] for check in plan["checks"]],
-            ["tool_loop", "same_prefix_cache", "exact_prefix_cache", "native_log_scan"],
+            [
+                "tool_loop",
+                "overlap_tool_loop",
+                "same_prefix_cache",
+                "exact_prefix_cache",
+                "native_log_scan",
+            ],
         )
         self.assertEqual(plan["checks"][0]["pressure_turns"], 8)
-        self.assertEqual(plan["checks"][1]["suffix_prefill_limit"], 256)
-        self.assertEqual(plan["checks"][2]["timeout_seconds"], 90.0)
-        self.assertEqual(plan["checks"][3]["scan_mode"], "appended_since_run_start")
+        self.assertEqual(plan["checks"][1]["overlap_requests"], 2)
+        self.assertEqual(plan["checks"][1]["min_cached_tokens"], 2048)
+        self.assertEqual(plan["checks"][2]["suffix_prefill_limit"], 256)
+        self.assertEqual(plan["checks"][3]["timeout_seconds"], 90.0)
+        self.assertEqual(plan["checks"][4]["scan_mode"], "appended_since_run_start")
 
     def test_parse_native_logs_dedupes_env_and_cli_paths(self):
         harness = load_module()
@@ -83,6 +91,112 @@ class KvToolLoopStabilityTests(unittest.TestCase):
         )
         self.assertFalse(first["parallel_tool_calls"])
         self.assertEqual(first["tools"][0]["function"]["name"], "lookup_probe_fact")
+
+    def test_overlap_requests_keep_same_prefix_and_distinct_tails(self):
+        harness = load_module()
+        requests = harness.build_overlap_requests("direct-model", attempt=3, overlap_requests=3)
+
+        self.assertEqual([request.label for request in requests], ["title", "tool_primary", "tool_2"])
+        self.assertEqual(
+            len({request.payload["messages"][0]["content"] for request in requests}),
+            1,
+        )
+        self.assertEqual(
+            len({request.payload["messages"][1]["content"] for request in requests}),
+            3,
+        )
+        self.assertFalse(requests[0].expects_tool_call)
+        self.assertTrue(requests[1].expects_tool_call)
+        self.assertTrue(requests[2].expects_tool_call)
+
+    def test_overlap_tool_loop_probe_runs_parallel_requests_and_cache_check(self):
+        harness = load_module()
+        original_post_json = harness.post_json
+        seen_payloads = []
+
+        def fake_post_json(base_url, path, payload, timeout):
+            del base_url, path, timeout
+            seen_payloads.append(payload)
+            last_user = next(
+                (
+                    message.get("content", "")
+                    for message in reversed(payload["messages"])
+                    if message.get("role") == "user"
+                ),
+                "",
+            )
+            if "Concurrent title probe" in last_user:
+                return {
+                    "choices": [{"message": {"content": f"title {harness.KV_PIN}"}}],
+                    "usage": {"prompt_tokens": 2200, "prompt_tokens_details": {"cached_tokens": 0}},
+                }, 200
+            if payload.get("tool_choice"):
+                key = "secondary" if "key=secondary" in last_user else "primary"
+                return {
+                    "choices": [
+                        {
+                            "finish_reason": "tool_calls",
+                            "message": {
+                                "tool_calls": [
+                                    {
+                                        "id": f"call-{key}-{len(seen_payloads)}",
+                                        "function": {
+                                            "name": harness.TOOL_NAME,
+                                            "arguments": json.dumps({"key": key}),
+                                        },
+                                    }
+                                ]
+                            },
+                        }
+                    ]
+                }, 200
+            if "Overlap measured tail" in last_user:
+                return {
+                    "choices": [{"message": {"content": harness.KV_PIN}}],
+                    "usage": {
+                        "prompt_tokens": 2240,
+                        "prompt_tokens_details": {"cached_tokens": 2176},
+                    },
+                }, 200
+            return {
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                f"{harness.KV_PIN} "
+                                f"{harness.FIXTURE_FACTS['primary']} "
+                                f"{harness.FIXTURE_FACTS['secondary']}"
+                            )
+                        }
+                    }
+                ],
+                "usage": {"prompt_tokens": 2240, "prompt_tokens_details": {"cached_tokens": 0}},
+            }, 200
+
+        harness.post_json = fake_post_json
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                result = harness.run_overlap_tool_loop_probe(
+                    base_url="http://localhost:9337/v1",
+                    model="direct-model",
+                    attempt=1,
+                    timeout=180.0,
+                    overlap_requests=2,
+                    min_cached_tokens=2048,
+                    suffix_prefill_limit=256,
+                    transcript_dir=Path(tmp),
+                )
+        finally:
+            harness.post_json = original_post_json
+
+        self.assertTrue(result.ok, result.detail)
+        self.assertEqual(result.phase, "overlap_tool_loop")
+        self.assertEqual(result.cached_tokens, 2176)
+        self.assertGreaterEqual(len(seen_payloads), 7)
+        self.assertEqual(
+            len({payload["messages"][0]["content"] for payload in seen_payloads[:2]}),
+            1,
+        )
 
     def test_cache_metrics_extract_openai_usage_tokens(self):
         harness = load_module()
@@ -276,6 +390,7 @@ class KvToolLoopStabilityTests(unittest.TestCase):
     def test_run_certification_resets_transcripts_before_writing(self):
         harness = load_module()
         original_tool_loop = harness.run_tool_loop_probe
+        original_overlap_tool_loop = harness.run_overlap_tool_loop_probe
         original_cache_probe = harness.run_cache_probe
 
         def fake_tool_loop(
@@ -301,6 +416,31 @@ class KvToolLoopStabilityTests(unittest.TestCase):
                 elapsed_ms=1,
             )
 
+        def fake_overlap_tool_loop(
+            base_url,
+            model,
+            attempt,
+            timeout,
+            overlap_requests,
+            min_cached_tokens,
+            suffix_prefill_limit,
+            transcript_dir,
+        ):
+            del base_url, timeout, overlap_requests, min_cached_tokens, suffix_prefill_limit
+            harness.record_transcript(
+                transcript_dir / f"{model}-attempt-{attempt}-overlap.jsonl",
+                "fresh_overlap",
+                200,
+            )
+            return harness.ProbeResult(
+                model=model,
+                attempt=attempt,
+                phase="overlap_tool_loop",
+                ok=True,
+                detail="overlap ok",
+                elapsed_ms=1,
+            )
+
         def fake_cache_probe(
             base_url,
             model,
@@ -320,6 +460,7 @@ class KvToolLoopStabilityTests(unittest.TestCase):
             )
 
         harness.run_tool_loop_probe = fake_tool_loop
+        harness.run_overlap_tool_loop_probe = fake_overlap_tool_loop
         harness.run_cache_probe = fake_cache_probe
         try:
             with tempfile.TemporaryDirectory() as tmp:
@@ -351,6 +492,7 @@ class KvToolLoopStabilityTests(unittest.TestCase):
             self.assertFalse(obsolete.exists())
         finally:
             harness.run_tool_loop_probe = original_tool_loop
+            harness.run_overlap_tool_loop_probe = original_overlap_tool_loop
             harness.run_cache_probe = original_cache_probe
 
     def test_record_transcript_appends_within_attempt(self):


### PR DESCRIPTION
## Summary
Adds a Goose/Pi-shaped overlap phase to the KV/tool-loop stability certification harness.

Maintainers can now exercise the failure shape that originally made #652 painful: a long stable tool-heavy prefix receiving simultaneous title/tool-start requests, then tool-result continuation, final recall, and same-prefix cache proof in the same run.

## Why
The existing KV/tool-loop certification proves repeated tool-result turns and cache reuse, but it did not model the overlapping title-generation plus main tool request pattern that Goose and Pi can issue against the same direct-model endpoint. That overlap is where unified-KV fragmentation and stale lane pressure were easiest to miss.

This PR does not change runtime behavior. It gives the already-merged runtime fixes a sharper regression harness and a repeatable evidence contract before agent workloads are trusted on small direct Skippy models.

## Diff scope
- Adds an `overlap_tool_loop` certification phase to `scripts/qa-kv-tool-loop-stability.py`.
- Launches simultaneous title/tool requests with the same stable system prefix and distinct tails.
- Completes tool-result continuation, second tool call, and final recall for overlap tool requests.
- Reuses the existing cache metric proof after the overlap phase so high concurrency cannot hide broken same-prefix reuse.
- Adds `--overlap-requests` / `MESH_KV_TOOL_LOOP_OVERLAP_REQUESTS` to tune the overlap pressure.
- Expands unit coverage for overlap request shape, parallel dispatch behavior, run integration, and plan metadata.

## Branch integrity
- Base branch: `main`
- Validated base: `3be3869d3dd3642b40e7cff1765810b5e105a991`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `3be3869d3dd3642b40e7cff1765810b5e105a991`
- Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity
- `03daeb771bd059bee60bab0456061a96c335fda6` — Add KV overlap tool-loop certification
- One logical commit.
- Final diff is limited to the KV/tool-loop certification script and its focused tests.
- Ledger: not applicable — not required for selected validation mode/change family.
- Version: not applicable — verification tooling only; no release/version sync required.

## Diff hygiene
- `git diff --name-status origin/main...HEAD`: PASS, intended files only.
  - `scripts/qa-kv-tool-loop-stability.py`
  - `scripts/tests/test_qa_kv_tool_loop_stability.py`
- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation mode and proof
Validation mode: Mode 4 — verification tooling update. This is sufficient because the change is scripts/tests only and does not affect runtime, protocol, workflow, release, or CI gate behavior.

Local validation:
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `3be3869d3dd3642b40e7cff1765810b5e105a991`.
- `git rebase origin/main`: PASS, no conflicts.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `python3 -m unittest scripts.tests.test_qa_kv_tool_loop_stability`: PASS, 18 passed.
- `python3 -m unittest scripts.tests.test_qa_kv_tool_loop_stability scripts.tests.test_qa_agent_tool_call_reliability`: PASS, 25 passed.
- `python3 -m py_compile scripts/qa-kv-tool-loop-stability.py scripts/tests/test_qa_kv_tool_loop_stability.py`: PASS.
- `python3 scripts/qa-kv-tool-loop-stability.py --print-plan --models Qwen/Qwen2.5-3B-Instruct-GGUF:q4_k_m --attempts 1 --pressure-turns 2 --overlap-requests 3 --timeout 30 --min-cached-tokens 128 --suffix-prefill-limit 64 --native-log /tmp/skippy-native.log --output-dir target/kv-tool-loop-stability/overlap-plan | python3 -m json.tool >/tmp/mesh-kv-overlap-plan.json`: PASS.

Remote validation on final SHA `03daeb771bd059bee60bab0456061a96c335fda6`:
- PR Builds / `changes`: PASS.
- PR Quality Checks / `changes`: PASS.
- PR Quality Checks / `summary`: PASS.
- Runtime/build matrix jobs: SKIPPED by CI path selection for this scripts-only change.

Not run:
- Live #652 direct-model overlap certification — no local loaded direct-model endpoint was available; deterministic unit and plan coverage prove the new harness branches.
- Cargo check/tests — not required for selected validation mode; no Rust/runtime code changed.

Required remote gates:
- PASS — GitHub CI completed on final SHA `03daeb771bd059bee60bab0456061a96c335fda6`.

## CI context confirmation
PASS — required GitHub checks completed on final SHA `03daeb771bd059bee60bab0456061a96c335fda6`; CI context names unchanged.

## Runtime safety
Not applicable — no runtime path changed.

## Documentation integrity
Not applicable — the existing KV/tool-loop certification docs already point at this harness and the PR only extends the harness behavior/options.

## Rollback plan
Rollback: revert this PR.
DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known residual risks
The live overlap certification should still be run by a maintainer or lab host with the affected direct-model Skippy endpoint and native log path available. Local validation proves the harness behavior and evidence contract; it does not claim a specific live model endpoint is stable.
