### PR TITLE
Expose native runtime install APIs

### DIFF
--- a/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/runtime.rs
@@ -16,13 +16,16 @@ pub(crate) async fn dispatch_runtime_command(command: Option<&RuntimeCommand>) -
             bundle_dirs,
             cache_dir,
             json,
-        }) => runtime_native::run_native_runtime_list(
-            *available,
-            manifest.as_deref(),
-            bundle_dirs,
-            cache_dir.as_deref(),
-            *json,
-        ),
+        }) => {
+            runtime_native::run_native_runtime_list(
+                *available,
+                manifest.as_deref(),
+                bundle_dirs,
+                cache_dir.as_deref(),
+                *json,
+            )
+            .await
+        }
         Some(RuntimeCommand::Install {
             runtime,
             manifest,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/runtime_native.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/runtime_native.rs
@@ -1,22 +1,17 @@
-use anyhow::{Context, Result, bail};
-use futures_util::StreamExt;
-use mesh_llm_native_runtime::{
-    HostGpuProfile, HostRuntimeProfile, NativeRuntimeCache, NativeRuntimeFlavor,
-    NativeRuntimeManifest, NativeRuntimePruneMode, NativeRuntimeReleaseManifest,
-    NativeRuntimeResolver, NativeRuntimeSource, RuntimeSelection,
+use crate::system::native_runtime_install::{
+    CURRENT_MESH_VERSION, NativeRuntimeDownloadProgressCallback, NativeRuntimeInstallOptions,
+    NativeRuntimeInstallStatus, NativeRuntimeManifestOptions, host_runtime_profile,
+    install_native_runtime, load_release_manifest, native_runtime_cache,
 };
+use anyhow::Result;
+use mesh_llm_native_runtime::{HostRuntimeProfile, NativeRuntimePruneMode, RuntimeSelection};
 use serde::Serialize;
 use serde_json::json;
-use sha2::Digest;
-use std::collections::BTreeSet;
-use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use tokio::io::AsyncWriteExt;
 
-const CURRENT_MESH_VERSION: &str = env!("CARGO_PKG_VERSION");
-
-pub(crate) fn run_native_runtime_list(
+pub(crate) async fn run_native_runtime_list(
     available: bool,
     manifest_path: Option<&Path>,
     bundle_dirs: &[PathBuf],
@@ -25,7 +20,15 @@ pub(crate) fn run_native_runtime_list(
 ) -> Result<()> {
     let cache = native_runtime_cache(cache_dir)?;
     if available {
-        let manifest = load_release_manifest(manifest_path, bundle_dirs)?;
+        if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
+            eprintln!("🔎 Loading native runtime release manifest");
+        }
+        let manifest = load_release_manifest(NativeRuntimeManifestOptions {
+            manifest_path: manifest_path.map(Path::to_path_buf),
+            bundle_dirs: bundle_dirs.to_vec(),
+            ..Default::default()
+        })
+        .await?;
         let profile = host_runtime_profile();
         let rows = manifest
             .artifacts
@@ -71,196 +74,92 @@ pub(crate) async fn run_native_runtime_install(
     json_output: bool,
 ) -> Result<()> {
     let selection = RuntimeSelection::parse(requested_runtime)?;
-    let manifest = load_release_manifest(manifest_path, bundle_dirs)?;
-    if manifest.artifacts.is_empty() {
-        bail!(
-            "no native runtime manifest entries found; pass --manifest or --bundle-dir before installing"
-        );
+    if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
+        eprintln!("🔎 Loading native runtime release manifest");
     }
-
     if !json_output {
         eprintln!("🔎 Detecting host runtime profile");
     }
-    let profile = host_runtime_profile();
-    let cache = native_runtime_cache(cache_dir)?;
-    let resolution =
-        NativeRuntimeResolver::new(CURRENT_MESH_VERSION, profile, manifest, cache.clone())
-            .with_bundle_dirs(bundle_dirs.to_vec())
-            .resolve(&selection)?;
-
-    match &resolution.source {
-        NativeRuntimeSource::Installed { path } => {
+    let outcome = install_native_runtime(NativeRuntimeInstallOptions {
+        selection,
+        manifest_path: manifest_path.map(Path::to_path_buf),
+        bundle_dirs: bundle_dirs.to_vec(),
+        cache_dir: cache_dir.map(Path::to_path_buf),
+        progress: cli_download_progress(json_output),
+        ..Default::default()
+    })
+    .await?;
+    match outcome.status {
+        NativeRuntimeInstallStatus::AlreadyInstalled => {
             if json_output {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&json!({
                         "status": "already_installed",
-                        "runtime": resolution.selected,
-                        "path": path,
+                        "runtime": outcome.runtime,
+                        "resolution": outcome.resolution,
                     }))?
                 );
             } else {
                 eprintln!(
                     "✅ Native runtime already installed: {}",
-                    resolution.selected.native_runtime_id
+                    outcome.runtime.native_runtime_id
                 );
-                eprintln!("   path: {}", path.display());
+                eprintln!("   path: {}", outcome.runtime.path.display());
             }
         }
-        NativeRuntimeSource::Bundle { path } => {
-            if !json_output {
-                eprintln!(
-                    "📦 Installing native runtime {}",
-                    resolution.selected.native_runtime_id
-                );
-            }
-            let installed = cache.install_from_dir(path)?;
+        NativeRuntimeInstallStatus::Installed => {
             if json_output {
                 println!(
                     "{}",
                     serde_json::to_string_pretty(&json!({
                         "status": "installed",
-                        "runtime": installed,
+                        "runtime": outcome.runtime,
+                        "resolution": outcome.resolution,
                     }))?
                 );
             } else {
-                eprintln!("✅ Installed {}", installed.native_runtime_id);
-                eprintln!("   version: {}", installed.mesh_version);
-                eprintln!("   flavor: {}", installed.flavor);
-                eprintln!("   path: {}", installed.path.display());
+                eprintln!("✅ Installed {}", outcome.runtime.native_runtime_id);
+                eprintln!("   version: {}", outcome.runtime.mesh_version);
+                eprintln!("   flavor: {}", outcome.runtime.flavor);
+                eprintln!("   path: {}", outcome.runtime.path.display());
             }
-        }
-        NativeRuntimeSource::Download { url } => {
-            let installed =
-                download_and_install_runtime(&cache, &resolution.selected, url, json_output)
-                    .await?;
-            if json_output {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&json!({
-                        "status": "installed",
-                        "runtime": installed,
-                    }))?
-                );
-            } else {
-                eprintln!("✅ Installed {}", installed.native_runtime_id);
-                eprintln!("   version: {}", installed.mesh_version);
-                eprintln!("   flavor: {}", installed.flavor);
-                eprintln!("   path: {}", installed.path.display());
-            }
-        }
-        NativeRuntimeSource::Missing => {
-            bail!(
-                "selected native runtime {} is not installed and no bundle or download URL was available",
-                resolution.selected.native_runtime_id
-            );
-        }
-    }
-    Ok(())
-}
-
-async fn download_and_install_runtime(
-    cache: &NativeRuntimeCache,
-    artifact: &mesh_llm_native_runtime::NativeRuntimeArtifact,
-    url: &str,
-    json_output: bool,
-) -> Result<mesh_llm_native_runtime::InstalledNativeRuntime> {
-    let temp = tempfile::Builder::new()
-        .prefix("mesh-native-runtime-")
-        .tempdir()
-        .context("create native runtime download workspace")?;
-    let archive = temp
-        .path()
-        .join(format!("{}.tar.gz", artifact.native_runtime_id));
-    if !json_output {
-        eprintln!(
-            "⬇️  Downloading native runtime {}",
-            artifact.native_runtime_id
-        );
-    }
-    download_runtime_archive(url, &archive, artifact.sha256.as_deref(), json_output).await?;
-    let extracted = temp.path().join("extracted");
-    fs::create_dir_all(&extracted).with_context(|| {
-        format!(
-            "create native runtime extraction dir {}",
-            extracted.display()
-        )
-    })?;
-    extract_runtime_archive(&archive, &extracted)?;
-    let bundle_dir = find_extracted_runtime_dir(&extracted)?;
-    cache.install_from_dir(&bundle_dir)
-}
-
-async fn download_runtime_archive(
-    url: &str,
-    path: &Path,
-    expected_sha256: Option<&str>,
-    json_output: bool,
-) -> Result<()> {
-    let response = reqwest::Client::builder()
-        .timeout(Duration::from_secs(600))
-        .build()
-        .context("build native runtime download HTTP client")?
-        .get(url)
-        .header("User-Agent", "mesh-llm")
-        .send()
-        .await
-        .with_context(|| format!("download native runtime {url}"))?
-        .error_for_status()
-        .with_context(|| format!("native runtime request failed for {url}"))?;
-    let total = response.content_length();
-    let mut stream = response.bytes_stream();
-    let mut file = tokio::fs::File::create(path)
-        .await
-        .with_context(|| format!("create native runtime archive {}", path.display()))?;
-    let mut downloaded = 0_u64;
-    let mut hasher = sha2::Sha256::new();
-    let mut progress = DownloadProgress::new(total, json_output);
-    while let Some(chunk) = stream.next().await {
-        let chunk = chunk.with_context(|| format!("read native runtime body from {url}"))?;
-        file.write_all(&chunk)
-            .await
-            .with_context(|| format!("write native runtime archive {}", path.display()))?;
-        downloaded += chunk.len() as u64;
-        sha2::Digest::update(&mut hasher, &chunk);
-        progress.tick(downloaded);
-    }
-    file.flush()
-        .await
-        .with_context(|| format!("flush native runtime archive {}", path.display()))?;
-    progress.finish(downloaded);
-    if let Some(expected) = expected_sha256 {
-        let expected = normalize_sha256(expected)?;
-        let actual = hex::encode(sha2::Digest::finalize(hasher));
-        if actual != expected {
-            bail!("native runtime checksum mismatch: expected {expected}, got {actual}");
         }
     }
     Ok(())
 }
 
 struct DownloadProgress {
-    total: Option<u64>,
-    quiet: bool,
+    native_runtime_id: Option<String>,
     last_percent: Option<u64>,
     last_tick: Instant,
 }
 
 impl DownloadProgress {
-    fn new(total: Option<u64>, quiet: bool) -> Self {
+    fn new() -> Self {
         Self {
-            total,
-            quiet,
+            native_runtime_id: None,
             last_percent: None,
             last_tick: Instant::now(),
         }
     }
 
-    fn tick(&mut self, downloaded: u64) {
-        if self.quiet {
+    fn tick(
+        &mut self,
+        native_runtime_id: &str,
+        downloaded: u64,
+        total: Option<u64>,
+        finished: bool,
+    ) {
+        if self.native_runtime_id.is_none() {
+            self.native_runtime_id = Some(native_runtime_id.to_string());
+            eprintln!("⬇️  Downloading native runtime {native_runtime_id}");
+        }
+        if finished {
+            self.finish(downloaded);
             return;
         }
-        let should_print = match self.total {
+        let should_print = match total {
             Some(total) if total > 0 => {
                 let percent = downloaded.saturating_mul(100) / total;
                 let crossed_step = self
@@ -278,7 +177,7 @@ impl DownloadProgress {
         };
         if should_print {
             self.last_tick = Instant::now();
-            match self.total {
+            match total {
                 Some(total) if total > 0 => eprintln!(
                     "   downloaded {} / {} ({})",
                     human_bytes(downloaded),
@@ -291,10 +190,26 @@ impl DownloadProgress {
     }
 
     fn finish(&mut self, downloaded: u64) {
-        if !self.quiet {
-            eprintln!("   downloaded {}", human_bytes(downloaded));
-        }
+        eprintln!("   downloaded {}", human_bytes(downloaded));
     }
+}
+
+fn cli_download_progress(json_output: bool) -> Option<NativeRuntimeDownloadProgressCallback> {
+    if json_output {
+        return None;
+    }
+    let progress = Arc::new(Mutex::new(DownloadProgress::new()));
+    Some(Arc::new(move |event| {
+        let Ok(mut progress) = progress.lock() else {
+            return;
+        };
+        progress.tick(
+            &event.native_runtime_id,
+            event.downloaded_bytes,
+            event.total_bytes,
+            event.finished,
+        );
+    }))
 }
 
 fn human_bytes(bytes: u64) -> String {
@@ -313,61 +228,6 @@ fn human_bytes(bytes: u64) -> String {
     } else {
         format!("{value:.1} {unit}")
     }
-}
-
-fn normalize_sha256(value: &str) -> Result<String> {
-    let trimmed = value.trim().strip_prefix("sha256:").unwrap_or(value.trim());
-    let digest = trimmed
-        .split_whitespace()
-        .next()
-        .unwrap_or_default()
-        .to_ascii_lowercase();
-    if digest.len() == 64 && digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
-        Ok(digest)
-    } else {
-        bail!("native runtime manifest contains invalid sha256: {value}");
-    }
-}
-
-fn extract_runtime_archive(archive: &Path, extracted: &Path) -> Result<()> {
-    let file = fs::File::open(archive)
-        .with_context(|| format!("open native runtime archive {}", archive.display()))?;
-    let decoder = flate2::read::GzDecoder::new(file);
-    let mut archive = tar::Archive::new(decoder);
-    archive.unpack(extracted).with_context(|| {
-        format!(
-            "extract native runtime archive into {}",
-            extracted.display()
-        )
-    })
-}
-
-fn find_extracted_runtime_dir(extracted: &Path) -> Result<PathBuf> {
-    let mut matches = Vec::new();
-    collect_runtime_manifest_dirs(extracted, &mut matches)?;
-    match matches.len() {
-        1 => Ok(matches.remove(0)),
-        0 => bail!("downloaded native runtime archive did not contain a manifest.json"),
-        count => bail!("downloaded native runtime archive contained {count} manifest.json files"),
-    }
-}
-
-fn collect_runtime_manifest_dirs(dir: &Path, matches: &mut Vec<PathBuf>) -> Result<()> {
-    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
-        let entry = entry?;
-        let path = entry.path();
-        if entry.file_type()?.is_dir() {
-            if path
-                .join(mesh_llm_native_runtime::NATIVE_RUNTIME_MANIFEST_FILE)
-                .is_file()
-            {
-                matches.push(path);
-            } else {
-                collect_runtime_manifest_dirs(&path, matches)?;
-            }
-        }
-    }
-    Ok(())
 }
 
 pub(crate) fn run_native_runtime_remove(
@@ -467,97 +327,6 @@ struct NativeRuntimeDoctorReport {
     selected_runtime_path: Option<PathBuf>,
     installed_count: usize,
     current_version_installed_count: usize,
-}
-
-fn native_runtime_cache(cache_dir: Option<&Path>) -> Result<NativeRuntimeCache> {
-    let root = match cache_dir {
-        Some(path) => path.to_path_buf(),
-        None => dirs::cache_dir()
-            .or_else(|| dirs::home_dir().map(|home| home.join(".cache")))
-            .context("cannot determine native runtime cache directory")?
-            .join("mesh-llm")
-            .join("native-runtimes"),
-    };
-    Ok(NativeRuntimeCache::new(root))
-}
-
-fn load_release_manifest(
-    manifest_path: Option<&Path>,
-    bundle_dirs: &[PathBuf],
-) -> Result<NativeRuntimeReleaseManifest> {
-    let mut artifacts = Vec::new();
-    let mut mesh_version = CURRENT_MESH_VERSION.to_string();
-    if let Some(path) = manifest_path {
-        let manifest = NativeRuntimeReleaseManifest::read_from_path(path)?;
-        mesh_version = manifest.mesh_version.clone();
-        artifacts.extend(manifest.artifacts);
-    }
-    for dir in bundle_dirs {
-        let manifest = NativeRuntimeManifest::read_from_dir(dir)
-            .with_context(|| format!("read bundled native runtime {}", dir.display()))?;
-        mesh_version = manifest.artifact.mesh_version.clone();
-        artifacts.push(manifest.artifact);
-    }
-    Ok(NativeRuntimeReleaseManifest {
-        mesh_version,
-        artifacts,
-    })
-}
-
-fn host_runtime_profile() -> HostRuntimeProfile {
-    let survey = crate::system::hardware::survey();
-    let gpus = survey
-        .gpus
-        .iter()
-        .map(|gpu| HostGpuProfile {
-            display_name: gpu.display_name.clone(),
-            backend_device: gpu.backend_device.clone(),
-            stable_id: gpu.stable_id.clone(),
-            vram_bytes: Some(gpu.vram_bytes),
-            unified_memory: gpu.unified_memory,
-        })
-        .collect::<Vec<_>>();
-    HostRuntimeProfile {
-        os: std::env::consts::OS.to_string(),
-        arch: std::env::consts::ARCH.to_string(),
-        target_triple: option_env!("TARGET").map(str::to_string),
-        available_flavors: detected_native_runtime_flavors(&survey.gpus),
-        gpus,
-    }
-}
-
-fn detected_native_runtime_flavors(
-    gpus: &[crate::system::hardware::GpuFacts],
-) -> BTreeSet<NativeRuntimeFlavor> {
-    let mut flavors = BTreeSet::from([NativeRuntimeFlavor::Cpu]);
-    if cfg!(target_os = "macos") {
-        flavors.insert(NativeRuntimeFlavor::Metal);
-    }
-    for gpu in gpus {
-        let label = format!(
-            "{} {}",
-            gpu.display_name,
-            gpu.backend_device.as_deref().unwrap_or_default()
-        )
-        .to_ascii_lowercase();
-        if label.contains("cuda") || label.contains("nvidia") {
-            flavors.insert(NativeRuntimeFlavor::Cuda);
-        }
-        if label.contains("blackwell")
-            || label.contains("gb200")
-            || label.contains("b200")
-            || label.contains("rtx 50")
-        {
-            flavors.insert(NativeRuntimeFlavor::CudaBlackwell);
-        }
-        if label.contains("rocm") || label.contains("hip") || label.contains("amd") {
-            flavors.insert(NativeRuntimeFlavor::Rocm);
-        }
-        if label.contains("vulkan") {
-            flavors.insert(NativeRuntimeFlavor::Vulkan);
-        }
-    }
-    flavors
 }
 
 fn print_available_runtimes(rows: &[serde_json::Value]) {

--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -33,6 +33,9 @@ pub mod config {
     };
 }
 
+#[path = "sdk/native_runtime.rs"]
+pub mod native_runtime;
+
 const DEFAULT_EMBEDDED_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
 const EMBEDDED_STARTUP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 

--- a/crates/mesh-llm-host-runtime/src/sdk/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk/native_runtime.rs
@@ -1,0 +1,18 @@
+//! Native runtime resolution and installation APIs for embedded MeshLLM clients.
+
+pub use crate::system::native_runtime_install::{
+    CURRENT_MESH_VERSION, NATIVE_RUNTIME_MANIFEST_URL_ENV, NativeRuntimeDownloadProgress,
+    NativeRuntimeDownloadProgressCallback, NativeRuntimeInstallOptions,
+    NativeRuntimeInstallOutcome, NativeRuntimeInstallStatus, NativeRuntimeManifestOptions,
+    NativeRuntimeVerificationPolicy, default_native_runtime_cache, default_release_manifest_url,
+    host_runtime_profile, install_native_runtime, load_release_manifest, native_runtime_cache,
+};
+pub use mesh_llm_native_runtime::{
+    CachePrunePlan, CandidateEvaluation, CandidateRejection, HostGpuProfile, HostRuntimeProfile,
+    InstalledNativeRuntime, NATIVE_RUNTIME_MANIFEST_FILE, NativeRuntimeArtifact,
+    NativeRuntimeCache, NativeRuntimeCacheRoot, NativeRuntimeFlavor, NativeRuntimeFlavorParseError,
+    NativeRuntimeLoadPlan, NativeRuntimeManifest, NativeRuntimePruneMode,
+    NativeRuntimeReleaseManifest, NativeRuntimeRequirement, NativeRuntimeResolution,
+    NativeRuntimeResolver, NativeRuntimeSource, RuntimeSelection, native_runtime_cache_root,
+    select_native_runtime,
+};

--- a/crates/mesh-llm-host-runtime/src/system/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/system/mod.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "dynamic-native-runtime")]
 pub(crate) mod native_runtime;
+pub(crate) mod native_runtime_install;
 
 pub(crate) use mesh_llm_system::{autoupdate, backend, benchmark, benchmark_prompts, hardware};

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime_install.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime_install.rs
@@ -1,0 +1,574 @@
+use anyhow::{Context, Result, bail};
+use futures_util::StreamExt;
+use mesh_llm_native_runtime::{
+    HostGpuProfile, HostRuntimeProfile, InstalledNativeRuntime, NativeRuntimeArtifact,
+    NativeRuntimeCache, NativeRuntimeFlavor, NativeRuntimeManifest, NativeRuntimeReleaseManifest,
+    NativeRuntimeResolver, NativeRuntimeSource, RuntimeSelection,
+};
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::AsyncWriteExt;
+
+pub const CURRENT_MESH_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const NATIVE_RUNTIME_MANIFEST_URL_ENV: &str = "MESH_LLM_NATIVE_RUNTIME_MANIFEST_URL";
+
+pub type NativeRuntimeDownloadProgressCallback =
+    Arc<dyn Fn(NativeRuntimeDownloadProgress) + Send + Sync + 'static>;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeRuntimeVerificationPolicy {
+    #[default]
+    RequireChecksum,
+    RequireChecksumAndSignature,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NativeRuntimeDownloadProgress {
+    pub native_runtime_id: String,
+    pub url: String,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub finished: bool,
+}
+
+#[derive(Clone)]
+pub struct NativeRuntimeManifestOptions {
+    pub mesh_version: String,
+    pub manifest_path: Option<PathBuf>,
+    pub manifest_url: Option<String>,
+    pub bundle_dirs: Vec<PathBuf>,
+    pub allow_default_manifest_url: bool,
+}
+
+#[derive(Clone)]
+pub struct NativeRuntimeInstallOptions {
+    pub mesh_version: String,
+    pub selection: RuntimeSelection,
+    pub manifest_path: Option<PathBuf>,
+    pub manifest_url: Option<String>,
+    pub bundle_dirs: Vec<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
+    pub verification_policy: NativeRuntimeVerificationPolicy,
+    pub progress: Option<NativeRuntimeDownloadProgressCallback>,
+    pub allow_download: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NativeRuntimeInstallStatus {
+    AlreadyInstalled,
+    Installed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NativeRuntimeInstallOutcome {
+    pub status: NativeRuntimeInstallStatus,
+    pub runtime: InstalledNativeRuntime,
+    pub resolution: mesh_llm_native_runtime::NativeRuntimeResolution,
+}
+
+impl Default for NativeRuntimeManifestOptions {
+    fn default() -> Self {
+        Self {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: None,
+            manifest_url: None,
+            bundle_dirs: Vec::new(),
+            allow_default_manifest_url: true,
+        }
+    }
+}
+
+impl Default for NativeRuntimeInstallOptions {
+    fn default() -> Self {
+        Self {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            selection: RuntimeSelection::Recommended,
+            manifest_path: None,
+            manifest_url: None,
+            bundle_dirs: Vec::new(),
+            cache_dir: None,
+            verification_policy: NativeRuntimeVerificationPolicy::RequireChecksum,
+            progress: None,
+            allow_download: true,
+        }
+    }
+}
+
+pub fn default_release_manifest_url(mesh_version: &str) -> String {
+    format!(
+        "https://github.com/Mesh-LLM/mesh-llm/releases/download/v{mesh_version}/native-runtimes.json"
+    )
+}
+
+pub fn default_native_runtime_cache() -> Result<NativeRuntimeCache> {
+    native_runtime_cache(None)
+}
+
+pub fn native_runtime_cache(cache_dir: Option<&Path>) -> Result<NativeRuntimeCache> {
+    let root = match cache_dir {
+        Some(path) => path.to_path_buf(),
+        None => dirs::cache_dir()
+            .or_else(|| dirs::home_dir().map(|home| home.join(".cache")))
+            .context("cannot determine native runtime cache directory")?
+            .join("mesh-llm")
+            .join("native-runtimes"),
+    };
+    Ok(NativeRuntimeCache::new(root))
+}
+
+pub fn host_runtime_profile() -> HostRuntimeProfile {
+    let survey = crate::system::hardware::survey();
+    let gpus = survey
+        .gpus
+        .iter()
+        .map(|gpu| HostGpuProfile {
+            display_name: gpu.display_name.clone(),
+            backend_device: gpu.backend_device.clone(),
+            stable_id: gpu.stable_id.clone(),
+            vram_bytes: Some(gpu.vram_bytes),
+            unified_memory: gpu.unified_memory,
+        })
+        .collect::<Vec<_>>();
+    HostRuntimeProfile {
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        target_triple: option_env!("TARGET").map(str::to_string),
+        available_flavors: detected_native_runtime_flavors(&survey.gpus),
+        gpus,
+    }
+}
+
+pub async fn load_release_manifest(
+    options: NativeRuntimeManifestOptions,
+) -> Result<NativeRuntimeReleaseManifest> {
+    let mut artifacts = Vec::new();
+    let mut mesh_version = options.mesh_version.clone();
+    if let Some(path) = options.manifest_path {
+        let manifest = NativeRuntimeReleaseManifest::read_from_path(&path)?;
+        mesh_version = manifest.mesh_version.clone();
+        artifacts.extend(manifest.artifacts);
+    } else if let Some(url) = manifest_url(&mesh_version, &options) {
+        let manifest = download_release_manifest(&url).await?;
+        mesh_version = manifest.mesh_version.clone();
+        artifacts.extend(manifest.artifacts);
+    }
+    append_bundle_artifacts(&mut artifacts, &mut mesh_version, &options.bundle_dirs)?;
+    Ok(NativeRuntimeReleaseManifest {
+        mesh_version,
+        artifacts,
+    })
+}
+
+pub async fn install_native_runtime(
+    options: NativeRuntimeInstallOptions,
+) -> Result<NativeRuntimeInstallOutcome> {
+    let manifest = load_release_manifest(NativeRuntimeManifestOptions {
+        mesh_version: options.mesh_version.clone(),
+        manifest_path: options.manifest_path.clone(),
+        manifest_url: options.manifest_url.clone(),
+        bundle_dirs: options.bundle_dirs.clone(),
+        allow_default_manifest_url: true,
+    })
+    .await?;
+    if manifest.artifacts.is_empty() {
+        bail!("no native runtime manifest entries found");
+    }
+    let cache = native_runtime_cache(options.cache_dir.as_deref())?;
+    let resolution = NativeRuntimeResolver::new(
+        &options.mesh_version,
+        host_runtime_profile(),
+        manifest,
+        cache.clone(),
+    )
+    .with_bundle_dirs(options.bundle_dirs.clone())
+    .resolve(&options.selection)?;
+    install_resolved_runtime(&cache, resolution, &options).await
+}
+
+async fn install_resolved_runtime(
+    cache: &NativeRuntimeCache,
+    resolution: mesh_llm_native_runtime::NativeRuntimeResolution,
+    options: &NativeRuntimeInstallOptions,
+) -> Result<NativeRuntimeInstallOutcome> {
+    match &resolution.source {
+        NativeRuntimeSource::Installed { path: _ } => installed_outcome(cache, resolution),
+        NativeRuntimeSource::Bundle { path } => {
+            let runtime = cache.install_from_dir(path)?;
+            Ok(NativeRuntimeInstallOutcome {
+                status: NativeRuntimeInstallStatus::Installed,
+                runtime,
+                resolution,
+            })
+        }
+        NativeRuntimeSource::Download { url } if options.allow_download => {
+            let runtime =
+                download_and_install_runtime(cache, &resolution.selected, url, options).await?;
+            Ok(NativeRuntimeInstallOutcome {
+                status: NativeRuntimeInstallStatus::Installed,
+                runtime,
+                resolution,
+            })
+        }
+        NativeRuntimeSource::Download { url: _ } => {
+            bail!("selected native runtime is downloadable, but downloads are disabled")
+        }
+        NativeRuntimeSource::Missing => {
+            bail!(
+                "selected native runtime {} is not installed and no bundle or download URL was available",
+                resolution.selected.native_runtime_id
+            )
+        }
+    }
+}
+
+fn installed_outcome(
+    cache: &NativeRuntimeCache,
+    resolution: mesh_llm_native_runtime::NativeRuntimeResolution,
+) -> Result<NativeRuntimeInstallOutcome> {
+    let runtime = cache
+        .find_installed(
+            &resolution.selected.mesh_version,
+            &resolution.selected.native_runtime_id,
+        )?
+        .context("selected native runtime was not found in cache")?;
+    Ok(NativeRuntimeInstallOutcome {
+        status: NativeRuntimeInstallStatus::AlreadyInstalled,
+        runtime,
+        resolution,
+    })
+}
+
+async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseManifest> {
+    let text = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()
+        .context("build native runtime manifest HTTP client")?
+        .get(url)
+        .header("User-Agent", "mesh-llm")
+        .send()
+        .await
+        .with_context(|| format!("download native runtime release manifest {url}"))?
+        .error_for_status()
+        .with_context(|| format!("native runtime release manifest request failed for {url}"))?
+        .text()
+        .await
+        .with_context(|| format!("read native runtime release manifest {url}"))?;
+    NativeRuntimeReleaseManifest::from_json_str(&text)
+        .with_context(|| format!("parse native runtime release manifest {url}"))
+}
+
+async fn download_and_install_runtime(
+    cache: &NativeRuntimeCache,
+    artifact: &NativeRuntimeArtifact,
+    url: &str,
+    options: &NativeRuntimeInstallOptions,
+) -> Result<InstalledNativeRuntime> {
+    let temp = tempfile::Builder::new()
+        .prefix("mesh-native-runtime-")
+        .tempdir()
+        .context("create native runtime download workspace")?;
+    let archive = temp
+        .path()
+        .join(format!("{}.tar.gz", artifact.native_runtime_id));
+    download_runtime_archive(url, &archive, artifact, options).await?;
+    let extracted = temp.path().join("extracted");
+    fs::create_dir_all(&extracted).with_context(|| {
+        format!(
+            "create native runtime extraction dir {}",
+            extracted.display()
+        )
+    })?;
+    extract_runtime_archive(&archive, &extracted)?;
+    let bundle_dir = find_extracted_runtime_dir(&extracted)?;
+    cache.install_from_dir(&bundle_dir)
+}
+
+async fn download_runtime_archive(
+    url: &str,
+    path: &Path,
+    artifact: &NativeRuntimeArtifact,
+    options: &NativeRuntimeInstallOptions,
+) -> Result<()> {
+    verify_download_policy_before_fetch(artifact, options.verification_policy)?;
+    let response = reqwest::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()
+        .context("build native runtime download HTTP client")?
+        .get(url)
+        .header("User-Agent", "mesh-llm")
+        .send()
+        .await
+        .with_context(|| format!("download native runtime {url}"))?
+        .error_for_status()
+        .with_context(|| format!("native runtime request failed for {url}"))?;
+    let total = response.content_length();
+    let mut stream = response.bytes_stream();
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .with_context(|| format!("create native runtime archive {}", path.display()))?;
+    let mut downloaded = 0_u64;
+    let mut hasher = sha2::Sha256::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.with_context(|| format!("read native runtime body from {url}"))?;
+        file.write_all(&chunk)
+            .await
+            .with_context(|| format!("write native runtime archive {}", path.display()))?;
+        downloaded += chunk.len() as u64;
+        sha2::Digest::update(&mut hasher, &chunk);
+        emit_download_progress(artifact, url, downloaded, total, false, options);
+    }
+    file.flush()
+        .await
+        .with_context(|| format!("flush native runtime archive {}", path.display()))?;
+    emit_download_progress(artifact, url, downloaded, total, true, options);
+    verify_downloaded_archive(artifact, hasher)?;
+    Ok(())
+}
+
+fn verify_download_policy_before_fetch(
+    artifact: &NativeRuntimeArtifact,
+    policy: NativeRuntimeVerificationPolicy,
+) -> Result<()> {
+    if artifact.sha256.is_none() {
+        bail!(
+            "native runtime {} is missing required sha256 verification metadata",
+            artifact.native_runtime_id
+        );
+    }
+    if policy == NativeRuntimeVerificationPolicy::RequireChecksumAndSignature {
+        let signature = artifact.signature.as_deref().unwrap_or_default();
+        if signature.trim().is_empty() {
+            bail!(
+                "native runtime {} is missing required signature metadata",
+                artifact.native_runtime_id
+            );
+        }
+        bail!("native runtime signature verification is not implemented yet");
+    }
+    Ok(())
+}
+
+fn verify_downloaded_archive(artifact: &NativeRuntimeArtifact, hasher: sha2::Sha256) -> Result<()> {
+    let expected = artifact
+        .sha256
+        .as_deref()
+        .context("native runtime sha256 missing after download")?;
+    let expected = normalize_sha256(expected)?;
+    let actual = hex::encode(sha2::Digest::finalize(hasher));
+    if actual != expected {
+        bail!("native runtime checksum mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+fn emit_download_progress(
+    artifact: &NativeRuntimeArtifact,
+    url: &str,
+    downloaded_bytes: u64,
+    total_bytes: Option<u64>,
+    finished: bool,
+    options: &NativeRuntimeInstallOptions,
+) {
+    let Some(progress) = &options.progress else {
+        return;
+    };
+    progress(NativeRuntimeDownloadProgress {
+        native_runtime_id: artifact.native_runtime_id.clone(),
+        url: url.to_string(),
+        downloaded_bytes,
+        total_bytes,
+        finished,
+    });
+}
+
+fn manifest_url(mesh_version: &str, options: &NativeRuntimeManifestOptions) -> Option<String> {
+    options
+        .manifest_url
+        .clone()
+        .or_else(|| {
+            std::env::var(NATIVE_RUNTIME_MANIFEST_URL_ENV)
+                .ok()
+                .filter(|value| !value.trim().is_empty())
+        })
+        .or_else(|| {
+            (options.allow_default_manifest_url && options.bundle_dirs.is_empty())
+                .then(|| default_release_manifest_url(mesh_version))
+        })
+}
+
+fn append_bundle_artifacts(
+    artifacts: &mut Vec<NativeRuntimeArtifact>,
+    mesh_version: &mut String,
+    bundle_dirs: &[PathBuf],
+) -> Result<()> {
+    for dir in bundle_dirs {
+        let manifest = NativeRuntimeManifest::read_from_dir(dir)
+            .with_context(|| format!("read bundled native runtime {}", dir.display()))?;
+        *mesh_version = manifest.artifact.mesh_version.clone();
+        artifacts.push(manifest.artifact);
+    }
+    Ok(())
+}
+
+fn detected_native_runtime_flavors(
+    gpus: &[crate::system::hardware::GpuFacts],
+) -> BTreeSet<NativeRuntimeFlavor> {
+    let mut flavors = BTreeSet::from([NativeRuntimeFlavor::Cpu]);
+    if cfg!(target_os = "macos") {
+        flavors.insert(NativeRuntimeFlavor::Metal);
+    }
+    for gpu in gpus {
+        let label = format!(
+            "{} {}",
+            gpu.display_name,
+            gpu.backend_device.as_deref().unwrap_or_default()
+        )
+        .to_ascii_lowercase();
+        if label.contains("cuda") || label.contains("nvidia") {
+            flavors.insert(NativeRuntimeFlavor::Cuda);
+        }
+        if label.contains("blackwell")
+            || label.contains("gb200")
+            || label.contains("b200")
+            || label.contains("rtx 50")
+        {
+            flavors.insert(NativeRuntimeFlavor::CudaBlackwell);
+        }
+        if label.contains("rocm") || label.contains("hip") || label.contains("amd") {
+            flavors.insert(NativeRuntimeFlavor::Rocm);
+        }
+        if label.contains("vulkan") {
+            flavors.insert(NativeRuntimeFlavor::Vulkan);
+        }
+    }
+    flavors
+}
+
+fn normalize_sha256(value: &str) -> Result<String> {
+    let trimmed = value.trim().strip_prefix("sha256:").unwrap_or(value.trim());
+    let digest = trimmed
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if digest.len() == 64 && digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        Ok(digest)
+    } else {
+        bail!("native runtime manifest contains invalid sha256: {value}");
+    }
+}
+
+fn extract_runtime_archive(archive: &Path, extracted: &Path) -> Result<()> {
+    let file = fs::File::open(archive)
+        .with_context(|| format!("open native runtime archive {}", archive.display()))?;
+    let decoder = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(decoder);
+    archive.unpack(extracted).with_context(|| {
+        format!(
+            "extract native runtime archive into {}",
+            extracted.display()
+        )
+    })
+}
+
+fn find_extracted_runtime_dir(extracted: &Path) -> Result<PathBuf> {
+    let mut matches = Vec::new();
+    collect_runtime_manifest_dirs(extracted, &mut matches)?;
+    match matches.len() {
+        1 => Ok(matches.remove(0)),
+        0 => bail!("downloaded native runtime archive did not contain a manifest.json"),
+        count => bail!("downloaded native runtime archive contained {count} manifest.json files"),
+    }
+}
+
+fn collect_runtime_manifest_dirs(dir: &Path, matches: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in fs::read_dir(dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if entry.file_type()?.is_dir() {
+            if path
+                .join(mesh_llm_native_runtime::NATIVE_RUNTIME_MANIFEST_FILE)
+                .is_file()
+            {
+                matches.push(path);
+            } else {
+                collect_runtime_manifest_dirs(&path, matches)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn artifact_with_sha(signature: Option<&str>) -> NativeRuntimeArtifact {
+        NativeRuntimeArtifact {
+            native_runtime_id: "meshllm-native-runtime-linux-x86_64-cpu".to_string(),
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            target_triple: Some("x86_64-unknown-linux-gnu".to_string()),
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            flavor: NativeRuntimeFlavor::Cpu,
+            priority: 0,
+            skippy_abi_version: None,
+            url: Some("https://example.invalid/runtime.tar.gz".to_string()),
+            sha256: Some("a".repeat(64)),
+            signature: signature.map(str::to_string),
+            library_paths: Vec::new(),
+            requirements: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn checksum_policy_requires_sha256() {
+        let mut artifact = artifact_with_sha(None);
+        artifact.sha256 = None;
+
+        let err = verify_download_policy_before_fetch(
+            &artifact,
+            NativeRuntimeVerificationPolicy::RequireChecksum,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("missing required sha256"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn signature_policy_fails_closed_until_implemented() {
+        let artifact = artifact_with_sha(Some("signature"));
+
+        let err = verify_download_policy_before_fetch(
+            &artifact,
+            NativeRuntimeVerificationPolicy::RequireChecksumAndSignature,
+        )
+        .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("signature verification is not implemented"),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn default_manifest_url_is_skipped_for_bundle_only_resolution() {
+        let options = NativeRuntimeManifestOptions {
+            bundle_dirs: vec![PathBuf::from("runtime-bundle")],
+            ..Default::default()
+        };
+
+        assert!(manifest_url(CURRENT_MESH_VERSION, &options).is_none());
+    }
+}

--- a/crates/mesh-llm-native-runtime/README.md
+++ b/crates/mesh-llm-native-runtime/README.md
@@ -281,9 +281,60 @@ mesh-llm runtime prune --active-only
 mesh-llm doctor --json
 ```
 
-The CLI owns network downloads, archive extraction, progress output, and
-checksum verification. This crate owns the manifest, compatibility, cache, and
-load-plan semantics those commands use.
+`mesh-llm runtime install` does not require `--manifest` in normal release
+usage. It resolves `native-runtimes.json` for the running MeshLLM version from
+the release URL, or from `MESH_LLM_NATIVE_RUNTIME_MANIFEST_URL` when that
+environment variable is set. `--manifest` and `--bundle-dir` remain available
+for CI, offline packages, and local artifact testing. Passing only
+`--bundle-dir` does not fetch the default release manifest.
+
+The host runtime's SDK layer owns network downloads, archive extraction,
+progress callbacks, checksum verification, and cache installation. This crate
+owns the manifest, compatibility, cache, and load-plan semantics those flows
+use.
+
+## Rust SDK Integration
+
+Rust SDK consumers use `mesh_llm::sdk::native_runtime` for first-class install
+and resolver access:
+
+```rust
+use mesh_llm::sdk::native_runtime::{
+    NativeRuntimeInstallOptions, RuntimeSelection, install_native_runtime,
+};
+
+# async fn example(cache_dir: std::path::PathBuf) -> anyhow::Result<()> {
+let outcome = install_native_runtime(NativeRuntimeInstallOptions {
+    selection: RuntimeSelection::Recommended,
+    cache_dir: Some(cache_dir),
+    progress: Some(std::sync::Arc::new(|event| {
+        eprintln!(
+            "{}: {} bytes",
+            event.native_runtime_id,
+            event.downloaded_bytes
+        );
+    })),
+    ..Default::default()
+})
+.await?;
+
+println!("installed {}", outcome.runtime.native_runtime_id);
+# Ok(())
+# }
+```
+
+The SDK module also re-exports the lower-level manifest, resolver, cache, and
+load-plan types from this crate for callers that need to query available
+runtimes, inspect candidate rejections, remove cached runtimes, or prune older
+MeshLLM versions.
+
+## Verification
+
+Release downloads require `sha256` metadata and fail if the archive digest does
+not match the release manifest. The SDK exposes
+`NativeRuntimeVerificationPolicy::RequireChecksumAndSignature`, but that policy
+currently fails closed because signature verification keys and attestation
+format are not implemented yet.
 
 TODO: teach the CLI/SDK to discover the release manifest automatically for the
 running MeshLLM version. Until then, install/list available flows need an
@@ -300,3 +351,6 @@ explicit `--manifest` or packaged `--bundle-dir`.
 - Dynamic loading is intentionally outside this crate; the shipped host runtime
   consumes `load_plan()` and loads the declared libraries through `skippy-ffi`
   when built with `dynamic-native-runtime`.
+- Generated runtime crates are not the supported distribution story for native
+  runtimes in this PR. The supported path is release artifacts plus
+  `native-runtimes.json`.

--- a/crates/mesh-llm-native-runtime/src/manifest.rs
+++ b/crates/mesh-llm-native-runtime/src/manifest.rs
@@ -123,15 +123,20 @@ impl NativeRuntimeReleaseManifest {
     pub fn read_from_path(path: &Path) -> Result<Self> {
         let text = fs::read_to_string(path)
             .with_context(|| format!("read native runtime release manifest {}", path.display()))?;
-        let mut value: Value = serde_json::from_str(&text)
-            .with_context(|| format!("parse native runtime release manifest {}", path.display()))?;
+        Self::from_json_str(&text)
+            .with_context(|| format!("parse native runtime release manifest {}", path.display()))
+    }
+
+    pub fn from_json_str(text: &str) -> Result<Self> {
+        let mut value: Value =
+            serde_json::from_str(text).context("parse native runtime release manifest JSON")?;
         if let Some(artifacts) = value.get_mut("artifacts").and_then(Value::as_array_mut) {
             for artifact in artifacts {
                 normalize_legacy_aliases(artifact)?;
             }
         }
-        let manifest: Self = serde_json::from_value(value)
-            .with_context(|| format!("parse native runtime release manifest {}", path.display()))?;
+        let manifest: Self =
+            serde_json::from_value(value).context("parse native runtime release manifest")?;
         manifest.validate()?;
         Ok(manifest)
     }

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -354,24 +354,23 @@ impl Collector for DefaultCollector {
             if metrics.contains(&Metric::IsSoc) {
                 survey.is_soc = true;
             }
-            if metrics.contains(&Metric::VramBytes) {
-                if let Some((vram_bytes, reserved_bytes)) =
-                    macos_metal_gpu_budget(query_metal_recommended_working_set_bytes())
-                {
-                    survey.vram_bytes = vram_bytes;
-                    survey.gpu_vram = vec![vram_bytes];
-                    survey.gpu_reserved = vec![reserved_bytes];
-                }
+            if let Some((vram_bytes, reserved_bytes)) = metrics
+                .contains(&Metric::VramBytes)
+                .then(|| macos_metal_gpu_budget(query_metal_recommended_working_set_bytes()))
+                .flatten()
+            {
+                survey.vram_bytes = vram_bytes;
+                survey.gpu_vram = vec![vram_bytes];
+                survey.gpu_reserved = vec![reserved_bytes];
             }
             if metrics.contains(&Metric::GpuName) {
                 let out = std::process::Command::new("sysctl")
                     .args(["-n", "machdep.cpu.brand_string"])
                     .output()
                     .ok();
-                if let Some(out) = out {
-                    if let Ok(s) = String::from_utf8(out.stdout) {
-                        survey.gpu_name = parse_macos_cpu_brand(&s);
-                    }
+                let gpu_name = out.and_then(|out| String::from_utf8(out.stdout).ok());
+                if let Some(s) = gpu_name {
+                    survey.gpu_name = parse_macos_cpu_brand(&s);
                 }
             }
             if metrics.contains(&Metric::GpuCount) {

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -462,46 +462,36 @@ The accepted packaging direction is documented in
 runtimes are release artifacts, not implicit Cargo builds, and the native
 runtime version must exactly match the MeshLLM version that loads it.
 
-Status: native runtime artifact packaging is in place, but the Rust SDK does
-not yet expose a first-class runtime resolver/downloader API. Current
-Sprout-style Rust integrations should depend on `mesh-llm-sdk` by git revision
-and use the source-build path shown above. The binary-runtime SDK flow below is
-the intended packaging direction and remains TODO before it should be presented
-as a supported Rust SDK install path.
-
-Swift and Kotlin load MeshLLM through `libmeshllm_ffi`, not through a public
-`libllama` contract. Flavor-specific llama.cpp builds are an implementation
-detail of the native runtime artifact.
-
 Native runtime artifacts use this layout:
 
 ```text
-meshllm-native-<platform>-<flavor>/
+meshllm-native-runtime-<platform>-<flavor>/
   manifest.json
   README.md
   lib/
-    libmeshllm_ffi.{dylib|so}
+    libllama.{dylib|so|dll}
+    libggml*.{dylib|so|dll}
 ```
 
 The manifest records the MeshLLM version, target triple, runtime flavor,
-library checksum, llama.cpp upstream SHA, patched SHA, and patch digest. SDK
-loaders verify the MeshLLM version and library checksum before loading the
-dynamic library.
+Skippy ABI metadata, load-order library paths, release URL, checksum, and
+optional signature metadata. SDK loaders reject runtimes whose `mesh_version`
+does not exactly match the running MeshLLM version.
 
 Baseline artifact names:
 
 | Artifact directory | Target | Flavor |
 |---|---|---|
-| `meshllm-native-darwin-aarch64-metal` | `aarch64-apple-darwin` | Metal |
-| `meshllm-native-darwin-aarch64-cpu` | `aarch64-apple-darwin` | CPU |
-| `meshllm-native-linux-x86_64-cpu` | `x86_64-unknown-linux-gnu` | CPU |
-| `meshllm-native-linux-x86_64-cuda` | `x86_64-unknown-linux-gnu` | CUDA |
-| `meshllm-native-linux-x86_64-vulkan` | `x86_64-unknown-linux-gnu` | Vulkan |
-| `meshllm-native-linux-x86_64-rocm` | `x86_64-unknown-linux-gnu` | ROCm/HIP |
-| `meshllm-native-windows-x86_64-cpu` | `x86_64-pc-windows-msvc` | CPU |
-| `meshllm-native-windows-x86_64-cuda` | `x86_64-pc-windows-msvc` | CUDA |
-| `meshllm-native-windows-x86_64-vulkan` | `x86_64-pc-windows-msvc` | Vulkan |
-| `meshllm-native-windows-x86_64-rocm` | `x86_64-pc-windows-msvc` | ROCm/HIP |
+| `meshllm-native-runtime-darwin-aarch64-metal` | `aarch64-apple-darwin` | Metal |
+| `meshllm-native-runtime-darwin-aarch64-cpu` | `aarch64-apple-darwin` | CPU |
+| `meshllm-native-runtime-linux-x86_64-cpu` | `x86_64-unknown-linux-gnu` | CPU |
+| `meshllm-native-runtime-linux-x86_64-cuda` | `x86_64-unknown-linux-gnu` | CUDA |
+| `meshllm-native-runtime-linux-x86_64-vulkan` | `x86_64-unknown-linux-gnu` | Vulkan |
+| `meshllm-native-runtime-linux-x86_64-rocm` | `x86_64-unknown-linux-gnu` | ROCm/HIP |
+| `meshllm-native-runtime-windows-x86_64-cpu` | `x86_64-pc-windows-msvc` | CPU |
+| `meshllm-native-runtime-windows-x86_64-cuda` | `x86_64-pc-windows-msvc` | CUDA |
+| `meshllm-native-runtime-windows-x86_64-vulkan` | `x86_64-pc-windows-msvc` | Vulkan |
+| `meshllm-native-runtime-windows-x86_64-rocm` | `x86_64-pc-windows-msvc` | ROCm/HIP |
 
 CUDA and ROCm artifacts may include hardware-specific flavor suffixes such as
 `cuda-sm80`, `cuda-blackwell`, or `rocm-gfx1100` when
@@ -511,94 +501,69 @@ CUDA and ROCm artifacts may include hardware-specific flavor suffixes such as
 Build and package one flavor:
 
 ```bash
-scripts/package-native-sdk.sh \
+scripts/package-native-runtime.sh \
   --build \
   --backend metal \
   --target aarch64-apple-darwin \
-  --out dist/native-sdk
-```
-
-Package an already-built `mesh-llm-ffi` library:
-
-```bash
-scripts/package-native-sdk.sh \
-  --backend cpu \
-  --target x86_64-unknown-linux-gnu
+  --out dist/native-runtimes
 ```
 
 Verify produced artifacts:
 
 ```bash
-scripts/verify-native-sdk-package.sh dist/native-sdk/*.tar.gz
+scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
 ```
 
 ## Selecting a Runtime From Cargo
 
-Status: planned. Generated native runtime crates are not published as part of
-the current Rust SDK flow.
+Cargo dependencies provide the MeshLLM Rust SDK. Native runtimes are resolved
+at install or application startup from release artifacts, not built implicitly
+by Cargo.
 
-Native runtime crates are generated from verified native runtime artifacts.
-They package release artifacts; they do not build native code implicitly:
+Normal online install:
 
 ```bash
-scripts/package-native-sdk-crate.sh \
-  dist/native-sdk/meshllm-native-darwin-aarch64-metal.tar.gz
+mesh-llm runtime install
 ```
 
-Generated crates contain the native runtime under `native/`, copy it into
-Cargo's `OUT_DIR/native` during the crate build, and use:
+Offline or packaged install:
 
-```toml
-links = "meshllm_native_runtime"
+```bash
+mesh-llm runtime install --bundle-dir path/to/meshllm-native-runtime-darwin-aarch64-metal
 ```
 
-Cargo exposes these paths to dependent build scripts:
-
-```text
-DEP_MESHLLM_NATIVE_RUNTIME_ARTIFACT_ID
-DEP_MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR
-DEP_MESHLLM_NATIVE_RUNTIME_MANIFEST
-DEP_MESHLLM_NATIVE_RUNTIME_LIB_DIR
-DEP_MESHLLM_NATIVE_RUNTIME_LIBRARY
-```
-
-Rust applications that want Cargo to select a runtime should depend on exactly
-one runtime crate for each target:
-
-```toml
-[target.'cfg(all(target_os = "macos", target_arch = "aarch64"))'.dependencies]
-meshllm-native-darwin-aarch64-metal = "0.68.0"
-
-[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
-meshllm-native-linux-x86-64-cpu = "0.68.0"
-```
-
-Because all runtime crates share `links = "meshllm_native_runtime"`, Cargo
-rejects selecting more than one for the same build. Apps that need to ship
-multiple runtime flavors in one installer should package multiple verified
-tarball artifacts explicitly and choose between those artifact directories at
-runtime.
-
-An app build script can copy the selected artifact into its final bundle,
-installer, container image, or package resource directory:
+Rust SDK consumers can use the same resolver/downloader path directly:
 
 ```rust
-use std::{env, fs, path::PathBuf};
+use mesh_llm::sdk::native_runtime::{
+    NativeRuntimeInstallOptions, RuntimeSelection, install_native_runtime,
+};
 
-fn main() {
-    let artifact_dir = PathBuf::from(
-        env::var("DEP_MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR")
-            .expect("meshllm native runtime dependency"),
-    );
-    let package_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR"))
-        .join("meshllm-native");
-    fs::create_dir_all(&package_dir).expect("create native runtime output dir");
-    // Copy artifact_dir recursively into package_dir with the app's packaging helper.
-}
+let outcome = install_native_runtime(NativeRuntimeInstallOptions {
+    selection: RuntimeSelection::Recommended,
+    cache_dir: Some(app_cache_dir.join("mesh-llm-native-runtimes")),
+    bundle_dirs: vec![app_resources.join("meshllm-native-runtime")],
+    progress: Some(std::sync::Arc::new(|event| {
+        update_progress(event.downloaded_bytes, event.total_bytes);
+    })),
+    ..Default::default()
+})
+.await?;
 ```
 
-At runtime, set one of these environment variables or, once the TODO resolver
-API exists, pass the artifact directory directly to that SDK resolver:
+Manifest discovery order:
+
+1. explicit manifest path
+2. explicit manifest URL
+3. `MESH_LLM_NATIVE_RUNTIME_MANIFEST_URL`
+4. GitHub release `native-runtimes.json` for the running MeshLLM version
+
+Generated runtime crates are not the supported distribution story for native
+runtimes in this PR. The supported path is release artifacts plus the release
+manifest, shared by the CLI, SDK, and autoupdater.
+
+At runtime, set one of these environment variables or pass the artifact
+directory directly to the SDK resolver for offline packages:
 
 ```text
 MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR
@@ -612,12 +577,12 @@ MESH_SDK_NATIVE_RUNTIME_DIR
 
 ```bash
 ./sdk/swift/scripts/build-xcframework.sh
-scripts/package-native-sdk.sh \
+scripts/package-native-runtime.sh \
   --backend metal \
   --target aarch64-apple-darwin \
-  --out dist/native-sdk
+  --out dist/native-runtimes
 
-MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR=dist/native-sdk/meshllm-native-darwin-aarch64-metal \
+MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR=dist/native-runtimes/meshllm-native-runtime-darwin-aarch64-metal \
 MESH_SDK_MODEL_REF=Qwen2.5-3B-Instruct-Q4_K_M \
 swift run --package-path sdk/swift/example/MeshExampleApp
 ```
@@ -627,7 +592,7 @@ Useful environment variables:
 | Variable | Meaning |
 |---|---|
 | `MESH_SDK_MODEL_REF` | Catalog, Hugging Face, or local model reference to download/load. |
-| `MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR` | Verified `meshllm-native-*` artifact directory for local serving. |
+| `MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR` | Verified `meshllm-native-runtime-*` artifact directory for local serving. |
 | `MESH_SDK_CACHE_DIR` | Hugging Face cache location. |
 | `MESH_SDK_RUNTIME_DIR` | Runtime scratch directory. |
 | `MESH_SDK_SKIP_DOWNLOAD=1` | Skip download when the model is already installed. |
@@ -636,12 +601,12 @@ Useful environment variables:
 ### Kotlin JVM Example
 
 ```bash
-scripts/package-native-sdk.sh \
+scripts/package-native-runtime.sh \
   --backend metal \
   --target aarch64-apple-darwin \
-  --out dist/native-sdk
+  --out dist/native-runtimes
 
-MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR=dist/native-sdk/meshllm-native-darwin-aarch64-metal \
+MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR=dist/native-runtimes/meshllm-native-runtime-darwin-aarch64-metal \
 MESH_SDK_MODEL_REF=Qwen2.5-3B-Instruct-Q4_K_M \
 ./gradlew --no-daemon run -p sdk/kotlin/example/example-jvm
 ```
@@ -653,7 +618,7 @@ cd sdk/node
 npm run build:native
 cd ../..
 
-MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR=dist/native-sdk/meshllm-native-linux-x86_64-cuda \
+MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR=dist/native-runtimes/meshllm-native-runtime-linux-x86_64-cuda \
 MESH_SDK_MODEL_REF=Qwen2.5-3B-Instruct-Q4_K_M \
 node sdk/node/example/local-inference.js
 ```
@@ -701,7 +666,7 @@ Run the SDK package checks:
 
 ```bash
 scripts/check-sdk-contract.sh
-scripts/verify-native-sdk-package.sh dist/native-sdk/*.tar.gz
+scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
 cargo test -p mesh-llm-ffi
 swift build --package-path sdk/swift/example/MeshExampleApp
 ./gradlew --no-daemon compileKotlin -p sdk/kotlin/example/example-jvm

--- a/docs/design/NATIVE_RUNTIMES.md
+++ b/docs/design/NATIVE_RUNTIMES.md
@@ -1,6 +1,6 @@
 # Native Runtimes
 
-Status: accepted SDK packaging direction.
+Status: accepted direction with an implemented resolver/install foundation.
 
 ## Terminology
 
@@ -20,9 +20,12 @@ version must match the MeshLLM crate, SDK, or binary version that loads it. The
 Skippy ABI version is useful diagnostic metadata, but it is not a substitute
 for the MeshLLM version match.
 
-Release CI owns the normal native runtime build. It builds, verifies, signs,
-and publishes the runtime artifacts for supported target/flavor combinations
-alongside the MeshLLM release.
+Release CI owns the normal native runtime build. It builds, verifies, and
+publishes the runtime artifacts for supported target/flavor combinations
+alongside the MeshLLM release. Downloaded artifacts require checksum metadata
+today. The API already has a policy knob for requiring signatures, but
+signature verification intentionally fails closed until signing keys and
+attestation format are implemented.
 
 ## Artifact Identity
 
@@ -63,13 +66,14 @@ The resolver flow is:
 
 1. Detect the local OS, architecture, available GPU devices, drivers, and
    supported runtime flavors.
-2. Load the signed release manifest for the exact running MeshLLM version.
+2. Load the release manifest for the exact running MeshLLM version.
 3. Filter artifacts to those compatible with the host.
 4. Rank compatible artifacts by flavor and hardware fit.
 5. Prefer an explicitly configured artifact directory when provided.
 6. Check the local cache for the selected runtime.
 7. If allowed, download the missing artifact while reporting progress.
-8. Verify checksum and signature before use.
+8. Verify the archive checksum before use, and require signature verification
+   when the caller selects that stricter policy.
 9. Return a `NativeRuntime` descriptor with paths, identity, manifest metadata,
    and diagnostics.
 
@@ -98,6 +102,24 @@ Packaged application mode should not require network access. An app can provide
 a bundled runtime directory, set downloads to false, and still use the same
 resolver path as a downloading SDK consumer.
 
+## Release Manifest Discovery
+
+The CLI and Rust SDK install API resolve manifests in this order:
+
+1. explicit manifest path
+2. explicit manifest URL
+3. `MESH_LLM_NATIVE_RUNTIME_MANIFEST_URL`
+4. the default release URL:
+
+```text
+https://github.com/Mesh-LLM/mesh-llm/releases/download/v<mesh_version>/native-runtimes.json
+```
+
+Bundled runtime directories are always appended to the candidate manifest. When
+only bundle directories are provided, the default release URL is not fetched.
+This lets packaged apps stay offline while the same code path can still inspect
+or install release artifacts for normal crates.io consumers.
+
 ## Upgrade And Pruning
 
 An updater must install and verify the new version-matched native runtime
@@ -124,49 +146,67 @@ MeshLLM host binary, then delegate native runtime selection to MeshLLM:
 mesh-llm runtime install
 ```
 
-The current implementation installs from an explicit release manifest or bundled
-runtime directory. The intended release path is for that command to install the
-recommended compatible native runtime for the active MeshLLM version without the
-caller duplicating flavor detection. Shell and PowerShell installers should use
-the same command as manual users and autoupdate flows, so CUDA, CUDA Blackwell,
-ROCm, Vulkan, CPU, verification, cache layout, and progress UX stay in one
-implementation.
+That command installs the recommended compatible native runtime for the active
+MeshLLM version without the caller duplicating flavor detection. Shell and
+PowerShell installers should use the same command as manual users and
+autoupdate flows, so CUDA, CUDA Blackwell, ROCm, Vulkan, CPU, verification,
+cache layout, and progress UX stay in one implementation.
 
 ## Consumer Shape
 
-Status: design/TODO. The current Rust SDK can run an embedded node from a git
-revision and can source-build the native runtime through Cargo. It does not yet
-expose the resolver builder shown below.
-
-A crates.io SDK consumer that wants dynamic local serving should configure the
-resolver instead of depending on a platform-specific source build. The API
-shape should be equivalent to:
+A crates.io SDK consumer that wants dynamic local serving should use
+`mesh_llm::sdk::native_runtime` instead of depending on a platform-specific
+source build:
 
 ```rust
-let runtime = NativeRuntimeResolver::builder()
-    .cache_dir(app_cache_dir.join("mesh-llm"))
-    .bundle_dir(app_resources.join("meshllm-native"))
-    .allow_download(true)
-    .on_progress(|event| {
+use mesh_llm::sdk::native_runtime::{
+    NativeRuntimeInstallOptions, RuntimeSelection, install_native_runtime,
+};
+
+let runtime = install_native_runtime(NativeRuntimeInstallOptions {
+    selection: RuntimeSelection::Recommended,
+    cache_dir: Some(app_cache_dir.join("mesh-llm-native-runtimes")),
+    bundle_dirs: vec![app_resources.join("meshllm-native-runtime")],
+    progress: Some(std::sync::Arc::new(|event| {
         update_download_progress(event.downloaded_bytes, event.total_bytes);
-    })
-    .resolve_best()
-    .await?;
+    })),
+    ..Default::default()
+})
+.await?;
 
 let node = MeshNode::builder()
-    .native_runtime(runtime)
+    .native_runtime(runtime.runtime)
     .build()?;
 ```
 
 An offline packaged app uses the same path with downloads disabled:
 
 ```rust
-let runtime = NativeRuntimeResolver::builder()
-    .bundle_dir(app_resources.join("meshllm-native"))
-    .allow_download(false)
-    .resolve_best()
-    .await?;
+let runtime = install_native_runtime(NativeRuntimeInstallOptions {
+    bundle_dirs: vec![app_resources.join("meshllm-native-runtime")],
+    allow_download: false,
+    ..Default::default()
+})
+.await?;
 ```
+
+The API returns the installed runtime, the selected release artifact, and the
+full candidate evaluation so callers can show diagnostics or record why another
+runtime was rejected.
+
+## Verification Policy
+
+Downloaded native runtime artifacts are fail-closed:
+
+- `sha256` metadata is required for downloads.
+- the downloaded archive digest must match the manifest digest.
+- `RequireChecksumAndSignature` requires signature metadata and then returns an
+  explicit unsupported-signature-verification error until signature verification
+  is implemented.
+
+This avoids silently presenting unsigned downloads as stronger than they are.
+Checksum-only verification is the default policy for the first release artifact
+lane.
 
 ## Query And Management API
 
@@ -188,15 +228,15 @@ mesh-llm runtime list --available
 mesh-llm runtime list --installed
 mesh-llm runtime install
 mesh-llm runtime install cuda
-mesh-llm runtime remove meshllm-native-linux-x86_64-cuda
+mesh-llm runtime remove meshllm-native-runtime-linux-x86_64-cuda
 mesh-llm runtime prune
 mesh-llm runtime prune --active-only
 ```
 
 With no runtime argument, `mesh-llm runtime install` detects the host and
-selects the recommended compatible native runtime from the supplied release
-manifest or bundle directories. Explicit flavor or runtime ID arguments are
-overrides for advanced users, CI, and prepared images.
+installs the recommended compatible native runtime from the release manifest,
+an explicit manifest, or bundle directories. Explicit flavor or runtime ID
+arguments are overrides for advanced users, CI, and prepared images.
 
 Selected-runtime diagnostics belong in `mesh-llm doctor`, not in a separate
 `mesh-llm runtime doctor` command. Doctor output should include the active
@@ -240,6 +280,28 @@ The source-build features are explicit escape hatches for developers and CI
 jobs. They should not be default features. Build scripts should reject multiple
 `native-build-*` features in one package build unless a crate is deliberately
 designed to produce a multi-runtime artifact.
+
+## Generated Runtime Crates
+
+Generated Cargo crates are not the supported native runtime distribution story
+for this PR. The supported path is release artifacts plus
+`native-runtimes.json`, resolved by the CLI, SDK, and autoupdater. Generated
+runtime crates should not be published as a user-facing API until they package
+the same native runtime artifact format and the release team explicitly decides
+Cargo-target selection is a product requirement.
+
+## Initial Release Matrix
+
+The initial release workflow packages native runtimes only where the current CI
+environment can build and smoke them reliably:
+
+- macOS `aarch64` Metal
+- Linux `x86_64` CPU
+
+CUDA, CUDA Blackwell, ROCm, Vulkan, Windows, and additional architecture lanes
+use the same manifest/flavor model but still need dedicated runner/toolchain
+work before the release matrix can claim coverage. The resolver is designed so
+adding these artifacts is manifest data plus release jobs, not SDK API churn.
 
 ## Dynamic Loading Shape
 


### PR DESCRIPTION
Stacked on #736. Follow-up to #751 and #769.

MeshLLM now exposes the native runtime resolver/download/install path to Rust SDK consumers instead of keeping it inside the CLI. `mesh-llm runtime install` and `runtime list --available` can also discover the version-matched `native-runtimes.json` from the release by default, while bundle-only flows stay offline.

## Summary
- Move native runtime manifest discovery, download, checksum verification, extraction, install, cache selection, host detection, and progress callbacks into shared host-runtime system code.
- Add `mesh_llm::sdk::native_runtime` as the first-class Rust SDK surface for resolver, manifest, cache, install, progress, and pruning types.
- Keep `mesh-llm runtime install` as the recommended-runtime install command, now backed by the shared SDK path.
- Add verification policy shape: checksum is required for downloads; signature-required mode fails closed until signing keys/attestation are implemented.
- Document the real distribution story: release artifacts plus `native-runtimes.json`; generated runtime crates are not supported in this PR; the initial release matrix is macOS aarch64 Metal and Linux x86_64 CPU.

## API Example
```rust
use mesh_llm::sdk::native_runtime::{
    NativeRuntimeInstallOptions, RuntimeSelection, install_native_runtime,
};
use std::sync::Arc;

let outcome = install_native_runtime(NativeRuntimeInstallOptions {
    selection: RuntimeSelection::Recommended,
    cache_dir: Some(app_cache_dir.join("mesh-llm-native-runtimes")),
    bundle_dirs: vec![app_resources.join("meshllm-native-runtime")],
    progress: Some(Arc::new(|event| {
        update_progress(event.downloaded_bytes, event.total_bytes);
    })),
    ..Default::default()
})
.await?;

println!(
    "using native runtime {} at {}",
    outcome.runtime.native_runtime_id,
    outcome.runtime.path.display()
);
```

For an offline packaged app, pass one or more `bundle_dirs` and set `allow_download: false`; the same resolver path installs from the bundled native runtime without fetching the default release manifest.

## Stacking
- Base: `micn/sprout-embedded-serve-sdk` (#736)
- This PR is intentionally not based on `main`.

## Validation
- `cargo check -p mesh-llm-host-runtime`
- `cargo check -p mesh-llm`
- `cargo check -p mesh-llm --features dynamic-native-runtime`
- `cargo test -p mesh-llm-native-runtime`
- `cargo test -p mesh-llm-host-runtime --lib system::native_runtime_install::tests`
- `cargo test -p mesh-llm-host-runtime --lib models::local::tests::mmproj_path_ignores_ambiguous_sibling_sidecars`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --features dynamic-native-runtime --all-targets -- -D warnings`
- `cargo test -p mesh-llm-host-runtime --lib` (`1747 passed; 0 failed; 7 ignored`)
- `cargo fmt --all -- --check`
- `git diff --check`
