### PR TITLE
Balance auto context and slots for shared mesh launches

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/context_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/context_planning.rs
@@ -36,6 +36,30 @@ const MIN_AUTO_CONTEXT_LENGTH: u32 = 512;
 const MAX_AUTO_PARALLEL_SLOTS: usize = 4;
 const KV_CACHE_BUDGET_NUMERATOR: u64 = 85;
 const KV_CACHE_BUDGET_DENOMINATOR: u64 = 100;
+const FALLBACK_CONTEXT_8K_FREE_BYTES: u64 = 3_000_000_000;
+const FALLBACK_CONTEXT_16K_FREE_BYTES: u64 = 6_000_000_000;
+const FALLBACK_CONTEXT_32K_FREE_BYTES: u64 = 12_000_000_000;
+const FALLBACK_CONTEXT_64K_FREE_BYTES: u64 = 30_000_000_000;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RuntimeResourcePlanningProfile {
+    /// Prefer the deepest safe local context when the operator did not ask for
+    /// a shared mesh-serving surface.
+    DedicatedLocal,
+    /// Prefer the default llama-server/skippy auto concurrency target for
+    /// shared mesh-serving launches, then choose the deepest context that still
+    /// fits it.
+    SharedMesh,
+}
+
+impl RuntimeResourcePlanningProfile {
+    fn context_slot_target(self) -> u64 {
+        match self {
+            Self::DedicatedLocal => 1,
+            Self::SharedMesh => MAX_AUTO_PARALLEL_SLOTS as u64,
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) struct RuntimeResourcePlan {
@@ -58,6 +82,7 @@ pub(super) struct RuntimeResourcePlanInput<'a> {
     /// Fraction of the model's layers that reside on this node (0.0–1.0).
     /// `None` means the whole model is local (fraction = 1.0).
     pub(super) local_layer_fraction: Option<f64>,
+    pub(super) planning_profile: RuntimeResourcePlanningProfile,
 }
 
 /// Plan context length and parallel slots.
@@ -80,16 +105,17 @@ pub(super) fn plan_runtime_resources(input: RuntimeResourcePlanInput<'_>) -> Run
 }
 
 fn planned_context_length(input: &RuntimeResourcePlanInput<'_>) -> u32 {
+    let fallback_context = fallback_context_length(input);
     let Some(metadata) = input.metadata else {
-        return DEFAULT_CONTEXT_LENGTH;
+        return fallback_context;
     };
     let native_context = metadata.context_length;
     if native_context == 0 {
-        return DEFAULT_CONTEXT_LENGTH;
+        return fallback_context;
     }
     let Some(kv_bytes_per_token_full) = input.kv_cache_quant.kv_cache_bytes_per_token(metadata)
     else {
-        return DEFAULT_CONTEXT_LENGTH.min(native_context);
+        return fallback_context.min(native_context);
     };
 
     // In a pipeline-parallel split each stage only holds KV state for its
@@ -100,7 +126,11 @@ fn planned_context_length(input: &RuntimeResourcePlanInput<'_>) -> u32 {
     if kv_bytes_per_token == 0 {
         return native_context;
     }
-    let max_affordable_context = kv_budget / kv_bytes_per_token;
+    let slot_target = context_slot_target(input);
+    let Some(kv_bytes_for_target_slots) = kv_bytes_per_token.checked_mul(slot_target) else {
+        return MIN_AUTO_CONTEXT_LENGTH.min(native_context);
+    };
+    let max_affordable_context = kv_budget / kv_bytes_for_target_slots;
     if max_affordable_context == 0 {
         return MIN_AUTO_CONTEXT_LENGTH.min(native_context);
     }
@@ -114,6 +144,13 @@ fn planned_context_length(input: &RuntimeResourcePlanInput<'_>) -> u32 {
     } else {
         snap_context_length_down(planned).max(minimum)
     }
+}
+
+fn context_slot_target(input: &RuntimeResourcePlanInput<'_>) -> u64 {
+    input
+        .parallel_override
+        .map(|slots| slots.max(1) as u64)
+        .unwrap_or_else(|| input.planning_profile.context_slot_target())
 }
 
 fn planned_parallel_slots(input: &RuntimeResourcePlanInput<'_>, context_length: u32) -> usize {
@@ -152,6 +189,21 @@ fn usable_kv_cache_budget(vram_bytes: u64, model_bytes: u64) -> u64 {
     let budget = u128::from(free_bytes) * u128::from(KV_CACHE_BUDGET_NUMERATOR)
         / u128::from(KV_CACHE_BUDGET_DENOMINATOR);
     budget.min(u128::from(u64::MAX)) as u64
+}
+
+fn fallback_context_length(input: &RuntimeResourcePlanInput<'_>) -> u32 {
+    let free_bytes = input.vram_bytes.saturating_sub(input.model_bytes);
+    if free_bytes >= FALLBACK_CONTEXT_64K_FREE_BYTES {
+        65_536
+    } else if free_bytes >= FALLBACK_CONTEXT_32K_FREE_BYTES {
+        32_768
+    } else if free_bytes >= FALLBACK_CONTEXT_16K_FREE_BYTES {
+        16_384
+    } else if free_bytes >= FALLBACK_CONTEXT_8K_FREE_BYTES {
+        8192
+    } else {
+        DEFAULT_CONTEXT_LENGTH
+    }
 }
 
 fn snap_parallel_slots_down(raw_slots: u64) -> usize {
@@ -202,6 +254,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert_eq!(plan.context_length, 16_384);
@@ -219,6 +272,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert_eq!(
@@ -242,6 +296,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::F16,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
         let q8_plan = plan_runtime_resources(RuntimeResourcePlanInput {
             ctx_size_override: None,
@@ -251,6 +306,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert!(
@@ -267,14 +323,50 @@ mod tests {
             ctx_size_override: None,
             parallel_override: None,
             model_bytes: 5_000_000_000,
-            vram_bytes: 24_000_000_000,
+            vram_bytes: 16_000_000_000,
             metadata: None,
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
-        assert_eq!(plan.context_length, 4096);
+        assert_eq!(plan.context_length, 16_384);
         assert_eq!(plan.slots, 4);
+    }
+
+    #[test]
+    fn shared_mesh_profile_prefers_concurrency_when_native_context_would_allow_only_one_slot() {
+        let metadata = gqa_metadata(131_072);
+        let dedicated_plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 16_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+        });
+        let shared_plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 16_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::SharedMesh,
+        });
+
+        assert_eq!(dedicated_plan.context_length, 131_072);
+        assert_eq!(dedicated_plan.slots, 1);
+        assert!(
+            shared_plan.context_length < dedicated_plan.context_length,
+            "shared mesh should trade context for concurrency: shared={}, dedicated={}",
+            shared_plan.context_length,
+            dedicated_plan.context_length
+        );
+        assert_eq!(shared_plan.slots, 4);
     }
 
     #[test]
@@ -288,6 +380,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert_eq!(plan.context_length, 32_768);
@@ -319,6 +412,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert_eq!(plan.context_length, 32_768);
@@ -342,6 +436,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert_eq!(plan.slots, 8);
@@ -372,6 +467,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         // With split awareness: local model ~174 GB, local KV fraction 0.66
@@ -383,6 +479,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: Some(local_fraction),
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert!(
@@ -409,6 +506,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
         let q4_plan = plan_runtime_resources(RuntimeResourcePlanInput {
             ctx_size_override: None,
@@ -418,6 +516,7 @@ mod tests {
             metadata: Some(&metadata),
             kv_cache_quant: GgufKvCacheQuant::Q4_0,
             local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
         });
 
         assert_eq!(q8_plan.context_length, q4_plan.context_length);

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1,6 +1,7 @@
 use super::capacity::{model_fits_runtime_capacity, runtime_model_required_bytes};
 use super::context_planning::{
-    RuntimeResourcePlan, RuntimeResourcePlanInput, plan_runtime_resources,
+    RuntimeResourcePlan, RuntimeResourcePlanInput, RuntimeResourcePlanningProfile,
+    plan_runtime_resources,
 };
 use super::split_planning::{
     PlannedRuntimeSliceTopology, RuntimeSliceStagePlan, SplitTopologyResourceInputs, format_gb,
@@ -197,6 +198,7 @@ pub(super) struct LocalRuntimeModelStartSpec<'a> {
     pub(super) n_ubatch_override: Option<u32>,
     pub(super) flash_attention_override: FlashAttentionType,
     pub(super) parallel_override: Option<usize>,
+    pub(super) planning_profile: RuntimeResourcePlanningProfile,
     pub(super) openai_guardrail_policy: OpenAiGuardrailPolicyHandle,
     pub(super) skippy_telemetry: skippy::SkippyTelemetryOptions,
     pub(super) survey_telemetry: survey::SurveyTelemetry,
@@ -628,6 +630,7 @@ pub(super) async fn start_runtime_local_model(
         metadata: compact_meta.as_ref(),
         kv_cache_quant,
         local_layer_fraction,
+        planning_profile: spec.planning_profile,
     });
 
     if let Some(package) = layer_package {
@@ -4221,6 +4224,7 @@ max_tokens = 222
             n_ubatch_override: None,
             flash_attention_override: FlashAttentionType::Auto,
             parallel_override: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
             openai_guardrail_policy: openai_guardrail_policy_handle(
                 openai_frontend::GuardrailMode::Disabled,
             ),

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -18,6 +18,7 @@ use self::capacity::{
     RuntimeCapacityLedger, RuntimeCapacityPool, RuntimeCapacityRequest, RuntimeCapacityReservation,
     model_fits_runtime_capacity,
 };
+use self::context_planning::RuntimeResourcePlanningProfile;
 use self::discovery::{lan_rediscovery, nostr_rediscovery, start_new_mesh};
 use self::interactive::InitialPromptMode;
 use self::local::{
@@ -1220,6 +1221,7 @@ struct StartupLocalModelTask {
     n_ubatch: Option<u32>,
     flash_attention: FlashAttentionType,
     parallel_override: Option<usize>,
+    resource_planning_profile: RuntimeResourcePlanningProfile,
     openai_guardrail_policy: OpenAiGuardrailPolicyHandle,
     split: bool,
     skippy_telemetry: skippy::SkippyTelemetryOptions,
@@ -1299,6 +1301,7 @@ struct StartupLoopContext<'a> {
     n_ubatch: Option<u32>,
     flash_attention: FlashAttentionType,
     parallel_override: Option<usize>,
+    resource_planning_profile: RuntimeResourcePlanningProfile,
     openai_guardrail_policy: OpenAiGuardrailPolicyHandle,
     skippy_telemetry: &'a skippy::SkippyTelemetryOptions,
     survey_telemetry: &'a survey::SurveyTelemetry,
@@ -1371,6 +1374,7 @@ struct StartupLaunchRuntimeContext<'a> {
     n_ubatch: Option<u32>,
     flash_attention: FlashAttentionType,
     parallel_override: Option<usize>,
+    resource_planning_profile: RuntimeResourcePlanningProfile,
     openai_guardrail_policy: OpenAiGuardrailPolicyHandle,
     skippy_telemetry: &'a skippy::SkippyTelemetryOptions,
     survey_telemetry: &'a survey::SurveyTelemetry,
@@ -1841,6 +1845,7 @@ async fn startup_handle_local_fallback_event(
             n_ubatch_override: ctx.n_ubatch,
             flash_attention_override: ctx.flash_attention,
             parallel_override: ctx.parallel_override,
+            planning_profile: ctx.resource_planning_profile,
             openai_guardrail_policy: ctx.openai_guardrail_policy.clone(),
             skippy_telemetry: ctx.skippy_telemetry.clone(),
             survey_telemetry: ctx.survey_telemetry.clone(),
@@ -2173,6 +2178,7 @@ async fn startup_launch_runtime(
         n_ubatch,
         flash_attention,
         parallel_override,
+        resource_planning_profile,
         openai_guardrail_policy,
         skippy_telemetry,
         survey_telemetry,
@@ -2200,6 +2206,7 @@ async fn startup_launch_runtime(
         n_ubatch_override: n_ubatch,
         flash_attention_override: flash_attention,
         parallel_override,
+        planning_profile: resource_planning_profile,
         openai_guardrail_policy: openai_guardrail_policy.clone(),
         skippy_telemetry: skippy_telemetry.clone(),
         survey_telemetry: survey_telemetry.clone(),
@@ -2313,6 +2320,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch,
         flash_attention,
         parallel_override,
+        resource_planning_profile,
         openai_guardrail_policy,
         split,
         skippy_telemetry,
@@ -2372,6 +2380,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
             n_ubatch,
             flash_attention,
             parallel_override,
+            resource_planning_profile,
             openai_guardrail_policy: openai_guardrail_policy.clone(),
             skippy_telemetry: &skippy_telemetry,
             survey_telemetry: &survey_telemetry,
@@ -2426,6 +2435,7 @@ async fn startup_local_model_loop(params: StartupLocalModelTask) {
         n_ubatch,
         flash_attention,
         parallel_override,
+        resource_planning_profile,
         openai_guardrail_policy,
         skippy_telemetry: &skippy_telemetry,
         survey_telemetry: &survey_telemetry,
@@ -3633,6 +3643,7 @@ fn runtime_options_for_test(args: &[&str]) -> RuntimeOptions {
             "client" | "--client" => options.client = true,
             "--auto" => options.auto = true,
             "--publish" => options.publish = true,
+            "--discover" => options.discover = Some(next_test_arg(&mut iter, arg).to_string()),
             "--split" => options.split = true,
             "--require-release-attestation" => options.require_release_attestation = true,
             "--join" => options.join.push(next_test_arg(&mut iter, arg).to_string()),
@@ -5968,6 +5979,23 @@ fn relay_policy_for_mesh_discovery_mode(
     }
 }
 
+fn runtime_resource_planning_profile(options: &RuntimeOptions) -> RuntimeResourcePlanningProfile {
+    if options.auto || options.publish || options.discover.is_some() || !options.join.is_empty() {
+        RuntimeResourcePlanningProfile::SharedMesh
+    } else {
+        RuntimeResourcePlanningProfile::DedicatedLocal
+    }
+}
+
+fn runtime_model_ctx_size_override(
+    options: &RuntimeOptions,
+    model_overrides: Option<&plugin::ModelConfigEntry>,
+) -> Option<u32> {
+    options
+        .ctx_size
+        .or_else(|| model_overrides.and_then(|model| model.ctx_size))
+}
+
 fn should_start_relay_health_monitor(mode: mesh_discovery::MeshDiscoveryMode) -> bool {
     matches!(
         relay_policy_for_mesh_discovery_mode(mode),
@@ -6739,6 +6767,7 @@ async fn spawn_run_auto_startup_model_tasks(
     let primary_parallel_override = primary_startup_model
         .and_then(|m| m.parallel)
         .or(config.gpu.parallel);
+    let resource_planning_profile = runtime_resource_planning_profile(options);
     let console_state_for_election = console_state.cloned();
     let interactive_console_state = console_state.cloned();
     let primary_mmproj = primary_startup_model.and_then(|model| model.mmproj_path.clone());
@@ -6777,6 +6806,7 @@ async fn spawn_run_auto_startup_model_tasks(
         n_ubatch: primary_n_ubatch,
         flash_attention: primary_flash_attention,
         parallel_override: primary_parallel_override,
+        resource_planning_profile,
         openai_guardrail_policy: runtime_state.openai_guardrail_policy.clone(),
         split: options.split,
         skippy_telemetry: skippy_telemetry.clone(),
@@ -7042,6 +7072,7 @@ async fn run_auto_load_runtime_model(
             })
     };
     let model_overrides = ctx.config.models.iter().find(|m| m.model == spec);
+    let ctx_size_override = runtime_model_ctx_size_override(ctx.options, model_overrides);
     let parallel_override = model_overrides
         .and_then(|m| m.parallel)
         .or(ctx.config.gpu.parallel);
@@ -7065,7 +7096,7 @@ async fn run_auto_load_runtime_model(
             model_path: &model_path,
             model_bytes,
             mmproj_override: None,
-            ctx_size_override: ctx.options.ctx_size,
+            ctx_size_override,
             pinned_gpu: None,
             capacity_budget_bytes: Some(capacity_budget_bytes),
             cache_type_k_override: model_overrides.and_then(|m| m.cache_type_k.as_deref()),
@@ -7076,6 +7107,7 @@ async fn run_auto_load_runtime_model(
                 .and_then(|m| m.flash_attention)
                 .unwrap_or(FlashAttentionType::Auto),
             parallel_override,
+            planning_profile: runtime_resource_planning_profile(ctx.options),
             openai_guardrail_policy: ctx.openai_guardrail_policy.clone(),
             skippy_telemetry: skippy_telemetry_options(ctx.options),
             survey_telemetry: ctx.survey_telemetry.clone(),
@@ -7095,7 +7127,7 @@ async fn run_auto_load_runtime_model(
                     launch_kind: survey::SurveyLaunchKind::RuntimeLoad,
                     pinned_gpu: None,
                     backend: None,
-                    context_length: ctx.options.ctx_size.map(u64::from),
+                    context_length: ctx_size_override.map(u64::from),
                 },
                 launch_started.elapsed(),
                 survey::classify_launch_failure(&err),
@@ -7892,6 +7924,7 @@ async fn spawn_run_auto_additional_model_tasks(ctx: RunAutoAdditionalModelsConte
             n_ubatch: extra_model.n_ubatch,
             flash_attention: extra_model.flash_attention,
             parallel_override: extra_model.parallel.or(ctx.config.gpu.parallel),
+            resource_planning_profile: runtime_resource_planning_profile(ctx.options),
             openai_guardrail_policy: ctx.openai_guardrail_policy.clone(),
             split: ctx.options.split,
             skippy_telemetry: ctx.skippy_telemetry.clone(),
@@ -10932,6 +10965,71 @@ mod tests {
         assert!(
             !line.contains("Management API"),
             "default passive output must not contain 'Management API', got: {line}"
+        );
+    }
+
+    #[test]
+    fn runtime_load_ctx_size_uses_model_override_when_cli_is_unset() {
+        let options = runtime_options_for_test(&["mesh-llm"]);
+        let model = plugin::ModelConfigEntry {
+            model: "runtime/model".to_string(),
+            ctx_size: Some(16_384),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            runtime_model_ctx_size_override(&options, Some(&model)),
+            Some(16_384)
+        );
+    }
+
+    #[test]
+    fn runtime_load_ctx_size_prefers_cli_override_over_model_override() {
+        let options = runtime_options_for_test(&["mesh-llm", "--ctx-size", "8192"]);
+        let model = plugin::ModelConfigEntry {
+            model: "runtime/model".to_string(),
+            ctx_size: Some(16_384),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            runtime_model_ctx_size_override(&options, Some(&model)),
+            Some(8192)
+        );
+    }
+
+    #[test]
+    fn shared_mesh_modes_use_concurrency_preserving_resource_planning_profile() {
+        assert_eq!(
+            runtime_resource_planning_profile(&runtime_options_for_test(&["mesh-llm"])),
+            RuntimeResourcePlanningProfile::DedicatedLocal
+        );
+        assert_eq!(
+            runtime_resource_planning_profile(&runtime_options_for_test(&["mesh-llm", "--auto"])),
+            RuntimeResourcePlanningProfile::SharedMesh
+        );
+        assert_eq!(
+            runtime_resource_planning_profile(&runtime_options_for_test(&[
+                "mesh-llm",
+                "--publish"
+            ])),
+            RuntimeResourcePlanningProfile::SharedMesh
+        );
+        assert_eq!(
+            runtime_resource_planning_profile(&runtime_options_for_test(&[
+                "mesh-llm",
+                "--discover",
+                "lab",
+            ])),
+            RuntimeResourcePlanningProfile::SharedMesh
+        );
+        assert_eq!(
+            runtime_resource_planning_profile(&runtime_options_for_test(&[
+                "mesh-llm",
+                "--join",
+                "mesh-token",
+            ])),
+            RuntimeResourcePlanningProfile::SharedMesh
         );
     }
 


### PR DESCRIPTION
## Summary

Auto runtime planning now chooses resource defaults based on launch intent, not public/private mesh status.

Dedicated local launches prefer the deepest safe context. Shared mesh-serving launches preserve concurrency by choosing the deepest context that still supports the default parallel slot target. Shared-serving modes now include `--auto`, `--publish`, `--discover`, and explicit invite joins via `--join`.

Explicit operator overrides still win: CLI/model `ctx_size` and `parallel` settings are preserved when provided.

## Why

The old framing treated public and private meshes as separate planning categories. That is not the right boundary: private invite meshes and large organization meshes can still be shared, multi-workload serving surfaces.

The relevant distinction is whether the node is acting as a dedicated local model launch or as part of a shared mesh-serving surface where preserving slots/concurrency is expected.

## Diff scope

- Adds a `RuntimeResourcePlanningProfile` for dedicated-local vs shared-mesh serving defaults.
- Uses shared-mesh concurrency planning for `--auto`, `--publish`, `--discover`, and `--join`.
- Keeps explicit `ctx_size` / `parallel` overrides ahead of automatic planning.
- Keeps runtime-demand model loading aligned with per-model `ctx_size` overrides.

## Branch integrity

- Base branch: `main`
- Validated base SHA: `ccefb8a8509d82b2bf517e82ef43e7e57bcfaba6`
- Head SHA: `b76d87c50f9287950b88ad7048600f19c1907b38`
- Ahead/behind: `0 behind / 1 ahead`
- Merge-base: `ccefb8a8509d82b2bf517e82ef43e7e57bcfaba6`
- Diff proof computed against fetched `origin/main`.

## Commit integrity

Introduced commit:

```text
b76d87c50f9287950b88ad7048600f19c1907b38 Balance auto runtime context for shared mesh serving
```

One logical runtime-planning change. Final PR diff contains only the intended runtime files:

```text
M crates/mesh-llm-host-runtime/src/runtime/context_planning.rs
M crates/mesh-llm-host-runtime/src/runtime/local.rs
M crates/mesh-llm-host-runtime/src/runtime/mod.rs
```

## Ledger / Version

Ledger: not applicable — not required for selected validation mode/change family.

Version: not applicable — no release/version sync required for this non-release runtime planning change.

## Diff hygiene

```text
git diff --check: PASS, no output
git diff --check origin/main...HEAD: PASS, no output
git diff --cached --check: PASS, no output
```

No `.env`, local environment files, secrets, tokens, credentials, caches, build output, pycache files, or unrelated generated artifacts are included.

## Validation mode and proof

Validation mode: Mode 3 — shared runtime resource planning. This changes runtime defaults for context/slot planning across startup and runtime-demand loading, but does not change protocol, migrations, auth, permissions, deployment tooling, or external service contracts.

Local validation:

```text
cargo fmt --all: PASS
cargo fmt --all -- --check: PASS
LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime context_planning --lib -- --test-threads=1: PASS, 10 passed
LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime runtime_load_ctx_size --lib -- --test-threads=1: PASS, 2 passed
LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime shared_mesh_modes --lib -- --test-threads=1: PASS, 1 passed
cargo test -p model-artifact gguf --lib -- --test-threads=1: PASS, 16 passed
LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm: PASS
LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal /opt/homebrew/bin/cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings: PASS
```

Not run locally: live multi-node mesh startup smoke — no local multi-node runtime mesh endpoint was available; deterministic resource-planning, startup profile, runtime-load override, shipped-binary check, and clippy cover the changed paths. Mandatory remote CI is the final full proof for merge.

## Migration notes

Not applicable — no DB migration changed.

## CI context confirmation

PASS — required CI completed for head `b76d87c50f9287950b88ad7048600f19c1907b38`. CI context names unchanged.

## Runtime safety

No new blocking locks, unbounded queues, protocol messages, gossip fields, or invariant removals were introduced. No invariant regression introduced.

## Documentation integrity

Not applicable — no docs/runbooks/commands changed.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: automatic defaults for shared mesh-serving launches would return to the previous context/slot behavior after revert.

## Known residual risks

None known after required CI passed on the final head SHA.
