### PR TITLE
Harden LAN-only mDNS discovery

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/http.rs
+++ b/crates/mesh-llm-host-runtime/src/api/http.rs
@@ -19,6 +19,7 @@ pub(super) async fn respond_error(
         .unwrap_or_else(|_| r#"{"error":"internal error"}"#.to_string());
     let status = match code {
         400 => "Bad Request",
+        403 => "Forbidden",
         404 => "Not Found",
         409 => "Conflict",
         422 => "Unprocessable Content",

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -23,7 +23,8 @@
 //!   DELETE /api/runtime/models/{model} — unload a local model
 //!   DELETE /api/runtime/instances/{instance_id} — unload one local runtime instance
 //!   GET  /api/events    — SSE stream of status updates
-//!   GET  /api/discover  — browse Nostr-published meshes
+//!   GET  /api/discover  — browse Nostr meshes or LAN mDNS advertisements
+//!   POST /api/discovery/lan-details — invite-token proof-gated LAN detail
 //!   POST /api/chat      — proxy to chat completions API
 //!   POST /api/responses — proxy to responses API
 //!   POST /api/objects   — upload a request-scoped media object
@@ -239,6 +240,8 @@ impl MeshApi {
                 api_port,
                 model_size_bytes,
                 mesh_name: None,
+                mesh_region: None,
+                mesh_max_clients: None,
                 latest_version: None,
                 nostr_relays: nostr::DEFAULT_RELAYS
                     .iter()
@@ -375,8 +378,16 @@ impl MeshApi {
             });
     }
 
-    pub async fn set_mesh_name(&self, name: String) {
-        self.inner.lock().await.mesh_name = Some(name);
+    pub async fn set_mesh_publication_metadata(
+        &self,
+        name: Option<String>,
+        region: Option<String>,
+        max_clients: Option<usize>,
+    ) {
+        let mut inner = self.inner.lock().await;
+        inner.mesh_name = name;
+        inner.mesh_region = region;
+        inner.mesh_max_clients = max_clients;
     }
 
     pub async fn set_nostr_relays(&self, relays: Vec<String>) {

--- a/crates/mesh-llm-host-runtime/src/api/routes/discover.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/discover.rs
@@ -1,4 +1,7 @@
-use super::super::{MeshApi, http::respond_error};
+use super::super::{
+    MeshApi,
+    http::{respond_error, respond_json},
+};
 use crate::network::{discovery, nostr};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
@@ -42,4 +45,67 @@ pub(super) async fn handle(stream: &mut TcpStream, state: &MeshApi) -> anyhow::R
         Err(_) => respond_error(stream, 500, "Failed to serialize").await?,
     }
     Ok(())
+}
+
+pub(super) async fn handle_lan_details(
+    stream: &mut TcpStream,
+    state: &MeshApi,
+    body: &str,
+) -> anyhow::Result<()> {
+    let request = match serde_json::from_str::<discovery::LanDetailsProofRequest>(body) {
+        Ok(request) => request,
+        Err(err) => {
+            respond_error(stream, 400, &format!("Invalid JSON body: {err}")).await?;
+            return Ok(());
+        }
+    };
+    let (mode, node, mesh_name, mesh_region, mesh_max_clients) = {
+        let inner = state.inner.lock().await;
+        (
+            inner.mesh_discovery_mode,
+            inner.node.clone(),
+            inner.mesh_name.clone(),
+            inner.mesh_region.clone(),
+            inner.mesh_max_clients,
+        )
+    };
+    if mode != discovery::MeshDiscoveryMode::Mdns {
+        respond_error(
+            stream,
+            404,
+            "LAN discovery details are only available in mDNS discovery mode",
+        )
+        .await?;
+        return Ok(());
+    }
+
+    let invite_token = node.invite_token().await;
+    if !discovery::verify_lan_details_token_proof(
+        &invite_token,
+        &request.token_fingerprint,
+        &request.challenge,
+        &request.proof,
+        current_unix_secs(),
+    ) {
+        respond_error(stream, 403, "Invalid LAN discovery proof").await?;
+        return Ok(());
+    }
+
+    let listing =
+        discovery::build_local_mesh_listing(&node, mesh_name, mesh_region, mesh_max_clients).await;
+    let response = discovery::LanDetailsResponse::from_local_listing(
+        listing,
+        request.token_fingerprint,
+        request.challenge,
+        Some(crate::VERSION),
+    );
+    respond_json(stream, 200, &response).await?;
+    Ok(())
+}
+
+fn current_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
 }

--- a/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
@@ -35,6 +35,10 @@ pub(super) const DISPATCH_REQUEST: DispatchRequestFn =
                     discover::handle(stream, state).await?;
                     Ok(true)
                 }
+                ("POST", p) if p == crate::network::discovery::LAN_DETAILS_PATH => {
+                    discover::handle_lan_details(stream, state, body).await?;
+                    Ok(true)
+                }
                 ("GET", "/api/diagnostics/split-readiness") => {
                     diagnostics::handle(stream, state, path).await?;
                     Ok(true)

--- a/crates/mesh-llm-host-runtime/src/api/state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/state.rs
@@ -199,6 +199,8 @@ pub(super) struct ApiInner {
     pub(super) api_port: u16,
     pub(super) model_size_bytes: u64,
     pub(super) mesh_name: Option<String>,
+    pub(super) mesh_region: Option<String>,
+    pub(super) mesh_max_clients: Option<usize>,
     pub(super) latest_version: Option<String>,
     pub(super) nostr_relays: Vec<String>,
     pub(super) mesh_discovery_mode: MeshDiscoveryMode,

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -3963,6 +3963,58 @@ data: [DONE]
 }
 
 #[tokio::test]
+async fn lan_details_uses_same_publication_metadata_as_mdns_advertisement() {
+    let state = build_test_mesh_api().await;
+    state
+        .set_mesh_discovery_mode(crate::network::discovery::MeshDiscoveryMode::Mdns)
+        .await;
+    state
+        .set_mesh_publication_metadata(
+            Some("garage-mesh".to_string()),
+            Some("workshop".to_string()),
+            Some(7),
+        )
+        .await;
+
+    let invite_token = state.node().await.invite_token().await;
+    let token_fingerprint = crate::network::discovery::lan_token_fingerprint(&invite_token);
+    let challenge = crate::network::discovery::lan_details_challenge(
+        &token_fingerprint,
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs(),
+    );
+    let proof = crate::network::discovery::lan_details_token_proof(&invite_token, &challenge);
+    let body = serde_json::json!({
+        "token_fingerprint": token_fingerprint,
+        "challenge": challenge,
+        "proof": proof,
+    })
+    .to_string();
+    let request = format!(
+        "POST {} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
+        crate::network::discovery::LAN_DETAILS_PATH,
+        body.len(),
+        body,
+    );
+    let (addr, handle) = spawn_management_test_server(state).await;
+    let response = send_management_request(addr, request).await;
+
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK"),
+        "expected LAN details success, got: {response}"
+    );
+    let payload = json_body(&response);
+    assert_eq!(payload["listing"]["name"], "garage-mesh");
+    assert_eq!(payload["listing"]["region"], "workshop");
+    assert_eq!(payload["listing"]["max_clients"], 7);
+    assert_eq!(payload["listing"]["invite_token"], "");
+
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn status_payload_populates_local_instances_from_scanner() {
     use crate::runtime::instance::LocalInstanceSnapshot;
     use std::path::PathBuf;

--- a/crates/mesh-llm-host-runtime/src/network/discovery.rs
+++ b/crates/mesh-llm-host-runtime/src/network/discovery.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::ValueEnum;
 use mdns_sd::{DaemonStatus, ResolvedService, ServiceDaemon, ServiceEvent, ServiceInfo};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -9,9 +9,14 @@ use std::time::Duration;
 use crate::network::nostr;
 
 pub(crate) const LAN_SERVICE_TYPE: &str = "_mesh-llm._tcp.local.";
+pub(crate) const LAN_DETAILS_PATH: &str = "/api/discovery/lan-details";
 const TXT_SCHEMA_VERSION: u8 = 1;
 const TXT_LIST_SEPARATOR: char = '|';
 const TXT_VALUE_LIMIT: usize = 220;
+const LAN_DETAILS_CHALLENGE_WINDOW_SECS: u64 = 300;
+const LAN_INVITE_TOKEN_FINGERPRINT_DOMAIN: &[u8] = b"mesh-llm-lan-invite-token-v1\0";
+const LAN_DETAILS_CHALLENGE_DOMAIN: &[u8] = b"mesh-llm-lan-details-challenge-v1\0";
+const LAN_DETAILS_TOKEN_PROOF_DOMAIN: &[u8] = b"mesh-llm-lan-details-proof-v1\0";
 const DAEMON_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
@@ -79,6 +84,8 @@ pub(crate) struct LanMeshAdvertisement {
     pub(crate) client_count: usize,
     pub(crate) max_clients: usize,
     pub(crate) token_fingerprint: Option<String>,
+    pub(crate) details_path: Option<String>,
+    pub(crate) proof_challenge: Option<String>,
     pub(crate) app_version: Option<String>,
     pub(crate) join_material: LanJoinMaterial,
 }
@@ -88,6 +95,7 @@ impl LanMeshAdvertisement {
         listing: &nostr::MeshListing,
         supplied_invite_token: Option<&str>,
         app_version: Option<&str>,
+        details_reachable: bool,
     ) -> Self {
         // LAN discovery intentionally publishes only a fingerprint of the join
         // token so mDNS remains an untrusted pointer surface rather than a
@@ -99,6 +107,16 @@ impl LanMeshAdvertisement {
                 (!listing.invite_token.trim().is_empty())
                     .then(|| lan_token_fingerprint(&listing.invite_token))
             });
+        let proof_challenge = if details_reachable {
+            token_fingerprint
+                .as_deref()
+                .map(|fingerprint| lan_details_challenge(fingerprint, current_unix_secs()))
+        } else {
+            None
+        };
+        let details_path = proof_challenge
+            .as_ref()
+            .map(|_| LAN_DETAILS_PATH.to_string());
 
         Self {
             mesh_id: listing.mesh_id.clone(),
@@ -112,6 +130,8 @@ impl LanMeshAdvertisement {
             client_count: listing.client_count,
             max_clients: listing.max_clients,
             token_fingerprint,
+            details_path,
+            proof_challenge,
             app_version: app_version.map(str::to_owned),
             join_material: LanJoinMaterial::RequiresSuppliedToken,
         }
@@ -145,6 +165,8 @@ impl LanMeshAdvertisement {
         push_optional_txt(&mut txt, "name", self.mesh_name.as_deref());
         push_optional_txt(&mut txt, "region", self.region.as_deref());
         push_optional_txt(&mut txt, "tok_fp", self.token_fingerprint.as_deref());
+        push_optional_txt(&mut txt, "details", self.details_path.as_deref());
+        push_optional_txt(&mut txt, "proof_challenge", self.proof_challenge.as_deref());
         push_optional_txt(&mut txt, "version", self.app_version.as_deref());
 
         for (key, value) in &txt {
@@ -182,6 +204,8 @@ impl LanMeshAdvertisement {
             "name",
             "region",
             "tok_fp",
+            "details",
+            "proof_challenge",
             "version",
         ]
         .into_iter()
@@ -221,6 +245,8 @@ pub(crate) struct LanDiscoveredMesh {
     pub(crate) addresses: Vec<String>,
     pub(crate) listing: nostr::MeshListing,
     pub(crate) token_fingerprint: Option<String>,
+    pub(crate) details_path: Option<String>,
+    pub(crate) proof_challenge: Option<String>,
     pub(crate) join_material: LanJoinMaterial,
     pub(crate) joinable_with_supplied_token: bool,
     pub(crate) published_version: Option<String>,
@@ -255,8 +281,55 @@ pub(crate) struct LanPublishConfig {
     pub(crate) region: Option<String>,
     pub(crate) max_clients: Option<usize>,
     pub(crate) api_port: u16,
+    pub(crate) details_reachable: bool,
     pub(crate) interval_secs: u64,
     pub(crate) status_tx: Option<tokio::sync::watch::Sender<Option<nostr::PublishStateUpdate>>>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct LanDetailsProofRequest {
+    pub(crate) token_fingerprint: String,
+    pub(crate) challenge: String,
+    pub(crate) proof: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct LanDetailsResponse {
+    pub(crate) mode: &'static str,
+    pub(crate) scope: DiscoveryScope,
+    pub(crate) source: &'static str,
+    pub(crate) service_type: &'static str,
+    pub(crate) listing: nostr::MeshListing,
+    pub(crate) token_fingerprint: String,
+    pub(crate) join_material: LanJoinMaterial,
+    pub(crate) joinable_with_supplied_token: bool,
+    pub(crate) details_path: &'static str,
+    pub(crate) proof_challenge: String,
+    pub(crate) published_version: Option<String>,
+}
+
+impl LanDetailsResponse {
+    pub(crate) fn from_local_listing(
+        mut listing: nostr::MeshListing,
+        token_fingerprint: String,
+        proof_challenge: String,
+        published_version: Option<&str>,
+    ) -> Self {
+        listing.invite_token.clear();
+        Self {
+            mode: MeshDiscoveryMode::Mdns.as_str(),
+            scope: MeshDiscoveryMode::Mdns.scope(),
+            source: MeshDiscoveryMode::Mdns.source(),
+            service_type: LAN_SERVICE_TYPE,
+            listing,
+            token_fingerprint,
+            join_material: LanJoinMaterial::RequiresSuppliedToken,
+            joinable_with_supplied_token: true,
+            details_path: LAN_DETAILS_PATH,
+            proof_challenge,
+            published_version: published_version.map(str::to_string),
+        }
+    }
 }
 
 pub(crate) async fn publish_lan_loop(node: crate::mesh::Node, config: LanPublishConfig) {
@@ -277,6 +350,7 @@ pub(crate) async fn publish_lan_loop(node: crate::mesh::Node, config: LanPublish
             region: config.region.clone(),
             max_clients: config.max_clients,
             api_port: config.api_port,
+            details_reachable: config.details_reachable,
             status_tx: &config.status_tx,
             last_reported: &mut last_reported,
             instance_name: &instance_name,
@@ -307,6 +381,7 @@ struct LanPublishAttempt<'a> {
     region: Option<String>,
     max_clients: Option<usize>,
     api_port: u16,
+    details_reachable: bool,
     status_tx: &'a Option<tokio::sync::watch::Sender<Option<nostr::PublishStateUpdate>>>,
     last_reported: &'a mut Option<nostr::PublishStateUpdate>,
     instance_name: &'a str,
@@ -321,6 +396,7 @@ async fn publish_lan_advertisement(attempt: LanPublishAttempt<'_>) {
         region,
         max_clients,
         api_port,
+        details_reachable,
         status_tx,
         last_reported,
         instance_name,
@@ -331,6 +407,7 @@ async fn publish_lan_advertisement(attempt: LanPublishAttempt<'_>) {
         &listing,
         Some(&listing.invite_token),
         Some(crate::VERSION),
+        details_reachable,
     );
     let Some(service_info) = encode_lan_service_info(
         &advert,
@@ -497,10 +574,76 @@ pub(crate) async fn discover_lan_join_candidates(
 
 pub(crate) fn lan_token_fingerprint(token: &str) -> String {
     let mut hasher = Sha256::new();
-    hasher.update(b"mesh-llm-lan-invite-token-v1\0");
+    hasher.update(LAN_INVITE_TOKEN_FINGERPRINT_DOMAIN);
     hasher.update(token.trim().as_bytes());
     let digest = hasher.finalize();
     hex::encode(&digest[..16])
+}
+
+pub(crate) fn lan_details_challenge(token_fingerprint: &str, now_secs: u64) -> String {
+    lan_details_challenge_for_bucket(
+        token_fingerprint,
+        now_secs / LAN_DETAILS_CHALLENGE_WINDOW_SECS,
+    )
+}
+
+pub(crate) fn lan_details_token_proof(invite_token: &str, challenge: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(LAN_DETAILS_TOKEN_PROOF_DOMAIN);
+    hasher.update(invite_token.trim().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(challenge.trim().as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+pub(crate) fn verify_lan_details_token_proof(
+    expected_invite_token: &str,
+    token_fingerprint: &str,
+    challenge: &str,
+    proof: &str,
+    now_secs: u64,
+) -> bool {
+    let token_fingerprint = token_fingerprint.trim();
+    if lan_token_fingerprint(expected_invite_token) != token_fingerprint {
+        return false;
+    }
+    let Some(challenge_bucket) = lan_details_challenge_bucket(challenge.trim()) else {
+        return false;
+    };
+    if !lan_details_challenge_bucket_is_recent(challenge_bucket, now_secs) {
+        return false;
+    }
+    if lan_details_challenge_for_bucket(token_fingerprint, challenge_bucket) != challenge.trim() {
+        return false;
+    }
+    lan_details_token_proof(expected_invite_token, challenge).eq_ignore_ascii_case(proof.trim())
+}
+
+fn lan_details_challenge_for_bucket(token_fingerprint: &str, bucket: u64) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(LAN_DETAILS_CHALLENGE_DOMAIN);
+    hasher.update(token_fingerprint.trim().as_bytes());
+    hasher.update(b"\0");
+    hasher.update(bucket.to_string().as_bytes());
+    let digest = hasher.finalize();
+    format!("v1:{bucket}:{}", hex::encode(&digest[..16]))
+}
+
+fn lan_details_challenge_bucket(challenge: &str) -> Option<u64> {
+    let mut parts = challenge.split(':');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("v1"), Some(bucket), Some(digest), None)
+            if digest.len() == 32 && digest.chars().all(|ch| ch.is_ascii_hexdigit()) =>
+        {
+            bucket.parse().ok()
+        }
+        _ => None,
+    }
+}
+
+fn lan_details_challenge_bucket_is_recent(bucket: u64, now_secs: u64) -> bool {
+    let current = now_secs / LAN_DETAILS_CHALLENGE_WINDOW_SECS;
+    bucket.abs_diff(current) <= 1
 }
 
 pub(crate) fn discovery_source_label(mode: MeshDiscoveryMode, operation: &str) -> String {
@@ -510,7 +653,7 @@ pub(crate) fn discovery_source_label(mode: MeshDiscoveryMode, operation: &str) -
     }
 }
 
-async fn build_local_mesh_listing(
+pub(crate) async fn build_local_mesh_listing(
     node: &crate::mesh::Node,
     name: Option<String>,
     region: Option<String>,
@@ -614,6 +757,8 @@ fn lan_discovered_mesh(
             .collect(),
         listing,
         token_fingerprint: advert.token_fingerprint,
+        details_path: advert.details_path,
+        proof_challenge: advert.proof_challenge,
         join_material: advert.join_material,
         joinable_with_supplied_token: joinable,
         published_version: advert.app_version,
@@ -758,6 +903,8 @@ fn parse_txt_properties(props: &HashMap<&str, &str>) -> Result<LanMeshAdvertisem
         client_count: parse_txt_number(props, "clients").unwrap_or(0),
         max_clients: parse_txt_number(props, "max_clients").unwrap_or(0),
         token_fingerprint: optional_txt(props, "tok_fp"),
+        details_path: optional_txt(props, "details"),
+        proof_challenge: optional_txt(props, "proof_challenge"),
         app_version: optional_txt(props, "version"),
         join_material: LanJoinMaterial::RequiresSuppliedToken,
     })
@@ -931,8 +1078,12 @@ mod tests {
     fn lan_advertisement_txt_round_trips_without_raw_invite_token() {
         let invite_token = "invite-token-that-must-not-leak";
         let listing = sample_listing(invite_token);
-        let advert =
-            LanMeshAdvertisement::from_listing(&listing, Some(invite_token), Some(crate::VERSION));
+        let advert = LanMeshAdvertisement::from_listing(
+            &listing,
+            Some(invite_token),
+            Some(crate::VERSION),
+            true,
+        );
 
         let txt = advert.to_txt_properties().expect("txt should encode");
         let serialized = txt
@@ -959,12 +1110,119 @@ mod tests {
     }
 
     #[test]
+    fn lan_advertisement_exposes_token_gated_details_without_raw_invite_token() {
+        let invite_token = "invite-token-for-details-proof";
+        let listing = sample_listing(invite_token);
+        let advert = LanMeshAdvertisement::from_listing(
+            &listing,
+            Some(invite_token),
+            Some(crate::VERSION),
+            true,
+        );
+
+        let txt = advert.to_txt_properties().expect("txt should encode");
+        let serialized = txt
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(";");
+
+        assert!(!serialized.contains(invite_token));
+        assert!(serialized.contains("details=/api/discovery/lan-details"));
+        assert!(serialized.contains("proof_challenge="));
+
+        let decoded = LanMeshAdvertisement::from_txt_properties(&txt).expect("txt should decode");
+        assert_eq!(decoded.details_path.as_deref(), Some(LAN_DETAILS_PATH));
+        assert!(decoded.proof_challenge.is_some());
+    }
+
+    #[test]
+    fn lan_advertisement_omits_details_when_management_api_is_loopback_only() {
+        let invite_token = "invite-token-for-loopback-only-console";
+        let listing = sample_listing(invite_token);
+        let advert = LanMeshAdvertisement::from_listing(
+            &listing,
+            Some(invite_token),
+            Some(crate::VERSION),
+            false,
+        );
+
+        let txt = advert.to_txt_properties().expect("txt should encode");
+        let serialized = txt
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(";");
+
+        assert!(serialized.contains("tok_fp="));
+        assert!(!serialized.contains("details="));
+        assert!(!serialized.contains("proof_challenge="));
+        assert_eq!(
+            advert.token_fingerprint.as_deref(),
+            Some(lan_token_fingerprint(invite_token).as_str())
+        );
+        assert!(advert.details_path.is_none());
+        assert!(advert.proof_challenge.is_none());
+    }
+
+    #[test]
+    fn lan_details_proof_accepts_matching_token_and_recent_challenge() {
+        let invite_token = "invite-token-for-proof";
+        let token_fingerprint = lan_token_fingerprint(invite_token);
+        let challenge = lan_details_challenge(&token_fingerprint, current_unix_secs());
+        let proof = lan_details_token_proof(invite_token, &challenge);
+
+        assert!(verify_lan_details_token_proof(
+            invite_token,
+            &token_fingerprint,
+            &challenge,
+            &proof,
+            current_unix_secs(),
+        ));
+    }
+
+    #[test]
+    fn lan_details_proof_rejects_public_fingerprint_without_token_secret() {
+        let invite_token = "invite-token-for-proof";
+        let token_fingerprint = lan_token_fingerprint(invite_token);
+        let challenge = lan_details_challenge(&token_fingerprint, current_unix_secs());
+        let attacker_proof = lan_details_token_proof("wrong-token", &challenge);
+
+        assert!(!verify_lan_details_token_proof(
+            invite_token,
+            &token_fingerprint,
+            &challenge,
+            &attacker_proof,
+            current_unix_secs(),
+        ));
+    }
+
+    #[test]
+    fn lan_details_response_sanitizes_invite_token() {
+        let invite_token = "invite-token-that-response-must-not-return";
+        let token_fingerprint = lan_token_fingerprint(invite_token);
+        let challenge = lan_details_challenge(&token_fingerprint, current_unix_secs());
+        let response = LanDetailsResponse::from_local_listing(
+            sample_listing(invite_token),
+            token_fingerprint.clone(),
+            challenge.clone(),
+            Some(crate::VERSION),
+        );
+
+        assert!(response.listing.invite_token.is_empty());
+        assert_eq!(response.token_fingerprint, token_fingerprint);
+        assert_eq!(response.details_path, LAN_DETAILS_PATH);
+        assert_eq!(response.proof_challenge, challenge);
+    }
+
+    #[test]
     fn lan_advertisement_requires_matching_supplied_join_token() {
         let invite_token = "invite-token-for-lab-mesh";
         let advert = LanMeshAdvertisement::from_listing(
             &sample_listing(invite_token),
             Some(invite_token),
             Some(crate::VERSION),
+            true,
         );
 
         assert!(advert.matches_supplied_token(Some(invite_token)));

--- a/crates/mesh-llm-host-runtime/src/runtime/discovery.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/discovery.rs
@@ -1,7 +1,7 @@
 use crate::cli::Cli;
 use crate::cli::output::{OutputEvent, emit_event};
 use crate::mesh;
-use crate::network::{nostr, router};
+use crate::network::{discovery as mesh_discovery, nostr, router};
 use anyhow::{Context, Result};
 use std::cmp::Reverse;
 
@@ -36,6 +36,83 @@ pub(super) async fn nostr_rediscovery(
     }
 }
 
+/// Re-discover LAN meshes via mDNS when all peers are lost.
+///
+/// This is only useful when the operator supplied an invite token. The mDNS
+/// advertisement intentionally carries a token fingerprint rather than the raw
+/// token, so rediscovery remains LAN-local and token-gated.
+pub(super) async fn lan_rediscovery(
+    node: mesh::Node,
+    supplied_join_tokens: Vec<String>,
+    mesh_name: Option<String>,
+    region: Option<String>,
+) {
+    if supplied_join_tokens.is_empty() {
+        return;
+    }
+
+    const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
+    const GRACE_PERIOD: std::time::Duration = std::time::Duration::from_secs(90);
+
+    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+
+    let mut alone_since: Option<std::time::Instant> = None;
+
+    loop {
+        tokio::time::sleep(CHECK_INTERVAL).await;
+        run_lan_rediscovery_tick(
+            &node,
+            &supplied_join_tokens,
+            mesh_name.as_deref(),
+            region.as_deref(),
+            GRACE_PERIOD,
+            &mut alone_since,
+        )
+        .await;
+    }
+}
+
+async fn run_lan_rediscovery_tick(
+    node: &mesh::Node,
+    supplied_join_tokens: &[String],
+    mesh_name: Option<&str>,
+    region: Option<&str>,
+    grace_period: std::time::Duration,
+    alone_since: &mut Option<std::time::Instant>,
+) {
+    if reset_rediscovery_timer_if_peers_recovered(node, alone_since, "mDNS LAN rediscovery").await {
+        return;
+    }
+
+    if rediscovery_grace_period_active(alone_since, grace_period, "mDNS LAN rediscovery") {
+        return;
+    }
+
+    let _ = emit_event(OutputEvent::DiscoveryStarting {
+        source: "mDNS LAN re-discovery".to_string(),
+    });
+
+    let Some(candidates) =
+        discover_lan_rediscovery_candidates(supplied_join_tokens, mesh_name, region, alone_since)
+            .await
+    else {
+        return;
+    };
+
+    if candidates.is_empty() {
+        report_no_lan_rediscovery_meshes(mesh_name, alone_since);
+        return;
+    }
+
+    let ranked = rank_lan_rediscovery_candidates(&candidates);
+    let our_mesh_id = node.mesh_id().await;
+    if try_rejoin_rediscovery_candidates(node, &ranked, our_mesh_id.as_deref()).await {
+        *alone_since = None;
+    } else {
+        report_rediscovery_retry(alone_since);
+    }
+}
+
 async fn run_rediscovery_tick(
     node: &mesh::Node,
     nostr_relays: &[String],
@@ -43,11 +120,11 @@ async fn run_rediscovery_tick(
     grace_period: std::time::Duration,
     alone_since: &mut Option<std::time::Instant>,
 ) {
-    if reset_rediscovery_timer_if_peers_recovered(node, alone_since).await {
+    if reset_rediscovery_timer_if_peers_recovered(node, alone_since, "Nostr rediscovery").await {
         return;
     }
 
-    if rediscovery_grace_period_active(alone_since, grace_period) {
+    if rediscovery_grace_period_active(alone_since, grace_period, "Nostr rediscovery") {
         return;
     }
 
@@ -77,12 +154,13 @@ async fn run_rediscovery_tick(
 async fn reset_rediscovery_timer_if_peers_recovered(
     node: &mesh::Node,
     alone_since: &mut Option<std::time::Instant>,
+    label: &str,
 ) -> bool {
     if node.peers().await.is_empty() {
         return false;
     }
     if alone_since.is_some() {
-        tracing::debug!("Nostr rediscovery: peers recovered, resetting timer");
+        tracing::debug!("{label}: peers recovered, resetting timer");
         *alone_since = None;
     }
     true
@@ -91,6 +169,7 @@ async fn reset_rediscovery_timer_if_peers_recovered(
 fn rediscovery_grace_period_active(
     alone_since: &mut Option<std::time::Instant>,
     grace_period: std::time::Duration,
+    label: &str,
 ) -> bool {
     let now = std::time::Instant::now();
     let start = *alone_since.get_or_insert(now);
@@ -99,7 +178,7 @@ fn rediscovery_grace_period_active(
         return false;
     }
     tracing::debug!(
-        "Nostr rediscovery: 0 peers for {}s (grace: {}s)",
+        "{label}: 0 peers for {}s (grace: {}s)",
         elapsed.as_secs(),
         grace_period.as_secs()
     );
@@ -122,6 +201,45 @@ async fn discover_rediscovery_meshes(
             None
         }
     }
+}
+
+async fn discover_lan_rediscovery_candidates(
+    supplied_join_tokens: &[String],
+    mesh_name: Option<&str>,
+    region: Option<&str>,
+    alone_since: &mut Option<std::time::Instant>,
+) -> Option<Vec<(String, nostr::DiscoveredMesh)>> {
+    let filter = nostr::MeshFilter {
+        name: mesh_name.map(str::to_string),
+        region: region.map(str::to_string),
+        ..Default::default()
+    };
+    let mut candidates = Vec::new();
+    for token in supplied_join_tokens
+        .iter()
+        .map(String::as_str)
+        .filter(|token| !token.trim().is_empty())
+    {
+        match mesh_discovery::discover_lan_join_candidates(
+            &filter,
+            Some(token),
+            std::time::Duration::from_secs(5),
+        )
+        .await
+        {
+            Ok(mut discovered) => candidates.append(&mut discovered),
+            Err(err) => {
+                let _ = emit_event(OutputEvent::DiscoveryFailed {
+                    message: "mDNS LAN re-discovery failed".to_string(),
+                    detail: Some(err.to_string()),
+                });
+                *alone_since = Some(std::time::Instant::now());
+                return None;
+            }
+        }
+    }
+    dedupe_lan_rediscovery_candidates(&mut candidates);
+    Some(candidates)
 }
 
 fn filter_rediscovery_meshes<'a>(
@@ -157,6 +275,23 @@ fn report_no_rediscovery_meshes(
     *alone_since = Some(std::time::Instant::now());
 }
 
+fn report_no_lan_rediscovery_meshes(
+    mesh_name: Option<&str>,
+    alone_since: &mut Option<std::time::Instant>,
+) {
+    let name_hint = mesh_name.unwrap_or("any");
+    let _ = emit_event(OutputEvent::DiscoveryFailed {
+        message: format!(
+            "No joinable LAN meshes found via mDNS matching \"{name_hint}\" — will retry"
+        ),
+        detail: Some(
+            "mDNS rediscovery only considers advertisements matching a supplied --join token"
+                .to_string(),
+        ),
+    });
+    *alone_since = Some(std::time::Instant::now());
+}
+
 fn rank_rediscovery_candidates<'a>(
     meshes: &[&'a nostr::DiscoveredMesh],
 ) -> Vec<(&'a nostr::DiscoveredMesh, i64)> {
@@ -173,6 +308,25 @@ fn rank_rediscovery_candidates<'a>(
         .collect();
     candidates.sort_by_key(|candidate| Reverse(candidate.1));
     candidates
+}
+
+fn rank_lan_rediscovery_candidates(
+    candidates: &[(String, nostr::DiscoveredMesh)],
+) -> Vec<(&nostr::DiscoveredMesh, i64)> {
+    let meshes = candidates.iter().map(|(_, mesh)| mesh).collect::<Vec<_>>();
+    rank_rediscovery_candidates(&meshes)
+}
+
+fn dedupe_lan_rediscovery_candidates(candidates: &mut Vec<(String, nostr::DiscoveredMesh)>) {
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|(token, mesh)| {
+        let key = (
+            token.clone(),
+            mesh.publisher_npub.clone(),
+            mesh.listing.mesh_id.clone(),
+        );
+        seen.insert(key)
+    });
 }
 
 async fn try_rejoin_rediscovery_candidates(
@@ -392,4 +546,82 @@ pub(crate) async fn check_mesh(
         context: Some(format!("port={port}")),
     });
     Ok((models, chosen, child))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rediscovery_mesh(
+        publisher: &str,
+        mesh_id: Option<&str>,
+        nodes: usize,
+    ) -> nostr::DiscoveredMesh {
+        nostr::DiscoveredMesh {
+            listing: nostr::MeshListing {
+                invite_token: "join-token".to_string(),
+                serving: vec!["Qwen3-8B-Q4_K_M".to_string()],
+                wanted: Vec::new(),
+                on_disk: Vec::new(),
+                total_vram_bytes: (nodes as u64) * 16_000_000_000,
+                node_count: nodes,
+                client_count: 0,
+                max_clients: 4,
+                name: Some("lab".to_string()),
+                region: Some("LAN".to_string()),
+                mesh_id: mesh_id.map(str::to_string),
+            },
+            publisher_npub: publisher.to_string(),
+            published_at: current_unix_secs(),
+            expires_at: None,
+        }
+    }
+
+    #[test]
+    fn lan_rediscovery_dedupes_same_token_publisher_and_mesh() {
+        let duplicate = (
+            "join-token".to_string(),
+            rediscovery_mesh("mdns:mesh-a", Some("mesh-a"), 2),
+        );
+        let mut candidates = vec![
+            duplicate.clone(),
+            duplicate,
+            (
+                "join-token".to_string(),
+                rediscovery_mesh("mdns:mesh-b", Some("mesh-b"), 2),
+            ),
+        ];
+
+        dedupe_lan_rediscovery_candidates(&mut candidates);
+
+        assert_eq!(candidates.len(), 2);
+        assert!(
+            candidates
+                .iter()
+                .any(|(_, mesh)| mesh.publisher_npub == "mdns:mesh-a")
+        );
+        assert!(
+            candidates
+                .iter()
+                .any(|(_, mesh)| mesh.publisher_npub == "mdns:mesh-b")
+        );
+    }
+
+    #[test]
+    fn lan_rediscovery_ranks_joinable_candidates_by_existing_mesh_score() {
+        let candidates = vec![
+            (
+                "join-token".to_string(),
+                rediscovery_mesh("mdns:small", Some("mesh-small"), 1),
+            ),
+            (
+                "join-token".to_string(),
+                rediscovery_mesh("mdns:large", Some("mesh-large"), 4),
+            ),
+        ];
+
+        let ranked = rank_lan_rediscovery_candidates(&candidates);
+
+        assert_eq!(ranked[0].0.publisher_npub, "mdns:large");
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -17,7 +17,7 @@ use self::capacity::{
     RuntimeCapacityLedger, RuntimeCapacityPool, RuntimeCapacityRequest, RuntimeCapacityReservation,
     model_fits_runtime_capacity,
 };
-use self::discovery::{nostr_rediscovery, start_new_mesh};
+use self::discovery::{lan_rediscovery, nostr_rediscovery, start_new_mesh};
 use self::interactive::InitialPromptMode;
 use self::local::{
     LocalRuntimeModelHandle, LocalRuntimeModelStartSpec, ManagedModelController,
@@ -5784,6 +5784,14 @@ fn should_start_relay_health_monitor(mode: mesh_discovery::MeshDiscoveryMode) ->
     )
 }
 
+fn should_start_lan_rediscovery(
+    mode: mesh_discovery::MeshDiscoveryMode,
+    join_tokens: &[String],
+) -> bool {
+    mode == mesh_discovery::MeshDiscoveryMode::Mdns
+        && join_tokens.iter().any(|token| !token.trim().is_empty())
+}
+
 fn start_relay_health_monitor_for_discovery_mode(
     node: &mesh::Node,
     mode: mesh_discovery::MeshDiscoveryMode,
@@ -5993,6 +6001,17 @@ async fn spawn_run_auto_post_join_tasks(cli: &Cli, node: &mesh::Node) {
             rediscover_relays,
             rediscover_relay_urls,
             rediscover_mesh_name,
+        )));
+    } else if should_start_lan_rediscovery(cli.mesh_discovery_mode, &cli.join) {
+        let rediscover_node = node.clone();
+        let rediscover_join_tokens = cli.join.clone();
+        let rediscover_mesh_name = cli.mesh_name.clone();
+        let rediscover_region = cli.region.clone();
+        tokio::spawn(Box::pin(lan_rediscovery(
+            rediscover_node,
+            rediscover_join_tokens,
+            rediscover_mesh_name,
+            rediscover_region,
         )));
     }
 }
@@ -7426,9 +7445,13 @@ async fn setup_run_auto_console_state(
             .to_string();
         console_state.set_draft_name(dn).await;
     }
-    if let Some(ref name) = ctx.cli.mesh_name {
-        console_state.set_mesh_name(name.clone()).await;
-    }
+    console_state
+        .set_mesh_publication_metadata(
+            ctx.cli.mesh_name.clone(),
+            ctx.cli.region.clone(),
+            ctx.cli.max_clients,
+        )
+        .await;
     Ok(Some(console_state))
 }
 
@@ -7539,6 +7562,7 @@ fn spawn_run_auto_mdns_publisher(
     let pub_region = cli.region.clone();
     let pub_max_clients = cli.max_clients;
     let pub_api_port = cli.console;
+    let pub_details_reachable = cli.listen_all;
     let (status_tx, status_rx) = tokio::sync::watch::channel(None);
     if let Some(cs) = console_state {
         bridge_publication_state(cs.clone(), status_rx);
@@ -7550,6 +7574,7 @@ fn spawn_run_auto_mdns_publisher(
             region: pub_region,
             max_clients: pub_max_clients,
             api_port: pub_api_port,
+            details_reachable: pub_details_reachable,
             interval_secs: 60,
             status_tx: Some(status_tx),
         },
@@ -8169,6 +8194,9 @@ async fn setup_passive_console_runtime(
         .set_mesh_discovery_mode(cli.mesh_discovery_mode)
         .await;
     console_state.set_nostr_discovery(cli.nostr_discovery).await;
+    console_state
+        .set_mesh_publication_metadata(cli.mesh_name.clone(), cli.region.clone(), cli.max_clients)
+        .await;
     if is_client {
         console_state.set_client(true).await;
         if cli.nostr_discovery {
@@ -8471,6 +8499,7 @@ async fn setup_passive_publication(
                 let pub_region = cli.region.clone();
                 let pub_max_clients = cli.max_clients;
                 let pub_api_port = cli.console;
+                let pub_details_reachable = cli.listen_all;
                 let (status_tx, status_rx) = tokio::sync::watch::channel(None);
                 setup.status_rx = Some(status_rx);
                 tokio::spawn(Box::pin(mesh_discovery::publish_lan_loop(
@@ -8480,6 +8509,7 @@ async fn setup_passive_publication(
                         region: pub_region,
                         max_clients: pub_max_clients,
                         api_port: pub_api_port,
+                        details_reachable: pub_details_reachable,
                         interval_secs: 60,
                         status_tx: Some(status_tx),
                     },
@@ -8786,6 +8816,22 @@ mod tests {
     fn nostr_discovery_starts_relay_health_monitor() {
         assert!(should_start_relay_health_monitor(
             mesh_discovery::MeshDiscoveryMode::Nostr
+        ));
+    }
+
+    #[test]
+    fn mdns_discovery_starts_lan_rediscovery_only_with_join_token() {
+        assert!(should_start_lan_rediscovery(
+            mesh_discovery::MeshDiscoveryMode::Mdns,
+            &["join-token".to_string()]
+        ));
+        assert!(!should_start_lan_rediscovery(
+            mesh_discovery::MeshDiscoveryMode::Mdns,
+            &[]
+        ));
+        assert!(!should_start_lan_rediscovery(
+            mesh_discovery::MeshDiscoveryMode::Nostr,
+            &["join-token".to_string()]
         ));
     }
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -67,8 +67,10 @@ Runtime switches:
 - `--discover [NAME]`: discover a mesh and join it. With a name, joins the mesh matching that name. Without a name, behaves like `--auto`.
 - `--mesh-discovery-mode <nostr|mdns>`: choose the discovery provider. `nostr`
   is the default public/WAN-capable mode. `mdns` browses LAN DNS-SD records,
-  requires a supplied matching invite token for join material, and disables
-  public iroh relays plus raw STUN startup probing.
+  requires a supplied matching invite token for join material and LAN detail
+  proof, and disables public iroh relays plus raw STUN startup probing. LAN
+  detail endpoints are only advertised when the management API is reachable
+  from LAN peers, for example with `--listen-all`.
 - `--auto`: auto-join the best discovered mesh.
 - `--model <MODEL>`: model to serve (catalog id from `models recommended`, HF ref/URL, or path).
 - `--gguf <GGUF>`: serve a specific local GGUF file directly (repeatable).

--- a/docs/MESHES.md
+++ b/docs/MESHES.md
@@ -188,6 +188,14 @@ mesh-llm discover --auto
 ```
 
 `discover --auto` prints the best invite token, which is useful for scripts.
+When using `--mesh-discovery-mode mdns`, discovery is LAN-scoped: mDNS TXT
+records advertise bounded capacity/model summaries and a token fingerprint.
+When the management API is reachable from LAN peers, for example with
+`--listen-all`, they also advertise a short-lived proof challenge and
+`/api/discovery/lan-details`. They never carry the raw invite token. A node can
+request local detail from that endpoint only by posting proof derived from the
+matching invite token, and mDNS re-discovery uses the same supplied-token gate
+if peers are lost.
 
 ## Console and management API
 
@@ -207,7 +215,9 @@ curl -s http://localhost:3131/api/discover | jq .
 ```
 
 `/api/status` reports whether the local mesh publication is `private`,
-`public`, or `publish_failed`.
+`public`, or `publish_failed`. `/api/discover` follows the active discovery
+mode: Nostr mode returns public relay results, while mDNS mode returns LAN
+advertisements with token fingerprints and challenge metadata only.
 
 ## Private ownership and trust
 
@@ -240,7 +250,9 @@ mesh-llm auth trust remove <owner-id>
 - `--mesh-discovery-mode mdns` is LAN-only discovery and transport startup:
   it does not contact Nostr relays, does not register with public iroh relays,
   and does not run raw public STUN probing. mDNS TXT records contain only a
-  token fingerprint; joins still require a matching supplied invite token.
+  token fingerprint plus, when the management API is LAN-reachable, challenge
+  metadata; joins and LAN detail requests still require proof from a matching
+  supplied invite token.
 - Mesh connectivity uses managed iroh relay infrastructure by default when
   direct paths are unavailable in Nostr mode.
 - Hidden relay override flags exist for lab/debug deployments, but normal users

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -261,7 +261,8 @@ and the embedded web dashboard.
 | `/api/model-interests/{model_ref}` | DELETE | Clear local explicit interest for one canonical model ref |
 | `/api/model-targets` | GET | Ranked model targets from explicit interest, active demand, and serving visibility |
 | `/api/events` | GET | SSE stream of status updates (2s interval + on change) |
-| `/api/discover` | GET | Browse Nostr-published meshes |
+| `/api/discover` | GET | Browse Nostr-published meshes, or LAN mDNS advertisements when `--mesh-discovery-mode mdns` is active |
+| `/api/discovery/lan-details` | POST | Return local LAN discovery detail after invite-token proof; advertised only when the management API is LAN-reachable, and the raw token is never returned |
 | `/api/chat` | POST | Proxy to inference API (`/v1/chat/completions`) |
 | `/` | GET | Embedded web dashboard |
 

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -620,6 +620,8 @@ curl localhost:3131/api/discover # Nostr meshes (current mesh marked by mesh_id)
 - `/api/model-targets` returns ranked targets with explicit-interest counts, request counts, serving-node counts, `wanted` for targets not currently served, and derived `capacity_advice` without changing ranking or routing behavior
 - If `[runtime] reconcile_model_targets = true` is enabled, unserved local explicit interests that are already present on disk and fit the current node may be runtime-loaded automatically. If `reconcile_model_target_demand_upgrades = true` is also enabled, an already-serving host may replace a lower-demand local model with a locally present, higher-demand unserved target whose active demand is still within `model_target_demand_upgrade_max_age_secs`. Leave these unset for read-only advisory checks.
 - Discover results can be matched to current mesh by `mesh_id`
+- In `--mesh-discovery-mode mdns`, `/api/discover` must show LAN advertisements without raw invite tokens; token fingerprints are expected, while proof challenges and `/api/discovery/lan-details` should appear only when the publishing node's management API is LAN-reachable, such as with `--listen-all`.
+- POST `/api/discovery/lan-details` must reject missing or wrong-token proof and must return local detail without echoing the raw invite token.
 
 ### 24. HTTP proxy single-request connection contract
 


### PR DESCRIPTION
## Summary

LAN-only discovery is safer and less misleading now. A node advertising over mDNS still publishes bounded LAN capacity/model summaries and a token fingerprint, but it only advertises the proof-gated LAN detail endpoint when the management API is actually reachable from LAN peers.

Peers that already have the supplied join token can still fetch the full LAN discovery details through `POST /api/discovery/lan-details`, and that detail response now uses the same mesh name, region, and max-client metadata as the mDNS publisher.

## Why

The LAN/mDNS path should not expose raw join material, and it also should not advertise an HTTP details path that a default loopback-only management API cannot serve to other LAN hosts. Review caught that split correctly: discovery metadata, details reachability, and the local details route need to agree.

## Diff scope

- Adds token-fingerprint and challenge/proof helpers for LAN detail lookup.
- Adds a proof-gated `POST /api/discovery/lan-details` management API route.
- Keeps raw invite tokens out of mDNS TXT records and sanitized LAN detail responses.
- Gates advertised `details`/`proof_challenge` TXT metadata on LAN-reachable management API binding, currently `--listen-all`.
- Stores mesh publication metadata in API state so LAN detail responses match the mDNS publish loop's `mesh_name`, `region`, and `max_clients`.
- Adds LAN rediscovery for supplied-token mDNS peers when joinable LAN peers are lost.
- Keeps mDNS discovery on the LAN-only relay policy path.
- Updates CLI, mesh, design, and testing docs for the LAN detail/recovery contract.

## Compatibility

No mesh protobuf, QUIC ALPN, gossip schema, Skippy ABI, or plugin protocol changes. The management API route is additive, and LAN advertisements remain local mDNS metadata rather than a cross-mesh protocol signal.

## Branch integrity

Base branch: `main`  
Validated base: `f9bd75a97378be014f52c4e68c13e81d3399e65e`  
Branch status: `0 behind / 1 ahead` against `origin/main`  
Introduced commit: `88971f73 Harden mDNS LAN discovery contract`

## Validation

Validation mode: Tier 2R - post-review correction for PR #766. The PR remains runtime-significant, but this update is a narrow same-PR correction around LAN details advertisement reachability and publication metadata consistency.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `f9bd75a97378be014f52c4e68c13e81d3399e65e`
- `git rebase origin/main`: PASS, no conflicts
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime lan_advertisement --lib -- --test-threads=1`: PASS, 4 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime mdns --lib -- --test-threads=1`: PASS, 8 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime lan_details --lib -- --test-threads=1`: PASS, 4 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS

## Required remote gates

PASS - required GitHub CI completed on final SHA `88971f734a91ae9f596c3fe983dc2add03253417`. Review gate remains on the prior CHANGES_REQUESTED review until the reviewer re-reviews the fixed SHA.

## Not run

- Live two-node LAN mDNS smoke: not run because no second LAN node was available in this isolated worktree. Advertisement gating, route metadata, token-proof, mDNS mode, relay policy, shipped-binary check, and clippy cover the changed branches locally.
- Full workspace suite locally: not required for this post-review correction; mandatory PR CI is the final full-suite proof.

## Rollback

Rollback: revert this PR.  
DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveats: none known.

