### PR TITLE
Fix Skippy unified-KV fragmentation under tool-loop pressure

### DIFF
--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -1,6 +1,6 @@
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 24;
+pub const ABI_VERSION_PATCH: u32 = 25;
 
 use std::ffi::{c_char, c_int, c_void};
 

--- a/third_party/llama.cpp/patches/0082-Compact-KV-cache-cells-during-optimized-memory-updates.patch
+++ b/third_party/llama.cpp/patches/0082-Compact-KV-cache-cells-during-optimized-memory-updates.patch
@@ -1,0 +1,258 @@
+From d683f8a5a1ca50a7f6021b6948e23a8250a4abf4 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 30 May 2026 13:13:23 -0700
+Subject: [PATCH] Compact KV cache cells during optimized memory updates
+
+---
+ include/skippy/common.h |   2 +-
+ src/llama-kv-cache.cpp  | 115 ++++++++++++++++++++++++++++++++++++++--
+ src/llama-kv-cache.h    |  13 ++++-
+ src/llama-kv-cells.h    |  36 ++++++++-----
+ 4 files changed, 145 insertions(+), 21 deletions(-)
+
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index 26e944d8..a680d342 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -26,7 +26,7 @@ extern "C" {
+
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 24
++#define SKIPPY_ABI_VERSION_PATCH 25
+
+ enum skippy_feature {
+     SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
+diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
+index 044fbeb8..b4f02eb8 100644
+--- a/src/llama-kv-cache.cpp
++++ b/src/llama-kv-cache.cpp
+@@ -673,11 +673,28 @@ llama_memory_context_ptr llama_kv_cache::init_full() {
+ }
+
+ llama_memory_context_ptr llama_kv_cache::init_update(llama_context * lctx, bool optimize) {
+-    GGML_UNUSED(optimize);
+-
+     bool do_shift = get_has_shift();
++    bool did_compact = false;
++
++    if (optimize) {
++        if (lctx != nullptr) {
++            lctx->synchronize();
++        }
++
++        const auto moves = compact_cells();
++        did_compact = !moves.empty();
++        if (did_compact) {
++            copy_compacted_cells(moves);
++            LLAMA_LOG_DEBUG("%s: compacted %zu KV cells\n", __func__, moves.size());
++        }
++    }
+
+-    return std::make_unique<llama_kv_cache_context>(this, lctx, do_shift, std::move(sc_info));
++    return std::make_unique<llama_kv_cache_context>(
++            this,
++            lctx,
++            do_shift,
++            std::move(sc_info),
++            did_compact);
+ }
+
+ llama_kv_cache::slot_info_vec_t llama_kv_cache::prepare(const std::vector<llama_ubatch> & ubatches) {
+@@ -1094,6 +1111,93 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
+     }
+ }
+
++std::vector<llama_kv_cache::compaction_move> llama_kv_cache::compact_cells() {
++    std::vector<compaction_move> moves;
++
++    for (uint32_t s = 0; s < n_stream; ++s) {
++        auto & cells = v_cells[s];
++        uint32_t dst = 0;
++
++        for (uint32_t src = 0; src < cells.size(); ++src) {
++            if (cells.is_empty(src)) {
++                continue;
++            }
++            if (src != dst) {
++                moves.push_back({ s, src, dst });
++                cells.mv(src, dst);
++            }
++            ++dst;
++        }
++
++        v_heads[s] = dst;
++    }
++
++    return moves;
++}
++
++static void llama_kv_cache_copy_tensor_bytes(
++        ggml_tensor * tensor,
++        size_t src_offset,
++        size_t dst_offset,
++        size_t size) {
++    if (tensor == nullptr || size == 0 || src_offset == dst_offset) {
++        return;
++    }
++
++    std::vector<uint8_t> bytes(size);
++    ggml_backend_tensor_get(tensor, bytes.data(), src_offset, size);
++    ggml_backend_tensor_set(tensor, bytes.data(), dst_offset, size);
++}
++
++void llama_kv_cache::copy_compacted_cells(const std::vector<compaction_move> & moves) const {
++    for (const auto & layer : layers) {
++        for (const compaction_move & move : moves) {
++            if (move.strm >= layer.k_stream.size()) {
++                continue;
++            }
++
++            auto * k = layer.k_stream[move.strm];
++            if (k != nullptr) {
++                const size_t k_row_bytes = ggml_row_size(k->type, hparams.n_embd_k_gqa(layer.il));
++                llama_kv_cache_copy_tensor_bytes(
++                        k,
++                        static_cast<size_t>(move.src) * k_row_bytes,
++                        static_cast<size_t>(move.dst) * k_row_bytes,
++                        k_row_bytes);
++            }
++
++            if (move.strm >= layer.v_stream.size()) {
++                continue;
++            }
++
++            auto * v = layer.v_stream[move.strm];
++            if (v == nullptr) {
++                continue;
++            }
++
++            const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer.il);
++            if (!v_trans) {
++                const size_t v_row_bytes = ggml_row_size(v->type, n_embd_v_gqa);
++                llama_kv_cache_copy_tensor_bytes(
++                        v,
++                        static_cast<size_t>(move.src) * v_row_bytes,
++                        static_cast<size_t>(move.dst) * v_row_bytes,
++                        v_row_bytes);
++            } else {
++                const size_t v_element_bytes = ggml_type_size(v->type);
++                const size_t cells_per_stream = v_cells[move.strm].size();
++                for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
++                    llama_kv_cache_copy_tensor_bytes(
++                            v,
++                            (static_cast<size_t>(move.src) + static_cast<size_t>(j) * cells_per_stream) * v_element_bytes,
++                            (static_cast<size_t>(move.dst) + static_cast<size_t>(j) * cells_per_stream) * v_element_bytes,
++                            v_element_bytes);
++                }
++            }
++        }
++    }
++}
++
+ bool llama_kv_cache::get_can_shift() const {
+     // Step35 uses per-layer RoPE dims; K-shift assumes a single global n_rot.
+     if (model.arch == LLM_ARCH_STEP35) {
+@@ -2764,8 +2868,9 @@ llama_kv_cache_context::llama_kv_cache_context(
+         llama_kv_cache * kv,
+         llama_context * lctx,
+         bool do_shift,
+-        stream_copy_info sc_info) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv), lctx(lctx), do_shift(do_shift), sc_info(std::move(sc_info)) {
+-    if (!do_shift && this->sc_info.empty()) {
++        stream_copy_info sc_info,
++        bool did_compact) : status(LLAMA_MEMORY_STATUS_SUCCESS), kv(kv), lctx(lctx), do_shift(do_shift), sc_info(std::move(sc_info)) {
++    if (!do_shift && this->sc_info.empty() && !did_compact) {
+         status = LLAMA_MEMORY_STATUS_NO_UPDATE;
+     }
+ }
+diff --git a/src/llama-kv-cache.h b/src/llama-kv-cache.h
+index be3c23a0..0783b359 100644
+--- a/src/llama-kv-cache.h
++++ b/src/llama-kv-cache.h
+@@ -95,6 +95,12 @@ public:
+
+     using slot_info_vec_t = std::vector<slot_info>;
+
++    struct compaction_move {
++        uint32_t strm;
++        uint32_t src;
++        uint32_t dst;
++    };
++
+     // TODO: refactor the memory instances to not depend on `llama_model`
+     //       instead pass all necessary info (e.g. hparams, dev layers, arch, etc.) directly
+     //       likely through `struct llama_memory_params`
+@@ -212,6 +218,10 @@ public:
+     // emplace the ubatch context into slot: [sinfo.idxs[0...ubatch.n_tokens - 1]]
+     void apply_ubatch(const slot_info & sinfo, const llama_ubatch & ubatch);
+
++    // move used cells toward the beginning of each stream and copy the backing KV rows
++    std::vector<compaction_move> compact_cells();
++    void copy_compacted_cells(const std::vector<compaction_move> & moves) const;
++
+     //
+     // input API
+     //
+@@ -349,7 +359,8 @@ public:
+             llama_kv_cache * kv,
+             llama_context * lctx,
+             bool do_shift,
+-            stream_copy_info sc_info);
++            stream_copy_info sc_info,
++            bool did_compact);
+
+     // used to create a batch processing context from a batch
+     llama_kv_cache_context(
+diff --git a/src/llama-kv-cells.h b/src/llama-kv-cells.h
+index 10063bf4..73ff1db0 100644
+--- a/src/llama-kv-cells.h
++++ b/src/llama-kv-cells.h
+@@ -97,24 +97,32 @@ public:
+     }
+
+     // move cell isrc to idst (used during defrag)
+-    //void mv(uint32_t isrc, uint32_t idst) {
+-    //    assert(isrc < pos.size());
+-    //    assert(idst < pos.size());
++    void mv(uint32_t isrc, uint32_t idst) {
++        assert(isrc < pos.size());
++        assert(idst < pos.size());
++        assert(isrc != idst);
+
+-    //    assert(pos[idst] == -1);
+-    //    assert(pos[isrc] != -1);
++        assert(pos[idst] == -1);
++        assert(seq[idst].none());
++        assert(pos[isrc] != -1);
+
+-    //    pos  [idst] = pos  [isrc];
+-    //    shift[idst] = shift[isrc];
+-    //    seq  [idst] = seq  [isrc];
++        seq_pos_rm(isrc);
+
+-    //    pos  [isrc] = -1;
+-    //    shift[isrc] =  0;
+-    //    seq  [isrc].reset();
++        pos  [idst] = pos  [isrc];
++        ext  [idst] = ext  [isrc];
++        shift[idst] = shift[isrc];
++        seq  [idst] = seq  [isrc];
+
+-    //    used.erase (isrc);
+-    //    used.insert(idst);
+-    //}
++        pos  [isrc] = -1;
++        ext  [isrc].reset();
++        shift[isrc] =  0;
++        seq  [isrc].reset();
++
++        used.erase (isrc);
++        used.insert(idst);
++
++        seq_pos_add(idst);
++    }
+
+     // copy the state of cells [i, i + n) (used for save/restore the state of the cells)
+     llama_kv_cells cp(uint32_t i, uint32_t n) const {
+--
+2.50.1 (Apple Git-155)


### PR DESCRIPTION
## Summary

This fixes the native Skippy unified-KV fragmentation path that can surface during long Goose/Pi-style tool loops and overlapping direct-model requests.

When llama.cpp retries an optimized memory update, the patched staged runtime now compacts the KV cell metadata and backing K/V rows before continuing. That gives the unified KV cache a deterministic way to reclaim fragmented space instead of relying only on higher-level cache eviction.

## Why

Issue #652 points at a hard class of failures: the Rust-side cache can decide eviction correctly while the native llama KV allocator still has fragmented cells. In that state, repeated tool-call traffic can fail even though total reclaimable KV capacity exists.

This PR moves the fix to the layer that actually owns the fragmented allocation state: the patched llama.cpp staged runtime.

## Diff Scope

- Adds llama.cpp patch `0082-Compact-KV-cache-cells-during-optimized-memory-updates.patch`.
- Restores/adds KV cell move support for compacting cell metadata and sequence positions.
- Copies K/V backing rows during optimized KV compaction, including the transposed/non-transposed V layouts.
- Synchronizes the context before moving native KV rows and marks the optimized update as successful when compaction performed work.
- Bumps the Skippy ABI patch mirror from `24` to `25` in both the llama patch queue and `skippy-ffi`.

## Compatibility

- Mesh wire protocol: unchanged.
- Gossip/schema/API surface: unchanged.
- Release metadata/version: unchanged.
- Skippy native ABI patch version: bumped to `25` because the patched llama.cpp runtime behavior changed.

## Branch Integrity

- Base branch: `main`
- Validated base: `8219dc76caf0d590c942c86f71358bf699e74860`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `8219dc76caf0d590c942c86f71358bf699e74860`
- Introduced commit: `0f7bfb30ef59c793dea704e68eb7f57359de36b2` `Compact skippy KV cache during optimized updates`

## Diff Hygiene

Changed files:

- `crates/skippy-ffi/src/lib.rs`
- `third_party/llama.cpp/patches/0082-Compact-KV-cache-cells-during-optimized-memory-updates.patch`

Proof:

- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.

## Validation

Validation tier: Tier 3 - native Skippy/llama KV runtime patch queue change for issue #652 unified-KV fragmentation, refreshed onto current main for PR #764; optimized llama memory updates now compact KV cell metadata and backing K/V rows before decode retry, with the Skippy ABI patch mirror refreshed.

- `git fetch --no-tags origin main:refs/remotes/origin/main codex/kv-fragmentation-root-fix:refs/remotes/origin/codex/kv-fragmentation-root-fix`: PASS, `origin/main` at `8219dc76`.
- `git rebase origin/main`: PASS, no conflicts.
- `scripts/prepare-llama.sh pinned`: PASS, 82 patches applied; upstream `22cadc1944f4658214aee03abd08240358840a95`, patched `6a78135b2f4ab22bd67d7c4bb252d9723a73e436`.
- `scripts/build-llama.sh`: PASS, patched CPU stage ABI libraries built in `.deps/llama-build/build-stage-abi-cpu`.
- `cargo fmt --all -- --check`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p skippy-runtime abi --lib -- --test-threads=1`: PASS, 2 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p skippy-runtime runtime_config_raw --lib -- --test-threads=1`: PASS, 5 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p skippy-runtime --lib -- --test-threads=1`: PASS, 47 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p skippy-server create_indexed_lane_resource --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p skippy-server --lib -- --test-threads=1`: PASS, 106 passed.
- `cargo test -p skippy-cache token_budget_triggers_lru_before_entry_cap_under_unified_kv --lib -- --test-threads=1`: PASS, 1 passed.
- `cargo test -p skippy-cache evict_lru_until_tokens_evicts_multiple_entries_until_target --lib -- --test-threads=1`: PASS, 1 passed.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo check -p mesh-llm`: PASS.
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo clippy -p skippy-runtime -p skippy-server --all-targets -- -D warnings`: PASS.
- `python3 -m unittest scripts.tests.test_qa_kv_tool_loop_stability`: PASS, 18 passed.

Required remote gates: PASS on refreshed head `0f7bfb30ef59c793dea704e68eb7f57359de36b2`; PR Builds and PR Quality Checks completed successfully.

Ledger: not applicable - not required for selected validation tier/change family.

Version: not applicable - Skippy ABI patch mirror updated, but no mesh release/version sync required for this non-release runtime patch.

## Not Run

- Live #652 Goose/Pi/direct-model fragmentation certification: no local loaded direct-model endpoint/tiny GGUF was available. The native patch queue apply/build plus Skippy runtime/server/cache/harness coverage validates the compile and deterministic changed paths.
- `just build`: not required for this validation tier because UI and release bundle are unchanged; native stage ABI build and shipped `mesh-llm` cargo check cover changed runtime linkage.

## Runtime Safety

- No new blocking locks.
- No new unbounded queues.
- No mesh protocol or gossip invariant changed.
- Native KV movement is scoped to optimized update/compaction and preserves cache metadata/backing row alignment.
- No invariant regression introduced.

## Rollback Plan

Rollback: revert this PR.

```bash
git revert <post_merge_commit_sha>
```

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: nodes using this patch should be rebuilt together with the ABI patch mirror so staged runtime and Rust ABI expectations stay aligned.

## Known Residual Risks

The remaining proof is a live #652 reproduction/certification run with a loaded direct-model endpoint under Goose/Pi-style overlapping tool-loop pressure. That should be treated as the final behavioral confirmation once suitable local or remote model hardware is available.
