### PR TITLE
Add Skippy stage role metadata

### DIFF
--- a/crates/skippy-topology/src/lib.rs
+++ b/crates/skippy-topology/src/lib.rs
@@ -70,6 +70,8 @@ pub struct StagePlan {
     pub stage_id: String,
     pub stage_index: u32,
     pub node_id: String,
+    #[serde(default)]
+    pub roles: Vec<StageRole>,
     pub layer_start: u32,
     pub layer_end: u32,
     pub layer_count: u32,
@@ -84,6 +86,15 @@ pub struct StagePlan {
     pub missing_artifact_bytes: u64,
     #[serde(default)]
     pub rtt_ms: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StageRole {
+    Driver,
+    Embedding,
+    Intermediate,
+    Readout,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
@@ -1066,6 +1077,7 @@ fn plan_ranges_with_signals(
             stage_id: format!("stage-{stage_index}"),
             stage_index: stage_index as u32,
             node_id,
+            roles: stage_roles(stage_index, ranges.len()),
             layer_start,
             layer_end,
             layer_count: (end - start) as u32,
@@ -1233,6 +1245,20 @@ fn stage_reason_codes(
         }
     }
     codes
+}
+
+fn stage_roles(stage_index: usize, stage_count: usize) -> Vec<StageRole> {
+    let mut roles = Vec::new();
+    if stage_index == 0 {
+        roles.push(StageRole::Driver);
+        roles.push(StageRole::Embedding);
+    }
+    if stage_index + 1 == stage_count {
+        roles.push(StageRole::Readout);
+    } else if stage_index > 0 {
+        roles.push(StageRole::Intermediate);
+    }
+    roles
 }
 
 fn boundaries_for(

--- a/crates/skippy-topology/src/tests.rs
+++ b/crates/skippy-topology/src/tests.rs
@@ -41,6 +41,13 @@ fn stage_layout(plan: &TopologyPlan) -> Vec<(&str, u32, u32)> {
         .collect()
 }
 
+fn role_layout(plan: &TopologyPlan) -> Vec<Vec<StageRole>> {
+    plan.stages
+        .iter()
+        .map(|stage| stage.roles.clone())
+        .collect()
+}
+
 #[test]
 fn dense_attention_plan_allows_costed_kv_migration() {
     let request = TopologyPlanRequest {
@@ -66,6 +73,52 @@ fn dense_attention_plan_allows_costed_kv_migration() {
             .all(|stage| stage.migration_policy == MigrationPolicy::CostedKv)
     );
     assert!(plan.diagnostics.is_empty());
+}
+
+#[test]
+fn split_topology_labels_driver_embedding_intermediate_and_readout_roles() {
+    let request = TopologyPlanRequest {
+        topology_id: "roles".to_string(),
+        model_id: "qwen3".to_string(),
+        layers: dense_attention_layers(9, 10),
+        nodes: nodes(3),
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_even_contiguous(&request).expect("plan");
+
+    assert_eq!(
+        role_layout(&plan),
+        vec![
+            vec![StageRole::Driver, StageRole::Embedding],
+            vec![StageRole::Intermediate],
+            vec![StageRole::Readout],
+        ]
+    );
+}
+
+#[test]
+fn single_stage_topology_labels_combined_driver_embedding_and_readout() {
+    let request = TopologyPlanRequest {
+        topology_id: "single-roles".to_string(),
+        model_id: "qwen3".to_string(),
+        layers: dense_attention_layers(2, 10),
+        nodes: nodes(1),
+        family: None,
+        policy: PlannerPolicy::default(),
+    };
+
+    let plan = plan_even_contiguous(&request).expect("plan");
+
+    assert_eq!(
+        role_layout(&plan),
+        vec![vec![
+            StageRole::Driver,
+            StageRole::Embedding,
+            StageRole::Readout,
+        ]]
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Add explicit role metadata to Skippy topology stages.

This PR is only about topology semantics. It does not change placement scoring, artifact diagnostics, protocol bytes, or runtime transport.

## Before

Stage behavior was inferred from numeric `stage_index` and layer range:

- stage 0 usually acted as the driver
- the first layer owner implicitly handled embedding-side work
- middle stages were just “not first or last”
- the final layer owner implicitly acted as the readout/logits stage

That worked internally, but it made diagnostics and future UI/API views rely on convention instead of data.

## How It Works

`StagePlan` now includes:

```rust
roles: Vec<StageRole>
```

with serde defaulting so older serialized plans that do not carry role data still deserialize.

Role assignment is deterministic:

- first stage: `Driver`, `Embedding`
- middle stages: `Intermediate`
- last stage: `Readout`
- single-stage plan: `Driver`, `Embedding`, `Readout`

```mermaid
flowchart LR
  S0["stage 0\nDriver + Embedding"] --> S1["stage 1\nIntermediate"]
  S1 --> S2["stage 2\nReadout"]
  S2 -. "prediction return" .-> S0
```

## Why This Is Good

Skippy should not reverse stage numbering just because MLX rank ordering makes readout ownership obvious. Stage 0 has driver/session meaning in Skippy.

Explicit roles give us the useful part without changing the numbering model:

- diagnostics can say what a stage does
- UI/API surfaces can display topology responsibilities directly
- direct-return and readout-stage experiments can reason about `Readout` independently from `stage_index`
- single-stage and split-stage topologies use the same role vocabulary

## Compatibility

The new `roles` field has `#[serde(default)]`, so older topology JSON that lacks role data still reads as an empty role list.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p skippy-topology --lib`
- `cargo clippy -p skippy-topology --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stages now include role classifications that identify their position and function in the execution pipeline: driver, embedding, intermediate, or readout.

* **Tests**
  * Added comprehensive test coverage to validate stage role assignments across various topology configurations, including multi-stage and single-stage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->