### PR TITLE
Adapt MLX pipeline concepts for Skippy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,18 @@ More work around using ngrams, drafting models is in progress.
 Some experimental work around predictive prompt completion into prefile has been done (yet to be proven, prefil is parallel so latency tolerant)
 MTP work with llama.cpp ongoing, but should be part of this to accelerate inference and especially reduce vulnerability to latency between layers. 
 
+## Skippy pipeline improvements
+
+Skippy's layer pipeline is the path for running models that do not fit on one
+machine. The next performance work should stay focused on that pipeline:
+transport-aware stage ordering, large prefill activation-frame transfer,
+metadata-first package planning, readout-stage topology experiments, and
+request/cache epoch coordination.
+
+The MLX distributed stack has useful ideas here, but they should be translated
+into Skippy rather than treated as a replacement backend. See
+[docs/skippy/MLX_CONCEPTS_FOR_SKIPPY.md](docs/skippy/MLX_CONCEPTS_FOR_SKIPPY.md).
+
 ## Demand-based rebalancing
 
 Partially done. Unified demand map via gossip, standby nodes promote to serve, and large-VRAM hosts can opt into fresh active-demand upgrades for local artifacts. Next: download-backed upgrades, split-aware upgrades, and replica-count balancing.

--- a/crates/skippy-protocol/src/binary/mod.rs
+++ b/crates/skippy-protocol/src/binary/mod.rs
@@ -19,9 +19,9 @@ pub use types::{
     MAX_STAGE_SIDEBAND_VALUES, MAX_STAGE_STATE_IMPORT_BYTES, READY_MAGIC,
     STAGE_LOGIT_BIAS_WIRE_BYTES, STAGE_SAMPLING_CONFIG_BASE_BYTES, STAGE_STATE_HEADER_BYTES,
     STAGE_STATE_VERSION, STAGE_WIRE_FIXED_HEADER_BYTES, StageLogitBias, StageReply,
-    StageReplyStats, StageSamplingConfig, StageStateHeader, StageWireMessage, WireActivationDType,
-    WireMessageKind, WireReplyKind, WireStagePhase, activation_frame_flags_from_state_flags,
-    activation_state_flags_from_frame_flags, state_flags,
+    StageReplyStats, StageRequestEpoch, StageSamplingConfig, StageStateHeader, StageWireMessage,
+    WireActivationDType, WireMessageKind, WireReplyKind, WireStagePhase,
+    activation_frame_flags_from_state_flags, activation_state_flags_from_frame_flags, state_flags,
 };
 
 pub(crate) fn invalid_data(message: &'static str) -> std::io::Error {
@@ -153,6 +153,7 @@ mod tests {
     fn stage_message_round_trips_f32() {
         let mut state =
             StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F32);
+        state.checkpoint_generation = 3;
         state.prompt_token_count = 1;
         state.decode_step = 0;
         state.current_token = 11;
@@ -192,6 +193,16 @@ mod tests {
         assert_eq!(decoded.state.source_stage_index, 0);
         assert_eq!(decoded.request_id, 7);
         assert_eq!(decoded.session_id, 11);
+        assert_eq!(
+            decoded.request_epoch(),
+            StageRequestEpoch {
+                request_id: 7,
+                session_id: 11,
+                checkpoint_generation: 3,
+                prompt_token_count: 1,
+                decode_step: 0,
+            }
+        );
         assert_ne!(decoded.state.flags & state_flags::SAMPLING, 0);
         assert_eq!(decoded.state.flags & state_flags::CHAT_SAMPLING_METADATA, 0);
         assert_eq!(decoded.chat_sampling_metadata, None);
@@ -201,6 +212,76 @@ mod tests {
         assert_eq!(sampling.logit_bias.len(), 1);
         assert_eq!(sampling.logit_bias[0].token_id, 123);
         assert_eq!(sampling.logit_bias[0].bias, -50.0);
+    }
+
+    #[test]
+    fn request_epoch_orders_only_matching_flows() {
+        let older = StageRequestEpoch {
+            request_id: 7,
+            session_id: 11,
+            checkpoint_generation: 1,
+            prompt_token_count: 8,
+            decode_step: 2,
+        };
+        let newer = StageRequestEpoch {
+            request_id: 7,
+            session_id: 11,
+            checkpoint_generation: 1,
+            prompt_token_count: 8,
+            decode_step: 3,
+        };
+        let different_session = StageRequestEpoch {
+            session_id: 12,
+            ..newer
+        };
+
+        assert!(older.same_flow(newer));
+        assert!(older.is_stale_for(newer));
+        assert!(!newer.is_stale_for(older));
+        assert!(!older.same_flow(different_session));
+        assert!(!older.is_stale_for(different_session));
+    }
+
+    #[test]
+    fn stage_message_estimates_full_wire_transfer_bytes() {
+        let message = StageWireMessage {
+            kind: WireMessageKind::PrefillEmbd,
+            pos_start: 0,
+            token_count: 2,
+            state: StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32),
+            request_id: 7,
+            session_id: 11,
+            sampling: Some(StageSamplingConfig {
+                flags: 1,
+                logit_bias: vec![
+                    StageLogitBias {
+                        token_id: 1,
+                        bias: -1.0,
+                    },
+                    StageLogitBias {
+                        token_id: 2,
+                        bias: 1.0,
+                    },
+                ],
+                ..StageSamplingConfig::default()
+            }),
+            chat_sampling_metadata: Some("{}".to_string()),
+            tokens: vec![1, 2],
+            positions: vec![0],
+            activation: vec![0; 16],
+            raw_bytes: Vec::new(),
+        };
+
+        assert_eq!(
+            message.estimated_wire_bytes(),
+            STAGE_WIRE_FIXED_HEADER_BYTES
+                + STAGE_SAMPLING_CONFIG_BASE_BYTES
+                + 2 * STAGE_LOGIT_BIAS_WIRE_BYTES
+                + std::mem::size_of::<u32>()
+                + 2
+                + 3 * std::mem::size_of::<i32>()
+                + 16
+        );
     }
 
     #[test]

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -343,6 +343,34 @@ impl Default for StageStateHeader {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct StageRequestEpoch {
+    pub request_id: u64,
+    pub session_id: u64,
+    pub checkpoint_generation: i32,
+    pub prompt_token_count: i32,
+    pub decode_step: i32,
+}
+
+impl StageRequestEpoch {
+    pub fn same_flow(self, other: Self) -> bool {
+        self.request_id == other.request_id && self.session_id == other.session_id
+    }
+
+    pub fn is_stale_for(self, current: Self) -> bool {
+        self.same_flow(current)
+            && (
+                self.checkpoint_generation,
+                self.prompt_token_count,
+                self.decode_step,
+            ) < (
+                current.checkpoint_generation,
+                current.prompt_token_count,
+                current.decode_step,
+            )
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct StageWireMessage {
     pub kind: WireMessageKind,
@@ -360,6 +388,46 @@ pub struct StageWireMessage {
 }
 
 impl StageWireMessage {
+    pub fn request_epoch(&self) -> StageRequestEpoch {
+        StageRequestEpoch {
+            request_id: self.request_id,
+            session_id: self.session_id,
+            checkpoint_generation: self.state.checkpoint_generation,
+            prompt_token_count: self.state.prompt_token_count,
+            decode_step: self.state.decode_step,
+        }
+    }
+
+    pub fn estimated_wire_bytes(&self) -> usize {
+        let sampling_bytes = self.sampling.as_ref().map_or(0, |sampling| {
+            STAGE_SAMPLING_CONFIG_BASE_BYTES
+                + sampling.logit_bias.len().min(MAX_STAGE_LOGIT_BIAS) * STAGE_LOGIT_BIAS_WIRE_BYTES
+        });
+        let chat_metadata_bytes = self
+            .chat_sampling_metadata
+            .as_ref()
+            .map_or(0, |metadata| std::mem::size_of::<u32>() + metadata.len());
+        STAGE_WIRE_FIXED_HEADER_BYTES
+            .saturating_add(sampling_bytes)
+            .saturating_add(chat_metadata_bytes)
+            .saturating_add(self.payload_wire_bytes())
+    }
+
+    fn payload_wire_bytes(&self) -> usize {
+        if self.kind == WireMessageKind::StateImport {
+            return self.raw_bytes.len();
+        }
+        self.tokens
+            .len()
+            .saturating_mul(std::mem::size_of::<i32>())
+            .saturating_add(
+                self.positions
+                    .len()
+                    .saturating_mul(std::mem::size_of::<i32>()),
+            )
+            .saturating_add(self.activation.len())
+    }
+
     pub fn stop(dtype: WireActivationDType) -> Self {
         Self::stop_with_identity(dtype, 0, 0)
     }

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -26,9 +26,8 @@ use skippy_metrics::{attr, metric};
 use skippy_protocol::{
     MessageBase, SCHEMA_VERSION, StageConfig, StageTopology,
     binary::{
-        STAGE_LOGIT_BIAS_WIRE_BYTES, STAGE_SAMPLING_CONFIG_BASE_BYTES,
-        STAGE_WIRE_FIXED_HEADER_BYTES, StageReply, StageReplyStats, StageSamplingConfig,
-        StageStateHeader, StageWireMessage, WireActivationDType, WireMessageKind, WireReplyKind,
+        StageReply, StageReplyStats, StageSamplingConfig, StageStateHeader, StageWireMessage,
+        WireActivationDType, WireMessageKind, WireReplyKind,
         activation_frame_flags_from_state_flags, read_stage_message, recv_reply, send_ready,
         send_reply_ack, send_reply_ack_with_stats, state_flags,
     },
@@ -438,7 +437,7 @@ fn handle_binary_connection(
         );
         recv_attrs.insert(
             "llama_stage.message_wire_bytes".to_string(),
-            json!(estimated_stage_message_wire_bytes(&message)),
+            json!(message.estimated_wire_bytes()),
         );
         recv_attrs.insert(
             "skippy.activation_bytes".to_string(),
@@ -1493,30 +1492,6 @@ fn insert_optional_unix_nanos(attrs: &mut BTreeMap<String, Value>, key: &str, va
     }
 }
 
-fn estimated_stage_message_wire_bytes(message: &StageWireMessage) -> usize {
-    let sampling_bytes = message.sampling.as_ref().map_or(0, |sampling| {
-        STAGE_SAMPLING_CONFIG_BASE_BYTES
-            + sampling
-                .logit_bias
-                .len()
-                .min(skippy_protocol::binary::MAX_STAGE_LOGIT_BIAS)
-                * STAGE_LOGIT_BIAS_WIRE_BYTES
-    });
-    let chat_metadata_bytes = message
-        .chat_sampling_metadata
-        .as_ref()
-        .map_or(0, |metadata| std::mem::size_of::<u32>() + metadata.len());
-    let payload_bytes = if message.kind == WireMessageKind::StateImport {
-        message.raw_bytes.len()
-    } else {
-        message.tokens.len() * std::mem::size_of::<i32>()
-            + message.positions.len() * std::mem::size_of::<i32>()
-            + message.activation.len()
-    };
-
-    STAGE_WIRE_FIXED_HEADER_BYTES + sampling_bytes + chat_metadata_bytes + payload_bytes
-}
-
 fn estimated_reply_wire_bytes(reply_kind: WireReplyKind, predicted_token_count: usize) -> usize {
     const REPLY_HEADER_BYTES: usize = 3 * std::mem::size_of::<i32>();
     const REPLY_STATS_BYTES: usize = 34 * std::mem::size_of::<i64>();
@@ -1609,6 +1584,7 @@ fn binary_message_attrs(
     message: &StageWireMessage,
 ) -> std::collections::BTreeMap<String, serde_json::Value> {
     let mut attrs = lifecycle_attrs(config);
+    let epoch = message.request_epoch();
     attrs.insert(attr::SESSION_ID.to_string(), json!(session_id.to_string()));
     attrs.insert(
         attr::REQUEST_ID.to_string(),
@@ -1624,13 +1600,14 @@ fn binary_message_attrs(
     );
     attrs.insert("skippy.token_count".to_string(), json!(message.token_count));
     attrs.insert(
-        "skippy.prompt_token_count".to_string(),
-        json!(message.state.prompt_token_count),
+        "skippy.checkpoint_generation".to_string(),
+        json!(epoch.checkpoint_generation),
     );
     attrs.insert(
-        "skippy.decode_step".to_string(),
-        json!(message.state.decode_step),
+        "skippy.prompt_token_count".to_string(),
+        json!(epoch.prompt_token_count),
     );
+    attrs.insert("skippy.decode_step".to_string(), json!(epoch.decode_step));
     let layer_count = i64::from(config.layer_end.saturating_sub(config.layer_start));
     let kv_tokens_after = estimated_kv_tokens_after(message);
     attrs.insert("skippy.kv_tokens_after".to_string(), json!(kv_tokens_after));

--- a/crates/skippy-server/src/binary_transport/wire.rs
+++ b/crates/skippy-server/src/binary_transport/wire.rs
@@ -24,25 +24,13 @@ impl WireCondition {
         let delay_seconds = self.delay_ms / 1000.0;
         let bandwidth_seconds = self
             .mbps
-            .map(|mbps| conditioned_wire_bytes(message) as f64 / (mbps * 125_000.0))
+            .map(|mbps| message.estimated_wire_bytes() as f64 / (mbps * 125_000.0))
             .unwrap_or(0.0);
         let seconds = delay_seconds + bandwidth_seconds;
         if seconds > 0.0 {
             thread::sleep(Duration::from_secs_f64(seconds));
         }
     }
-}
-
-fn conditioned_wire_bytes(message: &StageWireMessage) -> usize {
-    let header_bytes: usize = 4 * 4 + 9 * 4;
-    let token_bytes = message
-        .tokens
-        .len()
-        .saturating_mul(std::mem::size_of::<i32>());
-    header_bytes
-        .saturating_add(token_bytes)
-        .saturating_add(message.activation.len())
-        .saturating_add(message.raw_bytes.len())
 }
 
 pub(crate) fn write_stage_message_conditioned(

--- a/crates/skippy-topology/src/artifact_diagnostics.rs
+++ b/crates/skippy-topology/src/artifact_diagnostics.rs
@@ -1,0 +1,54 @@
+use crate::{DiagnosticSeverity, NodePlacementSignal, PlanDiagnostic, PlanReasonCode, StagePlan};
+
+pub(crate) fn append_artifact_diagnostics(
+    diagnostics: &mut Vec<PlanDiagnostic>,
+    stages: &[StagePlan],
+    placement_signals: &[NodePlacementSignal],
+) {
+    let cached_bytes = stages
+        .iter()
+        .map(|stage| stage.cached_slice_bytes)
+        .sum::<u64>();
+    let missing_bytes = stages
+        .iter()
+        .map(|stage| stage.missing_artifact_bytes)
+        .sum::<u64>();
+
+    if cached_bytes == 0 && missing_bytes == 0 {
+        return;
+    }
+
+    let peer_transfer_bytes = missing_bytes_by_transfer_support(stages, placement_signals, true);
+    let remote_download_bytes = missing_bytes.saturating_sub(peer_transfer_bytes);
+    let code = if missing_bytes > 0 {
+        PlanReasonCode::ArtifactTransferPenalty
+    } else {
+        PlanReasonCode::CacheLocalityPreferred
+    };
+
+    diagnostics.push(PlanDiagnostic {
+        severity: DiagnosticSeverity::Info,
+        code,
+        message: format!(
+            "artifact cold-start plan: cached={} bytes, missing={} bytes, peer-transfer-eligible={} bytes, remote-download-fallback={} bytes",
+            cached_bytes, missing_bytes, peer_transfer_bytes, remote_download_bytes
+        ),
+    });
+}
+
+fn missing_bytes_by_transfer_support(
+    stages: &[StagePlan],
+    placement_signals: &[NodePlacementSignal],
+    transfer_supported: bool,
+) -> u64 {
+    stages
+        .iter()
+        .filter(|stage| {
+            placement_signals
+                .iter()
+                .find(|signal| signal.node_id == stage.node_id)
+                .is_some_and(|signal| signal.artifact_transfer_supported == transfer_supported)
+        })
+        .map(|stage| stage.missing_artifact_bytes)
+        .sum()
+}

--- a/crates/skippy-topology/src/edge_order.rs
+++ b/crates/skippy-topology/src/edge_order.rs
@@ -1,0 +1,188 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    DiagnosticSeverity, NodePlacementSignal, NodeSpec, PlanDiagnostic, PlanReasonCode, TopologyPlan,
+};
+
+const UNKNOWN_EDGE_RTT_MS: u64 = 10_000;
+const MAX_EXHAUSTIVE_STAGE_COUNT: usize = 8;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct StageEdgeSignal {
+    pub source_node_id: String,
+    pub target_node_id: String,
+    #[serde(default)]
+    pub rtt_ms: Option<u32>,
+    #[serde(default)]
+    pub large_frame_bytes_per_sec: Option<u64>,
+    #[serde(default)]
+    pub direct_prediction_return_supported: bool,
+}
+
+pub(crate) fn order_pipeline_nodes(
+    nodes: Vec<(usize, NodeSpec)>,
+    placement_signals: &[NodePlacementSignal],
+    edge_signals: &[StageEdgeSignal],
+) -> Vec<(usize, NodeSpec)> {
+    if nodes.len() < 3 || edge_signals.is_empty() {
+        return nodes;
+    }
+    if nodes.len() <= MAX_EXHAUSTIVE_STAGE_COUNT {
+        return best_exhaustive_order(nodes, placement_signals, edge_signals);
+    }
+    greedy_order(nodes, placement_signals, edge_signals)
+}
+
+pub(crate) fn append_edge_diagnostics(plan: &mut TopologyPlan, edge_signals: &[StageEdgeSignal]) {
+    if edge_signals.is_empty() {
+        return;
+    }
+
+    for window in plan.stages.windows(2) {
+        let source = &window[0];
+        let target = &window[1];
+        let Some(edge) = edge_signal_for(edge_signals, &source.node_id, &target.node_id) else {
+            continue;
+        };
+        let Some(rtt_ms) = edge.rtt_ms else {
+            continue;
+        };
+        plan.diagnostics.push(PlanDiagnostic {
+            severity: DiagnosticSeverity::Info,
+            code: PlanReasonCode::NetworkPipelineCost,
+            message: format!(
+                "pipeline edge {} -> {} after {} has measured rtt {} ms",
+                source.node_id, target.node_id, source.stage_id, rtt_ms
+            ),
+        });
+    }
+}
+
+fn best_exhaustive_order(
+    nodes: Vec<(usize, NodeSpec)>,
+    placement_signals: &[NodePlacementSignal],
+    edge_signals: &[StageEdgeSignal],
+) -> Vec<(usize, NodeSpec)> {
+    let mut best_order = nodes.clone();
+    let mut best_score = order_score(&best_order, placement_signals, edge_signals);
+    let mut candidate = nodes;
+    permute(0, &mut candidate, &mut |order| {
+        let score = order_score(order, placement_signals, edge_signals);
+        if score < best_score {
+            best_score = score;
+            best_order = order.to_vec();
+        }
+    });
+    best_order
+}
+
+fn greedy_order(
+    nodes: Vec<(usize, NodeSpec)>,
+    placement_signals: &[NodePlacementSignal],
+    edge_signals: &[StageEdgeSignal],
+) -> Vec<(usize, NodeSpec)> {
+    let mut remaining = nodes;
+    let mut best_start = 0;
+    let mut best_cost = u64::MAX;
+    for (index, (_, node)) in remaining.iter().enumerate() {
+        let cost = node_latency_cost(node, placement_signals);
+        if cost < best_cost {
+            best_start = index;
+            best_cost = cost;
+        }
+    }
+
+    let mut ordered = vec![remaining.remove(best_start)];
+    while !remaining.is_empty() {
+        let source_id = &ordered.last().expect("ordered has a start").1.node_id;
+        let mut best_next = 0;
+        let mut best_next_cost = u64::MAX;
+        for (index, (_, candidate)) in remaining.iter().enumerate() {
+            let cost = edge_cost(
+                source_id,
+                &candidate.node_id,
+                placement_signals,
+                edge_signals,
+            );
+            if cost < best_next_cost {
+                best_next = index;
+                best_next_cost = cost;
+            }
+        }
+        ordered.push(remaining.remove(best_next));
+    }
+    ordered
+}
+
+fn permute(
+    start: usize,
+    values: &mut [(usize, NodeSpec)],
+    visit: &mut impl FnMut(&[(usize, NodeSpec)]),
+) {
+    if start == values.len() {
+        visit(values);
+        return;
+    }
+    for index in start..values.len() {
+        values.swap(start, index);
+        permute(start + 1, values, visit);
+        values.swap(start, index);
+    }
+}
+
+fn order_score(
+    order: &[(usize, NodeSpec)],
+    placement_signals: &[NodePlacementSignal],
+    edge_signals: &[StageEdgeSignal],
+) -> (u64, Vec<usize>) {
+    let edge_cost = order
+        .windows(2)
+        .map(|window| {
+            edge_cost(
+                &window[0].1.node_id,
+                &window[1].1.node_id,
+                placement_signals,
+                edge_signals,
+            )
+        })
+        .sum();
+    let stable_order = order.iter().map(|(index, _)| *index).collect();
+    (edge_cost, stable_order)
+}
+
+fn edge_cost(
+    source: &str,
+    target: &str,
+    placement_signals: &[NodePlacementSignal],
+    edge_signals: &[StageEdgeSignal],
+) -> u64 {
+    if let Some(edge) = edge_signal_for(edge_signals, source, target) {
+        return edge.rtt_ms.map(u64::from).unwrap_or(UNKNOWN_EDGE_RTT_MS);
+    }
+    node_latency_cost_by_id(source, placement_signals)
+        .saturating_add(node_latency_cost_by_id(target, placement_signals))
+        .max(UNKNOWN_EDGE_RTT_MS)
+}
+
+fn edge_signal_for<'a>(
+    edge_signals: &'a [StageEdgeSignal],
+    source: &str,
+    target: &str,
+) -> Option<&'a StageEdgeSignal> {
+    edge_signals
+        .iter()
+        .find(|edge| edge.source_node_id == source && edge.target_node_id == target)
+}
+
+fn node_latency_cost(node: &NodeSpec, placement_signals: &[NodePlacementSignal]) -> u64 {
+    node_latency_cost_by_id(&node.node_id, placement_signals)
+}
+
+fn node_latency_cost_by_id(node_id: &str, placement_signals: &[NodePlacementSignal]) -> u64 {
+    placement_signals
+        .iter()
+        .find(|signal| signal.node_id == node_id)
+        .and_then(|signal| signal.rtt_ms)
+        .map(u64::from)
+        .unwrap_or(UNKNOWN_EDGE_RTT_MS)
+}

--- a/crates/skippy-topology/src/lib.rs
+++ b/crates/skippy-topology/src/lib.rs
@@ -1,5 +1,9 @@
 use serde::{Deserialize, Serialize};
 
+mod artifact_diagnostics;
+mod edge_order;
+pub use edge_order::StageEdgeSignal;
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct TopologyPlanRequest {
     pub topology_id: String,
@@ -70,6 +74,8 @@ pub struct StagePlan {
     pub stage_id: String,
     pub stage_index: u32,
     pub node_id: String,
+    #[serde(default)]
+    pub roles: Vec<StageRole>,
     pub layer_start: u32,
     pub layer_end: u32,
     pub layer_count: u32,
@@ -84,6 +90,15 @@ pub struct StagePlan {
     pub missing_artifact_bytes: u64,
     #[serde(default)]
     pub rtt_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StageRole {
+    Driver,
+    Embedding,
+    Intermediate,
+    Readout,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -942,10 +957,19 @@ pub fn plan_package_aware_contiguous_with_signals(
     request: &TopologyPlanRequest,
     placement_signals: &[NodePlacementSignal],
 ) -> Result<TopologyPlan, PlanError> {
+    plan_package_aware_contiguous_with_transport(request, placement_signals, &[])
+}
+
+pub fn plan_package_aware_contiguous_with_transport(
+    request: &TopologyPlanRequest,
+    placement_signals: &[NodePlacementSignal],
+    edge_signals: &[StageEdgeSignal],
+) -> Result<TopologyPlan, PlanError> {
     validate_request(request)?;
 
     if !request.nodes.iter().any(|node| node.cached_slice_bytes > 0)
         && !placement_signals.iter().any(has_package_aware_signal)
+        && edge_signals.is_empty()
     {
         return plan_weighted_contiguous(request);
     }
@@ -964,6 +988,7 @@ pub fn plan_package_aware_contiguous_with_signals(
             .then_with(|| left_index.cmp(right_index))
             .then_with(|| left.node_id.cmp(&right.node_id))
     });
+    let nodes = edge_order::order_pipeline_nodes(nodes, placement_signals, edge_signals);
 
     let sorted_request = TopologyPlanRequest {
         topology_id: request.topology_id.clone(),
@@ -973,7 +998,9 @@ pub fn plan_package_aware_contiguous_with_signals(
         family: request.family.clone(),
         policy: request.policy,
     };
-    plan_weighted_contiguous_with_signals(&sorted_request, placement_signals)
+    let mut plan = plan_weighted_contiguous_with_signals(&sorted_request, placement_signals)?;
+    edge_order::append_edge_diagnostics(&mut plan, edge_signals);
+    Ok(plan)
 }
 
 pub fn plan_contiguous_with_splits(
@@ -1066,6 +1093,7 @@ fn plan_ranges_with_signals(
             stage_id: format!("stage-{stage_index}"),
             stage_index: stage_index as u32,
             node_id,
+            roles: stage_roles(stage_index, ranges.len()),
             layer_start,
             layer_end,
             layer_count: (end - start) as u32,
@@ -1087,6 +1115,7 @@ fn plan_ranges_with_signals(
     let diagnostics = diagnostics_for(
         &stages,
         &boundaries,
+        placement_signals,
         request.family.as_ref(),
         request.policy,
     );
@@ -1235,6 +1264,20 @@ fn stage_reason_codes(
     codes
 }
 
+fn stage_roles(stage_index: usize, stage_count: usize) -> Vec<StageRole> {
+    let mut roles = Vec::new();
+    if stage_index == 0 {
+        roles.push(StageRole::Driver);
+        roles.push(StageRole::Embedding);
+    }
+    if stage_index + 1 == stage_count {
+        roles.push(StageRole::Readout);
+    } else if stage_index > 0 {
+        roles.push(StageRole::Intermediate);
+    }
+    roles
+}
+
 fn boundaries_for(
     stages: &[StagePlan],
     family: Option<&FamilyCapabilityRecord>,
@@ -1375,10 +1418,12 @@ pub fn wire_payload_bytes_per_token(activation_width: u32, dtype: WireDType) -> 
 fn diagnostics_for(
     stages: &[StagePlan],
     boundaries: &[BoundaryPlan],
+    placement_signals: &[NodePlacementSignal],
     family: Option<&FamilyCapabilityRecord>,
     policy: PlannerPolicy,
 ) -> Vec<PlanDiagnostic> {
     let mut diagnostics = Vec::new();
+    artifact_diagnostics::append_artifact_diagnostics(&mut diagnostics, stages, placement_signals);
     for stage in stages {
         if matches!(
             stage.migration_policy,

--- a/crates/skippy-topology/src/tests.rs
+++ b/crates/skippy-topology/src/tests.rs
@@ -34,10 +34,27 @@ fn placement_signal(node_id: &str) -> NodePlacementSignal {
     }
 }
 
+fn edge(source: &str, target: &str, rtt_ms: u32) -> StageEdgeSignal {
+    StageEdgeSignal {
+        source_node_id: source.to_string(),
+        target_node_id: target.to_string(),
+        rtt_ms: Some(rtt_ms),
+        large_frame_bytes_per_sec: None,
+        direct_prediction_return_supported: true,
+    }
+}
+
 fn stage_layout(plan: &TopologyPlan) -> Vec<(&str, u32, u32)> {
     plan.stages
         .iter()
         .map(|stage| (stage.node_id.as_str(), stage.layer_start, stage.layer_end))
+        .collect()
+}
+
+fn role_layout(plan: &TopologyPlan) -> Vec<Vec<StageRole>> {
+    plan.stages
+        .iter()
+        .map(|stage| stage.roles.clone())
         .collect()
 }
 
@@ -66,6 +83,52 @@ fn dense_attention_plan_allows_costed_kv_migration() {
             .all(|stage| stage.migration_policy == MigrationPolicy::CostedKv)
     );
     assert!(plan.diagnostics.is_empty());
+}
+
+#[test]
+fn split_topology_labels_driver_embedding_intermediate_and_readout_roles() {
+    let request = TopologyPlanRequest {
+        topology_id: "roles".to_string(),
+        model_id: "qwen3".to_string(),
+        layers: dense_attention_layers(9, 10),
+        nodes: nodes(3),
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_even_contiguous(&request).expect("plan");
+
+    assert_eq!(
+        role_layout(&plan),
+        vec![
+            vec![StageRole::Driver, StageRole::Embedding],
+            vec![StageRole::Intermediate],
+            vec![StageRole::Readout],
+        ]
+    );
+}
+
+#[test]
+fn single_stage_topology_labels_combined_driver_embedding_and_readout() {
+    let request = TopologyPlanRequest {
+        topology_id: "single-roles".to_string(),
+        model_id: "qwen3".to_string(),
+        layers: dense_attention_layers(2, 10),
+        nodes: nodes(1),
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_even_contiguous(&request).expect("plan");
+
+    assert_eq!(
+        role_layout(&plan),
+        vec![vec![
+            StageRole::Driver,
+            StageRole::Embedding,
+            StageRole::Readout,
+        ]]
+    );
 }
 
 #[test]
@@ -170,6 +233,70 @@ fn package_aware_plan_prefers_cached_peer_for_equal_capacity() {
 }
 
 #[test]
+fn package_aware_plan_reports_cold_start_artifact_totals() {
+    let mut transfer_ready = placement_signal("transfer-ready");
+    transfer_ready.missing_artifact_bytes = 32;
+    transfer_ready.artifact_transfer_supported = true;
+    let mut remote_fallback = placement_signal("remote-fallback");
+    remote_fallback.missing_artifact_bytes = 16;
+    remote_fallback.artifact_transfer_supported = false;
+    let mut warm = placement_signal("warm");
+    warm.cached_slice_bytes = 64;
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(9, 10),
+        nodes: vec![
+            weighted_node("transfer-ready", 30),
+            weighted_node("remote-fallback", 30),
+            weighted_node("warm", 30),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_signals(
+        &request,
+        &[transfer_ready, remote_fallback, warm],
+    )
+    .expect("plan");
+
+    let diagnostic = plan
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == PlanReasonCode::ArtifactTransferPenalty)
+        .expect("artifact diagnostic");
+    assert!(diagnostic.message.contains("cached=64 bytes"));
+    assert!(diagnostic.message.contains("missing=48 bytes"));
+    assert!(
+        diagnostic
+            .message
+            .contains("peer-transfer-eligible=32 bytes")
+    );
+    assert!(
+        diagnostic
+            .message
+            .contains("remote-download-fallback=16 bytes")
+    );
+}
+
+#[test]
+fn weighted_plan_without_artifact_signals_stays_diagnostic_quiet() {
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(6, 10),
+        nodes: vec![weighted_node("node-a", 30), weighted_node("node-b", 30)],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_weighted_contiguous(&request).expect("plan");
+
+    assert!(plan.diagnostics.is_empty());
+}
+
+#[test]
 fn package_aware_plan_penalizes_missing_untransferable_artifacts() {
     let mut cold = placement_signal("cold-high-vram");
     cold.missing_artifact_bytes = 64;
@@ -252,6 +379,67 @@ fn package_aware_plan_can_promote_extra_cached_peer() {
         plan.stages
             .iter()
             .any(|stage| stage.node_id == "cold-a" || stage.node_id == "cold-b")
+    );
+}
+
+#[test]
+fn transport_aware_plan_orders_same_nodes_by_stage_edge_cost() {
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(9, 10),
+        nodes: vec![
+            weighted_node("node-a", 30),
+            weighted_node("node-b", 30),
+            weighted_node("node-c", 30),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_transport(
+        &request,
+        &[],
+        &[
+            edge("node-a", "node-b", 200),
+            edge("node-b", "node-c", 200),
+            edge("node-a", "node-c", 5),
+            edge("node-c", "node-b", 5),
+        ],
+    )
+    .expect("plan");
+
+    assert_eq!(
+        stage_layout(&plan),
+        vec![("node-a", 0, 3), ("node-c", 3, 6), ("node-b", 6, 9)]
+    );
+    assert!(plan.diagnostics.iter().any(|diagnostic| diagnostic.code
+        == PlanReasonCode::NetworkPipelineCost
+        && diagnostic.message.contains("node-a -> node-c")));
+}
+
+#[test]
+fn transport_aware_plan_preserves_package_order_when_edges_tie() {
+    let mut warm = placement_signal("warm");
+    warm.cached_slice_bytes = 64;
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(9, 10),
+        nodes: vec![
+            weighted_node("cold-a", 30),
+            weighted_node("warm", 30),
+            weighted_node("cold-b", 30),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_transport(&request, &[warm], &[]).expect("plan");
+
+    assert_eq!(
+        stage_layout(&plan),
+        vec![("warm", 0, 3), ("cold-a", 3, 6), ("cold-b", 6, 9)]
     );
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Use this hub to find project guides that are not owned by a single Rust crate.
 | [skippy/TOPOLOGY_PLANNER.md](skippy/TOPOLOGY_PLANNER.md) | Stage topology planning behavior |
 | [skippy/CONFIGURATION.md](skippy/CONFIGURATION.md) | Authoritative operator matrix for Skippy config keys and rejection boundaries |
 | [skippy/DATA_FLOW.md](skippy/DATA_FLOW.md) | Stage data flow and transport details |
+| [skippy/MLX_CONCEPTS_FOR_SKIPPY.md](skippy/MLX_CONCEPTS_FOR_SKIPPY.md) | MLX distributed-parallelism ideas translated into Skippy implementation work |
 | [skippy/LLAMA_PARITY.md](skippy/LLAMA_PARITY.md) | Remaining llama.cpp parity queue |
 | [specs/layer-package-repos.md](specs/layer-package-repos.md) | Manifest schema and package artifact rules |
 | [SKIPPY.md](SKIPPY.md) | Skippy integration readiness and parity notes |

--- a/docs/skippy/MLX_CONCEPTS_FOR_SKIPPY.md
+++ b/docs/skippy/MLX_CONCEPTS_FOR_SKIPPY.md
@@ -1,0 +1,286 @@
+# MLX Concepts To Steal For Skippy
+
+This plan captures useful distributed-parallelism ideas from MLX and translates
+them into Skippy split-serving work. The goal is not to add an MLX backend or
+to implement tensor parallelism in Skippy. The goal is to improve Skippy's
+existing layer pipeline by borrowing the parts of MLX that map cleanly onto
+GGUF stage serving.
+
+Reference source snapshot:
+
+| Repo | Commit | Relevant surface |
+| --- | --- | --- |
+| `ml-explore/mlx` | `968d264f2903d578e699c4452a4dbf48633921aa` | distributed ops, Ring transport, launch docs |
+| `ml-explore/mlx-lm` | `df48987708fc90b8fac72fb6db7538c5dbb1077d` | `sharded_load`, pipeline mixin, server request sync |
+
+## Boundary
+
+In scope:
+
+- transport-aware Skippy stage ordering;
+- large activation-frame transfer improvements;
+- package/artifact planning improvements inspired by metadata-first loading;
+- readout-stage topology experiments inspired by MLX rank ordering;
+- request and cache coordination ideas that apply to Skippy stage sessions.
+
+Out of scope:
+
+- adding an MLX serving backend;
+- reimplementing MLX tensor parallelism;
+- adding all-reduce collectives to Skippy decode;
+- changing the public OpenAI frontend ownership away from `openai-frontend`;
+- replacing GGUF layer packages with safetensors.
+
+Tensor parallelism can stay as research context. It is not a Skippy work item
+until there is a concrete llama.cpp staged-runtime design for tensor-sharded
+weights, collectives, KV layout, correctness certification, and mixed-version
+mesh behavior.
+
+## What MLX Does That Matters
+
+### Pipeline Rank Ordering
+
+MLX pipeline mode assigns rank `0` to the final layer range and the highest rank
+to the first layer range. Forward execution receives from `rank + 1`, computes
+local layers, sends to `rank - 1`, then gathers the final hidden state. This is
+the inverse of Skippy's public-facing mental model, where stage `0` owns the
+first layers and the OpenAI-facing driver.
+
+Skippy should not blindly reverse stage numbering, because stage `0` also owns
+tokenization, session control, and public routing. The useful idea is to treat
+the readout/final layer owner as a first-class topology role rather than only
+the tail of a chain.
+
+### Neighbor-Only Pipeline Shape
+
+MLX Ring over TCP only supports `send`/`recv` between direct neighbors. Pipeline
+models are shaped to match that constraint: activation flow is adjacent-rank
+only. Skippy already uses an activation chain, but the planner currently has
+room to become more explicit about ordered edge quality.
+
+The useful idea is not the ring itself; it is the discipline of making the
+pipeline topology match what the transport is good at.
+
+### Metadata-First Artifact Loading
+
+MLX `sharded_load` downloads non-weight metadata first, lazy-builds the model,
+applies pipeline pruning, then uses `model.safetensors.index.json` to fetch only
+the local rank's weight files. Skippy layer packages already provide per-layer
+artifacts, but the same two-phase planning shape is worth making explicit:
+
+1. resolve package metadata and layer inventory;
+2. plan stages using local cache and peer transfer signals;
+3. fetch only the artifacts needed for the accepted topology;
+4. publish routability only after the selected artifacts and stages are ready.
+
+### Multi-Connection Large Transfers
+
+MLX Ring can stripe large payloads over multiple neighbor sockets. Decode
+activations are small enough that striping would add complexity without much
+gain, but prefill activation frames can be large and dominate total transfer.
+
+Skippy should evaluate striping only for large prefill activation frames and
+artifact transfer, with decode left on the simple single-frame path.
+
+### Rank-0 Request Broadcast
+
+The MLX HTTP server lets rank `0` dequeue requests, then broadcasts serialized
+request data to all ranks through collectives so every process participates in
+the same generation loop. Skippy stages already receive typed stage messages,
+so this does not map directly. The useful idea is synchronized request epochs:
+every stage should agree on request/session/generation boundaries before work is
+allowed to overlap aggressively.
+
+## Workstream 1: Transport-Aware Stage Ordering
+
+Objective: make the Skippy topology planner score ordered stage edges, not just
+individual nodes.
+
+Implementation tasks:
+
+1. Extend topology inputs with pairwise edge measurements:
+   - RTT;
+   - sustained large-frame throughput when available;
+   - optional operator-provided fabric label such as `lan`, `thunderbolt`, or
+     `wan`;
+   - whether direct prediction return is available for the edge from final
+     stage to driver-facing stage.
+2. Add an edge-cost model in `skippy-topology`:
+   - decode edge cost: latency dominated;
+   - prefill edge cost: bytes divided by measured or estimated throughput;
+   - artifact edge cost: cold-path transfer cost, not decode hot path.
+3. Make candidate plans order-aware:
+   - choose stage permutations that minimize serialized decode edge cost;
+   - preserve memory and family-boundary constraints;
+   - keep fewer physical stages preferred when they satisfy residency.
+4. Emit diagnostics:
+   - chosen ordered edges;
+   - rejected lower-cost orders and the reason they failed;
+   - estimated decode network floor;
+   - estimated prefill transfer pressure.
+
+Acceptance evidence:
+
+- `skippy-topology` unit tests show the same node set can be ordered
+  differently when edge costs differ.
+- Split doctor reports ordered stage edges and their edge-cost reasons.
+- A two-node and four-node split still produce the same model outputs as the
+  current planner under identical boundaries.
+
+## Workstream 2: Large Prefill Activation-Frame Striping
+
+Objective: reduce prefill transfer time for large activation frames without
+making decode more fragile.
+
+Implementation tasks:
+
+1. Add a negotiated stage capability for striped activation frames.
+2. Keep the existing single-frame protocol as the compatibility default.
+3. Add a new large-frame path for prefill only:
+   - split frames above a configurable byte threshold;
+   - send chunks over multiple streams or connections;
+   - reassemble by request id, session id, frame sequence, and chunk index;
+   - enforce max decoded activation bytes before allocation.
+4. Keep decode activations single-path unless measurements prove otherwise.
+5. Add backpressure:
+   - per-request maximum in-flight chunks;
+   - per-stage maximum buffered reassembly bytes;
+   - timeout and cleanup for incomplete frames.
+6. Add telemetry:
+   - striped frame count;
+   - chunk count;
+   - reassembly wait time;
+   - bytes sent per stream;
+   - fallback count to single-frame mode.
+
+Acceptance evidence:
+
+- `skippy-protocol` tests cover chunk header parsing, out-of-order chunks,
+  duplicate chunks, timeout cleanup, and max-size rejection.
+- `skippy-server` tests cover single-frame fallback when a peer does not
+  advertise striping.
+- `skippy-bench` can compare no striping versus striping on a long-prompt
+  corpus and report TTFT plus per-stage forward-write time.
+
+## Workstream 3: Metadata-First Package Planning
+
+Objective: make Skippy's package resolution explicitly two-phase and avoid
+downloading or materializing artifacts before a topology is accepted.
+
+Implementation tasks:
+
+1. Separate package metadata resolution from artifact materialization:
+   - manifest;
+   - layer inventory;
+   - tokenizer/projector sidecar inventory;
+   - artifact sizes and hashes.
+2. Feed artifact presence into topology planning:
+   - local cached bytes;
+   - missing bytes;
+   - peer-transfer eligibility;
+   - Hugging Face fallback eligibility.
+3. After the topology is accepted, materialize only selected stage artifacts.
+4. Preserve original model layer indexes in every cache key and diagnostic.
+5. Report cold-start plan cost:
+   - local bytes already present;
+   - peer-transfer bytes;
+   - remote-download bytes;
+   - expected materialized stage bytes.
+
+Acceptance evidence:
+
+- Package-only certification can run metadata planning without materializing
+  unselected stage artifacts.
+- Split doctor shows why a node was selected when it had a better cached slice
+  despite lower raw availability score.
+- Materialized-stage cache cleanup still treats stage GGUFs as derived cache.
+
+## Workstream 4: Readout-Stage Topology Experiment
+
+Objective: test whether making the final/readout stage a first-class role can
+reduce decode hot-path latency or simplify direct prediction return.
+
+Candidate designs:
+
+| Design | Shape | Risk |
+| --- | --- | --- |
+| Current Skippy | stage `0` owns first layers and public driver; final stage returns prediction directly to stage `0` | Known path; direct return still pays final-to-stage0 hop |
+| MLX-like rank role | driver-facing process coordinates, but rank/readout `0` owns final layers | Requires careful session/control separation |
+| Split driver/readout | driver-facing stage owns OpenAI/session control; readout stage owns logits and direct client token return path | More protocol work; clearer role separation |
+
+Implementation tasks:
+
+1. Add topology role names distinct from numeric stage index:
+   - `driver`;
+   - `embedding`;
+   - `intermediate`;
+   - `readout`.
+2. Teach diagnostics to print roles and layer ranges separately.
+3. Build a benchmark-only prototype before changing production routing:
+   - same layers and peers as the current direct-return path;
+   - compare decode network floor, TTFT, and total tok/s;
+   - record failure and cancellation behavior.
+4. Decide whether the role model belongs in production topology planning.
+
+Acceptance evidence:
+
+- Benchmark report compares current direct-return topology with the role-based
+  prototype on the same hosts and model.
+- The prototype preserves OpenAI streaming order and cancellation behavior.
+- If results do not beat current generation 3 direct return, close this as an
+  experiment and keep only the role terminology if it improved diagnostics.
+
+## Workstream 5: Request And Cache Epoch Coordination
+
+Objective: borrow MLX's synchronized-request discipline without replacing
+Skippy's typed stage protocol.
+
+Implementation tasks:
+
+1. Add explicit request epoch fields to stage diagnostics:
+   - request id;
+   - session id;
+   - generation/config epoch;
+   - cache checkpoint generation.
+2. Assert that overlapped prefill, restore, trim, and decode frames cannot cross
+   incompatible epochs.
+3. Add a stage-local debug mode that records the last N epoch transitions per
+   session.
+4. Use epoch diagnostics in split doctor bundles when cache or cancellation
+   errors occur.
+
+Acceptance evidence:
+
+- Tests reject stale restore/trim messages that target an older checkpoint
+  generation when newer decode work has started.
+- A mini-agent tool-call loop with cache reuse still passes with epoch debug
+  enabled.
+
+## Do Not Do Yet: Tensor Parallelism
+
+MLX tensor parallelism shards every transformer block and uses all-reduce in the
+hot path. That is a different runtime architecture from Skippy's stage pipeline.
+For Skippy, tensor parallelism would require:
+
+- tensor-sharded GGUF loading;
+- llama.cpp graph changes for collectives;
+- KV-cache layout changes;
+- per-layer all-reduce transport;
+- new correctness certification;
+- new mixed-version mesh compatibility rules.
+
+Do not start this work under the MLX concept-stealing effort. If tensor
+parallelism becomes a goal later, it should have its own design document and
+explicit protocol-compatibility review.
+
+## Suggested Order
+
+1. Transport-aware stage ordering.
+2. Metadata-first package planning.
+3. Large prefill activation-frame striping.
+4. Request/cache epoch diagnostics.
+5. Readout-stage role experiment.
+
+This order improves the existing Skippy path first, keeps protocol risk
+contained, and avoids committing to a new backend or tensor-parallel runtime
+before the pipeline has absorbed the low-risk MLX lessons.


### PR DESCRIPTION
## Summary

Skippy can now borrow the useful parts of MLX pipeline parallelism without becoming an MLX backend and without adding tensor-parallel collectives.

The important translation is this:

- MLX pipeline mode is good at **owning only the layers a rank needs**, moving activations along a neighbor pipeline, and making request/rank state explicit.
- Skippy already has the right architectural shape for this with GGUF layer packages and stage servers.
- This PR makes Skippy’s existing pipeline more intentional: ordered transport edges, cold-start artifact accounting, explicit stage roles, request/cache epochs, and shared transfer-size accounting.

No public OpenAI API behavior changes. No stage wire-format bytes change. The new behavior is planner/protocol-helper/telemetry groundwork for better split serving.

## Big Picture

Before, Skippy’s pipeline mostly answered: “which nodes can hold these layer ranges?”

After this PR, the pipeline can also answer: “which ordered chain is cheapest to run, what artifacts will it need, what role does each stage play, what cache epoch is this message in, and how large is the activation transfer we are timing?”

```mermaid
flowchart LR
  Resolve["Package metadata\nlayer inventory"] --> Plan["Topology planner\ncapacity + cache + edge cost"]
  Plan --> Roles["Stage roles\nDriver / Embedding / Intermediate / Readout"]
  Roles --> Runtime["Stage runtime\nrequest epoch + activation transfer telemetry"]
  Runtime --> Diagnose["Diagnostics\nwhy this plan, what it costs"]
```

## 1. Transport-Aware Stage Ordering

### Before

The package-aware contiguous planner could prefer nodes based on node-local signals such as VRAM, cached artifact bytes, missing artifact bytes, and RTT-ish placement hints.

That was useful but incomplete for a pipeline. In a layer pipeline, adjacent stages exchange activations on every prefill/decode step. The cost that matters is not only “is node B good?” but also “is the edge from node A to node B good?”

So two plans could contain the same nodes and the same layer ranges, but have very different runtime behavior:

```mermaid
flowchart LR
  subgraph SameNodesBadOrder["Before: same selected nodes, unlucky order"]
    A["stage 0\nnode A"] -->|"18 ms"| B["stage 1\nnode B"]
    B -->|"24 ms"| C["stage 2\nnode C"]
    C -->|"3 ms"| D["stage 3\nnode D"]
  end
```

The old planner had no directed edge model to say that `A -> C -> B -> D` is a better chain than `A -> B -> C -> D` when both are otherwise valid.

### How It Works Now

This PR adds `StageEdgeSignal`:

- `source_node_id`
- `target_node_id`
- optional directed `rtt_ms`
- optional `large_frame_bytes_per_sec`
- `direct_prediction_return_supported`

The new `plan_package_aware_contiguous_with_transport(...)` entry point keeps the same package-aware placement constraints, then scores possible stage orderings by adjacent directed edge cost.

For small stage counts, it exhaustively evaluates permutations. For larger stage counts, it uses a greedy fallback so the planner does not explode combinatorially.

```mermaid
flowchart LR
  subgraph BetterOrder["After: ordered by adjacent edge cost"]
    A["stage 0\nnode A"] -->|"2 ms"| C["stage 1\nnode C"]
    C -->|"3 ms"| B["stage 2\nnode B"]
    B -->|"4 ms"| D["stage 3\nnode D"]
  end
```

Diagnostics now record measured chosen edges, for example:

```text
[info] pipeline edge mac-a -> mac-c after stage-0 has measured rtt 2 ms
[info] pipeline edge mac-c -> mac-b after stage-1 has measured rtt 3 ms
```

### Why This Is Good

Skippy split serving is latency-sensitive because decode is a serialized chain. A single bad adjacent hop can dominate the whole pipeline even if every individual node has enough memory.

This gives the planner the same practical discipline MLX gets from pipeline ranks over Ring/TCP: make the model topology match the transport shape. It is especially useful on real meshes where Ethernet, Wi-Fi, Thunderbolt, and remote nodes can all appear in the same candidate set.

### Reviewer Notes

- This does not use host-runtime peer RTT as if it were true stage-to-stage RTT.
- The API accepts directed edge signals explicitly, which keeps the planner honest until runtime stage-edge measurement is wired in.
- Existing package-aware planning still works via the old entry point.

## 2. Artifact Cold-Start Visibility

### Before

Skippy already has layer packages, and package locality can affect placement. But once the planner accepted a topology, it did not summarize the artifact cold-start cost of that topology.

Operators could infer some things from node selection, but they could not easily see:

- how many selected bytes are already cached
- how many bytes are missing
- how many missing bytes can come from peers
- how many missing bytes must fall back to remote download

That made slow startup harder to explain.

### How It Works Now

This PR adds `artifact_diagnostics`.

After a package-aware plan is selected, the planner aggregates selected-stage artifact data:

- `cached_slice_bytes`
- `missing_artifact_bytes`
- whether the selected node supports artifact transfer
- remote-download fallback bytes

Representative diagnostic:

```text
[info] artifact cold-start plan: cached=19327352832 bytes, missing=6442450944 bytes, peer-transfer-eligible=4294967296 bytes, remote-download-fallback=2147483648 bytes
```

The diagnostic stays quiet for plain weighted plans that did not provide artifact signals, so existing non-package planning does not get noisy placeholder output.

### Why This Is Good

This is the Skippy version of MLX’s metadata-first load trick.

MLX pipeline load first discovers metadata and rank-owned weights, then each rank downloads only the files it needs. Skippy cannot copy that mechanism directly because it serves GGUF layer packages rather than safetensors, but the idea transfers cleanly:

1. inspect package/layer metadata first
2. plan topology using cache and transfer signals
3. materialize only the accepted stage artifacts
4. explain the cold-start cost of that decision

This makes package planning less of a black box and gives us the data needed for future “prefer cached topology” and peer-transfer scheduling work.

## 3. Stage Role Metadata

### Before

`stage_index` carried too much meaning implicitly.

For example:

- stage 0 usually acts as the driver
- the first layer owner acts as the embedding stage
- middle stages are intermediate activation processors
- the final layer owner acts as the readout/logits stage

Those roles were real, but they were not explicit in the topology data. A reviewer or UI had to infer behavior from index and layer range.

### How It Works Now

This PR adds `StageRole`:

- `Driver`
- `Embedding`
- `Intermediate`
- `Readout`

Each `StagePlan` now carries a `roles: Vec<StageRole>` field with serde defaulting, so older serialized plans that do not include roles still deserialize.

Role assignment is deterministic:

- first stage: `Driver`, `Embedding`
- middle stages: `Intermediate`
- last stage: `Readout`
- single-stage plan: `Driver`, `Embedding`, `Readout`

```mermaid
flowchart LR
  S0["stage 0\nroles: Driver, Embedding\nlayers 0..12"] --> S1["stage 1\nroles: Intermediate\nlayers 12..28"]
  S1 --> S2["stage 2\nroles: Readout\nlayers 28..40"]
  S2 -. "prediction return" .-> S0
```

### Why This Is Good

MLX’s rank ordering made final/readout ownership obvious by convention. Skippy should not reverse public stage numbering just to copy MLX, because stage 0 owns driver/session responsibilities.

Explicit roles give us the useful part without destabilizing Skippy’s mental model:

- diagnostics can say what a stage does, not just what number it has
- UI/API surfaces can show role-aware topology
- future direct-return/readout experiments can reason about readout separately from numeric stage index
- single-stage and split-stage behavior are represented uniformly

This also reduces accidental coupling between “stage index” and “stage responsibility.”

## 4. Request / Cache Epoch Coordination

### Before

The binary stage protocol already carried the necessary identity fields:

- `request_id`
- `session_id`
- `checkpoint_generation`
- `prompt_token_count`
- `decode_step`

But code treated them as individual fields. There was no single value that meant “this stage message belongs to this request/cache generation.”

That makes future overlapping prefill, restore, trim, decode, and cache-reuse logic harder to audit.

### How It Works Now

This PR adds `StageRequestEpoch`, derived from existing wire/header fields:

```text
StageRequestEpoch {
  request_id,
  session_id,
  checkpoint_generation,
  prompt_token_count,
  decode_step,
}
```

`StageWireMessage::request_epoch()` centralizes extraction.

The epoch helper can compare whether two messages belong to the same request/session flow and whether one epoch is stale relative to another epoch.

Binary transport telemetry now includes checkpoint generation with the other epoch values:

```text
skippy.checkpoint_generation=3
skippy.prompt_token_count=8192
skippy.decode_step=0
```

### Why This Is Good

MLX rank 0 keeps ranks synchronized by broadcasting request state through collectives. Skippy does not need that exact broadcast pattern because Skippy has typed stage messages, but it needs the same discipline: every stage should agree about which request/session/cache generation a frame belongs to.

This PR does not start rejecting stale frames yet. It creates the safe vocabulary for that next step:

- cache restore/trim logic can compare epochs directly
- diagnostics can report exact request/cache generation
- tool-call loops with prefix reuse become easier to debug
- stale frame handling can be added without inventing a second identity model

### Compatibility

This is **not** a wire-format change.

- no new encoded fields
- no stage state version bump
- no protobuf/gossip change
- no mixed-version binary framing break

The protocol crate changed, but the on-the-wire bytes did not.

## 5. Activation-Frame Transfer Accounting

### Before

Skippy had two separate approximations of stage-message size:

- telemetry estimated `llama_stage.message_wire_bytes`
- downstream wire conditioning estimated transfer size for simulated bandwidth/delay

Those estimates could drift. The conditioned-wire path also undercounted parts of the message such as the full fixed header, position sidebands, sampling metadata, chat metadata, and raw import bytes.

For large prefill activation frames, that undercount makes simulated network pressure less trustworthy.

### How It Works Now

This PR adds `StageWireMessage::estimated_wire_bytes()`.

The estimate includes:

- fixed stage wire header
- sampling config bytes
- logit bias bytes
- chat sampling metadata length prefix and bytes
- token sideband bytes
- position sideband bytes
- state import raw bytes
- activation payload bytes

Both telemetry and wire conditioning now use the same helper.

Representative telemetry:

```text
llama_stage.message_wire_bytes=52429612
skippy.activation_bytes=52428800
skippy.checkpoint_generation=3
skippy.prompt_token_count=8192
skippy.decode_step=0
```

### Why This Is Good

MLX can stripe large payloads over multiple neighbor sockets. Skippy is not adding striping in this PR because that needs capability negotiation, chunk headers, reassembly buffers, backpressure, and mixed-version fallback.

But before adding striping, Skippy needs accurate accounting:

- telemetry should say how big the actual frame was
- bandwidth simulation should sleep based on the same size telemetry reports
- benchmark reports should use numbers that include sidebands and metadata
- future striping thresholds can be based on a shared transfer-size model

This is the low-risk foundation for later large prefill-frame striping.

## CLI / Operator Output

No stable CLI command output changes in this PR.

The new user-visible text is planner and telemetry diagnostic material. Existing doctor/status/reporting surfaces can display it once they consume the new topology diagnostics.

Simulated representative output:

```text
[info] pipeline edge mac-a -> mac-c after stage-0 has measured rtt 2 ms
[info] pipeline edge mac-c -> mac-b after stage-1 has measured rtt 3 ms
[info] artifact cold-start plan: cached=19327352832 bytes, missing=6442450944 bytes, peer-transfer-eligible=4294967296 bytes, remote-download-fallback=2147483648 bytes

llama_stage.message_wire_bytes=52429612
skippy.activation_bytes=52428800
skippy.checkpoint_generation=3
skippy.prompt_token_count=8192
skippy.decode_step=0
```

## What This PR Does Not Do

- It does not add an MLX backend.
- It does not implement tensor parallelism.
- It does not add all-reduce collectives to Skippy decode.
- It does not change the OpenAI frontend ownership.
- It does not change the stage binary wire layout.
- It does not implement activation-frame striping yet; it adds the accounting needed to evaluate that safely.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p skippy-protocol --lib`
- `cargo test -p skippy-topology --lib`
- `cargo test -p skippy-server --lib`
- `cargo clippy -p skippy-protocol --all-targets -- -D warnings`
- `cargo clippy -p skippy-topology --all-targets -- -D warnings`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
