### PR TITLE
Add A2A and ACP agent substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,20 @@
 version = 4
 
 [[package]]
+name = "a2a-lf"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb24275cca126dc3301d272eef07bd4cefd87f9a7dd5d6f27200fe87e8a83d0"
+dependencies = [
+ "base64",
+ "chrono",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,6 +55,57 @@ dependencies = [
  "ctr",
  "ghash",
  "subtle",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
 ]
 
 [[package]]
@@ -760,13 +825,22 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
  "quote",
  "rustversion",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1570,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1641,6 +1715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -2208,6 +2283,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2455,7 +2543,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2472,6 +2560,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -3066,6 +3160,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
@@ -3475,6 +3580,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3771,6 +3886,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "mesh-llm-a2a"
+version = "0.68.0"
+dependencies = [
+ "a2a-lf",
+ "anyhow",
+ "mesh-llm-config",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "mesh-llm-acp-bridge"
+version = "0.68.0"
+dependencies = [
+ "agent-client-protocol",
+ "anyhow",
+ "mesh-llm-a2a",
+ "mesh-llm-config",
+ "serde",
+]
+
+[[package]]
 name = "mesh-llm-api-client"
 version = "0.68.0"
 dependencies = [
@@ -3834,6 +3972,7 @@ dependencies = [
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
  "toml_edit",
+ "url",
 ]
 
 [[package]]
@@ -3909,6 +4048,8 @@ dependencies = [
  "keyring",
  "libc",
  "mdns-sd",
+ "mesh-llm-a2a",
+ "mesh-llm-acp-bridge",
  "mesh-llm-api-server",
  "mesh-llm-client",
  "mesh-llm-config",
@@ -3940,7 +4081,7 @@ dependencies = [
  "rmcp",
  "rpassword",
  "rustls",
- "schemars",
+ "schemars 1.2.1",
  "semver",
  "serde",
  "serde_json",
@@ -4018,7 +4159,7 @@ dependencies = [
  "prost-build",
  "protoc-bin-vendored",
  "rmcp",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tokio",
@@ -5395,7 +5536,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
 ]
 
 [[package]]
@@ -5526,7 +5667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap",
+ "indexmap 2.13.1",
  "quick-xml",
  "serde",
  "time",
@@ -5714,7 +5855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap",
+ "indexmap 2.13.1",
  "nix 0.31.2",
  "tokio",
  "tracing",
@@ -6400,7 +6541,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.2",
  "rmcp-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sse-stream",
@@ -6611,7 +6752,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6705,6 +6846,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -6992,12 +7145,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+dependencies = [
+ "base64",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.13.1",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "itoa",
  "ryu",
  "serde",
@@ -7108,6 +7293,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"
@@ -7833,9 +8024,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -7966,6 +8157,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "futures-util",
  "pin-project-lite",
@@ -8001,7 +8193,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -8016,7 +8208,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -8049,7 +8241,7 @@ version = "0.25.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -8119,7 +8311,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.13.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -8392,7 +8584,7 @@ dependencies = [
  "glob",
  "goblin",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "once_cell",
  "serde",
  "tempfile",
@@ -8434,7 +8626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f51ebca0d9a4b2aa6c644d5ede45c56f73906b96403c08a1985e75ccb64a01"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8477,7 +8669,7 @@ checksum = "a806dddc8208f22efd7e95a5cdf88ed43d0f3271e8f63b47e757a8bbdb43b63a"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "tempfile",
  "uniffi_internal_macros",
 ]
@@ -8762,7 +8954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.1",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -8801,7 +8993,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.1",
  "semver",
 ]
 
@@ -9387,7 +9579,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.1",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -9418,7 +9610,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "serde",
  "serde_derive",
@@ -9437,7 +9629,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.1",
  "log",
  "semver",
  "serde",
@@ -9910,7 +10102,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.13.1",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ members = [
     "crates/mesh-llm-plugin",
     "crates/mesh-llm-skills",
     "crates/mesh-llm-plugin-manager",
+    "crates/mesh-llm-a2a",
+    "crates/mesh-llm-acp-bridge",
     "crates/mesh-client",
     "crates/mesh-llm-api-client",
     "crates/mesh-llm-api-server",
@@ -64,6 +66,7 @@ mesh-llm-skills = { path = "crates/mesh-llm-skills" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
+url = "2"
 
 [patch.crates-io]
 hf-hub = { git = "https://github.com/Mesh-LLM/hf-hub", branch = "mesh-llm" }

--- a/crates/mesh-llm-a2a/Cargo.toml
+++ b/crates/mesh-llm-a2a/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mesh-llm-a2a"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "A2A agent directory primitives for Mesh LLM"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+a2a-lf = "0.3.0"
+anyhow.workspace = true
+mesh-llm-config = { path = "../mesh-llm-config" }
+serde.workspace = true
+serde_json.workspace = true
+url.workspace = true

--- a/crates/mesh-llm-a2a/README.md
+++ b/crates/mesh-llm-a2a/README.md
@@ -1,0 +1,7 @@
+# mesh-llm-a2a
+
+A2A agent directory primitives for Mesh LLM.
+
+This crate owns the local, configuration-backed agent directory and conversion
+to official `a2a-lf` agent cards. It intentionally does not start agent
+processes, publish gossip, or expose network servers.

--- a/crates/mesh-llm-a2a/src/lib.rs
+++ b/crates/mesh-llm-a2a/src/lib.rs
@@ -1,0 +1,377 @@
+use std::collections::BTreeSet;
+
+use a2a::{
+    AgentCapabilities, AgentCard, AgentInterface, AgentSkill, TRANSPORT_PROTOCOL_HTTP_JSON,
+    TRANSPORT_PROTOCOL_JSONRPC,
+};
+use anyhow::{Result, bail};
+use mesh_llm_config::{AgentConfigEntry, AgentProtocol, MeshConfig};
+use serde::Serialize;
+use url::Url;
+
+pub const MESH_AGENT_CARD_PROVIDER: &str = "Mesh LLM";
+pub const A2A_JSONRPC_TRANSPORT: &str = TRANSPORT_PROTOCOL_JSONRPC;
+pub const A2A_HTTP_JSON_TRANSPORT: &str = TRANSPORT_PROTOCOL_HTTP_JSON;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MeshAgent {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub protocol: AgentProtocol,
+    pub enabled: bool,
+    pub endpoint: Option<String>,
+    pub command: Option<String>,
+    pub args: Vec<String>,
+    pub skills: Vec<String>,
+    pub input_modes: Vec<String>,
+    pub output_modes: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct AgentDirectory {
+    agents: Vec<MeshAgent>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct AgentDirectorySummary {
+    pub total: usize,
+    pub enabled: usize,
+    pub a2a: usize,
+    pub acp: usize,
+    pub agents: Vec<MeshAgentSummary>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct MeshAgentSummary {
+    pub id: String,
+    pub name: String,
+    pub protocol: AgentProtocol,
+    pub enabled: bool,
+    pub endpoint: Option<String>,
+    pub command: Option<String>,
+    pub skills: Vec<String>,
+}
+
+impl AgentDirectory {
+    pub fn from_config(config: &MeshConfig) -> Result<Self> {
+        let mut seen = BTreeSet::new();
+        let mut agents = Vec::with_capacity(config.agents.len());
+        for entry in &config.agents {
+            let agent = MeshAgent::from_entry(entry)?;
+            if !seen.insert(agent.id.clone()) {
+                bail!("duplicate agent id `{}`", agent.id);
+            }
+            agents.push(agent);
+        }
+        Ok(Self { agents })
+    }
+
+    pub fn agents(&self) -> &[MeshAgent] {
+        &self.agents
+    }
+
+    pub fn enabled_agents(&self) -> impl Iterator<Item = &MeshAgent> {
+        self.agents.iter().filter(|agent| agent.enabled)
+    }
+
+    pub fn get(&self, id: &str) -> Option<&MeshAgent> {
+        self.agents.iter().find(|agent| agent.id == id)
+    }
+
+    pub fn summary(&self) -> AgentDirectorySummary {
+        AgentDirectorySummary {
+            total: self.agents.len(),
+            enabled: self.enabled_agents().count(),
+            a2a: self
+                .agents
+                .iter()
+                .filter(|agent| agent.protocol == AgentProtocol::A2a)
+                .count(),
+            acp: self
+                .agents
+                .iter()
+                .filter(|agent| agent.protocol == AgentProtocol::Acp)
+                .count(),
+            agents: self.agents.iter().map(MeshAgent::summary).collect(),
+        }
+    }
+
+    pub fn a2a_cards(&self) -> Result<Vec<AgentCard>> {
+        self.enabled_agents()
+            .filter(|agent| agent.protocol == AgentProtocol::A2a)
+            .map(MeshAgent::to_a2a_card)
+            .collect()
+    }
+}
+
+impl MeshAgent {
+    fn from_entry(entry: &AgentConfigEntry) -> Result<Self> {
+        let id = normalize_agent_id(&entry.id)?;
+        let name = normalize_required(&entry.name, "agent name")?.to_string();
+        let description = normalize_required(&entry.description, "agent description")?.to_string();
+        let skills = normalize_string_list(&entry.skills, "agent skills")?;
+        let input_modes = normalize_modes(&entry.input_modes);
+        let output_modes = normalize_modes(&entry.output_modes);
+        let enabled = entry.enabled.unwrap_or(true);
+        validate_protocol_binding(entry)?;
+
+        Ok(Self {
+            id,
+            name,
+            description,
+            protocol: entry.protocol,
+            enabled,
+            endpoint: normalize_optional_string(entry.endpoint.as_deref()),
+            command: normalize_optional_string(entry.command.as_deref()),
+            args: entry.args.clone(),
+            skills,
+            input_modes,
+            output_modes,
+        })
+    }
+
+    pub fn summary(&self) -> MeshAgentSummary {
+        MeshAgentSummary {
+            id: self.id.clone(),
+            name: self.name.clone(),
+            protocol: self.protocol,
+            enabled: self.enabled,
+            endpoint: self.endpoint.clone(),
+            command: self.command.clone(),
+            skills: self.skills.clone(),
+        }
+    }
+
+    pub fn to_a2a_card(&self) -> Result<AgentCard> {
+        if self.protocol != AgentProtocol::A2a {
+            bail!("agent `{}` is {:?}, not a2a", self.id, self.protocol);
+        }
+        let endpoint = self
+            .endpoint
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("agent `{}` has no A2A endpoint", self.id))?;
+        validate_http_endpoint(endpoint, "agent endpoint")?;
+        Ok(AgentCard {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            supported_interfaces: vec![AgentInterface::new(endpoint, A2A_JSONRPC_TRANSPORT)],
+            capabilities: AgentCapabilities {
+                streaming: Some(true),
+                push_notifications: Some(false),
+                extensions: None,
+                extended_agent_card: Some(false),
+            },
+            default_input_modes: self.input_modes.clone(),
+            default_output_modes: self.output_modes.clone(),
+            skills: self
+                .skills
+                .iter()
+                .map(|skill| AgentSkill {
+                    id: skill.clone(),
+                    name: skill.clone(),
+                    description: format!("Mesh agent skill `{skill}`"),
+                    tags: vec![skill.clone()],
+                    examples: None,
+                    input_modes: Some(self.input_modes.clone()),
+                    output_modes: Some(self.output_modes.clone()),
+                    security_requirements: None,
+                })
+                .collect(),
+            provider: Some(a2a::AgentProvider {
+                organization: MESH_AGENT_CARD_PROVIDER.to_string(),
+                url: "https://github.com/Mesh-LLM/mesh-llm".to_string(),
+            }),
+            documentation_url: None,
+            icon_url: None,
+            security_schemes: None,
+            security_requirements: None,
+            signatures: None,
+        })
+    }
+}
+
+fn normalize_agent_id(value: &str) -> Result<String> {
+    let value = normalize_required(value, "agent id")?;
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        Ok(value.to_string())
+    } else {
+        bail!("agent id `{value}` must contain only ASCII letters, numbers, '.', '_' or '-'")
+    }
+}
+
+fn normalize_required<'a>(value: &'a str, label: &str) -> Result<&'a str> {
+    let value = value.trim();
+    if value.is_empty() {
+        bail!("{label} must not be empty");
+    }
+    Ok(value)
+}
+
+fn normalize_optional_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn normalize_string_list(values: &[String], label: &str) -> Result<Vec<String>> {
+    let mut out = Vec::new();
+    for value in values {
+        let value = normalize_required(value, label)?;
+        if !out.iter().any(|existing| existing == value) {
+            out.push(value.to_string());
+        }
+    }
+    Ok(out)
+}
+
+fn normalize_modes(values: &[String]) -> Vec<String> {
+    let modes: Vec<String> = values
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect();
+    if modes.is_empty() {
+        vec!["text".to_string()]
+    } else {
+        modes
+    }
+}
+
+fn validate_protocol_binding(entry: &AgentConfigEntry) -> Result<()> {
+    match entry.protocol {
+        AgentProtocol::A2a => {
+            let endpoint = entry
+                .endpoint
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("agent `{}` requires endpoint for a2a", entry.id))?;
+            validate_http_endpoint(endpoint, "agent endpoint")?;
+        }
+        AgentProtocol::Acp => {
+            let command = entry
+                .command
+                .as_deref()
+                .ok_or_else(|| anyhow::anyhow!("agent `{}` requires command for acp", entry.id))?;
+            normalize_required(command, "agent command")?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_http_endpoint(value: &str, label: &str) -> Result<()> {
+    let url =
+        Url::parse(value).map_err(|err| anyhow::anyhow!("invalid {label} `{value}`: {err}"))?;
+    match url.scheme() {
+        "http" | "https" => Ok(()),
+        scheme => bail!("{label} `{value}` must use http or https, got {scheme}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(raw: &str) -> MeshConfig {
+        mesh_llm_config::parse_config_toml(raw).unwrap()
+    }
+
+    #[test]
+    fn loads_enabled_a2a_agent_card_from_config() {
+        let config = config(
+            r#"
+version = 1
+
+[[agent]]
+id = "coder"
+name = "Coder"
+description = "Writes code through the mesh"
+protocol = "a2a"
+endpoint = "http://127.0.0.1:3131/agents/coder"
+skills = ["coding", "tools"]
+"#,
+        );
+
+        let directory = AgentDirectory::from_config(&config).unwrap();
+        let cards = directory.a2a_cards().unwrap();
+
+        assert_eq!(directory.summary().enabled, 1);
+        assert_eq!(cards[0].name, "Coder");
+        assert_eq!(
+            cards[0].supported_interfaces[0].protocol_binding,
+            A2A_JSONRPC_TRANSPORT
+        );
+        assert_eq!(cards[0].skills.len(), 2);
+    }
+
+    #[test]
+    fn rejects_duplicate_agent_ids() {
+        let config = MeshConfig {
+            agents: vec![
+                AgentConfigEntry {
+                    id: "coder".to_string(),
+                    name: "Coder".to_string(),
+                    description: "one".to_string(),
+                    protocol: AgentProtocol::Acp,
+                    command: Some("codex".to_string()),
+                    ..agent_defaults()
+                },
+                AgentConfigEntry {
+                    id: "coder".to_string(),
+                    name: "Coder 2".to_string(),
+                    description: "two".to_string(),
+                    protocol: AgentProtocol::Acp,
+                    command: Some("goose".to_string()),
+                    ..agent_defaults()
+                },
+            ],
+            ..MeshConfig::default()
+        };
+
+        let err = AgentDirectory::from_config(&config)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("duplicate agent id"));
+    }
+
+    fn agent_defaults() -> AgentConfigEntry {
+        AgentConfigEntry {
+            id: String::new(),
+            name: String::new(),
+            description: String::new(),
+            protocol: AgentProtocol::Acp,
+            enabled: None,
+            endpoint: None,
+            command: None,
+            args: Vec::new(),
+            skills: Vec::new(),
+            input_modes: Vec::new(),
+            output_modes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn validates_protocol_specific_entry_shape() {
+        let err = mesh_llm_config::parse_config_toml(
+            r#"
+version = 1
+
+[[agent]]
+id = "remote"
+name = "Remote"
+description = "Bad endpoint"
+protocol = "a2a"
+endpoint = "file:///tmp/socket"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("http or https"));
+    }
+}

--- a/crates/mesh-llm-acp-bridge/Cargo.toml
+++ b/crates/mesh-llm-acp-bridge/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "mesh-llm-acp-bridge"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "ACP bridge planning primitives for Mesh LLM agents"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+agent-client-protocol = "0.12.1"
+anyhow.workspace = true
+mesh-llm-a2a = { path = "../mesh-llm-a2a" }
+mesh-llm-config = { path = "../mesh-llm-config" }
+serde.workspace = true

--- a/crates/mesh-llm-acp-bridge/README.md
+++ b/crates/mesh-llm-acp-bridge/README.md
@@ -1,0 +1,6 @@
+# mesh-llm-acp-bridge
+
+ACP bridge planning primitives for Mesh LLM agents.
+
+This crate translates a configured mesh agent into a deterministic ACP launch
+plan. It intentionally does not spawn the agent process or run an ACP server.

--- a/crates/mesh-llm-acp-bridge/src/lib.rs
+++ b/crates/mesh-llm-acp-bridge/src/lib.rs
@@ -1,0 +1,111 @@
+use std::{any::type_name, collections::BTreeMap, path::PathBuf};
+
+use anyhow::{Result, bail};
+use mesh_llm_a2a::MeshAgent;
+use mesh_llm_config::AgentProtocol;
+use serde::Serialize;
+
+pub const MESH_ACP_BRIDGE_NAME: &str = "mesh-llm-acp-bridge";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct AcpBridgePlan {
+    pub agent_id: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub working_directory: Option<PathBuf>,
+    pub environment: BTreeMap<String, String>,
+    pub client_role_type: &'static str,
+    pub agent_role_type: &'static str,
+}
+
+impl AcpBridgePlan {
+    pub fn from_agent(agent: &MeshAgent) -> Result<Self> {
+        if agent.protocol != AgentProtocol::Acp {
+            bail!("agent `{}` is {:?}, not acp", agent.id, agent.protocol);
+        }
+        let command = agent
+            .command
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow::anyhow!("agent `{}` has no ACP command", agent.id))?;
+        Ok(Self {
+            agent_id: agent.id.clone(),
+            command: command.to_string(),
+            args: agent.args.clone(),
+            working_directory: None,
+            environment: bridge_environment(agent),
+            client_role_type: type_name::<agent_client_protocol::Client>(),
+            agent_role_type: type_name::<agent_client_protocol::Agent>(),
+        })
+    }
+}
+
+fn bridge_environment(agent: &MeshAgent) -> BTreeMap<String, String> {
+    let mut environment = BTreeMap::new();
+    environment.insert("MESH_LLM_AGENT_ID".to_string(), agent.id.clone());
+    environment.insert("MESH_LLM_AGENT_NAME".to_string(), agent.name.clone());
+    environment.insert(
+        "MESH_LLM_ACP_BRIDGE".to_string(),
+        MESH_ACP_BRIDGE_NAME.to_string(),
+    );
+    environment
+}
+
+#[cfg(test)]
+mod tests {
+    use mesh_llm_a2a::AgentDirectory;
+
+    use super::*;
+
+    #[test]
+    fn builds_acp_launch_plan_from_configured_agent() {
+        let config = mesh_llm_config::parse_config_toml(
+            r#"
+version = 1
+
+[[agent]]
+id = "codex"
+name = "Codex"
+description = "Local coding agent"
+protocol = "acp"
+command = "codex"
+args = ["--model", "gpt-5"]
+"#,
+        )
+        .unwrap();
+        let directory = AgentDirectory::from_config(&config).unwrap();
+        let agent = directory.get("codex").unwrap();
+
+        let plan = AcpBridgePlan::from_agent(agent).unwrap();
+
+        assert_eq!(plan.command, "codex");
+        assert_eq!(plan.args, ["--model", "gpt-5"]);
+        assert_eq!(plan.environment["MESH_LLM_AGENT_ID"], "codex");
+        assert!(plan.client_role_type.contains("Client"));
+        assert!(plan.agent_role_type.contains("Agent"));
+    }
+
+    #[test]
+    fn rejects_non_acp_agent() {
+        let config = mesh_llm_config::parse_config_toml(
+            r#"
+version = 1
+
+[[agent]]
+id = "remote"
+name = "Remote"
+description = "Remote A2A agent"
+protocol = "a2a"
+endpoint = "https://agents.example.com/remote"
+"#,
+        )
+        .unwrap();
+        let directory = AgentDirectory::from_config(&config).unwrap();
+        let agent = directory.get("remote").unwrap();
+
+        let err = AcpBridgePlan::from_agent(agent).unwrap_err().to_string();
+
+        assert!(err.contains("not acp"));
+    }
+}

--- a/crates/mesh-llm-config/Cargo.toml
+++ b/crates/mesh-llm-config/Cargo.toml
@@ -15,6 +15,7 @@ skippy-protocol = { path = "../skippy-protocol" }
 toml = "0.9"
 toml_edit = "0.25"
 dirs = "6.0.0"
+url.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/mesh-llm-config/src/lib.rs
+++ b/crates/mesh-llm-config/src/lib.rs
@@ -14,8 +14,8 @@ pub use validate::validate_config;
 #[cfg(test)]
 mod tests {
     use super::{
-        ConfigStore, GpuAssignment, LocalServingNodeConfig, MeshConfig, ModelRuntimeKind,
-        parse_config_toml,
+        AgentProtocol, ConfigStore, GpuAssignment, LocalServingNodeConfig, MeshConfig,
+        ModelRuntimeKind, parse_config_toml,
     };
     use std::fs;
     use tempfile::TempDir;
@@ -206,6 +206,55 @@ reconcile_model_targets = true
         .unwrap();
 
         assert!(config.runtime.reconcile_model_targets);
+    }
+
+    #[test]
+    fn agent_directory_deserializes_from_toml() {
+        let config = parse_config_toml(
+            r#"
+version = 1
+
+[[agent]]
+id = "codex"
+name = "Codex"
+description = "Local coding agent"
+protocol = "acp"
+command = "codex"
+
+[[agent]]
+id = "remote-coder"
+name = "Remote Coder"
+description = "Remote A2A coding agent"
+protocol = "a2a"
+endpoint = "https://agents.example.com/remote-coder"
+skills = ["coding"]
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.agents.len(), 2);
+        assert_eq!(config.agents[0].protocol, AgentProtocol::Acp);
+        assert_eq!(config.agents[1].protocol, AgentProtocol::A2a);
+    }
+
+    #[test]
+    fn agent_directory_rejects_wrong_protocol_target() {
+        let err = parse_config_toml(
+            r#"
+version = 1
+
+[[agent]]
+id = "remote"
+name = "Remote"
+description = "bad"
+protocol = "a2a"
+endpoint = "file:///tmp/agent.sock"
+"#,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(err.contains("must use http or https"));
     }
 
     #[test]

--- a/crates/mesh-llm-config/src/model.rs
+++ b/crates/mesh-llm-config/src/model.rs
@@ -24,6 +24,8 @@ pub struct MeshConfig {
     pub models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     pub plugins: Vec<PluginConfigEntry>,
+    #[serde(rename = "agent", default)]
+    pub agents: Vec<AgentConfigEntry>,
     #[serde(flatten, default)]
     pub extra: BTreeMap<String, toml::Value>,
 }
@@ -618,6 +620,8 @@ struct RawMeshConfig {
     models: Vec<ModelConfigEntry>,
     #[serde(rename = "plugin", default)]
     plugins: Vec<PluginConfigEntry>,
+    #[serde(rename = "agent", default)]
+    agents: Vec<AgentConfigEntry>,
     #[serde(flatten, default)]
     extra: BTreeMap<String, toml::Value>,
 }
@@ -715,6 +719,7 @@ impl<'de> Deserialize<'de> for MeshConfig {
             runtime: raw.runtime,
             models: raw.models,
             plugins: raw.plugins,
+            agents: raw.agents,
             extra: raw.extra,
         })
     }
@@ -948,4 +953,33 @@ pub struct PluginConfigEntry {
     /// Optional URL passed to the plugin as `MESH_LLM_PLUGIN_URL`.
     #[serde(default)]
     pub url: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentProtocol {
+    A2a,
+    Acp,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct AgentConfigEntry {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub protocol: AgentProtocol,
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub endpoint: Option<String>,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default)]
+    pub skills: Vec<String>,
+    #[serde(default)]
+    pub input_modes: Vec<String>,
+    #[serde(default)]
+    pub output_modes: Vec<String>,
 }

--- a/crates/mesh-llm-config/src/validate.rs
+++ b/crates/mesh-llm-config/src/validate.rs
@@ -30,6 +30,7 @@ pub fn validate_config(config: &MeshConfig) -> Result<()> {
     }
     validate_mesh_requirements_config(&config.mesh_requirements)?;
     validate_telemetry_config(&config.telemetry)?;
+    validate_agents(&config.agents)?;
     let defaults_hardware = config
         .defaults
         .as_ref()
@@ -47,6 +48,50 @@ pub fn validate_config(config: &MeshConfig) -> Result<()> {
             config.gpu.assignment,
             defaults_hardware,
         )?;
+    }
+    Ok(())
+}
+
+fn validate_agents(agents: &[AgentConfigEntry]) -> Result<()> {
+    let mut seen = std::collections::BTreeSet::new();
+    for (index, agent) in agents.iter().enumerate() {
+        let base_path = format!("agent[{index}]");
+        validate_agent_id(&agent.id, &format!("{base_path}.id"))?;
+        if !seen.insert(agent.id.trim()) {
+            bail!("{base_path}.id duplicates another configured agent");
+        }
+        validate_non_empty(&agent.name, &format!("{base_path}.name"))?;
+        validate_non_empty(&agent.description, &format!("{base_path}.description"))?;
+        validate_string_list(&agent.skills, &format!("{base_path}.skills"))?;
+        validate_string_list(&agent.input_modes, &format!("{base_path}.input_modes"))?;
+        validate_string_list(&agent.output_modes, &format!("{base_path}.output_modes"))?;
+        validate_agent_protocol(agent, &base_path)?;
+    }
+    Ok(())
+}
+
+fn validate_agent_id(value: &str, path: &str) -> Result<()> {
+    validate_non_empty(value, path)?;
+    let value = value.trim();
+    if value
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.'))
+    {
+        Ok(())
+    } else {
+        bail!("{path} must contain only ASCII letters, numbers, '.', '_' or '-'");
+    }
+}
+
+fn validate_agent_protocol(agent: &AgentConfigEntry, base_path: &str) -> Result<()> {
+    match agent.protocol {
+        AgentProtocol::A2a => {
+            validate_required_string(agent.endpoint.as_deref(), &format!("{base_path}.endpoint"))?;
+            validate_http_url(agent.endpoint.as_deref(), &format!("{base_path}.endpoint"))?;
+        }
+        AgentProtocol::Acp => {
+            validate_required_string(agent.command.as_deref(), &format!("{base_path}.command"))?;
+        }
     }
     Ok(())
 }
@@ -827,6 +872,26 @@ fn validate_non_empty(value: &str, path: &str) -> Result<()> {
         bail!("{path} must not be empty when set");
     }
     Ok(())
+}
+
+fn validate_required_string(value: Option<&str>, path: &str) -> Result<()> {
+    match value {
+        Some(value) => validate_non_empty(value, path),
+        None => bail!("{path} must be set"),
+    }
+}
+
+fn validate_http_url(value: Option<&str>, path: &str) -> Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    validate_non_empty(value, path)?;
+    let parsed =
+        url::Url::parse(value).map_err(|err| anyhow::anyhow!("{path} is invalid: {err}"))?;
+    match parsed.scheme() {
+        "http" | "https" => Ok(()),
+        scheme => bail!("{path} must use http or https, got {scheme}"),
+    }
 }
 
 fn validate_optional_enum(value: Option<&str>, allowed: &[&str], path: &str) -> Result<()> {

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -20,6 +20,8 @@ workspace = true
 ansi-to-tui = "8"
 bytes = "1"
 mesh-mixture-of-agents = { path = "../mesh-mixture-of-agents" }
+mesh-llm-a2a = { path = "../mesh-llm-a2a" }
+mesh-llm-acp-bridge = { path = "../mesh-llm-acp-bridge" }
 mesh-llm-config = { path = "../mesh-llm-config" }
 mesh-llm-plugin = { path = "../mesh-llm-plugin" }
 mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager" }

--- a/crates/mesh-llm-host-runtime/src/cli/commands/agents.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/agents.rs
@@ -1,0 +1,205 @@
+use anyhow::{Context, Result, bail};
+use mesh_llm_a2a::{AgentDirectory, MeshAgent};
+use mesh_llm_acp_bridge::AcpBridgePlan;
+use serde::Serialize;
+
+use crate::cli::{AgentCommand, Cli};
+use crate::plugin;
+
+pub(crate) fn run_agents_command(command: &AgentCommand, cli: &Cli) -> Result<()> {
+    let directory = load_directory(cli)?;
+    match command {
+        AgentCommand::List { json } => list_agents(&directory, *json),
+        AgentCommand::Show { id, json } => show_agent(&directory, id, *json),
+        AgentCommand::Validate { json } => validate_agents(&directory, *json),
+    }
+}
+
+fn load_directory(cli: &Cli) -> Result<AgentDirectory> {
+    let config = plugin::load_config(cli.config.as_deref())?;
+    AgentDirectory::from_config(&config).context("invalid agent directory")
+}
+
+fn list_agents(directory: &AgentDirectory, json: bool) -> Result<()> {
+    if json {
+        print_json(&directory.summary())
+    } else {
+        print_agent_table(directory.agents());
+        Ok(())
+    }
+}
+
+fn show_agent(directory: &AgentDirectory, id: &str, json: bool) -> Result<()> {
+    let agent = directory
+        .get(id)
+        .ok_or_else(|| anyhow::anyhow!("agent `{id}` is not configured"))?;
+    if json {
+        print_json(&AgentDetail::from_agent(agent)?)
+    } else {
+        print_agent_detail(agent)
+    }
+}
+
+fn validate_agents(directory: &AgentDirectory, json: bool) -> Result<()> {
+    let report = ValidationReport {
+        status: "ok",
+        total: directory.agents().len(),
+        enabled: directory.enabled_agents().count(),
+        a2a_cards: directory.a2a_cards()?.len(),
+        acp_bridge_plans: directory
+            .enabled_agents()
+            .filter(|agent| agent.protocol == mesh_llm_config::AgentProtocol::Acp)
+            .map(AcpBridgePlan::from_agent)
+            .collect::<Result<Vec<_>>>()?
+            .len(),
+    };
+
+    if json {
+        print_json(&report)
+    } else {
+        println!(
+            "Agent directory ok: {} configured, {} enabled, {} A2A cards, {} ACP bridge plans",
+            report.total, report.enabled, report.a2a_cards, report.acp_bridge_plans
+        );
+        Ok(())
+    }
+}
+
+fn print_agent_table(agents: &[MeshAgent]) {
+    if agents.is_empty() {
+        println!("No agents configured.");
+        return;
+    }
+    println!("ID\tPROTOCOL\tENABLED\tTARGET\tNAME");
+    for agent in agents {
+        println!(
+            "{}\t{}\t{}\t{}\t{}",
+            agent.id,
+            protocol_label(agent.protocol),
+            agent.enabled,
+            agent_target(agent),
+            agent.name
+        );
+    }
+}
+
+fn print_agent_detail(agent: &MeshAgent) -> Result<()> {
+    println!("id: {}", agent.id);
+    println!("name: {}", agent.name);
+    println!("description: {}", agent.description);
+    println!("protocol: {}", protocol_label(agent.protocol));
+    println!("enabled: {}", agent.enabled);
+    println!("target: {}", agent_target(agent));
+    if !agent.skills.is_empty() {
+        println!("skills: {}", agent.skills.join(", "));
+    }
+    if agent.protocol == mesh_llm_config::AgentProtocol::Acp {
+        let plan = AcpBridgePlan::from_agent(agent)?;
+        println!("bridge: {}", plan.command);
+    }
+    Ok(())
+}
+
+fn agent_target(agent: &MeshAgent) -> String {
+    agent
+        .endpoint
+        .clone()
+        .or_else(|| agent.command.clone())
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn protocol_label(protocol: mesh_llm_config::AgentProtocol) -> &'static str {
+    match protocol {
+        mesh_llm_config::AgentProtocol::A2a => "a2a",
+        mesh_llm_config::AgentProtocol::Acp => "acp",
+    }
+}
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+#[derive(Serialize)]
+struct ValidationReport {
+    status: &'static str,
+    total: usize,
+    enabled: usize,
+    a2a_cards: usize,
+    acp_bridge_plans: usize,
+}
+
+#[derive(Serialize)]
+struct AgentDetail<'a> {
+    agent: &'a MeshAgent,
+    a2a_card: Option<serde_json::Value>,
+    acp_bridge_plan: Option<AcpBridgePlan>,
+}
+
+impl<'a> AgentDetail<'a> {
+    fn from_agent(agent: &'a MeshAgent) -> Result<Self> {
+        let a2a_card = match agent.protocol {
+            mesh_llm_config::AgentProtocol::A2a => {
+                Some(serde_json::to_value(agent.to_a2a_card()?)?)
+            }
+            mesh_llm_config::AgentProtocol::Acp => None,
+        };
+        let acp_bridge_plan = match agent.protocol {
+            mesh_llm_config::AgentProtocol::A2a => None,
+            mesh_llm_config::AgentProtocol::Acp => Some(AcpBridgePlan::from_agent(agent)?),
+        };
+        if a2a_card.is_none() && acp_bridge_plan.is_none() {
+            bail!("agent `{}` has no supported protocol projection", agent.id);
+        }
+        Ok(Self {
+            agent,
+            a2a_card,
+            acp_bridge_plan,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn cli_with_config(path: &std::path::Path) -> Cli {
+        use clap::Parser;
+
+        Cli::parse_from([
+            "mesh-llm",
+            "--config",
+            path.to_str().unwrap(),
+            "agents",
+            "list",
+        ])
+    }
+
+    #[test]
+    fn loads_agent_directory_from_cli_config() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"
+version = 1
+
+[[agent]]
+id = "codex"
+name = "Codex"
+description = "Local coding agent"
+protocol = "acp"
+command = "codex"
+"#,
+        )
+        .unwrap();
+
+        let cli = cli_with_config(&config_path);
+        let directory = load_directory(&cli).unwrap();
+
+        assert_eq!(directory.summary().total, 1);
+        assert_eq!(directory.summary().acp, 1);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/mod.rs
@@ -1,4 +1,5 @@
 mod agent_cli;
+mod agents;
 mod auth;
 mod benchmark;
 mod discover;
@@ -16,6 +17,7 @@ mod update;
 use anyhow::Result;
 
 use crate::cli::commands::agent_cli::{run_claude, run_goose, run_opencode, run_pi};
+use crate::cli::commands::agents::run_agents_command;
 use crate::cli::commands::benchmark::dispatch_benchmark_command;
 use crate::cli::commands::discover::{DiscoverOptions, run_discover, run_stop};
 use crate::cli::commands::doctor::dispatch_doctor_command;
@@ -62,6 +64,10 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
         }
         Command::Runtime { command } => dispatch_runtime_command(command.as_ref()).await,
         Command::Doctor { command } => dispatch_doctor_command(command).await,
+        Command::Agents { command } => {
+            run_agents_command(command, cli)?;
+            Ok(())
+        }
         Command::Load { name, port } => run_load(name, *port).await,
         Command::Unload { name, port } => run_drop(name, *port).await,
         Command::Status { port } => run_status(*port).await,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
@@ -568,6 +568,7 @@ mod tests {
             mesh_requirements: Default::default(),
             models: Vec::new(),
             plugins: Vec::new(),
+            agents: Vec::new(),
             owner_control: Default::default(),
             telemetry: Default::default(),
             defaults: None,

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -667,6 +667,11 @@ pub(crate) enum Command {
         #[command(subcommand)]
         command: DoctorCommand,
     },
+    /// Inspect configured A2A/ACP agents without starting them.
+    Agents {
+        #[command(subcommand)]
+        command: AgentCommand,
+    },
     /// Load a local model into a running mesh-llm instance.
     Load {
         /// Model name/path/url to load
@@ -908,6 +913,30 @@ pub(crate) enum PluginCommand {
     },
     /// List installed, auto-registered, and configured plugins.
     List,
+}
+
+#[derive(Subcommand, Debug)]
+pub(crate) enum AgentCommand {
+    /// List configured agents.
+    List {
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show one configured agent and its protocol projection.
+    Show {
+        /// Agent id from [[agent]].id.
+        id: String,
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Validate the configured agent directory.
+    Validate {
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -1078,6 +1078,7 @@ fn legacy_proto_config_to_mesh(
         runtime: Default::default(),
         models,
         plugins,
+        agents: Default::default(),
         extra: Default::default(),
     }
 }

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -2026,6 +2026,7 @@ alias = "model-alias"
                 args: vec!["--plugin".to_string()],
                 url: None,
             }],
+            agents: vec![],
             extra: Default::default(),
         };
         let snapshot = mesh_config_to_proto(&config);
@@ -2083,6 +2084,7 @@ alias = "model-alias"
             runtime: Default::default(),
             models: vec![],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
         let snapshot = mesh_config_to_proto(&original);
@@ -2219,6 +2221,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
         let snap1 = mesh_config_to_proto(&config);
@@ -2252,6 +2255,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
         let snap3 = mesh_config_to_proto(&config2);
@@ -2319,6 +2323,7 @@ alias = "model-alias"
                 ..Default::default()
             }],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
 

--- a/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
@@ -249,6 +249,7 @@ mod tests {
             runtime: Default::default(),
             models: vec![],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         }
     }
@@ -576,6 +577,7 @@ reasoning_format = "qwen"
                 ..Default::default()
             }],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
 
@@ -622,6 +624,7 @@ reasoning_format = "qwen"
                 ..Default::default()
             }],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
         state.apply(config_with_model, 0);
@@ -781,6 +784,7 @@ temperature = 0.2
                 ..Default::default()
             }],
             plugins: vec![],
+            agents: vec![],
             extra: Default::default(),
         };
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -257,6 +257,44 @@ reusable `nightly-stability-run.yml` workflow, which owns the harness run,
 artifact upload, and timing summary. Treat this as a trend/evidence harness,
 not a required PR gate.
 
+## Agent Directory
+
+Mesh LLM can read a local agent directory from `~/.mesh-llm/config.toml`.
+This is a control-plane registry only: it validates A2A/ACP agent metadata and
+lets operators inspect the projected A2A card or ACP bridge plan without
+starting an agent process or publishing anything to the mesh.
+
+```toml
+[[agent]]
+id = "codex"
+name = "Codex"
+description = "Local coding agent"
+protocol = "acp"
+command = "codex"
+args = ["--model", "gpt-5"]
+skills = ["coding", "tool-use"]
+
+[[agent]]
+id = "remote-coder"
+name = "Remote Coder"
+description = "Remote A2A-compatible coding agent"
+protocol = "a2a"
+endpoint = "https://agents.example.com/remote-coder"
+skills = ["coding"]
+```
+
+Inspect the directory:
+
+```bash
+mesh-llm agents list
+mesh-llm agents show codex --json
+mesh-llm agents validate
+```
+
+`protocol = "a2a"` requires an HTTP(S) `endpoint`. `protocol = "acp"`
+requires a local `command`; the current bridge plan is metadata-only and does
+not spawn the command.
+
 ## curl or any OpenAI client
 
 ```bash

--- a/scripts/affected-crates.sh
+++ b/scripts/affected-crates.sh
@@ -23,6 +23,8 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-plugin"
   "mesh-llm-skills"
   "mesh-llm-plugin-manager"
+  "mesh-llm-a2a"
+  "mesh-llm-acp-bridge"
   "mesh-llm-client"
   "mesh-mixture-of-agents"
   "mesh-llm-api-client"

--- a/scripts/plan-clippy-batches.sh
+++ b/scripts/plan-clippy-batches.sh
@@ -26,6 +26,8 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-plugin"
   "mesh-llm-skills"
   "mesh-llm-plugin-manager"
+  "mesh-llm-a2a"
+  "mesh-llm-acp-bridge"
   "mesh-llm-client"
   "mesh-llm-api-client"
   "mesh-llm-api-server"


### PR DESCRIPTION
## Summary

This adds the first safe substrate for A2A/ACP agents in mesh-llm: operators can now describe local or remote agents in `~/.mesh-llm/config.toml`, validate that directory, inspect configured agents, and project either an A2A agent card or an ACP bridge plan without starting agent processes or publishing anything to the mesh.

The goal is to make the agent surface concrete enough to build on, while deliberately stopping before execution, server exposure, gossip advertisement, or cross-node routing semantics.

## Why

Issue #692 needs a real agent foundation, not another loose integration stub. A2A and ACP are protocol-shaped surfaces with different trust and execution boundaries:

- A2A agents are remote HTTP(S) endpoints with official A2A agent-card projection.
- ACP agents are local command-backed agents with a deterministic launch/bridge plan.

This PR establishes those boundaries in config, validation, libraries, and CLI inspection so later PRs can add serving/execution paths without mixing protocol metadata, process spawning, and mesh discovery in one risky change.

## Diff Scope

- Adds `mesh-llm-a2a`, a non-published workspace crate using the official `a2a-lf` crate for agent-card projection.
- Adds `mesh-llm-acp-bridge`, a non-published workspace crate using the official `agent-client-protocol` crate for ACP bridge planning.
- Extends `mesh-llm-config` with `[[agent]]` entries, protocol-specific validation, and tests.
- Adds `mesh-llm agents list`, `mesh-llm agents show <id>`, and `mesh-llm agents validate` for local operator inspection.
- Updates `docs/AGENTS.md` with config examples and command usage.
- Updates workspace crate-list tooling so affected-crate and clippy planning know about the new crates.

## Explicit Non-Goals

- Does not spawn ACP agent commands.
- Does not host an A2A server.
- Does not gossip agent cards across the mesh.
- Does not change OpenAI routing, model routing, or agent execution semantics.
- Does not change the mesh wire protocol.

## Example Config

```toml
[[agent]]
id = "codex"
name = "Codex"
description = "Local coding agent"
protocol = "acp"
command = "codex"
args = ["--model", "gpt-5"]
skills = ["coding", "tool-use"]

[[agent]]
id = "remote-coder"
name = "Remote Coder"
description = "Remote A2A-compatible coding agent"
protocol = "a2a"
endpoint = "https://agents.example.com/remote-coder"
skills = ["coding"]
```

## Example Commands

```bash
mesh-llm agents list
mesh-llm agents show codex --json
mesh-llm agents validate
```

Representative text output:

```text
ID      PROTOCOL        ENABLED TARGET  NAME
codex   acp             true    codex   Codex
```

## Branch Integrity

- Base branch: `main`
- Validated base: `fef0f4deddadca3e7d95b8b86e52fa3a60ca0942`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `fef0f4deddadca3e7d95b8b86e52fa3a60ca0942`
- Introduced commit: `9da57ff3 Add A2A and ACP agent substrate`

## Commit Integrity

One logical commit is introduced. The final diff contains only agent substrate, config validation, CLI inspection, documentation, dependency lockfile, and crate-list updates required for the new workspace crates.

## Diff Hygiene

- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `git diff --check origin/main...HEAD`: PASS, no output.

## Validation

Validation tier: Tier 4 - agent control-plane substrate for issue #692; adds config schema, official A2A/ACP protocol crate adapters, CLI inspection, and workspace crate-list consistency without agent execution, gossip, or mesh protocol advertisement.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `fef0f4deddadca3e7d95b8b86e52fa3a60ca0942`.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all`: PASS.
- `cargo fmt --all -- --check`: PASS.
- `cargo check -p mesh-llm-a2a -p mesh-llm-acp-bridge -p mesh-llm`: PASS.
- `cargo test -p mesh-llm-config agent --lib -- --test-threads=1`: PASS, 2 passed.
- `cargo test -p mesh-llm-a2a --lib -- --test-threads=1`: PASS, 3 passed.
- `cargo test -p mesh-llm-acp-bridge --lib -- --test-threads=1`: PASS, 2 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime agents --lib -- --test-threads=1`: PASS, 1 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal /opt/homebrew/bin/cargo-clippy clippy -p mesh-llm-config -p mesh-llm-a2a -p mesh-llm-acp-bridge -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.
- `cargo run -p xtask -- repo-consistency ci-crate-lists`: PASS.
- `cargo run -p xtask -- repo-consistency publish-crates`: PASS.
- `cargo run -p xtask -- repo-consistency release-targets`: PASS.

## Ledger / Version

- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - no release/version sync required; Cargo.lock dependency updates are scoped to the new non-published agent substrate crates.

## Not Run

- Live A2A/ACP handshake/server smoke: not required because this PR only creates local config/directory/bridge-plan surfaces and does not spawn or expose agents.
- Live multi-node mesh/gossip smoke: not required because no mesh gossip/protocol advertisement path changed.

## Runtime Safety

- No new process spawning.
- No new network listener.
- No new mesh gossip field or protocol message.
- No new OpenAI routing behavior.
- No new blocking locks or unbounded queues.
- No invariant regression introduced.

## Documentation Integrity

`docs/AGENTS.md` now documents the local agent directory shape, protocol-specific requirements, and inspection commands.

## Rollback Plan

Rollback: revert this PR.

```bash
git revert <post_merge_commit_sha>
```

DB downgrade: not applicable.
Data repair: not applicable.
Operational caveats: none known. Since this PR is config/CLI/control-plane only, rollback removes the agent directory schema and inspection commands without runtime migration.

## Known Residual Risks

The next PRs still need the real execution and distribution layers: ACP process lifecycle, A2A serving/handshake behavior, security review for agent exposure, and any future mesh advertisement/routing semantics. Those are intentionally left out of this substrate PR.
