### PR TITLE
Stabilize OpenClaw tool loops through MoA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3948,6 +3948,7 @@ version = "0.68.0"
 dependencies = [
  "serde",
  "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -40,6 +40,16 @@
     "mmproj": null
   },
   {
+    "name": "Gemma-4-E4B-it-Q4_K_M",
+    "file": "gemma-4-E4B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
+    "size": "4.6GB",
+    "description": "Gemma 4 E4B instruction model, strong mini-class default",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
     "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
     "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",

--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -47,7 +47,23 @@
     "description": "Gemma 4 E4B instruction model, strong mini-class default",
     "draft": null,
     "extra_files": [],
-    "mmproj": null
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3.6-35B-A3B-UD-Q4_K_M",
+    "file": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    "size": "22.1GB",
+    "description": "Qwen3.6 35B-A3B MoE, vision-capable long-context public mesh worker",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-F16.gguf"
+    }
   },
   {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
@@ -382,19 +398,6 @@
     "mmproj": {
       "file": "Qwen3.5-4B-mmproj-BF16.gguf",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-BF16.gguf"
-    }
-  },
-  {
-    "name": "Qwen3.5-9B-Vision-Q4_K_M",
-    "file": "Qwen3.5-9B-Q4_K_M.gguf",
-    "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf",
-    "size": "5.8GB",
-    "description": "Vision + text, replaces Qwen3-8B with image understanding",
-    "draft": null,
-    "extra_files": [],
-    "mmproj": {
-      "file": "Qwen3.5-9B-mmproj-BF16.gguf",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/mmproj-BF16.gguf"
     }
   },
   {

--- a/crates/mesh-client/src/network/nostr.rs
+++ b/crates/mesh-client/src/network/nostr.rs
@@ -445,7 +445,7 @@ pub fn auto_model_pack(vram_gb: f64) -> Vec<String> {
         },
         Pack {
             min_vram: 8.0,
-            models: &["Qwen3-8B-Q4_K_M"],
+            models: &["Gemma-4-E4B-it-Q4_K_M"],
         },
         Pack {
             min_vram: 0.0,
@@ -510,13 +510,13 @@ mod auto_pack_tests {
     #[test]
     fn pack_8gb_single_model() {
         let pack = auto_model_pack(8.0);
-        assert_eq!(pack, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(pack, vec!["Gemma-4-E4B-it-Q4_K_M"]);
     }
 
     #[test]
     fn pack_16gb_single() {
         let pack = auto_model_pack(16.0);
-        assert_eq!(pack, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(pack, vec!["Gemma-4-E4B-it-Q4_K_M"]);
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/Cargo.toml
+++ b/crates/mesh-llm-guardrails/Cargo.toml
@@ -14,3 +14,4 @@ workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+url = "2"

--- a/crates/mesh-llm-guardrails/src/rescue.rs
+++ b/crates/mesh-llm-guardrails/src/rescue.rs
@@ -332,6 +332,7 @@ fn sentinel_tool_call_body(content: &str) -> Option<&str> {
     let trimmed = content.trim_start();
     let after_start = trimmed.strip_prefix("<|tool_call>")?;
     let end_index = [
+        "<|tool_call|>",
         "<tool_call|>",
         "<|/tool_call|>",
         "</tool_call>",
@@ -794,6 +795,18 @@ mod tests {
             calls[0].arguments["query"],
             "Mesh-LLM #808 Harden OpenClaw/MoA Telegram timeouts"
         );
+    }
+
+    #[test]
+    fn rescues_fully_delimited_sentinel_tool_call() {
+        let calls = rescue_tool_call_from_text(
+            r#"<|tool_call>call:web_search{query:<|"|>Mesh-LLM #808<|"|>}<|tool_call|>"#,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "web_search");
+        assert_eq!(calls[0].arguments["query"], "Mesh-LLM #808");
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/src/rescue.rs
+++ b/crates/mesh-llm-guardrails/src/rescue.rs
@@ -105,6 +105,12 @@ fn tool_call_candidates(content: &str) -> Vec<Value> {
     if let Some(value) = parse_qwen_xml_syntax(content) {
         candidates.push(value);
     }
+    if let Some(value) = parse_bracketed_tool_call_syntax(content) {
+        candidates.push(value);
+    }
+    if let Some(value) = parse_sentinel_tool_call_syntax(content) {
+        candidates.push(value);
+    }
     if let Some(value) = parse_granite_tool_call_syntax(content) {
         candidates.push(value);
     }
@@ -278,6 +284,268 @@ fn parse_granite_tool_call_syntax(content: &str) -> Option<Value> {
     serde_json::from_str(after_start[..end_index].trim()).ok()
 }
 
+fn parse_bracketed_tool_call_syntax(content: &str) -> Option<Value> {
+    let body = bracketed_tool_call_body(content)?;
+    if let Ok(value) = serde_json::from_str::<Value>(body.trim()) {
+        return Some(value);
+    }
+    let mut object = parse_pseudo_argument_object(body.trim())?;
+    let name = object
+        .remove("tool")
+        .or_else(|| object.remove("name"))
+        .or_else(|| object.remove("function"))
+        .and_then(|value| value.as_str().map(ToString::to_string))?;
+    let arguments = object
+        .remove("args")
+        .or_else(|| object.remove("arguments"))
+        .unwrap_or_else(|| Value::Object(Map::new()));
+    Some(json!({ "name": name, "arguments": arguments }))
+}
+
+fn bracketed_tool_call_body(content: &str) -> Option<&str> {
+    let trimmed = content.trim_start();
+    let after_start = trimmed.strip_prefix("[TOOL_CALL]")?;
+    let end_index = after_start.find("[/TOOL_CALL]")?;
+    Some(&after_start[..end_index])
+}
+
+fn parse_sentinel_tool_call_syntax(content: &str) -> Option<Value> {
+    let body = sentinel_tool_call_body(content)?;
+    let call_body = body.trim().strip_prefix("call:")?.trim_start();
+    let name_len = call_body
+        .char_indices()
+        .take_while(|(_, character)| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.')
+        })
+        .last()
+        .map(|(index, character)| index + character.len_utf8())?;
+    let name = call_body[..name_len].trim();
+    if name.is_empty() {
+        return None;
+    }
+    let arguments_text = call_body[name_len..].trim_start();
+    let arguments = parse_pseudo_argument_object(arguments_text)?;
+    Some(json!({ "name": name, "arguments": Value::Object(arguments) }))
+}
+
+fn sentinel_tool_call_body(content: &str) -> Option<&str> {
+    let trimmed = content.trim_start();
+    let after_start = trimmed.strip_prefix("<|tool_call>")?;
+    let end_index = [
+        "<tool_call|>",
+        "<|/tool_call|>",
+        "</tool_call>",
+        "<|end_tool_call|>",
+    ]
+    .iter()
+    .filter_map(|marker| after_start.find(marker))
+    .min()?;
+    Some(&after_start[..end_index])
+}
+
+fn parse_pseudo_argument_object(content: &str) -> Option<Map<String, Value>> {
+    let object_text = first_balanced_pseudo_object(content)?;
+    if let Ok(Value::Object(arguments)) = serde_json::from_str::<Value>(object_text) {
+        return Some(arguments);
+    }
+    parse_unquoted_argument_object(object_text)
+}
+
+fn first_balanced_pseudo_object(content: &str) -> Option<&str> {
+    let content = content.trim_start();
+    if !content.starts_with('{') {
+        return None;
+    }
+    let end = balanced_pseudo_object_end(content)?;
+    Some(&content[..=end])
+}
+
+fn balanced_pseudo_object_end(content: &str) -> Option<usize> {
+    let mut depth = 0_u32;
+    let mut in_string: Option<char> = None;
+    let mut escaped = false;
+    let mut in_sentinel_string = false;
+    let mut index = 0;
+    while index < content.len() {
+        if let Some(len) = sentinel_string_len_at(&content[index..]) {
+            in_sentinel_string = !in_sentinel_string;
+            index += len;
+            continue;
+        }
+        let character = content[index..].chars().next()?;
+        let next_index = index + character.len_utf8();
+        if in_sentinel_string {
+            index = next_index;
+            continue;
+        }
+        if let Some(quote) = in_string {
+            if escaped {
+                escaped = false;
+                index = next_index;
+                continue;
+            }
+            match character {
+                '\\' => escaped = true,
+                _ if character == quote => in_string = None,
+                _ => {}
+            }
+            index = next_index;
+            continue;
+        }
+        match character {
+            '"' | '\'' => in_string = Some(character),
+            '{' => depth += 1,
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+        index = next_index;
+    }
+    None
+}
+
+fn parse_unquoted_argument_object(object_text: &str) -> Option<Map<String, Value>> {
+    let inner = object_text
+        .trim()
+        .strip_prefix('{')?
+        .strip_suffix('}')?
+        .trim();
+    let mut arguments = Map::new();
+    for field in split_pseudo_fields(inner) {
+        let (key, value) = split_pseudo_key_value(field)?;
+        arguments.insert(key.to_string(), parse_pseudo_value(value));
+    }
+    (!arguments.is_empty()).then_some(arguments)
+}
+
+fn split_pseudo_fields(input: &str) -> Vec<&str> {
+    let mut fields = Vec::new();
+    let mut start = 0;
+    let mut depth = 0_u32;
+    let mut in_string: Option<char> = None;
+    let mut escaped = false;
+    let mut in_sentinel_string = false;
+    let mut index = 0;
+    while index < input.len() {
+        if let Some(len) = sentinel_string_len_at(&input[index..]) {
+            in_sentinel_string = !in_sentinel_string;
+            index += len;
+            continue;
+        }
+        let Some(character) = input[index..].chars().next() else {
+            break;
+        };
+        let next_index = index + character.len_utf8();
+        if in_sentinel_string {
+            index = next_index;
+            continue;
+        }
+        if let Some(quote) = in_string {
+            if escaped {
+                escaped = false;
+                index = next_index;
+                continue;
+            }
+            match character {
+                '\\' => escaped = true,
+                _ if character == quote => in_string = None,
+                _ => {}
+            }
+            index = next_index;
+            continue;
+        }
+        match character {
+            '"' | '\'' => in_string = Some(character),
+            '{' | '[' => depth += 1,
+            '}' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let field = input[start..index].trim();
+                if !field.is_empty() {
+                    fields.push(field);
+                }
+                start = index + character.len_utf8();
+            }
+            _ => {}
+        }
+        index = next_index;
+    }
+    let field = input[start..].trim();
+    if !field.is_empty() {
+        fields.push(field);
+    }
+    fields
+}
+
+fn sentinel_string_len_at(input: &str) -> Option<usize> {
+    ["<|\"|>", "<|'|>"]
+        .iter()
+        .find(|marker| input.starts_with(**marker))
+        .map(|marker| marker.len())
+}
+
+fn split_pseudo_key_value(field: &str) -> Option<(&str, &str)> {
+    if let Some(separator) = field.find("=>") {
+        return split_pseudo_key_value_at(field, separator, 2);
+    }
+    let separator = field.find(':').or_else(|| field.find('='))?;
+    split_pseudo_key_value_at(field, separator, 1)
+}
+
+fn split_pseudo_key_value_at(
+    field: &str,
+    separator: usize,
+    separator_len: usize,
+) -> Option<(&str, &str)> {
+    let key = field[..separator]
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'');
+    if key.is_empty() {
+        return None;
+    }
+    Some((key, field[separator + separator_len..].trim()))
+}
+
+fn parse_pseudo_value(value: &str) -> Value {
+    let value = value.trim();
+    if let Some(unwrapped) = strip_sentinel_string(value) {
+        return Value::String(unwrapped.to_string());
+    }
+    if let Ok(parsed) = serde_json::from_str::<Value>(value) {
+        return parsed;
+    }
+    let pseudo_object = value
+        .starts_with('{')
+        .then(|| parse_pseudo_argument_object(value))
+        .flatten();
+    if let Some(arguments) = pseudo_object {
+        return Value::Object(arguments);
+    }
+    let unquoted = value
+        .trim_matches('"')
+        .trim_matches('\'')
+        .trim()
+        .to_string();
+    Value::String(unquoted)
+}
+
+fn strip_sentinel_string(value: &str) -> Option<&str> {
+    let double = "<|\"|>";
+    let single = "<|'|>";
+    value
+        .strip_prefix(double)
+        .and_then(|inner| inner.strip_suffix(double))
+        .or_else(|| {
+            value
+                .strip_prefix(single)
+                .and_then(|inner| inner.strip_suffix(single))
+        })
+}
+
 fn first_balanced_object(content: &str) -> Option<String> {
     let start = content.find('{')?;
     let end = balanced_substring_end(content.as_bytes(), start, b'{', b'}')?;
@@ -327,16 +595,117 @@ fn parse_one_tool_call(
     let Some((name, arguments_value)) = extract_tool_name_and_arguments(value) else {
         return Err(ToolCallParseError::Malformed);
     };
-    if !allowed_tools.is_empty() && !allowed_tools.contains(name) {
-        return Err(ToolCallParseError::UnknownTool);
-    }
+    let name = resolve_allowed_tool_name(name, allowed_tools)?;
     let Some(arguments) = normalize_tool_arguments(arguments_value) else {
         return Err(ToolCallParseError::InvalidArguments);
     };
-    Ok(ParsedToolCall {
-        name: name.to_string(),
-        arguments,
-    })
+    Ok(ParsedToolCall { name, arguments })
+}
+
+fn resolve_allowed_tool_name(
+    raw_name: &str,
+    allowed_tools: &BTreeSet<&str>,
+) -> Result<String, ToolCallParseError> {
+    if allowed_tools.is_empty() {
+        return Ok(raw_name.to_string());
+    }
+    if allowed_tools.contains(raw_name) {
+        return Ok(raw_name.to_string());
+    }
+
+    let Some(matched) = high_confidence_name_match(raw_name, allowed_tools.iter().copied()) else {
+        return Err(ToolCallParseError::UnknownTool);
+    };
+    Ok(matched.to_string())
+}
+
+fn high_confidence_name_match<'a>(
+    raw_name: &str,
+    candidates: impl Iterator<Item = &'a str>,
+) -> Option<&'a str> {
+    let raw_norm = normalized_identifier(raw_name);
+    if raw_norm.len() < 4 {
+        return None;
+    }
+
+    let mut matches = candidates
+        .filter_map(|candidate| {
+            let candidate_norm = normalized_identifier(candidate);
+            name_match_score(raw_name, &raw_norm, candidate, &candidate_norm)
+                .map(|score| (score, candidate))
+        })
+        .collect::<Vec<_>>();
+    matches.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(right.1)));
+
+    let [(score, candidate), rest @ ..] = matches.as_slice() else {
+        return None;
+    };
+    let runner_up = rest.first().map(|(score, _)| *score).unwrap_or(0);
+    (*score >= 90 && *score >= runner_up + 12).then_some(*candidate)
+}
+
+fn name_match_score(
+    raw_name: &str,
+    raw_norm: &str,
+    candidate: &str,
+    candidate_norm: &str,
+) -> Option<u16> {
+    if raw_norm == candidate_norm {
+        return Some(120);
+    }
+    let raw_tokens = identifier_tokens(raw_name);
+    let candidate_tokens = identifier_tokens(candidate);
+    if !candidate_tokens.is_empty()
+        && token_suffix_matches(&raw_tokens, &candidate_tokens)
+        && candidate_norm.len() >= 6
+    {
+        return Some(105);
+    }
+    close_identifier_match(raw_norm, candidate_norm).then_some(95)
+}
+
+fn normalized_identifier(name: &str) -> String {
+    name.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn identifier_tokens(name: &str) -> Vec<String> {
+    name.split(|character: char| !character.is_ascii_alphanumeric())
+        .filter_map(|token| {
+            let token = token.trim().to_ascii_lowercase();
+            (!token.is_empty()).then_some(token)
+        })
+        .collect()
+}
+
+fn token_suffix_matches(raw_tokens: &[String], candidate_tokens: &[String]) -> bool {
+    raw_tokens.len() >= candidate_tokens.len()
+        && raw_tokens[raw_tokens.len() - candidate_tokens.len()..] == *candidate_tokens
+}
+
+fn close_identifier_match(left: &str, right: &str) -> bool {
+    if left.len().abs_diff(right.len()) > 2 || left.len().min(right.len()) < 6 {
+        return false;
+    }
+    levenshtein_distance(left, right) <= 1
+}
+
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    let mut previous: Vec<usize> = (0..=right.chars().count()).collect();
+    let mut current = vec![0; previous.len()];
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right.chars().enumerate() {
+            let insert = current[right_index] + 1;
+            let delete = previous[right_index + 1] + 1;
+            let replace = previous[right_index] + usize::from(left_char != right_char);
+            current[right_index + 1] = insert.min(delete).min(replace);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    previous[right.chars().count()]
 }
 
 #[cfg(test)]
@@ -373,5 +742,115 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error, ToolCallParseError::UnknownTool);
+    }
+
+    #[test]
+    fn canonicalizes_tool_name_from_allowed_catalog() {
+        let allowed_tools = vec!["web_search".to_string()];
+        let calls = rescue_tool_call_from_text(
+            r#"{"name":"web.search","arguments":{"query":"Mesh-LLM"}}"#,
+            &allowed_tools,
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "web_search");
+        assert_eq!(calls[0].arguments["query"], "Mesh-LLM");
+    }
+
+    #[test]
+    fn canonicalizes_namespaced_tool_name_only_when_unique() {
+        let allowed_tools = vec!["read_file".to_string()];
+        let calls = rescue_tool_call_from_text(
+            r#"{"name":"filesystem.read_file","arguments":{"path":"README.md"}}"#,
+            &allowed_tools,
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "read_file");
+    }
+
+    #[test]
+    fn ambiguous_tool_name_correction_fails_closed() {
+        let allowed_tools = vec!["read_file".to_string(), "write_file".to_string()];
+        let error = rescue_tool_call_from_text(
+            r#"{"name":"filesystem.file","arguments":{"path":"README.md"}}"#,
+            &allowed_tools,
+        )
+        .unwrap_err();
+
+        assert_eq!(error, ToolCallParseError::UnknownTool);
+    }
+
+    #[test]
+    fn rescues_sentinel_tool_call() {
+        let calls = rescue_tool_call_from_text(
+            r#"<|tool_call>call:web_search{query:<|"|>Mesh-LLM #808 Harden OpenClaw/MoA Telegram timeouts<|"|>}<tool_call|>"#,
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "web_search");
+        assert_eq!(
+            calls[0].arguments["query"],
+            "Mesh-LLM #808 Harden OpenClaw/MoA Telegram timeouts"
+        );
+    }
+
+    #[test]
+    fn rescues_bracketed_arrow_tool_call() {
+        let calls = rescue_tool_call_from_text(
+            "[TOOL_CALL]\n{tool => \"read_file\", args => {path: \"README.md\"}}\n[/TOOL_CALL]",
+            &[],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "read_file");
+        assert_eq!(calls[0].arguments["path"], "README.md");
+    }
+
+    #[test]
+    fn bracketed_arrow_tool_call_rejects_unknown_tool_when_catalog_is_present() {
+        let allowed_tools = vec!["read_file".to_string()];
+        let error = rescue_tool_call_from_text(
+            "[TOOL_CALL]\n{tool => \"filesystem_list_allowed_directories\", args => {}}\n[/TOOL_CALL]",
+            &allowed_tools,
+        )
+        .unwrap_err();
+
+        assert_eq!(error, ToolCallParseError::UnknownTool);
+    }
+
+    #[test]
+    fn explanatory_bracketed_tool_call_text_stays_malformed() {
+        let error = rescue_tool_call_from_text(
+            "Use this shape: [TOOL_CALL]\n{tool => \"read_file\", args => {path: \"README.md\"}}\n[/TOOL_CALL]",
+            &[],
+        )
+        .unwrap_err();
+
+        assert_eq!(error, ToolCallParseError::Malformed);
+    }
+
+    #[test]
+    fn sentinel_tool_call_rejects_unknown_tool_when_catalog_is_present() {
+        let allowed_tools = vec!["web_fetch".to_string()];
+        let error = rescue_tool_call_from_text(
+            r#"<|tool_call>call:web_search{query:<|"|>Mesh-LLM<|"|>}<tool_call|>"#,
+            &allowed_tools,
+        )
+        .unwrap_err();
+
+        assert_eq!(error, ToolCallParseError::UnknownTool);
+    }
+
+    #[test]
+    fn explanatory_sentinel_tool_call_text_stays_malformed() {
+        let error = rescue_tool_call_from_text(
+            r#"Use this shape when calling a tool: <|tool_call>call:web_search{query:<|"|>Mesh-LLM<|"|>}<tool_call|>"#,
+            &[],
+        )
+        .unwrap_err();
+
+        assert_eq!(error, ToolCallParseError::Malformed);
     }
 }

--- a/crates/mesh-llm-guardrails/src/tools.rs
+++ b/crates/mesh-llm-guardrails/src/tools.rs
@@ -377,31 +377,42 @@ fn string_value_matches_declared_format(
     let Some(text) = value.as_str() else {
         return true;
     };
-    if !schema_or_name_looks_url_like(schema, property_name) {
-        return true;
+    let text = text.trim();
+    match declared_string_format(schema).as_deref() {
+        Some("uri") => Url::parse(text).is_ok(),
+        Some("uri-reference") => uri_reference_is_valid(text),
+        Some("url") => http_url_is_valid(text),
+        _ if property_name_looks_url_like(property_name) => http_url_is_valid(text),
+        _ => true,
     }
-
-    let Ok(url) = Url::parse(text.trim()) else {
-        return false;
-    };
-    matches!(url.scheme(), "http" | "https")
 }
 
-fn schema_or_name_looks_url_like(schema: &Value, property_name: Option<&str>) -> bool {
+fn declared_string_format(schema: &Value) -> Option<String> {
     schema
         .get("format")
         .and_then(Value::as_str)
-        .is_some_and(|format| {
-            matches!(
-                format.to_ascii_lowercase().as_str(),
-                "url" | "uri" | "uri-reference"
-            )
-        })
-        || property_name.is_some_and(|name| {
-            identifier_tokens(name)
-                .iter()
-                .any(|token| matches!(token.as_str(), "url" | "uri"))
-        })
+        .map(|format| format.to_ascii_lowercase())
+}
+
+fn property_name_looks_url_like(property_name: Option<&str>) -> bool {
+    property_name.is_some_and(|name| {
+        identifier_tokens(name)
+            .iter()
+            .any(|token| matches!(token.as_str(), "url" | "uri"))
+    })
+}
+
+fn http_url_is_valid(text: &str) -> bool {
+    Url::parse(text).is_ok_and(|url| matches!(url.scheme(), "http" | "https"))
+}
+
+fn uri_reference_is_valid(text: &str) -> bool {
+    if Url::parse(text).is_ok() {
+        return true;
+    }
+    Url::parse("https://example.invalid/")
+        .and_then(|base| base.join(text))
+        .is_ok()
 }
 
 fn value_matches_type(value: &Value, schema_type: &str) -> bool {
@@ -618,6 +629,60 @@ mod tests {
         .unwrap();
 
         assert_eq!(cleaned, json!({"target": "https://example.com/path?q=1"}));
+    }
+
+    #[test]
+    fn schema_sanitizer_accepts_non_http_uri_format_argument() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "open_uri",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {"type": "string", "format": "uri"}
+                    },
+                    "required": ["target"],
+                    "additionalProperties": false
+                }
+            }
+        }]);
+
+        let cleaned = sanitize_tool_arguments_for_tool(
+            "open_uri",
+            &json!({"target": "mailto:user@example.com"}),
+            Some(&tools),
+        )
+        .unwrap();
+
+        assert_eq!(cleaned, json!({"target": "mailto:user@example.com"}));
+    }
+
+    #[test]
+    fn schema_sanitizer_accepts_relative_uri_reference_argument() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "open_reference",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {"type": "string", "format": "uri-reference"}
+                    },
+                    "required": ["target"],
+                    "additionalProperties": false
+                }
+            }
+        }]);
+
+        let cleaned = sanitize_tool_arguments_for_tool(
+            "open_reference",
+            &json!({"target": "../docs/readme.md#intro"}),
+            Some(&tools),
+        )
+        .unwrap();
+
+        assert_eq!(cleaned, json!({"target": "../docs/readme.md#intro"}));
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/src/tools.rs
+++ b/crates/mesh-llm-guardrails/src/tools.rs
@@ -1,6 +1,7 @@
 use serde_json::{Map, Value, json};
 use std::collections::HashSet;
 use std::fmt;
+use url::Url;
 
 use crate::{request_contract::GuardrailRequestContract, structured::StructuredOutputSpec};
 
@@ -55,8 +56,9 @@ pub fn model_param_size_b(name: &str) -> Option<f32> {
         if unit != b'b' && unit != b'B' {
             continue;
         }
-        if let Some(&after) = bytes.get(end + 1)
-            && after.is_ascii_digit()
+        if bytes
+            .get(end + 1)
+            .is_some_and(|after| after.is_ascii_digit())
         {
             continue;
         }
@@ -244,7 +246,8 @@ fn high_confidence_property_match<'a>(
     let mut matches = properties
         .iter()
         .filter(|(name, schema)| {
-            argument_value_matches_schema(value, schema) && (required.contains(name.as_str()))
+            argument_value_matches_schema(value, schema, Some(name))
+                && (required.contains(name.as_str()))
         })
         .filter_map(|(name, _)| property_match_score(raw_key, name).map(|score| (score, name)))
         .collect::<Vec<_>>();
@@ -336,14 +339,20 @@ fn sanitize_object_for_schema(arguments: &mut Value, schema: &Value) {
         let Some(property_schema) = properties.get(key) else {
             return allow_additional;
         };
-        argument_value_matches_schema(value, property_schema)
+        argument_value_matches_schema(value, property_schema, Some(key))
     });
 }
 
-fn argument_value_matches_schema(value: &Value, schema: &Value) -> bool {
-    if let Some(enum_values) = schema.get("enum").and_then(Value::as_array)
-        && !enum_values.iter().any(|allowed| allowed == value)
-    {
+fn argument_value_matches_schema(
+    value: &Value,
+    schema: &Value,
+    property_name: Option<&str>,
+) -> bool {
+    match schema.get("enum").and_then(Value::as_array) {
+        Some(enum_values) if !enum_values.iter().any(|allowed| allowed == value) => return false,
+        _ => {}
+    }
+    if !string_value_matches_declared_format(value, schema, property_name) {
         return false;
     }
 
@@ -358,6 +367,41 @@ fn argument_value_matches_schema(value: &Value, schema: &Value) -> bool {
     types
         .iter()
         .any(|schema_type| value_matches_type(value, schema_type))
+}
+
+fn string_value_matches_declared_format(
+    value: &Value,
+    schema: &Value,
+    property_name: Option<&str>,
+) -> bool {
+    let Some(text) = value.as_str() else {
+        return true;
+    };
+    if !schema_or_name_looks_url_like(schema, property_name) {
+        return true;
+    }
+
+    let Ok(url) = Url::parse(text.trim()) else {
+        return false;
+    };
+    matches!(url.scheme(), "http" | "https")
+}
+
+fn schema_or_name_looks_url_like(schema: &Value, property_name: Option<&str>) -> bool {
+    schema
+        .get("format")
+        .and_then(Value::as_str)
+        .is_some_and(|format| {
+            matches!(
+                format.to_ascii_lowercase().as_str(),
+                "url" | "uri" | "uri-reference"
+            )
+        })
+        || property_name.is_some_and(|name| {
+            identifier_tokens(name)
+                .iter()
+                .any(|token| matches!(token.as_str(), "url" | "uri"))
+        })
 }
 
 fn value_matches_type(value: &Value, schema_type: &str) -> bool {
@@ -514,6 +558,66 @@ mod tests {
                 fields: vec!["path".into()]
             }
         );
+    }
+
+    #[test]
+    fn schema_sanitizer_rejects_invalid_required_url_argument() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "web_fetch",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": {"type": "string"}
+                    },
+                    "required": ["url"],
+                    "additionalProperties": false
+                }
+            }
+        }]);
+
+        let err = sanitize_tool_arguments_for_tool(
+            "web_fetch",
+            &json!({"url": "s internal feedback directly."}),
+            Some(&tools),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err,
+            ToolArgumentSchemaError::MissingRequired {
+                tool_name: "web_fetch".into(),
+                fields: vec!["url".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn schema_sanitizer_preserves_valid_uri_format_argument() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "fetch",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target": {"type": "string", "format": "uri"}
+                    },
+                    "required": ["target"],
+                    "additionalProperties": false
+                }
+            }
+        }]);
+
+        let cleaned = sanitize_tool_arguments_for_tool(
+            "fetch",
+            &json!({"target": "https://example.com/path?q=1"}),
+            Some(&tools),
+        )
+        .unwrap();
+
+        assert_eq!(cleaned, json!({"target": "https://example.com/path?q=1"}));
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/src/tools.rs
+++ b/crates/mesh-llm-guardrails/src/tools.rs
@@ -1,4 +1,5 @@
 use serde_json::{Map, Value, json};
+use std::collections::HashSet;
 use std::fmt;
 
 use crate::{request_contract::GuardrailRequestContract, structured::StructuredOutputSpec};
@@ -164,6 +165,7 @@ pub fn sanitize_tool_arguments_for_tool(
         return Ok(arguments);
     };
 
+    repair_argument_keys_for_schema(&mut arguments, parameters);
     sanitize_object_for_schema(&mut arguments, parameters);
     ensure_required_arguments(tool_name, &arguments, parameters)?;
     Ok(arguments)
@@ -179,6 +181,143 @@ fn tool_parameters<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a 
                 .is_some_and(|name| name == tool_name)
         })?
         .pointer("/function/parameters")
+}
+
+fn repair_argument_keys_for_schema(arguments: &mut Value, schema: &Value) {
+    let Some(arguments) = arguments.as_object_mut() else {
+        return;
+    };
+    let Some(properties) = schema.get("properties").and_then(Value::as_object) else {
+        return;
+    };
+
+    for repair in argument_key_repairs(arguments, properties, required_fields(schema)) {
+        if arguments.contains_key(&repair.to) {
+            continue;
+        }
+        if let Some(value) = arguments.remove(&repair.from) {
+            arguments.insert(repair.to, value);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct ArgumentKeyRepair {
+    from: String,
+    to: String,
+}
+
+fn argument_key_repairs(
+    arguments: &Map<String, Value>,
+    properties: &Map<String, Value>,
+    required: HashSet<&str>,
+) -> Vec<ArgumentKeyRepair> {
+    arguments
+        .iter()
+        .filter(|(key, _)| !properties.contains_key(*key))
+        .filter_map(|(key, value)| {
+            let destination = high_confidence_property_match(key, value, properties, &required)?;
+            Some(ArgumentKeyRepair {
+                from: key.clone(),
+                to: destination.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn required_fields(schema: &Value) -> HashSet<&str> {
+    schema
+        .get("required")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect()
+}
+
+fn high_confidence_property_match<'a>(
+    raw_key: &str,
+    value: &Value,
+    properties: &'a Map<String, Value>,
+    required: &HashSet<&str>,
+) -> Option<&'a str> {
+    let mut matches = properties
+        .iter()
+        .filter(|(name, schema)| {
+            argument_value_matches_schema(value, schema) && (required.contains(name.as_str()))
+        })
+        .filter_map(|(name, _)| property_match_score(raw_key, name).map(|score| (score, name)))
+        .collect::<Vec<_>>();
+    matches.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(right.1)));
+
+    let [(score, name), rest @ ..] = matches.as_slice() else {
+        return None;
+    };
+    let runner_up = rest.first().map(|(score, _)| *score).unwrap_or(0);
+    (*score >= 90 && *score >= runner_up + 12).then_some(name.as_str())
+}
+
+fn property_match_score(raw_key: &str, candidate: &str) -> Option<u16> {
+    let raw_norm = normalized_identifier(raw_key);
+    let candidate_norm = normalized_identifier(candidate);
+    if raw_norm.len() < 3 || candidate_norm.len() < 3 {
+        return None;
+    }
+    if raw_norm == candidate_norm {
+        return Some(120);
+    }
+
+    let raw_tokens = identifier_tokens(raw_key);
+    let candidate_tokens = identifier_tokens(candidate);
+    if !candidate_tokens.is_empty() && token_suffix_matches(&raw_tokens, &candidate_tokens) {
+        return Some(105);
+    }
+
+    close_identifier_match(&raw_norm, &candidate_norm).then_some(95)
+}
+
+fn normalized_identifier(name: &str) -> String {
+    name.chars()
+        .filter(|character| character.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn identifier_tokens(name: &str) -> Vec<String> {
+    name.split(|character: char| !character.is_ascii_alphanumeric())
+        .filter_map(|token| {
+            let token = token.trim().to_ascii_lowercase();
+            (!token.is_empty()).then_some(token)
+        })
+        .collect()
+}
+
+fn token_suffix_matches(raw_tokens: &[String], candidate_tokens: &[String]) -> bool {
+    raw_tokens.len() >= candidate_tokens.len()
+        && raw_tokens[raw_tokens.len() - candidate_tokens.len()..] == *candidate_tokens
+}
+
+fn close_identifier_match(left: &str, right: &str) -> bool {
+    if left.len().abs_diff(right.len()) > 2 || left.len().min(right.len()) < 5 {
+        return false;
+    }
+    levenshtein_distance(left, right) <= 1
+}
+
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    let mut previous: Vec<usize> = (0..=right.chars().count()).collect();
+    let mut current = vec![0; previous.len()];
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+        for (right_index, right_char) in right.chars().enumerate() {
+            let insert = current[right_index] + 1;
+            let delete = previous[right_index + 1] + 1;
+            let replace = previous[right_index] + usize::from(left_char != right_char);
+            current[right_index + 1] = insert.min(delete).min(replace);
+        }
+        std::mem::swap(&mut previous, &mut current);
+    }
+    previous[right.chars().count()]
 }
 
 fn sanitize_object_for_schema(arguments: &mut Value, schema: &Value) {
@@ -375,6 +514,59 @@ mod tests {
                 fields: vec!["path".into()]
             }
         );
+    }
+
+    #[test]
+    fn schema_sanitizer_repairs_required_argument_key_from_schema() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path to read"}
+                    },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }
+            }
+        }]);
+
+        let cleaned = sanitize_tool_arguments_for_tool(
+            "read_file",
+            &json!({"file_path": "README.md"}),
+            Some(&tools),
+        )
+        .unwrap();
+
+        assert_eq!(cleaned, json!({"path": "README.md"}));
+    }
+
+    #[test]
+    fn schema_sanitizer_does_not_repair_non_required_argument_key() {
+        let tools = json!([{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string", "description": "File path to read"}
+                    },
+                    "additionalProperties": false
+                }
+            }
+        }]);
+
+        let cleaned = sanitize_tool_arguments_for_tool(
+            "read_file",
+            &json!({"file_path": "README.md"}),
+            Some(&tools),
+        )
+        .unwrap();
+
+        assert_eq!(cleaned, json!({}));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/models/remote_catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/remote_catalog.rs
@@ -57,6 +57,10 @@ const CATALOG_REFRESH_BACKOFF: Duration = Duration::from_secs(5 * 60);
 
 static CATALOG_ENTRIES_OVERRIDE_ACTIVE: AtomicBool = AtomicBool::new(false);
 
+const SUPPRESSED_RECOMMENDATION_NAMES: &[&str] = &["Qwen3.5-9B-Vision-Q4_K_M"];
+const BUNDLED_RECOMMENDATION_OVERLAY_NAMES: &[&str] =
+    &["Gemma-4-E4B-it-Q4_K_M", "Qwen3.6-35B-A3B-UD-Q4_K_M"];
+
 #[cfg(test)]
 type HfModelFileProbe = Arc<dyn Fn(&str, &str, &str) -> bool + Send + Sync>;
 
@@ -568,10 +572,77 @@ pub fn loaded_models() -> Result<Vec<RemoteCatalogModel>> {
     Ok(models)
 }
 
+pub fn recommended_models() -> Result<Vec<RemoteCatalogModel>> {
+    let mut models = loaded_models()?;
+    apply_bundled_recommendation_overlay(&mut models)?;
+    Ok(models)
+}
+
 /// Returns all loaded catalog entries (if any).
 pub fn catalog_entries() -> Option<Vec<CatalogEntry>> {
     let lock = CATALOG_ENTRIES.read().ok()?;
     lock.clone()
+}
+
+fn apply_bundled_recommendation_overlay(models: &mut Vec<RemoteCatalogModel>) -> Result<()> {
+    models.retain(|model| {
+        !SUPPRESSED_RECOMMENDATION_NAMES
+            .iter()
+            .any(|name| model.name.eq_ignore_ascii_case(name))
+    });
+
+    let mut overlays = mesh_llm_node::models::recommended_catalog_models()
+        .into_iter()
+        .filter(|model| {
+            BUNDLED_RECOMMENDATION_OVERLAY_NAMES
+                .iter()
+                .any(|name| model.name.eq_ignore_ascii_case(name))
+        })
+        .map(remote_model_from_bundled_recommendation)
+        .collect::<Result<Vec<_>>>()?;
+
+    for overlay in &overlays {
+        models.retain(|model| !model.name.eq_ignore_ascii_case(&overlay.name));
+    }
+    overlays.append(models);
+    *models = overlays;
+    Ok(())
+}
+
+fn remote_model_from_bundled_recommendation(
+    model: mesh_llm_node::models::CatalogRecommendedModel,
+) -> Result<RemoteCatalogModel> {
+    let source = remote_asset_from_bundled_url(&model.file, &model.url)?;
+    Ok(RemoteCatalogModel {
+        name: model.name,
+        file: source.file.clone(),
+        repo: source.repo.clone(),
+        revision: source.revision.clone(),
+        source_file: source.source_file.clone(),
+        size: Some(model.size),
+        description: Some(model.description),
+        draft: model.draft,
+        extra_files: model
+            .extra_files
+            .into_iter()
+            .map(|asset| remote_asset_from_bundled_url(&asset.file, &asset.url))
+            .collect::<Result<Vec<_>>>()?,
+        mmproj: model
+            .mmproj
+            .map(|asset| remote_asset_from_bundled_url(&asset.file, &asset.url))
+            .transpose()?,
+    })
+}
+
+fn remote_asset_from_bundled_url(file: &str, url: &str) -> Result<RemoteCatalogAsset> {
+    let (repo, revision, source_file) = model_resolver::parse_hf_resolve_url(url)
+        .with_context(|| format!("parse bundled catalog URL for {file}: {url}"))?;
+    Ok(RemoteCatalogAsset {
+        file: file.to_string(),
+        repo,
+        revision,
+        source_file,
+    })
 }
 
 fn resolver_from_loaded_entries() -> Option<ModelResolver<HfCatalogProvider>> {
@@ -984,6 +1055,40 @@ mod tests {
                 revision: Some("main".to_string()),
                 source_file: "mmproj-BF16.gguf".to_string(),
             })
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn recommended_models_apply_bundled_overlay() {
+        let _catalog = set_catalog_entries_for_test(vec![CatalogEntry {
+            schema_version: 1,
+            source_repo: "example/recommendations".to_string(),
+            variants: HashMap::from([
+                (
+                    "old-qwen".to_string(),
+                    test_variant("Qwen3.5-9B-Vision-Q4_K_M", "unsloth/Qwen3.5-9B-GGUF", &[]),
+                ),
+                (
+                    "other".to_string(),
+                    test_variant("Other-Recommendation-Q4_K_M", "example/other", &[]),
+                ),
+            ]),
+        }]);
+
+        let models = recommended_models().expect("recommended models");
+
+        assert_eq!(models[0].name, "Gemma-4-E4B-it-Q4_K_M");
+        assert_eq!(models[1].name, "Qwen3.6-35B-A3B-UD-Q4_K_M");
+        assert!(
+            models
+                .iter()
+                .any(|model| model.name == "Other-Recommendation-Q4_K_M")
+        );
+        assert!(
+            models
+                .iter()
+                .all(|model| model.name != "Qwen3.5-9B-Vision-Q4_K_M")
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/nostr.rs
+++ b/crates/mesh-llm-host-runtime/src/network/nostr.rs
@@ -1242,7 +1242,7 @@ fn model_tiers() -> Vec<(String, f64)> {
 ///
 /// Tiers:
 ///   <8GB:    Qwen3-4B (2.5G)
-///   8-24GB:  Qwen3-8B (5G)
+///   8-24GB:  Gemma-4-E4B-it (4.6G)
 ///   24-50GB: Qwen3.5-27B (17G) — vision + text
 ///   50-63GB: GLM-4.7-Flash (18G) — fast, tool calling
 ///   63-179GB: Qwen3-Coder-Next (48G) — frontier coder ~85B
@@ -1294,7 +1294,7 @@ pub fn auto_model_pack(vram_gb: f64) -> Vec<String> {
         },
         Pack {
             min_vram: 8.0,
-            models: vec![catalog_ref("Qwen3-8B-Q4_K_M")],
+            models: vec![catalog_ref("Gemma-4-E4B-it-Q4_K_M")],
         },
         Pack {
             min_vram: 0.0,
@@ -1408,13 +1408,13 @@ mod auto_pack_tests {
     #[test]
     fn pack_8gb_single_model() {
         let pack = auto_model_pack(8.0);
-        assert_single_pack_model(&pack, "Qwen3-8B-Q4_K_M");
+        assert_single_pack_model(&pack, "Gemma-4-E4B-it-Q4_K_M");
     }
 
     #[test]
     fn pack_16gb_single() {
         let pack = auto_model_pack(16.0);
-        assert_single_pack_model(&pack, "Qwen3-8B-Q4_K_M");
+        assert_single_pack_model(&pack, "Gemma-4-E4B-it-Q4_K_M");
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
@@ -1,0 +1,133 @@
+const MOA_DEFAULT_COMPLETION_BUDGET_TOKENS: u32 = 1024;
+const MOA_CHAT_CONTEXT_RESERVE_TOKENS: u32 = 1024;
+const MOA_TOOL_CONTEXT_RESERVE_TOKENS: u32 = 2048;
+const MOA_TOOL_RESULT_CONTEXT_RESERVE_TOKENS: u32 = 4096;
+
+pub(in crate::network::openai::moa_gateway) fn moa_required_tokens(
+    body: &serde_json::Value,
+    transport_required_tokens: Option<u32>,
+) -> Option<u32> {
+    let serialized_prompt_tokens = serde_json::to_vec(body)
+        .ok()
+        .map(|bytes| ceil_div_u32(saturating_u32(bytes.len()), 4));
+    let mut required = transport_required_tokens.or(serialized_prompt_tokens)?;
+
+    if completion_budget_missing(body) {
+        required = required.saturating_add(MOA_DEFAULT_COMPLETION_BUDGET_TOKENS);
+    }
+
+    Some(required.saturating_add(moa_context_reserve_tokens(body)))
+}
+
+fn moa_context_reserve_tokens(body: &serde_json::Value) -> u32 {
+    if body_has_tool_result(body) {
+        MOA_TOOL_RESULT_CONTEXT_RESERVE_TOKENS
+    } else if body_has_tools(body) {
+        MOA_TOOL_CONTEXT_RESERVE_TOKENS
+    } else {
+        MOA_CHAT_CONTEXT_RESERVE_TOKENS
+    }
+}
+
+fn body_has_tool_result(body: &serde_json::Value) -> bool {
+    body.get("messages")
+        .and_then(serde_json::Value::as_array)
+        .map(|messages| {
+            messages.iter().any(|message| {
+                message.get("role").and_then(serde_json::Value::as_str) == Some("tool")
+            })
+        })
+        .unwrap_or(false)
+}
+
+fn body_has_tools(body: &serde_json::Value) -> bool {
+    body.get("tools")
+        .and_then(serde_json::Value::as_array)
+        .map(|tools| !tools.is_empty())
+        .unwrap_or(false)
+}
+
+fn completion_budget_missing(body: &serde_json::Value) -> bool {
+    [
+        "max_completion_tokens",
+        "max_tokens",
+        "max_output_tokens",
+        "n_predict",
+    ]
+    .into_iter()
+    .all(|key| body.get(key).and_then(serde_json::Value::as_u64).is_none())
+}
+
+fn saturating_u32(value: usize) -> u32 {
+    value.try_into().unwrap_or(u32::MAX)
+}
+
+fn ceil_div_u32(value: u32, divisor: u32) -> u32 {
+    value.saturating_add(divisor - 1) / divisor
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn moa_required_tokens_adds_chat_completion_budget_and_reserve() {
+        let body = serde_json::json!({
+            "model": "mesh",
+            "messages": [{"role": "user", "content": "hello"}],
+        });
+
+        assert_eq!(
+            moa_required_tokens(&body, Some(2000)),
+            Some(2000 + MOA_DEFAULT_COMPLETION_BUDGET_TOKENS + MOA_CHAT_CONTEXT_RESERVE_TOKENS)
+        );
+    }
+
+    #[test]
+    fn moa_required_tokens_respects_explicit_max_tokens() {
+        let body = serde_json::json!({
+            "model": "mesh",
+            "messages": [{"role": "user", "content": "hello"}],
+            "max_tokens": 128,
+        });
+
+        assert_eq!(
+            moa_required_tokens(&body, Some(2000)),
+            Some(2000 + MOA_CHAT_CONTEXT_RESERVE_TOKENS)
+        );
+    }
+
+    #[test]
+    fn moa_required_tokens_keeps_extra_room_for_tools() {
+        let body = serde_json::json!({
+            "model": "mesh",
+            "messages": [{"role": "user", "content": "hello"}],
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+        });
+
+        assert_eq!(
+            moa_required_tokens(&body, Some(2000)),
+            Some(2000 + MOA_DEFAULT_COMPLETION_BUDGET_TOKENS + MOA_TOOL_CONTEXT_RESERVE_TOKENS)
+        );
+    }
+
+    #[test]
+    fn moa_required_tokens_keeps_most_room_for_tool_results() {
+        let body = serde_json::json!({
+            "model": "mesh",
+            "messages": [
+                {"role": "user", "content": "read"},
+                {"role": "tool", "content": "large output"}
+            ],
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+        });
+
+        assert_eq!(
+            moa_required_tokens(&body, Some(2000)),
+            Some(
+                2000 + MOA_DEFAULT_COMPLETION_BUDGET_TOKENS
+                    + MOA_TOOL_RESULT_CONTEXT_RESERVE_TOKENS
+            )
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
@@ -30,19 +30,44 @@ fn moa_context_reserve_tokens(body: &serde_json::Value) -> u32 {
 }
 
 fn body_has_tool_result(body: &serde_json::Value) -> bool {
-    body.get("messages")
+    if body
+        .get("messages")
         .and_then(serde_json::Value::as_array)
         .map(|messages| messages.iter().any(message_has_tool_result))
         .unwrap_or(false)
+    {
+        return true;
+    }
+
+    ["output", "items", "input"]
+        .into_iter()
+        .filter_map(|key| body.get(key))
+        .any(value_has_tool_result)
 }
 
 fn message_has_tool_result(message: &serde_json::Value) -> bool {
     message.get("role").and_then(serde_json::Value::as_str) == Some("tool")
+        || content_block_is_tool_result(message)
         || message
             .get("content")
             .and_then(serde_json::Value::as_array)
-            .map(|parts| parts.iter().any(content_block_is_tool_result))
+            .map(|parts| parts.iter().any(value_has_tool_result))
             .unwrap_or(false)
+        || message.get("content").is_some_and(value_has_tool_result)
+}
+
+fn value_has_tool_result(value: &serde_json::Value) -> bool {
+    if content_block_is_tool_result(value) {
+        return true;
+    }
+    match value {
+        serde_json::Value::Array(values) => values.iter().any(value_has_tool_result),
+        serde_json::Value::Object(map) => {
+            map.values().any(value_has_tool_result)
+                || map.get("role").and_then(serde_json::Value::as_str) == Some("tool")
+        }
+        _ => false,
+    }
 }
 
 fn content_block_is_tool_result(part: &serde_json::Value) -> bool {
@@ -51,7 +76,7 @@ fn content_block_is_tool_result(part: &serde_json::Value) -> bool {
     };
     matches!(
         normalize_content_block_type(kind).as_str(),
-        "toolresult" | "toolresponse"
+        "functioncalloutput" | "tooloutput" | "toolresult" | "toolresponse"
     )
 }
 
@@ -164,6 +189,30 @@ mod tests {
                     "content": [
                         {"type": "toolResult", "id": "call_1", "toolResult": {"value": "large output"}}
                     ]
+                }
+            ],
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+        });
+
+        assert_eq!(
+            moa_required_tokens(&body, Some(2000)),
+            Some(
+                2000 + MOA_DEFAULT_COMPLETION_BUDGET_TOKENS
+                    + MOA_TOOL_RESULT_CONTEXT_RESERVE_TOKENS
+            )
+        );
+    }
+
+    #[test]
+    fn moa_required_tokens_detects_responses_tool_outputs() {
+        let body = serde_json::json!({
+            "model": "mesh",
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "Need tool."}]},
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "large output"
                 }
             ],
             "tools": [{"type": "function", "function": {"name": "read_file"}}],

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
@@ -32,12 +32,34 @@ fn moa_context_reserve_tokens(body: &serde_json::Value) -> u32 {
 fn body_has_tool_result(body: &serde_json::Value) -> bool {
     body.get("messages")
         .and_then(serde_json::Value::as_array)
-        .map(|messages| {
-            messages.iter().any(|message| {
-                message.get("role").and_then(serde_json::Value::as_str) == Some("tool")
-            })
-        })
+        .map(|messages| messages.iter().any(message_has_tool_result))
         .unwrap_or(false)
+}
+
+fn message_has_tool_result(message: &serde_json::Value) -> bool {
+    message.get("role").and_then(serde_json::Value::as_str) == Some("tool")
+        || message
+            .get("content")
+            .and_then(serde_json::Value::as_array)
+            .map(|parts| parts.iter().any(content_block_is_tool_result))
+            .unwrap_or(false)
+}
+
+fn content_block_is_tool_result(part: &serde_json::Value) -> bool {
+    let Some(kind) = part.get("type").and_then(serde_json::Value::as_str) else {
+        return false;
+    };
+    matches!(
+        normalize_content_block_type(kind).as_str(),
+        "toolresult" | "toolresponse"
+    )
+}
+
+fn normalize_content_block_type(kind: &str) -> String {
+    kind.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn body_has_tools(body: &serde_json::Value) -> bool {
@@ -118,6 +140,31 @@ mod tests {
             "messages": [
                 {"role": "user", "content": "read"},
                 {"role": "tool", "content": "large output"}
+            ],
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+        });
+
+        assert_eq!(
+            moa_required_tokens(&body, Some(2000)),
+            Some(
+                2000 + MOA_DEFAULT_COMPLETION_BUDGET_TOKENS
+                    + MOA_TOOL_RESULT_CONTEXT_RESERVE_TOKENS
+            )
+        );
+    }
+
+    #[test]
+    fn moa_required_tokens_detects_user_wrapped_tool_result_blocks() {
+        let body = serde_json::json!({
+            "model": "mesh",
+            "messages": [
+                {"role": "user", "content": "read"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "toolResult", "id": "call_1", "toolResult": {"value": "large output"}}
+                    ]
+                }
             ],
             "tools": [{"type": "function", "function": {"name": "read_file"}}],
         });

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
@@ -1,4 +1,6 @@
 use crate::mesh;
+use std::cmp::Reverse;
+use std::collections::HashMap;
 
 pub(in crate::network::openai) fn context_can_satisfy(
     required_tokens: Option<u32>,
@@ -10,32 +12,84 @@ pub(in crate::network::openai) fn context_can_satisfy(
     }
 }
 
-pub(in crate::network::openai) async fn select_remote_host(
+pub(in crate::network::openai) async fn select_remote_hosts(
     node: &mesh::Node,
     model: &str,
     required_tokens: Option<u32>,
     hosts: Vec<iroh::EndpointId>,
-) -> Option<iroh::EndpointId> {
-    let Some(required_tokens) = required_tokens else {
-        return hosts.into_iter().next();
-    };
-
-    let mut unknown = None;
+) -> Vec<iroh::EndpointId> {
+    let latencies = remote_latency_map(node).await;
+    let mut adequate = Vec::new();
+    let mut unknown = Vec::new();
     for host in hosts {
         match node.peer_model_context_length(host, model).await {
-            Some(context) if context >= required_tokens => return Some(host),
             Some(context) => {
-                tracing::info!(
-                    "MoA: skipping remote worker {model} on {}; context {context} cannot fit {required_tokens} required tokens",
-                    host.fmt_short()
-                );
+                if required_tokens
+                    .map(|required| context >= required)
+                    .unwrap_or(true)
+                {
+                    adequate.push((host, context, latencies.get(&host).copied()));
+                } else if let Some(required_tokens) = required_tokens {
+                    tracing::info!(
+                        "MoA: skipping remote worker {model} on {}; context {context} cannot fit {required_tokens} required tokens",
+                        host.fmt_short()
+                    );
+                }
             }
             None => {
-                unknown.get_or_insert(host);
+                unknown.push((host, latencies.get(&host).copied()));
             }
         }
     }
+    adequate.sort_by_key(|candidate| (Reverse(candidate.1), candidate.2.unwrap_or(u32::MAX)));
+    if !adequate.is_empty() {
+        return adequate
+            .into_iter()
+            .map(|(host, _, _)| host)
+            .collect::<Vec<_>>();
+    }
+
+    unknown.sort_by_key(|candidate| candidate.1.unwrap_or(u32::MAX));
     unknown
+        .into_iter()
+        .map(|(host, _)| host)
+        .collect::<Vec<_>>()
+}
+
+pub(in crate::network::openai) async fn best_remote_context_length(
+    node: &mesh::Node,
+    model: &str,
+    hosts: &[iroh::EndpointId],
+) -> Option<u32> {
+    let mut best = None;
+    for host in hosts {
+        if let Some(context) = node.peer_model_context_length(*host, model).await {
+            best = Some(best.map_or(context, |current: u32| current.max(context)));
+        }
+    }
+    best
+}
+
+pub(in crate::network::openai) async fn best_remote_latency_ms(
+    node: &mesh::Node,
+    hosts: &[iroh::EndpointId],
+) -> Option<u32> {
+    let latencies = remote_latency_map(node).await;
+    hosts
+        .iter()
+        .filter_map(|host| latencies.get(host).copied())
+        .min()
+}
+
+async fn remote_latency_map(node: &mesh::Node) -> HashMap<iroh::EndpointId, u32> {
+    node.peers()
+        .await
+        .into_iter()
+        .filter_map(|peer| {
+            let latency = peer.display_latency().latency_ms?;
+            Some((peer.id, latency))
+        })
+        .collect()
 }
 
 pub(in crate::network::openai) fn virtual_mesh_context_length(

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
@@ -12,13 +12,13 @@ pub(in crate::network::openai) fn context_can_satisfy(
     }
 }
 
-pub(in crate::network::openai) async fn select_remote_hosts(
+pub(in crate::network::openai) async fn select_remote_hosts_with_latencies(
     node: &mesh::Node,
     model: &str,
     required_tokens: Option<u32>,
     hosts: Vec<iroh::EndpointId>,
+    latencies: &HashMap<iroh::EndpointId, u32>,
 ) -> Vec<iroh::EndpointId> {
-    let latencies = remote_latency_map(node).await;
     let mut adequate = Vec::new();
     let mut unknown = Vec::new();
     for host in hosts {
@@ -42,18 +42,12 @@ pub(in crate::network::openai) async fn select_remote_hosts(
         }
     }
     adequate.sort_by_key(|candidate| (Reverse(candidate.1), candidate.2.unwrap_or(u32::MAX)));
-    if !adequate.is_empty() {
-        return adequate
-            .into_iter()
-            .map(|(host, _, _)| host)
-            .collect::<Vec<_>>();
-    }
-
     unknown.sort_by_key(|candidate| candidate.1.unwrap_or(u32::MAX));
-    unknown
+    adequate
         .into_iter()
-        .map(|(host, _)| host)
-        .collect::<Vec<_>>()
+        .map(|(host, _, _)| host)
+        .chain(unknown.into_iter().map(|(host, _)| host))
+        .collect()
 }
 
 pub(in crate::network::openai) async fn best_remote_context_length(
@@ -70,18 +64,19 @@ pub(in crate::network::openai) async fn best_remote_context_length(
     best
 }
 
-pub(in crate::network::openai) async fn best_remote_latency_ms(
-    node: &mesh::Node,
+pub(in crate::network::openai) fn best_remote_latency_ms_from(
+    latencies: &HashMap<iroh::EndpointId, u32>,
     hosts: &[iroh::EndpointId],
 ) -> Option<u32> {
-    let latencies = remote_latency_map(node).await;
     hosts
         .iter()
         .filter_map(|host| latencies.get(host).copied())
         .min()
 }
 
-async fn remote_latency_map(node: &mesh::Node) -> HashMap<iroh::EndpointId, u32> {
+pub(in crate::network::openai) async fn remote_latency_map(
+    node: &mesh::Node,
+) -> HashMap<iroh::EndpointId, u32> {
     node.peers()
         .await
         .into_iter()

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
@@ -28,7 +28,12 @@ pub(in crate::network::openai) async fn select_remote_hosts_with_latencies(
                     .map(|required| context >= required)
                     .unwrap_or(true)
                 {
-                    adequate.push((host, context, latencies.get(&host).copied()));
+                    adequate.push((
+                        host,
+                        context,
+                        latencies.get(&host).copied(),
+                        host.to_string(),
+                    ));
                 } else if let Some(required_tokens) = required_tokens {
                     tracing::info!(
                         "MoA: skipping remote worker {model} on {}; context {context} cannot fit {required_tokens} required tokens",
@@ -37,16 +42,22 @@ pub(in crate::network::openai) async fn select_remote_hosts_with_latencies(
                 }
             }
             None => {
-                unknown.push((host, latencies.get(&host).copied()));
+                unknown.push((host, latencies.get(&host).copied(), host.to_string()));
             }
         }
     }
-    adequate.sort_by_key(|candidate| (Reverse(candidate.1), candidate.2.unwrap_or(u32::MAX)));
-    unknown.sort_by_key(|candidate| candidate.1.unwrap_or(u32::MAX));
+    adequate.sort_by_key(|candidate| {
+        (
+            Reverse(candidate.1),
+            candidate.2.unwrap_or(u32::MAX),
+            candidate.3.clone(),
+        )
+    });
+    unknown.sort_by_key(|candidate| (candidate.1.unwrap_or(u32::MAX), candidate.2.clone()));
     adequate
         .into_iter()
-        .map(|(host, _, _)| host)
-        .chain(unknown.into_iter().map(|(host, _)| host))
+        .map(|(host, _, _, _)| host)
+        .chain(unknown.into_iter().map(|(host, _, _)| host))
         .collect()
 }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -13,6 +13,7 @@
 use crate::inference::election;
 use crate::mesh;
 use crate::network::openai::transport as proxy;
+use crate::network::router;
 use context_budget::moa_required_tokens;
 use mesh_mixture_of_agents as moa;
 use progress::ProgressContinuation;
@@ -63,8 +64,11 @@ pub async fn try_handle_moa(
     let enable_thinking = effective_enable_thinking_for_moa(&body_json);
 
     let required_tokens = moa_required_tokens(&body_json, required_tokens);
+    let prefer_strong_workers = router::classify(&body_json).needs_tools;
     let _inflight = node.begin_inflight_request();
-    let Some(mut config) = build_moa_config(node, targets, required_tokens).await else {
+    let Some(mut config) =
+        build_moa_config(node, targets, required_tokens, prefer_strong_workers).await
+    else {
         let _ = proxy::send_503(tcp_stream, "MoA requires ≥2 models available in the mesh").await;
         return None;
     };
@@ -378,6 +382,7 @@ pub async fn build_moa_config(
     node: &mesh::Node,
     targets: Option<&election::ModelTargets>,
     required_tokens: Option<u32>,
+    prefer_strong_workers: bool,
 ) -> Option<moa::GatewayConfig> {
     let http = reqwest::Client::new();
     let mut backends: Vec<std::sync::Arc<dyn moa::ModelBackend>> = Vec::new();
@@ -388,6 +393,7 @@ pub async fn build_moa_config(
         targets,
         http: &http,
         required_tokens,
+        prefer_strong_workers,
     };
 
     let total_groups =
@@ -471,6 +477,7 @@ async fn add_ranked_worker_backends(
     let groups = rank_worker_groups(
         resolution.node,
         resolution.targets,
+        resolution.prefer_strong_workers,
         group_aliases_by_canonical_base(all_models, resolution.targets),
     )
     .await;
@@ -592,6 +599,7 @@ struct WorkerGroupRank {
     aliases: Vec<String>,
     has_local: bool,
     is_near: bool,
+    is_small: bool,
     best_context: Option<u32>,
     best_latency_ms: Option<u32>,
 }
@@ -599,13 +607,14 @@ struct WorkerGroupRank {
 async fn rank_worker_groups(
     node: &mesh::Node,
     targets: Option<&election::ModelTargets>,
+    prefer_strong_workers: bool,
     groups: Vec<Vec<String>>,
 ) -> Vec<Vec<String>> {
     let mut ranked = Vec::with_capacity(groups.len());
     for aliases in groups {
         ranked.push(worker_group_rank(node, targets, aliases).await);
     }
-    ranked.sort_by(compare_worker_groups);
+    ranked.sort_by(|left, right| compare_worker_groups(left, right, prefer_strong_workers));
     ranked.into_iter().map(|rank| rank.aliases).collect()
 }
 
@@ -617,6 +626,9 @@ async fn worker_group_rank(
     let mut has_local = false;
     let mut best_context = None;
     let mut best_latency_ms = None;
+    let is_small = aliases
+        .iter()
+        .all(|alias| moa::worker::is_single_digit_b_name(alias));
 
     for alias in &aliases {
         if is_locally_served(alias, targets) {
@@ -641,12 +653,27 @@ async fn worker_group_rank(
         has_local,
         is_near: has_local
             || best_latency_ms.is_some_and(|latency| latency <= MOA_NEAR_PEER_LATENCY_MS),
+        is_small,
         best_context,
         best_latency_ms,
     }
 }
 
-fn compare_worker_groups(left: &WorkerGroupRank, right: &WorkerGroupRank) -> std::cmp::Ordering {
+fn compare_worker_groups(
+    left: &WorkerGroupRank,
+    right: &WorkerGroupRank,
+    prefer_strong_workers: bool,
+) -> std::cmp::Ordering {
+    if prefer_strong_workers {
+        let strong_order = left
+            .is_small
+            .cmp(&right.is_small)
+            .then_with(|| right.best_context.cmp(&left.best_context));
+        if strong_order != std::cmp::Ordering::Equal {
+            return strong_order;
+        }
+    }
+
     right
         .is_near
         .cmp(&left.is_near)
@@ -704,6 +731,7 @@ struct WorkerBackendResolution<'a> {
     targets: Option<&'a election::ModelTargets>,
     http: &'a reqwest::Client,
     required_tokens: Option<u32>,
+    prefer_strong_workers: bool,
 }
 
 async fn add_worker_backend(
@@ -919,6 +947,9 @@ impl moa::ModelBackend for LocalModelBackend {
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
+            body.as_object_mut()
+                .unwrap()
+                .insert("parallel_tool_calls".to_string(), serde_json::json!(false));
         }
         moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
         let resp = self
@@ -1448,6 +1479,7 @@ mod tests {
             aliases: vec!["unsloth/Qwen3.5-9B-GGUF:Q4_K_M".to_string()],
             has_local: false,
             is_near: true,
+            is_small: true,
             best_context: Some(32_768),
             best_latency_ms: Some(2),
         };
@@ -1455,14 +1487,40 @@ mod tests {
             aliases: vec!["unsloth/MiniMax-M2.5-GGUF:Q4_K_M".to_string()],
             has_local: false,
             is_near: false,
+            is_small: false,
             best_context: Some(131_072),
             best_latency_ms: Some(350),
         };
         let mut groups = [distant_large, near];
 
-        groups.sort_by(compare_worker_groups);
+        groups.sort_by(|left, right| compare_worker_groups(left, right, false));
 
         assert_eq!(groups[0].aliases[0], "unsloth/Qwen3.5-9B-GGUF:Q4_K_M");
+    }
+
+    #[test]
+    fn worker_group_ranking_prefers_stronger_context_for_tool_turns() {
+        let local_small = WorkerGroupRank {
+            aliases: vec!["unsloth/Qwen3.5-9B-GGUF:Q4_K_M".to_string()],
+            has_local: true,
+            is_near: true,
+            is_small: true,
+            best_context: Some(32_768),
+            best_latency_ms: Some(0),
+        };
+        let remote_large = WorkerGroupRank {
+            aliases: vec!["unsloth/MiniMax-M2.5-GGUF:Q4_K_M".to_string()],
+            has_local: false,
+            is_near: true,
+            is_small: false,
+            best_context: Some(131_072),
+            best_latency_ms: Some(8),
+        };
+        let mut groups = [local_small, remote_large];
+
+        groups.sort_by(|left, right| compare_worker_groups(left, right, true));
+
+        assert_eq!(groups[0].aliases[0], "unsloth/MiniMax-M2.5-GGUF:Q4_K_M");
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -1458,7 +1458,7 @@ mod tests {
             best_context: Some(131_072),
             best_latency_ms: Some(350),
         };
-        let mut groups = vec![distant_large, near];
+        let mut groups = [distant_large, near];
 
         groups.sort_by(compare_worker_groups);
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -800,10 +800,15 @@ async fn try_add_local_worker(
     if should_skip_local_for_inflight(name, peer_inflight) {
         return false;
     }
-    if should_skip_local_for_remote_context(name, context_length, remote_context) {
+    if should_skip_local_for_required_context(name, resolution.required_tokens, context_length) {
         return false;
     }
-    if should_skip_local_for_required_context(name, resolution.required_tokens, context_length) {
+    if should_skip_local_for_remote_context(
+        name,
+        context_length,
+        remote_context,
+        resolution.prefer_strong_workers,
+    ) {
         return false;
     }
 
@@ -858,7 +863,11 @@ fn should_skip_local_for_remote_context(
     name: &str,
     local_context: Option<u32>,
     remote_context: Option<u32>,
+    prefer_strong_workers: bool,
 ) -> bool {
+    if !prefer_strong_workers {
+        return false;
+    }
     if should_prefer_remote_worker(local_context, remote_context) {
         tracing::info!(
             "MoA: preferring remote worker {name}; remote context {:?} is better than local context {:?}",
@@ -1549,6 +1558,26 @@ mod tests {
         assert!(should_skip_local_for_inflight(
             "local",
             MOA_LOCAL_INFLIGHT_SOFT_LIMIT
+        ));
+    }
+
+    #[test]
+    fn local_worker_not_skipped_for_larger_remote_context_without_strong_bias() {
+        assert!(!should_skip_local_for_remote_context(
+            "local",
+            Some(32_768),
+            Some(131_072),
+            false,
+        ));
+    }
+
+    #[test]
+    fn local_worker_skipped_for_larger_remote_context_with_strong_bias() {
+        assert!(should_skip_local_for_remote_context(
+            "local",
+            Some(32_768),
+            Some(131_072),
+            true,
         ));
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -796,7 +796,8 @@ async fn try_add_local_worker(
     let context_length = resolution.node.local_model_context_length(name).await;
     let remote_context =
         context_selection::best_remote_context_length(resolution.node, name, remote_hosts).await;
-    if should_skip_local_for_inflight(name, resolution.node.inflight_requests()) {
+    let peer_inflight = resolution.node.inflight_requests().saturating_sub(1);
+    if should_skip_local_for_inflight(name, peer_inflight) {
         return false;
     }
     if should_skip_local_for_remote_context(name, context_length, remote_context) {
@@ -1537,6 +1538,18 @@ mod tests {
         assert_eq!(max_optional_context(None, Some(32)), Some(32));
         assert_eq!(min_optional_latency(Some(300), Some(2)), Some(2));
         assert_eq!(min_optional_latency(None, Some(2)), Some(2));
+    }
+
+    #[test]
+    fn local_inflight_skip_starts_at_soft_limit() {
+        assert!(!should_skip_local_for_inflight(
+            "local",
+            MOA_LOCAL_INFLIGHT_SOFT_LIMIT - 1
+        ));
+        assert!(should_skip_local_for_inflight(
+            "local",
+            MOA_LOCAL_INFLIGHT_SOFT_LIMIT
+        ));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -18,6 +18,7 @@ use context_budget::moa_required_tokens;
 use mesh_mixture_of_agents as moa;
 use progress::ProgressContinuation;
 use remote_backend::RemoteModelBackend;
+use std::collections::HashMap;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
@@ -388,12 +389,14 @@ pub async fn build_moa_config(
     let mut backends: Vec<std::sync::Arc<dyn moa::ModelBackend>> = Vec::new();
     let mut models: Vec<moa::ModelEntry> = Vec::new();
     let mut local_count = 0usize;
+    let remote_latencies = context_selection::remote_latency_map(node).await;
     let resolution = WorkerBackendResolution {
         node,
         targets,
         http: &http,
         required_tokens,
         prefer_strong_workers,
+        remote_latencies,
     };
 
     let total_groups =
@@ -478,6 +481,7 @@ async fn add_ranked_worker_backends(
         resolution.node,
         resolution.targets,
         resolution.prefer_strong_workers,
+        &resolution.remote_latencies,
         group_aliases_by_canonical_base(all_models, resolution.targets),
     )
     .await;
@@ -608,11 +612,12 @@ async fn rank_worker_groups(
     node: &mesh::Node,
     targets: Option<&election::ModelTargets>,
     prefer_strong_workers: bool,
+    remote_latencies: &HashMap<iroh::EndpointId, u32>,
     groups: Vec<Vec<String>>,
 ) -> Vec<Vec<String>> {
     let mut ranked = Vec::with_capacity(groups.len());
     for aliases in groups {
-        ranked.push(worker_group_rank(node, targets, aliases).await);
+        ranked.push(worker_group_rank(node, targets, remote_latencies, aliases).await);
     }
     ranked.sort_by(|left, right| compare_worker_groups(left, right, prefer_strong_workers));
     ranked.into_iter().map(|rank| rank.aliases).collect()
@@ -621,6 +626,7 @@ async fn rank_worker_groups(
 async fn worker_group_rank(
     node: &mesh::Node,
     targets: Option<&election::ModelTargets>,
+    remote_latencies: &HashMap<iroh::EndpointId, u32>,
     aliases: Vec<String>,
 ) -> WorkerGroupRank {
     let mut has_local = false;
@@ -644,7 +650,7 @@ async fn worker_group_rank(
         );
         best_latency_ms = min_optional_latency(
             best_latency_ms,
-            context_selection::best_remote_latency_ms(node, &remote_hosts).await,
+            context_selection::best_remote_latency_ms_from(remote_latencies, &remote_hosts),
         );
     }
 
@@ -732,6 +738,7 @@ struct WorkerBackendResolution<'a> {
     http: &'a reqwest::Client,
     required_tokens: Option<u32>,
     prefer_strong_workers: bool,
+    remote_latencies: HashMap<iroh::EndpointId, u32>,
 }
 
 async fn add_worker_backend(
@@ -741,11 +748,12 @@ async fn add_worker_backend(
     models: &mut Vec<moa::ModelEntry>,
     local_count: &mut usize,
 ) -> bool {
-    let remote_hosts = context_selection::select_remote_hosts(
+    let remote_hosts = context_selection::select_remote_hosts_with_latencies(
         resolution.node,
         name,
         resolution.required_tokens,
         resolution.node.hosts_for_model(name).await,
+        &resolution.remote_latencies,
     )
     .await;
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -13,10 +13,20 @@
 use crate::inference::election;
 use crate::mesh;
 use crate::network::openai::transport as proxy;
+use context_budget::moa_required_tokens;
 use mesh_mixture_of_agents as moa;
 use progress::ProgressContinuation;
+use remote_backend::RemoteModelBackend;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
+
+const MOA_LOCAL_INFLIGHT_SOFT_LIMIT: u64 = 3;
+const MOA_MAX_WORKERS: usize = 3;
+const MOA_REMOTE_PEER_HEDGE_DELAY: std::time::Duration = std::time::Duration::from_secs(3);
+const MOA_WORKER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
+const MOA_REDUCER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
+const MOA_FIRST_ANSWER_GRACE: std::time::Duration = std::time::Duration::from_secs(2);
+const MOA_NEAR_PEER_LATENCY_MS: u32 = 50;
 
 /// Detect `model: "mesh"`, build a mesh-wide MoA config, run the turn,
 /// and write the HTTP response (JSON or SSE) directly to the stream.
@@ -52,6 +62,8 @@ pub async fn try_handle_moa(
 
     let enable_thinking = effective_enable_thinking_for_moa(&body_json);
 
+    let required_tokens = moa_required_tokens(&body_json, required_tokens);
+    let _inflight = node.begin_inflight_request();
     let Some(mut config) = build_moa_config(node, targets, required_tokens).await else {
         let _ = proxy::send_503(tcp_stream, "MoA requires ≥2 models available in the mesh").await;
         return None;
@@ -76,8 +88,10 @@ fn effective_enable_thinking_for_moa(body: &serde_json::Value) -> Option<bool> {
     extract_enable_thinking_override(body).or(Some(false))
 }
 
+mod context_budget;
 pub(in crate::network::openai) mod context_selection;
 mod progress;
+mod remote_backend;
 
 /// Pull the caller's "disable / enable thinking" preference out of an
 /// inbound chat-completion or responses JSON body. Mirrors the same
@@ -369,37 +383,15 @@ pub async fn build_moa_config(
     let mut backends: Vec<std::sync::Arc<dyn moa::ModelBackend>> = Vec::new();
     let mut models: Vec<moa::ModelEntry> = Vec::new();
     let mut local_count = 0usize;
+    let resolution = WorkerBackendResolution {
+        node,
+        targets,
+        http: &http,
+        required_tokens,
+    };
 
-    // Full mesh-wide model list (local + every peer's advertised
-    // routable models).
-    let all_models: Vec<String> = node
-        .models_being_served()
-        .await
-        .into_iter()
-        .filter(|n| n != moa::VIRTUAL_MODEL_NAME)
-        .collect();
-
-    // Group aliases by canonical base. The old shape sorted by name
-    // length, took the *first* alias per base, and dropped the rest —
-    // which silently dropped the model from the worker pool whenever the
-    // shortest-named peer was unreachable (regression flagged by PR #566
-    // review). Now we keep every alias per base and try them in order so
-    // a longer-named reachable alias can still resolve when the shortest
-    // one is offline.
-    let groups = group_aliases_by_canonical_base(all_models, targets);
-    for aliases in groups {
-        resolve_one_worker_from_aliases(
-            node,
-            targets,
-            &http,
-            &aliases,
-            required_tokens,
-            &mut backends,
-            &mut models,
-            &mut local_count,
-        )
-        .await;
-    }
+    let total_groups =
+        add_ranked_worker_backends(&resolution, &mut backends, &mut models, &mut local_count).await;
 
     if models.len() < 2 {
         tracing::warn!(
@@ -412,8 +404,9 @@ pub async fn build_moa_config(
 
     tracing::info!(
         required_tokens = ?required_tokens,
-        "MoA config: {} workers ({} local, {} remote): {:?}",
+        "MoA config: {} workers from {} model group(s) ({} local, {} remote): {:?}",
         models.len(),
+        total_groups,
         local_count,
         models.len() - local_count,
         models.iter().map(|m| m.name.as_str()).collect::<Vec<_>>(),
@@ -422,21 +415,12 @@ pub async fn build_moa_config(
     Some(moa::GatewayConfig {
         backends,
         models,
-        // Bumped from 15s → 60s. 15s was tight for big-context interactive
-        // turns: a large model with a 10–20k-token prompt and tool schema
-        // (typical for agent harnesses like OpenCode/Goose) can need 20–30s
-        // just to produce a first tool-call. Workers were getting killed
-        // mid-inference and MoA reported `kind=early-exit` with the small
-        // worker, never the strong one. 60s gives the strong worker room
-        // to land without making the no-progress wait painful.
-        worker_timeout: std::time::Duration::from_secs(60),
-        // Per-attempt cap; hedged_reducer_call hedges across candidates so the
-        // end-to-end wait is roughly reducer_timeout + a couple of hedge delays.
-        reducer_timeout: std::time::Duration::from_secs(60),
-        // Start a second reducer candidate after 5s if the first hasn't replied
-        // (or sooner on outright failure). Cheap on the happy path, big win on
-        // the cold-KV / stale-peer tail.
-        hedge_delay: std::time::Duration::from_secs(5),
+        // OpenClaw/Telegram agent lanes commonly surface provider failure
+        // around 75s. Keep MoA's worst normal path under that: bounded worker
+        // set, 25s worker phase, then a 25s hedged reducer phase.
+        worker_timeout: MOA_WORKER_TIMEOUT,
+        reducer_timeout: MOA_REDUCER_TIMEOUT,
+        hedge_delay: MOA_REMOTE_PEER_HEDGE_DELAY,
         // Chat-only grace: after this long since dispatch, if at least
         // one qualifying Answer is in hand we ship the highest-confidence
         // one. Tool turns bypass this entirely (consensus continues to
@@ -457,7 +441,7 @@ pub async fn build_moa_config(
         // With the relaxed eligibility added in this change, the timer
         // is the dominant chat path, so a tighter default is the right
         // default.
-        first_answer_grace: std::time::Duration::from_secs(3),
+        first_answer_grace: MOA_FIRST_ANSWER_GRACE,
         // Defaults to leaving each model's thinking behavior alone.
         // `try_handle_moa` overrides this from the inbound request body
         // when the caller has expressed a preference
@@ -468,31 +452,83 @@ pub async fn build_moa_config(
 
 /// Try each alias in `aliases` until one resolves to a backend, then stop.
 ///
-/// Aliases are pre-sorted by `group_aliases_by_canonical_base` so the most
-/// preferred (locally-served first, then shortest) is tried first. Falls
-/// back to longer aliases when the preferred one's peer is unreachable.
-#[allow(clippy::too_many_arguments)]
+/// Aliases are ranked by the best known context length available for that
+/// public model ID. This keeps a small local or low-latency alias from hiding
+/// a larger same-family peer when OpenClaw asks for the virtual `mesh` model.
+async fn add_ranked_worker_backends(
+    resolution: &WorkerBackendResolution<'_>,
+    backends: &mut Vec<std::sync::Arc<dyn moa::ModelBackend>>,
+    models: &mut Vec<moa::ModelEntry>,
+    local_count: &mut usize,
+) -> usize {
+    let all_models: Vec<String> = resolution
+        .node
+        .models_being_served()
+        .await
+        .into_iter()
+        .filter(|n| n != moa::VIRTUAL_MODEL_NAME)
+        .collect();
+    let groups = rank_worker_groups(
+        resolution.node,
+        resolution.targets,
+        group_aliases_by_canonical_base(all_models, resolution.targets),
+    )
+    .await;
+    let total_groups = groups.len();
+    for aliases in groups {
+        resolve_one_worker_from_aliases(resolution, &aliases, backends, models, local_count).await;
+        if models.len() >= MOA_MAX_WORKERS {
+            break;
+        }
+    }
+    total_groups
+}
+
 async fn resolve_one_worker_from_aliases(
-    node: &mesh::Node,
-    targets: Option<&election::ModelTargets>,
-    http: &reqwest::Client,
+    resolution: &WorkerBackendResolution<'_>,
     aliases: &[String],
-    required_tokens: Option<u32>,
     backends: &mut Vec<std::sync::Arc<dyn moa::ModelBackend>>,
     models: &mut Vec<moa::ModelEntry>,
     local_count: &mut usize,
 ) {
-    let resolution = WorkerBackendResolution {
-        node,
-        targets,
-        http,
-        required_tokens,
-    };
-    for name in aliases {
-        if add_worker_backend(&resolution, name, backends, models, local_count).await {
+    let ranked_aliases = rank_worker_aliases(resolution.node, resolution.targets, aliases).await;
+    for name in &ranked_aliases {
+        if add_worker_backend(resolution, name, backends, models, local_count).await {
             return;
         }
     }
+}
+
+async fn rank_worker_aliases(
+    node: &mesh::Node,
+    targets: Option<&election::ModelTargets>,
+    aliases: &[String],
+) -> Vec<String> {
+    let mut ranked = Vec::with_capacity(aliases.len());
+    for alias in aliases {
+        let local_context = if is_locally_served(alias, targets) {
+            node.local_model_context_length(alias).await
+        } else {
+            None
+        };
+        let remote_hosts = node.hosts_for_model(alias).await;
+        let remote_context =
+            context_selection::best_remote_context_length(node, alias, &remote_hosts).await;
+        ranked.push((
+            alias.clone(),
+            local_context.into_iter().chain(remote_context).max(),
+            is_locally_served(alias, targets),
+        ));
+    }
+    ranked.sort_by(|left, right| {
+        right
+            .1
+            .cmp(&left.1)
+            .then_with(|| right.2.cmp(&left.2))
+            .then_with(|| left.0.len().cmp(&right.0.len()))
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    ranked.into_iter().map(|(alias, _, _)| alias).collect()
 }
 
 /// Group all advertised model names by their canonical base so each
@@ -533,7 +569,8 @@ fn group_aliases_by_canonical_base(
     // Deterministic group order so the worker list is stable across
     // builds even though HashMap iteration is not. Sort group entries
     // (locally-served first, then shortest), then sort groups by their
-    // first ("best") alias.
+    // first deterministic alias. The resolver applies context-aware
+    // ranking inside each group before choosing a backend.
     let mut groups: Vec<Vec<String>> = by_base
         .into_values()
         .map(|mut aliases| {
@@ -549,6 +586,102 @@ fn group_aliases_by_canonical_base(
         .collect();
     groups.sort_by(|a, b| a[0].cmp(&b[0]));
     groups
+}
+
+struct WorkerGroupRank {
+    aliases: Vec<String>,
+    has_local: bool,
+    is_near: bool,
+    best_context: Option<u32>,
+    best_latency_ms: Option<u32>,
+}
+
+async fn rank_worker_groups(
+    node: &mesh::Node,
+    targets: Option<&election::ModelTargets>,
+    groups: Vec<Vec<String>>,
+) -> Vec<Vec<String>> {
+    let mut ranked = Vec::with_capacity(groups.len());
+    for aliases in groups {
+        ranked.push(worker_group_rank(node, targets, aliases).await);
+    }
+    ranked.sort_by(compare_worker_groups);
+    ranked.into_iter().map(|rank| rank.aliases).collect()
+}
+
+async fn worker_group_rank(
+    node: &mesh::Node,
+    targets: Option<&election::ModelTargets>,
+    aliases: Vec<String>,
+) -> WorkerGroupRank {
+    let mut has_local = false;
+    let mut best_context = None;
+    let mut best_latency_ms = None;
+
+    for alias in &aliases {
+        if is_locally_served(alias, targets) {
+            has_local = true;
+            best_context =
+                max_optional_context(best_context, node.local_model_context_length(alias).await);
+            best_latency_ms = Some(0);
+        }
+        let remote_hosts = node.hosts_for_model(alias).await;
+        best_context = max_optional_context(
+            best_context,
+            context_selection::best_remote_context_length(node, alias, &remote_hosts).await,
+        );
+        best_latency_ms = min_optional_latency(
+            best_latency_ms,
+            context_selection::best_remote_latency_ms(node, &remote_hosts).await,
+        );
+    }
+
+    WorkerGroupRank {
+        aliases,
+        has_local,
+        is_near: has_local
+            || best_latency_ms.is_some_and(|latency| latency <= MOA_NEAR_PEER_LATENCY_MS),
+        best_context,
+        best_latency_ms,
+    }
+}
+
+fn compare_worker_groups(left: &WorkerGroupRank, right: &WorkerGroupRank) -> std::cmp::Ordering {
+    right
+        .is_near
+        .cmp(&left.is_near)
+        .then_with(|| right.has_local.cmp(&left.has_local))
+        .then_with(|| {
+            right
+                .best_context
+                .is_some()
+                .cmp(&left.best_context.is_some())
+        })
+        .then_with(|| right.best_context.cmp(&left.best_context))
+        .then_with(|| {
+            left.best_latency_ms
+                .unwrap_or(u32::MAX)
+                .cmp(&right.best_latency_ms.unwrap_or(u32::MAX))
+        })
+        .then_with(|| left.aliases[0].cmp(&right.aliases[0]))
+}
+
+fn max_optional_context(left: Option<u32>, right: Option<u32>) -> Option<u32> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
+}
+
+fn min_optional_latency(left: Option<u32>, right: Option<u32>) -> Option<u32> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(left), None) => Some(left),
+        (None, Some(right)) => Some(right),
+        (None, None) => None,
+    }
 }
 
 /// Does the local routing table have a backend port for this exact name?
@@ -580,7 +713,38 @@ async fn add_worker_backend(
     models: &mut Vec<moa::ModelEntry>,
     local_count: &mut usize,
 ) -> bool {
-    // Prefer local skippy port when this node serves the model.
+    let remote_hosts = context_selection::select_remote_hosts(
+        resolution.node,
+        name,
+        resolution.required_tokens,
+        resolution.node.hosts_for_model(name).await,
+    )
+    .await;
+
+    if try_add_local_worker(
+        resolution,
+        name,
+        &remote_hosts,
+        backends,
+        models,
+        local_count,
+    )
+    .await
+    {
+        return true;
+    }
+
+    add_remote_worker(resolution, name, remote_hosts, backends, models)
+}
+
+async fn try_add_local_worker(
+    resolution: &WorkerBackendResolution<'_>,
+    name: &str,
+    remote_hosts: &[iroh::EndpointId],
+    backends: &mut Vec<std::sync::Arc<dyn moa::ModelBackend>>,
+    models: &mut Vec<moa::ModelEntry>,
+    local_count: &mut usize,
+) -> bool {
     let local_port = resolution.targets.and_then(|t| {
         t.targets.get(name).and_then(|tv| {
             tv.iter().find_map(|t| match t {
@@ -589,45 +753,51 @@ async fn add_worker_backend(
             })
         })
     });
-    if let Some(port) = local_port {
-        let context_length = resolution.node.local_model_context_length(name).await;
-        if context_selection::context_can_satisfy(resolution.required_tokens, context_length) {
-            let backend_idx = backends.len();
-            backends.push(std::sync::Arc::new(LocalModelBackend {
-                port,
-                http: resolution.http.clone(),
-            }));
-            models.push(moa::ModelEntry {
-                name: name.to_string(),
-                backend_index: backend_idx,
-            });
-            *local_count += 1;
-            return true;
-        } else {
-            tracing::info!(
-                "MoA: skipping local worker {name}; context {:?} cannot fit {:?} required tokens",
-                context_length,
-                resolution.required_tokens
-            );
-        }
+    let Some(port) = local_port else {
+        return false;
+    };
+
+    let context_length = resolution.node.local_model_context_length(name).await;
+    let remote_context =
+        context_selection::best_remote_context_length(resolution.node, name, remote_hosts).await;
+    if should_skip_local_for_inflight(name, resolution.node.inflight_requests()) {
+        return false;
+    }
+    if should_skip_local_for_remote_context(name, context_length, remote_context) {
+        return false;
+    }
+    if should_skip_local_for_required_context(name, resolution.required_tokens, context_length) {
+        return false;
     }
 
-    // Otherwise find a remote host. hosts_for_model returns peers in
-    // hash-preferred order; prefer hosts with enough advertised context.
-    let remote_hosts = resolution.node.hosts_for_model(name).await;
-    if let Some(peer_id) = context_selection::select_remote_host(
-        resolution.node,
-        name,
-        resolution.required_tokens,
-        remote_hosts,
-    )
-    .await
-    {
+    let backend_idx = backends.len();
+    backends.push(std::sync::Arc::new(LocalModelBackend {
+        node: resolution.node.clone(),
+        port,
+        http: resolution.http.clone(),
+    }));
+    models.push(moa::ModelEntry {
+        name: name.to_string(),
+        backend_index: backend_idx,
+    });
+    *local_count += 1;
+    true
+}
+
+fn add_remote_worker(
+    resolution: &WorkerBackendResolution<'_>,
+    name: &str,
+    remote_hosts: Vec<iroh::EndpointId>,
+    backends: &mut Vec<std::sync::Arc<dyn moa::ModelBackend>>,
+    models: &mut Vec<moa::ModelEntry>,
+) -> bool {
+    if !remote_hosts.is_empty() {
         let backend_idx = backends.len();
-        backends.push(std::sync::Arc::new(RemoteModelBackend {
-            node: resolution.node.clone(),
-            peer_id,
-        }));
+        backends.push(std::sync::Arc::new(RemoteModelBackend::new(
+            resolution.node.clone(),
+            remote_hosts,
+            MOA_REMOTE_PEER_HEDGE_DELAY,
+        )));
         models.push(moa::ModelEntry {
             name: name.to_string(),
             backend_index: backend_idx,
@@ -635,6 +805,56 @@ async fn add_worker_backend(
         return true;
     }
     false
+}
+
+fn should_skip_local_for_inflight(name: &str, local_inflight: u64) -> bool {
+    if local_inflight >= MOA_LOCAL_INFLIGHT_SOFT_LIMIT {
+        tracing::info!(
+            "MoA: skipping local worker {name}; local inflight {local_inflight} is at/above soft limit {MOA_LOCAL_INFLIGHT_SOFT_LIMIT}"
+        );
+        return true;
+    }
+    false
+}
+
+fn should_skip_local_for_remote_context(
+    name: &str,
+    local_context: Option<u32>,
+    remote_context: Option<u32>,
+) -> bool {
+    if should_prefer_remote_worker(local_context, remote_context) {
+        tracing::info!(
+            "MoA: preferring remote worker {name}; remote context {:?} is better than local context {:?}",
+            remote_context,
+            local_context
+        );
+        return true;
+    }
+    false
+}
+
+fn should_skip_local_for_required_context(
+    name: &str,
+    required_tokens: Option<u32>,
+    local_context: Option<u32>,
+) -> bool {
+    if !context_selection::context_can_satisfy(required_tokens, local_context) {
+        tracing::info!(
+            "MoA: skipping local worker {name}; context {:?} cannot fit {:?} required tokens",
+            local_context,
+            required_tokens
+        );
+        return true;
+    }
+    false
+}
+
+fn should_prefer_remote_worker(local_context: Option<u32>, remote_context: Option<u32>) -> bool {
+    match (local_context, remote_context) {
+        (Some(local), Some(remote)) => remote > local,
+        (None, Some(_)) => true,
+        _ => false,
+    }
 }
 
 /// Canonical name used for cross-peer dedup. Different peers advertise the
@@ -668,6 +888,7 @@ fn canonical_base_name(name: &str) -> String {
 
 /// Backend that calls a local model directly on its skippy HTTP port.
 struct LocalModelBackend {
+    node: mesh::Node,
     port: u16,
     http: reqwest::Client,
 }
@@ -684,6 +905,7 @@ impl moa::ModelBackend for LocalModelBackend {
         sampling: moa::SamplingParams,
     ) -> Result<serde_json::Value, String> {
         let url = format!("http://127.0.0.1:{}/v1/chat/completions", self.port);
+        let _inflight = self.node.begin_inflight_request();
         let mut body = serde_json::json!({
             "model": model,
             "messages": messages,
@@ -719,89 +941,6 @@ impl moa::ModelBackend for LocalModelBackend {
             .await
             .map_err(|e| format!("parse: {e}"))
     }
-}
-
-/// Backend that calls a remote model over the QUIC tunnel.
-struct RemoteModelBackend {
-    node: mesh::Node,
-    peer_id: iroh::EndpointId,
-}
-
-#[async_trait::async_trait]
-impl moa::ModelBackend for RemoteModelBackend {
-    async fn chat_completion(
-        &self,
-        model: &str,
-        messages: &[serde_json::Value],
-        tools: Option<&serde_json::Value>,
-        max_tokens: u32,
-        timeout: std::time::Duration,
-        sampling: moa::SamplingParams,
-    ) -> Result<serde_json::Value, String> {
-        let mut body = serde_json::json!({
-            "model": model,
-            "messages": messages,
-            "max_tokens": max_tokens,
-            "temperature": sampling.temperature,
-            "top_p": sampling.top_p,
-            "stream": false,
-            "mesh_hooks": false,
-        });
-        if let Some(tools) = tools {
-            body.as_object_mut()
-                .unwrap()
-                .insert("tools".to_string(), tools.clone());
-        }
-        moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
-        let body_bytes = serde_json::to_vec(&body).map_err(|e| format!("serialize: {e}"))?;
-        let http_request = format!(
-            "POST /v1/chat/completions HTTP/1.1\r\n\
-             Host: localhost\r\n\
-             Content-Type: application/json\r\n\
-             Content-Length: {}\r\n\
-             \r\n",
-            body_bytes.len()
-        );
-        let mut raw = http_request.into_bytes();
-        raw.extend_from_slice(&body_bytes);
-
-        tokio::time::timeout(timeout, async {
-            let (mut send, mut recv) = self
-                .node
-                .open_http_tunnel(self.peer_id)
-                .await
-                .map_err(|e| format!("tunnel: {e}"))?;
-            send.write_all(&raw)
-                .await
-                .map_err(|e| format!("send: {e}"))?;
-            send.finish().map_err(|e| format!("finish: {e}"))?;
-            let response = recv
-                .read_to_end(4 * 1024 * 1024)
-                .await
-                .map_err(|e| format!("recv: {e}"))?;
-            parse_quic_http_response(&response)
-        })
-        .await
-        .map_err(|_| format!("remote timeout after {}s", timeout.as_secs()))?
-    }
-}
-
-fn parse_quic_http_response(response: &[u8]) -> Result<serde_json::Value, String> {
-    let s = String::from_utf8_lossy(response);
-    let header_end = s
-        .find("\r\n\r\n")
-        .ok_or_else(|| "malformed HTTP response".to_string())?;
-    let status_line = s[..header_end].lines().next().unwrap_or("");
-    let status: u16 = status_line
-        .split_whitespace()
-        .nth(1)
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    if status != 200 {
-        return Err(format!("HTTP {status}: {}", moa::truncate_chars(&s, 200)));
-    }
-    let body = &s[header_end + 4..];
-    serde_json::from_str(body).map_err(|e| format!("parse: {e}"))
 }
 
 /// Send the MoA response as a one-shot SSE stream so SSE-only clients
@@ -945,11 +1084,7 @@ pub(in crate::network::openai::moa_gateway) async fn send_moa_as_sse_inner(
             let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
             stream.write_all(framed.as_bytes()).await?;
             stream.flush().await?;
-            if let Some(delay) = inter_chunk_delay
-                && idx + 1 < pieces.len()
-            {
-                tokio::time::sleep(delay).await;
-            }
+            sleep_between_stream_chunks(inter_chunk_delay, idx, pieces.len()).await;
         }
     }
 
@@ -1092,6 +1227,16 @@ fn content_pieces_for_streaming(
     }
 }
 
+async fn sleep_between_stream_chunks(
+    delay: Option<std::time::Duration>,
+    chunk_idx: usize,
+    chunk_count: usize,
+) {
+    if let (true, Some(delay)) = (chunk_idx + 1 < chunk_count, delay) {
+        tokio::time::sleep(delay).await;
+    }
+}
+
 /// Emit the MoA response as an OpenAI Responses-API SSE stream so callers
 /// that hit `/v1/responses` with `stream:true` get event shapes their parser
 /// understands.
@@ -1216,11 +1361,7 @@ pub(in crate::network::openai::moa_gateway) async fn send_moa_as_responses_sse_i
         let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
         stream.write_all(framed.as_bytes()).await?;
         stream.flush().await?;
-        if let Some(delay) = inter_chunk_delay
-            && idx + 1 < pieces.len()
-        {
-            tokio::time::sleep(delay).await;
-        }
+        sleep_between_stream_chunks(inter_chunk_delay, idx, pieces.len()).await;
     }
 
     let text_done =
@@ -1299,6 +1440,37 @@ mod tests {
             canonical_base_name("unsloth/Qwen3-32B-GGUF:Q4_K_M"),
             canonical_base_name("unsloth/MiniMax-M2.5-GGUF:Q4_K_M")
         );
+    }
+
+    #[test]
+    fn worker_group_ranking_prefers_near_known_candidate_over_distant_large_candidate() {
+        let near = WorkerGroupRank {
+            aliases: vec!["unsloth/Qwen3.5-9B-GGUF:Q4_K_M".to_string()],
+            has_local: false,
+            is_near: true,
+            best_context: Some(32_768),
+            best_latency_ms: Some(2),
+        };
+        let distant_large = WorkerGroupRank {
+            aliases: vec!["unsloth/MiniMax-M2.5-GGUF:Q4_K_M".to_string()],
+            has_local: false,
+            is_near: false,
+            best_context: Some(131_072),
+            best_latency_ms: Some(350),
+        };
+        let mut groups = vec![distant_large, near];
+
+        groups.sort_by(compare_worker_groups);
+
+        assert_eq!(groups[0].aliases[0], "unsloth/Qwen3.5-9B-GGUF:Q4_K_M");
+    }
+
+    #[test]
+    fn optional_rank_helpers_keep_best_context_and_latency() {
+        assert_eq!(max_optional_context(Some(8), Some(32)), Some(32));
+        assert_eq!(max_optional_context(None, Some(32)), Some(32));
+        assert_eq!(min_optional_latency(Some(300), Some(2)), Some(2));
+        assert_eq!(min_optional_latency(None, Some(2)), Some(2));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/remote_backend.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/remote_backend.rs
@@ -66,6 +66,9 @@ fn build_chat_completion_request(
         body.as_object_mut()
             .expect("chat completion body should be an object")
             .insert("tools".to_string(), tools.clone());
+        body.as_object_mut()
+            .expect("chat completion body should be an object")
+            .insert("parallel_tool_calls".to_string(), serde_json::json!(false));
     }
     moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
     let body_bytes = serde_json::to_vec(&body).map_err(|e| format!("serialize: {e}"))?;

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/remote_backend.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/remote_backend.rs
@@ -1,0 +1,280 @@
+use crate::mesh;
+use mesh_mixture_of_agents as moa;
+
+type RemoteJoinSet = tokio::task::JoinSet<(iroh::EndpointId, Result<serde_json::Value, String>)>;
+
+pub(in crate::network::openai::moa_gateway) struct RemoteModelBackend {
+    node: mesh::Node,
+    peer_ids: Vec<iroh::EndpointId>,
+    hedge_delay: std::time::Duration,
+}
+
+impl RemoteModelBackend {
+    pub(in crate::network::openai::moa_gateway) fn new(
+        node: mesh::Node,
+        peer_ids: Vec<iroh::EndpointId>,
+        hedge_delay: std::time::Duration,
+    ) -> Self {
+        Self {
+            node,
+            peer_ids,
+            hedge_delay,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl moa::ModelBackend for RemoteModelBackend {
+    async fn chat_completion(
+        &self,
+        model: &str,
+        messages: &[serde_json::Value],
+        tools: Option<&serde_json::Value>,
+        max_tokens: u32,
+        timeout: std::time::Duration,
+        sampling: moa::SamplingParams,
+    ) -> Result<serde_json::Value, String> {
+        let raw = build_chat_completion_request(model, messages, tools, max_tokens, sampling)?;
+        call_remote_candidates(
+            self.node.clone(),
+            self.peer_ids.clone(),
+            raw,
+            timeout,
+            self.hedge_delay,
+        )
+        .await
+    }
+}
+
+fn build_chat_completion_request(
+    model: &str,
+    messages: &[serde_json::Value],
+    tools: Option<&serde_json::Value>,
+    max_tokens: u32,
+    sampling: moa::SamplingParams,
+) -> Result<Vec<u8>, String> {
+    let mut body = serde_json::json!({
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": sampling.temperature,
+        "top_p": sampling.top_p,
+        "stream": false,
+        "mesh_hooks": false,
+    });
+    if let Some(tools) = tools {
+        body.as_object_mut()
+            .expect("chat completion body should be an object")
+            .insert("tools".to_string(), tools.clone());
+    }
+    moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
+    let body_bytes = serde_json::to_vec(&body).map_err(|e| format!("serialize: {e}"))?;
+    let http_request = format!(
+        "POST /v1/chat/completions HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         \r\n",
+        body_bytes.len()
+    );
+    let mut raw = http_request.into_bytes();
+    raw.extend_from_slice(&body_bytes);
+    Ok(raw)
+}
+
+async fn call_remote_candidates(
+    node: mesh::Node,
+    peer_ids: Vec<iroh::EndpointId>,
+    raw: Vec<u8>,
+    timeout: std::time::Duration,
+    hedge_delay: std::time::Duration,
+) -> Result<serde_json::Value, String> {
+    if peer_ids.is_empty() {
+        return Err("remote: no peer candidates".to_string());
+    }
+
+    let mut remaining = peer_ids.into_iter();
+    let mut join_set = tokio::task::JoinSet::new();
+    let mut last_err = None;
+    let mut attempts = 0u32;
+    let mut remaining_exhausted = false;
+
+    if let Some(peer_id) = remaining.next() {
+        spawn_remote_attempt(&mut join_set, node.clone(), peer_id, raw.clone(), timeout);
+        attempts += 1;
+    }
+
+    while !join_set.is_empty() {
+        if remaining_exhausted {
+            match next_remote_event(&mut join_set, true).await {
+                RemoteAttemptEvent::Success(body) => {
+                    finish_remote_attempts(&mut join_set).await;
+                    return Ok(body);
+                }
+                RemoteAttemptEvent::Failure(err) => last_err = Some(err),
+                RemoteAttemptEvent::Closed => break,
+            }
+            continue;
+        }
+
+        let hedge_sleep = tokio::time::sleep(hedge_delay);
+        tokio::pin!(hedge_sleep);
+        tokio::select! {
+            event = next_remote_event(&mut join_set, false) => {
+                match event {
+                    RemoteAttemptEvent::Success(body) => {
+                        finish_remote_attempts(&mut join_set).await;
+                        return Ok(body);
+                    }
+                    RemoteAttemptEvent::Failure(err) => {
+                        last_err = Some(err);
+                        remaining_exhausted = !try_spawn_next_remote(
+                            &mut join_set,
+                            &node,
+                            &mut remaining,
+                            &raw,
+                            timeout,
+                            &mut attempts,
+                        );
+                    }
+                    RemoteAttemptEvent::Closed => break,
+                }
+            }
+            _ = &mut hedge_sleep => {
+                remaining_exhausted = !try_spawn_next_remote(
+                    &mut join_set,
+                    &node,
+                    &mut remaining,
+                    &raw,
+                    timeout,
+                    &mut attempts,
+                );
+            }
+        }
+    }
+
+    Err(format!(
+        "remote: all {attempts} peer candidate(s) failed: {}",
+        last_err.unwrap_or_else(|| "unknown error".to_string())
+    ))
+}
+
+enum RemoteAttemptEvent {
+    Success(serde_json::Value),
+    Failure(String),
+    Closed,
+}
+
+async fn next_remote_event(join_set: &mut RemoteJoinSet, exhausted: bool) -> RemoteAttemptEvent {
+    match join_set.join_next().await {
+        Some(Ok((_, Ok(body)))) => RemoteAttemptEvent::Success(body),
+        Some(Ok((peer_id, Err(err)))) => {
+            log_remote_failure(peer_id, &err, exhausted);
+            RemoteAttemptEvent::Failure(err)
+        }
+        Some(Err(err)) => {
+            tracing::warn!("MoA: remote backend task join error: {err}");
+            RemoteAttemptEvent::Failure(err.to_string())
+        }
+        None => RemoteAttemptEvent::Closed,
+    }
+}
+
+fn log_remote_failure(peer_id: iroh::EndpointId, err: &str, exhausted: bool) {
+    if exhausted {
+        tracing::warn!(
+            "MoA: remote backend {} failed after hedge exhaustion: {err}",
+            peer_id.fmt_short()
+        );
+    } else {
+        tracing::warn!(
+            "MoA: remote backend {} failed: {err}, trying next host",
+            peer_id.fmt_short()
+        );
+    }
+}
+
+fn try_spawn_next_remote(
+    join_set: &mut RemoteJoinSet,
+    node: &mesh::Node,
+    remaining: &mut impl Iterator<Item = iroh::EndpointId>,
+    raw: &[u8],
+    timeout: std::time::Duration,
+    attempts: &mut u32,
+) -> bool {
+    let Some(peer_id) = remaining.next() else {
+        return false;
+    };
+    spawn_remote_attempt(join_set, node.clone(), peer_id, raw.to_vec(), timeout);
+    *attempts += 1;
+    true
+}
+
+fn spawn_remote_attempt(
+    join_set: &mut RemoteJoinSet,
+    node: mesh::Node,
+    peer_id: iroh::EndpointId,
+    raw: Vec<u8>,
+    timeout: std::time::Duration,
+) {
+    tracing::info!("MoA: remote backend candidate {}", peer_id.fmt_short());
+    join_set.spawn(async move {
+        let result = call_remote_peer(node, peer_id, raw, timeout).await;
+        (peer_id, result)
+    });
+}
+
+async fn finish_remote_attempts(join_set: &mut RemoteJoinSet) {
+    join_set.abort_all();
+    while join_set.join_next().await.is_some() {}
+}
+
+async fn call_remote_peer(
+    node: mesh::Node,
+    peer_id: iroh::EndpointId,
+    raw: Vec<u8>,
+    timeout: std::time::Duration,
+) -> Result<serde_json::Value, String> {
+    tokio::time::timeout(timeout, async {
+        let (mut send, mut recv) = node
+            .open_http_tunnel(peer_id)
+            .await
+            .map_err(|e| format!("tunnel {}: {e}", peer_id.fmt_short()))?;
+        send.write_all(&raw)
+            .await
+            .map_err(|e| format!("send {}: {e}", peer_id.fmt_short()))?;
+        send.finish()
+            .map_err(|e| format!("finish {}: {e}", peer_id.fmt_short()))?;
+        let response = recv
+            .read_to_end(4 * 1024 * 1024)
+            .await
+            .map_err(|e| format!("recv {}: {e}", peer_id.fmt_short()))?;
+        parse_quic_http_response(&response)
+    })
+    .await
+    .map_err(|_| {
+        format!(
+            "remote {} timeout after {}s",
+            peer_id.fmt_short(),
+            timeout.as_secs()
+        )
+    })?
+}
+
+fn parse_quic_http_response(response: &[u8]) -> Result<serde_json::Value, String> {
+    let s = String::from_utf8_lossy(response);
+    let header_end = s
+        .find("\r\n\r\n")
+        .ok_or_else(|| "malformed HTTP response".to_string())?;
+    let status_line = s[..header_end].lines().next().unwrap_or("");
+    let status: u16 = status_line
+        .split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    if status != 200 {
+        return Err(format!("HTTP {status}: {}", moa::truncate_chars(&s, 200)));
+    }
+    let body = &s[header_end + 4..];
+    serde_json::from_str(body).map_err(|e| format!("parse: {e}"))
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/remote_backend.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/remote_backend.rs
@@ -96,6 +96,28 @@ async fn call_remote_candidates(
         return Err("remote: no peer candidates".to_string());
     }
 
+    let candidate_count = peer_ids.len();
+    match tokio::time::timeout(
+        timeout,
+        call_remote_candidates_inner(node, peer_ids, raw, timeout, hedge_delay),
+    )
+    .await
+    {
+        Ok(result) => result,
+        Err(_) => Err(format!(
+            "remote: timed out after {}s across up to {candidate_count} peer candidate(s)",
+            timeout.as_secs()
+        )),
+    }
+}
+
+async fn call_remote_candidates_inner(
+    node: mesh::Node,
+    peer_ids: Vec<iroh::EndpointId>,
+    raw: Vec<u8>,
+    timeout: std::time::Duration,
+    hedge_delay: std::time::Duration,
+) -> Result<serde_json::Value, String> {
     let mut remaining = peer_ids.into_iter();
     let mut join_set = tokio::task::JoinSet::new();
     let mut last_err = None;

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -40,6 +40,16 @@
     "mmproj": null
   },
   {
+    "name": "Gemma-4-E4B-it-Q4_K_M",
+    "file": "gemma-4-E4B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
+    "size": "4.6GB",
+    "description": "Gemma 4 E4B instruction model, strong mini-class default",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": null
+  },
+  {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
     "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
     "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -47,7 +47,23 @@
     "description": "Gemma 4 E4B instruction model, strong mini-class default",
     "draft": null,
     "extra_files": [],
-    "mmproj": null
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3.6-35B-A3B-UD-Q4_K_M",
+    "file": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    "size": "22.1GB",
+    "description": "Qwen3.6 35B-A3B MoE, vision-capable long-context public mesh worker",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-F16.gguf"
+    }
   },
   {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
@@ -382,19 +398,6 @@
     "mmproj": {
       "file": "Qwen3.5-4B-mmproj-BF16.gguf",
       "url": "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/mmproj-BF16.gguf"
-    }
-  },
-  {
-    "name": "Qwen3.5-9B-Vision-Q4_K_M",
-    "file": "Qwen3.5-9B-Q4_K_M.gguf",
-    "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf",
-    "size": "5.8GB",
-    "description": "Vision + text, replaces Qwen3-8B with image understanding",
-    "draft": null,
-    "extra_files": [],
-    "mmproj": {
-      "file": "Qwen3.5-9B-mmproj-BF16.gguf",
-      "url": "https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/mmproj-BF16.gguf"
     }
   },
   {

--- a/crates/mesh-llm-node/src/models.rs
+++ b/crates/mesh-llm-node/src/models.rs
@@ -27,6 +27,24 @@ pub struct ModelSummary {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CatalogRecommendedModel {
+    pub name: String,
+    pub file: String,
+    pub url: String,
+    pub size: String,
+    pub description: String,
+    pub draft: Option<String>,
+    pub extra_files: Vec<CatalogRecommendedAsset>,
+    pub mmproj: Option<CatalogRecommendedAsset>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CatalogRecommendedAsset {
+    pub file: String,
+    pub url: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ModelSearchQuery {
     pub query: String,
     pub limit: usize,
@@ -202,14 +220,43 @@ fn maybe_push_model(root: &Path, path: PathBuf, models: &mut Vec<InstalledModel>
 }
 
 pub fn recommended_models() -> Vec<ModelSummary> {
+    recommended_catalog_models()
+        .into_iter()
+        .map(|model| {
+            let capabilities = infer_recommended_model_capabilities(&model);
+            ModelSummary {
+                id: model.name.clone(),
+                name: model.name,
+                size_label: Some(model.size),
+                description: Some(model.description),
+                capabilities,
+            }
+        })
+        .collect()
+}
+
+pub fn recommended_catalog_models() -> Vec<CatalogRecommendedModel> {
     catalog_models()
         .into_iter()
-        .map(|model| ModelSummary {
-            id: model.name.clone(),
+        .map(|model| CatalogRecommendedModel {
             name: model.name.clone(),
-            size_label: Some(model.size.clone()),
-            description: Some(model.description.clone()),
-            capabilities: infer_catalog_capabilities(&model),
+            file: model.file.clone(),
+            url: model.url.clone(),
+            size: model.size.clone(),
+            description: model.description.clone(),
+            draft: model.draft.clone(),
+            extra_files: model
+                .extra_files
+                .into_iter()
+                .map(|asset| CatalogRecommendedAsset {
+                    file: asset.file,
+                    url: asset.url,
+                })
+                .collect(),
+            mmproj: model.mmproj.map(|asset| CatalogRecommendedAsset {
+                file: asset.file,
+                url: asset.url,
+            }),
         })
         .collect()
 }
@@ -648,6 +695,30 @@ fn infer_catalog_capabilities(model: &CatalogModel) -> ModelCapabilities {
     caps.normalize()
 }
 
+fn infer_recommended_model_capabilities(model: &CatalogRecommendedModel) -> ModelCapabilities {
+    let mut caps = ModelCapabilities::default();
+    if let Some(mmproj) = &model.mmproj {
+        caps.vision = CapabilityLevel::Supported;
+        caps.multimodal = true;
+        caps = merge_name_signals(caps, &[mmproj.file.as_str(), mmproj.url.as_str()]);
+    }
+    let extra_file_signals = model
+        .extra_files
+        .iter()
+        .flat_map(|asset| [asset.file.as_str(), asset.url.as_str()])
+        .collect::<Vec<_>>();
+    caps = merge_name_signals(
+        caps,
+        &[
+            model.name.as_str(),
+            model.file.as_str(),
+            model.description.as_str(),
+        ],
+    );
+    caps = merge_name_signals(caps, &extra_file_signals);
+    caps.normalize()
+}
+
 fn infer_remote_capabilities(repo: &str, file: &str) -> ModelCapabilities {
     merge_name_signals(ModelCapabilities::default(), &[repo, file]).normalize()
 }
@@ -805,6 +876,22 @@ mod tests {
             recommended
                 .iter()
                 .any(|model| model.id == "Qwen3-4B-Q4_K_M")
+        );
+        let gemma_e4b = recommended
+            .iter()
+            .find(|model| model.id == "Gemma-4-E4B-it-Q4_K_M")
+            .expect("Gemma 4 E4B recommendation");
+        assert!(gemma_e4b.capabilities.multimodal);
+        assert_eq!(gemma_e4b.capabilities.vision, CapabilityLevel::Supported);
+        assert!(
+            recommended
+                .iter()
+                .any(|model| model.id == "Qwen3.6-35B-A3B-UD-Q4_K_M")
+        );
+        assert!(
+            recommended
+                .iter()
+                .all(|model| model.id != "Qwen3.5-9B-Vision-Q4_K_M")
         );
     }
 

--- a/crates/mesh-llm/src/commands/models/mod.rs
+++ b/crates/mesh-llm/src/commands/models/mod.rs
@@ -135,7 +135,7 @@ pub async fn run_model_search(
 pub fn run_model_recommended(json_output: bool) -> Result<()> {
     let formatter = models_formatter(json_output);
     remote_catalog::ensure_catalog()?;
-    let models = remote_catalog::loaded_models()?;
+    let models = remote_catalog::recommended_models()?;
     formatter.render_recommended(&models)
 }
 

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -365,6 +365,38 @@ mod tests {
     }
 
     #[test]
+    fn extract_text_keeps_only_first_native_tool_call() {
+        let resp: Value = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "exec",
+                                "arguments": "{\"command\":\"pwd\"}"
+                            }
+                        },
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"path\":\"USER.md\"}"
+                            }
+                        }
+                    ]
+                }
+            }]
+        });
+
+        let text = extract_text_from_response(&resp).expect("tool proposal text");
+
+        assert!(text.contains("tool: exec"), "{text}");
+        assert!(text.contains("arguments: {\"command\":\"pwd\"}"), "{text}");
+        assert!(!text.contains("tool: read"), "{text}");
+    }
+
+    #[test]
     fn worker_sampling_high_diversity() {
         let s = SamplingParams::worker();
         assert!(s.temperature > 0.5, "workers need high temp for diversity");

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -123,6 +123,9 @@ impl ModelBackend for HttpBackend {
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
+            body.as_object_mut()
+                .unwrap()
+                .insert("parallel_tool_calls".to_string(), json!(false));
         }
         apply_enable_thinking(&mut body, sampling.enable_thinking);
 
@@ -276,7 +279,9 @@ fn extract_text_from_response(resp: &Value) -> Result<String, String> {
         let name = tc
             .pointer("/function/name")
             .and_then(|n| n.as_str())
-            .unwrap_or("unknown");
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| "malformed tool call: missing function.name".to_string())?;
         let args = tc
             .pointer("/function/arguments")
             .and_then(|a| a.as_str())
@@ -394,6 +399,29 @@ mod tests {
         assert!(text.contains("tool: exec"), "{text}");
         assert!(text.contains("arguments: {\"command\":\"pwd\"}"), "{text}");
         assert!(!text.contains("tool: read"), "{text}");
+    }
+
+    #[test]
+    fn extract_text_rejects_empty_native_tool_call() {
+        let resp: Value = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "",
+                                "arguments": "{}"
+                            }
+                        }
+                    ]
+                }
+            }]
+        });
+
+        let err = extract_text_from_response(&resp).unwrap_err();
+
+        assert!(err.contains("missing function.name"), "{err}");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -18,16 +18,16 @@ use serde_json::{Value, json};
 
 const TOOL_RESULT_CONTEXT_WINDOW: usize = 10;
 const TOOL_EVIDENCE_MAX_RESULTS: usize = 8;
-const TOOL_EVIDENCE_MAX_RESULT_CHARS: usize = 800;
-const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
+const TOOL_EVIDENCE_MAX_RESULT_BYTES: usize = 800;
+const TOOL_RESULT_RAW_MAX_BYTES: usize = 2_400;
 const TOOL_RESULT_JSON_MAX_SCALARS: usize = 48;
 const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
-const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
-const SYSTEM_CONTEXT_MAX_CHARS: usize = 6_000;
-const FAST_USER_CONTEXT_MAX_CHARS: usize = 3_000;
-const SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS: usize = 2_000;
-const STRONG_MESSAGE_CONTEXT_MAX_CHARS: usize = 2_000;
-const REDUCER_USER_CONTEXT_MAX_CHARS: usize = 6_000;
+const TOOL_RESULT_SCALAR_MAX_BYTES: usize = 180;
+const SYSTEM_CONTEXT_MAX_BYTES: usize = 6_000;
+const FAST_USER_CONTEXT_MAX_BYTES: usize = 3_000;
+const SPECIALIST_MESSAGE_CONTEXT_MAX_BYTES: usize = 2_000;
+const STRONG_MESSAGE_CONTEXT_MAX_BYTES: usize = 2_000;
+const REDUCER_USER_CONTEXT_MAX_BYTES: usize = 6_000;
 const SPECIALIST_CONTEXT_WINDOW: usize = 3;
 const STRONG_CONTEXT_WINDOW: usize = 4;
 
@@ -86,7 +86,7 @@ fn augmented_system_prompt_for_mode(session: &Session, include_tool_guidance: bo
         }
         None => MOA_PREAMBLE.to_string(),
     };
-    compact_text_for_context(&prompt, SYSTEM_CONTEXT_MAX_CHARS)
+    compact_text_for_context(&prompt, SYSTEM_CONTEXT_MAX_BYTES)
 }
 
 fn strip_tool_guidance_sections(prompt: &str) -> String {
@@ -181,7 +181,7 @@ fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String])
             json!({"role": "system", "content": system}),
             json!({
                 "role": "user",
-                "content": compact_text_for_context(&user_text, FAST_USER_CONTEXT_MAX_CHARS),
+                "content": compact_text_for_context(&user_text, FAST_USER_CONTEXT_MAX_BYTES),
             }),
         ],
         max_tokens: 256,
@@ -213,7 +213,7 @@ fn pack_specialist(
                 && message_text_content(msg).is_some_and(|text| text == user_text.as_str());
             messages.push(compact_chat_message(
                 msg,
-                SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS,
+                SPECIALIST_MESSAGE_CONTEXT_MAX_BYTES,
             ));
         }
     }
@@ -224,7 +224,7 @@ fn pack_specialist(
             "role": "user",
             "content": compact_text_for_context(
                 &user_text,
-                SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS,
+                SPECIALIST_MESSAGE_CONTEXT_MAX_BYTES,
             ),
         }));
     }
@@ -261,14 +261,14 @@ fn pack_strong(
         if role != "system" && !role.is_empty() {
             has_last_user |= role == "user"
                 && message_text_content(msg).is_some_and(|text| text == user_text.as_str());
-            messages.push(compact_chat_message(msg, STRONG_MESSAGE_CONTEXT_MAX_CHARS));
+            messages.push(compact_chat_message(msg, STRONG_MESSAGE_CONTEXT_MAX_BYTES));
         }
     }
 
     if !has_last_user {
         messages.push(json!({
             "role": "user",
-            "content": compact_text_for_context(&user_text, STRONG_MESSAGE_CONTEXT_MAX_CHARS),
+            "content": compact_text_for_context(&user_text, STRONG_MESSAGE_CONTEXT_MAX_BYTES),
         }));
     }
 
@@ -344,7 +344,7 @@ pub fn pack_for_reducer_selected(
             json!({"role": "system", "content": system_parts.join("\n")}),
             json!({
                 "role": "user",
-                "content": compact_text_for_context(&user_text, REDUCER_USER_CONTEXT_MAX_CHARS),
+                "content": compact_text_for_context(&user_text, REDUCER_USER_CONTEXT_MAX_BYTES),
             }),
         ],
         tools,
@@ -514,7 +514,7 @@ pub fn pack_for_tool_result_turn_selected(
             } else {
                 messages.push(compact_chat_message(
                     &compacted,
-                    STRONG_MESSAGE_CONTEXT_MAX_CHARS,
+                    STRONG_MESSAGE_CONTEXT_MAX_BYTES,
                 ));
             }
         }
@@ -546,7 +546,7 @@ pub fn pack_for_tool_result_answer_only(session: &Session) -> Vec<Value> {
         user.push_str("User request:\n");
         user.push_str(&compact_text_for_context(
             &last_user,
-            REDUCER_USER_CONTEXT_MAX_CHARS / 2,
+            REDUCER_USER_CONTEXT_MAX_BYTES / 2,
         ));
         user.push_str("\n\n");
     }
@@ -556,7 +556,7 @@ pub fn pack_for_tool_result_answer_only(session: &Session) -> Vec<Value> {
     let start = results.len().saturating_sub(TOOL_EVIDENCE_MAX_RESULTS);
     for (tool, result) in &results[start..] {
         let compacted = compact_tool_result_text(result);
-        let compacted = compact_text_for_context(&compacted, TOOL_EVIDENCE_MAX_RESULT_CHARS);
+        let compacted = compact_text_for_context(&compacted, TOOL_EVIDENCE_MAX_RESULT_BYTES);
         user.push_str("- ");
         user.push_str(tool);
         user.push_str(": ");
@@ -587,10 +587,10 @@ fn tool_evidence_message(session: &Session) -> Option<Value> {
         .enumerate()
     {
         let compacted = compact_tool_result_text(result);
-        let result = if compacted.len() > TOOL_EVIDENCE_MAX_RESULT_CHARS {
+        let result = if compacted.len() > TOOL_EVIDENCE_MAX_RESULT_BYTES {
             format!(
                 "{}...",
-                crate::worker::truncate_chars(&compacted, TOOL_EVIDENCE_MAX_RESULT_CHARS - 3)
+                crate::worker::truncate_chars(&compacted, TOOL_EVIDENCE_MAX_RESULT_BYTES - 3)
             )
         } else {
             compacted
@@ -705,8 +705,8 @@ fn text_from_content_block(part: &Value) -> Option<&str> {
         .flatten()
 }
 
-fn compact_text_for_context(text: &str, max_chars: usize) -> String {
-    if text.len() <= max_chars {
+fn compact_text_for_context(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
         return text.to_string();
     }
 
@@ -715,11 +715,11 @@ fn compact_text_for_context(text: &str, max_chars: usize) -> String {
          The text after this notice is the preserved ending of the original message.]\n\n",
         text.len()
     );
-    if marker.len() >= max_chars {
-        return crate::worker::truncate_chars(text, max_chars).to_string();
+    if marker.len() >= max_bytes {
+        return crate::worker::truncate_chars(text, max_bytes).to_string();
     }
 
-    let remaining = max_chars - marker.len();
+    let remaining = max_bytes - marker.len();
     let head_budget = remaining / 3;
     let tail_budget = remaining.saturating_sub(head_budget);
     let head = crate::worker::truncate_chars(text, head_budget);
@@ -739,7 +739,7 @@ fn tail_start_at_char_boundary(text: &str, max_tail_bytes: usize) -> usize {
 }
 
 fn compact_tool_result_text(result: &str) -> String {
-    if result.len() <= TOOL_RESULT_RAW_MAX_CHARS {
+    if result.len() <= TOOL_RESULT_RAW_MAX_BYTES {
         return result.to_string();
     }
 
@@ -748,16 +748,16 @@ fn compact_tool_result_text(result: &str) -> String {
     }
 
     format!(
-        "Tool result compacted from {} chars; original was plain text.\n\
+        "Tool result compacted from {} bytes; original was plain text.\n\
          Text preview:\n{}...",
         result.len(),
-        crate::worker::truncate_chars(result, TOOL_RESULT_RAW_MAX_CHARS - 96)
+        crate::worker::truncate_chars(result, TOOL_RESULT_RAW_MAX_BYTES - 96)
     )
 }
 
 fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
     let mut lines = vec![format!(
-        "Tool result compacted from {original_len} chars; original was JSON."
+        "Tool result compacted from {original_len} bytes; original was JSON."
     )];
     append_json_shape(value, &mut lines);
     append_embedded_json_summaries(value, &mut lines);
@@ -912,7 +912,7 @@ fn scalar_to_string(value: &Value) -> Option<String> {
     match value {
         Value::String(text) => Some(format!(
             "\"{}\"",
-            crate::worker::truncate_chars(text, TOOL_RESULT_SCALAR_MAX_CHARS)
+            crate::worker::truncate_chars(text, TOOL_RESULT_SCALAR_MAX_BYTES)
         )),
         Value::Number(n) => Some(n.to_string()),
         Value::Bool(b) => Some(b.to_string()),
@@ -1127,8 +1127,8 @@ mod tests {
             .expect("user content");
 
         assert!(
-            content.len() <= FAST_USER_CONTEXT_MAX_CHARS + 256,
-            "fast worker content should be bounded, got {} chars",
+            content.len() <= FAST_USER_CONTEXT_MAX_BYTES + 256,
+            "fast worker content should be bounded, got {} bytes",
             content.len()
         );
         assert!(content.contains("MoA compacted this message"));
@@ -1342,7 +1342,7 @@ mod tests {
         let s = session_with(&msgs, Some(tools_two()));
 
         let packed = pack_for_worker(&s, WorkerRole::Strong, false);
-        let total_chars: usize = packed
+        let total_bytes: usize = packed
             .messages
             .iter()
             .map(|msg| msg.to_string().len())
@@ -1351,10 +1351,10 @@ mod tests {
         assert!(packed.tools.is_none());
         assert!(packed.messages.len() <= STRONG_CONTEXT_WINDOW + 1);
         assert!(
-            total_chars
-                <= SYSTEM_CONTEXT_MAX_CHARS
-                    + (STRONG_CONTEXT_WINDOW * (STRONG_MESSAGE_CONTEXT_MAX_CHARS + 512)),
-            "packed context should stay bounded, got {total_chars} chars",
+            total_bytes
+                <= SYSTEM_CONTEXT_MAX_BYTES
+                    + (STRONG_CONTEXT_WINDOW * (STRONG_MESSAGE_CONTEXT_MAX_BYTES + 512)),
+            "packed context should stay bounded, got {total_bytes} bytes",
         );
         assert_eq!(
             packed
@@ -1498,7 +1498,7 @@ mod tests {
             }
         ])
         .to_string();
-        assert!(result.len() > TOOL_RESULT_RAW_MAX_CHARS);
+        assert!(result.len() > TOOL_RESULT_RAW_MAX_BYTES);
 
         let s = session_with(
             &[
@@ -1531,8 +1531,8 @@ mod tests {
         assert!(content.contains("$[2]: number=799"));
         assert!(content.contains("Reuse Skippy decode wire messages"));
         assert!(
-            content.len() <= TOOL_RESULT_RAW_MAX_CHARS,
-            "compacted tool content should be small, got {} chars:\n{content}",
+            content.len() <= TOOL_RESULT_RAW_MAX_BYTES,
+            "compacted tool content should be small, got {} bytes:\n{content}",
             content.len()
         );
         assert!(
@@ -1577,7 +1577,7 @@ mod tests {
             )
         })
         .to_string();
-        assert!(result.len() > TOOL_RESULT_RAW_MAX_CHARS);
+        assert!(result.len() > TOOL_RESULT_RAW_MAX_BYTES);
 
         let s = session_with(
             &[

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -210,7 +210,7 @@ fn pack_specialist(
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
         if role == "user" || (role == "assistant" && msg.get("tool_calls").is_none()) {
             has_last_user |= role == "user"
-                && msg.get("content").and_then(Value::as_str) == Some(user_text.as_str());
+                && message_text_content(msg).is_some_and(|text| text == user_text.as_str());
             messages.push(compact_chat_message(
                 msg,
                 SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS,
@@ -260,7 +260,7 @@ fn pack_strong(
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
         if role != "system" && !role.is_empty() {
             has_last_user |= role == "user"
-                && msg.get("content").and_then(Value::as_str) == Some(user_text.as_str());
+                && message_text_content(msg).is_some_and(|text| text == user_text.as_str());
             messages.push(compact_chat_message(msg, STRONG_MESSAGE_CONTEXT_MAX_CHARS));
         }
     }
@@ -536,7 +536,7 @@ pub fn pack_for_tool_result_answer_only(session: &Session) -> Vec<Value> {
     );
 
     let mut user = String::new();
-    let last_user = session.last_user_text();
+    let last_user = session.active_user_text();
     if !last_user.trim().is_empty() {
         user.push_str("User request:\n");
         user.push_str(&compact_text_for_context(
@@ -617,8 +617,8 @@ fn compact_tool_message(msg: &Value) -> Value {
 }
 
 fn compact_chat_message(msg: &Value, max_chars: usize) -> Value {
-    let Some(content) = msg.get("content").and_then(Value::as_str) else {
-        return msg.clone();
+    let Some(content) = message_string_content(msg) else {
+        return compact_multipart_text_message(msg, max_chars);
     };
     let compacted = compact_text_for_context(content, max_chars);
     if compacted == content {
@@ -631,13 +631,82 @@ fn compact_chat_message(msg: &Value, max_chars: usize) -> Value {
     compact
 }
 
+fn compact_multipart_text_message(msg: &Value, max_chars: usize) -> Value {
+    let Some(parts) = msg.get("content").and_then(Value::as_array) else {
+        return msg.clone();
+    };
+    if parts
+        .iter()
+        .all(|part| text_from_content_block(part).is_some())
+    {
+        let content = parts
+            .iter()
+            .filter_map(text_from_content_block)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let mut compact = msg.clone();
+        if let Some(obj) = compact.as_object_mut() {
+            obj.insert(
+                "content".to_string(),
+                Value::String(compact_text_for_context(&content, max_chars)),
+            );
+        }
+        return compact;
+    }
+
+    let mut compact = msg.clone();
+    let Some(compact_parts) = compact.get_mut("content").and_then(Value::as_array_mut) else {
+        return compact;
+    };
+    for part in compact_parts {
+        let text = text_from_content_block(part).map(str::to_string);
+        if let (Some(text), Some(obj)) = (text, part.as_object_mut()) {
+            obj.insert(
+                "text".to_string(),
+                Value::String(compact_text_for_context(&text, max_chars)),
+            );
+        }
+    }
+    compact
+}
+
+fn message_string_content(message: &Value) -> Option<&str> {
+    message.get("content").and_then(Value::as_str)
+}
+
+fn message_text_content(message: &Value) -> Option<String> {
+    if let Some(text) = message_string_content(message) {
+        return Some(text.to_string());
+    }
+    let parts = message.get("content").and_then(Value::as_array)?;
+    let text = parts
+        .iter()
+        .filter_map(text_from_content_block)
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn text_from_content_block(part: &Value) -> Option<&str> {
+    let kind = part
+        .get("type")
+        .and_then(Value::as_str)?
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    (kind == "text")
+        .then(|| part.get("text").and_then(Value::as_str))
+        .flatten()
+}
+
 fn compact_text_for_context(text: &str, max_chars: usize) -> String {
     if text.len() <= max_chars {
         return text.to_string();
     }
 
     let marker = format!(
-        "\n\n[MoA compacted this message from {} chars. Middle content was omitted. \
+        "\n\n[MoA compacted this message from {} bytes. Middle content was omitted. \
          The text after this notice is the preserved ending of the original message.]\n\n",
         text.len()
     );
@@ -1099,6 +1168,44 @@ mod tests {
     }
 
     #[test]
+    fn specialist_worker_does_not_duplicate_multipart_last_user() {
+        let s = session_with(
+            &[
+                system_msg("Agent SP."),
+                user_msg("m1"),
+                assistant_msg("r1"),
+                json!({
+                    "role": "user",
+                    "content": [{"type": "Text", "text": "m2 multipart"}]
+                }),
+            ],
+            Some(tools_two()),
+        );
+
+        let packed = pack_for_worker(&s, WorkerRole::Specialist, true);
+        let user_messages = packed
+            .messages
+            .iter()
+            .filter(|msg| msg.get("role").and_then(Value::as_str) == Some("user"))
+            .collect::<Vec<_>>();
+        let matching = user_messages
+            .iter()
+            .filter(|msg| msg.get("content").and_then(Value::as_str) == Some("m2 multipart"))
+            .count();
+
+        assert_eq!(
+            matching, 1,
+            "multipart last user should not be appended twice"
+        );
+        assert!(
+            user_messages
+                .iter()
+                .any(|msg| msg.get("content").and_then(Value::as_str) == Some("m2 multipart")),
+            "multipart all-text content should be normalized into bounded string content"
+        );
+    }
+
+    #[test]
     fn ordinary_chat_omits_tool_summaries_and_native_tools() {
         let s = session_with(
             &[system_msg("Agent SP."), user_msg("What can you help with?")],
@@ -1190,6 +1297,32 @@ mod tests {
         );
         let last = packed.messages.last().unwrap();
         assert_eq!(last.get("content").and_then(|c| c.as_str()), Some("final"));
+    }
+
+    #[test]
+    fn answer_only_tool_result_context_uses_active_user_request() {
+        let s = session_with(
+            &[
+                user_msg("Find the current release notes and summarize the blocker."),
+                assistant_tool_msg(
+                    "call_1",
+                    "web_search",
+                    json!({"query": "mesh llm release notes"}),
+                ),
+                tool_result_msg("call_1", "release note result"),
+                user_msg("Please answer from that result."),
+            ],
+            Some(weather_tools()),
+        );
+
+        let packed = pack_for_tool_result_answer_only(&s);
+        let user_content = packed[1]
+            .get("content")
+            .and_then(Value::as_str)
+            .expect("answer-only user content");
+
+        assert!(user_content.contains("Find the current release notes"));
+        assert!(!user_content.contains("Please answer from that result."));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -744,7 +744,8 @@ fn compact_tool_result_text(result: &str) -> String {
     }
 
     if let Ok(json) = serde_json::from_str::<Value>(result) {
-        return compact_json_tool_result(result.len(), &json);
+        let summary = compact_json_tool_result(result.len(), &json);
+        return compact_text_for_context(&summary, TOOL_RESULT_RAW_MAX_BYTES);
     }
 
     format!(

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -23,8 +23,6 @@ const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
 const TOOL_RESULT_JSON_MAX_SCALARS: usize = 48;
 const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
 const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
-const TOOL_RESULT_GITHUB_MAX_ROWS: usize = 8;
-const TOOL_RESULT_GITHUB_MAX_REVIEWERS: usize = 4;
 const SYSTEM_CONTEXT_MAX_CHARS: usize = 6_000;
 const FAST_USER_CONTEXT_MAX_CHARS: usize = 3_000;
 const SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS: usize = 2_000;
@@ -117,10 +115,16 @@ fn system_with_tool_names(
     selected_tool_names: &[String],
 ) -> String {
     let mut prompt = augmented_system_prompt_for_mode(session, has_tools);
+    append_selected_tool_focus(&mut prompt, selected_tool_names);
     let tools = selected_tools(session, has_tools, selected_tool_names);
     let names = tool_names_from(tools.as_ref());
     if !names.is_empty() {
         prompt.push_str(&format!("\n\nAvailable tools: {}", names.join(", ")));
+    } else if !selected_tool_names.is_empty() {
+        prompt.push_str(&format!(
+            "\n\nAvailable tools: {}",
+            selected_tool_names.join(", ")
+        ));
     }
     prompt
 }
@@ -131,6 +135,7 @@ fn system_with_tool_summaries(
     selected_tool_names: &[String],
 ) -> String {
     let mut prompt = augmented_system_prompt_for_mode(session, has_tools);
+    append_selected_tool_focus(&mut prompt, selected_tool_names);
     let tools = selected_tools(session, has_tools, selected_tool_names);
     let summaries = tool_summaries_from(tools.as_ref());
     if !summaries.is_empty() {
@@ -138,8 +143,25 @@ fn system_with_tool_summaries(
         for s in &summaries {
             prompt.push_str(&format!("\n  - {s}"));
         }
+    } else if !selected_tool_names.is_empty() {
+        prompt.push_str("\n\nAvailable tools:");
+        for name in selected_tool_names {
+            prompt.push_str(&format!("\n  - {name}"));
+        }
     }
     prompt
+}
+
+fn append_selected_tool_focus(prompt: &mut String, selected_tool_names: &[String]) {
+    if selected_tool_names.is_empty() {
+        return;
+    }
+    prompt.push_str(&format!(
+        "\n\nSelected tools for this turn: {}.\n\
+         If the user asked for an action that requires one of these tools, \
+         return a structured tool call instead of prose or a command block.",
+        selected_tool_names.join(", ")
+    ));
 }
 
 // ── Fast worker ──────────────────────────────────────────────────────
@@ -224,7 +246,8 @@ fn pack_strong(
     has_tools: bool,
     selected_tool_names: &[String],
 ) -> PackedContext {
-    let system = augmented_system_prompt_for_mode(session, has_tools);
+    let mut system = augmented_system_prompt_for_mode(session, has_tools);
+    append_selected_tool_focus(&mut system, selected_tool_names);
 
     let mut messages = vec![json!({"role": "system", "content": system})];
 
@@ -506,9 +529,10 @@ pub fn pack_for_tool_result_answer_only(session: &Session) -> Vec<Value> {
     let mut system = augmented_system_prompt_for_mode(session, false);
     system.push_str(
         "\n\nTool result fallback: answer from the completed tool results below. \
-         Do not request another tool call. For GitHub/web results, use exact PR numbers, \
-         titles, authors, statuses, and URLs from the evidence. If the evidence is incomplete \
-         or contradicts the user's premise, say that directly instead of inventing missing facts.",
+         Do not request another tool call unless the declared tool schemas and existing evidence \
+         make the next call clearly necessary. Use exact values present in the evidence. If the \
+         evidence is incomplete or contradicts the user's premise, say that directly instead of \
+         inventing missing facts.",
     );
 
     let mut user = String::new();
@@ -548,7 +572,7 @@ fn tool_evidence_message(session: &Session) -> Option<Value> {
     }
 
     let mut lines = vec![
-        "Completed tool results. Preserve exact short values from these results when the user asks to include, recall, or return tool facts. For GitHub/web results, use exact numbers, titles, authors, statuses, and URLs from evidence; if the user's premise conflicts with evidence, say so instead of inventing a fit."
+        "Completed tool results. Preserve exact short values from these results when the user asks to include, recall, or return tool facts. Use exact values from evidence; if the user's premise conflicts with evidence, say so instead of inventing a fit."
             .to_string(),
     ];
     for (idx, (name, result)) in results
@@ -662,7 +686,6 @@ fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
         "Tool result compacted from {original_len} chars; original was JSON."
     )];
     append_json_shape(value, &mut lines);
-    append_structured_json_summaries(value, &mut lines);
     append_embedded_json_summaries(value, &mut lines);
     let mut scalars = Vec::new();
     collect_json_scalars(value, "$", &mut scalars, 0);
@@ -677,31 +700,6 @@ fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
     lines.join("\n")
 }
 
-pub(crate) fn github_evidence_rows_from_tool_result(result: &str) -> Vec<String> {
-    let Ok(value) = serde_json::from_str::<Value>(result) else {
-        return Vec::new();
-    };
-    let mut rows = github_item_rows(&value);
-
-    if let Some(text) = value.get("text").and_then(Value::as_str)
-        && let Some(embedded) = parse_embedded_json_text(text)
-    {
-        rows.extend(github_item_rows(&embedded));
-    }
-
-    dedupe_preserving_order(rows)
-}
-
-fn dedupe_preserving_order(rows: Vec<String>) -> Vec<String> {
-    let mut deduped = Vec::new();
-    for row in rows {
-        if !deduped.iter().any(|seen| seen == &row) {
-            deduped.push(row);
-        }
-    }
-    deduped
-}
-
 fn append_embedded_json_summaries(value: &Value, lines: &mut Vec<String>) {
     let Some(text) = value.get("text").and_then(Value::as_str) else {
         return;
@@ -710,9 +708,14 @@ fn append_embedded_json_summaries(value: &Value, lines: &mut Vec<String>) {
         return;
     };
 
-    lines.push("Embedded JSON extracted from web_fetch text:".to_string());
+    lines.push("Embedded JSON extracted from tool result text:".to_string());
     append_json_shape(&embedded, lines);
-    append_structured_json_summaries(&embedded, lines);
+    let mut scalars = Vec::new();
+    collect_json_scalars(&embedded, "embedded", &mut scalars, 0);
+    if !scalars.is_empty() {
+        lines.push("Embedded JSON scalar fields:".to_string());
+        lines.extend(scalars.into_iter().map(|line| format!("- {line}")));
+    }
 }
 
 fn parse_embedded_json_text(text: &str) -> Option<Value> {
@@ -731,120 +734,6 @@ fn parse_embedded_json_text(text: &str) -> Option<Value> {
     }
 
     serde_json::from_str(payload).ok()
-}
-
-fn append_structured_json_summaries(value: &Value, lines: &mut Vec<String>) {
-    let github_rows = github_item_rows(value);
-    if !github_rows.is_empty() {
-        lines.push("GitHub item summaries:".to_string());
-        lines.extend(github_rows.into_iter().map(|row| format!("- {row}")));
-    }
-
-    let file_rows = github_file_rows(value);
-    if !file_rows.is_empty() {
-        lines.push("GitHub file summaries:".to_string());
-        lines.extend(file_rows.into_iter().map(|row| format!("- {row}")));
-    }
-}
-
-fn github_item_rows(value: &Value) -> Vec<String> {
-    match value {
-        Value::Array(items) => items
-            .iter()
-            .take(TOOL_RESULT_GITHUB_MAX_ROWS)
-            .filter_map(github_item_row)
-            .collect(),
-        Value::Object(_) => github_item_row(value).into_iter().collect(),
-        _ => Vec::new(),
-    }
-}
-
-fn github_item_row(value: &Value) -> Option<String> {
-    let map = value.as_object()?;
-    let number = map.get("number").and_then(Value::as_i64)?;
-    let title = map.get("title").and_then(Value::as_str)?;
-
-    let mut fields = vec![
-        format!("#{number}"),
-        format!("title=\"{}\"", crate::worker::truncate_chars(title, 120)),
-    ];
-    push_named_scalar(map, "state", &mut fields);
-    push_nested_named_scalar(map, "author", "user", "login", &mut fields);
-    push_named_scalar(map, "draft", &mut fields);
-    push_named_scalar(map, "updated_at", &mut fields);
-    push_named_scalar(map, "html_url", &mut fields);
-    push_reviewer_logins(map, &mut fields);
-
-    Some(fields.join(", "))
-}
-
-fn github_file_rows(value: &Value) -> Vec<String> {
-    match value {
-        Value::Array(items) => items
-            .iter()
-            .take(TOOL_RESULT_GITHUB_MAX_ROWS)
-            .filter_map(github_file_row)
-            .collect(),
-        Value::Object(_) => github_file_row(value).into_iter().collect(),
-        _ => Vec::new(),
-    }
-}
-
-fn github_file_row(value: &Value) -> Option<String> {
-    let map = value.as_object()?;
-    let filename = map.get("filename").and_then(Value::as_str)?;
-    let mut fields = vec![format!(
-        "filename=\"{}\"",
-        crate::worker::truncate_chars(filename, 160)
-    )];
-    push_named_scalar(map, "status", &mut fields);
-    push_named_scalar(map, "additions", &mut fields);
-    push_named_scalar(map, "deletions", &mut fields);
-    push_named_scalar(map, "changes", &mut fields);
-    Some(fields.join(", "))
-}
-
-fn push_named_scalar(
-    map: &serde_json::Map<String, Value>,
-    key: &'static str,
-    fields: &mut Vec<String>,
-) {
-    let Some(value) = map.get(key).and_then(scalar_to_string) else {
-        return;
-    };
-    fields.push(format!("{key}={value}"));
-}
-
-fn push_nested_named_scalar(
-    map: &serde_json::Map<String, Value>,
-    label: &'static str,
-    object_key: &'static str,
-    scalar_key: &'static str,
-    fields: &mut Vec<String>,
-) {
-    let Some(value) = map
-        .get(object_key)
-        .and_then(Value::as_object)
-        .and_then(|nested| nested.get(scalar_key))
-        .and_then(scalar_to_string)
-    else {
-        return;
-    };
-    fields.push(format!("{label}={value}"));
-}
-
-fn push_reviewer_logins(map: &serde_json::Map<String, Value>, fields: &mut Vec<String>) {
-    let Some(reviewers) = map.get("requested_reviewers").and_then(Value::as_array) else {
-        return;
-    };
-    let logins = reviewers
-        .iter()
-        .filter_map(|reviewer| reviewer.get("login").and_then(Value::as_str))
-        .take(TOOL_RESULT_GITHUB_MAX_REVIEWERS)
-        .collect::<Vec<_>>();
-    if !logins.is_empty() {
-        fields.push(format!("requested_reviewers={}", logins.join(",")));
-    }
 }
 
 fn append_json_shape(value: &Value, lines: &mut Vec<String>) {
@@ -1243,6 +1132,37 @@ mod tests {
     }
 
     #[test]
+    fn prompt_only_tool_selection_is_visible_to_workers() {
+        let s = session_with(
+            &[
+                system_msg(
+                    "Agent.\n## Tooling\n- exec: Run shell commands\n- process: Manage background exec sessions",
+                ),
+                user_msg("Use gh to list recent open PRs."),
+            ],
+            None,
+        );
+        let selected = vec!["exec".to_string()];
+
+        let fast = pack_for_worker_selected(&s, WorkerRole::Fast, true, &selected);
+        let strong = pack_for_worker_selected(&s, WorkerRole::Strong, true, &selected);
+
+        for packed in [&fast, &strong] {
+            let system = system_text(&packed.messages);
+            assert!(
+                system.contains("Selected tools for this turn: exec."),
+                "selected prompt-only tool should be explicit in system prompt: {system}"
+            );
+            assert!(
+                system.contains("return a structured tool call"),
+                "tool-intent prompt should discourage prose-only answers: {system}"
+            );
+        }
+        assert!(fast.tools.is_none());
+        assert!(strong.tools.is_none());
+    }
+
+    #[test]
     fn strong_worker_has_deep_history_and_native_tools() {
         // Build a session with many turns so we can verify depth.
         let mut msgs = vec![system_msg("Agent ST.")];
@@ -1484,7 +1404,7 @@ mod tests {
     }
 
     #[test]
-    fn wrapped_github_api_json_preserves_pr_rows() {
+    fn wrapped_embedded_json_preserves_generic_scalar_rows() {
         let noisy_body = "x".repeat(8_000);
         let github_json = json!([
             {
@@ -1544,12 +1464,11 @@ mod tests {
             .and_then(Value::as_str)
             .expect("compacted content");
 
-        assert!(content.contains("Embedded JSON extracted from web_fetch text"));
-        assert!(content.contains("GitHub item summaries"));
-        assert!(content.contains("#806"));
-        assert!(content.contains("author=\"ndizazzo\""));
-        assert!(content.contains("requested_reviewers=michaelneale,i386"));
-        assert!(content.contains("#709"));
+        assert!(content.contains("Embedded JSON extracted from tool result text"));
+        assert!(content.contains("Embedded JSON scalar fields"));
+        assert!(content.contains("embedded[0]: number=806"));
+        assert!(content.contains("title=\"Add meshllm.cloud website"));
+        assert!(content.contains("embedded[1]: number=709"));
         assert!(content.contains("Use combined hf-hub fork for model downloads"));
         assert!(
             !content.contains(&"x".repeat(512)),

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -749,9 +749,9 @@ fn compact_tool_result_text(result: &str) -> String {
 
     format!(
         "Tool result compacted from {} bytes; original was plain text.\n\
-         Text preview:\n{}...",
+         Plain text excerpt with head and tail preserved:\n{}",
         result.len(),
-        crate::worker::truncate_chars(result, TOOL_RESULT_RAW_MAX_BYTES - 96)
+        compact_text_for_context(result, TOOL_RESULT_RAW_MAX_BYTES - 120)
     )
 }
 
@@ -1135,6 +1135,39 @@ mod tests {
         assert!(
             content.ends_with(marker),
             "compaction should preserve the user's tail marker"
+        );
+    }
+
+    #[test]
+    fn tool_result_compaction_preserves_plain_text_tail_evidence() {
+        let marker = "AGENTS.md";
+        let large_result = format!(
+            "{}\n{}",
+            "nested/path/that/fills/context\n".repeat(400),
+            marker
+        );
+        let s = session_with(
+            &[
+                user_msg(
+                    "Use tools to list the current directory and say whether AGENTS.md exists.",
+                ),
+                assistant_tool_msg("call_1", "tree", json!({"path": "."})),
+                tool_result_msg("call_1", &large_result),
+            ],
+            Some(tools_two()),
+        );
+
+        let (messages, _) = pack_for_tool_result_turn(&s, false);
+        let evidence = messages
+            .iter()
+            .filter_map(|msg| msg.get("content").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(evidence.contains("MoA compacted this message"));
+        assert!(
+            evidence.contains(marker),
+            "compacted tool-result context must retain tail evidence: {evidence}"
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -7,8 +7,8 @@
 //! and varies the depth per role:
 //!
 //! - Fast:       system prompt + last user msg + optional tool names
-//! - Specialist: system prompt + last 4 msgs + optional tool summaries/schemas
-//! - Strong:     system prompt + last 10 msgs + optional full tool schemas
+//! - Specialist: system prompt + last 3 msgs + optional tool summaries/schemas
+//! - Strong:     system prompt + last 4 msgs + optional full tool schemas
 //! - Reducer:    system prompt + worker outputs + optional full tool schemas
 
 use crate::normalize::WorkerOutput;
@@ -23,6 +23,13 @@ const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
 const TOOL_RESULT_JSON_MAX_SCALARS: usize = 48;
 const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
 const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
+const SYSTEM_CONTEXT_MAX_CHARS: usize = 6_000;
+const FAST_USER_CONTEXT_MAX_CHARS: usize = 3_000;
+const SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS: usize = 2_000;
+const STRONG_MESSAGE_CONTEXT_MAX_CHARS: usize = 2_000;
+const REDUCER_USER_CONTEXT_MAX_CHARS: usize = 6_000;
+const SPECIALIST_CONTEXT_WINDOW: usize = 3;
+const STRONG_CONTEXT_WINDOW: usize = 4;
 
 /// Packed context ready to send to a worker.
 pub struct PackedContext {
@@ -68,7 +75,7 @@ const MOA_PREAMBLE: &str = "\
 Respond with your best answer or tool call. Be direct.]";
 
 fn augmented_system_prompt_for_mode(session: &Session, include_tool_guidance: bool) -> String {
-    match session.system_prompt() {
+    let prompt = match session.system_prompt() {
         Some(sp) => {
             let prompt = if include_tool_guidance {
                 sp
@@ -78,7 +85,8 @@ fn augmented_system_prompt_for_mode(session: &Session, include_tool_guidance: bo
             format!("{MOA_PREAMBLE}\n\n{prompt}")
         }
         None => MOA_PREAMBLE.to_string(),
-    }
+    };
+    compact_text_for_context(&prompt, SYSTEM_CONTEXT_MAX_CHARS)
 }
 
 fn strip_tool_guidance_sections(prompt: &str) -> String {
@@ -147,7 +155,10 @@ fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String])
     PackedContext {
         messages: vec![
             json!({"role": "system", "content": system}),
-            json!({"role": "user", "content": user_text}),
+            json!({
+                "role": "user",
+                "content": compact_text_for_context(&user_text, FAST_USER_CONTEXT_MAX_CHARS),
+            }),
         ],
         max_tokens: 256,
         tools: None, // Fast worker doesn't get tool schemas — just names
@@ -155,7 +166,7 @@ fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String])
 }
 
 // ── Specialist worker ────────────────────────────────────────────────
-// System prompt + last 4 messages + tool name+description summaries.
+// System prompt + last 3 messages + tool name+description summaries.
 
 fn pack_specialist(
     session: &Session,
@@ -168,22 +179,30 @@ fn pack_specialist(
 
     // Recent messages — skip system (already included), skip raw tool results
     // (they'd confuse models that don't have the tool_call context)
-    let recent = session.recent_messages(4);
+    let recent = session.recent_messages(SPECIALIST_CONTEXT_WINDOW);
+    let user_text = session.last_user_text();
+    let mut has_last_user = false;
     for msg in &recent {
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
         if role == "user" || (role == "assistant" && msg.get("tool_calls").is_none()) {
-            messages.push(msg.clone());
+            has_last_user |= role == "user"
+                && msg.get("content").and_then(Value::as_str) == Some(user_text.as_str());
+            messages.push(compact_chat_message(
+                msg,
+                SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS,
+            ));
         }
     }
 
     // Ensure the last message is the current user turn
-    let user_text = session.last_user_text();
-    if messages
-        .last()
-        .and_then(|m| m.get("content").and_then(|c| c.as_str()))
-        != Some(&user_text)
-    {
-        messages.push(json!({"role": "user", "content": user_text}));
+    if !has_last_user {
+        messages.push(json!({
+            "role": "user",
+            "content": compact_text_for_context(
+                &user_text,
+                SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS,
+            ),
+        }));
     }
 
     PackedContext {
@@ -194,7 +213,7 @@ fn pack_specialist(
 }
 
 // ── Strong worker ────────────────────────────────────────────────────
-// System prompt + last 10 messages + full tool schemas forwarded natively.
+// System prompt + last 4 messages + full tool schemas forwarded natively.
 // This worker gets the deepest context and the actual tool definitions so
 // it can produce native tool_calls if the backend supports it.
 
@@ -209,21 +228,23 @@ fn pack_strong(
 
     // Deep recent history — include tool result messages too since this
     // worker gets full tool schemas and can understand the context
-    let recent = session.recent_messages(10);
+    let recent = session.recent_messages(STRONG_CONTEXT_WINDOW);
+    let user_text = session.last_user_text();
+    let mut has_last_user = false;
     for msg in &recent {
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
         if role != "system" && !role.is_empty() {
-            messages.push(msg.clone());
+            has_last_user |= role == "user"
+                && msg.get("content").and_then(Value::as_str) == Some(user_text.as_str());
+            messages.push(compact_chat_message(msg, STRONG_MESSAGE_CONTEXT_MAX_CHARS));
         }
     }
 
-    let user_text = session.last_user_text();
-    if messages
-        .last()
-        .and_then(|m| m.get("content").and_then(|c| c.as_str()))
-        != Some(&user_text)
-    {
-        messages.push(json!({"role": "user", "content": user_text}));
+    if !has_last_user {
+        messages.push(json!({
+            "role": "user",
+            "content": compact_text_for_context(&user_text, STRONG_MESSAGE_CONTEXT_MAX_CHARS),
+        }));
     }
 
     // Forward the real tool schemas — the strong worker can produce native
@@ -296,7 +317,10 @@ pub fn pack_for_reducer_selected(
     (
         vec![
             json!({"role": "system", "content": system_parts.join("\n")}),
-            json!({"role": "user", "content": user_text}),
+            json!({
+                "role": "user",
+                "content": compact_text_for_context(&user_text, REDUCER_USER_CONTEXT_MAX_CHARS),
+            }),
         ],
         tools,
     )
@@ -459,13 +483,58 @@ pub fn pack_for_tool_result_turn_selected(
     for msg in &all[start_idx..] {
         let role = message_role(msg);
         if role != "system" && !role.is_empty() {
-            messages.push(compact_tool_message(msg));
+            messages.push(compact_chat_message(
+                &compact_tool_message(msg),
+                STRONG_MESSAGE_CONTEXT_MAX_CHARS,
+            ));
         }
     }
 
     let tools = selected_tools(session, has_tools, selected_tool_names);
 
     (messages, tools)
+}
+
+/// Build an answer-only context for tool-result fallback.
+///
+/// Some backends reject native OpenAI tool-message grammar even when `tools`
+/// is omitted. This shape preserves completed tool evidence as plain text and
+/// avoids `assistant.tool_calls` / `role: tool` messages entirely.
+pub fn pack_for_tool_result_answer_only(session: &Session) -> Vec<Value> {
+    let mut system = augmented_system_prompt_for_mode(session, false);
+    system.push_str(
+        "\n\nTool result fallback: answer from the completed tool results below. \
+         Do not request another tool call.",
+    );
+
+    let mut user = String::new();
+    let last_user = session.last_user_text();
+    if !last_user.trim().is_empty() {
+        user.push_str("User request:\n");
+        user.push_str(&compact_text_for_context(
+            &last_user,
+            REDUCER_USER_CONTEXT_MAX_CHARS / 2,
+        ));
+        user.push_str("\n\n");
+    }
+
+    user.push_str("Completed tool results:\n");
+    let results = session.recent_tool_results();
+    let start = results.len().saturating_sub(TOOL_EVIDENCE_MAX_RESULTS);
+    for (tool, result) in &results[start..] {
+        let compacted = compact_tool_result_text(result);
+        let compacted = compact_text_for_context(&compacted, TOOL_EVIDENCE_MAX_RESULT_CHARS);
+        user.push_str("- ");
+        user.push_str(tool);
+        user.push_str(": ");
+        user.push_str(&compacted.replace('\n', "\\n"));
+        user.push('\n');
+    }
+
+    vec![
+        json!({"role": "system", "content": system}),
+        json!({"role": "user", "content": user}),
+    ]
 }
 
 fn tool_evidence_message(session: &Session) -> Option<Value> {
@@ -517,6 +586,54 @@ fn compact_tool_message(msg: &Value) -> Value {
         obj.insert("content".to_string(), Value::String(compacted));
     }
     compact
+}
+
+fn compact_chat_message(msg: &Value, max_chars: usize) -> Value {
+    let Some(content) = msg.get("content").and_then(Value::as_str) else {
+        return msg.clone();
+    };
+    let compacted = compact_text_for_context(content, max_chars);
+    if compacted == content {
+        return msg.clone();
+    }
+    let mut compact = msg.clone();
+    if let Some(obj) = compact.as_object_mut() {
+        obj.insert("content".to_string(), Value::String(compacted));
+    }
+    compact
+}
+
+fn compact_text_for_context(text: &str, max_chars: usize) -> String {
+    if text.len() <= max_chars {
+        return text.to_string();
+    }
+
+    let marker = format!(
+        "\n\n[MoA compacted this message from {} chars. Middle content was omitted. \
+         The text after this notice is the preserved ending of the original message.]\n\n",
+        text.len()
+    );
+    if marker.len() >= max_chars {
+        return crate::worker::truncate_chars(text, max_chars).to_string();
+    }
+
+    let remaining = max_chars - marker.len();
+    let head_budget = remaining / 3;
+    let tail_budget = remaining.saturating_sub(head_budget);
+    let head = crate::worker::truncate_chars(text, head_budget);
+    let tail_start = tail_start_at_char_boundary(text, tail_budget);
+    format!("{head}{marker}{}", &text[tail_start..])
+}
+
+fn tail_start_at_char_boundary(text: &str, max_tail_bytes: usize) -> usize {
+    if text.len() <= max_tail_bytes {
+        return 0;
+    }
+    let mut start = text.len().saturating_sub(max_tail_bytes);
+    while start < text.len() && !text.is_char_boundary(start) {
+        start += 1;
+    }
+    start
 }
 
 fn compact_tool_result_text(result: &str) -> String {
@@ -855,6 +972,34 @@ mod tests {
     }
 
     #[test]
+    fn fast_worker_compacts_large_user_context_and_preserves_tail() {
+        let marker = "FINAL_MARKER_VISIBLE";
+        let large = format!(
+            "{}{}",
+            "context-fill abcdefghijklmnopqrstuvwxyz 0123456789\n".repeat(3200),
+            marker
+        );
+        let s = session_with(&[user_msg(&large)], None);
+
+        let packed = pack_for_worker(&s, WorkerRole::Fast, false);
+        let content = packed.messages[1]
+            .get("content")
+            .and_then(Value::as_str)
+            .expect("user content");
+
+        assert!(
+            content.len() <= FAST_USER_CONTEXT_MAX_CHARS + 256,
+            "fast worker content should be bounded, got {} chars",
+            content.len()
+        );
+        assert!(content.contains("MoA compacted this message"));
+        assert!(
+            content.ends_with(marker),
+            "compaction should preserve the user's tail marker"
+        );
+    }
+
+    #[test]
     fn specialist_worker_has_summaries_and_native_tools() {
         let s = session_with(
             &[
@@ -939,15 +1084,52 @@ mod tests {
             packed.tools.is_some(),
             "strong must receive full native tool schemas",
         );
-        // Strong gets up to last 10 messages on top of the system prompt,
-        // so it should see deeper history than the specialist's 4-message window.
+        // Strong keeps a bounded tail on top of the system prompt; it should
+        // preserve the current turn without dragging a full agent transcript
+        // into every worker call.
         assert!(
-            packed.messages.len() >= 6,
-            "strong worker should retain deep history, got {} messages",
+            packed.messages.len() <= STRONG_CONTEXT_WINDOW + 1,
+            "strong worker should keep a bounded tail, got {} messages",
             packed.messages.len(),
         );
         let last = packed.messages.last().unwrap();
         assert_eq!(last.get("content").and_then(|c| c.as_str()), Some("final"));
+    }
+
+    #[test]
+    fn strong_worker_bounds_accumulated_agent_session_context() {
+        let large = "history ".repeat(2_000);
+        let mut msgs = vec![system_msg(&large)];
+        for idx in 0..12 {
+            msgs.push(user_msg(&format!("{large} user {idx}")));
+            msgs.push(assistant_msg(&format!("{large} assistant {idx}")));
+        }
+        msgs.push(user_msg("latest user request"));
+        let s = session_with(&msgs, Some(tools_two()));
+
+        let packed = pack_for_worker(&s, WorkerRole::Strong, false);
+        let total_chars: usize = packed
+            .messages
+            .iter()
+            .map(|msg| msg.to_string().len())
+            .sum();
+
+        assert!(packed.tools.is_none());
+        assert!(packed.messages.len() <= STRONG_CONTEXT_WINDOW + 1);
+        assert!(
+            total_chars
+                <= SYSTEM_CONTEXT_MAX_CHARS
+                    + (STRONG_CONTEXT_WINDOW * (STRONG_MESSAGE_CONTEXT_MAX_CHARS + 512)),
+            "packed context should stay bounded, got {total_chars} chars",
+        );
+        assert_eq!(
+            packed
+                .messages
+                .last()
+                .and_then(|msg| msg.get("content"))
+                .and_then(Value::as_str),
+            Some("latest user request")
+        );
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -23,6 +23,8 @@ const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
 const TOOL_RESULT_JSON_MAX_SCALARS: usize = 48;
 const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
 const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
+const TOOL_RESULT_GITHUB_MAX_ROWS: usize = 8;
+const TOOL_RESULT_GITHUB_MAX_REVIEWERS: usize = 4;
 const SYSTEM_CONTEXT_MAX_CHARS: usize = 6_000;
 const FAST_USER_CONTEXT_MAX_CHARS: usize = 3_000;
 const SPECIALIST_MESSAGE_CONTEXT_MAX_CHARS: usize = 2_000;
@@ -504,7 +506,9 @@ pub fn pack_for_tool_result_answer_only(session: &Session) -> Vec<Value> {
     let mut system = augmented_system_prompt_for_mode(session, false);
     system.push_str(
         "\n\nTool result fallback: answer from the completed tool results below. \
-         Do not request another tool call.",
+         Do not request another tool call. For GitHub/web results, use exact PR numbers, \
+         titles, authors, statuses, and URLs from the evidence. If the evidence is incomplete \
+         or contradicts the user's premise, say that directly instead of inventing missing facts.",
     );
 
     let mut user = String::new();
@@ -544,7 +548,7 @@ fn tool_evidence_message(session: &Session) -> Option<Value> {
     }
 
     let mut lines = vec![
-        "Completed tool results. Preserve exact short values from these results when the user asks to include, recall, or return tool facts."
+        "Completed tool results. Preserve exact short values from these results when the user asks to include, recall, or return tool facts. For GitHub/web results, use exact numbers, titles, authors, statuses, and URLs from evidence; if the user's premise conflicts with evidence, say so instead of inventing a fit."
             .to_string(),
     ];
     for (idx, (name, result)) in results
@@ -658,6 +662,8 @@ fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
         "Tool result compacted from {original_len} chars; original was JSON."
     )];
     append_json_shape(value, &mut lines);
+    append_structured_json_summaries(value, &mut lines);
+    append_embedded_json_summaries(value, &mut lines);
     let mut scalars = Vec::new();
     collect_json_scalars(value, "$", &mut scalars, 0);
 
@@ -669,6 +675,151 @@ fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
     }
 
     lines.join("\n")
+}
+
+fn append_embedded_json_summaries(value: &Value, lines: &mut Vec<String>) {
+    let Some(text) = value.get("text").and_then(Value::as_str) else {
+        return;
+    };
+    let Some(embedded) = parse_embedded_json_text(text) else {
+        return;
+    };
+
+    lines.push("Embedded JSON extracted from web_fetch text:".to_string());
+    append_json_shape(&embedded, lines);
+    append_structured_json_summaries(&embedded, lines);
+}
+
+fn parse_embedded_json_text(text: &str) -> Option<Value> {
+    let payload = text
+        .split_once("\n---\n")
+        .map(|(_, tail)| tail)
+        .unwrap_or(text);
+    let payload = payload
+        .split_once("\n<<<END_EXTERNAL_UNTRUSTED_CONTENT")
+        .map(|(head, _)| head)
+        .unwrap_or(payload)
+        .trim();
+
+    if !(payload.starts_with('[') || payload.starts_with('{')) {
+        return None;
+    }
+
+    serde_json::from_str(payload).ok()
+}
+
+fn append_structured_json_summaries(value: &Value, lines: &mut Vec<String>) {
+    let github_rows = github_item_rows(value);
+    if !github_rows.is_empty() {
+        lines.push("GitHub item summaries:".to_string());
+        lines.extend(github_rows.into_iter().map(|row| format!("- {row}")));
+    }
+
+    let file_rows = github_file_rows(value);
+    if !file_rows.is_empty() {
+        lines.push("GitHub file summaries:".to_string());
+        lines.extend(file_rows.into_iter().map(|row| format!("- {row}")));
+    }
+}
+
+fn github_item_rows(value: &Value) -> Vec<String> {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .take(TOOL_RESULT_GITHUB_MAX_ROWS)
+            .filter_map(github_item_row)
+            .collect(),
+        Value::Object(_) => github_item_row(value).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn github_item_row(value: &Value) -> Option<String> {
+    let map = value.as_object()?;
+    let number = map.get("number").and_then(Value::as_i64)?;
+    let title = map.get("title").and_then(Value::as_str)?;
+
+    let mut fields = vec![
+        format!("#{number}"),
+        format!("title=\"{}\"", crate::worker::truncate_chars(title, 120)),
+    ];
+    push_named_scalar(map, "state", &mut fields);
+    push_nested_named_scalar(map, "author", "user", "login", &mut fields);
+    push_named_scalar(map, "draft", &mut fields);
+    push_named_scalar(map, "updated_at", &mut fields);
+    push_named_scalar(map, "html_url", &mut fields);
+    push_reviewer_logins(map, &mut fields);
+
+    Some(fields.join(", "))
+}
+
+fn github_file_rows(value: &Value) -> Vec<String> {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .take(TOOL_RESULT_GITHUB_MAX_ROWS)
+            .filter_map(github_file_row)
+            .collect(),
+        Value::Object(_) => github_file_row(value).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn github_file_row(value: &Value) -> Option<String> {
+    let map = value.as_object()?;
+    let filename = map.get("filename").and_then(Value::as_str)?;
+    let mut fields = vec![format!(
+        "filename=\"{}\"",
+        crate::worker::truncate_chars(filename, 160)
+    )];
+    push_named_scalar(map, "status", &mut fields);
+    push_named_scalar(map, "additions", &mut fields);
+    push_named_scalar(map, "deletions", &mut fields);
+    push_named_scalar(map, "changes", &mut fields);
+    Some(fields.join(", "))
+}
+
+fn push_named_scalar(
+    map: &serde_json::Map<String, Value>,
+    key: &'static str,
+    fields: &mut Vec<String>,
+) {
+    let Some(value) = map.get(key).and_then(scalar_to_string) else {
+        return;
+    };
+    fields.push(format!("{key}={value}"));
+}
+
+fn push_nested_named_scalar(
+    map: &serde_json::Map<String, Value>,
+    label: &'static str,
+    object_key: &'static str,
+    scalar_key: &'static str,
+    fields: &mut Vec<String>,
+) {
+    let Some(value) = map
+        .get(object_key)
+        .and_then(Value::as_object)
+        .and_then(|nested| nested.get(scalar_key))
+        .and_then(scalar_to_string)
+    else {
+        return;
+    };
+    fields.push(format!("{label}={value}"));
+}
+
+fn push_reviewer_logins(map: &serde_json::Map<String, Value>, fields: &mut Vec<String>) {
+    let Some(reviewers) = map.get("requested_reviewers").and_then(Value::as_array) else {
+        return;
+    };
+    let logins = reviewers
+        .iter()
+        .filter_map(|reviewer| reviewer.get("login").and_then(Value::as_str))
+        .take(TOOL_RESULT_GITHUB_MAX_REVIEWERS)
+        .collect::<Vec<_>>();
+    if !logins.is_empty() {
+        fields.push(format!("requested_reviewers={}", logins.join(",")));
+    }
 }
 
 fn append_json_shape(value: &Value, lines: &mut Vec<String>) {
@@ -1304,6 +1455,80 @@ mod tests {
         assert!(
             !content.contains(&"x".repeat(512)),
             "large noisy fields should not be forwarded raw"
+        );
+    }
+
+    #[test]
+    fn wrapped_github_api_json_preserves_pr_rows() {
+        let noisy_body = "x".repeat(8_000);
+        let github_json = json!([
+            {
+                "number": 806,
+                "title": "Add meshllm.cloud website, catalog viewer, and onboarding docs",
+                "state": "open",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/806",
+                "updated_at": "2026-06-06T07:18:23Z",
+                "body": noisy_body,
+                "user": {"login": "ndizazzo"},
+                "requested_reviewers": [
+                    {"login": "michaelneale"},
+                    {"login": "i386"}
+                ]
+            },
+            {
+                "number": 709,
+                "title": "Use combined hf-hub fork for model downloads",
+                "state": "open",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/709",
+                "updated_at": "2026-05-27T11:26:00Z",
+                "body": "y".repeat(8_000),
+                "user": {"login": "i386"}
+            }
+        ])
+        .to_string();
+        let result = json!({
+            "url": "https://api.github.com/repos/Mesh-LLM/mesh-llm/pulls?state=open",
+            "status": 200,
+            "text": format!(
+                "SECURITY NOTICE\n\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Fetch\n---\n{github_json}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>"
+            )
+        })
+        .to_string();
+        assert!(result.len() > TOOL_RESULT_RAW_MAX_CHARS);
+
+        let s = session_with(
+            &[
+                user_msg("What is the new website PR status?"),
+                assistant_tool_msg(
+                    "call_fetch",
+                    "web_fetch",
+                    json!({"url": "https://api.github.com/repos/Mesh-LLM/mesh-llm/pulls"}),
+                ),
+                tool_result_msg("call_fetch", &result),
+            ],
+            Some(weather_tools()),
+        );
+
+        let (messages, _tools) = pack_for_tool_result_turn(&s, true);
+        let tool = messages
+            .iter()
+            .find(|msg| msg.get("role").and_then(Value::as_str) == Some("tool"))
+            .expect("tool message");
+        let content = tool
+            .get("content")
+            .and_then(Value::as_str)
+            .expect("compacted content");
+
+        assert!(content.contains("Embedded JSON extracted from web_fetch text"));
+        assert!(content.contains("GitHub item summaries"));
+        assert!(content.contains("#806"));
+        assert!(content.contains("author=\"ndizazzo\""));
+        assert!(content.contains("requested_reviewers=michaelneale,i386"));
+        assert!(content.contains("#709"));
+        assert!(content.contains("Use combined hf-hub fork for model downloads"));
+        assert!(
+            !content.contains(&"x".repeat(512)),
+            "large PR bodies should not be forwarded raw"
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -1588,7 +1588,7 @@ mod tests {
     }
 
     #[test]
-    fn ordinary_chat_strips_openclaw_tool_guidance_sections() {
+    fn ordinary_chat_strips_tool_guidance_sections() {
         let prompt = "\
 You are helpful.
 ## Tooling

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -677,6 +677,31 @@ fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
     lines.join("\n")
 }
 
+pub(crate) fn github_evidence_rows_from_tool_result(result: &str) -> Vec<String> {
+    let Ok(value) = serde_json::from_str::<Value>(result) else {
+        return Vec::new();
+    };
+    let mut rows = github_item_rows(&value);
+
+    if let Some(text) = value.get("text").and_then(Value::as_str)
+        && let Some(embedded) = parse_embedded_json_text(text)
+    {
+        rows.extend(github_item_rows(&embedded));
+    }
+
+    dedupe_preserving_order(rows)
+}
+
+fn dedupe_preserving_order(rows: Vec<String>) -> Vec<String> {
+    let mut deduped = Vec::new();
+    for row in rows {
+        if !deduped.iter().any(|seen| seen == &row) {
+            deduped.push(row);
+        }
+    }
+    deduped
+}
+
 fn append_embedded_json_summaries(value: &Value, lines: &mut Vec<String>) {
     let Some(text) = value.get("text").and_then(Value::as_str) else {
         return;

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -508,10 +508,15 @@ pub fn pack_for_tool_result_turn_selected(
     for msg in &all[start_idx..] {
         let role = message_role(msg);
         if role != "system" && !role.is_empty() {
-            messages.push(compact_chat_message(
-                &compact_tool_message(msg),
-                STRONG_MESSAGE_CONTEXT_MAX_CHARS,
-            ));
+            let compacted = compact_tool_message(msg);
+            if role == "tool" {
+                messages.push(compacted);
+            } else {
+                messages.push(compact_chat_message(
+                    &compacted,
+                    STRONG_MESSAGE_CONTEXT_MAX_CHARS,
+                ));
+            }
         }
     }
 
@@ -1526,7 +1531,7 @@ mod tests {
         assert!(content.contains("$[2]: number=799"));
         assert!(content.contains("Reuse Skippy decode wire messages"));
         assert!(
-            content.len() < 2_000,
+            content.len() <= TOOL_RESULT_RAW_MAX_CHARS,
             "compacted tool content should be small, got {} chars:\n{content}",
             content.len()
         );

--- a/crates/mesh-mixture-of-agents/src/fanout.rs
+++ b/crates/mesh-mixture-of-agents/src/fanout.rs
@@ -137,6 +137,7 @@ pub(crate) async fn gather_workers_incremental(
 
                 if let Some(decision) =
                     arbiter::try_early_decision(&outputs, total_workers, total_finished, has_tools)
+                        .filter(|decision| early_decision_allowed_for_mode(decision, grace_mode))
                 {
                     drain_after_early_exit(join_set, &mut summaries).await;
                     reconcile_dispatched(dispatched, &mut summaries);
@@ -163,6 +164,7 @@ pub(crate) async fn gather_workers_incremental(
 
                 if let Some(decision) =
                     arbiter::try_early_decision(&outputs, total_workers, total_finished, has_tools)
+                        .filter(|decision| early_decision_allowed_for_mode(decision, grace_mode))
                 {
                     drain_after_early_exit(join_set, &mut summaries).await;
                     reconcile_dispatched(dispatched, &mut summaries);
@@ -182,6 +184,13 @@ pub(crate) async fn gather_workers_incremental(
 
     reconcile_dispatched(dispatched, &mut summaries);
     (outputs, summaries, None)
+}
+
+fn early_decision_allowed_for_mode(decision: &arbiter::Decision, grace_mode: GraceMode) -> bool {
+    !matches!(
+        (grace_mode, decision),
+        (GraceMode::Tool, arbiter::Decision::Answer(_))
+    )
 }
 
 fn grace_answer_decision(outputs: &[WorkerOutput]) -> arbiter::Decision {
@@ -527,6 +536,69 @@ mod tests {
                 assert_eq!(arguments["path"], "/tmp/openclaw-tool-baseline.txt");
             }
             other => panic!("expected tool call, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tool_grace_blocks_generic_answer_early_exit() {
+        let mut js = tokio::task::JoinSet::new();
+        let dispatched = vec![
+            spawn_worker(
+                &mut js,
+                "refusal",
+                WorkerRole::Fast,
+                10,
+                Ok(answer_text("I cannot run commands from here.", 0.8)),
+            ),
+            spawn_worker(
+                &mut js,
+                "tool_worker",
+                WorkerRole::Specialist,
+                80,
+                Ok(tool_text("exec", 0.85)),
+            ),
+            spawn_worker(
+                &mut js,
+                "slow",
+                WorkerRole::Strong,
+                5_000,
+                Ok(answer_text("manual instructions", 0.7)),
+            ),
+        ];
+
+        let started = std::time::Instant::now();
+        let (outputs, _summaries, decision) = gather_workers_incremental(
+            &mut js,
+            &dispatched,
+            true,
+            &["exec".to_string()],
+            None,
+            Duration::from_millis(30),
+            GraceMode::Tool,
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(70),
+            "tool-intent turns must not accept the first plain answer; got {elapsed:?}"
+        );
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "tool proposal should still short-circuit the slow tail; got {elapsed:?}"
+        );
+        assert!(
+            outputs
+                .iter()
+                .any(|output| output.kind == normalize::OutputKind::ToolProposal),
+            "expected to wait for the tool proposal; got {outputs:?}"
+        );
+        match decision.expect("tool-intent turn should not return a plain answer") {
+            arbiter::Decision::Answer(answer) => {
+                panic!("tool-intent early exit must not return answer: {answer}")
+            }
+            arbiter::Decision::ToolCall { name, .. } => assert_eq!(name, "exec"),
+            arbiter::Decision::NeedsReducer { .. } => {}
         }
     }
 

--- a/crates/mesh-mixture-of-agents/src/fanout.rs
+++ b/crates/mesh-mixture-of-agents/src/fanout.rs
@@ -316,7 +316,7 @@ mod tests {
         serde_json::json!({
             "kind": "tool_proposal",
             "tool": name,
-            "arguments": {"path": "/tmp/openclaw-tool-baseline.txt"},
+            "arguments": {"path": "/tmp/moa-tool-baseline.txt"},
             "confidence": confidence,
             "payload": "Use the requested tool.",
         })
@@ -397,7 +397,7 @@ mod tests {
 
     #[tokio::test]
     async fn answer_grace_can_fire_when_tools_are_present() {
-        // OpenClaw-style clients attach tool schemas to ordinary chat turns.
+        // Agent clients often attach tool schemas to ordinary chat turns.
         // When the caller has classified the prompt as non-tool intent, answer
         // grace should still avoid waiting for the slow tail.
         let mut js = tokio::task::JoinSet::new();
@@ -533,7 +533,7 @@ mod tests {
         match decision.expect("tool grace should decide") {
             arbiter::Decision::ToolCall { name, arguments } => {
                 assert_eq!(name, "read");
-                assert_eq!(arguments["path"], "/tmp/openclaw-tool-baseline.txt");
+                assert_eq!(arguments["path"], "/tmp/moa-tool-baseline.txt");
             }
             other => panic!("expected tool call, got {other:?}"),
         }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -50,18 +50,21 @@ pub(crate) use tool_guard::enforce_tool_call_contract;
 
 use backend::call_backend;
 use fanout::{GraceMode, gather_workers_incremental};
-use mesh_llm_guardrails::{sanitize_tool_arguments_for_tool, tool_arguments_wire_string};
+use mesh_llm_guardrails::{
+    extract_tool_name_and_arguments, normalize_tool_arguments, sanitize_tool_arguments_for_tool,
+    tool_arguments_wire_string,
+};
 use normalize::WorkerOutput;
 use reducer::{hedged_reducer_call, reducer_candidates};
 use serde_json::{Value, json};
 use session::Session;
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 use worker::WorkerRole;
 pub use worker::{strip_thinking, truncate_chars};
 
 const SAME_TOOL_FORCE_ANSWER_THRESHOLD: usize = 3;
-const WEB_RESEARCH_FORCE_ANSWER_THRESHOLD: usize = 6;
-const WEB_RESEARCH_TOOLS: &[&str] = &["web_search", "web_fetch"];
+const TOOL_BUDGET_FORCE_ANSWER_THRESHOLD: usize = 6;
 
 /// The virtual model name that triggers MoA routing.
 pub const VIRTUAL_MODEL_NAME: &str = "mesh";
@@ -172,6 +175,7 @@ struct DecisionResolution<'a> {
     selected_tool_names: &'a [String],
     forced_tool: Option<&'a ForcedToolChoice>,
     allowed_tools: &'a [String],
+    prompt_tool_profiles: &'a [PromptToolProfile],
 }
 
 // ─── Gateway entry point ─────────────────────────────────────────────
@@ -184,34 +188,44 @@ pub async fn handle_turn(config: &GatewayConfig, body: &Value) -> TurnResult {
     let start = Instant::now();
 
     let mut session = Session::new();
-    let incoming_messages = body
-        .get("messages")
-        .and_then(|m| m.as_array())
-        .cloned()
-        .unwrap_or_default();
+    let incoming_messages = incoming_chat_messages(body);
     let tools = body.get("tools").cloned();
-    let has_tools = tools
+    let has_native_tools = tools
         .as_ref()
         .and_then(|t| t.as_array())
         .map(|a| !a.is_empty())
         .unwrap_or(false);
 
     session.ingest(&incoming_messages, &tools);
+    let prompt_tool_profiles = if has_native_tools {
+        Vec::new()
+    } else {
+        prompt_declared_tool_profiles(&session)
+    };
+    let allowed_tools = declared_tool_names(&session, &prompt_tool_profiles);
+    let has_tools = !allowed_tools.is_empty();
 
     let turn_type = session.classify_turn();
-    let forced_tool = forced_tool_choice(body, &session, &tools);
+    let forced_tool = forced_tool_choice(body, &session, &tools, &allowed_tools);
     tracing::info!(
-        "moa: turn={:?}, {} models, tools={}",
+        "moa: turn={:?}, {} models, tools={}, native_tools={}",
         turn_type,
         config.models.len(),
         has_tools,
+        has_native_tools,
     );
-
-    let allowed_tools = session.tool_names();
 
     match turn_type {
         session::TurnType::ToolResult => {
-            handle_tool_result(config, &session, has_tools, &allowed_tools, start).await
+            handle_tool_result(
+                config,
+                &session,
+                has_tools,
+                &allowed_tools,
+                &prompt_tool_profiles,
+                start,
+            )
+            .await
         }
         session::TurnType::Fresh => {
             handle_query(
@@ -219,12 +233,61 @@ pub async fn handle_turn(config: &GatewayConfig, body: &Value) -> TurnResult {
                 &session,
                 has_tools,
                 &allowed_tools,
+                &prompt_tool_profiles,
                 forced_tool.as_ref(),
                 start,
             )
             .await
         }
     }
+}
+
+fn incoming_chat_messages(body: &Value) -> Vec<Value> {
+    let mut messages = body
+        .get("messages")
+        .and_then(|m| m.as_array())
+        .cloned()
+        .unwrap_or_default();
+
+    let completion_prompt = messages
+        .is_empty()
+        .then(|| completion_prompt_text(body.get("prompt")))
+        .flatten();
+    if let Some(prompt) = completion_prompt {
+        messages.push(json!({"role": "user", "content": prompt}));
+    }
+
+    let missing_system = !messages
+        .iter()
+        .any(|message| message_role(message) == "system");
+    let system_prompt = missing_system
+        .then(|| top_level_system_prompt(body))
+        .flatten();
+    if let Some(system) = system_prompt {
+        messages.insert(0, json!({"role": "system", "content": system}));
+    }
+
+    messages
+}
+
+fn top_level_system_prompt(body: &Value) -> Option<String> {
+    ["systemPrompt", "system_prompt", "system"]
+        .iter()
+        .find_map(|key| body.get(*key).and_then(Value::as_str))
+        .map(str::to_string)
+        .filter(|text| !text.trim().is_empty())
+}
+
+fn completion_prompt_text(prompt: Option<&Value>) -> Option<String> {
+    match prompt? {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(values) => {
+            let texts: Vec<&str> = values.iter().filter_map(Value::as_str).collect();
+            (!texts.is_empty()).then(|| texts.join("\n"))
+        }
+        _ => None,
+    }
+    .filter(|text| !text.trim().is_empty())
 }
 
 // ─── Query handling ──────────────────────────────────────────────────
@@ -234,16 +297,27 @@ async fn handle_query(
     session: &Session,
     has_tools: bool,
     allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
     forced_tool: Option<&ForcedToolChoice>,
     start: Instant,
 ) -> TurnResult {
     let assignments = worker::assign_roles(&config.models);
-    let grace_mode = grace_mode_for_turn(session, has_tools);
-    let query_uses_tools = forced_tool.is_some() || matches!(grace_mode, GraceMode::Tool);
+    let grace_mode = grace_mode_for_turn(session, has_tools, prompt_tool_profiles);
+    let continuation_tool = prior_shell_command_tool_choice(
+        session,
+        &tools_value(session),
+        allowed_tools,
+        prompt_tool_profiles,
+    );
+    let query_uses_tools = forced_tool.is_some()
+        || continuation_tool.is_some()
+        || matches!(grace_mode, GraceMode::Tool);
     let selected_tool_names = if let Some(tool) = forced_tool {
         vec![tool.name.clone()]
+    } else if let Some(tool) = continuation_tool.as_ref() {
+        vec![tool.name.clone()]
     } else if query_uses_tools {
-        selected_tool_names_for_turn(session, allowed_tools)
+        selected_tool_names_for_turn(session, allowed_tools, prompt_tool_profiles)
     } else {
         Vec::new()
     };
@@ -252,7 +326,9 @@ async fn handle_query(
     } else {
         None
     };
-    let required_tool = forced_tool.or(intent_required_tool.as_ref());
+    let required_tool = forced_tool
+        .or(continuation_tool.as_ref())
+        .or(intent_required_tool.as_ref());
     if let Some(tool) = required_tool.filter(|_| has_tools) {
         tracing::info!(
             "moa: direct tool call for explicit {} intent",
@@ -352,6 +428,7 @@ async fn handle_query(
             selected_tool_names: &selected_tool_names,
             forced_tool: required_tool,
             allowed_tools,
+            prompt_tool_profiles,
         },
     )
     .await;
@@ -376,19 +453,23 @@ async fn handle_query(
     }
 }
 
-fn grace_mode_for_turn(session: &Session, has_tools: bool) -> GraceMode {
+fn grace_mode_for_turn(
+    session: &Session,
+    has_tools: bool,
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> GraceMode {
     if !has_tools {
         return GraceMode::Answer;
     }
-    if looks_like_tool_intent(&session.last_user_text()) {
+    if looks_like_tool_intent(session, prompt_tool_profiles) {
         GraceMode::Tool
     } else {
         GraceMode::Answer
     }
 }
 
-fn looks_like_tool_intent(text: &str) -> bool {
-    let text = text.to_ascii_lowercase();
+fn looks_like_tool_intent(session: &Session, prompt_tool_profiles: &[PromptToolProfile]) -> bool {
+    let text = session.last_user_text().to_ascii_lowercase();
     if contains_any(
         &text,
         &[
@@ -396,51 +477,188 @@ fn looks_like_tool_intent(text: &str) -> bool {
             "without tool",
             "do not use tool",
             "don't use tool",
-            "no web",
-            "without web",
-            "do not browse",
-            "don't browse",
-            "no lookup",
-            "without lookup",
         ],
     ) {
         return false;
     }
 
-    let tool_intent_phrases = [
-        "use a tool",
-        "using a tool",
-        "read ",
-        "inspect ",
-        "open ",
-        "fetch ",
-        "search ",
-        "look up",
-        "browse",
-        "web",
-        "url",
-        "http://",
-        "https://",
-        "file",
-        "directory",
-        "folder",
-        "list ",
-        "run ",
-        "execute",
-        "terminal",
-        "shell",
-        "github",
-        "issue",
-        "pull request",
-        "pr ",
-        "weather",
-    ];
-    tool_intent_phrases
-        .iter()
-        .any(|phrase| text.contains(phrase))
+    if contains_any(
+        &text,
+        &[
+            "use a tool",
+            "using a tool",
+            "call a tool",
+            "use the tool",
+            "call the tool",
+        ],
+    ) {
+        return true;
+    }
+
+    let available = session.tool_names();
+    if !explicitly_requested_tool_names(&available, &text).is_empty() {
+        return true;
+    }
+    if !command_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles)
+        .is_empty()
+    {
+        return true;
+    }
+    if !schema_matched_tool_names(session.tools(), &available, &text, prompt_tool_profiles)
+        .is_empty()
+    {
+        return true;
+    }
+    extract_shell_command_block(&text)
+        .and_then(|command| {
+            command_tool_choice_from_command(
+                &command,
+                session.tools(),
+                &available,
+                prompt_tool_profiles,
+            )
+        })
+        .is_some()
 }
 
-fn selected_tool_names_for_turn(session: &Session, allowed_tools: &[String]) -> Vec<String> {
+fn prior_shell_command_tool_choice(
+    session: &Session,
+    tools: &Option<Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<ForcedToolChoice> {
+    if !looks_like_prior_tool_confirmation(&session.last_user_text()) {
+        return None;
+    }
+    let assistant = previous_assistant_text(session)?;
+    let command = extract_shell_command_block(&assistant)?;
+    command_tool_choice_from_command(
+        &command,
+        tools.as_ref(),
+        allowed_tools,
+        prompt_tool_profiles,
+    )
+}
+
+fn looks_like_prior_tool_confirmation(text: &str) -> bool {
+    let text = latest_user_request_tail(text).to_ascii_lowercase();
+    if contains_any(
+        &text,
+        &[
+            "don't do that",
+            "do not do that",
+            "dont do that",
+            "don't run",
+            "do not run",
+            "dont run",
+        ],
+    ) || contains_word(&text, "no")
+    {
+        return false;
+    }
+
+    contains_any(
+        &text,
+        &[
+            "do that",
+            "do it",
+            "go ahead",
+            "please do",
+            "run it",
+            "run that",
+            "execute it",
+            "execute that",
+        ],
+    ) || ["ok", "okay", "yes", "yeah", "yep"]
+        .iter()
+        .any(|word| contains_word(&text, word))
+}
+
+fn contains_word(text: &str, word: &str) -> bool {
+    text.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|token| token == word)
+}
+
+fn latest_user_request_tail(text: &str) -> &str {
+    text.rsplit_once("\n\n")
+        .map(|(_, tail)| tail.trim())
+        .filter(|tail| !tail.is_empty())
+        .unwrap_or_else(|| text.trim())
+}
+
+fn previous_assistant_text(session: &Session) -> Option<String> {
+    let mut seen_latest_user = false;
+    for message in session.messages().iter().rev() {
+        match message_role(message) {
+            "user" if !seen_latest_user => seen_latest_user = true,
+            "assistant" if seen_latest_user => {
+                return message_text_content(message).filter(|text| !text.trim().is_empty());
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn message_text_content(message: &Value) -> Option<String> {
+    if let Some(text) = message.get("content").and_then(Value::as_str) {
+        return Some(text.to_string());
+    }
+    let parts = message.get("content").and_then(Value::as_array)?;
+    let texts: Vec<&str> = parts
+        .iter()
+        .filter_map(|part| {
+            if part.get("type").and_then(Value::as_str) == Some("text") {
+                part.get("text").and_then(Value::as_str)
+            } else {
+                None
+            }
+        })
+        .collect();
+    (!texts.is_empty()).then(|| texts.join("\n"))
+}
+
+fn extract_shell_command_block(text: &str) -> Option<String> {
+    let mut in_block = false;
+    let mut is_shell = false;
+    let mut lines = Vec::new();
+
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if let Some(lang) = trimmed.strip_prefix("```") {
+            if in_block {
+                if is_shell {
+                    let command = lines.join("\n").trim().to_string();
+                    if !command.is_empty() {
+                        return Some(command);
+                    }
+                }
+                in_block = false;
+                is_shell = false;
+                lines.clear();
+                continue;
+            }
+            let lang = lang.trim().to_ascii_lowercase();
+            in_block = true;
+            is_shell = matches!(
+                lang.as_str(),
+                "" | "bash" | "sh" | "shell" | "zsh" | "console"
+            );
+            continue;
+        }
+        if in_block && is_shell {
+            lines.push(line);
+        }
+    }
+
+    None
+}
+
+fn selected_tool_names_for_turn(
+    session: &Session,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
     let available = if allowed_tools.is_empty() {
         session.tool_names()
     } else {
@@ -456,13 +674,14 @@ fn selected_tool_names_for_turn(session: &Session, allowed_tools: &[String]) -> 
         return with_recent_tool_chain_names(session, &available, explicit);
     }
 
-    let mut selected = Vec::new();
-    for tool in &available {
-        let tool_lc = tool.to_ascii_lowercase();
-        if tool_is_relevant_to_text(&tool_lc, &text) {
-            selected.push(tool.clone());
-        }
+    let command_intent =
+        command_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
+    if !command_intent.is_empty() {
+        return with_recent_tool_chain_names(session, &available, command_intent);
     }
+
+    let selected =
+        schema_matched_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
 
     with_recent_tool_chain_names(session, &available, selected)
 }
@@ -498,31 +717,601 @@ fn tool_name_is_explicitly_requested(tool: &str, text: &str) -> bool {
         return false;
     }
 
-    let spaced = tool.replace('_', " ");
-    let patterns = [
-        format!("use {tool}"),
-        format!("use the {tool}"),
-        format!("{tool} tool"),
-        format!("tool {tool}"),
-        format!("call {tool}"),
-        format!("call the {tool}"),
-        format!("use {spaced}"),
-        format!("use the {spaced}"),
-        format!("{spaced} tool"),
-        format!("tool {spaced}"),
-        format!("call {spaced}"),
-        format!("call the {spaced}"),
-        format!("or {tool}"),
-        format!("and {tool}"),
-        format!("or {spaced}"),
-        format!("and {spaced}"),
-    ];
+    let text_tokens = lexical_tokens(text);
+    let tool_tokens = lexical_tokens(&tool.replace('_', " "));
+    if tool_tokens.is_empty() {
+        return false;
+    }
 
-    patterns.iter().any(|pattern| text.contains(pattern))
+    token_sequence_matches(&text_tokens, &["use"], &tool_tokens)
+        || token_sequence_matches(&text_tokens, &["use", "the"], &tool_tokens)
+        || token_sequence_matches(&text_tokens, &["call"], &tool_tokens)
+        || token_sequence_matches(&text_tokens, &["call", "the"], &tool_tokens)
+        || token_sequence_matches(&text_tokens, &["tool"], &tool_tokens)
+        || token_sequence_matches_suffix(&text_tokens, &tool_tokens, &["tool"])
+        || token_sequence_matches(&text_tokens, &["or"], &tool_tokens)
+        || token_sequence_matches(&text_tokens, &["and"], &tool_tokens)
+}
+
+fn token_sequence_matches(text: &[String], prefix: &[&str], target: &[String]) -> bool {
+    if text.len() < prefix.len() + target.len() {
+        return false;
+    }
+    text.windows(prefix.len() + target.len()).any(|window| {
+        prefix
+            .iter()
+            .enumerate()
+            .all(|(idx, token)| window[idx] == *token)
+            && target
+                .iter()
+                .enumerate()
+                .all(|(idx, token)| window[prefix.len() + idx] == *token)
+    })
+}
+
+fn token_sequence_matches_suffix(text: &[String], target: &[String], suffix: &[&str]) -> bool {
+    if text.len() < target.len() + suffix.len() {
+        return false;
+    }
+    text.windows(target.len() + suffix.len()).any(|window| {
+        target
+            .iter()
+            .enumerate()
+            .all(|(idx, token)| window[idx] == *token)
+            && suffix
+                .iter()
+                .enumerate()
+                .all(|(idx, token)| window[target.len() + idx] == *token)
+    })
 }
 
 fn tools_value(session: &Session) -> Option<Value> {
     session.tools().cloned()
+}
+
+#[derive(Debug)]
+struct ToolSchemaProfile {
+    name: String,
+    tokens: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct PromptToolProfile {
+    name: String,
+    tokens: HashSet<String>,
+}
+
+fn declared_tool_names(
+    session: &Session,
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
+    let native = session.tool_names();
+    if !native.is_empty() {
+        native
+    } else {
+        prompt_tool_profiles
+            .iter()
+            .map(|profile| profile.name.clone())
+            .collect()
+    }
+}
+
+fn prompt_declared_tool_profiles(session: &Session) -> Vec<PromptToolProfile> {
+    let Some(prompt) = prompt_tool_catalog_source(session) else {
+        return Vec::new();
+    };
+    let mut in_tooling_section = false;
+    let mut profiles = Vec::new();
+    let mut seen = HashSet::new();
+
+    for line in prompt.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("## ") {
+            in_tooling_section = prompt_tool_heading(trimmed);
+            continue;
+        }
+        if !in_tooling_section {
+            continue;
+        }
+        let Some(profile) = parse_prompt_tool_line(trimmed) else {
+            continue;
+        };
+        if seen.insert(profile.name.clone()) {
+            profiles.push(profile);
+        }
+    }
+
+    profiles
+}
+
+fn prompt_tool_catalog_source(session: &Session) -> Option<String> {
+    if let Some(system) = session
+        .system_prompt()
+        .filter(|prompt| !prompt.trim().is_empty())
+    {
+        return Some(system);
+    }
+
+    let parts: Vec<String> = session
+        .messages()
+        .iter()
+        .filter_map(message_text_content)
+        .collect();
+    (!parts.is_empty()).then(|| parts.join("\n"))
+}
+
+fn prompt_tool_heading(line: &str) -> bool {
+    matches!(
+        line.trim(),
+        "## Tooling" | "## Tools" | "## Available Tools"
+    )
+}
+
+fn parse_prompt_tool_line(line: &str) -> Option<PromptToolProfile> {
+    let rest = line.strip_prefix("- ")?;
+    let (name, description) = rest.split_once(':')?;
+    let name = name.trim();
+    let description = description.trim();
+    if !valid_prompt_tool_name(name) || description.is_empty() {
+        return None;
+    }
+
+    let mut tokens = text_tokens(name);
+    tokens.extend(text_tokens(description));
+    Some(PromptToolProfile {
+        name: name.to_string(),
+        tokens,
+    })
+}
+
+fn valid_prompt_tool_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 120 {
+        return false;
+    }
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+}
+
+fn schema_matched_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
+    let profiles = tool_text_profiles(tools, available, prompt_tool_profiles);
+    if profiles.is_empty() {
+        return Vec::new();
+    }
+    let user_tokens = text_tokens(user_text);
+    if user_tokens.is_empty() {
+        return Vec::new();
+    }
+
+    let mut scored: Vec<(String, usize)> = profiles
+        .iter()
+        .map(|profile| {
+            let overlap = user_tokens
+                .iter()
+                .filter(|token| profile.tokens.contains(*token))
+                .count();
+            (profile.name.clone(), overlap)
+        })
+        .filter(|(_, score)| *score >= 2)
+        .collect();
+    scored.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+
+    let Some((_, top_score)) = scored.first() else {
+        return Vec::new();
+    };
+    let top_score = *top_score;
+    let runner_up = scored.get(1).map(|(_, score)| *score).unwrap_or(0);
+    if top_score < 2 || runner_up + 2 > top_score {
+        return Vec::new();
+    }
+
+    scored
+        .into_iter()
+        .filter_map(|(name, score)| (score == top_score).then_some(name))
+        .collect()
+}
+
+fn tool_text_profiles(
+    tools: Option<&Value>,
+    available: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<ToolSchemaProfile> {
+    let schema_profiles = tool_schema_profiles(tools, available);
+    if !schema_profiles.is_empty() {
+        return schema_profiles;
+    }
+
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+    prompt_tool_profiles
+        .iter()
+        .filter(|profile| available.is_empty() || available.contains(profile.name.as_str()))
+        .map(|profile| ToolSchemaProfile {
+            name: profile.name.clone(),
+            tokens: profile.tokens.clone(),
+        })
+        .collect()
+}
+
+fn tool_schema_profiles(tools: Option<&Value>, available: &[String]) -> Vec<ToolSchemaProfile> {
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+    tools
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if !available.contains(name) {
+                return None;
+            }
+            let mut tokens = HashSet::new();
+            collect_tool_schema_tokens(tool, &mut tokens);
+            Some(ToolSchemaProfile {
+                name: name.to_string(),
+                tokens,
+            })
+        })
+        .collect()
+}
+
+fn collect_tool_schema_tokens(value: &Value, tokens: &mut HashSet<String>) {
+    match value {
+        Value::String(text) => tokens.extend(text_tokens(text)),
+        Value::Array(values) => {
+            for value in values {
+                collect_tool_schema_tokens(value, tokens);
+            }
+        }
+        Value::Object(map) => {
+            for (key, value) in map {
+                tokens.extend(text_tokens(key));
+                collect_tool_schema_tokens(value, tokens);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn text_tokens(text: &str) -> HashSet<String> {
+    lexical_tokens(text)
+        .into_iter()
+        .filter(|token| token.len() >= 3)
+        .filter(|token| !schema_match_stopword(token))
+        .collect()
+}
+
+fn lexical_tokens(text: &str) -> Vec<String> {
+    text.split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter_map(|token| {
+            let token = token.trim().to_ascii_lowercase();
+            (!token.is_empty()).then_some(token)
+        })
+        .collect()
+}
+
+fn schema_match_stopword(token: &str) -> bool {
+    matches!(
+        token,
+        "for"
+            | "the"
+            | "and"
+            | "use"
+            | "using"
+            | "with"
+            | "from"
+            | "into"
+            | "this"
+            | "that"
+            | "type"
+            | "function"
+            | "name"
+            | "description"
+            | "parameters"
+            | "properties"
+            | "required"
+            | "string"
+            | "object"
+            | "array"
+            | "boolean"
+            | "integer"
+            | "number"
+    )
+}
+
+fn command_tool_choice_from_command(
+    command: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<ForcedToolChoice> {
+    let candidates = command_tool_candidates(tools, allowed_tools, prompt_tool_profiles);
+    let [candidate] = candidates.as_slice() else {
+        tracing::info!(
+            "moa: shell command block found but command-like declared tool candidates={} (need exactly one)",
+            candidates.len()
+        );
+        return None;
+    };
+
+    let arguments = json!({ candidate.field.clone(): command });
+    match sanitize_tool_arguments_for_tool(&candidate.name, &arguments, tools) {
+        Ok(arguments) => Some(ForcedToolChoice {
+            name: candidate.name.clone(),
+            fallback_arguments: arguments,
+        }),
+        Err(err) => {
+            tracing::info!(
+                "moa: command block could not be used as {} args: {err}",
+                candidate.name
+            );
+            None
+        }
+    }
+}
+
+fn command_intent_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
+    let candidates = command_tool_candidates(tools, available, prompt_tool_profiles);
+    let [candidate] = candidates.as_slice() else {
+        return Vec::new();
+    };
+
+    if user_text_suggests_command_tool(user_text, &candidate.tokens) {
+        vec![candidate.name.clone()]
+    } else {
+        Vec::new()
+    }
+}
+
+fn user_text_suggests_command_tool(user_text: &str, schema_tokens: &HashSet<String>) -> bool {
+    let user_tokens = lexical_tokens(user_text);
+    if user_tokens
+        .iter()
+        .filter(|token| !schema_match_stopword(token))
+        .any(|token| schema_tokens.contains(token))
+    {
+        return true;
+    }
+
+    command_execution_pattern_matches(&user_tokens)
+}
+
+fn command_execution_pattern_matches(tokens: &[String]) -> bool {
+    tokens.windows(3).any(|window| {
+        matches!(window[0].as_str(), "use" | "using")
+            && executable_token(&window[1])
+            && window[2] == "to"
+    }) || tokens.windows(2).any(|window| {
+        matches!(window[0].as_str(), "run" | "execute") && executable_token(&window[1])
+    })
+}
+
+fn executable_token(token: &str) -> bool {
+    if !(2..=40).contains(&token.len()) {
+        return false;
+    }
+    !matches!(
+        token,
+        "it" | "that" | "this" | "the" | "a" | "an" | "tool" | "command"
+    ) && token.chars().any(|ch| ch.is_ascii_alphabetic())
+}
+
+#[derive(Debug)]
+struct CommandToolCandidate {
+    name: String,
+    field: String,
+    tokens: HashSet<String>,
+}
+
+fn command_tool_candidates(
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<CommandToolCandidate> {
+    let schema_candidates = command_schema_tool_candidates(tools, allowed_tools);
+    if !schema_candidates.is_empty() {
+        return clear_command_tool_candidates(schema_candidates);
+    }
+
+    clear_command_tool_candidates(prompt_command_tool_candidates(
+        allowed_tools,
+        prompt_tool_profiles,
+    ))
+}
+
+fn clear_command_tool_candidates(
+    candidates: Vec<CommandToolCandidate>,
+) -> Vec<CommandToolCandidate> {
+    if candidates.len() <= 1 {
+        return candidates;
+    }
+
+    let mut scored: Vec<(usize, CommandToolCandidate)> = candidates
+        .into_iter()
+        .map(|candidate| (command_tool_candidate_score(&candidate), candidate))
+        .collect();
+    scored.sort_by(|left, right| {
+        right
+            .0
+            .cmp(&left.0)
+            .then_with(|| left.1.name.cmp(&right.1.name))
+            .then_with(|| left.1.field.cmp(&right.1.field))
+    });
+
+    let [(score, _candidate), rest @ ..] = scored.as_slice() else {
+        return Vec::new();
+    };
+    let runner_up = rest.first().map(|(score, _)| *score).unwrap_or(0);
+    if *score >= runner_up + 3 {
+        vec![scored.remove(0).1]
+    } else {
+        scored.into_iter().map(|(_, candidate)| candidate).collect()
+    }
+}
+
+fn command_tool_candidate_score(candidate: &CommandToolCandidate) -> usize {
+    command_field_score(&candidate.field, &candidate.tokens)
+}
+
+fn command_schema_tool_candidates(
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+) -> Vec<CommandToolCandidate> {
+    let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
+    tools
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if !allowed.is_empty() && !allowed.contains(name) {
+                return None;
+            }
+            let params = tool.pointer("/function/parameters")?;
+            let (field, tokens) = command_like_string_field(params)?;
+            Some(CommandToolCandidate {
+                name: name.to_string(),
+                field,
+                tokens,
+            })
+        })
+        .collect()
+}
+
+fn prompt_command_tool_candidates(
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<CommandToolCandidate> {
+    let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
+    prompt_tool_profiles
+        .iter()
+        .filter(|profile| allowed.is_empty() || allowed.contains(profile.name.as_str()))
+        .filter(|profile| prompt_profile_looks_command_executor(profile))
+        .map(|profile| CommandToolCandidate {
+            name: profile.name.clone(),
+            field: "command".to_string(),
+            tokens: profile.tokens.clone(),
+        })
+        .collect()
+}
+
+fn prompt_profile_looks_command_executor(profile: &PromptToolProfile) -> bool {
+    let tokens = &profile.tokens;
+    let has_execute = tokens.contains("run") || tokens.contains("execute");
+    let has_command_target = ["command", "commands", "shell", "terminal", "cli", "clis"]
+        .iter()
+        .any(|token| tokens.contains(*token));
+    let looks_like_existing_process = (tokens.contains("manage") || tokens.contains("background"))
+        && (tokens.contains("session") || tokens.contains("sessions"))
+        && (tokens.contains("running") || tokens.contains("started"));
+
+    has_execute && has_command_target && !looks_like_existing_process
+}
+
+fn command_like_string_field(parameters: &Value) -> Option<(String, HashSet<String>)> {
+    let properties = parameters.get("properties").and_then(Value::as_object)?;
+    let required_matches = command_like_fields(
+        parameters
+            .get("required")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_str),
+        properties,
+    );
+    if let Some(field) = clear_command_like_field(required_matches) {
+        return Some(field);
+    }
+
+    clear_command_like_field(command_like_fields(
+        properties.keys().map(String::as_str),
+        properties,
+    ))
+}
+
+fn command_like_fields<'a>(
+    fields: impl Iterator<Item = &'a str>,
+    properties: &serde_json::Map<String, Value>,
+) -> Vec<(String, HashSet<String>)> {
+    let mut matches = Vec::new();
+    for field in fields {
+        let Some(schema) = properties.get(field) else {
+            continue;
+        };
+        if !schema_allows_string(schema) {
+            continue;
+        }
+        let mut tokens = text_tokens(field);
+        collect_tool_schema_tokens(schema, &mut tokens);
+        if schema_tokens_look_command_like(&tokens) {
+            matches.push((field.to_string(), tokens));
+        }
+    }
+    matches
+}
+
+fn clear_command_like_field(
+    matches: Vec<(String, HashSet<String>)>,
+) -> Option<(String, HashSet<String>)> {
+    if matches.is_empty() {
+        return None;
+    }
+    if matches.len() == 1 {
+        let (field, tokens) = matches.into_iter().next()?;
+        return Some((field, tokens));
+    };
+
+    let mut scored: Vec<(usize, String, HashSet<String>)> = matches
+        .into_iter()
+        .map(|(field, tokens)| (command_field_score(&field, &tokens), field, tokens))
+        .filter(|(score, _, _)| *score >= 4)
+        .collect();
+    scored.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+
+    let [(score, field, tokens), rest @ ..] = scored.as_slice() else {
+        return None;
+    };
+    let runner_up = rest.first().map(|(score, _, _)| *score).unwrap_or(0);
+    if *score >= runner_up + 3 {
+        Some((field.clone(), tokens.clone()))
+    } else {
+        None
+    }
+}
+
+fn command_field_score(field: &str, tokens: &HashSet<String>) -> usize {
+    let field_tokens = text_tokens(field);
+    let mut score = 0;
+    for token in &field_tokens {
+        score += match token.as_str() {
+            "command" | "commands" => 8,
+            "cmd" => 6,
+            _ => 0,
+        };
+    }
+    for token in tokens {
+        score += match token.as_str() {
+            "command" | "commands" => 2,
+            "cmd" => 1,
+            _ => 0,
+        };
+    }
+    score
+}
+
+fn schema_tokens_look_command_like(tokens: &HashSet<String>) -> bool {
+    tokens.contains("command") || tokens.contains("commands") || tokens.contains("cmd")
 }
 
 fn required_tool_choice_for_intent(
@@ -530,17 +1319,25 @@ fn required_tool_choice_for_intent(
     tools: &Option<Value>,
     selected_tool_names: &[String],
 ) -> Option<ForcedToolChoice> {
+    let tools = tools.as_ref()?;
     let [name] = selected_tool_names else {
         return None;
     };
 
-    let inferred =
-        infer_tool_arguments_from_prompt(name, tools.as_ref(), &session.last_user_text());
-    match sanitize_tool_arguments_for_tool(name, &inferred, tools.as_ref()) {
-        Ok(arguments) => Some(ForcedToolChoice {
-            name: name.clone(),
-            fallback_arguments: arguments,
-        }),
+    let inferred = infer_tool_arguments_from_prompt(name, Some(tools), &session.last_user_text());
+    match sanitize_tool_arguments_for_tool(name, &inferred, Some(tools)) {
+        Ok(arguments) => {
+            if is_empty_command_tool_arguments(name, tools, &arguments) {
+                tracing::info!(
+                    "moa: explicit command-tool intent selected {name}, but no command arguments were inferred"
+                );
+                return None;
+            }
+            Some(ForcedToolChoice {
+                name: name.clone(),
+                fallback_arguments: arguments,
+            })
+        }
         Err(err) => {
             tracing::info!(
                 "moa: explicit tool intent selected {name}, but arguments could not be inferred: {err}"
@@ -548,6 +1345,14 @@ fn required_tool_choice_for_intent(
             None
         }
     }
+}
+
+fn is_empty_command_tool_arguments(name: &str, tools: &Value, arguments: &Value) -> bool {
+    let candidates = command_schema_tool_candidates(Some(tools), &[name.to_string()]);
+    let [_candidate] = candidates.as_slice() else {
+        return false;
+    };
+    arguments.as_object().is_some_and(serde_json::Map::is_empty)
 }
 
 fn recent_tool_chain_names(session: &Session) -> Vec<String> {
@@ -586,70 +1391,6 @@ fn message_role(msg: &Value) -> &str {
     msg.get("role").and_then(Value::as_str).unwrap_or("")
 }
 
-fn tool_is_relevant_to_text(tool_name: &str, text: &str) -> bool {
-    if text.contains(tool_name) {
-        return true;
-    }
-
-    match tool_name {
-        "read" | "read_file" | "file_fetch" => contains_any(
-            text,
-            &["read ", "open ", "inspect ", "fetch file", "show file"],
-        ),
-        "edit" | "edit_file" | "file_write" | "write" => {
-            contains_any(text, &["edit ", "change ", "modify ", "write ", "create "])
-        }
-        "exec" | "run_command" | "process" => contains_any(
-            text,
-            &[
-                "run ", "execute ", "shell", "terminal", "command", "process",
-            ],
-        ),
-        "web_search" => contains_any(
-            text,
-            &[
-                "search ",
-                "look up",
-                "lookup",
-                "web",
-                "google",
-                "github",
-                "issue",
-                "pull request",
-                "pr ",
-                "weather",
-                "forecast",
-                "current",
-                "latest",
-                "today",
-                "tomorrow",
-            ],
-        ),
-        "web_fetch" => contains_any(
-            text,
-            &[
-                "fetch ",
-                "browse",
-                "url",
-                "http://",
-                "https://",
-                "github",
-                "github.com/",
-                "issue",
-                "pull request",
-                "pr ",
-            ],
-        ),
-        "dir_list" | "dir_fetch" | "list_files" => {
-            contains_any(text, &["list ", "directory", "folder", "dir "])
-        }
-        "image" | "image_generate" => contains_any(text, &["image", "picture", "generate"]),
-        "pdf" => text.contains("pdf"),
-        "memory_search" | "memory_get" => text.contains("memory"),
-        _ => false,
-    }
-}
-
 fn contains_any(text: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| text.contains(needle))
 }
@@ -658,13 +1399,14 @@ fn forced_tool_choice(
     body: &Value,
     session: &Session,
     tools: &Option<Value>,
+    allowed_tools: &[String],
 ) -> Option<ForcedToolChoice> {
     let name = body
         .get("tool_choice")?
         .get("function")?
         .get("name")?
         .as_str()?;
-    if name.is_empty() || !session.tool_names().iter().any(|tool| tool == name) {
+    if name.is_empty() || !allowed_tools.iter().any(|tool| tool == name) {
         return None;
     }
 
@@ -783,6 +1525,10 @@ fn is_path_like_candidate(candidate: &str, field: &str) -> bool {
         || candidate.starts_with("~/")
         || candidate.starts_with("./")
         || candidate.starts_with("../")
+        || ((field.contains("path") || field.contains("file"))
+            && candidate.contains('.')
+            && !candidate.starts_with('.')
+            && !candidate.ends_with('.'))
 }
 
 fn infer_query_argument(field: &str, prompt: &str) -> Option<String> {
@@ -813,22 +1559,26 @@ async fn handle_tool_result(
     session: &Session,
     has_tools: bool,
     allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
     start: Instant,
 ) -> TurnResult {
     let candidates = reducer_candidates(config);
     let candidate_count = candidates.len();
     let repeated_tool = repeated_same_tool_results(session);
-    let web_budget_exhausted = web_research_tool_budget_exhausted(session);
-    let mut selected_tool_names = selected_tool_names_for_turn(session, allowed_tools);
+    let tool_budget_exhausted = tool_budget_exhausted(session);
+    let mut selected_tool_names =
+        selected_tool_names_for_turn(session, allowed_tools, prompt_tool_profiles);
     if let Some((tool, _)) = repeated_tool.as_ref() {
         selected_tool_names.retain(|name| name != tool);
     }
-    if web_budget_exhausted.is_some() {
-        selected_tool_names.retain(|name| !is_web_research_tool(name));
+    let latest_answerable_tool = latest_completed_tool_result(session)
+        .filter(|(_, result)| tool_result_has_answerable_evidence(result));
+    if let Some((tool, _)) = latest_answerable_tool {
+        selected_tool_names.retain(|name| name != &tool);
     }
     let tools_enabled_for_reducer =
-        has_tools && !selected_tool_names.is_empty() && web_budget_exhausted.is_none();
-    let (mut messages, tools) = if web_budget_exhausted.is_some() {
+        has_tools && !selected_tool_names.is_empty() && tool_budget_exhausted.is_none();
+    let (mut messages, tools) = if tool_budget_exhausted.is_some() {
         (context::pack_for_tool_result_answer_only(session), None)
     } else {
         context::pack_for_tool_result_turn_selected(
@@ -843,9 +1593,18 @@ async fn handle_tool_result(
         );
         append_tool_loop_answer_instruction(&mut messages, tool, *count);
     }
-    if let Some(count) = web_budget_exhausted {
-        tracing::info!("moa: forcing answer after {count} completed web research tool calls");
-        append_web_research_budget_instruction(&mut messages, count);
+    if let Some(count) = tool_budget_exhausted {
+        tracing::info!("moa: forcing answer after {count} completed tool calls");
+        append_tool_budget_instruction(&mut messages, count);
+    }
+    if tools_enabled_for_reducer
+        && let Some((tool, _)) = latest_completed_tool_result(session)
+            .filter(|(_, result)| !tool_result_has_answerable_evidence(result))
+    {
+        tracing::info!(
+            "moa: latest {tool} tool result looks like error/usage output; asking reducer to retry"
+        );
+        append_tool_error_retry_instruction(&mut messages, &tool);
     }
 
     // Hedged ladder: start candidate 0, hedge to candidate 1 after hedge_delay
@@ -930,23 +1689,49 @@ async fn handle_tool_result(
 
     let (reducer_name, succeeded, response_body) = match chosen {
         Some((name, reduced, response_tools_enabled)) => {
-            // Be consistent with the fanout/arbiter path: emit a real
-            // `tool_calls` response whenever the reducer named a tool,
-            // even if `arguments` is missing. The fanout path emits `{}`
-            // for empty arguments; this path used to fall back to a
-            // chat_response carrying the reducer's prose, which broke
-            // agent harnesses (Goose, OpenCode) that only act on
-            // `tool_calls`. `tool_call_response` already collapses
-            // missing / non-object arguments to `"{}"`.
+            let empty_tools: &[String] = &[];
+            let empty_profiles: &[PromptToolProfile] = &[];
+            let response_allowed_tools = if response_tools_enabled {
+                allowed_tools
+            } else {
+                empty_tools
+            };
+            let response_prompt_profiles = if response_tools_enabled {
+                prompt_tool_profiles
+            } else {
+                empty_profiles
+            };
+            // When tools remain enabled, be consistent with the
+            // fanout/arbiter path and emit a real `tool_calls` response for
+            // valid reducer proposals. When tools are disabled, never pass
+            // tool-call-shaped text through as chat content; answer from the
+            // completed tool result instead.
             let body = match reduced.kind {
-                normalize::OutputKind::ToolProposal => {
-                    tool_proposal_response(&reduced, response_tools_enabled)
+                normalize::OutputKind::ToolProposal if !response_tools_enabled => {
+                    tool_result_answer_from_evidence_response(session)
                 }
+                normalize::OutputKind::ToolProposal => tool_proposal_response(
+                    &reduced,
+                    response_tools_enabled,
+                    session.tools(),
+                    response_allowed_tools,
+                    response_prompt_profiles,
+                    Some(&session.last_user_text()),
+                ),
                 normalize::OutputKind::Uncertainty => error_response(
                     "MoA reducer returned no usable answer",
                     MOA_ERR_NO_USABLE_ANSWER,
                 ),
-                _ => chat_response(&repair_tool_result_answer(session, &reduced.payload)),
+                _ => {
+                    let repaired = repair_tool_result_answer(session, &reduced.payload);
+                    chat_or_schema_command_tool_response(
+                        &repaired,
+                        session.tools(),
+                        response_allowed_tools,
+                        response_prompt_profiles,
+                        Some(&session.last_user_text()),
+                    )
+                }
             };
             (name, true, body)
         }
@@ -982,20 +1767,19 @@ async fn handle_tool_result(
 }
 
 fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
-    if let Some(github_answer) = grounded_github_tool_answer(session) {
-        return github_answer;
-    }
+    let repaired_rows =
+        repair_tabular_tool_result_answer(session, answer).unwrap_or_else(|| answer.to_string());
 
     if !tool_evidence_should_be_preserved(&session.last_user_text()) {
-        return answer.to_string();
+        return repaired_rows;
     }
 
-    let missing = missing_tool_evidence_values(session, answer);
+    let missing = missing_tool_evidence_values(session, &repaired_rows);
     if missing.is_empty() {
-        return answer.to_string();
+        return repaired_rows;
     }
 
-    let mut repaired = answer.trim().to_string();
+    let mut repaired = repaired_rows.trim().to_string();
     if !repaired.is_empty() {
         repaired.push_str("\n\n");
     }
@@ -1004,127 +1788,138 @@ fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
     repaired
 }
 
-fn grounded_github_tool_answer(session: &Session) -> Option<String> {
-    let user_text = session.last_user_text();
-    if !github_evidence_should_ground_answer(&user_text) {
-        return None;
-    }
+#[derive(Debug)]
+struct TabularToolRow {
+    id: String,
+    title: String,
+}
 
-    let rows = github_tool_evidence_rows(session);
+fn repair_tabular_tool_result_answer(session: &Session, answer: &str) -> Option<String> {
+    let (_, result) = latest_completed_tool_result(session)?;
+    let rows = tabular_tool_result_rows(&result);
     if rows.is_empty() {
         return None;
     }
 
-    let selected = select_relevant_github_rows(&user_text, &rows);
-    let heading = if selected.len() == 1 {
-        "Grounded GitHub evidence from the fetched tool result:"
-    } else {
-        "Grounded GitHub evidence from the fetched tool results:"
-    };
-    let mut answer = String::from(heading);
-    for row in selected {
-        answer.push_str("\n- ");
-        answer.push_str(row);
-    }
-    if user_text.to_ascii_lowercase().contains("nick") {
-        answer.push_str(
-            "\n\nI do not see a `Nick` author/login in those fetched rows; use the author/login shown above.",
-        );
-    }
-    Some(answer)
-}
-
-fn github_evidence_should_ground_answer(user_text: &str) -> bool {
-    let text = user_text.to_ascii_lowercase();
-    contains_any(
-        &text,
-        &[
-            "github",
-            "pull request",
-            "pr ",
-            "pr#",
-            "issue",
-            "status",
-            "review",
-        ],
-    )
-}
-
-fn github_tool_evidence_rows(session: &Session) -> Vec<String> {
-    let mut rows = Vec::new();
-    for (_, result) in session.recent_tool_results() {
-        rows.extend(context::github_evidence_rows_from_tool_result(&result));
-    }
-    let mut deduped = Vec::new();
-    for row in rows {
-        if !deduped.iter().any(|seen| seen == &row) {
-            deduped.push(row);
-        }
-    }
-    deduped
-}
-
-fn select_relevant_github_rows<'a>(user_text: &str, rows: &'a [String]) -> Vec<&'a String> {
-    let text = user_text.to_ascii_lowercase();
-    let explicit_numbers = github_pr_numbers_from_text(&text);
-    if !explicit_numbers.is_empty() {
-        let matches = rows
-            .iter()
-            .filter(|row| explicit_numbers.iter().any(|number| row.contains(number)))
-            .collect::<Vec<_>>();
-        if !matches.is_empty() {
-            return matches;
+    for row in &rows {
+        let has_id = answer_has_row_id(answer, &row.id);
+        let has_title = answer_contains_text(answer, &row.title);
+        if has_id && !has_title {
+            let exact_id_answer = answer
+                .trim()
+                .trim_start_matches('#')
+                .chars()
+                .all(|ch| ch.is_ascii_digit());
+            let row_text = format!("#{} - {}", row.id, row.title);
+            if exact_id_answer {
+                return Some(row_text);
+            }
+            return Some(append_tool_rows(answer, &[row_text]));
         }
     }
 
-    let keywords = github_relevance_keywords(&text);
-    if !keywords.is_empty() {
-        let matches = rows
-            .iter()
-            .filter(|row| {
-                let row = row.to_ascii_lowercase();
-                keywords.iter().any(|keyword| row.contains(keyword))
-            })
-            .collect::<Vec<_>>();
-        if !matches.is_empty() {
-            return matches;
-        }
-    }
-
-    rows.iter().take(5).collect()
-}
-
-fn github_pr_numbers_from_text(text: &str) -> Vec<String> {
-    text.split(|c: char| !c.is_ascii_alphanumeric() && c != '#')
-        .filter_map(|token| {
-            let number = token.strip_prefix('#').unwrap_or(token);
-            (number.len() >= 2 && number.chars().all(|c| c.is_ascii_digit()))
-                .then(|| format!("#{number}"))
+    let missing_rows: Vec<String> = rows
+        .iter()
+        .filter(|row| {
+            answer_contains_text(answer, &row.title) && !answer_has_row_id(answer, &row.id)
         })
-        .collect()
+        .map(|row| format!("#{} - {}", row.id, row.title))
+        .collect();
+    if missing_rows.is_empty() {
+        None
+    } else {
+        Some(append_tool_rows(answer, &missing_rows))
+    }
 }
 
-fn github_relevance_keywords(text: &str) -> Vec<String> {
-    text.split(|c: char| !c.is_ascii_alphanumeric() && c != '-')
-        .filter(|word| word.len() >= 4)
-        .filter(|word| {
-            !matches!(
-                *word,
-                "github"
-                    | "pull"
-                    | "request"
-                    | "status"
-                    | "review"
-                    | "opened"
-                    | "what"
-                    | "about"
-                    | "please"
-                    | "quality"
-                    | "quick"
+fn tabular_tool_result_rows(result: &str) -> Vec<TabularToolRow> {
+    result
+        .lines()
+        .filter_map(|line| {
+            let mut columns = line.split('\t').map(str::trim);
+            let id = columns.next()?.trim_start_matches('#');
+            let title = columns.next()?;
+            (!id.is_empty() && id.chars().all(|ch| ch.is_ascii_digit()) && !title.is_empty()).then(
+                || TabularToolRow {
+                    id: id.to_string(),
+                    title: title.to_string(),
+                },
             )
         })
-        .map(str::to_string)
         .collect()
+}
+
+fn answer_has_row_id(answer: &str, id: &str) -> bool {
+    answer.contains(&format!("#{id}"))
+        || answer
+            .split(|ch: char| !ch.is_ascii_alphanumeric())
+            .any(|token| token == id)
+}
+
+fn answer_contains_text(answer: &str, text: &str) -> bool {
+    answer
+        .to_ascii_lowercase()
+        .contains(&text.to_ascii_lowercase())
+}
+
+fn append_tool_rows(answer: &str, rows: &[String]) -> String {
+    let mut repaired = answer.trim().to_string();
+    if !repaired.is_empty() {
+        repaired.push_str("\n\n");
+    }
+    repaired.push_str("Tool rows: ");
+    repaired.push_str(&rows.join(", "));
+    repaired
+}
+
+fn tool_result_answer_from_evidence_response(session: &Session) -> Value {
+    match answer_from_latest_tool_result(session) {
+        Some(answer) => chat_response(&answer),
+        None => error_response(
+            "MoA reducer requested another tool after tools were disabled",
+            MOA_ERR_NO_USABLE_ANSWER,
+        ),
+    }
+}
+
+fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
+    let (_, result) = latest_completed_tool_result(session)?;
+    if !tool_result_has_answerable_evidence(&result) {
+        return None;
+    }
+
+    let mut lines = result
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty());
+    let first = lines.next()?;
+    let mut answer = format!(
+        "From the tool result, one relevant entry is: {}",
+        truncate_for_tool_result_answer(first)
+    );
+    let rest = lines.take(2).collect::<Vec<_>>();
+    if !rest.is_empty() {
+        answer.push_str("\n\nOther returned entries include:\n");
+        for line in rest {
+            answer.push_str("- ");
+            answer.push_str(&truncate_for_tool_result_answer(line));
+            answer.push('\n');
+        }
+        answer = answer.trim_end().to_string();
+    }
+
+    Some(truncate_for_tool_result_answer(&answer))
+}
+
+fn truncate_for_tool_result_answer(text: &str) -> String {
+    const LIMIT: usize = 900;
+    if text.chars().count() <= LIMIT {
+        return text.to_string();
+    }
+
+    let mut truncated = text.chars().take(LIMIT).collect::<String>();
+    truncated.push_str("...");
+    truncated
 }
 
 fn tool_evidence_should_be_preserved(user_text: &str) -> bool {
@@ -1212,13 +2007,9 @@ fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
     (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (tool_name.clone(), count))
 }
 
-fn web_research_tool_budget_exhausted(session: &Session) -> Option<usize> {
-    let count = completed_tool_names_since_latest_user_before_tool_result(session)
-        .iter()
-        .filter(|name| is_web_research_tool(name))
-        .count();
-
-    (count >= WEB_RESEARCH_FORCE_ANSWER_THRESHOLD).then_some(count)
+fn tool_budget_exhausted(session: &Session) -> Option<usize> {
+    let count = completed_tool_names_since_latest_user_before_tool_result(session).len();
+    (count >= TOOL_BUDGET_FORCE_ANSWER_THRESHOLD).then_some(count)
 }
 
 fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) -> Vec<String> {
@@ -1265,10 +2056,59 @@ fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) 
     completed
 }
 
-fn is_web_research_tool(name: &str) -> bool {
-    WEB_RESEARCH_TOOLS
-        .iter()
-        .any(|candidate| name.eq_ignore_ascii_case(candidate))
+fn latest_completed_tool_result(session: &Session) -> Option<(String, String)> {
+    session.recent_tool_results().into_iter().last()
+}
+
+fn tool_result_has_answerable_evidence(result: &str) -> bool {
+    let trimmed = result.trim();
+    if trimmed.is_empty() || matches!(trimmed, "{}" | "[]") {
+        return false;
+    }
+
+    if let Ok(parsed) = serde_json::from_str::<Value>(trimmed) {
+        return json_value_has_answerable_evidence(&parsed);
+    }
+
+    !plain_text_tool_result_looks_like_error(trimmed)
+}
+
+fn plain_text_tool_result_looks_like_error(result: &str) -> bool {
+    let normalized = result.replace('\r', "");
+    let lower = normalized.trim_start().to_ascii_lowercase();
+    let first_line = lower.lines().next().unwrap_or("").trim();
+    first_line.starts_with("unknown flag:")
+        || first_line.starts_with("unknown command")
+        || first_line.starts_with("error:")
+        || first_line.starts_with("fatal:")
+        || (lower.contains("\nusage:") && lower.lines().take(3).any(cli_error_line))
+}
+
+fn cli_error_line(line: &str) -> bool {
+    let line = line.trim();
+    line.starts_with("unknown ")
+        || line.starts_with("error:")
+        || line.starts_with("fatal:")
+        || line.contains("invalid")
+}
+
+fn json_value_has_answerable_evidence(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Bool(_) | Value::Number(_) => true,
+        Value::String(text) => !text.trim().is_empty(),
+        Value::Array(values) => values.iter().any(json_value_has_answerable_evidence),
+        Value::Object(map) => {
+            if map
+                .get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| status.eq_ignore_ascii_case("error"))
+            {
+                return false;
+            }
+            map.values().any(json_value_has_answerable_evidence)
+        }
+    }
 }
 
 fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count: usize) {
@@ -1281,13 +2121,22 @@ fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count
     append_system_instruction(messages, &instruction);
 }
 
-fn append_web_research_budget_instruction(messages: &mut [Value], count: usize) {
+fn append_tool_budget_instruction(messages: &mut [Value], count: usize) {
     let instruction = format!(
-        "\n\nWeb research budget guard: {count} completed web_search/web_fetch calls are already \
-         in context. Do not call web_search or web_fetch again. Answer now from the gathered \
-         evidence. For GitHub/web results, only use exact numbers, titles, authors, statuses, \
-         and URLs present in the evidence. If the evidence is incomplete, ambiguous, or conflicts \
-         with the user's premise, say that directly instead of inventing missing facts."
+        "\n\nTool budget guard: {count} completed tool calls are already in context. \
+         Do not call another tool unless the declared tool schema and current evidence make \
+         the next call clearly necessary. Prefer answering now from gathered tool results; \
+         if evidence is incomplete, ambiguous, or conflicts with the user's premise, say that \
+         directly instead of inventing missing facts."
+    );
+    append_system_instruction(messages, &instruction);
+}
+
+fn append_tool_error_retry_instruction(messages: &mut [Value], tool: &str) {
+    let instruction = format!(
+        "\n\nTool retry guard: the latest `{tool}` result appears to be command error or usage text, \
+         not answer evidence. If the user's request still needs data, call a corrected tool once. \
+         Do not answer from usage or error text."
     );
     append_system_instruction(messages, &instruction);
 }
@@ -1322,22 +2171,35 @@ async fn resolve_decision(
         selected_tool_names,
         forced_tool,
         allowed_tools,
+        prompt_tool_profiles,
     } = request;
+    let tools_available = !allowed_tools.is_empty();
+    let response_tool_names = response_tool_names(selected_tool_names, allowed_tools);
 
     match decision {
         arbiter::Decision::Answer(text) => {
-            if let Some(tool) = forced_tool.filter(|_| has_tools) {
+            if let Some(tool) = forced_tool.filter(|_| tools_available) {
                 (
                     tool_call_response(&tool.name, &tool.fallback_arguments),
                     false,
                     0,
                 )
             } else {
-                (chat_response(&text), false, 0)
+                (
+                    chat_or_schema_command_tool_response(
+                        &text,
+                        session.tools(),
+                        response_tool_names,
+                        prompt_tool_profiles,
+                        Some(&session.last_user_text()),
+                    ),
+                    false,
+                    0,
+                )
             }
         }
         arbiter::Decision::ToolCall { name, arguments } => {
-            if has_tools {
+            if tools_available {
                 (tool_call_response(&name, &arguments), false, 0)
             } else {
                 (
@@ -1383,7 +2245,7 @@ async fn resolve_decision(
                         normalize::normalize_worker_output(&text, &winner, WorkerRole::Reducer, 0);
                     enforce_tool_call_contract(
                         &mut reduced,
-                        allowed_tools,
+                        response_tool_names,
                         session.tools(),
                         &winner,
                     );
@@ -1406,28 +2268,59 @@ async fn resolve_decision(
                         // previous "both name AND args required" gate would
                         // silently fall back to a chat_response and break
                         // the calling agent's tool loop.
-                        (tool_proposal_response(&reduced, has_tools), true, attempts)
+                        (
+                            tool_proposal_response(
+                                &reduced,
+                                tools_available,
+                                session.tools(),
+                                response_tool_names,
+                                prompt_tool_profiles,
+                                Some(&session.last_user_text()),
+                            ),
+                            true,
+                            attempts,
+                        )
                     }
                     normalize::OutputKind::Uncertainty => {
-                        if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                        if let Some(tool) = forced_tool.filter(|_| tools_available) {
                             (
                                 tool_call_response(&tool.name, &tool.fallback_arguments),
                                 true,
                                 attempts,
                             )
                         } else {
-                            (fallback_worker_response(outputs), true, attempts)
+                            (
+                                fallback_worker_response(
+                                    outputs,
+                                    session,
+                                    session.tools(),
+                                    response_tool_names,
+                                    prompt_tool_profiles,
+                                ),
+                                true,
+                                attempts,
+                            )
                         }
                     }
                     _ => {
-                        if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                        if let Some(tool) = forced_tool.filter(|_| tools_available) {
                             (
                                 tool_call_response(&tool.name, &tool.fallback_arguments),
                                 true,
                                 attempts,
                             )
                         } else {
-                            (chat_response(&reduced.payload), true, attempts)
+                            (
+                                chat_or_schema_command_tool_response(
+                                    &reduced.payload,
+                                    session.tools(),
+                                    response_tool_names,
+                                    prompt_tool_profiles,
+                                    Some(&session.last_user_text()),
+                                ),
+                                true,
+                                attempts,
+                            )
                         }
                     }
                 },
@@ -1437,14 +2330,24 @@ async fn resolve_decision(
                     // produce the output we're returning — we fell back to
                     // a worker. attempts still reflects what was spawned so
                     // observability can see "we tried N times and all failed".
-                    if let Some(tool) = forced_tool.filter(|_| has_tools) {
+                    if let Some(tool) = forced_tool.filter(|_| tools_available) {
                         (
                             tool_call_response(&tool.name, &tool.fallback_arguments),
                             false,
                             attempts,
                         )
                     } else {
-                        (fallback_worker_response(outputs), false, attempts)
+                        (
+                            fallback_worker_response(
+                                outputs,
+                                session,
+                                session.tools(),
+                                response_tool_names,
+                                prompt_tool_profiles,
+                            ),
+                            false,
+                            attempts,
+                        )
                     }
                 }
             }
@@ -1471,7 +2374,13 @@ fn best_answer(outputs: &[WorkerOutput]) -> String {
         .unwrap_or_default()
 }
 
-fn fallback_worker_response(outputs: &[WorkerOutput]) -> Value {
+fn fallback_worker_response(
+    outputs: &[WorkerOutput],
+    session: &Session,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Value {
     let answer = best_answer(outputs);
     if answer.is_empty() {
         error_response(
@@ -1479,14 +2388,47 @@ fn fallback_worker_response(outputs: &[WorkerOutput]) -> Value {
             MOA_ERR_NO_USABLE_ANSWER,
         )
     } else {
-        chat_response(&answer)
+        chat_or_schema_command_tool_response(
+            &answer,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+            Some(&session.last_user_text()),
+        )
     }
 }
 
-fn tool_proposal_response(output: &WorkerOutput, has_tools: bool) -> Value {
+fn response_tool_names<'a>(
+    selected_tool_names: &'a [String],
+    allowed_tools: &'a [String],
+) -> &'a [String] {
+    if selected_tool_names.is_empty() {
+        allowed_tools
+    } else {
+        selected_tool_names
+    }
+}
+
+fn tool_proposal_response(
+    output: &WorkerOutput,
+    has_tools: bool,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
+) -> Value {
     if let (true, Some(name)) = (has_tools, output.tool_name.as_ref()) {
         let args = output.tool_arguments.as_ref().unwrap_or(&Value::Null);
-        return tool_call_response(name, args);
+        match validate_response_tool_arguments(
+            name,
+            args,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+        ) {
+            Ok(arguments) => return tool_call_response(name, &arguments),
+            Err(err) => tracing::info!("moa: tool proposal {name} rejected: {err}"),
+        }
     }
 
     if output.payload.trim().is_empty() || normalize::is_silent_reply_sentinel(&output.payload) {
@@ -1496,7 +2438,396 @@ fn tool_proposal_response(output: &WorkerOutput, has_tools: bool) -> Value {
         );
     }
 
+    if has_tools {
+        return chat_or_schema_command_tool_response(
+            &output.payload,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+            user_text,
+        );
+    }
+
     chat_response(&output.payload)
+}
+
+fn chat_or_schema_command_tool_response(
+    content: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
+) -> Value {
+    let command_tool = if fenced_command_tool_conversion_allowed(user_text) {
+        extract_shell_command_block(content).and_then(|command| {
+            command_tool_choice_from_command(&command, tools, allowed_tools, prompt_tool_profiles)
+        })
+    } else {
+        None
+    };
+    if let Some(tool) = command_tool {
+        return tool_call_response(&tool.name, &tool.fallback_arguments);
+    }
+    if let Some(tool) =
+        inline_json_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
+    {
+        return tool_call_response(&tool.name, &tool.fallback_arguments);
+    }
+    if let Some(tool) =
+        xml_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
+    {
+        return tool_call_response(&tool.name, &tool.fallback_arguments);
+    }
+    if let Some(tool) =
+        explicitly_named_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
+    {
+        return tool_call_response(&tool.name, &tool.fallback_arguments);
+    }
+
+    chat_response(content)
+}
+
+fn fenced_command_tool_conversion_allowed(user_text: Option<&str>) -> bool {
+    let Some(user_text) = user_text else {
+        return false;
+    };
+    let text = latest_user_request_tail(user_text).to_ascii_lowercase();
+    if contains_any(
+        &text,
+        &[
+            "don't run",
+            "do not run",
+            "dont run",
+            "don't execute",
+            "do not execute",
+            "dont execute",
+            "don't use",
+            "do not use",
+            "dont use",
+        ],
+    ) {
+        return false;
+    }
+
+    let tokens = lexical_tokens(&text);
+    command_execution_pattern_matches(&tokens)
+        || contains_any(
+            &text,
+            &[
+                "run the command",
+                "run this command",
+                "run that command",
+                "execute the command",
+                "execute this command",
+                "execute that command",
+                "use the command",
+                "use this command",
+                "use that command",
+            ],
+        )
+}
+
+fn inline_json_tool_choice_from_text(
+    content: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<ForcedToolChoice> {
+    for json_text in embedded_json_object_candidates(content) {
+        let Ok(value) = serde_json::from_str::<Value>(&json_text) else {
+            continue;
+        };
+        let Some((name, raw_arguments)) = extract_tool_name_and_arguments(&value) else {
+            continue;
+        };
+        if !declared_response_tool_names(tools, allowed_tools, prompt_tool_profiles)
+            .iter()
+            .any(|tool| tool == name)
+        {
+            continue;
+        }
+        let arguments = normalize_tool_arguments(raw_arguments)
+            .map(Value::Object)
+            .unwrap_or_else(|| json!({}));
+        match validate_response_tool_arguments(
+            name,
+            &arguments,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+        ) {
+            Ok(arguments) => {
+                return Some(ForcedToolChoice {
+                    name: name.to_string(),
+                    fallback_arguments: arguments,
+                });
+            }
+            Err(err) => {
+                tracing::info!("moa: inline JSON tool {name} could not be sanitized: {err}");
+            }
+        }
+    }
+    None
+}
+
+fn xml_tool_choice_from_text(
+    content: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<ForcedToolChoice> {
+    let invoke_start = content.find("<invoke ")?;
+    let invoke_tag_end = content[invoke_start..].find('>')? + invoke_start;
+    let invoke_tag = &content[invoke_start..=invoke_tag_end];
+    let name = xml_attr_value(invoke_tag, "name")?;
+    if !declared_response_tool_names(tools, allowed_tools, prompt_tool_profiles)
+        .iter()
+        .any(|tool| tool == &name)
+    {
+        return None;
+    }
+
+    let body_start = invoke_tag_end + 1;
+    let body_end = content[body_start..]
+        .find("</invoke>")
+        .map(|idx| body_start + idx)
+        .unwrap_or(content.len());
+    let arguments = xml_parameter_arguments(&content[body_start..body_end]);
+    match validate_response_tool_arguments(
+        &name,
+        &arguments,
+        tools,
+        allowed_tools,
+        prompt_tool_profiles,
+    ) {
+        Ok(arguments) => Some(ForcedToolChoice {
+            name,
+            fallback_arguments: arguments,
+        }),
+        Err(err) => {
+            tracing::info!("moa: XML tool choice could not be sanitized: {err}");
+            None
+        }
+    }
+}
+
+fn xml_attr_value(tag: &str, attr: &str) -> Option<String> {
+    let needle = format!("{attr}=\"");
+    let value_start = tag.find(&needle)? + needle.len();
+    let value_end = tag[value_start..].find('"')? + value_start;
+    Some(xml_text_unescape(&tag[value_start..value_end]))
+}
+
+fn xml_parameter_arguments(body: &str) -> Value {
+    let mut map = serde_json::Map::new();
+    let mut cursor = 0;
+    while let Some(parameter_rel) = body[cursor..].find("<parameter ") {
+        let parameter_start = cursor + parameter_rel;
+        let Some(tag_end_rel) = body[parameter_start..].find('>') else {
+            break;
+        };
+        let tag_end = parameter_start + tag_end_rel;
+        let tag = &body[parameter_start..=tag_end];
+        let Some(name) = xml_attr_value(tag, "name") else {
+            cursor = tag_end + 1;
+            continue;
+        };
+
+        let value_start = tag_end + 1;
+        let value_end = xml_parameter_value_end(body, value_start, &name);
+        let value = xml_text_unescape(body[value_start..value_end].trim());
+        map.insert(name, Value::String(value));
+        cursor = value_end;
+    }
+
+    Value::Object(map)
+}
+
+fn xml_parameter_value_end(body: &str, value_start: usize, name: &str) -> usize {
+    let named_close = format!("</{name}>");
+    ["</parameter>", named_close.as_str(), "<parameter "]
+        .iter()
+        .filter_map(|needle| {
+            body[value_start..]
+                .find(needle)
+                .map(|idx| value_start + idx)
+        })
+        .min()
+        .unwrap_or(body.len())
+}
+
+fn xml_text_unescape(text: &str) -> String {
+    text.replace("&quot;", "\"")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+}
+
+fn embedded_json_object_candidates(text: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    let mut stack = 0usize;
+    let mut start = None;
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '{' => {
+                if stack == 0 {
+                    start = Some(idx);
+                }
+                stack += 1;
+            }
+            '}' if stack > 0 => {
+                stack -= 1;
+                if stack == 0 {
+                    let Some(start_idx) = start.take() else {
+                        continue;
+                    };
+                    candidates.push(text[start_idx..idx + ch.len_utf8()].to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+    candidates
+}
+
+fn explicitly_named_tool_choice_from_text(
+    content: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<ForcedToolChoice> {
+    let lower = content.to_ascii_lowercase();
+    if contains_any(
+        &lower,
+        &[
+            "cannot use",
+            "can't use",
+            "will not use",
+            "would not use",
+            "do not use",
+            "don't use",
+        ],
+    ) {
+        return None;
+    }
+
+    let available = declared_response_tool_names(tools, allowed_tools, prompt_tool_profiles);
+    let selected = explicitly_requested_tool_names(&available, &lower);
+    let [name] = selected.as_slice() else {
+        return None;
+    };
+
+    let inferred = infer_tool_arguments_from_prompt(name, tools, content);
+    match validate_response_tool_arguments(
+        name,
+        &inferred,
+        tools,
+        allowed_tools,
+        prompt_tool_profiles,
+    ) {
+        Ok(arguments) => Some(ForcedToolChoice {
+            name: name.clone(),
+            fallback_arguments: arguments,
+        }),
+        Err(err) => {
+            tracing::info!("moa: explicit prose tool {name} could not be sanitized: {err}");
+            None
+        }
+    }
+}
+
+fn validate_response_tool_arguments(
+    name: &str,
+    arguments: &Value,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Result<Value, String> {
+    if tool_names_from_schemas(tools, allowed_tools)
+        .iter()
+        .any(|schema_name| schema_name == name)
+    {
+        return sanitize_tool_arguments_for_tool(name, arguments, tools)
+            .map_err(|err| err.to_string());
+    }
+
+    validate_prompt_tool_arguments(name, arguments, allowed_tools, prompt_tool_profiles)
+}
+
+fn validate_prompt_tool_arguments(
+    name: &str,
+    arguments: &Value,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Result<Value, String> {
+    let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
+    let declared = prompt_tool_profiles
+        .iter()
+        .any(|profile| profile.name == name && (allowed.is_empty() || allowed.contains(name)));
+    if !declared {
+        return Err(format!("tool {name} is not prompt-declared"));
+    }
+
+    let Some(arguments) = arguments.as_object() else {
+        return Err(format!(
+            "prompt-declared tool {name} requires object arguments"
+        ));
+    };
+    if arguments.is_empty() {
+        return Err(format!("prompt-declared tool {name} requires arguments"));
+    }
+
+    let candidates = prompt_command_tool_candidates(allowed_tools, prompt_tool_profiles);
+    if let Some(candidate) = candidates.iter().find(|candidate| candidate.name == name) {
+        let valid_command = arguments
+            .get(&candidate.field)
+            .and_then(Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty());
+        if !valid_command {
+            return Err(format!(
+                "prompt-declared command tool {name} requires non-empty {}",
+                candidate.field
+            ));
+        }
+    }
+
+    Ok(Value::Object(arguments.clone()))
+}
+
+fn declared_response_tool_names(
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
+    let schema_names = tool_names_from_schemas(tools, allowed_tools);
+    if !schema_names.is_empty() {
+        return schema_names;
+    }
+    let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
+    prompt_tool_profiles
+        .iter()
+        .filter(|profile| allowed.is_empty() || allowed.contains(profile.name.as_str()))
+        .map(|profile| profile.name.clone())
+        .collect()
+}
+
+fn tool_names_from_schemas(tools: Option<&Value>, allowed_tools: &[String]) -> Vec<String> {
+    let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
+    tools
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if allowed.is_empty() || allowed.contains(name) {
+                Some(name.to_string())
+            } else {
+                None
+            }
+        })
+        .collect()
 }
 
 /// Build a response body that signals MoA-level failure to the client.
@@ -1673,7 +3004,8 @@ mod response_builder_tests {
     #[test]
     fn fallback_worker_response_errors_when_only_silent_sentinel_remains() {
         let outputs = vec![answer("a", 0.99, "NO_REPLY")];
-        let resp = fallback_worker_response(&outputs);
+        let session = Session::new();
+        let resp = fallback_worker_response(&outputs, &session, None, &[], &[]);
         assert_eq!(
             resp.pointer("/error/code").and_then(Value::as_str),
             Some(MOA_ERR_NO_USABLE_ANSWER)
@@ -1698,9 +3030,33 @@ mod response_builder_tests {
         }
     }
 
+    fn read_file_tool_schema() -> Value {
+        serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]
+                }
+            }
+        }])
+    }
+
     #[test]
     fn tool_proposal_response_emits_tool_call_when_tools_enabled() {
-        let resp = tool_proposal_response(&tool_proposal("Need to read."), true);
+        let tools = read_file_tool_schema();
+        let allowed_tools = ["read_file".to_string()];
+        let resp = tool_proposal_response(
+            &tool_proposal("Need to read."),
+            true,
+            Some(&tools),
+            &allowed_tools,
+            &[],
+            None,
+        );
         assert_eq!(
             resp.pointer("/choices/0/message/tool_calls/0/function/name")
                 .and_then(Value::as_str),
@@ -1709,8 +3065,125 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn tool_proposal_response_rejects_undeclared_tool() {
+        let resp =
+            tool_proposal_response(&tool_proposal("Need to read."), true, None, &[], &[], None);
+
+        assert!(
+            resp.pointer("/choices/0/message/tool_calls").is_none(),
+            "undeclared worker tool proposals must not become tool calls: {resp}"
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("Need to read.")
+        );
+    }
+
+    #[test]
+    fn tool_proposal_response_rejects_prompt_tool_without_args() {
+        let (session, profiles, allowed) =
+            prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
+        let output = WorkerOutput {
+            kind: normalize::OutputKind::ToolProposal,
+            confidence: 0.8,
+            tool_name: Some("exec".to_string()),
+            tool_arguments: Some(json!({})),
+            payload: "I will use the exec tool.".to_string(),
+            model: "worker".to_string(),
+            role: WorkerRole::Fast,
+            elapsed_ms: 1,
+        };
+
+        let resp = tool_proposal_response(
+            &output,
+            true,
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert!(
+            resp.pointer("/choices/0/message/tool_calls").is_none(),
+            "prompt-declared command tools require a command argument: {resp}"
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("I will use the exec tool.")
+        );
+    }
+
+    #[test]
+    fn rejected_tool_proposal_repairs_fenced_command_with_user_intent() {
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]);
+        let allowed_tools = ["exec".to_string()];
+        let output = WorkerOutput {
+            kind: normalize::OutputKind::ToolProposal,
+            confidence: 0.8,
+            tool_name: Some("exec".to_string()),
+            tool_arguments: Some(json!({})),
+            payload: "I'll check it.\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\n```".to_string(),
+            model: "reducer".to_string(),
+            role: WorkerRole::Reducer,
+            elapsed_ms: 1,
+        };
+
+        let resp = tool_proposal_response(
+            &output,
+            true,
+            Some(&tools),
+            &allowed_tools,
+            &[],
+            Some(
+                "Use gh to list recent open PRs for mesh-LLM/mesh-llm, then tell me one interesting one.",
+            ),
+        );
+
+        assert_eq!(
+            resp.pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\"}")
+        );
+    }
+
+    #[test]
     fn tool_proposal_response_does_not_emit_tool_call_when_tools_disabled() {
-        let resp = tool_proposal_response(&tool_proposal("I need to read README.md."), false);
+        let resp = tool_proposal_response(
+            &tool_proposal("I need to read README.md."),
+            false,
+            None,
+            &[],
+            &[],
+            None,
+        );
         assert!(
             resp.pointer("/choices/0/message/tool_calls").is_none(),
             "disabled tools must not leak tool_calls: {resp}"
@@ -1812,6 +3285,47 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn incoming_chat_messages_synthesizes_completion_prompt_and_system_prompt() {
+        let messages = incoming_chat_messages(&serde_json::json!({
+            "model": "mesh",
+            "systemPrompt": "## Tooling\n- exec: Run shell commands",
+            "prompt": "Use gh to list recent PRs."
+        }));
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[0].get("role").and_then(Value::as_str),
+            Some("system")
+        );
+        assert_eq!(
+            messages[0].get("content").and_then(Value::as_str),
+            Some("## Tooling\n- exec: Run shell commands")
+        );
+        assert_eq!(
+            messages[1].get("content").and_then(Value::as_str),
+            Some("Use gh to list recent PRs.")
+        );
+    }
+
+    #[test]
+    fn incoming_chat_messages_adds_top_level_system_to_existing_messages() {
+        let messages = incoming_chat_messages(&serde_json::json!({
+            "systemPrompt": "system",
+            "messages": [{"role": "user", "content": "hello"}],
+        }));
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[0].get("role").and_then(Value::as_str),
+            Some("system")
+        );
+        assert_eq!(
+            messages[1].get("role").and_then(Value::as_str),
+            Some("user")
+        );
+    }
+
+    #[test]
     fn forced_tool_choice_infers_enum_argument_from_prompt() {
         let body = serde_json::json!({
             "tool_choice": {
@@ -1848,7 +3362,9 @@ mod response_builder_tests {
             .unwrap();
         session.ingest(&messages, &tools);
 
-        let forced = forced_tool_choice(&body, &session, &tools).expect("forced tool");
+        let allowed_tools = session.tool_names();
+        let forced =
+            forced_tool_choice(&body, &session, &tools, &allowed_tools).expect("forced tool");
 
         assert_eq!(forced.name, "lookup_probe_fact");
         assert_eq!(forced.fallback_arguments, json!({"key": "primary"}));
@@ -1992,6 +3508,107 @@ mod response_builder_tests {
     }
 
     #[tokio::test]
+    async fn approval_of_prior_shell_proposal_short_circuits_to_exec() {
+        let body = serde_json::json!({
+            "model": VIRTUAL_MODEL_NAME,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Any new interesting PRs? You have the gh command line I think can use"
+                },
+                {
+                    "role": "assistant",
+                    "content": "I can use the `gh` CLI. Let me fetch the list.\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open --sort=updated --direction desc --limit 20\n```"
+                },
+                {
+                    "role": "user",
+                    "content": "Conversation context (untrusted): prior messages\n\nOk you want to do that?"
+                }
+            ],
+            "tools": [{
+                "name": "exec",
+                "description": "Execute shell commands.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"]
+                }
+            }]
+        });
+        let config = GatewayConfig {
+            backends: Vec::new(),
+            models: Vec::new(),
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::from_millis(10),
+            enable_thinking: Some(false),
+        };
+
+        let result = handle_turn(&config, &body).await;
+
+        assert_eq!(result.turn_kind, TurnKind::DirectTool);
+        assert!(result.worker_summaries.is_empty());
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some(
+                "{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --sort=updated --direction desc --limit 20\"}"
+            )
+        );
+    }
+
+    #[test]
+    fn look_is_not_prior_shell_proposal_confirmation() {
+        let tools = Some(serde_json::json!([{
+            "name": "exec",
+            "description": "Execute shell commands.",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"]
+            }
+        }]));
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Any new interesting PRs?"
+                }),
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": "I can check with:\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open\n```"
+                }),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "look at that first"
+                }),
+            ],
+            &tools,
+        );
+        let allowed_tools = ["exec".to_string()];
+
+        assert!(prior_shell_command_tool_choice(&session, &tools, &allowed_tools, &[]).is_none());
+    }
+
+    #[tokio::test]
     async fn forced_tool_choice_overrides_answer_decision() {
         let mut session = Session::new();
         session.ingest(
@@ -2029,6 +3646,7 @@ mod response_builder_tests {
                 selected_tool_names: &selected_tool_names,
                 forced_tool: Some(&forced_tool),
                 allowed_tools: &allowed_tools,
+                prompt_tool_profiles: &[],
             },
         )
         .await;
@@ -2069,7 +3687,7 @@ mod response_builder_tests {
             &[serde_json::json!({"role": "user", "content": "How are you?"})],
             &Some(serde_json::json!([{"type": "function", "function": {"name": "read"}}])),
         );
-        assert_eq!(grace_mode_for_turn(&session, true), GraceMode::Answer);
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Answer);
     }
 
     #[test]
@@ -2082,7 +3700,7 @@ mod response_builder_tests {
             })],
             &Some(serde_json::json!([{"type": "function", "function": {"name": "read"}}])),
         );
-        assert_eq!(grace_mode_for_turn(&session, true), GraceMode::Tool);
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
     }
 
     #[test]
@@ -2091,11 +3709,11 @@ mod response_builder_tests {
         session.ingest(
             &[serde_json::json!({
                 "role": "user",
-                "content": "Plain check with no web lookup: reply OK",
+                "content": "Plain check with no tool use: reply OK",
             })],
             &Some(serde_json::json!([{"type": "function", "function": {"name": "web_search"}}])),
         );
-        assert_eq!(grace_mode_for_turn(&session, true), GraceMode::Answer);
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Answer);
     }
 
     #[test]
@@ -2105,7 +3723,7 @@ mod response_builder_tests {
             &[serde_json::json!({"role": "user", "content": "Reply OK"})],
             &None,
         );
-        assert_eq!(grace_mode_for_turn(&session, false), GraceMode::Answer);
+        assert_eq!(grace_mode_for_turn(&session, false, &[]), GraceMode::Answer);
     }
 
     #[test]
@@ -2114,19 +3732,27 @@ mod response_builder_tests {
         session.ingest(
             &[serde_json::json!({"role": "user", "content": "Read /tmp/file.txt"})],
             &Some(serde_json::json!([
-                {"type": "function", "function": {"name": "read"}},
-                {"type": "function", "function": {"name": "web_search"}},
-                {"type": "function", "function": {"name": "exec"}}
+                {"type": "function", "function": {
+                    "name": "read",
+                    "description": "Read file contents from a path",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string", "description": "File path to read"}},
+                        "required": ["path"]
+                    }
+                }},
+                {"type": "function", "function": {"name": "web_search", "description": "Search online sources"}},
+                {"type": "function", "function": {"name": "exec", "description": "Run shell commands"}}
             ])),
         );
         assert_eq!(
-            selected_tool_names_for_turn(&session, &[]),
+            selected_tool_names_for_turn(&session, &[], &[]),
             vec!["read".to_string()]
         );
     }
 
     #[test]
-    fn weather_prompt_selects_web_search_tool() {
+    fn schema_description_selects_weather_tool() {
         let mut session = Session::new();
         session.ingest(
             &[serde_json::json!({
@@ -2134,14 +3760,400 @@ mod response_builder_tests {
                 "content": "Check the current Melbourne weather forecast for today",
             })],
             &Some(serde_json::json!([
-                {"type": "function", "function": {"name": "read"}},
-                {"type": "function", "function": {"name": "web_search"}},
-                {"type": "function", "function": {"name": "exec"}}
+                {"type": "function", "function": {"name": "read", "description": "Read local files"}},
+                {"type": "function", "function": {"name": "lookup", "description": "Search current weather forecast information"}},
+                {"type": "function", "function": {"name": "runner", "description": "Run shell commands"}}
             ])),
         );
         assert_eq!(
-            selected_tool_names_for_turn(&session, &[]),
-            vec!["web_search".to_string()]
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["lookup".to_string()]
+        );
+    }
+
+    #[test]
+    fn executable_request_selects_command_schema_not_directory_tool() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {
+                    "name": "dir_list",
+                    "description": "List directory entries for a local filesystem path",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string", "description": "Directory path"}},
+                        "required": ["path"]
+                    }
+                }},
+                {"type": "function", "function": {
+                    "name": "exec",
+                    "description": "Run shell commands",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                        "required": ["command"]
+                    }
+                }}
+            ])),
+        );
+
+        assert_eq!(
+            session.tool_names(),
+            vec!["dir_list".to_string(), "exec".to_string()]
+        );
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["exec".to_string()]
+        );
+    }
+
+    #[test]
+    fn command_intent_stays_unselected_when_command_schemas_are_ambiguous() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {
+                    "name": "exec",
+                    "description": "Run shell commands",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                        "required": ["command"]
+                    }
+                }},
+                {"type": "function", "function": {
+                    "name": "remote_exec",
+                    "description": "Run terminal commands on a remote host",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string", "description": "Terminal command to run"}},
+                        "required": ["command"]
+                    }
+                }}
+            ])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn command_schema_can_use_single_optional_command_field() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(serde_json::json!([{
+                "type": "function",
+                "function": {
+                    "name": "exec",
+                    "description": "Run shell commands",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Shell command to execute"},
+                            "cwd": {"type": "string", "description": "Working directory"},
+                            "timeout_ms": {"type": "integer"}
+                        }
+                    }
+                }
+            }])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["exec".to_string()]
+        );
+    }
+
+    #[test]
+    fn command_schema_selects_clear_command_field_with_optional_metadata_fields() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(serde_json::json!([{
+                "type": "function",
+                "function": {
+                    "name": "exec",
+                    "description": "Run shell commands (pty available for TTY-required CLIs)",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Shell command to execute"},
+                            "workdir": {"type": "string", "description": "Working directory (defaults to cwd)"},
+                            "env": {"type": "object"},
+                            "yieldMs": {"type": "number", "description": "Milliseconds to wait before backgrounding"},
+                            "background": {"type": "boolean", "description": "Run in background immediately"},
+                            "timeout": {"type": "number", "description": "Timeout in seconds"},
+                            "pty": {"type": "boolean", "description": "Run in a pseudo-terminal"},
+                            "elevated": {"type": "boolean", "description": "Run on the host with elevated permissions"},
+                            "host": {"type": "string", "description": "Exec host/target (auto|sandbox|gateway|node)."},
+                            "security": {"type": "string", "description": "Ignored for normal calls; exec security is set by tools.exec.security and host approvals."},
+                            "ask": {"type": "string", "description": "Exec ask mode (off|on-miss|always)."},
+                            "node": {"type": "string", "description": "Node id/name for host=node."}
+                        }
+                    }
+                }
+            }])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["exec".to_string()]
+        );
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+    }
+
+    #[test]
+    fn optional_command_schema_intent_does_not_emit_empty_direct_tool_call() {
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "exec",
+                "description": "Run shell commands (pty available for TTY-required CLIs)",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string", "description": "Shell command to execute"},
+                        "host": {"type": "string", "description": "Exec host/target"},
+                        "ask": {"type": "string", "description": "Exec ask mode"}
+                    }
+                }
+            }
+        }]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(tools.clone()),
+        );
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["exec".to_string()]);
+        assert!(required_tool_choice_for_intent(&session, &Some(tools), &selected).is_none());
+    }
+
+    #[test]
+    fn command_intent_selects_exec_from_openclaw_like_tool_catalog() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(serde_json::json!([
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "exec",
+                        "description": "Run shell commands (pty available for TTY-required CLIs)",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "command": {"type": "string", "description": "Shell command to execute"},
+                                "host": {"type": "string", "description": "Exec host/target (auto|sandbox|gateway|node)."},
+                                "ask": {"type": "string", "description": "Exec ask mode (off|on-miss|always)."}
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "process",
+                        "description": "Manage background exec sessions",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "action": {"type": "string", "description": "Process action (list|poll|log|write|send-keys|submit|paste|kill|clear|remove)"},
+                                "sessionId": {"type": "string", "description": "Session id for actions other than list"},
+                                "text": {"type": "string", "description": "Text to paste for paste"}
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "gateway",
+                        "description": "Restart, apply config, or run updates on the running process",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "action": {"type": "string", "description": "Gateway action to run"},
+                                "path": {"type": "string", "description": "Config path"}
+                            }
+                        }
+                    }
+                }
+            ])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["exec".to_string()]
+        );
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+    }
+
+    #[test]
+    fn command_schema_ignores_ambiguous_optional_command_fields() {
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "runner",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string", "description": "Shell command to execute"},
+                        "fallback_command": {"type": "string", "description": "Alternative shell command"}
+                    }
+                }
+            }
+        }]);
+
+        assert_eq!(
+            command_schema_tool_candidates(Some(&tools), &["runner".to_string()]).len(),
+            0
+        );
+    }
+
+    #[test]
+    fn command_schema_ignores_tied_optional_command_fields() {
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "runner",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "primary_command": {"type": "string", "description": "Shell command to execute"},
+                        "fallback_command": {"type": "string", "description": "Shell command to execute if the primary command fails"}
+                    }
+                }
+            }
+        }]);
+
+        assert_eq!(
+            command_schema_tool_candidates(Some(&tools), &["runner".to_string()]).len(),
+            0
+        );
+    }
+
+    fn prompt_tool_catalog() -> String {
+        [
+            "You are an agent.",
+            "",
+            "## Tooling",
+            "- read: Read file contents",
+            "- exec: Run shell commands (pty available for TTY-required CLIs)",
+            "- process: Manage background exec sessions for commands already started",
+            "- dir_list: List directory entries for a local filesystem path",
+            "",
+            "## Tool Call Style",
+            "First-class tool exists: use it.",
+        ]
+        .join("\n")
+    }
+
+    fn prompt_tool_session(user_text: &str) -> (Session, Vec<PromptToolProfile>, Vec<String>) {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "system", "content": prompt_tool_catalog()}),
+                serde_json::json!({"role": "user", "content": user_text}),
+            ],
+            &None,
+        );
+        let profiles = prompt_declared_tool_profiles(&session);
+        let allowed = declared_tool_names(&session, &profiles);
+        (session, profiles, allowed)
+    }
+
+    #[test]
+    fn prompt_tool_catalog_extracts_declared_names() {
+        let (session, profiles, allowed) = prompt_tool_session("hello");
+
+        assert!(session.tool_names().is_empty());
+        assert_eq!(
+            profiles
+                .iter()
+                .map(|profile| profile.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["read", "exec", "process", "dir_list"]
+        );
+        assert_eq!(allowed, vec!["read", "exec", "process", "dir_list"]);
+    }
+
+    #[test]
+    fn prompt_tool_catalog_extracts_from_flattened_prompt_when_no_system_message() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": format!(
+                    "{}\n\n[Sun 2026-06-07 13:54 GMT+10] Use gh to list recent open PRs.",
+                    prompt_tool_catalog()
+                )
+            })],
+            &None,
+        );
+
+        let profiles = prompt_declared_tool_profiles(&session);
+
+        assert_eq!(
+            profiles
+                .iter()
+                .map(|profile| profile.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["read", "exec", "process", "dir_list"]
+        );
+    }
+
+    #[test]
+    fn prompt_catalog_command_intent_prefers_run_shell_over_process_management() {
+        let (session, profiles, allowed) =
+            prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &allowed, &profiles),
+            vec!["exec".to_string()]
+        );
+        assert_eq!(
+            grace_mode_for_turn(&session, !allowed.is_empty(), &profiles),
+            GraceMode::Tool
+        );
+    }
+
+    #[test]
+    fn prompt_only_command_intent_does_not_invent_empty_direct_tool_call() {
+        let (session, profiles, allowed) =
+            prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
+        let selected = selected_tool_names_for_turn(&session, &allowed, &profiles);
+
+        assert_eq!(selected, vec!["exec".to_string()]);
+        assert!(
+            required_tool_choice_for_intent(&session, &None, &selected).is_none(),
+            "prompt-only command intent must wait for an actual proposed command"
         );
     }
 
@@ -2174,7 +4186,7 @@ mod response_builder_tests {
         );
 
         assert_eq!(
-            selected_tool_names_for_turn(&session, &[]),
+            selected_tool_names_for_turn(&session, &[], &[]),
             vec!["exec".to_string()]
         );
     }
@@ -2195,7 +4207,7 @@ mod response_builder_tests {
         );
 
         assert_eq!(
-            selected_tool_names_for_turn(&session, &[]),
+            selected_tool_names_for_turn(&session, &[], &[]),
             vec!["exec".to_string()]
         );
     }
@@ -2216,7 +4228,7 @@ mod response_builder_tests {
         );
 
         assert_eq!(
-            selected_tool_names_for_turn(&session, &[]),
+            selected_tool_names_for_turn(&session, &[], &[]),
             vec!["exec".to_string(), "read".to_string()]
         );
     }
@@ -2324,61 +4336,349 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn repair_tool_result_answer_grounds_github_pr_rows() {
-        let github_json = serde_json::json!([
-            {
-                "number": 806,
-                "title": "Add meshllm.cloud website, catalog viewer, and onboarding docs",
-                "state": "open",
-                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/806",
-                "updated_at": "2026-06-06T07:18:23Z",
-                "body": "x".repeat(8_000),
-                "user": {"login": "ndizazzo"},
-                "requested_reviewers": [{"login": "michaelneale"}, {"login": "i386"}]
-            },
-            {
-                "number": 709,
-                "title": "Use combined hf-hub fork for model downloads",
-                "state": "open",
-                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/709",
-                "updated_at": "2026-05-27T11:26:00Z",
-                "user": {"login": "i386"}
-            }
-        ])
-        .to_string();
-        let wrapped = serde_json::json!({
-            "url": "https://api.github.com/repos/Mesh-LLM/mesh-llm/pulls?state=open",
-            "status": 200,
-            "text": format!(
-                "SECURITY NOTICE\n\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Fetch\n---\n{github_json}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>"
-            )
-        })
-        .to_string();
+    fn repair_tool_result_answer_adds_title_for_tabular_row_id() {
         let mut session = Session::new();
         session.ingest(
             &[
+                serde_json::json!({"role": "user", "content": "list rows"}),
+                tool_call_msg("call_1", "exec"),
+                tool_result_msg(
+                    "call_1",
+                    "808\tStabilize OpenClaw tool loops through MoA\tfix/openclaw-moa-telegram-timeouts\tOPEN\n806\tAdd meshllm.cloud website, catalog viewer, and onboarding docs\tfeature/new-public-website\tOPEN",
+                ),
                 serde_json::json!({
                     "role": "user",
-                    "content": "What is the status of the new website PR opened by Nick?"
+                    "content": "Answer with exactly one interesting PR number and title from the command output."
                 }),
-                tool_call_msg("call_1", "web_fetch"),
-                tool_result_msg("call_1", &wrapped),
+            ],
+            &None,
+        );
+
+        let repaired = repair_tool_result_answer(&session, "#808");
+
+        assert_eq!(repaired, "#808 - Stabilize OpenClaw tool loops through MoA");
+    }
+
+    #[test]
+    fn repair_tool_result_answer_adds_missing_row_id_for_tabular_title() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "list rows"}),
+                tool_call_msg("call_1", "exec"),
+                tool_result_msg(
+                    "call_1",
+                    "793\tLet clients mark stable prompt anchors for Skippy cache\tcodex/skippy-prompt-anchor-cache\tDRAFT",
+                ),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Tell me one interesting row from the command output."
+                }),
             ],
             &None,
         );
 
         let repaired = repair_tool_result_answer(
             &session,
-            "The website PR is #806 by i386 and was updated in May.",
+            "#805 - Let clients mark stable prompt anchors for Skippy cache",
         );
 
-        assert!(repaired.contains("#806"));
-        assert!(repaired.contains("website, catalog viewer"));
-        assert!(repaired.contains("author=\"ndizazzo\""));
-        assert!(repaired.contains("updated_at=\"2026-06-06T07:18:23Z\""));
-        assert!(repaired.contains("I do not see a `Nick` author/login"));
-        assert!(!repaired.contains("#709"));
-        assert!(!repaired.contains("updated in May"));
+        assert!(repaired.contains("#793 - Let clients mark stable prompt anchors"));
+    }
+
+    #[test]
+    fn cli_usage_error_is_not_answerable_tool_evidence() {
+        let result = "unknown flag: --since\r\n\r\nUsage:  gh pr list [flags]\r\n\r\nFlags:";
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
+    fn normal_tabular_cli_output_is_answerable_tool_evidence() {
+        let result = "808\tStabilize OpenClaw tool loops through MoA\tOPEN";
+
+        assert!(tool_result_has_answerable_evidence(result));
+    }
+
+    #[test]
+    fn fenced_command_answer_becomes_schema_declared_tool_call() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "runner",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]));
+        let allowed_tools = ["runner".to_string()];
+
+        let response = chat_or_schema_command_tool_response(
+            "I will check it.\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open\n```",
+            tools.as_ref(),
+            &allowed_tools,
+            &[],
+            Some("Use gh to list recent open PRs for mesh-LLM/mesh-llm."),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("runner")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open\"}")
+        );
+    }
+
+    #[test]
+    fn fenced_command_answer_uses_selected_tool_subset_when_catalog_is_ambiguous() {
+        let tools = Some(serde_json::json!([
+            {
+                "type": "function",
+                "function": {
+                    "name": "exec",
+                    "description": "Run shell commands",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Shell command to execute"}
+                        }
+                    }
+                }
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "remote_exec",
+                    "description": "Run terminal commands remotely",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Terminal command to run"}
+                        }
+                    }
+                }
+            }
+        ]));
+        let allowed_tools = ["exec".to_string(), "remote_exec".to_string()];
+        let selected_tools = ["exec".to_string()];
+        let content =
+            "I will check it.\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open\n```";
+
+        let ambiguous_response = chat_or_schema_command_tool_response(
+            content,
+            tools.as_ref(),
+            &allowed_tools,
+            &[],
+            Some("Use gh to list recent open PRs for mesh-LLM/mesh-llm."),
+        );
+        assert!(
+            ambiguous_response
+                .pointer("/choices/0/message/tool_calls")
+                .is_none(),
+            "full ambiguous catalog should not pick a command tool arbitrarily: {ambiguous_response}"
+        );
+
+        let selected_response = chat_or_schema_command_tool_response(
+            content,
+            tools.as_ref(),
+            response_tool_names(&selected_tools, &allowed_tools),
+            &[],
+            Some("Use gh to list recent open PRs for mesh-LLM/mesh-llm."),
+        );
+        assert_eq!(
+            selected_response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+    }
+
+    #[test]
+    fn fenced_command_answer_becomes_prompt_declared_tool_call_without_native_tools() {
+        let (session, profiles, allowed) =
+            prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
+
+        let response = chat_or_schema_command_tool_response(
+            "I will check it.\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\n```",
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\"}")
+        );
+    }
+
+    #[test]
+    fn fenced_command_answer_stays_chat_when_user_did_not_request_execution() {
+        let (session, profiles, allowed) = prompt_tool_session("look at that first");
+
+        let response = chat_or_schema_command_tool_response(
+            "The prior command was:\n\n```bash\ngh pr list --repo mesh-LLM/mesh-llm --state open\n```",
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert!(
+            response.pointer("/choices/0/message/tool_calls").is_none(),
+            "non-execution turns must not be corrected into a tool call: {response}"
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
+        );
+    }
+
+    #[test]
+    fn inline_json_tool_choice_uses_declared_schema() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "read_file",
+                "description": "Read a file",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]
+                }
+            }
+        }]));
+        let allowed_tools = ["read_file".to_string()];
+
+        let choice = inline_json_tool_choice_from_text(
+            r#"I'll read the README. {"function": "read_file", "arguments": {"path": "README.md"}}"#,
+            tools.as_ref(),
+            &allowed_tools,
+            &[],
+        )
+        .expect("inline tool choice");
+
+        assert_eq!(choice.name, "read_file");
+        assert_eq!(choice.fallback_arguments, json!({"path": "README.md"}));
+    }
+
+    #[test]
+    fn prompt_catalog_rejects_unknown_inline_tool() {
+        let (session, profiles, allowed) = prompt_tool_session("hello");
+
+        let response = chat_or_schema_command_tool_response(
+            r#"{"function": "delete_everything", "arguments": {"path": "/"}}"#,
+            session.tools(),
+            &allowed,
+            &profiles,
+            None,
+        );
+
+        assert!(
+            response.pointer("/choices/0/message/tool_calls").is_none(),
+            "unknown prompt-only tools must stay as chat text: {response}"
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some(r#"{"function": "delete_everything", "arguments": {"path": "/"}}"#)
+        );
+    }
+
+    #[test]
+    fn prompt_catalog_rejects_empty_explicit_tool_args() {
+        let (session, profiles, allowed) =
+            prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
+
+        let response = chat_or_schema_command_tool_response(
+            "I will use the `exec` tool to check.",
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert!(
+            response.pointer("/choices/0/message/tool_calls").is_none(),
+            "prompt-declared tools must not emit empty argument calls: {response}"
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("I will use the `exec` tool to check.")
+        );
+    }
+
+    #[test]
+    fn prompt_catalog_accepts_malformed_xml_parameter_close() {
+        let (session, profiles, allowed) =
+            prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
+
+        let response = chat_or_schema_command_tool_response(
+            "<minimax:tool_call>\n<invoke name=\"exec\">\n<parameter name=\"command\">gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10</command>\n</invoke>\n</minimax:tool_call>",
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\"}")
+        );
     }
 
     fn tool_call_msg(id: &str, name: &str) -> Value {
@@ -2401,6 +4701,19 @@ mod response_builder_tests {
         })
     }
 
+    fn session_with_tool_result(result: &str) -> Session {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "run command"}),
+                tool_call_msg("call_1", "exec"),
+                tool_result_msg("call_1", result),
+            ],
+            &None,
+        );
+        session
+    }
+
     #[test]
     fn ordinary_prompt_selects_no_tools() {
         let mut session = Session::new();
@@ -2412,7 +4725,7 @@ mod response_builder_tests {
             ])),
         );
         assert_eq!(
-            selected_tool_names_for_turn(&session, &[]),
+            selected_tool_names_for_turn(&session, &[], &[]),
             Vec::<String>::new()
         );
     }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -106,6 +106,8 @@ pub enum TurnKind {
     Fanout,
     /// Fan-out path with early-exit consensus before all workers returned.
     EarlyExit,
+    /// Explicit or safely inferred tool intent returned a native tool call directly.
+    DirectTool,
     /// Tool-result turn: skipped fan-out, went straight to reducer.
     ToolResult,
     /// All workers failed and no reducer recovery happened.
@@ -118,6 +120,7 @@ impl TurnKind {
         match self {
             Self::Fanout => "fanout",
             Self::EarlyExit => "early-exit",
+            Self::DirectTool => "direct-tool",
             Self::ToolResult => "tool-result",
             Self::Failed => "failed",
         }
@@ -242,6 +245,26 @@ async fn handle_query(
     } else {
         Vec::new()
     };
+    let intent_required_tool = if forced_tool.is_none() && query_uses_tools {
+        required_tool_choice_for_intent(session, &tools_value(session), &selected_tool_names)
+    } else {
+        None
+    };
+    let required_tool = forced_tool.or(intent_required_tool.as_ref());
+    if let Some(tool) = required_tool.filter(|_| has_tools) {
+        tracing::info!(
+            "moa: direct tool call for explicit {} intent",
+            tool.name.as_str()
+        );
+        return TurnResult {
+            response_body: tool_call_response(&tool.name, &tool.fallback_arguments),
+            worker_summaries: Vec::new(),
+            reducer_used: false,
+            reducer_attempts: 0,
+            turn_kind: TurnKind::DirectTool,
+            elapsed_ms: start.elapsed().as_millis() as u64,
+        };
+    }
 
     tracing::info!(
         "moa: dispatching to {} workers: [{}]",
@@ -325,7 +348,7 @@ async fn handle_query(
             outputs: &outputs,
             has_tools: query_uses_tools,
             selected_tool_names: &selected_tool_names,
-            forced_tool,
+            forced_tool: required_tool,
             allowed_tools,
         },
     )
@@ -492,6 +515,35 @@ fn tool_name_is_explicitly_requested(tool: &str, text: &str) -> bool {
     patterns.iter().any(|pattern| text.contains(pattern))
 }
 
+fn tools_value(session: &Session) -> Option<Value> {
+    session.tools().cloned()
+}
+
+fn required_tool_choice_for_intent(
+    session: &Session,
+    tools: &Option<Value>,
+    selected_tool_names: &[String],
+) -> Option<ForcedToolChoice> {
+    let [name] = selected_tool_names else {
+        return None;
+    };
+
+    let inferred =
+        infer_tool_arguments_from_prompt(name, tools.as_ref(), &session.last_user_text());
+    match sanitize_tool_arguments_for_tool(name, &inferred, tools.as_ref()) {
+        Ok(arguments) => Some(ForcedToolChoice {
+            name: name.clone(),
+            fallback_arguments: arguments,
+        }),
+        Err(err) => {
+            tracing::info!(
+                "moa: explicit tool intent selected {name}, but arguments could not be inferred: {err}"
+            );
+            None
+        }
+    }
+}
+
 fn recent_tool_chain_names(session: &Session) -> Vec<String> {
     let all = session.all_messages();
     let Some(latest_tool_idx) = all.iter().rposition(|msg| message_role(msg) == "tool") else {
@@ -645,7 +697,10 @@ fn infer_string_argument(field: &str, schema: &Value, prompt: &str) -> Option<St
         return None;
     }
 
-    infer_enum_argument(schema, prompt).or_else(|| infer_assignment_argument(field, prompt))
+    infer_enum_argument(schema, prompt)
+        .or_else(|| infer_assignment_argument(field, prompt))
+        .or_else(|| infer_path_like_argument(field, prompt))
+        .or_else(|| infer_query_argument(field, prompt))
 }
 
 fn schema_allows_string(schema: &Value) -> bool {
@@ -673,13 +728,60 @@ fn infer_assignment_argument(field: &str, prompt: &str) -> Option<String> {
     let field_lc = field.to_ascii_lowercase();
     let marker = format!("{field_lc}=");
     let start = prompt_lc.find(&marker)? + marker.len();
-    let tail = prompt_lc.get(start..)?;
+    let tail = prompt.get(start..)?;
     let value = tail
         .split(|c: char| c.is_whitespace() || c == ',' || c == '.' || c == ';')
         .next()
         .unwrap_or("")
         .trim_matches(|c| c == '"' || c == '\'' || c == '`');
     (!value.is_empty()).then(|| value.to_string())
+}
+
+fn infer_path_like_argument(field: &str, prompt: &str) -> Option<String> {
+    let field = field.to_ascii_lowercase();
+    let wants_path = contains_any(&field, &["path", "file", "url", "uri"]);
+    if !wants_path {
+        return None;
+    }
+
+    prompt
+        .split_whitespace()
+        .map(clean_path_token)
+        .find(|candidate| is_path_like_candidate(candidate, &field))
+}
+
+fn clean_path_token(token: &str) -> String {
+    token
+        .trim_matches(|c: char| {
+            matches!(
+                c,
+                '"' | '\'' | '`' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | ':'
+            )
+        })
+        .trim_end_matches(['.', ',', ';', ':', ')', ']', '}'])
+        .to_string()
+}
+
+fn is_path_like_candidate(candidate: &str, field: &str) -> bool {
+    if candidate.is_empty() {
+        return false;
+    }
+    if candidate.contains("://") {
+        return field.contains("url") || field.contains("uri") || field.contains("path");
+    }
+    candidate.starts_with('/')
+        || candidate.starts_with("~/")
+        || candidate.starts_with("./")
+        || candidate.starts_with("../")
+}
+
+fn infer_query_argument(field: &str, prompt: &str) -> Option<String> {
+    let field = field.to_ascii_lowercase();
+    if !matches!(field.as_str(), "q" | "query" | "search" | "search_query") {
+        return None;
+    }
+    let prompt = prompt.trim();
+    (!prompt.is_empty()).then(|| prompt.to_string())
 }
 
 fn tool_parameters<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a Value> {
@@ -731,8 +833,8 @@ async fn handle_tool_result(
     let hedge_result = hedged_reducer_call(
         &config.backends,
         candidates.clone(),
-        messages,
-        tools,
+        messages.clone(),
+        tools.clone(),
         config.reducer_timeout,
         config.hedge_delay,
         config.enable_thinking,
@@ -740,28 +842,71 @@ async fn handle_tool_result(
     .await;
 
     let mut last_err: Option<String> = None;
-    let (attempts, chosen): (u32, Option<(String, normalize::WorkerOutput)>) = match hedge_result {
-        Ok(reducer::HedgedReducerOk {
-            winner,
-            text,
-            attempts: spawned,
-        }) => {
-            let mut reduced =
-                normalize::normalize_worker_output(&text, &winner, WorkerRole::Reducer, 0);
-            enforce_tool_call_contract(&mut reduced, allowed_tools, session.tools(), &winner);
-            (spawned, Some((winner, reduced)))
-        }
-        Err(reducer::HedgedReducerErr {
-            err,
-            attempts: spawned,
-        }) => {
-            last_err = Some(err);
-            (spawned, None)
-        }
-    };
+    let (attempts, chosen): (u32, Option<(String, normalize::WorkerOutput, bool)>) =
+        match hedge_result {
+            Ok(reducer::HedgedReducerOk {
+                winner,
+                text,
+                attempts: spawned,
+            }) => {
+                let mut reduced =
+                    normalize::normalize_worker_output(&text, &winner, WorkerRole::Reducer, 0);
+                enforce_tool_call_contract(&mut reduced, allowed_tools, session.tools(), &winner);
+                (spawned, Some((winner, reduced, tools_enabled_for_reducer)))
+            }
+            Err(reducer::HedgedReducerErr {
+                err,
+                attempts: spawned,
+            }) => {
+                last_err = Some(err);
+                if tools.is_some() {
+                    let fallback_messages = context::pack_for_tool_result_answer_only(session);
+                    tracing::warn!(
+                        "moa: tool-result reducers failed with native tools; retrying answer-only reducer"
+                    );
+                    match hedged_reducer_call(
+                        &config.backends,
+                        candidates.clone(),
+                        fallback_messages,
+                        None,
+                        config.reducer_timeout,
+                        config.hedge_delay,
+                        config.enable_thinking,
+                    )
+                    .await
+                    {
+                        Ok(reducer::HedgedReducerOk {
+                            winner,
+                            text,
+                            attempts: retry_attempts,
+                        }) => {
+                            let reduced = normalize::normalize_worker_output(
+                                &text,
+                                &winner,
+                                WorkerRole::Reducer,
+                                0,
+                            );
+                            (
+                                spawned.saturating_add(retry_attempts),
+                                Some((winner, reduced, false)),
+                            )
+                        }
+                        Err(reducer::HedgedReducerErr {
+                            err,
+                            attempts: retry_attempts,
+                        }) => {
+                            last_err = Some(err);
+                            (spawned.saturating_add(retry_attempts), None)
+                        }
+                    }
+                } else {
+                    (spawned, None)
+                }
+            }
+        };
 
     let (reducer_name, succeeded, response_body) = match chosen {
-        Some((name, reduced)) => {
+        Some((name, reduced, response_tools_enabled)) => {
             // Be consistent with the fanout/arbiter path: emit a real
             // `tool_calls` response whenever the reducer named a tool,
             // even if `arguments` is missing. The fanout path emits `{}`
@@ -772,7 +917,7 @@ async fn handle_tool_result(
             // missing / non-object arguments to `"{}"`.
             let body = match reduced.kind {
                 normalize::OutputKind::ToolProposal => {
-                    tool_proposal_response(&reduced, tools_enabled_for_reducer)
+                    tool_proposal_response(&reduced, response_tools_enabled)
                 }
                 normalize::OutputKind::Uncertainty => error_response(
                     "MoA reducer returned no usable answer",
@@ -926,7 +1071,10 @@ fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count
          Answer now from the gathered tool results. Do not call another tool. \
          If the evidence is incomplete, say what can be determined and what is missing."
     );
+    append_system_instruction(messages, &instruction);
+}
 
+fn append_system_instruction(messages: &mut [Value], instruction: &str) {
     let system_content = messages
         .iter_mut()
         .find(|msg| msg.get("role").and_then(Value::as_str) == Some("system"))
@@ -936,7 +1084,7 @@ fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count
         });
     if let Some((system, content)) = system_content {
         let mut updated = content.to_string();
-        updated.push_str(&instruction);
+        updated.push_str(instruction);
         system["content"] = Value::String(updated);
     }
 }
@@ -1508,7 +1656,121 @@ mod response_builder_tests {
             "Use key=Primary",
         );
 
-        assert_eq!(args, json!({"key": "primary"}));
+        assert_eq!(args, json!({"key": "Primary"}));
+    }
+
+    #[test]
+    fn tool_argument_inference_extracts_absolute_path() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "read",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]
+                }
+            }
+        }]));
+
+        let args = infer_tool_arguments_from_prompt(
+            "read",
+            tools.as_ref(),
+            "Use the read tool to read /tmp/openclaw_moa_probe.txt.",
+        );
+
+        assert_eq!(args, json!({"path": "/tmp/openclaw_moa_probe.txt"}));
+    }
+
+    #[test]
+    fn explicit_single_tool_intent_becomes_required_tool_choice() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "read",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"]
+                }
+            }
+        }]));
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use the read tool to read /tmp/openclaw_moa_probe.txt."
+            })],
+            &tools,
+        );
+
+        let selected = vec!["read".to_string()];
+        let required =
+            required_tool_choice_for_intent(&session, &tools, &selected).expect("required tool");
+
+        assert_eq!(required.name, "read");
+        assert_eq!(
+            required.fallback_arguments,
+            json!({"path": "/tmp/openclaw_moa_probe.txt"})
+        );
+    }
+
+    #[tokio::test]
+    async fn inferred_required_tool_intent_short_circuits_workers() {
+        let body = serde_json::json!({
+            "model": VIRTUAL_MODEL_NAME,
+            "messages": [{
+                "role": "user",
+                "content": "Use the read tool to read /tmp/openclaw_moa_probe.txt."
+            }],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "read",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                        "required": ["path"]
+                    }
+                }
+            }]
+        });
+        let config = GatewayConfig {
+            backends: Vec::new(),
+            models: Vec::new(),
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::from_millis(10),
+            enable_thinking: Some(false),
+        };
+
+        let result = handle_turn(&config, &body).await;
+
+        assert_eq!(result.turn_kind, TurnKind::DirectTool);
+        assert!(result.worker_summaries.is_empty());
+        assert!(!result.reducer_used);
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("read")
+        );
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"path\":\"/tmp/openclaw_moa_probe.txt\"}")
+        );
     }
 
     #[tokio::test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -826,6 +826,27 @@ fn declared_tool_names(
     }
 }
 
+fn suppress_repeated_tool_from_selection(
+    mut selected_tool_names: Vec<String>,
+    declared_tool_names: &[String],
+    repeated_tool: Option<&str>,
+) -> Vec<String> {
+    let Some(tool) = repeated_tool else {
+        return selected_tool_names;
+    };
+
+    selected_tool_names.retain(|name| name != tool);
+    if selected_tool_names.is_empty() {
+        selected_tool_names.extend(
+            declared_tool_names
+                .iter()
+                .filter(|name| name.as_str() != tool)
+                .cloned(),
+        );
+    }
+    selected_tool_names
+}
+
 fn prompt_declared_tool_profiles(session: &Session) -> Vec<PromptToolProfile> {
     let Some(prompt) = prompt_tool_catalog_source(session) else {
         return Vec::new();
@@ -1819,11 +1840,12 @@ async fn handle_tool_result(
     let candidate_count = candidates.len();
     let repeated_tool = repeated_same_tool_results(session);
     let tool_budget_exhausted = tool_budget_exhausted(session);
-    let mut selected_tool_names =
-        selected_tool_names_for_turn(session, allowed_tools, prompt_tool_profiles);
-    if let Some((tool, _)) = repeated_tool.as_ref() {
-        selected_tool_names.retain(|name| name != tool);
-    }
+    let declared_tool_names = declared_tool_names(session, prompt_tool_profiles);
+    let mut selected_tool_names = suppress_repeated_tool_from_selection(
+        selected_tool_names_for_turn(session, allowed_tools, prompt_tool_profiles),
+        &declared_tool_names,
+        repeated_tool.as_ref().map(|(tool, _)| tool.as_str()),
+    );
     let latest_user_text = session.active_user_text();
     let prompt_requests_more_tool_steps =
         prompt_requests_additional_tool_step(&latest_user_text, session);
@@ -6458,6 +6480,36 @@ mod response_builder_tests {
             repeated_same_tool_results(&session),
             Some(("web_search".to_string(), 3))
         );
+    }
+
+    #[test]
+    fn repeated_tool_suppression_keeps_alternate_declared_tools_available() {
+        let selected = suppress_repeated_tool_from_selection(
+            vec!["web_search".to_string()],
+            &[
+                "web_search".to_string(),
+                "read_file".to_string(),
+                "exec".to_string(),
+            ],
+            Some("web_search"),
+        );
+
+        assert_eq!(selected, vec!["read_file".to_string(), "exec".to_string()]);
+    }
+
+    #[test]
+    fn repeated_tool_suppression_keeps_non_repeated_selection() {
+        let selected = suppress_repeated_tool_from_selection(
+            vec!["web_search".to_string(), "read_file".to_string()],
+            &[
+                "web_search".to_string(),
+                "read_file".to_string(),
+                "exec".to_string(),
+            ],
+            Some("web_search"),
+        );
+
+        assert_eq!(selected, vec!["read_file".to_string()]);
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -509,6 +509,9 @@ fn looks_like_tool_intent(session: &Session, prompt_tool_profiles: &[PromptToolP
     {
         return true;
     }
+    if looks_like_live_status_followup_tool_intent(session, &text) {
+        return true;
+    }
     extract_shell_command_block(&text)
         .and_then(|command| {
             command_tool_choice_from_command(
@@ -519,6 +522,33 @@ fn looks_like_tool_intent(session: &Session, prompt_tool_profiles: &[PromptToolP
             )
         })
         .is_some()
+}
+
+fn looks_like_live_status_followup_tool_intent(session: &Session, text: &str) -> bool {
+    if recent_tool_chain_names(session).is_empty() {
+        return false;
+    }
+
+    contains_any(
+        text,
+        &[
+            "now",
+            "current",
+            "currently",
+            "latest",
+            "status",
+            "still",
+            "updated",
+            "ci",
+            "check",
+            "checks",
+            "green",
+            "feedback",
+            "comment",
+            "comments",
+            "review",
+        ],
+    )
 }
 
 fn prior_shell_command_tool_choice(
@@ -890,6 +920,9 @@ fn schema_matched_tool_names(
     if user_tokens.is_empty() {
         return Vec::new();
     }
+    let explicit_tool_use = user_text_mentions_tool_use(user_text);
+    let minimum_score = if explicit_tool_use { 1 } else { 2 };
+    let required_margin = if explicit_tool_use { 1 } else { 2 };
 
     let mut scored: Vec<(String, usize)> = profiles
         .iter()
@@ -900,7 +933,7 @@ fn schema_matched_tool_names(
                 .count();
             (profile.name.clone(), overlap)
         })
-        .filter(|(_, score)| *score >= 2)
+        .filter(|(_, score)| *score >= minimum_score)
         .collect();
     scored.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
 
@@ -909,7 +942,7 @@ fn schema_matched_tool_names(
     };
     let top_score = *top_score;
     let runner_up = scored.get(1).map(|(_, score)| *score).unwrap_or(0);
-    if top_score < 2 || runner_up + 2 > top_score {
+    if top_score < minimum_score || runner_up + required_margin > top_score {
         return Vec::new();
     }
 
@@ -917,6 +950,16 @@ fn schema_matched_tool_names(
         .into_iter()
         .filter_map(|(name, score)| (score == top_score).then_some(name))
         .collect()
+}
+
+fn user_text_mentions_tool_use(user_text: &str) -> bool {
+    let tokens = lexical_tokens(user_text);
+    tokens
+        .iter()
+        .any(|token| token == "use" || token == "using" || token == "call")
+        && tokens
+            .iter()
+            .any(|token| token == "tool" || token == "tools")
 }
 
 fn tool_text_profiles(
@@ -1453,6 +1496,7 @@ fn infer_string_argument(field: &str, schema: &Value, prompt: &str) -> Option<St
         .or_else(|| infer_assignment_argument(field, prompt))
         .or_else(|| infer_path_like_argument(field, prompt))
         .or_else(|| infer_query_argument(field, prompt))
+        .or_else(|| infer_named_argument(field, schema, prompt))
 }
 
 fn schema_allows_string(schema: &Value) -> bool {
@@ -1540,6 +1584,159 @@ fn infer_query_argument(field: &str, prompt: &str) -> Option<String> {
     (!prompt.is_empty()).then(|| prompt.to_string())
 }
 
+fn infer_named_argument(field: &str, schema: &Value, prompt: &str) -> Option<String> {
+    let mut schema_tokens = text_tokens(field);
+    collect_tool_schema_tokens(schema, &mut schema_tokens);
+    if schema_tokens_look_command_like(&schema_tokens) {
+        return None;
+    }
+
+    infer_quoted_argument(prompt)
+        .or_else(|| infer_preposition_argument(prompt, &schema_tokens))
+        .or_else(|| infer_entity_like_argument(prompt, &schema_tokens))
+}
+
+fn infer_quoted_argument(prompt: &str) -> Option<String> {
+    for quote in ['"', '\'', '`'] {
+        let mut parts = prompt.split(quote);
+        while let Some(_before) = parts.next() {
+            let Some(value) = parts.next() else {
+                break;
+            };
+            let value = value.trim();
+            if usable_named_argument(value) {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn infer_preposition_argument(prompt: &str, schema_tokens: &HashSet<String>) -> Option<String> {
+    let words = prompt_words(prompt);
+    for (idx, word) in words.iter().enumerate() {
+        if !matches!(
+            word.lower.as_str(),
+            "in" | "for" | "about" | "near" | "at" | "to"
+        ) {
+            continue;
+        }
+        let mut phrase = Vec::new();
+        for next in words.iter().skip(idx + 1).take(5) {
+            if named_argument_boundary(&next.lower) {
+                break;
+            }
+            phrase.push(next.clean.clone());
+        }
+        let value = phrase.join(" ");
+        if usable_named_argument_for_schema(&value, schema_tokens) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn infer_entity_like_argument(prompt: &str, schema_tokens: &HashSet<String>) -> Option<String> {
+    let words = prompt_words(prompt);
+    let mut idx = 0;
+    while idx < words.len() {
+        if !word_looks_entity_like(&words[idx]) {
+            idx += 1;
+            continue;
+        }
+        let mut phrase = vec![words[idx].clean.clone()];
+        idx += 1;
+        while idx < words.len() && word_looks_entity_like(&words[idx]) {
+            phrase.push(words[idx].clean.clone());
+            idx += 1;
+        }
+        let value = phrase.join(" ");
+        if usable_named_argument_for_schema(&value, schema_tokens) {
+            return Some(value);
+        }
+    }
+    None
+}
+
+#[derive(Debug)]
+struct PromptWord {
+    clean: String,
+    lower: String,
+}
+
+fn prompt_words(prompt: &str) -> Vec<PromptWord> {
+    prompt
+        .split_whitespace()
+        .map(clean_named_argument_token)
+        .filter(|token| !token.is_empty())
+        .map(|clean| PromptWord {
+            lower: clean.to_ascii_lowercase(),
+            clean,
+        })
+        .collect()
+}
+
+fn clean_named_argument_token(token: &str) -> String {
+    token
+        .trim_matches(|c: char| {
+            matches!(
+                c,
+                '"' | '\'' | '`' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | ',' | ';' | ':'
+            )
+        })
+        .trim_end_matches(['.', ',', ';', ':', '?', '!', ')', ']', '}'])
+        .to_string()
+}
+
+fn named_argument_boundary(token: &str) -> bool {
+    matches!(
+        token,
+        "right"
+            | "now"
+            | "today"
+            | "currently"
+            | "please"
+            | "use"
+            | "using"
+            | "with"
+            | "the"
+            | "a"
+            | "an"
+            | "tool"
+            | "tools"
+            | "available"
+    )
+}
+
+fn usable_named_argument_for_schema(value: &str, schema_tokens: &HashSet<String>) -> bool {
+    usable_named_argument(value)
+        && !text_tokens(value)
+            .iter()
+            .any(|token| schema_tokens.contains(token))
+}
+
+fn usable_named_argument(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= 120
+        && !value.contains('\n')
+        && !matches!(
+            value.to_ascii_lowercase().as_str(),
+            "what" | "which" | "when" | "where" | "why" | "how" | "please"
+        )
+}
+
+fn word_looks_entity_like(word: &PromptWord) -> bool {
+    let Some(first) = word.clean.chars().next() else {
+        return false;
+    };
+    first.is_ascii_uppercase()
+        && !matches!(
+            word.lower.as_str(),
+            "what" | "which" | "when" | "where" | "why" | "how" | "use"
+        )
+}
+
 fn tool_parameters<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a Value> {
     tools?
         .as_array()?
@@ -1572,11 +1769,19 @@ async fn handle_tool_result(
         selected_tool_names.retain(|name| name != tool);
     }
     let latest_user_text = session.active_user_text();
+    let prompt_requests_more_tool_steps =
+        prompt_requests_additional_tool_step(&latest_user_text, session);
     let latest_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
         tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
     });
-    if let Some((tool, _)) = latest_answerable_tool {
+    if let Some((tool, _)) = latest_answerable_tool.filter(|_| !prompt_requests_more_tool_steps) {
         selected_tool_names.retain(|name| name != &tool);
+    }
+    let latest_non_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
+        !tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
+    });
+    if let Some((tool, _)) = latest_non_answerable_tool.as_ref() {
+        selected_tool_names.retain(|name| name == tool);
     }
     let tools_enabled_for_reducer =
         has_tools && !selected_tool_names.is_empty() && tool_budget_exhausted.is_none();
@@ -1599,14 +1804,14 @@ async fn handle_tool_result(
         tracing::info!("moa: forcing answer after {count} completed tool calls");
         append_tool_budget_instruction(&mut messages, count);
     }
-    let latest_non_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
-        !tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
-    });
     let retry_tool = if tools_enabled_for_reducer {
         latest_non_answerable_tool.clone()
     } else {
         None
     };
+    let retry_tool_call = retry_tool.as_ref().and_then(|(tool, _)| {
+        latest_completed_tool_call(session).filter(|call| &call.name == tool)
+    });
     if let Some((tool, _)) = retry_tool {
         tracing::info!(
             "moa: latest {tool} tool result looks like error/usage output; asking reducer to retry"
@@ -1717,18 +1922,39 @@ async fn handle_tool_result(
                 normalize::OutputKind::ToolProposal if !response_tools_enabled => {
                     tool_result_answer_from_evidence_response(session)
                 }
-                normalize::OutputKind::ToolProposal => tool_proposal_response(
-                    &reduced,
-                    response_tools_enabled,
-                    session.tools(),
-                    response_allowed_tools,
-                    response_prompt_profiles,
-                    Some(&session.last_user_text()),
-                ),
-                normalize::OutputKind::Uncertainty => error_response(
-                    "MoA reducer returned no usable answer",
-                    MOA_ERR_NO_USABLE_ANSWER,
-                ),
+                normalize::OutputKind::ToolProposal => {
+                    let body = tool_proposal_response(
+                        &reduced,
+                        response_tools_enabled,
+                        session.tools(),
+                        response_allowed_tools,
+                        response_prompt_profiles,
+                        Some(&session.last_user_text()),
+                    );
+                    retry_tool_result_response_if_plain(
+                        body,
+                        retry_tool_call.as_ref(),
+                        response_tools_enabled,
+                    )
+                }
+                normalize::OutputKind::Uncertainty => {
+                    if response_tools_enabled {
+                        retry_tool_call
+                            .as_ref()
+                            .map(retry_tool_call_response)
+                            .unwrap_or_else(|| {
+                                error_response(
+                                    "MoA reducer returned no usable answer",
+                                    MOA_ERR_NO_USABLE_ANSWER,
+                                )
+                            })
+                    } else {
+                        error_response(
+                            "MoA reducer returned no usable answer",
+                            MOA_ERR_NO_USABLE_ANSWER,
+                        )
+                    }
+                }
                 _ => {
                     let repaired = repair_tool_result_answer(session, &reduced.payload);
                     match latest_non_answerable_tool.as_ref() {
@@ -1756,12 +1982,17 @@ async fn handle_tool_result(
                         }
                         _ => {}
                     }
-                    chat_or_schema_command_tool_response(
+                    let body = chat_or_schema_command_tool_response(
                         &repaired,
                         session.tools(),
                         response_allowed_tools,
                         response_prompt_profiles,
                         Some(&session.last_user_text()),
+                    );
+                    retry_tool_result_response_if_plain(
+                        body,
+                        retry_tool_call.as_ref(),
+                        response_tools_enabled,
                     )
                 }
             };
@@ -1810,6 +2041,16 @@ async fn handle_tool_result(
 }
 
 fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
+    if let Some(answer) = answer_from_recent_prompt_specific_structured_tool_results(session) {
+        return answer;
+    }
+
+    if let Some(answer) = latest_completed_tool_result(session).and_then(|(_, result)| {
+        answer_from_prompt_specific_structured_tool_result(&result, &session.active_user_text())
+    }) {
+        return answer;
+    }
+
     let repaired_rows =
         repair_tabular_tool_result_answer(session, answer).unwrap_or_else(|| answer.to_string());
 
@@ -1829,6 +2070,31 @@ fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
     repaired.push_str("Tool facts: ");
     repaired.push_str(&missing.join(", "));
     repaired
+}
+
+fn answer_from_recent_prompt_specific_structured_tool_results(session: &Session) -> Option<String> {
+    let prompt = session.active_user_text();
+    if !(prompt_asks_for_ci_status(&prompt) && prompt_asks_for_copilot_feedback(&prompt)) {
+        return None;
+    }
+
+    let mut title = None;
+    let mut checks = None;
+    let mut feedback = None;
+    for (_, result) in session.recent_tool_results() {
+        let Some(value) = parse_tool_result_json(result.trim()) else {
+            continue;
+        };
+        title = title.or_else(|| github_title_state_summary(&value));
+        checks = checks.or_else(|| github_check_summary_from_value(&value));
+        feedback = feedback.or_else(|| github_feedback_summary_from_value(&value, &prompt));
+    }
+
+    let mut parts = Vec::new();
+    parts.extend(title);
+    parts.push(checks?);
+    parts.push(feedback?);
+    Some(truncate_for_tool_result_answer(&parts.join("\n")))
 }
 
 #[derive(Debug)]
@@ -2002,7 +2268,11 @@ fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str
 }
 
 fn answer_from_structured_tool_result(result: &str, prompt: &str) -> Option<String> {
-    let parsed = serde_json::from_str::<Value>(result.trim()).ok()?;
+    let parsed = parse_tool_result_json(result.trim())?;
+    if let Some(answer) = answer_from_prompt_specific_structured_value(&parsed, prompt) {
+        return Some(answer);
+    }
+
     let rows = structured_tool_result_rows(&parsed, prompt);
     let first = rows.first()?;
     let mut answer = format!(
@@ -2026,6 +2296,305 @@ fn answer_from_structured_tool_result(result: &str, prompt: &str) -> Option<Stri
     }
 
     Some(truncate_for_tool_result_answer(&answer))
+}
+
+fn answer_from_prompt_specific_structured_tool_result(
+    result: &str,
+    prompt: &str,
+) -> Option<String> {
+    let parsed = parse_tool_result_json(result.trim())?;
+    answer_from_prompt_specific_structured_value(&parsed, prompt)
+}
+
+fn answer_from_prompt_specific_structured_value(value: &Value, prompt: &str) -> Option<String> {
+    if prompt_asks_for_check_or_review_status(prompt) {
+        return answer_from_github_pr_detail_value(value, prompt);
+    }
+    None
+}
+
+fn parse_tool_result_json(result: &str) -> Option<Value> {
+    serde_json::from_str::<Value>(result)
+        .ok()
+        .or_else(|| parse_concatenated_json_values(result))
+        .or_else(|| parse_json_prefix_with_escaped_string_controls(result))
+}
+
+fn parse_concatenated_json_values(input: &str) -> Option<Value> {
+    let mut values = Vec::new();
+    let stream = serde_json::Deserializer::from_str(input).into_iter::<Value>();
+    for value in stream {
+        values.push(value.ok()?);
+    }
+    (values.len() > 1).then_some(Value::Array(values))
+}
+
+fn parse_json_prefix_with_escaped_string_controls(input: &str) -> Option<Value> {
+    let mut out = String::new();
+    let mut started = false;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut depth = 0usize;
+
+    for ch in input.chars() {
+        if !started {
+            if matches!(ch, '{' | '[') {
+                started = true;
+                depth = 1;
+                out.push(ch);
+            }
+            continue;
+        }
+
+        if in_string {
+            match ch {
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                '"' if !escaped => {
+                    in_string = false;
+                    out.push(ch);
+                }
+                _ => out.push(ch),
+            }
+            escaped = ch == '\\' && !escaped;
+            if ch != '\\' {
+                escaped = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                out.push(ch);
+            }
+            '{' | '[' => {
+                depth = depth.saturating_add(1);
+                out.push(ch);
+            }
+            '}' | ']' => {
+                depth = depth.saturating_sub(1);
+                out.push(ch);
+                if depth == 0 {
+                    break;
+                }
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    (started && depth == 0)
+        .then(|| serde_json::from_str::<Value>(&out).ok())
+        .flatten()
+}
+
+fn prompt_asks_for_check_or_review_status(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "ci", "check", "checks", "green", "status", "copilot", "feedback", "comment",
+            "comments", "review", "reviews",
+        ],
+    )
+}
+
+fn answer_from_github_pr_detail_value(value: &Value, prompt: &str) -> Option<String> {
+    if let Value::Array(_) = value {
+        return github_check_summary(Some(value)).filter(|_| prompt_asks_for_ci_status(prompt));
+    }
+
+    let map = value.as_object()?;
+    let mut parts = Vec::new();
+    let prompt_lower = prompt.to_ascii_lowercase();
+    if let Some(title) = first_string_field(map, &["title", "name"]) {
+        let state = first_string_field(map, &["state", "status"]);
+        parts.push(match state {
+            Some(state) => format!("{title} ({state})"),
+            None => title,
+        });
+    }
+
+    if contains_any(&prompt_lower, &["ci", "check", "checks", "green", "status"]) {
+        parts.extend(github_check_summary(map.get("statusCheckRollup")));
+    }
+
+    if contains_any(
+        &prompt_lower,
+        &[
+            "copilot", "feedback", "comment", "comments", "review", "reviews",
+        ],
+    ) {
+        parts.extend(github_feedback_summary(
+            map.get("comments"),
+            map.get("reviews"),
+            prompt_lower.contains("copilot"),
+        ));
+    }
+
+    (!parts.is_empty()).then(|| truncate_for_tool_result_answer(&parts.join("\n")))
+}
+
+fn github_title_state_summary(value: &Value) -> Option<String> {
+    let map = value.as_object()?;
+    let title = first_string_field(map, &["title", "name"])?;
+    let state = first_string_field(map, &["state", "status"]);
+    Some(match state {
+        Some(state) => format!("{title} ({state})"),
+        None => title,
+    })
+}
+
+fn github_check_summary_from_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => github_check_summary(map.get("statusCheckRollup")),
+        Value::Array(_) => github_check_summary(Some(value)),
+        _ => None,
+    }
+}
+
+fn github_feedback_summary_from_value(value: &Value, prompt: &str) -> Option<String> {
+    if !json_value_has_copilot_feedback_evidence(value) {
+        return None;
+    }
+
+    let copilot_only = prompt.to_ascii_lowercase().contains("copilot");
+    match value {
+        Value::Object(map) => {
+            if map.contains_key("comments") || map.contains_key("reviews") {
+                return github_feedback_summary(
+                    map.get("comments"),
+                    map.get("reviews"),
+                    copilot_only,
+                );
+            }
+            github_feedback_summary(None, Some(&Value::Array(vec![value.clone()])), copilot_only)
+        }
+        Value::Array(_) => github_feedback_summary(None, Some(value), copilot_only),
+        _ => None,
+    }
+}
+
+fn github_check_summary(value: Option<&Value>) -> Option<String> {
+    let checks = value?.as_array()?;
+    if checks.is_empty() {
+        return Some("CI/checks: no check runs were returned.".to_string());
+    }
+
+    let mut failing = Vec::new();
+    let mut pending = Vec::new();
+    for check in checks.iter().filter_map(Value::as_object) {
+        let name = first_string_field(check, &["name", "workflowName"]).unwrap_or_else(|| {
+            check
+                .get("__typename")
+                .and_then(Value::as_str)
+                .unwrap_or("check")
+                .to_string()
+        });
+        let conclusion = first_string_field(check, &["conclusion"]);
+        let status = first_string_field(check, &["status"]);
+        match conclusion.as_deref() {
+            Some("SUCCESS" | "SKIPPED" | "NEUTRAL") => {}
+            Some(other) => failing.push(format!("{name}: {other}")),
+            None if !matches!(status.as_deref(), Some("COMPLETED")) => {
+                pending.push(format!(
+                    "{name}: {}",
+                    status.unwrap_or_else(|| "pending".to_string())
+                ));
+            }
+            None => {}
+        }
+    }
+
+    if failing.is_empty() && pending.is_empty() {
+        Some(format!(
+            "CI/checks: all {} returned checks are green.",
+            checks.len()
+        ))
+    } else {
+        let mut text = String::from("CI/checks: not all green.");
+        if !failing.is_empty() {
+            text.push_str(" Failing: ");
+            text.push_str(&failing.into_iter().take(3).collect::<Vec<_>>().join("; "));
+            text.push('.');
+        }
+        if !pending.is_empty() {
+            text.push_str(" Pending: ");
+            text.push_str(&pending.into_iter().take(3).collect::<Vec<_>>().join("; "));
+            text.push('.');
+        }
+        Some(text)
+    }
+}
+
+fn github_feedback_summary(
+    comments: Option<&Value>,
+    reviews: Option<&Value>,
+    copilot_only: bool,
+) -> Option<String> {
+    let mut entries = Vec::new();
+    collect_github_feedback_entries(comments, "comment", copilot_only, &mut entries);
+    collect_github_feedback_entries(reviews, "review", copilot_only, &mut entries);
+
+    if entries.is_empty() {
+        if copilot_only {
+            return Some(
+                "Copilot feedback: no Copilot-authored comments or reviews were returned."
+                    .to_string(),
+            );
+        }
+        return Some("Feedback: no comments or reviews were returned.".to_string());
+    }
+
+    Some(format!(
+        "{}: {}",
+        if copilot_only {
+            "Copilot feedback"
+        } else {
+            "Feedback"
+        },
+        entries.into_iter().take(3).collect::<Vec<_>>().join("; ")
+    ))
+}
+
+fn collect_github_feedback_entries(
+    value: Option<&Value>,
+    kind: &str,
+    copilot_only: bool,
+    entries: &mut Vec<String>,
+) {
+    let Some(items) = value.and_then(Value::as_array) else {
+        return;
+    };
+    for item in items.iter().filter_map(Value::as_object) {
+        let author = item
+            .get("author")
+            .and_then(|author| author.get("login").or_else(|| author.get("name")))
+            .or_else(|| item.get("author"))
+            .or_else(|| item.get("user").and_then(|user| user.get("login")))
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let body = first_string_field(item, &["body"]).unwrap_or_default();
+        let author_or_body_mentions_copilot = author.to_ascii_lowercase().contains("copilot")
+            || body.to_ascii_lowercase().contains("copilot");
+        if copilot_only && !author_or_body_mentions_copilot {
+            continue;
+        }
+        let state = first_string_field(item, &["state"]);
+        let body_summary = first_non_empty_line(&body).unwrap_or_else(|| "(no body)".to_string());
+        entries.push(match state {
+            Some(state) => format!("{kind} by {author} ({state}): {body_summary}"),
+            None => format!("{kind} by {author}: {body_summary}"),
+        });
+    }
+}
+
+fn first_non_empty_line(text: &str) -> Option<String> {
+    text.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(truncate_for_tool_result_answer)
 }
 
 fn structured_tool_result_rows(value: &Value, prompt: &str) -> Vec<StructuredToolRow> {
@@ -2238,6 +2807,28 @@ fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
     (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (latest.name.clone(), count))
 }
 
+fn prompt_requests_additional_tool_step(prompt: &str, session: &Session) -> bool {
+    let completed = completed_tool_calls_since_latest_user_before_tool_result(session).len();
+    if completed == 0 || completed >= 2 {
+        return false;
+    }
+
+    let text = prompt.to_ascii_lowercase();
+    contains_any(
+        &text,
+        &[
+            "then run",
+            "then execute",
+            "then use",
+            "then call",
+            "after that run",
+            "afterwards run",
+            "also run",
+            "and run",
+        ],
+    )
+}
+
 fn tool_budget_exhausted(session: &Session) -> Option<usize> {
     let count = completed_tool_names_since_latest_user_before_tool_result(session).len();
     (count >= TOOL_BUDGET_FORCE_ANSWER_THRESHOLD).then_some(count)
@@ -2329,9 +2920,45 @@ fn latest_completed_tool_result(session: &Session) -> Option<(String, String)> {
     session.recent_tool_results().into_iter().last()
 }
 
+fn latest_completed_tool_call(session: &Session) -> Option<CompletedToolCall> {
+    completed_tool_calls_since_latest_user_before_tool_result(session)
+        .into_iter()
+        .last()
+}
+
+fn retry_tool_result_response_if_plain(
+    body: Value,
+    retry_tool_call: Option<&CompletedToolCall>,
+    tools_enabled: bool,
+) -> Value {
+    if !tools_enabled || response_contains_tool_call(&body) {
+        return body;
+    }
+    retry_tool_call
+        .map(retry_tool_call_response)
+        .unwrap_or(body)
+}
+
+fn retry_tool_call_response(call: &CompletedToolCall) -> Value {
+    tracing::info!(
+        "moa: reducer returned plain text after non-answerable {}; retrying same tool call",
+        call.name
+    );
+    tool_call_response(&call.name, &Value::String(call.arguments.clone()))
+}
+
+fn response_contains_tool_call(body: &Value) -> bool {
+    body.pointer("/choices/0/message/tool_calls")
+        .and_then(Value::as_array)
+        .is_some_and(|calls| !calls.is_empty())
+}
+
 fn tool_result_has_answerable_evidence(result: &str) -> bool {
     let trimmed = result.trim();
     if trimmed.is_empty() || matches!(trimmed, "{}" | "[]") {
+        return false;
+    }
+    if plain_text_tool_result_looks_empty(trimmed) {
         return false;
     }
 
@@ -2344,6 +2971,14 @@ fn tool_result_has_answerable_evidence(result: &str) -> bool {
 
 fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) -> bool {
     if !tool_result_has_answerable_evidence(result) {
+        return false;
+    }
+    if prompt_asks_for_ci_status(prompt) && !tool_result_has_ci_status_evidence(result) {
+        return false;
+    }
+    if prompt_asks_for_copilot_feedback(prompt)
+        && !tool_result_has_copilot_feedback_evidence(result)
+    {
         return false;
     }
     if prompt_asks_for_github_work_items(prompt)
@@ -2362,6 +2997,121 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
         return false;
     }
     true
+}
+
+fn prompt_asks_for_ci_status(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "ci",
+            "checks",
+            "green",
+            "status check",
+            "check run",
+            "check suite",
+            "build status",
+        ],
+    )
+}
+
+fn prompt_asks_for_copilot_feedback(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    lower.contains("copilot")
+        && contains_any(
+            &lower,
+            &["feedback", "comment", "comments", "review", "reviews"],
+        )
+}
+
+fn tool_result_has_ci_status_evidence(result: &str) -> bool {
+    if let Some(parsed) = parse_tool_result_json(result.trim()) {
+        return json_value_has_ci_status_evidence(&parsed);
+    }
+
+    let lower = result.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "statuscheckrollup",
+            "checkrun",
+            "check suite",
+            "checks:",
+            "ci/",
+            "\tpass",
+            "\tfail",
+            "\tsuccess",
+            "\tfailure",
+            " pending",
+            " queued",
+            " in_progress",
+        ],
+    )
+}
+
+fn tool_result_has_copilot_feedback_evidence(result: &str) -> bool {
+    if let Some(parsed) = parse_tool_result_json(result.trim()) {
+        return json_value_has_copilot_feedback_evidence(&parsed);
+    }
+
+    let lower = result.to_ascii_lowercase();
+    contains_any(
+        &lower,
+        &[
+            "copilot feedback",
+            "github-copilot",
+            "copilot-pull-request-reviewer",
+            "no copilot",
+            "copilot-authored",
+        ],
+    )
+}
+
+fn json_value_has_ci_status_evidence(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map
+                .get("statusCheckRollup")
+                .and_then(Value::as_array)
+                .is_some_and(|checks| !checks.is_empty())
+            {
+                return true;
+            }
+            let has_check_fields = map.contains_key("conclusion")
+                || (map.contains_key("status")
+                    && (map.contains_key("workflowName") || map.contains_key("detailsUrl")));
+            has_check_fields || map.values().any(json_value_has_ci_status_evidence)
+        }
+        Value::Array(values) => values.iter().any(json_value_has_ci_status_evidence),
+        _ => false,
+    }
+}
+
+fn json_value_has_copilot_feedback_evidence(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key("comments") || map.contains_key("reviews") {
+                return true;
+            }
+            map.values().any(json_value_has_copilot_feedback_evidence)
+        }
+        Value::Array(values) => values.iter().any(json_value_has_copilot_feedback_evidence),
+        Value::String(text) => text.to_ascii_lowercase().contains("copilot"),
+        _ => false,
+    }
+}
+
+fn plain_text_tool_result_looks_empty(result: &str) -> bool {
+    let normalized = result.replace('\r', "");
+    let lines: Vec<&str> = normalized
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .collect();
+    matches!(
+        lines.as_slice(),
+        ["(no output)" | "(empty output)" | "no output" | "empty output"]
+    )
 }
 
 fn prompt_asks_for_github_work_items(prompt: &str) -> bool {
@@ -4121,6 +4871,53 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn live_status_followup_after_tool_chain_uses_tool_grace() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"]
+                }
+            }
+        }]));
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "Any new interesting PRs?"}),
+                tool_call_msg("call_1", "exec"),
+                tool_result_msg(
+                    "call_1",
+                    "808\tStabilize OpenClaw tool loops through MoA\tOPEN",
+                ),
+                serde_json::json!({
+                    "role": "assistant",
+                    "content": "PR 808 looks relevant."
+                }),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "The stabilise one, PR 808 - is CI all green now? Any Copilot feedback?"
+                }),
+            ],
+            &tools,
+        );
+
+        let allowed = declared_tool_names(&session, &[]);
+
+        assert_eq!(
+            grace_mode_for_turn(&session, !allowed.is_empty(), &[]),
+            GraceMode::Tool
+        );
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &allowed, &[]),
+            vec!["exec"]
+        );
+    }
+
+    #[test]
     fn schema_description_selects_weather_tool() {
         let mut session = Session::new();
         session.ingest(
@@ -4137,6 +4934,49 @@ mod response_builder_tests {
         assert_eq!(
             selected_tool_names_for_turn(&session, &[], &[]),
             vec!["lookup".to_string()]
+        );
+    }
+
+    #[test]
+    fn schema_description_selects_available_weather_tool_phrase() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "read_file",
+                "description": "Read workspace file contents",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "File path"}},
+                    "required": ["path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "weather_lookup",
+                "description": "Look up current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string", "description": "City to check"}},
+                    "required": ["city"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "What is the weather in Sydney right now? Use the available weather tool."
+            })],
+            &Some(tools.clone()),
+        );
+
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["weather_lookup".to_string()]);
+        let forced =
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
+        assert_eq!(forced.name, "weather_lookup");
+        assert_eq!(
+            forced.fallback_arguments,
+            serde_json::json!({"city": "Sydney"})
         );
     }
 
@@ -4788,6 +5628,14 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn empty_tool_output_sentinel_is_not_answerable_tool_evidence() {
+        let result = "(no output)";
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
     fn github_auth_status_is_not_pr_request_evidence() {
         let result = "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true\n  - Git operations protocol: https";
         let prompt = "Any new interesting PRs? You have the gh command line I think can use";
@@ -4887,6 +5735,7 @@ mod response_builder_tests {
             "gh search not available or not authenticated",
             "search failed: gh search not available or not authenticated",
             "GraphQL: Could not resolve to a Repository with the name 'micn/mesh-llm'. (repository)",
+            "(no output)",
             "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
             "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
             "origin\tgit@github.com:Mesh-LLM/mesh-llm.git (fetch)\norigin\tgit@github.com:Mesh-LLM/mesh-llm.git (push)",
@@ -4959,6 +5808,156 @@ mod response_builder_tests {
         assert!(answer.contains("https://github.com/Mesh-LLM/mesh-llm/pull/809"));
         assert!(answer.contains("#808 - Stabilize OpenClaw"), "{answer}");
         assert!(!answer.contains("one relevant entry is: ["), "{answer}");
+    }
+
+    #[test]
+    fn pr_status_prompt_summarizes_checks_and_copilot_feedback_json() {
+        let prompt = "The stabilise one, PR 808 - is CI all green now? Any Copilot feedback?";
+        let result = serde_json::json!({
+            "title": "Stabilize OpenClaw tool loops through MoA",
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {
+                    "name": "Linux tests (skippy-smoke)",
+                    "conclusion": "FAILURE",
+                    "status": "COMPLETED"
+                },
+                {
+                    "name": "Linux CPU",
+                    "conclusion": "SUCCESS",
+                    "status": "COMPLETED"
+                }
+            ],
+            "comments": [
+                {
+                    "author": {"login": "github-copilot[bot]"},
+                    "body": "Copilot reviewed this and requested a small error handling change."
+                }
+            ],
+            "reviews": []
+        })
+        .to_string()
+            + "\n[... truncated]";
+
+        let answer =
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, &result))
+                .expect("PR detail JSON should answer status prompt");
+
+        assert!(answer.contains("Stabilize OpenClaw"), "{answer}");
+        assert!(answer.contains("not all green"), "{answer}");
+        assert!(
+            answer.contains("Linux tests (skippy-smoke): FAILURE"),
+            "{answer}"
+        );
+        assert!(answer.contains("Copilot feedback"), "{answer}");
+        assert!(answer.contains("github-copilot[bot]"), "{answer}");
+    }
+
+    #[test]
+    fn pr_status_prompt_rejects_comments_only_json_without_checks() {
+        let prompt = "The stabilise one, PR 808 - is CI all green now? Any Copilot feedback?";
+        let result = serde_json::json!({
+            "title": "Stabilize OpenClaw tool loops through MoA",
+            "state": "OPEN",
+            "comments": [
+                {
+                    "author": {"login": "github-copilot[bot]"},
+                    "body": "Copilot reviewed this PR."
+                }
+            ],
+            "reviews": [
+                {
+                    "author": {"login": "copilot-pull-request-reviewer"},
+                    "state": "COMMENTED",
+                    "body": "Pull request overview"
+                }
+            ]
+        })
+        .to_string();
+
+        assert!(
+            !tool_result_has_answerable_evidence_for_prompt(result.as_str(), prompt),
+            "CI prompt should not accept comments-only PR detail JSON"
+        );
+        assert!(
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, &result))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn pr_status_prompt_summarizes_jsonl_check_output() {
+        let prompt = "Please check PR 808 checks/CI status.";
+        let result = r#"{"name":"changes","status":"COMPLETED","conclusion":"SUCCESS"}
+{"name":"Linux tests (skippy-smoke)","status":"COMPLETED","conclusion":"FAILURE"}
+{"name":"two_node_split_smoke","status":"COMPLETED","conclusion":"SUCCESS"}"#;
+
+        let answer =
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, result))
+                .expect("JSONL check output should answer CI prompt");
+
+        assert!(answer.contains("CI/checks: not all green"), "{answer}");
+        assert!(
+            answer.contains("Linux tests (skippy-smoke): FAILURE"),
+            "{answer}"
+        );
+    }
+
+    #[test]
+    fn pr_status_and_copilot_prompt_rejects_checks_only_output() {
+        let prompt = "PR 808 - is CI all green now? Any Copilot feedback?";
+        let result = "Linux tests (skippy-smoke)\tfail\t1m39s\thttps://example.invalid/job";
+
+        assert!(
+            !tool_result_has_answerable_evidence_for_prompt(result, prompt),
+            "checks-only output should not satisfy Copilot feedback prompt"
+        );
+    }
+
+    #[test]
+    fn pr_status_and_copilot_prompt_combines_recent_structured_tool_results() {
+        let prompt = "PR 808 - is CI all green now? Any Copilot feedback?";
+        let status_result = serde_json::json!({
+            "title": "Stabilize OpenClaw tool loops through MoA",
+            "state": "OPEN",
+            "statusCheckRollup": [
+                {
+                    "name": "Linux tests (skippy-smoke)",
+                    "conclusion": "FAILURE",
+                    "status": "COMPLETED"
+                }
+            ]
+        })
+        .to_string();
+        let review_result = serde_json::json!({
+            "author": "copilot-pull-request-reviewer[bot]",
+            "body": "## Pull request overview\n\nCopilot reviewed this PR.",
+            "state": "COMMENTED"
+        })
+        .to_string();
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": prompt}),
+                tool_call_msg_with_args("call_1", "exec", r#"{"command":"gh pr view"}"#),
+                tool_result_msg("call_1", &status_result),
+                tool_call_msg_with_args("call_2", "exec", r#"{"command":"gh api reviews"}"#),
+                tool_result_msg("call_2", &review_result),
+            ],
+            &None,
+        );
+
+        let repaired = repair_tool_result_answer(&session, "CI/checks: pending.");
+
+        assert!(
+            repaired.contains("Linux tests (skippy-smoke): FAILURE"),
+            "{repaired}"
+        );
+        assert!(repaired.contains("Copilot feedback"), "{repaired}");
+        assert!(
+            repaired.contains("copilot-pull-request-reviewer[bot]"),
+            "{repaired}"
+        );
     }
 
     #[test]
@@ -5260,6 +6259,18 @@ mod response_builder_tests {
         })
     }
 
+    fn tool_call_msg_with_args(id: &str, name: &str, arguments: &str) -> Value {
+        serde_json::json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": id,
+                "type": "function",
+                "function": {"name": name, "arguments": arguments}
+            }]
+        })
+    }
+
     fn tool_result_msg(id: &str, text: &str) -> Value {
         serde_json::json!({
             "role": "tool",
@@ -5283,6 +6294,68 @@ mod response_builder_tests {
             &None,
         );
         session
+    }
+
+    #[test]
+    fn non_answerable_tool_result_plain_answer_retries_same_tool_call() {
+        let command =
+            r#"{"command":"gh pr list --repo Mesh-LLM/mesh-llm --state open --limit 10"}"#;
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Use exec to list recent open PRs, then tell me one interesting one."
+                }),
+                tool_call_msg_with_args("call_1", "exec", command),
+                tool_result_msg("call_1", "(no output)"),
+            ],
+            &None,
+        );
+
+        let retry = latest_completed_tool_call(&session).expect("completed tool call");
+        let body = retry_tool_result_response_if_plain(
+            chat_response("I could not retrieve any pull requests."),
+            Some(&retry),
+            true,
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some(command)
+        );
+        assert!(
+            body.pointer("/choices/0/message/content")
+                .and_then(Value::as_str)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn explicit_multi_step_tool_prompt_keeps_tool_available_after_first_result() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Actually use the shell tool. Run pwd, then run ls -1 | head -5."
+                }),
+                tool_call_msg_with_args("call_1", "exec", r#"{"command":"pwd"}"#),
+                tool_result_msg("call_1", "/tmp/workspace"),
+            ],
+            &None,
+        );
+
+        assert!(prompt_requests_additional_tool_step(
+            &session.active_user_text(),
+            &session
+        ));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1405,7 +1405,7 @@ fn recent_tool_chain_names(session: &Session) -> Vec<String> {
     };
     let start_idx = all[..=latest_tool_idx]
         .iter()
-        .rposition(|msg| message_role(msg) == "user")
+        .rposition(message_is_task_user)
         .unwrap_or(0);
 
     let mut names = Vec::new();
@@ -1432,6 +1432,32 @@ fn recent_tool_chain_names(session: &Session) -> Vec<String> {
 
 fn message_role(msg: &Value) -> &str {
     msg.get("role").and_then(Value::as_str).unwrap_or("")
+}
+
+fn message_is_task_user(msg: &Value) -> bool {
+    message_role(msg) == "user" && !message_is_synthetic_user(msg)
+}
+
+fn message_is_synthetic_user(msg: &Value) -> bool {
+    message_text(msg).is_some_and(|text| text.trim_start().starts_with("<info-msg>"))
+}
+
+fn message_text(msg: &Value) -> Option<String> {
+    if let Some(text) = msg.get("content").and_then(Value::as_str) {
+        return Some(text.to_string());
+    }
+    let text = msg
+        .get("content")
+        .and_then(Value::as_array)?
+        .iter()
+        .filter_map(|part| {
+            (part.get("type").and_then(Value::as_str) == Some("text"))
+                .then(|| part.get("text").and_then(Value::as_str))
+                .flatten()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
 }
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
@@ -2987,7 +3013,7 @@ fn completed_tool_calls_since_latest_user_before_tool_result(
     };
     let start_idx = all[..=latest_tool_idx]
         .iter()
-        .rposition(|msg| message_role(msg) == "user")
+        .rposition(message_is_task_user)
         .unwrap_or(0);
 
     let mut call_signatures = std::collections::HashMap::new();
@@ -6545,6 +6571,40 @@ mod response_builder_tests {
         );
 
         assert!(prompt_requests_additional_tool_step(
+            &session.active_user_text(),
+            &session
+        ));
+    }
+
+    #[test]
+    fn goose_info_message_does_not_reset_multi_step_tool_count() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Actually use the shell/developer tool. Run pwd, then run ls -1 | head -5, then answer."
+                }),
+                tool_call_msg_with_args("call_1", "shell", r#"{"command":"pwd"}"#),
+                tool_result_msg("call_1", "/tmp/workspace"),
+                serde_json::json!({
+                    "role": "user",
+                    "content": "<info-msg>\nWorking directory: /tmp/workspace\n</info-msg>"
+                }),
+                tool_call_msg_with_args("call_2", "shell", r#"{"command":"ls -1 | head -5"}"#),
+                tool_result_msg("call_2", "AGENTS.md\nCargo.toml"),
+            ],
+            &None,
+        );
+
+        let completed = completed_tool_calls_since_latest_user_before_tool_result(&session);
+
+        assert_eq!(completed.len(), 2);
+        assert_eq!(
+            session.active_user_text(),
+            "Actually use the shell/developer tool. Run pwd, then run ls -1 | head -5, then answer."
+        );
+        assert!(!prompt_requests_additional_tool_step(
             &session.active_user_text(),
             &session
         ));

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1571,8 +1571,10 @@ async fn handle_tool_result(
     if let Some((tool, _)) = repeated_tool.as_ref() {
         selected_tool_names.retain(|name| name != tool);
     }
-    let latest_answerable_tool = latest_completed_tool_result(session)
-        .filter(|(_, result)| tool_result_has_answerable_evidence(result));
+    let latest_user_text = session.last_user_text();
+    let latest_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
+        tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
+    });
     if let Some((tool, _)) = latest_answerable_tool {
         selected_tool_names.retain(|name| name != &tool);
     }
@@ -1598,8 +1600,9 @@ async fn handle_tool_result(
         append_tool_budget_instruction(&mut messages, count);
     }
     let retry_tool = if tools_enabled_for_reducer {
-        latest_completed_tool_result(session)
-            .filter(|(_, result)| !tool_result_has_answerable_evidence(result))
+        latest_completed_tool_result(session).filter(|(_, result)| {
+            !tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
+        })
     } else {
         None
     };
@@ -1741,14 +1744,25 @@ async fn handle_tool_result(
         None => {
             let err = last_err.unwrap_or_else(|| "no reducer candidates".into());
             tracing::warn!("moa: all {attempts} reducer candidates failed");
-            (
-                candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
-                false,
-                error_response(
-                    &format!("Reducer failed (tried {attempts}): {err}"),
-                    MOA_ERR_ALL_REDUCERS_FAILED,
-                ),
-            )
+            if let Some(answer) = answer_from_latest_tool_result(session) {
+                tracing::warn!(
+                    "moa: reducers failed after answerable tool evidence; answering from tool result"
+                );
+                (
+                    candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
+                    false,
+                    chat_response(&answer),
+                )
+            } else {
+                (
+                    candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
+                    false,
+                    error_response(
+                        &format!("Reducer failed (tried {attempts}): {err}"),
+                        MOA_ERR_ALL_REDUCERS_FAILED,
+                    ),
+                )
+            }
         }
     };
 
@@ -1887,7 +1901,7 @@ fn tool_result_answer_from_evidence_response(session: &Session) -> Value {
 
 fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     let (_, result) = latest_completed_tool_result(session)?;
-    if !tool_result_has_answerable_evidence(&result) {
+    if !tool_result_has_answerable_evidence_for_prompt(&result, &session.last_user_text()) {
         return None;
     }
 
@@ -2076,14 +2090,85 @@ fn tool_result_has_answerable_evidence(result: &str) -> bool {
     !plain_text_tool_result_looks_like_error(trimmed)
 }
 
+fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) -> bool {
+    if !tool_result_has_answerable_evidence(result) {
+        return false;
+    }
+    if prompt_asks_for_github_work_items(prompt)
+        && plain_text_tool_result_looks_like_github_auth_status(result)
+    {
+        return false;
+    }
+    !(prompt_asks_for_pull_requests(prompt)
+        && plain_text_tool_result_looks_like_github_repo_list(result))
+}
+
+fn prompt_asks_for_github_work_items(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    let asks_github = lower.contains("gh ")
+        || lower.contains("github")
+        || lower.contains("pull request")
+        || prompt_has_word(&lower, "pr")
+        || lower.contains("issue");
+    let asks_work_items = prompt_has_word(&lower, "pr")
+        || lower.contains("pull request")
+        || lower.contains("issue")
+        || lower.contains("interesting")
+        || lower.contains("recent")
+        || lower.contains("open");
+    asks_github && asks_work_items
+}
+
+fn prompt_asks_for_pull_requests(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    prompt_has_word(&lower, "pr")
+        || prompt_has_word(&lower, "prs")
+        || lower.contains("pull request")
+}
+
+fn prompt_has_word(prompt: &str, needle: &str) -> bool {
+    prompt
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .any(|token| token == needle)
+}
+
+fn plain_text_tool_result_looks_like_github_auth_status(result: &str) -> bool {
+    let normalized = result.replace('\r', "");
+    let lower = normalized.trim_start().to_ascii_lowercase();
+    let first_line = lower.lines().next().unwrap_or("").trim();
+    first_line == "github.com"
+        && lower.contains("logged in to github.com")
+        && lower.contains("active account:")
+}
+
+fn plain_text_tool_result_looks_like_github_repo_list(result: &str) -> bool {
+    let rows = result
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let mut columns = line.split('\t').map(str::trim);
+            Some((columns.next()?, columns.next()?, columns.next()?))
+        });
+    rows.take(3).any(|(repo, _description, visibility)| {
+        repo.contains('/')
+            && !repo.contains(char::is_whitespace)
+            && (visibility.contains("public") || visibility.contains("private"))
+    })
+}
+
 fn plain_text_tool_result_looks_like_error(result: &str) -> bool {
     let normalized = result.replace('\r', "");
     let lower = normalized.trim_start().to_ascii_lowercase();
     let first_line = lower.lines().next().unwrap_or("").trim();
     first_line.starts_with("unknown flag:")
+        || first_line.starts_with("unknown json field:")
         || first_line.starts_with("unknown command")
+        || first_line == "no git remotes found"
+        || first_line.contains("not available or not authenticated")
         || first_line.starts_with("error:")
         || first_line.starts_with("fatal:")
+        || (first_line.starts_with("unknown ") && lower.contains("\navailable fields:"))
         || (lower.contains("\nusage:") && lower.lines().take(3).any(cli_error_line))
 }
 
@@ -4398,6 +4483,80 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn cli_json_field_error_is_not_answerable_tool_evidence() {
+        let result = "Unknown JSON field: \"headRepositoryName\"\nAvailable fields:\n  additions\n  author\n  title\n\n(Command exited with code 1)";
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
+    fn cli_missing_git_remote_is_not_answerable_tool_evidence() {
+        let result = "no git remotes found\n\n(Command exited with code 1)";
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
+    fn cli_synthetic_unavailable_message_is_not_answerable_tool_evidence() {
+        let result = "gh search not available or not authenticated";
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
+    fn github_auth_status_is_not_pr_request_evidence() {
+        let result = "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true\n  - Git operations protocol: https";
+        let prompt = "Any new interesting PRs? You have the gh command line I think can use";
+
+        assert!(tool_result_has_answerable_evidence(result));
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+        assert!(
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, result))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn github_auth_status_can_answer_auth_prompt() {
+        let result = "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true";
+        let prompt = "Check whether gh is authenticated.";
+
+        assert!(tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+    }
+
+    #[test]
+    fn github_repo_list_is_not_pr_request_evidence() {
+        let result = "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z\nmichaelneale/ollama\tRun models\tpublic, fork\t2026-06-05T00:42:49Z";
+        let prompt = "Any new interesting PRs? You have the gh command line I think can use";
+
+        assert!(tool_result_has_answerable_evidence(result));
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+        assert!(
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, result))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn github_repo_list_can_answer_repo_prompt() {
+        let result = "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z";
+        let prompt = "List interesting GitHub repos.";
+
+        assert!(tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+    }
+
+    #[test]
     fn normal_tabular_cli_output_is_answerable_tool_evidence() {
         let result = "808\tStabilize tool loops through MoA\tOPEN";
 
@@ -4705,10 +4864,14 @@ mod response_builder_tests {
     }
 
     fn session_with_tool_result(result: &str) -> Session {
+        session_with_user_and_tool_result("run command", result)
+    }
+
+    fn session_with_user_and_tool_result(prompt: &str, result: &str) -> Session {
         let mut session = Session::new();
         session.ingest(
             &[
-                serde_json::json!({"role": "user", "content": "run command"}),
+                serde_json::json!({"role": "user", "content": prompt}),
                 tool_call_msg("call_1", "exec"),
                 tool_result_msg("call_1", result),
             ],

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1571,7 +1571,7 @@ async fn handle_tool_result(
     if let Some((tool, _)) = repeated_tool.as_ref() {
         selected_tool_names.retain(|name| name != tool);
     }
-    let latest_user_text = session.last_user_text();
+    let latest_user_text = session.active_user_text();
     let latest_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
         tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
     });
@@ -1599,10 +1599,11 @@ async fn handle_tool_result(
         tracing::info!("moa: forcing answer after {count} completed tool calls");
         append_tool_budget_instruction(&mut messages, count);
     }
+    let latest_non_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
+        !tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
+    });
     let retry_tool = if tools_enabled_for_reducer {
-        latest_completed_tool_result(session).filter(|(_, result)| {
-            !tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
-        })
+        latest_non_answerable_tool.clone()
     } else {
         None
     };
@@ -1730,6 +1731,31 @@ async fn handle_tool_result(
                 ),
                 _ => {
                     let repaired = repair_tool_result_answer(session, &reduced.payload);
+                    match latest_non_answerable_tool.as_ref() {
+                        Some((tool, result))
+                            if answer_appears_to_use_non_answerable_tool_result(
+                                &repaired, result,
+                            ) =>
+                        {
+                            let answer = non_answerable_tool_result_answer(session, tool, result);
+                            return TurnResult {
+                                response_body: chat_response(&answer),
+                                worker_summaries: vec![WorkerSummary {
+                                    model: name,
+                                    role: WorkerRole::Reducer,
+                                    succeeded: false,
+                                    elapsed_ms: start.elapsed().as_millis() as u64,
+                                    output_kind: None,
+                                    confidence: None,
+                                }],
+                                reducer_used: true,
+                                reducer_attempts: attempts,
+                                turn_kind: TurnKind::ToolResult,
+                                elapsed_ms: start.elapsed().as_millis() as u64,
+                            };
+                        }
+                        _ => {}
+                    }
                     chat_or_schema_command_tool_response(
                         &repaired,
                         session.tools(),
@@ -1909,7 +1935,7 @@ fn tool_result_answer_from_evidence_response(session: &Session) -> Value {
 
 fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     let (_, result) = latest_completed_tool_result(session)?;
-    let prompt = session.last_user_text();
+    let prompt = session.active_user_text();
     if !tool_result_has_answerable_evidence_for_prompt(&result, &prompt) {
         return None;
     }
@@ -1939,6 +1965,40 @@ fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     }
 
     Some(truncate_for_tool_result_answer(&answer))
+}
+
+fn answer_appears_to_use_non_answerable_tool_result(answer: &str, result: &str) -> bool {
+    let answer_lower = answer.to_ascii_lowercase();
+    if answer_lower.contains("from the tool result") || answer_lower.contains("one relevant entry")
+    {
+        return true;
+    }
+
+    result
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(3)
+        .any(|line| line.len() >= 12 && answer.contains(line))
+}
+
+fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str) -> String {
+    let prompt = session.active_user_text();
+    if prompt_asks_for_pull_requests(&prompt)
+        && plain_text_tool_result_looks_like_github_repo_list(result)
+    {
+        return "The latest tool result listed repositories, not pull requests, so I can't answer the PR request from that output. I need the target repository or a corrected PR-list result before I can pick an interesting PR.".to_string();
+    }
+
+    let first_line = result
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("empty output");
+    format!(
+        "The latest `{tool}` result is not answer evidence for the request: {}. I need a corrected tool result before I can answer.",
+        truncate_for_tool_result_answer(first_line)
+    )
 }
 
 fn answer_from_structured_tool_result(result: &str, prompt: &str) -> Option<String> {

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1988,6 +1988,12 @@ async fn handle_tool_result(
                     retry_tool_result_response_if_plain(
                         body,
                         retry_tool_call.as_ref(),
+                        latest_non_answerable_tool
+                            .as_ref()
+                            .map(|(_, result)| result.as_str()),
+                        session.tools(),
+                        response_allowed_tools,
+                        response_prompt_profiles,
                         response_tools_enabled,
                     )
                 }
@@ -1995,7 +2001,17 @@ async fn handle_tool_result(
                     if response_tools_enabled {
                         retry_tool_call
                             .as_ref()
-                            .map(retry_tool_call_response)
+                            .and_then(|call| {
+                                retry_tool_call_response(
+                                    call,
+                                    latest_non_answerable_tool
+                                        .as_ref()
+                                        .map(|(_, result)| result.as_str()),
+                                    session.tools(),
+                                    response_allowed_tools,
+                                    response_prompt_profiles,
+                                )
+                            })
                             .unwrap_or_else(|| {
                                 error_response(
                                     "MoA reducer returned no usable answer",
@@ -2046,6 +2062,12 @@ async fn handle_tool_result(
                     retry_tool_result_response_if_plain(
                         body,
                         retry_tool_call.as_ref(),
+                        latest_non_answerable_tool
+                            .as_ref()
+                            .map(|(_, result)| result.as_str()),
+                        session.tools(),
+                        response_allowed_tools,
+                        response_prompt_profiles,
                         response_tools_enabled,
                     )
                 }
@@ -2105,6 +2127,10 @@ fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
         return answer;
     }
 
+    if let Some(answer) = repair_structured_tool_result_answer(session, answer) {
+        return answer;
+    }
+
     let repaired_rows =
         repair_tabular_tool_result_answer(session, answer).unwrap_or_else(|| answer.to_string());
 
@@ -2149,6 +2175,110 @@ fn answer_from_recent_prompt_specific_structured_tool_results(session: &Session)
     parts.push(checks?);
     parts.push(feedback?);
     Some(truncate_for_tool_result_answer(&parts.join("\n")))
+}
+
+fn repair_structured_tool_result_answer(session: &Session, answer: &str) -> Option<String> {
+    let (_, result) = latest_completed_tool_result(session)?;
+    let prompt = session.active_user_text();
+    let parsed = parse_tool_result_json(result.trim())?;
+    let rows = structured_tool_result_rows(&parsed, &prompt);
+    if rows.is_empty() {
+        return None;
+    }
+
+    if prompt_asks_for_work_items(&prompt)
+        && !rows
+            .iter()
+            .any(|row| structured_tool_row_is_referenced(answer, row))
+    {
+        return answer_from_structured_tool_result(&result, &prompt);
+    }
+
+    if let (true, Some(trimmed)) = (
+        prompt_asks_for_work_items(&prompt),
+        trim_unrelated_prefix_before_structured_row(answer, &rows),
+    ) {
+        return Some(trimmed);
+    }
+
+    let missing_rows = rows
+        .iter()
+        .take(3)
+        .filter_map(|row| structured_tool_row_missing_reference(answer, row, &prompt))
+        .collect::<Vec<_>>();
+    if missing_rows.is_empty() {
+        None
+    } else {
+        Some(append_tool_rows(answer, &missing_rows))
+    }
+}
+
+fn structured_tool_row_is_referenced(answer: &str, row: &StructuredToolRow) -> bool {
+    answer_contains_text(answer, &row.title)
+        || row
+            .id
+            .as_deref()
+            .is_some_and(|id| answer_has_row_id(answer, id))
+        || row
+            .url
+            .as_deref()
+            .is_some_and(|url| answer_contains_text(answer, url))
+}
+
+fn structured_tool_row_missing_reference(
+    answer: &str,
+    row: &StructuredToolRow,
+    prompt: &str,
+) -> Option<String> {
+    let has_title = answer_contains_text(answer, &row.title);
+    let has_id = row
+        .id
+        .as_deref()
+        .is_some_and(|id| answer_has_row_id(answer, id));
+    ((has_id && !has_title) || (has_title && row.id.is_some() && !has_id))
+        .then(|| format_structured_tool_row(row, prompt))
+}
+
+fn trim_unrelated_prefix_before_structured_row(
+    answer: &str,
+    rows: &[StructuredToolRow],
+) -> Option<String> {
+    const MIN_PREFIX_CHARS: usize = 240;
+    let first_ref = rows
+        .iter()
+        .filter_map(|row| first_structured_row_reference_index(answer, row))
+        .min()?;
+    if answer[..first_ref].chars().count() < MIN_PREFIX_CHARS {
+        return None;
+    }
+    let start = answer[..first_ref]
+        .rfind('\n')
+        .map_or(first_ref, |index| index + 1);
+    let trimmed = answer[start..].trim_start();
+    (!trimmed.is_empty() && trimmed.len() < answer.trim_start().len()).then(|| trimmed.to_string())
+}
+
+fn first_structured_row_reference_index(answer: &str, row: &StructuredToolRow) -> Option<usize> {
+    let mut candidates = Vec::new();
+    if let Some(id) = row.id.as_deref() {
+        candidates.extend([
+            answer.find(&format!("#{id}")),
+            answer.find(&format!(" {id} ")),
+            answer.find(&format!("PR {id}")),
+            answer.find(&format!("issue {id}")),
+        ]);
+    }
+    candidates.push(case_insensitive_find(answer, &row.title));
+    if let Some(url) = row.url.as_deref() {
+        candidates.push(answer.find(url));
+    }
+    candidates.into_iter().flatten().min()
+}
+
+fn case_insensitive_find(haystack: &str, needle: &str) -> Option<usize> {
+    let haystack_lower = haystack.to_ascii_lowercase();
+    let needle_lower = needle.to_ascii_lowercase();
+    haystack_lower.find(&needle_lower)
 }
 
 #[derive(Debug)]
@@ -2308,6 +2438,11 @@ fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str
         && plain_text_tool_result_looks_like_repository_list(result)
     {
         return "The latest tool result listed repositories, not the requested work items, so I can't answer from that output. I need a corrected work-item result before I can pick an item.".to_string();
+    }
+    if prompt_asks_for_work_items(&prompt)
+        && plain_text_tool_result_looks_like_git_repository_metadata(result)
+    {
+        return "The latest tool result listed git repository metadata, not the requested work items, so I can't answer from that output. I need a corrected work-item result before I can pick an item.".to_string();
     }
 
     let first_line = result
@@ -3109,22 +3244,324 @@ fn latest_completed_tool_call(session: &Session) -> Option<CompletedToolCall> {
 fn retry_tool_result_response_if_plain(
     body: Value,
     retry_tool_call: Option<&CompletedToolCall>,
+    latest_tool_result: Option<&str>,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
     tools_enabled: bool,
 ) -> Value {
-    if !tools_enabled || response_contains_tool_call(&body) {
+    if !tools_enabled {
+        return body;
+    }
+    match (first_response_tool_call(&body), retry_tool_call) {
+        (Some(response_call), Some(retry_call))
+            if response_call.same_signature(retry_call)
+                && !same_tool_call_retry_allowed(latest_tool_result) =>
+        {
+            if let Some(corrected) = corrected_retry_tool_call(
+                retry_call,
+                latest_tool_result,
+                tools,
+                allowed_tools,
+                prompt_tool_profiles,
+            ) {
+                let arguments = Value::String(corrected.arguments);
+                return tool_call_response(&corrected.name, &arguments);
+            }
+            tracing::info!(
+                "moa: suppressing repeated failing {} tool call with unchanged arguments",
+                retry_call.name
+            );
+            return error_response(
+                "MoA refused to repeat an identical failing tool call",
+                MOA_ERR_NO_USABLE_ANSWER,
+            );
+        }
+        _ => {}
+    }
+    if response_contains_tool_call(&body) {
         return body;
     }
     retry_tool_call
-        .map(retry_tool_call_response)
+        .and_then(|call| {
+            retry_tool_call_response(
+                call,
+                latest_tool_result,
+                tools,
+                allowed_tools,
+                prompt_tool_profiles,
+            )
+        })
         .unwrap_or(body)
 }
 
-fn retry_tool_call_response(call: &CompletedToolCall) -> Value {
+fn retry_tool_call_response(
+    call: &CompletedToolCall,
+    latest_tool_result: Option<&str>,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<Value> {
+    if let Some(corrected) = corrected_retry_tool_call(
+        call,
+        latest_tool_result,
+        tools,
+        allowed_tools,
+        prompt_tool_profiles,
+    ) {
+        tracing::info!(
+            "moa: reducer returned plain text after non-answerable {}; retrying corrected tool call",
+            call.name
+        );
+        let arguments = Value::String(corrected.arguments);
+        return Some(tool_call_response(&corrected.name, &arguments));
+    }
+
+    if !same_tool_call_retry_allowed(latest_tool_result) {
+        tracing::info!(
+            "moa: reducer returned plain text after non-answerable {}; not retrying identical failing call",
+            call.name
+        );
+        return None;
+    }
+
     tracing::info!(
         "moa: reducer returned plain text after non-answerable {}; retrying same tool call",
         call.name
     );
-    tool_call_response(&call.name, &Value::String(call.arguments.clone()))
+    Some(tool_call_response(
+        &call.name,
+        &Value::String(call.arguments.clone()),
+    ))
+}
+
+fn same_tool_call_retry_allowed(latest_tool_result: Option<&str>) -> bool {
+    latest_tool_result.is_some_and(|result| plain_text_tool_result_looks_empty(result.trim()))
+}
+
+fn corrected_retry_tool_call(
+    call: &CompletedToolCall,
+    latest_tool_result: Option<&str>,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<CompletedToolCall> {
+    let result = latest_tool_result?;
+    let candidates = command_tool_candidates(tools, allowed_tools, prompt_tool_profiles);
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.name == call.name)?;
+    let mut arguments = serde_json::from_str::<Value>(&call.arguments).ok()?;
+    let command = arguments
+        .get(&candidate.field)
+        .and_then(Value::as_str)
+        .map(str::to_string)?;
+    let corrected = tool_result_is_shell_parse_error(result)
+        .then(|| quote_unquoted_shell_metachar_tokens(&command))
+        .flatten()
+        .or_else(|| remove_unknown_cli_flags_from_command(&command, result))?;
+    if corrected == command {
+        return None;
+    }
+    arguments[&candidate.field] = Value::String(corrected);
+    let sanitized = sanitize_tool_arguments_for_tool(&call.name, &arguments, tools).ok()?;
+    let wire = tool_arguments_wire_string(&sanitized);
+    if wire == call.arguments {
+        return None;
+    }
+    Some(CompletedToolCall {
+        name: call.name.clone(),
+        arguments: wire,
+    })
+}
+
+fn tool_result_is_shell_parse_error(result: &str) -> bool {
+    let lower = result.to_ascii_lowercase();
+    lower.contains("parse error near") || lower.contains("syntax error near")
+}
+
+fn remove_unknown_cli_flags_from_command(command: &str, result: &str) -> Option<String> {
+    let allowed = allowed_cli_long_flags_from_usage(result)?;
+    let tokens = split_shell_tokens(command)?;
+    let mut changed = false;
+    let mut filtered = Vec::with_capacity(tokens.len());
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        match shell_long_flag_name(token) {
+            Some(flag) if !allowed.contains(flag) => {
+                changed = true;
+                index += unknown_flag_token_span(&tokens, index);
+                continue;
+            }
+            _ => {}
+        }
+        filtered.push(token.clone());
+        index += 1;
+    }
+    changed.then(|| join_shell_tokens(&filtered))
+}
+
+fn allowed_cli_long_flags_from_usage(result: &str) -> Option<HashSet<String>> {
+    let lower = result.to_ascii_lowercase();
+    if !lower
+        .lines()
+        .take(4)
+        .any(|line| line.contains("unknown flag:"))
+        || !lower.contains("\nusage:")
+    {
+        return None;
+    }
+
+    let flags_section = result
+        .lines()
+        .skip_while(|line| line.trim() != "Flags:")
+        .skip(1)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let allowed = flags_section
+        .split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | ';' | ')' | '('))
+        .filter_map(|token| token.strip_prefix("--"))
+        .map(|token| {
+            token.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_')
+        })
+        .filter(|token| !token.is_empty())
+        .map(str::to_string)
+        .collect::<HashSet<_>>();
+    (!allowed.is_empty()).then_some(allowed)
+}
+
+fn shell_long_flag_name(token: &str) -> Option<&str> {
+    token
+        .strip_prefix("--")
+        .map(|flag| flag.split_once('=').map_or(flag, |(name, _)| name))
+        .filter(|flag| !flag.is_empty())
+}
+
+fn unknown_flag_token_span(tokens: &[String], index: usize) -> usize {
+    let token = &tokens[index];
+    if token.contains('=') {
+        return 1;
+    }
+    let Some(next) = tokens.get(index + 1) else {
+        return 1;
+    };
+    if next.starts_with('-') { 1 } else { 2 }
+}
+
+fn split_shell_tokens(command: &str) -> Option<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut token = String::new();
+    let mut quote: Option<char> = None;
+
+    for ch in command.chars() {
+        match ch {
+            '\'' | '"' if quote == Some(ch) => quote = None,
+            '\'' | '"' if quote.is_none() => quote = Some(ch),
+            ch if ch.is_whitespace() && quote.is_none() => {
+                if !token.is_empty() {
+                    tokens.push(std::mem::take(&mut token));
+                }
+            }
+            _ => token.push(ch),
+        }
+    }
+    if quote.is_some() {
+        return None;
+    }
+    if !token.is_empty() {
+        tokens.push(token);
+    }
+    (!tokens.is_empty()).then_some(tokens)
+}
+
+fn join_shell_tokens(tokens: &[String]) -> String {
+    tokens
+        .iter()
+        .map(|token| {
+            if shell_token_needs_join_quotes(token) {
+                format!("'{}'", token.replace('\'', r#"'"'"'"#))
+            } else {
+                token.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_token_needs_join_quotes(token: &str) -> bool {
+    token.is_empty()
+        || token
+            .chars()
+            .any(|ch| ch.is_whitespace() || matches!(ch, '&' | '|' | ';' | '<' | '>' | '(' | ')'))
+}
+
+fn quote_unquoted_shell_metachar_tokens(command: &str) -> Option<String> {
+    let mut changed = false;
+    let mut out = String::with_capacity(command.len() + 8);
+    let mut token = String::new();
+    let mut quote: Option<char> = None;
+
+    for ch in command.chars() {
+        match ch {
+            '\'' | '"' if quote == Some(ch) => {
+                quote = None;
+                token.push(ch);
+            }
+            '\'' | '"' if quote.is_none() => {
+                quote = Some(ch);
+                token.push(ch);
+            }
+            ch if ch.is_whitespace() && quote.is_none() => {
+                flush_shell_token(&mut out, &mut token, &mut changed);
+                out.push(ch);
+            }
+            _ => token.push(ch),
+        }
+    }
+    flush_shell_token(&mut out, &mut token, &mut changed);
+
+    changed.then_some(out)
+}
+
+fn flush_shell_token(out: &mut String, token: &mut String, changed: &mut bool) {
+    if token.is_empty() {
+        return;
+    }
+    if shell_token_needs_single_quotes(token) {
+        *changed = true;
+        out.push('\'');
+        out.push_str(&token.replace('\'', r#"'"'"'"#));
+        out.push('\'');
+    } else {
+        out.push_str(token);
+    }
+    token.clear();
+}
+
+fn shell_token_needs_single_quotes(token: &str) -> bool {
+    token.contains('&') && !shell_token_already_quoted(token)
+}
+
+fn shell_token_already_quoted(token: &str) -> bool {
+    (token.starts_with('\'') && token.ends_with('\''))
+        || (token.starts_with('"') && token.ends_with('"'))
+}
+
+fn first_response_tool_call(body: &Value) -> Option<CompletedToolCall> {
+    let call = body
+        .pointer("/choices/0/message/tool_calls")
+        .and_then(Value::as_array)?
+        .first()?;
+    let name = call.pointer("/function/name").and_then(Value::as_str)?;
+    let arguments = call
+        .pointer("/function/arguments")
+        .map(tool_call_arguments_signature)
+        .unwrap_or_default();
+    Some(CompletedToolCall {
+        name: name.to_string(),
+        arguments,
+    })
 }
 
 fn response_contains_tool_call(body: &Value) -> bool {
@@ -3163,6 +3600,11 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
         return false;
     }
     if prompt_asks_for_work_items(prompt) && plain_text_tool_result_looks_like_git_remotes(result) {
+        return false;
+    }
+    if prompt_asks_for_work_items(prompt)
+        && plain_text_tool_result_looks_like_git_repository_metadata(result)
+    {
         return false;
     }
     if plain_text_tool_result_looks_like_repository_list(result)
@@ -3412,6 +3854,62 @@ fn plain_text_tool_result_looks_like_git_remotes(result: &str) -> bool {
     })
 }
 
+fn plain_text_tool_result_looks_like_git_repository_metadata(result: &str) -> bool {
+    let lines: Vec<&str> = result
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .take(12)
+        .collect();
+    if lines.is_empty() {
+        return false;
+    }
+    let fetch_or_ref_lines = lines
+        .iter()
+        .filter(|line| git_metadata_status_line(line) || git_ref_listing_line(line))
+        .count();
+    let revision_lines = lines
+        .iter()
+        .filter(|line| git_revision_listing_line(line))
+        .count();
+    fetch_or_ref_lines > 0 || revision_lines >= 2 || revision_lines == lines.len()
+}
+
+fn git_metadata_status_line(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower == "already up to date."
+        || lower.contains("fetch_head")
+        || lower.starts_with("from https://")
+        || lower.starts_with("from http://")
+        || lower.starts_with("from git@")
+        || lower.starts_with("* branch ")
+}
+
+fn git_ref_listing_line(line: &str) -> bool {
+    let mut columns = line.split('\t').map(str::trim);
+    let Some(first) = columns.next() else {
+        return false;
+    };
+    let Some(second) = columns.next() else {
+        return false;
+    };
+    first.len() >= 7
+        && first.chars().all(|ch| ch.is_ascii_hexdigit())
+        && (second.starts_with("refs/heads/")
+            || second.starts_with("refs/tags/")
+            || second.starts_with("refs/remotes/"))
+}
+
+fn git_revision_listing_line(line: &str) -> bool {
+    let mut parts = line.splitn(2, char::is_whitespace);
+    let Some(revision) = parts.next() else {
+        return false;
+    };
+    parts.next().is_some_and(|rest| !rest.trim().is_empty())
+        && (7..=40).contains(&revision.len())
+        && revision.chars().all(|ch| ch.is_ascii_hexdigit())
+}
+
 fn looks_like_git_remote_location(remote: &str) -> bool {
     remote.contains("://")
         || remote.contains('@')
@@ -3427,6 +3925,8 @@ fn plain_text_tool_result_looks_like_error(result: &str) -> bool {
     first_line.starts_with("unknown flag:")
         || first_line.starts_with("unknown json field:")
         || first_line.starts_with("unknown command")
+        || first_line.contains("parse error")
+        || first_line.contains("syntax error")
         || first_line == "no git remotes found"
         || first_line.contains("not available or not authenticated")
         || first_line.starts_with("error:")
@@ -3987,9 +4487,7 @@ fn resolve_response_tool_name(
     let [candidate] = candidates.as_slice() else {
         return None;
     };
-    if candidate.field != "command"
-        && let Some(map) = arguments.as_object_mut()
-    {
+    if let (true, Some(map)) = (candidate.field != "command", arguments.as_object_mut()) {
         map.insert(candidate.field.clone(), Value::String(command));
     }
     Some(candidate.name.clone())
@@ -5910,6 +6408,50 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn repair_tool_result_answer_replaces_unrelated_answer_with_structured_work_item() {
+        let prompt = "Use shell/developer tool to look for recent important open GitHub issues or PRs in Mesh-LLM/mesh-llm. Inspect the results with a command, then reply with one specific issue or PR number/title and why it matters. Do not answer from memory.";
+        let result = serde_json::json!([{
+            "number": 808,
+            "title": "Stabilize OpenClaw tool loops through MoA",
+            "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/808",
+            "state": "open",
+            "body": "OpenClaw/Gateway users can now route Telegram-style agent turns through model=mesh without small-context workers or slow peers turning ordinary tool loops into timeouts."
+        }])
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        let repaired =
+            repair_tool_result_answer(&session, "Hey. I just came online. Who am I? Who are you?");
+
+        assert!(repaired.contains("#808 - Stabilize OpenClaw tool loops through MoA"));
+        assert!(repaired.contains("https://github.com/Mesh-LLM/mesh-llm/pull/808"));
+        assert!(!repaired.contains("Who am I"));
+    }
+
+    #[test]
+    fn repair_tool_result_answer_trims_identity_preamble_before_work_item() {
+        let prompt = "Use shell/developer tool to look for recent important open GitHub issues or PRs in Mesh-LLM/mesh-llm. Inspect the results with a command, then reply with one specific issue or PR number/title and why it matters. Do not answer from memory.";
+        let result = serde_json::json!([{
+            "number": 808,
+            "title": "Stabilize OpenClaw tool loops through MoA",
+            "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/808",
+            "state": "open"
+        }])
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+        let unrelated_prefix = "Hey. I just came online. Who am I? Who are you?\n\nI'm your personal assistant, running inside OpenClaw. I'm here to help you navigate the code, track down those tricky bugs, and maybe even find a little joy in the chaos of development. My vibe is collaborative, curious, and ready to dive into the weeds.\n\nNow, about that GitHub request. I dug into the recent activity.\n\n";
+        let answer = format!(
+            "{unrelated_prefix}**PR #808: Stabilize OpenClaw tool loops through MoA**\n\nThis matters because it targets agent tool-loop stability."
+        );
+
+        let repaired = repair_tool_result_answer(&session, &answer);
+
+        assert!(repaired.starts_with("**PR #808"));
+        assert!(!repaired.contains("Who am I"));
+        assert!(repaired.contains("tool-loop stability"));
+    }
+
+    #[test]
     fn cli_usage_error_is_not_answerable_tool_evidence() {
         let result = "unknown flag: --since\r\n\r\nUsage:  gh pr list [flags]\r\n\r\nFlags:";
 
@@ -5920,6 +6462,14 @@ mod response_builder_tests {
     #[test]
     fn cli_json_field_error_is_not_answerable_tool_evidence() {
         let result = "Unknown JSON field: \"headRepositoryName\"\nAvailable fields:\n  additions\n  author\n  title\n\n(Command exited with code 1)";
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
+    fn shell_parse_error_is_not_answerable_tool_evidence() {
+        let result = "(eval):1: parse error near `&'\n\n(Command exited with code 1)";
 
         assert!(!tool_result_has_answerable_evidence(result));
         assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
@@ -6053,6 +6603,8 @@ mod response_builder_tests {
             "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
             "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
             "origin\tgit@github.com:Mesh-LLM/mesh-llm.git (fetch)\norigin\tgit@github.com:Mesh-LLM/mesh-llm.git (push)",
+            "From https://github.com/Mesh-LLM/mesh-llm\n * branch            main       -> FETCH_HEAD\nAlready up to date.\n536f30a Reuse Skippy decode wire messages\nced32cc8e662a1433d51217787eb304da9121844\trefs/heads/acp-agent-pooling",
+            "536f30a Reuse Skippy decode wire messages\n70cbe09 Stabilize OpenClaw tool loops\nbfe8012 Refresh docs",
         ];
 
         for prompt in pr_prompts {
@@ -6727,6 +7279,26 @@ mod response_builder_tests {
         })
     }
 
+    fn command_tool_schema(name: &str) -> Value {
+        serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }])
+    }
+
     fn session_with_tool_result(result: &str) -> Session {
         session_with_user_and_tool_result("run command", result)
     }
@@ -6745,7 +7317,7 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn non_answerable_tool_result_plain_answer_retries_same_tool_call() {
+    fn empty_tool_result_plain_answer_retries_same_tool_call() {
         let command =
             r#"{"command":"gh pr list --repo Mesh-LLM/mesh-llm --state open --limit 10"}"#;
         let mut session = Session::new();
@@ -6765,6 +7337,10 @@ mod response_builder_tests {
         let body = retry_tool_result_response_if_plain(
             chat_response("I could not retrieve any pull requests."),
             Some(&retry),
+            Some("(no output)"),
+            None,
+            &[],
+            &[],
             true,
         );
 
@@ -6782,6 +7358,82 @@ mod response_builder_tests {
             body.pointer("/choices/0/message/content")
                 .and_then(Value::as_str)
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn shell_parse_error_retries_schema_corrected_command_tool_call() {
+        let tools = command_tool_schema("exec");
+        let allowed = ["exec".to_string()];
+        let command = r#"{"command":"gh api repos/Mesh-LLM/mesh-llm/issues?state=open&sort=updated&direction=desc --jq '.items[0:1]'"}"#;
+        let retry = CompletedToolCall {
+            name: "exec".to_string(),
+            arguments: command.to_string(),
+        };
+
+        let body = retry_tool_result_response_if_plain(
+            chat_response("The GitHub API command failed."),
+            Some(&retry),
+            Some("(eval):1: parse error near `&'\n\n(Command exited with code 1)"),
+            Some(&tools),
+            &allowed,
+            &[],
+            true,
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        let args = body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool args");
+        assert_eq!(
+            args.get("command").and_then(Value::as_str),
+            Some(
+                "gh api 'repos/Mesh-LLM/mesh-llm/issues?state=open&sort=updated&direction=desc' --jq '.items[0:1]'"
+            )
+        );
+    }
+
+    #[test]
+    fn cli_unknown_flag_error_retries_schema_corrected_command_tool_call() {
+        let tools = command_tool_schema("exec");
+        let allowed = ["exec".to_string()];
+        let command =
+            r#"{"command":"gh api repos/Mesh-LLM/mesh-llm/issues --state open --limit 1"}"#;
+        let retry = CompletedToolCall {
+            name: "exec".to_string(),
+            arguments: command.to_string(),
+        };
+        let result = "unknown flag: --state\n\nUsage:  gh api <endpoint> [flags]\n\nFlags:\n      --cache duration        Cache the response\n  -H, --header key:value      Add a HTTP request header\n      --paginate              Make additional HTTP requests\n\n(Command exited with code 1)";
+
+        let body = retry_tool_result_response_if_plain(
+            chat_response("Let me try again with a corrected command."),
+            Some(&retry),
+            Some(result),
+            Some(&tools),
+            &allowed,
+            &[],
+            true,
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        let args = body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool args");
+        assert_eq!(
+            args.get("command").and_then(Value::as_str),
+            Some("gh api repos/Mesh-LLM/mesh-llm/issues")
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -5866,17 +5866,19 @@ fn xml_tool_choice_from_text(
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
 ) -> Option<ForcedToolChoice> {
-    let invoke_start = content.find("<invoke")?;
-    let invoke_tag_end = content[invoke_start..].find('>')? + invoke_start;
-    let invoke_tag = &content[invoke_start..=invoke_tag_end];
+    let body = xml_tool_call_envelope_body(content)?;
+    let invoke_start = body.find("<invoke")?;
+    let invoke_tag_end = body[invoke_start..].find('>')? + invoke_start;
+    let invoke_tag = &body[invoke_start..=invoke_tag_end];
     let body_start = invoke_tag_end + 1;
-    let body_end = content[body_start..]
+    let body_end = body[body_start..]
         .find("</invoke>")
         .map(|idx| body_start + idx)
-        .unwrap_or(content.len());
-    let body = &content[body_start..body_end];
-    let mut arguments = xml_parameter_arguments(body);
-    let raw_name = xml_attr_value(invoke_tag, "name").or_else(|| xml_body_tool_name(body))?;
+        .unwrap_or(body.len());
+    let invoke_body = &body[body_start..body_end];
+    let mut arguments = xml_parameter_arguments(invoke_body);
+    let raw_name =
+        xml_attr_value(invoke_tag, "name").or_else(|| xml_body_tool_name(invoke_body))?;
     let name = resolve_response_tool_name(
         &raw_name,
         &mut arguments,
@@ -5900,6 +5902,43 @@ fn xml_tool_choice_from_text(
             None
         }
     }
+}
+
+fn xml_tool_call_envelope_body(content: &str) -> Option<&str> {
+    let (tag_end, tag_name) = first_xml_tool_call_open_tag(content)?;
+    let body_start = tag_end + 1;
+    let body = &content[body_start..];
+    let close = format!("</{tag_name}>");
+    let body_end = body.find(&close).unwrap_or(content.len() - body_start);
+    Some(&body[..body_end])
+}
+
+fn first_xml_tool_call_open_tag(content: &str) -> Option<(usize, &str)> {
+    let mut offset = 0;
+    while let Some(relative_start) = content[offset..].find('<') {
+        let tag_start = offset + relative_start;
+        let after_open = &content[tag_start + 1..];
+        if matches!(after_open.chars().next(), Some('/' | '!' | '?')) {
+            offset = tag_start + 1;
+            continue;
+        }
+        let tag_end = after_open.find('>')? + tag_start + 1;
+        let raw_tag = &content[tag_start + 1..tag_end];
+        let tag_name = raw_tag
+            .split(|c: char| c == '>' || c.is_ascii_whitespace())
+            .next()
+            .unwrap_or_default()
+            .trim_end_matches('/');
+        let local_name = tag_name
+            .rsplit_once(':')
+            .map_or(tag_name, |(_, local)| local)
+            .to_ascii_lowercase();
+        if local_name == "tool_call" {
+            return Some((tag_end, tag_name));
+        }
+        offset = tag_start + 1;
+    }
+    None
 }
 
 fn resolve_response_tool_name(
@@ -10328,6 +10367,52 @@ mod response_builder_tests {
                 .pointer("/choices/0/message/tool_calls/0/function/arguments")
                 .and_then(Value::as_str),
             Some("{\"command\":\"printf \\\"hello\\\"\"}")
+        );
+    }
+
+    #[test]
+    fn bare_xml_in_answer_stays_chat_even_with_matching_tool_schema() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Execute shell commands.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]));
+        let content = "This is only an XML example: <invoke name=\"shell\"><parameter name=\"command\">pwd</parameter></invoke>";
+        let response = chat_or_schema_command_tool_response(
+            content,
+            tools.as_ref(),
+            &["shell".to_string()],
+            &[],
+            Some("Do not call tools. Explain the XML example."),
+        );
+
+        assert!(
+            response.pointer("/choices/0/message/tool_calls").is_none(),
+            "bare XML examples must not be corrected into tool calls: {response}"
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some(content)
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -4629,9 +4629,13 @@ fn xml_body_tool_name(body: &str) -> Option<String> {
 }
 
 fn xml_attr_value(tag: &str, attr: &str) -> Option<String> {
-    let needle = format!("{attr}=\"");
+    xml_quoted_attr_value(tag, attr, '"').or_else(|| xml_quoted_attr_value(tag, attr, '\''))
+}
+
+fn xml_quoted_attr_value(tag: &str, attr: &str, quote: char) -> Option<String> {
+    let needle = format!("{attr}={quote}");
     let value_start = tag.find(&needle)? + needle.len();
-    let value_end = tag[value_start..].find('"')? + value_start;
+    let value_end = tag[value_start..].find(quote)? + value_start;
     Some(xml_text_unescape(&tag[value_start..value_end]))
 }
 
@@ -4689,12 +4693,22 @@ fn xml_parameter_value_end(body: &str, value_start: usize, name: &str, tag_prefi
 }
 
 fn xml_text_unescape(text: &str) -> String {
-    text.replace("&quot;", "\"")
-        .replace("&apos;", "'")
-        .replace("&#39;", "'")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&amp;", "&")
+    let mut decoded = text.to_string();
+    for _ in 0..3 {
+        let next = decoded
+            .replace("&quot;", "\"")
+            .replace("&#34;", "\"")
+            .replace("&apos;", "'")
+            .replace("&#39;", "'")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&amp;", "&");
+        if next == decoded {
+            break;
+        }
+        decoded = next;
+    }
+    decoded
 }
 
 fn embedded_json_object_candidates(text: &str) -> Vec<String> {
@@ -7360,6 +7374,38 @@ mod response_builder_tests {
                 .pointer("/choices/0/message/tool_calls/0/function/arguments")
                 .and_then(Value::as_str),
             Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\"}")
+        );
+    }
+
+    #[test]
+    fn prompt_catalog_xml_accepts_single_quotes_and_double_escaped_entities() {
+        let (session, profiles, allowed) = prompt_tool_session("Use printf with the exec tool.");
+
+        let response = chat_or_schema_command_tool_response(
+            "<tool_call>\n<invoke name='exec'>\n<parameter name='command'>printf &amp;quot;hello&#34;</parameter>\n</invoke>\n</tool_call>",
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"printf \\\"hello\\\"\"}")
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2013,15 +2013,15 @@ fn short_exact_value(value: &str) -> bool {
 }
 
 fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
-    let calls = completed_tool_names_since_latest_user_before_tool_result(session);
-    let tool_name = calls.last()?;
+    let calls = completed_tool_calls_since_latest_user_before_tool_result(session);
+    let latest = calls.last()?;
     let count = calls
         .iter()
         .rev()
-        .take_while(|name| *name == tool_name)
+        .take_while(|call| call.same_signature(latest))
         .count();
 
-    (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (tool_name.clone(), count))
+    (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (latest.name.clone(), count))
 }
 
 fn tool_budget_exhausted(session: &Session) -> Option<usize> {
@@ -2030,6 +2030,27 @@ fn tool_budget_exhausted(session: &Session) -> Option<usize> {
 }
 
 fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) -> Vec<String> {
+    completed_tool_calls_since_latest_user_before_tool_result(session)
+        .into_iter()
+        .map(|call| call.name)
+        .collect()
+}
+
+#[derive(Clone, Debug)]
+struct CompletedToolCall {
+    name: String,
+    arguments: String,
+}
+
+impl CompletedToolCall {
+    fn same_signature(&self, other: &Self) -> bool {
+        self.name == other.name && self.arguments == other.arguments
+    }
+}
+
+fn completed_tool_calls_since_latest_user_before_tool_result(
+    session: &Session,
+) -> Vec<CompletedToolCall> {
     let all = session.all_messages();
     let Some(latest_tool_idx) = all.iter().rposition(|msg| message_role(msg) == "tool") else {
         return Vec::new();
@@ -2039,7 +2060,7 @@ fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) 
         .rposition(|msg| message_role(msg) == "user")
         .unwrap_or(0);
 
-    let mut call_names = std::collections::HashMap::new();
+    let mut call_signatures = std::collections::HashMap::new();
     let mut completed = Vec::new();
     for msg in &all[start_idx..=latest_tool_idx] {
         match message_role(msg) {
@@ -2055,15 +2076,25 @@ fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) 
                     else {
                         continue;
                     };
-                    call_names.insert(id.to_string(), name.to_string());
+                    let arguments = tool_call
+                        .pointer("/function/arguments")
+                        .map(tool_call_arguments_signature)
+                        .unwrap_or_default();
+                    call_signatures.insert(
+                        id.to_string(),
+                        CompletedToolCall {
+                            name: name.to_string(),
+                            arguments,
+                        },
+                    );
                 }
             }
             "tool" => {
                 let Some(id) = msg.get("tool_call_id").and_then(Value::as_str) else {
                     continue;
                 };
-                if let Some(name) = call_names.get(id) {
-                    completed.push(name.clone());
+                if let Some(call) = call_signatures.get(id) {
+                    completed.push(call.clone());
                 }
             }
             _ => {}
@@ -2071,6 +2102,13 @@ fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) 
     }
 
     completed
+}
+
+fn tool_call_arguments_signature(value: &Value) -> String {
+    value
+        .as_str()
+        .map(str::to_string)
+        .unwrap_or_else(|| value.to_string())
 }
 
 fn latest_completed_tool_result(session: &Session) -> Option<(String, String)> {
@@ -2096,6 +2134,11 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     }
     if prompt_asks_for_github_work_items(prompt)
         && plain_text_tool_result_looks_like_github_auth_status(result)
+    {
+        return false;
+    }
+    if prompt_asks_for_pull_requests(prompt)
+        && plain_text_tool_result_looks_like_git_remotes(result)
     {
         return false;
     }
@@ -2155,6 +2198,16 @@ fn plain_text_tool_result_looks_like_github_repo_list(result: &str) -> bool {
         repo.contains('/')
             && !repo.contains(char::is_whitespace)
             && (visibility.contains("public") || visibility.contains("private"))
+    })
+}
+
+fn plain_text_tool_result_looks_like_git_remotes(result: &str) -> bool {
+    result.lines().map(str::trim).any(|line| {
+        let mut columns = line.split('\t').map(str::trim);
+        matches!(columns.next(), Some("origin" | "upstream"))
+            && columns.next().is_some_and(|remote| {
+                remote.contains("github.com:") || remote.contains("github.com/")
+            })
     })
 }
 
@@ -4559,6 +4612,31 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn git_remote_listing_is_not_pr_request_evidence() {
+        let result = "origin\tgit@github.com:Mesh-LLM/mesh-llm.git (fetch)\norigin\tgit@github.com:Mesh-LLM/mesh-llm.git (push)";
+        let prompt = "Any new interesting PRs? You have the gh command line I think can use";
+
+        assert!(tool_result_has_answerable_evidence(result));
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+        assert!(
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, result))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn git_remote_listing_can_answer_remote_prompt() {
+        let result = "origin\tgit@github.com:Mesh-LLM/mesh-llm.git (fetch)";
+        let prompt = "What git remote is configured?";
+
+        assert!(tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+    }
+
+    #[test]
     fn pr_prompt_rejects_bad_or_wrong_domain_tool_result_permutations() {
         let pr_prompts = [
             "Any new interesting PRs? You have the gh command line I think can use",
@@ -4574,6 +4652,7 @@ mod response_builder_tests {
             "GraphQL: Could not resolve to a Repository with the name 'micn/mesh-llm'. (repository)",
             "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
             "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
+            "origin\tgit@github.com:Mesh-LLM/mesh-llm.git (fetch)\norigin\tgit@github.com:Mesh-LLM/mesh-llm.git (push)",
         ];
 
         for prompt in pr_prompts {

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2445,13 +2445,9 @@ fn parse_json_prefix_with_escaped_string_controls(input: &str) -> Option<Value> 
 
 fn prompt_asks_for_check_or_review_status(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
-    contains_any(
-        &lower,
-        &[
-            "ci", "check", "checks", "green", "status", "copilot", "feedback", "comment",
-            "comments", "review", "reviews",
-        ],
-    )
+    prompt_asks_for_ci_status(prompt)
+        || prompt_asks_for_feedback(prompt)
+        || contains_any(&lower, &["status", "green"])
 }
 
 fn answer_from_structured_status_feedback_value(value: &Value, prompt: &str) -> Option<String> {
@@ -2550,7 +2546,7 @@ fn structured_feedback_summary_from_value(value: &Value, prompt: &str) -> Option
 
 fn structured_check_summary(checks: &[Value]) -> Option<String> {
     if checks.is_empty() {
-        return Some("CI/checks: no check runs were returned.".to_string());
+        return None;
     }
 
     let mut failing = Vec::new();
@@ -6200,6 +6196,31 @@ mod response_builder_tests {
         assert!(
             answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, &result))
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn weather_check_prompt_does_not_trigger_ci_status_summary() {
+        let prompt =
+            "Use the weather lookup tool to check Sydney. Now answer in one short sentence.";
+        let result = serde_json::json!({
+            "city": "Sydney",
+            "condition": "clear",
+            "temperature_c": 21
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        assert_eq!(
+            answer_from_prompt_specific_structured_tool_result(&result, prompt),
+            None
+        );
+        let answer = answer_from_latest_tool_result(&session).expect("weather JSON is evidence");
+        assert!(answer.contains("Sydney"), "{answer}");
+        assert!(!answer.contains("CI/checks"), "{answer}");
+        assert_eq!(
+            repair_tool_result_answer(&session, "Sydney is clear at 21C."),
+            "Sydney is clear at 21C."
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2123,6 +2123,7 @@ fn prompt_asks_for_pull_requests(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
     prompt_has_word(&lower, "pr")
         || prompt_has_word(&lower, "prs")
+        || prompt_has_word(&lower, "pulls")
         || lower.contains("pull request")
 }
 
@@ -4554,6 +4555,62 @@ mod response_builder_tests {
         assert!(tool_result_has_answerable_evidence_for_prompt(
             result, prompt
         ));
+    }
+
+    #[test]
+    fn pr_prompt_rejects_bad_or_wrong_domain_tool_result_permutations() {
+        let pr_prompts = [
+            "Any new interesting PRs? You have the gh command line I think can use",
+            "Use gh to find recent open pulls.",
+            "Find important GitHub pull requests.",
+        ];
+        let non_evidence_results = [
+            "unknown flag: --sort\n\nUsage: gh pr list [flags]",
+            "UNKNOWN JSON FIELD: \"repository\"\nAvailable fields:\n  author\n  title",
+            "  no git remotes found\n\n(Command exited with code 1)",
+            "gh search not available or not authenticated",
+            "search failed: gh search not available or not authenticated",
+            "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
+            "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
+        ];
+
+        for prompt in pr_prompts {
+            for result in non_evidence_results {
+                assert!(
+                    !tool_result_has_answerable_evidence_for_prompt(result, prompt),
+                    "prompt {prompt:?} should not accept tool output {result:?} as PR evidence"
+                );
+                assert!(
+                    answer_from_latest_tool_result(&session_with_user_and_tool_result(
+                        prompt, result
+                    ))
+                    .is_none(),
+                    "prompt {prompt:?} should not synthesize from {result:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn pr_prompt_accepts_pr_row_permutations() {
+        let prompt = "Use gh to list recent open PRs for mesh-LLM/mesh-llm.";
+        let pr_results = [
+            "808\tStabilize OpenClaw tool loops through MoA\tOPEN\t2026-06-06T06:17:33Z",
+            "#808\tStabilize OpenClaw tool loops through MoA\tOPEN",
+            "808\tStabilize OpenClaw tool loops through MoA",
+        ];
+
+        for result in pr_results {
+            assert!(
+                tool_result_has_answerable_evidence_for_prompt(result, prompt),
+                "prompt {prompt:?} should accept PR output {result:?}"
+            );
+            assert!(
+                answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, result))
+                    .is_some(),
+                "prompt {prompt:?} should synthesize from {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -862,12 +862,11 @@ fn prompt_tool_catalog_source(session: &Session) -> Option<String> {
         return Some(system);
     }
 
-    let parts: Vec<String> = session
+    session
         .messages()
-        .iter()
-        .filter_map(message_text_content)
-        .collect();
-    (!parts.is_empty()).then(|| parts.join("\n"))
+        .first()
+        .and_then(message_text_content)
+        .filter(|text| !text.trim().is_empty())
 }
 
 fn prompt_tool_heading(line: &str) -> bool {
@@ -1497,6 +1496,7 @@ fn forced_tool_choice(
     if name.is_empty() || !allowed_tools.iter().any(|tool| tool == name) {
         return None;
     }
+    tool_parameters(name, tools.as_ref())?;
 
     let inferred =
         infer_tool_arguments_from_prompt(name, tools.as_ref(), &session.last_user_text());
@@ -2052,13 +2052,17 @@ async fn handle_tool_result(
                         }
                         _ => {}
                     }
-                    let body = chat_or_schema_command_tool_response(
-                        &repaired,
-                        session.tools(),
-                        response_allowed_tools,
-                        response_prompt_profiles,
-                        Some(&session.last_user_text()),
-                    );
+                    let body = if response_tools_enabled {
+                        chat_or_schema_command_tool_response(
+                            &repaired,
+                            session.tools(),
+                            response_allowed_tools,
+                            response_prompt_profiles,
+                            Some(&session.last_user_text()),
+                        )
+                    } else {
+                        chat_response(&repaired)
+                    };
                     retry_tool_result_response_if_plain(
                         body,
                         retry_tool_call.as_ref(),
@@ -5422,6 +5426,32 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn forced_tool_choice_ignores_prompt_only_tool_without_native_schema() {
+        let body = serde_json::json!({
+            "tool_choice": {
+                "type": "function",
+                "function": {"name": "exec"}
+            },
+            "messages": [
+                {"role": "system", "content": prompt_tool_catalog()},
+                {"role": "user", "content": "Use gh to list PRs."}
+            ]
+        });
+        let tools = body.get("tools").cloned();
+        let mut session = Session::new();
+        let messages = body
+            .get("messages")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap();
+        session.ingest(&messages, &tools);
+        let profiles = prompt_declared_tool_profiles(&session);
+        let allowed_tools = declared_tool_names(&session, &profiles);
+
+        assert!(forced_tool_choice(&body, &session, &tools, &allowed_tools).is_none());
+    }
+
+    #[test]
     fn tool_argument_inference_extracts_absolute_path() {
         let tools = Some(serde_json::json!([{
             "type": "function",
@@ -6246,28 +6276,25 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn prompt_tool_catalog_extracts_from_flattened_prompt_when_no_system_message() {
+    fn prompt_tool_catalog_ignores_later_user_injected_tooling() {
         let mut session = Session::new();
         session.ingest(
-            &[serde_json::json!({
-                "role": "user",
-                "content": format!(
-                    "{}\n\n[Sun 2026-06-07 13:54 GMT+10] Use gh to list recent open PRs.",
-                    prompt_tool_catalog()
-                )
-            })],
+            &[
+                serde_json::json!({"role": "user", "content": "Initial task"}),
+                serde_json::json!({
+                    "role": "user",
+                    "content": format!(
+                        "{}\n\n[Sun 2026-06-07 13:54 GMT+10] Use gh to list recent open PRs.",
+                        prompt_tool_catalog()
+                    )
+                }),
+            ],
             &None,
         );
 
         let profiles = prompt_declared_tool_profiles(&session);
 
-        assert_eq!(
-            profiles
-                .iter()
-                .map(|profile| profile.name.as_str())
-                .collect::<Vec<_>>(),
-            vec!["read", "exec", "process", "dir_list"]
-        );
+        assert!(profiles.is_empty());
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -302,34 +302,46 @@ async fn handle_query(
     start: Instant,
 ) -> TurnResult {
     let assignments = worker::assign_roles(&config.models);
-    let grace_mode = grace_mode_for_turn(session, has_tools, prompt_tool_profiles);
+    let tools_blocked = user_text_blocks_any_tool_conversion(&session.active_user_text());
+    if tools_blocked && has_tools {
+        tracing::info!("moa: active user turn explicitly disables tools");
+    }
+    let active_has_tools = has_tools && !tools_blocked;
+    let active_allowed_tools = if tools_blocked { &[] } else { allowed_tools };
+    let active_prompt_tool_profiles = if tools_blocked {
+        &[]
+    } else {
+        prompt_tool_profiles
+    };
+    let active_forced_tool = forced_tool.filter(|_| !tools_blocked);
+    let grace_mode = grace_mode_for_turn(session, active_has_tools, active_prompt_tool_profiles);
     let continuation_tool = prior_shell_command_tool_choice(
         session,
         &tools_value(session),
-        allowed_tools,
-        prompt_tool_profiles,
+        active_allowed_tools,
+        active_prompt_tool_profiles,
     );
-    let query_uses_tools = forced_tool.is_some()
+    let query_uses_tools = active_forced_tool.is_some()
         || continuation_tool.is_some()
         || matches!(grace_mode, GraceMode::Tool);
-    let selected_tool_names = if let Some(tool) = forced_tool {
+    let selected_tool_names = if let Some(tool) = active_forced_tool {
         vec![tool.name.clone()]
     } else if let Some(tool) = continuation_tool.as_ref() {
         vec![tool.name.clone()]
     } else if query_uses_tools {
-        selected_tool_names_for_turn(session, allowed_tools, prompt_tool_profiles)
+        selected_tool_names_for_turn(session, active_allowed_tools, active_prompt_tool_profiles)
     } else {
         Vec::new()
     };
-    let intent_required_tool = if forced_tool.is_none() && query_uses_tools {
+    let intent_required_tool = if active_forced_tool.is_none() && query_uses_tools {
         required_tool_choice_for_intent(session, &tools_value(session), &selected_tool_names)
     } else {
         None
     };
-    let required_tool = forced_tool
+    let required_tool = active_forced_tool
         .or(continuation_tool.as_ref())
         .or(intent_required_tool.as_ref());
-    if let Some(tool) = required_tool.filter(|_| has_tools) {
+    if let Some(tool) = required_tool.filter(|_| active_has_tools) {
         tracing::info!(
             "moa: direct tool call for explicit {} intent",
             tool.name.as_str()
@@ -339,7 +351,7 @@ async fn handle_query(
             &tool.fallback_arguments,
             session.tools(),
             &selected_tool_names,
-            prompt_tool_profiles,
+            active_prompt_tool_profiles,
             Some(&session.last_user_text()),
         );
         return TurnResult {
@@ -404,7 +416,7 @@ async fn handle_query(
         &mut join_set,
         &dispatched,
         query_uses_tools,
-        allowed_tools,
+        active_allowed_tools,
         session.tools(),
         config.first_answer_grace,
         grace_mode,
@@ -435,8 +447,8 @@ async fn handle_query(
             has_tools: query_uses_tools,
             selected_tool_names: &selected_tool_names,
             forced_tool: required_tool,
-            allowed_tools,
-            prompt_tool_profiles,
+            allowed_tools: active_allowed_tools,
+            prompt_tool_profiles: active_prompt_tool_profiles,
         },
     )
     .await;
@@ -5571,6 +5583,19 @@ fn tool_proposal_response(
     prompt_tool_profiles: &[PromptToolProfile],
     user_text: Option<&str>,
 ) -> Value {
+    if !response_text_tool_conversion_allowed(user_text) {
+        if output.payload.trim().is_empty()
+            || normalize::is_silent_reply_sentinel(&output.payload)
+            || looks_like_unusable_pseudo_tool_text(&output.payload)
+        {
+            return error_response(
+                "MoA reducer returned no usable answer",
+                MOA_ERR_NO_USABLE_ANSWER,
+            );
+        }
+        return chat_response(&output.payload);
+    }
+
     if let (true, Some(name)) = (has_tools, output.tool_name.as_ref()) {
         let args = output.tool_arguments.as_ref().unwrap_or(&Value::Null);
         match validate_response_tool_arguments_for_prompt(
@@ -5631,6 +5656,9 @@ fn chat_or_schema_command_tool_response(
         );
         return tool_call_response(&tool.name, &arguments);
     }
+    if !response_text_tool_conversion_allowed(user_text) {
+        return chat_response(content);
+    }
     if let Some(response) = rescued_tool_call_response(content, tools, allowed_tools) {
         return response;
     }
@@ -5681,6 +5709,33 @@ fn chat_or_schema_command_tool_response(
     }
 
     chat_response(content)
+}
+
+fn response_text_tool_conversion_allowed(user_text: Option<&str>) -> bool {
+    !user_text.is_some_and(user_text_blocks_any_tool_conversion)
+}
+
+fn user_text_blocks_any_tool_conversion(user_text: &str) -> bool {
+    let text = latest_user_request_tail(user_text).to_ascii_lowercase();
+    contains_any(
+        &text,
+        &[
+            "don't call tools",
+            "do not call tools",
+            "dont call tools",
+            "don't call any tools",
+            "do not call any tools",
+            "dont call any tools",
+            "don't use tools",
+            "do not use tools",
+            "dont use tools",
+            "don't use any tools",
+            "do not use any tools",
+            "dont use any tools",
+            "no tools",
+            "without tools",
+        ],
+    )
 }
 
 fn response_is_invalid_pseudo_tool_failure(response: &Value) -> bool {
@@ -6799,6 +6854,30 @@ mod response_builder_tests {
             resp.pointer("/choices/0/message/tool_calls/0/function/name")
                 .and_then(Value::as_str),
             Some("read_file")
+        );
+    }
+
+    #[test]
+    fn tool_proposal_response_respects_user_no_tools_instruction() {
+        let tools = read_file_tool_schema();
+        let allowed_tools = ["read_file".to_string()];
+        let resp = tool_proposal_response(
+            &tool_proposal("This is only an example."),
+            true,
+            Some(&tools),
+            &allowed_tools,
+            &[],
+            Some("Do not call any tools. Explain the example."),
+        );
+
+        assert!(
+            resp.pointer("/choices/0/message/tool_calls").is_none(),
+            "no-tools user turns must not emit native tool calls: {resp}"
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
         );
     }
 
@@ -10413,6 +10492,87 @@ mod response_builder_tests {
                 .pointer("/choices/0/message/content")
                 .and_then(Value::as_str),
             Some(content)
+        );
+    }
+
+    #[test]
+    fn negated_tool_request_does_not_repair_xml_envelope_into_tool_call() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Execute shell commands.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]));
+        let content = "<tool_call><invoke name=\"shell\"><parameter name=\"command\">pwd</parameter></invoke></tool_call>";
+        let response = chat_or_schema_command_tool_response(
+            content,
+            tools.as_ref(),
+            &["shell".to_string()],
+            &[],
+            Some("Do not call any tools. Explain this example."),
+        );
+
+        assert!(
+            response.pointer("/choices/0/message/tool_calls").is_none(),
+            "negated tool turns must not be repaired into tool calls: {response}"
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
+        );
+    }
+
+    #[test]
+    fn negated_tool_request_does_not_repair_json_example_into_tool_call() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Execute shell commands.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]));
+        let content =
+            r#"This is only an example: {"function":"shell","arguments":{"command":"pwd"}}"#;
+        let response = chat_or_schema_command_tool_response(
+            content,
+            tools.as_ref(),
+            &["shell".to_string()],
+            &[],
+            Some("Do not call any tools. Explain this JSON example."),
+        );
+
+        assert!(
+            response.pointer("/choices/0/message/tool_calls").is_none(),
+            "negated JSON examples must not be repaired into tool calls: {response}"
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -334,8 +334,16 @@ async fn handle_query(
             "moa: direct tool call for explicit {} intent",
             tool.name.as_str()
         );
+        let arguments = corrected_response_tool_arguments_for_prompt(
+            &tool.name,
+            &tool.fallback_arguments,
+            session.tools(),
+            &selected_tool_names,
+            prompt_tool_profiles,
+            Some(&session.last_user_text()),
+        );
         return TurnResult {
-            response_body: tool_call_response(&tool.name, &tool.fallback_arguments),
+            response_body: tool_call_response(&tool.name, &arguments),
             worker_summaries: Vec::new(),
             reducer_used: false,
             reducer_attempts: 0,
@@ -494,6 +502,9 @@ fn looks_like_tool_intent(session: &Session, prompt_tool_profiles: &[PromptToolP
     ) {
         return true;
     }
+    if text_mentions_available_tools(&text) {
+        return true;
+    }
 
     let available = session.tool_names();
     if !explicitly_requested_tool_names(&available, &text).is_empty() {
@@ -505,6 +516,22 @@ fn looks_like_tool_intent(session: &Session, prompt_tool_profiles: &[PromptToolP
         return true;
     }
     if !schema_matched_tool_names(session.tools(), &available, &text, prompt_tool_profiles)
+        .is_empty()
+    {
+        return true;
+    }
+    if !url_intent_tool_names(session.tools(), &available, &text).is_empty() {
+        return true;
+    }
+    if !search_intent_tool_names(session.tools(), &available, &text).is_empty() {
+        return true;
+    }
+    if !file_read_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles)
+        .is_empty()
+    {
+        return true;
+    }
+    if !directory_list_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles)
         .is_empty()
     {
         return true;
@@ -708,6 +735,28 @@ fn selected_tool_names_for_turn(
         command_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
     if !command_intent.is_empty() {
         return with_recent_tool_chain_names(session, &available, command_intent);
+    }
+
+    let url_intent = url_intent_tool_names(session.tools(), &available, &text);
+    if !url_intent.is_empty() {
+        return with_recent_tool_chain_names(session, &available, url_intent);
+    }
+
+    let search_intent = search_intent_tool_names(session.tools(), &available, &text);
+    if !search_intent.is_empty() {
+        return with_recent_tool_chain_names(session, &available, search_intent);
+    }
+
+    let file_read_intent =
+        file_read_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
+    if !file_read_intent.is_empty() {
+        return with_recent_tool_chain_names(session, &available, file_read_intent);
+    }
+
+    let directory_list_intent =
+        directory_list_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
+    if !directory_list_intent.is_empty() {
+        return with_recent_tool_chain_names(session, &available, directory_list_intent);
     }
 
     let selected =
@@ -1022,6 +1071,508 @@ fn tool_schema_profiles(tools: Option<&Value>, available: &[String]) -> Vec<Tool
             })
         })
         .collect()
+}
+
+fn url_intent_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+) -> Vec<String> {
+    if !text_contains_http_url(user_text) {
+        return Vec::new();
+    }
+    let Some(tools) = tools else {
+        return Vec::new();
+    };
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+
+    tools
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if !available.contains(name) || tool_url_fields(tool).is_empty() {
+                return None;
+            }
+            let inferred = infer_tool_arguments_from_prompt(name, Some(tools), user_text);
+            sanitize_tool_arguments_for_tool(name, &inferred, Some(tools))
+                .ok()
+                .filter(|arguments| arguments_has_url_field(arguments, tool))
+                .map(|_| name.to_string())
+        })
+        .collect()
+}
+
+fn text_contains_http_url(text: &str) -> bool {
+    text.split_whitespace()
+        .map(clean_path_token)
+        .any(|token| token.starts_with("http://") || token.starts_with("https://"))
+}
+
+fn tool_url_fields(tool: &Value) -> Vec<String> {
+    let Some(properties) = tool
+        .pointer("/function/parameters/properties")
+        .and_then(Value::as_object)
+    else {
+        return Vec::new();
+    };
+    properties
+        .iter()
+        .filter(|(field, schema)| {
+            schema_allows_string(schema) && schema_or_field_looks_url_like(schema, field)
+        })
+        .map(|(field, _)| field.clone())
+        .collect()
+}
+
+fn schema_or_field_looks_url_like(schema: &Value, field: &str) -> bool {
+    schema
+        .get("format")
+        .and_then(Value::as_str)
+        .is_some_and(|format| {
+            matches!(
+                format.to_ascii_lowercase().as_str(),
+                "url" | "uri" | "uri-reference"
+            )
+        })
+        || text_tokens(field)
+            .iter()
+            .any(|token| matches!(token.as_str(), "url" | "uri"))
+}
+
+fn arguments_has_url_field(arguments: &Value, tool: &Value) -> bool {
+    let Some(arguments) = arguments.as_object() else {
+        return false;
+    };
+    tool_url_fields(tool).iter().any(|field| {
+        arguments
+            .get(field)
+            .and_then(Value::as_str)
+            .is_some_and(|value| value.starts_with("http://") || value.starts_with("https://"))
+    })
+}
+
+fn search_intent_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+) -> Vec<String> {
+    if !text_suggests_search_intent(user_text) {
+        return Vec::new();
+    }
+    let Some(tools) = tools else {
+        return Vec::new();
+    };
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+
+    let mut scored = tools
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if !available.contains(name) || !tool_looks_like_searcher(tool) {
+                return None;
+            }
+            let inferred = infer_tool_arguments_from_prompt(name, Some(tools), user_text);
+            let arguments = sanitize_tool_arguments_for_tool(name, &inferred, Some(tools)).ok()?;
+            if arguments.as_object().is_some_and(serde_json::Map::is_empty) {
+                return None;
+            }
+            Some((search_tool_score(tool, user_text), name.to_string()))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+
+    let Some((score, _)) = scored.first() else {
+        return Vec::new();
+    };
+    let top_score = *score;
+    let runner_up = scored.get(1).map(|(score, _)| *score).unwrap_or(0);
+    if top_score < 8 || top_score < runner_up + 2 {
+        return Vec::new();
+    }
+
+    scored
+        .into_iter()
+        .filter_map(|(score, name)| (score == top_score).then_some(name))
+        .collect()
+}
+
+fn text_suggests_search_intent(user_text: &str) -> bool {
+    let tokens = lexical_tokens(user_text);
+    if tokens
+        .iter()
+        .any(|token| matches!(token.as_str(), "search" | "find" | "lookup" | "research"))
+    {
+        return true;
+    }
+
+    tokens
+        .windows(2)
+        .any(|window| matches!(window[0].as_str(), "look" | "looking") && window[1] == "for")
+}
+
+fn tool_looks_like_searcher(tool: &Value) -> bool {
+    let mut tokens = HashSet::new();
+    collect_tool_schema_tokens(tool, &mut tokens);
+    let has_search_action = ["search", "find", "lookup", "research", "query"]
+        .iter()
+        .any(|token| tokens.contains(*token));
+    let has_query_target = ["query", "q", "search", "term", "terms", "keywords", "topic"]
+        .iter()
+        .any(|token| tokens.contains(*token));
+    has_search_action && has_query_target
+}
+
+fn search_tool_score(tool: &Value, user_text: &str) -> usize {
+    let mut tokens = HashSet::new();
+    if let Some(name) = tool.pointer("/function/name").and_then(Value::as_str) {
+        tokens.extend(text_tokens(name));
+    }
+    if let Some(description) = tool
+        .pointer("/function/description")
+        .and_then(Value::as_str)
+    {
+        tokens.extend(text_tokens(description));
+    }
+
+    let user_tokens = text_tokens(user_text);
+    let external_prompt = prompt_looks_external_search(&user_tokens);
+    let local_prompt = user_tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "memory" | "memories" | "session" | "sessions"
+        )
+    });
+
+    let mut score = 0;
+    for token in &tokens {
+        score += match token.as_str() {
+            "search" | "lookup" => 6,
+            "find" | "research" | "query" => 4,
+            "web" | "internet" | "online" | "browser" | "http" | "https" => 5,
+            "memory" | "memories" | "session" | "sessions" => 3,
+            _ => 0,
+        };
+    }
+    if external_prompt
+        && tokens.iter().any(|token| {
+            matches!(
+                token.as_str(),
+                "web" | "internet" | "online" | "browser" | "http" | "https"
+            )
+        })
+    {
+        score += 6;
+    }
+    if local_prompt
+        && tokens
+            .iter()
+            .any(|token| matches!(token.as_str(), "memory" | "memories"))
+    {
+        score += 6;
+    }
+    score
+}
+
+fn prompt_looks_external_search(tokens: &HashSet<String>) -> bool {
+    tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "web"
+                | "internet"
+                | "online"
+                | "issue"
+                | "issues"
+                | "discussion"
+                | "discussions"
+                | "current"
+                | "recent"
+                | "latest"
+        )
+    })
+}
+
+fn file_read_intent_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
+    if !text_suggests_file_read_intent(user_text) {
+        return Vec::new();
+    }
+
+    let direct = direct_file_read_tool_names(tools, available, user_text);
+    if !direct.is_empty() {
+        return direct;
+    }
+
+    let candidates = command_tool_candidates(tools, available, prompt_tool_profiles);
+    let [candidate] = candidates.as_slice() else {
+        return Vec::new();
+    };
+    vec![candidate.name.clone()]
+}
+
+fn directory_list_intent_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Vec<String> {
+    if !text_suggests_directory_list_intent(user_text) {
+        return Vec::new();
+    }
+    let direct = direct_directory_list_tool_names(tools, available, user_text);
+    if !direct.is_empty() {
+        return direct;
+    }
+
+    let candidates = command_tool_candidates(tools, available, prompt_tool_profiles);
+    let [candidate] = candidates.as_slice() else {
+        return Vec::new();
+    };
+    vec![candidate.name.clone()]
+}
+
+fn text_suggests_directory_list_intent(user_text: &str) -> bool {
+    let tokens = lexical_tokens(user_text);
+    let has_list_action = tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "list" | "show" | "view" | "inspect" | "tree" | "ls"
+        )
+    });
+    has_list_action
+        && (prompt_mentions_current_directory(user_text)
+            || tokens.iter().any(|token| {
+                matches!(
+                    token.as_str(),
+                    "directory" | "directories" | "folder" | "folders" | "files"
+                )
+            }))
+}
+
+fn direct_directory_list_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+) -> Vec<String> {
+    let Some(tools) = tools else {
+        return Vec::new();
+    };
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+    let local_directory_prompt =
+        prompt_mentions_current_directory(user_text) && !prompt_mentions_remote_target(user_text);
+
+    let mut scored = tools
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if !available.contains(name) || !tool_looks_like_directory_lister(tool) {
+                return None;
+            }
+            let inferred = infer_tool_arguments_from_prompt(name, Some(tools), user_text);
+            let arguments = sanitize_tool_arguments_for_tool(name, &inferred, Some(tools)).ok()?;
+            if arguments.as_object().is_some_and(serde_json::Map::is_empty) {
+                return None;
+            }
+            if local_directory_prompt && arguments_have_remote_target(&arguments) {
+                return None;
+            }
+            Some((directory_lister_score(tool), name.to_string()))
+        })
+        .collect::<Vec<_>>();
+    scored.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| left.1.cmp(&right.1)));
+
+    let Some((score, _)) = scored.first() else {
+        return Vec::new();
+    };
+    let top_score = *score;
+    let runner_up = scored.get(1).map(|(score, _)| *score).unwrap_or(0);
+    if top_score < runner_up + 2 {
+        return Vec::new();
+    }
+
+    scored
+        .into_iter()
+        .filter_map(|(score, name)| (score == top_score).then_some(name))
+        .collect()
+}
+
+fn prompt_mentions_remote_target(text: &str) -> bool {
+    let tokens = lexical_tokens(text);
+    tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "remote"
+                | "node"
+                | "nodes"
+                | "peer"
+                | "peers"
+                | "host"
+                | "hosts"
+                | "machine"
+                | "machines"
+                | "server"
+                | "servers"
+        )
+    })
+}
+
+fn arguments_have_remote_target(arguments: &Value) -> bool {
+    arguments.as_object().is_some_and(|map| {
+        map.keys().any(|key| {
+            text_tokens(key).iter().any(|token| {
+                matches!(
+                    token.as_str(),
+                    "node"
+                        | "nodes"
+                        | "host"
+                        | "hosts"
+                        | "peer"
+                        | "peers"
+                        | "target"
+                        | "machine"
+                        | "machines"
+                        | "server"
+                        | "servers"
+                )
+            })
+        })
+    })
+}
+
+fn tool_looks_like_directory_lister(tool: &Value) -> bool {
+    let mut tokens = HashSet::new();
+    collect_tool_schema_tokens(tool, &mut tokens);
+    let has_directory_target = [
+        "dir",
+        "dirs",
+        "directory",
+        "directories",
+        "folder",
+        "folders",
+        "tree",
+        "entries",
+    ]
+    .iter()
+    .any(|token| tokens.contains(*token));
+    let has_listing_action = ["list", "show", "view", "inspect", "tree", "entries", "ls"]
+        .iter()
+        .any(|token| tokens.contains(*token));
+    has_directory_target && has_listing_action
+}
+
+fn directory_lister_score(tool: &Value) -> usize {
+    let mut tokens = HashSet::new();
+    if let Some(name) = tool.pointer("/function/name").and_then(Value::as_str) {
+        tokens.extend(text_tokens(name));
+    }
+    if let Some(description) = tool
+        .pointer("/function/description")
+        .and_then(Value::as_str)
+    {
+        tokens.extend(text_tokens(description));
+    }
+
+    let mut score = 0;
+    for token in tokens {
+        score += match token.as_str() {
+            "list" | "ls" => 6,
+            "entries" => 5,
+            "tree" => 4,
+            "show" | "view" | "inspect" => 3,
+            "directory" | "directories" | "folder" | "folders" | "dir" | "dirs" => 2,
+            "fetch" => 1,
+            _ => 0,
+        };
+    }
+    score
+}
+
+fn text_suggests_file_read_intent(user_text: &str) -> bool {
+    let tokens = lexical_tokens(user_text);
+    if !tokens.iter().any(|token| {
+        matches!(
+            token.as_str(),
+            "read"
+                | "show"
+                | "open"
+                | "view"
+                | "inspect"
+                | "cat"
+                | "head"
+                | "tail"
+                | "excerpt"
+                | "summarize"
+                | "summarise"
+        )
+    }) {
+        return false;
+    }
+
+    text_contains_path_like_reference(user_text)
+}
+
+fn text_contains_path_like_reference(user_text: &str) -> bool {
+    user_text
+        .split_whitespace()
+        .map(clean_path_token)
+        .any(|candidate| is_path_like_candidate(&candidate, "path"))
+}
+
+fn direct_file_read_tool_names(
+    tools: Option<&Value>,
+    available: &[String],
+    user_text: &str,
+) -> Vec<String> {
+    let Some(tools) = tools else {
+        return Vec::new();
+    };
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+
+    tools
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|tool| {
+            let name = tool.pointer("/function/name")?.as_str()?;
+            if !available.contains(name) || !tool_looks_like_file_reader(tool) {
+                return None;
+            }
+            let inferred = infer_tool_arguments_from_prompt(name, Some(tools), user_text);
+            sanitize_tool_arguments_for_tool(name, &inferred, Some(tools))
+                .ok()
+                .filter(|arguments| !arguments.as_object().is_some_and(serde_json::Map::is_empty))
+                .map(|_| name.to_string())
+        })
+        .collect()
+}
+
+fn tool_looks_like_file_reader(tool: &Value) -> bool {
+    let mut tokens = HashSet::new();
+    collect_tool_schema_tokens(tool, &mut tokens);
+    let has_read_action = [
+        "read", "fetch", "open", "view", "inspect", "cat", "head", "tail",
+    ]
+    .iter()
+    .any(|token| tokens.contains(*token));
+    let has_file_target = ["file", "files", "path", "contents", "content"]
+        .iter()
+        .any(|token| tokens.contains(*token));
+    let looks_directory_only = ["dir", "directory", "directories", "entries"]
+        .iter()
+        .any(|token| tokens.contains(*token))
+        && !tokens.contains("file")
+        && !tokens.contains("files");
+
+    has_read_action && has_file_target && !looks_directory_only
 }
 
 fn collect_tool_schema_tokens(value: &Value, tokens: &mut HashSet<String>) {
@@ -1560,11 +2111,45 @@ fn infer_string_argument(field: &str, schema: &Value, prompt: &str) -> Option<St
         return None;
     }
 
-    infer_enum_argument(schema, prompt)
+    infer_command_argument(field, schema, prompt)
+        .or_else(|| infer_enum_argument(schema, prompt))
         .or_else(|| infer_assignment_argument(field, prompt))
-        .or_else(|| infer_path_like_argument(field, prompt))
+        .or_else(|| infer_path_like_argument(field, schema, prompt))
         .or_else(|| infer_query_argument(field, prompt))
         .or_else(|| infer_named_argument(field, schema, prompt))
+}
+
+fn infer_command_argument(field: &str, schema: &Value, prompt: &str) -> Option<String> {
+    let mut schema_tokens = text_tokens(field);
+    collect_tool_schema_tokens(schema, &mut schema_tokens);
+    if !schema_tokens_look_command_like(&schema_tokens) {
+        return None;
+    }
+
+    if text_suggests_directory_list_intent(prompt) {
+        let path = if prompt_mentions_current_directory(prompt) {
+            ".".to_string()
+        } else {
+            prompt
+                .split_whitespace()
+                .map(clean_path_token)
+                .find(|candidate| is_path_like_candidate(candidate, "path"))
+                .unwrap_or_else(|| ".".to_string())
+        };
+        return Some(format!("ls -la {}", shell_quote_path(&path)));
+    }
+
+    None
+}
+
+fn shell_quote_path(path: &str) -> String {
+    if path
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | '~'))
+    {
+        return path.to_string();
+    }
+    format!("'{}'", path.replace('\'', "'\\''"))
 }
 
 fn schema_allows_string(schema: &Value) -> bool {
@@ -1601,17 +2186,53 @@ fn infer_assignment_argument(field: &str, prompt: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
-fn infer_path_like_argument(field: &str, prompt: &str) -> Option<String> {
+fn infer_path_like_argument(field: &str, schema: &Value, prompt: &str) -> Option<String> {
     let field = field.to_ascii_lowercase();
     let wants_path = contains_any(&field, &["path", "file", "url", "uri"]);
     if !wants_path {
         return None;
+    }
+    if schema_or_field_looks_directory_like(schema, &field)
+        && prompt_mentions_current_directory(prompt)
+    {
+        return Some(".".to_string());
     }
 
     prompt
         .split_whitespace()
         .map(clean_path_token)
         .find(|candidate| is_path_like_candidate(candidate, &field))
+}
+
+fn schema_or_field_looks_directory_like(schema: &Value, field: &str) -> bool {
+    let mut tokens = text_tokens(field);
+    collect_tool_schema_tokens(schema, &mut tokens);
+    [
+        "dir",
+        "dirs",
+        "directory",
+        "directories",
+        "folder",
+        "folders",
+        "tree",
+    ]
+    .iter()
+    .any(|token| tokens.contains(*token))
+}
+
+fn prompt_mentions_current_directory(prompt: &str) -> bool {
+    let prompt = prompt.to_ascii_lowercase();
+    contains_any(
+        &prompt,
+        &[
+            "current directory",
+            "current folder",
+            "working directory",
+            "cwd",
+            "this directory",
+            "this folder",
+        ],
+    )
 }
 
 fn clean_path_token(token: &str) -> String {
@@ -1648,8 +2269,65 @@ fn infer_query_argument(field: &str, prompt: &str) -> Option<String> {
     if !matches!(field.as_str(), "q" | "query" | "search" | "search_query") {
         return None;
     }
-    let prompt = prompt.trim();
-    (!prompt.is_empty()).then(|| prompt.to_string())
+    let query = search_query_from_prompt(prompt);
+    (!query.is_empty()).then_some(query)
+}
+
+fn search_query_from_prompt(prompt: &str) -> String {
+    let prompt = strip_leading_timestamp(prompt).trim();
+    let lower = prompt.to_ascii_lowercase();
+    let search_markers = [
+        "look for ",
+        "search for ",
+        "search online for ",
+        "search the web for ",
+        "search ",
+        "find ",
+        "lookup ",
+        "look up ",
+        "research ",
+    ];
+    let mut query = search_markers
+        .iter()
+        .find_map(|marker| {
+            lower
+                .find(marker)
+                .and_then(|index| prompt.get(index + marker.len()..))
+        })
+        .unwrap_or(prompt)
+        .trim();
+
+    for separator in [
+        ", then ",
+        " then ",
+        ", and tell ",
+        " and tell ",
+        ", and summarize ",
+        " and summarize ",
+        ", and summarise ",
+        " and summarise ",
+    ] {
+        if let Some(index) = query.to_ascii_lowercase().find(separator) {
+            query = query[..index].trim();
+        }
+    }
+
+    query
+        .trim_matches(|ch: char| matches!(ch, '"' | '\'' | '`' | '.' | ',' | ';' | ':'))
+        .trim()
+        .to_string()
+}
+
+fn strip_leading_timestamp(prompt: &str) -> &str {
+    let trimmed = prompt.trim_start();
+    if !trimmed.starts_with('[') {
+        return trimmed;
+    }
+    let Some(end) = trimmed.find(']') else {
+        return trimmed;
+    };
+    let after = trimmed[end + 1..].trim_start();
+    if after.is_empty() { trimmed } else { after }
 }
 
 fn infer_named_argument(field: &str, schema: &Value, prompt: &str) -> Option<String> {
@@ -1815,15 +2493,46 @@ fn word_looks_entity_like(word: &PromptWord) -> bool {
 }
 
 fn tool_parameters<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a Value> {
-    tools?
-        .as_array()?
-        .iter()
-        .find(|tool| {
-            tool.pointer("/function/name")
-                .and_then(Value::as_str)
-                .is_some_and(|name| name == tool_name)
-        })?
-        .pointer("/function/parameters")
+    tool_by_name(tool_name, tools)?.pointer("/function/parameters")
+}
+
+fn tool_by_name<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a Value> {
+    tools?.as_array()?.iter().find(|tool| {
+        tool.pointer("/function/name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| name == tool_name)
+    })
+}
+
+fn tool_parameters_from_tool(tool: &Value) -> Option<&Value> {
+    tool.pointer("/function/parameters")
+}
+
+fn tool_name_and_description_look_directory_like(tool: &Value) -> bool {
+    let mut tokens = HashSet::new();
+    if let Some(name) = tool.pointer("/function/name").and_then(Value::as_str) {
+        tokens.extend(text_tokens(name));
+    }
+    if let Some(description) = tool
+        .pointer("/function/description")
+        .and_then(Value::as_str)
+    {
+        tokens.extend(text_tokens(description));
+    }
+    tokens.contains("tree")
+        || ["list", "show", "view", "inspect"]
+            .iter()
+            .any(|token| tokens.contains(*token))
+            && [
+                "dir",
+                "dirs",
+                "directory",
+                "directories",
+                "folder",
+                "folders",
+            ]
+            .iter()
+            .any(|token| tokens.contains(*token))
 }
 
 // ─── Tool result handling ────────────────────────────────────────────
@@ -1858,7 +2567,11 @@ async fn handle_tool_result(
     let latest_non_answerable_tool = latest_completed_tool_result(session).filter(|(_, result)| {
         !tool_result_has_answerable_evidence_for_prompt(result, &latest_user_text)
     });
-    if let Some((tool, _)) = latest_non_answerable_tool.as_ref() {
+    if let Some((tool, _)) = latest_non_answerable_tool.as_ref().filter(|(tool, _)| {
+        repeated_tool
+            .as_ref()
+            .is_none_or(|(repeated, _)| repeated != tool)
+    }) {
         selected_tool_names.retain(|name| name == tool);
     }
     let tools_enabled_for_reducer =
@@ -2043,10 +2756,14 @@ async fn handle_tool_result(
                                 )
                             })
                     } else {
-                        error_response(
-                            "MoA reducer returned no usable answer",
-                            MOA_ERR_NO_USABLE_ANSWER,
-                        )
+                        answer_from_latest_tool_result(session)
+                            .map(|answer| chat_response(&answer))
+                            .unwrap_or_else(|| {
+                                error_response(
+                                    "MoA reducer returned no usable answer",
+                                    MOA_ERR_NO_USABLE_ANSWER,
+                                )
+                            })
                     }
                 }
                 _ => {
@@ -2054,7 +2771,9 @@ async fn handle_tool_result(
                     match latest_non_answerable_tool.as_ref() {
                         Some((tool, result))
                             if answer_appears_to_use_non_answerable_tool_result(
-                                &repaired, result,
+                                &repaired,
+                                result,
+                                &session.active_user_text(),
                             ) =>
                         {
                             let answer = non_answerable_tool_result_answer(session, tool, result);
@@ -2146,6 +2865,12 @@ async fn handle_tool_result(
 
 fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
     if let Some(answer) = answer_from_recent_prompt_specific_structured_tool_results(session) {
+        return answer;
+    }
+
+    if let Some(answer) = latest_completed_tool_result(session).and_then(|(_, result)| {
+        answer_from_prompt_specific_plain_text_tool_result(&result, &session.active_user_text())
+    }) {
         return answer;
     }
 
@@ -2314,7 +3039,7 @@ struct TabularToolRow {
     title: String,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct StructuredToolRow {
     id: Option<String>,
     title: String,
@@ -2417,6 +3142,10 @@ fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
         return None;
     }
 
+    if let Some(answer) = answer_from_prompt_specific_plain_text_tool_result(&result, &prompt) {
+        return Some(answer);
+    }
+
     if let Some(answer) = answer_from_structured_tool_result(&result, &prompt) {
         return Some(answer);
     }
@@ -2444,9 +3173,19 @@ fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     Some(truncate_for_tool_result_answer(&answer))
 }
 
-fn answer_appears_to_use_non_answerable_tool_result(answer: &str, result: &str) -> bool {
+fn answer_appears_to_use_non_answerable_tool_result(
+    answer: &str,
+    result: &str,
+    prompt: &str,
+) -> bool {
     let answer_lower = answer.to_ascii_lowercase();
     if answer_lower.contains("from the tool result") || answer_lower.contains("one relevant entry")
+    {
+        return true;
+    }
+
+    if prompt_asks_for_work_items(prompt)
+        && answer_mentions_non_specific_work_item_collection(answer, result, prompt)
     {
         return true;
     }
@@ -2459,8 +3198,39 @@ fn answer_appears_to_use_non_answerable_tool_result(answer: &str, result: &str) 
         .any(|line| line.len() >= 12 && answer.contains(line))
 }
 
+fn answer_mentions_non_specific_work_item_collection(
+    answer: &str,
+    result: &str,
+    prompt: &str,
+) -> bool {
+    let Some(parsed) = parse_tool_result_json(result.trim()) else {
+        return false;
+    };
+    if !json_value_has_structured_result_collection(&parsed) {
+        return false;
+    }
+    let rows = structured_tool_result_rows_unfiltered(&parsed, prompt);
+    !rows.is_empty()
+        && !rows
+            .iter()
+            .any(structured_row_looks_like_specific_work_item)
+        && rows
+            .iter()
+            .any(|row| structured_tool_row_is_referenced(answer, row))
+}
+
 fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str) -> String {
     let prompt = session.active_user_text();
+    if prompt_asks_for_work_items(&prompt)
+        && parse_tool_result_json(result.trim()).is_some_and(|value| {
+            json_value_has_structured_result_collection(&value)
+                && structured_tool_result_rows(&value, &prompt).is_empty()
+        })
+    {
+        return format!(
+            "The latest `{tool}` result only listed generic collection/search pages, not a specific requested item, so I can't answer from that output."
+        );
+    }
     if prompt_asks_for_work_items(&prompt)
         && plain_text_tool_result_looks_like_repository_list(result)
     {
@@ -2515,6 +3285,79 @@ fn answer_from_structured_tool_result(result: &str, prompt: &str) -> Option<Stri
     }
 
     Some(truncate_for_tool_result_answer(&answer))
+}
+
+fn answer_from_prompt_specific_plain_text_tool_result(
+    result: &str,
+    prompt: &str,
+) -> Option<String> {
+    let requested = requested_path_existence_targets(prompt);
+    if requested.is_empty() {
+        return None;
+    }
+
+    let found = requested
+        .into_iter()
+        .filter(|path| plain_text_tool_result_contains_path(result, path))
+        .collect::<Vec<_>>();
+    match found.as_slice() {
+        [] => None,
+        [path] => Some(format!("`{path}` exists in the tool result.")),
+        paths => Some(format!(
+            "These requested paths exist in the tool result: {}.",
+            paths
+                .iter()
+                .map(|path| format!("`{path}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+fn requested_path_existence_targets(prompt: &str) -> Vec<String> {
+    let lower = prompt.to_ascii_lowercase();
+    if text_suggests_file_read_intent(&lower) {
+        return Vec::new();
+    }
+    if !contains_any(
+        &lower,
+        &[
+            "exist",
+            "exists",
+            "present",
+            "visible",
+            "whether",
+            "is there",
+            "are there",
+        ],
+    ) {
+        return Vec::new();
+    }
+
+    let mut seen = HashSet::new();
+    prompt
+        .split_whitespace()
+        .map(clean_path_token)
+        .filter(|candidate| is_path_like_candidate(candidate, "path"))
+        .filter(|candidate| seen.insert(candidate.clone()))
+        .collect()
+}
+
+fn plain_text_tool_result_contains_path(result: &str, path: &str) -> bool {
+    result.lines().any(|line| {
+        line.split_whitespace()
+            .map(clean_path_token)
+            .any(|candidate| path_token_matches(&candidate, path))
+    })
+}
+
+fn path_token_matches(candidate: &str, requested: &str) -> bool {
+    if candidate == requested {
+        return true;
+    }
+    candidate
+        .rsplit_once('/')
+        .is_some_and(|(_, tail)| tail == requested)
 }
 
 fn answer_from_prompt_specific_structured_tool_result(
@@ -3005,6 +3848,13 @@ fn first_non_empty_line(text: &str) -> Option<String> {
 }
 
 fn structured_tool_result_rows(value: &Value, prompt: &str) -> Vec<StructuredToolRow> {
+    filter_structured_rows_for_prompt(
+        structured_tool_result_rows_unfiltered(value, prompt),
+        prompt,
+    )
+}
+
+fn structured_tool_result_rows_unfiltered(value: &Value, prompt: &str) -> Vec<StructuredToolRow> {
     match value {
         Value::Array(values) => values
             .iter()
@@ -3029,11 +3879,63 @@ fn structured_tool_result_rows(value: &Value, prompt: &str) -> Vec<StructuredToo
             ]
             .iter()
             .filter_map(|key| map.get(*key))
-            .flat_map(|value| structured_tool_result_rows(value, prompt))
+            .flat_map(|value| structured_tool_result_rows_unfiltered(value, prompt))
             .collect()
         }
         _ => Vec::new(),
     }
+}
+
+fn filter_structured_rows_for_prompt(
+    rows: Vec<StructuredToolRow>,
+    prompt: &str,
+) -> Vec<StructuredToolRow> {
+    if !prompt_asks_for_work_items(prompt) {
+        return rows;
+    }
+    let specific = rows
+        .iter()
+        .filter(|row| structured_row_looks_like_specific_work_item(row))
+        .cloned()
+        .collect::<Vec<_>>();
+    if specific.is_empty() {
+        Vec::new()
+    } else {
+        specific
+    }
+}
+
+fn structured_row_looks_like_specific_work_item(row: &StructuredToolRow) -> bool {
+    if row
+        .id
+        .as_deref()
+        .is_some_and(|id| id.chars().any(|ch| ch.is_ascii_digit()))
+    {
+        return true;
+    }
+    let title = row.title.to_ascii_lowercase();
+    if title.contains("issue #")
+        || title.contains("pull request #")
+        || title.contains("pr #")
+        || title.contains("ticket #")
+    {
+        return true;
+    }
+    row.url
+        .as_deref()
+        .is_some_and(url_looks_like_specific_work_item)
+}
+
+fn url_looks_like_specific_work_item(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    ["/issues/", "/pull/", "/pulls/", "/merge_requests/"]
+        .iter()
+        .any(|marker| {
+            lower
+                .split_once(marker)
+                .and_then(|(_, tail)| tail.split(['/', '?', '#']).next())
+                .is_some_and(|id| !id.is_empty() && id.chars().all(|ch| ch.is_ascii_digit()))
+        })
 }
 
 fn structured_tool_row(value: &Value, prompt: &str) -> Option<StructuredToolRow> {
@@ -3060,9 +3962,26 @@ fn first_string_field(map: &serde_json::Map<String, Value>, fields: &[&str]) -> 
     fields
         .iter()
         .find_map(|field| map.get(*field).and_then(Value::as_str))
-        .map(str::trim)
+        .map(clean_structured_text_field)
         .filter(|value| !value.is_empty())
-        .map(str::to_string)
+}
+
+fn clean_structured_text_field(value: &str) -> String {
+    let trimmed = value.trim();
+    if !trimmed.contains("<<<EXTERNAL_UNTRUSTED_CONTENT") {
+        return trimmed.to_string();
+    }
+
+    let payload = trimmed
+        .split_once("\n---\n")
+        .map(|(_, tail)| tail)
+        .unwrap_or(trimmed);
+    payload
+        .split_once("\n<<<END_EXTERNAL_UNTRUSTED_CONTENT")
+        .map(|(head, _)| head)
+        .unwrap_or(payload)
+        .trim()
+        .to_string()
 }
 
 fn first_identifier_field(map: &serde_json::Map<String, Value>, fields: &[&str]) -> Option<String> {
@@ -3210,13 +4129,30 @@ fn short_exact_value(value: &str) -> bool {
 fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
     let calls = completed_tool_calls_since_latest_user_before_tool_result(session);
     let latest = calls.last()?;
-    let count = calls
+    let same_signature_count = calls
         .iter()
         .rev()
         .take_while(|call| call.same_signature(latest))
         .count();
+    let same_name_count = if tool_name_looks_search_like(&latest.name) {
+        calls
+            .iter()
+            .rev()
+            .take_while(|call| call.name == latest.name)
+            .count()
+    } else {
+        0
+    };
 
+    let count = same_signature_count.max(same_name_count);
     (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (latest.name.clone(), count))
+}
+
+fn tool_name_looks_search_like(name: &str) -> bool {
+    let tokens = text_tokens(name);
+    tokens
+        .iter()
+        .any(|token| matches!(token.as_str(), "search" | "lookup" | "research"))
 }
 
 fn prompt_requests_additional_tool_step(prompt: &str, session: &Session) -> bool {
@@ -3470,6 +4406,7 @@ fn corrected_retry_tool_call(
     let corrected = tool_result_suggests_unquoted_shell_token_error(result)
         .then(|| quote_unquoted_shell_metachar_tokens(&command))
         .flatten()
+        .or_else(|| remove_unknown_json_fields_from_command(&command, result))
         .or_else(|| remove_unknown_cli_flags_from_command(&command, result))
         .or_else(|| unescape_single_quoted_shell_double_quotes(&command, result))?;
     if corrected == command {
@@ -3530,6 +4467,67 @@ fn tool_result_suggests_shell_quoting_issue(result: &str) -> bool {
     let lower = result.to_ascii_lowercase();
     lower.contains("unix shell quoting issues")
         || (lower.contains("syntax error") && lower.contains("jq:"))
+}
+
+fn remove_unknown_json_fields_from_command(command: &str, result: &str) -> Option<String> {
+    let unknown = unknown_json_field_from_tool_result(result)?;
+    let tokens = split_shell_tokens(command)?;
+    let mut changed = false;
+    let mut filtered = Vec::with_capacity(tokens.len());
+    let mut index = 0;
+    while index < tokens.len() {
+        let token = &tokens[index];
+        if let Some(value) = token.strip_prefix("--json=") {
+            changed = true;
+            if let Some(updated) = remove_field_from_csv(value, &unknown) {
+                filtered.push(format!("--json={updated}"));
+            }
+            index += 1;
+            continue;
+        }
+        if token == "--json" {
+            let Some(value) = tokens.get(index + 1) else {
+                filtered.push(token.clone());
+                index += 1;
+                continue;
+            };
+            if let Some(updated) = remove_field_from_csv(value, &unknown) {
+                filtered.push(token.clone());
+                filtered.push(updated);
+            }
+            changed = true;
+            index += 2;
+            continue;
+        }
+        filtered.push(token.clone());
+        index += 1;
+    }
+    changed.then(|| join_shell_tokens(&filtered))
+}
+
+fn unknown_json_field_from_tool_result(result: &str) -> Option<String> {
+    result.lines().take(4).find_map(|line| {
+        let trimmed = line.trim();
+        let lower = trimmed.to_ascii_lowercase();
+        let rest = lower
+            .strip_prefix("unknown json field:")
+            .map(|_| &trimmed["unknown json field:".len()..])?;
+        let field = rest
+            .trim()
+            .trim_matches(|ch: char| matches!(ch, '"' | '\'' | '`' | ':' | ' '));
+        (!field.is_empty()).then(|| field.to_string())
+    })
+}
+
+fn remove_field_from_csv(value: &str, unknown: &str) -> Option<String> {
+    let fields = value
+        .split(',')
+        .map(str::trim)
+        .filter(|field| !field.is_empty())
+        .filter(|field| *field != unknown)
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    (!fields.is_empty()).then(|| fields.join(","))
 }
 
 fn remove_unknown_cli_flags_from_command(command: &str, result: &str) -> Option<String> {
@@ -3743,6 +4741,16 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     if prompt_asks_for_feedback(prompt) && !tool_result_has_feedback_evidence(result, prompt) {
         return false;
     }
+    let structured_rows = structured_tool_result_rows_from_result(result, prompt);
+    if !structured_rows.is_empty() {
+        return true;
+    }
+    if prompt_asks_for_work_items(prompt)
+        && parse_tool_result_json(result.trim())
+            .is_some_and(|value| json_value_has_structured_result_collection(&value))
+    {
+        return false;
+    }
     if prompt_asks_for_work_items(prompt) && plain_text_tool_result_looks_like_auth_status(result) {
         return false;
     }
@@ -3764,18 +4772,18 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
 
 fn prompt_asks_for_ci_status(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
-    contains_any(
-        &lower,
-        &[
-            "ci",
-            "checks",
-            "green",
-            "status check",
-            "check run",
-            "check suite",
-            "build status",
-        ],
-    )
+    prompt_has_word(&lower, "ci")
+        || contains_any(
+            &lower,
+            &[
+                "checks",
+                "green",
+                "status check",
+                "check run",
+                "check suite",
+                "build status",
+            ],
+        )
 }
 
 fn prompt_asks_for_feedback(prompt: &str) -> bool {
@@ -3867,6 +4875,35 @@ fn json_value_has_feedback_evidence(value: &Value, prompt: &str) -> bool {
         Value::String(text) => focus
             .as_deref()
             .is_some_and(|focus| text.to_ascii_lowercase().contains(focus)),
+        _ => false,
+    }
+}
+
+fn json_value_has_structured_result_collection(value: &Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            [
+                "items",
+                "results",
+                "nodes",
+                "data",
+                "pullRequests",
+                "mergeRequests",
+                "issues",
+                "tickets",
+                "tasks",
+                "workItems",
+                "work_items",
+            ]
+            .iter()
+            .any(|key| map.get(*key).is_some_and(Value::is_array))
+                || map
+                    .values()
+                    .any(json_value_has_structured_result_collection)
+        }
+        Value::Array(values) => values
+            .iter()
+            .any(json_value_has_structured_result_collection),
         _ => false,
     }
 }
@@ -4134,9 +5171,10 @@ fn append_tool_budget_instruction(messages: &mut [Value], count: usize) {
 
 fn append_tool_error_retry_instruction(messages: &mut [Value], tool: &str) {
     let instruction = format!(
-        "\n\nTool retry guard: the latest `{tool}` result appears to be command error or usage text, \
-         not answer evidence. If the user's request still needs data, call a corrected tool once. \
-         Do not answer from usage or error text."
+        "\n\nTool retry guard: the latest `{tool}` result is not answer evidence for the user's \
+         request. If the request still needs data, call a corrected or different declared tool \
+         once. Do not answer from error text, usage text, generic collection pages, or unrelated \
+         metadata."
     );
     append_system_instruction(messages, &instruction);
 }
@@ -4179,27 +5217,50 @@ async fn resolve_decision(
     match decision {
         arbiter::Decision::Answer(text) => {
             if let Some(tool) = forced_tool.filter(|_| tools_available) {
-                (
-                    tool_call_response(&tool.name, &tool.fallback_arguments),
-                    false,
-                    0,
-                )
+                let arguments = corrected_response_tool_arguments_for_prompt(
+                    &tool.name,
+                    &tool.fallback_arguments,
+                    session.tools(),
+                    response_tool_names,
+                    prompt_tool_profiles,
+                    Some(&session.last_user_text()),
+                );
+                (tool_call_response(&tool.name, &arguments), false, 0)
             } else {
-                (
-                    chat_or_schema_command_tool_response(
-                        &text,
+                let response = chat_or_schema_command_tool_response(
+                    &text,
+                    session.tools(),
+                    response_tool_names,
+                    prompt_tool_profiles,
+                    Some(&session.last_user_text()),
+                );
+                let response = if response_is_invalid_pseudo_tool_failure(&response) {
+                    tracing::warn!(
+                        "moa: arbiter answer contained malformed tool text; falling back to best worker answer"
+                    );
+                    fallback_worker_response(
+                        outputs,
+                        session,
                         session.tools(),
                         response_tool_names,
                         prompt_tool_profiles,
-                        Some(&session.last_user_text()),
-                    ),
-                    false,
-                    0,
-                )
+                    )
+                } else {
+                    response
+                };
+                (response, false, 0)
             }
         }
         arbiter::Decision::ToolCall { name, arguments } => {
             if tools_available {
+                let arguments = corrected_response_tool_arguments_for_prompt(
+                    &name,
+                    &arguments,
+                    session.tools(),
+                    response_tool_names,
+                    prompt_tool_profiles,
+                    Some(&session.last_user_text()),
+                );
                 (tool_call_response(&name, &arguments), false, 0)
             } else {
                 (
@@ -4283,11 +5344,15 @@ async fn resolve_decision(
                     }
                     normalize::OutputKind::Uncertainty => {
                         if let Some(tool) = forced_tool.filter(|_| tools_available) {
-                            (
-                                tool_call_response(&tool.name, &tool.fallback_arguments),
-                                true,
-                                attempts,
-                            )
+                            let arguments = corrected_response_tool_arguments_for_prompt(
+                                &tool.name,
+                                &tool.fallback_arguments,
+                                session.tools(),
+                                response_tool_names,
+                                prompt_tool_profiles,
+                                Some(&session.last_user_text()),
+                            );
+                            (tool_call_response(&tool.name, &arguments), true, attempts)
                         } else {
                             (
                                 fallback_worker_response(
@@ -4304,23 +5369,38 @@ async fn resolve_decision(
                     }
                     _ => {
                         if let Some(tool) = forced_tool.filter(|_| tools_available) {
-                            (
-                                tool_call_response(&tool.name, &tool.fallback_arguments),
-                                true,
-                                attempts,
-                            )
+                            let arguments = corrected_response_tool_arguments_for_prompt(
+                                &tool.name,
+                                &tool.fallback_arguments,
+                                session.tools(),
+                                response_tool_names,
+                                prompt_tool_profiles,
+                                Some(&session.last_user_text()),
+                            );
+                            (tool_call_response(&tool.name, &arguments), true, attempts)
                         } else {
-                            (
-                                chat_or_schema_command_tool_response(
-                                    &reduced.payload,
+                            let response = chat_or_schema_command_tool_response(
+                                &reduced.payload,
+                                session.tools(),
+                                response_tool_names,
+                                prompt_tool_profiles,
+                                Some(&session.last_user_text()),
+                            );
+                            let response = if response_is_invalid_pseudo_tool_failure(&response) {
+                                tracing::warn!(
+                                    "moa: reducer returned malformed tool text; falling back to best worker answer"
+                                );
+                                fallback_worker_response(
+                                    outputs,
+                                    session,
                                     session.tools(),
                                     response_tool_names,
                                     prompt_tool_profiles,
-                                    Some(&session.last_user_text()),
-                                ),
-                                true,
-                                attempts,
-                            )
+                                )
+                            } else {
+                                response
+                            };
+                            (response, true, attempts)
                         }
                     }
                 },
@@ -4331,11 +5411,15 @@ async fn resolve_decision(
                     // a worker. attempts still reflects what was spawned so
                     // observability can see "we tried N times and all failed".
                     if let Some(tool) = forced_tool.filter(|_| tools_available) {
-                        (
-                            tool_call_response(&tool.name, &tool.fallback_arguments),
-                            false,
-                            attempts,
-                        )
+                        let arguments = corrected_response_tool_arguments_for_prompt(
+                            &tool.name,
+                            &tool.fallback_arguments,
+                            session.tools(),
+                            response_tool_names,
+                            prompt_tool_profiles,
+                            Some(&session.last_user_text()),
+                        );
+                        (tool_call_response(&tool.name, &arguments), false, attempts)
                     } else {
                         (
                             fallback_worker_response(
@@ -4363,6 +5447,7 @@ fn best_answer(outputs: &[WorkerOutput]) -> String {
         .filter(|o| {
             matches!(o.kind, normalize::OutputKind::Answer)
                 && !normalize::is_silent_reply_sentinel(&o.payload)
+                && !looks_like_unusable_pseudo_tool_text(&o.payload)
         })
         // `total_cmp` is total over all f32 (including NaN/Inf); `partial_cmp`
         // can return `None` on NaN, which would panic on `unwrap`.
@@ -4372,6 +5457,38 @@ fn best_answer(outputs: &[WorkerOutput]) -> String {
         .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
         .map(|o| o.payload.clone())
         .unwrap_or_default()
+}
+
+fn looks_like_unusable_pseudo_tool_text(content: &str) -> bool {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+
+    starts_with_tool_call_envelope(trimmed)
+        || contains_pseudo_tool_markup(trimmed)
+        || is_tool_error_content(trimmed)
+}
+
+fn contains_pseudo_tool_markup(content: &str) -> bool {
+    let lower = content.to_ascii_lowercase();
+    let trimmed = lower.trim_start();
+    trimmed.starts_with("tool_code")
+        || trimmed.starts_with("tool code")
+        || lower.contains("<tool_code")
+        || lower.contains("</tool_code")
+        || lower.contains("<tool_call")
+        || lower.contains("</tool_call")
+        || lower.contains("[tool_call]")
+        || lower.contains("[/tool_call]")
+        || lower.contains("<function=")
+}
+
+fn is_tool_error_content(content: &str) -> bool {
+    let trimmed = content.trim();
+    trimmed.starts_with("[error: MoA reducer returned")
+        || trimmed.starts_with("MoA reducer returned an invalid tool call")
+        || trimmed.starts_with("MoA reducer returned an undeclared or invalid tool call")
 }
 
 fn fallback_worker_response(
@@ -4419,12 +5536,13 @@ fn tool_proposal_response(
 ) -> Value {
     if let (true, Some(name)) = (has_tools, output.tool_name.as_ref()) {
         let args = output.tool_arguments.as_ref().unwrap_or(&Value::Null);
-        match validate_response_tool_arguments(
+        match validate_response_tool_arguments_for_prompt(
             name,
             args,
             tools,
             allowed_tools,
             prompt_tool_profiles,
+            user_text,
         ) {
             Ok(arguments) => return tool_call_response(name, &arguments),
             Err(err) => tracing::info!("moa: tool proposal {name} rejected: {err}"),
@@ -4466,7 +5584,15 @@ fn chat_or_schema_command_tool_response(
         None
     };
     if let Some(tool) = command_tool {
-        return tool_call_response(&tool.name, &tool.fallback_arguments);
+        let arguments = corrected_response_tool_arguments_for_prompt(
+            &tool.name,
+            &tool.fallback_arguments,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+            user_text,
+        );
+        return tool_call_response(&tool.name, &arguments);
     }
     if let Some(response) = rescued_tool_call_response(content, tools, allowed_tools) {
         return response;
@@ -4474,20 +5600,68 @@ fn chat_or_schema_command_tool_response(
     if let Some(tool) =
         inline_json_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
     {
-        return tool_call_response(&tool.name, &tool.fallback_arguments);
+        let arguments = corrected_response_tool_arguments_for_prompt(
+            &tool.name,
+            &tool.fallback_arguments,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+            user_text,
+        );
+        return tool_call_response(&tool.name, &arguments);
     }
     if let Some(tool) =
         xml_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
     {
-        return tool_call_response(&tool.name, &tool.fallback_arguments);
+        let arguments = corrected_response_tool_arguments_for_prompt(
+            &tool.name,
+            &tool.fallback_arguments,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+            user_text,
+        );
+        return tool_call_response(&tool.name, &arguments);
     }
     if let Some(tool) =
         explicitly_named_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
     {
-        return tool_call_response(&tool.name, &tool.fallback_arguments);
+        let arguments = corrected_response_tool_arguments_for_prompt(
+            &tool.name,
+            &tool.fallback_arguments,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+            user_text,
+        );
+        return tool_call_response(&tool.name, &arguments);
+    }
+    if looks_like_unusable_pseudo_tool_text(content) {
+        return error_response(
+            "MoA could not turn malformed tool text into a valid declared tool call",
+            MOA_ERR_NO_USABLE_ANSWER,
+        );
     }
 
     chat_response(content)
+}
+
+fn response_is_invalid_pseudo_tool_failure(response: &Value) -> bool {
+    let Some(code) = response.pointer("/error/code").and_then(Value::as_str) else {
+        return false;
+    };
+    if code != MOA_ERR_NO_USABLE_ANSWER {
+        return false;
+    }
+
+    response
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .is_some_and(|content| {
+            content.contains("malformed tool text")
+                || content.contains("invalid tool call")
+                || content.contains("undeclared or invalid tool call")
+        })
 }
 
 fn rescued_tool_call_response(
@@ -4564,6 +5738,7 @@ fn fenced_command_tool_conversion_allowed(user_text: Option<&str>) -> bool {
 
     let tokens = lexical_tokens(&text);
     command_execution_pattern_matches(&tokens)
+        || text_mentions_available_tools(&text)
         || contains_any(
             &text,
             &[
@@ -4578,6 +5753,20 @@ fn fenced_command_tool_conversion_allowed(user_text: Option<&str>) -> bool {
                 "use that command",
             ],
         )
+}
+
+fn text_mentions_available_tools(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "available tool",
+            "available tools",
+            "with tool",
+            "with tools",
+            "using tool",
+            "using tools",
+        ],
+    )
 }
 
 fn inline_json_tool_choice_from_text(
@@ -4868,15 +6057,137 @@ fn validate_response_tool_arguments(
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
 ) -> Result<Value, String> {
+    validate_response_tool_arguments_for_prompt(
+        name,
+        arguments,
+        tools,
+        allowed_tools,
+        prompt_tool_profiles,
+        None,
+    )
+}
+
+fn validate_response_tool_arguments_for_prompt(
+    name: &str,
+    arguments: &Value,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
+) -> Result<Value, String> {
     if tool_names_from_schemas(tools, allowed_tools)
         .iter()
         .any(|schema_name| schema_name == name)
     {
-        return sanitize_tool_arguments_for_tool(name, arguments, tools)
-            .map_err(|err| err.to_string());
+        let mut arguments = sanitize_tool_arguments_for_tool(name, arguments, tools)
+            .map_err(|err| err.to_string())?;
+        if let Some(user_text) = user_text {
+            correct_directory_path_argument_for_prompt(name, &mut arguments, tools, user_text);
+        }
+        return Ok(arguments);
     }
 
-    validate_prompt_tool_arguments(name, arguments, allowed_tools, prompt_tool_profiles)
+    validate_prompt_tool_arguments(
+        name,
+        arguments,
+        allowed_tools,
+        prompt_tool_profiles,
+        user_text,
+    )
+}
+
+fn corrected_response_tool_arguments_for_prompt(
+    name: &str,
+    arguments: &Value,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
+) -> Value {
+    let mut corrected = arguments.clone();
+    if let Some(user_text) = user_text {
+        correct_directory_path_argument_for_prompt(name, &mut corrected, tools, user_text);
+        correct_prompt_directory_path_argument_for_prompt(
+            name,
+            &mut corrected,
+            prompt_tool_profiles,
+            user_text,
+        );
+        correct_tool_name_directory_path_argument_for_prompt(name, &mut corrected, user_text);
+    }
+    let _ = allowed_tools;
+    corrected
+}
+
+fn correct_tool_name_directory_path_argument_for_prompt(
+    name: &str,
+    arguments: &mut Value,
+    user_text: &str,
+) {
+    if !prompt_mentions_current_directory(user_text) || !tool_name_looks_directory_lister(name) {
+        return;
+    }
+    let Some(arguments) = arguments.as_object_mut() else {
+        return;
+    };
+    let Some(value) = arguments.get("path").and_then(Value::as_str) else {
+        return;
+    };
+    if value != "." && is_path_like_candidate(value, "path") {
+        arguments.insert("path".to_string(), Value::String(".".to_string()));
+    }
+}
+
+fn tool_name_looks_directory_lister(name: &str) -> bool {
+    let tokens = text_tokens(name);
+    tokens.contains("tree")
+        || (["list", "ls"].iter().any(|token| tokens.contains(*token))
+            && [
+                "dir",
+                "dirs",
+                "directory",
+                "directories",
+                "folder",
+                "folders",
+            ]
+            .iter()
+            .any(|token| tokens.contains(*token)))
+}
+
+fn correct_directory_path_argument_for_prompt(
+    name: &str,
+    arguments: &mut Value,
+    tools: Option<&Value>,
+    user_text: &str,
+) {
+    if !prompt_mentions_current_directory(user_text) {
+        return;
+    }
+    let Some(tool) = tool_by_name(name, tools) else {
+        return;
+    };
+    let tool_looks_directory_like = tool_name_and_description_look_directory_like(tool);
+    let Some(parameters) = tool_parameters_from_tool(tool) else {
+        return;
+    };
+    let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
+        return;
+    };
+    let Some(arguments) = arguments.as_object_mut() else {
+        return;
+    };
+
+    for (field, schema) in properties {
+        if !tool_looks_directory_like && !schema_or_field_looks_directory_like(schema, field) {
+            continue;
+        }
+        let Some(value) = arguments.get(field).and_then(Value::as_str) else {
+            continue;
+        };
+        if value != "." && is_path_like_candidate(value, "path") {
+            arguments.insert(field.clone(), Value::String(".".to_string()));
+        }
+    }
 }
 
 fn validate_prompt_tool_arguments(
@@ -4884,6 +6195,7 @@ fn validate_prompt_tool_arguments(
     arguments: &Value,
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
 ) -> Result<Value, String> {
     let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
     let declared = prompt_tool_profiles
@@ -4916,7 +6228,66 @@ fn validate_prompt_tool_arguments(
         }
     }
 
-    Ok(Value::Object(arguments.clone()))
+    let mut arguments = Value::Object(arguments.clone());
+    if let Some(user_text) = user_text {
+        correct_prompt_directory_path_argument_for_prompt(
+            name,
+            &mut arguments,
+            prompt_tool_profiles,
+            user_text,
+        );
+    }
+    Ok(arguments)
+}
+
+fn correct_prompt_directory_path_argument_for_prompt(
+    name: &str,
+    arguments: &mut Value,
+    prompt_tool_profiles: &[PromptToolProfile],
+    user_text: &str,
+) {
+    if !prompt_mentions_current_directory(user_text) {
+        return;
+    }
+    let Some(profile) = prompt_tool_profiles
+        .iter()
+        .find(|profile| profile.name == name)
+    else {
+        return;
+    };
+    if !prompt_profile_looks_directory_lister(profile) {
+        return;
+    }
+    let Some(arguments) = arguments.as_object_mut() else {
+        return;
+    };
+    for field in ["path", "dir", "directory", "folder"] {
+        let Some(value) = arguments.get(field).and_then(Value::as_str) else {
+            continue;
+        };
+        if value != "." && is_path_like_candidate(value, "path") {
+            arguments.insert(field.to_string(), Value::String(".".to_string()));
+        }
+    }
+}
+
+fn prompt_profile_looks_directory_lister(profile: &PromptToolProfile) -> bool {
+    let tokens = &profile.tokens;
+    let has_listing_action = ["list", "tree", "show", "view", "inspect"]
+        .iter()
+        .any(|token| tokens.contains(*token));
+    let has_directory_target = [
+        "dir",
+        "dirs",
+        "directory",
+        "directories",
+        "folder",
+        "folders",
+        "tree",
+    ]
+    .iter()
+    .any(|token| tokens.contains(*token));
+    has_listing_action && has_directory_target
 }
 
 fn declared_response_tool_names(
@@ -5084,6 +6455,7 @@ mod response_builder_tests {
     use super::*;
     use crate::normalize::{OutputKind, WorkerOutput};
     use crate::worker::WorkerRole;
+    use std::sync::Arc;
 
     fn answer(model: &str, confidence: f32, payload: &str) -> WorkerOutput {
         WorkerOutput {
@@ -5125,6 +6497,24 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn best_answer_ignores_pseudo_tool_markup() {
+        let outputs = vec![
+            answer("a", 0.99, "I will check it.\n\n<tool_code>\n</tool_code>"),
+            answer("b", 0.6, "Here is a real response."),
+        ];
+        assert_eq!(best_answer(&outputs), "Here is a real response.");
+    }
+
+    #[test]
+    fn best_answer_ignores_bare_tool_code_text() {
+        let outputs = vec![
+            answer("a", 0.99, "tool_code\nprint(list_files('.'))"),
+            answer("b", 0.6, "Here is a real response."),
+        ];
+        assert_eq!(best_answer(&outputs), "Here is a real response.");
+    }
+
+    #[test]
     fn fallback_worker_response_errors_when_only_silent_sentinel_remains() {
         let outputs = vec![answer("a", 0.99, "NO_REPLY")];
         let session = Session::new();
@@ -5138,6 +6528,277 @@ mod response_builder_tests {
                 .and_then(Value::as_str),
             Some("error")
         );
+    }
+
+    struct InvalidPseudoToolReducer;
+
+    #[async_trait::async_trait]
+    impl ModelBackend for InvalidPseudoToolReducer {
+        async fn chat_completion(
+            &self,
+            _model: &str,
+            _messages: &[Value],
+            _tools: Option<&Value>,
+            _max_tokens: u32,
+            _timeout: Duration,
+            _sampling: SamplingParams,
+        ) -> Result<Value, String> {
+            Ok(json!({
+                "choices": [{
+                    "message": {
+                        "content": "[TOOL_CALL]\n{tool => \"undeclared_tool\", args => {}}\n[/TOOL_CALL]"
+                    }
+                }]
+            }))
+        }
+    }
+
+    #[tokio::test]
+    async fn reducer_invalid_pseudo_tool_falls_back_to_worker_answer() {
+        let mut session = Session::new();
+        session.ingest(
+            &[json!({
+                "role": "user",
+                "content": "Use the available tools if needed, but answer safely."
+            })],
+            &None,
+        );
+        let outputs = vec![
+            answer("small", 0.99, "<tool_code>\n</tool_code>"),
+            answer("better", 0.6, "I can answer from the available context."),
+        ];
+        let allowed = vec!["exec".to_string()];
+        let profiles = vec![PromptToolProfile {
+            name: "exec".to_string(),
+            tokens: text_tokens("Run shell commands"),
+        }];
+        let backend: Arc<dyn ModelBackend> = Arc::new(InvalidPseudoToolReducer);
+        let config = GatewayConfig {
+            backends: vec![backend],
+            models: vec![ModelEntry {
+                name: "reducer-30b".to_string(),
+                backend_index: 0,
+            }],
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::ZERO,
+            enable_thinking: Some(false),
+        };
+
+        let (response, reducer_used, attempts) = resolve_decision(
+            &config,
+            DecisionResolution {
+                session: &session,
+                decision: arbiter::Decision::NeedsReducer {
+                    reason: "conflicting outputs".to_string(),
+                },
+                outputs: &outputs,
+                has_tools: true,
+                selected_tool_names: &[],
+                forced_tool: None,
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &profiles,
+            },
+        )
+        .await;
+
+        assert!(reducer_used);
+        assert_eq!(attempts, 1);
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("I can answer from the available context.")
+        );
+        assert!(
+            response.pointer("/error").is_none(),
+            "invalid reducer pseudo-tool must not poison the whole turn: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn arbiter_pseudo_tool_answer_falls_back_to_worker_answer() {
+        let mut session = Session::new();
+        session.ingest(
+            &[json!({
+                "role": "user",
+                "content": "Check the current status using tools if needed."
+            })],
+            &None,
+        );
+        let outputs = vec![
+            answer(
+                "small",
+                0.99,
+                "I will check it.\n\n<tool_code>\n</tool_code>",
+            ),
+            answer(
+                "better",
+                0.6,
+                "Current status is not available from the supplied context.",
+            ),
+        ];
+        let allowed = vec!["exec".to_string()];
+        let profiles = vec![PromptToolProfile {
+            name: "exec".to_string(),
+            tokens: text_tokens("Run shell commands"),
+        }];
+        let backend: Arc<dyn ModelBackend> = Arc::new(InvalidPseudoToolReducer);
+        let config = GatewayConfig {
+            backends: vec![backend],
+            models: vec![ModelEntry {
+                name: "reducer-30b".to_string(),
+                backend_index: 0,
+            }],
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::ZERO,
+            enable_thinking: Some(false),
+        };
+
+        let (response, reducer_used, attempts) = resolve_decision(
+            &config,
+            DecisionResolution {
+                session: &session,
+                decision: arbiter::Decision::Answer(
+                    "I will check it.\n\n<tool_code>\n</tool_code>".to_string(),
+                ),
+                outputs: &outputs,
+                has_tools: true,
+                selected_tool_names: &[],
+                forced_tool: None,
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &profiles,
+            },
+        )
+        .await;
+
+        assert!(!reducer_used);
+        assert_eq!(attempts, 0);
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("stop")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("Current status is not available from the supplied context.")
+        );
+        assert!(
+            response.pointer("/error").is_none(),
+            "invalid arbiter pseudo-tool must not poison the whole turn: {response}"
+        );
+    }
+
+    #[tokio::test]
+    async fn arbiter_tool_call_corrects_prompt_directory_path_for_current_directory() {
+        let config = GatewayConfig {
+            backends: Vec::new(),
+            models: Vec::new(),
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::ZERO,
+            enable_thinking: Some(false),
+        };
+        let mut session = Session::new();
+        session.ingest(
+            &[json!({
+                "role": "user",
+                "content": "Use your tools to list the current directory, then say whether AGENTS.md exists."
+            })],
+            &None,
+        );
+        let profiles = vec![PromptToolProfile {
+            name: "tree".to_string(),
+            tokens: text_tokens("tree: List directory tree for a path"),
+        }];
+        let allowed = vec!["tree".to_string()];
+        let (response, reducer_used, attempts) = resolve_decision(
+            &config,
+            DecisionResolution {
+                session: &session,
+                decision: arbiter::Decision::ToolCall {
+                    name: "tree".to_string(),
+                    arguments: json!({"path": "AGENTS.md"}),
+                },
+                outputs: &[],
+                has_tools: true,
+                selected_tool_names: &allowed,
+                forced_tool: None,
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &profiles,
+            },
+        )
+        .await;
+
+        assert!(!reducer_used);
+        assert_eq!(attempts, 0);
+        let args = response
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool arguments");
+        assert_eq!(args, json!({"path": "."}));
+    }
+
+    #[tokio::test]
+    async fn arbiter_tool_call_corrects_directory_path_from_tool_name_without_schema() {
+        let config = GatewayConfig {
+            backends: Vec::new(),
+            models: Vec::new(),
+            worker_timeout: Duration::from_secs(1),
+            reducer_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            first_answer_grace: Duration::ZERO,
+            enable_thinking: Some(false),
+        };
+        let mut session = Session::new();
+        session.ingest(
+            &[json!({
+                "role": "user",
+                "content": "Use your tools to list the current directory, then say whether AGENTS.md exists."
+            })],
+            &None,
+        );
+        let allowed = vec!["tree".to_string()];
+        let (response, reducer_used, attempts) = resolve_decision(
+            &config,
+            DecisionResolution {
+                session: &session,
+                decision: arbiter::Decision::ToolCall {
+                    name: "tree".to_string(),
+                    arguments: json!({"path": "AGENTS.md"}),
+                },
+                outputs: &[],
+                has_tools: true,
+                selected_tool_names: &allowed,
+                forced_tool: None,
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+            },
+        )
+        .await;
+
+        assert!(!reducer_used);
+        assert_eq!(attempts, 0);
+        let args = response
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool arguments");
+        assert_eq!(args, json!({"path": "."}));
     }
 
     fn tool_proposal(payload: &str) -> WorkerOutput {
@@ -5201,6 +6862,131 @@ mod response_builder_tests {
                 .and_then(Value::as_str),
             Some("Need to read.")
         );
+    }
+
+    #[test]
+    fn tool_proposal_response_rejects_invalid_required_url() {
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "web_fetch",
+                "description": "Fetch a URL",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"url": {"type": "string"}},
+                    "required": ["url"]
+                }
+            }
+        }]);
+        let output = WorkerOutput {
+            kind: normalize::OutputKind::ToolProposal,
+            confidence: 0.8,
+            tool_name: Some("web_fetch".to_string()),
+            tool_arguments: Some(json!({"url": "s internal feedback directly."})),
+            payload: "I need a valid URL before web_fetch can be used.".to_string(),
+            model: "worker".to_string(),
+            role: WorkerRole::Fast,
+            elapsed_ms: 1,
+        };
+
+        let resp = tool_proposal_response(
+            &output,
+            true,
+            Some(&tools),
+            &["web_fetch".to_string()],
+            &[],
+            Some("Fetch the details with available tools if needed."),
+        );
+
+        assert!(
+            resp.pointer("/choices/0/message/tool_calls").is_none(),
+            "invalid URL arguments must not become executable tool calls: {resp}"
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("I need a valid URL before web_fetch can be used.")
+        );
+    }
+
+    #[test]
+    fn tool_proposal_response_corrects_directory_path_for_current_directory_prompt() {
+        let tools = serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "tree",
+                "description": "List a directory tree",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "Path to list"}},
+                    "required": ["path"]
+                }
+            }
+        }]);
+        let output = WorkerOutput {
+            kind: normalize::OutputKind::ToolProposal,
+            confidence: 0.8,
+            tool_name: Some("tree".to_string()),
+            tool_arguments: Some(json!({"path": "AGENTS.md"})),
+            payload: "I'll list the directory.".to_string(),
+            model: "worker".to_string(),
+            role: WorkerRole::Specialist,
+            elapsed_ms: 1,
+        };
+
+        let resp = tool_proposal_response(
+            &output,
+            true,
+            Some(&tools),
+            &["tree".to_string()],
+            &[],
+            Some(
+                "Use your tools to list the current directory, then say whether AGENTS.md exists.",
+            ),
+        );
+
+        let args = resp
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool arguments");
+        assert_eq!(args, json!({"path": "."}));
+    }
+
+    #[test]
+    fn prompt_tool_proposal_corrects_directory_path_for_current_directory_prompt() {
+        let profiles = vec![PromptToolProfile {
+            name: "tree".to_string(),
+            tokens: text_tokens("tree: List directory tree for a path"),
+        }];
+        let output = WorkerOutput {
+            kind: normalize::OutputKind::ToolProposal,
+            confidence: 0.8,
+            tool_name: Some("tree".to_string()),
+            tool_arguments: Some(json!({"path": "AGENTS.md"})),
+            payload: "I'll list the directory.".to_string(),
+            model: "worker".to_string(),
+            role: WorkerRole::Specialist,
+            elapsed_ms: 1,
+        };
+
+        let resp = tool_proposal_response(
+            &output,
+            true,
+            None,
+            &["tree".to_string()],
+            &profiles,
+            Some(
+                "Use your tools to list the current directory, then say whether AGENTS.md exists.",
+            ),
+        );
+
+        let args = resp
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool arguments");
+        assert_eq!(args, json!({"path": "."}));
     }
 
     #[test]
@@ -5853,6 +7639,19 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn available_tools_phrase_uses_tool_grace() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Check the PR feedback with available tools if needed.",
+            })],
+            &Some(serde_json::json!([{"type": "function", "function": {"name": "exec", "description": "Run shell commands"}}])),
+        );
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+    }
+
+    #[test]
     fn negated_web_prompt_uses_answer_grace() {
         let mut session = Session::new();
         session.ingest(
@@ -5897,6 +7696,211 @@ mod response_builder_tests {
         assert_eq!(
             selected_tool_names_for_turn(&session, &[], &[]),
             vec!["read".to_string()]
+        );
+    }
+
+    #[test]
+    fn file_read_prompt_uses_tool_grace_with_direct_read_tool() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Read the first 8 lines of AGENTS.md and summarize them."
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {
+                    "name": "read",
+                    "description": "Read file contents from a path",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string", "description": "File path to read"}},
+                        "required": ["path"]
+                    }
+                }},
+                {"type": "function", "function": {"name": "web_search", "description": "Search online sources"}},
+                {"type": "function", "function": {"name": "exec", "description": "Run shell commands"}}
+            ])),
+        );
+
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["read".to_string()]
+        );
+    }
+
+    #[test]
+    fn file_read_prompt_falls_back_to_command_tool_when_file_tool_needs_unknown_node() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "file_fetch",
+                "description": "Fetch a file from a paired node",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "node": {"type": "string", "description": "Paired node name"},
+                        "path": {"type": "string", "description": "Remote file path"}
+                    },
+                    "required": ["node", "path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "dir_list",
+                "description": "List directory entries for a local filesystem path",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "Directory path"}},
+                    "required": ["path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                    "required": ["command"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "Use available tools to run pwd and then ls -la. Tell me whether AGENTS.md is visible."}),
+                tool_call_msg("call_1", "exec"),
+                tool_result_msg(
+                    "call_1",
+                    "/tmp/workspace\n-rw------- 1 me staff 7874 Jun 9 18:14 AGENTS.md",
+                ),
+                serde_json::json!({"role": "assistant", "content": "Yes, AGENTS.md is visible."}),
+                serde_json::json!({"role": "user", "content": "Read the first 8 lines of AGENTS.md if it is visible and tell me what instruction appears first."}),
+            ],
+            &Some(tools),
+        );
+
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["exec".to_string()]
+        );
+    }
+
+    #[test]
+    fn directory_list_prompt_selects_declared_lister_over_directory_fetcher() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "read",
+                "description": "Read file contents from a path",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "File path to read"}},
+                    "required": ["path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                    "required": ["command"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "dir_list",
+                "description": "List directory entries for a local filesystem path",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "Directory path"}},
+                    "required": ["path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "dir_fetch",
+                "description": "Fetch directory or file tree contents from a paired node",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "node": {"type": "string", "description": "Paired node name"},
+                        "path": {"type": "string", "description": "Directory path"}
+                    },
+                    "required": ["node", "path"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use your tools to list the current directory, then say whether AGENTS.md exists."
+            })],
+            &Some(tools.clone()),
+        );
+
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["dir_list".to_string()]);
+        let forced =
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
+        assert_eq!(forced.name, "dir_list");
+        assert_eq!(forced.fallback_arguments, serde_json::json!({"path": "."}));
+    }
+
+    #[test]
+    fn local_directory_prompt_uses_command_tool_when_directory_tools_need_node() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                    "required": ["command"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "dir_list",
+                "description": "Retrieve a structured directory listing from a paired node",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "node": {"type": "string", "description": "Node id, name, or IP"},
+                        "path": {"type": "string", "description": "Absolute path to the directory on the node"}
+                    },
+                    "required": ["node", "path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "dir_fetch",
+                "description": "Retrieve a directory tree from a paired node",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "node": {"type": "string", "description": "Node id, name, or IP"},
+                        "path": {"type": "string", "description": "Absolute path to the directory on the node"}
+                    },
+                    "required": ["node", "path"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use your tools to list the current directory, then say whether AGENTS.md exists."
+            })],
+            &Some(tools.clone()),
+        );
+
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["exec".to_string()]);
+        let forced =
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
+        assert_eq!(forced.name, "exec");
+        assert_eq!(
+            forced.fallback_arguments,
+            serde_json::json!({"command": "ls -la ."})
         );
     }
 
@@ -6011,6 +8015,142 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn literal_url_prompt_selects_url_tool_not_file_node_tool() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "file_fetch",
+                "description": "Fetch a file from a paired node",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "node": {"type": "string", "description": "Paired node name"},
+                        "path": {"type": "string", "description": "Remote file path"}
+                    },
+                    "required": ["node", "path"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "web_fetch",
+                "description": "Fetch an HTTP URL",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"url": {"type": "string", "description": "HTTP URL to fetch"}},
+                    "required": ["url"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Fetch https://example.com and summarize the main heading."
+            })],
+            &Some(tools.clone()),
+        );
+
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["web_fetch".to_string()]);
+        let forced =
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
+        assert_eq!(forced.name, "web_fetch");
+        assert_eq!(
+            forced.fallback_arguments,
+            serde_json::json!({"url": "https://example.com"})
+        );
+    }
+
+    #[test]
+    fn literal_url_prompt_uses_tool_grace_with_url_tool() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Fetch https://example.com and summarize it."
+            })],
+            &Some(serde_json::json!([{"type": "function", "function": {
+                "name": "web_fetch",
+                "description": "Fetch an HTTP URL",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"url": {"type": "string"}},
+                    "required": ["url"]
+                }
+            }}])),
+        );
+
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+    }
+
+    #[test]
+    fn external_search_prompt_selects_declared_web_search_over_memory_search() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "memory_search",
+                "description": "Search stored local memories",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Memory search query"}},
+                    "required": ["query"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "web_search",
+                "description": "Search online web sources",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Web search query"}},
+                    "required": ["query"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use available tools to look for open issues or recent discussion about mesh-LLM/mesh-llm on GitHub, then tell me one specific item."
+            })],
+            &Some(tools.clone()),
+        );
+
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["web_search".to_string()]);
+        let forced =
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
+        assert_eq!(forced.name, "web_search");
+        assert_eq!(
+            forced
+                .fallback_arguments
+                .pointer("/query")
+                .and_then(Value::as_str),
+            Some("open issues or recent discussion about mesh-LLM/mesh-llm on GitHub")
+        );
+    }
+
+    #[test]
+    fn external_search_prompt_uses_tool_grace_with_search_tool() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Search online for recent discussion about the project."
+            })],
+            &Some(serde_json::json!([{"type": "function", "function": {
+                "name": "search",
+                "description": "Search online sources",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"]
+                }
+            }}])),
+        );
+
+        assert_eq!(grace_mode_for_turn(&session, true, &[]), GraceMode::Tool);
+    }
+
+    #[test]
     fn named_argument_inference_skips_intent_verbs_after_prepositions() {
         let tools = serde_json::json!([
             {"type": "function", "function": {
@@ -6031,6 +8171,41 @@ mod response_builder_tests {
         );
 
         assert_eq!(args, serde_json::json!({"city": "Sydney"}));
+    }
+
+    #[test]
+    fn search_query_inference_strips_instruction_scaffolding() {
+        let query = search_query_from_prompt(
+            "[Tue 2026-06-09 19:21 GMT+10] Use available tools to look for open issues or recent discussion about mesh-LLM/mesh-llm on GitHub, then tell me one specific item.",
+        );
+
+        assert_eq!(
+            query,
+            "open issues or recent discussion about mesh-LLM/mesh-llm on GitHub"
+        );
+    }
+
+    #[test]
+    fn directory_path_inference_prefers_current_directory_over_mentioned_file() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "tree",
+                "description": "List a directory tree",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string", "description": "Directory path to list"}},
+                    "required": ["path"]
+                }
+            }}
+        ]);
+
+        let args = infer_tool_arguments_from_prompt(
+            "tree",
+            Some(&tools),
+            "Use your tools to list the current directory, then say whether AGENTS.md exists.",
+        );
+
+        assert_eq!(args, serde_json::json!({"path": "."}));
     }
 
     #[test]
@@ -6536,6 +8711,30 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn three_same_tool_name_results_force_answer_even_with_refined_arguments() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "search"}),
+                tool_call_msg_with_args("call_1", "web_search", r#"{"query":"alpha"}"#),
+                tool_result_msg("call_1", "result 1"),
+                tool_call_msg_with_args("call_2", "web_search", r#"{"query":"beta"}"#),
+                tool_result_msg("call_2", "result 2"),
+                tool_call_msg_with_args("call_3", "web_search", r#"{"query":"gamma"}"#),
+                tool_result_msg("call_3", "result 3"),
+            ],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "web_search"}}
+            ])),
+        );
+
+        assert_eq!(
+            repeated_same_tool_results(&session),
+            Some(("web_search".to_string(), 3))
+        );
+    }
+
+    #[test]
     fn repeated_tool_suppression_keeps_alternate_declared_tools_available() {
         let selected = suppress_repeated_tool_from_selection(
             vec!["web_search".to_string()],
@@ -6781,6 +8980,162 @@ mod response_builder_tests {
 
         assert!(!tool_result_has_answerable_evidence(result));
         assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
+    fn path_existence_prompt_answers_from_plain_text_tool_evidence() {
+        let prompt =
+            "Use your tools to list the current directory, then say whether AGENTS.md exists.";
+        let result = format!(
+            "{}\nAGENTS.md  [541]\nCargo.toml  [112]",
+            "nested/file.txt\n".repeat(300)
+        );
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        let answer = answer_from_latest_tool_result(&session).expect("path evidence answer");
+
+        assert_eq!(answer, "`AGENTS.md` exists in the tool result.");
+    }
+
+    #[test]
+    fn repair_tool_result_answer_corrects_false_missing_path_claim() {
+        let prompt =
+            "Use your tools to list the current directory, then say whether AGENTS.md exists.";
+        let result = "crates/\ndocs/\nAGENTS.md  [541]\nCargo.toml  [112]";
+        let session = session_with_user_and_tool_result(prompt, result);
+
+        let repaired =
+            repair_tool_result_answer(&session, "I do not see a file named `AGENTS.md`.");
+
+        assert_eq!(repaired, "`AGENTS.md` exists in the tool result.");
+    }
+
+    #[test]
+    fn read_prompt_with_existence_precondition_does_not_become_existence_answer() {
+        let prompt = "Read the first 8 lines of AGENTS.md if it exists and tell me what instruction appears first.";
+        let result = "ALWAYS respond to every message.\nNever reply NO_REPLY.\nStay in character.";
+        let session = session_with_user_and_tool_result(prompt, result);
+
+        let answer = answer_from_latest_tool_result(&session).expect("read evidence answer");
+
+        assert!(answer.contains("ALWAYS respond"), "{answer}");
+        assert!(!answer.contains("exists in the tool result"), "{answer}");
+    }
+
+    #[test]
+    fn web_search_result_json_can_answer_research_prompt_from_evidence() {
+        let prompt = "Use available tools to look for open issues or recent discussion about mesh-LLM/mesh-llm on GitHub, then tell me one specific item you found with a short reason it matters.";
+        let result = serde_json::json!({
+            "query": "\"mesh-llm\" \"issue\" GitHub",
+            "provider": "duckduckgo",
+            "count": 2,
+            "results": [
+                {
+                    "title": "Issues - Mesh-LLM/mesh-llm - GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/",
+                    "snippet": "Mesh-LLM / mesh-llm Public is:issue state:open"
+                },
+                {
+                    "title": "skipped branch prediction exploration - Issue #803 - Mesh-LLM/mesh-llm",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/803",
+                    "snippet": "Explore a Skippy-style branch prediction architecture for decode."
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        assert!(tool_result_has_answerable_evidence(&result));
+        let rows = structured_tool_result_rows_from_result(&result, prompt);
+        assert!(
+            !rows.is_empty(),
+            "structured rows should include search results"
+        );
+        assert!(tool_result_has_answerable_evidence_for_prompt(
+            &result, prompt
+        ));
+        let answer = answer_from_latest_tool_result(&session).expect("search result evidence");
+
+        assert!(answer.contains("Issue #803"), "{answer}");
+    }
+
+    #[test]
+    fn wrapped_web_search_title_is_cleaned_in_structured_answer() {
+        let prompt = "Find one specific open issue for mesh-LLM/mesh-llm.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Search\n---\nskippy: decode failed - Issue #652 - GitHub\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/652",
+                    "snippet": "Memory slot failure"
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        let answer = answer_from_latest_tool_result(&session).expect("specific issue evidence");
+
+        assert!(answer.contains("Issue #652"), "{answer}");
+        assert!(!answer.contains("EXTERNAL_UNTRUSTED_CONTENT"), "{answer}");
+        assert!(!answer.contains("Source: Web Search"), "{answer}");
+    }
+
+    #[test]
+    fn generic_issues_index_is_not_specific_work_item_evidence() {
+        let prompt = "Find one specific open issue for mesh-LLM/mesh-llm.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "Issues - Mesh-LLM/mesh-llm - GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/",
+                    "snippet": "is:issue state:open"
+                },
+                {
+                    "title": "GitHub - Mesh-LLM/mesh-llm",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm",
+                    "snippet": "Distributed AI/LLM for the people."
+                }
+            ]
+        })
+        .to_string();
+
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            &result, prompt
+        ));
+    }
+
+    #[test]
+    fn generic_discussions_index_answer_is_not_specific_work_item_evidence() {
+        let prompt = "Use available tools to look for open issues or recent discussion about mesh-LLM/mesh-llm on GitHub, then tell me one specific item you found.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "Issues · Mesh-LLM/mesh-llm · GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/",
+                    "snippet": "Distributed AI/LLM for the people. - Issues · Mesh-LLM/mesh-llm"
+                },
+                {
+                    "title": "Mesh-LLM mesh-llm · Discussions · GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/discussions",
+                    "snippet": "Explore the GitHub Discussions forum."
+                }
+            ]
+        })
+        .to_string();
+        let answer = "I found a specific item: the Discussions tab at https://github.com/Mesh-LLM/mesh-llm/discussions.";
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            &result, prompt
+        ));
+        assert!(answer_appears_to_use_non_answerable_tool_result(
+            answer, &result, prompt
+        ));
+        assert!(
+            non_answerable_tool_result_answer(&session, "web_search", &result)
+                .contains("generic collection/search pages")
+        );
     }
 
     #[test]
@@ -7347,6 +9702,40 @@ mod response_builder_tests {
                 .pointer("/choices/0/message/tool_calls/0/function/arguments")
                 .and_then(Value::as_str),
             Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\"}")
+        );
+    }
+
+    #[test]
+    fn fenced_command_answer_uses_prompt_tool_when_user_mentions_available_tools() {
+        let (session, profiles, allowed) = prompt_tool_session(
+            "Check the release status with available tools if needed, and summarize it.",
+        );
+
+        let response = chat_or_schema_command_tool_response(
+            "I will check it.\n\n```bash\ngh pr view 808 --json comments,reviewComments\n```",
+            session.tools(),
+            &allowed,
+            &profiles,
+            Some(&session.last_user_text()),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"gh pr view 808 --json comments,reviewComments\"}")
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -3851,23 +3851,24 @@ fn xml_tool_choice_from_text(
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
 ) -> Option<ForcedToolChoice> {
-    let invoke_start = content.find("<invoke ")?;
+    let invoke_start = content.find("<invoke")?;
     let invoke_tag_end = content[invoke_start..].find('>')? + invoke_start;
     let invoke_tag = &content[invoke_start..=invoke_tag_end];
-    let name = xml_attr_value(invoke_tag, "name")?;
-    if !declared_response_tool_names(tools, allowed_tools, prompt_tool_profiles)
-        .iter()
-        .any(|tool| tool == &name)
-    {
-        return None;
-    }
-
     let body_start = invoke_tag_end + 1;
     let body_end = content[body_start..]
         .find("</invoke>")
         .map(|idx| body_start + idx)
         .unwrap_or(content.len());
-    let arguments = xml_parameter_arguments(&content[body_start..body_end]);
+    let body = &content[body_start..body_end];
+    let mut arguments = xml_parameter_arguments(body);
+    let raw_name = xml_attr_value(invoke_tag, "name").or_else(|| xml_body_tool_name(body))?;
+    let name = resolve_response_tool_name(
+        &raw_name,
+        &mut arguments,
+        tools,
+        allowed_tools,
+        prompt_tool_profiles,
+    )?;
     match validate_response_tool_arguments(
         &name,
         &arguments,
@@ -3886,6 +3887,48 @@ fn xml_tool_choice_from_text(
     }
 }
 
+fn resolve_response_tool_name(
+    raw_name: &str,
+    arguments: &mut Value,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    prompt_tool_profiles: &[PromptToolProfile],
+) -> Option<String> {
+    let declared = declared_response_tool_names(tools, allowed_tools, prompt_tool_profiles);
+    if declared.iter().any(|tool| tool == raw_name) {
+        return Some(raw_name.to_string());
+    }
+
+    let command = arguments
+        .get("command")
+        .and_then(Value::as_str)?
+        .to_string();
+    if command.trim().is_empty() {
+        return None;
+    }
+    let candidates = command_tool_candidates(tools, allowed_tools, prompt_tool_profiles);
+    let [candidate] = candidates.as_slice() else {
+        return None;
+    };
+    if candidate.field != "command"
+        && let Some(map) = arguments.as_object_mut()
+    {
+        map.insert(candidate.field.clone(), Value::String(command));
+    }
+    Some(candidate.name.clone())
+}
+
+fn xml_body_tool_name(body: &str) -> Option<String> {
+    let marker = "tool:";
+    let marker_start = body.find(marker)? + marker.len();
+    let rest = body[marker_start..].trim_start();
+    let name: String = rest
+        .chars()
+        .take_while(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.'))
+        .collect();
+    (!name.is_empty()).then_some(name)
+}
+
 fn xml_attr_value(tag: &str, attr: &str) -> Option<String> {
     let needle = format!("{attr}=\"");
     let value_start = tag.find(&needle)? + needle.len();
@@ -3896,7 +3939,7 @@ fn xml_attr_value(tag: &str, attr: &str) -> Option<String> {
 fn xml_parameter_arguments(body: &str) -> Value {
     let mut map = serde_json::Map::new();
     let mut cursor = 0;
-    while let Some(parameter_rel) = body[cursor..].find("<parameter ") {
+    while let Some((parameter_rel, tag_prefix)) = next_xml_parameter_tag(&body[cursor..]) {
         let parameter_start = cursor + parameter_rel;
         let Some(tag_end_rel) = body[parameter_start..].find('>') else {
             break;
@@ -3909,7 +3952,7 @@ fn xml_parameter_arguments(body: &str) -> Value {
         };
 
         let value_start = tag_end + 1;
-        let value_end = xml_parameter_value_end(body, value_start, &name);
+        let value_end = xml_parameter_value_end(body, value_start, &name, tag_prefix);
         let value = xml_text_unescape(body[value_start..value_end].trim());
         map.insert(name, Value::String(value));
         cursor = value_end;
@@ -3918,17 +3961,32 @@ fn xml_parameter_arguments(body: &str) -> Value {
     Value::Object(map)
 }
 
-fn xml_parameter_value_end(body: &str, value_start: usize, name: &str) -> usize {
+fn next_xml_parameter_tag(body: &str) -> Option<(usize, &'static str)> {
+    [("<parameter ", "parameter"), ("<param ", "param")]
+        .into_iter()
+        .filter_map(|(needle, tag_prefix)| body.find(needle).map(|idx| (idx, tag_prefix)))
+        .min_by_key(|(idx, _)| *idx)
+}
+
+fn xml_parameter_value_end(body: &str, value_start: usize, name: &str, tag_prefix: &str) -> usize {
     let named_close = format!("</{name}>");
-    ["</parameter>", named_close.as_str(), "<parameter "]
-        .iter()
-        .filter_map(|needle| {
-            body[value_start..]
-                .find(needle)
-                .map(|idx| value_start + idx)
-        })
-        .min()
-        .unwrap_or(body.len())
+    let tag_close = format!("</{tag_prefix}>");
+    [
+        "</parameter>",
+        "</param>",
+        tag_close.as_str(),
+        named_close.as_str(),
+        "<parameter ",
+        "<param ",
+    ]
+    .iter()
+    .filter_map(|needle| {
+        body[value_start..]
+            .find(needle)
+            .map(|idx| value_start + idx)
+    })
+    .min()
+    .unwrap_or(body.len())
 }
 
 fn xml_text_unescape(text: &str) -> String {
@@ -6462,6 +6520,53 @@ mod response_builder_tests {
                 .pointer("/choices/0/message/tool_calls/0/function/arguments")
                 .and_then(Value::as_str),
             Some("{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10\"}")
+        );
+    }
+
+    #[test]
+    fn body_style_xml_tool_call_maps_to_single_command_tool() {
+        let tools = Some(serde_json::json!([{
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Execute shell commands.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "Shell command to execute"
+                        }
+                    },
+                    "required": ["command"]
+                }
+            }
+        }]));
+        let response = chat_or_schema_command_tool_response(
+            "I'll use the developer tool.\n<tool_call>\n<invoke>tool: developer, args: {\\n<param name=\"command\">pwd</param>}\n</tool_call>",
+            tools.as_ref(),
+            &["shell".to_string()],
+            &[],
+            Some("Run pwd."),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("shell")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/arguments")
+                .and_then(Value::as_str),
+            Some("{\"command\":\"pwd\"}")
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -510,6 +510,10 @@ fn tool_name_is_explicitly_requested(tool: &str, text: &str) -> bool {
         format!("tool {spaced}"),
         format!("call {spaced}"),
         format!("call the {spaced}"),
+        format!("or {tool}"),
+        format!("and {tool}"),
+        format!("or {spaced}"),
+        format!("and {spaced}"),
     ];
 
     patterns.iter().any(|pattern| text.contains(pattern))
@@ -627,7 +631,11 @@ fn tool_is_relevant_to_text(tool_name: &str, text: &str) -> bool {
                 "url",
                 "http://",
                 "https://",
+                "github",
                 "github.com/",
+                "issue",
+                "pull request",
+                "pr ",
             ],
         ),
         "dir_list" | "dir_fetch" | "list_files" => {
@@ -808,20 +816,20 @@ async fn handle_tool_result(
     let candidates = reducer_candidates(config);
     let candidate_count = candidates.len();
     let repeated_tool = repeated_same_tool_results(session);
-    let force_answer = repeated_tool.is_some();
-    let selected_tool_names = if force_answer {
-        Vec::new()
-    } else {
-        selected_tool_names_for_turn(session, allowed_tools)
-    };
-    let tools_enabled_for_reducer = has_tools && !force_answer;
+    let mut selected_tool_names = selected_tool_names_for_turn(session, allowed_tools);
+    if let Some((tool, _)) = repeated_tool.as_ref() {
+        selected_tool_names.retain(|name| name != tool);
+    }
+    let tools_enabled_for_reducer = has_tools && !selected_tool_names.is_empty();
     let (mut messages, tools) = context::pack_for_tool_result_turn_selected(
         session,
         tools_enabled_for_reducer,
         &selected_tool_names,
     );
     if let Some((tool, count)) = repeated_tool {
-        tracing::info!("moa: forcing answer after {count} consecutive completed {tool} tool calls");
+        tracing::info!(
+            "moa: suppressing repeated {tool} after {count} consecutive completed tool calls"
+        );
         append_tool_loop_answer_instruction(&mut messages, &tool, count);
     }
 
@@ -1068,8 +1076,9 @@ fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
 fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count: usize) {
     let instruction = format!(
         "\n\nTool loop guard: the last {count} completed tool calls all used `{tool}`. \
-         Answer now from the gathered tool results. Do not call another tool. \
-         If the evidence is incomplete, say what can be determined and what is missing."
+         Do not call `{tool}` again. If a different declared tool can materially advance the \
+         request, use that tool. Otherwise answer now from the gathered tool results; if the \
+         evidence is incomplete, say what can be determined and what is missing."
     );
     append_system_instruction(messages, &instruction);
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1811,6 +1811,14 @@ struct TabularToolRow {
     title: String,
 }
 
+#[derive(Debug)]
+struct StructuredToolRow {
+    id: Option<String>,
+    title: String,
+    url: Option<String>,
+    details: Vec<String>,
+}
+
 fn repair_tabular_tool_result_answer(session: &Session, answer: &str) -> Option<String> {
     let (_, result) = latest_completed_tool_result(session)?;
     let rows = tabular_tool_result_rows(&result);
@@ -1901,8 +1909,13 @@ fn tool_result_answer_from_evidence_response(session: &Session) -> Value {
 
 fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     let (_, result) = latest_completed_tool_result(session)?;
-    if !tool_result_has_answerable_evidence_for_prompt(&result, &session.last_user_text()) {
+    let prompt = session.last_user_text();
+    if !tool_result_has_answerable_evidence_for_prompt(&result, &prompt) {
         return None;
+    }
+
+    if let Some(answer) = answer_from_structured_tool_result(&result, &prompt) {
+        return Some(answer);
     }
 
     let mut lines = result
@@ -1926,6 +1939,147 @@ fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     }
 
     Some(truncate_for_tool_result_answer(&answer))
+}
+
+fn answer_from_structured_tool_result(result: &str, prompt: &str) -> Option<String> {
+    let parsed = serde_json::from_str::<Value>(result.trim()).ok()?;
+    let rows = structured_tool_result_rows(&parsed, prompt);
+    let first = rows.first()?;
+    let mut answer = format!(
+        "From the tool result, one relevant entry is: {}",
+        format_structured_tool_row(first, prompt)
+    );
+    let rest = rows
+        .iter()
+        .skip(1)
+        .take(2)
+        .map(|row| format_structured_tool_row(row, prompt))
+        .collect::<Vec<_>>();
+    if !rest.is_empty() {
+        answer.push_str("\n\nOther returned entries include:\n");
+        for row in rest {
+            answer.push_str("- ");
+            answer.push_str(&row);
+            answer.push('\n');
+        }
+        answer = answer.trim_end().to_string();
+    }
+
+    Some(truncate_for_tool_result_answer(&answer))
+}
+
+fn structured_tool_result_rows(value: &Value, prompt: &str) -> Vec<StructuredToolRow> {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .filter_map(|value| structured_tool_row(value, prompt))
+            .collect(),
+        Value::Object(map) => {
+            if let Some(row) = structured_tool_row(value, prompt) {
+                return vec![row];
+            }
+            [
+                "items",
+                "results",
+                "nodes",
+                "data",
+                "pullRequests",
+                "issues",
+            ]
+            .iter()
+            .filter_map(|key| map.get(*key))
+            .flat_map(|value| structured_tool_result_rows(value, prompt))
+            .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn structured_tool_row(value: &Value, prompt: &str) -> Option<StructuredToolRow> {
+    let Value::Object(map) = value else {
+        return None;
+    };
+
+    let title = first_string_field(map, &["title", "name", "subject", "summary"])?;
+    let id = first_identifier_field(map, &["number", "id", "key"]);
+    let url = first_string_field(map, &["url", "html_url", "web_url", "permalink"]);
+    if id.is_none() && url.is_none() && !prompt_asks_for_github_work_items(prompt) {
+        return None;
+    }
+
+    Some(StructuredToolRow {
+        id,
+        title,
+        url,
+        details: structured_tool_row_details(map),
+    })
+}
+
+fn first_string_field(map: &serde_json::Map<String, Value>, fields: &[&str]) -> Option<String> {
+    fields
+        .iter()
+        .find_map(|field| map.get(*field).and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+fn first_identifier_field(map: &serde_json::Map<String, Value>, fields: &[&str]) -> Option<String> {
+    fields.iter().find_map(|field| {
+        let value = map.get(*field)?;
+        match value {
+            Value::Number(number) => Some(number.to_string()),
+            Value::String(text) => {
+                let trimmed = text.trim();
+                (!trimmed.is_empty()).then(|| trimmed.to_string())
+            }
+            _ => None,
+        }
+    })
+}
+
+fn structured_tool_row_details(map: &serde_json::Map<String, Value>) -> Vec<String> {
+    let mut details = Vec::new();
+    if let Some(state) = first_string_field(map, &["state", "status"]) {
+        details.push(state);
+    }
+    if let Some(author) = map
+        .get("author")
+        .or_else(|| map.get("user"))
+        .and_then(|value| value.get("login").or_else(|| value.get("name")))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        details.push(format!("by {author}"));
+    }
+    if let Some(created) = first_string_field(map, &["createdAt", "created_at", "updatedAt"]) {
+        details.push(created);
+    }
+    details
+}
+
+fn format_structured_tool_row(row: &StructuredToolRow, prompt: &str) -> String {
+    let mut text = match row.id.as_deref() {
+        Some(id)
+            if prompt_asks_for_pull_requests(prompt)
+                && id.chars().all(|ch| ch.is_ascii_digit()) =>
+        {
+            format!("#{id} - {}", row.title)
+        }
+        Some(id) => format!("{id} - {}", row.title),
+        None => row.title.clone(),
+    };
+    if !row.details.is_empty() {
+        text.push_str(" (");
+        text.push_str(&row.details.join(", "));
+        text.push(')');
+    }
+    if let Some(url) = &row.url {
+        text.push_str(" - ");
+        text.push_str(url);
+    }
+    truncate_for_tool_result_answer(&text)
 }
 
 fn truncate_for_tool_result_answer(text: &str) -> String {
@@ -4692,6 +4846,36 @@ mod response_builder_tests {
                 "prompt {prompt:?} should synthesize from {result:?}"
             );
         }
+    }
+
+    #[test]
+    fn pr_prompt_summarizes_json_array_rows() {
+        let prompt = "Any new interesting PRs? You have the gh command line I think can use";
+        let result = serde_json::json!([
+            {
+                "number": 809,
+                "title": "feat: distributed mesh with PagedKV and Continuous Batching",
+                "url": "https://github.com/Mesh-LLM/mesh-llm/pull/809",
+                "createdAt": "2026-06-06T21:40:44Z",
+                "author": {"login": "Jackson57279"}
+            },
+            {
+                "number": 808,
+                "title": "Stabilize OpenClaw tool loops through MoA",
+                "url": "https://github.com/Mesh-LLM/mesh-llm/pull/808",
+                "author": {"login": "michaelneale"}
+            }
+        ])
+        .to_string();
+
+        let answer =
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, &result))
+                .expect("JSON PR array should synthesize a usable answer");
+
+        assert!(answer.contains("#809 - feat: distributed mesh"), "{answer}");
+        assert!(answer.contains("https://github.com/Mesh-LLM/mesh-llm/pull/809"));
+        assert!(answer.contains("#808 - Stabilize OpenClaw"), "{answer}");
+        assert!(!answer.contains("one relevant entry is: ["), "{answer}");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2169,6 +2169,7 @@ fn plain_text_tool_result_looks_like_error(result: &str) -> bool {
         || first_line.contains("not available or not authenticated")
         || first_line.starts_with("error:")
         || first_line.starts_with("fatal:")
+        || first_line.starts_with("graphql:")
         || (first_line.starts_with("unknown ") && lower.contains("\navailable fields:"))
         || (lower.contains("\nusage:") && lower.lines().take(3).any(cli_error_line))
 }
@@ -4570,6 +4571,7 @@ mod response_builder_tests {
             "  no git remotes found\n\n(Command exited with code 1)",
             "gh search not available or not authenticated",
             "search failed: gh search not available or not authenticated",
+            "GraphQL: Could not resolve to a Repository with the name 'micn/mesh-llm'. (repository)",
             "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
             "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
         ];

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2074,7 +2074,7 @@ fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
 
 fn answer_from_recent_prompt_specific_structured_tool_results(session: &Session) -> Option<String> {
     let prompt = session.active_user_text();
-    if !(prompt_asks_for_ci_status(&prompt) && prompt_asks_for_copilot_feedback(&prompt)) {
+    if !(prompt_asks_for_ci_status(&prompt) && prompt_asks_for_feedback(&prompt)) {
         return None;
     }
 
@@ -2085,9 +2085,9 @@ fn answer_from_recent_prompt_specific_structured_tool_results(session: &Session)
         let Some(value) = parse_tool_result_json(result.trim()) else {
             continue;
         };
-        title = title.or_else(|| github_title_state_summary(&value));
-        checks = checks.or_else(|| github_check_summary_from_value(&value));
-        feedback = feedback.or_else(|| github_feedback_summary_from_value(&value, &prompt));
+        title = title.or_else(|| structured_title_state_summary(&value));
+        checks = checks.or_else(|| structured_check_summary_from_value(&value));
+        feedback = feedback.or_else(|| structured_feedback_summary_from_value(&value, &prompt));
     }
 
     let mut parts = Vec::new();
@@ -2308,7 +2308,7 @@ fn answer_from_prompt_specific_structured_tool_result(
 
 fn answer_from_prompt_specific_structured_value(value: &Value, prompt: &str) -> Option<String> {
     if prompt_asks_for_check_or_review_status(prompt) {
-        return answer_from_github_pr_detail_value(value, prompt);
+        return answer_from_structured_status_feedback_value(value, prompt);
     }
     None
 }
@@ -2400,9 +2400,10 @@ fn prompt_asks_for_check_or_review_status(prompt: &str) -> bool {
     )
 }
 
-fn answer_from_github_pr_detail_value(value: &Value, prompt: &str) -> Option<String> {
+fn answer_from_structured_status_feedback_value(value: &Value, prompt: &str) -> Option<String> {
     if let Value::Array(_) = value {
-        return github_check_summary(Some(value)).filter(|_| prompt_asks_for_ci_status(prompt));
+        return structured_check_summary_from_value(value)
+            .filter(|_| prompt_asks_for_ci_status(prompt));
     }
 
     let map = value.as_object()?;
@@ -2417,26 +2418,17 @@ fn answer_from_github_pr_detail_value(value: &Value, prompt: &str) -> Option<Str
     }
 
     if contains_any(&prompt_lower, &["ci", "check", "checks", "green", "status"]) {
-        parts.extend(github_check_summary(map.get("statusCheckRollup")));
+        parts.extend(structured_check_summary_from_value(value));
     }
 
-    if contains_any(
-        &prompt_lower,
-        &[
-            "copilot", "feedback", "comment", "comments", "review", "reviews",
-        ],
-    ) {
-        parts.extend(github_feedback_summary(
-            map.get("comments"),
-            map.get("reviews"),
-            prompt_lower.contains("copilot"),
-        ));
+    if prompt_asks_for_feedback(prompt) {
+        parts.extend(structured_feedback_summary_from_value(value, prompt));
     }
 
     (!parts.is_empty()).then(|| truncate_for_tool_result_answer(&parts.join("\n")))
 }
 
-fn github_title_state_summary(value: &Value) -> Option<String> {
+fn structured_title_state_summary(value: &Value) -> Option<String> {
     let map = value.as_object()?;
     let title = first_string_field(map, &["title", "name"])?;
     let state = first_string_field(map, &["state", "status"]);
@@ -2446,38 +2438,63 @@ fn github_title_state_summary(value: &Value) -> Option<String> {
     })
 }
 
-fn github_check_summary_from_value(value: &Value) -> Option<String> {
+fn structured_check_summary_from_value(value: &Value) -> Option<String> {
+    let mut checks = Vec::new();
+    collect_structured_check_items(value, &mut checks);
+    structured_check_summary(&checks)
+}
+
+fn collect_structured_check_items(value: &Value, checks: &mut Vec<Value>) {
     match value {
-        Value::Object(map) => github_check_summary(map.get("statusCheckRollup")),
-        Value::Array(_) => github_check_summary(Some(value)),
-        _ => None,
+        Value::Object(map) if structured_object_looks_like_check(map) => {
+            checks.push(value.clone());
+        }
+        Value::Object(map) => {
+            for nested in map.values() {
+                collect_structured_check_items(nested, checks);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_structured_check_items(value, checks);
+            }
+        }
+        _ => {}
     }
 }
 
-fn github_feedback_summary_from_value(value: &Value, prompt: &str) -> Option<String> {
-    if !json_value_has_copilot_feedback_evidence(value) {
+fn structured_object_looks_like_check(map: &serde_json::Map<String, Value>) -> bool {
+    map.contains_key("conclusion")
+        || map.contains_key("outcome")
+        || map.contains_key("result")
+        || (map.contains_key("status")
+            && first_string_field(
+                map,
+                &[
+                    "name",
+                    "workflowName",
+                    "workflow_name",
+                    "jobName",
+                    "job_name",
+                    "detailsUrl",
+                    "details_url",
+                ],
+            )
+            .is_some())
+}
+
+fn structured_feedback_summary_from_value(value: &Value, prompt: &str) -> Option<String> {
+    if !json_value_has_feedback_evidence(value, prompt) {
         return None;
     }
 
-    let copilot_only = prompt.to_ascii_lowercase().contains("copilot");
-    match value {
-        Value::Object(map) => {
-            if map.contains_key("comments") || map.contains_key("reviews") {
-                return github_feedback_summary(
-                    map.get("comments"),
-                    map.get("reviews"),
-                    copilot_only,
-                );
-            }
-            github_feedback_summary(None, Some(&Value::Array(vec![value.clone()])), copilot_only)
-        }
-        Value::Array(_) => github_feedback_summary(None, Some(value), copilot_only),
-        _ => None,
-    }
+    let focus = feedback_focus_from_prompt(prompt);
+    let mut entries = Vec::new();
+    collect_structured_feedback_entries(value, focus.as_deref(), &mut entries);
+    structured_feedback_summary(entries, focus.as_deref())
 }
 
-fn github_check_summary(value: Option<&Value>) -> Option<String> {
-    let checks = value?.as_array()?;
+fn structured_check_summary(checks: &[Value]) -> Option<String> {
     if checks.is_empty() {
         return Some("CI/checks: no check runs were returned.".to_string());
     }
@@ -2485,19 +2502,36 @@ fn github_check_summary(value: Option<&Value>) -> Option<String> {
     let mut failing = Vec::new();
     let mut pending = Vec::new();
     for check in checks.iter().filter_map(Value::as_object) {
-        let name = first_string_field(check, &["name", "workflowName"]).unwrap_or_else(|| {
+        let name = first_string_field(
+            check,
+            &[
+                "name",
+                "workflowName",
+                "workflow_name",
+                "jobName",
+                "job_name",
+                "displayName",
+                "display_name",
+                "title",
+            ],
+        )
+        .unwrap_or_else(|| {
             check
                 .get("__typename")
                 .and_then(Value::as_str)
                 .unwrap_or("check")
                 .to_string()
         });
-        let conclusion = first_string_field(check, &["conclusion"]);
-        let status = first_string_field(check, &["status"]);
-        match conclusion.as_deref() {
-            Some("SUCCESS" | "SKIPPED" | "NEUTRAL") => {}
+        let conclusion = first_string_field(check, &["conclusion", "outcome", "result"]);
+        let status = first_string_field(check, &["status", "state"]);
+        let normalized_conclusion = conclusion.as_deref().map(str::to_ascii_uppercase);
+        match normalized_conclusion.as_deref() {
+            Some("SUCCESS" | "PASSED" | "PASS" | "SKIPPED" | "NEUTRAL") => {}
             Some(other) => failing.push(format!("{name}: {other}")),
-            None if !matches!(status.as_deref(), Some("COMPLETED")) => {
+            None if status.as_deref().is_some_and(status_value_looks_failure) => {
+                failing.push(format!("{name}: {}", status.unwrap_or_default()));
+            }
+            None if !status.as_deref().is_some_and(status_value_looks_completed) => {
                 pending.push(format!(
                     "{name}: {}",
                     status.unwrap_or_else(|| "pending".to_string())
@@ -2528,65 +2562,156 @@ fn github_check_summary(value: Option<&Value>) -> Option<String> {
     }
 }
 
-fn github_feedback_summary(
-    comments: Option<&Value>,
-    reviews: Option<&Value>,
-    copilot_only: bool,
-) -> Option<String> {
-    let mut entries = Vec::new();
-    collect_github_feedback_entries(comments, "comment", copilot_only, &mut entries);
-    collect_github_feedback_entries(reviews, "review", copilot_only, &mut entries);
+fn status_value_looks_completed(value: &str) -> bool {
+    matches!(
+        value.to_ascii_uppercase().as_str(),
+        "COMPLETED" | "COMPLETE" | "DONE" | "SUCCESS" | "PASSED" | "PASS"
+    )
+}
 
+fn status_value_looks_failure(value: &str) -> bool {
+    matches!(
+        value.to_ascii_uppercase().as_str(),
+        "FAILURE" | "FAILED" | "FAIL" | "ERROR" | "CANCELLED" | "CANCELED" | "TIMED_OUT"
+    )
+}
+
+fn structured_feedback_summary(entries: Vec<String>, focus: Option<&str>) -> Option<String> {
     if entries.is_empty() {
-        if copilot_only {
-            return Some(
-                "Copilot feedback: no Copilot-authored comments or reviews were returned."
-                    .to_string(),
-            );
+        if let Some(focus) = focus {
+            return Some(format!(
+                "{} feedback: no {}-authored comments or reviews were returned.",
+                feedback_label(focus),
+                focus
+            ));
         }
         return Some("Feedback: no comments or reviews were returned.".to_string());
     }
 
     Some(format!(
         "{}: {}",
-        if copilot_only {
-            "Copilot feedback"
-        } else {
-            "Feedback"
-        },
+        focus
+            .map(|focus| format!("{} feedback", feedback_label(focus)))
+            .unwrap_or_else(|| "Feedback".to_string()),
         entries.into_iter().take(3).collect::<Vec<_>>().join("; ")
     ))
 }
 
-fn collect_github_feedback_entries(
-    value: Option<&Value>,
-    kind: &str,
-    copilot_only: bool,
+fn collect_structured_feedback_entries(
+    value: &Value,
+    focus: Option<&str>,
     entries: &mut Vec<String>,
 ) {
-    let Some(items) = value.and_then(Value::as_array) else {
-        return;
-    };
-    for item in items.iter().filter_map(Value::as_object) {
-        let author = item
-            .get("author")
-            .and_then(|author| author.get("login").or_else(|| author.get("name")))
-            .or_else(|| item.get("author"))
-            .or_else(|| item.get("user").and_then(|user| user.get("login")))
-            .and_then(Value::as_str)
-            .unwrap_or("unknown");
-        let body = first_string_field(item, &["body"]).unwrap_or_default();
-        let author_or_body_mentions_copilot = author.to_ascii_lowercase().contains("copilot")
-            || body.to_ascii_lowercase().contains("copilot");
-        if copilot_only && !author_or_body_mentions_copilot {
-            continue;
+    match value {
+        Value::Object(map) if structured_object_looks_like_feedback_entry(map) => {
+            collect_structured_feedback_entry(map, "feedback", focus, entries);
         }
-        let state = first_string_field(item, &["state"]);
-        let body_summary = first_non_empty_line(&body).unwrap_or_else(|| "(no body)".to_string());
-        entries.push(match state {
-            Some(state) => format!("{kind} by {author} ({state}): {body_summary}"),
-            None => format!("{kind} by {author}: {body_summary}"),
-        });
+        Value::Object(map) => {
+            for key in FEEDBACK_COLLECTION_KEYS {
+                if let Some(nested) = map.get(*key) {
+                    collect_feedback_collection_entries(nested, key, focus, entries);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_structured_feedback_entries(value, focus, entries);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_feedback_collection_entries(
+    value: &Value,
+    key: &str,
+    focus: Option<&str>,
+    entries: &mut Vec<String>,
+) {
+    match value {
+        Value::Array(values) => {
+            for item in values.iter().filter_map(Value::as_object) {
+                collect_structured_feedback_entry(item, feedback_kind_for_key(key), focus, entries);
+            }
+        }
+        Value::Object(map) => {
+            collect_structured_feedback_entry(map, feedback_kind_for_key(key), focus, entries);
+        }
+        _ => {}
+    }
+}
+
+fn collect_structured_feedback_entry(
+    item: &serde_json::Map<String, Value>,
+    kind: &str,
+    focus: Option<&str>,
+    entries: &mut Vec<String>,
+) {
+    let author = item
+        .get("author")
+        .and_then(|author| author.get("login").or_else(|| author.get("name")))
+        .or_else(|| item.get("author"))
+        .or_else(|| item.get("user").and_then(|user| user.get("login")))
+        .or_else(|| item.get("creator").and_then(|user| user.get("login")))
+        .or_else(|| item.get("reviewer").and_then(|user| user.get("name")))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let body = first_string_field(item, &["body", "text", "comment", "message", "summary"])
+        .unwrap_or_default();
+    if let Some(focus) = focus {
+        let author_or_body_matches = author.to_ascii_lowercase().contains(focus)
+            || body.to_ascii_lowercase().contains(focus);
+        if !author_or_body_matches {
+            return;
+        }
+    }
+    let state = first_string_field(item, &["state"]);
+    let body_summary = first_non_empty_line(&body).unwrap_or_else(|| "(no body)".to_string());
+    entries.push(match state {
+        Some(state) => format!("{kind} by {author} ({state}): {body_summary}"),
+        None => format!("{kind} by {author}: {body_summary}"),
+    });
+}
+
+fn structured_object_looks_like_feedback_entry(map: &serde_json::Map<String, Value>) -> bool {
+    first_string_field(map, &["body", "text", "comment", "message", "summary"]).is_some()
+        && (map.contains_key("author")
+            || map.contains_key("user")
+            || map.contains_key("creator")
+            || map.contains_key("reviewer"))
+}
+
+const FEEDBACK_COLLECTION_KEYS: &[&str] = &[
+    "comments",
+    "reviews",
+    "feedback",
+    "notes",
+    "annotations",
+    "reviewComments",
+    "review_comments",
+];
+
+fn feedback_kind_for_key(key: &str) -> &str {
+    match key {
+        "comments" => "comment",
+        "reviews" => "review",
+        "annotations" => "annotation",
+        "notes" => "note",
+        "reviewComments" | "review_comments" => "review comment",
+        _ => "feedback",
+    }
+}
+
+fn feedback_focus_from_prompt(prompt: &str) -> Option<String> {
+    let lower = prompt.to_ascii_lowercase();
+    lower.contains("copilot").then(|| "copilot".to_string())
+}
+
+fn feedback_label(focus: &str) -> String {
+    let mut chars = focus.chars();
+    match chars.next() {
+        Some(first) => first.to_ascii_uppercase().to_string() + chars.as_str(),
+        None => "Requested".to_string(),
     }
 }
 
@@ -2976,9 +3101,7 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     if prompt_asks_for_ci_status(prompt) && !tool_result_has_ci_status_evidence(result) {
         return false;
     }
-    if prompt_asks_for_copilot_feedback(prompt)
-        && !tool_result_has_copilot_feedback_evidence(result)
-    {
+    if prompt_asks_for_feedback(prompt) && !tool_result_has_feedback_evidence(result, prompt) {
         return false;
     }
     if prompt_asks_for_github_work_items(prompt)
@@ -3015,13 +3138,19 @@ fn prompt_asks_for_ci_status(prompt: &str) -> bool {
     )
 }
 
-fn prompt_asks_for_copilot_feedback(prompt: &str) -> bool {
+fn prompt_asks_for_feedback(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
-    lower.contains("copilot")
-        && contains_any(
-            &lower,
-            &["feedback", "comment", "comments", "review", "reviews"],
-        )
+    contains_any(
+        &lower,
+        &[
+            "feedback",
+            "comment",
+            "comments",
+            "review comment",
+            "review comments",
+            "reviews",
+        ],
+    )
 }
 
 fn tool_result_has_ci_status_evidence(result: &str) -> bool {
@@ -3049,54 +3178,55 @@ fn tool_result_has_ci_status_evidence(result: &str) -> bool {
     )
 }
 
-fn tool_result_has_copilot_feedback_evidence(result: &str) -> bool {
+fn tool_result_has_feedback_evidence(result: &str, prompt: &str) -> bool {
     if let Some(parsed) = parse_tool_result_json(result.trim()) {
-        return json_value_has_copilot_feedback_evidence(&parsed);
+        return json_value_has_feedback_evidence(&parsed, prompt);
     }
 
     let lower = result.to_ascii_lowercase();
+    let focus = feedback_focus_from_prompt(prompt);
+    let focus_matches = focus.as_deref().is_some_and(|focus| lower.contains(focus));
     contains_any(
         &lower,
         &[
-            "copilot feedback",
-            "github-copilot",
-            "copilot-pull-request-reviewer",
-            "no copilot",
-            "copilot-authored",
+            "feedback",
+            "comment",
+            "comments",
+            "review",
+            "reviews",
+            "no feedback",
+            "no comments",
+            "no reviews",
         ],
-    )
+    ) && (focus.is_none() || focus_matches)
 }
 
 fn json_value_has_ci_status_evidence(value: &Value) -> bool {
+    let mut checks = Vec::new();
+    collect_structured_check_items(value, &mut checks);
+    !checks.is_empty()
+}
+
+fn json_value_has_feedback_evidence(value: &Value, prompt: &str) -> bool {
+    let focus = feedback_focus_from_prompt(prompt);
     match value {
         Value::Object(map) => {
-            if map
-                .get("statusCheckRollup")
-                .and_then(Value::as_array)
-                .is_some_and(|checks| !checks.is_empty())
+            if FEEDBACK_COLLECTION_KEYS
+                .iter()
+                .any(|key| map.contains_key(*key))
+                || structured_object_looks_like_feedback_entry(map)
             {
                 return true;
             }
-            let has_check_fields = map.contains_key("conclusion")
-                || (map.contains_key("status")
-                    && (map.contains_key("workflowName") || map.contains_key("detailsUrl")));
-            has_check_fields || map.values().any(json_value_has_ci_status_evidence)
+            map.values()
+                .any(|value| json_value_has_feedback_evidence(value, prompt))
         }
-        Value::Array(values) => values.iter().any(json_value_has_ci_status_evidence),
-        _ => false,
-    }
-}
-
-fn json_value_has_copilot_feedback_evidence(value: &Value) -> bool {
-    match value {
-        Value::Object(map) => {
-            if map.contains_key("comments") || map.contains_key("reviews") {
-                return true;
-            }
-            map.values().any(json_value_has_copilot_feedback_evidence)
-        }
-        Value::Array(values) => values.iter().any(json_value_has_copilot_feedback_evidence),
-        Value::String(text) => text.to_ascii_lowercase().contains("copilot"),
+        Value::Array(values) => values
+            .iter()
+            .any(|value| json_value_has_feedback_evidence(value, prompt)),
+        Value::String(text) => focus
+            .as_deref()
+            .is_some_and(|focus| text.to_ascii_lowercase().contains(focus)),
         _ => false,
     }
 }
@@ -5958,6 +6088,68 @@ mod response_builder_tests {
             repaired.contains("copilot-pull-request-reviewer[bot]"),
             "{repaired}"
         );
+    }
+
+    #[test]
+    fn generic_status_prompt_summarizes_nested_job_results() {
+        let prompt = "Is the deployment status green?";
+        let result = serde_json::json!({
+            "service": "billing-api",
+            "pipeline": {
+                "jobs": [
+                    {"jobName": "unit", "status": "SUCCESS"},
+                    {"jobName": "canary", "status": "FAILED"}
+                ]
+            }
+        })
+        .to_string();
+
+        let answer =
+            answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, &result))
+                .expect("generic nested job output should answer status prompt");
+
+        assert!(answer.contains("CI/checks: not all green"), "{answer}");
+        assert!(answer.contains("canary: FAILED"), "{answer}");
+    }
+
+    #[test]
+    fn generic_status_and_feedback_prompt_combines_recent_structured_tool_results() {
+        let prompt = "Is the release status green, and any review feedback?";
+        let status_result = serde_json::json!({
+            "release": "2026.06.08",
+            "checks": [
+                {"name": "deploy", "result": "passed"},
+                {"name": "smoke", "result": "failed"}
+            ]
+        })
+        .to_string();
+        let feedback_result = serde_json::json!({
+            "reviews": [
+                {
+                    "author": {"name": "nick"},
+                    "state": "COMMENTED",
+                    "message": "Please add one more timeout guard."
+                }
+            ]
+        })
+        .to_string();
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": prompt}),
+                tool_call_msg_with_args("call_1", "lookup", r#"{"id":"release"}"#),
+                tool_result_msg("call_1", &status_result),
+                tool_call_msg_with_args("call_2", "lookup", r#"{"id":"reviews"}"#),
+                tool_result_msg("call_2", &feedback_result),
+            ],
+            &None,
+        );
+
+        let repaired = repair_tool_result_answer(&session, "Status is still running.");
+
+        assert!(repaired.contains("smoke: FAILED"), "{repaired}");
+        assert!(repaired.contains("Feedback"), "{repaired}");
+        assert!(repaired.contains("review by nick"), "{repaired}");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -60,6 +60,8 @@ use worker::WorkerRole;
 pub use worker::{strip_thinking, truncate_chars};
 
 const SAME_TOOL_FORCE_ANSWER_THRESHOLD: usize = 3;
+const WEB_RESEARCH_FORCE_ANSWER_THRESHOLD: usize = 6;
+const WEB_RESEARCH_TOOLS: &[&str] = &["web_search", "web_fetch"];
 
 /// The virtual model name that triggers MoA routing.
 pub const VIRTUAL_MODEL_NAME: &str = "mesh";
@@ -816,21 +818,34 @@ async fn handle_tool_result(
     let candidates = reducer_candidates(config);
     let candidate_count = candidates.len();
     let repeated_tool = repeated_same_tool_results(session);
+    let web_budget_exhausted = web_research_tool_budget_exhausted(session);
     let mut selected_tool_names = selected_tool_names_for_turn(session, allowed_tools);
     if let Some((tool, _)) = repeated_tool.as_ref() {
         selected_tool_names.retain(|name| name != tool);
     }
-    let tools_enabled_for_reducer = has_tools && !selected_tool_names.is_empty();
-    let (mut messages, tools) = context::pack_for_tool_result_turn_selected(
-        session,
-        tools_enabled_for_reducer,
-        &selected_tool_names,
-    );
-    if let Some((tool, count)) = repeated_tool {
+    if web_budget_exhausted.is_some() {
+        selected_tool_names.retain(|name| !is_web_research_tool(name));
+    }
+    let tools_enabled_for_reducer =
+        has_tools && !selected_tool_names.is_empty() && web_budget_exhausted.is_none();
+    let (mut messages, tools) = if web_budget_exhausted.is_some() {
+        (context::pack_for_tool_result_answer_only(session), None)
+    } else {
+        context::pack_for_tool_result_turn_selected(
+            session,
+            tools_enabled_for_reducer,
+            &selected_tool_names,
+        )
+    };
+    if let Some((tool, count)) = repeated_tool.as_ref() {
         tracing::info!(
             "moa: suppressing repeated {tool} after {count} consecutive completed tool calls"
         );
-        append_tool_loop_answer_instruction(&mut messages, &tool, count);
+        append_tool_loop_answer_instruction(&mut messages, tool, *count);
+    }
+    if let Some(count) = web_budget_exhausted {
+        tracing::info!("moa: forcing answer after {count} completed web research tool calls");
+        append_web_research_budget_instruction(&mut messages, count);
     }
 
     // Hedged ladder: start candidate 0, hedge to candidate 1 after hedge_delay
@@ -1059,18 +1074,74 @@ fn short_exact_value(value: &str) -> bool {
 }
 
 fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
-    let calls = session.pending_tool_calls();
-    let last = calls.last()?;
-    last.result.as_ref()?;
-
-    let tool_name = last.function_name.as_str();
+    let calls = completed_tool_names_since_latest_user_before_tool_result(session);
+    let tool_name = calls.last()?;
     let count = calls
         .iter()
         .rev()
-        .take_while(|call| call.function_name == tool_name && call.result.is_some())
+        .take_while(|name| *name == tool_name)
         .count();
 
-    (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (tool_name.to_string(), count))
+    (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (tool_name.clone(), count))
+}
+
+fn web_research_tool_budget_exhausted(session: &Session) -> Option<usize> {
+    let count = completed_tool_names_since_latest_user_before_tool_result(session)
+        .iter()
+        .filter(|name| is_web_research_tool(name))
+        .count();
+
+    (count >= WEB_RESEARCH_FORCE_ANSWER_THRESHOLD).then_some(count)
+}
+
+fn completed_tool_names_since_latest_user_before_tool_result(session: &Session) -> Vec<String> {
+    let all = session.all_messages();
+    let Some(latest_tool_idx) = all.iter().rposition(|msg| message_role(msg) == "tool") else {
+        return Vec::new();
+    };
+    let start_idx = all[..=latest_tool_idx]
+        .iter()
+        .rposition(|msg| message_role(msg) == "user")
+        .unwrap_or(0);
+
+    let mut call_names = std::collections::HashMap::new();
+    let mut completed = Vec::new();
+    for msg in &all[start_idx..=latest_tool_idx] {
+        match message_role(msg) {
+            "assistant" => {
+                let Some(tool_calls) = msg.get("tool_calls").and_then(Value::as_array) else {
+                    continue;
+                };
+                for tool_call in tool_calls {
+                    let Some(id) = tool_call.get("id").and_then(Value::as_str) else {
+                        continue;
+                    };
+                    let Some(name) = tool_call.pointer("/function/name").and_then(Value::as_str)
+                    else {
+                        continue;
+                    };
+                    call_names.insert(id.to_string(), name.to_string());
+                }
+            }
+            "tool" => {
+                let Some(id) = msg.get("tool_call_id").and_then(Value::as_str) else {
+                    continue;
+                };
+                if let Some(name) = call_names.get(id) {
+                    completed.push(name.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    completed
+}
+
+fn is_web_research_tool(name: &str) -> bool {
+    WEB_RESEARCH_TOOLS
+        .iter()
+        .any(|candidate| name.eq_ignore_ascii_case(candidate))
 }
 
 fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count: usize) {
@@ -1079,6 +1150,16 @@ fn append_tool_loop_answer_instruction(messages: &mut [Value], tool: &str, count
          Do not call `{tool}` again. If a different declared tool can materially advance the \
          request, use that tool. Otherwise answer now from the gathered tool results; if the \
          evidence is incomplete, say what can be determined and what is missing."
+    );
+    append_system_instruction(messages, &instruction);
+}
+
+fn append_web_research_budget_instruction(messages: &mut [Value], count: usize) {
+    let instruction = format!(
+        "\n\nWeb research budget guard: {count} completed web_search/web_fetch calls are already \
+         in context. Do not call web_search or web_fetch again. Answer now from the gathered \
+         evidence. If the evidence is incomplete or ambiguous, give the best effort answer and \
+         state what is missing."
     );
     append_system_instruction(messages, &instruction);
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2180,8 +2180,7 @@ fn answer_from_recent_prompt_specific_structured_tool_results(session: &Session)
 fn repair_structured_tool_result_answer(session: &Session, answer: &str) -> Option<String> {
     let (_, result) = latest_completed_tool_result(session)?;
     let prompt = session.active_user_text();
-    let parsed = parse_tool_result_json(result.trim())?;
-    let rows = structured_tool_result_rows(&parsed, &prompt);
+    let rows = structured_tool_result_rows_from_result(&result, &prompt);
     if rows.is_empty() {
         return None;
     }
@@ -2457,12 +2456,15 @@ fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str
 }
 
 fn answer_from_structured_tool_result(result: &str, prompt: &str) -> Option<String> {
-    let parsed = parse_tool_result_json(result.trim())?;
-    if let Some(answer) = answer_from_prompt_specific_structured_value(&parsed, prompt) {
-        return Some(answer);
-    }
-
-    let rows = structured_tool_result_rows(&parsed, prompt);
+    let rows = match parse_tool_result_json(result.trim()) {
+        Some(parsed) => {
+            if let Some(answer) = answer_from_prompt_specific_structured_value(&parsed, prompt) {
+                return Some(answer);
+            }
+            structured_tool_result_rows(&parsed, prompt)
+        }
+        None => structured_tool_result_rows_from_embedded_json(result, prompt),
+    };
     let first = rows.first()?;
     let mut answer = format!(
         "From the tool result, one relevant entry is: {}",
@@ -2507,6 +2509,73 @@ fn parse_tool_result_json(result: &str) -> Option<Value> {
         .ok()
         .or_else(|| parse_concatenated_json_values(result))
         .or_else(|| parse_json_prefix_with_escaped_string_controls(result))
+}
+
+fn structured_tool_result_rows_from_result(result: &str, prompt: &str) -> Vec<StructuredToolRow> {
+    parse_tool_result_json(result.trim())
+        .map(|value| structured_tool_result_rows(&value, prompt))
+        .unwrap_or_else(|| structured_tool_result_rows_from_embedded_json(result, prompt))
+}
+
+fn structured_tool_result_rows_from_embedded_json(
+    result: &str,
+    prompt: &str,
+) -> Vec<StructuredToolRow> {
+    embedded_json_objects(result)
+        .into_iter()
+        .flat_map(|value| structured_tool_result_rows(&value, prompt))
+        .collect()
+}
+
+fn embedded_json_objects(input: &str) -> Vec<Value> {
+    let mut values = Vec::new();
+    let mut start = None;
+    let mut in_string = false;
+    let mut escaped = false;
+    let mut depth = 0usize;
+
+    for (index, ch) in input.char_indices() {
+        if depth == 0 {
+            if ch == '{' {
+                start = Some(index);
+                depth = 1;
+                in_string = false;
+                escaped = false;
+            }
+            continue;
+        }
+
+        if in_string {
+            match ch {
+                '"' if !escaped => in_string = false,
+                _ => {}
+            }
+            escaped = ch == '\\' && !escaped;
+            if ch != '\\' {
+                escaped = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => in_string = true,
+            '{' => depth = depth.saturating_add(1),
+            '}' => {
+                depth = depth.saturating_sub(1);
+                if depth == 0 {
+                    let parsed =
+                        start.and_then(|start| serde_json::from_str(&input[start..=index]).ok());
+                    start = None;
+                    if let Some(value) = parsed {
+                        values.push(value);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    values
 }
 
 fn parse_concatenated_json_values(input: &str) -> Option<Value> {
@@ -2946,7 +3015,7 @@ fn structured_tool_row(value: &Value, prompt: &str) -> Option<StructuredToolRow>
 
     let title = first_string_field(map, &["title", "name", "subject", "summary"])?;
     let id = first_identifier_field(map, &["number", "id", "key"]);
-    let url = first_string_field(map, &["url", "html_url", "web_url", "permalink"]);
+    let url = first_string_field(map, &["html_url", "web_url", "permalink", "url"]);
     if id.is_none() && url.is_none() && !prompt_asks_for_work_items(prompt) {
         return None;
     }
@@ -3279,7 +3348,21 @@ fn retry_tool_result_response_if_plain(
         }
         _ => {}
     }
-    if response_contains_tool_call(&body) {
+    if let Some(response_call) = first_response_tool_call(&body) {
+        if let Some(corrected) = corrected_retry_tool_call(
+            &response_call,
+            latest_tool_result,
+            tools,
+            allowed_tools,
+            prompt_tool_profiles,
+        ) {
+            tracing::info!(
+                "moa: reducer returned malformed follow-up {}; retrying corrected tool call",
+                response_call.name
+            );
+            let arguments = Value::String(corrected.arguments);
+            return tool_call_response(&corrected.name, &arguments);
+        }
         return body;
     }
     retry_tool_call
@@ -3356,10 +3439,11 @@ fn corrected_retry_tool_call(
         .get(&candidate.field)
         .and_then(Value::as_str)
         .map(str::to_string)?;
-    let corrected = tool_result_is_shell_parse_error(result)
+    let corrected = tool_result_suggests_unquoted_shell_token_error(result)
         .then(|| quote_unquoted_shell_metachar_tokens(&command))
         .flatten()
-        .or_else(|| remove_unknown_cli_flags_from_command(&command, result))?;
+        .or_else(|| remove_unknown_cli_flags_from_command(&command, result))
+        .or_else(|| unescape_single_quoted_shell_double_quotes(&command, result))?;
     if corrected == command {
         return None;
     }
@@ -3375,9 +3459,49 @@ fn corrected_retry_tool_call(
     })
 }
 
-fn tool_result_is_shell_parse_error(result: &str) -> bool {
+fn tool_result_suggests_unquoted_shell_token_error(result: &str) -> bool {
     let lower = result.to_ascii_lowercase();
-    lower.contains("parse error near") || lower.contains("syntax error near")
+    lower.contains("parse error near")
+        || lower.contains("syntax error near")
+        || lower.contains("no matches found")
+}
+
+fn unescape_single_quoted_shell_double_quotes(command: &str, result: &str) -> Option<String> {
+    if !tool_result_suggests_shell_quoting_issue(result) {
+        return None;
+    }
+
+    let mut changed = false;
+    let mut out = String::with_capacity(command.len());
+    let mut quote: Option<char> = None;
+    let mut chars = command.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\'' | '"' if quote == Some(ch) => {
+                quote = None;
+                out.push(ch);
+            }
+            '\'' | '"' if quote.is_none() => {
+                quote = Some(ch);
+                out.push(ch);
+            }
+            '\\' if quote == Some('\'') && chars.peek() == Some(&'"') => {
+                changed = true;
+                out.push('"');
+                chars.next();
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    changed.then_some(out)
+}
+
+fn tool_result_suggests_shell_quoting_issue(result: &str) -> bool {
+    let lower = result.to_ascii_lowercase();
+    lower.contains("unix shell quoting issues")
+        || (lower.contains("syntax error") && lower.contains("jq:"))
 }
 
 fn remove_unknown_cli_flags_from_command(command: &str, result: &str) -> Option<String> {
@@ -3540,7 +3664,8 @@ fn flush_shell_token(out: &mut String, token: &mut String, changed: &mut bool) {
 }
 
 fn shell_token_needs_single_quotes(token: &str) -> bool {
-    token.contains('&') && !shell_token_already_quoted(token)
+    token.chars().any(|ch| matches!(ch, '&' | '?' | '*' | '['))
+        && !shell_token_already_quoted(token)
 }
 
 fn shell_token_already_quoted(token: &str) -> bool {
@@ -3562,12 +3687,6 @@ fn first_response_tool_call(body: &Value) -> Option<CompletedToolCall> {
         name: name.to_string(),
         arguments,
     })
-}
-
-fn response_contains_tool_call(body: &Value) -> bool {
-    body.pointer("/choices/0/message/tool_calls")
-        .and_then(Value::as_array)
-        .is_some_and(|calls| !calls.is_empty())
 }
 
 fn tool_result_has_answerable_evidence(result: &str) -> bool {
@@ -3927,6 +4046,7 @@ fn plain_text_tool_result_looks_like_error(result: &str) -> bool {
         || first_line.starts_with("unknown command")
         || first_line.contains("parse error")
         || first_line.contains("syntax error")
+        || first_line.contains("no matches found")
         || first_line == "no git remotes found"
         || first_line.contains("not available or not authenticated")
         || first_line.starts_with("error:")
@@ -6429,6 +6549,22 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn repair_tool_result_answer_recovers_work_item_from_embedded_json_fragment() {
+        let prompt = "Use shell/developer tool to look for recent important open GitHub issues or PRs in Mesh-LLM/mesh-llm, then tell me about one. Do not answer from memory.";
+        let result = r###"ented Plugin-only routing setup from an earlier issue body...","closed_by":null},{"url":"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/786","html_url":"https://github.com/Mesh-LLM/mesh-llm/pull/786","number":786,"title":"[codex] make installer runtime-first","state":"open","user":{"login":"i386"},"created_at":"2026-06-03T22:46:21Z","pull_request":{"html_url":"https://github.com/Mesh-LLM/mesh-llm/pull/786"},"body":"## Summary\nMakes install.sh runtime-first."},{"url":"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/775","html_url":"https://github.com/Mesh-LLM/mesh-llm/issues/775","number":775,"title":"Plan KV cache sizing","state":"open","user":{"login":"micn"},"created_at":"2026-06-02T00:00:00Z","body":"Long design note."}]"###;
+        let session = session_with_user_and_tool_result(prompt, result);
+
+        let repaired = repair_tool_result_answer(
+            &session,
+            "From the tool result, one relevant entry is: ented Plugin-only routing setup...",
+        );
+
+        assert!(repaired.contains("#786 - [codex] make installer runtime-first"));
+        assert!(repaired.contains("https://github.com/Mesh-LLM/mesh-llm/pull/786"));
+        assert!(!repaired.contains("ented Plugin-only routing"));
+    }
+
+    #[test]
     fn repair_tool_result_answer_trims_identity_preamble_before_work_item() {
         let prompt = "Use shell/developer tool to look for recent important open GitHub issues or PRs in Mesh-LLM/mesh-llm. Inspect the results with a command, then reply with one specific issue or PR number/title and why it matters. Do not answer from memory.";
         let result = serde_json::json!([{
@@ -7400,6 +7536,84 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn shell_glob_error_retries_schema_corrected_command_tool_call() {
+        let tools = command_tool_schema("exec");
+        let allowed = ["exec".to_string()];
+        let command =
+            r#"{"command":"gh api repos/mesh-llm/mesh-llm/issues?state=open&per_page=1"}"#;
+        let retry = CompletedToolCall {
+            name: "exec".to_string(),
+            arguments: command.to_string(),
+        };
+        let result = "zsh:1: no matches found: repos/mesh-llm/mesh-llm/issues?state=open";
+        assert!(!tool_result_has_answerable_evidence(result));
+
+        let body = retry_tool_result_response_if_plain(
+            chat_response("The shell tool returned no matches found."),
+            Some(&retry),
+            Some(result),
+            Some(&tools),
+            &allowed,
+            &[],
+            true,
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        let args = body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool args");
+        assert_eq!(
+            args.get("command").and_then(Value::as_str),
+            Some("gh api 'repos/mesh-llm/mesh-llm/issues?state=open&per_page=1'")
+        );
+    }
+
+    #[test]
+    fn shell_glob_error_corrects_new_bad_followup_tool_call() {
+        let tools = command_tool_schema("exec");
+        let allowed = ["exec".to_string()];
+        let previous = CompletedToolCall {
+            name: "exec".to_string(),
+            arguments: r#"{"command":"curl -s https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open\\&per_page=1"}"#.to_string(),
+        };
+        let followup = r#"{"command":"curl -s https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open&per_page=1 | jq -r '.[0]'"}"#;
+        let result = "zsh:1: no matches found: https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open";
+
+        let body = retry_tool_result_response_if_plain(
+            tool_call_response("exec", &Value::String(followup.to_string())),
+            Some(&previous),
+            Some(result),
+            Some(&tools),
+            &allowed,
+            &[],
+            true,
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        let args = body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool args");
+        assert_eq!(
+            args.get("command").and_then(Value::as_str),
+            Some(
+                "curl -s 'https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open&per_page=1' | jq -r '.[0]'"
+            )
+        );
+    }
+
+    #[test]
     fn cli_unknown_flag_error_retries_schema_corrected_command_tool_call() {
         let tools = command_tool_schema("exec");
         let allowed = ["exec".to_string()];
@@ -7434,6 +7648,45 @@ mod response_builder_tests {
         assert_eq!(
             args.get("command").and_then(Value::as_str),
             Some("gh api repos/Mesh-LLM/mesh-llm/issues")
+        );
+    }
+
+    #[test]
+    fn jq_shell_quoting_error_retries_schema_corrected_command_tool_call() {
+        let tools = command_tool_schema("exec");
+        let allowed = ["exec".to_string()];
+        let command = r#"{"command":"curl -s \"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/808\" | jq -r '\\\"\\(.number) \\(.state) \\(.title)\\\"'"}"#;
+        let retry = CompletedToolCall {
+            name: "exec".to_string(),
+            arguments: command.to_string(),
+        };
+        let result = "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:\n\\\"\\(.number) \\(.state) \\(.title)\\\"\njq: 1 compile error\n\n(Command exited with code 3)";
+
+        let body = retry_tool_result_response_if_plain(
+            chat_response("I encountered an error while trying to fetch the details."),
+            Some(&retry),
+            Some(result),
+            Some(&tools),
+            &allowed,
+            &[],
+            true,
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("exec")
+        );
+        let args = body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool args");
+        assert_eq!(
+            args.get("command").and_then(Value::as_str),
+            Some(
+                "curl -s \"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/808\" | jq -r '\"\\(.number) \\(.state) \\(.title)\"'"
+            )
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1743,6 +1743,15 @@ fn named_argument_boundary(token: &str) -> bool {
             | "please"
             | "use"
             | "using"
+            | "look"
+            | "lookup"
+            | "check"
+            | "find"
+            | "get"
+            | "search"
+            | "run"
+            | "execute"
+            | "call"
             | "with"
             | "the"
             | "a"
@@ -5264,6 +5273,29 @@ mod response_builder_tests {
             forced.fallback_arguments,
             serde_json::json!({"city": "Sydney"})
         );
+    }
+
+    #[test]
+    fn named_argument_inference_skips_intent_verbs_after_prepositions() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "weather_lookup",
+                "description": "Look up current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string", "description": "City to check"}},
+                    "required": ["city"]
+                }
+            }}
+        ]);
+
+        let args = infer_tool_arguments_from_prompt(
+            "weather_lookup",
+            Some(&tools),
+            "Use the weather lookup tool to check Sydney.",
+        );
+
+        assert_eq!(args, serde_json::json!({"city": "Sydney"}));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1470,7 +1470,9 @@ fn strip_info_msg_prefix(text: String) -> Option<String> {
         return Some(text);
     }
     let close = "</info-msg>";
-    let close_start = trimmed.find(close)?;
+    let Some(close_start) = trimmed.find(close) else {
+        return Some(text);
+    };
     Some(
         trimmed[close_start + close.len()..]
             .trim_start()
@@ -7845,6 +7847,40 @@ mod response_builder_tests {
         assert_eq!(
             session.last_user_text(),
             "Actually use the shell tool. Run pwd."
+        );
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["shell".to_string()]
+        );
+    }
+
+    #[test]
+    fn malformed_goose_info_prefix_does_not_hide_tool_intent_text() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "<info-msg>\nWorking directory: /tmp/project\nActually use the shell tool. Run pwd."
+            })],
+            &Some(serde_json::json!([{
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "description": "Run shell commands",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Shell command to execute"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }])),
+        );
+
+        assert_eq!(
+            session.last_user_text(),
+            "<info-msg>\nWorking directory: /tmp/project\nActually use the shell tool. Run pwd."
         );
         assert_eq!(
             selected_tool_names_for_turn(&session, &[], &[]),

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -731,20 +731,24 @@ fn selected_tool_names_for_turn(
         return with_recent_tool_chain_names(session, &available, explicit);
     }
 
-    let command_intent =
-        command_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
-    if !command_intent.is_empty() {
-        return with_recent_tool_chain_names(session, &available, command_intent);
-    }
-
     let url_intent = url_intent_tool_names(session.tools(), &available, &text);
     if !url_intent.is_empty() {
         return with_recent_tool_chain_names(session, &available, url_intent);
     }
 
+    let command_intent =
+        command_intent_tool_names(session.tools(), &available, &text, prompt_tool_profiles);
+    if !command_intent.is_empty() && text_has_command_execution_pattern(&text) {
+        return with_recent_tool_chain_names(session, &available, command_intent);
+    }
+
     let search_intent = search_intent_tool_names(session.tools(), &available, &text);
     if !search_intent.is_empty() {
         return with_recent_tool_chain_names(session, &available, search_intent);
+    }
+
+    if !command_intent.is_empty() {
+        return with_recent_tool_chain_names(session, &available, command_intent);
     }
 
     let file_read_intent =
@@ -1240,12 +1244,13 @@ fn search_tool_score(tool: &Value, user_text: &str) -> usize {
 
     let user_tokens = text_tokens(user_text);
     let external_prompt = prompt_looks_external_search(&user_tokens);
-    let local_prompt = user_tokens.iter().any(|token| {
-        matches!(
-            token.as_str(),
-            "memory" | "memories" | "session" | "sessions"
-        )
-    });
+    let local_prompt = !external_prompt
+        && user_tokens.iter().any(|token| {
+            matches!(
+                token.as_str(),
+                "memory" | "memories" | "session" | "sessions"
+            )
+        });
 
     let mut score = 0;
     for token in &tokens {
@@ -1711,7 +1716,14 @@ fn command_execution_pattern_matches(tokens: &[String]) -> bool {
     })
 }
 
+fn text_has_command_execution_pattern(text: &str) -> bool {
+    command_execution_pattern_matches(&lexical_tokens(text))
+}
+
 fn executable_token(token: &str) -> bool {
+    if matches!(token, "tool" | "tools" | "available") {
+        return false;
+    }
     if !(2..=40).contains(&token.len()) {
         return false;
     }
@@ -2724,14 +2736,17 @@ async fn handle_tool_result(
                     );
                     retry_tool_result_response_if_plain(
                         body,
-                        retry_tool_call.as_ref(),
-                        latest_non_answerable_tool
-                            .as_ref()
-                            .map(|(_, result)| result.as_str()),
-                        session.tools(),
-                        response_allowed_tools,
-                        response_prompt_profiles,
-                        response_tools_enabled,
+                        RetryToolResultContext {
+                            retry_tool_call: retry_tool_call.as_ref(),
+                            latest_tool_result: latest_non_answerable_tool
+                                .as_ref()
+                                .map(|(_, result)| result.as_str()),
+                            tools: session.tools(),
+                            allowed_tools: response_allowed_tools,
+                            prompt_tool_profiles: response_prompt_profiles,
+                            user_text: Some(&session.active_user_text()),
+                            tools_enabled: response_tools_enabled,
+                        },
                     )
                 }
                 normalize::OutputKind::Uncertainty => {
@@ -2747,6 +2762,7 @@ async fn handle_tool_result(
                                     session.tools(),
                                     response_allowed_tools,
                                     response_prompt_profiles,
+                                    Some(&session.active_user_text()),
                                 )
                             })
                             .unwrap_or_else(|| {
@@ -2777,14 +2793,28 @@ async fn handle_tool_result(
                             ) =>
                         {
                             let answer = non_answerable_tool_result_answer(session, tool, result);
+                            let response_body = retry_tool_result_response_if_plain(
+                                chat_response(&answer),
+                                RetryToolResultContext {
+                                    retry_tool_call: retry_tool_call.as_ref(),
+                                    latest_tool_result: Some(result),
+                                    tools: session.tools(),
+                                    allowed_tools: response_allowed_tools,
+                                    prompt_tool_profiles: response_prompt_profiles,
+                                    user_text: Some(&session.active_user_text()),
+                                    tools_enabled: response_tools_enabled,
+                                },
+                            );
+                            let output_kind = first_response_tool_call(&response_body)
+                                .map(|_| normalize::OutputKind::ToolProposal);
                             return TurnResult {
-                                response_body: chat_response(&answer),
+                                response_body,
                                 worker_summaries: vec![WorkerSummary {
                                     model: name,
                                     role: WorkerRole::Reducer,
-                                    succeeded: false,
+                                    succeeded: output_kind.is_some(),
                                     elapsed_ms: start.elapsed().as_millis() as u64,
-                                    output_kind: None,
+                                    output_kind,
                                     confidence: None,
                                 }],
                                 reducer_used: true,
@@ -2804,18 +2834,21 @@ async fn handle_tool_result(
                             Some(&session.last_user_text()),
                         )
                     } else {
-                        chat_response(&repaired)
+                        disabled_tool_result_chat_or_evidence_response(session, &repaired)
                     };
                     retry_tool_result_response_if_plain(
                         body,
-                        retry_tool_call.as_ref(),
-                        latest_non_answerable_tool
-                            .as_ref()
-                            .map(|(_, result)| result.as_str()),
-                        session.tools(),
-                        response_allowed_tools,
-                        response_prompt_profiles,
-                        response_tools_enabled,
+                        RetryToolResultContext {
+                            retry_tool_call: retry_tool_call.as_ref(),
+                            latest_tool_result: latest_non_answerable_tool
+                                .as_ref()
+                                .map(|(_, result)| result.as_str()),
+                            tools: session.tools(),
+                            allowed_tools: response_allowed_tools,
+                            prompt_tool_profiles: response_prompt_profiles,
+                            user_text: Some(&session.active_user_text()),
+                            tools_enabled: response_tools_enabled,
+                        },
                     )
                 }
             };
@@ -3135,6 +3168,13 @@ fn tool_result_answer_from_evidence_response(session: &Session) -> Value {
     }
 }
 
+fn disabled_tool_result_chat_or_evidence_response(session: &Session, content: &str) -> Value {
+    if looks_like_unusable_pseudo_tool_text(content) {
+        return tool_result_answer_from_evidence_response(session);
+    }
+    chat_response(content)
+}
+
 fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
     let (_, result) = latest_completed_tool_result(session)?;
     let prompt = session.active_user_text();
@@ -3316,7 +3356,7 @@ fn answer_from_prompt_specific_plain_text_tool_result(
 
 fn requested_path_existence_targets(prompt: &str) -> Vec<String> {
     let lower = prompt.to_ascii_lowercase();
-    if text_suggests_file_read_intent(&lower) {
+    if text_suggests_file_read_intent(&lower) || text_suggests_url_content_fetch_intent(prompt) {
         return Vec::new();
     }
     if !contains_any(
@@ -3341,6 +3381,27 @@ fn requested_path_existence_targets(prompt: &str) -> Vec<String> {
         .filter(|candidate| is_path_like_candidate(candidate, "path"))
         .filter(|candidate| seen.insert(candidate.clone()))
         .collect()
+}
+
+fn text_suggests_url_content_fetch_intent(prompt: &str) -> bool {
+    if !text_contains_http_url(prompt) {
+        return false;
+    }
+    contains_any(
+        &prompt.to_ascii_lowercase(),
+        &[
+            "fetch",
+            "open",
+            "read",
+            "view",
+            "inspect",
+            "title",
+            "summarize",
+            "summarise",
+            "content",
+            "visible",
+        ],
+    )
 }
 
 fn plain_text_tool_result_contains_path(result: &str, path: &str) -> bool {
@@ -3372,7 +3433,47 @@ fn answer_from_prompt_specific_structured_value(value: &Value, prompt: &str) -> 
     if prompt_asks_for_check_or_review_status(prompt) {
         return answer_from_structured_status_feedback_value(value, prompt);
     }
+    if prompt_asks_for_title_field(prompt) && !prompt_asks_for_work_items(prompt) {
+        return answer_from_structured_title_value(value, prompt);
+    }
     None
+}
+
+fn prompt_asks_for_title_field(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    prompt_has_word(&lower, "title")
+        || prompt_has_word(&lower, "name")
+        || prompt_has_word(&lower, "subject")
+}
+
+fn answer_from_structured_title_value(value: &Value, prompt: &str) -> Option<String> {
+    let title = first_structured_title_value(value)?;
+    let label = if prompt_has_word(&prompt.to_ascii_lowercase(), "issue") {
+        "The issue title"
+    } else {
+        "The title"
+    };
+    Some(format!("{label} is: {title}"))
+}
+
+fn first_structured_title_value(value: &Value) -> Option<String> {
+    match value {
+        Value::Object(map) => {
+            for field in ["title", "name", "subject", "summary"] {
+                if let Some(title) = map
+                    .get(field)
+                    .and_then(Value::as_str)
+                    .map(clean_structured_text_field)
+                    .filter(|title| !title.is_empty())
+                {
+                    return Some(title);
+                }
+            }
+            map.values().find_map(first_structured_title_value)
+        }
+        Value::Array(values) => values.iter().find_map(first_structured_title_value),
+        _ => None,
+    }
 }
 
 fn parse_tool_result_json(result: &str) -> Option<Value> {
@@ -3972,16 +4073,42 @@ fn clean_structured_text_field(value: &str) -> String {
         return trimmed.to_string();
     }
 
-    let payload = trimmed
-        .split_once("\n---\n")
-        .map(|(_, tail)| tail)
-        .unwrap_or(trimmed);
-    payload
-        .split_once("\n<<<END_EXTERNAL_UNTRUSTED_CONTENT")
-        .map(|(head, _)| head)
-        .unwrap_or(payload)
-        .trim()
-        .to_string()
+    clean_external_untrusted_wrappers(trimmed)
+}
+
+fn clean_external_untrusted_wrappers(value: &str) -> String {
+    const START: &str = "<<<EXTERNAL_UNTRUSTED_CONTENT";
+    const END: &str = "<<<END_EXTERNAL_UNTRUSTED_CONTENT";
+
+    let mut rest = value;
+    let mut cleaned = String::with_capacity(value.len());
+    while let Some(start) = rest.find(START) {
+        cleaned.push_str(&rest[..start]);
+        let wrapped = &rest[start..];
+        let Some(start_close) = wrapped.find(">>>") else {
+            cleaned.push_str(wrapped);
+            return cleaned.trim().to_string();
+        };
+        let payload_and_tail = &wrapped[start_close + 3..];
+        let Some(end) = payload_and_tail.find(END) else {
+            cleaned.push_str(wrapped);
+            return cleaned.trim().to_string();
+        };
+
+        let mut payload = payload_and_tail[..end].trim_start_matches('\n');
+        if let Some((_, tail)) = payload.split_once("\n---\n") {
+            payload = tail;
+        }
+        cleaned.push_str(payload.trim());
+
+        let end_marker_and_tail = &payload_and_tail[end..];
+        rest = match end_marker_and_tail.find(">>>") {
+            Some(end_close) => &end_marker_and_tail[end_close + 3..],
+            None => &end_marker_and_tail[END.len()..],
+        };
+    }
+    cleaned.push_str(rest);
+    cleaned.trim().to_string()
 }
 
 fn first_identifier_field(map: &serde_json::Map<String, Value>, fields: &[&str]) -> Option<String> {
@@ -4274,29 +4401,32 @@ fn latest_completed_tool_call(session: &Session) -> Option<CompletedToolCall> {
         .last()
 }
 
-fn retry_tool_result_response_if_plain(
-    body: Value,
-    retry_tool_call: Option<&CompletedToolCall>,
-    latest_tool_result: Option<&str>,
-    tools: Option<&Value>,
-    allowed_tools: &[String],
-    prompt_tool_profiles: &[PromptToolProfile],
+struct RetryToolResultContext<'a> {
+    retry_tool_call: Option<&'a CompletedToolCall>,
+    latest_tool_result: Option<&'a str>,
+    tools: Option<&'a Value>,
+    allowed_tools: &'a [String],
+    prompt_tool_profiles: &'a [PromptToolProfile],
+    user_text: Option<&'a str>,
     tools_enabled: bool,
-) -> Value {
-    if !tools_enabled {
+}
+
+fn retry_tool_result_response_if_plain(body: Value, context: RetryToolResultContext<'_>) -> Value {
+    if !context.tools_enabled {
         return body;
     }
-    match (first_response_tool_call(&body), retry_tool_call) {
+    match (first_response_tool_call(&body), context.retry_tool_call) {
         (Some(response_call), Some(retry_call))
             if response_call.same_signature(retry_call)
-                && !same_tool_call_retry_allowed(latest_tool_result) =>
+                && !same_tool_call_retry_allowed(context.latest_tool_result) =>
         {
             if let Some(corrected) = corrected_retry_tool_call(
                 retry_call,
-                latest_tool_result,
-                tools,
-                allowed_tools,
-                prompt_tool_profiles,
+                context.latest_tool_result,
+                context.tools,
+                context.allowed_tools,
+                context.prompt_tool_profiles,
+                context.user_text,
             ) {
                 let arguments = Value::String(corrected.arguments);
                 return tool_call_response(&corrected.name, &arguments);
@@ -4315,10 +4445,11 @@ fn retry_tool_result_response_if_plain(
     if let Some(response_call) = first_response_tool_call(&body) {
         if let Some(corrected) = corrected_retry_tool_call(
             &response_call,
-            latest_tool_result,
-            tools,
-            allowed_tools,
-            prompt_tool_profiles,
+            context.latest_tool_result,
+            context.tools,
+            context.allowed_tools,
+            context.prompt_tool_profiles,
+            context.user_text,
         ) {
             tracing::info!(
                 "moa: reducer returned malformed follow-up {}; retrying corrected tool call",
@@ -4329,14 +4460,16 @@ fn retry_tool_result_response_if_plain(
         }
         return body;
     }
-    retry_tool_call
+    context
+        .retry_tool_call
         .and_then(|call| {
             retry_tool_call_response(
                 call,
-                latest_tool_result,
-                tools,
-                allowed_tools,
-                prompt_tool_profiles,
+                context.latest_tool_result,
+                context.tools,
+                context.allowed_tools,
+                context.prompt_tool_profiles,
+                context.user_text,
             )
         })
         .unwrap_or(body)
@@ -4348,6 +4481,7 @@ fn retry_tool_call_response(
     tools: Option<&Value>,
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
 ) -> Option<Value> {
     if let Some(corrected) = corrected_retry_tool_call(
         call,
@@ -4355,6 +4489,7 @@ fn retry_tool_call_response(
         tools,
         allowed_tools,
         prompt_tool_profiles,
+        user_text,
     ) {
         tracing::info!(
             "moa: reducer returned plain text after non-answerable {}; retrying corrected tool call",
@@ -4392,8 +4527,15 @@ fn corrected_retry_tool_call(
     tools: Option<&Value>,
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
+    user_text: Option<&str>,
 ) -> Option<CompletedToolCall> {
     let result = latest_tool_result?;
+    if let Some(corrected) =
+        corrected_search_retry_tool_call(call, result, tools, allowed_tools, user_text)
+    {
+        return Some(corrected);
+    }
+
     let candidates = command_tool_candidates(tools, allowed_tools, prompt_tool_profiles);
     let candidate = candidates
         .iter()
@@ -4422,6 +4564,104 @@ fn corrected_retry_tool_call(
         name: call.name.clone(),
         arguments: wire,
     })
+}
+
+fn corrected_search_retry_tool_call(
+    call: &CompletedToolCall,
+    result: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+    user_text: Option<&str>,
+) -> Option<CompletedToolCall> {
+    let prompt = user_text?;
+    if !tool_result_is_generic_structured_collection_for_prompt(result, prompt) {
+        return None;
+    }
+    if !allowed_tools.is_empty() && !allowed_tools.iter().any(|name| name == &call.name) {
+        return None;
+    }
+    let tool = tool_by_name(&call.name, tools)?;
+    if !tool_looks_like_searcher(tool) {
+        return None;
+    }
+
+    let mut arguments = serde_json::from_str::<Value>(&call.arguments).ok()?;
+    let field = search_query_argument_field(tool, &arguments)?;
+    let current = arguments.get(&field)?.as_str()?;
+    let refined = refine_search_query_for_specific_result(current, prompt)?;
+    arguments[&field] = Value::String(refined);
+    let sanitized = sanitize_tool_arguments_for_tool(&call.name, &arguments, tools).ok()?;
+    let wire = tool_arguments_wire_string(&sanitized);
+    if wire == call.arguments {
+        return None;
+    }
+    Some(CompletedToolCall {
+        name: call.name.clone(),
+        arguments: wire,
+    })
+}
+
+fn search_query_argument_field(tool: &Value, arguments: &Value) -> Option<String> {
+    let arguments = arguments.as_object()?;
+    for field in arguments.keys() {
+        if field_looks_like_search_query(field) {
+            return Some(field.clone());
+        }
+    }
+
+    let properties = tool
+        .pointer("/function/parameters/properties")
+        .and_then(Value::as_object)?;
+    properties.iter().find_map(|(field, schema)| {
+        (schema_allows_string(schema) && field_looks_like_search_query(field))
+            .then(|| field.clone())
+    })
+}
+
+fn field_looks_like_search_query(field: &str) -> bool {
+    matches!(
+        field.to_ascii_lowercase().as_str(),
+        "q" | "query" | "search" | "search_query" | "term" | "terms" | "keywords" | "topic"
+    )
+}
+
+fn refine_search_query_for_specific_result(query: &str, prompt: &str) -> Option<String> {
+    if !prompt_asks_for_work_items(prompt) {
+        return None;
+    }
+    let mut refined = query.trim().to_string();
+    if refined.is_empty() {
+        return None;
+    }
+
+    let prompt_lower = prompt.to_ascii_lowercase();
+    append_search_term_if_missing(&mut refined, "specific");
+    append_search_term_if_missing(&mut refined, "title");
+    append_search_term_if_missing(&mut refined, "number");
+    if contains_any(&prompt_lower, &["issue", "issues"]) {
+        append_search_term_if_missing(&mut refined, "issue");
+    }
+    if contains_any(
+        &prompt_lower,
+        &["pull request", "pull requests", " pr ", " prs "],
+    ) {
+        append_search_term_if_missing(&mut refined, "pull request");
+    }
+    if contains_any(&prompt_lower, &["discussion", "discussions"]) {
+        append_search_term_if_missing(&mut refined, "discussion");
+    }
+
+    (refined != query.trim()).then_some(refined)
+}
+
+fn append_search_term_if_missing(query: &mut String, term: &str) {
+    if !query
+        .to_ascii_lowercase()
+        .contains(&term.to_ascii_lowercase())
+    {
+        query.push(' ');
+        query.push_str(term);
+    }
 }
 
 fn tool_result_suggests_unquoted_shell_token_error(result: &str) -> bool {
@@ -4725,6 +4965,9 @@ fn tool_result_has_answerable_evidence(result: &str) -> bool {
     }
 
     if let Ok(parsed) = serde_json::from_str::<Value>(trimmed) {
+        if json_value_looks_like_disabled_empty_result(&parsed) {
+            return false;
+        }
         return json_value_has_answerable_evidence(&parsed);
     }
 
@@ -4745,10 +4988,7 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     if !structured_rows.is_empty() {
         return true;
     }
-    if prompt_asks_for_work_items(prompt)
-        && parse_tool_result_json(result.trim())
-            .is_some_and(|value| json_value_has_structured_result_collection(&value))
-    {
+    if tool_result_is_generic_structured_collection_for_prompt(result, prompt) {
         return false;
     }
     if prompt_asks_for_work_items(prompt) && plain_text_tool_result_looks_like_auth_status(result) {
@@ -4768,6 +5008,14 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
         return false;
     }
     true
+}
+
+fn tool_result_is_generic_structured_collection_for_prompt(result: &str, prompt: &str) -> bool {
+    prompt_asks_for_work_items(prompt)
+        && parse_tool_result_json(result.trim()).is_some_and(|value| {
+            json_value_has_structured_result_collection(&value)
+                && structured_tool_result_rows(&value, prompt).is_empty()
+        })
 }
 
 fn prompt_asks_for_ci_status(prompt: &str) -> bool {
@@ -4906,6 +5154,19 @@ fn json_value_has_structured_result_collection(value: &Value) -> bool {
             .any(json_value_has_structured_result_collection),
         _ => false,
     }
+}
+
+fn json_value_looks_like_disabled_empty_result(value: &Value) -> bool {
+    let Value::Object(map) = value else {
+        return false;
+    };
+    map.get("disabled").and_then(Value::as_bool) == Some(true)
+        && map
+            .get("results")
+            .or_else(|| map.get("items"))
+            .or_else(|| map.get("data"))
+            .and_then(Value::as_array)
+            .is_none_or(Vec::is_empty)
 }
 
 fn plain_text_tool_result_looks_empty(result: &str) -> bool {
@@ -5477,11 +5738,19 @@ fn contains_pseudo_tool_markup(content: &str) -> bool {
         || trimmed.starts_with("tool code")
         || lower.contains("<tool_code")
         || lower.contains("</tool_code")
-        || lower.contains("<tool_call")
-        || lower.contains("</tool_call")
+        || contains_xml_tool_call_tag(&lower)
         || lower.contains("[tool_call]")
         || lower.contains("[/tool_call]")
         || lower.contains("<function=")
+}
+
+fn contains_xml_tool_call_tag(lowercase_content: &str) -> bool {
+    lowercase_content
+        .split('<')
+        .skip(1)
+        .filter_map(|tail| tail.split(['>', ' ', '\t', '\n', '\r']).next())
+        .map(|tag| tag.trim_start_matches('/').trim_end_matches('/'))
+        .any(|tag| tag == "tool_call" || tag.ends_with(":tool_call"))
 }
 
 fn is_tool_error_content(content: &str) -> bool {
@@ -5710,8 +5979,19 @@ fn starts_with_tool_call_envelope(content: &str) -> bool {
     let trimmed = content.trim_start();
     trimmed.starts_with("[TOOL_CALL]")
         || trimmed.starts_with("<|tool_call>")
-        || trimmed.starts_with("<tool_call>")
+        || starts_with_xml_tool_call_tag(trimmed)
         || trimmed.starts_with("<function=")
+}
+
+fn starts_with_xml_tool_call_tag(content: &str) -> bool {
+    let Some(rest) = content.strip_prefix('<') else {
+        return false;
+    };
+    let Some(tag) = rest.split(['>', ' ', '\t', '\n', '\r']).next() else {
+        return false;
+    };
+    let tag = tag.trim_end_matches('/').to_ascii_lowercase();
+    tag == "tool_call" || tag.ends_with(":tool_call")
 }
 
 fn fenced_command_tool_conversion_allowed(user_text: Option<&str>) -> bool {
@@ -6391,6 +6671,11 @@ pub const MOA_ERR_ALL_REDUCERS_FAILED: &str = "all_reducers_failed";
 pub const MOA_ERR_NO_USABLE_ANSWER: &str = "no_usable_answer";
 
 fn chat_response(content: &str) -> Value {
+    let content = if content.contains("<<<EXTERNAL_UNTRUSTED_CONTENT") {
+        clean_external_untrusted_wrappers(content)
+    } else {
+        content.to_string()
+    };
     json!({
         "id": format!("chatcmpl-moa-{}", short_id()),
         "object": "chat.completion",
@@ -6400,7 +6685,7 @@ fn chat_response(content: &str) -> Value {
             "message": { "role": "assistant", "content": content },
             "finish_reason": "stop"
         }],
-        "usage": usage_for_content(content)
+        "usage": usage_for_content(&content)
     })
 }
 
@@ -6503,6 +6788,13 @@ mod response_builder_tests {
             answer("b", 0.6, "Here is a real response."),
         ];
         assert_eq!(best_answer(&outputs), "Here is a real response.");
+    }
+
+    #[test]
+    fn pseudo_tool_markup_detects_namespaced_xml_tool_call() {
+        let content = "I found a result.\n<minimax:tool_call>\n<invoke name=\"web_fetch\">\n<parameter name=\"url\">https://example.invalid</parameter>\n</invoke>\n</minimax:tool_call>";
+
+        assert!(looks_like_unusable_pseudo_tool_text(content));
     }
 
     #[test]
@@ -7616,6 +7908,21 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn chat_response_cleans_external_untrusted_wrappers() {
+        let resp = chat_response(
+            "The page title is:\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Fetch\n---\nExample Domain\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>",
+        );
+        let content = resp
+            .pointer("/choices/0/message/content")
+            .and_then(Value::as_str)
+            .expect("assistant content");
+
+        assert_eq!(content, "The page title is:\nExample Domain");
+        assert!(!content.contains("EXTERNAL_UNTRUSTED_CONTENT"), "{content}");
+        assert!(!content.contains("Source: Web Fetch"), "{content}");
+    }
+
+    #[test]
     fn tool_enabled_chat_uses_answer_grace() {
         let mut session = Session::new();
         session.ingest(
@@ -8125,6 +8432,126 @@ mod response_builder_tests {
                 .pointer("/query")
                 .and_then(Value::as_str),
             Some("open issues or recent discussion about mesh-LLM/mesh-llm on GitHub")
+        );
+    }
+
+    #[test]
+    fn web_search_prompt_selects_search_tool_over_shell_tool() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                    "required": ["command"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "web_search",
+                "description": "Search online web sources",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Web search query"}},
+                    "required": ["query"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use tools to search the web for mesh-llm memory slot batch issue and report one specific source URL."
+            })],
+            &Some(tools.clone()),
+        );
+
+        let selected = selected_tool_names_for_turn(&session, &[], &[]);
+
+        assert_eq!(selected, vec!["web_search".to_string()]);
+        let forced =
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
+        assert_eq!(forced.name, "web_search");
+        assert_eq!(
+            forced
+                .fallback_arguments
+                .pointer("/query")
+                .and_then(Value::as_str),
+            Some("mesh-llm memory slot batch issue and report one specific source URL")
+        );
+    }
+
+    #[test]
+    fn explicit_web_search_with_memory_subject_does_not_select_memory_search() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "memory_search",
+                "description": "Search stored local memories",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Memory search query"}},
+                    "required": ["query"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "web_search",
+                "description": "Search online web sources",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Web search query"}},
+                    "required": ["query"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use tools to search the web for mesh-llm memory slot batch issue and report one specific source URL."
+            })],
+            &Some(tools),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["web_search".to_string()]
+        );
+    }
+
+    #[test]
+    fn explicit_command_prompt_still_selects_shell_tool_over_search_tool() {
+        let tools = serde_json::json!([
+            {"type": "function", "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string", "description": "Shell command to execute"}},
+                    "required": ["command"]
+                }
+            }},
+            {"type": "function", "function": {
+                "name": "web_search",
+                "description": "Search online web sources",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string", "description": "Web search query"}},
+                    "required": ["query"]
+                }
+            }}
+        ]);
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use gh to list recent open PRs for mesh-LLM/mesh-llm."
+            })],
+            &Some(tools),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["exec".to_string()]
         );
     }
 
@@ -8983,6 +9410,14 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn disabled_empty_json_tool_result_is_not_answerable_evidence() {
+        let result = r#"{"results":[],"disabled":true}"#;
+
+        assert!(!tool_result_has_answerable_evidence(result));
+        assert!(answer_from_latest_tool_result(&session_with_tool_result(result)).is_none());
+    }
+
+    #[test]
     fn path_existence_prompt_answers_from_plain_text_tool_evidence() {
         let prompt =
             "Use your tools to list the current directory, then say whether AGENTS.md exists.";
@@ -9079,6 +9514,76 @@ mod response_builder_tests {
         assert!(answer.contains("Issue #652"), "{answer}");
         assert!(!answer.contains("EXTERNAL_UNTRUSTED_CONTENT"), "{answer}");
         assert!(!answer.contains("Source: Web Search"), "{answer}");
+    }
+
+    #[test]
+    fn disabled_tool_result_turn_pseudo_tool_text_answers_from_evidence() {
+        let prompt = "Find one specific open issue for mesh-LLM/mesh-llm.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "memory slot failure - Issue #652",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/652",
+                    "snippet": "decode failed to find a memory slot"
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+        let response = disabled_tool_result_chat_or_evidence_response(
+            &session,
+            "I found an issue. Let me fetch it:\n<minimax:tool_call>\n<invoke name=\"web_fetch\">\n<parameter name=\"url\">https://github.com/Mesh-LLM/mesh-llm/issues/652</parameter>\n</invoke>\n</minimax:tool_call>",
+        );
+        let content = response
+            .pointer("/choices/0/message/content")
+            .and_then(Value::as_str)
+            .expect("assistant content");
+
+        assert!(content.contains("Issue #652"), "{content}");
+        assert!(!content.contains("tool_call"), "{content}");
+    }
+
+    #[test]
+    fn fetched_url_title_is_content_evidence_not_path_existence() {
+        let prompt = "Use available tools to fetch https://example.invalid/issues/652 and tell me the issue title if visible.";
+        let result = serde_json::json!({
+            "url": "https://example.invalid/issues/652",
+            "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Fetch\n---\nskippy: decode failed - Issue #652\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>",
+            "text": "Issue details"
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        let answer = answer_from_latest_tool_result(&session).expect("fetched title evidence");
+
+        assert!(
+            answer.contains("skippy: decode failed - Issue #652"),
+            "{answer}"
+        );
+        assert!(!answer.contains("exists in the tool result"), "{answer}");
+        assert!(!answer.contains("EXTERNAL_UNTRUSTED_CONTENT"), "{answer}");
+    }
+
+    #[test]
+    fn repair_tool_result_answer_prefers_structured_title_over_security_notice() {
+        let prompt = "Use available tools to fetch https://example.invalid/issues/652 and tell me the issue title if visible.";
+        let result = serde_json::json!({
+            "url": "https://example.invalid/issues/652",
+            "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Fetch\n---\nskippy: decode failed - Issue #652\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>",
+            "text": "SECURITY NOTICE: external content follows\n\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"y\">>>\nSource: Web Fetch\n---\n## What\nBody text\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"y\">>>"
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        let repaired = repair_tool_result_answer(
+            &session,
+            "The issue title is not explicitly provided; the content begins with a SECURITY NOTICE.",
+        );
+
+        assert_eq!(
+            repaired,
+            "The issue title is: skippy: decode failed - Issue #652"
+        );
     }
 
     #[test]
@@ -10100,12 +10605,15 @@ mod response_builder_tests {
         let retry = latest_completed_tool_call(&session).expect("completed tool call");
         let body = retry_tool_result_response_if_plain(
             chat_response("I could not retrieve any pull requests."),
-            Some(&retry),
-            Some("(no output)"),
-            None,
-            &[],
-            &[],
-            true,
+            RetryToolResultContext {
+                retry_tool_call: Some(&retry),
+                latest_tool_result: Some("(no output)"),
+                tools: None,
+                allowed_tools: &[],
+                prompt_tool_profiles: &[],
+                user_text: None,
+                tools_enabled: true,
+            },
         );
 
         assert_eq!(
@@ -10137,12 +10645,17 @@ mod response_builder_tests {
 
         let body = retry_tool_result_response_if_plain(
             chat_response("The GitHub API command failed."),
-            Some(&retry),
-            Some("(eval):1: parse error near `&'\n\n(Command exited with code 1)"),
-            Some(&tools),
-            &allowed,
-            &[],
-            true,
+            RetryToolResultContext {
+                retry_tool_call: Some(&retry),
+                latest_tool_result: Some(
+                    "(eval):1: parse error near `&'\n\n(Command exited with code 1)",
+                ),
+                tools: Some(&tools),
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+                user_text: None,
+                tools_enabled: true,
+            },
         );
 
         assert_eq!(
@@ -10178,12 +10691,15 @@ mod response_builder_tests {
 
         let body = retry_tool_result_response_if_plain(
             chat_response("The shell tool returned no matches found."),
-            Some(&retry),
-            Some(result),
-            Some(&tools),
-            &allowed,
-            &[],
-            true,
+            RetryToolResultContext {
+                retry_tool_call: Some(&retry),
+                latest_tool_result: Some(result),
+                tools: Some(&tools),
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+                user_text: None,
+                tools_enabled: true,
+            },
         );
 
         assert_eq!(
@@ -10215,12 +10731,15 @@ mod response_builder_tests {
 
         let body = retry_tool_result_response_if_plain(
             tool_call_response("exec", &Value::String(followup.to_string())),
-            Some(&previous),
-            Some(result),
-            Some(&tools),
-            &allowed,
-            &[],
-            true,
+            RetryToolResultContext {
+                retry_tool_call: Some(&previous),
+                latest_tool_result: Some(result),
+                tools: Some(&tools),
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+                user_text: None,
+                tools_enabled: true,
+            },
         );
 
         assert_eq!(
@@ -10255,12 +10774,15 @@ mod response_builder_tests {
 
         let body = retry_tool_result_response_if_plain(
             chat_response("Let me try again with a corrected command."),
-            Some(&retry),
-            Some(result),
-            Some(&tools),
-            &allowed,
-            &[],
-            true,
+            RetryToolResultContext {
+                retry_tool_call: Some(&retry),
+                latest_tool_result: Some(result),
+                tools: Some(&tools),
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+                user_text: None,
+                tools_enabled: true,
+            },
         );
 
         assert_eq!(
@@ -10292,12 +10814,15 @@ mod response_builder_tests {
 
         let body = retry_tool_result_response_if_plain(
             chat_response("I encountered an error while trying to fetch the details."),
-            Some(&retry),
-            Some(result),
-            Some(&tools),
-            &allowed,
-            &[],
-            true,
+            RetryToolResultContext {
+                retry_tool_call: Some(&retry),
+                latest_tool_result: Some(result),
+                tools: Some(&tools),
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+                user_text: None,
+                tools_enabled: true,
+            },
         );
 
         assert_eq!(
@@ -10316,6 +10841,72 @@ mod response_builder_tests {
                 "curl -s \"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/808\" | jq -r '\"\\(.number) \\(.state) \\(.title)\"'"
             )
         );
+    }
+
+    #[test]
+    fn generic_collection_search_result_retries_with_more_specific_query() {
+        let tools = serde_json::json!([{"type": "function", "function": {
+            "name": "web_search",
+            "description": "Search online web sources",
+            "parameters": {
+                "type": "object",
+                "properties": {"query": {"type": "string", "description": "Search query"}},
+                "required": ["query"]
+            }
+        }}]);
+        let allowed = ["web_search".to_string()];
+        let prompt = "Find one specific open issue or recent discussion for mesh-LLM/mesh-llm.";
+        let retry = CompletedToolCall {
+            name: "web_search".to_string(),
+            arguments: r#"{"query":"open issues or recent discussion about mesh-LLM/mesh-llm"}"#
+                .to_string(),
+        };
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "Issues - Mesh-LLM/mesh-llm",
+                    "url": "https://example.invalid/Mesh-LLM/mesh-llm/issues/",
+                    "snippet": "Issue tracker"
+                },
+                {
+                    "title": "Mesh-LLM mesh-llm discussions",
+                    "url": "https://example.invalid/Mesh-LLM/mesh-llm/discussions",
+                    "snippet": "Discussion forum"
+                }
+            ]
+        })
+        .to_string();
+
+        let body = retry_tool_result_response_if_plain(
+            chat_response("The result only listed collection pages."),
+            RetryToolResultContext {
+                retry_tool_call: Some(&retry),
+                latest_tool_result: Some(&result),
+                tools: Some(&tools),
+                allowed_tools: &allowed,
+                prompt_tool_profiles: &[],
+                user_text: Some(prompt),
+                tools_enabled: true,
+            },
+        );
+
+        assert_eq!(
+            body.pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("web_search")
+        );
+        let args = body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .and_then(|text| serde_json::from_str::<Value>(text).ok())
+            .expect("tool args");
+        let query = args
+            .get("query")
+            .and_then(Value::as_str)
+            .expect("query arg");
+        assert!(query.contains("specific"), "{query}");
+        assert!(query.contains("title"), "{query}");
+        assert!(query.contains("number"), "{query}");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -657,6 +657,13 @@ fn previous_assistant_text(session: &Session) -> Option<String> {
     None
 }
 
+fn extract_urls_from_text(text: &str) -> Vec<String> {
+    text.split_whitespace()
+        .map(clean_path_token)
+        .filter(|token| token.starts_with("http://") || token.starts_with("https://"))
+        .collect()
+}
+
 fn message_text_content(message: &Value) -> Option<String> {
     if let Some(text) = message.get("content").and_then(Value::as_str) {
         return Some(text.to_string());
@@ -2123,45 +2130,11 @@ fn infer_string_argument(field: &str, schema: &Value, prompt: &str) -> Option<St
         return None;
     }
 
-    infer_command_argument(field, schema, prompt)
-        .or_else(|| infer_enum_argument(schema, prompt))
+    infer_enum_argument(schema, prompt)
         .or_else(|| infer_assignment_argument(field, prompt))
         .or_else(|| infer_path_like_argument(field, schema, prompt))
         .or_else(|| infer_query_argument(field, prompt))
         .or_else(|| infer_named_argument(field, schema, prompt))
-}
-
-fn infer_command_argument(field: &str, schema: &Value, prompt: &str) -> Option<String> {
-    let mut schema_tokens = text_tokens(field);
-    collect_tool_schema_tokens(schema, &mut schema_tokens);
-    if !schema_tokens_look_command_like(&schema_tokens) {
-        return None;
-    }
-
-    if text_suggests_directory_list_intent(prompt) {
-        let path = if prompt_mentions_current_directory(prompt) {
-            ".".to_string()
-        } else {
-            prompt
-                .split_whitespace()
-                .map(clean_path_token)
-                .find(|candidate| is_path_like_candidate(candidate, "path"))
-                .unwrap_or_else(|| ".".to_string())
-        };
-        return Some(format!("ls -la {}", shell_quote_path(&path)));
-    }
-
-    None
-}
-
-fn shell_quote_path(path: &str) -> String {
-    if path
-        .chars()
-        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '.' | '_' | '-' | '~'))
-    {
-        return path.to_string();
-    }
-    format!("'{}'", path.replace('\'', "'\\''"))
 }
 
 fn schema_allows_string(schema: &Value) -> bool {
@@ -2516,37 +2489,6 @@ fn tool_by_name<'a>(tool_name: &str, tools: Option<&'a Value>) -> Option<&'a Val
     })
 }
 
-fn tool_parameters_from_tool(tool: &Value) -> Option<&Value> {
-    tool.pointer("/function/parameters")
-}
-
-fn tool_name_and_description_look_directory_like(tool: &Value) -> bool {
-    let mut tokens = HashSet::new();
-    if let Some(name) = tool.pointer("/function/name").and_then(Value::as_str) {
-        tokens.extend(text_tokens(name));
-    }
-    if let Some(description) = tool
-        .pointer("/function/description")
-        .and_then(Value::as_str)
-    {
-        tokens.extend(text_tokens(description));
-    }
-    tokens.contains("tree")
-        || ["list", "show", "view", "inspect"]
-            .iter()
-            .any(|token| tokens.contains(*token))
-            && [
-                "dir",
-                "dirs",
-                "directory",
-                "directories",
-                "folder",
-                "folders",
-            ]
-            .iter()
-            .any(|token| tokens.contains(*token))
-}
-
 // ─── Tool result handling ────────────────────────────────────────────
 
 async fn handle_tool_result(
@@ -2741,47 +2683,23 @@ async fn handle_tool_result(
                             latest_tool_result: latest_non_answerable_tool
                                 .as_ref()
                                 .map(|(_, result)| result.as_str()),
-                            tools: session.tools(),
-                            allowed_tools: response_allowed_tools,
-                            prompt_tool_profiles: response_prompt_profiles,
-                            user_text: Some(&session.active_user_text()),
                             tools_enabled: response_tools_enabled,
                         },
                     )
                 }
-                normalize::OutputKind::Uncertainty => {
-                    if response_tools_enabled {
-                        retry_tool_call
-                            .as_ref()
-                            .and_then(|call| {
-                                retry_tool_call_response(
-                                    call,
-                                    latest_non_answerable_tool
-                                        .as_ref()
-                                        .map(|(_, result)| result.as_str()),
-                                    session.tools(),
-                                    response_allowed_tools,
-                                    response_prompt_profiles,
-                                    Some(&session.active_user_text()),
-                                )
-                            })
-                            .unwrap_or_else(|| {
-                                error_response(
-                                    "MoA reducer returned no usable answer",
-                                    MOA_ERR_NO_USABLE_ANSWER,
-                                )
-                            })
-                    } else {
-                        answer_from_latest_tool_result(session)
-                            .map(|answer| chat_response(&answer))
-                            .unwrap_or_else(|| {
-                                error_response(
-                                    "MoA reducer returned no usable answer",
-                                    MOA_ERR_NO_USABLE_ANSWER,
-                                )
-                            })
-                    }
-                }
+                normalize::OutputKind::Uncertainty => answer_from_latest_tool_result(session)
+                    .map(|answer| chat_response(&answer))
+                    .or_else(|| {
+                        latest_non_answerable_tool.as_ref().map(|(tool, result)| {
+                            chat_response(&non_answerable_tool_result_answer(session, tool, result))
+                        })
+                    })
+                    .unwrap_or_else(|| {
+                        error_response(
+                            "MoA reducer returned no usable answer",
+                            MOA_ERR_NO_USABLE_ANSWER,
+                        )
+                    }),
                 _ => {
                     let repaired = repair_tool_result_answer(session, &reduced.payload);
                     match latest_non_answerable_tool.as_ref() {
@@ -2790,7 +2708,7 @@ async fn handle_tool_result(
                                 &repaired,
                                 result,
                                 &session.active_user_text(),
-                            ) =>
+                            ) || answer_appears_to_use_stale_tool_result(session, &repaired) =>
                         {
                             let answer = non_answerable_tool_result_answer(session, tool, result);
                             let response_body = retry_tool_result_response_if_plain(
@@ -2798,10 +2716,6 @@ async fn handle_tool_result(
                                 RetryToolResultContext {
                                     retry_tool_call: retry_tool_call.as_ref(),
                                     latest_tool_result: Some(result),
-                                    tools: session.tools(),
-                                    allowed_tools: response_allowed_tools,
-                                    prompt_tool_profiles: response_prompt_profiles,
-                                    user_text: Some(&session.active_user_text()),
                                     tools_enabled: response_tools_enabled,
                                 },
                             );
@@ -2843,10 +2757,6 @@ async fn handle_tool_result(
                             latest_tool_result: latest_non_answerable_tool
                                 .as_ref()
                                 .map(|(_, result)| result.as_str()),
-                            tools: session.tools(),
-                            allowed_tools: response_allowed_tools,
-                            prompt_tool_profiles: response_prompt_profiles,
-                            user_text: Some(&session.active_user_text()),
                             tools_enabled: response_tools_enabled,
                         },
                     )
@@ -2865,6 +2775,15 @@ async fn handle_tool_result(
                     candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
                     false,
                     chat_response(&answer),
+                )
+            } else if let Some((tool, result)) = latest_non_answerable_tool.as_ref() {
+                tracing::warn!(
+                    "moa: reducers failed after non-answerable {tool} result; returning evidence gap"
+                );
+                (
+                    candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
+                    false,
+                    chat_response(&non_answerable_tool_result_answer(session, tool, result)),
                 )
             } else {
                 (
@@ -2938,6 +2857,19 @@ fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
     repaired
 }
 
+fn structured_title_looks_incomplete(title: &str) -> bool {
+    title.contains("...")
+}
+
+fn prompt_specific_plain_text_answer_is_present(result: &str, prompt: &str) -> bool {
+    prompt_asks_for_first_instruction(prompt) && instruction_line_from_plain_text(result).is_some()
+}
+
+fn plain_text_result_lacks_requested_evidence(result: &str, prompt: &str) -> bool {
+    prompt_asks_for_first_instruction(prompt)
+        && !prompt_specific_plain_text_answer_is_present(result, prompt)
+}
+
 fn answer_from_recent_prompt_specific_structured_tool_results(session: &Session) -> Option<String> {
     let prompt = session.active_user_text();
     if !(prompt_asks_for_ci_status(&prompt) && prompt_asks_for_feedback(&prompt)) {
@@ -2986,6 +2918,17 @@ fn repair_structured_tool_result_answer(session: &Session, answer: &str) -> Opti
         return Some(trimmed);
     }
 
+    if prompt_asks_for_title_field(&prompt)
+        && rows.iter().any(|row| {
+            row.url
+                .as_deref()
+                .is_some_and(|url| answer_contains_text(answer, url))
+                && !answer_contains_text(answer, &row.title)
+        })
+    {
+        return answer_from_structured_tool_result(&result, &prompt);
+    }
+
     let missing_rows = rows
         .iter()
         .take(3)
@@ -3020,7 +2963,13 @@ fn structured_tool_row_missing_reference(
         .id
         .as_deref()
         .is_some_and(|id| answer_has_row_id(answer, id));
-    ((has_id && !has_title) || (has_title && row.id.is_some() && !has_id))
+    let has_url = row
+        .url
+        .as_deref()
+        .is_some_and(|url| answer_contains_text(answer, url));
+    ((has_id && !has_title)
+        || (prompt_asks_for_title_field(prompt) && has_url && !has_title)
+        || (has_title && row.id.is_some() && !has_id))
         .then(|| format_structured_tool_row(row, prompt))
 }
 
@@ -3190,6 +3139,10 @@ fn answer_from_latest_tool_result(session: &Session) -> Option<String> {
         return Some(answer);
     }
 
+    if plain_text_result_lacks_requested_evidence(&result, &prompt) {
+        return None;
+    }
+
     let mut lines = result
         .lines()
         .map(str::trim)
@@ -3230,12 +3183,33 @@ fn answer_appears_to_use_non_answerable_tool_result(
         return true;
     }
 
+    if answer_mentions_incomplete_structured_title(answer, result, prompt) {
+        return true;
+    }
+
     result
         .lines()
         .map(str::trim)
         .filter(|line| !line.is_empty())
         .take(3)
         .any(|line| line.len() >= 12 && answer.contains(line))
+}
+
+fn answer_mentions_incomplete_structured_title(answer: &str, result: &str, prompt: &str) -> bool {
+    if !prompt_asks_for_title_field(prompt) {
+        return false;
+    }
+    let Some(parsed) = parse_tool_result_json(result.trim()) else {
+        return false;
+    };
+    structured_tool_result_rows_unfiltered(&parsed, prompt)
+        .iter()
+        .filter(|row| structured_title_looks_incomplete(&row.title))
+        .any(|row| {
+            answer_contains_text(answer, &row.title)
+                || incomplete_title_prefix(&row.title)
+                    .is_some_and(|prefix| answer_contains_text(answer, &prefix))
+        })
 }
 
 fn answer_mentions_non_specific_work_item_collection(
@@ -3257,6 +3231,63 @@ fn answer_mentions_non_specific_work_item_collection(
         && rows
             .iter()
             .any(|row| structured_tool_row_is_referenced(answer, row))
+}
+
+fn answer_appears_to_use_stale_tool_result(session: &Session, answer: &str) -> bool {
+    let current_results = current_turn_tool_result_texts(session);
+    if current_results.is_empty() {
+        return false;
+    }
+    let current_text = current_results.join("\n");
+    let prior_results = prior_turn_tool_result_texts(session);
+    if prior_results.is_empty() {
+        return false;
+    }
+
+    extract_urls_from_text(answer).into_iter().any(|url| {
+        !current_text.contains(&url) && prior_results.iter().any(|result| result.contains(&url))
+    }) || short_tool_result_values_from_results(&prior_results)
+        .into_iter()
+        .any(|value| !current_text.contains(&value) && answer_contains_text(answer, &value))
+}
+
+fn current_turn_tool_result_texts(session: &Session) -> Vec<String> {
+    tool_result_texts_partitioned_by_latest_user(session).1
+}
+
+fn prior_turn_tool_result_texts(session: &Session) -> Vec<String> {
+    tool_result_texts_partitioned_by_latest_user(session).0
+}
+
+fn tool_result_texts_partitioned_by_latest_user(session: &Session) -> (Vec<String>, Vec<String>) {
+    let messages = session.all_messages();
+    let latest_user_idx = messages
+        .iter()
+        .rposition(message_is_task_user)
+        .unwrap_or(messages.len());
+    let mut prior = Vec::new();
+    let mut current = Vec::new();
+    for (index, message) in messages.iter().enumerate() {
+        if message_role(message) != "tool" {
+            continue;
+        }
+        let Some(text) = message_text_content(message) else {
+            continue;
+        };
+        if index > latest_user_idx {
+            current.push(text);
+        } else {
+            prior.push(text);
+        }
+    }
+    (prior, current)
+}
+
+fn short_tool_result_values_from_results(results: &[String]) -> Vec<String> {
+    results
+        .iter()
+        .flat_map(|result| short_tool_result_values(result))
+        .collect()
 }
 
 fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str) -> String {
@@ -3331,6 +3362,10 @@ fn answer_from_prompt_specific_plain_text_tool_result(
     result: &str,
     prompt: &str,
 ) -> Option<String> {
+    if let Some(answer) = answer_from_first_plain_text_tool_content(result, prompt) {
+        return Some(answer);
+    }
+
     let requested = requested_path_existence_targets(prompt);
     if requested.is_empty() {
         return None;
@@ -3352,6 +3387,126 @@ fn answer_from_prompt_specific_plain_text_tool_result(
                 .join(", ")
         )),
     }
+}
+
+fn answer_from_first_plain_text_tool_content(result: &str, prompt: &str) -> Option<String> {
+    let lower = prompt.to_ascii_lowercase();
+    if !text_suggests_file_read_intent(&lower)
+        || !contains_any(
+            &lower,
+            &[
+                "first line",
+                "first lines",
+                "first few lines",
+                "first instruction",
+                "appears first",
+                "head",
+            ],
+        )
+    {
+        return None;
+    }
+
+    if prompt_asks_for_first_instruction(prompt) {
+        let line = instruction_line_from_plain_text(result)?;
+        return Some(format!(
+            "The first instruction in the tool result is: \"{line}\""
+        ));
+    }
+
+    let lines = first_plain_text_lines(result, requested_first_line_count(&lower))
+        .into_iter()
+        .map(|line| format!("- {line}"))
+        .collect::<Vec<_>>();
+    (!lines.is_empty()).then(|| {
+        format!(
+            "The first lines from the tool result are:\n{}",
+            lines.join("\n")
+        )
+    })
+}
+
+fn prompt_asks_for_first_instruction(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    contains_any(&lower, &["first instruction", "instruction appears first"])
+}
+
+fn requested_first_line_count(prompt_lower: &str) -> usize {
+    prompt_lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .collect::<Vec<_>>()
+        .windows(2)
+        .find_map(|window| match window {
+            [count, "line" | "lines"] => count.parse::<usize>().ok(),
+            _ => None,
+        })
+        .unwrap_or(3)
+        .clamp(1, 12)
+}
+
+fn first_plain_text_lines(result: &str, count: usize) -> Vec<String> {
+    result
+        .lines()
+        .filter_map(clean_plain_text_tool_line)
+        .take(count)
+        .collect()
+}
+
+fn instruction_line_from_plain_text(result: &str) -> Option<String> {
+    result
+        .lines()
+        .filter_map(clean_instruction_candidate_line)
+        .find(|line| plain_text_line_looks_like_instruction(line))
+}
+
+fn clean_instruction_candidate_line(line: &str) -> Option<String> {
+    let line = clean_plain_text_tool_line(line)?;
+    if instruction_scaffolding_line(&line) {
+        return None;
+    }
+    Some(line)
+}
+
+fn instruction_scaffolding_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with('#')
+        || trimmed == "---"
+        || (trimmed.starts_with("--- ") && trimmed.ends_with(" ---"))
+        || trimmed.starts_with("<!--")
+        || trimmed.ends_with("-->")
+        || (trimmed.starts_with('<') && trimmed.ends_with('>') && !trimmed.contains(' '))
+}
+
+fn clean_plain_text_tool_line(line: &str) -> Option<String> {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with("```") || markdown_table_separator_line(line) {
+        return None;
+    }
+    let line = line.trim_start_matches(['-', '*', '+', '>']).trim_start();
+    (!line.is_empty()).then(|| line.to_string())
+}
+
+fn markdown_table_separator_line(line: &str) -> bool {
+    let trimmed = line.trim_matches('|').trim();
+    !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|ch| matches!(ch, '-' | ':' | '|' | ' '))
+}
+
+fn plain_text_line_looks_like_instruction(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    lower.starts_with("always ")
+        || lower.starts_with("never ")
+        || lower.starts_with("do not ")
+        || lower.starts_with("don't ")
+        || lower.starts_with("when ")
+        || lower.starts_with("prefer ")
+        || lower.starts_with("avoid ")
+        || lower.starts_with("use ")
+        || lower.contains(" must ")
+        || lower.contains(" should ")
+        || lower.contains(" should not ")
 }
 
 fn requested_path_existence_targets(prompt: &str) -> Vec<String> {
@@ -3448,6 +3603,9 @@ fn prompt_asks_for_title_field(prompt: &str) -> bool {
 
 fn answer_from_structured_title_value(value: &Value, prompt: &str) -> Option<String> {
     let title = first_structured_title_value(value)?;
+    if structured_title_looks_incomplete(&title) {
+        return None;
+    }
     let label = if prompt_has_word(&prompt.to_ascii_lowercase(), "issue") {
         "The issue title"
     } else {
@@ -3950,9 +4108,98 @@ fn first_non_empty_line(text: &str) -> Option<String> {
 
 fn structured_tool_result_rows(value: &Value, prompt: &str) -> Vec<StructuredToolRow> {
     filter_structured_rows_for_prompt(
-        structured_tool_result_rows_unfiltered(value, prompt),
+        expand_incomplete_structured_row_titles(
+            structured_tool_result_rows_unfiltered(value, prompt),
+            value,
+        ),
         prompt,
     )
+}
+
+fn expand_incomplete_structured_row_titles(
+    rows: Vec<StructuredToolRow>,
+    value: &Value,
+) -> Vec<StructuredToolRow> {
+    if rows.is_empty() {
+        return rows;
+    }
+
+    let candidates = structured_text_candidates(value);
+    if candidates.is_empty() {
+        return rows;
+    }
+
+    rows.into_iter()
+        .map(|mut row| {
+            if let Some(expanded) = expanded_structured_title(&row.title, &candidates) {
+                row.title = expanded;
+            }
+            row
+        })
+        .collect()
+}
+
+fn expanded_structured_title(title: &str, candidates: &[String]) -> Option<String> {
+    let prefix = incomplete_title_prefix(title)?;
+    candidates
+        .iter()
+        .filter(|candidate| candidate.chars().count() > title.chars().count())
+        .filter(|candidate| {
+            candidate
+                .to_ascii_lowercase()
+                .contains(&prefix.to_ascii_lowercase())
+        })
+        .max_by_key(|candidate| candidate.chars().count())
+        .cloned()
+}
+
+fn incomplete_title_prefix(title: &str) -> Option<String> {
+    let before_ellipsis = title.split("...").next()?.trim();
+    if before_ellipsis == title {
+        return None;
+    }
+    (before_ellipsis.chars().count() >= 16).then(|| before_ellipsis.to_string())
+}
+
+fn structured_text_candidates(value: &Value) -> Vec<String> {
+    let mut candidates = Vec::new();
+    collect_structured_text_candidates(value, &mut candidates);
+    candidates
+}
+
+fn collect_structured_text_candidates(value: &Value, candidates: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for field in [
+                "title",
+                "name",
+                "subject",
+                "summary",
+                "snippet",
+                "description",
+                "body",
+                "text",
+            ] {
+                if let Some(text) = map
+                    .get(field)
+                    .and_then(Value::as_str)
+                    .map(clean_structured_text_field)
+                    .filter(|text| !text.is_empty())
+                {
+                    candidates.push(text);
+                }
+            }
+            for nested in map.values() {
+                collect_structured_text_candidates(nested, candidates);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_structured_text_candidates(value, candidates);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn structured_tool_result_rows_unfiltered(value: &Value, prompt: &str) -> Vec<StructuredToolRow> {
@@ -3988,9 +4235,12 @@ fn structured_tool_result_rows_unfiltered(value: &Value, prompt: &str) -> Vec<St
 }
 
 fn filter_structured_rows_for_prompt(
-    rows: Vec<StructuredToolRow>,
+    mut rows: Vec<StructuredToolRow>,
     prompt: &str,
 ) -> Vec<StructuredToolRow> {
+    if prompt_asks_for_title_field(prompt) {
+        rows.retain(|row| !structured_title_looks_incomplete(&row.title));
+    }
     if !prompt_asks_for_work_items(prompt) {
         return rows;
     }
@@ -4404,10 +4654,6 @@ fn latest_completed_tool_call(session: &Session) -> Option<CompletedToolCall> {
 struct RetryToolResultContext<'a> {
     retry_tool_call: Option<&'a CompletedToolCall>,
     latest_tool_result: Option<&'a str>,
-    tools: Option<&'a Value>,
-    allowed_tools: &'a [String],
-    prompt_tool_profiles: &'a [PromptToolProfile],
-    user_text: Option<&'a str>,
     tools_enabled: bool,
 }
 
@@ -4420,17 +4666,6 @@ fn retry_tool_result_response_if_plain(body: Value, context: RetryToolResultCont
             if response_call.same_signature(retry_call)
                 && !same_tool_call_retry_allowed(context.latest_tool_result) =>
         {
-            if let Some(corrected) = corrected_retry_tool_call(
-                retry_call,
-                context.latest_tool_result,
-                context.tools,
-                context.allowed_tools,
-                context.prompt_tool_profiles,
-                context.user_text,
-            ) {
-                let arguments = Value::String(corrected.arguments);
-                return tool_call_response(&corrected.name, &arguments);
-            }
             tracing::info!(
                 "moa: suppressing repeated failing {} tool call with unchanged arguments",
                 retry_call.name
@@ -4442,501 +4677,11 @@ fn retry_tool_result_response_if_plain(body: Value, context: RetryToolResultCont
         }
         _ => {}
     }
-    if let Some(response_call) = first_response_tool_call(&body) {
-        if let Some(corrected) = corrected_retry_tool_call(
-            &response_call,
-            context.latest_tool_result,
-            context.tools,
-            context.allowed_tools,
-            context.prompt_tool_profiles,
-            context.user_text,
-        ) {
-            tracing::info!(
-                "moa: reducer returned malformed follow-up {}; retrying corrected tool call",
-                response_call.name
-            );
-            let arguments = Value::String(corrected.arguments);
-            return tool_call_response(&corrected.name, &arguments);
-        }
-        return body;
-    }
-    context
-        .retry_tool_call
-        .and_then(|call| {
-            retry_tool_call_response(
-                call,
-                context.latest_tool_result,
-                context.tools,
-                context.allowed_tools,
-                context.prompt_tool_profiles,
-                context.user_text,
-            )
-        })
-        .unwrap_or(body)
-}
-
-fn retry_tool_call_response(
-    call: &CompletedToolCall,
-    latest_tool_result: Option<&str>,
-    tools: Option<&Value>,
-    allowed_tools: &[String],
-    prompt_tool_profiles: &[PromptToolProfile],
-    user_text: Option<&str>,
-) -> Option<Value> {
-    if let Some(corrected) = corrected_retry_tool_call(
-        call,
-        latest_tool_result,
-        tools,
-        allowed_tools,
-        prompt_tool_profiles,
-        user_text,
-    ) {
-        tracing::info!(
-            "moa: reducer returned plain text after non-answerable {}; retrying corrected tool call",
-            call.name
-        );
-        let arguments = Value::String(corrected.arguments);
-        return Some(tool_call_response(&corrected.name, &arguments));
-    }
-
-    if !same_tool_call_retry_allowed(latest_tool_result) {
-        tracing::info!(
-            "moa: reducer returned plain text after non-answerable {}; not retrying identical failing call",
-            call.name
-        );
-        return None;
-    }
-
-    tracing::info!(
-        "moa: reducer returned plain text after non-answerable {}; retrying same tool call",
-        call.name
-    );
-    Some(tool_call_response(
-        &call.name,
-        &Value::String(call.arguments.clone()),
-    ))
+    body
 }
 
 fn same_tool_call_retry_allowed(latest_tool_result: Option<&str>) -> bool {
     latest_tool_result.is_some_and(|result| plain_text_tool_result_looks_empty(result.trim()))
-}
-
-fn corrected_retry_tool_call(
-    call: &CompletedToolCall,
-    latest_tool_result: Option<&str>,
-    tools: Option<&Value>,
-    allowed_tools: &[String],
-    prompt_tool_profiles: &[PromptToolProfile],
-    user_text: Option<&str>,
-) -> Option<CompletedToolCall> {
-    let result = latest_tool_result?;
-    if let Some(corrected) =
-        corrected_search_retry_tool_call(call, result, tools, allowed_tools, user_text)
-    {
-        return Some(corrected);
-    }
-
-    let candidates = command_tool_candidates(tools, allowed_tools, prompt_tool_profiles);
-    let candidate = candidates
-        .iter()
-        .find(|candidate| candidate.name == call.name)?;
-    let mut arguments = serde_json::from_str::<Value>(&call.arguments).ok()?;
-    let command = arguments
-        .get(&candidate.field)
-        .and_then(Value::as_str)
-        .map(str::to_string)?;
-    let corrected = tool_result_suggests_unquoted_shell_token_error(result)
-        .then(|| quote_unquoted_shell_metachar_tokens(&command))
-        .flatten()
-        .or_else(|| remove_unknown_json_fields_from_command(&command, result))
-        .or_else(|| remove_unknown_cli_flags_from_command(&command, result))
-        .or_else(|| unescape_single_quoted_shell_double_quotes(&command, result))?;
-    if corrected == command {
-        return None;
-    }
-    arguments[&candidate.field] = Value::String(corrected);
-    let sanitized = sanitize_tool_arguments_for_tool(&call.name, &arguments, tools).ok()?;
-    let wire = tool_arguments_wire_string(&sanitized);
-    if wire == call.arguments {
-        return None;
-    }
-    Some(CompletedToolCall {
-        name: call.name.clone(),
-        arguments: wire,
-    })
-}
-
-fn corrected_search_retry_tool_call(
-    call: &CompletedToolCall,
-    result: &str,
-    tools: Option<&Value>,
-    allowed_tools: &[String],
-    user_text: Option<&str>,
-) -> Option<CompletedToolCall> {
-    let prompt = user_text?;
-    if !tool_result_is_generic_structured_collection_for_prompt(result, prompt) {
-        return None;
-    }
-    if !allowed_tools.is_empty() && !allowed_tools.iter().any(|name| name == &call.name) {
-        return None;
-    }
-    let tool = tool_by_name(&call.name, tools)?;
-    if !tool_looks_like_searcher(tool) {
-        return None;
-    }
-
-    let mut arguments = serde_json::from_str::<Value>(&call.arguments).ok()?;
-    let field = search_query_argument_field(tool, &arguments)?;
-    let current = arguments.get(&field)?.as_str()?;
-    let refined = refine_search_query_for_specific_result(current, prompt)?;
-    arguments[&field] = Value::String(refined);
-    let sanitized = sanitize_tool_arguments_for_tool(&call.name, &arguments, tools).ok()?;
-    let wire = tool_arguments_wire_string(&sanitized);
-    if wire == call.arguments {
-        return None;
-    }
-    Some(CompletedToolCall {
-        name: call.name.clone(),
-        arguments: wire,
-    })
-}
-
-fn search_query_argument_field(tool: &Value, arguments: &Value) -> Option<String> {
-    let arguments = arguments.as_object()?;
-    for field in arguments.keys() {
-        if field_looks_like_search_query(field) {
-            return Some(field.clone());
-        }
-    }
-
-    let properties = tool
-        .pointer("/function/parameters/properties")
-        .and_then(Value::as_object)?;
-    properties.iter().find_map(|(field, schema)| {
-        (schema_allows_string(schema) && field_looks_like_search_query(field))
-            .then(|| field.clone())
-    })
-}
-
-fn field_looks_like_search_query(field: &str) -> bool {
-    matches!(
-        field.to_ascii_lowercase().as_str(),
-        "q" | "query" | "search" | "search_query" | "term" | "terms" | "keywords" | "topic"
-    )
-}
-
-fn refine_search_query_for_specific_result(query: &str, prompt: &str) -> Option<String> {
-    if !prompt_asks_for_work_items(prompt) {
-        return None;
-    }
-    let mut refined = query.trim().to_string();
-    if refined.is_empty() {
-        return None;
-    }
-
-    let prompt_lower = prompt.to_ascii_lowercase();
-    append_search_term_if_missing(&mut refined, "specific");
-    append_search_term_if_missing(&mut refined, "title");
-    append_search_term_if_missing(&mut refined, "number");
-    if contains_any(&prompt_lower, &["issue", "issues"]) {
-        append_search_term_if_missing(&mut refined, "issue");
-    }
-    if contains_any(
-        &prompt_lower,
-        &["pull request", "pull requests", " pr ", " prs "],
-    ) {
-        append_search_term_if_missing(&mut refined, "pull request");
-    }
-    if contains_any(&prompt_lower, &["discussion", "discussions"]) {
-        append_search_term_if_missing(&mut refined, "discussion");
-    }
-
-    (refined != query.trim()).then_some(refined)
-}
-
-fn append_search_term_if_missing(query: &mut String, term: &str) {
-    if !query
-        .to_ascii_lowercase()
-        .contains(&term.to_ascii_lowercase())
-    {
-        query.push(' ');
-        query.push_str(term);
-    }
-}
-
-fn tool_result_suggests_unquoted_shell_token_error(result: &str) -> bool {
-    let lower = result.to_ascii_lowercase();
-    lower.contains("parse error near")
-        || lower.contains("syntax error near")
-        || lower.contains("no matches found")
-}
-
-fn unescape_single_quoted_shell_double_quotes(command: &str, result: &str) -> Option<String> {
-    if !tool_result_suggests_shell_quoting_issue(result) {
-        return None;
-    }
-
-    let mut changed = false;
-    let mut out = String::with_capacity(command.len());
-    let mut quote: Option<char> = None;
-    let mut chars = command.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        match ch {
-            '\'' | '"' if quote == Some(ch) => {
-                quote = None;
-                out.push(ch);
-            }
-            '\'' | '"' if quote.is_none() => {
-                quote = Some(ch);
-                out.push(ch);
-            }
-            '\\' if quote == Some('\'') && chars.peek() == Some(&'"') => {
-                changed = true;
-                out.push('"');
-                chars.next();
-            }
-            _ => out.push(ch),
-        }
-    }
-
-    changed.then_some(out)
-}
-
-fn tool_result_suggests_shell_quoting_issue(result: &str) -> bool {
-    let lower = result.to_ascii_lowercase();
-    lower.contains("unix shell quoting issues")
-        || (lower.contains("syntax error") && lower.contains("jq:"))
-}
-
-fn remove_unknown_json_fields_from_command(command: &str, result: &str) -> Option<String> {
-    let unknown = unknown_json_field_from_tool_result(result)?;
-    let tokens = split_shell_tokens(command)?;
-    let mut changed = false;
-    let mut filtered = Vec::with_capacity(tokens.len());
-    let mut index = 0;
-    while index < tokens.len() {
-        let token = &tokens[index];
-        if let Some(value) = token.strip_prefix("--json=") {
-            changed = true;
-            if let Some(updated) = remove_field_from_csv(value, &unknown) {
-                filtered.push(format!("--json={updated}"));
-            }
-            index += 1;
-            continue;
-        }
-        if token == "--json" {
-            let Some(value) = tokens.get(index + 1) else {
-                filtered.push(token.clone());
-                index += 1;
-                continue;
-            };
-            if let Some(updated) = remove_field_from_csv(value, &unknown) {
-                filtered.push(token.clone());
-                filtered.push(updated);
-            }
-            changed = true;
-            index += 2;
-            continue;
-        }
-        filtered.push(token.clone());
-        index += 1;
-    }
-    changed.then(|| join_shell_tokens(&filtered))
-}
-
-fn unknown_json_field_from_tool_result(result: &str) -> Option<String> {
-    result.lines().take(4).find_map(|line| {
-        let trimmed = line.trim();
-        let lower = trimmed.to_ascii_lowercase();
-        let rest = lower
-            .strip_prefix("unknown json field:")
-            .map(|_| &trimmed["unknown json field:".len()..])?;
-        let field = rest
-            .trim()
-            .trim_matches(|ch: char| matches!(ch, '"' | '\'' | '`' | ':' | ' '));
-        (!field.is_empty()).then(|| field.to_string())
-    })
-}
-
-fn remove_field_from_csv(value: &str, unknown: &str) -> Option<String> {
-    let fields = value
-        .split(',')
-        .map(str::trim)
-        .filter(|field| !field.is_empty())
-        .filter(|field| *field != unknown)
-        .map(str::to_string)
-        .collect::<Vec<_>>();
-    (!fields.is_empty()).then(|| fields.join(","))
-}
-
-fn remove_unknown_cli_flags_from_command(command: &str, result: &str) -> Option<String> {
-    let allowed = allowed_cli_long_flags_from_usage(result)?;
-    let tokens = split_shell_tokens(command)?;
-    let mut changed = false;
-    let mut filtered = Vec::with_capacity(tokens.len());
-    let mut index = 0;
-    while index < tokens.len() {
-        let token = &tokens[index];
-        match shell_long_flag_name(token) {
-            Some(flag) if !allowed.contains(flag) => {
-                changed = true;
-                index += unknown_flag_token_span(&tokens, index);
-                continue;
-            }
-            _ => {}
-        }
-        filtered.push(token.clone());
-        index += 1;
-    }
-    changed.then(|| join_shell_tokens(&filtered))
-}
-
-fn allowed_cli_long_flags_from_usage(result: &str) -> Option<HashSet<String>> {
-    let lower = result.to_ascii_lowercase();
-    if !lower
-        .lines()
-        .take(4)
-        .any(|line| line.contains("unknown flag:"))
-        || !lower.contains("\nusage:")
-    {
-        return None;
-    }
-
-    let flags_section = result
-        .lines()
-        .skip_while(|line| line.trim() != "Flags:")
-        .skip(1)
-        .collect::<Vec<_>>()
-        .join("\n");
-    let allowed = flags_section
-        .split(|ch: char| ch.is_whitespace() || matches!(ch, ',' | ';' | ')' | '('))
-        .filter_map(|token| token.strip_prefix("--"))
-        .map(|token| {
-            token.trim_matches(|ch: char| !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_')
-        })
-        .filter(|token| !token.is_empty())
-        .map(str::to_string)
-        .collect::<HashSet<_>>();
-    (!allowed.is_empty()).then_some(allowed)
-}
-
-fn shell_long_flag_name(token: &str) -> Option<&str> {
-    token
-        .strip_prefix("--")
-        .map(|flag| flag.split_once('=').map_or(flag, |(name, _)| name))
-        .filter(|flag| !flag.is_empty())
-}
-
-fn unknown_flag_token_span(tokens: &[String], index: usize) -> usize {
-    let token = &tokens[index];
-    if token.contains('=') {
-        return 1;
-    }
-    let Some(next) = tokens.get(index + 1) else {
-        return 1;
-    };
-    if next.starts_with('-') { 1 } else { 2 }
-}
-
-fn split_shell_tokens(command: &str) -> Option<Vec<String>> {
-    let mut tokens = Vec::new();
-    let mut token = String::new();
-    let mut quote: Option<char> = None;
-
-    for ch in command.chars() {
-        match ch {
-            '\'' | '"' if quote == Some(ch) => quote = None,
-            '\'' | '"' if quote.is_none() => quote = Some(ch),
-            ch if ch.is_whitespace() && quote.is_none() => {
-                if !token.is_empty() {
-                    tokens.push(std::mem::take(&mut token));
-                }
-            }
-            _ => token.push(ch),
-        }
-    }
-    if quote.is_some() {
-        return None;
-    }
-    if !token.is_empty() {
-        tokens.push(token);
-    }
-    (!tokens.is_empty()).then_some(tokens)
-}
-
-fn join_shell_tokens(tokens: &[String]) -> String {
-    tokens
-        .iter()
-        .map(|token| {
-            if shell_token_needs_join_quotes(token) {
-                format!("'{}'", token.replace('\'', r#"'"'"'"#))
-            } else {
-                token.clone()
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn shell_token_needs_join_quotes(token: &str) -> bool {
-    token.is_empty()
-        || token
-            .chars()
-            .any(|ch| ch.is_whitespace() || matches!(ch, '&' | '|' | ';' | '<' | '>' | '(' | ')'))
-}
-
-fn quote_unquoted_shell_metachar_tokens(command: &str) -> Option<String> {
-    let mut changed = false;
-    let mut out = String::with_capacity(command.len() + 8);
-    let mut token = String::new();
-    let mut quote: Option<char> = None;
-
-    for ch in command.chars() {
-        match ch {
-            '\'' | '"' if quote == Some(ch) => {
-                quote = None;
-                token.push(ch);
-            }
-            '\'' | '"' if quote.is_none() => {
-                quote = Some(ch);
-                token.push(ch);
-            }
-            ch if ch.is_whitespace() && quote.is_none() => {
-                flush_shell_token(&mut out, &mut token, &mut changed);
-                out.push(ch);
-            }
-            _ => token.push(ch),
-        }
-    }
-    flush_shell_token(&mut out, &mut token, &mut changed);
-
-    changed.then_some(out)
-}
-
-fn flush_shell_token(out: &mut String, token: &mut String, changed: &mut bool) {
-    if token.is_empty() {
-        return;
-    }
-    if shell_token_needs_single_quotes(token) {
-        *changed = true;
-        out.push('\'');
-        out.push_str(&token.replace('\'', r#"'"'"'"#));
-        out.push('\'');
-    } else {
-        out.push_str(token);
-    }
-    token.clear();
-}
-
-fn shell_token_needs_single_quotes(token: &str) -> bool {
-    token.chars().any(|ch| matches!(ch, '&' | '?' | '*' | '['))
-        && !shell_token_already_quoted(token)
-}
-
-fn shell_token_already_quoted(token: &str) -> bool {
-    (token.starts_with('\'') && token.ends_with('\''))
-        || (token.starts_with('"') && token.ends_with('"'))
 }
 
 fn first_response_tool_call(body: &Value) -> Option<CompletedToolCall> {
@@ -4988,6 +4733,11 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     if !structured_rows.is_empty() {
         return true;
     }
+    if prompt_asks_for_title_field(prompt)
+        && tool_result_has_only_incomplete_structured_title_rows(result, prompt)
+    {
+        return false;
+    }
     if tool_result_is_generic_structured_collection_for_prompt(result, prompt) {
         return false;
     }
@@ -5002,12 +4752,26 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     {
         return false;
     }
+    if plain_text_result_lacks_requested_evidence(result, prompt) {
+        return false;
+    }
     if plain_text_tool_result_looks_like_repository_list(result)
         && !prompt_asks_for_repositories(prompt)
     {
         return false;
     }
     true
+}
+
+fn tool_result_has_only_incomplete_structured_title_rows(result: &str, prompt: &str) -> bool {
+    let Some(parsed) = parse_tool_result_json(result.trim()) else {
+        return false;
+    };
+    let rows = structured_tool_result_rows_unfiltered(&parsed, prompt);
+    !rows.is_empty()
+        && rows
+            .iter()
+            .all(|row| structured_title_looks_incomplete(&row.title))
 }
 
 fn tool_result_is_generic_structured_collection_for_prompt(result: &str, prompt: &str) -> bool {
@@ -5206,9 +4970,13 @@ fn prompt_asks_for_work_items(prompt: &str) -> bool {
         &[
             "list",
             "find",
+            "search",
+            "searching",
             "show",
             "check",
             "get",
+            "look for",
+            "looking for",
             "recent",
             "open",
             "important",
@@ -5482,7 +5250,7 @@ async fn resolve_decision(
                     &tool.name,
                     &tool.fallback_arguments,
                     session.tools(),
-                    response_tool_names,
+                    allowed_tools,
                     prompt_tool_profiles,
                     Some(&session.last_user_text()),
                 );
@@ -5609,7 +5377,7 @@ async fn resolve_decision(
                                 &tool.name,
                                 &tool.fallback_arguments,
                                 session.tools(),
-                                response_tool_names,
+                                allowed_tools,
                                 prompt_tool_profiles,
                                 Some(&session.last_user_text()),
                             );
@@ -5634,7 +5402,7 @@ async fn resolve_decision(
                                 &tool.name,
                                 &tool.fallback_arguments,
                                 session.tools(),
-                                response_tool_names,
+                                allowed_tools,
                                 prompt_tool_profiles,
                                 Some(&session.last_user_text()),
                             );
@@ -5676,7 +5444,7 @@ async fn resolve_decision(
                             &tool.name,
                             &tool.fallback_arguments,
                             session.tools(),
-                            response_tool_names,
+                            allowed_tools,
                             prompt_tool_profiles,
                             Some(&session.last_user_text()),
                         );
@@ -6353,27 +6121,17 @@ fn validate_response_tool_arguments_for_prompt(
     tools: Option<&Value>,
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
-    user_text: Option<&str>,
+    _user_text: Option<&str>,
 ) -> Result<Value, String> {
     if tool_names_from_schemas(tools, allowed_tools)
         .iter()
         .any(|schema_name| schema_name == name)
     {
-        let mut arguments = sanitize_tool_arguments_for_tool(name, arguments, tools)
-            .map_err(|err| err.to_string())?;
-        if let Some(user_text) = user_text {
-            correct_directory_path_argument_for_prompt(name, &mut arguments, tools, user_text);
-        }
-        return Ok(arguments);
+        return sanitize_tool_arguments_for_tool(name, arguments, tools)
+            .map_err(|err| err.to_string());
     }
 
-    validate_prompt_tool_arguments(
-        name,
-        arguments,
-        allowed_tools,
-        prompt_tool_profiles,
-        user_text,
-    )
+    validate_prompt_tool_arguments(name, arguments, allowed_tools, prompt_tool_profiles)
 }
 
 fn corrected_response_tool_arguments_for_prompt(
@@ -6382,92 +6140,17 @@ fn corrected_response_tool_arguments_for_prompt(
     tools: Option<&Value>,
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
-    user_text: Option<&str>,
+    _user_text: Option<&str>,
 ) -> Value {
-    let mut corrected = arguments.clone();
-    if let Some(user_text) = user_text {
-        correct_directory_path_argument_for_prompt(name, &mut corrected, tools, user_text);
-        correct_prompt_directory_path_argument_for_prompt(
-            name,
-            &mut corrected,
-            prompt_tool_profiles,
-            user_text,
-        );
-        correct_tool_name_directory_path_argument_for_prompt(name, &mut corrected, user_text);
-    }
-    let _ = allowed_tools;
-    corrected
-}
-
-fn correct_tool_name_directory_path_argument_for_prompt(
-    name: &str,
-    arguments: &mut Value,
-    user_text: &str,
-) {
-    if !prompt_mentions_current_directory(user_text) || !tool_name_looks_directory_lister(name) {
-        return;
-    }
-    let Some(arguments) = arguments.as_object_mut() else {
-        return;
-    };
-    let Some(value) = arguments.get("path").and_then(Value::as_str) else {
-        return;
-    };
-    if value != "." && is_path_like_candidate(value, "path") {
-        arguments.insert("path".to_string(), Value::String(".".to_string()));
-    }
-}
-
-fn tool_name_looks_directory_lister(name: &str) -> bool {
-    let tokens = text_tokens(name);
-    tokens.contains("tree")
-        || (["list", "ls"].iter().any(|token| tokens.contains(*token))
-            && [
-                "dir",
-                "dirs",
-                "directory",
-                "directories",
-                "folder",
-                "folders",
-            ]
-            .iter()
-            .any(|token| tokens.contains(*token)))
-}
-
-fn correct_directory_path_argument_for_prompt(
-    name: &str,
-    arguments: &mut Value,
-    tools: Option<&Value>,
-    user_text: &str,
-) {
-    if !prompt_mentions_current_directory(user_text) {
-        return;
-    }
-    let Some(tool) = tool_by_name(name, tools) else {
-        return;
-    };
-    let tool_looks_directory_like = tool_name_and_description_look_directory_like(tool);
-    let Some(parameters) = tool_parameters_from_tool(tool) else {
-        return;
-    };
-    let Some(properties) = parameters.get("properties").and_then(Value::as_object) else {
-        return;
-    };
-    let Some(arguments) = arguments.as_object_mut() else {
-        return;
-    };
-
-    for (field, schema) in properties {
-        if !tool_looks_directory_like && !schema_or_field_looks_directory_like(schema, field) {
-            continue;
-        }
-        let Some(value) = arguments.get(field).and_then(Value::as_str) else {
-            continue;
-        };
-        if value != "." && is_path_like_candidate(value, "path") {
-            arguments.insert(field.clone(), Value::String(".".to_string()));
-        }
-    }
+    validate_response_tool_arguments_for_prompt(
+        name,
+        arguments,
+        tools,
+        allowed_tools,
+        prompt_tool_profiles,
+        None,
+    )
+    .unwrap_or_else(|_| arguments.clone())
 }
 
 fn validate_prompt_tool_arguments(
@@ -6475,7 +6158,6 @@ fn validate_prompt_tool_arguments(
     arguments: &Value,
     allowed_tools: &[String],
     prompt_tool_profiles: &[PromptToolProfile],
-    user_text: Option<&str>,
 ) -> Result<Value, String> {
     let allowed: HashSet<&str> = allowed_tools.iter().map(String::as_str).collect();
     let declared = prompt_tool_profiles
@@ -6508,66 +6190,7 @@ fn validate_prompt_tool_arguments(
         }
     }
 
-    let mut arguments = Value::Object(arguments.clone());
-    if let Some(user_text) = user_text {
-        correct_prompt_directory_path_argument_for_prompt(
-            name,
-            &mut arguments,
-            prompt_tool_profiles,
-            user_text,
-        );
-    }
-    Ok(arguments)
-}
-
-fn correct_prompt_directory_path_argument_for_prompt(
-    name: &str,
-    arguments: &mut Value,
-    prompt_tool_profiles: &[PromptToolProfile],
-    user_text: &str,
-) {
-    if !prompt_mentions_current_directory(user_text) {
-        return;
-    }
-    let Some(profile) = prompt_tool_profiles
-        .iter()
-        .find(|profile| profile.name == name)
-    else {
-        return;
-    };
-    if !prompt_profile_looks_directory_lister(profile) {
-        return;
-    }
-    let Some(arguments) = arguments.as_object_mut() else {
-        return;
-    };
-    for field in ["path", "dir", "directory", "folder"] {
-        let Some(value) = arguments.get(field).and_then(Value::as_str) else {
-            continue;
-        };
-        if value != "." && is_path_like_candidate(value, "path") {
-            arguments.insert(field.to_string(), Value::String(".".to_string()));
-        }
-    }
-}
-
-fn prompt_profile_looks_directory_lister(profile: &PromptToolProfile) -> bool {
-    let tokens = &profile.tokens;
-    let has_listing_action = ["list", "tree", "show", "view", "inspect"]
-        .iter()
-        .any(|token| tokens.contains(*token));
-    let has_directory_target = [
-        "dir",
-        "dirs",
-        "directory",
-        "directories",
-        "folder",
-        "folders",
-        "tree",
-    ]
-    .iter()
-    .any(|token| tokens.contains(*token));
-    has_listing_action && has_directory_target
+    Ok(Value::Object(arguments.clone()))
 }
 
 fn declared_response_tool_names(
@@ -6994,7 +6617,7 @@ mod response_builder_tests {
     }
 
     #[tokio::test]
-    async fn arbiter_tool_call_corrects_prompt_directory_path_for_current_directory() {
+    async fn arbiter_tool_call_preserves_prompt_directory_path_argument() {
         let config = GatewayConfig {
             backends: Vec::new(),
             models: Vec::new(),
@@ -7042,11 +6665,11 @@ mod response_builder_tests {
             .and_then(Value::as_str)
             .and_then(|text| serde_json::from_str::<Value>(text).ok())
             .expect("tool arguments");
-        assert_eq!(args, json!({"path": "."}));
+        assert_eq!(args, json!({"path": "AGENTS.md"}));
     }
 
     #[tokio::test]
-    async fn arbiter_tool_call_corrects_directory_path_from_tool_name_without_schema() {
+    async fn arbiter_tool_call_preserves_directory_path_argument_without_schema() {
         let config = GatewayConfig {
             backends: Vec::new(),
             models: Vec::new(),
@@ -7090,7 +6713,7 @@ mod response_builder_tests {
             .and_then(Value::as_str)
             .and_then(|text| serde_json::from_str::<Value>(text).ok())
             .expect("tool arguments");
-        assert_eq!(args, json!({"path": "."}));
+        assert_eq!(args, json!({"path": "AGENTS.md"}));
     }
 
     fn tool_proposal(payload: &str) -> WorkerOutput {
@@ -7202,7 +6825,7 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn tool_proposal_response_corrects_directory_path_for_current_directory_prompt() {
+    fn tool_proposal_response_preserves_directory_path_argument() {
         let tools = serde_json::json!([{
             "type": "function",
             "function": {
@@ -7242,11 +6865,11 @@ mod response_builder_tests {
             .and_then(Value::as_str)
             .and_then(|text| serde_json::from_str::<Value>(text).ok())
             .expect("tool arguments");
-        assert_eq!(args, json!({"path": "."}));
+        assert_eq!(args, json!({"path": "AGENTS.md"}));
     }
 
     #[test]
-    fn prompt_tool_proposal_corrects_directory_path_for_current_directory_prompt() {
+    fn prompt_tool_proposal_preserves_directory_path_argument() {
         let profiles = vec![PromptToolProfile {
             name: "tree".to_string(),
             tokens: text_tokens("tree: List directory tree for a path"),
@@ -7278,7 +6901,7 @@ mod response_builder_tests {
             .and_then(Value::as_str)
             .and_then(|text| serde_json::from_str::<Value>(text).ok())
             .expect("tool arguments");
-        assert_eq!(args, json!({"path": "."}));
+        assert_eq!(args, json!({"path": "AGENTS.md"}));
     }
 
     #[test]
@@ -7845,7 +7468,14 @@ mod response_builder_tests {
             })],
             &Some(serde_json::json!([{
                 "type": "function",
-                "function": {"name": "lookup_probe_fact"}
+                "function": {
+                    "name": "lookup_probe_fact",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"key": {"type": "string"}},
+                        "required": ["key"]
+                    }
+                }
             }])),
         );
         let config = GatewayConfig {
@@ -8154,7 +7784,7 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn local_directory_prompt_uses_command_tool_when_directory_tools_need_node() {
+    fn local_directory_prompt_selects_command_tool_but_does_not_invent_command_args() {
         let tools = serde_json::json!([
             {"type": "function", "function": {
                 "name": "exec",
@@ -8202,12 +7832,9 @@ mod response_builder_tests {
         let selected = selected_tool_names_for_turn(&session, &[], &[]);
 
         assert_eq!(selected, vec!["exec".to_string()]);
-        let forced =
-            required_tool_choice_for_intent(&session, &Some(tools), &selected).expect("tool");
-        assert_eq!(forced.name, "exec");
-        assert_eq!(
-            forced.fallback_arguments,
-            serde_json::json!({"command": "ls -la ."})
+        assert!(
+            required_tool_choice_for_intent(&session, &Some(tools), &selected).is_none(),
+            "MoA must not synthesize shell commands from directory-list intent"
         );
     }
 
@@ -9458,6 +9085,79 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn first_instruction_read_prompt_answers_from_plain_text_tool_result() {
+        let prompt =
+            "Read the first lines of AGENTS.md in the workspace and tell me the first instruction.";
+        let result = "# Agent Notes\n\n## Repo Overview\n\nThis repo contains a Rust binary.\n\n## Building\n\nAlways use `just`. Never build manually.\n\n```bash\njust build\n```";
+        let session = session_with_user_and_tool_result(prompt, result);
+
+        let answer = answer_from_latest_tool_result(&session).expect("read evidence answer");
+
+        assert_eq!(
+            answer,
+            "The first instruction in the tool result is: \"Always use `just`. Never build manually.\""
+        );
+    }
+
+    #[test]
+    fn first_instruction_read_prompt_skips_instruction_wrappers() {
+        let prompt =
+            "Read the first lines of AGENTS.md in the workspace and tell me the first instruction.";
+        let result = "<INSTRUCTIONS>\nWhen sending messages on my behalf, always clearly indicate the message is sent by my AI agent.\n</INSTRUCTIONS>";
+        let session = session_with_user_and_tool_result(prompt, result);
+
+        let answer = answer_from_latest_tool_result(&session).expect("read evidence answer");
+
+        assert_eq!(
+            answer,
+            "The first instruction in the tool result is: \"When sending messages on my behalf, always clearly indicate the message is sent by my AI agent.\""
+        );
+    }
+
+    #[test]
+    fn repair_tool_result_answer_replaces_clipped_prompt_context_for_first_instruction() {
+        let prompt =
+            "Read the first lines of AGENTS.md in the workspace and tell me the first instruction.";
+        let result = "# Agent Notes\n\n## Repo Overview\n\nThis repo contains a Rust binary.\n\n## Building\n\nAlways use `just`. Never build manually.";
+        let session = session_with_user_and_tool_result(prompt, result);
+
+        let repaired = repair_tool_result_answer(
+            &session,
+            "The first instruction in `AGENTS.md` is: \"rence through every model in `/v1/models`.\"",
+        );
+
+        assert_eq!(
+            repaired,
+            "The first instruction in the tool result is: \"Always use `just`. Never build manually.\""
+        );
+    }
+
+    #[test]
+    fn partial_plain_text_read_does_not_invent_continuation_args() {
+        let prompt =
+            "Read the first lines of AGENTS.md in the workspace and tell me the first instruction.";
+        let result = "# Agent Notes\n\n## Repo Overview\n\nThis repo contains a Rust binary.\n\n[151 more lines in file. Use offset=6 to continue.]";
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": prompt}),
+                tool_call_msg_with_args(
+                    "call_1",
+                    "read",
+                    r#"{"path":"/workspace/AGENTS.md","limit":5}"#,
+                ),
+                tool_result_msg("call_1", result),
+            ],
+            &None,
+        );
+
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            result, prompt
+        ));
+        assert!(answer_from_latest_tool_result(&session).is_none());
+    }
+
+    #[test]
     fn web_search_result_json_can_answer_research_prompt_from_evidence() {
         let prompt = "Use available tools to look for open issues or recent discussion about mesh-LLM/mesh-llm on GitHub, then tell me one specific item you found with a short reason it matters.";
         let result = serde_json::json!({
@@ -9495,6 +9195,193 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn web_search_exact_issue_title_prompt_uses_specific_url_and_expanded_snippet_title() {
+        let prompt = "Search the web for mesh-llm memory slot batch issue. Use web search if appropriate. Tell me one relevant GitHub issue URL and its exact title.";
+        let result = serde_json::json!({
+            "query": "mesh-llm memory slot batch issue github",
+            "provider": "duckduckgo",
+            "count": 2,
+            "results": [
+                {
+                    "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"a\">>>\nSource: Web Search\n---\nIssues · Mesh-LLM/mesh-llm · GitHub\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"a\">>>",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/",
+                    "snippet": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"b\">>>\nSource: Web Search\n---\nskippy: 'decode: failed to find a memory slot for batch of size 2048' on goose/pi after a few tool-laden turns\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"b\">>>",
+                    "siteName": "github.com"
+                },
+                {
+                    "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"c\">>>\nSource: Web Search\n---\nskippy: 'decode: failed to find a memory slot for batch of ... - GitHub\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"c\">>>",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/652",
+                    "snippet": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"d\">>>\nSource: Web Search\n---\nAnyone trying to use mesh-llm with a small local model in an agentic harness like goose or pi will hit this within 2-3 turns.\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"d\">>>",
+                    "siteName": "github.com"
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        assert!(prompt_asks_for_work_items(prompt));
+        assert!(tool_result_has_answerable_evidence_for_prompt(
+            &result, prompt
+        ));
+        let answer = answer_from_latest_tool_result(&session).expect("issue evidence");
+
+        assert!(
+            answer.contains("https://github.com/Mesh-LLM/mesh-llm/issues/652"),
+            "{answer}"
+        );
+        assert!(
+            answer.contains(
+                "skippy: 'decode: failed to find a memory slot for batch of size 2048' on goose/pi after a few tool-laden turns"
+            ),
+            "{answer}"
+        );
+        assert!(
+            !answer.contains("Issues · Mesh-LLM/mesh-llm · GitHub"),
+            "{answer}"
+        );
+        assert!(!answer.contains("EXTERNAL_UNTRUSTED_CONTENT"), "{answer}");
+    }
+
+    #[test]
+    fn repair_tool_result_answer_replaces_truncated_title_when_url_was_referenced() {
+        let prompt = "Search the web for mesh-llm memory slot batch issue. Tell me one relevant GitHub issue URL and its exact title.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "Issues · Mesh-LLM/mesh-llm · GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/",
+                    "snippet": "skippy: 'decode: failed to find a memory slot for batch of size 2048' on goose/pi after a few tool-laden turns"
+                },
+                {
+                    "title": "skippy: 'decode: failed to find a memory slot for batch of ... - GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/652",
+                    "snippet": "Anyone trying to use mesh-llm with a small local model in an agentic harness like goose or pi will hit this within 2-3 turns."
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        let repaired = repair_tool_result_answer(
+            &session,
+            "URL: https://github.com/Mesh-LLM/mesh-llm/issues/652\nTitle: skippy: 'decode: failed to find a memory slot for batch of... - GitHub",
+        );
+
+        assert!(
+            repaired.contains(
+                "skippy: 'decode: failed to find a memory slot for batch of size 2048' on goose/pi after a few tool-laden turns"
+            ),
+            "{repaired}"
+        );
+        assert!(
+            repaired.contains("https://github.com/Mesh-LLM/mesh-llm/issues/652"),
+            "{repaired}"
+        );
+        assert!(!repaired.contains("batch of... - GitHub"), "{repaired}");
+    }
+
+    #[test]
+    fn exact_title_search_result_with_truncated_title_is_not_answer_evidence() {
+        let prompt = "Search the web for mesh-llm memory slot batch issue. Tell me one relevant GitHub issue URL and its exact title.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "skippy: 'decode: failed to find a memory slot for batch of ... - GitHub",
+                    "url": "https://github.com/Mesh-LLM/mesh-llm/issues/652",
+                    "snippet": "Anyone trying to use mesh-llm with a small local model in an agentic harness like goose or pi will hit this within 2-3 turns."
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            &result, prompt
+        ));
+        assert!(answer_from_latest_tool_result(&session).is_none());
+    }
+
+    #[test]
+    fn reducer_answer_repeating_truncated_title_from_non_answerable_result_is_rejected() {
+        let prompt = "Find the exact title of the mesh-llm GitHub issue about decode failed to find a memory slot for batch.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "skippy: decode failed to find a memory slot for batch of ... - GitHub",
+                    "url": "https://example.invalid/issues/652",
+                    "snippet": "mesh-llm issue result"
+                }
+            ]
+        })
+        .to_string();
+        let answer = "The exact title is: skippy: decode failed to find a memory slot for batch of... - GitHub";
+
+        assert!(answer_appears_to_use_non_answerable_tool_result(
+            answer, &result, prompt
+        ));
+    }
+
+    #[test]
+    fn generic_exact_title_prompt_rejects_incomplete_structured_title() {
+        let prompt = "Find the exact title of the specific record about decode failed to find a memory slot for batch.";
+        let result = serde_json::json!({
+            "results": [
+                {
+                    "title": "decode failed to find a memory slot for batch of ...",
+                    "url": "https://example.invalid/records/652",
+                    "snippet": "one candidate record"
+                }
+            ]
+        })
+        .to_string();
+        let session = session_with_user_and_tool_result(prompt, &result);
+
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            &result, prompt
+        ));
+        assert!(answer_from_latest_tool_result(&session).is_none());
+    }
+
+    #[test]
+    fn deictic_url_prompt_does_not_synthesize_url_arguments_from_context() {
+        let tools = serde_json::json!([
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"query": {"type": "string"}},
+                        "required": ["query"]
+                    }
+                }
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_fetch",
+                    "description": "Fetch a web URL",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"url": {"type": "string", "format": "uri"}},
+                        "required": ["url"]
+                    }
+                }
+            }
+        ]);
+        let allowed = vec!["web_search".to_string(), "web_fetch".to_string()];
+
+        assert!(
+            url_intent_tool_names(
+                Some(&tools),
+                &allowed,
+                "Now fetch that issue URL and tell me the exact title."
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
     fn wrapped_web_search_title_is_cleaned_in_structured_answer() {
         let prompt = "Find one specific open issue for mesh-LLM/mesh-llm.";
         let result = serde_json::json!({
@@ -9514,6 +9401,40 @@ mod response_builder_tests {
         assert!(answer.contains("Issue #652"), "{answer}");
         assert!(!answer.contains("EXTERNAL_UNTRUSTED_CONTENT"), "{answer}");
         assert!(!answer.contains("Source: Web Search"), "{answer}");
+    }
+
+    #[test]
+    fn stale_prior_tool_url_is_not_valid_answer_for_new_non_answerable_turn() {
+        let mut session = Session::new();
+        let prior_result = serde_json::json!({
+            "url": "https://github.com/Mesh-LLM/mesh-llm/issues/652",
+            "title": "skippy: decode failed"
+        })
+        .to_string();
+        let current_result = serde_json::json!({
+            "query": "site:github.com/Mesh-LLM/mesh-llm/issues specific title",
+            "count": 0,
+            "results": []
+        })
+        .to_string();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "Fetch issue 652."}),
+                tool_call_msg("call_1", "web_fetch"),
+                tool_result_msg("call_1", &prior_result),
+                serde_json::json!({"role": "assistant", "content": "The issue title is skippy: decode failed."}),
+                serde_json::json!({"role": "user", "content": "Look for one open issue or recent discussion and tell me why it matters."}),
+                tool_call_msg("call_2", "web_search"),
+                tool_result_msg("call_2", &current_result),
+            ],
+            &None,
+        );
+        let stale_answer = "Based on the tool results, Issue #652 at https://github.com/Mesh-LLM/mesh-llm/issues/652 is about external content security.";
+
+        assert!(answer_appears_to_use_stale_tool_result(
+            &session,
+            stale_answer
+        ));
     }
 
     #[test]
@@ -10548,26 +10469,6 @@ mod response_builder_tests {
         })
     }
 
-    fn command_tool_schema(name: &str) -> Value {
-        serde_json::json!([{
-            "type": "function",
-            "function": {
-                "name": name,
-                "description": "Run shell commands",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "command": {
-                            "type": "string",
-                            "description": "Shell command to execute"
-                        }
-                    },
-                    "required": ["command"]
-                }
-            }
-        }])
-    }
-
     fn session_with_tool_result(result: &str) -> Session {
         session_with_user_and_tool_result("run command", result)
     }
@@ -10586,7 +10487,7 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn empty_tool_result_plain_answer_retries_same_tool_call() {
+    fn empty_tool_result_plain_answer_does_not_retry_same_tool_call() {
         let command =
             r#"{"command":"gh pr list --repo Mesh-LLM/mesh-llm --state open --limit 10"}"#;
         let mut session = Session::new();
@@ -10608,35 +10509,23 @@ mod response_builder_tests {
             RetryToolResultContext {
                 retry_tool_call: Some(&retry),
                 latest_tool_result: Some("(no output)"),
-                tools: None,
-                allowed_tools: &[],
-                prompt_tool_profiles: &[],
-                user_text: None,
                 tools_enabled: true,
             },
         );
 
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/name")
-                .and_then(Value::as_str),
-            Some("exec")
-        );
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/arguments")
-                .and_then(Value::as_str),
-            Some(command)
-        );
         assert!(
+            body.pointer("/choices/0/message/tool_calls/0").is_none(),
+            "{body}"
+        );
+        assert_eq!(
             body.pointer("/choices/0/message/content")
-                .and_then(Value::as_str)
-                .is_none()
+                .and_then(Value::as_str),
+            Some("I could not retrieve any pull requests.")
         );
     }
 
     #[test]
-    fn shell_parse_error_retries_schema_corrected_command_tool_call() {
-        let tools = command_tool_schema("exec");
-        let allowed = ["exec".to_string()];
+    fn identical_failing_followup_tool_call_is_suppressed() {
         let command = r#"{"command":"gh api repos/Mesh-LLM/mesh-llm/issues?state=open&sort=updated&direction=desc --jq '.items[0:1]'"}"#;
         let retry = CompletedToolCall {
             name: "exec".to_string(),
@@ -10644,100 +10533,39 @@ mod response_builder_tests {
         };
 
         let body = retry_tool_result_response_if_plain(
-            chat_response("The GitHub API command failed."),
+            tool_call_response("exec", &Value::String(command.to_string())),
             RetryToolResultContext {
                 retry_tool_call: Some(&retry),
                 latest_tool_result: Some(
                     "(eval):1: parse error near `&'\n\n(Command exited with code 1)",
                 ),
-                tools: Some(&tools),
-                allowed_tools: &allowed,
-                prompt_tool_profiles: &[],
-                user_text: None,
                 tools_enabled: true,
             },
         );
 
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/name")
-                .and_then(Value::as_str),
-            Some("exec")
+        assert!(
+            body.pointer("/choices/0/message/tool_calls/0").is_none(),
+            "{body}"
         );
-        let args = body
-            .pointer("/choices/0/message/tool_calls/0/function/arguments")
-            .and_then(Value::as_str)
-            .and_then(|text| serde_json::from_str::<Value>(text).ok())
-            .expect("tool args");
         assert_eq!(
-            args.get("command").and_then(Value::as_str),
-            Some(
-                "gh api 'repos/Mesh-LLM/mesh-llm/issues?state=open&sort=updated&direction=desc' --jq '.items[0:1]'"
-            )
+            body.pointer("/error/code").and_then(Value::as_str),
+            Some(MOA_ERR_NO_USABLE_ANSWER)
         );
     }
 
     #[test]
-    fn shell_glob_error_retries_schema_corrected_command_tool_call() {
-        let tools = command_tool_schema("exec");
-        let allowed = ["exec".to_string()];
-        let command =
-            r#"{"command":"gh api repos/mesh-llm/mesh-llm/issues?state=open&per_page=1"}"#;
-        let retry = CompletedToolCall {
-            name: "exec".to_string(),
-            arguments: command.to_string(),
-        };
-        let result = "zsh:1: no matches found: repos/mesh-llm/mesh-llm/issues?state=open";
-        assert!(!tool_result_has_answerable_evidence(result));
-
-        let body = retry_tool_result_response_if_plain(
-            chat_response("The shell tool returned no matches found."),
-            RetryToolResultContext {
-                retry_tool_call: Some(&retry),
-                latest_tool_result: Some(result),
-                tools: Some(&tools),
-                allowed_tools: &allowed,
-                prompt_tool_profiles: &[],
-                user_text: None,
-                tools_enabled: true,
-            },
-        );
-
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/name")
-                .and_then(Value::as_str),
-            Some("exec")
-        );
-        let args = body
-            .pointer("/choices/0/message/tool_calls/0/function/arguments")
-            .and_then(Value::as_str)
-            .and_then(|text| serde_json::from_str::<Value>(text).ok())
-            .expect("tool args");
-        assert_eq!(
-            args.get("command").and_then(Value::as_str),
-            Some("gh api 'repos/mesh-llm/mesh-llm/issues?state=open&per_page=1'")
-        );
-    }
-
-    #[test]
-    fn shell_glob_error_corrects_new_bad_followup_tool_call() {
-        let tools = command_tool_schema("exec");
-        let allowed = ["exec".to_string()];
+    fn different_model_emitted_followup_tool_call_is_preserved() {
         let previous = CompletedToolCall {
             name: "exec".to_string(),
-            arguments: r#"{"command":"curl -s https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open\\&per_page=1"}"#.to_string(),
+            arguments: r#"{"command":"gh pr list --limit 1"}"#.to_string(),
         };
-        let followup = r#"{"command":"curl -s https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open&per_page=1 | jq -r '.[0]'"}"#;
-        let result = "zsh:1: no matches found: https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open";
+        let followup = r#"{"command":"gh issue list --limit 1"}"#;
 
         let body = retry_tool_result_response_if_plain(
             tool_call_response("exec", &Value::String(followup.to_string())),
             RetryToolResultContext {
                 retry_tool_call: Some(&previous),
-                latest_tool_result: Some(result),
-                tools: Some(&tools),
-                allowed_tools: &allowed,
-                prompt_tool_profiles: &[],
-                user_text: None,
+                latest_tool_result: Some("unknown flag: --state"),
                 tools_enabled: true,
             },
         );
@@ -10754,108 +10582,12 @@ mod response_builder_tests {
             .expect("tool args");
         assert_eq!(
             args.get("command").and_then(Value::as_str),
-            Some(
-                "curl -s 'https://api.github.com/repos/Mesh-LLM/mesh-llm/issues?state=open&per_page=1' | jq -r '.[0]'"
-            )
+            Some("gh issue list --limit 1")
         );
     }
 
     #[test]
-    fn cli_unknown_flag_error_retries_schema_corrected_command_tool_call() {
-        let tools = command_tool_schema("exec");
-        let allowed = ["exec".to_string()];
-        let command =
-            r#"{"command":"gh api repos/Mesh-LLM/mesh-llm/issues --state open --limit 1"}"#;
-        let retry = CompletedToolCall {
-            name: "exec".to_string(),
-            arguments: command.to_string(),
-        };
-        let result = "unknown flag: --state\n\nUsage:  gh api <endpoint> [flags]\n\nFlags:\n      --cache duration        Cache the response\n  -H, --header key:value      Add a HTTP request header\n      --paginate              Make additional HTTP requests\n\n(Command exited with code 1)";
-
-        let body = retry_tool_result_response_if_plain(
-            chat_response("Let me try again with a corrected command."),
-            RetryToolResultContext {
-                retry_tool_call: Some(&retry),
-                latest_tool_result: Some(result),
-                tools: Some(&tools),
-                allowed_tools: &allowed,
-                prompt_tool_profiles: &[],
-                user_text: None,
-                tools_enabled: true,
-            },
-        );
-
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/name")
-                .and_then(Value::as_str),
-            Some("exec")
-        );
-        let args = body
-            .pointer("/choices/0/message/tool_calls/0/function/arguments")
-            .and_then(Value::as_str)
-            .and_then(|text| serde_json::from_str::<Value>(text).ok())
-            .expect("tool args");
-        assert_eq!(
-            args.get("command").and_then(Value::as_str),
-            Some("gh api repos/Mesh-LLM/mesh-llm/issues")
-        );
-    }
-
-    #[test]
-    fn jq_shell_quoting_error_retries_schema_corrected_command_tool_call() {
-        let tools = command_tool_schema("exec");
-        let allowed = ["exec".to_string()];
-        let command = r#"{"command":"curl -s \"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/808\" | jq -r '\\\"\\(.number) \\(.state) \\(.title)\\\"'"}"#;
-        let retry = CompletedToolCall {
-            name: "exec".to_string(),
-            arguments: command.to_string(),
-        };
-        let result = "jq: error: syntax error, unexpected INVALID_CHARACTER, expecting end of file (Unix shell quoting issues?) at <top-level>, line 1:\n\\\"\\(.number) \\(.state) \\(.title)\\\"\njq: 1 compile error\n\n(Command exited with code 3)";
-
-        let body = retry_tool_result_response_if_plain(
-            chat_response("I encountered an error while trying to fetch the details."),
-            RetryToolResultContext {
-                retry_tool_call: Some(&retry),
-                latest_tool_result: Some(result),
-                tools: Some(&tools),
-                allowed_tools: &allowed,
-                prompt_tool_profiles: &[],
-                user_text: None,
-                tools_enabled: true,
-            },
-        );
-
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/name")
-                .and_then(Value::as_str),
-            Some("exec")
-        );
-        let args = body
-            .pointer("/choices/0/message/tool_calls/0/function/arguments")
-            .and_then(Value::as_str)
-            .and_then(|text| serde_json::from_str::<Value>(text).ok())
-            .expect("tool args");
-        assert_eq!(
-            args.get("command").and_then(Value::as_str),
-            Some(
-                "curl -s \"https://api.github.com/repos/Mesh-LLM/mesh-llm/issues/808\" | jq -r '\"\\(.number) \\(.state) \\(.title)\"'"
-            )
-        );
-    }
-
-    #[test]
-    fn generic_collection_search_result_retries_with_more_specific_query() {
-        let tools = serde_json::json!([{"type": "function", "function": {
-            "name": "web_search",
-            "description": "Search online web sources",
-            "parameters": {
-                "type": "object",
-                "properties": {"query": {"type": "string", "description": "Search query"}},
-                "required": ["query"]
-            }
-        }}]);
-        let allowed = ["web_search".to_string()];
-        let prompt = "Find one specific open issue or recent discussion for mesh-LLM/mesh-llm.";
+    fn generic_collection_result_plain_answer_does_not_refine_search_query() {
         let retry = CompletedToolCall {
             name: "web_search".to_string(),
             arguments: r#"{"query":"open issues or recent discussion about mesh-LLM/mesh-llm"}"#
@@ -10882,31 +10614,19 @@ mod response_builder_tests {
             RetryToolResultContext {
                 retry_tool_call: Some(&retry),
                 latest_tool_result: Some(&result),
-                tools: Some(&tools),
-                allowed_tools: &allowed,
-                prompt_tool_profiles: &[],
-                user_text: Some(prompt),
                 tools_enabled: true,
             },
         );
 
-        assert_eq!(
-            body.pointer("/choices/0/message/tool_calls/0/function/name")
-                .and_then(Value::as_str),
-            Some("web_search")
+        assert!(
+            body.pointer("/choices/0/message/tool_calls/0").is_none(),
+            "{body}"
         );
-        let args = body
-            .pointer("/choices/0/message/tool_calls/0/function/arguments")
-            .and_then(Value::as_str)
-            .and_then(|text| serde_json::from_str::<Value>(text).ok())
-            .expect("tool args");
-        let query = args
-            .get("query")
-            .and_then(Value::as_str)
-            .expect("query arg");
-        assert!(query.contains("specific"), "{query}");
-        assert!(query.contains("title"), "{query}");
-        assert!(query.contains("number"), "{query}");
+        assert_eq!(
+            body.pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("The result only listed collection pages.")
+        );
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2356,8 +2356,12 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     {
         return false;
     }
-    !(prompt_asks_for_pull_requests(prompt)
-        && plain_text_tool_result_looks_like_github_repo_list(result))
+    if plain_text_tool_result_looks_like_github_repo_list(result)
+        && !prompt_asks_for_github_repositories(prompt)
+    {
+        return false;
+    }
+    true
 }
 
 fn prompt_asks_for_github_work_items(prompt: &str) -> bool {
@@ -2382,6 +2386,14 @@ fn prompt_asks_for_pull_requests(prompt: &str) -> bool {
         || prompt_has_word(&lower, "prs")
         || prompt_has_word(&lower, "pulls")
         || lower.contains("pull request")
+}
+
+fn prompt_asks_for_github_repositories(prompt: &str) -> bool {
+    let lower = prompt.to_ascii_lowercase();
+    prompt_has_word(&lower, "repo")
+        || prompt_has_word(&lower, "repos")
+        || lower.contains("repository")
+        || lower.contains("repositories")
 }
 
 fn prompt_has_word(prompt: &str, needle: &str) -> bool {
@@ -4813,6 +4825,17 @@ mod response_builder_tests {
             answer_from_latest_tool_result(&session_with_user_and_tool_result(prompt, result))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn github_repo_list_needs_repo_prompt() {
+        let result = "aaif/working-group-proposals\tPropose a new working group\tpublic\t2026-05-29T18:18:10Z";
+
+        assert!(tool_result_has_answerable_evidence(result));
+        assert!(!tool_result_has_answerable_evidence_for_prompt(
+            result,
+            "Any new interesting items?"
+        ));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -982,6 +982,10 @@ async fn handle_tool_result(
 }
 
 fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
+    if let Some(github_answer) = grounded_github_tool_answer(session) {
+        return github_answer;
+    }
+
     if !tool_evidence_should_be_preserved(&session.last_user_text()) {
         return answer.to_string();
     }
@@ -998,6 +1002,129 @@ fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
     repaired.push_str("Tool facts: ");
     repaired.push_str(&missing.join(", "));
     repaired
+}
+
+fn grounded_github_tool_answer(session: &Session) -> Option<String> {
+    let user_text = session.last_user_text();
+    if !github_evidence_should_ground_answer(&user_text) {
+        return None;
+    }
+
+    let rows = github_tool_evidence_rows(session);
+    if rows.is_empty() {
+        return None;
+    }
+
+    let selected = select_relevant_github_rows(&user_text, &rows);
+    let heading = if selected.len() == 1 {
+        "Grounded GitHub evidence from the fetched tool result:"
+    } else {
+        "Grounded GitHub evidence from the fetched tool results:"
+    };
+    let mut answer = String::from(heading);
+    for row in selected {
+        answer.push_str("\n- ");
+        answer.push_str(row);
+    }
+    if user_text.to_ascii_lowercase().contains("nick") {
+        answer.push_str(
+            "\n\nI do not see a `Nick` author/login in those fetched rows; use the author/login shown above.",
+        );
+    }
+    Some(answer)
+}
+
+fn github_evidence_should_ground_answer(user_text: &str) -> bool {
+    let text = user_text.to_ascii_lowercase();
+    contains_any(
+        &text,
+        &[
+            "github",
+            "pull request",
+            "pr ",
+            "pr#",
+            "issue",
+            "status",
+            "review",
+        ],
+    )
+}
+
+fn github_tool_evidence_rows(session: &Session) -> Vec<String> {
+    let mut rows = Vec::new();
+    for (_, result) in session.recent_tool_results() {
+        rows.extend(context::github_evidence_rows_from_tool_result(&result));
+    }
+    let mut deduped = Vec::new();
+    for row in rows {
+        if !deduped.iter().any(|seen| seen == &row) {
+            deduped.push(row);
+        }
+    }
+    deduped
+}
+
+fn select_relevant_github_rows<'a>(user_text: &str, rows: &'a [String]) -> Vec<&'a String> {
+    let text = user_text.to_ascii_lowercase();
+    let explicit_numbers = github_pr_numbers_from_text(&text);
+    if !explicit_numbers.is_empty() {
+        let matches = rows
+            .iter()
+            .filter(|row| explicit_numbers.iter().any(|number| row.contains(number)))
+            .collect::<Vec<_>>();
+        if !matches.is_empty() {
+            return matches;
+        }
+    }
+
+    let keywords = github_relevance_keywords(&text);
+    if !keywords.is_empty() {
+        let matches = rows
+            .iter()
+            .filter(|row| {
+                let row = row.to_ascii_lowercase();
+                keywords.iter().any(|keyword| row.contains(keyword))
+            })
+            .collect::<Vec<_>>();
+        if !matches.is_empty() {
+            return matches;
+        }
+    }
+
+    rows.iter().take(5).collect()
+}
+
+fn github_pr_numbers_from_text(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric() && c != '#')
+        .filter_map(|token| {
+            let number = token.strip_prefix('#').unwrap_or(token);
+            (number.len() >= 2 && number.chars().all(|c| c.is_ascii_digit()))
+                .then(|| format!("#{number}"))
+        })
+        .collect()
+}
+
+fn github_relevance_keywords(text: &str) -> Vec<String> {
+    text.split(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+        .filter(|word| word.len() >= 4)
+        .filter(|word| {
+            !matches!(
+                *word,
+                "github"
+                    | "pull"
+                    | "request"
+                    | "status"
+                    | "review"
+                    | "opened"
+                    | "what"
+                    | "about"
+                    | "please"
+                    | "quality"
+                    | "quick"
+            )
+        })
+        .map(str::to_string)
+        .collect()
 }
 
 fn tool_evidence_should_be_preserved(user_text: &str) -> bool {
@@ -2194,6 +2321,64 @@ mod response_builder_tests {
         let repaired = repair_tool_result_answer(&session, "Done.");
 
         assert_eq!(repaired, "Done.");
+    }
+
+    #[test]
+    fn repair_tool_result_answer_grounds_github_pr_rows() {
+        let github_json = serde_json::json!([
+            {
+                "number": 806,
+                "title": "Add meshllm.cloud website, catalog viewer, and onboarding docs",
+                "state": "open",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/806",
+                "updated_at": "2026-06-06T07:18:23Z",
+                "body": "x".repeat(8_000),
+                "user": {"login": "ndizazzo"},
+                "requested_reviewers": [{"login": "michaelneale"}, {"login": "i386"}]
+            },
+            {
+                "number": 709,
+                "title": "Use combined hf-hub fork for model downloads",
+                "state": "open",
+                "html_url": "https://github.com/Mesh-LLM/mesh-llm/pull/709",
+                "updated_at": "2026-05-27T11:26:00Z",
+                "user": {"login": "i386"}
+            }
+        ])
+        .to_string();
+        let wrapped = serde_json::json!({
+            "url": "https://api.github.com/repos/Mesh-LLM/mesh-llm/pulls?state=open",
+            "status": 200,
+            "text": format!(
+                "SECURITY NOTICE\n\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>\nSource: Web Fetch\n---\n{github_json}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"x\">>>"
+            )
+        })
+        .to_string();
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({
+                    "role": "user",
+                    "content": "What is the status of the new website PR opened by Nick?"
+                }),
+                tool_call_msg("call_1", "web_fetch"),
+                tool_result_msg("call_1", &wrapped),
+            ],
+            &None,
+        );
+
+        let repaired = repair_tool_result_answer(
+            &session,
+            "The website PR is #806 by i386 and was updated in May.",
+        );
+
+        assert!(repaired.contains("#806"));
+        assert!(repaired.contains("website, catalog viewer"));
+        assert!(repaired.contains("author=\"ndizazzo\""));
+        assert!(repaired.contains("updated_at=\"2026-06-06T07:18:23Z\""));
+        assert!(repaired.contains("I do not see a `Nick` author/login"));
+        assert!(!repaired.contains("#709"));
+        assert!(!repaired.contains("updated in May"));
     }
 
     fn tool_call_msg(id: &str, name: &str) -> Value {

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1158,8 +1158,9 @@ fn append_web_research_budget_instruction(messages: &mut [Value], count: usize) 
     let instruction = format!(
         "\n\nWeb research budget guard: {count} completed web_search/web_fetch calls are already \
          in context. Do not call web_search or web_fetch again. Answer now from the gathered \
-         evidence. If the evidence is incomplete or ambiguous, give the best effort answer and \
-         state what is missing."
+         evidence. For GitHub/web results, only use exact numbers, titles, authors, statuses, \
+         and URLs present in the evidence. If the evidence is incomplete, ambiguous, or conflicts \
+         with the user's premise, say that directly instead of inventing missing facts."
     );
     append_system_instruction(messages, &instruction);
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -2295,10 +2295,10 @@ fn answer_appears_to_use_non_answerable_tool_result(answer: &str, result: &str) 
 
 fn non_answerable_tool_result_answer(session: &Session, tool: &str, result: &str) -> String {
     let prompt = session.active_user_text();
-    if prompt_asks_for_pull_requests(&prompt)
-        && plain_text_tool_result_looks_like_github_repo_list(result)
+    if prompt_asks_for_work_items(&prompt)
+        && plain_text_tool_result_looks_like_repository_list(result)
     {
-        return "The latest tool result listed repositories, not pull requests, so I can't answer the PR request from that output. I need the target repository or a corrected PR-list result before I can pick an interesting PR.".to_string();
+        return "The latest tool result listed repositories, not the requested work items, so I can't answer from that output. I need a corrected work-item result before I can pick an item.".to_string();
     }
 
     let first_line = result
@@ -2783,7 +2783,12 @@ fn structured_tool_result_rows(value: &Value, prompt: &str) -> Vec<StructuredToo
                 "nodes",
                 "data",
                 "pullRequests",
+                "mergeRequests",
                 "issues",
+                "tickets",
+                "tasks",
+                "workItems",
+                "work_items",
             ]
             .iter()
             .filter_map(|key| map.get(*key))
@@ -2802,7 +2807,7 @@ fn structured_tool_row(value: &Value, prompt: &str) -> Option<StructuredToolRow>
     let title = first_string_field(map, &["title", "name", "subject", "summary"])?;
     let id = first_identifier_field(map, &["number", "id", "key"]);
     let url = first_string_field(map, &["url", "html_url", "web_url", "permalink"]);
-    if id.is_none() && url.is_none() && !prompt_asks_for_github_work_items(prompt) {
+    if id.is_none() && url.is_none() && !prompt_asks_for_work_items(prompt) {
         return None;
     }
 
@@ -2861,7 +2866,7 @@ fn structured_tool_row_details(map: &serde_json::Map<String, Value>) -> Vec<Stri
 fn format_structured_tool_row(row: &StructuredToolRow, prompt: &str) -> String {
     let mut text = match row.id.as_deref() {
         Some(id)
-            if prompt_asks_for_pull_requests(prompt)
+            if prompt_asks_for_numbered_work_items(prompt)
                 && id.chars().all(|ch| ch.is_ascii_digit()) =>
         {
             format!("#{id} - {}", row.title)
@@ -3149,18 +3154,14 @@ fn tool_result_has_answerable_evidence_for_prompt(result: &str, prompt: &str) ->
     if prompt_asks_for_feedback(prompt) && !tool_result_has_feedback_evidence(result, prompt) {
         return false;
     }
-    if prompt_asks_for_github_work_items(prompt)
-        && plain_text_tool_result_looks_like_github_auth_status(result)
-    {
+    if prompt_asks_for_work_items(prompt) && plain_text_tool_result_looks_like_auth_status(result) {
         return false;
     }
-    if prompt_asks_for_pull_requests(prompt)
-        && plain_text_tool_result_looks_like_git_remotes(result)
-    {
+    if prompt_asks_for_work_items(prompt) && plain_text_tool_result_looks_like_git_remotes(result) {
         return false;
     }
-    if plain_text_tool_result_looks_like_github_repo_list(result)
-        && !prompt_asks_for_github_repositories(prompt)
+    if plain_text_tool_result_looks_like_repository_list(result)
+        && !prompt_asks_for_repositories(prompt)
     {
         return false;
     }
@@ -3289,31 +3290,57 @@ fn plain_text_tool_result_looks_empty(result: &str) -> bool {
     )
 }
 
-fn prompt_asks_for_github_work_items(prompt: &str) -> bool {
+fn prompt_asks_for_work_items(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
-    let asks_github = lower.contains("gh ")
-        || lower.contains("github")
+    let asks_specific_work_items = prompt_has_word(&lower, "pr")
+        || prompt_has_word(&lower, "prs")
+        || prompt_has_word(&lower, "pulls")
         || lower.contains("pull request")
-        || prompt_has_word(&lower, "pr")
-        || lower.contains("issue");
-    let asks_work_items = prompt_has_word(&lower, "pr")
-        || lower.contains("pull request")
+        || lower.contains("pull requests")
+        || lower.contains("merge request")
+        || lower.contains("merge requests")
         || lower.contains("issue")
-        || lower.contains("interesting")
-        || lower.contains("recent")
-        || lower.contains("open");
-    asks_github && asks_work_items
+        || lower.contains("issues")
+        || lower.contains("ticket")
+        || lower.contains("tickets")
+        || lower.contains("task")
+        || lower.contains("tasks")
+        || lower.contains("bug")
+        || lower.contains("bugs")
+        || lower.contains("work item")
+        || lower.contains("work items");
+    let asks_listing = contains_any(
+        &lower,
+        &[
+            "list",
+            "find",
+            "show",
+            "check",
+            "get",
+            "recent",
+            "open",
+            "important",
+            "interesting",
+            "status",
+        ],
+    );
+    asks_specific_work_items && asks_listing
 }
 
-fn prompt_asks_for_pull_requests(prompt: &str) -> bool {
+fn prompt_asks_for_numbered_work_items(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
     prompt_has_word(&lower, "pr")
         || prompt_has_word(&lower, "prs")
         || prompt_has_word(&lower, "pulls")
         || lower.contains("pull request")
+        || lower.contains("merge request")
+        || lower.contains("issue")
+        || lower.contains("ticket")
+        || lower.contains("task")
+        || lower.contains("work item")
 }
 
-fn prompt_asks_for_github_repositories(prompt: &str) -> bool {
+fn prompt_asks_for_repositories(prompt: &str) -> bool {
     let lower = prompt.to_ascii_lowercase();
     prompt_has_word(&lower, "repo")
         || prompt_has_word(&lower, "repos")
@@ -3327,16 +3354,18 @@ fn prompt_has_word(prompt: &str, needle: &str) -> bool {
         .any(|token| token == needle)
 }
 
-fn plain_text_tool_result_looks_like_github_auth_status(result: &str) -> bool {
+fn plain_text_tool_result_looks_like_auth_status(result: &str) -> bool {
     let normalized = result.replace('\r', "");
     let lower = normalized.trim_start().to_ascii_lowercase();
     let first_line = lower.lines().next().unwrap_or("").trim();
-    first_line == "github.com"
-        && lower.contains("logged in to github.com")
-        && lower.contains("active account:")
+    let first_line_looks_like_service =
+        first_line.contains('.') && !first_line.contains(char::is_whitespace);
+    first_line_looks_like_service
+        && (lower.contains("logged in to") || lower.contains("authenticated"))
+        && (lower.contains("active account") || lower.contains("account:"))
 }
 
-fn plain_text_tool_result_looks_like_github_repo_list(result: &str) -> bool {
+fn plain_text_tool_result_looks_like_repository_list(result: &str) -> bool {
     let rows = result
         .lines()
         .map(str::trim)
@@ -3346,20 +3375,44 @@ fn plain_text_tool_result_looks_like_github_repo_list(result: &str) -> bool {
             Some((columns.next()?, columns.next()?, columns.next()?))
         });
     rows.take(3).any(|(repo, _description, visibility)| {
-        repo.contains('/')
-            && !repo.contains(char::is_whitespace)
+        repository_slug_looks_like_owner_name(repo)
             && (visibility.contains("public") || visibility.contains("private"))
     })
+}
+
+fn repository_slug_looks_like_owner_name(value: &str) -> bool {
+    let mut parts = value.split('/');
+    let Some(owner) = parts.next() else {
+        return false;
+    };
+    let Some(name) = parts.next() else {
+        return false;
+    };
+    parts.next().is_none()
+        && !owner.is_empty()
+        && !name.is_empty()
+        && owner.chars().all(repository_slug_char)
+        && name.chars().all(repository_slug_char)
+}
+
+fn repository_slug_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | '.')
 }
 
 fn plain_text_tool_result_looks_like_git_remotes(result: &str) -> bool {
     result.lines().map(str::trim).any(|line| {
         let mut columns = line.split('\t').map(str::trim);
         matches!(columns.next(), Some("origin" | "upstream"))
-            && columns.next().is_some_and(|remote| {
-                remote.contains("github.com:") || remote.contains("github.com/")
-            })
+            && columns.next().is_some_and(looks_like_git_remote_location)
     })
+}
+
+fn looks_like_git_remote_location(remote: &str) -> bool {
+    remote.contains("://")
+        || remote.contains('@')
+        || remote.contains(".git")
+        || remote.contains(" (fetch)")
+        || remote.contains(" (push)")
 }
 
 fn plain_text_tool_result_looks_like_error(result: &str) -> bool {

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -51,8 +51,8 @@ pub(crate) use tool_guard::enforce_tool_call_contract;
 use backend::call_backend;
 use fanout::{GraceMode, gather_workers_incremental};
 use mesh_llm_guardrails::{
-    extract_tool_name_and_arguments, normalize_tool_arguments, sanitize_tool_arguments_for_tool,
-    tool_arguments_wire_string,
+    ToolCallParseError, extract_tool_name_and_arguments, normalize_tool_arguments,
+    rescue_tool_call_from_text, sanitize_tool_arguments_for_tool, tool_arguments_wire_string,
 };
 use normalize::WorkerOutput;
 use reducer::{hedged_reducer_call, reducer_candidates};
@@ -4468,6 +4468,9 @@ fn chat_or_schema_command_tool_response(
     if let Some(tool) = command_tool {
         return tool_call_response(&tool.name, &tool.fallback_arguments);
     }
+    if let Some(response) = rescued_tool_call_response(content, tools, allowed_tools) {
+        return response;
+    }
     if let Some(tool) =
         inline_json_tool_choice_from_text(content, tools, allowed_tools, prompt_tool_profiles)
     {
@@ -4485,6 +4488,56 @@ fn chat_or_schema_command_tool_response(
     }
 
     chat_response(content)
+}
+
+fn rescued_tool_call_response(
+    content: &str,
+    tools: Option<&Value>,
+    allowed_tools: &[String],
+) -> Option<Value> {
+    if allowed_tools.is_empty() {
+        return None;
+    }
+    match rescue_tool_call_from_text(content, allowed_tools) {
+        Ok(calls) => {
+            let call = calls.into_iter().next()?;
+            match validate_response_tool_arguments(
+                &call.name,
+                &Value::Object(call.arguments),
+                tools,
+                allowed_tools,
+                &[],
+            ) {
+                Ok(arguments) => Some(tool_call_response(&call.name, &arguments)),
+                Err(err) => {
+                    tracing::info!("moa: rescued tool call {} rejected: {err}", call.name);
+                    Some(error_response(
+                        "MoA reducer returned an invalid tool call",
+                        MOA_ERR_NO_USABLE_ANSWER,
+                    ))
+                }
+            }
+        }
+        Err(ToolCallParseError::UnknownTool | ToolCallParseError::InvalidArguments)
+            if starts_with_tool_call_envelope(content) =>
+        {
+            Some(error_response(
+                "MoA reducer returned an undeclared or invalid tool call",
+                MOA_ERR_NO_USABLE_ANSWER,
+            ))
+        }
+        Err(ToolCallParseError::Malformed)
+        | Err(ToolCallParseError::UnknownTool)
+        | Err(ToolCallParseError::InvalidArguments) => None,
+    }
+}
+
+fn starts_with_tool_call_envelope(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed.starts_with("[TOOL_CALL]")
+        || trimmed.starts_with("<|tool_call>")
+        || trimmed.starts_with("<tool_call>")
+        || trimmed.starts_with("<function=")
 }
 
 fn fenced_command_tool_conversion_allowed(user_text: Option<&str>) -> bool {
@@ -7507,6 +7560,65 @@ mod response_builder_tests {
                 .pointer("/choices/0/message/tool_calls/0/function/arguments")
                 .and_then(Value::as_str),
             Some("{\"command\":\"pwd\"}")
+        );
+    }
+
+    #[test]
+    fn bracketed_arrow_tool_call_maps_to_declared_tool() {
+        let tools = read_file_tool_schema();
+        let response = chat_or_schema_command_tool_response(
+            "[TOOL_CALL]\n{tool => \"read_file\", args => {path: \"README.md\"}}\n[/TOOL_CALL]",
+            Some(&tools),
+            &["read_file".to_string()],
+            &[],
+            Some("Read README.md."),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls")
+        );
+        assert_eq!(
+            response
+                .pointer("/choices/0/message/tool_calls/0/function/name")
+                .and_then(Value::as_str),
+            Some("read_file")
+        );
+        assert_eq!(
+            response.pointer("/choices/0/message/tool_calls/0/function/arguments"),
+            Some(&Value::String("{\"path\":\"README.md\"}".to_string()))
+        );
+    }
+
+    #[test]
+    fn unknown_bracketed_arrow_tool_call_does_not_leak_as_content() {
+        let tools = read_file_tool_schema();
+        let response = chat_or_schema_command_tool_response(
+            "[TOOL_CALL]\n{tool => \"filesystem_list_allowed_directories\", args => {}}\n[/TOOL_CALL]",
+            Some(&tools),
+            &["read_file".to_string()],
+            &[],
+            Some("Read README.md."),
+        );
+
+        assert_eq!(
+            response
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("error")
+        );
+        assert_eq!(
+            response.pointer("/error/code").and_then(Value::as_str),
+            Some(MOA_ERR_NO_USABLE_ANSWER)
+        );
+        assert!(
+            response
+                .pointer("/choices/0/message/content")
+                .and_then(Value::as_str)
+                .is_some_and(|content| !content.contains("[TOOL_CALL]")),
+            "pseudo tool call must not leak to client: {response}"
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1435,11 +1435,16 @@ fn message_role(msg: &Value) -> &str {
 }
 
 fn message_is_task_user(msg: &Value) -> bool {
-    message_role(msg) == "user" && !message_is_synthetic_user(msg)
+    task_text_from_message(msg).is_some()
 }
 
-fn message_is_synthetic_user(msg: &Value) -> bool {
-    message_text(msg).is_some_and(|text| text.trim_start().starts_with("<info-msg>"))
+fn task_text_from_message(msg: &Value) -> Option<String> {
+    (message_role(msg) == "user")
+        .then(|| message_text(msg))
+        .flatten()
+        .and_then(strip_info_msg_prefix)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
 }
 
 fn message_text(msg: &Value) -> Option<String> {
@@ -1458,6 +1463,20 @@ fn message_text(msg: &Value) -> Option<String> {
         .collect::<Vec<_>>()
         .join("\n");
     (!text.is_empty()).then_some(text)
+}
+
+fn strip_info_msg_prefix(text: String) -> Option<String> {
+    let trimmed = text.trim_start();
+    if !trimmed.starts_with("<info-msg>") {
+        return Some(text);
+    }
+    let close = "</info-msg>";
+    let close_start = trimmed.find(close)?;
+    Some(
+        trimmed[close_start + close.len()..]
+            .trim_start()
+            .to_string(),
+    )
 }
 
 fn contains_any(text: &str, needles: &[&str]) -> bool {
@@ -6713,6 +6732,40 @@ mod response_builder_tests {
             &session.active_user_text(),
             &session
         ));
+    }
+
+    #[test]
+    fn goose_info_prefix_preserves_tool_intent_text() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "<info-msg>\nWorking directory: /tmp/project\n</info-msg>\nActually use the shell tool. Run pwd."
+            })],
+            &Some(serde_json::json!([{
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "description": "Run shell commands",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Shell command to execute"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }])),
+        );
+
+        assert_eq!(
+            session.last_user_text(),
+            "Actually use the shell tool. Run pwd."
+        );
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[], &[]),
+            vec!["shell".to_string()]
+        );
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1597,10 +1597,13 @@ async fn handle_tool_result(
         tracing::info!("moa: forcing answer after {count} completed tool calls");
         append_tool_budget_instruction(&mut messages, count);
     }
-    if tools_enabled_for_reducer
-        && let Some((tool, _)) = latest_completed_tool_result(session)
+    let retry_tool = if tools_enabled_for_reducer {
+        latest_completed_tool_result(session)
             .filter(|(_, result)| !tool_result_has_answerable_evidence(result))
-    {
+    } else {
+        None
+    };
+    if let Some((tool, _)) = retry_tool {
         tracing::info!(
             "moa: latest {tool} tool result looks like error/usage output; asking reducer to retry"
         );
@@ -3410,10 +3413,10 @@ mod response_builder_tests {
         let args = infer_tool_arguments_from_prompt(
             "read",
             tools.as_ref(),
-            "Use the read tool to read /tmp/openclaw_moa_probe.txt.",
+            "Use the read tool to read /tmp/moa_probe.txt.",
         );
 
-        assert_eq!(args, json!({"path": "/tmp/openclaw_moa_probe.txt"}));
+        assert_eq!(args, json!({"path": "/tmp/moa_probe.txt"}));
     }
 
     #[test]
@@ -3433,7 +3436,7 @@ mod response_builder_tests {
         session.ingest(
             &[serde_json::json!({
                 "role": "user",
-                "content": "Use the read tool to read /tmp/openclaw_moa_probe.txt."
+                "content": "Use the read tool to read /tmp/moa_probe.txt."
             })],
             &tools,
         );
@@ -3445,7 +3448,7 @@ mod response_builder_tests {
         assert_eq!(required.name, "read");
         assert_eq!(
             required.fallback_arguments,
-            json!({"path": "/tmp/openclaw_moa_probe.txt"})
+            json!({"path": "/tmp/moa_probe.txt"})
         );
     }
 
@@ -3455,7 +3458,7 @@ mod response_builder_tests {
             "model": VIRTUAL_MODEL_NAME,
             "messages": [{
                 "role": "user",
-                "content": "Use the read tool to read /tmp/openclaw_moa_probe.txt."
+                "content": "Use the read tool to read /tmp/moa_probe.txt."
             }],
             "tools": [{
                 "type": "function",
@@ -3503,7 +3506,7 @@ mod response_builder_tests {
                 .response_body
                 .pointer("/choices/0/message/tool_calls/0/function/arguments")
                 .and_then(Value::as_str),
-            Some("{\"path\":\"/tmp/openclaw_moa_probe.txt\"}")
+            Some("{\"path\":\"/tmp/moa_probe.txt\"}")
         );
     }
 
@@ -3696,7 +3699,7 @@ mod response_builder_tests {
         session.ingest(
             &[serde_json::json!({
                 "role": "user",
-                "content": "Use a tool to read /tmp/openclaw-tool-baseline.txt",
+                "content": "Use a tool to read /tmp/moa-tool-baseline.txt",
             })],
             &Some(serde_json::json!([{"type": "function", "function": {"name": "read"}}])),
         );
@@ -3951,7 +3954,7 @@ mod response_builder_tests {
     }
 
     #[test]
-    fn command_intent_selects_exec_from_openclaw_like_tool_catalog() {
+    fn command_intent_selects_exec_from_agent_tool_catalog() {
         let mut session = Session::new();
         session.ingest(
             &[serde_json::json!({
@@ -4344,7 +4347,7 @@ mod response_builder_tests {
                 tool_call_msg("call_1", "exec"),
                 tool_result_msg(
                     "call_1",
-                    "808\tStabilize OpenClaw tool loops through MoA\tfix/openclaw-moa-telegram-timeouts\tOPEN\n806\tAdd meshllm.cloud website, catalog viewer, and onboarding docs\tfeature/new-public-website\tOPEN",
+                    "808\tStabilize tool loops through MoA\tfix/moa-tool-timeouts\tOPEN\n806\tAdd meshllm.cloud website, catalog viewer, and onboarding docs\tfeature/new-public-website\tOPEN",
                 ),
                 serde_json::json!({
                     "role": "user",
@@ -4356,7 +4359,7 @@ mod response_builder_tests {
 
         let repaired = repair_tool_result_answer(&session, "#808");
 
-        assert_eq!(repaired, "#808 - Stabilize OpenClaw tool loops through MoA");
+        assert_eq!(repaired, "#808 - Stabilize tool loops through MoA");
     }
 
     #[test]
@@ -4396,7 +4399,7 @@ mod response_builder_tests {
 
     #[test]
     fn normal_tabular_cli_output_is_answerable_tool_evidence() {
-        let result = "808\tStabilize OpenClaw tool loops through MoA\tOPEN";
+        let result = "808\tStabilize tool loops through MoA\tOPEN";
 
         assert!(tool_result_has_answerable_evidence(result));
     }
@@ -4654,7 +4657,7 @@ mod response_builder_tests {
             prompt_tool_session("Use gh to list recent open PRs for mesh-LLM/mesh-llm.");
 
         let response = chat_or_schema_command_tool_response(
-            "<minimax:tool_call>\n<invoke name=\"exec\">\n<parameter name=\"command\">gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10</command>\n</invoke>\n</minimax:tool_call>",
+            "<tool_call>\n<invoke name=\"exec\">\n<parameter name=\"command\">gh pr list --repo mesh-LLM/mesh-llm --state open --limit 10</command>\n</invoke>\n</tool_call>",
             session.tools(),
             &allowed,
             &profiles,

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -59,6 +59,7 @@ pub fn normalize_worker_output(
     // can panic on `unwrap`.
     let output = try_json_parse(text, model, role, elapsed_ms)
         .or_else(|| try_kv_parse(text, model, role, elapsed_ms))
+        .or_else(|| try_minimax_xml_tool_call(text, model, role, elapsed_ms))
         .unwrap_or_else(|| {
             let mut heuristic = heuristic_classify(text, model, role, elapsed_ms);
             // Heuristic path can leak stray KV envelope lines into the payload
@@ -372,6 +373,28 @@ fn try_kv_parse(raw: &str, model: &str, role: WorkerRole, elapsed_ms: u64) -> Op
     })
 }
 
+/// Try parsing Minimax's XML-ish tool-call envelope:
+///
+/// `<minimax:tool_call><invoke name="web_fetch">...`
+fn try_minimax_xml_tool_call(
+    raw: &str,
+    model: &str,
+    role: WorkerRole,
+    elapsed_ms: u64,
+) -> Option<WorkerOutput> {
+    let (tool_name, arguments) = extract_minimax_xml_tool_call(raw)?;
+    Some(WorkerOutput {
+        kind: OutputKind::ToolProposal,
+        confidence: 0.75,
+        tool_name: Some(tool_name),
+        tool_arguments: Some(Value::Object(arguments)),
+        payload: raw.to_string(),
+        model: model.to_string(),
+        role,
+        elapsed_ms,
+    })
+}
+
 /// Heuristic: classify raw text by content patterns.
 fn heuristic_classify(raw: &str, model: &str, role: WorkerRole, elapsed_ms: u64) -> WorkerOutput {
     if let Some(tool_call) = first_rescued_tool_call(raw) {
@@ -526,6 +549,10 @@ fn looks_like_uncertainty(lower: &str) -> bool {
 
 /// Try to extract a tool name and arguments from messy text.
 fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
+    if let Some((tool_name, arguments)) = extract_minimax_xml_tool_call(raw) {
+        return (Some(tool_name), Some(Value::Object(arguments)));
+    }
+
     if let Some(tool_call) = first_rescued_tool_call(raw) {
         return (
             Some(tool_call.name),
@@ -563,6 +590,59 @@ fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
     }
 
     (None, None)
+}
+
+fn extract_minimax_xml_tool_call(raw: &str) -> Option<(String, serde_json::Map<String, Value>)> {
+    if !raw.contains("<invoke") || !raw.contains("<parameter") {
+        return None;
+    }
+
+    let invoke_start = raw.find("<invoke")?;
+    let invoke_tail = &raw[invoke_start..];
+    let invoke_tag_end = invoke_tail.find('>')?;
+    let invoke_tag = &invoke_tail[..=invoke_tag_end];
+    let tool_name = extract_xml_attr(invoke_tag, "name")?;
+
+    let mut arguments = serde_json::Map::new();
+    let mut cursor = raw;
+    while let Some(parameter_start) = cursor.find("<parameter") {
+        cursor = &cursor[parameter_start..];
+        let tag_end = cursor.find('>')?;
+        let tag = &cursor[..=tag_end];
+        let name = extract_xml_attr(tag, "name")?;
+        let value_start = tag_end + 1;
+        let value_tail = &cursor[value_start..];
+        let value_end = value_tail.find("</parameter>")?;
+        let value = xml_unescape(value_tail[..value_end].trim());
+        arguments.insert(name, Value::String(value));
+        cursor = &value_tail[value_end + "</parameter>".len()..];
+    }
+
+    Some((tool_name, arguments))
+}
+
+fn extract_xml_attr(tag: &str, attr: &str) -> Option<String> {
+    extract_quoted_xml_attr(tag, attr, '"').or_else(|| extract_quoted_xml_attr(tag, attr, '\''))
+}
+
+fn extract_quoted_xml_attr(tag: &str, attr: &str, quote: char) -> Option<String> {
+    let marker = format!("{attr}={quote}");
+    let value_start = tag.find(&marker)? + marker.len();
+    let value_tail = &tag[value_start..];
+    let value_end = value_tail.find(quote)?;
+    let value = value_tail[..value_end].trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+fn xml_unescape(value: &str) -> String {
+    value
+        .replace("&quot;", "\"")
+        .replace("&#34;", "\"")
+        .replace("&apos;", "'")
+        .replace("&#39;", "'")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
 }
 
 /// Find the first JSON object in text (handles markdown fences, etc.).
@@ -853,5 +933,21 @@ mod tests {
         assert_eq!(out.kind, OutputKind::ToolProposal);
         assert_eq!(out.tool_name.as_deref(), Some("read_file"));
         assert_eq!(out.tool_arguments.expect("args")["path"], "README.md");
+    }
+
+    #[test]
+    fn minimax_xml_tool_call_uses_local_rescue() {
+        let raw = r#"<minimax:tool_call>
+<invoke name="web_fetch">
+<parameter name="url">https://github.com/Mesh-LLM/mesh-llm/issues?q=is%3Aissue+is%3Aopen+label%3Abug&amp;sort=updated</parameter>
+</invoke>
+</minimax:tool_call>"#;
+        let out = normalize_worker_output(raw, "minimax", WorkerRole::Reducer, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("web_fetch"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["url"],
+            "https://github.com/Mesh-LLM/mesh-llm/issues?q=is%3Aissue+is%3Aopen+label%3Abug&sort=updated"
+        );
     }
 }

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -468,21 +468,6 @@ fn heuristic_classify(raw: &str, model: &str, role: WorkerRole, elapsed_ms: u64)
     }
 }
 
-/// Known tool names that models might reference in prose.  These are
-/// matched against the lowercased text to detect tool proposals that
-/// weren't formatted as structured output.
-const KNOWN_TOOLS: &[&str] = &[
-    "read_file",
-    "edit_file",
-    "run_command",
-    "search_code",
-    "web_search",
-    "get_weather",
-    "create_file",
-    "delete_file",
-    "list_files",
-];
-
 fn looks_like_tool_proposal(lower: &str, _raw: &str) -> bool {
     // Explicit structured markers
     let has_structured = lower.contains("tool_call")
@@ -493,28 +478,6 @@ fn looks_like_tool_proposal(lower: &str, _raw: &str) -> bool {
 
     if has_structured && !lower.contains("i would not") {
         return true;
-    }
-
-    // Agentic patterns: model describes using a tool by name
-    let mentions_tool = KNOWN_TOOLS.iter().any(|t| lower.contains(t));
-    if mentions_tool {
-        // Must also have an action verb — not just mentioning the tool in discussion
-        let has_action = lower.contains("i'll use")
-            || lower.contains("i will use")
-            || lower.contains("let me use")
-            || lower.contains("i need to use")
-            || lower.contains("use the")
-            || lower.contains("using the")
-            || lower.contains("should use")
-            || lower.contains("call the")
-            || lower.contains("calling")
-            || lower.contains("propose")
-            || lower.contains("**tool**")
-            || lower.contains("tool:")
-            || lower.contains("identify the tool");
-        if has_action {
-            return true;
-        }
     }
 
     false
@@ -563,30 +526,12 @@ fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
     // Strategy 1: Look for structured JSON in the text
     let parsed_json =
         extract_json_object(raw).and_then(|json_str| serde_json::from_str::<Value>(&json_str).ok());
-    if let Some(obj) = parsed_json {
-        if let Some((name, arguments)) = extract_tool_name_and_arguments(&obj) {
-            let args = normalize_tool_arguments(arguments).map(Value::Object);
-            return (Some(name.to_string()), args);
-        }
-        // Could be the arguments themselves (e.g. {"path": "src/auth.py"})
-        // Look for a tool name in the surrounding text
-        let lower = raw.to_lowercase();
-        for tool in KNOWN_TOOLS {
-            if lower.contains(tool) {
-                return (Some(tool.to_string()), Some(obj));
-            }
-        }
-    }
-
-    // Strategy 2: Find a known tool name in prose and try to extract args
-    let lower = raw.to_lowercase();
-    for tool in KNOWN_TOOLS {
-        if lower.contains(tool) {
-            // Try to find JSON arguments nearby
-            let args =
-                extract_json_object(raw).and_then(|s| serde_json::from_str::<Value>(&s).ok());
-            return (Some(tool.to_string()), args);
-        }
+    if let Some((name, arguments)) = parsed_json
+        .as_ref()
+        .and_then(extract_tool_name_and_arguments)
+    {
+        let args = normalize_tool_arguments(arguments).map(Value::Object);
+        return (Some(name.to_string()), args);
     }
 
     (None, None)
@@ -776,21 +721,19 @@ mod tests {
     }
 
     #[test]
-    fn prose_tool_proposal() {
-        // Small models often describe tool usage in prose instead of structured output
+    fn prose_known_tool_name_without_schema_stays_answer() {
         let raw = "I'll use the read_file tool to examine the code:\n```json\n{\"path\": \"src/auth.py\"}\n```";
         let out = normalize_worker_output(raw, "small-model", WorkerRole::Fast, 100);
-        assert_eq!(out.kind, OutputKind::ToolProposal);
-        assert_eq!(out.tool_name.as_deref(), Some("read_file"));
+        assert_eq!(out.kind, OutputKind::Answer);
+        assert_eq!(out.tool_name, None);
     }
 
     #[test]
-    fn prose_edit_proposal() {
+    fn prose_edit_name_without_schema_stays_answer() {
         let raw = "I need to use the edit_file tool to fix this bug. The arguments would be:\n{\"path\": \"src/auth.py\", \"old_text\": \"== password\", \"new_text\": \"== hash(password)\"}";
         let out = normalize_worker_output(raw, "qwen3:4b", WorkerRole::Specialist, 200);
-        assert_eq!(out.kind, OutputKind::ToolProposal);
-        assert_eq!(out.tool_name.as_deref(), Some("edit_file"));
-        assert!(out.tool_arguments.is_some());
+        assert_eq!(out.kind, OutputKind::Answer);
+        assert_eq!(out.tool_name, None);
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -415,16 +415,18 @@ fn heuristic_classify(raw: &str, model: &str, role: WorkerRole, elapsed_ms: u64)
     // Check for tool call patterns
     if looks_like_tool_proposal(&lower, raw) {
         let (name, args) = extract_tool_proposal(raw);
-        return WorkerOutput {
-            kind: OutputKind::ToolProposal,
-            confidence: 0.6,
-            tool_name: name,
-            tool_arguments: args,
-            payload: raw.to_string(),
-            model: model.to_string(),
-            role,
-            elapsed_ms,
-        };
+        if name.is_some() || args.is_some() {
+            return WorkerOutput {
+                kind: OutputKind::ToolProposal,
+                confidence: 0.6,
+                tool_name: name,
+                tool_arguments: args,
+                payload: raw.to_string(),
+                model: model.to_string(),
+                role,
+                elapsed_ms,
+            };
+        }
     }
 
     // Check for critique patterns
@@ -538,6 +540,9 @@ fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
 }
 
 fn extract_xml_tool_call(raw: &str) -> Option<(String, serde_json::Map<String, Value>)> {
+    if !starts_with_xml_tool_call_wrapper(raw) {
+        return None;
+    }
     if !raw.contains("<invoke") || !raw.contains("<parameter") {
         return None;
     }
@@ -564,6 +569,22 @@ fn extract_xml_tool_call(raw: &str) -> Option<(String, serde_json::Map<String, V
     }
 
     Some((tool_name, arguments))
+}
+
+fn starts_with_xml_tool_call_wrapper(raw: &str) -> bool {
+    let Some(rest) = raw.trim_start().strip_prefix('<') else {
+        return false;
+    };
+    if matches!(rest.chars().next(), Some('/' | '!' | '?')) {
+        return false;
+    }
+    let tag = rest
+        .split(|c: char| c == '>' || c.is_ascii_whitespace())
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches('/');
+    let tag = tag.to_ascii_lowercase();
+    tag == "tool_call" || tag.ends_with(":tool_call")
 }
 
 fn xml_parameter_close(value_tail: &str, parameter_name: &str) -> Option<(usize, usize)> {
@@ -916,6 +937,37 @@ mod tests {
             out.tool_arguments.expect("args")["url"],
             "https://github.com/Mesh-LLM/mesh-llm/issues?q=is%3Aissue+is%3Aopen+label%3Abug&sort=updated"
         );
+    }
+
+    #[test]
+    fn namespaced_xml_tool_call_uses_local_rescue() {
+        let raw = r#"<minimax:tool_call>
+<invoke name="web_fetch">
+<parameter name="url">https://github.com/Mesh-LLM/mesh-llm/pull/808</parameter>
+</invoke>
+</minimax:tool_call>"#;
+        let out = normalize_worker_output(raw, "minimax", WorkerRole::Reducer, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("web_fetch"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["url"],
+            "https://github.com/Mesh-LLM/mesh-llm/pull/808"
+        );
+    }
+
+    #[test]
+    fn explanatory_xml_tool_call_text_stays_answer() {
+        let raw = r#"Use this XML shape when calling a tool:
+<tool_call>
+<invoke name="web_fetch">
+<parameter name="url">https://example.com</parameter>
+</invoke>
+</tool_call>"#;
+        let out = normalize_worker_output(raw, "xml-worker", WorkerRole::Reducer, 100);
+        assert_eq!(out.kind, OutputKind::Answer);
+        assert_eq!(out.tool_name, None);
+        assert_eq!(out.tool_arguments, None);
+        assert!(out.payload.contains("Use this XML shape"));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -905,6 +905,28 @@ mod tests {
     }
 
     #[test]
+    fn sentinel_tool_call_uses_guardrail_rescue() {
+        let raw = r#"<|tool_call>call:web_search{query:<|"|>Mesh-LLM #808 Harden OpenClaw/MoA Telegram timeouts<|"|>}<tool_call|>"#;
+        let out = normalize_worker_output(raw, "gemma", WorkerRole::Reducer, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("web_search"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["query"],
+            "Mesh-LLM #808 Harden OpenClaw/MoA Telegram timeouts"
+        );
+    }
+
+    #[test]
+    fn bracketed_arrow_tool_call_uses_guardrail_rescue() {
+        let raw =
+            "[TOOL_CALL]\n{tool => \"read_file\", args => {path: \"README.md\"}}\n[/TOOL_CALL]";
+        let out = normalize_worker_output(raw, "worker", WorkerRole::Reducer, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("read_file"));
+        assert_eq!(out.tool_arguments.expect("args")["path"], "README.md");
+    }
+
+    #[test]
     fn parenthesized_tool_call_uses_guardrail_rescue() {
         let raw = r#"read_file({"path":"README.md"})"#;
         let out = normalize_worker_output(raw, "small-model", WorkerRole::Fast, 100);

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -59,7 +59,7 @@ pub fn normalize_worker_output(
     // can panic on `unwrap`.
     let output = try_json_parse(text, model, role, elapsed_ms)
         .or_else(|| try_kv_parse(text, model, role, elapsed_ms))
-        .or_else(|| try_minimax_xml_tool_call(text, model, role, elapsed_ms))
+        .or_else(|| try_xml_tool_call(text, model, role, elapsed_ms))
         .unwrap_or_else(|| {
             let mut heuristic = heuristic_classify(text, model, role, elapsed_ms);
             // Heuristic path can leak stray KV envelope lines into the payload
@@ -100,10 +100,10 @@ fn sanitize_worker_output(mut output: WorkerOutput) -> WorkerOutput {
     output
 }
 
-/// OpenClaw and similar messaging clients use an exact `NO_REPLY` assistant
-/// message as an app-level "stay silent" directive. MoA workers can copy that
-/// directive from tool/system prompts even for ordinary user questions; treat
-/// it as no usable answer inside the aggregator.
+/// Some agent clients use an exact `NO_REPLY` assistant message as an app-level
+/// "stay silent" directive. MoA workers can copy that directive from tool or
+/// system prompts even for ordinary user questions; treat it as no usable
+/// answer inside the aggregator.
 pub fn is_silent_reply_sentinel(text: &str) -> bool {
     let trimmed = text.trim();
     let unquoted = trimmed
@@ -373,16 +373,16 @@ fn try_kv_parse(raw: &str, model: &str, role: WorkerRole, elapsed_ms: u64) -> Op
     })
 }
 
-/// Try parsing Minimax's XML-ish tool-call envelope:
+/// Try parsing XML-ish tool-call envelopes:
 ///
-/// `<minimax:tool_call><invoke name="web_fetch">...`
-fn try_minimax_xml_tool_call(
+/// `<tool_call><invoke name="read_file"><parameter name="path">README.md</parameter>...`
+fn try_xml_tool_call(
     raw: &str,
     model: &str,
     role: WorkerRole,
     elapsed_ms: u64,
 ) -> Option<WorkerOutput> {
-    let (tool_name, arguments) = extract_minimax_xml_tool_call(raw)?;
+    let (tool_name, arguments) = extract_xml_tool_call(raw)?;
     Some(WorkerOutput {
         kind: OutputKind::ToolProposal,
         confidence: 0.75,
@@ -512,7 +512,7 @@ fn looks_like_uncertainty(lower: &str) -> bool {
 
 /// Try to extract a tool name and arguments from messy text.
 fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
-    if let Some((tool_name, arguments)) = extract_minimax_xml_tool_call(raw) {
+    if let Some((tool_name, arguments)) = extract_xml_tool_call(raw) {
         return (Some(tool_name), Some(Value::Object(arguments)));
     }
 
@@ -537,7 +537,7 @@ fn extract_tool_proposal(raw: &str) -> (Option<String>, Option<Value>) {
     (None, None)
 }
 
-fn extract_minimax_xml_tool_call(raw: &str) -> Option<(String, serde_json::Map<String, Value>)> {
+fn extract_xml_tool_call(raw: &str) -> Option<(String, serde_json::Map<String, Value>)> {
     if !raw.contains("<invoke") || !raw.contains("<parameter") {
         return None;
     }
@@ -557,13 +557,29 @@ fn extract_minimax_xml_tool_call(raw: &str) -> Option<(String, serde_json::Map<S
         let name = extract_xml_attr(tag, "name")?;
         let value_start = tag_end + 1;
         let value_tail = &cursor[value_start..];
-        let value_end = value_tail.find("</parameter>")?;
+        let (value_end, close_len) = xml_parameter_close(value_tail, &name)?;
         let value = xml_unescape(value_tail[..value_end].trim());
         arguments.insert(name, Value::String(value));
-        cursor = &value_tail[value_end + "</parameter>".len()..];
+        cursor = &value_tail[value_end + close_len..];
     }
 
     Some((tool_name, arguments))
+}
+
+fn xml_parameter_close(value_tail: &str, parameter_name: &str) -> Option<(usize, usize)> {
+    let generic = "</parameter>";
+    let named_close = format!("</{parameter_name}>");
+    let generic_match = value_tail.find(generic).map(|idx| (idx, generic.len()));
+    let named_match = value_tail
+        .find(&named_close)
+        .map(|idx| (idx, named_close.len()));
+
+    match (generic_match, named_match) {
+        (Some(generic), Some(named)) => Some(if generic.0 <= named.0 { generic } else { named }),
+        (Some(generic), None) => Some(generic),
+        (None, Some(named)) => Some(named),
+        (None, None) => None,
+    }
 }
 
 fn extract_xml_attr(tag: &str, attr: &str) -> Option<String> {
@@ -580,14 +596,22 @@ fn extract_quoted_xml_attr(tag: &str, attr: &str, quote: char) -> Option<String>
 }
 
 fn xml_unescape(value: &str) -> String {
-    value
-        .replace("&quot;", "\"")
-        .replace("&#34;", "\"")
-        .replace("&apos;", "'")
-        .replace("&#39;", "'")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&amp;", "&")
+    let mut decoded = value.to_string();
+    for _ in 0..3 {
+        let next = decoded
+            .replace("&quot;", "\"")
+            .replace("&#34;", "\"")
+            .replace("&apos;", "'")
+            .replace("&#39;", "'")
+            .replace("&lt;", "<")
+            .replace("&gt;", ">")
+            .replace("&amp;", "&");
+        if next == decoded {
+            break;
+        }
+        decoded = next;
+    }
+    decoded
 }
 
 /// Find the first JSON object in text (handles markdown fences, etc.).
@@ -879,18 +903,32 @@ mod tests {
     }
 
     #[test]
-    fn minimax_xml_tool_call_uses_local_rescue() {
-        let raw = r#"<minimax:tool_call>
+    fn xml_tool_call_uses_local_rescue() {
+        let raw = r#"<tool_call>
 <invoke name="web_fetch">
 <parameter name="url">https://github.com/Mesh-LLM/mesh-llm/issues?q=is%3Aissue+is%3Aopen+label%3Abug&amp;sort=updated</parameter>
 </invoke>
-</minimax:tool_call>"#;
-        let out = normalize_worker_output(raw, "minimax", WorkerRole::Reducer, 100);
+</tool_call>"#;
+        let out = normalize_worker_output(raw, "xml-worker", WorkerRole::Reducer, 100);
         assert_eq!(out.kind, OutputKind::ToolProposal);
         assert_eq!(out.tool_name.as_deref(), Some("web_fetch"));
         assert_eq!(
             out.tool_arguments.expect("args")["url"],
             "https://github.com/Mesh-LLM/mesh-llm/issues?q=is%3Aissue+is%3Aopen+label%3Abug&sort=updated"
         );
+    }
+
+    #[test]
+    fn xml_tool_call_accepts_named_parameter_close_and_double_escaped_entities() {
+        let raw = r#"<tool_call>
+<invoke name="read_file">
+<parameter name="path">&amp;lt;README.md&amp;gt;</path>
+</invoke>
+</tool_call>"#;
+        let out = normalize_worker_output(raw, "xml-worker", WorkerRole::Reducer, 100);
+
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("read_file"));
+        assert_eq!(out.tool_arguments.expect("args")["path"], "<README.md>");
     }
 }

--- a/crates/mesh-mixture-of-agents/src/reducer.rs
+++ b/crates/mesh-mixture-of-agents/src/reducer.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 /// Pick the reducer — prefers first model (typically local, zero RTT).
 /// Reducer candidates in priority order: big-tier models first (multi-
-/// digit B, or names with no size like MiniMax), then small-tier models
+/// digit B, or names with no size), then small-tier models
 /// as last-resort fallback. Callers should try each in order and stop
 /// on the first that succeeds, so a broken big-tier peer (e.g. a peer
 /// running a stale binary that 502s on tool calls) doesn't take down

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -519,11 +519,7 @@ fn canonicalize_tool_response_blocks(msg: &Value) -> Option<Vec<Value>> {
 }
 
 fn canonical_tool_result_from_block(part: &Value) -> Option<Value> {
-    let id = part
-        .get("id")
-        .and_then(Value::as_str)
-        .or_else(|| part.pointer("/toolResult/id").and_then(Value::as_str))
-        .filter(|id| !id.is_empty())?;
+    let id = tool_result_call_id(part)?;
     let content = tool_result_text(part);
 
     Some(serde_json::json!({
@@ -531,6 +527,24 @@ fn canonical_tool_result_from_block(part: &Value) -> Option<Value> {
         "tool_call_id": id,
         "content": content,
     }))
+}
+
+fn tool_result_call_id(part: &Value) -> Option<&str> {
+    [
+        "/id",
+        "/tool_use_id",
+        "/toolUseId",
+        "/tool_call_id",
+        "/toolCallId",
+        "/toolResult/id",
+        "/toolResult/tool_use_id",
+        "/toolResult/toolUseId",
+        "/toolResult/tool_call_id",
+        "/toolResult/toolCallId",
+    ]
+    .into_iter()
+    .find_map(|pointer| part.pointer(pointer).and_then(Value::as_str))
+    .filter(|id| !id.is_empty())
 }
 
 fn tool_result_text(part: &Value) -> String {
@@ -996,6 +1010,44 @@ mod tests {
         assert_eq!(
             messages[4],
             json!({"role": "user", "content": "Please answer briefly."})
+        );
+    }
+
+    #[test]
+    fn tool_result_block_accepts_tool_use_id_alias() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "Read and summarize"}),
+                json!({
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"README.md\"}"}
+                    }]
+                }),
+                json!({
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Tool finished."},
+                        {
+                            "type": "toolResult",
+                            "tool_use_id": "call_read",
+                            "content": "# Mesh LLM"
+                        }
+                    ]
+                }),
+            ],
+            &None,
+        );
+
+        assert_eq!(s.classify_turn(), TurnType::ToolResult);
+        let messages = s.all_messages();
+        assert_eq!(
+            messages[3],
+            json!({"role": "tool", "tool_call_id": "call_read", "content": "# Mesh LLM"})
         );
     }
 }

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -151,9 +151,17 @@ impl Session {
                         .and_then(|c| c.as_str())
                         .unwrap_or("")
                         .to_string();
-                    if let Some(pending) =
-                        self.pending_tools.iter_mut().find(|p| p.call_id == call_id)
+                    if let Some(idx) = self
+                        .pending_tools
+                        .iter()
+                        .rposition(|p| p.call_id == call_id && p.result.is_none())
+                        .or_else(|| {
+                            self.pending_tools
+                                .iter()
+                                .rposition(|p| p.call_id == call_id)
+                        })
                     {
+                        let pending = &mut self.pending_tools[idx];
                         pending.result = Some(content);
                         tracing::info!(
                             "moa session: tool result received for {}({})",
@@ -678,6 +686,31 @@ mod tests {
         assert_eq!(pairs.len(), 1);
         assert_eq!(pairs[0].0, "get_weather");
         assert_eq!(pairs[0].1, "22°C, sunny");
+    }
+
+    #[test]
+    fn repeated_tool_call_ids_pair_with_latest_unresolved_call() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "first"}),
+                json!({"role": "assistant", "content": null, "tool_calls": [{"id": "call_repeat", "type": "function", "function": {"name": "lookup", "arguments": "{\"q\":\"first\"}"}}]}),
+                json!({"role": "tool", "tool_call_id": "call_repeat", "content": "first result"}),
+                json!({"role": "user", "content": "second"}),
+                json!({"role": "assistant", "content": null, "tool_calls": [{"id": "call_repeat", "type": "function", "function": {"name": "lookup", "arguments": "{\"q\":\"second\"}"}}]}),
+                json!({"role": "tool", "tool_call_id": "call_repeat", "content": "second result"}),
+            ],
+            &Some(json!([{"type": "function", "function": {"name": "lookup", "description": "Lookup", "parameters": {}}}])),
+        );
+
+        let pairs = s.recent_tool_results();
+        assert_eq!(
+            pairs,
+            vec![
+                ("lookup".to_string(), "first result".to_string()),
+                ("lookup".to_string(), "second result".to_string())
+            ]
+        );
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -223,7 +223,7 @@ impl Session {
         self.messages
             .iter()
             .rev()
-            .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
+            .find(|m| is_task_user_message(m))
             .and_then(extract_text_content)
             .unwrap_or_default()
     }
@@ -254,7 +254,7 @@ impl Session {
         self.messages[..tool_call_idx]
             .iter()
             .rev()
-            .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
+            .find(|m| is_task_user_message(m))
             .and_then(extract_text_content)
             .unwrap_or_else(|| self.last_user_text())
     }
@@ -599,6 +599,14 @@ fn extract_text_content(msg: &Value) -> Option<String> {
     None
 }
 
+fn is_task_user_message(msg: &Value) -> bool {
+    msg.get("role").and_then(Value::as_str) == Some("user") && !is_synthetic_user_message(msg)
+}
+
+fn is_synthetic_user_message(msg: &Value) -> bool {
+    extract_text_content(msg).is_some_and(|text| text.trim_start().starts_with("<info-msg>"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -828,6 +836,41 @@ mod tests {
             pairs[0].1.contains("unknown flag: --sort"),
             "tool-result text must be available to reducer retry logic: {pairs:?}"
         );
+    }
+
+    #[test]
+    fn goose_info_user_message_does_not_replace_active_task() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "Run pwd, then run ls, then answer."}),
+                json!({
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_pwd",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": "{\"command\":\"pwd\"}"}
+                    }]
+                }),
+                json!({"role": "tool", "tool_call_id": "call_pwd", "content": "/tmp/project"}),
+                json!({"role": "user", "content": "<info-msg>\nWorking directory: /tmp/project\n</info-msg>"}),
+                json!({
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_ls",
+                        "type": "function",
+                        "function": {"name": "shell", "arguments": "{\"command\":\"ls -1\"}"}
+                    }]
+                }),
+                json!({"role": "tool", "tool_call_id": "call_ls", "content": "AGENTS.md"}),
+            ],
+            &None,
+        );
+
+        assert_eq!(s.last_user_text(), "Run pwd, then run ls, then answer.");
+        assert_eq!(s.active_user_text(), "Run pwd, then run ls, then answer.");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -77,7 +77,7 @@ impl Session {
     /// pairing them into `pending_tools` so the reducer-side context packer
     /// can surface tool outputs.
     pub fn ingest(&mut self, messages: &[Value], tools: &Option<Value>) {
-        self.tools = tools.clone();
+        self.tools = tools.as_ref().map(normalize_tool_schemas);
         self.messages = messages.to_vec();
 
         // Rebuild `pending_tools` from the canonical history. Previously
@@ -306,6 +306,44 @@ impl Session {
     }
 }
 
+fn normalize_tool_schemas(tools: &Value) -> Value {
+    let Some(items) = tools.as_array() else {
+        return tools.clone();
+    };
+
+    Value::Array(items.iter().map(normalize_tool_schema).collect())
+}
+
+fn normalize_tool_schema(tool: &Value) -> Value {
+    if tool.get("type").and_then(Value::as_str) == Some("function")
+        && tool.get("function").and_then(Value::as_object).is_some()
+    {
+        return tool.clone();
+    }
+
+    let Some(name) = tool.get("name").and_then(Value::as_str) else {
+        return tool.clone();
+    };
+
+    let mut function = serde_json::Map::new();
+    function.insert("name".to_string(), Value::String(name.to_string()));
+    if let Some(description) = tool.get("description").cloned() {
+        function.insert("description".to_string(), description);
+    }
+    if let Some(parameters) = tool
+        .get("parameters")
+        .or_else(|| tool.get("input_schema"))
+        .cloned()
+    {
+        function.insert("parameters".to_string(), parameters);
+    }
+
+    serde_json::json!({
+        "type": "function",
+        "function": Value::Object(function),
+    })
+}
+
 /// Extract text content from a message (handles both string and multipart).
 fn extract_text_content(msg: &Value) -> Option<String> {
     if let Some(s) = msg.get("content").and_then(|c| c.as_str()) {
@@ -408,6 +446,41 @@ mod tests {
             ])),
         );
         assert_eq!(s.tool_names(), vec!["read_file", "web_search"]);
+    }
+
+    #[test]
+    fn flat_openclaw_tools_are_normalized_to_openai_function_tools() {
+        let mut s = Session::new();
+        s.ingest(
+            &[json!({"role": "user", "content": "Use read on /tmp/a.txt"})],
+            &Some(json!([{
+                "name": "read",
+                "description": "Read the contents of a file.",
+                "parameters": {
+                    "type": "object",
+                    "required": ["path"],
+                    "properties": {
+                        "path": {"type": "string"},
+                        "offset": {"type": "number"},
+                        "limit": {"type": "number"}
+                    }
+                }
+            }])),
+        );
+
+        assert_eq!(s.tool_names(), vec!["read"]);
+        assert_eq!(
+            s.tools()
+                .and_then(|tools| tools.pointer("/0/function/name"))
+                .and_then(Value::as_str),
+            Some("read")
+        );
+        assert_eq!(
+            s.tools()
+                .and_then(|tools| tools.pointer("/0/function/parameters/required/0"))
+                .and_then(Value::as_str),
+            Some("path")
+        );
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -228,6 +228,37 @@ impl Session {
             .unwrap_or_default()
     }
 
+    /// The user request that owns the active tool chain.
+    ///
+    /// Agent transports may wrap tool results in `role: user` content
+    /// blocks, and some clients append small user nudges after a tool
+    /// result. During a tool-result turn, prompt-aware guards need the
+    /// request that caused the latest assistant tool call, not the latest
+    /// transport-level user wrapper.
+    pub fn active_user_text(&self) -> String {
+        let Some(latest_tool_idx) = self
+            .messages
+            .iter()
+            .rposition(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"))
+        else {
+            return self.last_user_text();
+        };
+
+        let Some(tool_call_idx) = self.messages[..latest_tool_idx].iter().rposition(|m| {
+            m.get("role").and_then(|r| r.as_str()) == Some("assistant")
+                && m.get("tool_calls").is_some()
+        }) else {
+            return self.last_user_text();
+        };
+
+        self.messages[..tool_call_idx]
+            .iter()
+            .rev()
+            .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
+            .and_then(extract_text_content)
+            .unwrap_or_else(|| self.last_user_text())
+    }
+
     /// System prompt (first system message).
     pub fn system_prompt(&self) -> Option<String> {
         self.messages
@@ -774,6 +805,7 @@ mod tests {
         );
 
         assert_eq!(s.classify_turn(), TurnType::ToolResult);
+        assert_eq!(s.active_user_text(), "List recent PRs");
 
         let messages = s.all_messages();
         assert_eq!(
@@ -832,6 +864,8 @@ mod tests {
         );
 
         assert_eq!(s.classify_turn(), TurnType::ToolResult);
+        assert_eq!(s.last_user_text(), "Please answer briefly.");
+        assert_eq!(s.active_user_text(), "Read and summarize");
         let messages = s.all_messages();
         assert_eq!(messages.len(), 5);
         assert_eq!(

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -347,7 +347,16 @@ fn normalize_tool_schema(tool: &Value) -> Value {
     if tool.get("type").and_then(Value::as_str) == Some("function")
         && tool.get("function").and_then(Value::as_object).is_some()
     {
-        return tool.clone();
+        let mut normalized = tool.clone();
+        if let (true, Some(function)) = (
+            normalized.pointer("/function/parameters").is_none(),
+            normalized
+                .get_mut("function")
+                .and_then(Value::as_object_mut),
+        ) {
+            function.insert("parameters".to_string(), default_tool_parameters());
+        }
+        return normalized;
     }
 
     let Some(name) = tool.get("name").and_then(Value::as_str) else {
@@ -365,12 +374,18 @@ fn normalize_tool_schema(tool: &Value) -> Value {
         .cloned()
     {
         function.insert("parameters".to_string(), parameters);
+    } else {
+        function.insert("parameters".to_string(), default_tool_parameters());
     }
 
     serde_json::json!({
         "type": "function",
         "function": Value::Object(function),
     })
+}
+
+fn default_tool_parameters() -> Value {
+    serde_json::json!({"type": "object", "properties": {}})
 }
 
 fn canonicalize_agent_tool_messages(messages: &[Value]) -> Vec<Value> {
@@ -560,9 +575,10 @@ fn normalize_content_block_type(kind: &str) -> String {
 }
 
 fn text_from_content_block(part: &Value) -> Option<&str> {
-    match part.get("type").and_then(Value::as_str) {
-        Some("text") => part.get("text").and_then(Value::as_str),
-        _ => None,
+    if is_content_block_type(part, &["text"]) {
+        part.get("text").and_then(Value::as_str)
+    } else {
+        None
     }
 }
 
@@ -580,16 +596,7 @@ fn extract_text_content(msg: &Value) -> Option<String> {
         return Some(s.to_string());
     }
     if let Some(parts) = msg.get("content").and_then(|c| c.as_array()) {
-        let texts: Vec<&str> = parts
-            .iter()
-            .filter_map(|p| {
-                if p.get("type").and_then(|t| t.as_str()) == Some("text") {
-                    p.get("text").and_then(|t| t.as_str())
-                } else {
-                    None
-                }
-            })
-            .collect();
+        let texts: Vec<&str> = parts.iter().filter_map(text_from_content_block).collect();
         if !texts.is_empty() {
             return Some(texts.join("\n"));
         }
@@ -734,6 +741,45 @@ mod tests {
                 .and_then(Value::as_str),
             Some("path")
         );
+    }
+
+    #[test]
+    fn tool_schema_normalization_defaults_missing_parameters() {
+        let mut s = Session::new();
+        s.ingest(
+            &[json!({"role": "user", "content": "run it"})],
+            &Some(json!([
+                {"name": "flat_tool", "description": "No parameter schema"},
+                {"type": "function", "function": {"name": "native_tool"}}
+            ])),
+        );
+
+        assert_eq!(
+            s.tools()
+                .and_then(|tools| tools.pointer("/0/function/parameters/type"))
+                .and_then(Value::as_str),
+            Some("object")
+        );
+        assert_eq!(
+            s.tools()
+                .and_then(|tools| tools.pointer("/1/function/parameters/type"))
+                .and_then(Value::as_str),
+            Some("object")
+        );
+    }
+
+    #[test]
+    fn text_content_blocks_are_case_insensitive() {
+        let mut s = Session::new();
+        s.ingest(
+            &[json!({
+                "role": "user",
+                "content": [{"type": "TEXT", "text": "mixed case content"}]
+            })],
+            &None,
+        );
+
+        assert_eq!(s.last_user_text(), "mixed case content");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -633,7 +633,9 @@ fn strip_info_msg_prefix(text: String) -> Option<String> {
         return Some(text);
     }
     let close = "</info-msg>";
-    let close_start = trimmed.find(close)?;
+    let Some(close_start) = trimmed.find(close) else {
+        return Some(text);
+    };
     Some(
         trimmed[close_start + close.len()..]
             .trim_start()
@@ -959,6 +961,27 @@ mod tests {
 
         assert_eq!(s.last_user_text(), "Run pwd.");
         assert_eq!(s.active_user_text(), "Run pwd.");
+    }
+
+    #[test]
+    fn malformed_goose_info_prefix_keeps_user_text() {
+        let mut s = Session::new();
+        s.ingest(
+            &[json!({
+                "role": "user",
+                "content": "<info-msg>\nWorking directory: /tmp/project\nRun pwd."
+            })],
+            &None,
+        );
+
+        assert_eq!(
+            s.last_user_text(),
+            "<info-msg>\nWorking directory: /tmp/project\nRun pwd."
+        );
+        assert_eq!(
+            s.active_user_text(),
+            "<info-msg>\nWorking directory: /tmp/project\nRun pwd."
+        );
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -44,7 +44,7 @@ pub struct PendingToolCall {
 
 /// Canonical session state for one request.
 pub struct Session {
-    /// Full message history as received from the caller.
+    /// Full message history, normalized to OpenAI chat/tool message shape.
     messages: Vec<Value>,
     /// Tool schemas from the caller.
     tools: Option<Value>,
@@ -72,20 +72,20 @@ impl Session {
     ///
     /// The caller sends the full conversation each time (OpenAI convention),
     /// so we replace our history with theirs — they're authoritative. We
-    /// scan the new history for `role: "assistant"` messages carrying
-    /// `tool_calls` and `role: "tool"` messages carrying `tool_call_id`,
-    /// pairing them into `pending_tools` so the reducer-side context packer
-    /// can surface tool outputs.
+    /// normalize known content-block tool request/result shapes into
+    /// canonical OpenAI `assistant.tool_calls` / `role: "tool"` messages,
+    /// then scan that history for paired tool calls/results so the
+    /// reducer-side context packer can surface tool outputs.
     pub fn ingest(&mut self, messages: &[Value], tools: &Option<Value>) {
         self.tools = tools.as_ref().map(normalize_tool_schemas);
-        self.messages = messages.to_vec();
+        self.messages = canonicalize_agent_tool_messages(messages);
 
         // Rebuild `pending_tools` from the canonical history. Previously
         // this was deltas-since-last-ingest, which only worked when the
         // gateway persisted Sessions across requests. With per-request
         // sessions, we scan the full caller-provided history every time.
         self.pending_tools.clear();
-        for msg in messages {
+        for msg in &self.messages {
             let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
             match role {
                 "assistant" => {
@@ -344,6 +344,207 @@ fn normalize_tool_schema(tool: &Value) -> Value {
     })
 }
 
+fn canonicalize_agent_tool_messages(messages: &[Value]) -> Vec<Value> {
+    messages
+        .iter()
+        .flat_map(canonicalize_agent_tool_message)
+        .collect()
+}
+
+fn canonicalize_agent_tool_message(msg: &Value) -> Vec<Value> {
+    if let Some(msg) = canonicalize_tool_request_blocks(msg) {
+        return vec![msg];
+    }
+
+    if let Some(messages) = canonicalize_tool_response_blocks(msg) {
+        return messages;
+    }
+
+    vec![msg.clone()]
+}
+
+fn canonicalize_tool_request_blocks(msg: &Value) -> Option<Value> {
+    if msg.get("role").and_then(Value::as_str) != Some("assistant") {
+        return None;
+    }
+    if msg.get("tool_calls").is_some() {
+        return None;
+    }
+
+    let parts = msg.get("content").and_then(Value::as_array)?;
+    let mut tool_calls = Vec::new();
+    let mut text_parts = Vec::new();
+
+    for part in parts {
+        if is_content_block_type(part, &["toolrequest", "toolcall"]) {
+            if let Some(tool_call) = canonical_tool_call_from_block(part) {
+                tool_calls.push(tool_call);
+            }
+        } else if let Some(text) = text_from_content_block(part) {
+            text_parts.push(text.to_string());
+        }
+    }
+
+    if tool_calls.is_empty() {
+        return None;
+    }
+
+    let content = if text_parts.is_empty() {
+        Value::Null
+    } else {
+        Value::String(text_parts.join("\n"))
+    };
+
+    Some(serde_json::json!({
+        "role": "assistant",
+        "content": content,
+        "tool_calls": tool_calls,
+    }))
+}
+
+fn canonical_tool_call_from_block(part: &Value) -> Option<Value> {
+    let call = part
+        .pointer("/toolCall/value")
+        .or_else(|| part.get("toolCall"))
+        .or_else(|| part.get("tool_call"))
+        .or_else(|| part.get("value"))?;
+    let id = part
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| call.get("id").and_then(Value::as_str))
+        .filter(|id| !id.is_empty())?;
+    let name = call
+        .get("name")
+        .and_then(Value::as_str)
+        .or_else(|| call.pointer("/function/name").and_then(Value::as_str))
+        .filter(|name| !name.is_empty())?;
+    let arguments = call
+        .get("arguments")
+        .or_else(|| call.pointer("/function/arguments"))
+        .cloned()
+        .unwrap_or(Value::Null);
+
+    Some(serde_json::json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": openai_arguments_string(&arguments),
+        },
+    }))
+}
+
+fn canonicalize_tool_response_blocks(msg: &Value) -> Option<Vec<Value>> {
+    let parts = msg.get("content").and_then(Value::as_array)?;
+    if !parts
+        .iter()
+        .any(|part| is_content_block_type(part, &["toolresponse", "toolresult"]))
+    {
+        return None;
+    }
+
+    let role = msg.get("role").and_then(Value::as_str).unwrap_or("user");
+    let mut messages = Vec::new();
+    let mut pending_text = Vec::new();
+
+    for part in parts {
+        if is_content_block_type(part, &["toolresponse", "toolresult"]) {
+            if !pending_text.is_empty() {
+                messages.push(serde_json::json!({
+                    "role": role,
+                    "content": pending_text.join("\n"),
+                }));
+                pending_text.clear();
+            }
+            if let Some(tool_msg) = canonical_tool_result_from_block(part) {
+                messages.push(tool_msg);
+            }
+        } else if let Some(text) = text_from_content_block(part) {
+            pending_text.push(text.to_string());
+        }
+    }
+
+    if !pending_text.is_empty() {
+        messages.push(serde_json::json!({
+            "role": role,
+            "content": pending_text.join("\n"),
+        }));
+    }
+
+    Some(messages)
+}
+
+fn canonical_tool_result_from_block(part: &Value) -> Option<Value> {
+    let id = part
+        .get("id")
+        .and_then(Value::as_str)
+        .or_else(|| part.pointer("/toolResult/id").and_then(Value::as_str))
+        .filter(|id| !id.is_empty())?;
+    let content = tool_result_text(part);
+
+    Some(serde_json::json!({
+        "role": "tool",
+        "tool_call_id": id,
+        "content": content,
+    }))
+}
+
+fn tool_result_text(part: &Value) -> String {
+    let result = part
+        .get("toolResult")
+        .or_else(|| part.get("tool_result"))
+        .or_else(|| part.get("result"))
+        .unwrap_or(part);
+    let value = result.get("value").unwrap_or(result);
+
+    if let Some(text) = value.get("content").and_then(Value::as_str) {
+        return text.to_string();
+    }
+
+    if let Some(parts) = value.get("content").and_then(Value::as_array) {
+        let text: Vec<&str> = parts.iter().filter_map(text_from_content_block).collect();
+        if !text.is_empty() {
+            return text.join("\n");
+        }
+    }
+
+    if let Some(text) = value.get("text").and_then(Value::as_str) {
+        return text.to_string();
+    }
+
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+fn is_content_block_type(part: &Value, expected: &[&str]) -> bool {
+    let Some(kind) = part.get("type").and_then(Value::as_str) else {
+        return false;
+    };
+    let normalized = normalize_content_block_type(kind);
+    expected.iter().any(|candidate| normalized == *candidate)
+}
+
+fn normalize_content_block_type(kind: &str) -> String {
+    kind.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+fn text_from_content_block(part: &Value) -> Option<&str> {
+    match part.get("type").and_then(Value::as_str) {
+        Some("text") => part.get("text").and_then(Value::as_str),
+        _ => None,
+    }
+}
+
+fn openai_arguments_string(arguments: &Value) -> String {
+    match arguments {
+        Value::String(s) => s.clone(),
+        Value::Null => "{}".to_string(),
+        other => serde_json::to_string(other).unwrap_or_else(|_| "{}".to_string()),
+    }
+}
+
 /// Extract text content from a message (handles both string and multipart).
 fn extract_text_content(msg: &Value) -> Option<String> {
     if let Some(s) = msg.get("content").and_then(|c| c.as_str()) {
@@ -449,7 +650,7 @@ mod tests {
     }
 
     #[test]
-    fn flat_openclaw_tools_are_normalized_to_openai_function_tools() {
+    fn flat_tool_schemas_are_normalized_to_openai_function_tools() {
         let mut s = Session::new();
         s.ingest(
             &[json!({"role": "user", "content": "Use read on /tmp/a.txt"})],
@@ -520,5 +721,130 @@ mod tests {
         assert_eq!(pending[0].function_name, "good");
         // The orphaned tool result did not attach — result still None.
         assert!(pending[0].result.is_none());
+    }
+
+    #[test]
+    fn content_block_tool_request_and_response_are_canonicalized() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "List recent PRs"}),
+                json!({
+                    "role": "assistant",
+                    "content": [{
+                        "type": "toolRequest",
+                        "id": "call_shell",
+                        "toolCall": {
+                            "status": "success",
+                            "value": {
+                                "name": "shell",
+                                "arguments": {
+                                    "command": "gh pr list --sort created"
+                                }
+                            }
+                        }
+                    }]
+                }),
+                json!({
+                    "role": "user",
+                    "content": [{
+                        "type": "toolResponse",
+                        "id": "call_shell",
+                        "toolResult": {
+                            "status": "success",
+                            "value": {
+                                "content": [{
+                                    "type": "text",
+                                    "text": "unknown flag: --sort\n\nUsage: gh pr list"
+                                }],
+                                "isError": true
+                            }
+                        }
+                    }]
+                }),
+            ],
+            &Some(json!([{
+                "type": "function",
+                "function": {
+                    "name": "shell",
+                    "description": "Run a shell command",
+                    "parameters": {}
+                }
+            }])),
+        );
+
+        assert_eq!(s.classify_turn(), TurnType::ToolResult);
+
+        let messages = s.all_messages();
+        assert_eq!(
+            messages[1].pointer("/tool_calls/0/function/name"),
+            Some(&Value::String("shell".to_string()))
+        );
+        assert_eq!(
+            messages[2].get("role").and_then(Value::as_str),
+            Some("tool")
+        );
+        assert_eq!(
+            messages[2].get("tool_call_id").and_then(Value::as_str),
+            Some("call_shell")
+        );
+
+        let pairs = s.recent_tool_results();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "shell");
+        assert!(
+            pairs[0].1.contains("unknown flag: --sort"),
+            "tool-result text must be available to reducer retry logic: {pairs:?}"
+        );
+    }
+
+    #[test]
+    fn mixed_content_block_tool_response_preserves_text_order() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "Read and summarize"}),
+                json!({
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_read",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"README.md\"}"}
+                    }]
+                }),
+                json!({
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Tool finished."},
+                        {
+                            "type": "toolResult",
+                            "id": "call_read",
+                            "toolResult": {
+                                "value": {"content": "# Mesh LLM"}
+                            }
+                        },
+                        {"type": "text", "text": "Please answer briefly."}
+                    ]
+                }),
+            ],
+            &None,
+        );
+
+        assert_eq!(s.classify_turn(), TurnType::ToolResult);
+        let messages = s.all_messages();
+        assert_eq!(messages.len(), 5);
+        assert_eq!(
+            messages[2],
+            json!({"role": "user", "content": "Tool finished."})
+        );
+        assert_eq!(
+            messages[3].get("role").and_then(Value::as_str),
+            Some("tool")
+        );
+        assert_eq!(
+            messages[4],
+            json!({"role": "user", "content": "Please answer briefly."})
+        );
     }
 }

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -223,8 +223,7 @@ impl Session {
         self.messages
             .iter()
             .rev()
-            .find(|m| is_task_user_message(m))
-            .and_then(extract_text_content)
+            .find_map(task_text_from_user_message)
             .unwrap_or_default()
     }
 
@@ -254,8 +253,7 @@ impl Session {
         self.messages[..tool_call_idx]
             .iter()
             .rev()
-            .find(|m| is_task_user_message(m))
-            .and_then(extract_text_content)
+            .find_map(task_text_from_user_message)
             .unwrap_or_else(|| self.last_user_text())
     }
 
@@ -599,12 +597,27 @@ fn extract_text_content(msg: &Value) -> Option<String> {
     None
 }
 
-fn is_task_user_message(msg: &Value) -> bool {
-    msg.get("role").and_then(Value::as_str) == Some("user") && !is_synthetic_user_message(msg)
+fn task_text_from_user_message(msg: &Value) -> Option<String> {
+    (msg.get("role").and_then(Value::as_str) == Some("user"))
+        .then(|| extract_text_content(msg))
+        .flatten()
+        .and_then(strip_info_msg_prefix)
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
 }
 
-fn is_synthetic_user_message(msg: &Value) -> bool {
-    extract_text_content(msg).is_some_and(|text| text.trim_start().starts_with("<info-msg>"))
+fn strip_info_msg_prefix(text: String) -> Option<String> {
+    let trimmed = text.trim_start();
+    if !trimmed.starts_with("<info-msg>") {
+        return Some(text);
+    }
+    let close = "</info-msg>";
+    let close_start = trimmed.find(close)?;
+    Some(
+        trimmed[close_start + close.len()..]
+            .trim_start()
+            .to_string(),
+    )
 }
 
 #[cfg(test)]
@@ -871,6 +884,21 @@ mod tests {
 
         assert_eq!(s.last_user_text(), "Run pwd, then run ls, then answer.");
         assert_eq!(s.active_user_text(), "Run pwd, then run ls, then answer.");
+    }
+
+    #[test]
+    fn goose_info_prefix_preserves_following_user_task() {
+        let mut s = Session::new();
+        s.ingest(
+            &[json!({
+                "role": "user",
+                "content": "<info-msg>\nWorking directory: /tmp/project\n</info-msg>\nRun pwd."
+            })],
+            &None,
+        );
+
+        assert_eq!(s.last_user_text(), "Run pwd.");
+        assert_eq!(s.active_user_text(), "Run pwd.");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/worker.rs
+++ b/crates/mesh-mixture-of-agents/src/worker.rs
@@ -108,7 +108,7 @@ pub fn assign_roles(models: &[ModelEntry]) -> Vec<Assignment> {
 ///
 /// Mirrors `pick_model_classified`'s sizing heuristic in the main
 /// router so MoA picks the same "strong" model as `auto` would.
-pub(crate) fn is_single_digit_b_name(name: &str) -> bool {
+pub fn is_single_digit_b_name(name: &str) -> bool {
     let bytes = name.as_bytes();
     for i in 0..bytes.len() {
         let c = bytes[i];

--- a/crates/mesh-mixture-of-agents/src/worker.rs
+++ b/crates/mesh-mixture-of-agents/src/worker.rs
@@ -58,7 +58,7 @@ pub fn assign_roles(models: &[ModelEntry]) -> Vec<Assignment> {
     //                     count (1B-9B), e.g. Qwen3-8B, Qwen2.5-3B
     //   - "big tier"    = everything else: multi-digit B (31B, 70B) or
     //                     names that don't encode a size at all
-    //                     (MiniMax-M2.5, Coder-Next, fine-tune tags)
+    //                     (frontier aliases, Coder-Next, fine-tune tags)
     //
     // This mirrors the same heuristic `pick_model_classified` uses in the
     // main router so MoA's reducer/strong worker matches what `auto` would
@@ -286,11 +286,11 @@ mod tests {
     #[test]
     fn assign_roles_sorts_by_size_tier() {
         // 3B is last in list-order, but should NOT end up as Strong —
-        // MiniMax (no digit) and Qwen3-32B (multi-digit) belong in the
-        // big tier; Qwen2.5-3B and Qwen3-8B belong in the small tier.
+        // A no-size alias and Qwen3-32B (multi-digit) belong in the big
+        // tier; Qwen2.5-3B and Qwen3-8B belong in the small tier.
         let models = vec![
             ModelEntry {
-                name: "MiniMax-M2.5".into(),
+                name: "frontier-reasoner".into(),
                 backend_index: 0,
             },
             ModelEntry {
@@ -315,7 +315,7 @@ mod tests {
             "fast should be small-tier, got {}",
             assignments[0].model_name
         );
-        // Strong = a big-tier model (MiniMax or 32B)
+        // Strong = a big-tier model (no-size alias or 32B)
         assert_eq!(assignments[3].role, WorkerRole::Strong);
         assert!(
             !is_single_digit_b_name(&assignments[3].model_name),
@@ -337,7 +337,7 @@ mod tests {
         assert!(!is_single_digit_b_name("llama-3-70b"));
 
         // No size in name → big tier
-        assert!(!is_single_digit_b_name("MiniMax-M2.5"));
+        assert!(!is_single_digit_b_name("frontier-reasoner"));
         assert!(!is_single_digit_b_name("Coder-Next"));
 
         // Active-params subset (A3B inside larger name) → big tier

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -325,6 +325,72 @@ fn web_tools() -> Value {
 }
 
 #[tokio::test]
+async fn different_exec_commands_do_not_trigger_same_tool_loop_guard() {
+    let backend = RecordingBackend::new(
+        r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr list --repo Mesh-LLM/mesh-llm --state open --limit 20","timeout":30}}"#,
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": exec_tool(),
+        "messages": [
+            {"role": "user", "content": "Any new interesting PRs? You have the gh command line I think can use"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh pr list --repo AAIF/mesh-llm --state open --sort updated --limit 20\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "unknown flag: --sort\n\nUsage: gh pr list [flags]\n\nCommand exited with code 1"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_2",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh pr list --repo AAIF/mesh-llm --state open --limit 20\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_2", "content": "GraphQL: Could not resolve to a Repository with the name 'AAIF/mesh-llm'. (repository)\n\nCommand exited with code 1"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_3",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"git remote -v\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_3", "content": "origin\tgit@github.com:Mesh-LLM/mesh-llm.git (fetch)\norigin\tgit@github.com:Mesh-LLM/mesh-llm.git (push)"},
+        ],
+        "max_tokens": 96,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("tool_calls"),
+        "different exec commands should not be suppressed as a repeated exact tool loop: {}",
+        result.response_body
+    );
+    let args = result
+        .response_body
+        .pointer("/choices/0/message/tool_calls/0/function/arguments")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(args.contains("Mesh-LLM/mesh-llm"), "{args}");
+}
+
+#[tokio::test]
 async fn pr_prompt_retries_after_bad_tool_result_permutations() {
     let bad_results = [
         "unknown flag: --sort\n\nUsage: gh pr list [flags]",

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -188,6 +188,114 @@ fn read_file_tool() -> Value {
     }])
 }
 
+fn web_tools() -> Value {
+    json!([
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"query": {"type": "string"}},
+                    "required": ["query"],
+                }
+            }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "web_fetch",
+                "description": "Fetch a URL",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"url": {"type": "string"}},
+                    "required": ["url"],
+                }
+            }
+        }
+    ])
+}
+
+#[tokio::test]
+async fn repeated_tool_guard_allows_different_tool_from_minimax_xml() {
+    let backend = RecordingBackend::new(
+        r#"<minimax:tool_call>
+<invoke name="web_fetch">
+<parameter name="url">https://github.com/Mesh-LLM/mesh-llm/issues</parameter>
+</invoke>
+</minimax:tool_call>"#,
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "minimax".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": web_tools(),
+        "messages": [
+            {"role": "user", "content": "Use web_search or web_fetch as needed. Find important GitHub issues."},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"Mesh-LLM issues\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"results\":[]}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_2",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"Mesh-LLM bug fixes\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_2", "content": "{\"results\":[]}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_3",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"Mesh-LLM pull requests\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_3", "content": "{\"results\":[]}"},
+        ],
+        "max_tokens": 64,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(backend.calls(), 1);
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("tool_calls"),
+        "Minimax XML tool proposal must not leak as assistant text: {}",
+        result.response_body
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/message/tool_calls/0/function/name")
+            .and_then(Value::as_str),
+        Some("web_fetch")
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str),
+        Some("{\"url\":\"https://github.com/Mesh-LLM/mesh-llm/issues\"}")
+    );
+}
+
 #[tokio::test]
 async fn tool_result_retries_answer_only_when_schema_reducer_fails() {
     let backend = ToolSchemaFailBackend::new();

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -460,6 +460,76 @@ async fn pr_prompt_retries_after_bad_tool_result_permutations() {
 }
 
 #[tokio::test]
+async fn goose_repo_list_tool_result_is_not_final_pr_evidence() {
+    let backend = RecordingBackend::new(
+        "From the tool result, one relevant entry is: michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": exec_tool(),
+        "messages": [
+            {"role": "user", "content": [{"type": "text", "text": "Any new interesting PRs? You have the gh command line I think can use. Use tools if useful."}]},
+            {"role": "assistant", "content": [{
+                "type": "toolRequest",
+                "id": "call_exec",
+                "toolCall": {
+                    "status": "success",
+                    "value": {
+                        "name": "exec",
+                        "arguments": {"command": "gh repo list --limit 20"}
+                    }
+                }
+            }]},
+            {"role": "user", "content": [{
+                "type": "toolResponse",
+                "id": "call_exec",
+                "toolResult": {
+                    "status": "success",
+                    "value": {
+                        "content": [{
+                            "type": "text",
+                            "text": "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z\nmichaelneale/ollama\tRun models\tpublic, fork\t2026-06-05T00:42:49Z"
+                        }]
+                    }
+                }
+            }]},
+        ],
+        "max_tokens": 96,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+    let answer = result
+        .response_body
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert!(
+        answer.contains("listed repositories, not pull requests"),
+        "{answer}"
+    );
+    assert!(
+        !answer.contains("michaelneale/sprout"),
+        "repo rows must not escape as a final PR answer: {answer}"
+    );
+}
+
+#[tokio::test]
 async fn github_auth_status_for_pr_prompt_allows_corrective_exec_followup() {
     let backend = RecordingBackend::new(
         r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr list --state open --limit 20 --json number,title,updatedAt,url,author","timeout":30}}"#,

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -652,6 +652,64 @@ async fn cli_json_field_error_allows_corrective_exec_followup() {
 }
 
 #[tokio::test]
+async fn cli_json_field_error_with_plain_reducer_answer_retries_corrected_exec() {
+    let backend = RecordingBackend::new(
+        "I was unable to retrieve the requested feedback because the latest command used an unknown JSON field.",
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": exec_tool(),
+        "messages": [
+            {"role": "user", "content": "The PR 808 - how much review feedback is there? Check it with available tools if needed."},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_exec",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh pr view 808 --json feedbacks\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_exec", "content": "Unknown JSON field: \"feedbacks\"\nAvailable fields:\n  additions\n  author\n  comments\n  reviews\n  statusCheckRollup\n  title\n  url\n\n(Command exited with code 1)"},
+        ],
+        "max_tokens": 96,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(backend.calls(), 1);
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("tool_calls"),
+        "plain reducer text after CLI field errors should become a corrected tool call: {}",
+        result.response_body
+    );
+    let args = result
+        .response_body
+        .pointer("/choices/0/message/tool_calls/0/function/arguments")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        args.contains("gh pr view 808") && !args.contains("feedbacks") && !args.contains("--json"),
+        "corrective exec should strip the unusable JSON field list: {args}"
+    );
+}
+
+#[tokio::test]
 async fn reducer_failure_after_answerable_exec_result_answers_from_evidence() {
     let backend = AlwaysFailBackend::new();
     let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
@@ -1034,6 +1092,97 @@ async fn tool_result_retries_answer_only_when_schema_reducer_fails() {
             .unwrap_or("")
             .contains("file_a.log")
     );
+}
+
+#[tokio::test]
+async fn exhausted_search_loop_uncertainty_answers_from_latest_evidence() {
+    let backend = RecordingBackend::new(
+        r#"{"kind":"uncertainty","confidence":0.2,"payload":"Need more search results."}"#,
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+    let search_result = json!({
+        "query": "\"mesh-llm\" \"issue\" GitHub",
+        "provider": "duckduckgo",
+        "count": 2,
+        "results": [
+            {
+                "title": "Issues - Mesh-LLM/mesh-llm - GitHub",
+                "url": "https://github.com/Mesh-LLM/mesh-llm/issues/",
+                "snippet": "Mesh-LLM / mesh-llm Public is:issue state:open"
+            },
+            {
+                "title": "skipped branch prediction exploration - Issue #803 - Mesh-LLM/mesh-llm",
+                "url": "https://github.com/Mesh-LLM/mesh-llm/issues/803",
+                "snippet": "Explore a Skippy-style branch prediction architecture for decode."
+            }
+        ]
+    })
+    .to_string();
+    let mut messages = vec![json!({
+        "role": "user",
+        "content": "Use available tools to look for open issues or recent discussion about mesh-LLM/mesh-llm on GitHub, then tell me one specific item you found."
+    })];
+    for idx in 1..=6 {
+        let call_id = format!("call_{idx}");
+        messages.push(json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "arguments": format!(r#"{{"query":"mesh-llm issue {idx}"}}"#)
+                }
+            }]
+        }));
+        messages.push(json!({
+            "role": "tool",
+            "tool_call_id": format!("call_{idx}"),
+            "content": search_result
+        }));
+    }
+    let body = json!({
+        "model": "mesh",
+        "tools": web_tools(),
+        "messages": messages,
+        "max_tokens": 128,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(backend.calls(), 1);
+    assert!(
+        result.response_body.get("error").is_none(),
+        "uncertain reducer after answerable search evidence must not surface a MoA error: {}",
+        result.response_body
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("stop")
+    );
+    let content = result
+        .response_body
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    assert!(content.contains("Issue #803"), "{content}");
 }
 
 #[tokio::test]

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -48,6 +48,10 @@ struct RecordingBackend {
     calls: AtomicUsize,
 }
 
+struct AlwaysFailBackend {
+    calls: AtomicUsize,
+}
+
 struct ToolSchemaFailBackend {
     calls_with_tools: AtomicUsize,
     calls_without_tools: AtomicUsize,
@@ -95,6 +99,34 @@ impl InspectingAnswerBackend {
 
     fn native_tool_messages(&self) -> usize {
         self.native_tool_messages.load(Ordering::SeqCst)
+    }
+}
+
+impl AlwaysFailBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+        })
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl moa::ModelBackend for AlwaysFailBackend {
+    async fn chat_completion(
+        &self,
+        _model: &str,
+        _messages: &[Value],
+        _tools: Option<&Value>,
+        _max_tokens: u32,
+        _timeout: Duration,
+        _sampling: moa::SamplingParams,
+    ) -> Result<Value, String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err("remote reducer timed out".to_string())
     }
 }
 
@@ -233,6 +265,21 @@ fn config_with_three_recording_workers() -> (
     (config, fast, mid, strong)
 }
 
+fn exec_tool() -> Value {
+    json!([{
+        "type": "function",
+        "function": {
+            "name": "exec",
+            "description": "Run shell commands",
+            "parameters": {
+                "type": "object",
+                "properties": {"command": {"type": "string"}},
+                "required": ["command"]
+            }
+        }
+    }])
+}
+
 fn read_file_tool() -> Value {
     json!([{
         "type": "function",
@@ -275,6 +322,195 @@ fn web_tools() -> Value {
             }
         }
     ])
+}
+
+#[tokio::test]
+async fn github_auth_status_for_pr_prompt_allows_corrective_exec_followup() {
+    let backend = RecordingBackend::new(
+        r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr list --state open --limit 20 --json number,title,updatedAt,url,author","timeout":30}}"#,
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": exec_tool(),
+        "messages": [
+            {"role": "user", "content": "Any new interesting PRs? You have the gh command line I think can use"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_exec",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh auth status\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_exec", "content": "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true\n  - Git operations protocol: https"},
+        ],
+        "max_tokens": 96,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("tool_calls"),
+        "auth status is not PR evidence and should allow a corrective command: {}",
+        result.response_body
+    );
+    let args = result
+        .response_body
+        .pointer("/choices/0/message/tool_calls/0/function/arguments")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        args.contains("gh pr list"),
+        "corrective exec should list PRs: {args}"
+    );
+}
+
+#[tokio::test]
+async fn cli_json_field_error_allows_corrective_exec_followup() {
+    let backend = RecordingBackend::new(
+        r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr list --state open --limit 20 --json number,title,createdAt,url,author,labels","timeout":30}}"#,
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": exec_tool(),
+        "messages": [
+            {"role": "user", "content": "Use gh to list recent open PRs, then tell me one interesting one."},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_exec",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh pr list --state open --limit 20 --json number,title,createdAt,headRepositoryName,url,author,labels\",\"timeout\":30}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_exec", "content": "Unknown JSON field: \"headRepositoryName\"\nAvailable fields:\n  additions\n  author\n  title\n  url\n\n(Command exited with code 1)"},
+        ],
+        "max_tokens": 96,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(backend.calls(), 1);
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("tool_calls"),
+        "CLI field errors should invite a corrected tool call, not a final answer: {}",
+        result.response_body
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/message/tool_calls/0/function/name")
+            .and_then(Value::as_str),
+        Some("exec")
+    );
+    let args = result
+        .response_body
+        .pointer("/choices/0/message/tool_calls/0/function/arguments")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        args.contains("gh pr list") && !args.contains("headRepositoryName"),
+        "corrective exec should avoid the invalid gh field: {args}"
+    );
+}
+
+#[tokio::test]
+async fn reducer_failure_after_answerable_exec_result_answers_from_evidence() {
+    let backend = AlwaysFailBackend::new();
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "flaky-reducer".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_millis(100),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": exec_tool(),
+        "messages": [
+            {"role": "user", "content": "Use gh to list recent open PRs, then tell me one interesting one."},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_exec",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 20\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_exec", "content": "808\tGeneralize MoA agent tool loops\tfix/openclaw-moa-telegram-timeouts\tOPEN\t2026-06-07T10:20:01Z\n806\tAdd meshllm.cloud website and onboarding docs\tmain\tOPEN\t2026-06-06T19:31:18Z"},
+        ],
+        "max_tokens": 96,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(
+        backend.calls(),
+        1,
+        "answerable exec evidence should suppress another native-tool reducer attempt"
+    );
+    assert!(
+        result.response_body.get("error").is_none(),
+        "answerable tool evidence must survive reducer failure: {}",
+        result.response_body
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("stop")
+    );
+    let content = result
+        .response_body
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        content.contains("808") && content.contains("Generalize MoA agent tool loops"),
+        "fallback answer should be grounded in the completed exec result: {content}"
+    );
+    assert!(
+        !content.contains("Reducer failed") && !content.contains("remote reducer timed out"),
+        "fallback must not surface internal reducer failure text: {content}"
+    );
 }
 
 #[tokio::test]

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -278,7 +278,7 @@ fn web_tools() -> Value {
 }
 
 #[tokio::test]
-async fn exhausted_web_research_budget_forces_answer_only_context() {
+async fn exhausted_tool_budget_forces_answer_only_context() {
     let backend = InspectingAnswerBackend::new();
     let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
     let config = moa::GatewayConfig {
@@ -345,7 +345,7 @@ async fn exhausted_web_research_budget_forces_answer_only_context() {
     assert_eq!(
         backend.calls_with_tools(),
         0,
-        "web budget exhaustion must stop forwarding web tool schemas"
+        "tool budget exhaustion must stop forwarding tool schemas"
     );
     assert_eq!(backend.calls_without_tools(), 1);
     assert_eq!(
@@ -365,7 +365,7 @@ async fn exhausted_web_research_budget_forces_answer_only_context() {
             .response_body
             .pointer("/choices/0/message/tool_calls")
             .is_none(),
-        "budget exhaustion must produce an answer, not another web tool call"
+        "budget exhaustion must produce an answer, not another tool call"
     );
 }
 
@@ -449,6 +449,85 @@ async fn repeated_tool_guard_allows_different_tool_from_minimax_xml() {
 }
 
 #[tokio::test]
+async fn non_empty_tool_result_suppresses_same_tool_followup() {
+    let backend = RecordingBackend::new(
+        r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr view 806 --repo mesh-LLM/mesh-llm"}}"#,
+    );
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "exec",
+                "description": "Run shell commands",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"]
+                }
+            }
+        }],
+        "messages": [
+            {"role": "user", "content": "Use gh to list recent open PRs, then tell me one interesting one."},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_exec",
+                "type": "function",
+                "function": {"name": "exec", "arguments": "{\"command\":\"gh pr list --repo mesh-LLM/mesh-llm\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_exec", "content": "#806 Add meshllm.cloud website and onboarding docs"},
+        ],
+        "max_tokens": 64,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(backend.calls(), 1);
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("stop")
+    );
+    assert!(
+        result
+            .response_body
+            .pointer("/choices/0/message/tool_calls")
+            .is_none(),
+        "same tool must not be emitted again after answerable evidence: {}",
+        result.response_body
+    );
+    let content = result
+        .response_body
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        content.contains("#806 Add meshllm.cloud website and onboarding docs"),
+        "answer should be grounded in the completed tool result: {content}"
+    );
+    assert!(
+        !content.contains("tool_proposal") && !content.contains("gh pr view"),
+        "suppressed tool proposals must not leak as assistant text: {content}"
+    );
+}
+
+#[tokio::test]
 async fn tool_result_retries_answer_only_when_schema_reducer_fails() {
     let backend = ToolSchemaFailBackend::new();
     let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
@@ -479,7 +558,7 @@ async fn tool_result_retries_answer_only_when_schema_reducer_fails() {
                     "function": {"name": "read_file", "arguments": "{\"path\":\"/tmp\"}"}
                 }]
             },
-            {"role": "tool", "tool_call_id": "call_1", "content": "file_a.log\nfile_b.log\n"},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{}"},
         ],
         "max_tokens": 64,
     });

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -48,6 +48,60 @@ struct RecordingBackend {
     calls: AtomicUsize,
 }
 
+struct ToolSchemaFailBackend {
+    calls_with_tools: AtomicUsize,
+    calls_without_tools: AtomicUsize,
+}
+
+impl ToolSchemaFailBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls_with_tools: AtomicUsize::new(0),
+            calls_without_tools: AtomicUsize::new(0),
+        })
+    }
+
+    fn calls_with_tools(&self) -> usize {
+        self.calls_with_tools.load(Ordering::SeqCst)
+    }
+
+    fn calls_without_tools(&self) -> usize {
+        self.calls_without_tools.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl moa::ModelBackend for ToolSchemaFailBackend {
+    async fn chat_completion(
+        &self,
+        _model: &str,
+        messages: &[Value],
+        tools: Option<&Value>,
+        _max_tokens: u32,
+        _timeout: Duration,
+        _sampling: moa::SamplingParams,
+    ) -> Result<Value, String> {
+        if tools.is_some() {
+            self.calls_with_tools.fetch_add(1, Ordering::SeqCst);
+            return Err("tool grammar rejected request".to_string());
+        }
+
+        if messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("tool")
+                || message.get("tool_calls").is_some()
+        }) {
+            return Err("native tool messages leaked into answer-only retry".to_string());
+        }
+
+        self.calls_without_tools.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({
+            "choices": [{
+                "message": {"content": "The tool output lists file_a.log and file_b.log."}
+            }],
+        }))
+    }
+}
+
 impl RecordingBackend {
     fn new(text: impl Into<String>) -> Arc<Self> {
         Arc::new(Self {
@@ -132,6 +186,74 @@ fn read_file_tool() -> Value {
             }
         }
     }])
+}
+
+#[tokio::test]
+async fn tool_result_retries_answer_only_when_schema_reducer_fails() {
+    let backend = ToolSchemaFailBackend::new();
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": read_file_tool(),
+        "messages": [
+            {"role": "user", "content": "Summarize the tool output."},
+            {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{\"path\":\"/tmp\"}"}
+                }]
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "file_a.log\nfile_b.log\n"},
+        ],
+        "max_tokens": 64,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(backend.calls_with_tools(), 1);
+    assert_eq!(
+        backend.calls_without_tools(),
+        1,
+        "schema-backed reducer failure must retry once without native tools"
+    );
+    assert_eq!(result.reducer_attempts, 2);
+    assert!(
+        result.response_body.get("error").is_none(),
+        "tool-result answer-only fallback should not surface a MoA error: {}",
+        result.response_body
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("stop")
+    );
+    assert!(
+        result
+            .response_body
+            .pointer("/choices/0/message/content")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .contains("file_a.log")
+    );
 }
 
 #[tokio::test]

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -325,6 +325,74 @@ fn web_tools() -> Value {
 }
 
 #[tokio::test]
+async fn pr_prompt_retries_after_bad_tool_result_permutations() {
+    let bad_results = [
+        "unknown flag: --sort\n\nUsage: gh pr list [flags]",
+        "Unknown JSON field: \"repository\"\nAvailable fields:\n  author\n  title",
+        "no git remotes found\n\n(Command exited with code 1)",
+        "gh search not available or not authenticated",
+        "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
+        "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
+    ];
+
+    for bad_result in bad_results {
+        let backend = RecordingBackend::new(
+            r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr list --repo mesh-LLM/mesh-llm --state open --limit 20 --json number,title,updatedAt,url,author","timeout":30}}"#,
+        );
+        let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+        let config = moa::GatewayConfig {
+            backends,
+            models: vec![moa::ModelEntry {
+                name: "strong-32b".into(),
+                backend_index: 0,
+            }],
+            worker_timeout: Duration::from_secs(2),
+            hedge_delay: Duration::from_millis(50),
+            reducer_timeout: Duration::from_secs(2),
+            first_answer_grace: Duration::ZERO,
+            enable_thinking: None,
+        };
+
+        let body = json!({
+            "model": "mesh",
+            "tools": exec_tool(),
+            "messages": [
+                {"role": "user", "content": "Any new interesting PRs? You have the gh command line I think can use"},
+                {"role": "assistant", "content": null, "tool_calls": [{
+                    "id": "call_exec",
+                    "type": "function",
+                    "function": {"name": "exec", "arguments": "{\"command\":\"gh auth status\"}"}
+                }]},
+                {"role": "tool", "tool_call_id": "call_exec", "content": bad_result},
+            ],
+            "max_tokens": 96,
+        });
+
+        let result = moa::handle_turn(&config, &body).await;
+
+        assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+        assert_eq!(
+            result
+                .response_body
+                .pointer("/choices/0/finish_reason")
+                .and_then(Value::as_str),
+            Some("tool_calls"),
+            "bad PR-adjacent output should not finalize as an answer: {bad_result:?}; body={}",
+            result.response_body
+        );
+        let args = result
+            .response_body
+            .pointer("/choices/0/message/tool_calls/0/function/arguments")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        assert!(
+            args.contains("gh pr list") && args.contains("--repo"),
+            "corrective exec should list PRs with explicit repo: {args}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn github_auth_status_for_pr_prompt_allows_corrective_exec_followup() {
     let backend = RecordingBackend::new(
         r#"{"kind":"tool_proposal","confidence":0.9,"tool":"exec","arguments":{"command":"gh pr list --state open --limit 20 --json number,title,updatedAt,url,author","timeout":30}}"#,

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -53,6 +53,12 @@ struct ToolSchemaFailBackend {
     calls_without_tools: AtomicUsize,
 }
 
+struct InspectingAnswerBackend {
+    calls_with_tools: AtomicUsize,
+    calls_without_tools: AtomicUsize,
+    native_tool_messages: AtomicUsize,
+}
+
 impl ToolSchemaFailBackend {
     fn new() -> Arc<Self> {
         Arc::new(Self {
@@ -67,6 +73,28 @@ impl ToolSchemaFailBackend {
 
     fn calls_without_tools(&self) -> usize {
         self.calls_without_tools.load(Ordering::SeqCst)
+    }
+}
+
+impl InspectingAnswerBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls_with_tools: AtomicUsize::new(0),
+            calls_without_tools: AtomicUsize::new(0),
+            native_tool_messages: AtomicUsize::new(0),
+        })
+    }
+
+    fn calls_with_tools(&self) -> usize {
+        self.calls_with_tools.load(Ordering::SeqCst)
+    }
+
+    fn calls_without_tools(&self) -> usize {
+        self.calls_without_tools.load(Ordering::SeqCst)
+    }
+
+    fn native_tool_messages(&self) -> usize {
+        self.native_tool_messages.load(Ordering::SeqCst)
     }
 }
 
@@ -97,6 +125,38 @@ impl moa::ModelBackend for ToolSchemaFailBackend {
         Ok(json!({
             "choices": [{
                 "message": {"content": "The tool output lists file_a.log and file_b.log."}
+            }],
+        }))
+    }
+}
+
+#[async_trait]
+impl moa::ModelBackend for InspectingAnswerBackend {
+    async fn chat_completion(
+        &self,
+        _model: &str,
+        messages: &[Value],
+        tools: Option<&Value>,
+        _max_tokens: u32,
+        _timeout: Duration,
+        _sampling: moa::SamplingParams,
+    ) -> Result<Value, String> {
+        if tools.is_some() {
+            self.calls_with_tools.fetch_add(1, Ordering::SeqCst);
+        } else {
+            self.calls_without_tools.fetch_add(1, Ordering::SeqCst);
+        }
+
+        if messages.iter().any(|message| {
+            message.get("role").and_then(Value::as_str) == Some("tool")
+                || message.get("tool_calls").is_some()
+        }) {
+            self.native_tool_messages.fetch_add(1, Ordering::SeqCst);
+        }
+
+        Ok(json!({
+            "choices": [{
+                "message": {"content": "Recent PR evidence is thin; review the latest open pull requests page and prioritize obvious bug-fix PRs."}
             }],
         }))
     }
@@ -215,6 +275,98 @@ fn web_tools() -> Value {
             }
         }
     ])
+}
+
+#[tokio::test]
+async fn exhausted_web_research_budget_forces_answer_only_context() {
+    let backend = InspectingAnswerBackend::new();
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let config = moa::GatewayConfig {
+        backends,
+        models: vec![moa::ModelEntry {
+            name: "strong-32b".into(),
+            backend_index: 0,
+        }],
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(50),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+
+    let body = json!({
+        "model": "mesh",
+        "tools": web_tools(),
+        "messages": [
+            {"role": "user", "content": "Find recent important GitHub bug-fix PRs for Mesh-LLM/mesh-llm."},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"mesh-llm recent bug fixes\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_1", "content": "{\"results\":[{\"url\":\"https://github.com/Mesh-LLM/mesh-llm/pulls\"}]}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_2",
+                "type": "function",
+                "function": {"name": "web_fetch", "arguments": "{\"url\":\"https://github.com/Mesh-LLM/mesh-llm/pulls\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_2", "content": "{\"status\":200,\"title\":\"Pull requests\"}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_3",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"site:github.com/Mesh-LLM/mesh-llm/pulls bug fix\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_3", "content": "{\"results\":[]}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_4",
+                "type": "function",
+                "function": {"name": "web_fetch", "arguments": "{\"url\":\"https://api.github.com/repos/Mesh-LLM/mesh-llm/pulls\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_4", "content": "{\"status\":200,\"items\":[]}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_5",
+                "type": "function",
+                "function": {"name": "web_search", "arguments": "{\"query\":\"Mesh-LLM mesh-llm pull request important bug\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_5", "content": "{\"status\":\"error\",\"error\":\"bot challenge\"}"},
+            {"role": "assistant", "content": null, "tool_calls": [{
+                "id": "call_6",
+                "type": "function",
+                "function": {"name": "web_fetch", "arguments": "{\"url\":\"https://github.com/Mesh-LLM/mesh-llm/pulls?q=is%3Apr+sort%3Aupdated-desc\"}"}
+            }]},
+            {"role": "tool", "tool_call_id": "call_6", "content": "{\"status\":200,\"title\":\"Pull requests\"}"},
+        ],
+        "max_tokens": 128,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert_eq!(
+        backend.calls_with_tools(),
+        0,
+        "web budget exhaustion must stop forwarding web tool schemas"
+    );
+    assert_eq!(backend.calls_without_tools(), 1);
+    assert_eq!(
+        backend.native_tool_messages(),
+        0,
+        "budgeted synthesis should use compact answer-only context, not native tool messages"
+    );
+    assert_eq!(
+        result
+            .response_body
+            .pointer("/choices/0/finish_reason")
+            .and_then(Value::as_str),
+        Some("stop")
+    );
+    assert!(
+        result
+            .response_body
+            .pointer("/choices/0/message/tool_calls")
+            .is_none(),
+        "budget exhaustion must produce an answer, not another web tool call"
+    );
 }
 
 #[tokio::test]

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -520,7 +520,7 @@ async fn goose_repo_list_tool_result_is_not_final_pr_evidence() {
 
     assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
     assert!(
-        answer.contains("listed repositories, not pull requests"),
+        answer.contains("listed repositories, not the requested work items"),
         "{answer}"
     );
     assert!(

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -370,19 +370,19 @@ async fn exhausted_tool_budget_forces_answer_only_context() {
 }
 
 #[tokio::test]
-async fn repeated_tool_guard_allows_different_tool_from_minimax_xml() {
+async fn repeated_tool_guard_allows_different_tool_from_xml_call() {
     let backend = RecordingBackend::new(
-        r#"<minimax:tool_call>
+        r#"<tool_call>
 <invoke name="web_fetch">
 <parameter name="url">https://github.com/Mesh-LLM/mesh-llm/issues</parameter>
 </invoke>
-</minimax:tool_call>"#,
+</tool_call>"#,
     );
     let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
     let config = moa::GatewayConfig {
         backends,
         models: vec![moa::ModelEntry {
-            name: "minimax".into(),
+            name: "xml-worker".into(),
             backend_index: 0,
         }],
         worker_timeout: Duration::from_secs(2),
@@ -429,7 +429,7 @@ async fn repeated_tool_guard_allows_different_tool_from_minimax_xml() {
             .pointer("/choices/0/finish_reason")
             .and_then(Value::as_str),
         Some("tool_calls"),
-        "Minimax XML tool proposal must not leak as assistant text: {}",
+        "XML tool proposal must not leak as assistant text: {}",
         result.response_body
     );
     assert_eq!(

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -331,6 +331,7 @@ async fn pr_prompt_retries_after_bad_tool_result_permutations() {
         "Unknown JSON field: \"repository\"\nAvailable fields:\n  author\n  title",
         "no git remotes found\n\n(Command exited with code 1)",
         "gh search not available or not authenticated",
+        "GraphQL: Could not resolve to a Repository with the name 'micn/mesh-llm'. (repository)",
         "github.com\n  ✓ Logged in to github.com account user (keyring)\n  - Active account: true",
         "michaelneale/sprout\tA hive mind communication platform\tpublic, fork\t2026-06-06T05:22:29Z",
     ];


### PR DESCRIPTION
OpenClaw/Gateway users can now route Telegram-style agent turns through `model=mesh` without small-context workers or slow peers turning ordinary tool loops into timeouts.

## What changed
- Bound MoA worker/reducer context for OpenClaw-sized sessions and tool schemas.
- Rank mesh workers by usable context and latency, with remote backend hedging.
- Normalize OpenClaw flat tool schemas into OpenAI function tools.
- Preserve tool-result loops and retry answer-only when native tool-schema reducers fail.
- Emit direct native tool calls when a single safe required tool and arguments can be inferred, avoiding slow worker arbitration for obvious `read`/search-style requests.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p mesh-mixture-of-agents`
- `cargo test -p mesh-llm-host-runtime --lib moa_gateway`
- `just build`
- `cargo clippy -p mesh-mixture-of-agents --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`

## Lab proof on mini
- Deployed debug binary hash `9c882b66a51409cd658334fbf8994d32472692ad` to mini as `~/mesh-llm-main` and `~/mesh-llm-fastjoin`; OpenClaw Gateway remained running.
- Confirmed `/v1/models` exposed `mesh` with `context_length=131072` and local `unsloth/Qwen3.5-9B-GGUF:Q4_K_M` ready.
- Reproduced the real failure class from existing OpenClaw logs: Telegram inbound `agent:main:main` turns timing out with `FailoverError: LLM request timed out`.
- Verified no-delivery Telegram-channel OpenClaw turn on the real `agent:main:main` session: `SENTINEL_OPENCLAW_TELEGRAM_MAIN_OK_606` in 5.65s.
- Verified Telegram-channel read-tool loop on the real `agent:main:main` session: native `read` tool call executed and returned `SENTINEL_FILE_VALUE_DIRECT_TOOL_606`; final answer `SENTINEL_OPENCLAW_TELEGRAM_DIRECT_TOOL_OK_606 SENTINEL_FILE_VALUE_DIRECT_TOOL_606` in 14.70s.
- Session JSONL shows direct tool call emitted at `16:15:13.587`, tool result at `16:15:13.610`, final answer at `16:15:25.553`.

## Notes
- I did not use `--deliver`; this exercised OpenClaw Gateway with `--channel telegram --reply-channel telegram --reply-to telegram:8454832168` against the real Telegram session without sending a test message back to Telegram.
- Current mini mesh process layout after validation: OpenClaw Gateway PID 18559, mesh serve PID 75938, mesh client PID 75939.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new recommended model listings and updated model selection for mid/large VRAM tiers.
  * Support for additional tool-call syntaxes (bracketed, sentinel, and XML) and recommended-model overlays.

* **Improvements**
  * Schema-driven argument repair and stronger URL validation for tool arguments.
  * Latency-aware, multi-host selection and hedged remote request backend for better reliability.
  * Byte-based context packing and improved token budgeting for gateways.

* **Bug Fixes / Tests**
  * Expanded tests covering parsing, canonicalization, and MoA behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->