### PR TITLE
fix: speed up client auto-join bootstrap

### DIFF
--- a/crates/mesh-llm-host-runtime/src/exact_test_wrappers.rs
+++ b/crates/mesh-llm-host-runtime/src/exact_test_wrappers.rs
@@ -296,6 +296,11 @@ fn requirement_aware_mesh_without_attestation_rejects_missing_direct_proof() {
 }
 
 #[test]
+fn fast_join_apply_failure_closes_connection_and_propagates_err() {
+    mesh::tests::assert_fast_join_apply_failure_closes_connection_and_propagates_err();
+}
+
+#[test]
 fn requirement_aware_mesh_without_attestation_rejects_invalid_direct_proof() {
     mesh::tests::assert_requirement_aware_mesh_without_attestation_rejects_invalid_direct_proof();
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -21,6 +21,8 @@ use crate::models::append_external_inference_models;
 /// targeted bypass.
 const MIN_REBROADCAST_VERSION_MAJOR: u64 = 0;
 const MIN_REBROADCAST_VERSION_MINOR: u64 = 60;
+const CLIENT_AUTO_JOIN_PROBE_LIMIT: usize = 4;
+const CLIENT_AUTO_JOIN_PROBE_TIMEOUT: std::time::Duration = PEER_CONNECT_AND_GOSSIP_TIMEOUT;
 
 #[derive(Clone, Copy)]
 struct AnnouncedPeerContext {
@@ -28,6 +30,42 @@ struct AnnouncedPeerContext {
     rtt_ms: Option<u32>,
     negotiated_protocol_generation: Option<u32>,
     direct_peer_requirements_validated: bool,
+}
+
+struct JoinProbeCandidate {
+    token: String,
+    mesh_name: Option<String>,
+    addr: EndpointAddr,
+}
+
+struct JoinProbeSuccess {
+    candidate: JoinProbeCandidate,
+    conn: Connection,
+    announcements: Vec<(EndpointAddr, PeerAnnouncement)>,
+    rtt_ms: u32,
+    elapsed: std::time::Duration,
+}
+
+fn emit_join_probe_race_started(candidate_count: usize) {
+    tracing::info!(
+        candidates = candidate_count,
+        timeout_ms = CLIENT_AUTO_JOIN_PROBE_TIMEOUT.as_millis(),
+        "Racing auto-join bootstrap candidates"
+    );
+    emit_mesh_info(format!(
+        "Racing {candidate_count} auto-join bootstrap candidates"
+    ));
+}
+
+fn emit_join_probe_fallback(last_error: Option<&anyhow::Error>) {
+    if let Some(error) = last_error {
+        tracing::debug!(
+            "No auto-join candidate completed the fast probe; falling back to serial join: {error:#}"
+        );
+    }
+    emit_mesh_info(
+        "No auto-join candidate completed the fast probe; falling back to serial join".to_string(),
+    );
 }
 
 /// Returns `true` if `version` is recent enough to include in outbound
@@ -446,6 +484,42 @@ impl Node {
                 );
             }
         }
+    }
+
+    async fn connect_discovered_peers(
+        &self,
+        their_announcements: &[(EndpointAddr, PeerAnnouncement)],
+        known_peer_check_uses_connections: bool,
+        log_discovery_failure_as_warning: bool,
+    ) {
+        let my_role = self.role.lock().await.clone();
+        for (addr, ann) in their_announcements {
+            self.maybe_connect_discovered_peer(
+                &my_role,
+                addr.clone(),
+                ann,
+                known_peer_check_uses_connections,
+                log_discovery_failure_as_warning,
+            )
+            .await;
+        }
+    }
+
+    fn spawn_discovered_peer_connects(
+        &self,
+        their_announcements: Vec<(EndpointAddr, PeerAnnouncement)>,
+        known_peer_check_uses_connections: bool,
+        log_discovery_failure_as_warning: bool,
+    ) {
+        let node = self.clone();
+        tokio::spawn(async move {
+            node.connect_discovered_peers(
+                &their_announcements,
+                known_peer_check_uses_connections,
+                log_discovery_failure_as_warning,
+            )
+            .await;
+        });
     }
 
     /// Returns `true` if the announcement would be rejected by the same
@@ -973,6 +1047,206 @@ impl Node {
         }
     }
 
+    pub(crate) async fn join_first_responsive_candidate(
+        &self,
+        join_attempts: &[(String, Option<String>)],
+    ) -> Result<Option<(String, Option<String>)>> {
+        let candidates = self.collect_join_probe_candidates(join_attempts).await;
+        if candidates.len() <= 1 {
+            tracing::debug!(
+                valid_candidates = candidates.len(),
+                "auto-join probe skipped"
+            );
+            return Ok(None);
+        }
+
+        emit_join_probe_race_started(candidates.len());
+        match self.race_join_probe_candidates(candidates).await {
+            Some(success) => self.commit_join_probe_success(success).await.map(Some),
+            None => Ok(None),
+        }
+    }
+
+    async fn collect_join_probe_candidates(
+        &self,
+        join_attempts: &[(String, Option<String>)],
+    ) -> Vec<JoinProbeCandidate> {
+        if join_attempts.len() <= 1 {
+            return Vec::new();
+        }
+
+        let mut candidates = Vec::new();
+        let mut invalid = 0usize;
+        for (token, mesh_name) in join_attempts.iter().take(CLIENT_AUTO_JOIN_PROBE_LIMIT) {
+            match self
+                .prepare_join_probe_candidate(token, mesh_name.clone())
+                .await
+            {
+                Ok(Some(candidate)) => candidates.push(candidate),
+                Ok(None) => {}
+                Err(error) => {
+                    invalid += 1;
+                    tracing::debug!("Skipping invalid auto-join candidate: {error:#}");
+                }
+            }
+        }
+        tracing::debug!(
+            valid_candidates = candidates.len(),
+            invalid_candidates = invalid,
+            "collected auto-join probe candidates"
+        );
+        candidates
+    }
+
+    async fn race_join_probe_candidates(
+        &self,
+        candidates: Vec<JoinProbeCandidate>,
+    ) -> Option<JoinProbeSuccess> {
+        let mut probes = tokio::task::JoinSet::new();
+        for candidate in candidates {
+            let node = self.clone();
+            probes.spawn(async move { node.probe_join_candidate(candidate).await });
+        }
+
+        let mut last_error = None;
+        while let Some(result) = probes.join_next().await {
+            match result {
+                Ok(Ok(success)) => {
+                    probes.abort_all();
+                    return Some(success);
+                }
+                Ok(Err(error)) => {
+                    tracing::debug!("auto-join candidate probe failed: {error:#}");
+                    last_error = Some(error);
+                }
+                Err(error) => {
+                    tracing::debug!("auto-join candidate probe task failed: {error:#}");
+                }
+            }
+        }
+
+        emit_join_probe_fallback(last_error.as_ref());
+        None
+    }
+
+    async fn prepare_join_probe_candidate(
+        &self,
+        token: &str,
+        mesh_name: Option<String>,
+    ) -> Result<Option<JoinProbeCandidate>> {
+        let addr = match parse_invite_token(token)
+            .map_err(|reason| anyhow::anyhow!("join rejected: {}", reason.code()))?
+        {
+            InviteTokenMaterial::Legacy(addr) => addr,
+            // Requirement-aware bootstrap tokens may require installing the
+            // signed policy before gossip. Keep those on the established
+            // serial join path rather than probing them out-of-band.
+            InviteTokenMaterial::Signed(_) => return Ok(None),
+        };
+
+        if addr.id == self.endpoint.id() {
+            return Ok(None);
+        }
+
+        let state = self.state.lock().await;
+        if state.connections.contains_key(&addr.id) {
+            return Ok(None);
+        }
+        if state
+            .dead_peers
+            .get(&addr.id)
+            .is_some_and(|t| t.elapsed() < DEAD_PEER_TTL)
+        {
+            return Ok(None);
+        }
+        drop(state);
+
+        Ok(Some(JoinProbeCandidate {
+            token: token.to_string(),
+            mesh_name,
+            addr,
+        }))
+    }
+
+    async fn probe_join_candidate(
+        &self,
+        candidate: JoinProbeCandidate,
+    ) -> Result<JoinProbeSuccess> {
+        let peer_id = candidate.addr.id;
+        let started = std::time::Instant::now();
+        let result = tokio::time::timeout(CLIENT_AUTO_JOIN_PROBE_TIMEOUT, async {
+            let conn = connect_mesh(&self.endpoint, candidate.addr.clone()).await?;
+            let (announcements, rtt_ms) = self.gossip_round_trip(&conn, peer_id).await?;
+            Ok::<_, anyhow::Error>((conn, announcements, rtt_ms))
+        })
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!(
+                "candidate {} timed out after {}s",
+                peer_id.fmt_short(),
+                CLIENT_AUTO_JOIN_PROBE_TIMEOUT.as_secs()
+            )
+        })??;
+
+        Ok(JoinProbeSuccess {
+            candidate,
+            conn: result.0,
+            announcements: result.1,
+            rtt_ms: result.2,
+            elapsed: started.elapsed(),
+        })
+    }
+
+    async fn commit_join_probe_success(
+        &self,
+        success: JoinProbeSuccess,
+    ) -> Result<(String, Option<String>)> {
+        let JoinProbeSuccess {
+            candidate,
+            conn,
+            announcements,
+            rtt_ms,
+            elapsed,
+        } = success;
+        let peer_id = candidate.addr.id;
+
+        {
+            let mut state = self.state.lock().await;
+            state.dead_peers.remove(&peer_id);
+            state.connections.insert(peer_id, conn.clone());
+        }
+        let node_for_dispatch = self.clone();
+        let conn_for_dispatch = conn.clone();
+        tokio::spawn(async move {
+            node_for_dispatch
+                .dispatch_streams(conn_for_dispatch, peer_id)
+                .await;
+        });
+
+        if let Err(error) = self
+            .apply_gossip_announcements(peer_id, rtt_ms, &announcements, false)
+            .await
+        {
+            self.state.lock().await.connections.remove(&peer_id);
+            return Err(error);
+        }
+        self.spawn_discovered_peer_connects(announcements, true, false);
+
+        tracing::info!(
+            peer = %peer_id.fmt_short(),
+            elapsed_ms = elapsed_ms_u64(elapsed),
+            rtt_ms,
+            "Fast auto-join probe selected bootstrap candidate"
+        );
+        emit_mesh_info(format!(
+            "Fast auto-join selected peer {} in {}ms",
+            peer_id.fmt_short(),
+            elapsed_ms_u64(elapsed)
+        ));
+
+        Ok((candidate.token, candidate.mesh_name))
+    }
+
     pub(super) async fn initiate_gossip_inner(
         &self,
         conn: Connection,
@@ -1028,20 +1302,13 @@ impl Node {
         self.refresh_gossip_path_rtt(remote, Some(rtt_ms)).await;
 
         if discover_peers {
-            let my_role = self.role.lock().await.clone();
-            for (addr, ann) in their_announcements {
-                self.maybe_connect_discovered_peer(&my_role, addr.clone(), ann, true, false)
-                    .await;
-            }
+            self.connect_discovered_peers(their_announcements, true, false)
+                .await;
         }
 
         Ok(())
     }
 
-    #[expect(
-        clippy::cognitive_complexity,
-        reason = "gossip stream handling keeps protocol validation, response, and peer discovery ordered in one flow"
-    )]
     pub(super) async fn handle_gossip_stream(
         &self,
         remote: EndpointId,
@@ -1142,11 +1409,8 @@ impl Node {
         .await?;
         self.refresh_gossip_path_rtt(remote, None).await;
 
-        let my_role = self.role.lock().await.clone();
-        for (addr, ann) in their_announcements {
-            self.maybe_connect_discovered_peer(&my_role, addr, &ann, false, true)
-                .await;
-        }
+        self.connect_discovered_peers(&their_announcements, false, true)
+            .await;
 
         Ok(())
     }
@@ -2131,5 +2395,47 @@ mod tests {
             !state.peers.contains_key(&idle_id),
             "idle transitive client must not be added (this path is dial-only)"
         );
+    }
+
+    #[tokio::test]
+    async fn client_auto_join_probe_returns_none_for_single_candidate() {
+        let node = Node::new_for_tests(NodeRole::Client).await.unwrap();
+        let token = encode_endpoint_addr_token(&test_addr(0x42));
+
+        let selected = node
+            .join_first_responsive_candidate(&[(token, Some("single".to_string()))])
+            .await
+            .unwrap();
+
+        assert!(selected.is_none());
+    }
+
+    #[tokio::test]
+    async fn client_auto_join_probe_candidate_collection_filters_unusable_tokens() {
+        let node = Node::new_for_tests(NodeRole::Client).await.unwrap();
+        let valid_addr = test_addr(0x42);
+        let dead_addr = test_addr(0x43);
+        let self_token = encode_endpoint_addr_token(&node.endpoint_addr_for_advertisement());
+        let dead_token = encode_endpoint_addr_token(&dead_addr);
+        let valid_token = encode_endpoint_addr_token(&valid_addr);
+
+        node.state
+            .lock()
+            .await
+            .dead_peers
+            .insert(dead_addr.id, std::time::Instant::now());
+
+        let candidates = node
+            .collect_join_probe_candidates(&[
+                ("not-an-invite-token".to_string(), None),
+                (self_token, None),
+                (dead_token, None),
+                (valid_token, Some("usable".to_string())),
+            ])
+            .await;
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].addr.id, valid_addr.id);
+        assert_eq!(candidates[0].mesh_name.as_deref(), Some("usable"));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -1227,9 +1227,20 @@ impl Node {
             .apply_gossip_announcements(peer_id, rtt_ms, &announcements, false)
             .await
         {
+            // Drop the tracked entry AND close the QUIC connection. The
+            // dispatcher task above holds its own `conn` clone, so removing the
+            // map entry alone would leave a live, keep-alive'd connection and a
+            // running dispatcher for a peer nobody tracks (and one whose
+            // close-recovery path could even reconnect it). Closing here makes
+            // the dispatcher's `accept_*` calls error so it unwinds cleanly.
             self.state.lock().await.connections.remove(&peer_id);
+            conn.close(0u32.into(), b"join announcement-apply failed");
             return Err(error);
         }
+
+        // Match `connect_to_peer`: the probe gossip RTT above likely reflects
+        // relay latency, so refresh the selected-path/RTT after holepunch.
+        self.schedule_selected_path_recheck(peer_id);
         self.spawn_discovered_peer_connects(announcements, true, false);
 
         tracing::info!(

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -38,12 +38,38 @@ struct JoinProbeCandidate {
     addr: EndpointAddr,
 }
 
-struct JoinProbeSuccess {
+pub(super) struct JoinProbeSuccess {
     candidate: JoinProbeCandidate,
     conn: Connection,
     announcements: Vec<(EndpointAddr, PeerAnnouncement)>,
     rtt_ms: u32,
     elapsed: std::time::Duration,
+}
+
+#[cfg(test)]
+impl JoinProbeSuccess {
+    /// Test-only constructor so sibling test modules can drive
+    /// `commit_join_probe_success` against a real QUIC connection.
+    pub(super) fn new_for_tests(
+        token: String,
+        mesh_name: Option<String>,
+        addr: EndpointAddr,
+        conn: Connection,
+        announcements: Vec<(EndpointAddr, PeerAnnouncement)>,
+        rtt_ms: u32,
+    ) -> Self {
+        Self {
+            candidate: JoinProbeCandidate {
+                token,
+                mesh_name,
+                addr,
+            },
+            conn,
+            announcements,
+            rtt_ms,
+            elapsed: std::time::Duration::from_millis(0),
+        }
+    }
 }
 
 fn emit_join_probe_race_started(candidate_count: usize) {
@@ -1197,7 +1223,7 @@ impl Node {
         })
     }
 
-    async fn commit_join_probe_success(
+    pub(super) async fn commit_join_probe_success(
         &self,
         success: JoinProbeSuccess,
     ) -> Result<(String, Option<String>)> {

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -8750,6 +8750,17 @@ impl Node {
         // (high RTT) because direct holepunch hasn't completed yet. After a few
         // seconds the direct path is usually ready, so re-check path info to get
         // the real RTT and potentially trigger a re-election for split mode.
+        self.schedule_selected_path_recheck(peer_id);
+        Ok(())
+    }
+
+    /// Spawn a delayed task that re-reads the currently-selected QUIC path for
+    /// `peer_id` after the relay→direct transition typically completes, and
+    /// updates the tracked selected-path/RTT observation. The first gossip
+    /// round-trip often runs over the relay (inflated RTT) before holepunch
+    /// finishes; this refresh records the real direct RTT and can trigger a
+    /// re-election for split mode.
+    pub(super) fn schedule_selected_path_recheck(&self, peer_id: EndpointId) {
         let node_for_recheck = self.clone();
         tokio::spawn(async move {
             tokio::time::sleep(std::time::Duration::from_secs(5)).await;
@@ -8760,40 +8771,41 @@ impl Node {
                 .connections
                 .get(&peer_id)
                 .cloned();
-            if let Some(conn) = conn {
-                let path_list = conn.paths();
-                for path_info in &path_list {
-                    if path_info.is_selected() {
-                        let rtt_ms = path_info.rtt().as_millis() as u32;
-                        let rtt_ms = (rtt_ms != 0).then_some(rtt_ms);
-                        let path_type = if path_info.is_ip() { "direct" } else { "relay" };
-                        if let Some(rtt_ms) = rtt_ms {
-                            emit_mesh_info(format!(
-                                "📡 Peer {} RTT recheck: {}ms ({})",
-                                peer_id.fmt_short(),
-                                rtt_ms,
-                                path_type
-                            ));
-                        }
-                        node_for_recheck
-                            .update_peer_selected_path(
-                                peer_id,
-                                SelectedPathObservation {
-                                    path_type,
-                                    rtt_ms,
-                                    observed_direct_remote_addr: match path_info.remote_addr() {
-                                        TransportAddr::Ip(addr) => Some(*addr),
-                                        _ => None,
-                                    },
-                                },
-                            )
-                            .await;
-                        break;
-                    }
+            let Some(conn) = conn else {
+                return;
+            };
+            let path_list = conn.paths();
+            for path_info in &path_list {
+                if !path_info.is_selected() {
+                    continue;
                 }
+                let rtt_ms = path_info.rtt().as_millis() as u32;
+                let rtt_ms = (rtt_ms != 0).then_some(rtt_ms);
+                let path_type = if path_info.is_ip() { "direct" } else { "relay" };
+                if let Some(rtt_ms) = rtt_ms {
+                    emit_mesh_info(format!(
+                        "📡 Peer {} RTT recheck: {}ms ({})",
+                        peer_id.fmt_short(),
+                        rtt_ms,
+                        path_type
+                    ));
+                }
+                node_for_recheck
+                    .update_peer_selected_path(
+                        peer_id,
+                        SelectedPathObservation {
+                            path_type,
+                            rtt_ms,
+                            observed_direct_remote_addr: match path_info.remote_addr() {
+                                TransportAddr::Ip(addr) => Some(*addr),
+                                _ => None,
+                            },
+                        },
+                    )
+                    .await;
+                break;
             }
         });
-        Ok(())
     }
 
     async fn handle_tunnel_map_stream(

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -6300,6 +6300,88 @@ pub(crate) fn assert_requirement_aware_mesh_without_attestation_rejects_missing_
     });
 }
 
+/// On the fast auto-join probe, if `apply_gossip_announcements` fails after the
+/// dispatcher has already been spawned, the winning candidate must be both
+/// dropped from `state.connections` AND have its QUIC connection closed (so the
+/// dispatcher unwinds and no orphaned, keep-alive'd connection lingers), and the
+/// `Err` must propagate so the caller falls back to the serial join path.
+pub(crate) fn assert_fast_join_apply_failure_closes_connection_and_propagates_err() {
+    let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
+    runtime.block_on(async {
+        // Joiner enforces a release-attestation requirement.
+        let trusted_signer = test_release_signer_key_id(9);
+        let policy = requirement_policy(&trusted_signer);
+        let joiner = make_test_node(super::NodeRole::Worker)
+            .await
+            .expect("joiner test node");
+        configure_requirement_node(&joiner, &policy, Some(&trusted_signer))
+            .await
+            .expect("configure joiner policy");
+
+        // Bootstrap peer accepts a real QUIC connection from the joiner.
+        let bootstrap = make_test_node(super::NodeRole::Worker)
+            .await
+            .expect("bootstrap test node");
+        bootstrap.start_accepting();
+        joiner.start_accepting();
+
+        let bootstrap_id = bootstrap.id();
+        let bootstrap_addr = bootstrap.endpoint_addr_for_advertisement();
+        let conn = connect_mesh(&joiner.endpoint, bootstrap_addr.clone())
+            .await
+            .expect("joiner connects to bootstrap");
+
+        // Self-announcement from the bootstrap peer carrying NO release
+        // attestation. `apply_announced_peer` hits the `peer_id == remote`
+        // branch, `validate_direct_peer_requirements` rejects it, and
+        // `apply_gossip_announcements` returns `Err`.
+        let mut self_ann = requirement_peer_announcement(0x00, &policy, None, None);
+        self_ann.addr = super::EndpointAddr {
+            id: bootstrap_id,
+            addrs: Default::default(),
+        };
+        let announcements = vec![(self_ann.addr.clone(), self_ann.clone())];
+
+        let success = super::gossip::JoinProbeSuccess::new_for_tests(
+            joiner.invite_token().await,
+            None,
+            super::EndpointAddr {
+                id: bootstrap_id,
+                addrs: Default::default(),
+            },
+            conn.clone(),
+            announcements,
+            42,
+        );
+
+        let result = joiner.commit_join_probe_success(success).await;
+        assert!(
+            result.is_err(),
+            "apply failure must propagate Err so the caller falls back to serial join"
+        );
+
+        // The tracked entry must be gone.
+        assert!(
+            !joiner
+                .state
+                .lock()
+                .await
+                .connections
+                .contains_key(&bootstrap_id),
+            "failed candidate must be removed from tracked connections"
+        );
+
+        // The QUIC connection must be closed, not merely untracked. If it were
+        // only untracked, `closed()` would hang here because the keep-alive
+        // would hold the orphaned connection open.
+        let closed = tokio::time::timeout(std::time::Duration::from_secs(2), conn.closed()).await;
+        assert!(
+            closed.is_ok(),
+            "QUIC connection must be closed on apply failure, not left orphaned"
+        );
+    });
+}
+
 pub(crate) fn assert_requirement_aware_mesh_without_attestation_rejects_invalid_direct_proof() {
     let runtime = tokio::runtime::Runtime::new().expect("tokio runtime");
     runtime.block_on(async {

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -5869,12 +5869,23 @@ async fn build_run_auto_node_setup(
 async fn attempt_run_auto_join(
     node: &mesh::Node,
     join_attempts: &[(String, Option<String>)],
+    is_client: bool,
 ) -> RunAutoJoinOutcome {
     let mut outcome = RunAutoJoinOutcome {
         joined: false,
         last_join_error: None,
         successful_join: None,
     };
+
+    if is_client {
+        match attempt_fast_client_auto_join(node, join_attempts).await {
+            Some(Ok(successful_join)) => {
+                return build_successful_run_auto_join(node, successful_join).await;
+            }
+            Some(Err(err)) => outcome.last_join_error = Some(format!("{err:#}")),
+            None => {}
+        }
+    }
 
     for (token, mesh_name) in join_attempts {
         match node.join_with_retry(token).await {
@@ -5898,6 +5909,38 @@ async fn attempt_run_auto_join(
     }
 
     outcome
+}
+
+async fn attempt_fast_client_auto_join(
+    node: &mesh::Node,
+    join_attempts: &[(String, Option<String>)],
+) -> Option<Result<(String, Option<String>)>> {
+    match node.join_first_responsive_candidate(join_attempts).await {
+        Ok(Some(successful_join)) => Some(Ok(successful_join)),
+        Ok(None) => None,
+        Err(err) => {
+            tracing::warn!("Fast auto-join probe failed: {err:#}");
+            Some(Err(err))
+        }
+    }
+}
+
+async fn build_successful_run_auto_join(
+    node: &mesh::Node,
+    successful_join: (String, Option<String>),
+) -> RunAutoJoinOutcome {
+    if node.mesh_id().await.is_some() {
+        record_first_joined_mesh_ts(node).await;
+    }
+    let _ = emit_event(OutputEvent::Info {
+        message: "Connected to bootstrap peer; awaiting mesh admission".to_string(),
+        context: None,
+    });
+    RunAutoJoinOutcome {
+        joined: true,
+        last_join_error: None,
+        successful_join: Some(successful_join),
+    }
 }
 
 fn update_cli_with_successful_run_auto_join(
@@ -5933,7 +5976,7 @@ async fn run_auto_join_existing_mesh(
     } else {
         auto_join_candidates.to_vec()
     };
-    let outcome = attempt_run_auto_join(node, &join_attempts).await;
+    let outcome = attempt_run_auto_join(node, &join_attempts, cli.client).await;
     update_cli_with_successful_run_auto_join(cli, outcome.successful_join);
 
     if !outcome.joined {


### PR DESCRIPTION
🤖 Draft PR opened by Mic's AI agent.

## Summary
- Race client --auto bootstrap candidates and commit the first successful gossip exchange.
- Move follow-on discovered-peer dials off the readiness path for the fast client path.
- Leave signed/admission tokens and single-candidate joins on the existing serial path.
- Avoid cloning full gossip payloads when dialing discovered peers.

## Validation
- cargo fmt --all -- --check
- cargo check -p mesh-llm
- cargo clippy -p mesh-llm -- -D warnings
- cargo test -p mesh-llm-host-runtime client_auto_join_probe --lib -- --test-threads=1
- cargo test -p mesh-llm-host-runtime maybe_connect_discovered_peer_skips_filtered_announcements --lib -- --test-threads=1
- just build
- Public client smoke: discovery_joined at 08:22:42.907Z, API ready at 08:22:44.495Z, and /v1/models returned mesh models.