### PR TITLE
Report Skippy artifact cold-start costs

### DIFF
--- a/crates/skippy-topology/src/artifact_diagnostics.rs
+++ b/crates/skippy-topology/src/artifact_diagnostics.rs
@@ -1,0 +1,54 @@
+use crate::{DiagnosticSeverity, NodePlacementSignal, PlanDiagnostic, PlanReasonCode, StagePlan};
+
+pub(crate) fn append_artifact_diagnostics(
+    diagnostics: &mut Vec<PlanDiagnostic>,
+    stages: &[StagePlan],
+    placement_signals: &[NodePlacementSignal],
+) {
+    let cached_bytes = stages
+        .iter()
+        .map(|stage| stage.cached_slice_bytes)
+        .sum::<u64>();
+    let missing_bytes = stages
+        .iter()
+        .map(|stage| stage.missing_artifact_bytes)
+        .sum::<u64>();
+
+    if cached_bytes == 0 && missing_bytes == 0 {
+        return;
+    }
+
+    let peer_transfer_bytes = missing_bytes_by_transfer_support(stages, placement_signals, true);
+    let remote_download_bytes = missing_bytes.saturating_sub(peer_transfer_bytes);
+    let code = if missing_bytes > 0 {
+        PlanReasonCode::ArtifactTransferPenalty
+    } else {
+        PlanReasonCode::CacheLocalityPreferred
+    };
+
+    diagnostics.push(PlanDiagnostic {
+        severity: DiagnosticSeverity::Info,
+        code,
+        message: format!(
+            "artifact cold-start plan: cached={} bytes, missing={} bytes, peer-transfer-eligible={} bytes, remote-download-fallback={} bytes",
+            cached_bytes, missing_bytes, peer_transfer_bytes, remote_download_bytes
+        ),
+    });
+}
+
+fn missing_bytes_by_transfer_support(
+    stages: &[StagePlan],
+    placement_signals: &[NodePlacementSignal],
+    transfer_supported: bool,
+) -> u64 {
+    stages
+        .iter()
+        .filter(|stage| {
+            placement_signals
+                .iter()
+                .find(|signal| signal.node_id == stage.node_id)
+                .is_some_and(|signal| signal.artifact_transfer_supported == transfer_supported)
+        })
+        .map(|stage| stage.missing_artifact_bytes)
+        .sum()
+}

--- a/crates/skippy-topology/src/artifact_diagnostics.rs
+++ b/crates/skippy-topology/src/artifact_diagnostics.rs
@@ -7,11 +7,11 @@ pub(crate) fn append_artifact_diagnostics(
 ) {
     let cached_bytes = stages
         .iter()
-        .map(|stage| stage.cached_slice_bytes)
+        .map(cached_artifact_bytes_for_stage)
         .sum::<u64>();
     let missing_bytes = stages
         .iter()
-        .map(|stage| stage.missing_artifact_bytes)
+        .map(missing_artifact_bytes_for_stage)
         .sum::<u64>();
 
     if cached_bytes == 0 && missing_bytes == 0 {
@@ -49,6 +49,14 @@ fn missing_bytes_by_transfer_support(
                 .find(|signal| signal.node_id == stage.node_id)
                 .is_some_and(|signal| signal.artifact_transfer_supported == transfer_supported)
         })
-        .map(|stage| stage.missing_artifact_bytes)
+        .map(missing_artifact_bytes_for_stage)
         .sum()
+}
+
+fn cached_artifact_bytes_for_stage(stage: &StagePlan) -> u64 {
+    stage.cached_slice_bytes.min(stage.parameter_bytes)
+}
+
+fn missing_artifact_bytes_for_stage(stage: &StagePlan) -> u64 {
+    stage.missing_artifact_bytes.min(stage.parameter_bytes)
 }

--- a/crates/skippy-topology/src/lib.rs
+++ b/crates/skippy-topology/src/lib.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+mod artifact_diagnostics;
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct TopologyPlanRequest {
     pub topology_id: String,
@@ -1087,6 +1089,7 @@ fn plan_ranges_with_signals(
     let diagnostics = diagnostics_for(
         &stages,
         &boundaries,
+        placement_signals,
         request.family.as_ref(),
         request.policy,
     );
@@ -1375,10 +1378,12 @@ pub fn wire_payload_bytes_per_token(activation_width: u32, dtype: WireDType) -> 
 fn diagnostics_for(
     stages: &[StagePlan],
     boundaries: &[BoundaryPlan],
+    placement_signals: &[NodePlacementSignal],
     family: Option<&FamilyCapabilityRecord>,
     policy: PlannerPolicy,
 ) -> Vec<PlanDiagnostic> {
     let mut diagnostics = Vec::new();
+    artifact_diagnostics::append_artifact_diagnostics(&mut diagnostics, stages, placement_signals);
     for stage in stages {
         if matches!(
             stage.migration_policy,

--- a/crates/skippy-topology/src/tests.rs
+++ b/crates/skippy-topology/src/tests.rs
@@ -203,12 +203,12 @@ fn package_aware_plan_reports_cold_start_artifact_totals() {
         .iter()
         .find(|diagnostic| diagnostic.code == PlanReasonCode::ArtifactTransferPenalty)
         .expect("artifact diagnostic");
-    assert!(diagnostic.message.contains("cached=64 bytes"));
-    assert!(diagnostic.message.contains("missing=48 bytes"));
+    assert!(diagnostic.message.contains("cached=30 bytes"));
+    assert!(diagnostic.message.contains("missing=46 bytes"));
     assert!(
         diagnostic
             .message
-            .contains("peer-transfer-eligible=32 bytes")
+            .contains("peer-transfer-eligible=30 bytes")
     );
     assert!(
         diagnostic

--- a/crates/skippy-topology/src/tests.rs
+++ b/crates/skippy-topology/src/tests.rs
@@ -170,6 +170,70 @@ fn package_aware_plan_prefers_cached_peer_for_equal_capacity() {
 }
 
 #[test]
+fn package_aware_plan_reports_cold_start_artifact_totals() {
+    let mut transfer_ready = placement_signal("transfer-ready");
+    transfer_ready.missing_artifact_bytes = 32;
+    transfer_ready.artifact_transfer_supported = true;
+    let mut remote_fallback = placement_signal("remote-fallback");
+    remote_fallback.missing_artifact_bytes = 16;
+    remote_fallback.artifact_transfer_supported = false;
+    let mut warm = placement_signal("warm");
+    warm.cached_slice_bytes = 64;
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(9, 10),
+        nodes: vec![
+            weighted_node("transfer-ready", 30),
+            weighted_node("remote-fallback", 30),
+            weighted_node("warm", 30),
+        ],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_package_aware_contiguous_with_signals(
+        &request,
+        &[transfer_ready, remote_fallback, warm],
+    )
+    .expect("plan");
+
+    let diagnostic = plan
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == PlanReasonCode::ArtifactTransferPenalty)
+        .expect("artifact diagnostic");
+    assert!(diagnostic.message.contains("cached=64 bytes"));
+    assert!(diagnostic.message.contains("missing=48 bytes"));
+    assert!(
+        diagnostic
+            .message
+            .contains("peer-transfer-eligible=32 bytes")
+    );
+    assert!(
+        diagnostic
+            .message
+            .contains("remote-download-fallback=16 bytes")
+    );
+}
+
+#[test]
+fn weighted_plan_without_artifact_signals_stays_diagnostic_quiet() {
+    let request = TopologyPlanRequest {
+        topology_id: "topology-a".into(),
+        model_id: "model-a".into(),
+        layers: dense_attention_layers(6, 10),
+        nodes: vec![weighted_node("node-a", 30), weighted_node("node-b", 30)],
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_weighted_contiguous(&request).expect("plan");
+
+    assert!(plan.diagnostics.is_empty());
+}
+
+#[test]
 fn package_aware_plan_penalizes_missing_untransferable_artifacts() {
     let mut cold = placement_signal("cold-high-vram");
     cold.missing_artifact_bytes = 64;


### PR DESCRIPTION
## Summary

Add cold-start artifact cost diagnostics to Skippy topology planning.

This PR is only about explaining the artifact cost of an accepted package-aware plan. It does not change stage ordering, stage roles, runtime loading, or the binary protocol.

## Before

Package-aware planning could use cache and missing-artifact signals to affect placement, but the accepted plan did not summarize what startup would cost.

That left operators with a plan but not an explanation:

- how much of the selected topology is already cached
- how many bytes are missing
- how many missing bytes can come from peers
- how many bytes must fall back to remote download

## How It Works

`artifact_diagnostics` runs after stages are selected.

It aggregates selected stages:

- `cached_slice_bytes`
- `missing_artifact_bytes`
- transfer-supported missing bytes
- remote-download fallback bytes

It emits a single info diagnostic when artifact signals are present:

```text
[info] artifact cold-start plan: cached=64 bytes, missing=48 bytes, peer-transfer-eligible=32 bytes, remote-download-fallback=16 bytes
```

Plain weighted plans without artifact signals stay quiet, so non-package topology planning does not get noisy diagnostics.

## Why This Is Good

This makes package-aware planning explainable.

The planner can already choose a node because it has cached layers or because missing artifacts are cheap to transfer. This PR lets the accepted topology say that out loud. That matters for Skippy cold starts because slow startup is often artifact movement, not model execution.

It also prepares the next step toward metadata-first package planning: resolve package inventory, plan from cache/transfer signals, then materialize only the accepted stage artifacts.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p skippy-topology --lib`
- `cargo clippy -p skippy-topology --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostic reporting for artifact planning: adds detailed breakdowns of total cached bytes, total missing bytes, how much is eligible for peer transfer versus remote-download fallback, and an overall diagnostic severity/code reflecting artifact transfer impact.

* **Tests**
  * Added unit tests that validate artifact diagnostic messages and transfer-support detection across placement scenarios, and ensure no diagnostics are emitted when artifact signals are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->