### PR TITLE
Improve MoA reliability for agent tool loops

### DIFF
--- a/crates/mesh-mixture-of-agents/src/arbiter.rs
+++ b/crates/mesh-mixture-of-agents/src/arbiter.rs
@@ -237,10 +237,12 @@ pub fn try_early_decision(
     // Two workers saying "Paris" and "Berlin" must not be treated as
     // consensus. Find the largest cluster of content-similar answers
     // and only early-exit if it's ≥2 workers AND a majority of answers.
-    if answers.len() >= 2
-        && tool_proposals.is_empty()
-        && let Some((cluster_size, best)) = largest_agreeing_cluster(&answers)
-    {
+    let agreeing_cluster = if answers.len() >= 2 && tool_proposals.is_empty() {
+        largest_agreeing_cluster(&answers)
+    } else {
+        None
+    };
+    if let Some((cluster_size, best)) = agreeing_cluster {
         let majority = cluster_size * 2 >= answers.len();
         if majority && best.confidence >= 0.5 {
             tracing::info!(

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -268,9 +268,11 @@ fn extract_text_from_response(resp: &Value) -> Result<String, String> {
         .ok_or_else(|| "malformed response: missing choices[0].message".to_string())?;
 
     // Native tool_calls → KV format for normalizer
-    if let Some(tool_calls) = message.get("tool_calls").and_then(|tc| tc.as_array())
-        && let Some(tc) = tool_calls.first()
-    {
+    let first_tool_call = message
+        .get("tool_calls")
+        .and_then(|tc| tc.as_array())
+        .and_then(|tool_calls| tool_calls.first());
+    if let Some(tc) = first_tool_call {
         let name = tc
             .pointer("/function/name")
             .and_then(|n| n.as_str())

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -17,6 +17,12 @@ use crate::worker::WorkerRole;
 use serde_json::{Value, json};
 
 const TOOL_RESULT_CONTEXT_WINDOW: usize = 10;
+const TOOL_EVIDENCE_MAX_RESULTS: usize = 8;
+const TOOL_EVIDENCE_MAX_RESULT_CHARS: usize = 800;
+const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
+const TOOL_RESULT_JSON_MAX_SCALARS: usize = 48;
+const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
+const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
 
 /// Packed context ready to send to a worker.
 pub struct PackedContext {
@@ -402,6 +408,9 @@ pub fn pack_for_tool_result_turn_selected(
     let system = augmented_system_prompt_for_mode(session, has_tools);
 
     let mut messages = vec![json!({"role": "system", "content": system})];
+    if let Some(evidence) = tool_evidence_message(session) {
+        messages.push(evidence);
+    }
 
     // Forward the tail of the conversation that includes the current user turn,
     // assistant tool_call messages, and their tool results. Tool-call chains
@@ -450,7 +459,7 @@ pub fn pack_for_tool_result_turn_selected(
     for msg in &all[start_idx..] {
         let role = message_role(msg);
         if role != "system" && !role.is_empty() {
-            messages.push(msg.clone());
+            messages.push(compact_tool_message(msg));
         }
     }
 
@@ -458,6 +467,228 @@ pub fn pack_for_tool_result_turn_selected(
 
     (messages, tools)
 }
+
+fn tool_evidence_message(session: &Session) -> Option<Value> {
+    let results = session.recent_tool_results();
+    if results.is_empty() {
+        return None;
+    }
+
+    let mut lines = vec![
+        "Completed tool results. Preserve exact short values from these results when the user asks to include, recall, or return tool facts."
+            .to_string(),
+    ];
+    for (idx, (name, result)) in results
+        .iter()
+        .rev()
+        .take(TOOL_EVIDENCE_MAX_RESULTS)
+        .enumerate()
+    {
+        let compacted = compact_tool_result_text(result);
+        let result = if compacted.len() > TOOL_EVIDENCE_MAX_RESULT_CHARS {
+            format!(
+                "{}...",
+                crate::worker::truncate_chars(&compacted, TOOL_EVIDENCE_MAX_RESULT_CHARS - 3)
+            )
+        } else {
+            compacted
+        };
+        lines.push(format!("{}. {name}: {result}", idx + 1));
+    }
+
+    Some(json!({"role": "system", "content": lines.join("\n")}))
+}
+
+fn compact_tool_message(msg: &Value) -> Value {
+    if message_role(msg) != "tool" {
+        return msg.clone();
+    }
+
+    let Some(content) = msg.get("content").and_then(Value::as_str) else {
+        return msg.clone();
+    };
+    let compacted = compact_tool_result_text(content);
+    if compacted == content {
+        return msg.clone();
+    }
+
+    let mut compact = msg.clone();
+    if let Some(obj) = compact.as_object_mut() {
+        obj.insert("content".to_string(), Value::String(compacted));
+    }
+    compact
+}
+
+fn compact_tool_result_text(result: &str) -> String {
+    if result.len() <= TOOL_RESULT_RAW_MAX_CHARS {
+        return result.to_string();
+    }
+
+    if let Ok(json) = serde_json::from_str::<Value>(result) {
+        return compact_json_tool_result(result.len(), &json);
+    }
+
+    format!(
+        "Tool result compacted from {} chars; original was plain text.\n\
+         Text preview:\n{}...",
+        result.len(),
+        crate::worker::truncate_chars(result, TOOL_RESULT_RAW_MAX_CHARS - 96)
+    )
+}
+
+fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
+    let mut lines = vec![format!(
+        "Tool result compacted from {original_len} chars; original was JSON."
+    )];
+    append_json_shape(value, &mut lines);
+    let mut scalars = Vec::new();
+    collect_json_scalars(value, "$", &mut scalars, 0);
+
+    if scalars.is_empty() {
+        lines.push("No compact scalar fields found.".to_string());
+    } else {
+        lines.push("Key scalar fields:".to_string());
+        lines.extend(scalars.into_iter().map(|line| format!("- {line}")));
+    }
+
+    lines.join("\n")
+}
+
+fn append_json_shape(value: &Value, lines: &mut Vec<String>) {
+    match value {
+        Value::Array(items) => {
+            lines.push(format!("JSON array with {} item(s).", items.len()));
+        }
+        Value::Object(map) => {
+            lines.push(format!("JSON object with {} top-level key(s).", map.len()));
+        }
+        _ => {}
+    }
+}
+
+fn collect_json_scalars(value: &Value, path: &str, out: &mut Vec<String>, depth: usize) {
+    if out.len() >= TOOL_RESULT_JSON_MAX_SCALARS || depth > 6 {
+        return;
+    }
+
+    match value {
+        Value::Array(items) => collect_array_scalars(items, path, out, depth),
+        Value::Object(map) => collect_object_scalars(map, path, out, depth),
+        _ => push_scalar(path, value, out),
+    }
+}
+
+fn collect_array_scalars(items: &[Value], path: &str, out: &mut Vec<String>, depth: usize) {
+    for (idx, item) in items
+        .iter()
+        .take(TOOL_RESULT_JSON_MAX_ARRAY_ITEMS)
+        .enumerate()
+    {
+        if out.len() >= TOOL_RESULT_JSON_MAX_SCALARS {
+            break;
+        }
+
+        let item_path = format!("{path}[{idx}]");
+        if let Some(row) = compact_object_row(item, &item_path) {
+            out.push(row);
+        } else {
+            collect_json_scalars(item, &item_path, out, depth + 1);
+        }
+    }
+}
+
+fn collect_object_scalars(
+    map: &serde_json::Map<String, Value>,
+    path: &str,
+    out: &mut Vec<String>,
+    depth: usize,
+) {
+    for key in PREFERRED_JSON_KEYS {
+        if out.len() >= TOOL_RESULT_JSON_MAX_SCALARS {
+            return;
+        }
+        let Some(value) = map.get(*key) else {
+            continue;
+        };
+        if is_scalar(value) {
+            push_scalar(&format!("{path}.{key}"), value, out);
+        }
+    }
+
+    for (key, value) in map {
+        if out.len() >= TOOL_RESULT_JSON_MAX_SCALARS {
+            return;
+        }
+        if PREFERRED_JSON_KEYS.contains(&key.as_str()) {
+            continue;
+        }
+        let child_path = format!("{path}.{key}");
+        collect_json_scalars(value, &child_path, out, depth + 1);
+    }
+}
+
+fn compact_object_row(value: &Value, path: &str) -> Option<String> {
+    let map = value.as_object()?;
+    let mut fields = Vec::new();
+    for key in PREFERRED_JSON_KEYS {
+        let Some(value) = map.get(*key) else {
+            continue;
+        };
+        if let Some(scalar) = scalar_to_string(value) {
+            fields.push(format!("{key}={scalar}"));
+        }
+        if fields.len() >= 6 {
+            break;
+        }
+    }
+
+    (!fields.is_empty()).then(|| format!("{path}: {}", fields.join(", ")))
+}
+
+fn push_scalar(path: &str, value: &Value, out: &mut Vec<String>) {
+    let Some(scalar) = scalar_to_string(value) else {
+        return;
+    };
+    out.push(format!("{path}: {scalar}"));
+}
+
+fn scalar_to_string(value: &Value) -> Option<String> {
+    match value {
+        Value::String(text) => Some(format!(
+            "\"{}\"",
+            crate::worker::truncate_chars(text, TOOL_RESULT_SCALAR_MAX_CHARS)
+        )),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Null | Value::Array(_) | Value::Object(_) => None,
+    }
+}
+
+fn is_scalar(value: &Value) -> bool {
+    matches!(value, Value::String(_) | Value::Number(_) | Value::Bool(_))
+}
+
+const PREFERRED_JSON_KEYS: &[&str] = &[
+    "number",
+    "title",
+    "name",
+    "full_name",
+    "state",
+    "status",
+    "html_url",
+    "url",
+    "path",
+    "file",
+    "value",
+    "fact",
+    "result",
+    "answer",
+    "summary",
+    "message",
+    "stdout",
+    "stderr",
+    "description",
+];
 
 fn message_role(msg: &Value) -> &str {
     msg.get("role").and_then(|r| r.as_str()).unwrap_or("")
@@ -748,19 +979,27 @@ mod tests {
 
         assert_eq!(
             roles,
-            vec!["system", "user", "assistant", "tool", "assistant", "tool"],
+            vec![
+                "system",
+                "system",
+                "user",
+                "assistant",
+                "tool",
+                "assistant",
+                "tool"
+            ],
             "tool-result reducer context must not start with a bare tool message",
         );
         assert_eq!(
-            messages[1].get("content").and_then(|c| c.as_str()),
+            messages[2].get("content").and_then(|c| c.as_str()),
             Some("What is the weather today?"),
         );
         assert!(
-            messages[2].get("tool_calls").is_some(),
+            messages[3].get("tool_calls").is_some(),
             "first tool result must retain its preceding assistant tool_call",
         );
         assert!(
-            messages[4].get("tool_calls").is_some(),
+            messages[5].get("tool_calls").is_some(),
             "latest tool result must retain its preceding assistant tool_call",
         );
         assert!(
@@ -790,6 +1029,99 @@ mod tests {
         assert_eq!(
             tools[0].pointer("/function/name").and_then(Value::as_str),
             Some("read_file")
+        );
+    }
+
+    #[test]
+    fn small_tool_result_content_is_preserved_exactly() {
+        let s = session_with(
+            &[
+                user_msg("Read /tmp/a"),
+                assistant_tool_msg("call_read", "read_file", json!({"path": "/tmp/a"})),
+                tool_result_msg("call_read", "short exact result"),
+            ],
+            Some(tools_two()),
+        );
+
+        let (messages, _tools) = pack_for_tool_result_turn(&s, true);
+        let tool = messages
+            .iter()
+            .find(|msg| msg.get("role").and_then(Value::as_str) == Some("tool"))
+            .expect("tool message");
+
+        assert_eq!(
+            tool.get("content").and_then(Value::as_str),
+            Some("short exact result")
+        );
+    }
+
+    #[test]
+    fn large_json_tool_result_is_compacted_for_reducer() {
+        let noisy_body = "x".repeat(8_000);
+        let result = json!([
+            {
+                "number": 801,
+                "title": "Batch Skippy decode across concurrent requests",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/801",
+                "body": noisy_body,
+                "user": {"login": "i386"}
+            },
+            {
+                "number": 800,
+                "title": "Reuse Skippy forwarded decode frames",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/issues/800",
+                "body": "y".repeat(8_000),
+                "user": {"login": "i386"}
+            },
+            {
+                "number": 799,
+                "title": "Reuse Skippy decode wire messages",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/issues/799",
+                "body": "z".repeat(8_000),
+                "user": {"login": "i386"}
+            }
+        ])
+        .to_string();
+        assert!(result.len() > TOOL_RESULT_RAW_MAX_CHARS);
+
+        let s = session_with(
+            &[
+                user_msg("Summarize the issues"),
+                assistant_tool_msg(
+                    "call_exec",
+                    "exec",
+                    json!({"command": "curl https://api.github.com/repos/Mesh-LLM/mesh-llm/issues"}),
+                ),
+                tool_result_msg("call_exec", &result),
+            ],
+            Some(tools_two()),
+        );
+
+        let (messages, _tools) = pack_for_tool_result_turn(&s, true);
+        let tool = messages
+            .iter()
+            .find(|msg| msg.get("role").and_then(Value::as_str) == Some("tool"))
+            .expect("tool message");
+        let content = tool
+            .get("content")
+            .and_then(Value::as_str)
+            .expect("compacted content");
+
+        assert!(content.contains("Tool result compacted from"));
+        assert!(content.contains("$[0]: number=801"));
+        assert!(content.contains("Batch Skippy decode across concurrent requests"));
+        assert!(content.contains("$[1]: number=800"));
+        assert!(content.contains("Reuse Skippy forwarded decode frames"));
+        assert!(content.contains("$[2]: number=799"));
+        assert!(content.contains("Reuse Skippy decode wire messages"));
+        assert!(
+            content.len() < 2_000,
+            "compacted tool content should be small, got {} chars:\n{content}",
+            content.len()
+        );
+        assert!(
+            !content.contains(&"x".repeat(512)),
+            "large noisy fields should not be forwarded raw"
         );
     }
 
@@ -844,16 +1176,16 @@ mod tests {
             "packed context should keep the MoA system preamble",
         );
         assert_eq!(
-            roles[1], "user",
+            roles[2], "user",
             "long bounded context should still include the original user query",
         );
         assert!(
-            packed.len() <= TOOL_RESULT_CONTEXT_WINDOW + 2,
-            "expected system + user prefix + bounded recent tail, got {} messages",
+            packed.len() <= TOOL_RESULT_CONTEXT_WINDOW + 3,
+            "expected system + evidence + user prefix + bounded recent tail, got {} messages",
             packed.len(),
         );
         assert_ne!(
-            roles[2], "tool",
+            roles[3], "tool",
             "bounded recent tail must not start with a bare tool message",
         );
     }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -159,6 +159,16 @@ struct ForcedToolChoice {
     fallback_arguments: Value,
 }
 
+struct DecisionResolution<'a> {
+    session: &'a Session,
+    decision: arbiter::Decision,
+    outputs: &'a [WorkerOutput],
+    has_tools: bool,
+    selected_tool_names: &'a [String],
+    forced_tool: Option<&'a ForcedToolChoice>,
+    allowed_tools: &'a [String],
+}
+
 // ─── Gateway entry point ─────────────────────────────────────────────
 
 /// Process one MoA turn.
@@ -309,13 +319,15 @@ async fn handle_query(
     let decision = early_decision.unwrap_or_else(|| arbiter::arbitrate(&outputs, query_uses_tools));
     let (response_body, reducer_used, reducer_attempts) = resolve_decision(
         config,
-        session,
-        decision,
-        &outputs,
-        query_uses_tools,
-        &selected_tool_names,
-        forced_tool,
-        allowed_tools,
+        DecisionResolution {
+            session,
+            decision,
+            outputs: &outputs,
+            has_tools: query_uses_tools,
+            selected_tool_names: &selected_tool_names,
+            forced_tool,
+            allowed_tools,
+        },
     )
     .await;
 
@@ -934,14 +946,18 @@ fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count
 /// Returns (response body, reducer_used, reducer_attempts).
 async fn resolve_decision(
     config: &GatewayConfig,
-    session: &Session,
-    decision: arbiter::Decision,
-    outputs: &[WorkerOutput],
-    has_tools: bool,
-    selected_tool_names: &[String],
-    forced_tool: Option<&ForcedToolChoice>,
-    allowed_tools: &[String],
+    request: DecisionResolution<'_>,
 ) -> (Value, bool, u32) {
+    let DecisionResolution {
+        session,
+        decision,
+        outputs,
+        has_tools,
+        selected_tool_names,
+        forced_tool,
+        allowed_tools,
+    } = request;
+
     match decision {
         arbiter::Decision::Answer(text) => {
             if let Some(tool) = forced_tool.filter(|_| has_tools) {
@@ -1521,15 +1537,19 @@ mod response_builder_tests {
             name: "lookup_probe_fact".to_string(),
             fallback_arguments: json!({"key": "primary"}),
         };
+        let selected_tool_names = ["lookup_probe_fact".to_string()];
+        let allowed_tools = ["lookup_probe_fact".to_string()];
         let (resp, reducer_used, attempts) = resolve_decision(
             &config,
-            &session,
-            arbiter::Decision::Answer("I would call the tool.".to_string()),
-            &[],
-            true,
-            &["lookup_probe_fact".to_string()],
-            Some(&forced_tool),
-            &["lookup_probe_fact".to_string()],
+            DecisionResolution {
+                session: &session,
+                decision: arbiter::Decision::Answer("I would call the tool.".to_string()),
+                outputs: &[],
+                has_tools: true,
+                selected_tool_names: &selected_tool_names,
+                forced_tool: Some(&forced_tool),
+                allowed_tools: &allowed_tools,
+            },
         )
         .await;
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -50,7 +50,7 @@ pub(crate) use tool_guard::enforce_tool_call_contract;
 
 use backend::call_backend;
 use fanout::{GraceMode, gather_workers_incremental};
-use mesh_llm_guardrails::tool_arguments_wire_string;
+use mesh_llm_guardrails::{sanitize_tool_arguments_for_tool, tool_arguments_wire_string};
 use normalize::WorkerOutput;
 use reducer::{hedged_reducer_call, reducer_candidates};
 use serde_json::{Value, json};
@@ -153,6 +153,12 @@ pub struct WorkerSummary {
     pub confidence: Option<f32>,
 }
 
+#[derive(Debug, Clone)]
+struct ForcedToolChoice {
+    name: String,
+    fallback_arguments: Value,
+}
+
 // ─── Gateway entry point ─────────────────────────────────────────────
 
 /// Process one MoA turn.
@@ -178,6 +184,7 @@ pub async fn handle_turn(config: &GatewayConfig, body: &Value) -> TurnResult {
     session.ingest(&incoming_messages, &tools);
 
     let turn_type = session.classify_turn();
+    let forced_tool = forced_tool_choice(body, &session, &tools);
     tracing::info!(
         "moa: turn={:?}, {} models, tools={}",
         turn_type,
@@ -192,7 +199,15 @@ pub async fn handle_turn(config: &GatewayConfig, body: &Value) -> TurnResult {
             handle_tool_result(config, &session, has_tools, &allowed_tools, start).await
         }
         session::TurnType::Fresh => {
-            handle_query(config, &session, has_tools, &allowed_tools, start).await
+            handle_query(
+                config,
+                &session,
+                has_tools,
+                &allowed_tools,
+                forced_tool.as_ref(),
+                start,
+            )
+            .await
         }
     }
 }
@@ -204,12 +219,15 @@ async fn handle_query(
     session: &Session,
     has_tools: bool,
     allowed_tools: &[String],
+    forced_tool: Option<&ForcedToolChoice>,
     start: Instant,
 ) -> TurnResult {
     let assignments = worker::assign_roles(&config.models);
     let grace_mode = grace_mode_for_turn(session, has_tools);
-    let query_uses_tools = matches!(grace_mode, GraceMode::Tool);
-    let selected_tool_names = if query_uses_tools {
+    let query_uses_tools = forced_tool.is_some() || matches!(grace_mode, GraceMode::Tool);
+    let selected_tool_names = if let Some(tool) = forced_tool {
+        vec![tool.name.clone()]
+    } else if query_uses_tools {
         selected_tool_names_for_turn(session, allowed_tools)
     } else {
         Vec::new()
@@ -296,6 +314,7 @@ async fn handle_query(
         &outputs,
         query_uses_tools,
         &selected_tool_names,
+        forced_tool,
         allowed_tools,
     )
     .await;
@@ -395,6 +414,11 @@ fn selected_tool_names_for_turn(session: &Session, allowed_tools: &[String]) -> 
     }
 
     let text = session.last_user_text().to_ascii_lowercase();
+    let explicit = explicitly_requested_tool_names(&available, &text);
+    if !explicit.is_empty() {
+        return with_recent_tool_chain_names(session, &available, explicit);
+    }
+
     let mut selected = Vec::new();
     for tool in &available {
         let tool_lc = tool.to_ascii_lowercase();
@@ -403,6 +427,14 @@ fn selected_tool_names_for_turn(session: &Session, allowed_tools: &[String]) -> 
         }
     }
 
+    with_recent_tool_chain_names(session, &available, selected)
+}
+
+fn with_recent_tool_chain_names(
+    session: &Session,
+    available: &[String],
+    mut selected: Vec<String>,
+) -> Vec<String> {
     for tool in recent_tool_chain_names(session) {
         if available.iter().any(|available| available == &tool) && !selected.contains(&tool) {
             selected.push(tool);
@@ -410,10 +442,42 @@ fn selected_tool_names_for_turn(session: &Session, allowed_tools: &[String]) -> 
     }
 
     if selected.is_empty() && available.len() == 1 {
-        available
+        available.to_vec()
     } else {
         selected
     }
+}
+
+fn explicitly_requested_tool_names(available: &[String], text: &str) -> Vec<String> {
+    available
+        .iter()
+        .filter(|tool| tool_name_is_explicitly_requested(&tool.to_ascii_lowercase(), text))
+        .cloned()
+        .collect()
+}
+
+fn tool_name_is_explicitly_requested(tool: &str, text: &str) -> bool {
+    if tool.len() < 3 {
+        return false;
+    }
+
+    let spaced = tool.replace('_', " ");
+    let patterns = [
+        format!("use {tool}"),
+        format!("use the {tool}"),
+        format!("{tool} tool"),
+        format!("tool {tool}"),
+        format!("call {tool}"),
+        format!("call the {tool}"),
+        format!("use {spaced}"),
+        format!("use the {spaced}"),
+        format!("{spaced} tool"),
+        format!("tool {spaced}"),
+        format!("call {spaced}"),
+        format!("call the {spaced}"),
+    ];
+
+    patterns.iter().any(|pattern| text.contains(pattern))
 }
 
 fn recent_tool_chain_names(session: &Session) -> Vec<String> {
@@ -516,6 +580,108 @@ fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
 }
 
+fn forced_tool_choice(
+    body: &Value,
+    session: &Session,
+    tools: &Option<Value>,
+) -> Option<ForcedToolChoice> {
+    let name = body
+        .get("tool_choice")?
+        .get("function")?
+        .get("name")?
+        .as_str()?;
+    if name.is_empty() || !session.tool_names().iter().any(|tool| tool == name) {
+        return None;
+    }
+
+    let inferred =
+        infer_tool_arguments_from_prompt(name, tools.as_ref(), &session.last_user_text());
+    let fallback_arguments =
+        sanitize_tool_arguments_for_tool(name, &inferred, tools.as_ref()).unwrap_or(inferred);
+
+    Some(ForcedToolChoice {
+        name: name.to_string(),
+        fallback_arguments,
+    })
+}
+
+fn infer_tool_arguments_from_prompt(name: &str, tools: Option<&Value>, prompt: &str) -> Value {
+    let Some(parameters) = tool_parameters(name, tools) else {
+        return json!({});
+    };
+    let Some(required) = parameters.get("required").and_then(Value::as_array) else {
+        return json!({});
+    };
+    let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
+        return json!({});
+    };
+
+    let mut args = serde_json::Map::new();
+    for field in required.iter().filter_map(Value::as_str) {
+        let Some(schema) = properties.get(field) else {
+            continue;
+        };
+        if let Some(value) = infer_string_argument(field, schema, prompt) {
+            args.insert(field.to_string(), Value::String(value));
+        }
+    }
+    Value::Object(args)
+}
+
+fn infer_string_argument(field: &str, schema: &Value, prompt: &str) -> Option<String> {
+    if !schema_allows_string(schema) {
+        return None;
+    }
+
+    infer_enum_argument(schema, prompt).or_else(|| infer_assignment_argument(field, prompt))
+}
+
+fn schema_allows_string(schema: &Value) -> bool {
+    match schema.get("type") {
+        Some(Value::String(value)) => value == "string",
+        Some(Value::Array(values)) => values.iter().any(|value| value.as_str() == Some("string")),
+        None => true,
+        _ => false,
+    }
+}
+
+fn infer_enum_argument(schema: &Value, prompt: &str) -> Option<String> {
+    let prompt_lc = prompt.to_ascii_lowercase();
+    schema
+        .get("enum")?
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .find(|candidate| prompt_lc.contains(&candidate.to_ascii_lowercase()))
+        .map(str::to_string)
+}
+
+fn infer_assignment_argument(field: &str, prompt: &str) -> Option<String> {
+    let prompt_lc = prompt.to_ascii_lowercase();
+    let field_lc = field.to_ascii_lowercase();
+    let marker = format!("{field_lc}=");
+    let start = prompt_lc.find(&marker)? + marker.len();
+    let tail = prompt_lc.get(start..)?;
+    let value = tail
+        .split(|c: char| c.is_whitespace() || c == ',' || c == '.' || c == ';')
+        .next()
+        .unwrap_or("")
+        .trim_matches(|c| c == '"' || c == '\'' || c == '`');
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn tool_parameters<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a Value> {
+    tools?
+        .as_array()?
+        .iter()
+        .find(|tool| {
+            tool.pointer("/function/name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| name == tool_name)
+        })?
+        .pointer("/function/parameters")
+}
+
 // ─── Tool result handling ────────────────────────────────────────────
 
 async fn handle_tool_result(
@@ -600,7 +766,7 @@ async fn handle_tool_result(
                     "MoA reducer returned no usable answer",
                     MOA_ERR_NO_USABLE_ANSWER,
                 ),
-                _ => chat_response(&reduced.payload),
+                _ => chat_response(&repair_tool_result_answer(session, &reduced.payload)),
             };
             (name, true, body)
         }
@@ -635,6 +801,98 @@ async fn handle_tool_result(
     }
 }
 
+fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
+    if !tool_evidence_should_be_preserved(&session.last_user_text()) {
+        return answer.to_string();
+    }
+
+    let missing = missing_tool_evidence_values(session, answer);
+    if missing.is_empty() {
+        return answer.to_string();
+    }
+
+    let mut repaired = answer.trim().to_string();
+    if !repaired.is_empty() {
+        repaired.push_str("\n\n");
+    }
+    repaired.push_str("Tool facts: ");
+    repaired.push_str(&missing.join(", "));
+    repaired
+}
+
+fn tool_evidence_should_be_preserved(user_text: &str) -> bool {
+    let text = user_text.to_ascii_lowercase();
+    contains_any(
+        &text,
+        &[
+            "tool fact",
+            "tool facts",
+            "tool result",
+            "tool output",
+            "final recall",
+            "include both",
+            "include all",
+            "answer with the tool",
+            "return the tool",
+        ],
+    )
+}
+
+fn missing_tool_evidence_values(session: &Session, answer: &str) -> Vec<String> {
+    let mut missing = Vec::new();
+    for (_, result) in session.recent_tool_results() {
+        for value in short_tool_result_values(&result) {
+            if !answer.contains(&value) && !missing.iter().any(|seen| seen == &value) {
+                missing.push(value);
+            }
+        }
+    }
+    missing
+}
+
+fn short_tool_result_values(result: &str) -> Vec<String> {
+    let Ok(parsed) = serde_json::from_str::<Value>(result) else {
+        return Vec::new();
+    };
+
+    let mut values = Vec::new();
+    collect_short_tool_result_values(&parsed, &mut values);
+    values
+}
+
+fn collect_short_tool_result_values(value: &Value, values: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, nested) in map {
+                if !tool_result_value_key_is_evidence(key) {
+                    continue;
+                }
+                if let Some(scalar) = nested.as_str().filter(|s| short_exact_value(s)) {
+                    values.push(scalar.to_string());
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_short_tool_result_values(item, values);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn tool_result_value_key_is_evidence(key: &str) -> bool {
+    matches!(
+        key.to_ascii_lowercase().as_str(),
+        "value" | "fact" | "result" | "answer"
+    )
+}
+
+fn short_exact_value(value: &str) -> bool {
+    let trimmed = value.trim();
+    !trimmed.is_empty() && trimmed.len() <= 160 && !trimmed.contains('\n')
+}
+
 fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
     let calls = session.pending_tool_calls();
     let last = calls.last()?;
@@ -657,11 +915,14 @@ fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count
          If the evidence is incomplete, say what can be determined and what is missing."
     );
 
-    if let Some(system) = messages
+    let system_content = messages
         .iter_mut()
         .find(|msg| msg.get("role").and_then(Value::as_str) == Some("system"))
-        && let Some(content) = system.get("content").and_then(Value::as_str)
-    {
+        .and_then(|system| {
+            let content = system.get("content").and_then(Value::as_str)?.to_string();
+            Some((system, content))
+        });
+    if let Some((system, content)) = system_content {
         let mut updated = content.to_string();
         updated.push_str(&instruction);
         system["content"] = Value::String(updated);
@@ -678,10 +939,21 @@ async fn resolve_decision(
     outputs: &[WorkerOutput],
     has_tools: bool,
     selected_tool_names: &[String],
+    forced_tool: Option<&ForcedToolChoice>,
     allowed_tools: &[String],
 ) -> (Value, bool, u32) {
     match decision {
-        arbiter::Decision::Answer(text) => (chat_response(&text), false, 0),
+        arbiter::Decision::Answer(text) => {
+            if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                (
+                    tool_call_response(&tool.name, &tool.fallback_arguments),
+                    false,
+                    0,
+                )
+            } else {
+                (chat_response(&text), false, 0)
+            }
+        }
         arbiter::Decision::ToolCall { name, arguments } => {
             if has_tools {
                 (tool_call_response(&name, &arguments), false, 0)
@@ -755,9 +1027,27 @@ async fn resolve_decision(
                         (tool_proposal_response(&reduced, has_tools), true, attempts)
                     }
                     normalize::OutputKind::Uncertainty => {
-                        (fallback_worker_response(outputs), true, attempts)
+                        if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                            (
+                                tool_call_response(&tool.name, &tool.fallback_arguments),
+                                true,
+                                attempts,
+                            )
+                        } else {
+                            (fallback_worker_response(outputs), true, attempts)
+                        }
                     }
-                    _ => (chat_response(&reduced.payload), true, attempts),
+                    _ => {
+                        if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                            (
+                                tool_call_response(&tool.name, &tool.fallback_arguments),
+                                true,
+                                attempts,
+                            )
+                        } else {
+                            (chat_response(&reduced.payload), true, attempts)
+                        }
+                    }
                 },
                 None => {
                     tracing::warn!("moa: all reducer candidates failed, using best worker");
@@ -765,7 +1055,15 @@ async fn resolve_decision(
                     // produce the output we're returning — we fell back to
                     // a worker. attempts still reflects what was spawned so
                     // observability can see "we tried N times and all failed".
-                    (fallback_worker_response(outputs), false, attempts)
+                    if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                        (
+                            tool_call_response(&tool.name, &tool.fallback_arguments),
+                            false,
+                            attempts,
+                        )
+                    } else {
+                        (fallback_worker_response(outputs), false, attempts)
+                    }
                 }
             }
         }
@@ -804,7 +1102,7 @@ fn fallback_worker_response(outputs: &[WorkerOutput]) -> Value {
 }
 
 fn tool_proposal_response(output: &WorkerOutput, has_tools: bool) -> Value {
-    if has_tools && let Some(name) = output.tool_name.as_ref() {
+    if let (true, Some(name)) = (has_tools, output.tool_name.as_ref()) {
         let args = output.tool_arguments.as_ref().unwrap_or(&Value::Null);
         return tool_call_response(name, args);
     }
@@ -1132,6 +1430,129 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn forced_tool_choice_infers_enum_argument_from_prompt() {
+        let body = serde_json::json!({
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "lookup_probe_fact"}
+            },
+            "messages": [{
+                "role": "user",
+                "content": "Use lookup_probe_fact with primary and report the result."
+            }],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup_probe_fact",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["primary", "secondary"]
+                            }
+                        },
+                        "required": ["key"]
+                    }
+                }
+            }]
+        });
+        let tools = body.get("tools").cloned();
+        let mut session = Session::new();
+        let messages = body
+            .get("messages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap();
+        session.ingest(&messages, &tools);
+
+        let forced = forced_tool_choice(&body, &session, &tools).expect("forced tool");
+
+        assert_eq!(forced.name, "lookup_probe_fact");
+        assert_eq!(forced.fallback_arguments, json!({"key": "primary"}));
+    }
+
+    #[test]
+    fn forced_tool_choice_infers_assignment_argument_from_prompt() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "lookup_probe_fact",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"key": {"type": "string"}},
+                    "required": ["key"]
+                }
+            }
+        }]));
+
+        let args = infer_tool_arguments_from_prompt(
+            "lookup_probe_fact",
+            tools.as_ref(),
+            "Use key=Primary",
+        );
+
+        assert_eq!(args, json!({"key": "primary"}));
+    }
+
+    #[tokio::test]
+    async fn forced_tool_choice_overrides_answer_decision() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use lookup_probe_fact with primary"
+            })],
+            &Some(serde_json::json!([{
+                "type": "function",
+                "function": {"name": "lookup_probe_fact"}
+            }])),
+        );
+        let config = GatewayConfig {
+            backends: Vec::new(),
+            models: Vec::new(),
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::from_millis(10),
+            enable_thinking: Some(false),
+        };
+        let forced_tool = ForcedToolChoice {
+            name: "lookup_probe_fact".to_string(),
+            fallback_arguments: json!({"key": "primary"}),
+        };
+        let (resp, reducer_used, attempts) = resolve_decision(
+            &config,
+            &session,
+            arbiter::Decision::Answer("I would call the tool.".to_string()),
+            &[],
+            true,
+            &["lookup_probe_fact".to_string()],
+            Some(&forced_tool),
+            &["lookup_probe_fact".to_string()],
+        )
+        .await;
+
+        assert!(!reducer_used);
+        assert_eq!(attempts, 0);
+        assert_eq!(
+            resp.pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("lookup_probe_fact")
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"key\":\"primary\"}")
+        );
+    }
+
+    #[test]
     fn error_response_reports_message_based_completion_tokens() {
         let resp = error_response("All MoA workers failed", MOA_ERR_ALL_WORKERS_FAILED);
         let tokens = resp
@@ -1259,6 +1680,48 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn explicit_exec_request_suppresses_url_broadened_tools() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use exec exactly once. Command: curl https://api.github.com/repos/Mesh-LLM/mesh-llm/issues"
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "exec"}},
+                {"type": "function", "function": {"name": "web_search"}},
+                {"type": "function", "function": {"name": "web_fetch"}}
+            ])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[]),
+            vec!["exec".to_string()]
+        );
+    }
+
+    #[test]
+    fn explicit_multiple_tool_request_keeps_named_tools() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use the exec tool once to run pwd, then use read to inspect USER.md."
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "exec"}},
+                {"type": "function", "function": {"name": "read"}},
+                {"type": "function", "function": {"name": "web_search"}}
+            ])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[]),
+            vec!["exec".to_string(), "read".to_string()]
+        );
+    }
+
+    #[test]
     fn two_same_tool_results_do_not_force_answer() {
         let mut session = Session::new();
         session.ingest(
@@ -1299,6 +1762,65 @@ mod response_builder_tests {
             repeated_same_tool_results(&session),
             Some(("web_search".to_string(), 3))
         );
+    }
+
+    #[test]
+    fn repair_tool_result_answer_preserves_short_json_values_on_recall() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "search"}),
+                tool_call_msg("call_1", "lookup"),
+                tool_result_msg("call_1", r#"{"key":"primary","value":"PRIMARY-FACT-123"}"#),
+                tool_call_msg("call_2", "lookup"),
+                tool_result_msg(
+                    "call_2",
+                    r#"{"key":"secondary","value":"SECONDARY-FACT-456"}"#,
+                ),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Final recall: include both tool facts."
+                }),
+            ],
+            &None,
+        );
+
+        let repaired =
+            repair_tool_result_answer(&session, "The secondary fact is SECONDARY-FACT-456.");
+
+        assert!(repaired.contains("PRIMARY-FACT-123"));
+        assert!(repaired.contains("SECONDARY-FACT-456"));
+        assert!(!repaired.contains("primary"));
+    }
+
+    #[test]
+    fn repair_tool_result_answer_ignores_large_or_non_evidence_tool_values() {
+        let huge = "x".repeat(200);
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "search"}),
+                tool_call_msg("call_1", "lookup"),
+                tool_result_msg(
+                    "call_1",
+                    &serde_json::json!({
+                        "value": huge,
+                        "debug": "SHORT-BUT-NOT-EVIDENCE",
+                        "result": "multi\nline",
+                    })
+                    .to_string(),
+                ),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Final recall: include tool facts."
+                }),
+            ],
+            &None,
+        );
+
+        let repaired = repair_tool_result_answer(&session, "Done.");
+
+        assert_eq!(repaired, "Done.");
     }
 
     fn tool_call_msg(id: &str, name: &str) -> Value {

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -189,9 +189,12 @@ fn try_json_parse(
     // — if the worker writes inline tool JSON and we miss it, MoA leaks
     // the JSON back as `content` and the agent does nothing. This is
     // the failure mode PR #566 review called out.
-    if obj.get("kind").is_none()
-        && let Some((tool_name, arguments)) = extract_tool_name_and_arguments(&obj)
-    {
+    let openai_tool_call = obj
+        .get("kind")
+        .is_none()
+        .then(|| extract_tool_name_and_arguments(&obj))
+        .flatten();
+    if let Some((tool_name, arguments)) = openai_tool_call {
         let args = normalize_tool_arguments(arguments).map(Value::Object);
         return Some(WorkerOutput {
             kind: OutputKind::ToolProposal,
@@ -531,9 +534,9 @@ fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
     }
 
     // Strategy 1: Look for structured JSON in the text
-    if let Some(json_str) = extract_json_object(raw)
-        && let Ok(obj) = serde_json::from_str::<Value>(&json_str)
-    {
+    let parsed_json =
+        extract_json_object(raw).and_then(|json_str| serde_json::from_str::<Value>(&json_str).ok());
+    if let Some(obj) = parsed_json {
         if let Some((name, arguments)) = extract_tool_name_and_arguments(&obj) {
             let args = normalize_tool_arguments(arguments).map(Value::Object);
             return (Some(name.to_string()), args);

--- a/crates/mesh-mixture-of-agents/src/worker.rs
+++ b/crates/mesh-mixture-of-agents/src/worker.rs
@@ -135,9 +135,7 @@ pub(crate) fn is_single_digit_b_name(name: &str) -> bool {
             continue;
         }
         // Byte after must not be another digit (avoid BF16-like continuations)
-        if let Some(&after) = bytes.get(i + 2)
-            && after.is_ascii_digit()
-        {
+        if bytes.get(i + 2).is_some_and(u8::is_ascii_digit) {
             continue;
         }
         return true;


### PR DESCRIPTION
🤖 Improves MoA behavior for agentic tool loops by keeping tool selection tighter and bounding large tool-result context before reducer synthesis.

What changed:
- Preserve exact small tool results for follow-up recall.
- Compact large JSON/text tool results into bounded evidence before reducer calls.
- Prefer explicitly requested tools, so prompts like "use exec" do not broaden into unrelated web tools.
- Add deterministic repair for short tool facts that reducers omit.

Why:
Large tool outputs, especially GitHub/API JSON, could make the post-tool reducer path slow or time out even after the tool call succeeded.

Validation:
- cargo test -p mesh-mixture-of-agents --lib
- cargo fmt --all -- --check
- MESH_LLM_DYNAMIC_NATIVE_RUNTIME=0 just release-build
- Deployed static build to mini and validated OpenClaw via mesh/mesh with a GitHub exec workflow and same-session follow-up recall.