### PR TITLE
Add local target reputation routing

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -1,7 +1,7 @@
 //! Prefix affinity and sticky routing helpers for inference target selection.
 
 use crate::inference::election;
-use crate::network::target_health::{TargetHealth, TargetHealthOutcome};
+use crate::network::target_health::{TargetHealth, TargetHealthOutcome, TargetReputationStats};
 use iroh::EndpointId;
 use serde::Serialize;
 use serde_json::Value;
@@ -34,6 +34,7 @@ pub struct AffinityStatsSnapshot {
     pub session_routes: u64,
     pub learned: u64,
     pub evicted: u64,
+    pub target_reputation: TargetReputationStats,
 }
 
 fn prefix_only_enabled() -> bool {
@@ -119,6 +120,7 @@ impl AffinityRouter {
         stats.prefix_entries = state.entries.len();
         stats.prefix_enabled = self.config.prefix_enabled;
         stats.sticky_enabled = self.config.sticky_enabled;
+        stats.target_reputation = self.target_health.reputation_stats();
         stats
     }
 
@@ -739,14 +741,45 @@ mod tests {
     use crate::network::target_health::TargetHealthOutcome;
     use iroh::SecretKey;
 
+    const TEST_MODEL: &str = "qwen";
+
     fn make_id(seed: u8) -> EndpointId {
         let mut bytes = [0u8; 32];
         bytes[0] = seed;
         SecretKey::from_bytes(&bytes).public()
     }
 
+    fn remote(seed: u8) -> election::InferenceTarget {
+        election::InferenceTarget::Remote(make_id(seed))
+    }
+
     fn parse_body(body: &str) -> Value {
         serde_json::from_str(body).unwrap()
+    }
+
+    struct SimulatedMeshRouter {
+        affinity: AffinityRouter,
+        hosts: Vec<EndpointId>,
+    }
+
+    impl SimulatedMeshRouter {
+        fn new(host_seeds: &[u8]) -> Self {
+            Self {
+                affinity: AffinityRouter::default(),
+                hosts: host_seeds.iter().map(|seed| make_id(*seed)).collect(),
+            }
+        }
+
+        fn route_order(&self) -> Vec<election::InferenceTarget> {
+            prepare_remote_targets_for_request(TEST_MODEL, &self.hosts, None, &self.affinity)
+                .ordered
+        }
+
+        fn record_peer_outcome(&self, host_index: usize, outcome: TargetHealthOutcome) {
+            let target = election::InferenceTarget::Remote(self.hosts[host_index]);
+            self.affinity
+                .record_target_outcome(Some(TEST_MODEL), &target, outcome);
+        }
     }
 
     #[test]
@@ -916,6 +949,47 @@ mod tests {
                 .route_strict_eligible_candidates("qwen", std::slice::from_ref(&target))
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn stats_snapshot_exposes_local_target_reputation() {
+        let id_a = make_id(1);
+        let id_b = make_id(2);
+        let first = election::InferenceTarget::Remote(id_a);
+        let second = election::InferenceTarget::Remote(id_b);
+        let affinity = AffinityRouter::with_config(true, true);
+
+        affinity.record_target_outcome(Some("qwen"), &first, TargetHealthOutcome::Unavailable);
+
+        assert_eq!(
+            affinity.route_eligible_candidates("qwen", &[first.clone(), second.clone()]),
+            vec![second]
+        );
+        let stats = affinity.stats_snapshot();
+        assert_eq!(stats.target_reputation.penalized_targets, 1);
+        assert_eq!(stats.target_reputation.routes_penalized, 0);
+    }
+
+    #[test]
+    fn simulated_multi_node_reputation_changes_remote_request_flow() {
+        let mesh = SimulatedMeshRouter::new(&[1, 2, 3]);
+
+        assert_eq!(mesh.route_order(), vec![remote(1), remote(2), remote(3)]);
+
+        mesh.record_peer_outcome(0, TargetHealthOutcome::Unavailable);
+
+        assert_eq!(mesh.route_order(), vec![remote(2), remote(3)]);
+        assert_eq!(
+            mesh.affinity
+                .stats_snapshot()
+                .target_reputation
+                .penalized_targets,
+            1
+        );
+
+        mesh.record_peer_outcome(0, TargetHealthOutcome::Success);
+
+        assert_eq!(mesh.route_order(), vec![remote(1), remote(2), remote(3)]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/target_health.rs
+++ b/crates/mesh-llm-host-runtime/src/network/target_health.rs
@@ -1,10 +1,11 @@
 //! Local outcome-aware target health for routing decisions.
 //!
 //! This state is intentionally process-local. It helps the local proxy avoid a
-//! target that just timed out or returned unavailable, but it is not a mesh
-//! protocol signal and should not be gossiped.
+//! target that just timed out or repeatedly failed, but it is not a mesh
+//! protocol signal, not cryptographic trust, and should not be gossiped.
 
 use crate::inference::election::InferenceTarget;
+use serde::Serialize;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -12,6 +13,8 @@ use std::time::{Duration, Instant};
 const DEFAULT_BASE_COOLDOWN: Duration = Duration::from_secs(30);
 const DEFAULT_MAX_COOLDOWN: Duration = Duration::from_secs(5 * 60);
 const DEFAULT_MAX_ENTRIES: usize = 2048;
+const DEFAULT_REPUTATION_TTL: Duration = Duration::from_secs(20 * 60);
+const DEFAULT_REPUTATION_RECOVERY_SUCCESSES: u32 = 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum TargetHealthOutcome {
@@ -35,11 +38,20 @@ struct TargetEntry {
     cool_until: Instant,
 }
 
+#[derive(Clone, Debug)]
+struct ReputationEntry {
+    penalty: u32,
+    recovery_successes: u32,
+    last_observed: Instant,
+}
+
 #[derive(Clone, Copy, Debug)]
 struct TargetHealthConfig {
     base_cooldown: Duration,
     max_cooldown: Duration,
     max_entries: usize,
+    reputation_ttl: Duration,
+    reputation_recovery_successes: u32,
 }
 
 impl Default for TargetHealthConfig {
@@ -48,6 +60,8 @@ impl Default for TargetHealthConfig {
             base_cooldown: DEFAULT_BASE_COOLDOWN,
             max_cooldown: DEFAULT_MAX_COOLDOWN,
             max_entries: DEFAULT_MAX_ENTRIES,
+            reputation_ttl: DEFAULT_REPUTATION_TTL,
+            reputation_recovery_successes: DEFAULT_REPUTATION_RECOVERY_SUCCESSES,
         }
     }
 }
@@ -55,8 +69,16 @@ impl Default for TargetHealthConfig {
 #[derive(Default)]
 struct TargetHealthState {
     entries: HashMap<TargetKey, TargetEntry>,
+    reputation: HashMap<TargetKey, ReputationEntry>,
     lru: VecDeque<TargetKey>,
     routes_avoided: u64,
+    routes_penalized: u64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+pub struct TargetReputationStats {
+    pub penalized_targets: usize,
+    pub routes_penalized: u64,
 }
 
 #[cfg(test)]
@@ -64,6 +86,7 @@ struct TargetHealthState {
 pub(crate) struct TargetHealthSnapshot {
     pub cooling_targets: usize,
     pub routes_avoided: u64,
+    pub reputation: TargetReputationStats,
 }
 
 #[derive(Clone)]
@@ -94,6 +117,8 @@ impl TargetHealth {
                 base_cooldown,
                 max_cooldown,
                 max_entries,
+                reputation_ttl: DEFAULT_REPUTATION_TTL,
+                reputation_recovery_successes: DEFAULT_REPUTATION_RECOVERY_SUCCESSES,
             },
         }
     }
@@ -115,12 +140,17 @@ impl TargetHealth {
             target: target.clone(),
         };
         let mut state = self.inner.lock().unwrap();
-        state.prune_expired(Instant::now());
+        let now = Instant::now();
+        state.prune_expired(now, self.config);
 
         match outcome {
-            TargetHealthOutcome::Success => state.remove_key(&key),
+            TargetHealthOutcome::Success => {
+                state.remove_key(&key);
+                state.record_reputation_success(&key, now, self.config);
+            }
             TargetHealthOutcome::Timeout | TargetHealthOutcome::Unavailable => {
-                state.record_failure(key, Instant::now(), self.config);
+                state.record_failure(key.clone(), now, self.config);
+                state.record_reputation_penalty(key, now, 1, self.config);
             }
             TargetHealthOutcome::ContextOverflow
             | TargetHealthOutcome::Rejected
@@ -158,7 +188,7 @@ impl TargetHealth {
         };
         let now = Instant::now();
         let mut state = self.inner.lock().unwrap();
-        state.prune_expired(now);
+        state.prune_expired(now, self.config);
 
         let mut eligible = Vec::with_capacity(candidates.len());
         let mut cooling = 0usize;
@@ -174,21 +204,30 @@ impl TargetHealth {
             }
         }
 
-        if cooling == 0 || (preserve_availability && !has_routable_candidate(&eligible)) {
+        if cooling == 0 && state.no_reputation_penalties(&model, candidates) {
             candidates.to_vec()
+        } else if preserve_availability && !has_routable_candidate(&eligible) {
+            state.reputation_ordered_candidates(&model, candidates, now)
         } else {
             state.routes_avoided = state.routes_avoided.saturating_add(cooling as u64);
-            eligible
+            state.reputation_ordered_candidates(&model, &eligible, now)
         }
+    }
+
+    pub(crate) fn reputation_stats(&self) -> TargetReputationStats {
+        let mut state = self.inner.lock().unwrap();
+        state.prune_expired(Instant::now(), self.config);
+        state.reputation_stats()
     }
 
     #[cfg(test)]
     pub(crate) fn snapshot(&self) -> TargetHealthSnapshot {
         let mut state = self.inner.lock().unwrap();
-        state.prune_expired(Instant::now());
+        state.prune_expired(Instant::now(), self.config);
         TargetHealthSnapshot {
             cooling_targets: state.entries.len(),
             routes_avoided: state.routes_avoided,
+            reputation: state.reputation_stats(),
         }
     }
 }
@@ -219,7 +258,51 @@ impl TargetHealthState {
             .unwrap_or(false)
     }
 
-    fn prune_expired(&mut self, now: Instant) {
+    fn record_reputation_penalty(
+        &mut self,
+        key: TargetKey,
+        now: Instant,
+        penalty: u32,
+        config: TargetHealthConfig,
+    ) {
+        let entry = self
+            .reputation
+            .entry(key.clone())
+            .or_insert_with(|| ReputationEntry {
+                penalty: 0,
+                recovery_successes: 0,
+                last_observed: now,
+            });
+        entry.penalty = entry.penalty.saturating_add(penalty).min(16);
+        entry.recovery_successes = 0;
+        entry.last_observed = now;
+        self.touch_key(&key);
+        self.prune_over_capacity(config.max_entries);
+    }
+
+    fn record_reputation_success(
+        &mut self,
+        key: &TargetKey,
+        now: Instant,
+        config: TargetHealthConfig,
+    ) {
+        let Some(entry) = self.reputation.get_mut(key) else {
+            return;
+        };
+        entry.last_observed = now;
+        entry.recovery_successes = entry.recovery_successes.saturating_add(1);
+        if entry.recovery_successes < config.reputation_recovery_successes {
+            return;
+        }
+        entry.recovery_successes = 0;
+        entry.penalty = entry.penalty.saturating_sub(1);
+        if entry.penalty == 0 {
+            self.reputation.remove(key);
+            self.lru.retain(|existing| existing != key);
+        }
+    }
+
+    fn prune_expired(&mut self, now: Instant, config: TargetHealthConfig) {
         let expired: Vec<TargetKey> = self
             .entries
             .iter()
@@ -228,14 +311,29 @@ impl TargetHealthState {
         for key in expired {
             self.remove_key(&key);
         }
+        let stale_reputation: Vec<TargetKey> = self
+            .reputation
+            .iter()
+            .filter_map(|(key, entry)| {
+                (now.duration_since(entry.last_observed) >= config.reputation_ttl)
+                    .then_some(key.clone())
+            })
+            .collect();
+        for key in stale_reputation {
+            self.reputation.remove(&key);
+            if !self.entries.contains_key(&key) {
+                self.lru.retain(|existing| existing != &key);
+            }
+        }
     }
 
     fn prune_over_capacity(&mut self, max_entries: usize) {
-        while self.entries.len() > max_entries {
+        while self.entries.len().max(self.reputation.len()) > max_entries {
             let Some(key) = self.lru.pop_front() else {
                 break;
             };
             self.entries.remove(&key);
+            self.reputation.remove(&key);
         }
     }
 
@@ -246,7 +344,77 @@ impl TargetHealthState {
 
     fn remove_key(&mut self, key: &TargetKey) {
         self.entries.remove(key);
-        self.lru.retain(|existing| existing != key);
+        if !self.reputation.contains_key(key) {
+            self.lru.retain(|existing| existing != key);
+        }
+    }
+
+    fn no_reputation_penalties(&self, model: &str, candidates: &[InferenceTarget]) -> bool {
+        candidates.iter().all(|target| {
+            let key = TargetKey {
+                model: model.to_string(),
+                target: target.clone(),
+            };
+            self.reputation_score(&key) == 0
+        })
+    }
+
+    fn reputation_ordered_candidates(
+        &mut self,
+        model: &str,
+        candidates: &[InferenceTarget],
+        now: Instant,
+    ) -> Vec<InferenceTarget> {
+        let mut ordered = candidates.to_vec();
+        ordered.sort_by_key(|target| {
+            let key = TargetKey {
+                model: model.to_string(),
+                target: target.clone(),
+            };
+            (
+                matches!(target, InferenceTarget::None),
+                self.reputation_score(&key),
+            )
+        });
+        let penalized = candidates.iter().filter(|target| {
+            let key = TargetKey {
+                model: model.to_string(),
+                target: (*target).clone(),
+            };
+            self.reputation_score(&key) > 0
+        });
+        let penalized_count = penalized.count();
+        if penalized_count > 0 && ordered != candidates {
+            self.routes_penalized = self.routes_penalized.saturating_add(penalized_count as u64);
+            for target in candidates {
+                let key = TargetKey {
+                    model: model.to_string(),
+                    target: target.clone(),
+                };
+                if let Some(entry) = self.reputation.get_mut(&key) {
+                    entry.last_observed = now;
+                }
+            }
+        }
+        ordered
+    }
+
+    fn reputation_score(&self, key: &TargetKey) -> u32 {
+        self.reputation
+            .get(key)
+            .map(|entry| entry.penalty)
+            .unwrap_or(0)
+    }
+
+    fn reputation_stats(&self) -> TargetReputationStats {
+        TargetReputationStats {
+            penalized_targets: self
+                .reputation
+                .values()
+                .filter(|entry| entry.penalty > 0)
+                .count(),
+            routes_penalized: self.routes_penalized,
+        }
     }
 }
 
@@ -297,20 +465,28 @@ mod tests {
             TargetHealthSnapshot {
                 cooling_targets: 1,
                 routes_avoided: 1,
+                reputation: TargetReputationStats {
+                    penalized_targets: 1,
+                    ..TargetReputationStats::default()
+                },
             }
         );
     }
 
     #[test]
-    fn success_clears_target_cooldown() {
+    fn success_clears_target_cooldown_before_reputation_fully_recovers() {
         let health = TargetHealth::default();
         let candidates = vec![local(9001), local(9002)];
 
         health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
         health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Success);
 
-        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(
+            health.eligible_candidates("qwen", &candidates),
+            vec![local(9002), local(9001)]
+        );
         assert_eq!(health.snapshot().cooling_targets, 0);
+        assert_eq!(health.snapshot().reputation.penalized_targets, 1);
     }
 
     #[test]
@@ -327,6 +503,7 @@ mod tests {
 
         assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
         assert_eq!(health.snapshot().cooling_targets, 0);
+        assert_eq!(health.snapshot().reputation.penalized_targets, 0);
     }
 
     #[test]
@@ -354,6 +531,10 @@ mod tests {
             TargetHealthSnapshot {
                 cooling_targets: 1,
                 routes_avoided: 0,
+                reputation: TargetReputationStats {
+                    penalized_targets: 1,
+                    ..TargetReputationStats::default()
+                },
             }
         );
     }
@@ -376,6 +557,10 @@ mod tests {
             TargetHealthSnapshot {
                 cooling_targets: 1,
                 routes_avoided: 1,
+                reputation: TargetReputationStats {
+                    penalized_targets: 1,
+                    ..TargetReputationStats::default()
+                },
             }
         );
     }
@@ -399,6 +584,10 @@ mod tests {
             TargetHealthSnapshot {
                 cooling_targets: 2,
                 routes_avoided: 2,
+                reputation: TargetReputationStats {
+                    penalized_targets: 2,
+                    ..TargetReputationStats::default()
+                },
             }
         );
     }
@@ -428,7 +617,10 @@ mod tests {
 
         health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Timeout);
 
-        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(
+            health.eligible_candidates("qwen", &candidates),
+            vec![local(9002), local(9001)]
+        );
         assert_eq!(health.snapshot().cooling_targets, 0);
     }
 
@@ -445,5 +637,39 @@ mod tests {
             vec![local(9001)]
         );
         assert_eq!(health.snapshot().cooling_targets, 1);
+    }
+
+    #[test]
+    fn retryable_failure_leaves_behavioral_penalty_after_cooldown() {
+        let health = TargetHealth::with_config(
+            Duration::from_millis(0),
+            Duration::from_millis(0),
+            DEFAULT_MAX_ENTRIES,
+        );
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Unavailable);
+
+        assert_eq!(
+            health.eligible_candidates("qwen", &candidates),
+            vec![local(9002), local(9001)]
+        );
+        let snapshot = health.snapshot();
+        assert_eq!(snapshot.cooling_targets, 0);
+        assert_eq!(snapshot.reputation.penalized_targets, 1);
+        assert_eq!(snapshot.reputation.routes_penalized, 1);
+    }
+
+    #[test]
+    fn behavioral_success_rebuilds_target_reputation() {
+        let health = TargetHealth::default();
+        let candidates = vec![local(9001), local(9002)];
+
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Unavailable);
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Success);
+        health.record_outcome(Some("qwen"), &local(9001), TargetHealthOutcome::Success);
+
+        assert_eq!(health.eligible_candidates("qwen", &candidates), candidates);
+        assert_eq!(health.snapshot().reputation.penalized_targets, 0);
     }
 }

--- a/docs/MESHES.md
+++ b/docs/MESHES.md
@@ -209,6 +209,13 @@ curl -s http://localhost:3131/api/discover | jq .
 `/api/status` reports whether the local mesh publication is `private`,
 `public`, or `publish_failed`.
 
+The same status payload also includes `routing_affinity.target_reputation`.
+Those counters are local behavioral health signals used by the current proxy to
+avoid peers that recently timed out or returned unavailable. They are not
+gossiped, not persisted as mesh trust, and not proof of a peer's identity or
+model honesty. See [NODE_REP.md](NODE_REP.md) for the local reputation model,
+status fields, and testing boundary.
+
 ## Private ownership and trust
 
 For owner-attested private deployments, initialize an owner key and start nodes

--- a/docs/NODE_REP.md
+++ b/docs/NODE_REP.md
@@ -1,0 +1,106 @@
+# Local Node Reputation
+
+Local node reputation is a process-local routing safety mechanism. It helps a
+node avoid peers or local serving targets that recently timed out or returned
+unavailable, while preserving mesh availability when there is no healthy
+alternative.
+
+This is not a mesh trust system. Reputation is not gossiped, not persisted as a
+network-wide score, and not used to prove peer identity, model honesty, owner
+attestation, or release provenance.
+
+## Goals
+
+- Prefer targets that have recently completed requests successfully.
+- Temporarily cool down targets that returned retryable transport or
+  availability failures.
+- Keep request routing available when every candidate is cooling.
+- Expose small operator counters in `/api/status` without leaking request
+  content or peer-private state.
+- Keep all policy local until the project has a reviewed design for
+  cross-node reputation.
+
+## Non-goals
+
+- No gossip field or protocol change.
+- No distributed trust or peer scoring.
+- No punishment for client-side disconnects, request rejection, or known
+  context-fit failures.
+- No persistent ban list.
+- No replacement for owner identity, release attestation, or future output
+  verification.
+
+## Signals
+
+The local proxy records an outcome after a target attempt:
+
+| Outcome | Reputation effect |
+|---|---|
+| Success | Clears active cooldown and gradually recovers any local penalty |
+| Timeout | Adds a retryable failure cooldown and local penalty |
+| Unavailable | Adds a retryable failure cooldown and local penalty |
+| Context overflow | No reputation penalty |
+| Rejected | No reputation penalty |
+| Client disconnected | No reputation penalty |
+
+Timeouts and unavailable results are treated as retryable health signals because
+the next target may still serve the same request. Context overflow and explicit
+rejections are admission or request-fit outcomes, so penalizing the peer would
+mix routing health with request semantics.
+
+## Routing Behavior
+
+For a model-specific candidate list, routing first removes cooling targets when
+there is at least one routable alternative. Remaining candidates are ordered by
+local penalty, so a peer that has recovered from cooldown can still sit behind
+clean peers until it proves itself again.
+
+If every candidate is cooling, explicit model routing preserves availability by
+returning the original candidates instead of making the model unreachable. Auto
+routing can use the stricter eligible set so it may pick another model/target
+instead of immediately retrying a known cooling target.
+
+Successful attempts rebuild reputation gradually. One success clears the active
+cooldown; repeated successes remove the residual penalty.
+
+## Status Surface
+
+`GET /api/status` exposes local counters under:
+
+```text
+routing_affinity.target_reputation
+```
+
+The current counters are:
+
+| Field | Meaning |
+|---|---|
+| `penalized_targets` | Number of local model+target entries that still carry a penalty |
+| `routes_penalized` | Number of route orderings that moved penalized candidates behind cleaner alternatives |
+
+These counters are local to the node that served `/api/status`. They should be
+read as operator diagnostics, not as mesh-wide health truth.
+
+## Testing Model
+
+Unit tests cover the target-health state machine directly and the routing
+integration through `AffinityRouter`. The integration tests include a simulated
+three-peer candidate list: a peer starts first in route order, receives a local
+unavailable outcome, is avoided on the next request, and returns to normal
+routing after a successful attempt clears the active cooldown. Lower-level
+target-health tests cover residual penalty ordering after cooldown.
+
+This simulation is intentionally local. It proves how the routing layer consumes
+local reputation without requiring a live multi-node mesh or adding protocol
+fixtures for a behavior that is not gossiped.
+
+## Future Work
+
+Any cross-node reputation design needs a separate proposal. Before gossiping or
+sharing any reputation signal, the design should answer:
+
+- What exact evidence is being shared.
+- How peers prevent spoofing, Sybil amplification, or retaliation loops.
+- How private meshes can opt in or out.
+- How old nodes ignore the signal safely.
+- How status and API surfaces distinguish local observation from remote claims.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Use this hub to find project guides that are not owned by a single Rust crate.
 |---|---|
 | Install, run, service mode, model storage | [USAGE.md](USAGE.md) |
 | Private meshes, published meshes, public joining | [MESHES.md](MESHES.md) |
+| Local routing reputation and target cooldowns | [NODE_REP.md](NODE_REP.md) |
 | SDK usage, examples, errors, lifecycle, platform support | [SDK.md](SDK.md) |
 | Run big models with Skippy layer splits | [SKIPPY_SPLITS.md](SKIPPY_SPLITS.md) |
 | Contribute or publish layer package repositories | [LAYER_PACKAGE_REPOS.md](LAYER_PACKAGE_REPOS.md) |

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -411,6 +411,14 @@ By default, nodes broadcast their GPU name, hostname, VRAM capacity, and reserve
 
 For ROCm and Intel hosts, `reserved_bytes` is omitted because their standard CLI telemetry exposes live used-memory counters rather than a true reserved/system-memory value.
 
+Routing health in `/api/status.routing_affinity.target_reputation` is local to
+the process that served the management API. It records behavioral routing
+signals such as penalized targets and routes reordered away from penalized
+targets. This is a local availability/reliability aid only: it is not gossiped,
+not a cross-mesh trust score, and not a replacement for owner attestation or
+model-output verification. The operator-facing behavior is specified in
+[Local Node Reputation](../NODE_REP.md).
+
 `peers[]` entries (only when peer has not passed `--no-enumerate-host`):
 ```json
 {"hostname": "lemony-28", "is_soc": true, "gpus": [{"name": "Tegra AGX Orin", "vram_bytes": 0}]}


### PR DESCRIPTION
## Summary

The local OpenAI/mesh proxy now learns from retryable target failures instead of treating every expired cooldown as fully equal again. When a peer times out or returns unavailable, the router keeps a bounded local reputation signal, prefers healthier alternatives when available, and exposes the local counters in `/api/status.routing_affinity.target_reputation`.

This update also adds the requested design note in `docs/NODE_REP.md` and a routing simulation test that exercises a three-peer candidate set, marks one adjacent peer unavailable, and verifies subsequent request flow avoids it until a successful outcome restores routing.

## Why

Issue #265 points at the need for behavioral peer scoring, but a real mesh-wide trust system needs output verification and protocol design. This PR deliberately implements the safe first layer: local routing-health reputation only. It improves availability and diagnostics without pretending to provide cryptographic trust, global peer reputation, or model-honesty attestation.

The review feedback was right that this is a sharp routing surface. The policy is now documented separately from the general mesh docs so future discussion can evolve the design without burying the trust boundary in implementation details.

## Diff scope

- Adds bounded, process-local target reputation state beside existing target cooldowns.
- Penalizes retryable timeout/unavailable outcomes while leaving client-side rejection, context overflow, and disconnect paths out of reputation scoring.
- Gradually recovers a penalized target after successful responses.
- Reorders eligible candidates away from penalized targets while preserving availability fallback semantics.
- Keeps `InferenceTarget::None` from becoming preferred only because a real target is penalized.
- Exposes local reputation counters through the existing affinity/status payload.
- Adds `docs/NODE_REP.md` for the local reputation model, non-goals, signals, status surface, testing boundary, and future cross-node design questions.
- Adds an affinity-routing simulation test for a multi-peer candidate list with a locally penalized adjacent peer.

## Compatibility

No mesh protobuf, QUIC ALPN, gossip schema, Skippy ABI, plugin protocol, or release metadata changes. The status field is additive and the reputation state is process-local.

## Branch integrity

Base branch: `main`  
Validated base: `f9bd75a97378be014f52c4e68c13e81d3399e65e`  
Branch status: `0 behind / 1 ahead` against `origin/main`  
Introduced commit: `9800b62f Add local target reputation routing`

## Validation

Validation mode: Tier 3 - shared OpenAI/mesh routing health behavior plus post-review design/test hardening.

- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, `origin/main` at `f9bd75a97378be014f52c4e68c13e81d3399e65e`
- `git rebase origin/main`: PASS, no conflicts
- `git diff --check origin/main...HEAD`: PASS, no output
- `git diff --check`: PASS, no output
- `git diff --cached --check`: PASS, no output
- `cargo fmt --all`: PASS
- `cargo fmt --all -- --check`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime affinity --lib -- --test-threads=1`: PASS, 18 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo test -p mesh-llm-host-runtime target_health --lib -- --test-threads=1`: PASS, 13 passed
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo check -p mesh-llm`: PASS
- `LLAMA_STAGE_BUILD_DIR=<stage-build-dir> cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS

## Required remote gates

PASS - required GitHub CI completed on final SHA `9800b62fdd4f4aafa442ebc6022c80683b1a8672`.

## Not run

- Live multi-node reputation/routing smoke: not run because no local multi-node model runtime endpoint was available. Deterministic target-health and affinity-routing simulation tests cover the changed local behavior.
- Full workspace suite locally: not required for this validation mode; mandatory PR CI is the final full-suite proof.

## Rollback

Rollback: revert this PR.  
DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveats: none known.

