### PR TITLE
Reduce Skippy decode hot-path overhead (3/3)

### DIFF
--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -425,38 +425,40 @@ fn handle_binary_connection(
         let message_started = Instant::now();
         let session_id = binary_message_session_id(connection_session_id, &message);
         let session_key = session_id.to_string();
-        let mut recv_attrs = binary_message_attrs(config, session_id, &message);
-        recv_attrs.insert(
-            "llama_stage.recv_start_unix_nanos".to_string(),
-            json!(recv_start_unix_nanos),
-        );
-        recv_attrs.insert(
-            "llama_stage.recv_end_unix_nanos".to_string(),
-            json!(recv_end_unix_nanos),
-        );
-        recv_attrs.insert("llama_stage.recv_read_ms".to_string(), json!(recv_read_ms));
-        recv_attrs.insert(
-            "llama_stage.source_stage_index".to_string(),
-            json!(message.state.source_stage_index),
-        );
-        recv_attrs.insert(
-            "llama_stage.configured_upstream_stage_index".to_string(),
-            json!(config.upstream.as_ref().map(|peer| peer.stage_index)),
-        );
-        recv_attrs.insert(
-            "llama_stage.message_wire_bytes".to_string(),
-            json!(estimated_stage_message_wire_bytes(&message)),
-        );
-        recv_attrs.insert(
-            "skippy.activation_bytes".to_string(),
-            json!(message.activation.len()),
-        );
-        telemetry.emit_debug_span(
-            "stage.binary_recv",
-            recv_attrs,
-            recv_start_unix_nanos,
-            recv_end_unix_nanos,
-        );
+        if telemetry.is_debug_enabled() {
+            let mut recv_attrs = binary_message_attrs(config, session_id, &message);
+            recv_attrs.insert(
+                "llama_stage.recv_start_unix_nanos".to_string(),
+                json!(recv_start_unix_nanos),
+            );
+            recv_attrs.insert(
+                "llama_stage.recv_end_unix_nanos".to_string(),
+                json!(recv_end_unix_nanos),
+            );
+            recv_attrs.insert("llama_stage.recv_read_ms".to_string(), json!(recv_read_ms));
+            recv_attrs.insert(
+                "llama_stage.source_stage_index".to_string(),
+                json!(message.state.source_stage_index),
+            );
+            recv_attrs.insert(
+                "llama_stage.configured_upstream_stage_index".to_string(),
+                json!(config.upstream.as_ref().map(|peer| peer.stage_index)),
+            );
+            recv_attrs.insert(
+                "llama_stage.message_wire_bytes".to_string(),
+                json!(estimated_stage_message_wire_bytes(&message)),
+            );
+            recv_attrs.insert(
+                "skippy.activation_bytes".to_string(),
+                json!(message.activation.len()),
+            );
+            telemetry.emit_debug_span(
+                "stage.binary_recv",
+                recv_attrs,
+                recv_start_unix_nanos,
+                recv_end_unix_nanos,
+            );
+        }
 
         if message.kind == WireMessageKind::Stop {
             if pending_prefill_replies != 0 {
@@ -908,6 +910,11 @@ fn handle_binary_connection(
                     executable_token_ids,
                     input.as_ref(),
                     message.kind == WireMessageKind::PrefillFinalEmbd && downstream.is_none(),
+                    stage_output_activation_capacity(
+                        config,
+                        message.token_count,
+                        activation_width,
+                    )?,
                 )
                 .context("execute binary stage message")?;
                 runtime_sessions_after = Some(runtime.session_stats());
@@ -918,63 +925,65 @@ fn handle_binary_connection(
             compute_end_unix_nanos = now_unix_nanos() as u64;
             (result.0, result.1, result.2, compute_ms)
         };
-        let mut decode_attrs = binary_message_attrs(config, session_id, &message);
-        decode_attrs.insert(
-            "skippy.output_activation_bytes".to_string(),
-            json!(output.payload.len()),
-        );
-        decode_attrs.insert("skippy.compute_ms".to_string(), json!(compute_ms));
-        decode_attrs.insert(
-            "llama_stage.input_activation_decode_ms".to_string(),
-            json!(input_activation_decode_ms),
-        );
-        decode_attrs.insert(
-            "llama_stage.runtime_lock_wait_ms".to_string(),
-            json!(runtime_lock_wait_ms),
-        );
-        decode_attrs.insert(
-            "llama_stage.runtime_lock_hold_ms".to_string(),
-            json!(runtime_lock_hold_ms),
-        );
-        decode_attrs.insert(
-            "llama_stage.runtime_lock_acquires".to_string(),
-            json!(runtime_lock_acquires),
-        );
-        if let Some(stats) = runtime_sessions_before.as_ref() {
-            insert_runtime_session_stats(
-                &mut decode_attrs,
-                "llama_stage.runtime_sessions_before",
-                stats,
+        if telemetry.is_debug_enabled() {
+            let mut decode_attrs = binary_message_attrs(config, session_id, &message);
+            decode_attrs.insert(
+                "skippy.output_activation_bytes".to_string(),
+                json!(output.payload.len()),
+            );
+            decode_attrs.insert("skippy.compute_ms".to_string(), json!(compute_ms));
+            decode_attrs.insert(
+                "llama_stage.input_activation_decode_ms".to_string(),
+                json!(input_activation_decode_ms),
+            );
+            decode_attrs.insert(
+                "llama_stage.runtime_lock_wait_ms".to_string(),
+                json!(runtime_lock_wait_ms),
+            );
+            decode_attrs.insert(
+                "llama_stage.runtime_lock_hold_ms".to_string(),
+                json!(runtime_lock_hold_ms),
+            );
+            decode_attrs.insert(
+                "llama_stage.runtime_lock_acquires".to_string(),
+                json!(runtime_lock_acquires),
+            );
+            if let Some(stats) = runtime_sessions_before.as_ref() {
+                insert_runtime_session_stats(
+                    &mut decode_attrs,
+                    "llama_stage.runtime_sessions_before",
+                    stats,
+                );
+            }
+            if let Some(stats) = runtime_sessions_after.as_ref() {
+                insert_runtime_session_stats(
+                    &mut decode_attrs,
+                    "llama_stage.runtime_sessions_after",
+                    stats,
+                );
+            }
+            if let Some(eviction) = proactive_eviction.as_ref() {
+                eviction.insert_attrs(&mut decode_attrs);
+            }
+            decode_attrs.insert(
+                "skippy.kv.restored_prefill".to_string(),
+                json!(restored_prefill),
+            );
+            decode_attrs.insert(
+                "llama_stage.compute_start_unix_nanos".to_string(),
+                json!(compute_start_unix_nanos),
+            );
+            decode_attrs.insert(
+                "llama_stage.compute_end_unix_nanos".to_string(),
+                json!(compute_end_unix_nanos),
+            );
+            telemetry.emit_debug_span(
+                "stage.binary_llama_decode",
+                decode_attrs,
+                compute_start_unix_nanos,
+                compute_end_unix_nanos,
             );
         }
-        if let Some(stats) = runtime_sessions_after.as_ref() {
-            insert_runtime_session_stats(
-                &mut decode_attrs,
-                "llama_stage.runtime_sessions_after",
-                stats,
-            );
-        }
-        if let Some(eviction) = proactive_eviction.as_ref() {
-            eviction.insert_attrs(&mut decode_attrs);
-        }
-        decode_attrs.insert(
-            "skippy.kv.restored_prefill".to_string(),
-            json!(restored_prefill),
-        );
-        decode_attrs.insert(
-            "llama_stage.compute_start_unix_nanos".to_string(),
-            json!(compute_start_unix_nanos),
-        );
-        decode_attrs.insert(
-            "llama_stage.compute_end_unix_nanos".to_string(),
-            json!(compute_end_unix_nanos),
-        );
-        telemetry.emit_debug_span(
-            "stage.binary_llama_decode",
-            decode_attrs,
-            compute_start_unix_nanos,
-            compute_end_unix_nanos,
-        );
         if let Some(eviction) = proactive_eviction {
             telemetry.emit("stage.binary_kv_record_decision", eviction.attrs());
         }
@@ -1085,28 +1094,33 @@ fn handle_binary_connection(
             )?;
             forward_activation_encode_ms += forwarded.activation_encode_ms;
             forward_activation_bytes = forwarded.message.activation.len();
-            let mut downstream_write_attrs = binary_message_attrs(config, session_id, &message);
-            downstream_write_attrs.insert(
-                "llama_stage.forward_activation_bytes".to_string(),
-                json!(forward_activation_bytes),
-            );
-            downstream_write_attrs.insert(
-                "llama_stage.activation_encode_ms".to_string(),
-                json!(forwarded.activation_encode_ms),
-            );
-            downstream_write_attrs.insert(
-                "llama_stage.output_activation_bytes".to_string(),
-                json!(output.payload.len()),
-            );
+            let mut downstream_write_attrs = BTreeMap::new();
+            if telemetry.is_debug_enabled() {
+                downstream_write_attrs = binary_message_attrs(config, session_id, &message);
+                downstream_write_attrs.insert(
+                    "llama_stage.forward_activation_bytes".to_string(),
+                    json!(forward_activation_bytes),
+                );
+                downstream_write_attrs.insert(
+                    "llama_stage.activation_encode_ms".to_string(),
+                    json!(forwarded.activation_encode_ms),
+                );
+                downstream_write_attrs.insert(
+                    "llama_stage.output_activation_bytes".to_string(),
+                    json!(output.payload.len()),
+                );
+            }
             let forward_start_unix_nanos = now_unix_nanos() as u64;
             forward_write_start_unix_nanos = Some(forward_start_unix_nanos);
             let forward_started = Instant::now();
             if async_prefill_forward && early_prefill_ack && max_deferred_prefill_replies > 0 {
                 forward_mode = "async_enqueue";
-                downstream_write_attrs.insert(
-                    "llama_stage.forward_mode".to_string(),
-                    json!("async_writer"),
-                );
+                if telemetry.is_debug_enabled() {
+                    downstream_write_attrs.insert(
+                        "llama_stage.forward_mode".to_string(),
+                        json!("async_writer"),
+                    );
+                }
                 let forwarder = async_forwarder
                     .as_mut()
                     .context("missing async activation forwarder")?;
@@ -1120,8 +1134,10 @@ fn handle_binary_connection(
                     .context("queue async activation frame downstream")?;
             } else {
                 forward_mode = "sync_write";
-                downstream_write_attrs
-                    .insert("llama_stage.forward_mode".to_string(), json!("sync_write"));
+                if telemetry.is_debug_enabled() {
+                    downstream_write_attrs
+                        .insert("llama_stage.forward_mode".to_string(), json!("sync_write"));
+                }
                 if let Some(forwarder) = async_forwarder.as_mut() {
                     forwarder.flush().context("flush async activation frames")?;
                 }
@@ -1135,16 +1151,18 @@ fn handle_binary_connection(
                 )
                 .context("forward activation frame downstream")?;
                 let downstream_write_end_unix_nanos = now_unix_nanos() as u64;
-                downstream_write_attrs.insert(
-                    "llama_stage.forward_write_ms".to_string(),
-                    json!(elapsed_ms(downstream_write_started)),
-                );
-                telemetry.emit_debug_span(
-                    "stage.binary_downstream_write",
-                    downstream_write_attrs,
-                    downstream_write_start_unix_nanos,
-                    downstream_write_end_unix_nanos,
-                );
+                if telemetry.is_debug_enabled() {
+                    downstream_write_attrs.insert(
+                        "llama_stage.forward_write_ms".to_string(),
+                        json!(elapsed_ms(downstream_write_started)),
+                    );
+                    telemetry.emit_debug_span(
+                        "stage.binary_downstream_write",
+                        downstream_write_attrs,
+                        downstream_write_start_unix_nanos,
+                        downstream_write_end_unix_nanos,
+                    );
+                }
             }
             forward_write_end_unix_nanos = Some(now_unix_nanos() as u64);
             forward_write_ms += elapsed_ms(forward_started);
@@ -1369,148 +1387,150 @@ fn handle_binary_connection(
             deferred_prefill_replies_drained,
         });
 
-        let mut timing_attrs = binary_message_attrs(config, session_id, &message);
-        timing_attrs.insert(
-            "llama_stage.message_start_unix_nanos".to_string(),
-            json!(message_start_unix_nanos),
-        );
-        timing_attrs.insert(
-            "llama_stage.message_end_unix_nanos".to_string(),
-            json!(message_end_unix_nanos),
-        );
-        timing_attrs.insert(
-            "llama_stage.compute_start_unix_nanos".to_string(),
-            json!(compute_start_unix_nanos),
-        );
-        timing_attrs.insert(
-            "llama_stage.compute_end_unix_nanos".to_string(),
-            json!(compute_end_unix_nanos),
-        );
-        timing_attrs.insert("llama_stage.compute_ms".to_string(), json!(compute_ms));
-        timing_attrs.insert(
-            "llama_stage.input_activation_decode_ms".to_string(),
-            json!(input_activation_decode_ms),
-        );
-        timing_attrs.insert(
-            "llama_stage.runtime_lock_wait_ms".to_string(),
-            json!(runtime_lock_wait_ms),
-        );
-        timing_attrs.insert(
-            "llama_stage.runtime_lock_hold_ms".to_string(),
-            json!(runtime_lock_hold_ms),
-        );
-        timing_attrs.insert(
-            "llama_stage.runtime_lock_acquires".to_string(),
-            json!(runtime_lock_acquires),
-        );
-        if let Some(stats) = runtime_sessions_before.as_ref() {
-            insert_runtime_session_stats(
+        if telemetry.is_debug_enabled() {
+            let mut timing_attrs = binary_message_attrs(config, session_id, &message);
+            timing_attrs.insert(
+                "llama_stage.message_start_unix_nanos".to_string(),
+                json!(message_start_unix_nanos),
+            );
+            timing_attrs.insert(
+                "llama_stage.message_end_unix_nanos".to_string(),
+                json!(message_end_unix_nanos),
+            );
+            timing_attrs.insert(
+                "llama_stage.compute_start_unix_nanos".to_string(),
+                json!(compute_start_unix_nanos),
+            );
+            timing_attrs.insert(
+                "llama_stage.compute_end_unix_nanos".to_string(),
+                json!(compute_end_unix_nanos),
+            );
+            timing_attrs.insert("llama_stage.compute_ms".to_string(), json!(compute_ms));
+            timing_attrs.insert(
+                "llama_stage.input_activation_decode_ms".to_string(),
+                json!(input_activation_decode_ms),
+            );
+            timing_attrs.insert(
+                "llama_stage.runtime_lock_wait_ms".to_string(),
+                json!(runtime_lock_wait_ms),
+            );
+            timing_attrs.insert(
+                "llama_stage.runtime_lock_hold_ms".to_string(),
+                json!(runtime_lock_hold_ms),
+            );
+            timing_attrs.insert(
+                "llama_stage.runtime_lock_acquires".to_string(),
+                json!(runtime_lock_acquires),
+            );
+            if let Some(stats) = runtime_sessions_before.as_ref() {
+                insert_runtime_session_stats(
+                    &mut timing_attrs,
+                    "llama_stage.runtime_sessions_before",
+                    stats,
+                );
+            }
+            if let Some(stats) = runtime_sessions_after.as_ref() {
+                insert_runtime_session_stats(
+                    &mut timing_attrs,
+                    "llama_stage.runtime_sessions_after",
+                    stats,
+                );
+            }
+            timing_attrs.insert(
+                "llama_stage.forward_write_ms".to_string(),
+                json!(forward_write_ms),
+            );
+            timing_attrs.insert(
+                "llama_stage.activation_encode_ms".to_string(),
+                json!(forward_activation_encode_ms),
+            );
+            timing_attrs.insert(
+                "llama_stage.downstream_wait_ms".to_string(),
+                json!(downstream_wait_ms),
+            );
+            timing_attrs.insert("skippy.compute_ms".to_string(), json!(compute_ms));
+            timing_attrs.insert(
+                "skippy.forward_write_ms".to_string(),
+                json!(forward_write_ms),
+            );
+            timing_attrs.insert(
+                "skippy.downstream_wait_ms".to_string(),
+                json!(downstream_wait_ms),
+            );
+            timing_attrs.insert(
+                "skippy.upstream_reply_ms".to_string(),
+                json!(upstream_reply_ms),
+            );
+            timing_attrs.insert("llama_stage.forward_mode".to_string(), json!(forward_mode));
+            insert_optional_unix_nanos(
                 &mut timing_attrs,
-                "llama_stage.runtime_sessions_before",
-                stats,
+                "llama_stage.forward_write_start_unix_nanos",
+                forward_write_start_unix_nanos,
+            );
+            insert_optional_unix_nanos(
+                &mut timing_attrs,
+                "llama_stage.forward_write_end_unix_nanos",
+                forward_write_end_unix_nanos,
+            );
+            insert_optional_unix_nanos(
+                &mut timing_attrs,
+                "llama_stage.downstream_wait_start_unix_nanos",
+                downstream_wait_start_unix_nanos,
+            );
+            insert_optional_unix_nanos(
+                &mut timing_attrs,
+                "llama_stage.downstream_wait_end_unix_nanos",
+                downstream_wait_end_unix_nanos,
+            );
+            insert_optional_unix_nanos(
+                &mut timing_attrs,
+                "llama_stage.upstream_reply_start_unix_nanos",
+                upstream_reply_start_unix_nanos,
+            );
+            insert_optional_unix_nanos(
+                &mut timing_attrs,
+                "llama_stage.upstream_reply_end_unix_nanos",
+                upstream_reply_end_unix_nanos,
+            );
+            timing_attrs.insert(
+                "skippy.message_elapsed_ms".to_string(),
+                json!(message_elapsed_ms),
+            );
+            timing_attrs.insert(
+                "skippy.input_activation_bytes".to_string(),
+                json!(input_activation_bytes),
+            );
+            timing_attrs.insert(
+                "skippy.output_activation_bytes".to_string(),
+                json!(output.payload.len()),
+            );
+            timing_attrs.insert(
+                "skippy.prefill_credit_limit".to_string(),
+                json!(max_deferred_prefill_replies),
+            );
+            timing_attrs.insert(
+                "skippy.prefill_pending_replies_before".to_string(),
+                json!(pending_prefill_replies_before),
+            );
+            timing_attrs.insert(
+                "skippy.prefill_pending_replies_after".to_string(),
+                json!(pending_prefill_replies),
+            );
+            timing_attrs.insert(
+                "skippy.prefill_credit_wait_count".to_string(),
+                json!(credit_wait_count),
+            );
+            timing_attrs.insert(
+                "skippy.prefill_deferred_replies_drained".to_string(),
+                json!(deferred_prefill_replies_drained),
+            );
+            telemetry.emit_debug_span(
+                "stage.binary_message_timing",
+                timing_attrs,
+                message_start_unix_nanos,
+                message_end_unix_nanos,
             );
         }
-        if let Some(stats) = runtime_sessions_after.as_ref() {
-            insert_runtime_session_stats(
-                &mut timing_attrs,
-                "llama_stage.runtime_sessions_after",
-                stats,
-            );
-        }
-        timing_attrs.insert(
-            "llama_stage.forward_write_ms".to_string(),
-            json!(forward_write_ms),
-        );
-        timing_attrs.insert(
-            "llama_stage.activation_encode_ms".to_string(),
-            json!(forward_activation_encode_ms),
-        );
-        timing_attrs.insert(
-            "llama_stage.downstream_wait_ms".to_string(),
-            json!(downstream_wait_ms),
-        );
-        timing_attrs.insert("skippy.compute_ms".to_string(), json!(compute_ms));
-        timing_attrs.insert(
-            "skippy.forward_write_ms".to_string(),
-            json!(forward_write_ms),
-        );
-        timing_attrs.insert(
-            "skippy.downstream_wait_ms".to_string(),
-            json!(downstream_wait_ms),
-        );
-        timing_attrs.insert(
-            "skippy.upstream_reply_ms".to_string(),
-            json!(upstream_reply_ms),
-        );
-        timing_attrs.insert("llama_stage.forward_mode".to_string(), json!(forward_mode));
-        insert_optional_unix_nanos(
-            &mut timing_attrs,
-            "llama_stage.forward_write_start_unix_nanos",
-            forward_write_start_unix_nanos,
-        );
-        insert_optional_unix_nanos(
-            &mut timing_attrs,
-            "llama_stage.forward_write_end_unix_nanos",
-            forward_write_end_unix_nanos,
-        );
-        insert_optional_unix_nanos(
-            &mut timing_attrs,
-            "llama_stage.downstream_wait_start_unix_nanos",
-            downstream_wait_start_unix_nanos,
-        );
-        insert_optional_unix_nanos(
-            &mut timing_attrs,
-            "llama_stage.downstream_wait_end_unix_nanos",
-            downstream_wait_end_unix_nanos,
-        );
-        insert_optional_unix_nanos(
-            &mut timing_attrs,
-            "llama_stage.upstream_reply_start_unix_nanos",
-            upstream_reply_start_unix_nanos,
-        );
-        insert_optional_unix_nanos(
-            &mut timing_attrs,
-            "llama_stage.upstream_reply_end_unix_nanos",
-            upstream_reply_end_unix_nanos,
-        );
-        timing_attrs.insert(
-            "skippy.message_elapsed_ms".to_string(),
-            json!(message_elapsed_ms),
-        );
-        timing_attrs.insert(
-            "skippy.input_activation_bytes".to_string(),
-            json!(input_activation_bytes),
-        );
-        timing_attrs.insert(
-            "skippy.output_activation_bytes".to_string(),
-            json!(output.payload.len()),
-        );
-        timing_attrs.insert(
-            "skippy.prefill_credit_limit".to_string(),
-            json!(max_deferred_prefill_replies),
-        );
-        timing_attrs.insert(
-            "skippy.prefill_pending_replies_before".to_string(),
-            json!(pending_prefill_replies_before),
-        );
-        timing_attrs.insert(
-            "skippy.prefill_pending_replies_after".to_string(),
-            json!(pending_prefill_replies),
-        );
-        timing_attrs.insert(
-            "skippy.prefill_credit_wait_count".to_string(),
-            json!(credit_wait_count),
-        );
-        timing_attrs.insert(
-            "skippy.prefill_deferred_replies_drained".to_string(),
-            json!(deferred_prefill_replies_drained),
-        );
-        telemetry.emit_debug_span(
-            "stage.binary_message_timing",
-            timing_attrs,
-            message_start_unix_nanos,
-            message_end_unix_nanos,
-        );
     }
 }
 
@@ -1542,6 +1562,22 @@ fn estimated_stage_message_wire_bytes(message: &StageWireMessage) -> usize {
     };
 
     STAGE_WIRE_FIXED_HEADER_BYTES + sampling_bytes + chat_metadata_bytes + payload_bytes
+}
+
+pub(crate) fn stage_output_activation_capacity(
+    config: &StageConfig,
+    token_count: i32,
+    activation_width: i32,
+) -> Result<usize> {
+    if config.downstream.is_none() || token_count <= 0 {
+        return Ok(0);
+    }
+    skippy_protocol::binary::activation_wire_bytes(
+        WireActivationDType::F32,
+        token_count,
+        activation_width,
+    )
+    .context("estimate output activation capacity")
 }
 
 fn estimated_reply_wire_bytes(reply_kind: WireReplyKind, predicted_token_count: usize) -> usize {
@@ -2135,6 +2171,7 @@ fn handle_binary_restore_prefill_decode_control(
             &[current_token],
             input.as_ref(),
             downstream.is_none(),
+            stage_output_activation_capacity(config, decode_message.token_count, activation_width)?,
         )
         .context("execute restore-decode stage message")?;
         (
@@ -3247,6 +3284,7 @@ pub(crate) fn run_binary_stage_message(
     token_ids: &[i32],
     input: Option<&ActivationFrame>,
     sample_final_prefill: bool,
+    output_capacity: usize,
 ) -> Result<(i32, Vec<i32>, ActivationFrame)> {
     match message.kind {
         WireMessageKind::PrefillEmbd => {
@@ -3288,12 +3326,18 @@ pub(crate) fn run_binary_stage_message(
                 .copied()
                 .unwrap_or(message.state.current_token);
             let sampling = runtime_sampling_config(message.sampling.as_ref());
-            let (predicted, output) =
-                runtime.decode_frame_sampled(session_id, token_id, sampling.as_ref(), input)?;
+            let (predicted, output) = runtime.decode_frame_sampled(
+                session_id,
+                token_id,
+                sampling.as_ref(),
+                input,
+                output_capacity,
+            )?;
             Ok((predicted, Vec::new(), output))
         }
         WireMessageKind::VerifySpan => {
-            let (predicted_tokens, output) = runtime.verify_frame(session_id, token_ids, input)?;
+            let (predicted_tokens, output) =
+                runtime.verify_frame(session_id, token_ids, input, output_capacity)?;
             let predicted = predicted_tokens.first().copied().unwrap_or(0);
             Ok((predicted, predicted_tokens, output))
         }

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -59,7 +59,7 @@ use crate::{
     binary_transport::{
         PredictionReturnHub, PredictionReturnReceiver, WireCondition, connect_binary_downstream,
         forwarded_stage_message, forwarded_stage_message_timed, run_binary_stage_message,
-        write_stage_message_conditioned,
+        stage_output_activation_capacity, write_stage_message_conditioned,
     },
     cli::ServeOpenAiArgs,
     config::{load_json, validate_config},

--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -42,6 +42,12 @@ impl StageOpenAiBackend {
                 token_ids,
                 None,
                 false,
+                stage_output_activation_capacity(
+                    request.config,
+                    message.token_count,
+                    request.activation_width,
+                )
+                .map_err(openai_backend_error)?,
             )
             .map_err(openai_backend_error)?
             .2;

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -599,6 +599,17 @@ impl StageOpenAiBackend {
                 .expect("checked non-empty prompt");
             let mut context_tokens = request.prompt_token_ids.to_vec();
             let mut exact_replay_tokens = Vec::new();
+            let mut decode_message = ReusableDecodeMessage::new(
+                request.wire_dtype,
+                ReusableDecodeMessageArgs {
+                    request_id,
+                    session_id,
+                    prompt_token_count: request.prompt_token_ids.len(),
+                    base_pos_start: prefill_token_count,
+                    sampling: wire_sampling.clone(),
+                    sideband_capacity: skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES,
+                },
+            )?;
             let mut fused_reached_stop = false;
             if let Some(fused) = fused_first_decode.take() {
                 current = fused.predicted;
@@ -1088,34 +1099,25 @@ impl StageOpenAiBackend {
                         continue;
                     }
                 }
-                let mut state =
-                    StageStateHeader::new(WireMessageKind::DecodeEmbd, request.wire_dtype);
-                state.seq_id = 0;
-                state.prompt_token_count = i32::try_from(request.prompt_token_ids.len())
-                    .map_err(|_| OpenAiError::backend("prompt token count exceeds i32"))?;
-                state.decode_step = i32::try_from(decode_step)
-                    .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
-                state.current_token = current;
-                state.source_stage_index = -1;
-                let message_tokens = decode_sideband_tokens(&context_tokens, current);
-                let records_replay_checkpoint =
-                    message_tokens.len() == context_tokens.len() && message_tokens.len() > 1;
-                let records_full_prompt_checkpoint =
-                    decode_step == 0 && message_tokens.len() == request.prompt_token_ids.len();
-                let message = StageWireMessage {
-                    kind: WireMessageKind::DecodeEmbd,
-                    pos_start: i32::try_from(prefill_token_count + decode_step as usize)
-                        .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?,
-                    token_count: 1,
-                    state,
-                    request_id,
-                    session_id,
-                    sampling: wire_sampling.clone(),
-                    chat_sampling_metadata: None,
-                    tokens: message_tokens,
-                    positions: Vec::new(),
-                    activation: Vec::new(),
-                    raw_bytes: Vec::new(),
+                let uses_context_sideband = decode_uses_context_sideband(
+                    &context_tokens,
+                    current,
+                    skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES,
+                );
+                let records_replay_checkpoint = uses_context_sideband && context_tokens.len() > 1;
+                let records_full_prompt_checkpoint = decode_step == 0
+                    && uses_context_sideband
+                    && context_tokens.len() == request.prompt_token_ids.len();
+                let decode_step_index = usize::try_from(decode_step)
+                    .map_err(|_| OpenAiError::backend("decode step exceeds usize"))?;
+                let message = if uses_context_sideband {
+                    decode_message.update_with_tokens(
+                        decode_step_index,
+                        current,
+                        &context_tokens,
+                    )?
+                } else {
+                    decode_message.update(decode_step_index, current)?
                 };
                 let stage0_timer = PhaseTimer::start();
                 let token_runtime_lock_wait_ms;
@@ -1137,7 +1139,7 @@ impl StageOpenAiBackend {
                     let output = run_binary_stage_message(
                         &mut runtime,
                         &session_key,
-                        &message,
+                        message,
                         &[current],
                         None,
                         false,
@@ -1161,7 +1163,7 @@ impl StageOpenAiBackend {
                 decode_stage0_compute_ms += stage0_compute_ms;
                 let forwarded = forwarded_stage_message_timed(
                     request.config,
-                    &message,
+                    message,
                     &output,
                     request.wire_dtype,
                     request.activation_width,
@@ -1398,11 +1400,11 @@ impl StageOpenAiBackend {
     }
 }
 
-fn decode_sideband_tokens(context_token_ids: &[i32], current: i32) -> Vec<i32> {
-    if context_token_ids.len() <= skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES
+fn decode_uses_context_sideband(
+    context_token_ids: &[i32],
+    current: i32,
+    sideband_capacity: usize,
+) -> bool {
+    context_token_ids.len() <= sideband_capacity
         && context_token_ids.last().copied() == Some(current)
-    {
-        return context_token_ids.to_vec();
-    }
-    vec![current]
 }

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -221,6 +221,7 @@ impl StageOpenAiBackend {
                                 chunk,
                                 None,
                                 false,
+                                0,
                             )
                             .map_err(openai_backend_error)?
                             .2;
@@ -621,95 +622,98 @@ impl StageOpenAiBackend {
                     current = token;
                     exact_replay_tokens.push(current);
                     context_tokens.push(current);
-                    let mut token_attrs = self.openai_attrs(request.ids);
-                    token_attrs.insert("llama_stage.decode_step".to_string(), json!(index));
-                    token_attrs.insert(
-                        "llama_stage.decode_token_phase".to_string(),
-                        json!(fused.token_phase),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.message_kind".to_string(),
-                        json!(fused.message_kind),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.elapsed_ms".to_string(),
-                        json!(if index == 0 { fused.elapsed_ms } else { 0.0 }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.cached_replay_token_index".to_string(),
-                        json!(index),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.cached_replay_token_count".to_string(),
-                        json!(fused.predicted_tokens.len()),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.stage0_compute_ms".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.stage0_compute_ms
-                        } else {
-                            0.0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.runtime_lock_wait_ms".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.runtime_lock_wait_ms
-                        } else {
-                            0.0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.runtime_lock_hold_ms".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.runtime_lock_hold_ms
-                        } else {
-                            0.0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.output_activation_bytes".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.output_activation_bytes
-                        } else {
-                            0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.forward_activation_bytes".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.forward_activation_bytes
-                        } else {
-                            0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.activation_encode_ms".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.activation_encode_ms
-                        } else {
-                            0.0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.forward_write_ms".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.forward_write_ms
-                        } else {
-                            0.0
-                        }),
-                    );
-                    token_attrs.insert(
-                        "llama_stage.downstream_wait_ms".to_string(),
-                        json!(if index == 0 {
-                            fused.execution.downstream_wait_ms
-                        } else {
-                            0.0
-                        }),
-                    );
-                    token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
-                    self.telemetry
-                        .emit_debug("stage.openai_decode_token", token_attrs);
+                    if self.telemetry.is_debug_enabled() {
+                        let mut token_attrs = self.openai_attrs(request.ids);
+                        token_attrs.insert("llama_stage.decode_step".to_string(), json!(index));
+                        token_attrs.insert(
+                            "llama_stage.decode_token_phase".to_string(),
+                            json!(fused.token_phase),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.message_kind".to_string(),
+                            json!(fused.message_kind),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.elapsed_ms".to_string(),
+                            json!(if index == 0 { fused.elapsed_ms } else { 0.0 }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.cached_replay_token_index".to_string(),
+                            json!(index),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.cached_replay_token_count".to_string(),
+                            json!(fused.predicted_tokens.len()),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.stage0_compute_ms".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.stage0_compute_ms
+                            } else {
+                                0.0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.runtime_lock_wait_ms".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.runtime_lock_wait_ms
+                            } else {
+                                0.0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.runtime_lock_hold_ms".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.runtime_lock_hold_ms
+                            } else {
+                                0.0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.output_activation_bytes".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.output_activation_bytes
+                            } else {
+                                0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.forward_activation_bytes".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.forward_activation_bytes
+                            } else {
+                                0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.activation_encode_ms".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.activation_encode_ms
+                            } else {
+                                0.0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.forward_write_ms".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.forward_write_ms
+                            } else {
+                                0.0
+                            }),
+                        );
+                        token_attrs.insert(
+                            "llama_stage.downstream_wait_ms".to_string(),
+                            json!(if index == 0 {
+                                fused.execution.downstream_wait_ms
+                            } else {
+                                0.0
+                            }),
+                        );
+                        token_attrs
+                            .insert("llama_stage.predicted_token".to_string(), json!(current));
+                        self.telemetry
+                            .emit_debug("stage.openai_decode_token", token_attrs);
+                    }
                     if on_token(current)? == TokenControl::Stop {
                         fused_reached_stop = true;
                         break;
@@ -1137,6 +1141,12 @@ impl StageOpenAiBackend {
                         &[current],
                         None,
                         false,
+                        stage_output_activation_capacity(
+                            request.config,
+                            message.token_count,
+                            request.activation_width,
+                        )
+                        .map_err(openai_backend_error)?,
                     )
                     .map_err(openai_backend_error)?
                     .2;
@@ -1210,47 +1220,49 @@ impl StageOpenAiBackend {
                 decoded_tokens += 1;
                 exact_replay_tokens.push(current);
                 context_tokens.push(current);
-                let mut token_attrs = self.openai_attrs(request.ids);
-                token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
-                token_attrs.insert(
-                    "llama_stage.decode_token_phase".to_string(),
-                    json!(decode_token_phase(decode_step)),
-                );
-                token_attrs.insert(
-                    "llama_stage.stage0_compute_ms".to_string(),
-                    json!(stage0_compute_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.runtime_lock_wait_ms".to_string(),
-                    json!(token_runtime_lock_wait_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.runtime_lock_hold_ms".to_string(),
-                    json!(token_runtime_lock_hold_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.output_activation_bytes".to_string(),
-                    json!(output.payload.len()),
-                );
-                token_attrs.insert(
-                    "llama_stage.forward_activation_bytes".to_string(),
-                    json!(forwarded.message.activation.len()),
-                );
-                token_attrs.insert(
-                    "llama_stage.activation_encode_ms".to_string(),
-                    json!(forwarded.activation_encode_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.forward_write_ms".to_string(),
-                    json!(forward_write_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.downstream_wait_ms".to_string(),
-                    json!(downstream_wait_ms),
-                );
-                token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
-                token_attrs.insert("llama_stage.message_kind".to_string(), json!("DecodeEmbd"));
-                self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
+                if self.telemetry.is_debug_enabled() {
+                    let mut token_attrs = self.openai_attrs(request.ids);
+                    token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
+                    token_attrs.insert(
+                        "llama_stage.decode_token_phase".to_string(),
+                        json!(decode_token_phase(decode_step)),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.stage0_compute_ms".to_string(),
+                        json!(stage0_compute_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.runtime_lock_wait_ms".to_string(),
+                        json!(token_runtime_lock_wait_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.runtime_lock_hold_ms".to_string(),
+                        json!(token_runtime_lock_hold_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.output_activation_bytes".to_string(),
+                        json!(output.payload.len()),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.forward_activation_bytes".to_string(),
+                        json!(forwarded.message.activation.len()),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.activation_encode_ms".to_string(),
+                        json!(forwarded.activation_encode_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.forward_write_ms".to_string(),
+                        json!(forward_write_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.downstream_wait_ms".to_string(),
+                        json!(downstream_wait_ms),
+                    );
+                    token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
+                    token_attrs.insert("llama_stage.message_kind".to_string(), json!("DecodeEmbd"));
+                    self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
+                }
                 if on_token(current)? == TokenControl::Stop {
                     break;
                 }

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -811,6 +811,12 @@ impl StageOpenAiBackend {
                         &[current],
                         None,
                         false,
+                        stage_output_activation_capacity(
+                            &request.config,
+                            message.token_count,
+                            request.activation_width,
+                        )
+                        .map_err(openai_backend_error)?,
                     )
                     .map_err(openai_backend_error)?
                     .2;
@@ -853,26 +859,28 @@ impl StageOpenAiBackend {
                 let downstream_wait_ms = wait_timer.elapsed_ms();
                 decode_downstream_wait_ms += downstream_wait_ms;
                 current = reply.predicted;
-                let mut token_attrs = self.openai_attrs(&request.ids);
-                token_attrs.insert(
-                    "llama_stage.decode_step".to_string(),
-                    json!(decode_input_index),
-                );
-                token_attrs.insert(
-                    "llama_stage.stage0_compute_ms".to_string(),
-                    json!(stage0_compute_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.forward_write_ms".to_string(),
-                    json!(forward_write_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.downstream_wait_ms".to_string(),
-                    json!(downstream_wait_ms),
-                );
-                token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
-                token_attrs.insert("llama_stage.message_kind".to_string(), json!("DecodeEmbd"));
-                self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
+                if self.telemetry.is_debug_enabled() {
+                    let mut token_attrs = self.openai_attrs(&request.ids);
+                    token_attrs.insert(
+                        "llama_stage.decode_step".to_string(),
+                        json!(decode_input_index),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.stage0_compute_ms".to_string(),
+                        json!(stage0_compute_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.forward_write_ms".to_string(),
+                        json!(forward_write_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.downstream_wait_ms".to_string(),
+                        json!(downstream_wait_ms),
+                    );
+                    token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
+                    token_attrs.insert("llama_stage.message_kind".to_string(), json!("DecodeEmbd"));
+                    self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
+                }
             }
 
             let mut decode_attrs = self.openai_attrs(&request.ids);

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -762,6 +762,17 @@ impl StageOpenAiBackend {
             let mut decode_downstream_wait_ms = 0.0;
             let mut decode_output_activation_bytes = 0usize;
             let mut decode_forward_activation_bytes = 0usize;
+            let mut decode_message = ReusableDecodeMessage::new(
+                request.wire_dtype,
+                ReusableDecodeMessageArgs {
+                    request_id,
+                    session_id,
+                    prompt_token_count: prefill.token_count,
+                    base_pos_start: prefill.token_count,
+                    sampling: wire_sampling.clone(),
+                    sideband_capacity: 1,
+                },
+            )?;
 
             while decoded_tokens < max_tokens as usize {
                 if request
@@ -780,18 +791,7 @@ impl StageOpenAiBackend {
                 }
 
                 let decode_input_index = decoded_tokens - 1;
-                let message = embedded_decode_message(
-                    request.wire_dtype,
-                    DecodeMessageArgs {
-                        request_id,
-                        session_id,
-                        prompt_token_count: prefill.token_count,
-                        pos_start: prefill.token_count + decode_input_index,
-                        decode_step: decode_input_index,
-                        current,
-                        sampling: wire_sampling.clone(),
-                    },
-                )?;
+                let message = decode_message.update(decode_input_index, current)?;
                 let token_timer = PhaseTimer::start();
                 let stage0_timer = PhaseTimer::start();
                 let output = {
@@ -807,7 +807,7 @@ impl StageOpenAiBackend {
                     let output = run_binary_stage_message(
                         &mut runtime,
                         &session_key,
-                        &message,
+                        message,
                         &[current],
                         None,
                         false,
@@ -827,7 +827,7 @@ impl StageOpenAiBackend {
                 decode_stage0_compute_ms += stage0_compute_ms;
                 let forwarded = forwarded_stage_message_timed(
                     &request.config,
-                    &message,
+                    message,
                     &output,
                     request.wire_dtype,
                     request.activation_width,

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -932,6 +932,12 @@ impl StageOpenAiBackend {
                 &[current],
                 None,
                 false,
+                stage_output_activation_capacity(
+                    request.config,
+                    decode_message.token_count,
+                    request.activation_width,
+                )
+                .map_err(openai_backend_error)?,
             )
             .map_err(openai_backend_error)?
             .2;

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1495,6 +1495,55 @@ fn restore_prefill_decode_message_carries_chat_sampling_metadata() {
 }
 
 #[test]
+fn reusable_decode_message_updates_hot_path_fields() {
+    let sampling = WireSamplingConfig {
+        flags: 1,
+        seed: 7,
+        ..WireSamplingConfig::default()
+    };
+    let mut message = ReusableDecodeMessage::new(
+        WireActivationDType::F16,
+        ReusableDecodeMessageArgs {
+            request_id: 11,
+            session_id: 13,
+            prompt_token_count: 4,
+            base_pos_start: 4,
+            sampling: Some(sampling.clone()),
+            sideband_capacity: 4,
+        },
+    )
+    .unwrap();
+
+    let first = message.update(0, 104).unwrap();
+    assert_eq!(first.kind, WireMessageKind::DecodeEmbd);
+    assert_eq!(first.request_id, 11);
+    assert_eq!(first.session_id, 13);
+    assert_eq!(first.sampling, Some(sampling.clone()));
+    assert_eq!(first.pos_start, 4);
+    assert_eq!(first.token_count, 1);
+    assert_eq!(first.state.prompt_token_count, 4);
+    assert_eq!(first.state.decode_step, 0);
+    assert_eq!(first.state.current_token, 104);
+    assert_eq!(first.tokens, vec![104]);
+
+    let second = message
+        .update_with_tokens(1, 105, &[101, 102, 104, 105])
+        .unwrap();
+    assert_eq!(second.request_id, 11);
+    assert_eq!(second.session_id, 13);
+    assert_eq!(second.sampling, Some(sampling));
+    assert_eq!(second.pos_start, 5);
+    assert_eq!(second.token_count, 1);
+    assert_eq!(second.state.prompt_token_count, 4);
+    assert_eq!(second.state.decode_step, 1);
+    assert_eq!(second.state.current_token, 105);
+    assert_eq!(second.tokens, vec![101, 102, 104, 105]);
+    assert!(second.positions.is_empty());
+    assert!(second.activation.is_empty());
+    assert!(second.raw_bytes.is_empty());
+}
+
+#[test]
 fn hook_injected_text_concatenates_injection_actions() {
     let outcome = ChatHookOutcome {
         actions: vec![

--- a/crates/skippy-server/src/frontend/wire_messages.rs
+++ b/crates/skippy-server/src/frontend/wire_messages.rs
@@ -14,29 +14,111 @@ pub(super) fn embedded_decode_message(
     wire_dtype: WireActivationDType,
     args: DecodeMessageArgs,
 ) -> OpenAiResult<StageWireMessage> {
-    let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, wire_dtype);
-    state.seq_id = 0;
-    state.prompt_token_count = i32::try_from(args.prompt_token_count)
-        .map_err(|_| OpenAiError::backend("prompt token count exceeds i32"))?;
-    state.decode_step = i32::try_from(args.decode_step)
-        .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
-    state.current_token = args.current;
-    state.source_stage_index = -1;
-    Ok(StageWireMessage {
-        kind: WireMessageKind::DecodeEmbd,
-        pos_start: i32::try_from(args.pos_start)
-            .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?,
-        token_count: 1,
-        state,
-        request_id: args.request_id,
-        session_id: args.session_id,
-        sampling: args.sampling,
-        chat_sampling_metadata: None,
-        tokens: vec![args.current],
-        positions: Vec::new(),
-        activation: Vec::new(),
-        raw_bytes: Vec::new(),
-    })
+    let mut message = ReusableDecodeMessage::new(
+        wire_dtype,
+        ReusableDecodeMessageArgs {
+            request_id: args.request_id,
+            session_id: args.session_id,
+            prompt_token_count: args.prompt_token_count,
+            base_pos_start: args.pos_start,
+            sampling: args.sampling,
+            sideband_capacity: 1,
+        },
+    )?;
+    message.update_at_pos(
+        args.decode_step,
+        args.pos_start,
+        args.current,
+        &[args.current],
+    )?;
+    Ok(message.into_message())
+}
+
+pub(super) struct ReusableDecodeMessageArgs {
+    pub(super) request_id: u64,
+    pub(super) session_id: u64,
+    pub(super) prompt_token_count: usize,
+    pub(super) base_pos_start: usize,
+    pub(super) sampling: Option<WireSamplingConfig>,
+    pub(super) sideband_capacity: usize,
+}
+
+pub(super) struct ReusableDecodeMessage {
+    message: StageWireMessage,
+    base_pos_start: usize,
+}
+
+impl ReusableDecodeMessage {
+    pub(super) fn new(
+        wire_dtype: WireActivationDType,
+        args: ReusableDecodeMessageArgs,
+    ) -> OpenAiResult<Self> {
+        let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, wire_dtype);
+        state.seq_id = 0;
+        state.prompt_token_count = i32::try_from(args.prompt_token_count)
+            .map_err(|_| OpenAiError::backend("prompt token count exceeds i32"))?;
+        state.source_stage_index = -1;
+        Ok(Self {
+            message: StageWireMessage {
+                kind: WireMessageKind::DecodeEmbd,
+                pos_start: i32::try_from(args.base_pos_start)
+                    .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?,
+                token_count: 1,
+                state,
+                request_id: args.request_id,
+                session_id: args.session_id,
+                sampling: args.sampling,
+                chat_sampling_metadata: None,
+                tokens: Vec::with_capacity(args.sideband_capacity.max(1)),
+                positions: Vec::new(),
+                activation: Vec::new(),
+                raw_bytes: Vec::new(),
+            },
+            base_pos_start: args.base_pos_start,
+        })
+    }
+
+    pub(super) fn update(
+        &mut self,
+        decode_step: usize,
+        current: i32,
+    ) -> OpenAiResult<&StageWireMessage> {
+        self.update_with_tokens(decode_step, current, &[current])
+    }
+
+    pub(super) fn update_with_tokens(
+        &mut self,
+        decode_step: usize,
+        current: i32,
+        tokens: &[i32],
+    ) -> OpenAiResult<&StageWireMessage> {
+        let pos_start = self
+            .base_pos_start
+            .checked_add(decode_step)
+            .ok_or_else(|| OpenAiError::backend("decode position overflow"))?;
+        self.update_at_pos(decode_step, pos_start, current, tokens)
+    }
+
+    fn update_at_pos(
+        &mut self,
+        decode_step: usize,
+        pos_start: usize,
+        current: i32,
+        tokens: &[i32],
+    ) -> OpenAiResult<&StageWireMessage> {
+        self.message.pos_start = i32::try_from(pos_start)
+            .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?;
+        self.message.state.decode_step = i32::try_from(decode_step)
+            .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
+        self.message.state.current_token = current;
+        self.message.tokens.clear();
+        self.message.tokens.extend_from_slice(tokens);
+        Ok(&self.message)
+    }
+
+    fn into_message(self) -> StageWireMessage {
+        self.message
+    }
 }
 
 pub(super) struct VerifySpanMessageArgs<'a> {

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -241,7 +241,7 @@ impl RuntimeState {
         token_id: i32,
         input: Option<&ActivationFrame>,
     ) -> Result<(i32, ActivationFrame)> {
-        self.decode_frame_sampled(session_id, token_id, None, input)
+        self.decode_frame_sampled(session_id, token_id, None, input, 0)
     }
 
     pub fn decode_frame_sampled(
@@ -250,9 +250,11 @@ impl RuntimeState {
         token_id: i32,
         sampling: Option<&SamplingConfig>,
         input: Option<&ActivationFrame>,
+        output_capacity: usize,
     ) -> Result<(i32, ActivationFrame)> {
         let session = self.session(session_id)?;
-        let output = session.decode_step_frame_sampled(token_id, sampling, input, 0)?;
+        let output =
+            session.decode_step_frame_sampled(token_id, sampling, input, output_capacity)?;
         self.add_session_tokens(session_id, 1);
         Ok(output)
     }
@@ -262,9 +264,10 @@ impl RuntimeState {
         session_id: &str,
         token_ids: &[i32],
         input: Option<&ActivationFrame>,
+        output_capacity: usize,
     ) -> Result<(Vec<i32>, ActivationFrame)> {
         let session = self.session(session_id)?;
-        let output = session.verify_tokens_frame(token_ids, input, 0)?;
+        let output = session.verify_tokens_frame(token_ids, input, output_capacity)?;
         self.add_session_tokens(session_id, token_ids.len() as u64);
         Ok(output)
     }


### PR DESCRIPTION
## Summary
Skippy decode now does less CPU-side work on every token hop when debug telemetry is off, and downstream decode/verify frames get a correctly sized output activation buffer before entering the native stage runtime.

This is the first controlled cleanup PR on the path to higher decode throughput. It keeps the optimization small and reviewable so we can benchmark follow-up decode changes independently instead of bundling several theories together.

## Before
Decode handling paid two recurring costs in the hot path:

- Binary transport and OpenAI frontend decode loops built detailed debug telemetry attribute maps for every token even when debug telemetry was disabled.
- Decode and verify stage execution passed `0` as the native output activation buffer capacity, leaving dense downstream activation output sizing to the slower fallback/probe path.

```mermaid
flowchart LR
    A["Receive decode frame"] --> B["Build debug attrs"]
    B --> C["Run llama stage with output capacity = 0"]
    C --> D["Maybe resize/probe output buffer"]
    D --> E["Build more debug attrs"]
    E --> F["Forward activation / return token"]
```

## After
The hot path now avoids that avoidable work unless it is actually needed:

- Debug span attributes are only constructed when `telemetry.is_debug_enabled()` is true.
- Decode/verify output capacity is precomputed for downstream stages from `token_count * activation_width * f32`, matching the existing wire activation size calculation.
- Final stages and empty-token paths still pass zero capacity because they do not need downstream activation output.
- Prefill behavior is intentionally unchanged in this PR.

```mermaid
flowchart LR
    A["Receive decode frame"] --> B{"Debug telemetry enabled?"}
    B -- "yes" --> C["Build debug attrs"]
    B -- "no" --> D["Skip debug attr construction"]
    C --> E["Estimate downstream activation capacity"]
    D --> E
    E --> F["Run llama stage with pre-sized output buffer"]
    F --> G["Forward activation / return token"]
```

## Performance Impact
This targets fixed per-token overhead rather than model math:

- Lower CPU allocation/serialization work in the normal non-debug telemetry mode.
- Fewer native output-buffer fallback/probe opportunities for dense downstream decode and verify frames.
- Expected benefit is most visible when decode TPOT is dominated by orchestration overhead, transport latency, or small per-token CPU costs around stage execution.

No lab benchmark numbers are included here because the benchmark lab is currently delayed. This PR is meant to be the clean baseline for the next controlled benchmark pass.

## Compatibility
No protocol, ABI, topology, sampling, or activation dtype changes. This is internal hot-path cleanup only.

## Validation
- `cargo fmt -p skippy-server -- --check`
- `cargo check -p skippy-server`
- `cargo test -p skippy-server --lib` — 115 passed
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
