### PR TITLE
Make demand rebalancing capacity aware

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -35,8 +35,8 @@ use self::local::{
 use self::model_target_reconciliation::{
     ModelTargetReconciliationAction, ModelTargetReconciliationCandidate,
     ModelTargetReconciliationCapacityState, ModelTargetReconciliationInput,
-    ModelTargetReconciliationPolicy, ModelTargetReconciliationState,
-    plan_model_target_reconciliation,
+    ModelTargetReconciliationNoAction, ModelTargetReconciliationPolicy,
+    ModelTargetReconciliationState, plan_model_target_reconciliation_with_reasons,
 };
 pub use self::options::{MeshGuardrailMode, RuntimeOptions, RuntimeSurface};
 use self::proxy::{api_proxy, bootstrap_proxy};
@@ -3762,6 +3762,12 @@ async fn reconcile_model_targets_once(ctx: ReconcileModelTargetsContext<'_>) {
         .await
         .into_iter()
         .collect::<BTreeSet<_>>();
+    let protected_model_refs = node
+        .requested_models()
+        .await
+        .into_iter()
+        .chain(local_interest_model_refs.iter().cloned())
+        .collect::<BTreeSet<_>>();
     let loaded_model_refs = runtime_loaded_model_refs(runtime_models, managed_models);
     if local_interest_model_refs.is_empty() && loaded_model_refs.is_empty() {
         state.prune_expired(runtime_unix_secs());
@@ -3802,25 +3808,31 @@ async fn reconcile_model_targets_once(ctx: ReconcileModelTargetsContext<'_>) {
                 capacity_state: ModelTargetReconciliationCapacityState::from(
                     target.capacity_advice.state,
                 ),
+                required_bytes: target.capacity_advice.required_bytes,
                 local_path,
             }
         })
         .collect::<Vec<_>>();
 
     let now_secs = runtime_unix_secs();
-    let actions = plan_model_target_reconciliation(
+    let plan = plan_model_target_reconciliation_with_reasons(
         policy,
         state,
         ModelTargetReconciliationInput {
             now_secs,
             local_role: node.role().await,
+            local_capacity_bytes: local_vram_bytes,
             local_interest_model_refs: &local_interest_model_refs,
             loaded_model_refs: &loaded_model_refs,
+            protected_model_refs: &protected_model_refs,
             targets: &targets,
         },
     );
+    if plan.actions.is_empty() {
+        emit_model_target_reconciliation_no_action(state, &plan.no_action_reasons, now_secs);
+    }
 
-    for action in actions {
+    for action in plan.actions {
         let load_spec = action.load_spec.to_string_lossy().to_string();
         state.mark_load_started(&action.model_ref);
         let event_tx = runtime_event_tx.clone();
@@ -3897,6 +3909,26 @@ fn emit_model_target_reconciliation_queued(action: &ModelTargetReconciliationAct
     let _ = emit_event(OutputEvent::Info {
         message: format!("Model target reconciliation {verb} '{}'", action.model_ref),
         context,
+    });
+}
+
+fn emit_model_target_reconciliation_no_action(
+    state: &mut ModelTargetReconciliationState,
+    reasons: &[ModelTargetReconciliationNoAction],
+    now_secs: u64,
+) {
+    let Some(reason) = reasons.first() else {
+        return;
+    };
+    if !state.should_emit_no_action_reason(reason, now_secs) {
+        return;
+    }
+    let _ = emit_event(OutputEvent::Info {
+        message: format!(
+            "Model target reconciliation no action for '{}'",
+            reason.model_ref
+        ),
+        context: Some(format!("reason={}", reason.reason.as_str())),
     });
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/model_target_reconciliation.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/model_target_reconciliation.rs
@@ -3,6 +3,8 @@ use crate::mesh::NodeRole;
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
+const NO_ACTION_REASON_EVENT_MIN_INTERVAL_SECS: u64 = 5 * 60;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct ModelTargetReconciliationPolicy {
     pub(crate) enabled: bool,
@@ -35,16 +37,20 @@ pub(crate) struct ModelTargetReconciliationState {
     in_flight_model_refs: BTreeSet<String>,
     failed_until_secs: BTreeMap<String, u64>,
     manual_unload_until_secs: BTreeMap<String, u64>,
+    last_no_action_reason_key: Option<(String, &'static str)>,
+    last_no_action_emit_secs: Option<u64>,
 }
 
 impl ModelTargetReconciliationState {
     pub(crate) fn mark_load_started(&mut self, model_ref: &str) {
         self.in_flight_model_refs.insert(model_ref.to_string());
+        self.clear_last_no_action_reason();
     }
 
     pub(crate) fn record_load_success(&mut self, model_ref: &str) {
         self.in_flight_model_refs.remove(model_ref);
         self.failed_until_secs.remove(model_ref);
+        self.clear_last_no_action_reason();
     }
 
     pub(crate) fn record_load_failure(
@@ -60,6 +66,7 @@ impl ModelTargetReconciliationState {
                 now_secs.saturating_add(policy.failure_cooldown_secs),
             );
         }
+        self.clear_last_no_action_reason();
     }
 
     pub(crate) fn record_manual_unload(
@@ -75,12 +82,34 @@ impl ModelTargetReconciliationState {
                 now_secs.saturating_add(policy.manual_unload_cooldown_secs),
             );
         }
+        self.clear_last_no_action_reason();
     }
 
     pub(crate) fn prune_expired(&mut self, now_secs: u64) {
         self.failed_until_secs.retain(|_, until| *until > now_secs);
         self.manual_unload_until_secs
             .retain(|_, until| *until > now_secs);
+    }
+
+    pub(crate) fn should_emit_no_action_reason(
+        &mut self,
+        reason: &ModelTargetReconciliationNoAction,
+        now_secs: u64,
+    ) -> bool {
+        let key = (reason.model_ref.clone(), reason.reason.as_str());
+        let repeated_reason = self
+            .last_no_action_reason_key
+            .as_ref()
+            .is_some_and(|last| last == &key);
+        let recently_emitted = self.last_no_action_emit_secs.is_some_and(|last| {
+            now_secs.saturating_sub(last) < NO_ACTION_REASON_EVENT_MIN_INTERVAL_SECS
+        });
+        if repeated_reason && recently_emitted {
+            return false;
+        }
+        self.last_no_action_reason_key = Some(key);
+        self.last_no_action_emit_secs = Some(now_secs);
+        true
     }
 
     fn suppressed(&self, model_ref: &str, model_name: Option<&str>, now_secs: u64) -> bool {
@@ -109,14 +138,21 @@ impl ModelTargetReconciliationState {
                     || model_name.is_some_and(|name| model_identity_matches(key, name)))
         })
     }
+
+    fn clear_last_no_action_reason(&mut self) {
+        self.last_no_action_reason_key = None;
+        self.last_no_action_emit_secs = None;
+    }
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct ModelTargetReconciliationInput<'a> {
     pub(crate) now_secs: u64,
     pub(crate) local_role: NodeRole,
+    pub(crate) local_capacity_bytes: u64,
     pub(crate) local_interest_model_refs: &'a BTreeSet<String>,
     pub(crate) loaded_model_refs: &'a BTreeSet<String>,
+    pub(crate) protected_model_refs: &'a BTreeSet<String>,
     pub(crate) targets: &'a [ModelTargetReconciliationCandidate],
 }
 
@@ -131,6 +167,7 @@ pub(crate) struct ModelTargetReconciliationCandidate {
     pub(crate) last_active_secs_ago: Option<u64>,
     pub(crate) serving_node_count: usize,
     pub(crate) capacity_state: ModelTargetReconciliationCapacityState,
+    pub(crate) required_bytes: Option<u64>,
     pub(crate) local_path: Option<PathBuf>,
 }
 
@@ -167,57 +204,159 @@ pub(crate) struct ModelTargetReconciliationAction {
     pub(crate) replace_model_ref: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct ModelTargetReconciliationPlan {
+    pub(crate) actions: Vec<ModelTargetReconciliationAction>,
+    pub(crate) no_action_reasons: Vec<ModelTargetReconciliationNoAction>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ModelTargetReconciliationNoAction {
+    pub(crate) model_ref: String,
+    pub(crate) reason: ModelTargetReconciliationNoActionReason,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum ModelTargetReconciliationNoActionReason {
+    NotWanted,
+    AlreadyServed,
+    NotSingleNodeFit,
+    MissingLocalModel,
+    AlreadyLoaded,
+    SuppressedByCooldownOrInFlight,
+    NoLocalInterestOrFreshDemand,
+    NoSafeReplacementTarget,
+}
+
+impl ModelTargetReconciliationNoActionReason {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::NotWanted => "not_wanted",
+            Self::AlreadyServed => "already_served",
+            Self::NotSingleNodeFit => "not_single_node_fit",
+            Self::MissingLocalModel => "missing_local_model",
+            Self::AlreadyLoaded => "already_loaded",
+            Self::SuppressedByCooldownOrInFlight => "suppressed_by_cooldown_or_in_flight",
+            Self::NoLocalInterestOrFreshDemand => "no_local_interest_or_fresh_demand",
+            Self::NoSafeReplacementTarget => "no_safe_replacement_target",
+        }
+    }
+}
+
+#[cfg(test)]
 pub(crate) fn plan_model_target_reconciliation(
     policy: &ModelTargetReconciliationPolicy,
     state: &mut ModelTargetReconciliationState,
     input: ModelTargetReconciliationInput<'_>,
 ) -> Vec<ModelTargetReconciliationAction> {
+    plan_model_target_reconciliation_with_reasons(policy, state, input).actions
+}
+
+pub(crate) fn plan_model_target_reconciliation_with_reasons(
+    policy: &ModelTargetReconciliationPolicy,
+    state: &mut ModelTargetReconciliationState,
+    input: ModelTargetReconciliationInput<'_>,
+) -> ModelTargetReconciliationPlan {
     state.prune_expired(input.now_secs);
     if !policy.enabled
         || policy.max_loads_per_tick == 0
         || matches!(input.local_role, NodeRole::Client)
     {
-        return Vec::new();
+        return ModelTargetReconciliationPlan::default();
     }
 
     let mut actions = Vec::new();
+    let mut no_action_reasons = Vec::new();
     for target in input.targets {
         if actions.len() >= policy.max_loads_per_tick {
             break;
         }
-        let Some(load_spec) = target.local_path.clone() else {
-            continue;
-        };
-        let replace_model_ref =
-            replacement_target(policy, input.loaded_model_refs, input.targets, target);
-        let has_local_interest = input.local_interest_model_refs.contains(&target.model_ref);
-        if !target.wanted
-            || target.serving_node_count > 0
-            || target.capacity_state != ModelTargetReconciliationCapacityState::SingleNodeFit
-            || (!has_local_interest && replace_model_ref.is_none())
-            || loaded_target(input.loaded_model_refs, target)
-            || state.suppressed(
-                &target.model_ref,
-                target.model_name.as_deref(),
-                input.now_secs,
-            )
-        {
-            continue;
+        match model_target_reconciliation_action(policy, state, &input, target) {
+            Ok(action) => actions.push(action),
+            Err(reason) if target.wanted => {
+                no_action_reasons.push(ModelTargetReconciliationNoAction {
+                    model_ref: target.model_ref.clone(),
+                    reason,
+                });
+            }
+            Err(_) => {}
         }
-
-        actions.push(ModelTargetReconciliationAction {
-            model_ref: target.model_ref.clone(),
-            model_name: target.model_name.clone(),
-            load_spec,
-            replace_model_ref,
-        });
     }
-    actions
+    ModelTargetReconciliationPlan {
+        actions,
+        no_action_reasons,
+    }
+}
+
+fn model_target_reconciliation_action(
+    policy: &ModelTargetReconciliationPolicy,
+    state: &ModelTargetReconciliationState,
+    input: &ModelTargetReconciliationInput<'_>,
+    target: &ModelTargetReconciliationCandidate,
+) -> Result<ModelTargetReconciliationAction, ModelTargetReconciliationNoActionReason> {
+    if !target.wanted {
+        return Err(ModelTargetReconciliationNoActionReason::NotWanted);
+    }
+    if target.serving_node_count > 0 {
+        return Err(ModelTargetReconciliationNoActionReason::AlreadyServed);
+    }
+    if target.capacity_state != ModelTargetReconciliationCapacityState::SingleNodeFit {
+        return Err(ModelTargetReconciliationNoActionReason::NotSingleNodeFit);
+    }
+    let Some(load_spec) = target.local_path.clone() else {
+        return Err(ModelTargetReconciliationNoActionReason::MissingLocalModel);
+    };
+    if loaded_target(input.loaded_model_refs, target) {
+        return Err(ModelTargetReconciliationNoActionReason::AlreadyLoaded);
+    }
+    if state.suppressed(
+        &target.model_ref,
+        target.model_name.as_deref(),
+        input.now_secs,
+    ) {
+        return Err(ModelTargetReconciliationNoActionReason::SuppressedByCooldownOrInFlight);
+    }
+
+    let has_local_interest = input.local_interest_model_refs.contains(&target.model_ref);
+    let replace_model_ref = if has_local_interest {
+        None
+    } else if demand_upgrade_candidate(policy, input.loaded_model_refs, target) {
+        replacement_for_demand_upgrade(policy, input, target)?
+    } else {
+        return Err(ModelTargetReconciliationNoActionReason::NoLocalInterestOrFreshDemand);
+    };
+
+    Ok(ModelTargetReconciliationAction {
+        model_ref: target.model_ref.clone(),
+        model_name: target.model_name.clone(),
+        load_spec,
+        replace_model_ref,
+    })
+}
+
+fn replacement_for_demand_upgrade(
+    policy: &ModelTargetReconciliationPolicy,
+    input: &ModelTargetReconciliationInput<'_>,
+    target: &ModelTargetReconciliationCandidate,
+) -> Result<Option<String>, ModelTargetReconciliationNoActionReason> {
+    if demand_target_fits_alongside_loaded(input, target) {
+        return Ok(None);
+    }
+    replacement_target(
+        policy,
+        input.loaded_model_refs,
+        input.protected_model_refs,
+        input.targets,
+        target,
+    )
+    .map(Some)
+    .ok_or(ModelTargetReconciliationNoActionReason::NoSafeReplacementTarget)
 }
 
 fn replacement_target(
     policy: &ModelTargetReconciliationPolicy,
     loaded_model_refs: &BTreeSet<String>,
+    protected_model_refs: &BTreeSet<String>,
     targets: &[ModelTargetReconciliationCandidate],
     target: &ModelTargetReconciliationCandidate,
 ) -> Option<String> {
@@ -226,7 +365,10 @@ fn replacement_target(
     }
     loaded_model_refs
         .iter()
-        .find(|loaded| replacement_improves_target_mix(loaded, targets, target))
+        .find(|loaded| {
+            !protected_loaded_model(protected_model_refs, loaded, targets)
+                && replacement_improves_target_mix(loaded, targets, target)
+        })
         .cloned()
 }
 
@@ -253,12 +395,62 @@ fn replacement_improves_target_mix(
         .iter()
         .find(|candidate| model_target_matches_loaded(candidate, loaded_model_ref))
     else {
-        return true;
+        return false;
     };
     if loaded.request_count >= target.request_count {
         return false;
     }
     target.rank < loaded.rank || loaded.request_count == 0
+}
+
+fn demand_target_fits_alongside_loaded(
+    input: &ModelTargetReconciliationInput<'_>,
+    target: &ModelTargetReconciliationCandidate,
+) -> bool {
+    let Some(target_required) = target.required_bytes else {
+        return false;
+    };
+    let Some(loaded_required) = loaded_required_bytes(input.loaded_model_refs, input.targets)
+    else {
+        return false;
+    };
+    loaded_required
+        .checked_add(target_required)
+        .is_some_and(|required| required <= input.local_capacity_bytes)
+}
+
+fn loaded_required_bytes(
+    loaded_model_refs: &BTreeSet<String>,
+    targets: &[ModelTargetReconciliationCandidate],
+) -> Option<u64> {
+    let mut total = 0_u64;
+    for loaded in loaded_model_refs {
+        let target = targets
+            .iter()
+            .find(|candidate| model_target_matches_loaded(candidate, loaded))?;
+        total = total.checked_add(target.required_bytes?)?;
+    }
+    Some(total)
+}
+
+fn protected_loaded_model(
+    protected_model_refs: &BTreeSet<String>,
+    loaded_model_ref: &str,
+    targets: &[ModelTargetReconciliationCandidate],
+) -> bool {
+    protected_model_refs.iter().any(|protected| {
+        model_identity_matches(protected, loaded_model_ref)
+            || targets
+                .iter()
+                .find(|candidate| model_target_matches_loaded(candidate, loaded_model_ref))
+                .is_some_and(|candidate| {
+                    model_identity_matches(protected, &candidate.model_ref)
+                        || candidate
+                            .model_name
+                            .as_deref()
+                            .is_some_and(|name| model_identity_matches(protected, name))
+                })
+    })
 }
 
 fn loaded_target(
@@ -337,6 +529,7 @@ mod tests {
             last_active_secs_ago: None,
             serving_node_count: 0,
             capacity_state: ModelTargetReconciliationCapacityState::SingleNodeFit,
+            required_bytes: Some(10),
             local_path: Some(PathBuf::from("/models/qwen.gguf")),
         }
     }
@@ -349,8 +542,10 @@ mod tests {
         ModelTargetReconciliationInput {
             now_secs: NOW,
             local_role: NodeRole::Host { http_port: 9337 },
+            local_capacity_bytes: 0,
             local_interest_model_refs: local_interests,
             loaded_model_refs: loaded,
+            protected_model_refs: local_interests,
             targets,
         }
     }
@@ -432,6 +627,114 @@ mod tests {
                 replace_model_ref: Some("Small".to_string()),
             }]
         );
+    }
+
+    #[test]
+    fn large_capacity_node_adds_demanded_model_without_replacement() {
+        let mut wanted_large = target("org/large@main:file.gguf");
+        wanted_large.rank = 1;
+        wanted_large.model_name = Some("Large".to_string());
+        wanted_large.wanted_reason = Some("active_demand");
+        wanted_large.request_count = 8;
+        wanted_large.last_active_secs_ago = Some(30);
+        wanted_large.required_bytes = Some(60);
+        wanted_large.local_path = Some(PathBuf::from("/models/large.gguf"));
+        let mut loaded_small = target("org/small@main:file.gguf");
+        loaded_small.rank = 2;
+        loaded_small.model_name = Some("Small".to_string());
+        loaded_small.wanted = false;
+        loaded_small.request_count = 1;
+        loaded_small.serving_node_count = 1;
+        loaded_small.capacity_state = ModelTargetReconciliationCapacityState::AlreadyServing;
+        loaded_small.required_bytes = Some(20);
+        loaded_small.local_path = None;
+        let targets = vec![wanted_large, loaded_small];
+        let local_interests = BTreeSet::new();
+        let loaded = BTreeSet::from(["Small".to_string()]);
+        let protected = BTreeSet::new();
+        let mut state = ModelTargetReconciliationState::default();
+
+        let plan = plan_model_target_reconciliation_with_reasons(
+            &demand_upgrade_policy(),
+            &mut state,
+            ModelTargetReconciliationInput {
+                local_capacity_bytes: 100,
+                protected_model_refs: &protected,
+                ..input(&local_interests, &loaded, &targets)
+            },
+        );
+
+        assert_eq!(
+            plan.actions,
+            vec![ModelTargetReconciliationAction {
+                model_ref: "org/large@main:file.gguf".to_string(),
+                model_name: Some("Large".to_string()),
+                load_spec: PathBuf::from("/models/large.gguf"),
+                replace_model_ref: None,
+            }]
+        );
+        assert!(plan.no_action_reasons.is_empty());
+    }
+
+    #[test]
+    fn protected_loaded_model_blocks_replacement_with_reason() {
+        let mut wanted_large = target("org/large@main:file.gguf");
+        wanted_large.rank = 1;
+        wanted_large.model_name = Some("Large".to_string());
+        wanted_large.wanted_reason = Some("active_demand");
+        wanted_large.request_count = 8;
+        wanted_large.last_active_secs_ago = Some(30);
+        wanted_large.required_bytes = Some(90);
+        wanted_large.local_path = Some(PathBuf::from("/models/large.gguf"));
+        let mut loaded_small = target("org/small@main:file.gguf");
+        loaded_small.rank = 2;
+        loaded_small.model_name = Some("Small".to_string());
+        loaded_small.wanted = false;
+        loaded_small.request_count = 1;
+        loaded_small.serving_node_count = 1;
+        loaded_small.capacity_state = ModelTargetReconciliationCapacityState::AlreadyServing;
+        loaded_small.required_bytes = Some(20);
+        loaded_small.local_path = None;
+        let targets = vec![wanted_large, loaded_small];
+        let local_interests = BTreeSet::new();
+        let loaded = BTreeSet::from(["Small".to_string()]);
+        let protected = BTreeSet::from(["Small".to_string()]);
+        let mut state = ModelTargetReconciliationState::default();
+
+        let plan = plan_model_target_reconciliation_with_reasons(
+            &demand_upgrade_policy(),
+            &mut state,
+            ModelTargetReconciliationInput {
+                local_capacity_bytes: 100,
+                protected_model_refs: &protected,
+                ..input(&local_interests, &loaded, &targets)
+            },
+        );
+
+        assert!(plan.actions.is_empty());
+        assert_eq!(
+            plan.no_action_reasons,
+            vec![ModelTargetReconciliationNoAction {
+                model_ref: "org/large@main:file.gguf".to_string(),
+                reason: ModelTargetReconciliationNoActionReason::NoSafeReplacementTarget,
+            }]
+        );
+    }
+
+    #[test]
+    fn repeated_no_action_reason_events_are_rate_limited() {
+        let mut state = ModelTargetReconciliationState::default();
+        let reason = ModelTargetReconciliationNoAction {
+            model_ref: "org/large@main:file.gguf".to_string(),
+            reason: ModelTargetReconciliationNoActionReason::NoSafeReplacementTarget,
+        };
+
+        assert!(state.should_emit_no_action_reason(&reason, NOW));
+        assert!(!state.should_emit_no_action_reason(&reason, NOW + 60));
+        assert!(state.should_emit_no_action_reason(
+            &reason,
+            NOW + NO_ACTION_REASON_EVENT_MIN_INTERVAL_SECS + 1
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make demand-based model-target reconciliation capacity-aware and safer when a host already has local models loaded.

Hosts can now load a demanded model alongside existing loaded models when the aggregate required bytes fit local capacity. If the demanded model cannot fit alongside the current loaded set, the planner only considers replacement when it can identify a safe lower-demand replacement target.

## Why

The current demand-upgrade path can only think in terms of replacement. That is too blunt for large-capacity nodes: if a node can fit both the existing model and the demanded model, it should add capacity rather than unload something unnecessarily.

At the same time, replacement needs stronger guardrails so requested, startup, and explicit local-interest models are not evicted just because another target has fresher demand.

## Diff scope

- Adds local capacity and target `required_bytes` to model-target reconciliation planning.
- Allows demanded models to be loaded alongside existing loaded models when aggregate required bytes fit local capacity.
- Protects requested models and explicit local interests from demand-based replacement.
- Refuses replacement when the loaded model cannot be matched to target metadata safely.
- Adds bounded no-action reasons for wanted targets that cannot be scheduled.
- Rate-limits repeated no-action runtime events for stable reasons.
- Keeps the change inside runtime reconciliation; no mesh protocol, protobuf, API schema, or UI changes.

## Branch integrity

- Base branch: `main`
- Validated base SHA: `95101ce99577077af392bc10ffb04ffc8ad34a32`
- Branch state: `0 behind / 1 ahead` at local validation time
- Merge-base SHA: `95101ce99577077af392bc10ffb04ffc8ad34a32`
- Commit: `8cc936f4a8de9b32af9a23f2533ae5f82c099a5e`

## Diff hygiene

- `git diff --name-status origin/main...HEAD`: only runtime reconciliation files changed.
- `git diff --check origin/main...HEAD`: PASS, no output.


## Validation mode and proof

Validation mode: Tier 3 - shared runtime model-target reconciliation/resource planning.

Local validation passed:

```text
git fetch --no-tags origin main:refs/remotes/origin/main: PASS, origin/main at 95101ce99577077af392bc10ffb04ffc8ad34a32
git diff --check: PASS, no output
git diff --cached --check: PASS, no output
git diff --check origin/main...HEAD: PASS, no output
cargo fmt --all: PASS
cargo fmt --all -- --check: PASS
LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo test -p mesh-llm-host-runtime model_target_reconciliation --lib -- --test-threads=1: PASS, 25 passed
LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo check -p mesh-llm: PASS
LLAMA_STAGE_BUILD_DIR=<llama-stage-build-dir> cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings: PASS
```

Remote CI: pending after PR creation.

## Runtime safety

- No mesh protocol, protobuf, or wire-format fields changed.
- Demand upgrades remain gated by the existing `reconcile_model_target_demand_upgrades` config.
- Unknown loaded-model size/metadata does not trigger additive loading or unsafe replacement.
- Protected requested and local-interest models are not replaced by demand upgrades.
- Repeated no-action events are rate-limited.
- No new unbounded queues or blocking locks were introduced.
- No invariant regression introduced.

## Ledger / version

Ledger: not applicable - not required for this change family.

Version: not applicable - no release/version sync required for this non-release runtime planning change.

## Rollback plan

Rollback: revert this PR.

DB downgrade: not applicable.

Data repair: not applicable.

Operational caveats: none known.

## Known residual risks

Live multi-node mesh startup, public-mesh client smoke, and agent harness were not run locally because no local multi-node runtime mesh/model endpoint was available. Mandatory remote CI and reviewer-requested live smoke remain the final merge proof.
