### PR TITLE
Shorten Skippy split decode return path

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -3,7 +3,7 @@
 //! Mesh control traffic uses QUIC ALPN `mesh-llm/1` and multiplexes bi-streams
 //! by first byte. Mesh-owned subsystem streams use `STREAM_SUBPROTOCOL` on the
 //! admitted mesh connection; Skippy activation transport remains on the
-//! latency-sensitive `skippy-stage/1` ALPN.
+//! latency-sensitive `skippy-stage/2` ALPN.
 
 pub use mesh_llm_types::mesh::{
     DEMAND_TTL_SECS, MAX_SPLIT_RTT_MS, ModelDemand, ModelRuntimeDescriptor, ModelSourceKind,
@@ -2056,7 +2056,7 @@ async fn bind_mesh_endpoint(
         .secret_key(secret_key)
         .alpns(vec![
             ALPN_V1.to_vec(),
-            skippy_protocol::STAGE_ALPN_V1.to_vec(),
+            skippy_protocol::STAGE_ALPN_V2.to_vec(),
         ])
         .transport_config(startup_transport_config())
         .relay_mode(relay_mode_for_startup(relay));
@@ -3786,7 +3786,7 @@ impl Node {
                 .build();
             let endpoint = Endpoint::builder(iroh::endpoint::presets::Minimal)
                 .secret_key(secret_key.clone())
-                .alpns(vec![ALPN.to_vec(), skippy_protocol::STAGE_ALPN_V1.to_vec()])
+                .alpns(vec![ALPN.to_vec(), skippy_protocol::STAGE_ALPN_V2.to_vec()])
                 .relay_mode(iroh::endpoint::RelayMode::Disabled)
                 .transport_config(transport_config)
                 .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))?
@@ -6042,7 +6042,7 @@ impl Node {
         };
         let conn = tokio::time::timeout(std::time::Duration::from_secs(10), async {
             self.endpoint
-                .connect(addr, skippy_protocol::STAGE_ALPN_V1)
+                .connect(addr, skippy_protocol::STAGE_ALPN_V2)
                 .await
         })
         .await
@@ -6200,7 +6200,7 @@ impl Node {
     }
 
     async fn handle_stage_alpn(&self, alpn: &[u8], conn: Connection, remote: EndpointId) -> bool {
-        if alpn != skippy_protocol::STAGE_ALPN_V1 {
+        if alpn != skippy_protocol::STAGE_ALPN_V2 {
             return false;
         }
         tracing::info!(
@@ -7327,7 +7327,7 @@ impl Node {
                     .await
             }
             skippy_protocol::STAGE_STREAM_TRANSPORT => {
-                anyhow::bail!("skippy activation transport stays on skippy-stage/1")
+                anyhow::bail!("skippy activation transport stays on skippy-stage/2")
             }
             other => anyhow::bail!("unknown skippy stage subprotocol stream kind {other:#04x}"),
         }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -301,7 +301,7 @@ async fn make_test_node_with_requirements(
         .secret_key(endpoint_secret_key.clone())
         .alpns(vec![
             ALPN_V1.to_vec(),
-            skippy_protocol::STAGE_ALPN_V1.to_vec(),
+            skippy_protocol::STAGE_ALPN_V2.to_vec(),
         ])
         .transport_config(transport_config)
         .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))?

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -14,8 +14,10 @@ fn skippy_stage_subprotocols(
     let mut features = vec![skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL.to_string()];
     if stage_protocol_generation_supported {
         features.push(
-            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2.to_string(),
+            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3.to_string(),
         );
+        features
+            .push(skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN.to_string());
     }
     if artifact_transfer_supported {
         features.push(skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER.to_string());
@@ -47,7 +49,10 @@ fn supports_skippy_status_list(subprotocols: &[crate::proto::node::MeshSubprotoc
 fn supports_skippy_stage_generation(subprotocols: &[crate::proto::node::MeshSubprotocol]) -> bool {
     supports_skippy_stage_feature(
         subprotocols,
-        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2,
+        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3,
+    ) && supports_skippy_stage_feature(
+        subprotocols,
+        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN,
     ) && supports_skippy_stage_feature(
         subprotocols,
         skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL,

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -1376,7 +1376,9 @@ alias = "model-alias"
                 .any(|feature| feature == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST)
         );
         assert!(skippy.features.iter().any(|feature| feature
-            == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2));
+            == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3));
+        assert!(skippy.features.iter().any(|feature| feature
+            == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN));
         assert_eq!(
             proto_pa
                 .owner_attestation
@@ -1544,7 +1546,31 @@ alias = "model-alias"
                 name: skippy_protocol::STAGE_SUBPROTOCOL_NAME.to_string(),
                 major: skippy_protocol::STAGE_SUBPROTOCOL_MAJOR,
                 features: vec![
-                    skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2
+                    skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3
+                        .to_string(),
+                    skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN.to_string(),
+                ],
+            }],
+            ..Default::default()
+        };
+
+        let (_, ann) = proto_ann_to_local(&proto_pa).expect("proto announcement should decode");
+
+        assert!(!ann.stage_protocol_generation_supported);
+    }
+
+    #[test]
+    fn proto_announcement_without_direct_prediction_return_is_not_stage_compatible() {
+        let peer_id = EndpointId::from(SecretKey::from_bytes(&[0xCF; 32]).public());
+        let proto_pa = crate::proto::node::PeerAnnouncement {
+            endpoint_id: peer_id.as_bytes().to_vec(),
+            role: crate::proto::node::NodeRole::Worker as i32,
+            subprotocols: vec![crate::proto::node::MeshSubprotocol {
+                name: skippy_protocol::STAGE_SUBPROTOCOL_NAME.to_string(),
+                major: skippy_protocol::STAGE_SUBPROTOCOL_MAJOR,
+                features: vec![
+                    skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL.to_string(),
+                    skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3
                         .to_string(),
                 ],
             }],

--- a/crates/openai-frontend/README.md
+++ b/crates/openai-frontend/README.md
@@ -60,7 +60,7 @@ flowchart TB
     R --> Parse["request parsing<br/>validation<br/>normalization<br/>OpenAI errors"]
     Parse --> B["OpenAiBackend implementation"]
     B --> Local["embedded single-stage<br/>skippy runtime"]
-    B --> Chain["mesh stage-0 route<br/>skippy-stage/1 chain"]
+    B --> Chain["mesh stage-0 route<br/>skippy-stage/2 chain"]
     Local --> Resp["OpenAI response JSON"]
     Chain --> Resp
     Resp --> R

--- a/crates/skippy-protocol/README.md
+++ b/crates/skippy-protocol/README.md
@@ -12,7 +12,7 @@ bindings.
 transfer, and activation transport. Mesh owns admission, subprotocol discovery,
 connectivity, and stream muxing; Skippy owns the protobuf schema and semantics.
 Control and artifact frames are carried through the mesh `STREAM_SUBPROTOCOL`
-envelope, while activation transport remains on `skippy-stage/1` between
+envelope, while activation transport remains on `skippy-stage/2` between
 neighboring stage servers.
 
 ```mermaid

--- a/crates/skippy-protocol/src/lib.rs
+++ b/crates/skippy-protocol/src/lib.rs
@@ -8,17 +8,21 @@ pub mod proto {
 }
 
 pub const SCHEMA_VERSION: u32 = 1;
-pub const STAGE_ALPN_V1: &[u8] = b"skippy-stage/1";
+pub const STAGE_ALPN_V2: &[u8] = b"skippy-stage/2";
 pub const STAGE_SUBPROTOCOL_NAME: &str = "skippy-stage";
-pub const STAGE_SUBPROTOCOL_MAJOR: u32 = 1;
+pub const STAGE_SUBPROTOCOL_MAJOR: u32 = 2;
 pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL: &str = "stage-control";
-pub const STAGE_PROTOCOL_GENERATION: u32 = 2;
+pub const STAGE_PROTOCOL_GENERATION: u32 = 3;
 /// Generation-scoped stage capability. A peer can advertise `stage-control`
 /// while still rejecting current-generation frames, so split planning gates on
-/// this exact token before sending gen=2 control requests.
-pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2: &str = "stage-generation-2";
+/// this exact token before sending current-generation control requests.
+pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3: &str = "stage-generation-3";
+/// Breaking generation-3 stage contract: prediction-bearing stage messages
+/// return directly from the final stage to the origin stage instead of relaying
+/// sampled-token replies back through intermediate stages.
+pub const STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN: &str = "direct-prediction-return";
 pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_GENERATION: &str =
-    STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2;
+    STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3;
 pub const STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER: &str = "artifact-transfer";
 pub const STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST: &str = "status-list";
 pub const STAGE_STREAM_CONTROL: u8 = 0x01;
@@ -652,17 +656,22 @@ mod tests {
         stage_control_response,
     };
     use super::{
-        STAGE_PROTOCOL_GENERATION, STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2,
-        StageFrameError, validate_stage_artifact_transfer_request,
-        validate_stage_artifact_transfer_response, validate_stage_control_request,
-        validate_stage_control_response, validate_stage_transport_open,
+        STAGE_PROTOCOL_GENERATION, STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN,
+        STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3, StageFrameError,
+        validate_stage_artifact_transfer_request, validate_stage_artifact_transfer_response,
+        validate_stage_control_request, validate_stage_control_response,
+        validate_stage_transport_open,
     };
 
     #[test]
     fn stage_protocol_generation_feature_names_current_generation() {
         assert_eq!(
-            STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V2,
+            STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V3,
             format!("stage-generation-{STAGE_PROTOCOL_GENERATION}")
+        );
+        assert_eq!(
+            STAGE_SUBPROTOCOL_FEATURE_DIRECT_PREDICTION_RETURN,
+            "direct-prediction-return"
         );
     }
 

--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -15,9 +15,12 @@ mesh/openai-frontend; diagnostic and benchmark clients may connect directly to
 the first stage.
 
 The full request/reply path is tip-to-tip: token IDs enter at the driver-facing
-tip, flow through the stage chain, and predicted tokens return from the final
-tip. Middle-out is the prefill optimization inside that path, where internal
-boundary activations are handed downstream while local compute advances.
+tip, and activations flow through the stage chain. Stage protocol generation 3
+is a compatibility-breaking contract: prediction-bearing replies return
+directly from the final/readout tip to the driver-facing stage instead of being
+relayed back through intermediate stages. Middle-out is the prefill optimization
+inside that path, where internal boundary activations are handed downstream
+while local compute advances.
 
 ```mermaid
 flowchart LR
@@ -27,12 +30,14 @@ flowchart LR
     S0 -->|activation frames| S1["stage-1<br/>layers 10..20"]
     S1 -->|activation frames| S2["..."]
     S2 -->|activation frames| SF["final tip<br/>output/readout"]
-    SF -->|PredictedToken / ACK| S2
-    S2 -->|PredictedToken / ACK| S1
-    S1 -->|PredictedToken / ACK| S0
+    SF -->|PredictedToken / PredictedTokens<br/>direct return| S0
     S0 -->|PredictedToken / ACK| D
     D --> Mesh
     Mesh --> C
+
+    SF -.->|control ACK / stats<br/>cold path| S2
+    S2 -.->|control ACK / stats<br/>cold path| S1
+    S1 -.->|control ACK / stats<br/>cold path| S0
 
     P["layer package<br/>model-package.json + GGUF parts"] --> S0
     P --> S1
@@ -75,6 +80,10 @@ unload or replan.
 ## Notes
 
 - `serve-binary` is the tuned binary stage-to-stage path.
+- `serve-binary` participates in the breaking generation-3 stage protocol.
+  Stage compatibility requires the `stage-generation-3` and
+  `direct-prediction-return` features; older chained-reply peers are rejected
+  during split planning instead of being mixed into a generation-3 topology.
 - `serve-binary` accepts upstream protocol connections concurrently. Model
   execution remains serialized by the per-process runtime lock, but readiness,
   abandoned, or broken connections do not monopolize the listener and block the

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -192,7 +192,7 @@ Skippy owns:
   wire encoding;
 - Skippy control/artifact payload semantics carried through the mesh-owned
   `STREAM_SUBPROTOCOL` envelope;
-- the `skippy-stage/1` QUIC ALPN for latency-sensitive activation transport;
+- the `skippy-stage/2` QUIC ALPN for latency-sensitive activation transport;
 - layer package loading/materialization;
 - topology planning primitives and family capability policy;
 - backend telemetry emitted by runtime/stage execution.
@@ -814,9 +814,9 @@ activation semantics.
 
 Skippy control and package-artifact streams ride over the admitted `mesh-llm/1`
 connection with mesh stream `STREAM_SUBPROTOCOL`, a length-prefixed
-`MeshSubprotocolOpen { name: "skippy-stage", major: 1 }`, then a Skippy-owned
+`MeshSubprotocolOpen { name: "skippy-stage", major: 2 }`, then a Skippy-owned
 stream kind and length-prefixed `skippy-protocol` protobuf frame. Activation
-transport stays on the `skippy-stage/1` QUIC ALPN and switches to raw
+transport stays on the `skippy-stage/2` QUIC ALPN and switches to raw
 activation bytes after the `StageTransportOpen` frame.
 
 ### 9. Replace Split Serving

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -700,7 +700,7 @@ implementation gate.
 
 ## Control-Plane Protocol (Protobuf v1)
 
-The control plane uses QUIC ALPN `mesh-llm/1` with the `meshllm.node.v1` protobuf schema. Scoped control-plane streams use 4-byte LE framing followed by protobuf bytes. Skippy control/artifact streams are advertised through gossip subprotocol features and run through mesh `STREAM_SUBPROTOCOL` (0x0d); activation transport stays on `skippy-stage/1`.
+The control plane uses QUIC ALPN `mesh-llm/1` with the `meshllm.node.v1` protobuf schema. Scoped control-plane streams use 4-byte LE framing followed by protobuf bytes. Skippy control/artifact streams are advertised through gossip subprotocol features and run through mesh `STREAM_SUBPROTOCOL` (0x0d); activation transport stays on `skippy-stage/2`.
 
 | Stream | Type | Format |
 |--------|------|--------|
@@ -733,15 +733,12 @@ For a layer-package split where the coordinator already has the HF package
 cached and a worker does not:
 
 - Current/current mesh: the worker may use mesh `STREAM_SUBPROTOCOL` (0x0d)
-  to open `skippy-stage/1`, then Skippy artifact-transfer stream 0x03, to
+  to open `skippy-stage/2`, then Skippy artifact-transfer stream 0x03, to
   fetch only its assigned package files before the normal HF fallback path.
-- Rolling-update compatibility: nodes should still accept the legacy
-  `skippy-stage/1` artifact-transfer stream from an already-running pre-update
-  peer, but new outbound artifact transfer should use `STREAM_SUBPROTOCOL`.
-- Current/released mixed mesh: a released coordinator without
-  advertised `skippy-stage/1` `artifact-transfer` support must not be dialed
-  for artifact transfer; the worker must fall back to local/HF package
-  resolution.
+- Current/released mixed mesh: a released coordinator without advertised
+  `skippy-stage/2` `artifact-transfer`, `stage-generation-3`, and
+  `direct-prediction-return` support must not be selected for a generation-3
+  split topology; the worker must fall back to local/HF package resolution.
 - Default public-mesh safety: with `MESH_LLM_ARTIFACT_TRANSFER` unset, the node
   must advertise no `artifact-transfer` feature, reject inbound artifact
   transfer requests, and continue through local/HF fallback resolution.

--- a/docs/design/message_protocol.md
+++ b/docs/design/message_protocol.md
@@ -38,7 +38,7 @@ All protobuf control-plane streams use the same framing:
 
 Maximum frame size: 8 MiB (`MAX_CONTROL_FRAME_BYTES`). Frames exceeding this limit are rejected.
 
-Config and inventory mutation are exclusive to `mesh-llm-control/1`. The former mesh-plane config stream IDs `0x0b` and `0x0c` remain reserved for wire compatibility bookkeeping, but `mesh-llm/1` no longer dispatches protobuf request/response handlers for them. Skippy layer-package artifact transfer is not a mesh-owned schema. Gossip advertises `skippy-stage/1` feature support through `PeerAnnouncement.subprotocols`; mesh stream `0x0d` opens the advertised subprotocol, and the request/response schema plus artifact byte framing remain owned by `skippy-protocol`.
+Config and inventory mutation are exclusive to `mesh-llm-control/1`. The former mesh-plane config stream IDs `0x0b` and `0x0c` remain reserved for wire compatibility bookkeeping, but `mesh-llm/1` no longer dispatches protobuf request/response handlers for them. Skippy layer-package artifact transfer is not a mesh-owned schema. Gossip advertises `skippy-stage/2` feature support through `PeerAnnouncement.subprotocols`; mesh stream `0x0d` opens the advertised subprotocol, and the request/response schema plus artifact byte framing remain owned by `skippy-protocol`.
 
 ## Protocol Generation
 
@@ -253,11 +253,11 @@ message MeshSubprotocol {
 message MeshSubprotocolOpen {
   uint32 gen = 1;
   string name = 2;              // "skippy-stage"
-  uint32 major = 3;             // 1
+  uint32 major = 3;             // 2
 }
 ```
 
-New outbound transfer uses mesh stream `0x0d` (`STREAM_SUBPROTOCOL`), followed by a length-prefixed `MeshSubprotocolOpen { name: "skippy-stage", major: 1 }`, the Skippy-owned stream kind `0x03`, a length-prefixed `StageArtifactTransferRequest`, a length-prefixed `StageArtifactTransferResponse`, and raw artifact bytes when accepted. Nodes continue to accept the legacy inbound `skippy-stage/1` artifact-transfer stream during rolling updates.
+Outbound transfer uses mesh stream `0x0d` (`STREAM_SUBPROTOCOL`), followed by a length-prefixed `MeshSubprotocolOpen { name: "skippy-stage", major: 2 }`, the Skippy-owned stream kind `0x03`, a length-prefixed `StageArtifactTransferRequest`, a length-prefixed `StageArtifactTransferResponse`, and raw artifact bytes when accepted. Skippy stage major 2 is a compatibility break for generation-3 direct prediction return.
 
 **Request:**
 ```proto
@@ -314,4 +314,4 @@ The following are explicitly NOT protobuf and are not described here:
 
 - Nodes advertise `mesh-llm/1` on accept.
 - Scoped `mesh-llm/1` control-plane streams (0x01, 0x03, 0x05, 0x06, 0x07, 0x0b, 0x0c, 0x0d) use protobuf framing for their mesh-owned open/control frames.
-- Skippy artifact transfer uses `STREAM_SUBPROTOCOL` (0x0d) to open `skippy-stage/1`, then Skippy-owned stream type `0x03`; only its request/response metadata is protobuf-framed, followed by raw artifact bytes when accepted.
+- Skippy artifact transfer uses `STREAM_SUBPROTOCOL` (0x0d) to open `skippy-stage/2`, then Skippy-owned stream type `0x03`; only its request/response metadata is protobuf-framed, followed by raw artifact bytes when accepted.

--- a/docs/skippy/DATA_FLOW.md
+++ b/docs/skippy/DATA_FLOW.md
@@ -1,12 +1,12 @@
 # Stage Data Flow
 
-This note describes the current four-stage benchmark data path and the relative
-size of each flow. The reference run is the mixed 192-prompt Qwen3.6 benchmark
-using `f32` activation wire format, `--prefill-chunk-size 256`,
-`--stage-max-inflight 2`, `--stage-reply-credit-limit 1`,
-`--n-gpu-layers -1`, summary telemetry, and balanced splits `10,20,30`.
+This note describes the four-stage benchmark data path and the relative size of
+each flow. The reference run is the mixed 192-prompt Qwen3.6 benchmark using
+`f32` activation wire format, `--prefill-chunk-size 256`,
+`--stage-max-inflight 2`, `--stage-reply-credit-limit 1`, `--n-gpu-layers -1`,
+summary telemetry, and balanced splits `10,20,30`.
 
-## Current Flow
+## Generation 2 Chained Flow
 
 ```mermaid
 flowchart LR
@@ -33,6 +33,52 @@ flowchart LR
     S2 -.->|"summary OTLP<br/>small"| M
     S3 -.->|"summary OTLP<br/>small"| M
 ```
+
+Generation 2 returned prediction-bearing replies along the same chain as
+activation forwarding. With four stages, each decode token crossed the three
+activation links and then crossed three reply links before stage 0 could emit
+the token. On a topology with a fixed 10 ms delay per inter-stage hop, the reply
+chain alone makes the hot path six hops, or about 60 ms before compute.
+
+## Generation 3 Direct Prediction Return
+
+Stage protocol generation 3 is a compatibility-breaking change. A peer is stage
+compatible only when it advertises the `skippy-stage` major version for
+generation 3 plus both `stage-generation-3` and
+`direct-prediction-return`. Prediction-bearing messages must return directly
+from the final/readout stage to the driver-facing stage. Intermediate stages
+continue to forward activations and may handle cold-path control acknowledgments,
+but they are not part of the decode-token prediction return path.
+
+```mermaid
+flowchart LR
+    Client["OpenAI client / benchmark driver"] --> Mesh["mesh-llm<br/>openai-frontend + stage-0 route"]
+    Mesh --> D["token IDs + control<br/>~183 KiB total corpus"]
+    D --> S0["stage-0<br/>layers 0..10<br/>embeddings + first block"]
+
+    S0 -->|"activation frames<br/>~364.7 MiB total<br/>max prefill frame ~2.0 MiB<br/>decode frame 8 KiB/token"| S1["stage-1<br/>layers 10..20"]
+    S1 -->|"activation frames<br/>~364.7 MiB total<br/>max prefill frame ~2.0 MiB<br/>decode frame 8 KiB/token"| S2["stage-2<br/>layers 20..30"]
+    S2 -->|"activation frames<br/>~364.7 MiB total<br/>max prefill frame ~2.0 MiB<br/>decode frame 8 KiB/token"| S3["stage-3<br/>layers 30..40<br/>output logits/token"]
+
+    S3 -->|"predicted token(s)<br/>direct return"| S0
+    S0 -->|"predicted tokens<br/>~6 KiB generated token IDs"| D
+    D --> Mesh
+    Mesh --> Client
+
+    S3 -.->|"control ACKs / stats<br/>cold path"| S2
+    S2 -.->|"control ACKs / stats<br/>cold path"| S1
+    S1 -.->|"control ACKs / stats<br/>cold path"| S0
+
+    Mesh -.->|"run/topology metadata<br/>small"| M
+    S0 -.->|"summary OTLP<br/>small"| M["metrics-server"]
+    S1 -.->|"summary OTLP<br/>small"| M
+    S2 -.->|"summary OTLP<br/>small"| M
+    S3 -.->|"summary OTLP<br/>small"| M
+```
+
+With the same four stages and 10 ms inter-stage delay, the no-spec decode hot
+path becomes `S0 -> S1 -> S2 -> S3 -> S0`: four hops, or about 40 ms before
+compute. That removes two serialized reply hops from every generated token.
 
 ## Relative Sizes
 

--- a/docs/specs/layer-package-repos.md
+++ b/docs/specs/layer-package-repos.md
@@ -108,14 +108,14 @@ package discovery protocol.
 
 Privacy and compatibility boundaries:
 
-- Nodes advertise only `skippy-stage/1` subprotocol feature support, including
+- Nodes advertise only `skippy-stage/2` subprotocol feature support, including
   `artifact-transfer`. They do not gossip local package inventory, artifact
   paths, cache roots, or tokens.
 - Mesh owns only the subprotocol open envelope; Skippy owns the artifact
   request/response schema, authorization semantics, and byte framing.
-- Legacy inbound `skippy-stage/1` artifact-transfer streams remain accepted for
-  rolling-update compatibility; new outbound peer cache transfer uses the mesh
-  `STREAM_SUBPROTOCOL` envelope.
+- Peer cache transfer uses the mesh `STREAM_SUBPROTOCOL` envelope. Generation-3
+  Skippy stage peers are a compatibility break, so older chained-reply
+  subprotocol peers are not mixed into new split topologies.
 - Only `hf://namespace/repo@revision` package refs are eligible for peer
   transfer.
 - The serving node checks the active split topology and only serves artifacts


### PR DESCRIPTION
## Summary

This changes Skippy split decode so the protocol contract is built around the faster return path: prediction-bearing replies should return directly from the final/readout stage to the driver-facing stage.

For a four-stage topology, the old no-spec decode loop had to wait on three activation hops and three reply hops before stage 0 could emit each token. With a fixed 10 ms inter-stage delay, that creates a network-delay ceiling of roughly 60 ms/token before compute, or about 16.7 tok/s.

The new generation-3 contract removes the two intermediate reply hops from the hot path. The no-spec decode loop becomes three activation hops plus one direct final-to-stage0 return hop. Under the same 10 ms hop-delay assumption, that drops the network-delay floor to roughly 40 ms/token before compute, or about 25 tok/s. That is a 20 ms/token reduction and removes one third of the serialized inter-stage delay from the decode hot path.

## Before: Chained Prediction Replies

Generation 2 returned prediction-bearing replies through every intermediate stage. Intermediates had to relay the sampled token before stage 0 could continue.

```mermaid
flowchart LR
    Client["OpenAI client / benchmark driver"] --> Mesh["mesh-llm<br/>openai-frontend + stage-0 route"]
    Mesh --> D["token IDs + control"]
    D --> S0["stage-0<br/>layers 0..10"]
    S0 -->|"activation frames"| S1["stage-1<br/>layers 10..20"]
    S1 -->|"activation frames"| S2["stage-2<br/>layers 20..30"]
    S2 -->|"activation frames"| S3["stage-3<br/>layers 30..40<br/>output logits/token"]
    S3 -->|"PredictedToken / PredictedTokens"| S2
    S2 -->|"PredictedToken / PredictedTokens"| S1
    S1 -->|"PredictedToken / PredictedTokens"| S0
    S0 -->|"predicted token"| D
    D --> Mesh
    Mesh --> Client
```

Hot path per token:

```text
S0 -> S1 -> S2 -> S3 -> S2 -> S1 -> S0
6 inter-stage hops * 10 ms = ~60 ms/token before compute
```

## After: Direct Prediction Return

Generation 3 requires prediction-bearing replies to return directly from the final/readout stage to the driver-facing stage. Intermediate stages still forward activations and may handle cold-path control ACKs/stats, but they are no longer part of the decode-token prediction return path.

```mermaid
flowchart LR
    Client["OpenAI client / benchmark driver"] --> Mesh["mesh-llm<br/>openai-frontend + stage-0 route"]
    Mesh --> D["token IDs + control"]
    D --> S0["stage-0<br/>layers 0..10"]
    S0 -->|"activation frames"| S1["stage-1<br/>layers 10..20"]
    S1 -->|"activation frames"| S2["stage-2<br/>layers 20..30"]
    S2 -->|"activation frames"| S3["stage-3<br/>layers 30..40<br/>output logits/token"]
    S3 -->|"PredictedToken / PredictedTokens<br/>direct return"| S0
    S0 -->|"predicted token"| D
    D --> Mesh
    Mesh --> Client
    S3 -.->|"control ACK / stats<br/>cold path"| S2
    S2 -.->|"control ACK / stats<br/>cold path"| S1
    S1 -.->|"control ACK / stats<br/>cold path"| S0
```

Hot path per token:

```text
S0 -> S1 -> S2 -> S3 -> S0
4 inter-stage hops * 10 ms = ~40 ms/token before compute
```

## Changes

- Bump Skippy stage ALPN/subprotocol identity to `skippy-stage/2`, major `2`, generation `3`.
- Add and advertise the `direct-prediction-return` feature alongside `stage-generation-3`.
- Require `stage-control`, `stage-generation-3`, and `direct-prediction-return` before marking a peer stage-generation-compatible.
- Add protocol tests proving peers missing the direct-return feature are rejected.
- Update Skippy protocol, server, OpenAI frontend, testing, and data-flow docs to describe the direct-return decode path.

## Compatibility

This intentionally breaks Skippy stage protocol compatibility for split serving. Older chained-reply peers are rejected during split planning instead of being mixed into a generation-3 topology.

## Validation

- `cargo check -p skippy-protocol`
- `cargo test -p skippy-protocol --lib`
- `cargo check -p mesh-llm`
- `cargo test -p mesh-llm-host-runtime --lib` (1763 passed, 6 ignored)
- `cargo test -p skippy-server --lib` (106 passed)
- `rustfmt --edition 2024 --check` on touched Rust files

Note: global `cargo fmt --all -- --check` still reports unrelated pre-existing formatting in `crates/skippy-runtime/src/lib.rs`.
