### PR TITLE
Retry low-quality OpenAI responses before commit

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod auto_route;
 pub(crate) mod ingress;
 pub(crate) mod moa_gateway;
 pub(crate) mod response_adapter;
+mod response_quality;
 mod tool_call_ids;
 pub(crate) mod transport;

--- a/crates/mesh-llm-host-runtime/src/network/openai/response_quality.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response_quality.rs
@@ -1,0 +1,304 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResponseQualityFailure {
+    EmptyAssistantOutput,
+    LengthFinishReason,
+    RepetitiveOutput,
+}
+
+impl ResponseQualityFailure {
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::EmptyAssistantOutput => "empty_assistant_output",
+            Self::LengthFinishReason => "length_finish_reason",
+            Self::RepetitiveOutput => "repetitive_output",
+        }
+    }
+}
+
+pub(crate) fn failure_from_json_body(body: &[u8]) -> Option<ResponseQualityFailure> {
+    let json = serde_json::from_slice::<serde_json::Value>(body).ok()?;
+    if response_has_length_finish_reason(&json) {
+        return Some(ResponseQualityFailure::LengthFinishReason);
+    }
+    if response_has_empty_assistant_output(&json) {
+        return Some(ResponseQualityFailure::EmptyAssistantOutput);
+    }
+    if output_text_is_repetitive(&response_output_text(&json)) {
+        return Some(ResponseQualityFailure::RepetitiveOutput);
+    }
+    None
+}
+
+fn response_has_length_finish_reason(json: &serde_json::Value) -> bool {
+    chat_choices_have_length_finish_reason(json) || responses_incomplete_for_length(json)
+}
+
+fn chat_choices_have_length_finish_reason(json: &serde_json::Value) -> bool {
+    json.get("choices")
+        .and_then(serde_json::Value::as_array)
+        .map(|choices| {
+            choices.iter().any(|choice| {
+                choice
+                    .get("finish_reason")
+                    .and_then(serde_json::Value::as_str)
+                    .map(|reason| reason.eq_ignore_ascii_case("length"))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn responses_incomplete_for_length(json: &serde_json::Value) -> bool {
+    let incomplete_status = json
+        .get("status")
+        .and_then(serde_json::Value::as_str)
+        .map(|status| status.eq_ignore_ascii_case("incomplete"))
+        .unwrap_or(false);
+    let length_reason = json
+        .get("incomplete_details")
+        .and_then(|details| details.get("reason"))
+        .and_then(serde_json::Value::as_str)
+        .map(|reason| {
+            matches!(
+                reason.to_ascii_lowercase().as_str(),
+                "length" | "max_output_tokens" | "max_tokens"
+            )
+        })
+        .unwrap_or(false);
+    incomplete_status && length_reason
+}
+
+fn response_has_empty_assistant_output(json: &serde_json::Value) -> bool {
+    chat_response_has_empty_assistant_output(json)
+        || responses_body_has_empty_assistant_output(json)
+}
+
+fn chat_response_has_empty_assistant_output(json: &serde_json::Value) -> bool {
+    let Some(choices) = json.get("choices").and_then(serde_json::Value::as_array) else {
+        return false;
+    };
+    !choices.is_empty()
+        && choices
+            .iter()
+            .all(|choice| !chat_choice_has_tool_call(choice) && chat_choice_text(choice).is_empty())
+}
+
+fn chat_choice_has_tool_call(choice: &serde_json::Value) -> bool {
+    let message = choice.get("message");
+    value_array_is_non_empty(message.and_then(|value| value.get("tool_calls")))
+        || value_array_is_non_empty(choice.get("tool_calls"))
+        || message
+            .and_then(|value| value.get("function_call"))
+            .map(|value| !value.is_null())
+            .unwrap_or(false)
+}
+
+fn chat_choice_text(choice: &serde_json::Value) -> String {
+    let mut text = String::new();
+    if let Some(message) = choice.get("message") {
+        append_openai_content_text(message.get("content"), &mut text);
+    }
+    append_openai_content_text(choice.get("text"), &mut text);
+    text
+}
+
+fn responses_body_has_empty_assistant_output(json: &serde_json::Value) -> bool {
+    let Some(output) = json.get("output").and_then(serde_json::Value::as_array) else {
+        return false;
+    };
+    let mut saw_message = false;
+    let mut saw_payload = false;
+    for item in output {
+        if responses_output_item_is_tool_call(item) {
+            saw_payload = true;
+        } else if responses_output_item_is_message(item) {
+            saw_message = true;
+            saw_payload |= !responses_output_item_text(item).is_empty();
+        }
+    }
+    saw_message && !saw_payload
+}
+
+fn responses_output_item_is_tool_call(item: &serde_json::Value) -> bool {
+    item.get("type")
+        .and_then(serde_json::Value::as_str)
+        .map(|kind| kind.contains("tool") || kind == "function_call")
+        .unwrap_or(false)
+}
+
+fn responses_output_item_is_message(item: &serde_json::Value) -> bool {
+    item.get("type")
+        .and_then(serde_json::Value::as_str)
+        .map(|kind| kind == "message")
+        .unwrap_or(true)
+}
+
+fn responses_output_item_text(item: &serde_json::Value) -> String {
+    let mut text = String::new();
+    append_openai_content_text(item.get("content"), &mut text);
+    append_openai_content_text(item.get("text"), &mut text);
+    text
+}
+
+fn response_output_text(json: &serde_json::Value) -> String {
+    let mut text = String::new();
+    if let Some(choices) = json.get("choices").and_then(serde_json::Value::as_array) {
+        for choice in choices {
+            append_text(&mut text, &chat_choice_text(choice));
+        }
+    }
+    if let Some(output) = json.get("output").and_then(serde_json::Value::as_array) {
+        for item in output {
+            append_text(&mut text, &responses_output_item_text(item));
+        }
+    }
+    append_openai_content_text(json.get("output_text"), &mut text);
+    text
+}
+
+fn append_openai_content_text(value: Option<&serde_json::Value>, output: &mut String) {
+    match value {
+        Some(serde_json::Value::String(text)) => append_text(output, text),
+        Some(serde_json::Value::Array(items)) => {
+            for item in items {
+                append_openai_content_text(Some(item), output);
+            }
+        }
+        Some(serde_json::Value::Object(map)) => {
+            append_openai_content_text(map.get("text"), output);
+            append_openai_content_text(map.get("content"), output);
+        }
+        _ => {}
+    }
+}
+
+fn append_text(output: &mut String, text: &str) {
+    let trimmed = text.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+    if !output.is_empty() {
+        output.push('\n');
+    }
+    output.push_str(trimmed);
+}
+
+fn value_array_is_non_empty(value: Option<&serde_json::Value>) -> bool {
+    value
+        .and_then(serde_json::Value::as_array)
+        .map(|items| !items.is_empty())
+        .unwrap_or(false)
+}
+
+fn output_text_is_repetitive(text: &str) -> bool {
+    const MIN_WORDS: usize = 24;
+    const MIN_REPEATS: usize = 4;
+    const MAX_PATTERN_WORDS: usize = 8;
+
+    let words = normalized_response_words(text);
+    if words.len() < MIN_WORDS {
+        return false;
+    }
+    (1..=MAX_PATTERN_WORDS)
+        .any(|width| repeated_prefix_covers(&words, width, MIN_WORDS, MIN_REPEATS))
+}
+
+fn normalized_response_words(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(|word| {
+            word.trim_matches(|ch: char| !ch.is_alphanumeric())
+                .to_ascii_lowercase()
+        })
+        .filter(|word| !word.is_empty())
+        .collect()
+}
+
+fn repeated_prefix_covers(
+    words: &[String],
+    width: usize,
+    min_words: usize,
+    min_repeats: usize,
+) -> bool {
+    if words.len() < width.saturating_mul(min_repeats) {
+        return false;
+    }
+    let pattern = &words[..width];
+    let mut matched_words = 0usize;
+    for chunk in words.chunks(width) {
+        if chunk.len() != width || chunk != pattern {
+            break;
+        }
+        matched_words += width;
+    }
+    matched_words >= min_words
+        && matched_words >= width.saturating_mul(min_repeats)
+        && matched_words.saturating_mul(100) >= words.len().saturating_mul(80)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_empty_chat_output() {
+        let body =
+            br#"{"choices":[{"message":{"role":"assistant","content":""},"finish_reason":"stop"}]}"#;
+        assert_eq!(
+            failure_from_json_body(body),
+            Some(ResponseQualityFailure::EmptyAssistantOutput)
+        );
+    }
+
+    #[test]
+    fn allows_tool_call_without_text() {
+        let body = br#"{"choices":[{"message":{"role":"assistant","content":"","tool_calls":[{"type":"function","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}]}"#;
+        assert_eq!(failure_from_json_body(body), None);
+    }
+
+    #[test]
+    fn detects_length_finish_reason() {
+        let body = br#"{"choices":[{"message":{"role":"assistant","content":"partial"},"finish_reason":"length"}]}"#;
+        assert_eq!(
+            failure_from_json_body(body),
+            Some(ResponseQualityFailure::LengthFinishReason)
+        );
+    }
+
+    #[test]
+    fn detects_responses_incomplete_for_max_tokens() {
+        let body = br#"{"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","content":[{"type":"output_text","text":"partial"}]}]}"#;
+        assert_eq!(
+            failure_from_json_body(body),
+            Some(ResponseQualityFailure::LengthFinishReason)
+        );
+    }
+
+    #[test]
+    fn allows_responses_incomplete_for_non_length_reason() {
+        let body = br#"{"status":"incomplete","incomplete_details":{"reason":"content_filter"},"output":[{"type":"message","content":[{"type":"output_text","text":"blocked"}]}]}"#;
+        assert_eq!(failure_from_json_body(body), None);
+    }
+
+    #[test]
+    fn allows_length_reason_without_incomplete_status() {
+        let body = br#"{"status":"completed","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","content":[{"type":"output_text","text":"complete"}]}]}"#;
+        assert_eq!(failure_from_json_body(body), None);
+    }
+
+    #[test]
+    fn detects_repetitive_output() {
+        let repeated = "loop answer ".repeat(16);
+        let body = serde_json::json!({
+            "choices": [{
+                "message": {"role": "assistant", "content": repeated},
+                "finish_reason": "stop"
+            }]
+        })
+        .to_string();
+
+        assert_eq!(
+            failure_from_json_body(body.as_bytes()),
+            Some(ResponseQualityFailure::RepetitiveOutput)
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -10,6 +10,7 @@ use crate::network::affinity::{
 };
 use crate::network::openai::auto_route;
 use crate::network::openai::response_adapter;
+use crate::network::openai::response_quality::{self, ResponseQualityFailure};
 use crate::network::openai::tool_call_ids::{
     ChatStreamNormalizationState, normalize_chat_completion_json_body,
 };
@@ -112,10 +113,26 @@ enum RouteAttemptResult {
     RetryableTimeout,
     RetryableUnavailable,
     RetryableContextOverflow,
+    RetryableResponseQuality(ResponseQualityFailure),
     ClientDisconnected,
 }
 
 const REMOTE_UNCOMMITTED_RETRIES: usize = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ResponseRetryPolicy {
+    context_overflow: bool,
+    response_quality: bool,
+}
+
+impl ResponseRetryPolicy {
+    fn next_target_available(available: bool) -> Self {
+        Self {
+            context_overflow: available,
+            response_quality: available,
+        }
+    }
+}
 
 fn route_attempt_result_label(result: &RouteAttemptResult) -> &'static str {
     match result {
@@ -123,6 +140,7 @@ fn route_attempt_result_label(result: &RouteAttemptResult) -> &'static str {
         RouteAttemptResult::RetryableTimeout => "retryable_timeout",
         RouteAttemptResult::RetryableUnavailable => "retryable_unavailable",
         RouteAttemptResult::RetryableContextOverflow => "retryable_context_overflow",
+        RouteAttemptResult::RetryableResponseQuality(_) => "retryable_response_quality",
         RouteAttemptResult::ClientDisconnected => "client_disconnected",
     }
 }
@@ -139,6 +157,7 @@ fn target_health_outcome_for_attempt(result: &RouteAttemptResult) -> TargetHealt
         RouteAttemptResult::RetryableTimeout => TargetHealthOutcome::Timeout,
         RouteAttemptResult::RetryableUnavailable => TargetHealthOutcome::Unavailable,
         RouteAttemptResult::RetryableContextOverflow => TargetHealthOutcome::ContextOverflow,
+        RouteAttemptResult::RetryableResponseQuality(_) => TargetHealthOutcome::Rejected,
         RouteAttemptResult::ClientDisconnected => TargetHealthOutcome::ClientDisconnected,
     }
 }
@@ -1238,6 +1257,21 @@ fn parse_completion_tokens_from_json_body(body: &[u8]) -> Option<u64> {
         .and_then(|value| value.as_u64())
 }
 
+fn retryable_quality_result(
+    body: &[u8],
+    policy: ResponseRetryPolicy,
+) -> Option<RouteAttemptResult> {
+    if !policy.response_quality {
+        return None;
+    }
+    let failure = response_quality::failure_from_json_body(body)?;
+    tracing::warn!(
+        reason = failure.label(),
+        "API proxy: upstream returned retryable low-quality success response before commit"
+    );
+    Some(RouteAttemptResult::RetryableResponseQuality(failure))
+}
+
 fn response_is_event_stream(headers: &ParsedResponseHeaders) -> bool {
     headers
         .content_type
@@ -1257,9 +1291,9 @@ async fn relay_normalized_chat_completion_stream<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
 ) -> Result<RouteAttemptResult> {
-    if retry_context_overflow && probe.retryable_context_overflow {
+    if retry_policy.context_overflow && probe.retryable_context_overflow {
         return Ok(RouteAttemptResult::RetryableContextOverflow);
     }
 
@@ -1270,7 +1304,7 @@ async fn relay_normalized_chat_completion_stream<R: AsyncRead + Unpin>(
     let parsed = try_parse_response_headers(&probe.buffered)?
         .ok_or_else(|| anyhow!("incomplete HTTP response"))?;
     if !response_is_event_stream(&parsed) {
-        return relay_success_response(tcp_stream, reader, probe, parsed).await;
+        return relay_success_response(tcp_stream, reader, probe, parsed, retry_policy).await;
     }
 
     let mut carry = String::from_utf8_lossy(&probe.buffered[parsed.header_end..]).to_string();
@@ -1359,7 +1393,7 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
 ) -> Result<RouteAttemptResult> {
     fn should_parse_stream_chunk(data: &str, model_missing: bool, usage_missing: bool) -> bool {
         model_missing
@@ -1370,7 +1404,7 @@ async fn relay_translated_responses_stream<R: AsyncRead + Unpin>(
             || data.contains("\"usage\"")
     }
 
-    if retry_context_overflow && probe.retryable_context_overflow {
+    if retry_policy.context_overflow && probe.retryable_context_overflow {
         return Ok(RouteAttemptResult::RetryableContextOverflow);
     }
 
@@ -1711,9 +1745,9 @@ async fn relay_translated_responses_json<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
 ) -> Result<RouteAttemptResult> {
-    if retry_context_overflow && probe.retryable_context_overflow {
+    if retry_policy.context_overflow && probe.retryable_context_overflow {
         return Ok(RouteAttemptResult::RetryableContextOverflow);
     }
 
@@ -1725,8 +1759,11 @@ async fn relay_translated_responses_json<R: AsyncRead + Unpin>(
 
     let parsed = try_parse_response_headers(&buffered)?
         .ok_or_else(|| anyhow!("incomplete HTTP response"))?;
-    let translated_body =
-        response_adapter::translate_chat_completion_to_responses(&buffered[parsed.header_end..])?;
+    let body = &buffered[parsed.header_end..];
+    if let Some(result) = retryable_quality_result(body, retry_policy) {
+        return Ok(result);
+    }
+    let translated_body = response_adapter::translate_chat_completion_to_responses(body)?;
     let completion_tokens = parse_completion_tokens_from_json_body(&translated_body);
     let header = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -1745,9 +1782,9 @@ async fn relay_normalized_chat_completion_json<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
 ) -> Result<RouteAttemptResult> {
-    if retry_context_overflow && probe.retryable_context_overflow {
+    if retry_policy.context_overflow && probe.retryable_context_overflow {
         return Ok(RouteAttemptResult::RetryableContextOverflow);
     }
 
@@ -1770,6 +1807,9 @@ async fn relay_normalized_chat_completion_json<R: AsyncRead + Unpin>(
     let body = &buffered[parsed.header_end..body_end];
     let normalized_body =
         normalize_chat_completion_json_body(body).unwrap_or_else(|| body.to_vec());
+    if let Some(result) = retryable_quality_result(&normalized_body, retry_policy) {
+        return Ok(result);
+    }
     let completion_tokens = parse_completion_tokens_from_json_body(&normalized_body);
     let header = format!(
         "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
@@ -2123,6 +2163,7 @@ async fn relay_success_response<R: AsyncRead + Unpin>(
     reader: &mut R,
     probe: ResponseProbe,
     parsed: ParsedResponseHeaders,
+    retry_policy: ResponseRetryPolicy,
 ) -> Result<RouteAttemptResult> {
     if let Some(content_length) = parsed.content_length {
         const MAX_SUCCESS_METRICS_BODY_BYTES: usize = 1024 * 1024;
@@ -2130,6 +2171,11 @@ async fn relay_success_response<R: AsyncRead + Unpin>(
             let mut buffered = probe.buffered;
             while buffered.len() < parsed.header_end + content_length {
                 read_response_chunk(reader, &mut buffered).await?;
+            }
+            if let Some(result) =
+                retryable_quality_result(&buffered[parsed.header_end..], retry_policy)
+            {
+                return Ok(result);
             }
             let completion_tokens =
                 parse_completion_tokens_from_json_body(&buffered[parsed.header_end..]);
@@ -2157,14 +2203,14 @@ async fn relay_probed_response<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> Result<RouteAttemptResult> {
     if let Some(result) = relay_adapted_response(
         tcp_stream,
         reader,
         probe.clone(),
-        retry_context_overflow,
+        retry_policy,
         response_adapter,
     )
     .await?
@@ -2172,7 +2218,7 @@ async fn relay_probed_response<R: AsyncRead + Unpin>(
         return Ok(result);
     }
 
-    if retry_context_overflow && probe.retryable_context_overflow {
+    if retry_policy.context_overflow && probe.retryable_context_overflow {
         return Ok(RouteAttemptResult::RetryableContextOverflow);
     }
     if !(200..300).contains(&probe.status_code) {
@@ -2181,42 +2227,29 @@ async fn relay_probed_response<R: AsyncRead + Unpin>(
 
     let parsed = try_parse_response_headers(&probe.buffered)?
         .ok_or_else(|| anyhow!("incomplete HTTP response"))?;
-    relay_success_response(tcp_stream, reader, probe, parsed).await
+    relay_success_response(tcp_stream, reader, probe, parsed, retry_policy).await
 }
 
 async fn relay_adapted_response<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> Result<Option<RouteAttemptResult>> {
     match response_adapter {
         ResponseAdapter::OpenAiChatCompletionsJson => Ok(Some(
-            relay_normalized_chat_completion_json(
-                tcp_stream,
-                reader,
-                probe,
-                retry_context_overflow,
-            )
-            .await?,
+            relay_normalized_chat_completion_json(tcp_stream, reader, probe, retry_policy).await?,
         )),
         ResponseAdapter::OpenAiChatCompletionsStream => Ok(Some(
-            relay_normalized_chat_completion_stream(
-                tcp_stream,
-                reader,
-                probe,
-                retry_context_overflow,
-            )
-            .await?,
+            relay_normalized_chat_completion_stream(tcp_stream, reader, probe, retry_policy)
+                .await?,
         )),
         ResponseAdapter::OpenAiResponsesJson => Ok(Some(
-            relay_translated_responses_json(tcp_stream, reader, probe, retry_context_overflow)
-                .await?,
+            relay_translated_responses_json(tcp_stream, reader, probe, retry_policy).await?,
         )),
         ResponseAdapter::OpenAiResponsesStream => Ok(Some(
-            relay_translated_responses_stream(tcp_stream, reader, probe, retry_context_overflow)
-                .await?,
+            relay_translated_responses_stream(tcp_stream, reader, probe, retry_policy).await?,
         )),
         ResponseAdapter::None => Ok(None),
     }
@@ -2227,7 +2260,7 @@ async fn route_local_attempt(
     tcp_stream: &mut TcpStream,
     port: u16,
     prefetched: &[u8],
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     match TcpStream::connect(format!("127.0.0.1:{port}")).await {
@@ -2244,7 +2277,7 @@ async fn route_local_attempt(
                 tcp_stream,
                 &mut upstream,
                 port,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
             )
             .await
@@ -2260,7 +2293,7 @@ async fn route_local_attempt_after_forward(
     tcp_stream: &mut TcpStream,
     upstream: &mut TcpStream,
     port: u16,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     match probe_http_response_local(upstream).await {
@@ -2269,7 +2302,7 @@ async fn route_local_attempt_after_forward(
                 tcp_stream,
                 upstream,
                 probe,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
                 "API proxy (local): downstream client disconnected during relay",
                 "API proxy (local) ended after commit",
@@ -2294,7 +2327,7 @@ async fn route_remote_attempt(
     tcp_stream: &mut TcpStream,
     host_id: iroh::EndpointId,
     prefetched: &[u8],
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     match node.open_http_tunnel(host_id).await {
@@ -2310,7 +2343,7 @@ async fn route_remote_attempt(
                 tcp_stream,
                 &mut quic_recv,
                 host_id,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
             )
             .await
@@ -2329,7 +2362,7 @@ async fn route_remote_attempt_after_forward(
     tcp_stream: &mut TcpStream,
     quic_recv: &mut iroh::endpoint::RecvStream,
     host_id: iroh::EndpointId,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     match probe_http_response(quic_recv).await {
@@ -2338,7 +2371,7 @@ async fn route_remote_attempt_after_forward(
                 tcp_stream,
                 quic_recv,
                 probe,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
                 "API proxy (remote): downstream client disconnected during relay",
                 "API proxy (remote) ended after commit",
@@ -2360,7 +2393,7 @@ async fn route_http_endpoint_attempt(
     base_url: &str,
     prefetched: &[u8],
     request_path: &str,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     let target = match build_external_endpoint_target(base_url, request_path, prefetched) {
@@ -2378,7 +2411,7 @@ async fn route_http_endpoint_attempt(
         tcp_stream,
         &mut upstream,
         base_url,
-        retry_context_overflow,
+        retry_policy,
         response_adapter,
     )
     .await
@@ -2428,7 +2461,7 @@ async fn route_http_endpoint_attempt_after_forward(
     tcp_stream: &mut TcpStream,
     upstream: &mut TcpStream,
     base_url: &str,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     match probe_http_response(upstream).await {
@@ -2437,7 +2470,7 @@ async fn route_http_endpoint_attempt_after_forward(
                 tcp_stream,
                 upstream,
                 probe,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
                 "API proxy (external endpoint): downstream client disconnected during relay",
                 "API proxy (external endpoint) ended after commit",
@@ -2463,21 +2496,13 @@ async fn relay_attempted_response<R: AsyncRead + Unpin>(
     tcp_stream: &mut TcpStream,
     reader: &mut R,
     probe: ResponseProbe,
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
     disconnect_message: &str,
     commit_message: &str,
 ) -> RouteAttemptResult {
     let status_code = probe.status_code;
-    match relay_probed_response(
-        tcp_stream,
-        reader,
-        probe,
-        retry_context_overflow,
-        response_adapter,
-    )
-    .await
-    {
+    match relay_probed_response(tcp_stream, reader, probe, retry_policy, response_adapter).await {
         Ok(result) => result,
         Err(err) => {
             if is_client_disconnect_error(&err) {
@@ -2514,6 +2539,9 @@ fn attempt_outcome_for_result(
         }
         RouteAttemptResult::RetryableContextOverflow => {
             crate::network::metrics::AttemptOutcome::ContextOverflow
+        }
+        RouteAttemptResult::RetryableResponseQuality(_) => {
+            crate::network::metrics::AttemptOutcome::Rejected
         }
         RouteAttemptResult::ClientDisconnected => {
             crate::network::metrics::AttemptOutcome::Unavailable
@@ -3058,7 +3086,7 @@ async fn route_mesh_request_attempts(
             &mut tcp_stream,
             *target_host,
             &request.raw,
-            idx + 1 < total_targets,
+            ResponseRetryPolicy::next_target_available(idx + 1 < total_targets),
             request.response_adapter,
         )
         .await;
@@ -3149,6 +3177,9 @@ fn handle_mesh_attempt_result(
             handle_delivered_mesh_attempt(context, status_code)
         }
         RouteAttemptResult::RetryableContextOverflow => handle_retryable_context_overflow(context),
+        RouteAttemptResult::RetryableResponseQuality(failure) => {
+            handle_retryable_mesh_response_quality(context, failure)
+        }
         RouteAttemptResult::RetryableTimeout => handle_retryable_mesh_timeout(context),
         RouteAttemptResult::RetryableUnavailable => handle_retryable_mesh_unavailable(context),
         RouteAttemptResult::ClientDisconnected => {
@@ -3201,6 +3232,25 @@ fn handle_retryable_context_overflow(
     );
     tracing::warn!(
         "Host {} rejected request with context overflow-style 400, trying next",
+        context.target_host.fmt_short()
+    );
+    context.state.last_retryable = true;
+    MeshAttemptDisposition::Continue
+}
+
+fn handle_retryable_mesh_response_quality(
+    context: &mut MeshAttemptResultContext<'_>,
+    failure: ResponseQualityFailure,
+) -> MeshAttemptDisposition {
+    forget_mesh_cached_target(
+        context.effective_model,
+        context.prepared,
+        context.attempt_target,
+        context.affinity,
+    );
+    tracing::warn!(
+        reason = failure.label(),
+        "Host {} returned low-quality success response, trying next",
         context.target_host.fmt_short()
     );
     context.state.last_retryable = true;
@@ -3463,7 +3513,7 @@ async fn route_attempt_for_target(
     tcp_stream: &mut TcpStream,
     target: &election::InferenceTarget,
     prefetched: &[u8],
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     match target {
@@ -3473,7 +3523,7 @@ async fn route_attempt_for_target(
                 tcp_stream,
                 *port,
                 prefetched,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
             )
             .await
@@ -3484,7 +3534,7 @@ async fn route_attempt_for_target(
                 tcp_stream,
                 *host_id,
                 prefetched,
-                retry_context_overflow,
+                retry_policy,
                 response_adapter,
             )
             .await
@@ -3498,7 +3548,7 @@ async fn route_remote_attempt_with_retry(
     tcp_stream: &mut TcpStream,
     host_id: iroh::EndpointId,
     prefetched: &[u8],
-    retry_context_overflow: bool,
+    retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
 ) -> RouteAttemptResult {
     let mut result = route_remote_attempt(
@@ -3506,7 +3556,7 @@ async fn route_remote_attempt_with_retry(
         tcp_stream,
         host_id,
         prefetched,
-        retry_context_overflow,
+        retry_policy,
         response_adapter,
     )
     .await;
@@ -3525,7 +3575,7 @@ async fn route_remote_attempt_with_retry(
             tcp_stream,
             host_id,
             prefetched,
-            retry_context_overflow,
+            retry_policy,
             response_adapter,
         )
         .await;
@@ -3636,13 +3686,13 @@ async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> bool {
     for (idx, target) in ordered.into_iter().enumerate() {
         state.attempts += 1;
         let attempt_started = Instant::now();
-        let retry_context_overflow = idx + 1 < total_targets;
+        let retry_policy = ResponseRetryPolicy::next_target_available(idx + 1 < total_targets);
         let attempt_result = route_attempt_for_target(
             &node,
             &mut tcp_stream,
             &target,
             &request.raw,
-            retry_context_overflow,
+            retry_policy,
             request.response_adapter,
         )
         .await;
@@ -3790,6 +3840,11 @@ fn handle_route_model_attempt_result(
         RouteAttemptResult::RetryableContextOverflow => {
             handle_retryable_route_model_context(model, target, selection, affinity)
         }
+        RouteAttemptResult::RetryableResponseQuality(failure) => {
+            handle_retryable_route_model_response_quality(
+                model, target, selection, affinity, failure,
+            )
+        }
         RouteAttemptResult::RetryableTimeout => {
             handle_retryable_route_model_timeout(node, model, target, selection, state, affinity)
         }
@@ -3846,6 +3901,21 @@ fn handle_retryable_route_model_context(
     forget_selected_route_model_target(model, target, selection, affinity);
     tracing::warn!(
         "Target {target:?} rejected request with context overflow-style 400, trying next"
+    );
+    RouteModelDisposition::Continue
+}
+
+fn handle_retryable_route_model_response_quality(
+    model: &str,
+    target: &election::InferenceTarget,
+    selection: &TargetSelection,
+    affinity: &AffinityRouter,
+    failure: ResponseQualityFailure,
+) -> RouteModelDisposition {
+    forget_selected_route_model_target(model, target, selection, affinity);
+    tracing::warn!(
+        reason = failure.label(),
+        "Target {target:?} returned low-quality success response, trying next"
     );
     RouteModelDisposition::Continue
 }
@@ -3945,7 +4015,7 @@ pub async fn route_to_target(
         &mut tcp_stream,
         &target,
         prefetched,
-        false,
+        ResponseRetryPolicy::next_target_available(false),
         response_adapter,
     )
     .await;
@@ -3974,6 +4044,7 @@ pub async fn route_to_target(
         }
         RouteAttemptResult::RetryableTimeout
         | RouteAttemptResult::RetryableContextOverflow
+        | RouteAttemptResult::RetryableResponseQuality(_)
         | RouteAttemptResult::RetryableUnavailable => {
             node.record_routed_request(
                 model,
@@ -4006,7 +4077,7 @@ pub async fn route_http_endpoint_request(
         base_url,
         prefetched,
         request_path,
-        false,
+        ResponseRetryPolicy::next_target_available(false),
         response_adapter,
     )
     .await;
@@ -4042,6 +4113,7 @@ pub async fn route_http_endpoint_request(
         }
         RouteAttemptResult::RetryableTimeout
         | RouteAttemptResult::RetryableContextOverflow
+        | RouteAttemptResult::RetryableResponseQuality(_)
         | RouteAttemptResult::RetryableUnavailable => {
             node.record_routed_request(
                 model,
@@ -5227,6 +5299,12 @@ mod tests {
             "retryable_context_overflow"
         );
         assert_eq!(
+            route_attempt_result_label(&RouteAttemptResult::RetryableResponseQuality(
+                ResponseQualityFailure::EmptyAssistantOutput
+            )),
+            "retryable_response_quality"
+        );
+        assert_eq!(
             route_attempt_result_label(&RouteAttemptResult::ClientDisconnected),
             "client_disconnected"
         );
@@ -5260,6 +5338,12 @@ mod tests {
             TargetHealthOutcome::ContextOverflow
         );
         assert_eq!(
+            target_health_outcome_for_attempt(&RouteAttemptResult::RetryableResponseQuality(
+                ResponseQualityFailure::LengthFinishReason
+            )),
+            TargetHealthOutcome::Rejected
+        );
+        assert_eq!(
             target_health_outcome_for_attempt(&RouteAttemptResult::RetryableTimeout),
             TargetHealthOutcome::Timeout
         );
@@ -5275,6 +5359,11 @@ mod tests {
         ));
         assert!(!should_retry_uncommitted_remote_attempt(
             RouteAttemptResult::RetryableContextOverflow
+        ));
+        assert!(!should_retry_uncommitted_remote_attempt(
+            RouteAttemptResult::RetryableResponseQuality(
+                ResponseQualityFailure::EmptyAssistantOutput
+            )
         ));
         assert!(!should_retry_uncommitted_remote_attempt(
             RouteAttemptResult::ClientDisconnected
@@ -6155,7 +6244,7 @@ mod tests {
                 &mut client_socket,
                 &mut upstream_reader,
                 probe,
-                false,
+                ResponseRetryPolicy::next_target_available(false),
             )
             .await
             .expect("relay")
@@ -6408,7 +6497,7 @@ mod tests {
                 &mut client_socket,
                 &mut upstream_reader,
                 probe,
-                false,
+                ResponseRetryPolicy::next_target_available(false),
             )
             .await
             .expect("relay")

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy/tests.rs
@@ -1687,6 +1687,129 @@ async fn test_api_proxy_rejects_request_when_all_known_contexts_too_small() {
 }
 
 #[tokio::test]
+async fn test_api_proxy_retries_empty_success_response_to_next_target() {
+    let empty_body = json!({
+        "id": "chatcmpl-empty",
+        "object": "chat.completion",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": ""},
+            "finish_reason": "stop"
+        }]
+    })
+    .to_string();
+    let healthy_body = json!({
+        "id": "chatcmpl-healthy",
+        "object": "chat.completion",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "recovered answer"},
+            "finish_reason": "stop"
+        }]
+    })
+    .to_string();
+    let (empty_port, empty_rx, empty_handle) = spawn_capturing_upstream(&empty_body).await;
+    let (healthy_port, healthy_rx, healthy_handle) = spawn_capturing_upstream(&healthy_body).await;
+    let (proxy_addr, proxy_handle) =
+        spawn_api_proxy_test_harness(single_model_targets("test", &[empty_port, healthy_port]))
+            .await;
+
+    let body = json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "empty then retry"}],
+    })
+    .to_string();
+    let request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+
+    let response = send_request_and_read_response(proxy_addr, vec![request.into_bytes()]).await;
+    let empty_raw = String::from_utf8(empty_rx.await.unwrap()).unwrap();
+    let healthy_raw = String::from_utf8(
+        tokio::time::timeout(Duration::from_secs(2), healthy_rx)
+            .await
+            .expect("proxy did not retry empty success response to the healthy target")
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains("recovered answer"));
+    assert!(!response.contains("chatcmpl-empty"));
+    assert!(empty_raw.contains("empty then retry"));
+    assert!(healthy_raw.contains("empty then retry"));
+
+    proxy_handle.abort();
+    let _ = empty_handle.await;
+    let _ = healthy_handle.await;
+}
+
+#[tokio::test]
+async fn test_api_proxy_retries_length_finish_success_response_to_next_target() {
+    let truncated_body = json!({
+        "id": "chatcmpl-length",
+        "object": "chat.completion",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "partial"},
+            "finish_reason": "length"
+        }]
+    })
+    .to_string();
+    let healthy_body = json!({
+        "id": "chatcmpl-healthy",
+        "object": "chat.completion",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "complete answer"},
+            "finish_reason": "stop"
+        }]
+    })
+    .to_string();
+    let (truncated_port, truncated_rx, truncated_handle) =
+        spawn_capturing_upstream(&truncated_body).await;
+    let (healthy_port, healthy_rx, healthy_handle) = spawn_capturing_upstream(&healthy_body).await;
+    let (proxy_addr, proxy_handle) = spawn_api_proxy_test_harness(single_model_targets(
+        "test",
+        &[truncated_port, healthy_port],
+    ))
+    .await;
+
+    let body = json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "length then retry"}],
+    })
+    .to_string();
+    let request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+
+    let response = send_request_and_read_response(proxy_addr, vec![request.into_bytes()]).await;
+    let truncated_raw = String::from_utf8(truncated_rx.await.unwrap()).unwrap();
+    let healthy_raw = String::from_utf8(
+        tokio::time::timeout(Duration::from_secs(2), healthy_rx)
+            .await
+            .expect("proxy did not retry length-truncated success response to the healthy target")
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert!(response.starts_with("HTTP/1.1 200 OK"));
+    assert!(response.contains("complete answer"));
+    assert!(!response.contains("chatcmpl-length"));
+    assert!(truncated_raw.contains("length then retry"));
+    assert!(healthy_raw.contains("length then retry"));
+
+    proxy_handle.abort();
+    let _ = truncated_handle.await;
+    let _ = healthy_handle.await;
+}
+
+#[tokio::test]
 async fn test_api_proxy_does_not_retry_generic_bad_request() {
     let bad_request_body = r#"{"error":{"message":"missing required field: messages"}}"#;
     let (bad_port, bad_rx, bad_handle) =


### PR DESCRIPTION
## Summary

Users now get a cleaner OpenAI-compatible routing path when an upstream mesh target returns a technically successful but unusable non-streaming response. Before committing the response to the client, mesh-llm detects empty assistant output without tool calls, length-truncated responses, and repetitive responses, then tries the next eligible target when one is available.

Streaming responses keep the existing commit-on-first-byte behavior, and single-target routes still preserve availability by returning the target response instead of converting quality admission into a hard failure.

## Why

Agent harnesses can get stuck when a target returns a 200 response that is effectively unusable. This gives the router a deterministic, pre-commit quality gate for the non-streaming JSON path while avoiding unsafe retries after a stream has already started.

## Post-Review Update

The review comment on Responses `status: "incomplete"` handling is addressed in the refreshed head. Responses payloads are now retried as length failures only when the response is incomplete and `incomplete_details.reason` is a length/max-token condition. Non-length incomplete reasons, such as content-filter style terminal responses, are preserved instead of being hidden behind another target retry.

## Diff Scope

- Adds OpenAI response quality classification in `network/openai/response_quality.rs`.
- Wires quality admission into non-streaming OpenAI transport retries.
- Requires Responses incomplete retries to have both incomplete status and a length/max-token reason.
- Marks rejected targets as non-cooling rejected health observations and clears cached affinity so the next eligible target can be tried.
- Keeps streaming retries guarded so responses are not retried after client-visible bytes are committed.
- Adds regression coverage for empty content, truncation, repetition, Responses incomplete reason handling, retry behavior, and streaming no-retry behavior.

## Compatibility

No mesh protocol, plugin protocol, Skippy ABI, schema, or release metadata changes.

## Branch Integrity

- Base branch: `main`
- Validated base: `f9bd75a97378be014f52c4e68c13e81d3399e65e`
- Head branch: `codex/router-quality-gates`
- Head commit: `4bafc3eeb43a4eb141f2550f11bc5d344971e9dd`
- Ahead/behind after local rebase: `0 behind / 1 ahead`

## Diff Hygiene

- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.

## Validation

Validation tier: Tier 3 - shared OpenAI routing/proxy behavior refreshed onto current main for PR #762; non-streaming JSON success responses get deterministic quality admission before client-visible commit, while Responses `status: incomplete` retries now require a length/max-token reason so non-length terminal responses are preserved.

- `git fetch --no-tags origin main:refs/remotes/origin/main codex/router-quality-gates:refs/remotes/origin/codex/router-quality-gates`: PASS, `origin/main` at `f9bd75a9`.
- `git rebase origin/main`: PASS after resolving one proxy test-module conflict by preserving both the landed context-fit admission test and this PR's response-quality retry tests.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all -- --check`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime response_quality --lib -- --test-threads=1`: PASS, 7 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime test_api_proxy_retries --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime openai::transport --lib -- --test-threads=1`: PASS, 67 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo check -p mesh-llm`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.

Required remote gates: PASS on refreshed head `4bafc3eeb43a4eb141f2550f11bc5d344971e9dd`; the initial `Linux tests (skippy-smoke)` compiler/sccache abort passed after rerunning the failed GitHub Actions job with no code changes.

Ledger: not applicable - not required for selected validation tier/change family.

Version: not applicable - no release/version sync required for this non-release routing behavior change.

## Not Run

- `just build`: not required for selected validation tier; no UI assets or release bundle changed.
- Live multi-node agent smoke: no local model/runtime mesh endpoint was available; deterministic proxy, transport, quality-detector, and stream-guard tests cover the changed paths.

## Runtime Safety

The retry decision is limited to non-streaming JSON responses before client-visible commit. Streaming responses keep the existing first-byte commit guard. No new protocol state, blocking locks, unbounded queues, or invariant removals were introduced.

## Rollback

Revert this PR.

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known.

## Known Residual Risks

Final merge readiness still depends on mandatory GitHub CI/review for the pushed SHA. A live multi-node agent smoke would be useful as an additional confidence pass when a suitable mesh endpoint is available.

