### PR TITLE
Diagnose split startup blockers

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -70,6 +70,7 @@ pub(crate) struct SplitReadinessReport {
     pub(crate) capacity_advice: Option<ModelTargetCapacityAdvicePayload>,
     pub(crate) participants: Vec<SplitReadinessParticipant>,
     pub(crate) exclusions: Vec<SplitReadinessExclusion>,
+    pub(crate) blockers: Vec<SplitReadinessBlocker>,
     pub(crate) recommendations: Vec<String>,
 }
 
@@ -95,6 +96,14 @@ pub(crate) struct SplitReadinessExclusion {
     pub(crate) reason: &'static str,
     pub(crate) recommendation: &'static str,
     pub(crate) vram_bytes: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub(crate) struct SplitReadinessBlocker {
+    pub(crate) reason: &'static str,
+    pub(crate) count: usize,
+    pub(crate) short_node_ids: Vec<String>,
+    pub(crate) recommendation: &'static str,
 }
 
 impl MeshApi {
@@ -164,6 +173,7 @@ pub(crate) fn build_split_readiness_report(input: SplitReadinessInput) -> SplitR
         participants.len(),
         capacity_advice.as_ref(),
     );
+    let blockers = split_readiness_blockers(&exclusions);
     let recommendations = split_readiness_recommendations(&input.model_ref, verdict, &exclusions);
     SplitReadinessReport {
         model_ref: input.model_ref,
@@ -175,6 +185,7 @@ pub(crate) fn build_split_readiness_report(input: SplitReadinessInput) -> SplitR
         capacity_advice,
         participants,
         exclusions,
+        blockers,
         recommendations,
     }
 }
@@ -483,6 +494,62 @@ fn split_readiness_recommendations(
         ));
     }
     recommendations
+}
+
+fn split_readiness_blockers(exclusions: &[SplitReadinessExclusion]) -> Vec<SplitReadinessBlocker> {
+    let mut blockers = split_readiness_exclusion_reason_order()
+        .into_iter()
+        .filter_map(|reason| split_readiness_blocker(exclusions, reason))
+        .collect::<Vec<_>>();
+    blockers.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| blocker_rank(left.reason).cmp(&blocker_rank(right.reason)))
+    });
+    blockers
+}
+
+fn split_readiness_blocker(
+    exclusions: &[SplitReadinessExclusion],
+    reason: SplitReadinessExclusionReason,
+) -> Option<SplitReadinessBlocker> {
+    let matching = exclusions
+        .iter()
+        .filter(|item| item.reason == reason.as_str())
+        .collect::<Vec<_>>();
+    if matching.is_empty() {
+        return None;
+    }
+    Some(SplitReadinessBlocker {
+        reason: reason.as_str(),
+        count: matching.len(),
+        short_node_ids: matching
+            .into_iter()
+            .map(|item| item.short_node_id.clone())
+            .collect(),
+        recommendation: reason.recommendation(),
+    })
+}
+
+const fn split_readiness_exclusion_reason_order() -> [SplitReadinessExclusionReason; 8] {
+    [
+        SplitReadinessExclusionReason::MissingModelSource,
+        SplitReadinessExclusionReason::MissingStagePath,
+        SplitReadinessExclusionReason::StagePathRelayOnly,
+        SplitReadinessExclusionReason::StagePathTooSlow,
+        SplitReadinessExclusionReason::StageProtocolGeneration,
+        SplitReadinessExclusionReason::MissingVram,
+        SplitReadinessExclusionReason::MissingModelInterest,
+        SplitReadinessExclusionReason::Client,
+    ]
+}
+
+fn blocker_rank(reason: &str) -> usize {
+    split_readiness_exclusion_reason_order()
+        .iter()
+        .position(|candidate| candidate.as_str() == reason)
+        .unwrap_or(usize::MAX)
 }
 
 fn node_wants_model(model_ref: &str, node: &SplitReadinessNodeInput) -> bool {
@@ -794,6 +861,15 @@ mod tests {
         assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
         assert_eq!(report.participant_count, 1);
         assert_eq!(report.exclusions[0].reason, "missing_model_source");
+        assert_eq!(
+            report.blockers,
+            vec![SplitReadinessBlocker {
+                reason: "missing_model_source",
+                count: 1,
+                short_node_ids: vec!["peer0000".to_string()],
+                recommendation: "Ensure this peer can resolve or inventory the layer package before split serving.",
+            }]
+        );
         assert!(
             report
                 .recommendations
@@ -824,6 +900,8 @@ mod tests {
         assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
         assert_eq!(report.participant_count, 1);
         assert_eq!(report.exclusions[0].reason, "missing_stage_path");
+        assert_eq!(report.blockers[0].reason, "missing_stage_path");
+        assert_eq!(report.blockers[0].count, 1);
         assert!(
             report
                 .recommendations
@@ -885,5 +963,47 @@ mod tests {
         assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
         assert_eq!(report.participant_count, 1);
         assert_eq!(report.exclusions[0].reason, "stage_path_relay_only");
+        assert_eq!(report.blockers[0].reason, "stage_path_relay_only");
+    }
+
+    #[test]
+    fn split_readiness_blockers_prioritize_largest_actionable_group() {
+        let mut missing_source_a = node(
+            "missinga000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        missing_source_a.artifact_transfer_supported = false;
+        let mut missing_source_b = node(
+            "missingb000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        missing_source_b.artifact_transfer_supported = false;
+        let mut slow_path = node(
+            "slowpath000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        slow_path.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        slow_path.stage_path =
+            crate::mesh::SplitStagePathSnapshot::direct(Some(crate::mesh::MAX_SPLIT_RTT_MS + 1));
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![slow_path, missing_source_a, missing_source_b],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.blockers[0].reason, "missing_model_source");
+        assert_eq!(report.blockers[0].count, 2);
+        assert_eq!(
+            report.blockers[0].short_node_ids,
+            vec!["missinga".to_string(), "missingb".to_string()]
+        );
+        assert_eq!(report.blockers[1].reason, "stage_path_too_slow");
     }
 }

--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -173,7 +173,12 @@ pub(crate) fn build_split_readiness_report(input: SplitReadinessInput) -> SplitR
         participants.len(),
         capacity_advice.as_ref(),
     );
-    let blockers = split_readiness_blockers(&exclusions);
+    let blockers = split_readiness_blockers(
+        &exclusions,
+        verdict,
+        capacity_advice.as_ref(),
+        &participants,
+    );
     let recommendations = split_readiness_recommendations(&input.model_ref, verdict, &exclusions);
     SplitReadinessReport {
         model_ref: input.model_ref,
@@ -241,8 +246,10 @@ fn split_node_exclusion_reason(
     {
         return Some(split_readiness_stage_path_rejection(rejection));
     }
-    if node.source == SplitReadinessNodeSource::Peer && !node_has_stage_source(model_ref, node) {
-        return Some(SplitReadinessExclusionReason::MissingModelSource);
+    if node.source == SplitReadinessNodeSource::Peer
+        && let Some(reason) = split_stage_source_exclusion_reason(model_ref, node)
+    {
+        return Some(reason);
     }
     None
 }
@@ -468,6 +475,47 @@ fn split_readiness_recommendations(
     }
     if exclusions
         .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::StageControlUnreachable.as_str())
+    {
+        recommendations.push(
+            "Check excluded peer runtime logs and stage-control connectivity; preflight passed but inventory/control did not return usable data."
+                .to_string(),
+        );
+    }
+    if exclusions.iter().any(|item| {
+        item.reason == SplitReadinessExclusionReason::ArtifactTransferUnavailable.as_str()
+    }) {
+        recommendations.push(
+            "Enable artifact transfer, use an HF-resolvable package, or choose peers that already have the requested package cached."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::StageInventoryEmpty.as_str())
+    {
+        recommendations.push(
+            "Wait for stage inventory refresh or prepare the requested package on excluded peers."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
+        .any(|item| item.reason == SplitReadinessExclusionReason::PackageManifestMismatch.as_str())
+    {
+        recommendations.push(
+            "Refresh stale layer packages so excluded peers advertise the package manifest requested by this split."
+                .to_string(),
+        );
+    }
+    if verdict == SplitReadinessVerdict::InsufficientCapacity {
+        recommendations.push(
+            "Add split-capable workers with enough aggregate VRAM, lower the requested context, or choose a smaller package before retrying split serving."
+                .to_string(),
+        );
+    }
+    if exclusions
+        .iter()
         .any(|item| item.reason == SplitReadinessExclusionReason::MissingStagePath.as_str())
     {
         recommendations.push(
@@ -496,11 +544,20 @@ fn split_readiness_recommendations(
     recommendations
 }
 
-fn split_readiness_blockers(exclusions: &[SplitReadinessExclusion]) -> Vec<SplitReadinessBlocker> {
+fn split_readiness_blockers(
+    exclusions: &[SplitReadinessExclusion],
+    verdict: SplitReadinessVerdict,
+    capacity_advice: Option<&ModelTargetCapacityAdvicePayload>,
+    participants: &[SplitReadinessParticipant],
+) -> Vec<SplitReadinessBlocker> {
     let mut blockers = split_readiness_exclusion_reason_order()
         .into_iter()
         .filter_map(|reason| split_readiness_blocker(exclusions, reason))
         .collect::<Vec<_>>();
+    if let Some(blocker) = split_capacity_shortfall_blocker(verdict, capacity_advice, participants)
+    {
+        blockers.push(blocker);
+    }
     blockers.sort_by(|left, right| {
         right
             .count
@@ -532,8 +589,40 @@ fn split_readiness_blocker(
     })
 }
 
-const fn split_readiness_exclusion_reason_order() -> [SplitReadinessExclusionReason; 8] {
+fn split_capacity_shortfall_blocker(
+    verdict: SplitReadinessVerdict,
+    capacity_advice: Option<&ModelTargetCapacityAdvicePayload>,
+    participants: &[SplitReadinessParticipant],
+) -> Option<SplitReadinessBlocker> {
+    if verdict != SplitReadinessVerdict::InsufficientCapacity {
+        return None;
+    }
+    let advice = capacity_advice?;
+    if !matches!(
+        advice.state,
+        ModelTargetCapacityAdviceState::InsufficientCapacity
+            | ModelTargetCapacityAdviceState::NoEligibleHosts
+            | ModelTargetCapacityAdviceState::UnknownCapacity
+    ) {
+        return None;
+    }
+    Some(SplitReadinessBlocker {
+        reason: "split_capacity_shortfall",
+        count: participants.len(),
+        short_node_ids: participants
+            .iter()
+            .map(|participant| participant.short_node_id.clone())
+            .collect(),
+        recommendation: "Add split-capable workers with enough aggregate VRAM, lower the requested context, or choose a smaller package before retrying split serving.",
+    })
+}
+
+const fn split_readiness_exclusion_reason_order() -> [SplitReadinessExclusionReason; 12] {
     [
+        SplitReadinessExclusionReason::StageControlUnreachable,
+        SplitReadinessExclusionReason::PackageManifestMismatch,
+        SplitReadinessExclusionReason::ArtifactTransferUnavailable,
+        SplitReadinessExclusionReason::StageInventoryEmpty,
         SplitReadinessExclusionReason::MissingModelSource,
         SplitReadinessExclusionReason::MissingStagePath,
         SplitReadinessExclusionReason::StagePathRelayOnly,
@@ -546,6 +635,9 @@ const fn split_readiness_exclusion_reason_order() -> [SplitReadinessExclusionRea
 }
 
 fn blocker_rank(reason: &str) -> usize {
+    if reason == "split_capacity_shortfall" {
+        return 0;
+    }
     split_readiness_exclusion_reason_order()
         .iter()
         .position(|candidate| candidate.as_str() == reason)
@@ -605,6 +697,58 @@ fn node_has_stage_source(model_ref: &str, node: &SplitReadinessNodeInput) -> boo
     )
 }
 
+fn split_stage_source_exclusion_reason(
+    model_ref: &str,
+    node: &SplitReadinessNodeInput,
+) -> Option<SplitReadinessExclusionReason> {
+    if node_has_stage_source(model_ref, node) {
+        return None;
+    }
+    if node_has_package_manifest_mismatch_signal(model_ref, node) {
+        return Some(SplitReadinessExclusionReason::PackageManifestMismatch);
+    }
+    if !node.artifact_transfer_supported {
+        return Some(SplitReadinessExclusionReason::ArtifactTransferUnavailable);
+    }
+    if node_has_stage_inventory_surface(node) {
+        return Some(SplitReadinessExclusionReason::StageInventoryEmpty);
+    }
+    Some(SplitReadinessExclusionReason::MissingModelSource)
+}
+
+fn node_has_package_manifest_mismatch_signal(
+    model_ref: &str,
+    node: &SplitReadinessNodeInput,
+) -> bool {
+    node.model_source
+        .as_deref()
+        .is_some_and(|source| non_matching_model_signal(source, model_ref))
+        || node
+            .serving_models
+            .iter()
+            .chain(node.hosted_models.iter())
+            .chain(node.available_models.iter())
+            .any(|candidate| non_matching_model_signal(candidate, model_ref))
+}
+
+fn node_has_stage_inventory_surface(node: &SplitReadinessNodeInput) -> bool {
+    node.artifact_transfer_supported
+        || node
+            .model_source
+            .as_deref()
+            .is_some_and(|source| !source.trim().is_empty())
+        || node
+            .serving_models
+            .iter()
+            .chain(node.hosted_models.iter())
+            .chain(node.available_models.iter())
+            .any(|candidate| !candidate.trim().is_empty())
+}
+
+fn non_matching_model_signal(candidate: &str, model_ref: &str) -> bool {
+    !candidate.trim().is_empty() && !model_matches(candidate, model_ref)
+}
+
 fn model_matches(candidate: &str, model_ref: &str) -> bool {
     let candidate = candidate.trim();
     let model_ref = model_ref.trim();
@@ -625,6 +769,10 @@ enum SplitReadinessExclusionReason {
     MissingStagePath,
     StagePathRelayOnly,
     StagePathTooSlow,
+    StageControlUnreachable,
+    ArtifactTransferUnavailable,
+    StageInventoryEmpty,
+    PackageManifestMismatch,
     MissingModelSource,
 }
 
@@ -638,6 +786,10 @@ impl SplitReadinessExclusionReason {
             Self::MissingStagePath => "missing_stage_path",
             Self::StagePathRelayOnly => "stage_path_relay_only",
             Self::StagePathTooSlow => "stage_path_too_slow",
+            Self::StageControlUnreachable => "stage_control_unreachable",
+            Self::ArtifactTransferUnavailable => "artifact_transfer_unavailable",
+            Self::StageInventoryEmpty => "stage_inventory_empty",
+            Self::PackageManifestMismatch => "package_manifest_mismatch",
             Self::MissingModelSource => "missing_model_source",
         }
     }
@@ -662,6 +814,18 @@ impl SplitReadinessExclusionReason {
             }
             Self::StagePathTooSlow => {
                 "Use a lower-latency path or peer before admitting this peer to split serving."
+            }
+            Self::StageControlUnreachable => {
+                "Check stage-control connectivity and peer runtime logs before retrying."
+            }
+            Self::ArtifactTransferUnavailable => {
+                "Enable artifact transfer, use an HF-resolvable package, or choose a peer with the package already cached."
+            }
+            Self::StageInventoryEmpty => {
+                "Wait for inventory refresh or prepare the requested package on this peer."
+            }
+            Self::PackageManifestMismatch => {
+                "Refresh stale layer packages so this peer advertises the requested package manifest."
             }
             Self::MissingModelSource => {
                 "Ensure this peer can resolve or inventory the layer package before split serving."
@@ -815,6 +979,12 @@ mod tests {
             ModelTargetCapacityAdviceState::InsufficientCapacity
         );
         assert_eq!(capacity.shortfall_bytes, Some(2_000_000_000));
+        assert!(
+            report
+                .blockers
+                .iter()
+                .any(|blocker| blocker.reason == "split_capacity_shortfall")
+        );
     }
 
     #[test]
@@ -841,7 +1011,7 @@ mod tests {
     }
 
     #[test]
-    fn split_readiness_excludes_interested_peer_with_unknown_model_source() {
+    fn split_readiness_excludes_peer_without_transfer_or_cached_artifacts() {
         let mut peer = node(
             "peer000000000000000000000000000000000",
             SplitReadinessNodeRole::Worker,
@@ -860,21 +1030,78 @@ mod tests {
 
         assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
         assert_eq!(report.participant_count, 1);
-        assert_eq!(report.exclusions[0].reason, "missing_model_source");
+        assert_eq!(report.exclusions[0].reason, "artifact_transfer_unavailable");
         assert_eq!(
             report.blockers,
             vec![SplitReadinessBlocker {
-                reason: "missing_model_source",
+                reason: "artifact_transfer_unavailable",
                 count: 1,
                 short_node_ids: vec!["peer0000".to_string()],
-                recommendation: "Ensure this peer can resolve or inventory the layer package before split serving.",
+                recommendation: "Enable artifact transfer, use an HF-resolvable package, or choose a peer with the package already cached.",
             }]
         );
         assert!(
             report
                 .recommendations
                 .iter()
-                .any(|item| item.contains("resolvable package source"))
+                .any(|item| item.contains("Enable artifact transfer"))
+        );
+    }
+
+    #[test]
+    fn split_readiness_excludes_peer_with_empty_stage_inventory_surface() {
+        let peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.exclusions[0].reason, "stage_inventory_empty");
+        assert_eq!(report.blockers[0].reason, "stage_inventory_empty");
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|item| item.contains("inventory refresh"))
+        );
+    }
+
+    #[test]
+    fn split_readiness_excludes_peer_with_package_manifest_mismatch() {
+        let mut peer = node(
+            "peer000000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        peer.available_models = vec!["meshllm/OtherModel-Q4_K_M-layers".to_string()];
+
+        let report = build_split_readiness_report(SplitReadinessInput {
+            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
+            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
+            peers: vec![peer],
+            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
+            active_topology_count: 0,
+            active_stage_count: 0,
+        });
+
+        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
+        assert_eq!(report.exclusions[0].reason, "package_manifest_mismatch");
+        assert_eq!(report.blockers[0].reason, "package_manifest_mismatch");
+        assert!(
+            report
+                .recommendations
+                .iter()
+                .any(|item| item.contains("stale layer packages"))
         );
     }
 
@@ -998,7 +1225,7 @@ mod tests {
             active_stage_count: 0,
         });
 
-        assert_eq!(report.blockers[0].reason, "missing_model_source");
+        assert_eq!(report.blockers[0].reason, "artifact_transfer_unavailable");
         assert_eq!(report.blockers[0].count, 2);
         assert_eq!(
             report.blockers[0].short_node_ids,

--- a/crates/mesh-llm-host-runtime/src/cli/commands/doctor.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/commands/doctor.rs
@@ -303,6 +303,15 @@ fn split_readiness_lines(report: &Value) -> Vec<String> {
         format!("Excluded peers: {exclusions}"),
     ];
 
+    if let Some(items) = report["blockers"].as_array() {
+        let blockers = split_readiness_blocker_lines(items);
+        if !blockers.is_empty() {
+            lines.push(String::new());
+            lines.push("Blockers:".to_string());
+            lines.extend(blockers);
+        }
+    }
+
     if let Some(items) = report["recommendations"].as_array() {
         let recommendations = items
             .iter()
@@ -322,6 +331,42 @@ fn split_readiness_lines(report: &Value) -> Vec<String> {
     lines
 }
 
+fn split_readiness_blocker_lines(items: &[Value]) -> Vec<String> {
+    items
+        .iter()
+        .filter_map(split_readiness_blocker_line)
+        .collect()
+}
+
+fn split_readiness_blocker_line(item: &Value) -> Option<String> {
+    let reason = item["reason"].as_str()?;
+    let count = item["count"].as_u64().unwrap_or_default();
+    let nodes = item["short_node_ids"]
+        .as_array()
+        .map(|items| split_readiness_short_node_list(items.as_slice()))
+        .unwrap_or_else(|| "unknown nodes".to_string());
+    let recommendation = item["recommendation"].as_str().unwrap_or_default();
+    let suffix = if recommendation.is_empty() {
+        String::new()
+    } else {
+        format!(" - {recommendation}")
+    };
+    Some(format!("  - {reason}: {count} peer(s), {nodes}{suffix}"))
+}
+
+fn split_readiness_short_node_list(items: &[Value]) -> String {
+    let nodes = items
+        .iter()
+        .filter_map(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+    if nodes.is_empty() {
+        "unknown nodes".to_string()
+    } else {
+        format!("nodes [{}]", nodes.join(", "))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -339,6 +384,14 @@ mod tests {
             "verdict": "waiting_for_peers",
             "participant_count": 1,
             "exclusion_count": 1,
+            "blockers": [
+                {
+                    "reason": "missing_model_source",
+                    "count": 1,
+                    "short_node_ids": ["peer0000"],
+                    "recommendation": "Ensure this peer can resolve or inventory the layer package before split serving."
+                }
+            ],
             "recommendations": [
                 "Start at least one more worker/host with --model meshllm/Qwen3-8B-Q4_K_M-layers --split and join it to this mesh."
             ]
@@ -352,6 +405,12 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Eligible participants: 1"))
         );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("missing_model_source"))
+        );
+        assert!(lines.iter().any(|line| line.contains("peer0000")));
         assert!(
             lines
                 .iter()

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1091,6 +1091,39 @@ impl SplitParticipantExclusionReason {
             Self::MissingModelSource => "missing_model_source",
         }
     }
+
+    const fn recommendation(self) -> &'static str {
+        match self {
+            Self::Client => "Run this peer in serve mode if it should contribute compute.",
+            Self::MissingVram => {
+                "Check GPU visibility or lower --max-vram only after confirming backend/device detection."
+            }
+            Self::MissingModelInterest => {
+                "Start the peer with the same --model value or explicit split model interest."
+            }
+            Self::StageProtocolGeneration => {
+                "Upgrade this peer so it advertises current stage protocol support."
+            }
+            Self::MissingStagePath => {
+                "Wait for direct peer latency to be measured or fix direct QUIC connectivity."
+            }
+            Self::StagePathRelayOnly => {
+                "Fix firewall/NAT/direct-path connectivity; relay-only stage paths are not admitted."
+            }
+            Self::StagePathTooSlow => "Use a lower-latency peer or network path for split serving.",
+            Self::MissingModelSource => {
+                "Start the peer with a resolvable package source or wait for stage inventory to prove the package is available."
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct SplitParticipantBlockerSummary {
+    reason: &'static str,
+    count: usize,
+    short_node_ids: Vec<String>,
+    recommendation: &'static str,
 }
 
 struct SplitGenerationLoadSpec<'a> {
@@ -2701,14 +2734,96 @@ fn ensure_split_participant_timeout_has_quorum(
     best: &[SplitParticipant],
     best_excluded: &[SplitParticipantExclusion],
 ) -> Result<()> {
-    anyhow::ensure!(
-        best.len() >= SPLIT_DEFAULT_MIN_PARTICIPANTS,
-        "split runtime needs at least two participating nodes for {model_ref}; found {} eligible [{}]; excluded [{}]",
+    if best.len() >= SPLIT_DEFAULT_MIN_PARTICIPANTS {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "split runtime needs at least two participating nodes for {model_ref}; found {} eligible [{}]; excluded [{}]; blockers [{}]; next_step: {}",
         best.len(),
         split_participant_labels(best).join(", "),
-        split_participant_exclusion_labels(best_excluded).join(", ")
-    );
-    Ok(())
+        split_participant_exclusion_labels(best_excluded).join(", "),
+        split_participant_blocker_labels(best_excluded).join("; "),
+        split_participant_next_step(best_excluded)
+    )
+}
+
+fn split_participant_blocker_labels(excluded: &[SplitParticipantExclusion]) -> Vec<String> {
+    split_participant_blockers(excluded)
+        .into_iter()
+        .map(|blocker| {
+            format!(
+                "{}={} nodes=[{}]",
+                blocker.reason,
+                blocker.count,
+                blocker.short_node_ids.join(", ")
+            )
+        })
+        .collect()
+}
+
+fn split_participant_next_step(excluded: &[SplitParticipantExclusion]) -> &'static str {
+    split_participant_blockers(excluded)
+        .first()
+        .map(|blocker| blocker.recommendation)
+        .unwrap_or("Start at least one more worker/host with the same --model value and --split.")
+}
+
+fn split_participant_blockers(
+    excluded: &[SplitParticipantExclusion],
+) -> Vec<SplitParticipantBlockerSummary> {
+    let mut blockers = split_participant_exclusion_reason_order()
+        .into_iter()
+        .filter_map(|reason| split_participant_blocker(excluded, reason))
+        .collect::<Vec<_>>();
+    blockers.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| blocker_reason_rank(left.reason).cmp(&blocker_reason_rank(right.reason)))
+    });
+    blockers
+}
+
+fn split_participant_blocker(
+    excluded: &[SplitParticipantExclusion],
+    reason: SplitParticipantExclusionReason,
+) -> Option<SplitParticipantBlockerSummary> {
+    let matching = excluded
+        .iter()
+        .filter(|item| item.reason == reason)
+        .collect::<Vec<_>>();
+    if matching.is_empty() {
+        return None;
+    }
+    Some(SplitParticipantBlockerSummary {
+        reason: reason.as_str(),
+        count: matching.len(),
+        short_node_ids: matching
+            .into_iter()
+            .map(|item| item.node_id.fmt_short().to_string())
+            .collect(),
+        recommendation: reason.recommendation(),
+    })
+}
+
+const fn split_participant_exclusion_reason_order() -> [SplitParticipantExclusionReason; 8] {
+    [
+        SplitParticipantExclusionReason::MissingModelSource,
+        SplitParticipantExclusionReason::MissingStagePath,
+        SplitParticipantExclusionReason::StagePathRelayOnly,
+        SplitParticipantExclusionReason::StagePathTooSlow,
+        SplitParticipantExclusionReason::StageProtocolGeneration,
+        SplitParticipantExclusionReason::MissingVram,
+        SplitParticipantExclusionReason::MissingModelInterest,
+        SplitParticipantExclusionReason::Client,
+    ]
+}
+
+fn blocker_reason_rank(reason: &str) -> usize {
+    split_participant_exclusion_reason_order()
+        .iter()
+        .position(|candidate| candidate.as_str() == reason)
+        .unwrap_or(usize::MAX)
 }
 
 fn best_split_participant_snapshot(
@@ -4358,6 +4473,38 @@ max_tokens = 222
         };
 
         assert!(signal.can_stage_with(&package, false));
+    }
+
+    #[test]
+    fn split_participant_timeout_error_reports_blocker_summary() {
+        let participants = vec![SplitParticipant::new(make_id(1), 2_000_000_000, None)];
+        let excluded = vec![
+            SplitParticipantExclusion {
+                node_id: make_id(2),
+                reason: SplitParticipantExclusionReason::MissingModelSource,
+            },
+            SplitParticipantExclusion {
+                node_id: make_id(3),
+                reason: SplitParticipantExclusionReason::MissingModelSource,
+            },
+            SplitParticipantExclusion {
+                node_id: make_id(4),
+                reason: SplitParticipantExclusionReason::MissingModelInterest,
+            },
+        ];
+
+        let error = ensure_split_participant_timeout_has_quorum(
+            "meshllm/Qwen3-layers",
+            &participants,
+            &excluded,
+        )
+        .expect_err("one participant should not satisfy split quorum")
+        .to_string();
+
+        assert!(error.contains("found 1 eligible"));
+        assert!(error.contains("blockers [missing_model_source=2 nodes=["));
+        assert!(error.contains("missing_model_interest=1 nodes=["));
+        assert!(error.contains("next_step: Start the peer with a resolvable package source"));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -1075,6 +1075,10 @@ pub(super) enum SplitParticipantExclusionReason {
     MissingStagePath,
     StagePathRelayOnly,
     StagePathTooSlow,
+    StageControlUnreachable,
+    ArtifactTransferUnavailable,
+    StageInventoryEmpty,
+    PackageManifestMismatch,
     MissingModelSource,
 }
 
@@ -1088,6 +1092,10 @@ impl SplitParticipantExclusionReason {
             Self::MissingStagePath => "missing_stage_path",
             Self::StagePathRelayOnly => "stage_path_relay_only",
             Self::StagePathTooSlow => "stage_path_too_slow",
+            Self::StageControlUnreachable => "stage_control_unreachable",
+            Self::ArtifactTransferUnavailable => "artifact_transfer_unavailable",
+            Self::StageInventoryEmpty => "stage_inventory_empty",
+            Self::PackageManifestMismatch => "package_manifest_mismatch",
             Self::MissingModelSource => "missing_model_source",
         }
     }
@@ -1111,6 +1119,18 @@ impl SplitParticipantExclusionReason {
                 "Fix firewall/NAT/direct-path connectivity; relay-only stage paths are not admitted."
             }
             Self::StagePathTooSlow => "Use a lower-latency peer or network path for split serving.",
+            Self::StageControlUnreachable => {
+                "Check stage-control connectivity and peer runtime logs before retrying split serving."
+            }
+            Self::ArtifactTransferUnavailable => {
+                "Enable artifact transfer, use an HF-resolvable package, or choose a peer with the package already cached."
+            }
+            Self::StageInventoryEmpty => {
+                "Wait for stage inventory refresh or prepare the requested package on this peer."
+            }
+            Self::PackageManifestMismatch => {
+                "Refresh stale layer packages so this peer advertises the requested package manifest."
+            }
             Self::MissingModelSource => {
                 "Start the peer with a resolvable package source or wait for stage inventory to prove the package is available."
             }
@@ -2806,8 +2826,12 @@ fn split_participant_blocker(
     })
 }
 
-const fn split_participant_exclusion_reason_order() -> [SplitParticipantExclusionReason; 8] {
+const fn split_participant_exclusion_reason_order() -> [SplitParticipantExclusionReason; 12] {
     [
+        SplitParticipantExclusionReason::StageControlUnreachable,
+        SplitParticipantExclusionReason::PackageManifestMismatch,
+        SplitParticipantExclusionReason::ArtifactTransferUnavailable,
+        SplitParticipantExclusionReason::StageInventoryEmpty,
         SplitParticipantExclusionReason::MissingModelSource,
         SplitParticipantExclusionReason::MissingStagePath,
         SplitParticipantExclusionReason::StagePathRelayOnly,
@@ -2878,11 +2902,17 @@ async fn collect_split_participants(
             continue;
         }
 
-        if let Some(package_signal) =
-            split_peer_package_signal(node, peer.id, model_ref, package).await
+        let artifact_transfer_allowed = node.artifact_transfer_allowed_for_peer(&peer).await;
+        match split_peer_package_signal(
+            node,
+            peer.id,
+            model_ref,
+            package,
+            artifact_transfer_allowed,
+        )
+        .await
         {
-            let artifact_transfer_allowed = node.artifact_transfer_allowed_for_peer(&peer).await;
-            if package_signal.can_stage_with(package, artifact_transfer_allowed) {
+            Ok(package_signal) => {
                 participants.push(
                     SplitParticipant::new(peer.id, peer.vram_bytes, peer.first_joined_mesh_ts)
                         .with_package_signals(
@@ -2891,17 +2921,13 @@ async fn collect_split_participants(
                             artifact_transfer_allowed,
                         ),
                 );
-            } else {
+            }
+            Err(reason) => {
                 excluded.push(SplitParticipantExclusion {
                     node_id: peer.id,
-                    reason: SplitParticipantExclusionReason::MissingModelSource,
+                    reason,
                 });
             }
-        } else {
-            excluded.push(SplitParticipantExclusion {
-                node_id: peer.id,
-                reason: SplitParticipantExclusionReason::MissingModelSource,
-            });
         }
     }
     participants.sort_by_key(|participant| participant.node_id.to_string());
@@ -2984,7 +3010,8 @@ async fn split_peer_package_signal(
     peer_id: iroh::EndpointId,
     model_ref: &str,
     package: &skippy::SkippyPackageIdentity,
-) -> Option<SplitParticipantPackageSignal> {
+    artifact_transfer_supported: bool,
+) -> std::result::Result<SplitParticipantPackageSignal, SplitParticipantExclusionReason> {
     let request = skippy::StageInventoryRequest {
         model_id: model_ref.to_string(),
         package_ref: package.package_ref.clone(),
@@ -2993,10 +3020,56 @@ async fn split_peer_package_signal(
     let result = node
         .send_stage_control(peer_id, skippy::StageControlRequest::Inventory(request))
         .await;
-    let Ok(skippy::StageControlResponse::Inventory(inventory)) = result else {
-        return None;
+    let Ok(response) = result else {
+        return Err(SplitParticipantExclusionReason::StageControlUnreachable);
     };
-    Some(split_inventory_package_signal(&inventory, package))
+    let skippy::StageControlResponse::Inventory(inventory) = response else {
+        return Err(SplitParticipantExclusionReason::StageControlUnreachable);
+    };
+    split_inventory_package_signal_result(&inventory, package, artifact_transfer_supported)
+}
+
+fn split_inventory_package_signal_result(
+    inventory: &skippy::StageLayerInventory,
+    package: &skippy::SkippyPackageIdentity,
+    artifact_transfer_supported: bool,
+) -> std::result::Result<SplitParticipantPackageSignal, SplitParticipantExclusionReason> {
+    if split_inventory_manifest_mismatch(inventory, package) {
+        return Err(SplitParticipantExclusionReason::PackageManifestMismatch);
+    }
+    if split_inventory_has_no_stage_surface(inventory) {
+        return Err(SplitParticipantExclusionReason::StageInventoryEmpty);
+    }
+    let signal = split_inventory_package_signal(inventory, package);
+    if signal.can_stage_with(package, artifact_transfer_supported) {
+        return Ok(signal);
+    }
+    if signal.missing_artifact_bytes > 0 && !artifact_transfer_supported {
+        return Err(SplitParticipantExclusionReason::ArtifactTransferUnavailable);
+    }
+    Err(SplitParticipantExclusionReason::MissingModelSource)
+}
+
+fn split_inventory_manifest_mismatch(
+    inventory: &skippy::StageLayerInventory,
+    package: &skippy::SkippyPackageIdentity,
+) -> bool {
+    inventory.package_ref != package.package_ref
+        || inventory.manifest_sha256 != package.manifest_sha256
+}
+
+fn split_inventory_has_no_stage_surface(inventory: &skippy::StageLayerInventory) -> bool {
+    inventory.layer_count == 0
+        && inventory.ready_ranges.is_empty()
+        && inventory.available_ranges.is_empty()
+        && inventory.missing_ranges.is_empty()
+        && inventory.preparing_ranges.is_empty()
+        && inventory.source_model_path.is_none()
+        && inventory.source_model_bytes.is_none()
+        && matches!(
+            inventory.source_model_kind,
+            skippy::SourceModelKind::Unknown
+        )
 }
 
 fn split_inventory_package_signal(
@@ -3220,23 +3293,30 @@ async fn prepare_split_stage(
         load,
         coordinator_id: Some(node.id()),
     };
+    let prepare_stage_id = prepare.load.stage_id.clone();
     let response = if stage_node_id == node.id() {
         node.send_local_stage_control(skippy::StageControlRequest::Prepare(prepare))
             .await
     } else {
         node.send_stage_control(stage_node_id, skippy::StageControlRequest::Prepare(prepare))
             .await
-    }?;
+    }
+    .with_context(|| stage_control_unreachable_message(&prepare_stage_id, stage_node_id))?;
     let skippy::StageControlResponse::PrepareAccepted(accepted) = response else {
-        anyhow::bail!("unexpected response while preparing split stage");
+        anyhow::bail!(
+            "{}",
+            stage_control_unreachable_message(&prepare_stage_id, stage_node_id)
+        );
     };
     anyhow::ensure!(
         accepted.accepted,
-        "stage {} rejected prepare: {}",
-        accepted.status.stage_id,
-        accepted
-            .error
-            .unwrap_or_else(|| "unknown error".to_string())
+        "{}",
+        stage_source_prepare_failed_message(
+            &accepted.status.stage_id,
+            &accepted
+                .error
+                .unwrap_or_else(|| "unknown error".to_string())
+        )
     );
     Ok(())
 }
@@ -3249,7 +3329,9 @@ async fn wait_for_split_stage_source(
 ) -> Result<()> {
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
-        let inventory = query_stage_inventory(node, stage_node_id, load).await?;
+        let inventory = query_stage_inventory(node, stage_node_id, load)
+            .await
+            .with_context(|| stage_control_unreachable_message(&load.stage_id, stage_node_id))?;
         if split_stage_source_is_ready(&inventory, load) {
             tracing::info!(
                 topology_id = %load.topology_id,
@@ -3265,20 +3347,39 @@ async fn wait_for_split_stage_source(
                 && matches!(status.state, skippy::StagePreparationState::Failed)
         }) {
             anyhow::bail!(
-                "stage {} source prepare failed: {}",
-                load.stage_id,
-                failed.error.as_deref().unwrap_or("unknown error")
+                "{}",
+                stage_source_prepare_failed_message(
+                    &load.stage_id,
+                    failed.error.as_deref().unwrap_or("unknown error")
+                )
             );
         }
         if tokio::time::Instant::now() >= deadline {
             anyhow::bail!(
-                "timed out waiting for stage {} source availability after {:?}",
-                load.stage_id,
-                timeout
+                "{}",
+                stage_source_prepare_timeout_message(&load.stage_id, timeout)
             );
         }
         tokio::time::sleep(Duration::from_secs(2)).await;
     }
+}
+
+fn stage_control_unreachable_message(stage_id: &str, stage_node_id: iroh::EndpointId) -> String {
+    format!(
+        "stage_control_unreachable: inventory/control request failed for stage {} on {}",
+        stage_id,
+        stage_node_id.fmt_short()
+    )
+}
+
+fn stage_source_prepare_failed_message(stage_id: &str, error: &str) -> String {
+    format!("stage_source_prepare_failed: stage {stage_id} source prepare failed: {error}")
+}
+
+fn stage_source_prepare_timeout_message(stage_id: &str, timeout: Duration) -> String {
+    format!(
+        "stage_source_prepare_timeout: timed out waiting for stage {stage_id} source availability after {timeout:?}"
+    )
 }
 
 fn split_stage_source_is_ready(
@@ -4719,6 +4820,112 @@ max_tokens = 222
                 availability_score: 0,
             }
         );
+    }
+
+    #[test]
+    fn split_inventory_package_signal_result_classifies_empty_inventory() {
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        let inventory = skippy::StageLayerInventory {
+            model_id: "model-a".to_string(),
+            package_ref: package.package_ref.clone(),
+            manifest_sha256: package.manifest_sha256.clone(),
+            layer_count: 0,
+            ready_ranges: Vec::new(),
+            available_ranges: Vec::new(),
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: None,
+            source_model_bytes: None,
+            source_model_kind: skippy::SourceModelKind::Unknown,
+        };
+
+        assert_eq!(
+            split_inventory_package_signal_result(&inventory, &package, true),
+            Err(SplitParticipantExclusionReason::StageInventoryEmpty)
+        );
+    }
+
+    #[test]
+    fn split_inventory_package_signal_result_classifies_manifest_mismatch() {
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        let mut inventory = skippy::StageLayerInventory {
+            model_id: "model-a".to_string(),
+            package_ref: package.package_ref.clone(),
+            manifest_sha256: package.manifest_sha256.clone(),
+            layer_count: 10,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 10,
+            }],
+            missing_ranges: Vec::new(),
+            preparing_ranges: Vec::new(),
+            source_model_path: Some("/cache/layer-package".to_string()),
+            source_model_bytes: Some(1_000),
+            source_model_kind: skippy::SourceModelKind::LayerPackage,
+        };
+        inventory.manifest_sha256 = "other-manifest".to_string();
+
+        assert_eq!(
+            split_inventory_package_signal_result(&inventory, &package, true),
+            Err(SplitParticipantExclusionReason::PackageManifestMismatch)
+        );
+    }
+
+    #[test]
+    fn split_inventory_package_signal_result_requires_transfer_for_partial_package() {
+        let package = skippy::SkippyPackageIdentity {
+            source_model_bytes: 1_000,
+            layer_count: 10,
+            ..package(10)
+        };
+        let inventory = skippy::StageLayerInventory {
+            model_id: "model-a".to_string(),
+            package_ref: package.package_ref.clone(),
+            manifest_sha256: package.manifest_sha256.clone(),
+            layer_count: 10,
+            ready_ranges: Vec::new(),
+            available_ranges: vec![skippy::LayerRange {
+                layer_start: 0,
+                layer_end: 4,
+            }],
+            missing_ranges: vec![skippy::LayerRange {
+                layer_start: 4,
+                layer_end: 10,
+            }],
+            preparing_ranges: Vec::new(),
+            source_model_path: Some("/cache/layer-package".to_string()),
+            source_model_bytes: Some(1_000),
+            source_model_kind: skippy::SourceModelKind::LayerPackage,
+        };
+
+        assert_eq!(
+            split_inventory_package_signal_result(&inventory, &package, false),
+            Err(SplitParticipantExclusionReason::ArtifactTransferUnavailable)
+        );
+        assert!(split_inventory_package_signal_result(&inventory, &package, true).is_ok());
+    }
+
+    #[test]
+    fn split_startup_error_messages_include_specific_blocker_tokens() {
+        let control = stage_control_unreachable_message("stage-1", make_id(2));
+        let failed = stage_source_prepare_failed_message("stage-1", "package missing");
+        let timeout = stage_source_prepare_timeout_message("stage-1", Duration::from_secs(30));
+
+        assert!(control.contains("stage_control_unreachable"));
+        assert!(control.contains(&make_id(2).fmt_short().to_string()));
+        assert!(failed.contains("stage_source_prepare_failed"));
+        assert!(failed.contains("package missing"));
+        assert!(timeout.contains("stage_source_prepare_timeout"));
+        assert!(timeout.contains("30s"));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
@@ -292,7 +292,7 @@ fn split_topology_failure_reason(
     let estimated_total_bytes = bytes_per_layer.saturating_mul(u64::from(package.layer_count));
 
     format!(
-        "unable to plan split topology for {model_ref}: native_context={}, minimum_context={}, evaluated_context={}, evaluated_lanes={}, layer_count={}, estimated_bytes_per_layer={}, estimated_total_bytes={}, total_usable_vram={}, max_placeable_layers_at_evaluated_shape={}/{}; participants [{}]; excluded [{}]",
+        "split_capacity_shortfall: unable to plan split topology for {model_ref}: native_context={}, minimum_context={}, evaluated_context={}, evaluated_lanes={}, layer_count={}, estimated_bytes_per_layer={}, estimated_total_bytes={}, total_usable_vram={}, max_placeable_layers_at_evaluated_shape={}/{}; participants [{}]; excluded [{}]",
         resources.native_context_length,
         minimum_context,
         evaluated_context,
@@ -494,7 +494,7 @@ impl SplitCapacityReadinessReport {
 
     fn error_message(&self, model_ref: &str) -> String {
         let mut message = format!(
-            "aggregate split capacity for {model_ref} requires {}, mesh has {} across {} participant(s), short by {}",
+            "split_capacity_shortfall: aggregate split capacity for {model_ref} requires {}, mesh has {} across {} participant(s), short by {}",
             format_gb(self.required_bytes),
             format_gb(self.available_bytes),
             self.participants.len(),
@@ -631,6 +631,7 @@ mod tests {
             &excluded,
         );
 
+        assert!(message.contains("split_capacity_shortfall"));
         assert!(message.contains("model-a"));
         assert!(message.contains("short by 60.0GB"));
         assert!(message.contains("participants ["));


### PR DESCRIPTION
## Summary

This makes split startup failures explainable before operators have to infer the root cause from raw logs.

When split serving cannot form a usable participant set, the split-readiness report now includes structured blockers with stable reason codes, counts, affected short node IDs, and targeted recommendations. The same blocker summary is rendered in `mesh doctor`, split no-quorum startup failures include the highest-priority blocker plus a concrete next step, and post-review startup diagnostics now distinguish stage-control, artifact-transfer, inventory, manifest, capacity, and source-prepare failure modes.

## Why

Recent split bring-up reports showed nodes could see each other in the dashboard while `--split` still stalled or exited with unclear reasons such as `waiting_for_peers`, `excluded`, or broad `missing_model_source`. The raw readiness data existed, but operators had to infer which peer was excluded and what to fix first.

Review feedback correctly called out that several operator actions were still collapsed into `missing_model_source`. This PR now separates those cases so the diagnostic points at the right next action: peer runtime/stage-control logs, artifact transfer/package cache, inventory refresh, stale manifest/package identity, aggregate split capacity, or stage source prepare failure/timeout.

## Diff Scope

- Add additive `blockers` data to the split-readiness report:
  - `reason`
  - `count`
  - `short_node_ids`
  - `recommendation`
- Group readiness exclusions into prioritized blocker summaries so repeated failures point to the dominant actionable cause.
- Split broad source blockers into specific reasons where evidence is available:
  - `stage_control_unreachable`
  - `artifact_transfer_unavailable`
  - `stage_inventory_empty`
  - `package_manifest_mismatch`
  - `missing_model_source`
- Add broader startup blocker tokens for post-eligibility failures:
  - `split_capacity_shortfall`
  - `stage_source_prepare_failed`
  - `stage_source_prepare_timeout`
- Render blocker summaries in the existing split-readiness doctor output.
- Include blocker summaries and `next_step` guidance in split participant timeout/no-quorum errors.
- Add regression coverage for missing source/action-specific blockers, stage path blockers, capacity shortfall, doctor rendering, no-quorum timeout messaging, inventory classification, and source-prepare startup messages.

## Compatibility

No mesh protobuf, QUIC ALPN, gossip schema, Skippy ABI, package manifest format, or package resolver behavior changes.

The split-readiness API change is additive. Existing clients can ignore `blockers`.

## Branch Integrity

- Base branch: `main`
- Validated base SHA: `c221017829c78c365a5f3b8faf1e5daed1b5be95`
- Head SHA: `04d421e8c52dc49b3c94ef1fc761d8f7049322fa`
- Ahead/behind: `0 behind / 2 ahead` relative to fetched `origin/main`
- Merge-base: `c221017829c78c365a5f3b8faf1e5daed1b5be95`
- Rebase: `git rebase origin/main` PASS, no conflicts.

## Commit Integrity

- `da96c79d466b9f144d56575029729df7902db309 Diagnose split startup blockers`
- `04d421e8c52dc49b3c94ef1fc761d8f7049322fa Classify split startup blockers`

The PR contains one original diagnostic change plus one focused post-review correction. The final PR diff contains only the intended split-readiness, doctor, startup timeout/source, and split-capacity diagnostics.

## Diff Hygiene

Changed files:

- `crates/mesh-llm-host-runtime/src/api/split_readiness.rs`
- `crates/mesh-llm-host-runtime/src/cli/commands/doctor.rs`
- `crates/mesh-llm-host-runtime/src/runtime/local.rs`
- `crates/mesh-llm-host-runtime/src/runtime/split_planning.rs`

`git diff --check origin/main...HEAD`: PASS, no output.

## Validation

- Validation tier: Tier 2R - post-review diagnostic correction for PR #774; split readiness and split startup diagnostics now separate stage-control, artifact-transfer, inventory-empty, manifest-mismatch, capacity-shortfall, and stage-source prepare blockers without mesh protocol or Skippy ABI changes.
- `git fetch --no-tags origin main:refs/remotes/origin/main`: PASS, origin/main at `c221017829c78c365a5f3b8faf1e5daed1b5be95`.
- `git rebase origin/main`: PASS, no conflicts.
- `git diff --check origin/main...HEAD`: PASS, no output.
- `git diff --check`: PASS, no output.
- `git diff --cached --check`: PASS, no output.
- `cargo fmt --all`: PASS.
- `cargo fmt --all -- --check`: PASS.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_readiness --lib -- --test-threads=1`: PASS, 15 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_participant --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_inventory_package_signal_result --lib -- --test-threads=1`: PASS, 3 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_startup_error_messages_include_specific_blocker_tokens --lib -- --test-threads=1`: PASS, 1 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime split_topology --lib -- --test-threads=1`: PASS, 8 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo test -p mesh-llm-host-runtime capacity_report_includes_participants_and_exclusions --lib -- --test-threads=1`: PASS, 1 passed.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal cargo check -p mesh-llm`: PASS.
- `LLAMA_STAGE_BUILD_DIR=/Users/Funtland/Downloads/mesh-llm/.deps/llama-build/build-stage-abi-metal /opt/homebrew/bin/cargo-clippy clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`: PASS.
- Remote CI on final SHA `04d421e8c52dc49b3c94ef1fc761d8f7049322fa`: PASS, PR Quality Checks and PR Builds completed successfully, including Linux/macOS CPU, Linux unit/protocol/skippy shards, inference smoke, two-node client smoke, and two-node split smoke.
- Ledger: not applicable - not required for selected validation tier/change family.
- Version: not applicable - no release/version sync required for this post-review diagnostic/runtime-message correction.
- Not run: `just build` - not required for selected validation tier; no UI assets or release bundle changed.
- Not run: local live two-node split startup smoke - no second split-capable local node/runtime endpoint was available; remote `two_node_split_smoke` passed on the final SHA.

## Required Remote Gates

PASS - mandatory GitHub checks completed successfully on final SHA `04d421e8c52dc49b3c94ef1fc761d8f7049322fa`.

## Runtime Safety

No mesh membership, gossip, transport, model loading, package resolution, or Skippy execution invariant is changed.

No new blocking locks, unbounded queues, protocol fields, or runtime execution paths are introduced. No invariant regression introduced.

## Documentation Integrity

No docs or runbooks changed. The new operator-facing guidance is emitted by the existing doctor/readiness/runtime error surfaces.

## Rollback Plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none known.

## Known Residual Risks

No known merge-blocking residual risk. Live operator bring-up can still reveal environment-specific issues, but the final PR SHA passed the mandatory remote two-node split smoke and targeted local diagnostic coverage.
