### PR TITLE
Wire live Skippy activation striping

### DIFF
--- a/crates/skippy-bench/src/activation_striping.rs
+++ b/crates/skippy-bench/src/activation_striping.rs
@@ -1,0 +1,351 @@
+use std::time::Instant;
+
+use anyhow::{Context, Result, bail};
+use model_artifact::gguf::scan_gguf_compact_meta;
+use serde::Serialize;
+use skippy_protocol::binary::{
+    StageActivationStripeReassembler, StageStateHeader, StageWireMessage, WireActivationDType,
+    WireMessageKind, read_activation_stripe_chunk, read_stage_message, state_flags,
+    stripe_activation_payload, write_activation_stripe_chunk, write_stage_message,
+};
+
+use crate::cli::ActivationStripingArgs;
+
+#[derive(Debug, Clone)]
+struct ActivationShape {
+    name: String,
+    tokens: usize,
+    hidden_size: usize,
+    bytes_per_element: usize,
+}
+
+impl ActivationShape {
+    fn payload_bytes(&self) -> Result<usize> {
+        self.tokens
+            .checked_mul(self.hidden_size)
+            .and_then(|value| value.checked_mul(self.bytes_per_element))
+            .context("activation payload byte count overflow")
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct BenchRow {
+    shape: String,
+    tokens: usize,
+    hidden_size: usize,
+    bytes_per_element: usize,
+    payload_bytes: usize,
+    stripes: usize,
+    chunk_bytes: usize,
+    chunks: usize,
+    synthetic_per_stream_mbps: f64,
+    wall_ms: f64,
+    transfer_floor_ms: f64,
+    effective_mbps: f64,
+    speedup_vs_single_stream: f64,
+}
+
+pub fn activation_striping(args: ActivationStripingArgs) -> Result<()> {
+    let shapes = activation_shapes(&args)?;
+    let stripe_counts = parse_usize_list(&args.stripes, "stripes")?;
+    if args.per_stream_mbps <= 0.0 {
+        bail!("--per-stream-mbps must be greater than zero");
+    }
+    if args.chunk_mib == 0 {
+        bail!("--chunk-mib must be greater than zero");
+    }
+    if args.repetitions == 0 {
+        bail!("--repetitions must be greater than zero");
+    }
+    let chunk_bytes = args
+        .chunk_mib
+        .checked_mul(1024 * 1024)
+        .context("--chunk-mib overflow")?;
+
+    let mut rows = Vec::new();
+    for shape in shapes {
+        let payload = deterministic_payload(shape.payload_bytes()?);
+        let baseline_floor_ms = synthetic_transfer_ms(payload.len(), 1, args.per_stream_mbps);
+        for stripes in &stripe_counts {
+            let row = bench_shape(
+                &shape,
+                &payload,
+                *stripes,
+                chunk_bytes,
+                args.per_stream_mbps,
+                baseline_floor_ms,
+                args.repetitions,
+            )?;
+            rows.push(row);
+        }
+    }
+
+    print_markdown_table(&rows);
+    println!();
+    println!("```json");
+    println!("{}", serde_json::to_string_pretty(&rows)?);
+    println!("```");
+    Ok(())
+}
+
+fn activation_shapes(args: &ActivationStripingArgs) -> Result<Vec<ActivationShape>> {
+    let mut shapes = parse_shapes(&args.activation_shapes)?;
+    if let Some(model_path) = &args.model_path {
+        shapes.extend(model_activation_shapes(args, model_path)?);
+    }
+    if shapes.is_empty() {
+        bail!("no activation shapes were provided");
+    }
+    Ok(shapes)
+}
+
+fn model_activation_shapes(
+    args: &ActivationStripingArgs,
+    model_path: &std::path::Path,
+) -> Result<Vec<ActivationShape>> {
+    if args.model_bytes_per_element == 0 {
+        bail!("--model-bytes-per-element must be greater than zero");
+    }
+    let meta = scan_gguf_compact_meta(model_path)
+        .with_context(|| format!("failed to read GGUF metadata from {}", model_path.display()))?;
+    let hidden_size =
+        usize::try_from(meta.embedding_size).context("model embedding_length exceeds usize")?;
+    if hidden_size == 0 {
+        bail!(
+            "GGUF metadata for {} does not contain embedding_length",
+            model_path.display()
+        );
+    }
+    let token_counts = parse_usize_list(&args.model_token_counts, "model token count")?;
+    if token_counts.is_empty() {
+        bail!("--model-token-counts must contain at least one token count");
+    }
+    let model_name = args.model_name.clone().unwrap_or_else(|| {
+        model_path
+            .file_stem()
+            .and_then(std::ffi::OsStr::to_str)
+            .unwrap_or("model")
+            .to_string()
+    });
+    Ok(token_counts
+        .into_iter()
+        .map(|tokens| ActivationShape {
+            name: format!(
+                "{model_name}-{tokens}tok-{}bpe",
+                args.model_bytes_per_element
+            ),
+            tokens,
+            hidden_size,
+            bytes_per_element: args.model_bytes_per_element,
+        })
+        .collect())
+}
+
+fn bench_shape(
+    shape: &ActivationShape,
+    payload: &[u8],
+    stripes: usize,
+    chunk_bytes: usize,
+    per_stream_mbps: f64,
+    baseline_floor_ms: f64,
+    repetitions: usize,
+) -> Result<BenchRow> {
+    let stripe_count = stripes.max(1);
+    let started = Instant::now();
+    let mut chunks = 0;
+    for _ in 0..repetitions {
+        if stripe_count == 1 {
+            bench_single_stream(shape, payload)?;
+            chunks = 1;
+        } else {
+            chunks = bench_striped(shape, payload, stripe_count, chunk_bytes)?;
+        }
+    }
+    let wall_ms = started.elapsed().as_secs_f64() * 1000.0 / repetitions as f64;
+    let active_streams = stripe_count.min(chunks).max(1);
+    let transfer_floor_ms = synthetic_transfer_ms(payload.len(), active_streams, per_stream_mbps);
+    let effective_mbps = effective_mbps(payload.len(), transfer_floor_ms);
+    Ok(BenchRow {
+        shape: shape.name.clone(),
+        tokens: shape.tokens,
+        hidden_size: shape.hidden_size,
+        bytes_per_element: shape.bytes_per_element,
+        payload_bytes: payload.len(),
+        stripes: stripe_count,
+        chunk_bytes,
+        chunks,
+        synthetic_per_stream_mbps: per_stream_mbps,
+        wall_ms,
+        transfer_floor_ms,
+        effective_mbps,
+        speedup_vs_single_stream: baseline_floor_ms / transfer_floor_ms,
+    })
+}
+
+fn bench_single_stream(shape: &ActivationShape, payload: &[u8]) -> Result<()> {
+    let mut state = StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F16);
+    state.source_stage_index = 0;
+    let message = StageWireMessage {
+        kind: WireMessageKind::PrefillEmbd,
+        pos_start: 0,
+        token_count: i32::try_from(shape.tokens).context("token count exceeds i32")?,
+        state,
+        request_id: 7,
+        session_id: 11,
+        sampling: None,
+        chat_sampling_metadata: None,
+        tokens: Vec::new(),
+        positions: Vec::new(),
+        activation: payload.to_vec(),
+        raw_bytes: Vec::new(),
+    };
+    let mut encoded = Vec::new();
+    write_stage_message(&mut encoded, &message, WireActivationDType::F16)?;
+    let decoded = read_stage_message(
+        encoded.as_slice(),
+        i32::try_from(shape.hidden_size).context("hidden size exceeds i32")?,
+    )?;
+    if decoded.activation != payload {
+        bail!("baseline activation payload mismatch");
+    }
+    Ok(())
+}
+
+fn bench_striped(
+    shape: &ActivationShape,
+    payload: &[u8],
+    stripes: usize,
+    chunk_bytes: usize,
+) -> Result<usize> {
+    let mut control_state =
+        StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F16);
+    control_state.source_stage_index = 0;
+    control_state.flags |= state_flags::STRIPED_ACTIVATION;
+    let control = StageWireMessage {
+        kind: WireMessageKind::PrefillEmbd,
+        pos_start: 0,
+        token_count: i32::try_from(shape.tokens).context("token count exceeds i32")?,
+        state: control_state,
+        request_id: 7,
+        session_id: 11,
+        sampling: None,
+        chat_sampling_metadata: None,
+        tokens: Vec::new(),
+        positions: Vec::new(),
+        activation: Vec::new(),
+        raw_bytes: Vec::new(),
+    };
+    let mut control_encoded = Vec::new();
+    write_stage_message(&mut control_encoded, &control, WireActivationDType::F16)?;
+    let decoded_control = read_stage_message(
+        control_encoded.as_slice(),
+        i32::try_from(shape.hidden_size).context("hidden size exceeds i32")?,
+    )?;
+    if !decoded_control.state.uses_striped_activation() {
+        bail!("striped control flag did not round-trip");
+    }
+
+    let chunks = stripe_activation_payload(7, 11, 13, payload, chunk_bytes)?;
+    let mut streams = (0..stripes).map(|_| Vec::new()).collect::<Vec<_>>();
+    for (index, chunk) in chunks.iter().enumerate() {
+        let stream_index = index % streams.len();
+        write_activation_stripe_chunk(&mut streams[stream_index], chunk)?;
+    }
+
+    let mut decoded_chunks = Vec::with_capacity(chunks.len());
+    for stream in streams {
+        let mut cursor = std::io::Cursor::new(stream);
+        while usize::try_from(cursor.position()).unwrap_or(usize::MAX) < cursor.get_ref().len() {
+            decoded_chunks.push(read_activation_stripe_chunk(&mut cursor)?);
+        }
+    }
+    decoded_chunks.sort_by_key(|chunk| std::cmp::Reverse(chunk.chunk_index));
+    let mut iter = decoded_chunks.into_iter();
+    let first = iter.next().context("missing first stripe chunk")?;
+    let mut reassembler = StageActivationStripeReassembler::new(first)?;
+    for chunk in iter {
+        reassembler.push(chunk)?;
+    }
+    let reassembled = reassembler.finish()?;
+    if reassembled != payload {
+        bail!("striped activation payload mismatch");
+    }
+    Ok(chunks.len())
+}
+
+fn synthetic_transfer_ms(payload_bytes: usize, stripes: usize, per_stream_mbps: f64) -> f64 {
+    let effective_mbps = per_stream_mbps * stripes.max(1) as f64;
+    payload_bytes as f64 / (effective_mbps * 125_000.0) * 1000.0
+}
+
+fn effective_mbps(payload_bytes: usize, transfer_ms: f64) -> f64 {
+    payload_bytes as f64 / (transfer_ms / 1000.0) / 125_000.0
+}
+
+fn deterministic_payload(size: usize) -> Vec<u8> {
+    (0..size).map(|index| (index % 251) as u8).collect()
+}
+
+fn parse_shapes(value: &str) -> Result<Vec<ActivationShape>> {
+    value
+        .split(',')
+        .filter(|entry| !entry.trim().is_empty())
+        .map(parse_shape)
+        .collect()
+}
+
+fn parse_shape(value: &str) -> Result<ActivationShape> {
+    let parts = value.split(':').collect::<Vec<_>>();
+    if parts.len() != 4 {
+        bail!("activation shape must be NAME:TOKENS:HIDDEN_SIZE:BYTES_PER_ELEMENT");
+    }
+    Ok(ActivationShape {
+        name: parts[0].to_string(),
+        tokens: parts[1]
+            .parse()
+            .with_context(|| format!("invalid token count in shape {value}"))?,
+        hidden_size: parts[2]
+            .parse()
+            .with_context(|| format!("invalid hidden size in shape {value}"))?,
+        bytes_per_element: parts[3]
+            .parse()
+            .with_context(|| format!("invalid bytes per element in shape {value}"))?,
+    })
+}
+
+fn parse_usize_list(value: &str, label: &str) -> Result<Vec<usize>> {
+    value
+        .split(',')
+        .filter(|entry| !entry.trim().is_empty())
+        .map(|entry| {
+            entry
+                .trim()
+                .parse()
+                .with_context(|| format!("invalid {label} value {entry}"))
+        })
+        .collect()
+}
+
+fn print_markdown_table(rows: &[BenchRow]) {
+    println!(
+        "| Shape | Payload | Stripes | Chunks | Encode + reassemble wall ms | Synthetic transfer floor ms | Synthetic speedup |"
+    );
+    println!("|---|---:|---:|---:|---:|---:|---:|");
+    for row in rows {
+        println!(
+            "| {} | {} | {} | {} | {:.3} | {:.3} | {:.2}x |",
+            row.shape,
+            human_bytes(row.payload_bytes),
+            row.stripes,
+            row.chunks,
+            row.wall_ms,
+            row.transfer_floor_ms,
+            row.speedup_vs_single_stream
+        );
+    }
+}
+
+fn human_bytes(bytes: usize) -> String {
+    const MIB: f64 = 1024.0 * 1024.0;
+    format!("{:.1} MiB", bytes as f64 / MIB)
+}

--- a/crates/skippy-bench/src/cli.rs
+++ b/crates/skippy-bench/src/cli.rs
@@ -434,6 +434,18 @@ pub struct LocalSplitPrefillBinaryArgs {
     pub prefill_chunk_size: usize,
     #[arg(long, default_value_t = 1)]
     pub repetitions: usize,
+    #[arg(
+        long,
+        default_value_t = 1,
+        help = "Number of live activation stripe streams. 1 keeps the inline path."
+    )]
+    pub activation_stripes: usize,
+    #[arg(
+        long,
+        default_value_t = 4,
+        help = "Maximum activation stripe chunk size in MiB."
+    )]
+    pub activation_stripe_chunk_mib: usize,
     #[arg(long, default_value = "127.0.0.1:19041")]
     pub stage1_bind_addr: SocketAddr,
     #[arg(long, default_value = "f16")]

--- a/crates/skippy-bench/src/cli.rs
+++ b/crates/skippy-bench/src/cli.rs
@@ -20,6 +20,8 @@ pub enum CommandKind {
     LocalSplitBinary(LocalSplitBinaryArgs),
     LocalSplitCompare(LocalSplitCompareArgs),
     LocalSplitChainBinary(LocalSplitChainBinaryArgs),
+    #[command(name = "activation-striping")]
+    ActivationStriping(ActivationStripingArgs),
     #[command(name = "chat-corpus")]
     ChatCorpus(ChatCorpusArgs),
     #[command(name = "token-lengths")]
@@ -27,6 +29,58 @@ pub enum CommandKind {
     #[command(name = "focused-runtime")]
     FocusedRuntime(FocusedRuntimeArgs),
     Run(RunArgs),
+}
+
+#[derive(Parser)]
+pub struct ActivationStripingArgs {
+    #[arg(
+        long,
+        help = "Optional GGUF model path. When set, skippy-bench derives activation shapes from the model embedding_length."
+    )]
+    pub model_path: Option<PathBuf>,
+    #[arg(
+        long,
+        help = "Display name for --model-path derived rows. Defaults to the GGUF filename stem."
+    )]
+    pub model_name: Option<String>,
+    #[arg(
+        long,
+        default_value = "512,2048,8192",
+        help = "Comma-separated token counts used for --model-path derived activation shapes."
+    )]
+    pub model_token_counts: String,
+    #[arg(
+        long,
+        default_value_t = 2,
+        help = "Bytes per activation element used for --model-path derived shapes. f16 is 2, f32 is 4."
+    )]
+    pub model_bytes_per_element: usize,
+    #[arg(
+        long,
+        default_value = "qwen3-0.6b-512tok-f16:512:1024:2,llama-8b-512tok-f16:512:4096:2,llama-8b-2048tok-f16:2048:4096:2,llama-8b-8192tok-f16:8192:4096:2",
+        help = "Comma-separated NAME:TOKENS:HIDDEN_SIZE:BYTES_PER_ELEMENT activation shapes."
+    )]
+    pub activation_shapes: String,
+    #[arg(
+        long,
+        default_value = "1,2,4,8",
+        help = "Comma-separated stripe counts. 1 is always treated as the baseline."
+    )]
+    pub stripes: String,
+    #[arg(
+        long,
+        default_value_t = 1000.0,
+        help = "Synthetic per-stream bandwidth cap in megabits per second."
+    )]
+    pub per_stream_mbps: f64,
+    #[arg(
+        long,
+        default_value_t = 4,
+        help = "Maximum activation stripe chunk size in MiB."
+    )]
+    pub chunk_mib: usize,
+    #[arg(long, default_value_t = 1, help = "Timed repetitions per scenario.")]
+    pub repetitions: usize,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]

--- a/crates/skippy-bench/src/cli.rs
+++ b/crates/skippy-bench/src/cli.rs
@@ -18,6 +18,7 @@ pub enum CommandKind {
     LocalSingle(LocalSingleArgs),
     LocalSplitInprocess(LocalSplitInprocessArgs),
     LocalSplitBinary(LocalSplitBinaryArgs),
+    LocalSplitPrefillBinary(LocalSplitPrefillBinaryArgs),
     LocalSplitCompare(LocalSplitCompareArgs),
     LocalSplitChainBinary(LocalSplitChainBinaryArgs),
     #[command(name = "activation-striping")]
@@ -402,6 +403,44 @@ pub struct LocalSplitBinaryArgs {
     #[arg(long)]
     pub child_logs: bool,
     #[arg(long, default_value_t = 60)]
+    pub startup_timeout_secs: u64,
+}
+
+#[derive(Parser)]
+pub struct LocalSplitPrefillBinaryArgs {
+    #[arg(long, default_value = "target/debug/skippy-server")]
+    pub stage_server_bin: PathBuf,
+    #[arg(long)]
+    pub model_path: PathBuf,
+    #[arg(long, default_value = DEFAULT_LOCAL_MODEL_ID)]
+    pub model_id: String,
+    #[arg(long, default_value_t = 15)]
+    pub split_layer: u32,
+    #[arg(long, default_value_t = 30)]
+    pub layer_end: u32,
+    #[arg(long, default_value_t = 8192)]
+    pub ctx_size: u32,
+    #[arg(long, default_value_t = 0)]
+    pub n_gpu_layers: i32,
+    #[arg(long, default_value = "Hello")]
+    pub prompt: String,
+    #[arg(
+        long,
+        default_value = "512,2048,8192",
+        help = "Comma-separated prompt token counts to benchmark."
+    )]
+    pub token_counts: String,
+    #[arg(long, default_value_t = 512)]
+    pub prefill_chunk_size: usize,
+    #[arg(long, default_value_t = 1)]
+    pub repetitions: usize,
+    #[arg(long, default_value = "127.0.0.1:19041")]
+    pub stage1_bind_addr: SocketAddr,
+    #[arg(long, default_value = "f16")]
+    pub activation_wire_dtype: String,
+    #[arg(long)]
+    pub child_logs: bool,
+    #[arg(long, default_value_t = 120)]
     pub startup_timeout_secs: u64,
 }
 

--- a/crates/skippy-bench/src/local_split.rs
+++ b/crates/skippy-bench/src/local_split.rs
@@ -682,15 +682,15 @@ fn run_binary_chain(args: LocalSplitChainBinaryArgs) -> Result<BinaryChainResult
     })
 }
 
-struct LocalSplitTopologyStage<'a> {
-    stage_id: &'a str,
-    stage_index: u32,
-    endpoint: String,
-    layer_start: u32,
-    layer_end: u32,
+pub(crate) struct LocalSplitTopologyStage<'a> {
+    pub(crate) stage_id: &'a str,
+    pub(crate) stage_index: u32,
+    pub(crate) endpoint: String,
+    pub(crate) layer_start: u32,
+    pub(crate) layer_end: u32,
 }
 
-fn local_split_topology(
+pub(crate) fn local_split_topology(
     topology_id: &str,
     model_id: &str,
     stages: &[LocalSplitTopologyStage<'_>],
@@ -712,7 +712,7 @@ fn local_split_topology(
     })
 }
 
-fn send_generation_config(
+pub(crate) fn send_generation_config(
     stream: &mut std::net::TcpStream,
     wire_dtype: skippy_protocol::binary::WireActivationDType,
     request_id: u64,
@@ -735,7 +735,7 @@ fn send_generation_config(
     Ok(())
 }
 
-fn validate_local_topology_plan(
+pub(crate) fn validate_local_topology_plan(
     model_path: &std::path::Path,
     layer_end: u32,
     splits: &[u32],
@@ -803,7 +803,7 @@ fn validate_local_topology_plan(
     Ok(())
 }
 
-fn configure_child_logs(command: &mut Command, child_logs: bool) {
+pub(crate) fn configure_child_logs(command: &mut Command, child_logs: bool) {
     if child_logs {
         command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     } else {

--- a/crates/skippy-bench/src/local_split_prefill.rs
+++ b/crates/skippy-bench/src/local_split_prefill.rs
@@ -1,15 +1,16 @@
 use std::{
-    fs,
+    fs, io,
     process::Command,
+    thread,
     time::{Duration, Instant},
 };
 
-use anyhow::{Context, Result, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use serde::Serialize;
 use serde_json::{Value, json};
 use skippy_protocol::binary::{
-    StageStateHeader, StageWireMessage, WireMessageKind, WireReplyKind, recv_reply,
-    write_stage_message,
+    StageStateHeader, StageWireMessage, WireMessageKind, WireReplyKind, recv_reply, state_flags,
+    stripe_activation_payload, write_activation_stripe_chunk, write_stage_message,
 };
 use skippy_runtime::{RuntimeConfig, RuntimeLoadMode, StageModel};
 
@@ -37,6 +38,7 @@ struct PrefillTotals {
     runtime_payload_bytes: u64,
     max_wire_payload_bytes: usize,
     max_runtime_payload_bytes: u64,
+    stripe_chunk_count: usize,
 }
 
 #[derive(Serialize)]
@@ -54,6 +56,9 @@ struct PrefillRunReport {
     runtime_payload_bytes: u64,
     max_chunk_wire_payload_bytes: usize,
     max_chunk_runtime_payload_bytes: u64,
+    transport_mode: String,
+    activation_stripes: usize,
+    stripe_chunk_count: usize,
 }
 
 #[derive(Serialize)]
@@ -68,6 +73,9 @@ struct PrefillSummary {
     mean_wire_payload_bytes: f64,
     max_chunk_wire_payload_bytes: usize,
     max_chunk_runtime_payload_bytes: u64,
+    transport_mode: String,
+    activation_stripes: usize,
+    stripe_chunk_count: usize,
 }
 
 pub fn local_split_prefill_binary(args: LocalSplitPrefillBinaryArgs) -> Result<()> {
@@ -122,6 +130,8 @@ pub fn local_split_prefill_binary(args: LocalSplitPrefillBinaryArgs) -> Result<(
             "activation_width": activation_width,
             "wire_dtype": args.activation_wire_dtype,
             "prefill_chunk_size": args.prefill_chunk_size,
+            "activation_stripes": args.activation_stripes,
+            "activation_stripe_chunk_mib": args.activation_stripe_chunk_mib,
             "repetitions": args.repetitions,
             "results": runs,
             "summary": summaries,
@@ -145,6 +155,12 @@ fn validate_args(args: &LocalSplitPrefillBinaryArgs) -> Result<()> {
     }
     if args.repetitions == 0 {
         bail!("repetitions must be greater than zero");
+    }
+    if args.activation_stripes == 0 {
+        bail!("activation_stripes must be greater than zero");
+    }
+    if args.activation_stripe_chunk_mib == 0 {
+        bail!("activation_stripe_chunk_mib must be greater than zero");
     }
     Ok(())
 }
@@ -304,6 +320,16 @@ fn run_prefill_case(
         token_ids.len(),
     )
     .context("send prefill generation config")?;
+    let mut stripe_streams = if args.activation_stripes > 1 {
+        open_activation_stripe_streams(
+            args.stage1_bind_addr,
+            args.startup_timeout_secs,
+            wire_dtype,
+            args.activation_stripes,
+        )?
+    } else {
+        Vec::new()
+    };
 
     let started = Instant::now();
     let mut totals = PrefillTotals::default();
@@ -342,9 +368,22 @@ fn run_prefill_case(
             .max_runtime_payload_bytes
             .max(boundary.desc.payload_bytes);
 
+        let frame_id = u64::try_from(chunk_index + 1).context("stripe frame id overflow")?;
         let write_started = Instant::now();
-        write_stage_message(&mut stream, &message, wire_dtype)
-            .context("send real split prefill activation")?;
+        if stripe_streams.is_empty() {
+            write_stage_message(&mut stream, &message, wire_dtype)
+                .context("send real split prefill activation")?;
+        } else {
+            totals.stripe_chunk_count += write_striped_stage_message(
+                &mut stream,
+                &mut stripe_streams,
+                &message,
+                wire_dtype,
+                frame_id,
+                args.activation_stripe_chunk_mib * 1024 * 1024,
+            )
+            .context("send real split striped prefill activation")?;
+        }
         totals.write += write_started.elapsed();
         let ack_started = Instant::now();
         let reply = recv_reply(&mut stream).context("receive real split prefill ACK")?;
@@ -374,7 +413,91 @@ fn run_prefill_case(
         runtime_payload_bytes: totals.runtime_payload_bytes,
         max_chunk_wire_payload_bytes: totals.max_wire_payload_bytes,
         max_chunk_runtime_payload_bytes: totals.max_runtime_payload_bytes,
+        transport_mode: if stripe_streams.is_empty() {
+            "inline".to_string()
+        } else {
+            "striped".to_string()
+        },
+        activation_stripes: args.activation_stripes,
+        stripe_chunk_count: totals.stripe_chunk_count,
     })
+}
+
+fn open_activation_stripe_streams(
+    addr: std::net::SocketAddr,
+    timeout_secs: u64,
+    wire_dtype: skippy_protocol::binary::WireActivationDType,
+    count: usize,
+) -> Result<Vec<std::net::TcpStream>> {
+    let mut streams = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut stream = connect_ready(addr, timeout_secs).context("connect activation stripe")?;
+        let open = StageWireMessage {
+            kind: WireMessageKind::ActivationStripeOpen,
+            pos_start: 0,
+            token_count: 0,
+            state: StageStateHeader::new(WireMessageKind::ActivationStripeOpen, wire_dtype),
+            request_id: 0,
+            session_id: 0,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: Vec::new(),
+            positions: Vec::new(),
+            activation: Vec::new(),
+            raw_bytes: Vec::new(),
+        };
+        write_stage_message(&mut stream, &open, wire_dtype).context("open activation stripe")?;
+        streams.push(stream);
+    }
+    Ok(streams)
+}
+
+fn write_striped_stage_message(
+    control_stream: &mut std::net::TcpStream,
+    stripe_streams: &mut [std::net::TcpStream],
+    message: &StageWireMessage,
+    wire_dtype: skippy_protocol::binary::WireActivationDType,
+    frame_id: u64,
+    max_chunk_bytes: usize,
+) -> Result<usize> {
+    let chunks = stripe_activation_payload(
+        message.request_id,
+        message.session_id,
+        frame_id,
+        &message.activation,
+        max_chunk_bytes,
+    )?;
+    let mut control = message.clone();
+    control.activation.clear();
+    control.state.flags |= state_flags::STRIPED_ACTIVATION;
+    control.state.checkpoint_generation =
+        i32::try_from(frame_id).context("stripe frame id exceeds i32")?;
+    write_stage_message(control_stream, &control, wire_dtype).context("send stripe control")?;
+
+    let mut groups = vec![Vec::new(); stripe_streams.len()];
+    for (index, chunk) in chunks.iter().cloned().enumerate() {
+        let stream_index = index % stripe_streams.len();
+        groups[stream_index].push(chunk);
+    }
+    thread::scope(|scope| -> Result<()> {
+        let mut handles = Vec::with_capacity(stripe_streams.len());
+        for (stream, group) in stripe_streams.iter_mut().zip(groups) {
+            handles.push(scope.spawn(move || -> io::Result<()> {
+                for chunk in &group {
+                    write_activation_stripe_chunk(&mut *stream, chunk)?;
+                }
+                Ok(())
+            }));
+        }
+        for handle in handles {
+            handle
+                .join()
+                .map_err(|_| anyhow!("activation stripe writer panicked"))?
+                .context("write activation stripe chunks")?;
+        }
+        Ok(())
+    })?;
+    Ok(chunks.len())
 }
 
 struct PrefillBoundaryMessageArgs<'a> {
@@ -509,6 +632,15 @@ fn summarize_token_count(runs: &[PrefillRunReport], token_count: usize) -> Optio
             .map(|run| run.max_chunk_runtime_payload_bytes)
             .max()
             .unwrap_or_default(),
+        transport_mode: matches
+            .first()
+            .map(|run| run.transport_mode.clone())
+            .unwrap_or_default(),
+        activation_stripes: matches
+            .first()
+            .map(|run| run.activation_stripes)
+            .unwrap_or_default(),
+        stripe_chunk_count: matches.iter().map(|run| run.stripe_chunk_count).sum(),
     })
 }
 

--- a/crates/skippy-bench/src/local_split_prefill.rs
+++ b/crates/skippy-bench/src/local_split_prefill.rs
@@ -1,0 +1,521 @@
+use std::{
+    fs,
+    process::Command,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use serde_json::{Value, json};
+use skippy_protocol::binary::{
+    StageStateHeader, StageWireMessage, WireMessageKind, WireReplyKind, recv_reply,
+    write_stage_message,
+};
+use skippy_runtime::{RuntimeConfig, RuntimeLoadMode, StageModel};
+
+use crate::{
+    cli::LocalSplitPrefillBinaryArgs,
+    direct_return::BenchDirectReturnServer,
+    local_split::{
+        LocalSplitTopologyStage, configure_child_logs, local_split_topology,
+        send_generation_config, validate_local_topology_plan,
+    },
+    model_identity::model_identity_for_path,
+    support::{
+        ChildGuard, activation_width, connect_ready, generate_run_id, parse_wire_dtype,
+        temp_config_path_for,
+    },
+};
+
+#[derive(Default)]
+struct PrefillTotals {
+    stage0_compute: Duration,
+    activation_encode: Duration,
+    write: Duration,
+    ack_wait: Duration,
+    wire_payload_bytes: usize,
+    runtime_payload_bytes: u64,
+    max_wire_payload_bytes: usize,
+    max_runtime_payload_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct PrefillRunReport {
+    repetition: usize,
+    token_count: usize,
+    chunk_count: usize,
+    effective_prefill_chunk_size: usize,
+    stage0_compute_ms: f64,
+    activation_encode_ms: f64,
+    downstream_write_ms: f64,
+    downstream_ack_wait_ms: f64,
+    elapsed_ms: f64,
+    wire_payload_bytes: usize,
+    runtime_payload_bytes: u64,
+    max_chunk_wire_payload_bytes: usize,
+    max_chunk_runtime_payload_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct PrefillSummary {
+    token_count: usize,
+    repetitions: usize,
+    mean_elapsed_ms: f64,
+    mean_stage0_compute_ms: f64,
+    mean_activation_encode_ms: f64,
+    mean_downstream_write_ms: f64,
+    mean_downstream_ack_wait_ms: f64,
+    mean_wire_payload_bytes: f64,
+    max_chunk_wire_payload_bytes: usize,
+    max_chunk_runtime_payload_bytes: u64,
+}
+
+pub fn local_split_prefill_binary(args: LocalSplitPrefillBinaryArgs) -> Result<()> {
+    validate_args(&args)?;
+    validate_local_topology_plan(
+        &args.model_path,
+        args.layer_end,
+        &[args.split_layer],
+        2,
+        &args.activation_wire_dtype,
+    )?;
+    let token_counts = parse_token_counts(&args.token_counts)?;
+    let wire_dtype = parse_wire_dtype(&args.activation_wire_dtype)?;
+    let model_identity = model_identity_for_path(&args.model_id, Some(&args.model_path))?;
+    let stage0 = open_stage0(&args)?;
+    let activation_width = determine_activation_width(&stage0, &args.prompt)?;
+    let direct_returns = BenchDirectReturnServer::start("127.0.0.1:0")?;
+    let topology = write_stage1_configs(&args, &model_identity.model_id, &direct_returns)?;
+    let _stage1 = spawn_stage1(
+        &args,
+        activation_width,
+        &topology.config_path,
+        &topology.path,
+    )?;
+
+    let mut runs = Vec::new();
+    for token_count in token_counts {
+        let token_ids = tokens_for_count(&stage0, &args.prompt, token_count)?;
+        for repetition in 0..args.repetitions {
+            runs.push(run_prefill_case(
+                &args,
+                &stage0,
+                &direct_returns,
+                &token_ids,
+                activation_width,
+                repetition,
+                wire_dtype,
+            )?);
+        }
+    }
+
+    let summaries = summarize_runs(&runs);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "mode": "local-split-prefill-binary",
+            "model_identity": model_identity,
+            "split": {
+                "stage0_layers": [0, args.split_layer],
+                "stage1_layers": [args.split_layer, args.layer_end],
+            },
+            "activation_width": activation_width,
+            "wire_dtype": args.activation_wire_dtype,
+            "prefill_chunk_size": args.prefill_chunk_size,
+            "repetitions": args.repetitions,
+            "results": runs,
+            "summary": summaries,
+        }))?
+    );
+
+    Ok(())
+}
+
+struct StageTopologyFiles {
+    path: std::path::PathBuf,
+    config_path: std::path::PathBuf,
+}
+
+fn validate_args(args: &LocalSplitPrefillBinaryArgs) -> Result<()> {
+    if args.split_layer == 0 || args.split_layer >= args.layer_end {
+        bail!("split_layer must be greater than zero and less than layer_end");
+    }
+    if args.prefill_chunk_size == 0 {
+        bail!("prefill_chunk_size must be greater than zero");
+    }
+    if args.repetitions == 0 {
+        bail!("repetitions must be greater than zero");
+    }
+    Ok(())
+}
+
+fn open_stage0(args: &LocalSplitPrefillBinaryArgs) -> Result<StageModel> {
+    StageModel::open(
+        &args.model_path,
+        &RuntimeConfig {
+            stage_index: 0,
+            layer_start: 0,
+            layer_end: args.split_layer,
+            ctx_size: args.ctx_size,
+            lane_count: 1,
+            n_batch: None,
+            n_ubatch: None,
+            n_threads: None,
+            n_threads_batch: None,
+            n_gpu_layers: args.n_gpu_layers,
+            selected_backend_device: None,
+            cache_type_k: skippy_runtime::GGML_TYPE_F16,
+            cache_type_v: skippy_runtime::GGML_TYPE_F16,
+            flash_attn_type: skippy_runtime::FlashAttentionType::Auto,
+            load_mode: RuntimeLoadMode::RuntimeSlice,
+            projector_path: None,
+            include_embeddings: true,
+            include_output: false,
+            filter_tensors_on_load: true,
+        },
+    )
+    .context("failed to open stage 0")
+}
+
+fn determine_activation_width(stage0: &StageModel, prompt: &str) -> Result<i32> {
+    let tokens = stage0
+        .tokenize(prompt, true)
+        .context("failed to tokenize prompt")?;
+    let token_id = *tokens.first().context("prompt produced no tokens")?;
+    let mut session = stage0
+        .create_session()
+        .context("failed to create stage 0 session")?;
+    let (_predicted, boundary) = session
+        .decode_step_frame(token_id, None, 0)
+        .context("stage 0 failed to produce activation frame")?;
+    activation_width(&boundary)
+}
+
+fn write_stage1_configs(
+    args: &LocalSplitPrefillBinaryArgs,
+    model_id: &str,
+    direct_returns: &BenchDirectReturnServer,
+) -> Result<StageTopologyFiles> {
+    let run_id = generate_run_id();
+    let config_path = temp_config_path_for(&run_id, "stage-1");
+    let topology_path = temp_config_path_for(&run_id, "topology");
+    let config = json!({
+        "run_id": run_id,
+        "topology_id": "local-split-prefill-binary",
+        "model_id": model_id,
+        "model_path": args.model_path,
+        "stage_id": "stage-1",
+        "stage_index": 1,
+        "layer_start": args.split_layer,
+        "layer_end": args.layer_end,
+        "ctx_size": args.ctx_size,
+        "n_gpu_layers": args.n_gpu_layers,
+        "filter_tensors_on_load": true,
+        "load_mode": "runtime-slice",
+        "bind_addr": args.stage1_bind_addr,
+        "upstream": {
+            "stage_id": "stage-0",
+            "stage_index": 0,
+            "endpoint": "driver"
+        },
+        "downstream": null
+    });
+    let topology = local_split_topology(
+        "local-split-prefill-binary",
+        model_id,
+        &[
+            LocalSplitTopologyStage {
+                stage_id: "stage-0",
+                stage_index: 0,
+                endpoint: format!("tcp://{}", direct_returns.endpoint()),
+                layer_start: 0,
+                layer_end: args.split_layer,
+            },
+            LocalSplitTopologyStage {
+                stage_id: "stage-1",
+                stage_index: 1,
+                endpoint: format!("tcp://{}", args.stage1_bind_addr),
+                layer_start: args.split_layer,
+                layer_end: args.layer_end,
+            },
+        ],
+    );
+    fs::write(&config_path, serde_json::to_vec_pretty(&config)?)
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+    fs::write(&topology_path, serde_json::to_vec_pretty(&topology)?)
+        .with_context(|| format!("failed to write {}", topology_path.display()))?;
+    Ok(StageTopologyFiles {
+        path: topology_path,
+        config_path,
+    })
+}
+
+fn spawn_stage1(
+    args: &LocalSplitPrefillBinaryArgs,
+    activation_width: i32,
+    config_path: &std::path::Path,
+    topology_path: &std::path::Path,
+) -> Result<ChildGuard> {
+    let mut command = Command::new(&args.stage_server_bin);
+    command.args([
+        "serve-binary",
+        "--config",
+        config_path
+            .to_str()
+            .context("stage config path is not valid UTF-8")?,
+        "--topology",
+        topology_path
+            .to_str()
+            .context("stage topology path is not valid UTF-8")?,
+        "--activation-width",
+        &activation_width.to_string(),
+        "--activation-wire-dtype",
+        &args.activation_wire_dtype,
+    ]);
+    configure_child_logs(&mut command, args.child_logs);
+    ChildGuard::spawn(command)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_prefill_case(
+    args: &LocalSplitPrefillBinaryArgs,
+    stage0: &StageModel,
+    direct_returns: &BenchDirectReturnServer,
+    token_ids: &[i32],
+    activation_width: i32,
+    repetition: usize,
+    wire_dtype: skippy_protocol::binary::WireActivationDType,
+) -> Result<PrefillRunReport> {
+    let mut stream = connect_ready(args.stage1_bind_addr, args.startup_timeout_secs)
+        .context("stage 1 binary server did not become ready")?;
+    let token_count_u64 =
+        u64::try_from(token_ids.len()).context("token count exceeds u64 range")?;
+    let request_id = token_count_u64
+        .checked_mul(1_000)
+        .and_then(|base| base.checked_add(repetition as u64))
+        .context("request id overflow")?;
+    let session_id = request_id + 500_000;
+    let _direct_return = direct_returns.register(request_id, session_id)?;
+    send_generation_config(
+        &mut stream,
+        wire_dtype,
+        request_id,
+        session_id,
+        token_ids.len(),
+    )
+    .context("send prefill generation config")?;
+
+    let started = Instant::now();
+    let mut totals = PrefillTotals::default();
+    let mut session0 = stage0
+        .create_session()
+        .context("failed to create stage 0 session")?;
+    for (chunk_index, chunk) in token_ids.chunks(args.prefill_chunk_size).enumerate() {
+        let pos_start = chunk_index
+            .checked_mul(args.prefill_chunk_size)
+            .context("prefill chunk position overflow")?;
+        let positions = positions_for_chunk(pos_start, chunk.len())?;
+        let compute_started = Instant::now();
+        let boundary = session0
+            .prefill_chunk_frame_with_positions(chunk, &positions, None, 0)
+            .context("stage 0 failed to produce prefill activation frame")?;
+        totals.stage0_compute += compute_started.elapsed();
+        let encode_started = Instant::now();
+        let message = prefill_boundary_message(PrefillBoundaryMessageArgs {
+            request_id,
+            session_id,
+            pos_start,
+            prefill_token_count: token_ids.len(),
+            tokens: chunk,
+            positions: &positions,
+            activation_width,
+            wire_dtype,
+            boundary: &boundary,
+        })?;
+        totals.activation_encode += encode_started.elapsed();
+        totals.wire_payload_bytes += message.activation.len();
+        totals.runtime_payload_bytes = totals
+            .runtime_payload_bytes
+            .saturating_add(boundary.desc.payload_bytes);
+        totals.max_wire_payload_bytes = totals.max_wire_payload_bytes.max(message.activation.len());
+        totals.max_runtime_payload_bytes = totals
+            .max_runtime_payload_bytes
+            .max(boundary.desc.payload_bytes);
+
+        let write_started = Instant::now();
+        write_stage_message(&mut stream, &message, wire_dtype)
+            .context("send real split prefill activation")?;
+        totals.write += write_started.elapsed();
+        let ack_started = Instant::now();
+        let reply = recv_reply(&mut stream).context("receive real split prefill ACK")?;
+        totals.ack_wait += ack_started.elapsed();
+        if reply.kind != WireReplyKind::Ack {
+            bail!("expected prefill ACK, got {:?}", reply.kind);
+        }
+    }
+    write_stage_message(
+        &mut stream,
+        &StageWireMessage::stop_with_identity(wire_dtype, request_id, session_id),
+        wire_dtype,
+    )
+    .context("send real split prefill stop")?;
+
+    Ok(PrefillRunReport {
+        repetition,
+        token_count: token_ids.len(),
+        chunk_count: token_ids.len().div_ceil(args.prefill_chunk_size),
+        effective_prefill_chunk_size: args.prefill_chunk_size,
+        stage0_compute_ms: duration_ms(totals.stage0_compute),
+        activation_encode_ms: duration_ms(totals.activation_encode),
+        downstream_write_ms: duration_ms(totals.write),
+        downstream_ack_wait_ms: duration_ms(totals.ack_wait),
+        elapsed_ms: duration_ms(started.elapsed()),
+        wire_payload_bytes: totals.wire_payload_bytes,
+        runtime_payload_bytes: totals.runtime_payload_bytes,
+        max_chunk_wire_payload_bytes: totals.max_wire_payload_bytes,
+        max_chunk_runtime_payload_bytes: totals.max_runtime_payload_bytes,
+    })
+}
+
+struct PrefillBoundaryMessageArgs<'a> {
+    request_id: u64,
+    session_id: u64,
+    pos_start: usize,
+    prefill_token_count: usize,
+    tokens: &'a [i32],
+    positions: &'a [i32],
+    activation_width: i32,
+    wire_dtype: skippy_protocol::binary::WireActivationDType,
+    boundary: &'a skippy_runtime::ActivationFrame,
+}
+
+fn prefill_boundary_message(args: PrefillBoundaryMessageArgs<'_>) -> Result<StageWireMessage> {
+    let token_count =
+        i32::try_from(args.tokens.len()).context("prefill token count exceeds i32")?;
+    let mut state = StageStateHeader::new(WireMessageKind::PrefillEmbd, args.wire_dtype);
+    state.prompt_token_count =
+        i32::try_from(args.prefill_token_count).context("prompt token count exceeds i32")?;
+    state.current_token = *args.tokens.last().context("prefill chunk is empty")?;
+    state.source_stage_index = 0;
+    state.flags |=
+        skippy_protocol::binary::activation_state_flags_from_frame_flags(args.boundary.desc.flags);
+    let activation = skippy_protocol::binary::encode_f32_activation_payload_with_state_flags(
+        args.wire_dtype,
+        token_count,
+        args.activation_width,
+        &args.boundary.payload,
+        state.flags,
+    )
+    .context("failed to encode prefill activation for wire")?;
+    Ok(StageWireMessage {
+        kind: WireMessageKind::PrefillEmbd,
+        pos_start: i32::try_from(args.pos_start).context("prefill position exceeds i32")?,
+        token_count,
+        state,
+        request_id: args.request_id,
+        session_id: args.session_id,
+        sampling: None,
+        chat_sampling_metadata: None,
+        tokens: args.tokens.to_vec(),
+        positions: args.positions.to_vec(),
+        activation,
+        raw_bytes: Vec::new(),
+    })
+}
+
+fn tokens_for_count(stage0: &StageModel, prompt: &str, token_count: usize) -> Result<Vec<i32>> {
+    if token_count == 0 {
+        bail!("token counts must be greater than zero");
+    }
+    let seed = stage0
+        .tokenize(prompt, true)
+        .context("failed to tokenize prompt")?;
+    if seed.is_empty() {
+        bail!("prompt produced no tokens");
+    }
+    let mut tokens = Vec::with_capacity(token_count);
+    while tokens.len() < token_count {
+        tokens.extend_from_slice(&seed);
+    }
+    tokens.truncate(token_count);
+    Ok(tokens)
+}
+
+fn positions_for_chunk(pos_start: usize, len: usize) -> Result<Vec<i32>> {
+    let pos_start = i32::try_from(pos_start).context("prefill position exceeds i32")?;
+    let len = i32::try_from(len).context("prefill chunk length exceeds i32")?;
+    Ok((pos_start..pos_start + len).collect())
+}
+
+fn parse_token_counts(raw: &str) -> Result<Vec<usize>> {
+    let mut counts = Vec::new();
+    for part in raw.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        let value = part
+            .parse::<usize>()
+            .with_context(|| format!("invalid token count '{part}'"))?;
+        if value == 0 {
+            bail!("token counts must be greater than zero");
+        }
+        counts.push(value);
+    }
+    if counts.is_empty() {
+        bail!("at least one token count is required");
+    }
+    counts.sort_unstable();
+    counts.dedup();
+    Ok(counts)
+}
+
+fn summarize_runs(runs: &[PrefillRunReport]) -> Vec<Value> {
+    let mut token_counts = runs.iter().map(|run| run.token_count).collect::<Vec<_>>();
+    token_counts.sort_unstable();
+    token_counts.dedup();
+    token_counts
+        .into_iter()
+        .filter_map(|token_count| summarize_token_count(runs, token_count))
+        .map(|summary| json!(summary))
+        .collect()
+}
+
+fn summarize_token_count(runs: &[PrefillRunReport], token_count: usize) -> Option<PrefillSummary> {
+    let matches = runs
+        .iter()
+        .filter(|run| run.token_count == token_count)
+        .collect::<Vec<_>>();
+    let repetitions = matches.len();
+    if repetitions == 0 {
+        return None;
+    }
+    Some(PrefillSummary {
+        token_count,
+        repetitions,
+        mean_elapsed_ms: mean(&matches, |run| run.elapsed_ms),
+        mean_stage0_compute_ms: mean(&matches, |run| run.stage0_compute_ms),
+        mean_activation_encode_ms: mean(&matches, |run| run.activation_encode_ms),
+        mean_downstream_write_ms: mean(&matches, |run| run.downstream_write_ms),
+        mean_downstream_ack_wait_ms: mean(&matches, |run| run.downstream_ack_wait_ms),
+        mean_wire_payload_bytes: mean(&matches, |run| run.wire_payload_bytes as f64),
+        max_chunk_wire_payload_bytes: matches
+            .iter()
+            .map(|run| run.max_chunk_wire_payload_bytes)
+            .max()
+            .unwrap_or_default(),
+        max_chunk_runtime_payload_bytes: matches
+            .iter()
+            .map(|run| run.max_chunk_runtime_payload_bytes)
+            .max()
+            .unwrap_or_default(),
+    })
+}
+
+fn mean(runs: &[&PrefillRunReport], value: impl Fn(&PrefillRunReport) -> f64) -> f64 {
+    runs.iter().map(|run| value(run)).sum::<f64>() / runs.len() as f64
+}
+
+fn duration_ms(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1000.0
+}

--- a/crates/skippy-bench/src/main.rs
+++ b/crates/skippy-bench/src/main.rs
@@ -1,3 +1,4 @@
+mod activation_striping;
 mod chat_corpus;
 mod cli;
 mod direct_return;
@@ -12,6 +13,7 @@ use anyhow::Result;
 use clap::Parser;
 
 use crate::{
+    activation_striping::activation_striping,
     chat_corpus::chat_corpus,
     cli::{Cli, CommandKind},
     distributed::{focused_runtime, run_distributed},
@@ -29,6 +31,7 @@ fn main() -> Result<()> {
         CommandKind::LocalSplitBinary(args) => local_split_binary(args),
         CommandKind::LocalSplitCompare(args) => local_split_compare(args),
         CommandKind::LocalSplitChainBinary(args) => local_split_chain_binary(args),
+        CommandKind::ActivationStriping(args) => activation_striping(args),
         CommandKind::ChatCorpus(args) => chat_corpus(args),
         CommandKind::TokenLengths(args) => token_lengths(args),
         CommandKind::FocusedRuntime(args) => focused_runtime(args),

--- a/crates/skippy-bench/src/main.rs
+++ b/crates/skippy-bench/src/main.rs
@@ -5,6 +5,7 @@ mod direct_return;
 mod distributed;
 mod local_single;
 mod local_split;
+mod local_split_prefill;
 mod model_identity;
 mod support;
 mod token_lengths;
@@ -21,6 +22,7 @@ use crate::{
     local_split::{
         local_split_binary, local_split_chain_binary, local_split_compare, local_split_inprocess,
     },
+    local_split_prefill::local_split_prefill_binary,
     token_lengths::token_lengths,
 };
 
@@ -29,6 +31,7 @@ fn main() -> Result<()> {
         CommandKind::LocalSingle(args) => local_single(args),
         CommandKind::LocalSplitInprocess(args) => local_split_inprocess(args),
         CommandKind::LocalSplitBinary(args) => local_split_binary(args),
+        CommandKind::LocalSplitPrefillBinary(args) => local_split_prefill_binary(args),
         CommandKind::LocalSplitCompare(args) => local_split_compare(args),
         CommandKind::LocalSplitChainBinary(args) => local_split_chain_binary(args),
         CommandKind::ActivationStriping(args) => activation_striping(args),

--- a/crates/skippy-protocol/src/binary/codec.rs
+++ b/crates/skippy-protocol/src/binary/codec.rs
@@ -174,6 +174,14 @@ pub fn write_stage_message(
     for position in &message.positions {
         write_i32(&mut writer, *position)?;
     }
+    if state.uses_striped_activation() {
+        if !message.activation.is_empty() {
+            return Err(invalid_input(
+                "striped activation control message must not carry inline activation bytes",
+            ));
+        }
+        return Ok(());
+    }
     writer.write_all(&message.activation)?;
     Ok(())
 }
@@ -276,12 +284,14 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
     for _ in 0..position_sideband_count {
         positions.push(read_i32(&mut reader)?);
     }
-    let activation_bytes =
-        if state.source_stage_index < 0 || kind.is_activationless_prefix_cache_control() {
-            0
-        } else {
-            activation_wire_bytes_with_state_flags(dtype, token_count, n_embd, state.flags)?
-        };
+    let activation_bytes = if state.source_stage_index < 0
+        || kind.is_activationless_prefix_cache_control()
+        || state.uses_striped_activation()
+    {
+        0
+    } else {
+        activation_wire_bytes_with_state_flags(dtype, token_count, n_embd, state.flags)?
+    };
     if activation_bytes > MAX_STAGE_ACTIVATION_BYTES {
         return Err(invalid_data(
             "activation payload byte count exceeds maximum",

--- a/crates/skippy-protocol/src/binary/mod.rs
+++ b/crates/skippy-protocol/src/binary/mod.rs
@@ -204,6 +204,48 @@ mod tests {
     }
 
     #[test]
+    fn stage_message_estimates_full_wire_transfer_bytes() {
+        let message = StageWireMessage {
+            kind: WireMessageKind::PrefillEmbd,
+            pos_start: 0,
+            token_count: 2,
+            state: StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32),
+            request_id: 7,
+            session_id: 11,
+            sampling: Some(StageSamplingConfig {
+                flags: 1,
+                logit_bias: vec![
+                    StageLogitBias {
+                        token_id: 1,
+                        bias: -1.0,
+                    },
+                    StageLogitBias {
+                        token_id: 2,
+                        bias: 1.0,
+                    },
+                ],
+                ..StageSamplingConfig::default()
+            }),
+            chat_sampling_metadata: Some("{}".to_string()),
+            tokens: vec![1, 2],
+            positions: vec![0],
+            activation: vec![0; 16],
+            raw_bytes: Vec::new(),
+        };
+
+        assert_eq!(
+            message.estimated_wire_bytes(),
+            STAGE_WIRE_FIXED_HEADER_BYTES
+                + STAGE_SAMPLING_CONFIG_BASE_BYTES
+                + 2 * STAGE_LOGIT_BIAS_WIRE_BYTES
+                + std::mem::size_of::<u32>()
+                + 2
+                + 3 * std::mem::size_of::<i32>()
+                + 16
+        );
+    }
+
+    #[test]
     fn generation_config_round_trips_sampling_metadata() {
         let message = StageWireMessage::configure_generation(
             WireActivationDType::F32,

--- a/crates/skippy-protocol/src/binary/mod.rs
+++ b/crates/skippy-protocol/src/binary/mod.rs
@@ -1,5 +1,6 @@
 mod activation;
 mod codec;
+mod striping;
 mod types;
 
 pub use activation::{
@@ -11,6 +12,12 @@ pub use codec::{
     read_stage_message, recv_ready, recv_reply, send_ready, send_reply_ack,
     send_reply_ack_with_stats, send_reply_predicted, send_reply_predicted_tokens_with_stats,
     send_reply_predicted_with_stats, write_stage_message,
+};
+pub use striping::{
+    ACTIVATION_STRIPE_CHUNK_MAGIC, ACTIVATION_STRIPE_CHUNK_VERSION,
+    MAX_STAGE_ACTIVATION_STRIPE_CHUNK_BYTES, MAX_STAGE_ACTIVATION_STRIPE_CHUNKS,
+    StageActivationStripeChunk, StageActivationStripeReassembler, read_activation_stripe_chunk,
+    stripe_activation_payload, write_activation_stripe_chunk,
 };
 pub use types::{
     ACTIVATION_FLAG_GEMMA3N_ALTUP, ACTIVATION_FLAG_RWKV7_V_FIRST, LLAMA_TOKEN_NULL,
@@ -242,6 +249,67 @@ mod tests {
                 + 2
                 + 3 * std::mem::size_of::<i32>()
                 + 16
+        );
+    }
+
+    #[test]
+    fn striped_activation_control_message_round_trips_without_inline_activation() {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32);
+        state.source_stage_index = 0;
+        state.flags |= state_flags::STRIPED_ACTIVATION;
+        let message = StageWireMessage {
+            kind: WireMessageKind::PrefillEmbd,
+            pos_start: 0,
+            token_count: 2,
+            state,
+            request_id: 7,
+            session_id: 11,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: vec![1, 2],
+            positions: Vec::new(),
+            activation: Vec::new(),
+            raw_bytes: Vec::new(),
+        };
+
+        let mut bytes = Vec::new();
+        write_stage_message(&mut bytes, &message, WireActivationDType::F32).unwrap();
+        let decoded = read_stage_message(Cursor::new(bytes), 2).unwrap();
+
+        assert!(decoded.state.uses_striped_activation());
+        assert_eq!(decoded.tokens, vec![1, 2]);
+        assert!(decoded.activation.is_empty());
+    }
+
+    #[test]
+    fn striped_activation_control_rejects_inline_activation_payload() {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32);
+        state.source_stage_index = 0;
+        state.flags |= state_flags::STRIPED_ACTIVATION;
+        let message = StageWireMessage {
+            kind: WireMessageKind::PrefillEmbd,
+            pos_start: 0,
+            token_count: 2,
+            state,
+            request_id: 7,
+            session_id: 11,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: vec![1, 2],
+            positions: Vec::new(),
+            activation: vec![1; 8],
+            raw_bytes: Vec::new(),
+        };
+
+        let mut bytes = Vec::new();
+        let error = write_stage_message(&mut bytes, &message, WireActivationDType::F32)
+            .expect_err("striped control must not inline activation bytes");
+
+        assert_eq!(
+            error.to_string(),
+            "striped activation control message must not carry inline activation bytes"
         );
     }
 

--- a/crates/skippy-protocol/src/binary/striping.rs
+++ b/crates/skippy-protocol/src/binary/striping.rs
@@ -1,0 +1,399 @@
+use std::io::{self, Read, Write};
+
+use super::{MAX_STAGE_ACTIVATION_BYTES, invalid_data, invalid_input};
+
+pub const ACTIVATION_STRIPE_CHUNK_MAGIC: i32 = 0x5354_5249; // "STRI"
+pub const ACTIVATION_STRIPE_CHUNK_VERSION: i32 = 1;
+pub const MAX_STAGE_ACTIVATION_STRIPE_CHUNKS: usize = 4096;
+pub const MAX_STAGE_ACTIVATION_STRIPE_CHUNK_BYTES: usize = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StageActivationStripeChunk {
+    pub request_id: u64,
+    pub session_id: u64,
+    pub frame_id: u64,
+    pub chunk_index: u32,
+    pub chunk_count: u32,
+    pub total_bytes: u64,
+    pub offset: u64,
+    pub payload: Vec<u8>,
+}
+
+impl StageActivationStripeChunk {
+    pub fn end_offset(&self) -> io::Result<u64> {
+        self.offset
+            .checked_add(
+                u64::try_from(self.payload.len())
+                    .map_err(|_| invalid_data("stripe chunk byte count overflow"))?,
+            )
+            .ok_or_else(|| invalid_data("stripe chunk byte range overflow"))
+    }
+}
+
+pub fn stripe_activation_payload(
+    request_id: u64,
+    session_id: u64,
+    frame_id: u64,
+    payload: &[u8],
+    max_chunk_bytes: usize,
+) -> io::Result<Vec<StageActivationStripeChunk>> {
+    if max_chunk_bytes == 0 {
+        return Err(invalid_input(
+            "stripe chunk byte limit must be greater than zero",
+        ));
+    }
+    if max_chunk_bytes > MAX_STAGE_ACTIVATION_STRIPE_CHUNK_BYTES {
+        return Err(invalid_input("stripe chunk byte limit exceeds maximum"));
+    }
+    if payload.len() > MAX_STAGE_ACTIVATION_BYTES {
+        return Err(invalid_input(
+            "striped activation byte count exceeds maximum",
+        ));
+    }
+    if payload.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let chunk_count = payload.len().div_ceil(max_chunk_bytes);
+    if chunk_count > MAX_STAGE_ACTIVATION_STRIPE_CHUNKS {
+        return Err(invalid_input("stripe chunk count exceeds maximum"));
+    }
+    let chunk_count_u32 = u32::try_from(chunk_count)
+        .map_err(|_| invalid_input("stripe chunk count exceeds maximum"))?;
+    let total_bytes = u64::try_from(payload.len())
+        .map_err(|_| invalid_input("striped activation byte count exceeds maximum"))?;
+
+    payload
+        .chunks(max_chunk_bytes)
+        .enumerate()
+        .map(|(chunk_index, chunk)| {
+            Ok(StageActivationStripeChunk {
+                request_id,
+                session_id,
+                frame_id,
+                chunk_index: u32::try_from(chunk_index)
+                    .map_err(|_| invalid_input("stripe chunk count exceeds maximum"))?,
+                chunk_count: chunk_count_u32,
+                total_bytes,
+                offset: u64::try_from(chunk_index.saturating_mul(max_chunk_bytes))
+                    .map_err(|_| invalid_input("stripe chunk offset exceeds maximum"))?,
+                payload: chunk.to_vec(),
+            })
+        })
+        .collect()
+}
+
+pub fn write_activation_stripe_chunk(
+    mut writer: impl Write,
+    chunk: &StageActivationStripeChunk,
+) -> io::Result<()> {
+    validate_chunk(chunk)?;
+    write_i32(&mut writer, ACTIVATION_STRIPE_CHUNK_MAGIC)?;
+    write_i32(&mut writer, ACTIVATION_STRIPE_CHUNK_VERSION)?;
+    write_u64(&mut writer, chunk.request_id)?;
+    write_u64(&mut writer, chunk.session_id)?;
+    write_u64(&mut writer, chunk.frame_id)?;
+    write_u32(&mut writer, chunk.chunk_index)?;
+    write_u32(&mut writer, chunk.chunk_count)?;
+    write_u64(&mut writer, chunk.total_bytes)?;
+    write_u64(&mut writer, chunk.offset)?;
+    write_u32(
+        &mut writer,
+        u32::try_from(chunk.payload.len())
+            .map_err(|_| invalid_input("stripe chunk byte count exceeds maximum"))?,
+    )?;
+    writer.write_all(&chunk.payload)
+}
+
+pub fn read_activation_stripe_chunk(
+    mut reader: impl Read,
+) -> io::Result<StageActivationStripeChunk> {
+    let magic = read_i32(&mut reader)?;
+    if magic != ACTIVATION_STRIPE_CHUNK_MAGIC {
+        return Err(invalid_data("activation stripe chunk magic mismatch"));
+    }
+    let version = read_i32(&mut reader)?;
+    if version != ACTIVATION_STRIPE_CHUNK_VERSION {
+        return Err(invalid_data("unsupported activation stripe chunk version"));
+    }
+    let request_id = read_u64(&mut reader)?;
+    let session_id = read_u64(&mut reader)?;
+    let frame_id = read_u64(&mut reader)?;
+    let chunk_index = read_u32(&mut reader)?;
+    let chunk_count = read_u32(&mut reader)?;
+    let total_bytes = read_u64(&mut reader)?;
+    let offset = read_u64(&mut reader)?;
+    let payload_len = checked_u32_len(
+        read_u32(&mut reader)?,
+        MAX_STAGE_ACTIVATION_STRIPE_CHUNK_BYTES,
+        "stripe chunk byte count exceeds maximum",
+    )?;
+    let mut payload = vec![0_u8; payload_len];
+    reader.read_exact(&mut payload)?;
+    let chunk = StageActivationStripeChunk {
+        request_id,
+        session_id,
+        frame_id,
+        chunk_index,
+        chunk_count,
+        total_bytes,
+        offset,
+        payload,
+    };
+    validate_chunk(&chunk)?;
+    Ok(chunk)
+}
+
+#[derive(Debug)]
+pub struct StageActivationStripeReassembler {
+    request_id: u64,
+    session_id: u64,
+    frame_id: u64,
+    chunk_count: u32,
+    total_bytes: u64,
+    received_bytes: u64,
+    received_ranges: Vec<(u64, u64)>,
+    chunks: Vec<Option<StageActivationStripeChunk>>,
+}
+
+impl StageActivationStripeReassembler {
+    pub fn new(first: StageActivationStripeChunk) -> io::Result<Self> {
+        validate_chunk(&first)?;
+        let chunk_count = first.chunk_count;
+        let chunks_len = usize::try_from(chunk_count)
+            .map_err(|_| invalid_data("stripe chunk count exceeds maximum"))?;
+        let mut reassembler = Self {
+            request_id: first.request_id,
+            session_id: first.session_id,
+            frame_id: first.frame_id,
+            chunk_count,
+            total_bytes: first.total_bytes,
+            received_bytes: 0,
+            received_ranges: Vec::with_capacity(chunks_len),
+            chunks: vec![None; chunks_len],
+        };
+        reassembler.push(first)?;
+        Ok(reassembler)
+    }
+
+    pub fn push(&mut self, chunk: StageActivationStripeChunk) -> io::Result<bool> {
+        validate_chunk(&chunk)?;
+        self.validate_matching_frame(&chunk)?;
+        let index = usize::try_from(chunk.chunk_index)
+            .map_err(|_| invalid_data("stripe chunk index exceeds maximum"))?;
+        if self.chunks[index].is_some() {
+            return Err(invalid_data("duplicate activation stripe chunk"));
+        }
+        let end_offset = chunk.end_offset()?;
+        if self
+            .received_ranges
+            .iter()
+            .any(|(start, end)| ranges_overlap(chunk.offset, end_offset, *start, *end))
+        {
+            return Err(invalid_data("overlapping activation stripe chunk"));
+        }
+        self.received_bytes = self
+            .received_bytes
+            .checked_add(
+                u64::try_from(chunk.payload.len())
+                    .map_err(|_| invalid_data("stripe chunk byte count overflow"))?,
+            )
+            .ok_or_else(|| invalid_data("striped activation byte count overflow"))?;
+        self.received_ranges.push((chunk.offset, end_offset));
+        self.chunks[index] = Some(chunk);
+        Ok(self.is_complete())
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.received_bytes == self.total_bytes && self.chunks.iter().all(Option::is_some)
+    }
+
+    pub fn finish(self) -> io::Result<Vec<u8>> {
+        if !self.is_complete() {
+            return Err(invalid_data("activation stripe frame is incomplete"));
+        }
+        let total_len = usize::try_from(self.total_bytes)
+            .map_err(|_| invalid_data("striped activation byte count exceeds maximum"))?;
+        let mut payload = vec![0_u8; total_len];
+        for chunk in self.chunks.into_iter().flatten() {
+            let start = usize::try_from(chunk.offset)
+                .map_err(|_| invalid_data("stripe chunk offset exceeds maximum"))?;
+            let end = start
+                .checked_add(chunk.payload.len())
+                .ok_or_else(|| invalid_data("stripe chunk byte range overflow"))?;
+            if end > payload.len() {
+                return Err(invalid_data("stripe chunk byte range exceeds frame"));
+            }
+            payload[start..end].copy_from_slice(&chunk.payload);
+        }
+        Ok(payload)
+    }
+
+    fn validate_matching_frame(&self, chunk: &StageActivationStripeChunk) -> io::Result<()> {
+        if chunk.request_id != self.request_id
+            || chunk.session_id != self.session_id
+            || chunk.frame_id != self.frame_id
+            || chunk.chunk_count != self.chunk_count
+            || chunk.total_bytes != self.total_bytes
+        {
+            return Err(invalid_data(
+                "activation stripe chunk belongs to a different frame",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_chunk(chunk: &StageActivationStripeChunk) -> io::Result<()> {
+    let chunk_count = checked_u32_len(
+        chunk.chunk_count,
+        MAX_STAGE_ACTIVATION_STRIPE_CHUNKS,
+        "stripe chunk count exceeds maximum",
+    )?;
+    if chunk_count == 0 {
+        return Err(invalid_data("stripe chunk count must be greater than zero"));
+    }
+    let chunk_index = usize::try_from(chunk.chunk_index)
+        .map_err(|_| invalid_data("stripe chunk index exceeds maximum"))?;
+    if chunk_index >= chunk_count {
+        return Err(invalid_data("stripe chunk index exceeds count"));
+    }
+    if chunk.payload.is_empty() {
+        return Err(invalid_data("stripe chunk payload is empty"));
+    }
+    if chunk.payload.len() > MAX_STAGE_ACTIVATION_STRIPE_CHUNK_BYTES {
+        return Err(invalid_data("stripe chunk byte count exceeds maximum"));
+    }
+    let total_bytes = usize::try_from(chunk.total_bytes)
+        .map_err(|_| invalid_data("striped activation byte count exceeds maximum"))?;
+    if total_bytes > MAX_STAGE_ACTIVATION_BYTES {
+        return Err(invalid_data(
+            "striped activation byte count exceeds maximum",
+        ));
+    }
+    if chunk.end_offset()? > chunk.total_bytes {
+        return Err(invalid_data("stripe chunk byte range exceeds frame"));
+    }
+    Ok(())
+}
+
+fn ranges_overlap(left_start: u64, left_end: u64, right_start: u64, right_end: u64) -> bool {
+    left_start < right_end && right_start < left_end
+}
+
+fn checked_u32_len(value: u32, max: usize, too_large_message: &'static str) -> io::Result<usize> {
+    let value = usize::try_from(value).map_err(|_| invalid_data(too_large_message))?;
+    if value > max {
+        return Err(invalid_data(too_large_message));
+    }
+    Ok(value)
+}
+
+fn write_i32(mut writer: impl Write, value: i32) -> io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn write_u32(mut writer: impl Write, value: u32) -> io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn write_u64(mut writer: impl Write, value: u64) -> io::Result<()> {
+    writer.write_all(&value.to_le_bytes())
+}
+
+fn read_i32(mut reader: impl Read) -> io::Result<i32> {
+    let mut bytes = [0; 4];
+    reader.read_exact(&mut bytes)?;
+    Ok(i32::from_le_bytes(bytes))
+}
+
+fn read_u32(mut reader: impl Read) -> io::Result<u32> {
+    let mut bytes = [0; 4];
+    reader.read_exact(&mut bytes)?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_u64(mut reader: impl Read) -> io::Result<u64> {
+    let mut bytes = [0; 8];
+    reader.read_exact(&mut bytes)?;
+    Ok(u64::from_le_bytes(bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn activation_stripe_chunks_round_trip_and_reassemble_out_of_order() {
+        let payload = (0..257).map(|value| value as u8).collect::<Vec<_>>();
+        let chunks = stripe_activation_payload(7, 11, 13, &payload, 64).unwrap();
+        assert_eq!(chunks.len(), 5);
+
+        let mut encoded = Vec::new();
+        write_activation_stripe_chunk(&mut encoded, &chunks[3]).unwrap();
+        let decoded = read_activation_stripe_chunk(Cursor::new(encoded)).unwrap();
+        assert_eq!(decoded, chunks[3]);
+
+        let mut reassembler = StageActivationStripeReassembler::new(chunks[3].clone()).unwrap();
+        assert!(!reassembler.is_complete());
+        for index in [0, 4, 1, 2] {
+            reassembler.push(chunks[index].clone()).unwrap();
+        }
+        assert_eq!(reassembler.finish().unwrap(), payload);
+    }
+
+    #[test]
+    fn activation_stripe_rejects_duplicate_chunks() {
+        let payload = vec![1_u8; 128];
+        let chunks = stripe_activation_payload(7, 11, 13, &payload, 64).unwrap();
+        let mut reassembler = StageActivationStripeReassembler::new(chunks[0].clone()).unwrap();
+
+        let error = reassembler
+            .push(chunks[0].clone())
+            .expect_err("duplicate chunk must fail");
+        assert_eq!(error.to_string(), "duplicate activation stripe chunk");
+    }
+
+    #[test]
+    fn activation_stripe_rejects_overlapping_chunks() {
+        let payload = vec![1_u8; 128];
+        let mut chunks = stripe_activation_payload(7, 11, 13, &payload, 64).unwrap();
+        chunks[1].offset = 32;
+        let mut reassembler = StageActivationStripeReassembler::new(chunks[0].clone()).unwrap();
+
+        let error = reassembler
+            .push(chunks[1].clone())
+            .expect_err("overlapping chunk must fail");
+        assert_eq!(error.to_string(), "overlapping activation stripe chunk");
+    }
+
+    #[test]
+    fn activation_stripe_rejects_mismatched_frames() {
+        let payload = vec![1_u8; 128];
+        let chunks = stripe_activation_payload(7, 11, 13, &payload, 64).unwrap();
+        let mut wrong_frame = chunks[1].clone();
+        wrong_frame.frame_id = 99;
+        let mut reassembler = StageActivationStripeReassembler::new(chunks[0].clone()).unwrap();
+
+        let error = reassembler
+            .push(wrong_frame)
+            .expect_err("mismatched frame must fail");
+        assert_eq!(
+            error.to_string(),
+            "activation stripe chunk belongs to a different frame"
+        );
+    }
+
+    #[test]
+    fn activation_stripe_rejects_incomplete_finish() {
+        let payload = vec![1_u8; 128];
+        let chunks = stripe_activation_payload(7, 11, 13, &payload, 64).unwrap();
+        let reassembler = StageActivationStripeReassembler::new(chunks[0].clone()).unwrap();
+
+        let error = reassembler
+            .finish()
+            .expect_err("incomplete frame must fail");
+        assert_eq!(error.to_string(), "activation stripe frame is incomplete");
+    }
+}

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -64,6 +64,7 @@ pub enum WireMessageKind {
     TryRestorePrefillDecode = 18,
     TrimSession = 19,
     PredictionReturnOpen = 20,
+    ActivationStripeOpen = 21,
 }
 
 impl WireMessageKind {
@@ -145,6 +146,7 @@ impl TryFrom<i32> for WireMessageKind {
             18 => Ok(Self::TryRestorePrefillDecode),
             19 => Ok(Self::TrimSession),
             20 => Ok(Self::PredictionReturnOpen),
+            21 => Ok(Self::ActivationStripeOpen),
             _ => Err(invalid_data("unknown stage message kind")),
         }
     }
@@ -322,7 +324,9 @@ impl StageStateHeader {
     pub fn matches_kind(self, kind: WireMessageKind) -> bool {
         if matches!(
             kind,
-            WireMessageKind::StateImport | WireMessageKind::StateExport
+            WireMessageKind::StateImport
+                | WireMessageKind::StateExport
+                | WireMessageKind::ActivationStripeOpen
         ) || kind.is_session_control()
             || kind.is_generation_control()
         {
@@ -658,7 +662,9 @@ fn expected_phase(kind: WireMessageKind) -> WireStagePhase {
     if kind.is_prefill()
         || matches!(
             kind,
-            WireMessageKind::StateImport | WireMessageKind::StateExport
+            WireMessageKind::StateImport
+                | WireMessageKind::StateExport
+                | WireMessageKind::ActivationStripeOpen
         )
         || kind.is_session_control()
         || kind.is_generation_control()

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -189,6 +189,7 @@ pub mod state_flags {
     pub const CHAT_SAMPLING_METADATA: i32 = 1 << 5;
     pub const RWKV7_V_FIRST_SIDEBAND: i32 = 1 << 6;
     pub const GEMMA3N_ALTUP_SIDEBAND: i32 = 1 << 7;
+    pub const STRIPED_ACTIVATION: i32 = 1 << 8;
 }
 
 pub const ACTIVATION_FLAG_RWKV7_V_FIRST: u64 = 1 << 0;
@@ -312,6 +313,10 @@ impl StageStateHeader {
 
     pub fn dtype(self) -> io::Result<WireActivationDType> {
         WireActivationDType::try_from(self.reserved)
+    }
+
+    pub fn uses_striped_activation(self) -> bool {
+        (self.flags & state_flags::STRIPED_ACTIVATION) != 0
     }
 
     pub fn matches_kind(self, kind: WireMessageKind) -> bool {

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -360,6 +360,36 @@ pub struct StageWireMessage {
 }
 
 impl StageWireMessage {
+    pub fn estimated_wire_bytes(&self) -> usize {
+        let sampling_bytes = self.sampling.as_ref().map_or(0, |sampling| {
+            STAGE_SAMPLING_CONFIG_BASE_BYTES
+                + sampling.logit_bias.len().min(MAX_STAGE_LOGIT_BIAS) * STAGE_LOGIT_BIAS_WIRE_BYTES
+        });
+        let chat_metadata_bytes = self
+            .chat_sampling_metadata
+            .as_ref()
+            .map_or(0, |metadata| std::mem::size_of::<u32>() + metadata.len());
+        STAGE_WIRE_FIXED_HEADER_BYTES
+            .saturating_add(sampling_bytes)
+            .saturating_add(chat_metadata_bytes)
+            .saturating_add(self.payload_wire_bytes())
+    }
+
+    fn payload_wire_bytes(&self) -> usize {
+        if self.kind == WireMessageKind::StateImport {
+            return self.raw_bytes.len();
+        }
+        self.tokens
+            .len()
+            .saturating_mul(std::mem::size_of::<i32>())
+            .saturating_add(
+                self.positions
+                    .len()
+                    .saturating_mul(std::mem::size_of::<i32>()),
+            )
+            .saturating_add(self.activation.len())
+    }
+
     pub fn stop(dtype: WireActivationDType) -> Self {
         Self::stop_with_identity(dtype, 0, 0)
     }

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -26,9 +26,8 @@ use skippy_metrics::{attr, metric};
 use skippy_protocol::{
     MessageBase, SCHEMA_VERSION, StageConfig, StageTopology,
     binary::{
-        STAGE_LOGIT_BIAS_WIRE_BYTES, STAGE_SAMPLING_CONFIG_BASE_BYTES,
-        STAGE_WIRE_FIXED_HEADER_BYTES, StageReply, StageReplyStats, StageSamplingConfig,
-        StageStateHeader, StageWireMessage, WireActivationDType, WireMessageKind, WireReplyKind,
+        StageReply, StageReplyStats, StageSamplingConfig, StageStateHeader, StageWireMessage,
+        WireActivationDType, WireMessageKind, WireReplyKind,
         activation_frame_flags_from_state_flags, read_stage_message, recv_reply, send_ready,
         send_reply_ack, send_reply_ack_with_stats, state_flags,
     },
@@ -446,7 +445,7 @@ fn handle_binary_connection(
             );
             recv_attrs.insert(
                 "llama_stage.message_wire_bytes".to_string(),
-                json!(estimated_stage_message_wire_bytes(&message)),
+                json!(message.estimated_wire_bytes()),
             );
             recv_attrs.insert(
                 "skippy.activation_bytes".to_string(),
@@ -1538,30 +1537,6 @@ fn insert_optional_unix_nanos(attrs: &mut BTreeMap<String, Value>, key: &str, va
     if let Some(value) = value {
         attrs.insert(key.to_string(), json!(value));
     }
-}
-
-fn estimated_stage_message_wire_bytes(message: &StageWireMessage) -> usize {
-    let sampling_bytes = message.sampling.as_ref().map_or(0, |sampling| {
-        STAGE_SAMPLING_CONFIG_BASE_BYTES
-            + sampling
-                .logit_bias
-                .len()
-                .min(skippy_protocol::binary::MAX_STAGE_LOGIT_BIAS)
-                * STAGE_LOGIT_BIAS_WIRE_BYTES
-    });
-    let chat_metadata_bytes = message
-        .chat_sampling_metadata
-        .as_ref()
-        .map_or(0, |metadata| std::mem::size_of::<u32>() + metadata.len());
-    let payload_bytes = if message.kind == WireMessageKind::StateImport {
-        message.raw_bytes.len()
-    } else {
-        message.tokens.len() * std::mem::size_of::<i32>()
-            + message.positions.len() * std::mem::size_of::<i32>()
-            + message.activation.len()
-    };
-
-    STAGE_WIRE_FIXED_HEADER_BYTES + sampling_bytes + chat_metadata_bytes + payload_bytes
 }
 
 pub(crate) fn stage_output_activation_capacity(

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -29,7 +29,7 @@ use skippy_protocol::{
         StageReply, StageReplyStats, StageSamplingConfig, StageStateHeader, StageWireMessage,
         WireActivationDType, WireMessageKind, WireReplyKind,
         activation_frame_flags_from_state_flags, read_stage_message, recv_reply, send_ready,
-        send_reply_ack, send_reply_ack_with_stats, state_flags,
+        send_reply_ack, send_reply_ack_with_stats, state_flags, write_stage_message,
     },
 };
 use skippy_runtime::{
@@ -38,6 +38,7 @@ use skippy_runtime::{
 };
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
+mod activation_stripes;
 pub(crate) mod direct_return;
 pub(crate) mod forwarding;
 mod kv_eviction;
@@ -45,6 +46,7 @@ mod options;
 mod socket;
 mod wire;
 
+use self::activation_stripes::{ActivationStripeFrameKey, ActivationStripeHub};
 pub use self::direct_return::PredictionReturnHub;
 pub use self::direct_return::PredictionReturnListener;
 pub(crate) use self::direct_return::PredictionReturnReceiver;
@@ -58,9 +60,40 @@ use self::kv_eviction::{
 pub use self::options::{BinaryStageOptions, EmbeddedOpenAiStageOptions, parse_wire_dtype};
 use self::socket::*;
 pub use self::wire::WireCondition;
-pub(crate) use self::wire::write_stage_message_conditioned;
+pub(crate) use self::wire::{
+    should_stripe_activation, write_stage_message_conditioned, write_stage_message_striped_tcp,
+};
 
 static BINARY_SESSION_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Copy)]
+struct DownstreamActivationStripeConfig {
+    stream_count: usize,
+    max_chunk_bytes: usize,
+}
+
+impl DownstreamActivationStripeConfig {
+    fn new(stream_count: usize, chunk_mib: usize) -> Result<Self> {
+        if stream_count == 0 {
+            bail!("downstream activation stripe stream count must be greater than zero");
+        }
+        let max_chunk_bytes = chunk_mib
+            .checked_mul(1024)
+            .and_then(|value| value.checked_mul(1024))
+            .context("downstream activation stripe chunk size overflow")?;
+        if max_chunk_bytes == 0 {
+            bail!("downstream activation stripe chunk size must be greater than zero");
+        }
+        Ok(Self {
+            stream_count,
+            max_chunk_bytes,
+        })
+    }
+
+    fn enabled(self) -> bool {
+        self.stream_count > 1
+    }
+}
 
 #[derive(Default)]
 struct BinaryKvLookupResult {
@@ -190,9 +223,15 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         reply_credit_limit,
         async_prefill_forward,
         downstream_wire_condition,
+        downstream_activation_stripes,
+        downstream_activation_stripe_chunk_mib,
         downstream_connect_timeout_secs,
         openai,
     } = options;
+    let downstream_activation_stripe_config = DownstreamActivationStripeConfig::new(
+        downstream_activation_stripes,
+        downstream_activation_stripe_chunk_mib,
+    )?;
     validate_config(&config, topology.as_ref())?;
     let max_inflight = config.lane_count as usize;
     let telemetry = Telemetry::new(
@@ -232,6 +271,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
     }
     let kv = KvStageIntegration::from_config(&config)?.map(Arc::new);
     let prediction_returns = Arc::new(PredictionReturnHub::default());
+    let activation_stripes = ActivationStripeHub::default();
     let listener = TcpListener::bind(bind_addr)?;
     listener.set_nonblocking(true)?;
     if let Some(openai_options) = openai {
@@ -304,6 +344,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         let kv = kv.clone();
         let telemetry = telemetry.clone();
         let prediction_returns = prediction_returns.clone();
+        let activation_stripes = activation_stripes.clone();
         thread::spawn(move || {
             let connection_result = (|| -> Result<()> {
                 send_ready(&mut upstream).context("failed to send binary ready")?;
@@ -312,6 +353,9 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                     Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
                     Err(error) => return Err(error.into()),
                 };
+                if first_message.kind == WireMessageKind::ActivationStripeOpen {
+                    return activation_stripes.push_stream_chunks(upstream);
+                }
                 if first_message.kind == WireMessageKind::PredictionReturnOpen {
                     return prediction_returns.handle_return_connection(first_message, upstream);
                 }
@@ -331,8 +375,10 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                     reply_credit_limit,
                     async_prefill_forward,
                     downstream_wire_condition,
+                    downstream_activation_stripe_config,
                     downstream_connect_timeout_secs,
                     first_message,
+                    &activation_stripes,
                 )
             })()
             .context("binary stage connection failed");
@@ -373,13 +419,26 @@ fn handle_binary_connection(
     reply_credit_limit: Option<usize>,
     async_prefill_forward: bool,
     downstream_wire_condition: WireCondition,
+    downstream_activation_stripe_config: DownstreamActivationStripeConfig,
     downstream_connect_timeout_secs: u64,
     first_message: StageWireMessage,
+    activation_stripes: &ActivationStripeHub,
 ) -> Result<()> {
     if let Some(downstream) = downstream.as_mut() {
         skippy_protocol::binary::recv_ready(&mut *downstream)
             .context("downstream binary stage did not become ready")?;
     }
+    let stripe_frame_counter = Arc::new(AtomicU64::new(1));
+    let mut downstream_activation_stripe_streams = if downstream.is_some() {
+        open_downstream_activation_stripe_streams(
+            config,
+            downstream_connect_timeout_secs,
+            wire_dtype,
+            downstream_activation_stripe_config.stream_count,
+        )?
+    } else {
+        Vec::new()
+    };
 
     let connection_session_id = BINARY_SESSION_COUNTER.fetch_add(1, Ordering::Relaxed);
     let max_deferred_prefill_replies =
@@ -393,7 +452,17 @@ fn handle_binary_connection(
     let mut async_forwarder = if async_prefill_forward {
         downstream
             .as_ref()
-            .map(|downstream| AsyncForwarder::new(downstream, telemetry.clone()))
+            .map(|downstream| {
+                AsyncForwarder::new(
+                    downstream,
+                    config,
+                    wire_dtype,
+                    downstream_connect_timeout_secs,
+                    downstream_activation_stripe_config,
+                    stripe_frame_counter.clone(),
+                    telemetry.clone(),
+                )
+            })
             .transpose()
             .context("create async activation forwarder")?
     } else {
@@ -418,6 +487,15 @@ fn handle_binary_connection(
                 Err(error) => return Err(error).context("read binary stage message"),
             }
         };
+        if message.state.uses_striped_activation() {
+            let frame_id = striped_activation_frame_id(&message)?;
+            message.activation = activation_stripes
+                .take_complete(
+                    ActivationStripeFrameKey::new(message.request_id, message.session_id, frame_id),
+                    Duration::from_secs(300),
+                )
+                .context("reassemble striped activation frame")?;
+        }
         let recv_end_unix_nanos = now_unix_nanos() as u64;
         let recv_read_ms = elapsed_ms(recv_started);
         let message_start_unix_nanos = now_unix_nanos() as u64;
@@ -1142,8 +1220,11 @@ fn handle_binary_connection(
                 }
                 let downstream_write_start_unix_nanos = now_unix_nanos() as u64;
                 let downstream_write_started = Instant::now();
-                write_stage_message_conditioned(
-                    &mut *downstream,
+                let striped_chunks = write_forwarded_activation_downstream(
+                    downstream,
+                    &mut downstream_activation_stripe_streams,
+                    &stripe_frame_counter,
+                    downstream_activation_stripe_config,
                     &forwarded.message,
                     wire_dtype,
                     downstream_wire_condition,
@@ -1151,6 +1232,10 @@ fn handle_binary_connection(
                 .context("forward activation frame downstream")?;
                 let downstream_write_end_unix_nanos = now_unix_nanos() as u64;
                 if telemetry.is_debug_enabled() {
+                    downstream_write_attrs.insert(
+                        "llama_stage.forward_striped_activation_chunks".to_string(),
+                        json!(striped_chunks),
+                    );
                     downstream_write_attrs.insert(
                         "llama_stage.forward_write_ms".to_string(),
                         json!(elapsed_ms(downstream_write_started)),
@@ -2940,17 +3025,35 @@ struct AsyncForwardJob {
 }
 
 impl AsyncForwarder {
-    fn new(downstream: &TcpStream, telemetry: Telemetry) -> Result<Self> {
+    fn new(
+        downstream: &TcpStream,
+        config: &StageConfig,
+        wire_dtype: WireActivationDType,
+        downstream_connect_timeout_secs: u64,
+        stripe_config: DownstreamActivationStripeConfig,
+        stripe_frame_counter: Arc<AtomicU64>,
+        telemetry: Telemetry,
+    ) -> Result<Self> {
         let mut writer = downstream
             .try_clone()
             .context("clone downstream stream for async activation forwarding")?;
+        let mut stripe_writers = open_downstream_activation_stripe_streams(
+            config,
+            downstream_connect_timeout_secs,
+            wire_dtype,
+            stripe_config.stream_count,
+        )
+        .context("open async activation stripe streams")?;
         let (sender, receiver) = mpsc::sync_channel::<AsyncForwardJob>(1);
         thread::spawn(move || {
             while let Ok(job) = receiver.recv() {
                 let write_start_unix_nanos = now_unix_nanos() as u64;
                 let write_started = Instant::now();
-                let result = write_stage_message_conditioned(
+                let result = write_forwarded_activation_downstream(
                     &mut writer,
+                    &mut stripe_writers,
+                    &stripe_frame_counter,
+                    stripe_config,
                     &job.message,
                     job.wire_dtype,
                     job.condition,
@@ -2962,13 +3065,19 @@ impl AsyncForwarder {
                     "llama_stage.forward_write_ms".to_string(),
                     json!(elapsed_ms(write_started)),
                 );
+                if let Ok(striped_chunks) = result.as_ref() {
+                    attrs.insert(
+                        "llama_stage.forward_striped_activation_chunks".to_string(),
+                        json!(striped_chunks),
+                    );
+                }
                 telemetry.emit_debug_span(
                     "stage.binary_downstream_write",
                     attrs,
                     write_start_unix_nanos,
                     write_end_unix_nanos,
                 );
-                let _ = job.done.send(result);
+                let _ = job.done.send(result.map(|_| ()));
             }
         });
         Ok(Self {
@@ -3252,6 +3361,73 @@ pub(crate) fn connect_binary_downstream(
         )))
 }
 
+fn open_downstream_activation_stripe_streams(
+    config: &StageConfig,
+    timeout_secs: u64,
+    wire_dtype: WireActivationDType,
+    count: usize,
+) -> Result<Vec<TcpStream>> {
+    if count <= 1 || config.downstream.is_none() {
+        return Ok(Vec::new());
+    }
+
+    let mut streams = Vec::with_capacity(count);
+    for _ in 0..count {
+        let mut stream =
+            connect_binary_downstream(config, timeout_secs)?.context("stage has no downstream")?;
+        skippy_protocol::binary::recv_ready(&mut stream)
+            .context("downstream activation stripe did not become ready")?;
+        let open = StageWireMessage {
+            kind: WireMessageKind::ActivationStripeOpen,
+            pos_start: 0,
+            token_count: 0,
+            state: StageStateHeader::new(WireMessageKind::ActivationStripeOpen, wire_dtype),
+            request_id: 0,
+            session_id: 0,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: Vec::new(),
+            positions: Vec::new(),
+            activation: Vec::new(),
+            raw_bytes: Vec::new(),
+        };
+        write_stage_message(&mut stream, &open, wire_dtype).context("open activation stripe")?;
+        streams.push(stream);
+    }
+    Ok(streams)
+}
+
+fn write_forwarded_activation_downstream(
+    downstream: &mut TcpStream,
+    stripe_streams: &mut [TcpStream],
+    stripe_frame_counter: &AtomicU64,
+    stripe_config: DownstreamActivationStripeConfig,
+    message: &StageWireMessage,
+    wire_dtype: WireActivationDType,
+    downstream_wire_condition: WireCondition,
+) -> Result<usize> {
+    if stripe_config.enabled()
+        && !stripe_streams.is_empty()
+        && should_stripe_activation(message, stripe_config.max_chunk_bytes)
+    {
+        let frame_id = stripe_frame_counter.fetch_add(1, Ordering::Relaxed);
+        return write_stage_message_striped_tcp(
+            downstream,
+            stripe_streams,
+            message,
+            wire_dtype,
+            frame_id,
+            stripe_config.max_chunk_bytes,
+            downstream_wire_condition,
+        )
+        .context("write striped activation frame downstream");
+    }
+
+    write_stage_message_conditioned(downstream, message, wire_dtype, downstream_wire_condition)
+        .context("write inline activation frame downstream")?;
+    Ok(0)
+}
+
 pub(crate) fn run_binary_stage_message(
     runtime: &mut RuntimeState,
     session_id: &str,
@@ -3327,7 +3503,8 @@ pub(crate) fn run_binary_stage_message(
         | WireMessageKind::RestorePrefill
         | WireMessageKind::TryRestorePrefill
         | WireMessageKind::TryRestorePrefillDecode
-        | WireMessageKind::PredictionReturnOpen => {
+        | WireMessageKind::PredictionReturnOpen
+        | WireMessageKind::ActivationStripeOpen => {
             bail!("message kind is not executable")
         }
     }
@@ -3388,6 +3565,13 @@ fn input_activation_frame(
         },
         payload,
     }))
+}
+
+fn striped_activation_frame_id(message: &StageWireMessage) -> Result<u64> {
+    if message.state.checkpoint_generation < 0 {
+        bail!("striped activation frame id must not be negative");
+    }
+    Ok(message.state.checkpoint_generation as u64)
 }
 
 fn empty_activation_frame(config: &StageConfig, message: &StageWireMessage) -> ActivationFrame {

--- a/crates/skippy-server/src/binary_transport/activation_stripes.rs
+++ b/crates/skippy-server/src/binary_transport/activation_stripes.rs
@@ -1,0 +1,132 @@
+use std::{
+    collections::BTreeMap,
+    io,
+    net::TcpStream,
+    sync::{Arc, Condvar, Mutex},
+    time::{Duration, Instant},
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use skippy_protocol::binary::{StageActivationStripeReassembler, read_activation_stripe_chunk};
+
+#[derive(Clone, Default)]
+pub(crate) struct ActivationStripeHub {
+    inner: Arc<(Mutex<ActivationStripeState>, Condvar)>,
+}
+
+#[derive(Default)]
+struct ActivationStripeState {
+    frames: BTreeMap<ActivationStripeFrameKey, StageActivationStripeReassembler>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct ActivationStripeFrameKey {
+    request_id: u64,
+    session_id: u64,
+    frame_id: u64,
+}
+
+impl ActivationStripeFrameKey {
+    pub(crate) fn new(request_id: u64, session_id: u64, frame_id: u64) -> Self {
+        Self {
+            request_id,
+            session_id,
+            frame_id,
+        }
+    }
+}
+
+impl ActivationStripeHub {
+    pub(crate) fn push_stream_chunks(&self, mut stream: TcpStream) -> Result<()> {
+        loop {
+            match read_activation_stripe_chunk(&mut stream) {
+                Ok(chunk) => self.push_chunk(chunk)?,
+                Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+                Err(error) => return Err(error).context("read activation stripe chunk"),
+            }
+        }
+    }
+
+    pub(crate) fn take_complete(
+        &self,
+        key: ActivationStripeFrameKey,
+        timeout: Duration,
+    ) -> Result<Vec<u8>> {
+        let started = Instant::now();
+        let (lock, ready) = &*self.inner;
+        let mut state = lock
+            .lock()
+            .map_err(|_| anyhow!("activation stripe hub lock poisoned"))?;
+        loop {
+            if state
+                .frames
+                .get(&key)
+                .is_some_and(StageActivationStripeReassembler::is_complete)
+            {
+                let frame = state
+                    .frames
+                    .remove(&key)
+                    .context("missing complete striped activation frame")?;
+                return frame.finish().map_err(Into::into);
+            }
+
+            let elapsed = started.elapsed();
+            if elapsed >= timeout {
+                bail!(
+                    "timed out waiting for striped activation frame request={} session={} frame={}",
+                    key.request_id,
+                    key.session_id,
+                    key.frame_id
+                );
+            }
+            let remaining = timeout.saturating_sub(elapsed);
+            let wait = ready
+                .wait_timeout(state, remaining)
+                .map_err(|_| anyhow!("activation stripe hub lock poisoned"))?;
+            state = wait.0;
+        }
+    }
+
+    fn push_chunk(&self, chunk: skippy_protocol::binary::StageActivationStripeChunk) -> Result<()> {
+        let key = ActivationStripeFrameKey::new(chunk.request_id, chunk.session_id, chunk.frame_id);
+        let (lock, ready) = &*self.inner;
+        let mut state = lock
+            .lock()
+            .map_err(|_| anyhow!("activation stripe hub lock poisoned"))?;
+        if let Some(frame) = state.frames.get_mut(&key) {
+            frame.push(chunk)?;
+        } else {
+            state
+                .frames
+                .insert(key, StageActivationStripeReassembler::new(chunk)?);
+        }
+        ready.notify_all();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skippy_protocol::binary::stripe_activation_payload;
+
+    #[test]
+    fn hub_reassembles_complete_frame() {
+        let hub = ActivationStripeHub::default();
+        let payload = (0..128).map(|value| value as u8).collect::<Vec<_>>();
+        let mut chunks = stripe_activation_payload(7, 11, 13, &payload, 32).unwrap();
+        chunks.reverse();
+
+        for chunk in chunks {
+            hub.push_chunk(chunk).unwrap();
+        }
+
+        let reassembled = hub
+            .take_complete(
+                ActivationStripeFrameKey::new(7, 11, 13),
+                Duration::from_millis(10),
+            )
+            .unwrap();
+        assert_eq!(reassembled, payload);
+    }
+}

--- a/crates/skippy-server/src/binary_transport/options.rs
+++ b/crates/skippy-server/src/binary_transport/options.rs
@@ -21,6 +21,8 @@ pub struct BinaryStageOptions {
     pub reply_credit_limit: Option<usize>,
     pub async_prefill_forward: bool,
     pub downstream_wire_condition: WireCondition,
+    pub downstream_activation_stripes: usize,
+    pub downstream_activation_stripe_chunk_mib: usize,
     pub downstream_connect_timeout_secs: u64,
     pub openai: Option<EmbeddedOpenAiStageOptions>,
 }
@@ -57,6 +59,12 @@ impl BinaryStageOptions {
         let wire_dtype = parse_wire_dtype(&args.activation_wire_dtype)?;
         let downstream_wire_condition =
             WireCondition::new(args.downstream_wire_delay_ms, args.downstream_wire_mbps)?;
+        if args.downstream_activation_stripes == 0 {
+            bail!("--downstream-activation-stripes must be greater than zero");
+        }
+        if args.downstream_activation_stripe_chunk_mib == 0 {
+            bail!("--downstream-activation-stripe-chunk-mib must be greater than zero");
+        }
         let config = load_json::<StageConfig>(&args.config)
             .with_context(|| format!("load stage config {}", args.config.display()))?;
         let topology = match args.topology.as_ref() {
@@ -98,6 +106,8 @@ impl BinaryStageOptions {
             reply_credit_limit: args.reply_credit_limit,
             async_prefill_forward: args.async_prefill_forward || !args.no_async_prefill_forward,
             downstream_wire_condition,
+            downstream_activation_stripes: args.downstream_activation_stripes,
+            downstream_activation_stripe_chunk_mib: args.downstream_activation_stripe_chunk_mib,
             downstream_connect_timeout_secs: args.downstream_connect_timeout_secs,
             openai,
         })

--- a/crates/skippy-server/src/binary_transport/wire.rs
+++ b/crates/skippy-server/src/binary_transport/wire.rs
@@ -24,25 +24,13 @@ impl WireCondition {
         let delay_seconds = self.delay_ms / 1000.0;
         let bandwidth_seconds = self
             .mbps
-            .map(|mbps| conditioned_wire_bytes(message) as f64 / (mbps * 125_000.0))
+            .map(|mbps| message.estimated_wire_bytes() as f64 / (mbps * 125_000.0))
             .unwrap_or(0.0);
         let seconds = delay_seconds + bandwidth_seconds;
         if seconds > 0.0 {
             thread::sleep(Duration::from_secs_f64(seconds));
         }
     }
-}
-
-fn conditioned_wire_bytes(message: &StageWireMessage) -> usize {
-    let header_bytes: usize = 4 * 4 + 9 * 4;
-    let token_bytes = message
-        .tokens
-        .len()
-        .saturating_mul(std::mem::size_of::<i32>());
-    header_bytes
-        .saturating_add(token_bytes)
-        .saturating_add(message.activation.len())
-        .saturating_add(message.raw_bytes.len())
 }
 
 pub(crate) fn write_stage_message_conditioned(

--- a/crates/skippy-server/src/binary_transport/wire.rs
+++ b/crates/skippy-server/src/binary_transport/wire.rs
@@ -3,6 +3,11 @@ use std::{io, thread, time::Duration};
 use anyhow::{Result, bail};
 use skippy_protocol::binary::{StageWireMessage, WireActivationDType, write_stage_message};
 
+#[cfg(test)]
+use skippy_protocol::binary::{
+    state_flags, stripe_activation_payload, write_activation_stripe_chunk,
+};
+
 #[derive(Clone, Copy, Debug)]
 pub struct WireCondition {
     delay_ms: f64,
@@ -41,4 +46,123 @@ pub(crate) fn write_stage_message_conditioned(
 ) -> io::Result<()> {
     condition.sleep_for(message);
     write_stage_message(writer, message, dtype)
+}
+
+#[cfg(test)]
+fn should_stripe_activation(message: &StageWireMessage, threshold_bytes: usize) -> bool {
+    threshold_bytes > 0
+        && message.kind.is_prefill()
+        && message.state.source_stage_index >= 0
+        && message.activation.len() >= threshold_bytes
+}
+
+#[cfg(test)]
+fn write_stage_message_striped(
+    control_writer: &mut dyn io::Write,
+    stripe_writers: &mut [&mut dyn io::Write],
+    message: &StageWireMessage,
+    dtype: WireActivationDType,
+    frame_id: u64,
+    max_chunk_bytes: usize,
+    condition: WireCondition,
+) -> io::Result<usize> {
+    if stripe_writers.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "striped activation requires at least one stripe writer",
+        ));
+    }
+    let chunks = stripe_activation_payload(
+        message.request_id,
+        message.session_id,
+        frame_id,
+        &message.activation,
+        max_chunk_bytes,
+    )?;
+    let mut control = message.clone();
+    control.activation.clear();
+    control.state.flags |= state_flags::STRIPED_ACTIVATION;
+    write_stage_message_conditioned(control_writer, &control, dtype, condition)?;
+
+    for (index, chunk) in chunks.iter().enumerate() {
+        let writer_index = index % stripe_writers.len();
+        write_activation_stripe_chunk(&mut stripe_writers[writer_index], chunk)?;
+    }
+    Ok(chunks.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skippy_protocol::binary::{
+        StageStateHeader, WireMessageKind, read_activation_stripe_chunk, read_stage_message,
+    };
+    use std::io::Cursor;
+
+    fn prefill_message(activation: Vec<u8>) -> StageWireMessage {
+        let mut state =
+            StageStateHeader::new(WireMessageKind::PrefillEmbd, WireActivationDType::F32);
+        state.source_stage_index = 0;
+        StageWireMessage {
+            kind: WireMessageKind::PrefillEmbd,
+            pos_start: 0,
+            token_count: 4,
+            state,
+            request_id: 7,
+            session_id: 11,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: vec![1, 2, 3, 4],
+            positions: Vec::new(),
+            activation,
+            raw_bytes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn should_stripe_only_large_prefill_activations_from_upstream_stage() {
+        assert!(should_stripe_activation(&prefill_message(vec![1; 128]), 64));
+        assert!(!should_stripe_activation(&prefill_message(vec![1; 32]), 64));
+
+        let mut decode = prefill_message(vec![1; 128]);
+        decode.kind = WireMessageKind::DecodeEmbd;
+        assert!(!should_stripe_activation(&decode, 64));
+
+        let mut driver_origin = prefill_message(vec![1; 128]);
+        driver_origin.state.source_stage_index = -1;
+        assert!(!should_stripe_activation(&driver_origin, 64));
+    }
+
+    #[test]
+    fn striped_writer_emits_control_message_and_round_robin_chunks() {
+        let message = prefill_message((0..128).map(|value| value as u8).collect());
+        let mut control = Vec::new();
+        let mut stripe_a = Vec::new();
+        let mut stripe_b = Vec::new();
+        let mut writers: Vec<&mut dyn io::Write> = vec![&mut stripe_a, &mut stripe_b];
+
+        let chunk_count = write_stage_message_striped(
+            &mut control,
+            &mut writers,
+            &message,
+            WireActivationDType::F32,
+            99,
+            32,
+            WireCondition::new(0.0, None).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(chunk_count, 4);
+        let control_message = read_stage_message(Cursor::new(control), 4).unwrap();
+        assert!(control_message.state.uses_striped_activation());
+        assert!(control_message.activation.is_empty());
+        assert_eq!(control_message.tokens, vec![1, 2, 3, 4]);
+
+        let first_a = read_activation_stripe_chunk(Cursor::new(&stripe_a)).unwrap();
+        let first_b = read_activation_stripe_chunk(Cursor::new(&stripe_b)).unwrap();
+        assert_eq!(first_a.chunk_index, 0);
+        assert_eq!(first_b.chunk_index, 1);
+        assert_eq!(first_a.frame_id, 99);
+        assert_eq!(first_b.frame_id, 99);
+    }
 }

--- a/crates/skippy-server/src/binary_transport/wire.rs
+++ b/crates/skippy-server/src/binary_transport/wire.rs
@@ -1,12 +1,11 @@
-use std::{io, thread, time::Duration};
+use std::{io, net::TcpStream, thread, time::Duration};
 
 use anyhow::{Result, bail};
-use skippy_protocol::binary::{StageWireMessage, WireActivationDType, write_stage_message};
-
-#[cfg(test)]
 use skippy_protocol::binary::{
-    state_flags, stripe_activation_payload, write_activation_stripe_chunk,
+    StageWireMessage, WireActivationDType, state_flags, stripe_activation_payload,
+    write_activation_stripe_chunk, write_stage_message,
 };
+use std::io::Error;
 
 #[derive(Clone, Copy, Debug)]
 pub struct WireCondition {
@@ -48,16 +47,58 @@ pub(crate) fn write_stage_message_conditioned(
     write_stage_message(writer, message, dtype)
 }
 
-#[cfg(test)]
-fn should_stripe_activation(message: &StageWireMessage, threshold_bytes: usize) -> bool {
+pub(crate) fn should_stripe_activation(message: &StageWireMessage, threshold_bytes: usize) -> bool {
     threshold_bytes > 0
         && message.kind.is_prefill()
         && message.state.source_stage_index >= 0
         && message.activation.len() >= threshold_bytes
 }
 
+pub(crate) fn write_stage_message_striped_tcp(
+    control_writer: &mut TcpStream,
+    stripe_writers: &mut [TcpStream],
+    message: &StageWireMessage,
+    dtype: WireActivationDType,
+    frame_id: u64,
+    max_chunk_bytes: usize,
+    condition: WireCondition,
+) -> io::Result<usize> {
+    if stripe_writers.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "striped activation requires at least one stripe writer",
+        ));
+    }
+    let (control, chunks) = striped_control_and_chunks(message, frame_id, max_chunk_bytes)?;
+    write_stage_message_conditioned(control_writer, &control, dtype, condition)?;
+
+    let mut groups = vec![Vec::new(); stripe_writers.len()];
+    for (index, chunk) in chunks.iter().cloned().enumerate() {
+        let writer_index = index % stripe_writers.len();
+        groups[writer_index].push(chunk);
+    }
+    thread::scope(|scope| -> io::Result<()> {
+        let mut handles = Vec::with_capacity(stripe_writers.len());
+        for (writer, group) in stripe_writers.iter_mut().zip(groups) {
+            handles.push(scope.spawn(move || -> io::Result<()> {
+                for chunk in &group {
+                    write_activation_stripe_chunk(&mut *writer, chunk)?;
+                }
+                Ok(())
+            }));
+        }
+        for handle in handles {
+            handle
+                .join()
+                .map_err(|_| Error::other("activation stripe writer panicked"))??;
+        }
+        Ok(())
+    })?;
+    Ok(chunks.len())
+}
+
 #[cfg(test)]
-fn write_stage_message_striped(
+fn write_stage_message_striped_buffered(
     control_writer: &mut dyn io::Write,
     stripe_writers: &mut [&mut dyn io::Write],
     message: &StageWireMessage,
@@ -72,6 +113,24 @@ fn write_stage_message_striped(
             "striped activation requires at least one stripe writer",
         ));
     }
+    let (control, chunks) = striped_control_and_chunks(message, frame_id, max_chunk_bytes)?;
+    write_stage_message_conditioned(control_writer, &control, dtype, condition)?;
+
+    for (index, chunk) in chunks.iter().enumerate() {
+        let writer_index = index % stripe_writers.len();
+        write_activation_stripe_chunk(&mut stripe_writers[writer_index], chunk)?;
+    }
+    Ok(chunks.len())
+}
+
+fn striped_control_and_chunks(
+    message: &StageWireMessage,
+    frame_id: u64,
+    max_chunk_bytes: usize,
+) -> io::Result<(
+    StageWireMessage,
+    Vec<skippy_protocol::binary::StageActivationStripeChunk>,
+)> {
     let chunks = stripe_activation_payload(
         message.request_id,
         message.session_id,
@@ -82,13 +141,9 @@ fn write_stage_message_striped(
     let mut control = message.clone();
     control.activation.clear();
     control.state.flags |= state_flags::STRIPED_ACTIVATION;
-    write_stage_message_conditioned(control_writer, &control, dtype, condition)?;
-
-    for (index, chunk) in chunks.iter().enumerate() {
-        let writer_index = index % stripe_writers.len();
-        write_activation_stripe_chunk(&mut stripe_writers[writer_index], chunk)?;
-    }
-    Ok(chunks.len())
+    control.state.checkpoint_generation = i32::try_from(frame_id)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "stripe frame id exceeds i32"))?;
+    Ok((control, chunks))
 }
 
 #[cfg(test)]
@@ -141,7 +196,7 @@ mod tests {
         let mut stripe_b = Vec::new();
         let mut writers: Vec<&mut dyn io::Write> = vec![&mut stripe_a, &mut stripe_b];
 
-        let chunk_count = write_stage_message_striped(
+        let chunk_count = write_stage_message_striped_buffered(
             &mut control,
             &mut writers,
             &message,
@@ -155,6 +210,7 @@ mod tests {
         assert_eq!(chunk_count, 4);
         let control_message = read_stage_message(Cursor::new(control), 4).unwrap();
         assert!(control_message.state.uses_striped_activation());
+        assert_eq!(control_message.state.checkpoint_generation, 99);
         assert!(control_message.activation.is_empty());
         assert_eq!(control_message.tokens, vec![1, 2, 3, 4]);
 

--- a/crates/skippy-server/src/cli.rs
+++ b/crates/skippy-server/src/cli.rs
@@ -78,6 +78,18 @@ pub struct ServeBinaryArgs {
         help = "Artificial downstream activation bandwidth cap in megabits per second."
     )]
     pub downstream_wire_mbps: Option<f64>,
+    #[arg(
+        long,
+        default_value_t = 1,
+        help = "Number of downstream activation stripe streams. 1 keeps inline activation frames."
+    )]
+    pub downstream_activation_stripes: usize,
+    #[arg(
+        long,
+        default_value_t = 4,
+        help = "Maximum downstream activation stripe chunk size in MiB."
+    )]
+    pub downstream_activation_stripe_chunk_mib: usize,
     #[arg(long, default_value_t = 60)]
     pub downstream_connect_timeout_secs: u64,
     #[arg(

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1242,6 +1242,8 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
             reply_credit_limit: None,
             async_prefill_forward: false,
             downstream_wire_condition: WireCondition::new(0.0, None)?,
+            downstream_activation_stripes: 1,
+            downstream_activation_stripe_chunk_mib: 4,
             downstream_connect_timeout_secs: 5,
             openai: None,
         });


### PR DESCRIPTION
This PR wires activation striping into Skippy's binary stage transport and benchmarks it against a real split.

The important change: a large prefill activation no longer has to ride inside the main `StageWireMessage`. The sender can send a small control message on the normal stage stream, then spread the activation bytes across side-channel TCP streams. The receiver waits for the matching striped frame, reassembles the bytes, and then runs the stage exactly as if the activation had arrived inline.

## What Changed

Before, every inter-stage activation was one big inline message:

```mermaid
flowchart LR
  A["Stage 0"] --> B["main TCP stream"] --> C["StageWireMessage header + activation bytes"] --> D["Stage 1"]
```

After, striped activation uses the main stream only for ordering/control, and side streams for bulk bytes:

```mermaid
flowchart LR
  A["Stage 0"] --> M["main stream: STRIPED_ACTIVATION control frame"] --> R["Stage 1 reassembler"]
  A --> S0["stripe stream 0"] --> R
  A --> S1["stripe stream 1"] --> R
  A --> S2["stripe stream 2"] --> R
  A --> S3["stripe stream 3"] --> R
  R --> E["normal stage execution"]
```

| Area | Before | After |
|---|---|---|
| Stage wire protocol | Activation bytes were inline in `StageWireMessage`. | `STRIPED_ACTIVATION` marks a control frame with no inline activation bytes. |
| Bulk transfer | One stream carried the whole activation. | Activation bytes are split into `StageActivationStripeChunk` records and distributed round-robin across stripe streams. |
| Receiver | Read one message, decoded inline activation bytes, executed. | Reads the control message, waits for matching `(request_id, session_id, frame_id)` chunks, reassembles, then executes. |
| Normal default | Inline only. | Still inline by default. Striping is opt-in with `--downstream-activation-stripes > 1` or benchmark `--activation-stripes > 1`. |
| Adaptive prefill chunks | Chunk size only changed how many tokens were in each activation frame. | Same policy still decides token chunk size; striping only subdivides each resulting activation byte payload. |

## Why This Is Good

This attacks the exact place where split serving pays a network cost: the boundary activation between stages. For Qwen2.5 Coder 7B at this split, each 1024-token f16 boundary activation is about 7.0 MiB on the wire. An 8192-token prefill sends eight of those frames, about 56.0 MiB total.

Striping does not reduce bytes. It reduces the chance that one TCP stream is the limiter. On links where a single stream cannot fill the available path, multiple streams can keep more of the link busy while the main stage stream remains a small ordered control lane.

## Real Split Benchmark

This benchmark starts a real stage-1 `skippy-server`, runs real stage-0 prefill, sends the boundary activation over the live binary protocol, waits for stage-1 ACKs, and reports the measured write/ACK/wall time.

| Field | Value |
|---|---|
| Model | Qwen2.5 Coder 7B Instruct Q4_K_M |
| Split | `0..14 -> 14..28` |
| Runtime | local CPU stage execution |
| Transport | localhost TCP |
| Context | 8192 |
| Prefill chunk size | 1024 tokens |
| Activation width | 3584 |
| Wire dtype | f16 |
| Activation per chunk | 7.0 MiB |
| Total activation wire payload | 56.0 MiB |

| Mode | Streams | Prefill chunks | Stripe chunks | Wire payload | Write ms | Write delta | ACK ms | Wall ms | Wall delta |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| Inline | 1 | 8 | 0 | 56.0 MiB | 98.209 | baseline | 5.062 | 57308.471 | baseline |
| Striped | 4 | 8 | 16 | 56.0 MiB | 104.619 | 6.5% slower | 6.470 | 57768.443 | 0.8% slower |

Read this narrowly: localhost is not the environment where striping should win. Loopback has no real constrained network path to saturate, and this CPU-only run is dominated by stage compute and activation encode. The useful result is that the live striped path works end-to-end against a real split and preserves the exact activation payload size; the performance claim still needs a constrained network benchmark.

## CLI Surface

`skippy-server serve-binary` now has opt-in downstream striping:

```bash
skippy-server serve-binary \
  --config stage-0.json \
  --activation-width 3584 \
  --downstream-activation-stripes 4 \
  --downstream-activation-stripe-chunk-mib 4
```

`skippy-bench local-split-prefill-binary` can exercise the live receiver path directly:

```bash
cargo run -p skippy-bench -- local-split-prefill-binary \
  --stage-server-bin target/debug/skippy-server \
  --model-path /Volumes/External/skippy-quant-packs/qwen25-coder-7b-proxy/sweep/baseline-source-quant/baseline-source-quant.gguf \
  --model-id local/qwen25-coder-7b-proxy:Q4_K_M \
  --split-layer 14 \
  --layer-end 28 \
  --ctx-size 8192 \
  --n-gpu-layers 0 \
  --activation-wire-dtype f16 \
  --token-counts 8192 \
  --prefill-chunk-size 1024 \
  --activation-stripes 4 \
  --activation-stripe-chunk-mib 4 \
  --repetitions 1
```

Representative changed JSON fields:

```json
{
  "transport_mode": "striped",
  "activation_stripes": 4,
  "chunk_count": 8,
  "stripe_chunk_count": 16,
  "wire_payload_bytes": 58720256,
  "downstream_write_ms": 104.61916599999999,
  "elapsed_ms": 57768.442792
}
```

## Protocol

| Item | Impact |
|---|---|
| Mesh ALPN | Unchanged. No ALPN bump. |
| Skippy stage message kind | Adds `ActivationStripeOpen = 21`. |
| Skippy stage flags | Uses `STRIPED_ACTIVATION` to mark no-inline-activation control frames. |
| Compatibility default | Inline remains the default, so existing unstriped runs keep working. |
| Compatibility when enabled | Both Skippy endpoints must understand this PR's striped stage wire shape. |

## Validation

```bash
cargo fmt --all -- --check
cargo check -p skippy-server
cargo check -p skippy-bench
just with-lld cargo build -p skippy-server
cargo test -p skippy-protocol --lib
cargo test -p skippy-server --lib
cargo test -p skippy-bench
cargo clippy -p skippy-protocol --all-targets -- -D warnings
cargo clippy -p skippy-server --all-targets -- -D warnings
cargo clippy -p skippy-bench --all-targets -- -D warnings
```
