### PR TITLE
Expose peer throughput hints in status

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -418,6 +418,8 @@ pub(crate) struct PeerPayload {
     pub(crate) serving_models: Vec<String>,
     pub(crate) hosted_models: Vec<String>,
     pub(crate) hosted_models_known: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub(crate) advertised_model_throughput: Vec<metrics::ModelThroughputHint>,
     pub(crate) version: Option<String>,
     pub(crate) rtt_ms: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -987,6 +989,7 @@ mod tests {
             serving_models: vec![],
             hosted_models: vec![],
             hosted_models_known: false,
+            advertised_model_throughput: vec![],
             version: Some("0.56.0".to_string()),
             rtt_ms: None,
             latency_ms: None,
@@ -1001,6 +1004,7 @@ mod tests {
 
         let json = serde_json::to_string(&peer).expect("serialization failed");
         assert!(json.contains("\"version\":\"0.56.0\""));
+        assert!(!json.contains("advertised_model_throughput"));
     }
 
     #[test]
@@ -1018,6 +1022,7 @@ mod tests {
             serving_models: vec![],
             hosted_models: vec![],
             hosted_models_known: false,
+            advertised_model_throughput: vec![],
             version: None,
             rtt_ms: None,
             latency_ms: None,
@@ -1304,6 +1309,7 @@ mod tests {
             serving_models: vec!["Qwen".to_string()],
             hosted_models: vec!["Qwen".to_string()],
             hosted_models_known: true,
+            advertised_model_throughput: vec![],
             version: Some("0.60.2".to_string()),
             rtt_ms: Some(12),
             latency_ms: None,

--- a/crates/mesh-llm-host-runtime/src/network/metrics.rs
+++ b/crates/mesh-llm-host-runtime/src/network/metrics.rs
@@ -220,7 +220,7 @@ pub(crate) struct RoutingCollectorSnapshot {
 /// Values are fixed-point milli tokens/second to keep gossip deterministic and
 /// avoid protobuf floating-point edge cases. They are advisory only; routing
 /// clamps and local observations take precedence.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub(crate) struct ModelThroughputHint {
     pub(crate) model_name: String,
     pub(crate) avg_tokens_per_second_milli: u64,

--- a/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
@@ -1050,6 +1050,7 @@ fn build_peer_payload(peer: &mesh::PeerInfo) -> PeerPayload {
         serving_models: peer.serving_models.clone(),
         hosted_models: peer.hosted_models.clone(),
         hosted_models_known: peer.hosted_models_known,
+        advertised_model_throughput: peer.advertised_model_throughput.clone(),
         version: peer.version.clone(),
         rtt_ms: peer.rtt_ms,
         latency_ms: display_latency.latency_ms,

--- a/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
@@ -619,6 +619,130 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn status_payload_exposes_peer_advertised_model_throughput() {
+        let collector = RuntimeDataCollector::new();
+        let peer_id = EndpointId::from(SecretKey::from_bytes(&[0x44; 32]).public());
+        let peer = PeerInfo {
+            id: peer_id,
+            addr: EndpointAddr {
+                id: peer_id,
+                addrs: Default::default(),
+            },
+            mesh_id: None,
+            mesh_policy_hash: None,
+            genesis_policy: None,
+            role: NodeRole::Worker,
+            first_joined_mesh_ts: Some(456),
+            models: vec!["Qwen/Qwen3-Coder".into()],
+            vram_bytes: 32_000_000_000,
+            rtt_ms: Some(7),
+            model_source: None,
+            admitted: true,
+            serving_models: vec!["Qwen/Qwen3-Coder".into()],
+            hosted_models: vec!["Qwen/Qwen3-Coder".into()],
+            hosted_models_known: true,
+            available_models: vec!["Qwen/Qwen3-Coder".into()],
+            requested_models: vec![],
+            explicit_model_interests: vec![],
+            last_seen: std::time::Instant::now(),
+            last_mentioned: std::time::Instant::now(),
+            version: Some("0.70.0".into()),
+            gpu_name: None,
+            hostname: Some("peer.local".into()),
+            is_soc: Some(false),
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            available_model_metadata: vec![],
+            experts_summary: None,
+            available_model_sizes: HashMap::new(),
+            served_model_descriptors: vec![],
+            served_model_runtime: vec![],
+            owner_attestation: None,
+            release_attestation_summary: ReleaseAttestationSummary::default(),
+            artifact_transfer_supported: false,
+            stage_protocol_generation_supported: false,
+            stage_status_list_supported: false,
+            advertised_model_throughput: vec![crate::network::metrics::ModelThroughputHint {
+                model_name: "Qwen/Qwen3-Coder".into(),
+                avg_tokens_per_second_milli: 13_400,
+                throughput_samples: 27,
+            }],
+            display_rtt: None,
+            selected_path: None,
+            propagated_latency: None,
+            owner_summary: crate::crypto::OwnershipSummary::default(),
+        };
+        let hardware = collector.build_hardware_view(HardwareViewInput {
+            gpu_name: None,
+            gpu_vram: None,
+            gpu_reserved_bytes: None,
+            gpu_mem_bandwidth_gbps: None,
+            gpu_compute_tflops_fp32: None,
+            gpu_compute_tflops_fp16: None,
+            my_hostname: Some("node.local".into()),
+            my_is_soc: Some(false),
+            my_vram_gb: 24.0,
+            model_size_gb: 8.0,
+            first_joined_mesh_ts: Some(123),
+        });
+        let snapshot = collector.build_status_view(StatusViewInput {
+            version: "0.70.0".into(),
+            latest_version: Some("0.70.0".into()),
+            node_id: "node-1".into(),
+            owner: crate::crypto::OwnershipSummary::default(),
+            release_attestation: ReleaseAttestationSummary::default(),
+            token: "invite-token".into(),
+            is_host: true,
+            is_client: false,
+            llama_ready: true,
+            model_name: "Self-Model".into(),
+            models: vec!["Self-Model".into()],
+            available_models: vec!["Self-Model".into()],
+            requested_models: vec![],
+            serving_models: vec!["Self-Model".into()],
+            hosted_models: vec!["Self-Model".into()],
+            draft_name: None,
+            api_port: 3131,
+            inflight_requests: 1,
+            mesh_id: Some("mesh-1".into()),
+            mesh_name: Some("test-mesh".into()),
+            mesh_discovery_mode: "nostr".into(),
+            discovery_scope: "public".into(),
+            discovery_source: "nostr-relay".into(),
+            nostr_discovery: false,
+            publication_state: "private".into(),
+            local_processes: vec![],
+            peers: vec![peer],
+            wakeable_nodes: vec![],
+            routing_affinity: crate::network::affinity::AffinityStatsSnapshot::default(),
+            hardware,
+        });
+
+        assert_eq!(
+            snapshot.peers[0].advertised_model_throughput[0].model_name,
+            "Qwen/Qwen3-Coder"
+        );
+
+        let payload = status_payload(snapshot);
+        assert_eq!(payload.peers[0].advertised_model_throughput.len(), 1);
+
+        let json = serde_json::to_value(&payload).expect("serialize status payload");
+        assert_eq!(
+            json["peers"][0]["advertised_model_throughput"],
+            json!([
+                {
+                    "model_name": "Qwen/Qwen3-Coder",
+                    "avg_tokens_per_second_milli": 13400,
+                    "throughput_samples": 27,
+                }
+            ])
+        );
+    }
+
+    #[test]
     fn runtime_data_model_snapshot_matches_api_payloads() {
         let collector = RuntimeDataCollector::new();
         let local_inventory = LocalModelInventorySnapshot {


### PR DESCRIPTION
## Summary

Expose each peer's gossiped `advertised_model_throughput` hints in `/api/status` peer entries.

Routing already consumes these hints from gossip after #600; this PR makes the same evidence visible to operators, the console, and external status clients so people can answer “what throughput is this peer advertising?” without instrumenting the router internals.

Fixes #632.

## Why

#600 made throughput hints available to routing, but `/api/status` still dropped them at the API boundary. That left a real observability gap: a peer could advertise useful tok/s data, the router could use it, and the obvious debug surface would still show nothing.

This is intentionally additive and compatibility-preserving: peers with no hints omit the field, while peers with hints expose the sanitized gossiped values already stored on `PeerInfo`.

On FTTT/TTFT: that is important for agentic workloads, but this PR does not synthesize it. There is no first-token latency value in the peer-advertised throughput hint today, and RTT/attempt duration would be a misleading substitute. The right shape is a separate telemetry/gossip design PR that measures first-token latency explicitly and advertises it with its own compatibility rules.

## Diff scope

- Adds `advertised_model_throughput` to `PeerPayload` with `skip_serializing_if = Vec::is_empty`.
- Derives `Serialize` for `ModelThroughputHint` so the existing sanitized hint shape is reused directly.
- Copies `peer.advertised_model_throughput` in `build_peer_payload()`.
- Adds regression coverage proving the field survives `RuntimeDataCollector -> StatusPayload -> JSON`.
- Adds compatibility coverage that empty peer hints are omitted from serialized peer JSON.
- Refreshes the test fixture for current `StatusViewInput` discovery fields after rebasing onto current main.

## Branch integrity

Base branch: `main`  
Validated base: `f9bd75a97378be014f52c4e68c13e81d3399e65e`  
Branch status: `0 behind / 1 ahead` against `origin/main`  
Merge base: `f9bd75a97378be014f52c4e68c13e81d3399e65e`  
Fast-forward safety: `origin/main` is an ancestor of this branch.

## Commit integrity

- `026bc029 Expose peer throughput hints in status`
- One logical commit.
- Final diff is limited to status payload serialization, collector mapping, the existing throughput hint type derive, and focused tests.
- Ledger: not applicable - not required for selected validation mode/change family.
- Version: not applicable - no release/version sync required for this non-release additive status field.

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: PASS, intended files only.
  - `crates/mesh-llm-host-runtime/src/api/status.rs`
  - `crates/mesh-llm-host-runtime/src/network/metrics.rs`
  - `crates/mesh-llm-host-runtime/src/runtime_data/collector.rs`
  - `crates/mesh-llm-host-runtime/src/runtime_data/mod.rs`
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.

## Validation mode and proof

Validation mode: Mode 2R - post-rebase correction for a narrow additive `/api/status` serialization PR. This is sufficient because the diff exposes already-gossiped data without changing gossip, routing decisions, protocol schemas, or runtime control flow.

Local validation:

- TDD red: `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime status_payload_exposes_peer_advertised_model_throughput --lib -- --test-threads=1`: FAIL as expected before original implementation, `PeerPayload` had no `advertised_model_throughput` field.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `f9bd75a97378be014f52c4e68c13e81d3399e65e`
- `git rebase origin/main`: PASS, no conflicts
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime status_payload_exposes_peer_advertised_model_throughput --lib -- --test-threads=1`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime test_peer_payload_serializes_version_field --lib -- --test-threads=1`: PASS, 1 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS

## Required remote gates

PASS - GitHub CI passed on final SHA `026bc029`; required checks are complete and green.

## Not run

- Local live multi-node `/api/status` smoke: not required for selected validation mode; focused collector/API serialization regression covers the exposed field and remote CI is the final full proof.
- FTTT peer-advertisement implementation: not part of this status-only PR because no first-token latency signal is currently measured or gossiped in the peer hint.

## CI context confirmation

PASS - required GitHub checks completed successfully for final SHA `026bc029`; CI context names unchanged.

## Runtime safety

- No protocol, protobuf, gossip, routing, Skippy ABI, plugin protocol, or workflow change.
- No new locks, queues, retries, network calls, or background tasks.
- No invariant regression introduced.
- Empty throughput hints are omitted from peer JSON for compatibility.

## Documentation integrity

Not applicable - no docs/runbooks/commands changed. This closes the narrow status exposure gap from #632.

## Rollback plan

Rollback: revert this PR.  
DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveats: none known.

## Known residual risks

Live multi-node verification was not run locally because the change is an additive serialization path and the regression test constructs the gossiped peer state directly. First-token latency/FTTT should be handled as a follow-up telemetry and peer-advertisement design, not as a derived field in this PR.

