### PR TITLE
prepare-llama.sh: prevent git -C from escaping into an enclosing repo

### DIFF
--- a/scripts/prepare-llama.sh
+++ b/scripts/prepare-llama.sh
@@ -21,6 +21,28 @@ fi
 
 mkdir -p "$(dirname "$LLAMA_WORKDIR")"
 
+# All git operations below run as `git -C "$LLAMA_WORKDIR"`. `git -C` only
+# changes directory; it does NOT pin git to that directory. If $LLAMA_WORKDIR
+# has no valid .git (e.g. an interrupted/partial clone), git's normal upward
+# repository discovery walks PAST it to the nearest enclosing .git. When
+# mesh-llm is vendored inside another git repo's working tree (cargo/hermit git
+# checkouts do exactly this), that enclosing repo gets mutated instead -- its
+# origin rewritten by `remote set-url`, its HEAD clobbered by `git am`. Pin the
+# ceiling to the workdir's parent so discovery can never escape upward: a
+# missing .git then errors loudly here instead of corrupting the parent repo.
+# This is transparent to a normal build, where $LLAMA_WORKDIR has its own .git
+# at or below this ceiling.
+#
+# Resolve to a physical path (pwd -P): git compares GIT_CEILING_DIRECTORIES
+# against symlink-resolved paths, so a logical path could silently fail to
+# match and let discovery escape. Fail loudly if resolution fails rather than
+# exporting an empty ceiling, which would disable the guard entirely.
+LLAMA_WORKDIR_PARENT="$(cd "$(dirname "$LLAMA_WORKDIR")" && pwd -P)" || {
+  echo "error: cannot resolve parent directory of LLAMA_WORKDIR ($LLAMA_WORKDIR)" >&2
+  exit 1
+}
+export GIT_CEILING_DIRECTORIES="$LLAMA_WORKDIR_PARENT"
+
 git_retry() {
   local attempt=1
   local max_attempts="${LLAMA_GIT_MAX_ATTEMPTS:-4}"
@@ -72,7 +94,15 @@ clone_llama_workdir() {
   done
 }
 
-if [[ ! -d "$LLAMA_WORKDIR/.git" ]]; then
+# Re-clone unless $LLAMA_WORKDIR is genuinely its own git repository. A bare
+# `[[ ! -d "$LLAMA_WORKDIR/.git" ]]` check passes a partial/corrupt checkout
+# (dir present, .git missing or incomplete) straight through to the `git -C`
+# operations below; combined with discovery walking upward, that is what lets
+# this script escape into an enclosing repo. `rev-parse --git-dir` only
+# succeeds for a real repo rooted at the workdir (discovery cannot escape past
+# GIT_CEILING_DIRECTORIES set above). clone_llama_workdir rm -rf's first, so
+# re-cloning a partial dir is safe.
+if ! git -C "$LLAMA_WORKDIR" rev-parse --git-dir >/dev/null 2>&1; then
   clone_llama_workdir
 fi
 


### PR DESCRIPTION
## Problem

`scripts/prepare-llama.sh` runs all of its git operations as `git -C "$LLAMA_WORKDIR"`. `git -C <dir>` only changes directory — it does **not** pin git to that directory. If `$LLAMA_WORKDIR` (default `.deps/llama.cpp`) has no valid `.git` at the moment those commands run (an interrupted or partial clone, or a wiped `.git`), git's normal upward repository discovery walks **past** it to the nearest enclosing `.git`.

When mesh-llm is consumed as a git/cargo dependency, it gets vendored **inside the consuming repo's working tree** — cargo's git checkout dir and hermit's `.hermit/rust/git/checkouts/...` both do this. In that layout, the "nearest enclosing `.git`" that discovery finds is the **consuming repo**, so the script mutates it instead of the llama checkout.

### Observed impact (real, in a consuming repo)

Triggered during a routine `cargo clippy --workspace --all-targets` that built mesh-llm:

1. **Origin rewritten** — `git -C "$LLAMA_WORKDIR" remote set-url origin "$LLAMA_UPSTREAM_URL"` resolved against the consuming repo and rewrote *its* `remote.origin.url` to `https://github.com/ggml-org/llama.cpp.git`. A later `git push` then attempted to push the consuming repo's commits to `ggml-org/llama.cpp` (it 403'd for us — no write access — so nothing leaked, but it was a wrong-destination push attempt).
2. **HEAD clobbered** — the `git am --3way "${PATCHES[@]}"` series applied onto the consuming repo's worktree HEAD: HEAD detached, several `Mesh-LLM CI <ci@mesh-llm.local>` commits stacked on top, working tree showing thousands of phantom deletions.

Both required manual repair. The danger is that it's **silent** (happens during a normal build, not an explicit git op) and, with write access to the rewritten upstream, the origin rewrite could exfiltrate the consuming repo's code.

### Root cause

The clone guard `[[ ! -d "$LLAMA_WORKDIR/.git" ]]` only re-clones when `.git` is *entirely absent*. A partial/corrupt checkout (dir present, `.git` missing or incomplete) passes straight through to the `git -C` operations, and discovery then escapes upward.

## Fix

Two minimal, behavior-preserving guards in `scripts/prepare-llama.sh`:

1. **Pin discovery so it can't escape** — `export GIT_CEILING_DIRECTORIES` to the absolute parent of `$LLAMA_WORKDIR`. Git discovery can no longer walk above that ceiling, so a missing/partial `.git` now errors *loudly here* instead of corrupting the parent repo. This closes **every** `git -C` call site at once (including the `rev-parse HEAD` in the "already prepared" fast-path).
2. **Harden the clone guard** — replace the bare `[[ ! -d .../.git ]]` with `git rev-parse --git-dir`, so a partial/corrupt checkout is re-cloned rather than passed through. `clone_llama_workdir` already `rm -rf`s before cloning, so re-cloning a partial dir is safe.

## Why this is safe for mesh-llm's own build

In a normal mesh-llm build, `$LLAMA_WORKDIR` is a real clone with its own `.git` **at** the workdir — i.e. at/below the ceiling — so discovery still finds it and every operation behaves exactly as before. The ceiling only blocks discovery *above* the workdir's parent, which never happens on the happy path. The happy path is byte-for-byte unchanged; the only new behavior is that a missing/partial `.git` fails fast instead of escaping.

## Verification

Local functional tests (not just review):

- **Bug path** — workdir with no valid `.git` inside an enclosing repo: without the ceiling, `git -C` resolves to the enclosing `.git`; with the ceiling, `rev-parse --git-dir` fails as intended (guard re-clones), and a `remote set-url` errors `fatal: not a git repository` instead of touching the parent. Enclosing `origin` unchanged before/after.
- **Happy path** — workdir *with* its own `.git` at/below the ceiling: `rev-parse --git-dir` succeeds, `rev-parse --show-toplevel` correctly resolves to the child workdir, and `remote set-url` affects only the child. Parent untouched.
- `bash -n scripts/prepare-llama.sh` clean.

Scope is limited to `scripts/prepare-llama.sh` — no refactor, no reformat, no changes to the patch flow or CI.
