### PR TITLE
Cache HF models in CI smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,6 +314,15 @@ jobs:
       - name: Build mesh-llm binary (debug)
         run: cargo build -p mesh-llm --bin mesh-llm
 
+      - name: Restore Skippy smoke model cache
+        id: skippy_smoke_model_cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/skippy-ci-smoke-models
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-skippy-ci-smoke-models-SmolLM2-135M-Instruct.Q4_K_M.gguf-Falcon-H1-0.5B-Instruct-Q4_K_M.gguf-${{ hashFiles('.github/cache-version.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-skippy-ci-smoke-models-
+
       - name: Unit tests
         if: ${{ needs.changes.outputs.all_rust == 'true' || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'model-artifact') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-host-runtime') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm') }}
         env:
@@ -339,7 +348,15 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
           WORK_DIR: ${{ runner.temp }}/skippy-ci-smoke
+          MODEL_DIR: ${{ runner.temp }}/skippy-ci-smoke-models
         run: scripts/skippy-ci-smoke.sh
+
+      - name: Save Skippy smoke model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.skippy_smoke_model_cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/skippy-ci-smoke-models
+          key: ${{ steps.skippy_smoke_model_cache.outputs.cache-primary-key }}
 
       - name: Protocol compatibility matrix
         if: ${{ needs.changes.outputs.all_rust == 'true' || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-protocol') }}

--- a/.github/workflows/hf-download-smoke.yml
+++ b/.github/workflows/hf-download-smoke.yml
@@ -48,5 +48,21 @@ jobs:
           cache-bin: "false"
           prefix-key: ${{ env.CACHE_NAMESPACE }}-rust-${{ hashFiles('.github/cache-version.txt') }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Restore Hugging Face download test model cache
+        id: hf_download_model_cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/mesh-llm-hf-download-cache
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-hf-download-smoke-models-${{ hashFiles('.github/cache-version.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-hf-download-smoke-models-
       - name: HuggingFace download integration tests
+        env:
+          MESH_HF_DOWNLOAD_TEST_CACHE_DIR: ${{ runner.temp }}/mesh-llm-hf-download-cache
         run: scripts/ci-hf-download-smoke.sh
+      - name: Save Hugging Face download test model cache
+        if: ${{ github.ref == 'refs/heads/main' && steps.hf_download_model_cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/mesh-llm-hf-download-cache
+          key: ${{ steps.hf_download_model_cache.outputs.cache-primary-key }}

--- a/.github/workflows/llama-upstream-canary.yml
+++ b/.github/workflows/llama-upstream-canary.yml
@@ -60,12 +60,30 @@ jobs:
         if: steps.sha.outputs.changed == 'true'
         run: cargo check -p skippy-ffi -p skippy-runtime -p skippy-server -p skippy-model-package -p skippy-correctness -p llama-spec-bench
 
+      - name: Restore Skippy smoke model cache
+        if: steps.sha.outputs.changed == 'true' && env.LLAMA_UPSTREAM_CANARY_SMOKE != '0' && env.LLAMA_UPSTREAM_CANARY_SMOKE != 'false'
+        id: skippy_smoke_model_cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/skippy-ci-smoke-models
+          key: mesh-llm-${{ runner.os }}-skippy-ci-smoke-models-SmolLM2-135M-Instruct.Q4_K_M.gguf-Falcon-H1-0.5B-Instruct-Q4_K_M.gguf-${{ hashFiles('.github/cache-version.txt') }}
+          restore-keys: |
+            mesh-llm-${{ runner.os }}-skippy-ci-smoke-models-
+
       - name: Skippy smoke tests
         if: steps.sha.outputs.changed == 'true' && env.LLAMA_UPSTREAM_CANARY_SMOKE != '0' && env.LLAMA_UPSTREAM_CANARY_SMOKE != 'false'
         timeout-minutes: 45
         env:
           WORK_DIR: ${{ runner.temp }}/skippy-ci-smoke
+          MODEL_DIR: ${{ runner.temp }}/skippy-ci-smoke-models
         run: scripts/skippy-ci-smoke.sh
+
+      - name: Save Skippy smoke model cache
+        if: steps.sha.outputs.changed == 'true' && env.LLAMA_UPSTREAM_CANARY_SMOKE != '0' && env.LLAMA_UPSTREAM_CANARY_SMOKE != 'false' && github.ref == 'refs/heads/main' && steps.skippy_smoke_model_cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/skippy-ci-smoke-models
+          key: ${{ steps.skippy_smoke_model_cache.outputs.cache-primary-key }}
 
       - name: Update llama.cpp upstream pin
         if: steps.sha.outputs.changed == 'true'

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -523,6 +523,16 @@ jobs:
         if: ${{ steps.llama_cache.outputs.cache-hit != 'true' }}
         run: scripts/build-llama.sh
 
+      - name: Restore Skippy smoke model cache
+        if: ${{ matrix.group == 'skippy-smoke' }}
+        id: skippy_smoke_model_cache
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}/skippy-ci-smoke-models
+          key: ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-skippy-ci-smoke-models-SmolLM2-135M-Instruct.Q4_K_M.gguf-Falcon-H1-0.5B-Instruct-Q4_K_M.gguf-${{ hashFiles('.github/cache-version.txt') }}
+          restore-keys: |
+            ${{ env.CACHE_NAMESPACE }}-${{ runner.os }}-skippy-ci-smoke-models-
+
       - name: SDK and API crate tests
         if: ${{ matrix.group == 'sdk-api' && (needs.changes.outputs.all_rust == 'true' || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-client') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-api-client') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-api-server') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-config') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-commands') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-events') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-hardware-profile') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-runtime-install') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-sdk') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-cli') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-tui') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-embedded-runtime') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-console-server') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-ffi') || contains(fromJson(needs.changes.outputs.affected_crates || '[]'), 'mesh-llm-nodejs')) }}
         run: |
@@ -596,7 +606,15 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HUGGING_FACE_HUB_TOKEN: ${{ secrets.HF_TOKEN }}
           WORK_DIR: ${{ runner.temp }}/skippy-ci-smoke
+          MODEL_DIR: ${{ runner.temp }}/skippy-ci-smoke-models
         run: scripts/skippy-ci-smoke.sh
+
+      - name: Save Skippy smoke model cache
+        if: ${{ matrix.group == 'skippy-smoke' && github.ref == 'refs/heads/main' && steps.skippy_smoke_model_cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}/skippy-ci-smoke-models
+          key: ${{ steps.skippy_smoke_model_cache.outputs.cache-primary-key }}
 
       - name: Show sccache stats
         if: ${{ always() }}

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -133,6 +133,13 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
 
 - Smoke jobs restore binaries through `.github/actions/restore-smoke-inputs` and
   reusable workflows instead of rebuilding `mesh-llm` or patched llama.cpp.
+- `restore-smoke-inputs` also owns the single-GGUF smoke model cache used by
+  inference, scripted two-node, and SDK smokes. The Skippy CI smoke lanes
+  restore a separate two-model cache for dense and recurrent GGUF fixtures, and
+  `hf-download-smoke.yml` points the Rust HF integration tests at a cached model
+  directory via `MESH_HF_DOWNLOAD_TEST_CACHE_DIR`.
+- Shared model caches are restored in PRs and saved only from trusted `main`
+  runs.
 - Linux CPU artifacts feed inference, two-node, native SDK, and Kotlin SDK
   smokes. macOS CPU artifacts feed Swift SDK smokes.
 - Artifact-consuming smokes are additionally gated on the matching CPU producer

--- a/crates/model-hf/tests/hf_download.rs
+++ b/crates/model-hf/tests/hf_download.rs
@@ -14,14 +14,27 @@
 
 use model_artifact::{ModelArtifactFile, ModelFormat, ModelRepository, resolve_model_artifact_ref};
 use model_hf::HfModelRepository;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// Build a repository pointed at a fresh temp cache directory.
+/// Build a repository pointed at a fresh temp cache directory by default.
+///
+/// CI can set MESH_HF_DOWNLOAD_TEST_CACHE_DIR to reuse the GitHub Actions
+/// model cache while still exercising the real Rust HF download path on misses.
 fn make_repo(tmp: &Path) -> HfModelRepository {
     HfModelRepository::builder()
-        .cache_dir(tmp.join("hf-cache"))
+        .cache_dir(test_cache_dir(tmp))
         .build()
         .expect("build HfModelRepository")
+}
+
+fn test_cache_dir(tmp: &Path) -> PathBuf {
+    if let Some(cache_dir) = std::env::var_os("MESH_HF_DOWNLOAD_TEST_CACHE_DIR") {
+        let cache_dir = PathBuf::from(cache_dir);
+        std::fs::create_dir_all(&cache_dir).expect("create MESH_HF_DOWNLOAD_TEST_CACHE_DIR");
+        cache_dir
+    } else {
+        tmp.join("hf-cache")
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -198,8 +211,8 @@ async fn resolve_artifact_ref_split_gguf() {
 /// Download the actual GGUF file via the Rust HF client and verify the result.
 ///
 /// Uses `jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF` (~100 MB). The same
-/// model is already cached in CI, and this test uses a dedicated temp cache
-/// directory so it always exercises the real download path.
+/// model is restored from the GitHub Actions cache in CI when available, and
+/// local runs keep using a dedicated temp cache by default.
 #[tokio::test]
 #[ignore]
 async fn download_single_gguf_file() {

--- a/scripts/skippy-ci-smoke.sh
+++ b/scripts/skippy-ci-smoke.sh
@@ -16,7 +16,7 @@ resolve_llama_build_dir() {
 LLAMA_BUILD_DIR="$(resolve_llama_build_dir)"
 WORK_DIR="${WORK_DIR:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/skippy-ci-smoke}"
 REPORT_DIR="${WORK_DIR}/reports"
-MODEL_DIR="${WORK_DIR}/models"
+MODEL_DIR="${MODEL_DIR:-${WORK_DIR}/models}"
 
 DENSE_MODEL_REPO="${DENSE_MODEL_REPO:-jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF}"
 DENSE_MODEL_FILE="${DENSE_MODEL_FILE:-SmolLM2-135M-Instruct.Q4_K_M.gguf}"
@@ -122,6 +122,12 @@ download_model() {
   local file="$2"
   local out_dir="$3"
   mkdir -p "$out_dir"
+  local cached_path="${out_dir}/${file}"
+  if [[ -s "$cached_path" ]]; then
+    echo "using cached ${repo}/${file} at ${cached_path}" >&2
+    printf '%s\n' "$cached_path"
+    return 0
+  fi
   echo "downloading ${repo}/${file}" >&2
   local output path
   output="$(run_with_timeout "download ${repo}/${file}" hf download "$repo" "$file" --local-dir "$out_dir")"

--- a/scripts/skippy-openai-smoke.sh
+++ b/scripts/skippy-openai-smoke.sh
@@ -9,6 +9,7 @@ MODEL_ID="${MODEL_ID:-${MODEL_REPO}:${MODEL_SELECTOR}}"
 MODEL_PATH="${MODEL_PATH:-}"
 TOKENIZER="${TOKENIZER:-HuggingFaceTB/SmolLM2-135M-Instruct}"
 WORK_DIR="${WORK_DIR:-/tmp/skippy-openai-smoke}"
+MODEL_CACHE_DIR="${MODEL_CACHE_DIR:-${WORK_DIR}/model}"
 HOST="${HOST:-127.0.0.1}"
 PORT="${PORT:-9337}"
 BASE_URL="http://${HOST}:${PORT}/v1"
@@ -49,14 +50,19 @@ if [[ ! -d "$LLAMA_BUILD_DIR" ]]; then
   exit 1
 fi
 
-mkdir -p "$WORK_DIR/model"
+mkdir -p "$MODEL_CACHE_DIR"
 
 if [[ -z "$MODEL_PATH" ]]; then
-  require_cmd hf
-  echo "downloading ${MODEL_REPO}/${MODEL_FILE} into ${WORK_DIR}/model"
-  MODEL_PATH="$(hf download "$MODEL_REPO" "$MODEL_FILE" --local-dir "$WORK_DIR/model" | sed -n 's/^path=//p' | tail -n 1)"
-  if [[ -z "$MODEL_PATH" ]]; then
-    MODEL_PATH="${WORK_DIR}/model/${MODEL_FILE}"
+  MODEL_PATH="${MODEL_CACHE_DIR}/${MODEL_FILE}"
+  if [[ -s "$MODEL_PATH" ]]; then
+    echo "using cached ${MODEL_REPO}/${MODEL_FILE} at ${MODEL_PATH}"
+  else
+    require_cmd hf
+    echo "downloading ${MODEL_REPO}/${MODEL_FILE} into ${MODEL_CACHE_DIR}"
+    MODEL_PATH="$(hf download "$MODEL_REPO" "$MODEL_FILE" --local-dir "$MODEL_CACHE_DIR" | sed -n 's/^path=//p' | tail -n 1)"
+    if [[ -z "$MODEL_PATH" ]]; then
+      MODEL_PATH="${MODEL_CACHE_DIR}/${MODEL_FILE}"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Summary
- Restore and save GitHub Actions caches for HF model files used by Skippy smoke lanes.
- Cache the Rust HF download integration test directory in CI while keeping local runs isolated by default.
- Teach Skippy smoke scripts to reuse pre-restored model files before downloading from Hugging Face.
- Document the CI model-cache contract.

## Validation
- YAML parse for all workflows/actions
- Duplicate workflow step ID check
- PR-trigger policy check
- `bash -n scripts/skippy-ci-smoke.sh scripts/skippy-openai-smoke.sh scripts/ci-hf-download-smoke.sh`
- `GIT_MASTER=1 git diff --check`
- `cargo run -p xtask -- repo-consistency release-targets`
- `cargo test -p model-hf --test hf_download -- --list`
- `cargo fmt --all -- --check`
- `cargo check -p model-hf`
- `cargo clippy -p model-hf --all-targets -- -D warnings`

## Notes
- The ignored live HF download tests were compiled/listed locally, not executed, to avoid local network model downloads.
- Shared model caches restore in PRs and save only from trusted `main` runs.