### PR TITLE
Expose bounded route diagnostics

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -1109,6 +1109,114 @@ mod tests {
     }
 
     #[test]
+    fn status_payload_exposes_bounded_route_decision_diagnostics() {
+        let routing_metrics = metrics::RoutingMetricsStatusSnapshot {
+            recent_route_decisions: vec![
+                crate::network::route_diagnostics::RouteDecisionSnapshot {
+                    model: "qwen".into(),
+                    required_tokens: Some(8192),
+                    selected_target: Some("peer-a".into()),
+                    selected_kind: Some("remote".into()),
+                    reason_codes: vec!["selected".into()],
+                    age_secs: 0,
+                    targets: vec![
+                        crate::network::route_diagnostics::RouteDecisionTargetSnapshot {
+                            target: "peer-a".into(),
+                            kind: "remote".into(),
+                            selected: true,
+                            context_length: Some(32768),
+                            required_tokens: Some(8192),
+                            avg_tokens_per_second_milli: Some(41_000),
+                            throughput_samples: 7,
+                            reason_codes: vec!["selected".into()],
+                        },
+                        crate::network::route_diagnostics::RouteDecisionTargetSnapshot {
+                            target: "https://example.test/v1".into(),
+                            kind: "endpoint".into(),
+                            selected: false,
+                            context_length: Some(4096),
+                            required_tokens: Some(8192),
+                            avg_tokens_per_second_milli: None,
+                            throughput_samples: 0,
+                            reason_codes: vec!["context_too_small".into(), "not_selected".into()],
+                        },
+                    ],
+                },
+            ],
+            ..Default::default()
+        };
+
+        let status = StatusPayload {
+            version: "0.60.2".to_string(),
+            latest_version: None,
+            node_id: "node-1".to_string(),
+            owner: test_owner_payload(),
+            release_attestation: test_release_attestation_summary(),
+            token: "token-1".to_string(),
+            node_state: NodeState::Loading,
+            node_status: NodeState::Loading.node_status_alias().to_string(),
+            is_host: true,
+            is_client: false,
+            llama_ready: false,
+            runtime: RuntimeStatusPayload {
+                backend: None,
+                openai_guardrails: None,
+                models: vec![],
+                stages: vec![],
+            },
+            model_name: "Qwen".to_string(),
+            models: vec![],
+            available_models: vec![],
+            requested_models: vec![],
+            wanted_model_refs: vec![],
+            serving_models: vec![],
+            hosted_models: vec![],
+            draft_name: None,
+            api_port: 3131,
+            my_vram_gb: 0.0,
+            model_size_gb: 0.0,
+            peers: vec![],
+            wakeable_nodes: vec![],
+            local_instances: vec![],
+            launch_pi: None,
+            launch_goose: None,
+            inflight_requests: 0,
+            mesh_id: None,
+            mesh_name: None,
+            mesh_discovery_mode: "nostr".into(),
+            discovery_scope: "public".into(),
+            discovery_source: "nostr-relay".into(),
+            nostr_discovery: false,
+            publication_state: "private".into(),
+            my_hostname: None,
+            my_is_soc: None,
+            gpus: vec![],
+            routing_affinity: affinity::AffinityStatsSnapshot::default(),
+            routing_metrics,
+            first_joined_mesh_ts: None,
+            mesh_requirements: None,
+            recent_mesh_rejections: vec![],
+        };
+
+        let json = serde_json::to_value(&status).expect("serialization failed");
+
+        let decision = &json["routing_metrics"]["recent_route_decisions"][0];
+        assert_eq!(decision["selected_target"], serde_json::json!("peer-a"));
+        assert_eq!(
+            decision["targets"][0]["avg_tokens_per_second_milli"],
+            serde_json::json!(41_000)
+        );
+        assert_eq!(
+            decision["targets"][1]["reason_codes"][0],
+            serde_json::json!("context_too_small")
+        );
+        assert_eq!(
+            decision["targets"][1]["target"],
+            serde_json::json!("https://example.test/v1")
+        );
+    }
+
+    #[test]
     fn status_payload_keeps_node_status_for_compatibility() {
         let status = StatusPayload {
             version: "0.60.2".to_string(),

--- a/crates/mesh-llm-host-runtime/src/network/metrics.rs
+++ b/crates/mesh-llm-host-runtime/src/network/metrics.rs
@@ -1,6 +1,7 @@
 //! Bounded in-memory routing outcome and local routing pressure metrics for
 //! operator/API surfaces.
 
+use crate::inference::election;
 use serde::Serialize;
 use std::collections::hash_map::DefaultHasher;
 use std::collections::{HashMap, HashSet};
@@ -53,7 +54,7 @@ pub(crate) struct MetricGroupMetadata {
     pub(crate) description: &'static str,
 }
 
-pub(crate) const ROUTING_METRIC_GROUPS: [MetricGroupMetadata; 5] = [
+pub(crate) const ROUTING_METRIC_GROUPS: [MetricGroupMetadata; 6] = [
     MetricGroupMetadata {
         name: "routing_metrics",
         layer: MetricLayer::Information,
@@ -74,6 +75,13 @@ pub(crate) const ROUTING_METRIC_GROUPS: [MetricGroupMetadata; 5] = [
         scope: MetricScope::LocalOnly,
         api_surface: "/api/status",
         description: "Current-node service mix summary for locally fronted traffic.",
+    },
+    MetricGroupMetadata {
+        name: "routing_metrics.recent_route_decisions",
+        layer: MetricLayer::Information,
+        scope: MetricScope::LocalOnly,
+        api_surface: "/api/status",
+        description: "Bounded local target choice/rejection reasons for recent routing decisions.",
     },
     MetricGroupMetadata {
         name: "mesh_models[].routing_metrics",
@@ -127,6 +135,9 @@ pub struct RoutingMetricsStatusSnapshot {
     pub local_node: LocalNodePressureSnapshot,
     /// Current-node service mix for requests fronted by this node.
     pub pressure: RoutingPressureSnapshot,
+    /// Bounded local target choice/rejection reasons for recent routing decisions.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub recent_route_decisions: Vec<crate::network::route_diagnostics::RouteDecisionSnapshot>,
 }
 
 impl Default for RoutingMetricsStatusSnapshot {
@@ -148,6 +159,7 @@ impl Default for RoutingMetricsStatusSnapshot {
             throughput_samples: 0,
             local_node: LocalNodePressureSnapshot::default(),
             pressure: RoutingPressureSnapshot::default(),
+            recent_route_decisions: Vec::new(),
         }
     }
 }
@@ -287,6 +299,18 @@ pub(crate) enum AttemptTarget {
 }
 
 impl AttemptTarget {
+    pub(crate) fn from_inference_target(target: &election::InferenceTarget) -> Option<Self> {
+        match target {
+            election::InferenceTarget::Local(port) => {
+                Some(Self::Local(format!("127.0.0.1:{port}")))
+            }
+            election::InferenceTarget::Remote(peer_id) => {
+                Some(Self::Remote(peer_id.fmt_short().to_string()))
+            }
+            election::InferenceTarget::None => None,
+        }
+    }
+
     fn key(&self) -> TargetKey {
         match self {
             Self::Local(label) => TargetKey {
@@ -345,6 +369,7 @@ pub(crate) trait RoutingTelemetrySink: Send + Sync {
 pub struct RoutingMetrics {
     globals: Arc<GlobalMetrics>,
     shards: Arc<Vec<Mutex<ModelShard>>>,
+    route_diagnostics: crate::network::route_diagnostics::RouteDiagnostics,
     config: MetricsConfig,
 }
 
@@ -362,6 +387,7 @@ impl RoutingMetrics {
         Self {
             globals: Arc::new(GlobalMetrics::default()),
             shards: Arc::new(shards),
+            route_diagnostics: crate::network::route_diagnostics::RouteDiagnostics::new(),
             config,
         }
     }
@@ -442,7 +468,9 @@ impl RoutingMetrics {
     }
 
     pub fn status_snapshot(&self, current_inflight_requests: u64) -> RoutingMetricsStatusSnapshot {
-        self.globals.status_snapshot(current_inflight_requests)
+        let mut snapshot = self.globals.status_snapshot(current_inflight_requests);
+        snapshot.recent_route_decisions = self.route_diagnostics.snapshot();
+        snapshot
     }
 
     pub fn model_snapshots(&self) -> HashMap<String, ModelRoutingMetricsSnapshot> {
@@ -466,6 +494,13 @@ impl RoutingMetrics {
             status: self.status_snapshot(current_inflight_requests),
             models: self.model_snapshots(),
         }
+    }
+
+    pub(crate) fn record_route_decision(
+        &self,
+        record: crate::network::route_diagnostics::RouteDecisionRecord,
+    ) {
+        self.route_diagnostics.record(record);
     }
 
     /// Cheap per-model throughput lookup for routing decisions.
@@ -824,6 +859,7 @@ impl GlobalMetrics {
             throughput_samples,
             local_node,
             pressure,
+            recent_route_decisions: Vec::new(),
         }
     }
 }
@@ -1223,6 +1259,7 @@ mod tests {
                 "routing_metrics",
                 "routing_metrics.local_node",
                 "routing_metrics.pressure",
+                "routing_metrics.recent_route_decisions",
             ]
         );
         assert!(

--- a/crates/mesh-llm-host-runtime/src/network/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod metrics;
 pub(crate) mod nostr;
 pub(crate) mod openai;
 pub(crate) mod proxy;
+pub(crate) mod route_diagnostics;
 pub(crate) mod router;
 pub(crate) mod target_health;
 pub(crate) mod tunnel;

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -1011,7 +1011,15 @@ struct RankedTarget<T> {
     throughput: Option<TargetThroughputRank>,
 }
 
+#[derive(Clone)]
+struct TargetRouteDiagnostic {
+    target: election::InferenceTarget,
+    context_length: Option<u32>,
+    throughput: Option<TargetThroughputRank>,
+}
+
 const LOCAL_THROUGHPUT_PRECEDENCE_SAMPLES: u64 = 3;
+const GOSSIPED_THROUGHPUT_MIN_RANK_SAMPLES: u64 = 3;
 const TARGET_THROUGHPUT_MAX_SCORE_SAMPLES: u64 = 32;
 
 fn target_throughput_rank_key(throughput: Option<TargetThroughputRank>) -> (bool, bool, u64, u64) {
@@ -1019,6 +1027,11 @@ fn target_throughput_rank_key(throughput: Option<TargetThroughputRank>) -> (bool
         return (false, false, 0, 0);
     };
     if throughput.avg_tokens_per_second_milli == 0 || throughput.throughput_samples == 0 {
+        return (false, false, 0, 0);
+    }
+    if !throughput.local_observation
+        && throughput.throughput_samples < GOSSIPED_THROUGHPUT_MIN_RANK_SAMPLES
+    {
         return (false, false, 0, 0);
     }
     let sample_weight = throughput
@@ -1151,12 +1164,11 @@ async fn order_remote_hosts_by_context(
     reorder_candidates_by_context_and_throughput(&candidates, required_tokens)
 }
 
-async fn order_targets_by_context(
+async fn collect_target_route_diagnostics(
     node: &mesh::Node,
     model: &str,
-    required_tokens: Option<u32>,
     targets: &[election::InferenceTarget],
-) -> Vec<election::InferenceTarget> {
+) -> Vec<TargetRouteDiagnostic> {
     let mut candidates = Vec::with_capacity(targets.len());
     for target in targets {
         let context_length = match target {
@@ -1172,8 +1184,29 @@ async fn order_targets_by_context(
             }
             _ => local_target_throughput_rank(node, model, target),
         };
-        candidates.push((target.clone(), context_length, throughput));
+        candidates.push(TargetRouteDiagnostic {
+            target: target.clone(),
+            context_length,
+            throughput,
+        });
     }
+    candidates
+}
+
+fn order_target_route_diagnostics(
+    candidates: &[TargetRouteDiagnostic],
+    required_tokens: Option<u32>,
+) -> Vec<election::InferenceTarget> {
+    let candidates = candidates
+        .iter()
+        .map(|candidate| {
+            (
+                candidate.target.clone(),
+                candidate.context_length,
+                candidate.throughput,
+            )
+        })
+        .collect::<Vec<_>>();
     reorder_candidates_by_context_and_throughput(&candidates, required_tokens)
 }
 
@@ -3606,10 +3639,21 @@ async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> bool {
     } = args;
     let route_started = Instant::now();
     let mut tcp_stream = tcp_stream;
-    let ordered_candidates =
-        order_targets_by_context(&node, model, required_tokens, &targets.candidates(model)).await;
-    let ordered_candidates = affinity.route_eligible_candidates(model, &ordered_candidates);
+    let route_diagnostics =
+        collect_target_route_diagnostics(&node, model, &targets.candidates(model)).await;
+    let context_ordered_candidates =
+        order_target_route_diagnostics(&route_diagnostics, required_tokens);
+    let ordered_candidates = affinity.route_eligible_candidates(model, &context_ordered_candidates);
     if ordered_candidates.is_empty() {
+        record_route_model_decision(
+            &node,
+            model,
+            required_tokens,
+            &route_diagnostics,
+            &ordered_candidates,
+            None,
+            None,
+        );
         record_route_model_unavailable(&node, model, 0);
         let reason = no_context_eligible_target_reason(model, required_tokens);
         let _ = send_503(tcp_stream, &reason).await;
@@ -3622,6 +3666,15 @@ async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> bool {
         model,
         request.body_json.as_ref(),
         affinity,
+    );
+    record_route_model_decision(
+        &node,
+        model,
+        required_tokens,
+        &route_diagnostics,
+        &ordered_candidates,
+        Some(&selection.target),
+        selection.cached_target.as_ref(),
     );
     if matches!(selection.target, election::InferenceTarget::None) {
         return send_route_model_none_target(&node, tcp_stream, model).await;
@@ -3722,6 +3775,99 @@ async fn send_route_model_none_target(
     )
     .await;
     true
+}
+
+fn record_route_model_decision(
+    node: &mesh::Node,
+    model: &str,
+    required_tokens: Option<u32>,
+    candidates: &[TargetRouteDiagnostic],
+    eligible_candidates: &[election::InferenceTarget],
+    selected_target: Option<&election::InferenceTarget>,
+    cached_target: Option<&election::InferenceTarget>,
+) {
+    use crate::network::route_diagnostics::{
+        RouteDecisionReason, RouteDecisionRecord, RouteDecisionTargetRecord,
+    };
+
+    let selected_attempt_target =
+        selected_target.and_then(crate::network::metrics::AttemptTarget::from_inference_target);
+    let has_selected_target = selected_attempt_target.is_some();
+    let targets = candidates
+        .iter()
+        .filter_map(|candidate| {
+            let attempt_target =
+                crate::network::metrics::AttemptTarget::from_inference_target(&candidate.target)?;
+            let selected = selected_target == Some(&candidate.target);
+            let reason_codes = route_model_target_reason_codes(
+                required_tokens,
+                candidate,
+                eligible_candidates,
+                selected,
+                cached_target == Some(&candidate.target),
+            );
+            Some(RouteDecisionTargetRecord {
+                target: attempt_target,
+                context_length: candidate.context_length,
+                required_tokens,
+                avg_tokens_per_second_milli: candidate
+                    .throughput
+                    .map(|throughput| throughput.avg_tokens_per_second_milli),
+                throughput_samples: candidate
+                    .throughput
+                    .map(|throughput| throughput.throughput_samples)
+                    .unwrap_or(0),
+                reason_codes,
+            })
+        })
+        .collect();
+
+    node.routing_metrics()
+        .record_route_decision(RouteDecisionRecord {
+            model: model.to_string(),
+            required_tokens,
+            selected_target: selected_attempt_target,
+            reason_codes: if has_selected_target {
+                vec![RouteDecisionReason::Selected]
+            } else {
+                vec![RouteDecisionReason::NoEligibleTarget]
+            },
+            targets,
+        });
+}
+
+fn route_model_target_reason_codes(
+    required_tokens: Option<u32>,
+    candidate: &TargetRouteDiagnostic,
+    eligible_candidates: &[election::InferenceTarget],
+    selected: bool,
+    affinity_selected: bool,
+) -> Vec<crate::network::route_diagnostics::RouteDecisionReason> {
+    use crate::network::route_diagnostics::RouteDecisionReason;
+
+    let mut reasons = Vec::new();
+    if selected {
+        reasons.push(RouteDecisionReason::Selected);
+    }
+    if affinity_selected {
+        reasons.push(RouteDecisionReason::AffinitySelected);
+    }
+    if matches!(
+        (required_tokens, candidate.context_length),
+        (Some(required), Some(context)) if context < required
+    ) {
+        reasons.push(RouteDecisionReason::ContextTooSmall);
+    } else if required_tokens.is_some() && candidate.context_length.is_none() {
+        reasons.push(RouteDecisionReason::ContextUnknown);
+    } else if !eligible_candidates.contains(&candidate.target) {
+        reasons.push(RouteDecisionReason::HealthFiltered);
+    } else if !selected {
+        reasons.push(RouteDecisionReason::NotSelected);
+    }
+    if selected && candidate.throughput.is_some() {
+        reasons.push(RouteDecisionReason::ThroughputPreferred);
+    }
+    reasons
 }
 
 async fn finish_exhausted_route_model_request(
@@ -5758,6 +5904,49 @@ mod tests {
     }
 
     #[test]
+    fn test_route_model_target_reason_codes_prefer_context_rejection_reason() {
+        let target = election::InferenceTarget::Local(9337);
+        let candidate = TargetRouteDiagnostic {
+            target,
+            context_length: Some(4096),
+            throughput: None,
+        };
+
+        let reasons = route_model_target_reason_codes(Some(8192), &candidate, &[], false, false);
+
+        assert_eq!(
+            reasons,
+            vec![crate::network::route_diagnostics::RouteDecisionReason::ContextTooSmall]
+        );
+    }
+
+    #[test]
+    fn test_route_model_target_reason_codes_mark_selected_affinity_and_throughput() {
+        let target = election::InferenceTarget::Local(9337);
+        let candidate = TargetRouteDiagnostic {
+            target: target.clone(),
+            context_length: Some(8192),
+            throughput: Some(TargetThroughputRank {
+                avg_tokens_per_second_milli: 40_000,
+                throughput_samples: 4,
+                local_observation: true,
+            }),
+        };
+
+        let reasons =
+            route_model_target_reason_codes(Some(4096), &candidate, &[target], true, true);
+
+        assert_eq!(
+            reasons,
+            vec![
+                crate::network::route_diagnostics::RouteDecisionReason::Selected,
+                crate::network::route_diagnostics::RouteDecisionReason::AffinitySelected,
+                crate::network::route_diagnostics::RouteDecisionReason::ThroughputPreferred,
+            ]
+        );
+    }
+
+    #[test]
     fn test_mesh_blob_token_from_url_requires_client_id_segment() {
         assert_eq!(
             mesh_blob_token_from_url("mesh://blob/client-1/token-123"),
@@ -5865,7 +6054,7 @@ mod tests {
                     Some(8192),
                     Some(TargetThroughputRank {
                         avg_tokens_per_second_milli: 40_000,
-                        throughput_samples: 2,
+                        throughput_samples: 4,
                         local_observation: false,
                     }),
                 ),
@@ -5874,6 +6063,35 @@ mod tests {
         );
 
         assert_eq!(ordered, vec![2, 1]);
+    }
+
+    #[test]
+    fn test_reorder_candidates_ignores_low_sample_gossip_hint() {
+        let ordered = reorder_candidates_by_context_and_throughput(
+            &[
+                (
+                    1u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 20_000,
+                        throughput_samples: 32,
+                        local_observation: false,
+                    }),
+                ),
+                (
+                    2u8,
+                    Some(8192),
+                    Some(TargetThroughputRank {
+                        avg_tokens_per_second_milli: 40_000,
+                        throughput_samples: 2,
+                        local_observation: false,
+                    }),
+                ),
+            ],
+            Some(4096),
+        );
+
+        assert_eq!(ordered, vec![1, 2]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/route_diagnostics.rs
+++ b/crates/mesh-llm-host-runtime/src/network/route_diagnostics.rs
@@ -1,0 +1,372 @@
+//! Bounded local routing decision diagnostics for operator-facing status.
+
+use crate::network::metrics::AttemptTarget;
+use serde::Serialize;
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+const MAX_ROUTE_DECISIONS: usize = 16;
+const MAX_TARGETS_PER_DECISION: usize = 16;
+const MAX_REASON_CODES: usize = 2;
+const MAX_LABEL_BYTES: usize = 128;
+const REDACTED_SUFFIX: &str = "...";
+
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
+pub struct RouteDecisionSnapshot {
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_target: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_kind: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub reason_codes: Vec<String>,
+    pub targets: Vec<RouteDecisionTargetSnapshot>,
+    pub age_secs: u64,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RouteDecisionRecord {
+    pub(crate) model: String,
+    pub(crate) required_tokens: Option<u32>,
+    pub(crate) selected_target: Option<AttemptTarget>,
+    pub(crate) reason_codes: Vec<RouteDecisionReason>,
+    pub(crate) targets: Vec<RouteDecisionTargetRecord>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct RouteDecisionTargetRecord {
+    pub(crate) target: AttemptTarget,
+    pub(crate) context_length: Option<u32>,
+    pub(crate) required_tokens: Option<u32>,
+    pub(crate) avg_tokens_per_second_milli: Option<u64>,
+    pub(crate) throughput_samples: u64,
+    pub(crate) reason_codes: Vec<RouteDecisionReason>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RouteDecisionReason {
+    Selected,
+    NotSelected,
+    ContextTooSmall,
+    ContextUnknown,
+    HealthFiltered,
+    NoEligibleTarget,
+    ThroughputPreferred,
+    AffinitySelected,
+}
+
+impl RouteDecisionReason {
+    fn code(self) -> &'static str {
+        match self {
+            Self::Selected => "selected",
+            Self::NotSelected => "not_selected",
+            Self::ContextTooSmall => "context_too_small",
+            Self::ContextUnknown => "context_unknown",
+            Self::HealthFiltered => "health_filtered",
+            Self::NoEligibleTarget => "no_eligible_target",
+            Self::ThroughputPreferred => "throughput_preferred",
+            Self::AffinitySelected => "affinity_selected",
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, PartialEq, Eq)]
+pub struct RouteDecisionTargetSnapshot {
+    pub target: String,
+    pub kind: String,
+    pub selected: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_length: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_tokens_per_second_milli: Option<u64>,
+    pub throughput_samples: u64,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub reason_codes: Vec<String>,
+}
+
+#[derive(Clone)]
+pub(crate) struct RouteDiagnostics {
+    inner: Arc<Mutex<VecDeque<RouteDecisionEntry>>>,
+    capacity: usize,
+    target_capacity: usize,
+}
+
+impl Default for RouteDiagnostics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RouteDiagnostics {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+            capacity: MAX_ROUTE_DECISIONS,
+            target_capacity: MAX_TARGETS_PER_DECISION,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_capacity_for_test(capacity: usize, target_capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(VecDeque::new())),
+            capacity: capacity.max(1),
+            target_capacity: target_capacity.max(1),
+        }
+    }
+
+    pub(crate) fn record(&self, record: RouteDecisionRecord) {
+        let mut entries = self.inner.lock().unwrap();
+        entries.push_front(RouteDecisionEntry::from_record(
+            record,
+            self.target_capacity,
+        ));
+        while entries.len() > self.capacity {
+            entries.pop_back();
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<RouteDecisionSnapshot> {
+        self.inner
+            .lock()
+            .unwrap()
+            .iter()
+            .map(RouteDecisionEntry::snapshot)
+            .collect()
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RouteDecisionEntry {
+    model: String,
+    required_tokens: Option<u32>,
+    selected_target: Option<TargetLabel>,
+    reason_codes: Vec<RouteDecisionReason>,
+    targets: Vec<RouteDecisionTargetEntry>,
+    recorded_at: Instant,
+}
+
+impl RouteDecisionEntry {
+    fn from_record(record: RouteDecisionRecord, target_capacity: usize) -> Self {
+        Self {
+            model: sanitize_label(&record.model),
+            required_tokens: record.required_tokens,
+            selected_target: record
+                .selected_target
+                .as_ref()
+                .map(TargetLabel::from_attempt),
+            reason_codes: bounded_reason_codes(record.reason_codes),
+            targets: record
+                .targets
+                .into_iter()
+                .take(target_capacity)
+                .map(RouteDecisionTargetEntry::from_record)
+                .collect(),
+            recorded_at: Instant::now(),
+        }
+    }
+
+    fn snapshot(&self) -> RouteDecisionSnapshot {
+        RouteDecisionSnapshot {
+            model: self.model.clone(),
+            required_tokens: self.required_tokens,
+            selected_target: self
+                .selected_target
+                .as_ref()
+                .map(|target| target.label.clone()),
+            selected_kind: self
+                .selected_target
+                .as_ref()
+                .map(|target| target.kind.clone()),
+            reason_codes: reason_strings(&self.reason_codes),
+            targets: self
+                .targets
+                .iter()
+                .map(RouteDecisionTargetEntry::snapshot)
+                .collect(),
+            age_secs: self.recorded_at.elapsed().as_secs(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RouteDecisionTargetEntry {
+    target: TargetLabel,
+    selected: bool,
+    context_length: Option<u32>,
+    required_tokens: Option<u32>,
+    avg_tokens_per_second_milli: Option<u64>,
+    throughput_samples: u64,
+    reason_codes: Vec<RouteDecisionReason>,
+}
+
+impl RouteDecisionTargetEntry {
+    fn from_record(record: RouteDecisionTargetRecord) -> Self {
+        let selected = record.reason_codes.contains(&RouteDecisionReason::Selected);
+        Self {
+            target: TargetLabel::from_attempt(&record.target),
+            selected,
+            context_length: record.context_length,
+            required_tokens: record.required_tokens,
+            avg_tokens_per_second_milli: record.avg_tokens_per_second_milli,
+            throughput_samples: record.throughput_samples,
+            reason_codes: bounded_reason_codes(record.reason_codes),
+        }
+    }
+
+    fn snapshot(&self) -> RouteDecisionTargetSnapshot {
+        RouteDecisionTargetSnapshot {
+            target: self.target.label.clone(),
+            kind: self.target.kind.clone(),
+            selected: self.selected,
+            context_length: self.context_length,
+            required_tokens: self.required_tokens,
+            avg_tokens_per_second_milli: self.avg_tokens_per_second_milli,
+            throughput_samples: self.throughput_samples,
+            reason_codes: reason_strings(&self.reason_codes),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TargetLabel {
+    label: String,
+    kind: String,
+}
+
+impl TargetLabel {
+    fn from_attempt(target: &AttemptTarget) -> Self {
+        match target {
+            AttemptTarget::Local(label) => Self {
+                label: sanitize_label(label),
+                kind: "local".to_string(),
+            },
+            AttemptTarget::Remote(label) => Self {
+                label: sanitize_label(label),
+                kind: "remote".to_string(),
+            },
+            AttemptTarget::Endpoint(label) => Self {
+                label: sanitize_label(&endpoint_label_without_secrets(label)),
+                kind: "endpoint".to_string(),
+            },
+        }
+    }
+}
+
+fn bounded_reason_codes(reasons: Vec<RouteDecisionReason>) -> Vec<RouteDecisionReason> {
+    let mut bounded = Vec::new();
+    for reason in reasons {
+        if !bounded.contains(&reason) {
+            bounded.push(reason);
+        }
+        if bounded.len() >= MAX_REASON_CODES {
+            break;
+        }
+    }
+    bounded
+}
+
+fn reason_strings(reasons: &[RouteDecisionReason]) -> Vec<String> {
+    reasons
+        .iter()
+        .map(|reason| reason.code().to_string())
+        .collect()
+}
+
+fn strip_query(label: &str) -> &str {
+    label
+        .split_once('?')
+        .map(|(prefix, _)| prefix)
+        .unwrap_or(label)
+}
+
+fn endpoint_label_without_secrets(label: &str) -> String {
+    let stripped = strip_query(label);
+    let Some((scheme, rest)) = stripped.split_once("://") else {
+        return stripped.to_string();
+    };
+    let authority_end = rest.find('/').unwrap_or(rest.len());
+    let (authority, suffix) = rest.split_at(authority_end);
+    let host_authority = authority
+        .rsplit_once('@')
+        .map(|(_, authority)| authority)
+        .unwrap_or(authority);
+    format!("{scheme}://{host_authority}{suffix}")
+}
+
+fn sanitize_label(label: &str) -> String {
+    let trimmed = label.trim();
+    if trimmed.len() <= MAX_LABEL_BYTES {
+        return trimmed.to_string();
+    }
+    let keep = MAX_LABEL_BYTES.saturating_sub(REDACTED_SUFFIX.len());
+    let boundary = trimmed
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .take_while(|idx| *idx <= keep)
+        .last()
+        .unwrap_or(0);
+    format!("{}{}", &trimmed[..boundary], REDACTED_SUFFIX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::metrics::AttemptTarget;
+
+    #[test]
+    fn route_diagnostics_snapshot_bounds_reasons_and_redacts_target_labels() {
+        let diagnostics = RouteDiagnostics::with_capacity_for_test(2, 2);
+        diagnostics.record(RouteDecisionRecord {
+            model: "qwen".into(),
+            required_tokens: Some(8192),
+            selected_target: Some(AttemptTarget::Remote("peer-a".into())),
+            reason_codes: vec![RouteDecisionReason::Selected],
+            targets: vec![
+                RouteDecisionTargetRecord {
+                    target: AttemptTarget::Remote("peer-a".into()),
+                    context_length: Some(32768),
+                    required_tokens: Some(8192),
+                    avg_tokens_per_second_milli: Some(41_000),
+                    throughput_samples: 7,
+                    reason_codes: vec![RouteDecisionReason::Selected],
+                },
+                RouteDecisionTargetRecord {
+                    target: AttemptTarget::Endpoint(
+                        "https://user:sk-secret-body@example.test/v1?api_key=sk-secret-query"
+                            .into(),
+                    ),
+                    context_length: Some(4096),
+                    required_tokens: Some(8192),
+                    avg_tokens_per_second_milli: None,
+                    throughput_samples: 0,
+                    reason_codes: vec![
+                        RouteDecisionReason::ContextTooSmall,
+                        RouteDecisionReason::NotSelected,
+                        RouteDecisionReason::HealthFiltered,
+                    ],
+                },
+            ],
+        });
+
+        let snapshot = diagnostics.snapshot();
+
+        assert_eq!(snapshot.len(), 1);
+        assert_eq!(snapshot[0].reason_codes, vec!["selected"]);
+        assert_eq!(snapshot[0].selected_target.as_deref(), Some("peer-a"));
+        assert_eq!(snapshot[0].targets.len(), 2);
+        assert_eq!(snapshot[0].targets[1].target, "https://example.test/v1");
+        let json = serde_json::to_string(&snapshot).unwrap();
+        assert!(!json.contains("sk-secret-body"));
+        assert!(!json.contains("sk-secret-query"));
+        assert_eq!(
+            snapshot[0].targets[1].reason_codes,
+            vec!["context_too_small", "not_selected"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Expose bounded local route-decision diagnostics in `/api/status` and make gossiped throughput hints safer for routing decisions.

This PR adds a small operator-facing diagnostics window that explains recent model-routing choices: which targets were considered, which target was selected, and why other targets were rejected or deprioritized. It also prevents very low-sample gossiped throughput hints from reordering otherwise eligible targets.

## Why

When routing fails because of context fit, target health, affinity, or throughput ordering, the current status payload does not explain enough to debug the decision. This makes routing behavior easier to inspect without changing mesh protocol compatibility or exposing request contents.

## Diff scope

- Adds `routing_metrics.recent_route_decisions` to the local `/api/status` routing metrics payload.
- Records bounded per-target route reason codes from existing route-model candidate data.
- Includes context length, required token budget, throughput hint, sample count, selected target, and reason codes where available.
- Redacts endpoint query strings and endpoint userinfo before storing diagnostics.
- Ignores low-sample gossiped throughput hints for target ranking.
- Keeps diagnostics local-only; no gossip, protobuf, or wire-format changes.

## Compatibility and safety

- No mesh protocol changes.
- No protobuf/schema changes.
- No request body content is stored.
- Diagnostics are bounded in memory.
- No new unbounded queues or blocking locks.
- No invariant regression introduced.

## Validation

Validation tier: Tier 3 - shared runtime routing/status behavior.

Local validation passed:

```text
git fetch --no-tags origin main:refs/remotes/origin/main: PASS, origin/main at 95101ce99577077af392bc10ffb04ffc8ad34a32
git diff --check: PASS, no output
git diff --cached --check: PASS, no output
cargo fmt --all: PASS
cargo fmt --all -- --check: PASS
cargo test -p mesh-llm-host-runtime route_diagnostics --lib -- --test-threads=1: PASS, 1 passed
cargo test -p mesh-llm-host-runtime reorder_candidates --lib -- --test-threads=1: PASS, 9 passed
cargo test -p mesh-llm-host-runtime route_model_target_reason_codes --lib -- --test-threads=1: PASS, 2 passed
cargo test -p mesh-llm-host-runtime status_payload_exposes_bounded_route_decision_diagnostics --lib -- --test-threads=1: PASS, 1 passed
cargo test -p mesh-llm-host-runtime routing_metric --lib -- --test-threads=1: PASS, 10 passed
cargo test -p mesh-llm-host-runtime test_api_proxy_rejects_request_when_all_known_contexts_too_small --lib -- --test-threads=1: PASS, 1 passed
cargo test -p mesh-llm-host-runtime request_budget_tokens --lib -- --test-threads=1: PASS, 3 passed
cargo check -p mesh-llm: PASS
cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings: PASS