### PR TITLE
Reduce Skippy F32 activation receive overhead

### DIFF
--- a/crates/skippy-protocol/src/binary/mod.rs
+++ b/crates/skippy-protocol/src/binary/mod.rs
@@ -633,6 +633,56 @@ mod tests {
     }
 
     #[test]
+    fn f32_activation_payload_can_be_moved_without_clone() {
+        let state = StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F32);
+        let activation = vec![1_u8, 2, 3, 4, 5, 6, 7, 8];
+        let mut message = StageWireMessage {
+            kind: WireMessageKind::DecodeEmbd,
+            pos_start: 0,
+            token_count: 1,
+            state,
+            request_id: 7,
+            session_id: 9,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: vec![42],
+            positions: Vec::new(),
+            activation: activation.clone(),
+            raw_bytes: Vec::new(),
+        };
+
+        let payload = message.take_activation_f32_payload(2).unwrap();
+
+        assert_eq!(payload, activation);
+        assert!(message.activation.is_empty());
+    }
+
+    #[test]
+    fn f32_activation_payload_clone_helper_preserves_wire_payload() {
+        let state = StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F32);
+        let activation = vec![1_u8, 2, 3, 4, 5, 6, 7, 8];
+        let message = StageWireMessage {
+            kind: WireMessageKind::DecodeEmbd,
+            pos_start: 0,
+            token_count: 1,
+            state,
+            request_id: 7,
+            session_id: 9,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: vec![42],
+            positions: Vec::new(),
+            activation: activation.clone(),
+            raw_bytes: Vec::new(),
+        };
+
+        let payload = message.activation_f32_payload(2).unwrap();
+
+        assert_eq!(payload, activation);
+        assert_eq!(message.activation, activation);
+    }
+
+    #[test]
     fn gemma3n_altup_sideband_activation_round_trips() {
         let mut state =
             StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F32);

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -433,6 +433,29 @@ impl StageWireMessage {
             ),
         }
     }
+
+    pub fn take_activation_f32_payload(&mut self, n_embd: i32) -> io::Result<Vec<u8>> {
+        if self.activation.is_empty() {
+            return Ok(Vec::new());
+        }
+        match self.state.dtype()? {
+            WireActivationDType::F32 => {
+                if self.activation.len() > MAX_STAGE_DECODED_ACTIVATION_BYTES {
+                    return Err(invalid_data(
+                        "decoded activation payload byte count exceeds maximum",
+                    ));
+                }
+                Ok(std::mem::take(&mut self.activation))
+            }
+            WireActivationDType::F16 => decode_f16_to_f32_bytes(&self.activation),
+            WireActivationDType::Q8 => decode_q8_to_f32_bytes_with_state_flags(
+                &self.activation,
+                self.token_count,
+                n_embd,
+                self.state.flags,
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -396,7 +396,7 @@ fn handle_binary_connection(
     loop {
         let recv_start_unix_nanos = now_unix_nanos() as u64;
         let recv_started = Instant::now();
-        let message = if let Some(message) = next_message.take() {
+        let mut message = if let Some(message) = next_message.take() {
             message
         } else {
             match read_stage_message(&mut *upstream, activation_width) {
@@ -696,7 +696,7 @@ fn handle_binary_connection(
                     telemetry,
                     &session_key,
                     session_id,
-                    &message,
+                    message,
                     downstream.as_mut(),
                     wire_dtype,
                     downstream_wire_condition,
@@ -823,6 +823,7 @@ fn handle_binary_connection(
         let mut runtime_lock_acquires = 0usize;
         let mut runtime_sessions_before = None;
         let mut runtime_sessions_after = None;
+        let input_activation_bytes = message.activation.len();
         let (predicted_token, predicted_tokens, output, compute_ms) = if restored_prefill {
             let now = now_unix_nanos() as u64;
             compute_start_unix_nanos = now;
@@ -838,8 +839,8 @@ fn handle_binary_connection(
             )
         } else {
             let input_decode_started = Instant::now();
-            let input = input_activation_frame(config, topology, &message, activation_width)?;
-            input_activation_decode_ms = if message.activation.is_empty() {
+            let input = input_activation_frame(config, topology, &mut message, activation_width)?;
+            input_activation_decode_ms = if input_activation_bytes == 0 {
                 0.0
             } else {
                 elapsed_ms(input_decode_started)
@@ -1302,7 +1303,7 @@ fn handle_binary_connection(
             downstream_wait_ms,
             upstream_reply_ms,
             message_elapsed_ms,
-            input_activation_bytes: message.activation.len(),
+            input_activation_bytes,
             output_activation_bytes: output.payload.len(),
             input_activation_decode_ms,
             forward_activation_encode_ms,
@@ -1424,7 +1425,7 @@ fn handle_binary_connection(
         );
         timing_attrs.insert(
             "skippy.input_activation_bytes".to_string(),
-            json!(message.activation.len()),
+            json!(input_activation_bytes),
         );
         timing_attrs.insert(
             "skippy.output_activation_bytes".to_string(),
@@ -1981,7 +1982,7 @@ fn handle_binary_restore_prefill_decode_control(
     telemetry: &Telemetry,
     session_id: &str,
     wire_session_id: u64,
-    message: &StageWireMessage,
+    mut message: StageWireMessage,
     downstream: Option<&mut TcpStream>,
     wire_dtype: WireActivationDType,
     downstream_wire_condition: WireCondition,
@@ -1991,19 +1992,19 @@ fn handle_binary_restore_prefill_decode_control(
     prediction_return_streams: &mut BTreeMap<(u64, u64), TcpStream>,
     downstream_connect_timeout_secs: u64,
 ) -> Result<()> {
-    let (prefix_tokens, current_token) = restore_decode_sideband(message)?;
+    let (prefix_tokens, current_token) = restore_decode_sideband(&message)?;
     let local = maybe_prefix_cache_control(
         config,
         runtime,
         kv,
         telemetry,
         session_id,
-        message,
+        &message,
         prefix_tokens,
     );
     control_stats.merge(local.stats);
     if !local.hit {
-        let mut attrs = binary_message_attrs(config, wire_session_id, message);
+        let mut attrs = binary_message_attrs(config, wire_session_id, &message);
         attrs.insert("skippy.kv.control_hit".to_string(), json!(false));
         attrs.insert(
             "llama_stage.elapsed_ms".to_string(),
@@ -2013,7 +2014,7 @@ fn handle_binary_restore_prefill_decode_control(
         send_one_off_direct_return(
             config,
             topology,
-            message,
+            &message,
             wire_dtype,
             downstream_connect_timeout_secs,
             StageReply {
@@ -2026,8 +2027,8 @@ fn handle_binary_restore_prefill_decode_control(
         return Ok(());
     }
 
-    let input = input_activation_frame(config, topology, message, activation_width)?;
-    let decode_message = restore_prefill_decode_as_decode_message(message, current_token);
+    let input = input_activation_frame(config, topology, &mut message, activation_width)?;
+    let decode_message = restore_prefill_decode_as_decode_message(&message, current_token);
     let compute_started = Instant::now();
     let (predicted_token, output, runtime_lock_wait_ms, runtime_lock_hold_ms) = {
         let lock_started = Instant::now();
@@ -2065,7 +2066,7 @@ fn handle_binary_restore_prefill_decode_control(
 
     if let Some(downstream) = downstream {
         let forwarded =
-            forwarded_stage_message_timed(config, message, &output, wire_dtype, activation_width)
+            forwarded_stage_message_timed(config, &message, &output, wire_dtype, activation_width)
                 .context("forward restore-decode activation")?;
         write_stage_message_conditioned(
             &mut *downstream,
@@ -2074,7 +2075,7 @@ fn handle_binary_restore_prefill_decode_control(
             downstream_wire_condition,
         )
         .context("forward restore-decode downstream")?;
-        let mut attrs = binary_message_attrs(config, wire_session_id, message);
+        let mut attrs = binary_message_attrs(config, wire_session_id, &message);
         attrs.insert("skippy.kv.control_hit".to_string(), json!(true));
         attrs.insert(
             "llama_stage.elapsed_ms".to_string(),
@@ -2109,12 +2110,12 @@ fn handle_binary_restore_prefill_decode_control(
             kv,
             telemetry,
             session_id,
-            message,
+            &message,
             message.tokens.as_slice(),
         );
         add_binary_record_stats(&mut control_stats, config, &record);
     }
-    let mut attrs = binary_message_attrs(config, wire_session_id, message);
+    let mut attrs = binary_message_attrs(config, wire_session_id, &message);
     attrs.insert("skippy.kv.control_hit".to_string(), json!(true));
     attrs.insert(
         "llama_stage.elapsed_ms".to_string(),
@@ -3254,14 +3255,14 @@ fn runtime_sampling_config(sampling: Option<&StageSamplingConfig>) -> Option<Sam
 fn input_activation_frame(
     config: &StageConfig,
     topology: Option<&StageTopology>,
-    message: &StageWireMessage,
+    message: &mut StageWireMessage,
     activation_width: i32,
 ) -> Result<Option<ActivationFrame>> {
     if message.activation.is_empty() {
         return Ok(None);
     }
     let payload = message
-        .activation_f32_payload(activation_width)
+        .take_activation_f32_payload(activation_width)
         .context("decode wire activation payload")?;
     let (layer_start, layer_end) = upstream_layer_range(config, topology, message);
     Ok(Some(ActivationFrame {


### PR DESCRIPTION
## Summary

This PR reduces Skippy stage receive overhead for F32 activation frames by moving the decoded wire payload into the runtime input frame instead of cloning it first.

It is stacked on #794 because the direct-return-only protocol change made the old `skippy-bench run` driver wait on a chained reply path that no longer exists. The benchmark compatibility fix lives in #794; this PR only carries the activation receive-path optimization and its protocol tests.

## Why this helps

For F32 activation wire frames, the transport already receives the payload as an owned `Vec<u8>`. Before this change, `input_activation_frame()` asked `StageWireMessage::activation_f32_payload()` for a decoded F32 payload, which cloned the existing bytes in the F32 case before building the `ActivationFrame`.

After this change, the F32 case validates the received payload size and uses `std::mem::take()` to transfer ownership directly. F16 and Q8 still decode into F32 bytes exactly as before.

## Benchmark

Existing `skippy-bench` corpus and package:

- Corpus: `crates/skippy-bench/corpora/kv_mixed_prompts.jsonl`
- Model/package: `unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_XL`
- Stage package: `/Volumes/External/tmp/skippy-family-packages/qwen36-a3b-ud-q4-k-xl`
- Split: `20`, layer end `40`, activation width `2048`
- Activation wire dtype: `f32`
- Prompt limit: `2`
- Max new tokens: `8`
- Hosts: `localhost,127.0.0.1`

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Generated tok/s | 18.50 | 19.95 | +7.9% |
| Total tok/s | 34.68 | 37.41 | +7.9% |
| Total elapsed | 865 ms | 802 ms | -7.3% |
| Mean TTFT | 159.5 ms | 136.5 ms | -14.4% |
| Mean decode elapsed | 360.5 ms | 335.0 ms | -7.1% |
| Mean wire elapsed | 403.0 ms | 365.0 ms | -9.4% |

This is intentionally a small A/B run against the existing bench corpus. It is enough to show the change is directionally useful and that #794 restores the benchmark path, but it should not be treated as a final throughput claim for every topology.

## Validation

- `just with-lld cargo fmt --all -- --check`
- `just with-lld cargo check -p skippy-bench`
- `just with-lld cargo test -p skippy-bench`
- `just with-lld cargo test -p skippy-protocol --lib`
- `just with-lld cargo test -p skippy-server --lib`
- `just with-lld cargo clippy -p skippy-bench --all-targets -- -D warnings`
- `just with-lld cargo clippy -p skippy-protocol --all-targets -- -D warnings`
- `just with-lld cargo clippy -p skippy-server --all-targets -- -D warnings`
- `just with-lld cargo build --release -p skippy-server -p skippy-bench -p metrics-server`
