### PR TITLE
Add embedded SDK knobs: disable iroh relays + join-token on running node

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/state.rs
@@ -43,6 +43,10 @@ impl Serialize for PublicationState {
 }
 
 pub enum RuntimeControlRequest {
+    Join {
+        invite_token: String,
+        resp: tokio::sync::oneshot::Sender<anyhow::Result<()>>,
+    },
     Load {
         spec: String,
         resp: tokio::sync::oneshot::Sender<anyhow::Result<RuntimeLoadResponse>>,

--- a/crates/mesh-llm-host-runtime/src/cli/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/cli/mod.rs
@@ -536,6 +536,10 @@ pub(crate) struct Cli {
     #[arg(long = "relay-auth", value_parser = parse_relay_auth_pair, hide = true)]
     pub(crate) relay_auth: Vec<(String, String)>,
 
+    /// Disable iroh relay registration. Direct addresses and explicit EndpointAddr dials still work.
+    #[arg(long, hide = true)]
+    pub(crate) disable_iroh_relays: bool,
+
     /// Bind QUIC to a fixed UDP port (for NAT port forwarding).
     #[arg(long, hide = true)]
     pub(crate) bind_port: Option<u16>,

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -399,6 +399,7 @@ pub struct RelayConfig<'a> {
 pub enum RelayPolicy {
     #[default]
     DefaultPublic,
+    ExplicitlyDisabled,
     Disabled,
 }
 
@@ -408,7 +409,7 @@ impl RelayPolicy {
     }
 
     fn uses_raw_stun(self) -> bool {
-        matches!(self, Self::DefaultPublic)
+        matches!(self, Self::DefaultPublic | Self::ExplicitlyDisabled)
     }
 }
 
@@ -557,7 +558,7 @@ fn filter_endpoint_addr_for_bind_ip(
 
 fn effective_relay_urls(policy: RelayPolicy, relay_urls: &[String]) -> Vec<String> {
     match policy {
-        RelayPolicy::Disabled => Vec::new(),
+        RelayPolicy::Disabled | RelayPolicy::ExplicitlyDisabled => Vec::new(),
         RelayPolicy::DefaultPublic if relay_urls.is_empty() => vec![
             "https://usw1-2.relay.michaelneale.mesh-llm.iroh.link./".into(),
             "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
@@ -588,12 +589,15 @@ mod relay_policy_tests {
     }
 
     #[test]
-    fn disabled_policy_uses_no_relays_or_raw_stun() {
+    fn disabled_policy_uses_no_relays_but_explicit_disable_keeps_raw_stun() {
         let custom = vec!["https://relay.example/".to_string()];
 
         assert!(effective_relay_urls(RelayPolicy::Disabled, &custom).is_empty());
+        assert!(effective_relay_urls(RelayPolicy::ExplicitlyDisabled, &custom).is_empty());
         assert!(!RelayPolicy::Disabled.uses_relay());
+        assert!(!RelayPolicy::ExplicitlyDisabled.uses_relay());
         assert!(!RelayPolicy::Disabled.uses_raw_stun());
+        assert!(RelayPolicy::ExplicitlyDisabled.uses_raw_stun());
     }
 }
 
@@ -2032,7 +2036,12 @@ fn relay_mode_for_startup(relay: RelayConfig<'_>) -> iroh::endpoint::RelayMode {
         tracing::info!("Relay: {:?}", urls);
         iroh::endpoint::RelayMode::Custom(relay_map_from_urls(&urls, relay.auths))
     } else {
-        tracing::info!("Relay: disabled by LAN-only discovery mode");
+        let reason = match relay.policy {
+            RelayPolicy::ExplicitlyDisabled => "disabled by embedded config",
+            RelayPolicy::Disabled => "disabled by LAN-only discovery mode",
+            RelayPolicy::DefaultPublic => unreachable!("default public uses relays"),
+        };
+        tracing::info!("Relay: {reason}");
         iroh::endpoint::RelayMode::Disabled
     }
 }

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -172,6 +172,7 @@ pub(crate) struct EmbeddedRuntimeOptions {
     pub(crate) discovery_mode: EmbeddedRuntimeDiscoveryMode,
     pub(crate) relay: Vec<String>,
     pub(crate) relay_auth: Vec<(String, String)>,
+    pub(crate) disable_iroh_relays: bool,
     pub(crate) nostr_relay: Vec<String>,
     pub(crate) region: Option<String>,
     pub(crate) node_name: Option<String>,
@@ -3511,6 +3512,7 @@ fn cli_from_embedded_options(options: EmbeddedRuntimeOptions) -> Cli {
     };
     cli.relay = options.relay;
     cli.relay_auth = options.relay_auth;
+    cli.disable_iroh_relays = options.disable_iroh_relays;
     cli.nostr_relay = options.nostr_relay;
     cli.region = options.region;
     cli.name = options.node_name;
@@ -5646,7 +5648,7 @@ pub(crate) async fn run_plugin_mcp(cli: &Cli) -> Result<()> {
         mesh::RelayConfig {
             urls: &cli.relay,
             auths: &relay_auths,
-            policy: relay_policy_for_mesh_discovery_mode(cli.mesh_discovery_mode),
+            policy: relay_policy_for_runtime(cli),
         },
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
@@ -5884,7 +5886,7 @@ async fn start_run_auto_node_and_plugins(
         mesh::RelayConfig {
             urls: &cli.relay,
             auths: &relay_auths,
-            policy: relay_policy_for_mesh_discovery_mode(cli.mesh_discovery_mode),
+            policy: relay_policy_for_runtime(cli),
         },
         mesh::QuicBindSelection {
             ip: cli.bind_ip,
@@ -5913,6 +5915,14 @@ async fn start_run_auto_node_and_plugins(
     node.set_plugin_manager(plugin_manager.clone()).await;
     node.start_plugin_channel_forwarder(plugin_mesh_rx);
     Ok((node, channels, plugin_manager))
+}
+
+fn relay_policy_for_runtime(cli: &Cli) -> mesh::RelayPolicy {
+    if cli.disable_iroh_relays {
+        mesh::RelayPolicy::ExplicitlyDisabled
+    } else {
+        relay_policy_for_mesh_discovery_mode(cli.mesh_discovery_mode)
+    }
 }
 
 fn relay_policy_for_mesh_discovery_mode(
@@ -7367,6 +7377,11 @@ async fn run_auto_handle_control_request(
     cmd: api::RuntimeControlRequest,
 ) -> bool {
     match cmd {
+        api::RuntimeControlRequest::Join { invite_token, resp } => {
+            let result = ctx.node.join_with_retry(&invite_token).await;
+            let _ = resp.send(result);
+            false
+        }
         api::RuntimeControlRequest::Load { spec, resp } => {
             let result = run_auto_load_runtime_model(ctx, spec).await;
             let _ = resp.send(result);
@@ -8410,15 +8425,22 @@ async fn run_passive_listener_loop(
                 return Ok(Some(model_name));
             }
             Some(cmd) = control_rx.recv() => {
-                if let api::RuntimeControlRequest::Shutdown { source } = cmd {
-                    shutdown_passive_runtime(
-                        &node,
-                        &plugin_manager,
-                        &mut console_server_handle,
-                        source,
-                    )
-                    .await;
-                    return Ok(None);
+                match cmd {
+                    api::RuntimeControlRequest::Shutdown { source } => {
+                        shutdown_passive_runtime(
+                            &node,
+                            &plugin_manager,
+                            &mut console_server_handle,
+                            source,
+                        )
+                        .await;
+                        return Ok(None);
+                    }
+                    api::RuntimeControlRequest::Join { invite_token, resp } => {
+                        let result = node.join_with_retry(&invite_token).await;
+                        let _ = resp.send(result);
+                    }
+                    _ => {}
                 }
             }
             signal = wait_shutdown_signal() => {
@@ -8926,6 +8948,19 @@ mod tests {
             relay_policy_for_mesh_discovery_mode(mesh_discovery::MeshDiscoveryMode::Nostr),
             mesh::RelayPolicy::DefaultPublic
         );
+    }
+
+    #[test]
+    fn explicit_disable_iroh_relays_overrides_nostr_relay_policy() {
+        let mut cli = Cli::parse_from(["mesh-llm"]);
+        cli.mesh_discovery_mode = mesh_discovery::MeshDiscoveryMode::Nostr;
+        cli.disable_iroh_relays = true;
+
+        assert_eq!(
+            relay_policy_for_runtime(&cli),
+            mesh::RelayPolicy::ExplicitlyDisabled
+        );
+        assert!(!relay_policy_for_runtime(&cli).uses_relay());
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -83,6 +83,22 @@ impl EmbeddedServeHandle {
         })
     }
 
+    pub async fn join_token(&self, invite_token: impl Into<String>) -> Result<()> {
+        let control_tx = self
+            .control_tx
+            .as_ref()
+            .context("embedded mesh runtime control channel is unavailable")?;
+        let (resp, rx) = tokio::sync::oneshot::channel();
+        control_tx
+            .send(crate::api::RuntimeControlRequest::Join {
+                invite_token: invite_token.into(),
+                resp,
+            })
+            .map_err(|_| anyhow::anyhow!("embedded mesh runtime control channel is closed"))?;
+        rx.await
+            .context("embedded mesh runtime join response dropped")?
+    }
+
     pub async fn stop(mut self) -> Result<()> {
         if !self.request_shutdown("sdk") && !self.task_finished() {
             anyhow::bail!("embedded mesh runtime control channel is unavailable");
@@ -200,6 +216,7 @@ fn embedded_runtime_options(
             EmbeddedMeshDiscoveryMode::Mdns => crate::runtime::EmbeddedRuntimeDiscoveryMode::Mdns,
         },
         relay: config.network.iroh_relays.clone(),
+        disable_iroh_relays: config.network.disable_iroh_relays,
         relay_auth: config
             .network
             .iroh_relay_auth
@@ -711,6 +728,7 @@ mod tests {
             .max_vram_gb(3.0)
             .iroh_relay("https://relay.example")
             .iroh_relay_auth("https://relay.example", "token")
+            .disable_iroh_relays(true)
             .nostr_relay("wss://nostr.example")
             .bind_port(17777)
             .owner_key("/tmp/sprout-owner.json")
@@ -742,6 +760,7 @@ mod tests {
             options.relay_auth,
             vec![("https://relay.example".to_string(), "token".to_string())]
         );
+        assert!(options.disable_iroh_relays);
         assert_eq!(options.nostr_relay, vec!["wss://nostr.example".to_string()]);
         assert_eq!(options.bind_port, Some(17777));
     }

--- a/crates/mesh-llm-host-runtime/src/sdk/embedded_config.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk/embedded_config.rs
@@ -91,6 +91,7 @@ pub struct EmbeddedMeshNetworkConfig {
     pub node_name: Option<String>,
     pub iroh_relays: Vec<String>,
     pub iroh_relay_auth: BTreeMap<String, String>,
+    pub disable_iroh_relays: bool,
     pub nostr_relays: Vec<String>,
     pub bind_ip: Option<IpAddr>,
     pub bind_port: Option<u16>,
@@ -110,6 +111,7 @@ impl Default for EmbeddedMeshNetworkConfig {
             node_name: None,
             iroh_relays: Vec::new(),
             iroh_relay_auth: BTreeMap::new(),
+            disable_iroh_relays: false,
             nostr_relays: Vec::new(),
             bind_ip: None,
             bind_port: None,
@@ -312,6 +314,11 @@ impl EmbeddedMeshNodeBuilder {
         self
     }
 
+    pub fn disable_iroh_relays(mut self, disabled: bool) -> Self {
+        self.config.network.disable_iroh_relays = disabled;
+        self
+    }
+
     pub fn nostr_relay(mut self, url: impl Into<String>) -> Self {
         self.config.network.nostr_relays.push(url.into());
         self
@@ -485,6 +492,7 @@ pub struct EmbeddedServeConfig {
     pub discovery_mode: EmbeddedMeshDiscoveryMode,
     pub relay: Vec<String>,
     pub relay_auth: BTreeMap<String, String>,
+    pub disable_iroh_relays: bool,
     pub nostr_relay: Vec<String>,
     pub region: Option<String>,
     pub node_name: Option<String>,
@@ -515,6 +523,7 @@ impl Default for EmbeddedServeConfig {
             discovery_mode: EmbeddedMeshDiscoveryMode::Nostr,
             relay: Vec::new(),
             relay_auth: BTreeMap::new(),
+            disable_iroh_relays: false,
             nostr_relay: Vec::new(),
             region: None,
             node_name: None,
@@ -555,6 +564,7 @@ impl From<EmbeddedServeConfig> for EmbeddedMeshNodeConfig {
                 node_name: config.node_name,
                 iroh_relays: config.relay,
                 iroh_relay_auth: config.relay_auth,
+                disable_iroh_relays: config.disable_iroh_relays,
                 nostr_relays: config.nostr_relay,
                 bind_ip: config.bind_ip,
                 bind_port: config.bind_port,
@@ -587,6 +597,7 @@ impl From<EmbeddedMeshNodeConfig> for EmbeddedServeConfig {
             discovery_mode: config.network.discovery_mode,
             relay: config.network.iroh_relays,
             relay_auth: config.network.iroh_relay_auth,
+            disable_iroh_relays: config.network.disable_iroh_relays,
             nostr_relay: config.network.nostr_relays,
             region: config.network.region,
             node_name: config.network.node_name,

--- a/crates/mesh-llm-sdk/src/lib.rs
+++ b/crates/mesh-llm-sdk/src/lib.rs
@@ -73,6 +73,7 @@ pub struct NetworkConfig {
     pub node_name: Option<String>,
     pub iroh_relays: Vec<String>,
     pub iroh_relay_auth: BTreeMap<String, String>,
+    pub disable_iroh_relays: bool,
     pub nostr_relays: Vec<String>,
     pub bind_ip: Option<IpAddr>,
     pub bind_port: Option<u16>,
@@ -92,6 +93,7 @@ impl Default for NetworkConfig {
             node_name: None,
             iroh_relays: Vec::new(),
             iroh_relay_auth: BTreeMap::new(),
+            disable_iroh_relays: false,
             nostr_relays: Vec::new(),
             bind_ip: None,
             bind_port: None,
@@ -227,6 +229,11 @@ macro_rules! impl_common_builder_methods {
                 .network
                 .iroh_relay_auth
                 .insert(relay_url.into(), bearer_token.into());
+            self
+        }
+
+        pub fn disable_iroh_relays(mut self, disabled: bool) -> Self {
+            self.config.network.disable_iroh_relays = disabled;
             self
         }
 
@@ -407,6 +414,10 @@ impl EmbeddedNodeHandle {
 
     pub async fn status(&self) -> Result<EmbeddedNodeStatus> {
         self.inner.status().await.map(EmbeddedNodeStatus::from)
+    }
+
+    pub async fn join_token(&self, token: impl Into<String>) -> Result<()> {
+        self.inner.join_token(token).await
     }
 
     pub async fn stop(self) -> Result<()> {
@@ -640,6 +651,7 @@ fn host_config(parts: EmbeddedNodeParts) -> mesh_llm_host_runtime::sdk::Embedded
             node_name: parts.network.node_name,
             iroh_relays: parts.network.iroh_relays,
             iroh_relay_auth: parts.network.iroh_relay_auth,
+            disable_iroh_relays: parts.network.disable_iroh_relays,
             nostr_relays: parts.network.nostr_relays,
             bind_ip: parts.network.bind_ip,
             bind_port: parts.network.bind_port,
@@ -700,6 +712,7 @@ mod tests {
             .api_port(19337)
             .console_port(13131)
             .discovery_mode(MeshDiscoveryMode::Mdns)
+            .disable_iroh_relays(true)
             .log_format(LogFormat::Pretty)
             .build();
 
@@ -708,6 +721,7 @@ mod tests {
         assert_eq!(config.http.api_port, 19337);
         assert_eq!(config.http.console_port, 13131);
         assert_eq!(config.network.discovery_mode, MeshDiscoveryMode::Mdns);
+        assert!(config.network.disable_iroh_relays);
         assert_eq!(config.log_format, LogFormat::Pretty);
     }
 


### PR DESCRIPTION
## What

Two opt-in, default-false seams the Sprout v1 mesh integration needs on the embedded SDK:

- **`disable_iroh_relays(bool)`** — when true, `bind_mesh_endpoint` uses `RelayMode::Disabled` instead of the existing `RelayMode::Custom` path. Lets a consumer say "no public relay" explicitly; today an empty relay list silently falls back to public `*.iroh.link`. Default `false` preserves existing behavior byte-for-byte.
- **`EmbeddedNodeHandle::join_token(token)`** — forwards an invite token over the existing `RuntimeControl` channel to `node.join_with_retry`, so an already-running embedded node can dial a new `EndpointAddr` without restart (the call-me-now primitive).

Purely additive. Defaults preserve current behavior for all other consumers. +87/−9 across 6 files.

## Base

This PR targets **`micn/sprout-embedded-serve-sdk`** (the branch behind #736), not `main`. The knobs extend the `crates/mesh-llm-sdk` crate, which only exists on the #736 stack — it is not on `main` yet. A PR against `main` would be unreviewable noise (the whole SDK stack would show as the diff). This is a dependent PR; it should land after / with #736.

## Verification

`cargo check -p mesh-llm-sdk --features client,serve` green. Consumed and exercised in Sprout's desktop mesh integration (relay-gated discovery → connect → call-me-now → inference).

Co-authored with Max (Sprout team).

## Connectivity: WAN via STUN, relay transport off

`disable_iroh_relays(true)` → `RelayPolicy::ExplicitlyDisabled` turns off the iroh **relay transport** (no `*.iroh.link` traffic) but **keeps raw STUN on** (`uses_raw_stun()` matches `DefaultPublic | ExplicitlyDisabled`). The STUN-discovered public address is injected into the invite token / `EndpointAddr`, so a relay-signaled peer can hole-punch directly over **WAN** without an iroh relay. STUN is a "what's my public IP" lookup, not a data path — the privacy posture (no relay traffic) holds.

`Disabled` (LAN-only mDNS mode) stays STUN-off, intentionally.

Residual limit: no relay **transport fallback**, so two peers both behind **symmetric NATs** may fail to hole-punch (the case iroh relays normally cover). Fine for the common cases (≥1 side cone-NAT/forwarded/server). (Reviewed by Perci.)
