### PR TITLE
Reuse Skippy decode wire messages (2/3)

### DIFF
--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -599,6 +599,17 @@ impl StageOpenAiBackend {
                 .expect("checked non-empty prompt");
             let mut context_tokens = request.prompt_token_ids.to_vec();
             let mut exact_replay_tokens = Vec::new();
+            let mut decode_message = ReusableDecodeMessage::new(
+                request.wire_dtype,
+                ReusableDecodeMessageArgs {
+                    request_id,
+                    session_id,
+                    prompt_token_count: request.prompt_token_ids.len(),
+                    base_pos_start: prefill_token_count,
+                    sampling: wire_sampling.clone(),
+                    sideband_capacity: skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES,
+                },
+            )?;
             let mut fused_reached_stop = false;
             if let Some(fused) = fused_first_decode.take() {
                 current = fused.predicted;
@@ -1088,34 +1099,25 @@ impl StageOpenAiBackend {
                         continue;
                     }
                 }
-                let mut state =
-                    StageStateHeader::new(WireMessageKind::DecodeEmbd, request.wire_dtype);
-                state.seq_id = 0;
-                state.prompt_token_count = i32::try_from(request.prompt_token_ids.len())
-                    .map_err(|_| OpenAiError::backend("prompt token count exceeds i32"))?;
-                state.decode_step = i32::try_from(decode_step)
-                    .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
-                state.current_token = current;
-                state.source_stage_index = -1;
-                let message_tokens = decode_sideband_tokens(&context_tokens, current);
-                let records_replay_checkpoint =
-                    message_tokens.len() == context_tokens.len() && message_tokens.len() > 1;
-                let records_full_prompt_checkpoint =
-                    decode_step == 0 && message_tokens.len() == request.prompt_token_ids.len();
-                let message = StageWireMessage {
-                    kind: WireMessageKind::DecodeEmbd,
-                    pos_start: i32::try_from(prefill_token_count + decode_step as usize)
-                        .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?,
-                    token_count: 1,
-                    state,
-                    request_id,
-                    session_id,
-                    sampling: wire_sampling.clone(),
-                    chat_sampling_metadata: None,
-                    tokens: message_tokens,
-                    positions: Vec::new(),
-                    activation: Vec::new(),
-                    raw_bytes: Vec::new(),
+                let uses_context_sideband = decode_uses_context_sideband(
+                    &context_tokens,
+                    current,
+                    skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES,
+                );
+                let records_replay_checkpoint = uses_context_sideband && context_tokens.len() > 1;
+                let records_full_prompt_checkpoint = decode_step == 0
+                    && uses_context_sideband
+                    && context_tokens.len() == request.prompt_token_ids.len();
+                let decode_step_index = usize::try_from(decode_step)
+                    .map_err(|_| OpenAiError::backend("decode step exceeds usize"))?;
+                let message = if uses_context_sideband {
+                    decode_message.update_with_tokens(
+                        decode_step_index,
+                        current,
+                        &context_tokens,
+                    )?
+                } else {
+                    decode_message.update(decode_step_index, current)?
                 };
                 let stage0_timer = PhaseTimer::start();
                 let token_runtime_lock_wait_ms;
@@ -1137,7 +1139,7 @@ impl StageOpenAiBackend {
                     let output = run_binary_stage_message(
                         &mut runtime,
                         &session_key,
-                        &message,
+                        message,
                         &[current],
                         None,
                         false,
@@ -1161,7 +1163,7 @@ impl StageOpenAiBackend {
                 decode_stage0_compute_ms += stage0_compute_ms;
                 let forwarded = forwarded_stage_message_timed(
                     request.config,
-                    &message,
+                    message,
                     &output,
                     request.wire_dtype,
                     request.activation_width,
@@ -1398,11 +1400,11 @@ impl StageOpenAiBackend {
     }
 }
 
-fn decode_sideband_tokens(context_token_ids: &[i32], current: i32) -> Vec<i32> {
-    if context_token_ids.len() <= skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES
+fn decode_uses_context_sideband(
+    context_token_ids: &[i32],
+    current: i32,
+    sideband_capacity: usize,
+) -> bool {
+    context_token_ids.len() <= sideband_capacity
         && context_token_ids.last().copied() == Some(current)
-    {
-        return context_token_ids.to_vec();
-    }
-    vec![current]
 }

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -762,6 +762,17 @@ impl StageOpenAiBackend {
             let mut decode_downstream_wait_ms = 0.0;
             let mut decode_output_activation_bytes = 0usize;
             let mut decode_forward_activation_bytes = 0usize;
+            let mut decode_message = ReusableDecodeMessage::new(
+                request.wire_dtype,
+                ReusableDecodeMessageArgs {
+                    request_id,
+                    session_id,
+                    prompt_token_count: prefill.token_count,
+                    base_pos_start: prefill.token_count,
+                    sampling: wire_sampling.clone(),
+                    sideband_capacity: 1,
+                },
+            )?;
 
             while decoded_tokens < max_tokens as usize {
                 if request
@@ -780,18 +791,7 @@ impl StageOpenAiBackend {
                 }
 
                 let decode_input_index = decoded_tokens - 1;
-                let message = embedded_decode_message(
-                    request.wire_dtype,
-                    DecodeMessageArgs {
-                        request_id,
-                        session_id,
-                        prompt_token_count: prefill.token_count,
-                        pos_start: prefill.token_count + decode_input_index,
-                        decode_step: decode_input_index,
-                        current,
-                        sampling: wire_sampling.clone(),
-                    },
-                )?;
+                let message = decode_message.update(decode_input_index, current)?;
                 let token_timer = PhaseTimer::start();
                 let stage0_timer = PhaseTimer::start();
                 let output = {
@@ -807,7 +807,7 @@ impl StageOpenAiBackend {
                     let output = run_binary_stage_message(
                         &mut runtime,
                         &session_key,
-                        &message,
+                        message,
                         &[current],
                         None,
                         false,
@@ -827,7 +827,7 @@ impl StageOpenAiBackend {
                 decode_stage0_compute_ms += stage0_compute_ms;
                 let forwarded = forwarded_stage_message_timed(
                     &request.config,
-                    &message,
+                    message,
                     &output,
                     request.wire_dtype,
                     request.activation_width,

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1495,6 +1495,55 @@ fn restore_prefill_decode_message_carries_chat_sampling_metadata() {
 }
 
 #[test]
+fn reusable_decode_message_updates_hot_path_fields() {
+    let sampling = WireSamplingConfig {
+        flags: 1,
+        seed: 7,
+        ..WireSamplingConfig::default()
+    };
+    let mut message = ReusableDecodeMessage::new(
+        WireActivationDType::F16,
+        ReusableDecodeMessageArgs {
+            request_id: 11,
+            session_id: 13,
+            prompt_token_count: 4,
+            base_pos_start: 4,
+            sampling: Some(sampling.clone()),
+            sideband_capacity: 4,
+        },
+    )
+    .unwrap();
+
+    let first = message.update(0, 104).unwrap();
+    assert_eq!(first.kind, WireMessageKind::DecodeEmbd);
+    assert_eq!(first.request_id, 11);
+    assert_eq!(first.session_id, 13);
+    assert_eq!(first.sampling, Some(sampling.clone()));
+    assert_eq!(first.pos_start, 4);
+    assert_eq!(first.token_count, 1);
+    assert_eq!(first.state.prompt_token_count, 4);
+    assert_eq!(first.state.decode_step, 0);
+    assert_eq!(first.state.current_token, 104);
+    assert_eq!(first.tokens, vec![104]);
+
+    let second = message
+        .update_with_tokens(1, 105, &[101, 102, 104, 105])
+        .unwrap();
+    assert_eq!(second.request_id, 11);
+    assert_eq!(second.session_id, 13);
+    assert_eq!(second.sampling, Some(sampling));
+    assert_eq!(second.pos_start, 5);
+    assert_eq!(second.token_count, 1);
+    assert_eq!(second.state.prompt_token_count, 4);
+    assert_eq!(second.state.decode_step, 1);
+    assert_eq!(second.state.current_token, 105);
+    assert_eq!(second.tokens, vec![101, 102, 104, 105]);
+    assert!(second.positions.is_empty());
+    assert!(second.activation.is_empty());
+    assert!(second.raw_bytes.is_empty());
+}
+
+#[test]
 fn hook_injected_text_concatenates_injection_actions() {
     let outcome = ChatHookOutcome {
         actions: vec![

--- a/crates/skippy-server/src/frontend/wire_messages.rs
+++ b/crates/skippy-server/src/frontend/wire_messages.rs
@@ -14,29 +14,111 @@ pub(super) fn embedded_decode_message(
     wire_dtype: WireActivationDType,
     args: DecodeMessageArgs,
 ) -> OpenAiResult<StageWireMessage> {
-    let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, wire_dtype);
-    state.seq_id = 0;
-    state.prompt_token_count = i32::try_from(args.prompt_token_count)
-        .map_err(|_| OpenAiError::backend("prompt token count exceeds i32"))?;
-    state.decode_step = i32::try_from(args.decode_step)
-        .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
-    state.current_token = args.current;
-    state.source_stage_index = -1;
-    Ok(StageWireMessage {
-        kind: WireMessageKind::DecodeEmbd,
-        pos_start: i32::try_from(args.pos_start)
-            .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?,
-        token_count: 1,
-        state,
-        request_id: args.request_id,
-        session_id: args.session_id,
-        sampling: args.sampling,
-        chat_sampling_metadata: None,
-        tokens: vec![args.current],
-        positions: Vec::new(),
-        activation: Vec::new(),
-        raw_bytes: Vec::new(),
-    })
+    let mut message = ReusableDecodeMessage::new(
+        wire_dtype,
+        ReusableDecodeMessageArgs {
+            request_id: args.request_id,
+            session_id: args.session_id,
+            prompt_token_count: args.prompt_token_count,
+            base_pos_start: args.pos_start,
+            sampling: args.sampling,
+            sideband_capacity: 1,
+        },
+    )?;
+    message.update_at_pos(
+        args.decode_step,
+        args.pos_start,
+        args.current,
+        &[args.current],
+    )?;
+    Ok(message.into_message())
+}
+
+pub(super) struct ReusableDecodeMessageArgs {
+    pub(super) request_id: u64,
+    pub(super) session_id: u64,
+    pub(super) prompt_token_count: usize,
+    pub(super) base_pos_start: usize,
+    pub(super) sampling: Option<WireSamplingConfig>,
+    pub(super) sideband_capacity: usize,
+}
+
+pub(super) struct ReusableDecodeMessage {
+    message: StageWireMessage,
+    base_pos_start: usize,
+}
+
+impl ReusableDecodeMessage {
+    pub(super) fn new(
+        wire_dtype: WireActivationDType,
+        args: ReusableDecodeMessageArgs,
+    ) -> OpenAiResult<Self> {
+        let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, wire_dtype);
+        state.seq_id = 0;
+        state.prompt_token_count = i32::try_from(args.prompt_token_count)
+            .map_err(|_| OpenAiError::backend("prompt token count exceeds i32"))?;
+        state.source_stage_index = -1;
+        Ok(Self {
+            message: StageWireMessage {
+                kind: WireMessageKind::DecodeEmbd,
+                pos_start: i32::try_from(args.base_pos_start)
+                    .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?,
+                token_count: 1,
+                state,
+                request_id: args.request_id,
+                session_id: args.session_id,
+                sampling: args.sampling,
+                chat_sampling_metadata: None,
+                tokens: Vec::with_capacity(args.sideband_capacity.max(1)),
+                positions: Vec::new(),
+                activation: Vec::new(),
+                raw_bytes: Vec::new(),
+            },
+            base_pos_start: args.base_pos_start,
+        })
+    }
+
+    pub(super) fn update(
+        &mut self,
+        decode_step: usize,
+        current: i32,
+    ) -> OpenAiResult<&StageWireMessage> {
+        self.update_with_tokens(decode_step, current, &[current])
+    }
+
+    pub(super) fn update_with_tokens(
+        &mut self,
+        decode_step: usize,
+        current: i32,
+        tokens: &[i32],
+    ) -> OpenAiResult<&StageWireMessage> {
+        let pos_start = self
+            .base_pos_start
+            .checked_add(decode_step)
+            .ok_or_else(|| OpenAiError::backend("decode position overflow"))?;
+        self.update_at_pos(decode_step, pos_start, current, tokens)
+    }
+
+    fn update_at_pos(
+        &mut self,
+        decode_step: usize,
+        pos_start: usize,
+        current: i32,
+        tokens: &[i32],
+    ) -> OpenAiResult<&StageWireMessage> {
+        self.message.pos_start = i32::try_from(pos_start)
+            .map_err(|_| OpenAiError::backend("decode position exceeds i32"))?;
+        self.message.state.decode_step = i32::try_from(decode_step)
+            .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
+        self.message.state.current_token = current;
+        self.message.tokens.clear();
+        self.message.tokens.extend_from_slice(tokens);
+        Ok(&self.message)
+    }
+
+    fn into_message(self) -> StageWireMessage {
+        self.message
+    }
 }
 
 pub(super) struct VerifySpanMessageArgs<'a> {


### PR DESCRIPTION
## Summary
Skippy split decode now reuses the per-token decode wire-message envelope in the frontend hot path instead of rebuilding the same `StageWireMessage` shape every token.

This is stacked on #798 and is intentionally scoped to allocation churn around decode message construction. It does not change topology, protocol, sampling, activation dtype, or native stage execution.

## What changed
- Added `ReusableDecodeMessage`, a small frontend wire-message helper that owns the stable decode envelope once.
- Normal split decode mutates only `decode_step`, `pos_start`, `current_token`, and the one-token sideband each iteration.
- Multimodal/split decode reuses the same message and token buffer, including the short exact-replay sideband checkpoint case.
- Kept the existing one-shot `embedded_decode_message` helper for prefix-cache and repair paths.
- Added a focused unit test for reusable decode message mutation and stable request/session/sampling fields.

## Before
```mermaid
flowchart LR
    A["Each decode token"] --> B["Allocate StageStateHeader"]
    B --> C["Clone sampling config"]
    C --> D["Allocate tokens Vec"]
    D --> E["Allocate empty positions/activation/raw Vecs"]
    E --> F["Run stage + forward activation"]
```

## After
```mermaid
flowchart LR
    A["Before decode loop"] --> B["Create reusable DecodeEmbd message"]
    B --> C["Each decode token"]
    C --> D["Mutate step/position/current token"]
    D --> E["Refill existing token sideband buffer"]
    E --> F["Run stage + forward activation"]
```

## Performance Impact
This targets small but repeated CPU-side work in TPOT:

- Removes per-token allocation of the decode message's stable empty vectors.
- Avoids per-token sampling clone in the two split decode loops.
- Reuses the sideband token buffer for exact-replay checkpoint frames instead of allocating a fresh `Vec` every eligible token.

This should be a modest fixed-overhead improvement rather than a model-compute improvement. It is designed to compose with #798 and remain easy to benchmark independently once lab capacity is available.

## Compatibility
No protocol or ABI changes. The emitted decode wire messages keep the same fields and token sideband semantics.

## Validation
- `cargo fmt -p skippy-server -- --check`
- `cargo check -p skippy-server`
- `cargo test -p skippy-server --lib` — 116 passed
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
