### PR TITLE
Implement latency-aware Skippy stage-count planning

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
@@ -11,6 +11,7 @@ use super::local::{SplitParticipant, SplitParticipantExclusion};
 // recommendedMaxWorkingSetSize on macOS).  No additional headroom deduction.
 const RUNTIME_NODE_HEADROOM_NUMERATOR: u64 = 0;
 const RUNTIME_NODE_HEADROOM_DENOMINATOR: u64 = 10;
+const DEFAULT_TARGET_DECODE_TPOT_MS: u32 = 33;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SplitTopologyPlanInput {
@@ -20,6 +21,7 @@ pub(super) struct SplitTopologyPlanInput {
     pub(super) kv_bytes_per_token: u64,
     pub(super) context_length_override: Option<u32>,
     pub(super) parallel_lanes_override: Option<usize>,
+    pub(super) target_decode_tpot_ms: Option<u32>,
     pub(super) minimum_nodes: usize,
     pub(super) nodes: Vec<SplitTopologyPlanNode>,
 }
@@ -30,12 +32,15 @@ pub(super) struct SplitTopologyPlanNode {
     pub(super) detected_vram_bytes: u64,
     pub(super) max_vram_bytes: Option<u64>,
     pub(super) runtime_headroom_bytes: u64,
+    pub(super) stage_transfer_latency_ms: Option<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SplitTopologyPlan {
     pub(super) context_length: u32,
     pub(super) parallel_lanes: usize,
+    pub(super) estimated_decode_network_ms_per_token: Option<u32>,
+    pub(super) decode_tpot_target_met: Option<bool>,
     pub(super) stages: Vec<TopologyStagePlan>,
 }
 
@@ -79,16 +84,20 @@ pub(super) fn plan_split_topology(input: SplitTopologyPlanInput) -> Result<Split
                 detected_vram_bytes: node.detected_vram_bytes,
                 max_vram_bytes: node.max_vram_bytes,
                 runtime_headroom_bytes: node.runtime_headroom_bytes,
+                stage_transfer_latency_ms: node.stage_transfer_latency_ms,
             })
             .collect(),
         context_length_override: input.context_length_override,
         parallel_lanes_override: input.parallel_lanes_override,
+        target_decode_tpot_ms: input.target_decode_tpot_ms,
     })
     .context("plan skippy split topology")?;
 
     Ok(SplitTopologyPlan {
         context_length: plan.context_length,
         parallel_lanes: plan.parallel_lanes,
+        estimated_decode_network_ms_per_token: plan.estimated_decode_network_ms_per_token,
+        decode_tpot_target_met: plan.decode_tpot_target_met,
         stages: plan.stages,
     })
 }
@@ -151,6 +160,8 @@ pub(super) fn plan_runtime_slice_topology_with_resources(
         model_ref,
         context_length = plan.context_length,
         slots = plan.parallel_lanes,
+        estimated_decode_network_ms_per_token = plan.estimated_decode_network_ms_per_token,
+        decode_tpot_target_met = plan.decode_tpot_target_met,
         stages = ?split_stage_plan_labels(&stages),
         "planned resource-aware split runtime topology"
     );
@@ -214,6 +225,7 @@ fn runtime_slice_plan_input(
         kv_bytes_per_token: resources.kv_bytes_per_token,
         context_length_override: resources.ctx_size_override,
         parallel_lanes_override: resources.parallel_override,
+        target_decode_tpot_ms: Some(DEFAULT_TARGET_DECODE_TPOT_MS),
         minimum_nodes: super::local::SPLIT_DEFAULT_MIN_PARTICIPANTS,
         nodes: participants
             .iter()
@@ -222,6 +234,7 @@ fn runtime_slice_plan_input(
                 detected_vram_bytes: participant.vram_bytes,
                 max_vram_bytes: Some(participant.vram_bytes),
                 runtime_headroom_bytes: default_runtime_headroom_bytes(participant.vram_bytes),
+                stage_transfer_latency_ms: participant.rtt_ms,
             })
             .collect(),
     }
@@ -545,6 +558,12 @@ mod tests {
         SplitParticipant::new(make_id(seed), vram_bytes, None)
     }
 
+    fn participant_with_rtt(seed: u8, vram_bytes: u64, rtt_ms: u32) -> SplitParticipant {
+        let mut participant = participant(seed, vram_bytes);
+        participant.rtt_ms = Some(rtt_ms);
+        participant
+    }
+
     #[test]
     fn default_runtime_headroom_is_zero() {
         assert_eq!(default_runtime_headroom_bytes(100), 0);
@@ -613,6 +632,36 @@ mod tests {
         assert!(plan.slots > 0);
         assert_eq!(plan.stages.first().unwrap().layer_start, 0);
         assert_eq!(plan.stages.last().unwrap().layer_end, 30);
+    }
+
+    #[test]
+    fn resource_planner_prefers_lower_tpot_stage_count_from_participant_rtt() {
+        let participants = vec![
+            participant_with_rtt(1, 23_000_000_000, 10),
+            participant_with_rtt(2, 23_000_000_000, 10),
+            participant_with_rtt(3, 23_000_000_000, 10),
+            participant_with_rtt(4, 23_000_000_000, 10),
+        ];
+
+        let plan = plan_runtime_slice_topology_with_resources(
+            "topology-test",
+            "model-a",
+            &package(40, 40_000_000_000),
+            &participants,
+            &[],
+            SplitTopologyResourceInputs {
+                native_context_length: 262_144,
+                kv_bytes_per_token: 64 * 1024,
+                ctx_size_override: None,
+                parallel_override: None,
+            },
+        )
+        .expect("latency-aware runtime topology");
+
+        assert_eq!(plan.context_length, 65_536);
+        assert_eq!(plan.stages.len(), 2);
+        assert_eq!(plan.stages.first().unwrap().layer_start, 0);
+        assert_eq!(plan.stages.last().unwrap().layer_end, 40);
     }
 
     #[test]

--- a/crates/skippy-coordinator/README.md
+++ b/crates/skippy-coordinator/README.md
@@ -138,16 +138,20 @@ The planner inputs are:
 - KV bytes per token for the selected KV cache type
 - minimum node count
 - available nodes, each with detected VRAM, optional max VRAM, and runtime
-  headroom
+  headroom, plus optional stage-transfer latency
 - optional explicit context or parallel-lane overrides
+- optional decode TPOT target
 
 The planner output is:
 
 - selected context length
 - selected parallel lanes
 - ordered stage list, with one contiguous layer range per selected node
+- optional estimated decode-network milliseconds per output token
+- optional TPOT target-met flag
 
-Planning priority is deliberately ordered for decode speed:
+Without latency inputs, planning priority is deliberately ordered for decode
+speed:
 
 1. Choose the highest valid context length, never exceeding the model's native
    GGUF context length.
@@ -162,6 +166,21 @@ set can already run the chosen context. More nodes add split boundaries and
 network hops, which can reduce decode speed, so the planner treats fewer nodes
 as more important than additional parallel lanes.
 
+When stage-transfer latency or a target decode TPOT is provided, the planner
+enumerates every feasible context/node/lane candidate and chooses by estimated
+decode-network TPOT first. The network estimate is:
+
+```text
+estimated_decode_network_ms_per_token =
+    selected_stage_count * max(selected_stage_transfer_latency_ms)
+```
+
+Candidates that meet the TPOT target beat candidates that miss it. Within the
+same target-met bucket, lower estimated network TPOT wins before context length,
+parallel lanes, and remaining VRAM margin. This lets a lower-context two-stage
+topology beat a higher-context four-stage topology when the deeper topology
+cannot hit the decode budget.
+
 ```mermaid
 flowchart TD
     Input["Model metadata and node VRAM budgets"]
@@ -169,14 +188,19 @@ flowchart TD
     Nodes["Try node counts from minimum upward"]
     Lanes["Try parallel lanes from 4 down to 1"]
     Fit{"Can all layers fit?"}
-    Plan["Return first valid plan"]
+    Latency{"Latency inputs?"}
+    Score["Score by TPOT, then context, lanes, VRAM"]
+    Plan["Return selected plan"]
     Reject["Reject topology"]
 
     Input --> Context
     Context --> Nodes
     Nodes --> Lanes
     Lanes --> Fit
-    Fit -- "yes" --> Plan
+    Fit -- "yes" --> Latency
+    Latency -- "no" --> Plan
+    Latency -- "yes" --> Score
+    Score --> Plan
     Fit -- "no" --> Lanes
     Context -- "below 64k floor" --> Reject
 ```

--- a/crates/skippy-coordinator/src/topology.rs
+++ b/crates/skippy-coordinator/src/topology.rs
@@ -17,6 +17,7 @@ pub struct TopologyPlanningInput {
     pub nodes: Vec<TopologyNode>,
     pub context_length_override: Option<u32>,
     pub parallel_lanes_override: Option<usize>,
+    pub target_decode_tpot_ms: Option<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -25,6 +26,7 @@ pub struct TopologyNode {
     pub detected_vram_bytes: u64,
     pub max_vram_bytes: Option<u64>,
     pub runtime_headroom_bytes: u64,
+    pub stage_transfer_latency_ms: Option<u32>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -32,6 +34,8 @@ pub struct TopologyPlan {
     pub context_length: u32,
     pub parallel_lanes: usize,
     pub stages: Vec<TopologyStagePlan>,
+    pub estimated_decode_network_ms_per_token: Option<u32>,
+    pub decode_tpot_target_met: Option<bool>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -77,27 +81,44 @@ pub fn plan_topology(input: &TopologyPlanningInput) -> Result<TopologyPlan, Topo
     )?;
     let lane_candidates = parallel_lane_candidates(input.parallel_lanes_override)?;
     let nodes = usable_nodes(&input.nodes);
+    let latency_aware = latency_aware_planning(input, &nodes);
 
     let minimum_nodes = input.minimum_nodes.max(1);
+    let mut best_latency_candidate: Option<CandidatePlan> = None;
     for context_length in context_candidates {
         for node_count in minimum_nodes..=nodes.len().min(input.layer_count as usize) {
             for parallel_lanes in lane_candidates.iter().copied() {
                 let mut best_for_count: Option<CandidatePlan> = None;
                 for_each_node_subset(&nodes, node_count, |subset| {
-                    if let Some(candidate) =
+                    let Some(candidate) =
                         fit_candidate(input, subset, context_length, parallel_lanes)
-                        && best_for_count
-                            .as_ref()
-                            .is_none_or(|current| candidate.cmp(current) == Ordering::Greater)
+                    else {
+                        return;
+                    };
+                    if best_for_count
+                        .as_ref()
+                        .is_none_or(|current| candidate_better_for_same_shape(&candidate, current))
                     {
                         best_for_count = Some(candidate);
                     }
                 });
                 if let Some(candidate) = best_for_count {
+                    if latency_aware {
+                        if best_latency_candidate.as_ref().is_none_or(|current| {
+                            latency_candidate_better(&candidate, current, input)
+                        }) {
+                            best_latency_candidate = Some(candidate);
+                        }
+                        continue;
+                    }
                     return Ok(candidate.plan);
                 }
             }
         }
+    }
+
+    if let Some(candidate) = best_latency_candidate {
+        return Ok(candidate.plan);
     }
 
     Err(TopologyPlanError::NoValidTopology { minimum_context })
@@ -175,6 +196,7 @@ pub fn minimum_valid_context(native_context: u32) -> u32 {
 struct UsableNode {
     node_id: String,
     usable_vram_bytes: u64,
+    stage_transfer_latency_ms: Option<u32>,
 }
 
 fn usable_nodes(nodes: &[TopologyNode]) -> Vec<UsableNode> {
@@ -188,6 +210,7 @@ fn usable_nodes(nodes: &[TopologyNode]) -> Vec<UsableNode> {
             UsableNode {
                 node_id: node.node_id.clone(),
                 usable_vram_bytes: capped.saturating_sub(node.runtime_headroom_bytes),
+                stage_transfer_latency_ms: node.stage_transfer_latency_ms,
             }
         })
         .collect::<Vec<_>>();
@@ -356,15 +379,96 @@ fn fit_candidate(
         next_layer = layer_end;
     }
 
-    (next_layer == input.layer_count).then_some(CandidatePlan {
+    if next_layer != input.layer_count {
+        return None;
+    }
+
+    let estimated_decode_network_ms_per_token = estimate_decode_network_ms_per_token(nodes);
+    Some(CandidatePlan {
         plan: TopologyPlan {
             context_length,
             parallel_lanes,
             stages,
+            estimated_decode_network_ms_per_token,
+            decode_tpot_target_met: decode_tpot_target_met(
+                estimated_decode_network_ms_per_token,
+                input.target_decode_tpot_ms,
+            ),
         },
         minimum_remaining_vram,
         total_remaining_vram,
     })
+}
+
+fn latency_aware_planning(_input: &TopologyPlanningInput, nodes: &[UsableNode]) -> bool {
+    nodes
+        .iter()
+        .any(|node| node.stage_transfer_latency_ms.is_some())
+}
+
+fn candidate_better_for_same_shape(candidate: &CandidatePlan, current: &CandidatePlan) -> bool {
+    let candidate_estimate = candidate
+        .plan
+        .estimated_decode_network_ms_per_token
+        .unwrap_or_default();
+    let current_estimate = current
+        .plan
+        .estimated_decode_network_ms_per_token
+        .unwrap_or_default();
+    candidate_estimate < current_estimate
+        || (candidate_estimate == current_estimate && candidate.cmp(current) == Ordering::Greater)
+}
+
+fn latency_candidate_better(
+    candidate: &CandidatePlan,
+    current: &CandidatePlan,
+    input: &TopologyPlanningInput,
+) -> bool {
+    latency_candidate_ordering(candidate, current, input) == Ordering::Greater
+}
+
+fn latency_candidate_ordering(
+    left: &CandidatePlan,
+    right: &CandidatePlan,
+    input: &TopologyPlanningInput,
+) -> Ordering {
+    let left_estimate = left
+        .plan
+        .estimated_decode_network_ms_per_token
+        .unwrap_or_default();
+    let right_estimate = right
+        .plan
+        .estimated_decode_network_ms_per_token
+        .unwrap_or_default();
+    let left_target_met = decode_tpot_target_met(
+        left.plan.estimated_decode_network_ms_per_token,
+        input.target_decode_tpot_ms,
+    )
+    .unwrap_or(true);
+    let right_target_met = decode_tpot_target_met(
+        right.plan.estimated_decode_network_ms_per_token,
+        input.target_decode_tpot_ms,
+    )
+    .unwrap_or(true);
+
+    left_target_met
+        .cmp(&right_target_met)
+        .then_with(|| right_estimate.cmp(&left_estimate))
+        .then_with(|| left.plan.context_length.cmp(&right.plan.context_length))
+        .then_with(|| left.plan.parallel_lanes.cmp(&right.plan.parallel_lanes))
+        .then_with(|| left.cmp(right))
+}
+
+fn estimate_decode_network_ms_per_token(nodes: &[UsableNode]) -> Option<u32> {
+    let hop_latency = nodes
+        .iter()
+        .filter_map(|node| node.stage_transfer_latency_ms)
+        .max()?;
+    Some(hop_latency.saturating_mul(nodes.len() as u32))
+}
+
+fn decode_tpot_target_met(estimate: Option<u32>, target: Option<u32>) -> Option<bool> {
+    Some(estimate? <= target?)
 }
 
 fn candidate_bytes_per_layer(
@@ -400,6 +504,14 @@ mod tests {
             detected_vram_bytes: gib * GIB,
             max_vram_bytes: None,
             runtime_headroom_bytes: 0,
+            stage_transfer_latency_ms: None,
+        }
+    }
+
+    fn latency_node(id: &str, gib: u64, stage_transfer_latency_ms: u32) -> TopologyNode {
+        TopologyNode {
+            stage_transfer_latency_ms: Some(stage_transfer_latency_ms),
+            ..node(id, gib)
         }
     }
 
@@ -413,6 +525,7 @@ mod tests {
             nodes,
             context_length_override: None,
             parallel_lanes_override: None,
+            target_decode_tpot_ms: None,
         }
     }
 
@@ -426,6 +539,7 @@ mod tests {
             nodes,
             context_length_override: None,
             parallel_lanes_override: None,
+            target_decode_tpot_ms: None,
         }
     }
 
@@ -445,6 +559,7 @@ mod tests {
             // Metal recommendedMaxWorkingSetSize is already the usable budget
             // reported by the local runtime.
             runtime_headroom_bytes: 0,
+            stage_transfer_latency_ms: None,
         }
     }
 
@@ -509,6 +624,43 @@ mod tests {
             .find(|stage| stage.node_id == "capped")
             .unwrap();
         assert!(capped_stage.layer_end - capped_stage.layer_start < 20);
+    }
+
+    #[test]
+    fn latency_aware_planner_prefers_lower_tpot_over_native_context() {
+        let mut request = input(vec![
+            latency_node("a", 23, 10),
+            latency_node("b", 23, 10),
+            latency_node("c", 23, 10),
+            latency_node("d", 23, 10),
+        ]);
+        request.native_context_length = 262_144;
+        request.minimum_nodes = 2;
+        request.target_decode_tpot_ms = Some(33);
+
+        let plan = plan_topology(&request).unwrap();
+
+        assert_eq!(plan.context_length, 65_536);
+        assert_eq!(plan.stages.len(), 2);
+        assert_eq!(plan.estimated_decode_network_ms_per_token, Some(20));
+        assert_eq!(plan.decode_tpot_target_met, Some(true));
+    }
+
+    #[test]
+    fn latency_aware_planner_reports_target_miss_when_memory_requires_more_stages() {
+        let mut request = qwen_coder_480b_input(qwen_nodes(4, 80));
+        request
+            .nodes
+            .iter_mut()
+            .for_each(|node| node.stage_transfer_latency_ms = Some(10));
+        request.target_decode_tpot_ms = Some(33);
+
+        let plan = plan_topology(&request).unwrap();
+
+        assert_eq!(plan.context_length, 65_536);
+        assert_eq!(plan.stages.len(), 4);
+        assert_eq!(plan.estimated_decode_network_ms_per_token, Some(40));
+        assert_eq!(plan.decode_tpot_target_met, Some(false));
     }
 
     #[test]

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -205,4 +205,4 @@ transfer. Received artifacts are size/SHA-256 verified and installed atomically.
 - [LAYER_PACKAGE_REPOS.md](LAYER_PACKAGE_REPOS.md) explains how to contribute packages.
 - [specs/layer-package-repos.md](specs/layer-package-repos.md) is the manifest spec.
 - [skippy/FAMILY_STATUS.md](skippy/FAMILY_STATUS.md) lists certified families.
-- [skippy/TOPOLOGY_PLANNER.md](skippy/TOPOLOGY_PLANNER.md) documents topology planning.
+- [skippy/TOPOLOGY_PLANNER.md](skippy/TOPOLOGY_PLANNER.md) documents topology planning, including latency-aware physical stage counts.

--- a/docs/skippy/TOPOLOGY_PLANNER.md
+++ b/docs/skippy/TOPOLOGY_PLANNER.md
@@ -106,6 +106,81 @@ Qwen3 dense, Gemma3, GLM4, Gemma4 A4B, Gemma4 E4B, MiniMax M2.7, OLMo, and
 Qwen3Next failed q8 exactness smokes while Llama, DeepSeek2, GLM-4.7 Flash,
 Gemma2, and Falcon-H1 passed validated q8 smokes.
 
+## Latency-Aware Stage Count
+
+The planner should choose the number of physical stages from an end-to-end
+decode latency budget. It should not maximize the stage count just because more
+eligible peers are available.
+
+Small layer slices remain useful package and cache units, but physical stages
+are serialized execution hops during decode. Every additional remote stage adds
+one more activation transfer on the critical path. Current upstream replies add
+more serialized return hops; even with direct predicted-token return, the last
+stage still pays one return hop to stage 0. For no speculative decoding, the
+steady-state decode budget is:
+
+```text
+decode_ms_per_token =
+  serialized_network_hops_ms + max(stage_decode_compute_ms) + protocol_overhead_ms
+```
+
+For a 30 tok/s target, the full decode loop must stay under `33.3 ms/token`.
+With a working assumption of `10 ms` per inter-stage transfer, the optimistic
+direct-return network floor already constrains feasible physical stage counts:
+
+| Physical stages | Serialized hops per token | Network floor | Best possible before compute |
+| --- | ---: | ---: | ---: |
+| 2 | 2 | 20 ms/token | 50.0 tok/s |
+| 3 | 3 | 30 ms/token | 33.3 tok/s |
+| 4 | 4 | 40 ms/token | 25.0 tok/s |
+| 5 | 5 | 50 ms/token | 20.0 tok/s |
+
+Under that assumption, a four-stage topology cannot reach 30 tok/s even before
+local decode compute is counted. A three-stage topology is only feasible if
+compute and protocol overhead are almost zero. A two-stage topology leaves real
+latency headroom, if the two peers can satisfy residency.
+
+The old planning intuition was memory-first: use every feasible peer, split the
+layers evenly, and accept the extra hops as the cost of fitting the model.
+
+```mermaid
+flowchart LR
+    P["Planner"] --> C["Use all eligible peers<br/>balanced layer count"]
+    C --> S0["stage 0<br/>host A"]
+    S0 -->|"activation<br/>10 ms"| S1["stage 1<br/>host B"]
+    S1 -->|"activation<br/>10 ms"| S2["stage 2<br/>host C"]
+    S2 -->|"activation<br/>10 ms"| S3["stage 3<br/>host D"]
+    S3 -->|"predicted token<br/>10 ms"| S0
+    S0 --> O["OpenAI stream"]
+```
+
+The latency-aware planner should instead enumerate feasible physical stage
+counts, reject candidates that do not fit resident memory, and choose the
+lowest estimated time per output token among the survivors.
+
+```mermaid
+flowchart TB
+    P["Latency-aware planner"] --> C2["2 physical stages<br/>2 serialized hops"]
+    P --> C3["3 physical stages<br/>3 serialized hops"]
+    P --> C4["4 physical stages<br/>4 serialized hops"]
+
+    C2 --> M["Residency check"]
+    C3 --> M
+    C4 --> M
+
+    M --> S["Score TPOT<br/>hops * RTT + max stage compute + overhead"]
+    S --> Pick["Pick lowest TPOT<br/>that fits memory"]
+    Pick --> R["Report target miss<br/>when no candidate can hit budget"]
+```
+
+This is a planner decision independent of the wire format: direct return
+improves the constants, but it does not remove the monotonic cost of added
+physical decode hops. The resource planner keeps one logical stage per physical
+peer and uses measured or configured stage-transfer latency to score feasible
+context/node/lane candidates. Later work can let one peer own multiple adjacent
+logical stages, but the first planner decision is simpler: prefer fewer
+physical decode hops whenever residency allows it.
+
 ## Family Capability Records
 
 Family capability records let the planner reason from measured model-family


### PR DESCRIPTION
This PR makes Skippy split planning latency-aware. Instead of treating the highest-context topology as always better, the resource planner can now use measured stage-transfer latency to choose the physical stage count with the best estimated decode TPOT while still respecting memory and context constraints.

Target branch: `main`.

## Performance

`TPOT` means time per output token. For staged decode, the planner now tracks the network portion of the decode loop:

```text
decode_ms_per_token =
  serialized_network_hops_ms + max(stage_decode_compute_ms) + protocol_overhead_ms
```

The implementation estimates the network floor as:

```text
estimated_decode_network_ms_per_token =
  selected_stage_count * max(selected_stage_transfer_latency_ms)
```

For a 30 tok/s target, TPOT must stay under `33.3 ms/token`. With a 10 ms transfer assumption, physical stage count alone gives this floor:

| Physical stages | Serialized hops per token | Network floor | Best possible before compute |
| --- | ---: | ---: | ---: |
| 2 | 2 | 20 ms/token | 50.0 tok/s |
| 3 | 3 | 30 ms/token | 33.3 tok/s |
| 4 | 4 | 40 ms/token | 25.0 tok/s |
| 5 | 5 | 50 ms/token | 20.0 tok/s |

So a four-stage topology cannot hit 30 tok/s under this assumption before local decode compute is counted. The planner now prefers fewer physical stages when measured transfer latency shows the deeper topology is the bottleneck.

## Target Miss Behavior

If no feasible topology can hit the 30 tok/s target, the planner does not fail the split launch in this PR. It still chooses the best feasible topology by estimated network TPOT and reports `decode_tpot_target_met = false`. That keeps large-model serving available when the only topology that fits is slower than the target, while making the miss explicit in diagnostics/logging.

Example: with 10 ms transfers, a required four-stage topology has a 40 ms/token network floor, or about 25 tok/s before local compute. That plan can still be useful if it is the only one that fits, but the planner should surface the target miss rather than implying it can reach 30 tok/s. A later policy knob can make this strict, for example `warn` by default and `strict` to fail closed when the target cannot be met.

## Transport and Overlap Audit

I also checked the two likely hot-path improvements behind the latency model:

- **Persistent hot-path transport:** stage0 already prewarms a persistent downstream lane pool sized to generation concurrency, uses long-lived TCP streams with `TCP_NODELAY`, and replaces a lane only after failure. Normal OpenAI generation admission is bounded by the same generation-concurrency semaphore, so steady-state decode should not reconnect per token or per request when the pool is healthy.
- **Decode-loop overlap:** prefill already has bounded deferred ACKs, so stage0 can keep feeding downstream prefill chunks instead of waiting after every chunk. No-spec decode is different: each output token requires stage0 local decode, activation forwarding, downstream stage execution, and the tail-stage predicted token before the next decode input is known. That makes the no-spec token loop lock-step by semantics. Speculative `VerifySpan` remains the existing path for amortizing several token decisions over one downstream round trip.

```mermaid
sequenceDiagram
    participant S0 as stage0
    participant S1 as downstream stages
    participant Client as OpenAI stream

    loop no-spec decode token N
        S0->>S0: run local stage0 decode(current token)
        S0->>S1: forward activation on persistent lane
        S1-->>S0: predicted token
        S0-->>Client: emit token
    end

    Note over S0,S1: Token N+1 cannot start until the predicted token for N returns.
```

Operationally, this means the stage-count planner is targeting the right first-order bottleneck: serialized stage-transfer latency in decode. Further 30 tok/s work should focus on reducing physical hops, lowering measured transfer latency, and increasing accepted speculative spans. Serious TPOT runs should also avoid `SKIPPY_TELEMETRY_STDERR`, which intentionally adds synchronous stderr writes for debugging.

## Before

The old resource planner tried context candidates from highest to lowest, then returned the first valid shape by node count/lane count. That could choose a deeper high-context topology even when a shallower lower-context topology had a much better decode latency floor.

```mermaid
flowchart LR
    P["Planner"] --> C["Highest context first"]
    C --> N["Fewest nodes that fit that context"]
    N --> S0["stage 0<br/>host A"]
    S0 -->|"activation<br/>10 ms"| S1["stage 1<br/>host B"]
    S1 -->|"activation<br/>10 ms"| S2["stage 2<br/>host C"]
    S2 -->|"activation<br/>10 ms"| S3["stage 3<br/>host D"]
    S3 -->|"predicted token<br/>10 ms"| S0
    S0 --> O["OpenAI stream"]
```

## After

When stage-transfer latency is available, the planner enumerates feasible context/node/lane candidates and scores them by estimated decode-network TPOT. Candidates that meet the 33 ms target beat candidates that miss; within the same target-met bucket, lower estimated TPOT wins before context length, lanes, and VRAM margin.

```mermaid
flowchart TB
    P["Latency-aware planner"] --> C2["2 physical stages<br/>2 serialized hops"]
    P --> C3["3 physical stages<br/>3 serialized hops"]
    P --> C4["4 physical stages<br/>4 serialized hops"]

    C2 --> M["Residency/context check"]
    C3 --> M
    C4 --> M

    M --> S["Score network TPOT<br/>stages * max transfer latency"]
    S --> Pick["Pick lowest TPOT<br/>that fits memory"]
    Pick --> R["Expose target-met flag<br/>for target misses"]
```

## Changed

- Adds optional `stage_transfer_latency_ms` per topology node in `skippy-coordinator`.
- Adds optional `target_decode_tpot_ms`, `estimated_decode_network_ms_per_token`, and `decode_tpot_target_met` to the coordinator plan path.
- Threads measured split participant RTT from `mesh-llm-host-runtime` into the resource planner as the stage-transfer latency estimate.
- Uses a default runtime target of `33 ms/token`, matching the 30 tok/s planning goal.
- Keeps old context-first behavior when no transfer latency is available, so missing RTT data does not accidentally reshuffle topology.
- Updates planner docs and coordinator README with the implemented scoring rule and before/after diagrams.

## Protocol

No wire protocol or compatibility behavior changes in this PR. This only changes local topology planning and diagnostics for Skippy split placement.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p skippy-coordinator`
- `cargo test -p mesh-llm-host-runtime runtime::split_planning --lib`
- `cargo clippy -p skippy-coordinator --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `git diff --check`
- `just build`


