### PR TITLE
Reuse Skippy forwarded decode frames (1/3)

### DIFF
--- a/crates/skippy-protocol/src/binary/activation.rs
+++ b/crates/skippy-protocol/src/binary/activation.rs
@@ -73,6 +73,26 @@ pub fn encode_f32_activation_payload_with_state_flags(
     f32_payload: &[u8],
     state_flag_bits: i32,
 ) -> io::Result<Vec<u8>> {
+    let mut out = Vec::new();
+    encode_f32_activation_payload_with_state_flags_into(
+        dtype,
+        token_count,
+        n_embd,
+        f32_payload,
+        state_flag_bits,
+        &mut out,
+    )?;
+    Ok(out)
+}
+
+pub fn encode_f32_activation_payload_with_state_flags_into(
+    dtype: WireActivationDType,
+    token_count: i32,
+    n_embd: i32,
+    f32_payload: &[u8],
+    state_flag_bits: i32,
+    out: &mut Vec<u8>,
+) -> io::Result<()> {
     let expected_f32_bytes = activation_wire_bytes_with_state_flags(
         WireActivationDType::F32,
         token_count,
@@ -87,14 +107,18 @@ pub fn encode_f32_activation_payload_with_state_flags(
     if f32_payload.len() != expected_f32_bytes {
         return Err(invalid_data("F32 activation payload size mismatch"));
     }
+    out.clear();
     match dtype {
-        WireActivationDType::F32 => Ok(f32_payload.to_vec()),
-        WireActivationDType::F16 => encode_f32_to_f16_bytes(f32_payload),
+        WireActivationDType::F32 => {
+            out.extend_from_slice(f32_payload);
+            Ok(())
+        }
+        WireActivationDType::F16 => encode_f32_to_f16_bytes_into(f32_payload, out),
         WireActivationDType::Q8 => {
             let token_count = token_count
                 .checked_mul(activation_payload_multiplier_from_state_flags(state_flag_bits) as i32)
                 .ok_or_else(|| invalid_data("Q8 activation token count overflow"))?;
-            encode_f32_to_q8_bytes(f32_payload, token_count, n_embd)
+            encode_f32_to_q8_bytes_into(f32_payload, token_count, n_embd, out)
         }
     }
 }
@@ -130,16 +154,17 @@ pub(crate) fn decode_f16_to_f32_bytes(input: &[u8]) -> io::Result<Vec<u8>> {
     Ok(out)
 }
 
-fn encode_f32_to_f16_bytes(input: &[u8]) -> io::Result<Vec<u8>> {
+fn encode_f32_to_f16_bytes_into(input: &[u8], out: &mut Vec<u8>) -> io::Result<()> {
     if input.len() & 3 != 0 {
         return Err(invalid_data("F32 activation payload size is not aligned"));
     }
-    let mut out = Vec::with_capacity(input.len() / 2);
+    out.clear();
+    out.reserve(input.len() / 2);
     for chunk in input.chunks_exact(4) {
         let value = f32::from_le_bytes(chunk.try_into().expect("chunks_exact size"));
         out.extend_from_slice(&f32_to_f16_bits(value).to_le_bytes());
     }
-    Ok(out)
+    Ok(())
 }
 
 pub(crate) fn decode_q8_to_f32_bytes_with_state_flags(
@@ -204,7 +229,12 @@ pub(crate) fn decode_q8_to_f32_bytes(
     decode_q8_to_f32_bytes_with_state_flags(input, token_count, n_embd, 0)
 }
 
-fn encode_f32_to_q8_bytes(input: &[u8], token_count: i32, n_embd: i32) -> io::Result<Vec<u8>> {
+fn encode_f32_to_q8_bytes_into(
+    input: &[u8],
+    token_count: i32,
+    n_embd: i32,
+    out: &mut Vec<u8>,
+) -> io::Result<()> {
     if token_count < 0 || n_embd < 0 {
         return Err(invalid_data("negative Q8 activation dimensions"));
     }
@@ -218,8 +248,17 @@ fn encode_f32_to_q8_bytes(input: &[u8], token_count: i32, n_embd: i32) -> io::Re
         return Err(invalid_data("Q8 source payload size mismatch"));
     }
 
-    let mut scales = Vec::with_capacity(token_count * 4);
-    let mut packed = Vec::with_capacity(token_count * n_embd);
+    let scale_bytes = token_count
+        .checked_mul(4)
+        .ok_or_else(|| invalid_data("Q8 scale byte count overflow"))?;
+    let packed_bytes = token_count
+        .checked_mul(n_embd)
+        .ok_or_else(|| invalid_data("Q8 value byte count overflow"))?;
+    let total_bytes = scale_bytes
+        .checked_add(packed_bytes)
+        .ok_or_else(|| invalid_data("Q8 activation payload byte count overflow"))?;
+    out.clear();
+    out.resize(total_bytes, 0);
     for token_index in 0..token_count {
         let row_offset = token_index * n_embd * 4;
         let row = &input[row_offset..row_offset + n_embd * 4];
@@ -229,15 +268,16 @@ fn encode_f32_to_q8_bytes(input: &[u8], token_count: i32, n_embd: i32) -> io::Re
             max_abs = max_abs.max(value.abs());
         }
         let scale = if max_abs > 0.0 { max_abs / 127.0 } else { 1.0 };
-        scales.extend_from_slice(&scale.to_le_bytes());
-        for chunk in row.chunks_exact(4) {
+        let scale_offset = token_index * 4;
+        out[scale_offset..scale_offset + 4].copy_from_slice(&scale.to_le_bytes());
+        let packed_row_offset = scale_bytes + token_index * n_embd;
+        for (value_index, chunk) in row.chunks_exact(4).enumerate() {
             let value = f32::from_le_bytes(chunk.try_into().expect("chunks_exact size"));
             let quantized = (value / scale).round().clamp(-127.0, 127.0) as i8;
-            packed.push(quantized as u8);
+            out[packed_row_offset + value_index] = quantized as u8;
         }
     }
-    scales.extend_from_slice(&packed);
-    Ok(scales)
+    Ok(())
 }
 
 fn f16_bits_to_f32(bits: u16) -> f32 {

--- a/crates/skippy-protocol/src/binary/mod.rs
+++ b/crates/skippy-protocol/src/binary/mod.rs
@@ -6,6 +6,7 @@ pub use activation::{
     activation_payload_multiplier_from_state_flags, activation_wire_bytes,
     activation_wire_bytes_with_state_flags, encode_f32_activation_payload,
     encode_f32_activation_payload_with_state_flags,
+    encode_f32_activation_payload_with_state_flags_into,
 };
 pub use codec::{
     read_stage_message, recv_ready, recv_reply, send_ready, send_reply_ack,
@@ -610,6 +611,42 @@ mod tests {
         let second = f32::from_le_bytes(decoded[4..8].try_into().unwrap());
         assert!((first - 1.0).abs() < 0.01);
         assert!((second + 1.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn f32_payload_encodes_into_reused_buffer() {
+        let mut input = Vec::new();
+        for value in [1.0_f32, -1.0, 0.5, -0.5] {
+            input.extend_from_slice(&value.to_le_bytes());
+        }
+        let mut encoded = Vec::with_capacity(64);
+        let initial_capacity = encoded.capacity();
+
+        encode_f32_activation_payload_with_state_flags_into(
+            WireActivationDType::Q8,
+            2,
+            2,
+            &input,
+            0,
+            &mut encoded,
+        )
+        .unwrap();
+        assert_eq!(encoded.len(), 12);
+        assert!(encoded.capacity() >= initial_capacity);
+        let decoded = activation::decode_q8_to_f32_bytes(&encoded, 2, 2).unwrap();
+        assert_eq!(decoded.len(), input.len());
+
+        encode_f32_activation_payload_with_state_flags_into(
+            WireActivationDType::F16,
+            2,
+            2,
+            &input,
+            0,
+            &mut encoded,
+        )
+        .unwrap();
+        assert_eq!(encoded.len(), 8);
+        assert!(encoded.capacity() >= initial_capacity);
     }
 
     #[test]

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -48,7 +48,9 @@ mod wire;
 pub use self::direct_return::PredictionReturnHub;
 pub use self::direct_return::PredictionReturnListener;
 pub(crate) use self::direct_return::PredictionReturnReceiver;
-pub(crate) use self::forwarding::{forwarded_stage_message, forwarded_stage_message_timed};
+pub(crate) use self::forwarding::{
+    ReusableForwardedStageMessage, forwarded_stage_message, forwarded_stage_message_timed,
+};
 pub use self::options::{BinaryStageOptions, EmbeddedOpenAiStageOptions, parse_wire_dtype};
 use self::socket::*;
 pub use self::wire::WireCondition;

--- a/crates/skippy-server/src/binary_transport/forwarding.rs
+++ b/crates/skippy-server/src/binary_transport/forwarding.rs
@@ -25,6 +25,11 @@ pub(crate) struct ForwardedStageMessage {
     pub activation_encode_ms: f64,
 }
 
+pub(crate) struct ForwardedStageMessageRef<'a> {
+    pub message: &'a StageWireMessage,
+    pub activation_encode_ms: f64,
+}
+
 pub(crate) fn forwarded_stage_message_timed(
     config: &StageConfig,
     incoming: &StageWireMessage,
@@ -32,46 +37,98 @@ pub(crate) fn forwarded_stage_message_timed(
     wire_dtype: WireActivationDType,
     activation_width: i32,
 ) -> Result<ForwardedStageMessage> {
-    let mut state = incoming.state;
-    state.source_stage_index = config.stage_index as i32;
-    state.reserved = wire_dtype as i32;
-    state.flags |= activation_state_flags_from_frame_flags(output.desc.flags);
-    let encode_started = Instant::now();
-    let activation = skippy_protocol::binary::encode_f32_activation_payload_with_state_flags(
-        wire_dtype,
-        incoming.token_count,
-        activation_width,
-        &output.payload,
-        state.flags,
-    )
-    .with_context(|| {
-        format!(
-            "encode output activation payload; wire_dtype={wire_dtype:?} incoming_tokens={} output_tokens={} activation_width={} payload_bytes={} frame_payload_bytes={} state_flags={}",
-            incoming.token_count,
-            output.desc.token_count,
-            activation_width,
-            output.payload.len(),
-            output.desc.payload_bytes,
-            state.flags,
-        )
-    })?;
+    let mut reusable = ReusableForwardedStageMessage::new();
+    let activation_encode_ms = reusable
+        .update(config, incoming, output, wire_dtype, activation_width)?
+        .activation_encode_ms;
     Ok(ForwardedStageMessage {
-        message: StageWireMessage {
-            kind: incoming.kind,
-            pos_start: incoming.pos_start,
-            token_count: incoming.token_count,
-            state,
-            request_id: incoming.request_id,
-            session_id: incoming.session_id,
-            sampling: incoming.sampling.clone(),
-            chat_sampling_metadata: None,
-            tokens: incoming.tokens.clone(),
-            positions: incoming.positions.clone(),
-            activation,
-            raw_bytes: Vec::new(),
-        },
-        activation_encode_ms: encode_started.elapsed().as_secs_f64() * 1000.0,
+        message: reusable.into_message(),
+        activation_encode_ms,
     })
+}
+
+pub(crate) struct ReusableForwardedStageMessage {
+    message: StageWireMessage,
+}
+
+impl ReusableForwardedStageMessage {
+    pub(crate) fn new() -> Self {
+        Self {
+            message: StageWireMessage {
+                kind: skippy_protocol::binary::WireMessageKind::PrefillEmbd,
+                pos_start: 0,
+                token_count: 0,
+                state: Default::default(),
+                request_id: 0,
+                session_id: 0,
+                sampling: None,
+                chat_sampling_metadata: None,
+                tokens: Vec::new(),
+                positions: Vec::new(),
+                activation: Vec::new(),
+                raw_bytes: Vec::new(),
+            },
+        }
+    }
+
+    pub(crate) fn update(
+        &mut self,
+        config: &StageConfig,
+        incoming: &StageWireMessage,
+        output: &ActivationFrame,
+        wire_dtype: WireActivationDType,
+        activation_width: i32,
+    ) -> Result<ForwardedStageMessageRef<'_>> {
+        let mut state = incoming.state;
+        state.source_stage_index = config.stage_index as i32;
+        state.reserved = wire_dtype as i32;
+        state.flags |= activation_state_flags_from_frame_flags(output.desc.flags);
+        let encode_started = Instant::now();
+        skippy_protocol::binary::encode_f32_activation_payload_with_state_flags_into(
+            wire_dtype,
+            incoming.token_count,
+            activation_width,
+            &output.payload,
+            state.flags,
+            &mut self.message.activation,
+        )
+        .with_context(|| {
+            format!(
+                "encode output activation payload; wire_dtype={wire_dtype:?} incoming_tokens={} output_tokens={} activation_width={} payload_bytes={} frame_payload_bytes={} state_flags={}",
+                incoming.token_count,
+                output.desc.token_count,
+                activation_width,
+                output.payload.len(),
+                output.desc.payload_bytes,
+                state.flags,
+            )
+        })?;
+        self.message.kind = incoming.kind;
+        self.message.pos_start = incoming.pos_start;
+        self.message.token_count = incoming.token_count;
+        self.message.state = state;
+        self.message.request_id = incoming.request_id;
+        self.message.session_id = incoming.session_id;
+        if self.message.sampling != incoming.sampling {
+            self.message.sampling = incoming.sampling.clone();
+        }
+        self.message.chat_sampling_metadata = None;
+        self.message.tokens.clear();
+        self.message.tokens.extend_from_slice(&incoming.tokens);
+        self.message.positions.clear();
+        self.message
+            .positions
+            .extend_from_slice(&incoming.positions);
+        self.message.raw_bytes.clear();
+        Ok(ForwardedStageMessageRef {
+            message: &self.message,
+            activation_encode_ms: encode_started.elapsed().as_secs_f64() * 1000.0,
+        })
+    }
+
+    fn into_message(self) -> StageWireMessage {
+        self.message
+    }
 }
 
 #[cfg(test)]
@@ -142,6 +199,35 @@ mod tests {
         }
     }
 
+    fn incoming_message_with_tokens(tokens: Vec<i32>) -> StageWireMessage {
+        let mut message = incoming_message();
+        message.token_count = tokens.len() as i32;
+        message.tokens = tokens;
+        message
+    }
+
+    fn f32_activation_frame(token_count: u32, values: &[f32]) -> ActivationFrame {
+        let mut payload = Vec::new();
+        for value in values {
+            payload.extend_from_slice(&value.to_le_bytes());
+        }
+        ActivationFrame {
+            desc: ActivationDesc {
+                version: 1,
+                dtype: RuntimeActivationDType::F32,
+                layout: RuntimeActivationLayout::TokenMajor,
+                producer_stage_index: 1,
+                layer_start: 4,
+                layer_end: 8,
+                token_count,
+                sequence_count: 1,
+                payload_bytes: payload.len() as u64,
+                flags: 0,
+            },
+            payload,
+        }
+    }
+
     fn rwkv7_sideband_frame() -> ActivationFrame {
         let mut payload = Vec::new();
         for value in [1.0_f32, 2.0, 3.0, 4.0] {
@@ -202,5 +288,42 @@ mod tests {
             forwarded.message.state.flags & state_flags::RWKV7_V_FIRST_SIDEBAND,
             0
         );
+    }
+
+    #[test]
+    fn reusable_forwarded_stage_message_reuses_activation_buffer() {
+        let config = stage_config();
+        let first_incoming = incoming_message_with_tokens(vec![11, 12]);
+        let first_output = f32_activation_frame(2, &[1.0, 2.0, 3.0, 4.0]);
+        let second_incoming = incoming_message_with_tokens(vec![13]);
+        let second_output = f32_activation_frame(1, &[5.0, 6.0]);
+        let mut reusable = ReusableForwardedStageMessage::new();
+
+        let first = reusable
+            .update(
+                &config,
+                &first_incoming,
+                &first_output,
+                WireActivationDType::F32,
+                2,
+            )
+            .unwrap();
+        assert_eq!(first.message.tokens, vec![11, 12]);
+        assert_eq!(first.message.activation.len(), 16);
+        let first_capacity = first.message.activation.capacity();
+
+        let second = reusable
+            .update(
+                &config,
+                &second_incoming,
+                &second_output,
+                WireActivationDType::F32,
+                2,
+            )
+            .unwrap();
+        assert_eq!(second.message.tokens, vec![13]);
+        assert_eq!(second.message.activation.len(), 8);
+        assert!(second.message.activation.capacity() >= first_capacity);
+        assert_eq!(second.message.state.source_stage_index, 1);
     }
 }

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -57,9 +57,10 @@ use tokio::{
 
 use crate::{
     binary_transport::{
-        PredictionReturnHub, PredictionReturnReceiver, WireCondition, connect_binary_downstream,
-        forwarded_stage_message, forwarded_stage_message_timed, run_binary_stage_message,
-        stage_output_activation_capacity, write_stage_message_conditioned,
+        PredictionReturnHub, PredictionReturnReceiver, ReusableForwardedStageMessage,
+        WireCondition, connect_binary_downstream, forwarded_stage_message,
+        forwarded_stage_message_timed, run_binary_stage_message, stage_output_activation_capacity,
+        write_stage_message_conditioned,
     },
     cli::ServeOpenAiArgs,
     config::{load_json, validate_config},

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -610,6 +610,7 @@ impl StageOpenAiBackend {
                     sideband_capacity: skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES,
                 },
             )?;
+            let mut forwarded_decode_message = ReusableForwardedStageMessage::new();
             let mut fused_reached_stop = false;
             if let Some(fused) = fused_first_decode.take() {
                 current = fused.predicted;
@@ -1161,14 +1162,15 @@ impl StageOpenAiBackend {
                 };
                 let stage0_compute_ms = stage0_timer.elapsed_ms();
                 decode_stage0_compute_ms += stage0_compute_ms;
-                let forwarded = forwarded_stage_message_timed(
-                    request.config,
-                    message,
-                    &output,
-                    request.wire_dtype,
-                    request.activation_width,
-                )
-                .map_err(openai_backend_error)?;
+                let forwarded = forwarded_decode_message
+                    .update(
+                        request.config,
+                        message,
+                        &output,
+                        request.wire_dtype,
+                        request.activation_width,
+                    )
+                    .map_err(openai_backend_error)?;
                 decode_forward_activation_encode_ms += forwarded.activation_encode_ms;
                 decode_output_activation_bytes =
                     decode_output_activation_bytes.saturating_add(output.payload.len());
@@ -1177,7 +1179,7 @@ impl StageOpenAiBackend {
                 let write_timer = PhaseTimer::start();
                 write_stage_message_conditioned(
                     &mut *downstream,
-                    &forwarded.message,
+                    forwarded.message,
                     request.wire_dtype,
                     request.downstream_wire_condition,
                 )

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -732,6 +732,7 @@ impl StageOpenAiBackend {
                     sideband_capacity: 1,
                 },
             )?;
+            let mut forwarded_decode_message = ReusableForwardedStageMessage::new();
 
             while decoded_tokens < max_tokens as usize {
                 if request
@@ -784,14 +785,15 @@ impl StageOpenAiBackend {
                 };
                 let stage0_compute_ms = stage0_timer.elapsed_ms();
                 decode_stage0_compute_ms += stage0_compute_ms;
-                let forwarded = forwarded_stage_message_timed(
-                    &request.config,
-                    message,
-                    &output,
-                    request.wire_dtype,
-                    request.activation_width,
-                )
-                .map_err(openai_backend_error)?;
+                let forwarded = forwarded_decode_message
+                    .update(
+                        &request.config,
+                        message,
+                        &output,
+                        request.wire_dtype,
+                        request.activation_width,
+                    )
+                    .map_err(openai_backend_error)?;
                 decode_output_activation_bytes =
                     decode_output_activation_bytes.saturating_add(output.payload.len());
                 decode_forward_activation_bytes = decode_forward_activation_bytes
@@ -799,7 +801,7 @@ impl StageOpenAiBackend {
                 let write_timer = PhaseTimer::start();
                 write_stage_message_conditioned(
                     &mut lane.stream,
-                    &forwarded.message,
+                    forwarded.message,
                     request.wire_dtype,
                     request.downstream_wire_condition,
                 )


### PR DESCRIPTION
## Summary
Skippy split decode now reuses the forwarded activation frame envelope and activation encode buffer across decode tokens.

This is stacked on #799. It keeps the existing writer and wire format unchanged, but removes repeated forwarded `StageWireMessage` construction and gives activation encoding a caller-owned buffer to refill.

## What changed
- Added an internal in-place activation encoder: `encode_f32_activation_payload_with_state_flags_into(...)`.
- Kept the existing `Vec`-returning activation encode API by delegating to the in-place helper.
- Added `ReusableForwardedStageMessage` for the decode forwarding hot path.
- Reused forwarded decode frame containers in normal split decode and multimodal split decode.
- Preserved existing one-shot `forwarded_stage_message_timed(...)` for non-loop callsites.

## Before
```mermaid
flowchart LR
    A["Native decode output"] --> B["Encode activation into new Vec"]
    B --> C["Build new forwarded StageWireMessage"]
    C --> D["Clone sampling/tokens/positions"]
    D --> E["write_stage_message_conditioned"]
```

## After
```mermaid
flowchart LR
    A["Before decode loop"] --> B["Create reusable forwarded frame"]
    B --> C["Native decode output"]
    C --> D["Refill activation encode buffer"]
    D --> E["Update forwarded frame fields"]
    E --> F["write_stage_message_conditioned"]
```

## Performance Impact
This targets fixed CPU/allocation overhead on decode TPOT:

- Reuses the activation encode buffer instead of allocating a fresh activation `Vec` every forwarded decode token.
- Reuses token/position/raw-byte containers on the forwarded message.
- Avoids repeatedly cloning stable sampling config in the two split decode loops unless it actually changes.

Expected impact is still modest because GPU forward, network wait, activation wire bytes, and downstream compute remain unchanged. This should be more meaningful than #799 when activation encode allocation shows up in profiles, but it is still a cleanup-class improvement rather than the main 30 tok/s lever.

## High-impact follow-up
The bigger decode lever remains overlap/pipelining: hide stage0 setup, sampler/direct-return handling, or downstream wait behind work already in flight. That can remove or hide milliseconds of TPOT; this PR removes repeated local allocation work.

## Compatibility
No wire protocol, ABI, topology, sampling, or activation dtype changes. The emitted stage messages keep the same fields and activation bytes.

## Validation
- `cargo fmt -p skippy-protocol -p skippy-server -- --check`
- `cargo check -p skippy-server`
- `cargo test -p skippy-protocol --lib` — 34 passed
- `cargo test -p skippy-server --lib` — 117 passed
- `cargo clippy -p skippy-protocol --all-targets -- -D warnings`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
