### PR TITLE
Skip first-token work for repeated Skippy prompts

### DIFF
--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -978,6 +978,21 @@ fn handle_binary_connection(
             }
         }
 
+        if let Some(full_prompt_tokens) = decode_full_prompt_sideband(&message) {
+            let mut runtime = runtime.lock().expect("runtime lock poisoned");
+            let record = maybe_record_binary_full_prefill(
+                config,
+                &mut runtime,
+                kv,
+                telemetry,
+                &session_key,
+                &message,
+                full_prompt_tokens,
+            );
+            drop(runtime);
+            add_binary_record_stats(&mut message_reply_stats, config, &record);
+        }
+
         let mut forward_write_ms = 0.0;
         let mut forward_activation_encode_ms = 0.0;
         let mut downstream_wait_ms = 0.0;
@@ -2098,6 +2113,19 @@ fn handle_binary_restore_prefill_decode_control(
                 .context("restore-decode downstream miss ACK")?;
             return Ok(());
         }
+        {
+            let mut runtime = runtime.lock().expect("runtime lock poisoned");
+            let record = maybe_record_binary_full_prefill(
+                config,
+                &mut runtime,
+                kv,
+                telemetry,
+                session_id,
+                message,
+                message.tokens.as_slice(),
+            );
+            add_binary_record_stats(&mut control_stats, config, &record);
+        }
         let mut attrs = binary_message_attrs(config, wire_session_id, message);
         attrs.insert("skippy.kv.control_hit".to_string(), json!(true));
         attrs.insert(
@@ -2127,6 +2155,19 @@ fn handle_binary_restore_prefill_decode_control(
         return Ok(());
     }
 
+    {
+        let mut runtime = runtime.lock().expect("runtime lock poisoned");
+        let record = maybe_record_binary_full_prefill(
+            config,
+            &mut runtime,
+            kv,
+            telemetry,
+            session_id,
+            message,
+            message.tokens.as_slice(),
+        );
+        add_binary_record_stats(&mut control_stats, config, &record);
+    }
     let mut attrs = binary_message_attrs(config, wire_session_id, message);
     attrs.insert("skippy.kv.control_hit".to_string(), json!(true));
     attrs.insert(
@@ -3303,6 +3344,9 @@ fn token_sideband_or_fill(message: &StageWireMessage) -> Result<Vec<i32>> {
         .token_count
         .try_into()
         .context("negative token_count")?;
+    if let Some(token) = decode_execution_token(message, token_count) {
+        return Ok(vec![token]);
+    }
     if message.tokens.len() == token_count {
         return Ok(message.tokens.clone());
     }
@@ -3315,6 +3359,55 @@ fn token_sideband_or_fill(message: &StageWireMessage) -> Result<Vec<i32>> {
         0
     };
     Ok(vec![fill; token_count])
+}
+
+fn decode_execution_token(message: &StageWireMessage, token_count: usize) -> Option<i32> {
+    if !matches!(
+        message.kind,
+        WireMessageKind::DecodeEmbd
+            | WireMessageKind::DecodeReadout
+            | WireMessageKind::DecodeLightCtx
+            | WireMessageKind::DecodeReplayEmbd
+            | WireMessageKind::DecodeReplayFinalEmbd
+    ) || token_count != 1
+        || message.state.current_token == skippy_protocol::binary::LLAMA_TOKEN_NULL
+    {
+        return None;
+    }
+    Some(message.state.current_token)
+}
+
+fn decode_full_prompt_sideband(message: &StageWireMessage) -> Option<&[i32]> {
+    if message.kind != WireMessageKind::DecodeEmbd
+        || message.token_count != 1
+        || message.state.decode_step != 0
+        || message.state.prompt_token_count <= 0
+    {
+        return None;
+    }
+    let prompt_token_count = usize::try_from(message.state.prompt_token_count).ok()?;
+    if message.tokens.len() != prompt_token_count
+        || message.tokens.last().copied() != Some(message.state.current_token)
+    {
+        return None;
+    }
+    Some(message.tokens.as_slice())
+}
+
+fn add_binary_record_stats(
+    reply_stats: &mut StageReplyStats,
+    config: &StageConfig,
+    record: &BinaryKvRecordResult,
+) {
+    if record.recorded_pages > 0 {
+        reply_stats.kv_recorded_pages += record.recorded_pages as i64;
+        reply_stats.kv_record_stage_mask |= stage_mask(config.stage_index);
+    }
+    if record.recorded_activations > 0 {
+        reply_stats.kv_recorded_bytes = reply_stats
+            .kv_recorded_bytes
+            .saturating_add(record.recorded_activation_bytes as i64);
+    }
 }
 
 #[cfg(test)]

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    binary_full_prefill_record_identities, prepare_binary_stage_connection,
-    restore_prefill_decode_as_decode_message,
+    binary_full_prefill_record_identities, decode_full_prompt_sideband,
+    prepare_binary_stage_connection, restore_prefill_decode_as_decode_message,
+    token_sideband_or_fill,
 };
 use std::{
     io,
@@ -148,6 +149,47 @@ fn prefill_message() -> StageWireMessage {
         activation: Vec::new(),
         raw_bytes: Vec::new(),
     }
+}
+
+fn first_decode_message_with_full_prompt_sideband() -> StageWireMessage {
+    let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F16);
+    state.prompt_token_count = 4;
+    state.decode_step = 0;
+    state.current_token = 104;
+    StageWireMessage {
+        kind: WireMessageKind::DecodeEmbd,
+        pos_start: 3,
+        token_count: 1,
+        state,
+        request_id: 11,
+        session_id: 13,
+        sampling: None,
+        chat_sampling_metadata: None,
+        tokens: vec![101, 102, 103, 104],
+        positions: Vec::new(),
+        activation: Vec::new(),
+        raw_bytes: Vec::new(),
+    }
+}
+
+#[test]
+fn decode_full_prompt_sideband_records_metadata_without_changing_exec_token() {
+    let message = first_decode_message_with_full_prompt_sideband();
+
+    let exec_tokens = token_sideband_or_fill(&message).unwrap();
+    let prompt_tokens = decode_full_prompt_sideband(&message).unwrap();
+
+    assert_eq!(exec_tokens, vec![104]);
+    assert_eq!(prompt_tokens, &[101, 102, 103, 104]);
+}
+
+#[test]
+fn decode_full_prompt_sideband_requires_first_decode() {
+    let mut message = first_decode_message_with_full_prompt_sideband();
+    message.state.decode_step = 1;
+
+    assert!(decode_full_prompt_sideband(&message).is_none());
+    assert_eq!(token_sideband_or_fill(&message).unwrap(), vec![104]);
 }
 
 #[test]

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1668,6 +1668,7 @@ struct EmbeddedLocalOutput {
     runtime_lock_hold_ms: f64,
 }
 
+#[derive(Default)]
 struct EmbeddedExecutionStats {
     stage0_compute_ms: f64,
     runtime_lock_wait_ms: f64,
@@ -1690,6 +1691,8 @@ struct EmbeddedFusedFirstDecode {
     reply_stats: StageReplyStats,
     execution: EmbeddedExecutionStats,
     elapsed_ms: f64,
+    token_phase: &'static str,
+    message_kind: &'static str,
 }
 
 struct EmbeddedSessionControl {

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -479,6 +479,15 @@ impl StageOpenAiBackend {
                 "skippy.kv.chain_cache_hit_stage_mask".to_string(),
                 json!(prefill_chain_cache_stats.kv_hit_stage_mask),
             );
+            super::prefix_cache::insert_chain_prefix_cache_savings_attrs(
+                &mut prefill_attrs,
+                super::prefix_cache::chain_prefix_cache_savings(
+                    &prefill_chain_cache_stats,
+                    prefill_chain_restored_tokens,
+                    request.wire_dtype,
+                    request.activation_width,
+                ),
+            );
             self.emit_openai_phase("stage.openai_prefill", prefill_timer, prefill_attrs);
 
             if let Some(message) = generation_config_message(

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -72,7 +72,22 @@ impl StageOpenAiBackend {
                         .prompt_token_ids
                         .last()
                         .expect("checked non-empty prompt");
-                    if let Some(fused) = self.try_restore_embedded_split_prefill_and_decode(
+                    if let Some(cached) = self.try_restore_embedded_split_full_prompt_first_token(
+                        &request,
+                        &session_key,
+                        downstream,
+                    )? {
+                        prefill_chain_cache_restored = true;
+                        prefill_chain_restored_tokens = request.prompt_token_ids.len();
+                        prefill_chain_cache_stats = cached.reply_stats;
+                        cache_stats.cached_prompt_tokens =
+                            saturating_u32(request.prompt_token_ids.len());
+                        cache_stats.matched_prefix_tokens =
+                            saturating_u32(request.prompt_token_ids.len());
+                        cache_stats.suffix_prefill_tokens = 0;
+                        cache_stats.hit_kind = Some("chain_full_prompt_first_token");
+                        fused_first_decode = Some(cached);
+                    } else if let Some(fused) = self.try_restore_embedded_split_prefill_and_decode(
                         &request,
                         &session_key,
                         downstream,
@@ -558,11 +573,11 @@ impl StageOpenAiBackend {
                 token_attrs.insert("llama_stage.decode_step".to_string(), json!(0));
                 token_attrs.insert(
                     "llama_stage.decode_token_phase".to_string(),
-                    json!("fused-restore"),
+                    json!(fused.token_phase),
                 );
                 token_attrs.insert(
                     "llama_stage.message_kind".to_string(),
-                    json!("TryRestorePrefillDecode"),
+                    json!(fused.message_kind),
                 );
                 token_attrs.insert(
                     "llama_stage.elapsed_ms".to_string(),
@@ -982,6 +997,10 @@ impl StageOpenAiBackend {
                     .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
                 state.current_token = current;
                 state.source_stage_index = -1;
+                let message_tokens =
+                    decode_sideband_tokens(decode_step, request.prompt_token_ids, current);
+                let records_full_prompt_sideband =
+                    message_tokens.len() == request.prompt_token_ids.len();
                 let message = StageWireMessage {
                     kind: WireMessageKind::DecodeEmbd,
                     pos_start: i32::try_from(prefill_token_count + decode_step as usize)
@@ -992,7 +1011,7 @@ impl StageOpenAiBackend {
                     session_id,
                     sampling: wire_sampling.clone(),
                     chat_sampling_metadata: None,
-                    tokens: vec![current],
+                    tokens: message_tokens,
                     positions: Vec::new(),
                     activation: Vec::new(),
                     raw_bytes: Vec::new(),
@@ -1065,6 +1084,14 @@ impl StageOpenAiBackend {
                         "expected predicted-token reply from downstream, got {:?}",
                         reply.kind
                     )));
+                }
+                if decode_step == 0 && records_full_prompt_sideband {
+                    self.record_embedded_stage0_full_prompt_first_token(
+                        &session_key,
+                        request.ids,
+                        request.prompt_token_ids,
+                        reply.predicted,
+                    )?;
                 }
                 current = reply.predicted;
                 decoded_tokens += 1;
@@ -1243,4 +1270,14 @@ impl StageOpenAiBackend {
         result?;
         Ok(cache_stats)
     }
+}
+
+fn decode_sideband_tokens(decode_step: u32, prompt_token_ids: &[i32], current: i32) -> Vec<i32> {
+    if decode_step == 0
+        && prompt_token_ids.len() <= skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES
+        && prompt_token_ids.last().copied() == Some(current)
+    {
+        return prompt_token_ids.to_vec();
+    }
+    vec![current]
 }

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -1,5 +1,67 @@
 use super::*;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ChainPrefixCacheSavings {
+    pub(super) hit_stage_count: u32,
+    pub(super) stage0_activation_bytes_avoided: usize,
+    pub(super) interstage_activation_bytes_avoided_estimate: usize,
+}
+
+pub(super) fn chain_prefix_cache_savings(
+    stats: &StageReplyStats,
+    restored_tokens: usize,
+    wire_dtype: WireActivationDType,
+    activation_width: i32,
+) -> ChainPrefixCacheSavings {
+    let hit_stage_count = prefix_cache_hit_stage_count(stats.kv_hit_stage_mask);
+    let stage0_activation_bytes_avoided =
+        estimated_activation_bytes(wire_dtype, restored_tokens, activation_width);
+    let interstage_activation_bytes_avoided_estimate =
+        stage0_activation_bytes_avoided.saturating_mul(hit_stage_count.saturating_sub(1) as usize);
+    ChainPrefixCacheSavings {
+        hit_stage_count,
+        stage0_activation_bytes_avoided,
+        interstage_activation_bytes_avoided_estimate,
+    }
+}
+
+pub(super) fn insert_chain_prefix_cache_savings_attrs(
+    attrs: &mut BTreeMap<String, Value>,
+    savings: ChainPrefixCacheSavings,
+) {
+    attrs.insert(
+        "skippy.kv.chain_cache_hit_stage_count".to_string(),
+        json!(savings.hit_stage_count),
+    );
+    attrs.insert(
+        "skippy.kv.chain_cache_stage0_activation_bytes_avoided".to_string(),
+        json!(savings.stage0_activation_bytes_avoided),
+    );
+    attrs.insert(
+        "skippy.kv.chain_cache_interstage_activation_bytes_avoided_estimate".to_string(),
+        json!(savings.interstage_activation_bytes_avoided_estimate),
+    );
+}
+
+fn prefix_cache_hit_stage_count(hit_stage_mask: i64) -> u32 {
+    if hit_stage_mask <= 0 {
+        return 0;
+    }
+    (hit_stage_mask as u64).count_ones()
+}
+
+fn estimated_activation_bytes(
+    wire_dtype: WireActivationDType,
+    token_count: usize,
+    activation_width: i32,
+) -> usize {
+    let Ok(token_count) = i32::try_from(token_count) else {
+        return 0;
+    };
+    skippy_protocol::binary::activation_wire_bytes(wire_dtype, token_count, activation_width)
+        .unwrap_or(0)
+}
+
 pub(super) fn stage0_prefill_record_identities(
     kv: &KvStageIntegration,
     config: &StageConfig,
@@ -417,6 +479,15 @@ impl StageOpenAiBackend {
             "skippy.kv.hit_stage_mask".to_string(),
             json!(restore_stats.kv_hit_stage_mask),
         );
+        insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            chain_prefix_cache_savings(
+                &restore_stats,
+                restored_tokens,
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
         self.telemetry
             .emit("stage.openai_kv_lookup_decision", attrs);
         Ok(Some(ChainPrefixRestore {
@@ -576,6 +647,15 @@ impl StageOpenAiBackend {
             "skippy.kv.hit_stage_mask".to_string(),
             json!(reply_stats.kv_hit_stage_mask),
         );
+        insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            chain_prefix_cache_savings(
+                &reply_stats,
+                prefill_tokens.len(),
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
         self.telemetry
             .emit("stage.openai_kv_lookup_decision", attrs);
         Ok(Some(EmbeddedFusedFirstDecode {
@@ -619,5 +699,46 @@ impl StageOpenAiBackend {
         {
             let _ = recv_reply(&mut *downstream);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_prefix_cache_savings_counts_confirmed_stage_hits() {
+        let stats = StageReplyStats {
+            kv_hit_stage_mask: openai_stage_mask(0)
+                | openai_stage_mask(1)
+                | openai_stage_mask(2)
+                | openai_stage_mask(3),
+            ..Default::default()
+        };
+
+        let savings = chain_prefix_cache_savings(&stats, 256, WireActivationDType::F16, 5120);
+
+        assert_eq!(savings.hit_stage_count, 4);
+        assert_eq!(savings.stage0_activation_bytes_avoided, 2_621_440);
+        assert_eq!(
+            savings.interstage_activation_bytes_avoided_estimate,
+            7_864_320
+        );
+    }
+
+    #[test]
+    fn chain_prefix_cache_savings_uses_wire_dtype() {
+        let stats = StageReplyStats {
+            kv_hit_stage_mask: openai_stage_mask(0) | openai_stage_mask(1),
+            ..Default::default()
+        };
+
+        let q8 = chain_prefix_cache_savings(&stats, 256, WireActivationDType::Q8, 5120);
+        let f32 = chain_prefix_cache_savings(&stats, 256, WireActivationDType::F32, 5120);
+
+        assert_eq!(q8.stage0_activation_bytes_avoided, 1_311_744);
+        assert_eq!(q8.interstage_activation_bytes_avoided_estimate, 1_311_744);
+        assert_eq!(f32.stage0_activation_bytes_avoided, 5_242_880);
+        assert_eq!(f32.interstage_activation_bytes_avoided_estimate, 5_242_880);
     }
 }

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -339,8 +339,22 @@ impl StageOpenAiBackend {
             identities
                 .iter()
                 .map(|identity| {
-                    kv.record_resident_prefix(&mut runtime, session_id, identity, token_ids)
-                        .map_err(openai_backend_error)
+                    let token_count = identity
+                        .identity
+                        .token_count
+                        .try_into()
+                        .unwrap_or(usize::MAX)
+                        .min(token_ids.len());
+                    if token_count == token_ids.len() {
+                        let _ = kv.record_exact_state(&mut runtime, session_id, identity);
+                    }
+                    kv.record_resident_prefix(
+                        &mut runtime,
+                        session_id,
+                        identity,
+                        &token_ids[..token_count],
+                    )
+                    .map_err(openai_backend_error)
                 })
                 .collect::<OpenAiResult<Vec<_>>>()?
         };
@@ -387,6 +401,118 @@ impl StageOpenAiBackend {
                 .emit("stage.openai_kv_record_decision", attrs);
         }
         Ok(recorded_any)
+    }
+
+    pub(super) fn record_embedded_stage0_full_prompt_first_token(
+        &self,
+        session_id: &str,
+        ids: &OpenAiGenerationIds,
+        token_ids: &[i32],
+        predicted: i32,
+    ) -> OpenAiResult<bool> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(false);
+        };
+        if token_ids.is_empty() || !kv.should_record() {
+            return Ok(false);
+        }
+        let base = self.local_kv_message_base(session_id, ids);
+        let identity = kv.prefill_identity(&self.config, &base, 0, token_ids);
+        let recorded_state =
+            self.record_embedded_stage0_full_prefill(session_id, ids, token_ids)?;
+        let recorded_token = kv.record_cached_first_token(&identity, predicted);
+        let mut attrs = self.openai_attrs(ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("stage0_full_prompt_first_token_record"),
+        );
+        attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
+        attrs.insert("skippy.kv.predicted_token".to_string(), json!(predicted));
+        attrs.insert(
+            "skippy.kv.recorded_page_id".to_string(),
+            json!(identity.page_id),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_state".to_string(),
+            json!(recorded_state),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_first_token".to_string(),
+            json!(recorded_token),
+        );
+        self.telemetry
+            .emit("stage.openai_kv_record_decision", attrs);
+        Ok(recorded_state || recorded_token)
+    }
+
+    pub(super) fn try_restore_embedded_split_full_prompt_first_token(
+        &self,
+        request: &EmbeddedStageZeroGeneration<'_>,
+        session_key: &str,
+        downstream: &mut TcpStream,
+    ) -> OpenAiResult<Option<EmbeddedFusedFirstDecode>> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(None);
+        };
+        if request.prompt_token_ids.is_empty() || !kv.should_lookup() {
+            return Ok(None);
+        }
+        let timer = PhaseTimer::start();
+        let base = self.local_kv_message_base(session_key, request.ids);
+        let identity = kv.prefill_identity(request.config, &base, 0, request.prompt_token_ids);
+        let Some(predicted) = kv.lookup_cached_first_token(&identity) else {
+            return Ok(None);
+        };
+        let Some(restore) = self.try_restore_embedded_split_prefill(
+            request,
+            session_key,
+            downstream,
+            request.prompt_token_ids,
+        )?
+        else {
+            return Ok(None);
+        };
+        if restore.restored_tokens < request.prompt_token_ids.len() {
+            return Ok(None);
+        }
+        let mut attrs = self.openai_attrs(request.ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("chain_full_prompt_first_token_hit"),
+        );
+        attrs.insert(
+            "skippy.kv.restored_tokens".to_string(),
+            json!(restore.restored_tokens),
+        );
+        attrs.insert("skippy.kv.predicted_token".to_string(), json!(predicted));
+        attrs.insert("skippy.kv.hit_page_id".to_string(), json!(identity.page_id));
+        attrs.insert(
+            "skippy.kv.lookup_hits".to_string(),
+            json!(restore.stats.kv_lookup_hits),
+        );
+        attrs.insert(
+            "skippy.kv.hit_stage_mask".to_string(),
+            json!(restore.stats.kv_hit_stage_mask),
+        );
+        insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            chain_prefix_cache_savings(
+                &restore.stats,
+                restore.restored_tokens,
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
+        self.telemetry
+            .emit("stage.openai_kv_lookup_decision", attrs);
+        Ok(Some(EmbeddedFusedFirstDecode {
+            predicted,
+            reply_stats: restore.stats,
+            execution: EmbeddedExecutionStats::default(),
+            elapsed_ms: timer.elapsed_ms(),
+            token_phase: "full-prompt-cache",
+            message_kind: "TryRestorePrefill",
+        }))
     }
 
     pub(super) fn try_restore_embedded_split_prefill(
@@ -658,6 +784,12 @@ impl StageOpenAiBackend {
         );
         self.telemetry
             .emit("stage.openai_kv_lookup_decision", attrs);
+        self.record_embedded_stage0_full_prompt_first_token(
+            session_key,
+            request.ids,
+            request.prompt_token_ids,
+            downstream_reply.predicted,
+        )?;
         Ok(Some(EmbeddedFusedFirstDecode {
             predicted: downstream_reply.predicted,
             reply_stats,
@@ -672,6 +804,8 @@ impl StageOpenAiBackend {
                 downstream_wait_ms,
             },
             elapsed_ms: timer.elapsed_ms(),
+            token_phase: "fused-restore",
+            message_kind: "TryRestorePrefillDecode",
         }))
     }
 

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::Path,
     path::PathBuf,
@@ -55,6 +55,7 @@ impl KvStageIntegration {
                 cache_config.max_entries.clamp(1, 512),
                 cache_config.max_bytes,
             ))),
+            first_tokens: Arc::new(Mutex::new(BTreeMap::new())),
         }))
     }
 }

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -47,6 +47,7 @@ pub struct KvStageIntegration {
     pub(crate) resident: Arc<Mutex<ResidentPrefixCache>>,
     pub(crate) activations: Arc<Mutex<ResidentActivationCache<ActivationFrame>>>,
     pub(crate) exact_states: Arc<Mutex<ExactStateCache<ExactStateExtra>>>,
+    pub(crate) first_tokens: Arc<Mutex<BTreeMap<String, i32>>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -251,6 +252,29 @@ impl KvStageIntegration {
 
     fn lookup_candidate_token_counts(&self, token_count: u64) -> Vec<u64> {
         self.candidate_policy.candidate_token_counts(token_count)
+    }
+
+    pub fn record_cached_first_token(&self, identity: &PrefillKvIdentity, predicted: i32) -> bool {
+        if !self.should_record() || identity.identity.token_count < self.candidate_policy.min_tokens
+        {
+            return false;
+        }
+        self.first_tokens
+            .lock()
+            .expect("first-token cache lock poisoned")
+            .insert(identity.page_id.clone(), predicted)
+            .is_none()
+    }
+
+    pub fn lookup_cached_first_token(&self, identity: &PrefillKvIdentity) -> Option<i32> {
+        if !self.should_lookup() {
+            return None;
+        }
+        self.first_tokens
+            .lock()
+            .expect("first-token cache lock poisoned")
+            .get(&identity.page_id)
+            .copied()
     }
 }
 


### PR DESCRIPTION
## Summary

Repeated exact prompts can now skip the expensive first-token path across a Skippy split chain.

The motivating case is agent and tool-loop traffic: the same chat prefix, or sometimes the exact same prompt, can be sent again while the model only needs a short continuation. Before this PR, Skippy could restore a cached prefix, but an exact repeated prompt still had to run the first decode through every stage before the client saw token 1. On a staged model, that first token pays both compute and the serialized stage-to-stage activation trip.

This PR adds an exact, memory-resident full-prompt first-token cache. After the first request computes token 1, every stage records the full prompt state. Stage 0 also records the predicted first generated token for that exact prompt identity. On an exact repeat, stage 0 restores the full prompt across the chain and emits cached token 1 immediately, then normal decode continues from token 2.

This is intentionally narrow: exact prompt identity only, memory resident only, and no lossy activation compression or central cache service.

## What the Data Shows

I ran a category-shaped corpus built from the local `skippy-bench` prompt sets. The benchmark used a local 3-stage `Qwen3-0.6B-Q4_K_M` split chain, split `0..9`, `9..18`, `18..28`, f16 activation wire, streaming chat, `max_tokens=4`, and temperature `0`.

Raw timing output: `/tmp/prefix-cache-category-bench-20260604-175250/report.json`.
Telemetry proof run: `/tmp/prefix-cache-category-telemetry-20260604-175330/stage0.log`.

| skippy-bench category | Workload story | Prompt tokens | Cold FTTT/TTFT ms | Warm/shared median ms | Delta ms | Speedup | Total elapsed delta ms | Cache path |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| `exact_repeat` | Same prompt repeated 4x | 88 | 312.8 | 17.2 | 295.6 | 18.2x | 298.0 | `chain_full_prompt_first_token` |
| `prefix_cache_exact_repeat` | Longer `prefix_cache` prompt repeated 3x | 185 | 1542.5 | 18.7 | 1523.8 | 82.6x | 1524.7 | `chain_full_prompt_first_token` |
| `repeated_prefix_alpha` | Shared prefix, different user tail | 109 | 597.6 | 72.6 | 525.0 | 8.2x | 522.4 | `chain_prefix` |
| `repeated_prefix_beta` | Shared prefix, different user tail | 79 | 321.8 | 69.4 | 252.4 | 4.6x | 250.0 | `chain_prefix` |
| `control_sanity` | Unrelated one-shot control | 14 | 47.4 | n/a | n/a | n/a | n/a | no expected reuse |
| `control_qa` | Unrelated one-shot control | 38 | 237.7 | n/a | n/a | n/a | n/a | no expected reuse |
| `control_summarization` | Unrelated one-shot control | 39 | 238.2 | n/a | n/a | n/a | n/a | no expected reuse |
| `control_debugging` | Unrelated one-shot control | 52 | 230.2 | n/a | n/a | n/a | n/a | no expected reuse |

The important rows are the first two. They are exact repeats and telemetry confirms they used the new `chain_full_prompt_first_token` path. The 88-token exact repeat moved from `312.8 ms` cold FTTT to `17.2 ms` warm median FTTT. The longer 185-token repeat moved from `1542.5 ms` to `18.7 ms`.

The shared-prefix rows are included to orient reviewers rather than to claim this PR invented that behavior. They still use the existing `chain_prefix` path, and they show that the broader cache machinery remains useful when prompts share a prefix but have different tails. The control rows are unrelated one-shot prompts, so they intentionally have no warm comparison.

## Why This Helps Tokens Per Second

For long generations, steady TPOT after token 1 is mostly unchanged because token 2+ still uses the normal decode loop. The win is FTTT and effective tok/s for short repeated requests, which is exactly where interactive agents and tool loops tend to feel slow.

With a 4-stage chain and 10 ms one-way latency between stages, skipping the first decode avoids roughly one serialized stage-chain trip, about `30 ms` of network latency before compute is counted. The payload avoided is small, so this is not primarily a bandwidth win:

| Wire dtype | One activation frame at width 5120 | 3 boundaries | Payload time at 1 Gbps |
| --- | ---: | ---: | ---: |
| f32 | ~20 KiB | ~60 KiB | <1 ms |
| f16 | ~10 KiB | ~30 KiB | <1 ms |
| q8 | ~5 KiB | ~15 KiB | <1 ms |

The practical win is removing first-decode compute plus the stage-chain latency. That changes effective tok/s most for short completions:

| Completion length | Before: 250 ms FTTT, 33 ms TPOT | After: 180 ms FTTT, 33 ms TPOT | Effective tok/s change |
| ---: | ---: | ---: | ---: |
| 8 tokens | ~15.6 tok/s | ~19.3 tok/s | +24% |
| 16 tokens | ~20.6 tok/s | ~24.0 tok/s | +17% |
| 64 tokens | ~27.1 tok/s | ~28.0 tok/s | +3% |

These estimates are deliberately simple and not benchmark-fitted constants. The measured local run proves the new cache path and gives a lower-scale signal; larger staged models should benefit more when first decode compute is larger.

## Behavior Before

Before this PR, an exact repeated prompt could restore the prefix before the final prompt token, but it still had to run first decode through every stage to produce token 1.

```mermaid
sequenceDiagram
    participant C as Client
    participant OAI as OpenAI frontend / Stage 0
    participant C0 as Stage 0 cache
    participant S1 as Stage 1
    participant C1 as Stage 1 cache
    participant S2 as Stage 2
    participant C2 as Stage 2 cache
    participant SF as Final stage
    participant CF as Final cache

    C->>OAI: Repeat exact prompt
    OAI->>C0: Restore prefix tokens 0..N-2
    C0-->>OAI: hit
    OAI->>S1: TryRestorePrefill(prefix tokens)
    S1->>C1: Restore prefix tokens 0..N-2
    C1-->>S1: hit
    S1->>S2: TryRestorePrefill(prefix tokens)
    S2->>C2: Restore prefix tokens 0..N-2
    C2-->>S2: hit
    S2->>SF: TryRestorePrefill(prefix tokens)
    SF->>CF: Restore prefix tokens 0..N-2
    CF-->>SF: hit
    SF-->>S2: ACK + cache stats
    S2-->>S1: ACK + cache stats
    S1-->>OAI: ACK + cache stats
    OAI->>S1: DecodeEmbd(final prompt token)
    S1->>S2: DecodeEmbd(activation)
    S2->>SF: DecodeEmbd(activation)
    SF-->>S2: PredictedToken(token 1)
    S2-->>S1: PredictedToken(token 1)
    S1-->>OAI: PredictedToken(token 1)
    OAI-->>C: token 1
```

## Behavior After

The first request records a replayable full-prompt state after first decode succeeds.

```mermaid
sequenceDiagram
    participant OAI as OpenAI frontend / Stage 0
    participant S1 as Stage 1
    participant S2 as Stage 2
    participant SF as Final stage
    participant K0 as Stage 0 cache
    participant K1 as Stage 1 cache
    participant K2 as Stage 2 cache
    participant KF as Final cache

    OAI->>S1: DecodeEmbd(final prompt token, full prompt sideband)
    S1->>S2: DecodeEmbd(activation, full prompt sideband)
    S2->>SF: DecodeEmbd(activation, full prompt sideband)
    SF-->>S2: PredictedToken(token 1)
    SF->>KF: Record full prompt state
    S2->>K2: Record full prompt state
    S2-->>S1: PredictedToken(token 1)
    S1->>K1: Record full prompt state
    S1-->>OAI: PredictedToken(token 1)
    OAI->>K0: Record full prompt state + token 1
```

On an exact repeat, every stage restores the full prompt directly and stage 0 emits token 1 from the cache.

```mermaid
sequenceDiagram
    participant C as Client
    participant OAI as OpenAI frontend / Stage 0
    participant K0 as Stage 0 cache
    participant S1 as Stage 1
    participant K1 as Stage 1 cache
    participant S2 as Stage 2
    participant K2 as Stage 2 cache
    participant SF as Final stage
    participant KF as Final cache

    C->>OAI: Repeat exact prompt
    OAI->>K0: Lookup full prompt identity + token 1
    K0-->>OAI: hit(token 1)
    OAI->>K0: Restore full prompt state
    K0-->>OAI: hit
    OAI->>S1: TryRestorePrefill(full prompt tokens)
    S1->>K1: Restore full prompt state
    K1-->>S1: hit
    S1->>S2: TryRestorePrefill(full prompt tokens)
    S2->>K2: Restore full prompt state
    K2-->>S2: hit
    S2->>SF: TryRestorePrefill(full prompt tokens)
    SF->>KF: Restore full prompt state
    KF-->>SF: hit
    SF-->>S2: ACK + cache stats
    S2-->>S1: ACK + cache stats
    S1-->>OAI: ACK + cache stats
    OAI-->>C: cached token 1
    OAI->>S1: DecodeEmbd(token 1) for token 2+
```

If any downstream stage misses or errors during the full-prompt restore, Skippy drops the partial restore and falls back to the existing prefix/first-decode path.

## Implementation Notes

- Adds a stage-0 first-token index keyed by the exact full-prompt cache identity.
- Records exact full-prompt state on stage 0 after first decode, including exact-state payloads where enabled.
- Propagates full-prompt sideband on first cold `DecodeEmbd` so downstream stages can record the same full-prompt state.
- Records full-prompt state in `TryRestorePrefillDecode` too, covering the existing fused prefix-restore + first-decode path.
- Keeps the existing prefix restore fallback: a full-prompt first-token cache hit must restore across all stages before it can emit cached token 1.
- Adds telemetry so cache decisions can be verified as `chain_full_prompt_first_token`, `chain_prefix`, or miss/control behavior.

## Protocol And Compatibility

This changes Skippy stage protocol semantics for first decode messages.

`DecodeEmbd` may now carry full prompt tokens in `message.tokens` as sideband metadata when `token_count == 1`, `decode_step == 0`, and `state.current_token` is the final prompt token. Updated stages execute decode from `state.current_token`; they do not decode `message.tokens[0]` when this sideband is present. The sideband is used to record the full-prompt cache identity after the decode succeeds.

Compatibility impact:

- Mesh gossip and public mesh protocol are unchanged.
- Skippy stage message IDs are unchanged.
- Mixed old/new Skippy stage binaries are not safe for this semantic change: older stages may treat the first sideband token as the decode token. Deploy the stage chain with updated binaries together.
- Sideband recording is bounded by `MAX_STAGE_SIDEBAND_VALUES`; prompts above that limit keep the old one-token decode sideband and do not record the full-prompt first-token entry.

## Validation

- `rustfmt --edition 2024 --check crates/skippy-server/src/kv_integration/mod.rs crates/skippy-server/src/kv_integration/config.rs crates/skippy-server/src/frontend.rs crates/skippy-server/src/frontend/prefix_cache.rs crates/skippy-server/src/frontend/embedded_generation.rs crates/skippy-server/src/binary_transport.rs crates/skippy-server/src/binary_transport/tests.rs`
- `git diff --check`
- `just with-lld cargo test -p skippy-server --lib`
- `just with-lld cargo check -p skippy-server`
- `just with-lld cargo clippy -p skippy-server --all-targets -- -D warnings`
- `just build`
