### PR TITLE
Stabilize mesh MoA context and tool loops

### DIFF
--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -40,6 +40,19 @@
     "mmproj": null
   },
   {
+    "name": "Gemma-4-E4B-it-Q4_K_M",
+    "file": "gemma-4-E4B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
+    "size": "4.6GB",
+    "description": "Gemma 4 E4B instruction model, strong mini-class default",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+    }
+  },
+  {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
     "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
     "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",

--- a/crates/mesh-client/src/network/nostr.rs
+++ b/crates/mesh-client/src/network/nostr.rs
@@ -445,7 +445,7 @@ pub fn auto_model_pack(vram_gb: f64) -> Vec<String> {
         },
         Pack {
             min_vram: 8.0,
-            models: &["Qwen3-8B-Q4_K_M"],
+            models: &["Gemma-4-E4B-it-Q4_K_M"],
         },
         Pack {
             min_vram: 0.0,
@@ -510,13 +510,13 @@ mod auto_pack_tests {
     #[test]
     fn pack_8gb_single_model() {
         let pack = auto_model_pack(8.0);
-        assert_eq!(pack, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(pack, vec!["Gemma-4-E4B-it-Q4_K_M"]);
     }
 
     #[test]
     fn pack_16gb_single() {
         let pack = auto_model_pack(16.0);
-        assert_eq!(pack, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(pack, vec!["Gemma-4-E4B-it-Q4_K_M"]);
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/src/rescue.rs
+++ b/crates/mesh-llm-guardrails/src/rescue.rs
@@ -105,6 +105,18 @@ fn tool_call_candidates(content: &str) -> Vec<Value> {
     if let Some(value) = parse_qwen_xml_syntax(content) {
         candidates.push(value);
     }
+    if let Some(value) = parse_openclaw_tool_call_syntax(content) {
+        candidates.push(value);
+    }
+    if let Some(value) = parse_xml_tag_tool_call_syntax(content) {
+        candidates.push(value);
+    }
+    if let Some(value) = parse_named_object_tool_call_syntax(content) {
+        candidates.push(value);
+    }
+    if let Some(value) = parse_call_colon_tool_syntax(content) {
+        candidates.push(value);
+    }
     if let Some(value) = parse_granite_tool_call_syntax(content) {
         candidates.push(value);
     }
@@ -278,6 +290,293 @@ fn parse_granite_tool_call_syntax(content: &str) -> Option<Value> {
     serde_json::from_str(after_start[..end_index].trim()).ok()
 }
 
+fn parse_call_colon_tool_syntax(content: &str) -> Option<Value> {
+    let marker = "call:";
+    let marker_index = content.find(marker)?;
+    let after_marker = &content[marker_index + marker.len()..];
+    let object_start = after_marker.find('{')?;
+    let name = after_marker[..object_start]
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'');
+    if !valid_tool_name(name) {
+        return None;
+    }
+
+    let json_text = first_balanced_object(&after_marker[object_start..])?;
+    let arguments = parse_relaxed_object(&json_text)?;
+    Some(json!({ "name": name, "arguments": Value::Object(arguments) }))
+}
+
+fn parse_openclaw_tool_call_syntax(content: &str) -> Option<Value> {
+    let body = bracketed_tool_call_body(content).unwrap_or(content);
+    let tool_name = arrow_field_value(body, "tool").and_then(parse_arrow_tool_name)?;
+    if !valid_tool_name(&tool_name) {
+        return None;
+    }
+
+    let args_tail = arrow_field_value(body, "args")?;
+    let json_text = first_balanced_object(args_tail)?;
+    let arguments = parse_openclaw_args_object(&json_text)?;
+    Some(json!({ "name": tool_name, "arguments": Value::Object(arguments) }))
+}
+
+fn parse_xml_tag_tool_call_syntax(content: &str) -> Option<Value> {
+    let body = lower_tool_call_body(content)?;
+    let (tool_name, raw_arguments) = first_xml_tool_tag(body)?;
+    if !valid_tool_name(&tool_name) {
+        return None;
+    }
+
+    let arguments = parse_xml_tool_arguments(&tool_name, raw_arguments.trim())?;
+    Some(json!({ "name": tool_name, "arguments": Value::Object(arguments) }))
+}
+
+fn parse_named_object_tool_call_syntax(content: &str) -> Option<Value> {
+    let body = lower_tool_call_body(content)?;
+    let object_start = body.find('{')?;
+    let name = body[..object_start]
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'');
+    if !valid_tool_name(name) {
+        return None;
+    }
+
+    let json_text = first_balanced_object(&body[object_start..])?;
+    let arguments = parse_relaxed_object(&json_text)?;
+    Some(json!({ "name": name, "arguments": Value::Object(arguments) }))
+}
+
+fn lower_tool_call_body(content: &str) -> Option<&str> {
+    let start_tag = "<tool_call>";
+    let start_index = content.find(start_tag)?;
+    let after_start = &content[start_index + start_tag.len()..];
+    match after_start.find("</tool_call>") {
+        Some(end_index) => Some(&after_start[..end_index]),
+        None => Some(after_start),
+    }
+}
+
+fn first_xml_tool_tag(content: &str) -> Option<(String, &str)> {
+    let tag_start = content.find('<')?;
+    let after_open = &content[tag_start + 1..];
+    if after_open.starts_with('/') {
+        return None;
+    }
+    let tag_end = after_open.find('>')?;
+    let name = after_open[..tag_end].trim();
+    if name.chars().any(char::is_whitespace) || !valid_tool_name(name) {
+        return None;
+    }
+    let after_tag = &after_open[tag_end + 1..];
+    let end_tag = format!("</{name}>");
+    let body_end = after_tag.find(&end_tag)?;
+    Some((name.to_string(), &after_tag[..body_end]))
+}
+
+fn parse_xml_tool_arguments(tool_name: &str, raw_arguments: &str) -> Option<Map<String, Value>> {
+    if let Ok(Value::Object(object)) = serde_json::from_str::<Value>(raw_arguments) {
+        return Some(object);
+    }
+
+    let argument_key = bare_xml_argument_key(tool_name)?;
+    let mut arguments = Map::new();
+    arguments.insert(
+        argument_key.to_string(),
+        Value::String(raw_arguments.to_string()),
+    );
+    Some(arguments)
+}
+
+fn bare_xml_argument_key(tool_name: &str) -> Option<&'static str> {
+    match tool_name {
+        "exec" | "run_command" | "shell" => Some("command"),
+        "web_search" => Some("query"),
+        "web_fetch" => Some("url"),
+        "read" | "read_file" | "file_fetch" => Some("path"),
+        _ => None,
+    }
+}
+
+fn bracketed_tool_call_body(content: &str) -> Option<&str> {
+    let start_tag = "[TOOL_CALL]";
+    let end_tag = "[/TOOL_CALL]";
+    let start_index = content.find(start_tag)?;
+    let after_start = &content[start_index + start_tag.len()..];
+    let end_index = after_start.find(end_tag)?;
+    Some(&after_start[..end_index])
+}
+
+fn arrow_field_value<'a>(content: &'a str, field: &str) -> Option<&'a str> {
+    let mut search_start = 0usize;
+    while search_start < content.len() {
+        let relative_index = content[search_start..].find(field)?;
+        let field_index = search_start + relative_index;
+        let before_is_boundary = content[..field_index]
+            .chars()
+            .next_back()
+            .is_none_or(|character| !is_identifier_character(character));
+        let after_field = &content[field_index + field.len()..];
+        let after_field = after_field.trim_start();
+        if before_is_boundary && after_field.starts_with("=>") {
+            return Some(after_field[2..].trim_start());
+        }
+        search_start = field_index + field.len();
+    }
+    None
+}
+
+fn parse_arrow_tool_name(value: &str) -> Option<String> {
+    let trimmed = value.trim_start();
+    if let Some(quote) = trimmed.chars().next().filter(|ch| matches!(ch, '"' | '\'')) {
+        let rest = &trimmed[quote.len_utf8()..];
+        let end = rest.find(quote)?;
+        let name = rest[..end].trim();
+        return valid_tool_name(name).then(|| name.to_string());
+    }
+
+    let end = trimmed
+        .find(|character: char| character.is_whitespace() || matches!(character, ',' | '}' | ']'))
+        .unwrap_or(trimmed.len());
+    let name = trimmed[..end].trim();
+    valid_tool_name(name).then(|| name.to_string())
+}
+
+fn is_identifier_character(character: char) -> bool {
+    character.is_ascii_alphanumeric() || character == '_' || character == '-'
+}
+
+fn parse_openclaw_args_object(content: &str) -> Option<Map<String, Value>> {
+    parse_relaxed_object(content).or_else(|| parse_openclaw_flag_args_object(content))
+}
+
+fn parse_openclaw_flag_args_object(content: &str) -> Option<Map<String, Value>> {
+    let inner = content.strip_prefix('{')?.strip_suffix('}')?;
+    let mut object = Map::new();
+    for field in split_top_level_fields(inner) {
+        if let Some((key, value)) = split_openclaw_arg_field(field) {
+            object.insert(key.to_string(), parse_relaxed_value(value));
+            continue;
+        }
+        for line in field.lines() {
+            if let Some((key, value)) = split_openclaw_arg_field(line) {
+                object.insert(key.to_string(), parse_relaxed_value(value));
+            }
+        }
+    }
+    (!object.is_empty()).then_some(object)
+}
+
+fn split_openclaw_arg_field(field: &str) -> Option<(&str, &str)> {
+    let field = field.trim().trim_end_matches(',');
+    if let Some(rest) = field.strip_prefix("--") {
+        let value_start = rest.find(char::is_whitespace)?;
+        let key = rest[..value_start].trim();
+        if !valid_argument_key(key) {
+            return None;
+        }
+        return Some((key, rest[value_start..].trim()));
+    }
+
+    let separator = field.find("=>")?;
+    let key = field[..separator]
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'');
+    if !valid_argument_key(key) {
+        return None;
+    }
+    Some((key, field[separator + 2..].trim()))
+}
+
+fn valid_tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '_' || character == '-'
+        })
+}
+
+fn parse_relaxed_object(content: &str) -> Option<Map<String, Value>> {
+    if let Ok(Value::Object(object)) = serde_json::from_str::<Value>(content) {
+        return Some(object);
+    }
+
+    let inner = content.strip_prefix('{')?.strip_suffix('}')?;
+    let mut object = Map::new();
+    for field in split_top_level_fields(inner) {
+        let (key, value) = split_key_value(field)?;
+        object.insert(key.to_string(), parse_relaxed_value(value));
+    }
+    (!object.is_empty()).then_some(object)
+}
+
+fn split_top_level_fields(content: &str) -> Vec<&str> {
+    let mut fields = Vec::new();
+    let mut start = 0usize;
+    let mut depth = 0i32;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (idx, ch) in content.char_indices() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_string = true,
+            '{' | '[' => depth += 1,
+            '}' | ']' => depth -= 1,
+            ',' if depth == 0 => {
+                fields.push(content[start..idx].trim());
+                start = idx + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    let tail = content[start..].trim();
+    if !tail.is_empty() {
+        fields.push(tail);
+    }
+    fields
+}
+
+fn split_key_value(field: &str) -> Option<(&str, &str)> {
+    let separator = field.find(':')?;
+    let key = field[..separator]
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'');
+    if !valid_argument_key(key) {
+        return None;
+    }
+    Some((key, field[separator + 1..].trim()))
+}
+
+fn valid_argument_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.chars().all(|character| {
+            character.is_ascii_alphanumeric() || character == '_' || character == '-'
+        })
+}
+
+fn parse_relaxed_value(value: &str) -> Value {
+    serde_json::from_str::<Value>(value).unwrap_or_else(|_| {
+        Value::String(
+            value
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string(),
+        )
+    })
+}
+
 fn first_balanced_object(content: &str) -> Option<String> {
     let start = content.find('{')?;
     let end = balanced_substring_end(content.as_bytes(), start, b'{', b'}')?;
@@ -361,6 +660,59 @@ mod tests {
 
         assert_eq!(calls[0].name, "read_file");
         assert_eq!(calls[0].arguments["path"], "README.md");
+    }
+
+    #[test]
+    fn rescues_call_colon_tool_call_with_relaxed_arguments() {
+        let calls = rescue_tool_call_from_text(
+            r#"<tool_call>call:exec{command: "printf ok > /tmp/out"}<tool_call>"#,
+            &["exec".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "exec");
+        assert_eq!(calls[0].arguments["command"], "printf ok > /tmp/out");
+    }
+
+    #[test]
+    fn rescues_openclaw_tool_call_block() {
+        let calls = rescue_tool_call_from_text(
+            r#"[TOOL_CALL]
+{tool => "exec", args => {
+  --command "printf ok > /tmp/out"
+}}
+[/TOOL_CALL]"#,
+            &["exec".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "exec");
+        assert_eq!(calls[0].arguments["command"], "printf ok > /tmp/out");
+    }
+
+    #[test]
+    fn rescues_xml_tag_tool_call_block() {
+        let calls = rescue_tool_call_from_text(
+            r#"<tool_call>
+<exec>printf ok > /tmp/out</exec>"#,
+            &["exec".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "exec");
+        assert_eq!(calls[0].arguments["command"], "printf ok > /tmp/out");
+    }
+
+    #[test]
+    fn rescues_named_object_tool_call_block() {
+        let calls = rescue_tool_call_from_text(
+            r#"<tool_call>exec{command:"printf ok > /tmp/out"}<tool_call>"#,
+            &["exec".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "exec");
+        assert_eq!(calls[0].arguments["command"], "printf ok > /tmp/out");
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/src/rescue.rs
+++ b/crates/mesh-llm-guardrails/src/rescue.rs
@@ -109,6 +109,9 @@ fn tool_call_candidates(content: &str) -> Vec<Value> {
     if let Some(value) = parse_openclaw_tool_call_syntax(content) {
         candidates.push(value);
     }
+    if let Some(value) = parse_minimax_tool_call_syntax(content) {
+        candidates.push(value);
+    }
     if let Some(value) = parse_xml_tag_tool_call_syntax(content) {
         candidates.push(value);
     }
@@ -320,6 +323,74 @@ fn parse_openclaw_tool_call_syntax(content: &str) -> Option<Value> {
     let json_text = first_balanced_object(args_tail)?;
     let arguments = parse_openclaw_args_object(&json_text)?;
     Some(json!({ "name": tool_name, "arguments": Value::Object(arguments) }))
+}
+
+fn parse_minimax_tool_call_syntax(content: &str) -> Option<Value> {
+    let body = minimax_tool_call_body(content)?;
+    let invoke_start = body.find("<invoke")?;
+    let invoke_open = &body[invoke_start + "<invoke".len()..];
+    let invoke_tag_end = invoke_open.find('>')?;
+    let invoke_attrs = &invoke_open[..invoke_tag_end];
+    let tool_name = xml_attr_value(invoke_attrs, "name")?;
+    if !valid_tool_name(&tool_name) {
+        return None;
+    }
+
+    let invoke_body = &invoke_open[invoke_tag_end + 1..];
+    let invoke_body = invoke_body
+        .find("</invoke>")
+        .map(|end| &invoke_body[..end])
+        .unwrap_or(invoke_body);
+    let arguments = parse_minimax_parameters(invoke_body);
+    Some(json!({ "name": tool_name, "arguments": Value::Object(arguments) }))
+}
+
+fn minimax_tool_call_body(content: &str) -> Option<&str> {
+    let start_tag = "<minimax:tool_call>";
+    let start_index = content.find(start_tag)?;
+    let after_start = &content[start_index + start_tag.len()..];
+    match after_start.find("</minimax:tool_call>") {
+        Some(end_index) => Some(&after_start[..end_index]),
+        None => Some(after_start),
+    }
+}
+
+fn parse_minimax_parameters(mut content: &str) -> Map<String, Value> {
+    let mut arguments = Map::new();
+    while let Some(parameter_start) = content.find("<parameter") {
+        let after_parameter = &content[parameter_start + "<parameter".len()..];
+        let Some(tag_end) = after_parameter.find('>') else {
+            break;
+        };
+        let attrs = &after_parameter[..tag_end];
+        let Some(name) = xml_attr_value(attrs, "name").filter(|name| valid_tool_name(name)) else {
+            content = &after_parameter[tag_end + 1..];
+            continue;
+        };
+        let after_tag = &after_parameter[tag_end + 1..];
+        let Some(value_end) = after_tag.find("</parameter>") else {
+            break;
+        };
+        arguments.insert(
+            name,
+            Value::String(after_tag[..value_end].trim().to_string()),
+        );
+        content = &after_tag[value_end + "</parameter>".len()..];
+    }
+    arguments
+}
+
+fn xml_attr_value(attrs: &str, attr: &str) -> Option<String> {
+    let marker = format!("{attr}=");
+    let start = attrs.find(&marker)? + marker.len();
+    let rest = attrs[start..].trim_start();
+    let quote = rest.chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let value = &rest[quote.len_utf8()..];
+    let end = value.find(quote)?;
+    Some(value[..end].to_string())
 }
 
 fn parse_xml_tag_tool_call_syntax(content: &str) -> Option<Value> {
@@ -689,6 +760,22 @@ mod tests {
 
         assert_eq!(calls[0].name, "exec");
         assert_eq!(calls[0].arguments["command"], "printf ok > /tmp/out");
+    }
+
+    #[test]
+    fn rescues_minimax_namespaced_tool_call_block() {
+        let calls = rescue_tool_call_from_text(
+            r#"<minimax:tool_call>
+<invoke name="shell">
+<parameter name="command">cat src/smoke_calc.py</parameter>
+</invoke>
+</minimax:tool_call>"#,
+            &["shell".to_string()],
+        )
+        .unwrap();
+
+        assert_eq!(calls[0].name, "shell");
+        assert_eq!(calls[0].arguments["command"], "cat src/smoke_calc.py");
     }
 
     #[test]

--- a/crates/mesh-llm-guardrails/src/rescue.rs
+++ b/crates/mesh-llm-guardrails/src/rescue.rs
@@ -93,6 +93,7 @@ fn strip_tag_pairs(content: &str, start_tag: &str, end_tag: &str) -> String {
 }
 
 fn tool_call_candidates(content: &str) -> Vec<Value> {
+    let content = bounded_prefix(content, MAX_RESCUE_INPUT_BYTES);
     let mut candidates = Vec::new();
     for json_candidate in json_candidates(content) {
         if let Ok(value) = serde_json::from_str::<Value>(&json_candidate) {
@@ -713,6 +714,17 @@ mod tests {
 
         assert_eq!(calls[0].name, "exec");
         assert_eq!(calls[0].arguments["command"], "printf ok > /tmp/out");
+    }
+
+    #[test]
+    fn rescue_syntax_parsers_only_scan_bounded_prefix() {
+        let content = format!(
+            "{}<tool_call>exec{{command:\"printf late > /tmp/out\"}}<tool_call>",
+            "x".repeat(MAX_RESCUE_INPUT_BYTES + 16)
+        );
+        let error = rescue_tool_call_from_text(&content, &["exec".to_string()]).unwrap_err();
+
+        assert_eq!(error, ToolCallParseError::Malformed);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -1852,6 +1852,24 @@ impl PeerInfo {
     }
 
     pub fn advertised_context_length(&self, model: &str) -> Option<u32> {
+        self.advertised_context_length_for_runtime_model(model)
+            .or_else(|| {
+                self.served_model_descriptors
+                    .iter()
+                    .find(|descriptor| {
+                        let runtime_name = descriptor.identity.model_name.as_str();
+                        runtime_name != model
+                            && self.public_model_id_for_routable_model(runtime_name) == model
+                    })
+                    .and_then(|descriptor| {
+                        self.advertised_context_length_for_runtime_model(
+                            &descriptor.identity.model_name,
+                        )
+                    })
+            })
+    }
+
+    fn advertised_context_length_for_runtime_model(&self, model: &str) -> Option<u32> {
         self.served_model_runtime
             .iter()
             .find(|runtime| runtime.model_name == model)

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -1856,12 +1856,12 @@ impl PeerInfo {
             .or_else(|| {
                 self.served_model_descriptors
                     .iter()
-                    .find(|descriptor| {
+                    .filter(|descriptor| {
                         let runtime_name = descriptor.identity.model_name.as_str();
                         runtime_name != model
                             && self.public_model_id_for_routable_model(runtime_name) == model
                     })
-                    .and_then(|descriptor| {
+                    .find_map(|descriptor| {
                         self.advertised_context_length_for_runtime_model(
                             &descriptor.identity.model_name,
                         )

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1153,20 +1153,33 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
 #[test]
 fn peer_context_lookup_accepts_public_model_alias() {
     let internal = "Qwen3-8B-Q4_K_M";
+    let stale_internal = "Qwen3-8B-Q4_K_M-stale";
     let public = "unsloth/Qwen3-8B-GGUF:Q4_K_M";
     let mut peer = make_test_peer_info(make_test_endpoint_id(23));
     peer.role = super::NodeRole::Host { http_port: 9337 };
     peer.serving_models = vec![internal.to_string()];
-    peer.served_model_descriptors = vec![ServedModelDescriptor {
-        identity: ServedModelIdentity {
-            model_name: internal.to_string(),
-            source_kind: ModelSourceKind::HuggingFace,
-            repository: Some("unsloth/Qwen3-8B-GGUF".to_string()),
-            artifact: Some("Qwen3-8B-Q4_K_M.gguf".to_string()),
+    peer.served_model_descriptors = vec![
+        ServedModelDescriptor {
+            identity: ServedModelIdentity {
+                model_name: stale_internal.to_string(),
+                source_kind: ModelSourceKind::HuggingFace,
+                repository: Some("unsloth/Qwen3-8B-GGUF".to_string()),
+                artifact: Some("Qwen3-8B-Q4_K_M.gguf".to_string()),
+                ..Default::default()
+            },
             ..Default::default()
         },
-        ..Default::default()
-    }];
+        ServedModelDescriptor {
+            identity: ServedModelIdentity {
+                model_name: internal.to_string(),
+                source_kind: ModelSourceKind::HuggingFace,
+                repository: Some("unsloth/Qwen3-8B-GGUF".to_string()),
+                artifact: Some("Qwen3-8B-Q4_K_M.gguf".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ];
     peer.served_model_runtime = vec![ModelRuntimeDescriptor {
         model_name: internal.to_string(),
         identity_hash: Some("sha256:qwen3-8b".to_string()),

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1150,6 +1150,34 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
     }
 }
 
+#[test]
+fn peer_context_lookup_accepts_public_model_alias() {
+    let internal = "Qwen3-8B-Q4_K_M";
+    let public = "unsloth/Qwen3-8B-GGUF:Q4_K_M";
+    let mut peer = make_test_peer_info(make_test_endpoint_id(23));
+    peer.role = super::NodeRole::Host { http_port: 9337 };
+    peer.serving_models = vec![internal.to_string()];
+    peer.served_model_descriptors = vec![ServedModelDescriptor {
+        identity: ServedModelIdentity {
+            model_name: internal.to_string(),
+            source_kind: ModelSourceKind::HuggingFace,
+            repository: Some("unsloth/Qwen3-8B-GGUF".to_string()),
+            artifact: Some("Qwen3-8B-Q4_K_M.gguf".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    }];
+    peer.served_model_runtime = vec![ModelRuntimeDescriptor {
+        model_name: internal.to_string(),
+        identity_hash: Some("sha256:qwen3-8b".to_string()),
+        context_length: Some(32_768),
+        ready: true,
+    }];
+
+    assert!(peer.routes_http_model(public));
+    assert_eq!(peer.advertised_context_length(public), Some(32_768));
+}
+
 fn make_test_endpoint_id(seed: u8) -> EndpointId {
     let mut bytes = [0u8; 32];
     bytes[0] = seed;

--- a/crates/mesh-llm-host-runtime/src/network/nostr.rs
+++ b/crates/mesh-llm-host-runtime/src/network/nostr.rs
@@ -1242,7 +1242,7 @@ fn model_tiers() -> Vec<(String, f64)> {
 ///
 /// Tiers:
 ///   <8GB:    Qwen3-4B (2.5G)
-///   8-24GB:  Qwen3-8B (5G)
+///   8-24GB:  Gemma-4-E4B-it (4.6G)
 ///   24-50GB: Qwen3.5-27B (17G) — vision + text
 ///   50-63GB: GLM-4.7-Flash (18G) — fast, tool calling
 ///   63-179GB: Qwen3-Coder-Next (48G) — frontier coder ~85B
@@ -1294,7 +1294,7 @@ pub fn auto_model_pack(vram_gb: f64) -> Vec<String> {
         },
         Pack {
             min_vram: 8.0,
-            models: vec![catalog_ref("Qwen3-8B-Q4_K_M")],
+            models: vec![catalog_ref("Gemma-4-E4B-it-Q4_K_M")],
         },
         Pack {
             min_vram: 0.0,
@@ -1408,13 +1408,13 @@ mod auto_pack_tests {
     #[test]
     fn pack_8gb_single_model() {
         let pack = auto_model_pack(8.0);
-        assert_single_pack_model(&pack, "Qwen3-8B-Q4_K_M");
+        assert_single_pack_model(&pack, "Gemma-4-E4B-it-Q4_K_M");
     }
 
     #[test]
     fn pack_16gb_single() {
         let pack = auto_model_pack(16.0);
-        assert_single_pack_model(&pack, "Qwen3-8B-Q4_K_M");
+        assert_single_pack_model(&pack, "Gemma-4-E4B-it-Q4_K_M");
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
@@ -1,0 +1,110 @@
+use serde_json::Value;
+
+const MOA_BASE_RESERVE_TOKENS: u32 = 512;
+const MOA_TOOL_SCHEMA_RESERVE_TOKENS: u32 = 512;
+const MOA_TOOL_RESULT_RESERVE_TOKENS: u32 = 1_024;
+
+pub(in crate::network::openai::moa_gateway) fn add_moa_context_reserve(
+    body: &Value,
+    required_tokens: Option<u32>,
+) -> Option<u32> {
+    required_tokens.map(|tokens| tokens.saturating_add(moa_context_reserve_tokens(body)))
+}
+
+fn moa_context_reserve_tokens(body: &Value) -> u32 {
+    let mut reserve = MOA_BASE_RESERVE_TOKENS;
+    if body_has_tools(body) {
+        reserve = reserve.saturating_add(MOA_TOOL_SCHEMA_RESERVE_TOKENS);
+    }
+    if body_has_tool_result(body) {
+        reserve = reserve.saturating_add(MOA_TOOL_RESULT_RESERVE_TOKENS);
+    }
+    reserve
+}
+
+fn body_has_tools(body: &Value) -> bool {
+    body.get("tools")
+        .and_then(Value::as_array)
+        .is_some_and(|tools| !tools.is_empty())
+}
+
+fn body_has_tool_result(body: &Value) -> bool {
+    body.get("messages")
+        .and_then(Value::as_array)
+        .is_some_and(|messages| messages.iter().any(value_is_tool_result))
+        || value_contains_responses_tool_result(body)
+}
+
+fn value_contains_responses_tool_result(value: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(value_contains_responses_tool_result),
+        Value::Object(object) => {
+            value_is_tool_result(value)
+                || object
+                    .iter()
+                    .filter(|(key, _)| matches!(key.as_str(), "output" | "items" | "content"))
+                    .any(|(_, nested)| value_contains_responses_tool_result(nested))
+        }
+        _ => false,
+    }
+}
+
+fn value_is_tool_result(value: &Value) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if object.get("role").and_then(Value::as_str) == Some("tool") {
+        return true;
+    }
+    matches!(
+        object.get("type").and_then(Value::as_str),
+        Some("tool_result" | "tool_call_output" | "function_call_output")
+    ) || object.contains_key("tool_call_id")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn adds_base_reserve_for_plain_moa_request() {
+        let body = json!({"messages": [{"role": "user", "content": "hi"}]});
+
+        assert_eq!(add_moa_context_reserve(&body, Some(1_000)), Some(1_512));
+    }
+
+    #[test]
+    fn adds_tool_schema_and_tool_result_reserve_for_chat_shape() {
+        let body = json!({
+            "tools": [{"type": "function", "function": {"name": "read_file"}}],
+            "messages": [
+                {"role": "user", "content": "read"},
+                {"role": "tool", "tool_call_id": "call_1", "content": "result"}
+            ]
+        });
+
+        assert_eq!(add_moa_context_reserve(&body, Some(1_000)), Some(3_048));
+    }
+
+    #[test]
+    fn detects_responses_api_tool_outputs() {
+        let body = json!({
+            "input": "continue",
+            "output": [{
+                "type": "function_call_output",
+                "call_id": "call_1",
+                "output": "result"
+            }]
+        });
+
+        assert_eq!(add_moa_context_reserve(&body, Some(1_000)), Some(2_536));
+    }
+
+    #[test]
+    fn preserves_unknown_required_tokens() {
+        let body = json!({"messages": []});
+
+        assert_eq!(add_moa_context_reserve(&body, None), None);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_budget.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 const MOA_BASE_RESERVE_TOKENS: u32 = 512;
 const MOA_TOOL_SCHEMA_RESERVE_TOKENS: u32 = 512;
 const MOA_TOOL_RESULT_RESERVE_TOKENS: u32 = 1_024;
+const TOOL_RESULT_SCAN_MAX_DEPTH: usize = 32;
 
 pub(in crate::network::openai::moa_gateway) fn add_moa_context_reserve(
     body: &Value,
@@ -36,14 +37,25 @@ fn body_has_tool_result(body: &Value) -> bool {
 }
 
 fn value_contains_responses_tool_result(value: &Value) -> bool {
+    value_contains_responses_tool_result_at_depth(value, 0)
+}
+
+fn value_contains_responses_tool_result_at_depth(value: &Value, depth: usize) -> bool {
+    if depth > TOOL_RESULT_SCAN_MAX_DEPTH {
+        return false;
+    }
     match value {
-        Value::Array(values) => values.iter().any(value_contains_responses_tool_result),
+        Value::Array(values) => values
+            .iter()
+            .any(|nested| value_contains_responses_tool_result_at_depth(nested, depth + 1)),
         Value::Object(object) => {
             value_is_tool_result(value)
                 || object
                     .iter()
                     .filter(|(key, _)| matches!(key.as_str(), "output" | "items" | "content"))
-                    .any(|(_, nested)| value_contains_responses_tool_result(nested))
+                    .any(|(_, nested)| {
+                        value_contains_responses_tool_result_at_depth(nested, depth + 1)
+                    })
         }
         _ => false,
     }
@@ -99,6 +111,17 @@ mod tests {
         });
 
         assert_eq!(add_moa_context_reserve(&body, Some(1_000)), Some(2_536));
+    }
+
+    #[test]
+    fn responses_tool_output_scan_is_depth_limited() {
+        let mut nested = json!({"type": "function_call_output", "output": "late"});
+        for _ in 0..40 {
+            nested = json!({"output": [nested]});
+        }
+        let body = json!({"input": nested});
+
+        assert_eq!(add_moa_context_reserve(&body, Some(1_000)), Some(1_512));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
@@ -1,11 +1,14 @@
 use crate::mesh;
 
+const UNKNOWN_CONTEXT_FALLBACK_MAX_TOKENS: u32 = 8_192;
+
 pub(in crate::network::openai) fn context_can_satisfy(
     required_tokens: Option<u32>,
     context_length: Option<u32>,
 ) -> bool {
     match (required_tokens, context_length) {
         (Some(required), Some(context)) => context >= required,
+        (Some(required), None) => required <= UNKNOWN_CONTEXT_FALLBACK_MAX_TOKENS,
         _ => true,
     }
 }
@@ -30,32 +33,34 @@ pub(in crate::network::openai) async fn select_remote_host(
                     host.fmt_short()
                 );
             }
-            None => {
+            None if context_can_satisfy(Some(required_tokens), None) => {
                 unknown.get_or_insert(host);
+            }
+            None => {
+                tracing::info!(
+                    "MoA: skipping remote worker {model} on {}; context is unknown and request needs {required_tokens} tokens",
+                    host.fmt_short()
+                );
             }
         }
     }
     unknown
 }
 
-pub(in crate::network::openai) fn virtual_mesh_context_length(
-    models: &[String],
-    runtimes: &[mesh::ModelRuntimeDescriptor],
-) -> Option<u32> {
-    let mut contexts_by_model = Vec::new();
-    for model in models {
-        if model == mesh_mixture_of_agents::VIRTUAL_MODEL_NAME {
-            continue;
-        }
-        let context = runtimes
-            .iter()
-            .filter(|runtime| runtime.model_name == *model)
-            .filter_map(mesh::ModelRuntimeDescriptor::advertised_context_length)
-            .max();
-        if let Some(context) = context {
-            contexts_by_model.push(context);
-        }
+pub(in crate::network::openai) fn virtual_mesh_context_length_from_known_contexts<I>(
+    contexts: I,
+) -> Option<u32>
+where
+    I: IntoIterator<Item = (String, u32)>,
+{
+    let mut by_model = std::collections::BTreeMap::<String, u32>::new();
+    for (model_key, context) in contexts {
+        by_model
+            .entry(model_key)
+            .and_modify(|existing| *existing = (*existing).max(context))
+            .or_insert(context);
     }
+    let mut contexts_by_model = by_model.into_values().collect::<Vec<_>>();
     contexts_by_model.sort_unstable_by(|left, right| right.cmp(left));
     contexts_by_model.get(1).copied()
 }
@@ -73,18 +78,10 @@ pub(in crate::network::openai) fn should_advertise_virtual_mesh(models: &[String
 mod tests {
     use super::*;
 
-    fn runtime(model_name: &str, context_length: Option<u32>) -> mesh::ModelRuntimeDescriptor {
-        mesh::ModelRuntimeDescriptor {
-            model_name: model_name.to_string(),
-            identity_hash: None,
-            context_length,
-            ready: true,
-        }
-    }
-
     #[test]
     fn context_can_satisfy_keeps_unknown_as_fallback() {
-        assert!(context_can_satisfy(Some(16_384), None));
+        assert!(context_can_satisfy(Some(4_096), None));
+        assert!(!context_can_satisfy(Some(16_384), None));
         assert!(context_can_satisfy(None, Some(4096)));
         assert!(context_can_satisfy(Some(16_384), Some(32_768)));
         assert!(!context_can_satisfy(Some(16_384), Some(4096)));
@@ -92,52 +89,46 @@ mod tests {
 
     #[test]
     fn virtual_mesh_context_is_minimum_when_only_two_known_contributors_fit() {
-        let models = vec![
-            "small".to_string(),
-            "large".to_string(),
-            mesh_mixture_of_agents::VIRTUAL_MODEL_NAME.to_string(),
-        ];
-        let runtimes = vec![runtime("small", Some(8192)), runtime("large", Some(65_536))];
-        assert_eq!(virtual_mesh_context_length(&models, &runtimes), Some(8192));
+        let contexts = vec![("small".to_string(), 8192), ("large".to_string(), 65_536)];
+        assert_eq!(
+            virtual_mesh_context_length_from_known_contexts(contexts),
+            Some(8192)
+        );
     }
 
     #[test]
     fn virtual_mesh_context_uses_second_highest_known_model_context() {
-        let models = vec![
-            "small".to_string(),
-            "large-a".to_string(),
-            "large-b".to_string(),
-        ];
-        let runtimes = vec![
-            runtime("small", Some(32_768)),
-            runtime("large-a", Some(131_072)),
-            runtime("large-b", Some(131_072)),
+        let contexts = vec![
+            ("small".to_string(), 32_768),
+            ("large-a".to_string(), 131_072),
+            ("large-b".to_string(), 131_072),
         ];
         assert_eq!(
-            virtual_mesh_context_length(&models, &runtimes),
+            virtual_mesh_context_length_from_known_contexts(contexts),
             Some(131_072)
         );
     }
 
     #[test]
     fn virtual_mesh_context_counts_each_model_once() {
-        let models = vec!["small".to_string(), "large".to_string()];
-        let runtimes = vec![
-            runtime("large", Some(131_072)),
-            runtime("large", Some(131_072)),
-            runtime("small", Some(16_384)),
+        let contexts = vec![
+            ("large".to_string(), 131_072),
+            ("large".to_string(), 131_072),
+            ("small".to_string(), 16_384),
         ];
         assert_eq!(
-            virtual_mesh_context_length(&models, &runtimes),
+            virtual_mesh_context_length_from_known_contexts(contexts),
             Some(16_384)
         );
     }
 
     #[test]
     fn virtual_mesh_context_needs_two_known_contributor_contexts() {
-        let models = vec!["unknown".to_string(), "known".to_string()];
-        let runtimes = vec![runtime("unknown", None), runtime("known", Some(32_768))];
-        assert_eq!(virtual_mesh_context_length(&models, &runtimes), None);
+        let contexts = vec![("known".to_string(), 32_768)];
+        assert_eq!(
+            virtual_mesh_context_length_from_known_contexts(contexts),
+            None
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -51,8 +51,9 @@ pub async fn try_handle_moa(
     };
 
     let enable_thinking = effective_enable_thinking_for_moa(&body_json);
+    let moa_required_tokens = context_budget::add_moa_context_reserve(&body_json, required_tokens);
 
-    let Some(mut config) = build_moa_config(node, targets, required_tokens).await else {
+    let Some(mut config) = build_moa_config(node, targets, moa_required_tokens).await else {
         let _ = proxy::send_503(tcp_stream, "MoA requires ≥2 models available in the mesh").await;
         return None;
     };
@@ -76,6 +77,7 @@ fn effective_enable_thinking_for_moa(body: &serde_json::Value) -> Option<bool> {
     extract_enable_thinking_override(body).or(Some(false))
 }
 
+mod context_budget;
 pub(in crate::network::openai) mod context_selection;
 mod progress;
 
@@ -378,6 +380,7 @@ pub async fn build_moa_config(
         .into_iter()
         .filter(|n| n != moa::VIRTUAL_MODEL_NAME)
         .collect();
+    let descriptors = node.all_served_model_descriptors().await;
 
     // Group aliases by canonical base. The old shape sorted by name
     // length, took the *first* alias per base, and dropped the rest —
@@ -394,6 +397,7 @@ pub async fn build_moa_config(
             &http,
             &aliases,
             required_tokens,
+            &descriptors,
             &mut backends,
             &mut models,
             &mut local_count,
@@ -478,6 +482,7 @@ async fn resolve_one_worker_from_aliases(
     http: &reqwest::Client,
     aliases: &[String],
     required_tokens: Option<u32>,
+    descriptors: &[mesh::ServedModelDescriptor],
     backends: &mut Vec<std::sync::Arc<dyn moa::ModelBackend>>,
     models: &mut Vec<moa::ModelEntry>,
     local_count: &mut usize,
@@ -487,6 +492,7 @@ async fn resolve_one_worker_from_aliases(
         targets,
         http,
         required_tokens,
+        descriptors,
     };
     for name in aliases {
         if add_worker_backend(&resolution, name, backends, models, local_count).await {
@@ -571,6 +577,7 @@ struct WorkerBackendResolution<'a> {
     targets: Option<&'a election::ModelTargets>,
     http: &'a reqwest::Client,
     required_tokens: Option<u32>,
+    descriptors: &'a [mesh::ServedModelDescriptor],
 }
 
 async fn add_worker_backend(
@@ -600,6 +607,7 @@ async fn add_worker_backend(
             models.push(moa::ModelEntry {
                 name: name.to_string(),
                 backend_index: backend_idx,
+                parameter_count_b: model_parameter_count_b(name, resolution.descriptors),
             });
             *local_count += 1;
             return true;
@@ -631,10 +639,17 @@ async fn add_worker_backend(
         models.push(moa::ModelEntry {
             name: name.to_string(),
             backend_index: backend_idx,
+            parameter_count_b: model_parameter_count_b(name, resolution.descriptors),
         });
         return true;
     }
     false
+}
+
+fn model_parameter_count_b(name: &str, descriptors: &[mesh::ServedModelDescriptor]) -> Option<f64> {
+    super::transport::descriptor_metadata_for_model(name, descriptors)
+        .and_then(|metadata| metadata.parameter_count_b)
+        .filter(|count| count.is_finite() && *count > 0.0)
 }
 
 /// Canonical name used for cross-peer dedup. Different peers advertise the
@@ -697,6 +712,9 @@ impl moa::ModelBackend for LocalModelBackend {
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
+            body.as_object_mut()
+                .unwrap()
+                .insert("parallel_tool_calls".to_string(), serde_json::json!(false));
         }
         moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
         let resp = self
@@ -751,6 +769,9 @@ impl moa::ModelBackend for RemoteModelBackend {
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
+            body.as_object_mut()
+                .unwrap()
+                .insert("parallel_tool_calls".to_string(), serde_json::json!(false));
         }
         moa::apply_enable_thinking(&mut body, sampling.enable_thinking);
         let body_bytes = serde_json::to_vec(&body).map_err(|e| format!("serialize: {e}"))?;
@@ -1096,12 +1117,12 @@ fn content_pieces_for_streaming(
 /// that hit `/v1/responses` with `stream:true` get event shapes their parser
 /// understands.
 ///
-/// We synthesize the minimum set the standard Responses-API stream emits:
-/// `response.created`, one or more `response.output_text.delta` events,
-/// `response.output_text.done`, and `response.completed`. The text chunking
-/// mode is chosen from the completed MoA turn: committed non-reducer answers
-/// can be split for issue #618's visible streaming path, while reducer output
-/// remains one-shot until reducer streaming is implemented deliberately.
+/// We synthesize the same text-output lifecycle that the standard Responses
+/// relay emits: response creation, output item/content part start, text delta,
+/// text/content/item done, and final completion. The text chunking mode is
+/// chosen from the completed MoA turn: committed non-reducer answers can be
+/// split for issue #618's visible streaming path, while reducer output remains
+/// one-shot until reducer streaming is implemented deliberately.
 async fn send_moa_as_responses_sse(
     stream: TcpStream,
     response: &serde_json::Value,
@@ -1191,11 +1212,23 @@ pub(in crate::network::openai::moa_gateway) async fn send_moa_as_responses_sse_i
                 serde_json::Value::String(response_id.clone()),
             );
         }
-        let data = format!("data: {created}\n\n");
-        let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
-        stream.write_all(framed.as_bytes()).await?;
-        stream.flush().await?;
+        write_responses_sse_event(&mut stream, "response.created", &created).await?;
     }
+
+    if let Some(tool_call) = first_responses_tool_call_item(response, created_at) {
+        write_responses_tool_call_sse_events(&mut stream, response, &tool_call, sequence_number)
+            .await?;
+        write_responses_sse_done(&mut stream).await?;
+        return Ok(());
+    }
+
+    let item_added = resp::responses_stream_output_item_added_event(&item_id, sequence_number);
+    sequence_number = sequence_number.saturating_add(1);
+    write_responses_sse_event(&mut stream, "response.output_item.added", &item_added).await?;
+
+    let part_added = resp::responses_stream_content_part_added_event(&item_id, sequence_number);
+    sequence_number = sequence_number.saturating_add(1);
+    write_responses_sse_event(&mut stream, "response.content_part.added", &part_added).await?;
 
     let pieces = content_pieces_for_streaming(&content, text_stream_mode);
     let chunk_delay = MOA_STREAM_CHUNK_DELAY;
@@ -1212,10 +1245,7 @@ pub(in crate::network::openai::moa_gateway) async fn send_moa_as_responses_sse_i
             sequence_number,
         );
         sequence_number = sequence_number.saturating_add(1);
-        let data = format!("data: {}\n\n", delta_event);
-        let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
-        stream.write_all(framed.as_bytes()).await?;
-        stream.flush().await?;
+        write_responses_sse_event(&mut stream, "response.output_text.delta", &delta_event).await?;
         if let Some(delay) = inter_chunk_delay
             && idx + 1 < pieces.len()
         {
@@ -1226,6 +1256,12 @@ pub(in crate::network::openai::moa_gateway) async fn send_moa_as_responses_sse_i
     let text_done =
         resp::responses_stream_text_done_event_with_sequence(&item_id, &content, sequence_number);
     sequence_number = sequence_number.saturating_add(1);
+    let part_done =
+        resp::responses_stream_content_part_done_event(&item_id, &content, sequence_number);
+    sequence_number = sequence_number.saturating_add(1);
+    let item_done =
+        resp::responses_stream_output_item_done_event(&item_id, &content, sequence_number);
+    sequence_number = sequence_number.saturating_add(1);
     let completed = resp::responses_stream_completed_event_with_sequence(
         &response_id,
         created_at,
@@ -1235,20 +1271,167 @@ pub(in crate::network::openai::moa_gateway) async fn send_moa_as_responses_sse_i
         usage,
         sequence_number,
     );
-    let tail = [text_done, completed];
-    for event in &tail {
-        let data = format!("data: {}\n\n", event);
-        let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
-        stream.write_all(framed.as_bytes()).await?;
+    let tail = [
+        ("response.output_text.done", text_done),
+        ("response.content_part.done", part_done),
+        ("response.output_item.done", item_done),
+        ("response.completed", completed),
+    ];
+    for (event_name, event) in &tail {
+        write_responses_sse_event(&mut stream, event_name, event).await?;
     }
 
+    write_responses_sse_done(&mut stream).await
+}
+
+struct ResponsesToolCallItem {
+    item_id: String,
+    call_id: String,
+    name: String,
+    arguments: String,
+}
+
+fn first_responses_tool_call_item(
+    response: &serde_json::Value,
+    created_at: i64,
+) -> Option<ResponsesToolCallItem> {
+    let tool_call = response
+        .pointer("/choices/0/message/tool_calls")
+        .and_then(serde_json::Value::as_array)?
+        .first()?;
+    let call_id = tool_call
+        .get("id")
+        .and_then(serde_json::Value::as_str)
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("call_{created_at}_0"));
+    let function = tool_call
+        .get("function")
+        .and_then(serde_json::Value::as_object);
+    let name = function
+        .and_then(|function| function.get("name"))
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| tool_call.get("name").and_then(serde_json::Value::as_str))?
+        .trim();
+    if name.is_empty() {
+        return None;
+    }
+    let arguments = function
+        .and_then(|function| function.get("arguments"))
+        .or_else(|| tool_call.get("arguments"))
+        .map(|arguments| match arguments {
+            serde_json::Value::String(arguments) => arguments.clone(),
+            other => other.to_string(),
+        })
+        .unwrap_or_default();
+
+    Some(ResponsesToolCallItem {
+        item_id: format!("fc_moa_{}", short_id_from_response(response)),
+        call_id,
+        name: name.to_string(),
+        arguments,
+    })
+}
+
+async fn write_responses_tool_call_sse_events(
+    stream: &mut TcpStream,
+    response: &serde_json::Value,
+    tool_call: &ResponsesToolCallItem,
+    mut sequence_number: i32,
+) -> std::io::Result<()> {
+    let item_added = responses_tool_call_item_event(
+        "response.output_item.added",
+        tool_call,
+        "",
+        "in_progress",
+        sequence_number,
+    );
+    sequence_number = sequence_number.saturating_add(1);
+    write_responses_sse_event(stream, "response.output_item.added", &item_added).await?;
+
+    let args_delta = serde_json::json!({
+        "type": "response.function_call_arguments.delta",
+        "sequence_number": sequence_number,
+        "item_id": tool_call.item_id,
+        "output_index": 0,
+        "delta": tool_call.arguments,
+    });
+    sequence_number = sequence_number.saturating_add(1);
+    write_responses_sse_event(
+        stream,
+        "response.function_call_arguments.delta",
+        &args_delta,
+    )
+    .await?;
+
+    let args_done = serde_json::json!({
+        "type": "response.function_call_arguments.done",
+        "sequence_number": sequence_number,
+        "item_id": tool_call.item_id,
+        "output_index": 0,
+        "arguments": tool_call.arguments,
+    });
+    sequence_number = sequence_number.saturating_add(1);
+    write_responses_sse_event(stream, "response.function_call_arguments.done", &args_done).await?;
+
+    let item_done = responses_tool_call_item_event(
+        "response.output_item.done",
+        tool_call,
+        &tool_call.arguments,
+        "completed",
+        sequence_number,
+    );
+    sequence_number = sequence_number.saturating_add(1);
+    write_responses_sse_event(stream, "response.output_item.done", &item_done).await?;
+
+    let completed = serde_json::json!({
+        "type": "response.completed",
+        "sequence_number": sequence_number,
+        "response": chat_completion_to_responses_json(response),
+    });
+    write_responses_sse_event(stream, "response.completed", &completed).await
+}
+
+fn responses_tool_call_item_event(
+    event_type: &'static str,
+    tool_call: &ResponsesToolCallItem,
+    arguments: &str,
+    status: &'static str,
+    sequence_number: i32,
+) -> serde_json::Value {
+    serde_json::json!({
+        "type": event_type,
+        "sequence_number": sequence_number,
+        "output_index": 0,
+        "item": {
+            "id": tool_call.item_id,
+            "type": "function_call",
+            "status": status,
+            "call_id": tool_call.call_id,
+            "name": tool_call.name,
+            "arguments": arguments,
+        },
+    })
+}
+
+async fn write_responses_sse_done(stream: &mut TcpStream) -> std::io::Result<()> {
     let done = "data: [DONE]\n\n";
     let framed = format!("{:x}\r\n{}\r\n", done.len(), done);
     stream.write_all(framed.as_bytes()).await?;
-
     stream.write_all(b"0\r\n\r\n").await?;
-    stream.shutdown().await?;
-    Ok(())
+    stream.shutdown().await
+}
+
+async fn write_responses_sse_event(
+    stream: &mut TcpStream,
+    event_name: &'static str,
+    event: &serde_json::Value,
+) -> std::io::Result<()> {
+    crate::network::openai::response_adapter::write_chunked_sse_event(
+        stream,
+        Some(event_name),
+        &event.to_string(),
+    )
+    .await
 }
 
 /// Convert a chat.completion JSON body to a Responses-API JSON body.
@@ -1670,6 +1853,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn responses_sse_emits_output_item_lifecycle() {
+        // Regression: MoA's Responses stream emitted text deltas and
+        // completion, but omitted the output-item/content-part lifecycle
+        // events that agent clients use to attach text to an assistant
+        // message.
+        let response = serde_json::json!({
+            "id": "chatcmpl-moa-lifecycle",
+            "object": "chat.completion",
+            "model": "mesh",
+            "choices": [{
+                "index": 0,
+                "message": { "role": "assistant", "content": "visible answer" },
+                "finish_reason": "stop"
+            }]
+        });
+
+        let raw =
+            capture_responses_sse_body_with_mode(response, MoaFinalTextStreamMode::OneShot).await;
+
+        let expected = vec![
+            "response.created".to_string(),
+            "response.output_item.added".to_string(),
+            "response.content_part.added".to_string(),
+            "response.output_text.delta".to_string(),
+            "response.output_text.done".to_string(),
+            "response.content_part.done".to_string(),
+            "response.output_item.done".to_string(),
+            "response.completed".to_string(),
+        ];
+        let events = response_sse_event_names(&raw);
+        assert_eq!(
+            events, expected,
+            "unexpected Responses SSE event sequence; raw: {raw}"
+        );
+
+        let payload_types = response_sse_payload_types(&raw);
+        assert_eq!(
+            payload_types, events,
+            "event names and payload types must agree; raw: {raw}"
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_sse_emits_function_call_item_for_tool_calls() {
+        let response = serde_json::json!({
+            "id": "chatcmpl-moa-tool",
+            "object": "chat.completion",
+            "model": "mesh",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [{
+                        "id": "call_lookup",
+                        "type": "function",
+                        "function": {
+                            "name": "lookup_fixture_fact",
+                            "arguments": "{\"key\":\"codeword\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+
+        let raw =
+            capture_responses_sse_body_with_mode(response, MoaFinalTextStreamMode::OneShot).await;
+
+        assert_eq!(
+            response_sse_event_names(&raw),
+            [
+                "response.created",
+                "response.output_item.added",
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+                "response.output_item.done",
+                "response.completed"
+            ],
+            "unexpected Responses tool-call SSE event sequence; raw: {raw}"
+        );
+        let payload_types = response_sse_payload_types(&raw);
+        assert!(
+            !payload_types
+                .iter()
+                .any(|kind| kind == "response.output_text.delta"),
+            "tool-call stream must not emit empty output_text deltas; raw: {raw}"
+        );
+
+        let payloads = response_sse_payloads(&raw);
+        let completed = payloads
+            .iter()
+            .find(|event| event.get("type").and_then(|t| t.as_str()) == Some("response.completed"))
+            .expect("response.completed event");
+        assert_eq!(completed["response"]["output"][0]["type"], "function_call");
+        assert_eq!(
+            completed["response"]["output"][0]["name"],
+            "lookup_fixture_fact"
+        );
+        assert_eq!(
+            completed["response"]["output"][0]["arguments"],
+            "{\"key\":\"codeword\"}"
+        );
+    }
+
+    #[tokio::test]
     async fn responses_sse_emits_responses_shape_usage_not_chat_shape() {
         // Regression: MoA was forwarding the chat-completion `usage`
         // object (prompt_tokens/completion_tokens) straight into the
@@ -1718,6 +2007,32 @@ mod tests {
             !raw.contains("\"completion_tokens\":"),
             "chat-shape completion_tokens must NOT leak into Responses-API SSE; got: {raw}"
         );
+    }
+
+    fn response_sse_event_names(raw: &str) -> Vec<String> {
+        raw.lines()
+            .filter_map(|line| line.strip_prefix("event: "))
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    fn response_sse_payload_types(raw: &str) -> Vec<String> {
+        response_sse_payloads(raw)
+            .into_iter()
+            .filter_map(|v| {
+                v.get("type")
+                    .and_then(|t| t.as_str())
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    }
+
+    fn response_sse_payloads(raw: &str) -> Vec<serde_json::Value> {
+        raw.lines()
+            .filter_map(|line| line.strip_prefix("data: "))
+            .filter(|payload| payload.trim() != "[DONE]")
+            .filter_map(|payload| serde_json::from_str::<serde_json::Value>(payload).ok())
+            .collect()
     }
 
     // ── extract_enable_thinking_override ────────────────────────────────

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/progress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/progress.rs
@@ -378,7 +378,14 @@ async fn write_progress_body(
 ) -> std::io::Result<()> {
     let body = &moa_result.response_body;
     if is_moa_failure_body(body) {
-        return write_failure_as_sse_tail(&mut tcp_stream, body, adapter, completion_id).await;
+        return write_failure_as_sse_tail(
+            &mut tcp_stream,
+            body,
+            adapter,
+            completion_id,
+            continuation,
+        )
+        .await;
     }
     let text_stream_mode = final_text_stream_mode_for_result(moa_result);
     match adapter {
@@ -497,6 +504,7 @@ async fn write_failure_as_sse_tail(
     body: &serde_json::Value,
     adapter: proxy::ResponseAdapter,
     completion_id: &str,
+    continuation: Option<ProgressContinuation>,
 ) -> std::io::Result<()> {
     let err_msg = body
         .pointer("/error/message")
@@ -505,13 +513,16 @@ async fn write_failure_as_sse_tail(
 
     let data = match adapter {
         proxy::ResponseAdapter::OpenAiResponsesStream => {
-            let ev = serde_json::json!({
+            let mut ev = serde_json::json!({
                 "type": "response.failed",
                 "response": {
                     "id": completion_id,
                     "error": { "message": err_msg },
                 },
             });
+            if let Some(continuation) = continuation {
+                ev["sequence_number"] = serde_json::Value::from(continuation.next_sequence_number);
+            }
             format!("data: {ev}\n\n")
         }
         _ => {
@@ -775,6 +786,7 @@ mod tests {
     async fn capture_failure_tail(
         adapter: proxy::ResponseAdapter,
         body: serde_json::Value,
+        continuation: Option<ProgressContinuation>,
     ) -> String {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
@@ -782,9 +794,15 @@ mod tests {
         let addr = listener.local_addr().expect("addr");
         let server = tokio::spawn(async move {
             let (mut socket, _) = listener.accept().await.expect("accept");
-            write_failure_as_sse_tail(&mut socket, &body, adapter, TEST_COMPLETION_ID)
-                .await
-                .expect("write");
+            write_failure_as_sse_tail(
+                &mut socket,
+                &body,
+                adapter,
+                TEST_COMPLETION_ID,
+                continuation,
+            )
+            .await
+            .expect("write");
             socket.shutdown().await.expect("shutdown");
         });
         let mut client = tokio::net::TcpStream::connect(addr).await.expect("connect");
@@ -804,7 +822,7 @@ mod tests {
         let body = serde_json::json!({
             "error": { "message": "All workers failed", "code": "all_workers_failed" }
         });
-        let raw = capture_failure_tail(proxy::ResponseAdapter::None, body).await;
+        let raw = capture_failure_tail(proxy::ResponseAdapter::None, body, None).await;
         assert!(
             raw.contains("\"finish_reason\":\"error\""),
             "failure tail must set finish_reason=error; got: {raw}"
@@ -819,6 +837,31 @@ mod tests {
         assert!(
             raw.contains(TEST_COMPLETION_ID),
             "expected completion id {TEST_COMPLETION_ID} on the error chunk; got: {raw}"
+        );
+    }
+
+    #[tokio::test]
+    async fn responses_failure_tail_keeps_progress_sequence_number() {
+        let body = serde_json::json!({
+            "error": { "message": "All workers failed", "code": "all_workers_failed" }
+        });
+        let raw = capture_failure_tail(
+            proxy::ResponseAdapter::OpenAiResponsesStream,
+            body,
+            Some(ProgressContinuation {
+                created_at: 1_700_000_000,
+                next_sequence_number: 7,
+            }),
+        )
+        .await;
+
+        assert!(
+            raw.contains(r#""sequence_number":7"#),
+            "Responses failure tail must continue progress sequence; got: {raw}"
+        );
+        assert!(
+            raw.contains("[DONE]"),
+            "failure tail must terminate the Responses SSE stream with [DONE]; got: {raw}"
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/progress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/progress.rs
@@ -25,6 +25,14 @@ use tokio::net::TcpStream;
 /// turn finishes in ~3s, so we emit two or three lines before the
 /// real answer starts streaming.
 const MOA_PROGRESS_INTERVAL: std::time::Duration = std::time::Duration::from_millis(1000);
+const VISIBLE_PROGRESS_LINES: &[&str] = &[
+    "Routing through mesh...",
+    "Querying peer models...",
+    "Comparing responses...",
+    "Waiting on a slow peer...",
+    "Still gathering responses...",
+    "Keeping the mesh request alive...",
+];
 
 /// Streaming MoA turn with `reasoning_content` progress drip.
 ///
@@ -334,9 +342,12 @@ where
         }
         let text = progress_line(step, adapter);
         step += 1;
-        if let Err(e) =
+        let write_result = if let Some(text) = text {
             write_progress_event(stream, &text, adapter, completion_id, &mut sequence_number).await
-        {
+        } else {
+            write_progress_keepalive(stream).await
+        };
+        if let Err(e) = write_result {
             // Progress write failed — almost always means the client
             // closed the connection. Returning Err here drops the
             // pinned MoA future, cancelling worker dispatch and any
@@ -388,26 +399,20 @@ async fn write_progress_body(
 
 /// The lines we drip into the thinking pane while MoA arbitrates.
 /// Short, factual, and grounded in what mesh-llm is actually doing —
-/// not invented model "thoughts". The opening three lines fire
-/// once each at ~1s/2s/3s; the rest are a slow "waiting on a slow
-/// peer" cycle that explains a long tail without spamming repeats.
-fn progress_line(step: usize, _adapter: proxy::ResponseAdapter) -> String {
-    const OPENING: &[&str] = &[
-        "Routing through mesh…",
-        "Querying peer models…",
-        "Comparing responses…",
-    ];
-    const TAIL_CYCLE: &[&str] = &[
-        "Waiting on a slow peer…",
-        "Still gathering responses…",
-        "Hold on, this one's taking a moment…",
-    ];
-    let line = if step < OPENING.len() {
-        OPENING[step]
-    } else {
-        TAIL_CYCLE[(step - OPENING.len()) % TAIL_CYCLE.len()]
-    };
-    format!("{line}\n")
+/// not invented model "thoughts". Once this finite list is exhausted,
+/// the stream switches to quiet SSE comments so clients stay connected
+/// without accumulating repeated thinking text.
+fn progress_line(step: usize, _adapter: proxy::ResponseAdapter) -> Option<String> {
+    VISIBLE_PROGRESS_LINES
+        .get(step)
+        .map(|line| format!("{line}\n"))
+}
+
+async fn write_progress_keepalive(stream: &mut TcpStream) -> std::io::Result<()> {
+    let data = ": moa-progress\n\n";
+    let framed = format!("{:x}\r\n{}\r\n", data.len(), data);
+    stream.write_all(framed.as_bytes()).await?;
+    stream.flush().await
 }
 
 async fn write_progress_event(
@@ -546,24 +551,23 @@ mod tests {
     const TEST_COMPLETION_ID: &str = "chatcmpl-moa-deadbeef";
 
     #[test]
-    fn progress_line_walks_opening_then_cycles_tail() {
-        // First 3 lines are the opening; we never want to repeat one
-        // of those within the first three ticks.
-        let a = progress_line(0, proxy::ResponseAdapter::None);
-        let b = progress_line(1, proxy::ResponseAdapter::None);
-        let c = progress_line(2, proxy::ResponseAdapter::None);
+    fn progress_line_emits_finite_visible_updates_then_keepalive() {
+        let a = progress_line(0, proxy::ResponseAdapter::None).expect("line 0");
+        let b = progress_line(1, proxy::ResponseAdapter::None).expect("line 1");
+        let c = progress_line(2, proxy::ResponseAdapter::None).expect("line 2");
         assert_ne!(a, b);
         assert_ne!(b, c);
         assert_ne!(a, c);
-        // After the opening, the tail cycles so we never go silent.
-        let d = progress_line(3, proxy::ResponseAdapter::None);
-        let e = progress_line(4, proxy::ResponseAdapter::None);
-        let f = progress_line(5, proxy::ResponseAdapter::None);
-        let g = progress_line(6, proxy::ResponseAdapter::None);
+
+        let d = progress_line(3, proxy::ResponseAdapter::None).expect("line 3");
+        let e = progress_line(4, proxy::ResponseAdapter::None).expect("line 4");
+        let f = progress_line(5, proxy::ResponseAdapter::None).expect("line 5");
         assert_ne!(d, e);
         assert_ne!(e, f);
-        // step=6 is one full TAIL_CYCLE past step=3 → must be equal.
-        assert_eq!(d, g, "tail must cycle so a slow MoA turn keeps printing");
+        assert!(
+            progress_line(6, proxy::ResponseAdapter::None).is_none(),
+            "after finite visible progress, the stream should switch to quiet keepalives"
+        );
     }
 
     /// Capture the wire bytes produced by `write_progress_event` for
@@ -599,7 +603,7 @@ mod tests {
         // delta.reasoning_content (so goose/openai-sdk-aware clients
         // route it to a thinking pane, not the main answer).
         let raw =
-            capture_progress_event(proxy::ResponseAdapter::None, "Routing through mesh…\n").await;
+            capture_progress_event(proxy::ResponseAdapter::None, "Routing through mesh...\n").await;
         let payload = raw
             .lines()
             .find_map(|l| l.strip_prefix("data: "))
@@ -608,7 +612,7 @@ mod tests {
         assert_eq!(
             v.pointer("/choices/0/delta/reasoning_content")
                 .and_then(|s| s.as_str()),
-            Some("Routing through mesh…\n"),
+            Some("Routing through mesh...\n"),
             "progress events for chat adapter must drip into \
              delta.reasoning_content so they don't pollute the answer; payload: {payload}"
         );
@@ -625,6 +629,31 @@ mod tests {
             "progress chunks must reuse completion_id so clients correlate the stream; \
              payload: {payload}"
         );
+    }
+
+    #[tokio::test]
+    async fn progress_keepalive_uses_sse_comment_not_reasoning_text() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback");
+        let addr = listener.local_addr().expect("local_addr");
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            write_progress_keepalive(&mut socket)
+                .await
+                .expect("write keepalive");
+            socket.shutdown().await.expect("shutdown");
+        });
+        let mut client = tokio::net::TcpStream::connect(addr).await.expect("connect");
+        use tokio::io::AsyncReadExt;
+        let mut bytes = Vec::new();
+        client.read_to_end(&mut bytes).await.expect("read");
+        server.await.expect("server task");
+
+        let raw = String::from_utf8_lossy(&bytes);
+        assert!(raw.contains(": moa-progress"));
+        assert!(!raw.contains("reasoning_content"));
+        assert!(!raw.contains("response.reasoning_text.delta"));
     }
 
     #[test]
@@ -820,7 +849,7 @@ mod tests {
             let mut seq = 1i32;
             write_progress_event(
                 &mut socket,
-                "Routing through mesh…\n",
+                "Routing through mesh...\n",
                 proxy::ResponseAdapter::OpenAiResponsesStream,
                 TEST_COMPLETION_ID,
                 &mut seq,

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -4157,12 +4157,15 @@ fn models_list_json(
     let mut data: Vec<serde_json::Value> = models
         .iter()
         .filter_map(|m| {
-            let descriptor = descriptor_for_model(descriptors, m);
+            let descriptor = descriptor_for_visible_model(descriptors, m);
+            let metadata_model_name = descriptor
+                .map(|descriptor| descriptor.identity.model_name.as_str())
+                .unwrap_or(m);
             let public_id = public_model_id(m, descriptor);
             if !seen.insert(public_id.clone()) {
                 return None;
             }
-            let capabilities = capabilities_for_model(m, descriptors);
+            let capabilities = capabilities_for_model(metadata_model_name, descriptors);
             let has_multimodal = capabilities.supports_multimodal_runtime();
             let has_vision = capabilities.supports_vision_runtime();
             let has_audio = capabilities.supports_audio_runtime();
@@ -4195,7 +4198,7 @@ fn models_list_json(
                 "audio_status": capabilities.audio_status(),
                 "reasoning_status": capabilities.reasoning_status(),
             });
-            if let Some(metadata) = model_metadata_json(m, descriptor, runtimes)
+            if let Some(metadata) = model_metadata_json(metadata_model_name, descriptor, runtimes)
                 && let Some(object) = model.as_object_mut()
             {
                 object.insert("metadata".to_string(), metadata);
@@ -4218,10 +4221,7 @@ fn models_list_json(
             "audio_status": "unsupported",
             "reasoning_status": "unknown",
         });
-        if let Some(context_length) =
-            crate::network::openai::moa_gateway::context_selection::virtual_mesh_context_length(
-                models, runtimes,
-            )
+        if let Some(context_length) = virtual_mesh_context_length(models, descriptors, runtimes)
             && let Some(object) = model.as_object_mut()
         {
             object.insert(
@@ -4233,6 +4233,37 @@ fn models_list_json(
     }
 
     serde_json::json!({ "object": "list", "data": data })
+}
+
+fn virtual_mesh_context_length(
+    models: &[String],
+    descriptors: &[mesh::ServedModelDescriptor],
+    runtimes: &[mesh::ModelRuntimeDescriptor],
+) -> Option<u32> {
+    let contexts = models.iter().filter_map(|model| {
+        if model == mesh_mixture_of_agents::VIRTUAL_MODEL_NAME {
+            return None;
+        }
+        visible_model_context_entry(model, descriptors, runtimes)
+    });
+    crate::network::openai::moa_gateway::context_selection::virtual_mesh_context_length_from_known_contexts(contexts)
+}
+
+fn visible_model_context_entry(
+    model_name: &str,
+    descriptors: &[mesh::ServedModelDescriptor],
+    runtimes: &[mesh::ModelRuntimeDescriptor],
+) -> Option<(String, u32)> {
+    let descriptor = descriptor_for_model(descriptors, model_name)
+        .or_else(|| descriptor_for_public_model_id(descriptors, model_name));
+    let runtime_model_name = descriptor
+        .map(|descriptor| descriptor.identity.model_name.as_str())
+        .unwrap_or(model_name);
+    let context = runtime_context_lengths_for_model(runtime_model_name, runtimes)?.max;
+    let model_key = descriptor
+        .and_then(|descriptor| descriptor.identity.identity_hash.clone())
+        .unwrap_or_else(|| public_model_id(runtime_model_name, descriptor));
+    Some((model_key, context))
 }
 
 fn model_metadata_json(
@@ -4353,6 +4384,23 @@ fn descriptor_for_model<'a>(
     descriptors
         .iter()
         .find(|descriptor| descriptor.identity.model_name == model_name)
+}
+
+fn descriptor_for_visible_model<'a>(
+    descriptors: &'a [mesh::ServedModelDescriptor],
+    model_name: &str,
+) -> Option<&'a mesh::ServedModelDescriptor> {
+    descriptor_for_model(descriptors, model_name)
+        .or_else(|| descriptor_for_public_model_id(descriptors, model_name))
+}
+
+fn descriptor_for_public_model_id<'a>(
+    descriptors: &'a [mesh::ServedModelDescriptor],
+    public_id: &str,
+) -> Option<&'a mesh::ServedModelDescriptor> {
+    descriptors.iter().find(|descriptor| {
+        public_model_id(&descriptor.identity.model_name, Some(descriptor)) == public_id
+    })
 }
 
 fn public_model_id(model_name: &str, descriptor: Option<&mesh::ServedModelDescriptor>) -> String {
@@ -5246,6 +5294,61 @@ mod tests {
 
         assert_eq!(mesh["display_name"], "Mesh (MoA)");
         assert_eq!(mesh["metadata"]["context_length"], 16_384);
+    }
+
+    #[test]
+    fn models_list_maps_public_aliases_to_runtime_context() {
+        let internal = "Falcon-H1-1.5B-Instruct-Q4_K_M";
+        let public = "tiiuae/Falcon-H1-1.5B-Instruct-GGUF:Q4_K_M".to_string();
+        let descriptors = vec![hf_descriptor(internal)];
+        let runtimes = vec![mesh::ModelRuntimeDescriptor {
+            model_name: internal.to_string(),
+            identity_hash: Some("sha256:falcon".to_string()),
+            context_length: Some(32_768),
+            ready: true,
+        }];
+
+        let body = models_list_json(std::slice::from_ref(&public), &descriptors, &runtimes);
+        let model = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|model| model["id"] == public)
+            .expect("public model should be listed");
+
+        assert_eq!(model["metadata"]["context_length"], 32_768);
+    }
+
+    #[test]
+    fn virtual_mesh_context_counts_public_alias_runtime_contexts() {
+        let fast_internal = "Falcon-H1-1.5B-Instruct-Q4_K_M";
+        let fast_public = "tiiuae/Falcon-H1-1.5B-Instruct-GGUF:Q4_K_M".to_string();
+        let strong = "strong-32b".to_string();
+        let descriptors = vec![hf_descriptor(fast_internal)];
+        let runtimes = vec![
+            mesh::ModelRuntimeDescriptor {
+                model_name: fast_internal.to_string(),
+                identity_hash: Some("sha256:falcon".to_string()),
+                context_length: Some(32_768),
+                ready: true,
+            },
+            mesh::ModelRuntimeDescriptor {
+                model_name: strong.clone(),
+                identity_hash: Some("sha256:strong".to_string()),
+                context_length: Some(131_072),
+                ready: true,
+            },
+        ];
+
+        let body = models_list_json(&[fast_public, strong], &descriptors, &runtimes);
+        let mesh = body["data"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|model| model["id"] == mesh_mixture_of_agents::VIRTUAL_MODEL_NAME)
+            .expect("virtual mesh model should be listed");
+
+        assert_eq!(mesh["metadata"]["context_length"], 32_768);
     }
 
     #[test]

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -40,6 +40,19 @@
     "mmproj": null
   },
   {
+    "name": "Gemma-4-E4B-it-Q4_K_M",
+    "file": "gemma-4-E4B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
+    "size": "4.6GB",
+    "description": "Gemma 4 E4B instruction model, strong mini-class default",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+    }
+  },
+  {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
     "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
     "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",

--- a/crates/mesh-llm-ui/src/components/ui/tooltip.tsx
+++ b/crates/mesh-llm-ui/src/components/ui/tooltip.tsx
@@ -1,4 +1,5 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip'
+import { useSyncExternalStore } from 'react'
 import type { ReactElement, ReactNode } from 'react'
 
 // eslint-disable-next-line react-refresh/only-export-components -- re-exports of Radix UI components for convenience
@@ -38,7 +39,36 @@ type TooltipProps = {
   side?: RadixTooltip.TooltipContentProps['side']
 }
 
+const TOUCH_TOOLTIP_QUERY = '(hover: none), (pointer: coarse)'
+
+function tooltipShouldBeDisabledForTouch() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(TOUCH_TOOLTIP_QUERY).matches
+}
+
+function subscribeToTouchTooltipChanges(onStoreChange: () => void) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {}
+
+  const mediaQuery = window.matchMedia(TOUCH_TOOLTIP_QUERY)
+  const handleChange = () => onStoreChange()
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }
+
+  mediaQuery.addListener(handleChange)
+  return () => mediaQuery.removeListener(handleChange)
+}
+
+function useTooltipDisabledForTouch() {
+  return useSyncExternalStore(subscribeToTouchTooltipChanges, tooltipShouldBeDisabledForTouch, () => false)
+}
+
 export function Tooltip({ children, content, side = 'top' }: TooltipProps) {
+  const disabledForTouch = useTooltipDisabledForTouch()
+  if (disabledForTouch) return children
+
   return (
     <RadixTooltip.Provider delayDuration={250} skipDelayDuration={120}>
       <RadixTooltip.Root>

--- a/crates/mesh-llm-ui/src/features/chat/api/use-chat.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/api/use-chat.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { DEFAULT_SYSTEM_PROMPT } from '@/constants/system-prompt'
 import { useMeshChat } from '@/features/chat/api/use-chat'
+import type { ThreadMessage } from '@/features/app-tabs/types'
 
 type UseChatOptions = {
   id: string
@@ -22,12 +23,19 @@ function createUserMessage(content: string): UIMessage {
   }
 }
 
-async function drainStream(adapter: ConnectConnectionAdapter, message: UIMessage) {
-  for await (const chunk of adapter.connect([message], undefined, undefined)) {
+async function drainMessageStream(adapter: ConnectConnectionAdapter, messages: UIMessage[]) {
+  for await (const chunk of adapter.connect(messages, undefined, undefined)) {
     void chunk
     // Drain the stream so the request body is built and posted.
   }
 }
+
+const useChatMockState = vi.hoisted(() => ({
+  resetMessages: [] as unknown[][],
+  reset() {
+    this.resetMessages = []
+  }
+}))
 
 vi.mock('@tanstack/ai-react', async () => {
   const React = await import('react')
@@ -35,11 +43,18 @@ vi.mock('@tanstack/ai-react', async () => {
   return {
     useChat: vi.fn(({ connection, initialMessages }: UseChatOptions) => {
       const connectionRef = React.useRef(connection)
+      const messagesRef = React.useRef(initialMessages)
+      const setMessages = vi.fn((messages: UIMessage[]) => {
+        messagesRef.current = messages
+        useChatMockState.resetMessages.push(messages)
+      })
 
       return {
-        messages: initialMessages,
-        sendMessage: vi.fn((content: string) => drainStream(connectionRef.current, createUserMessage(content))),
-        setMessages: vi.fn(),
+        messages: messagesRef.current,
+        sendMessage: vi.fn((content: string) =>
+          drainMessageStream(connectionRef.current, [...messagesRef.current, createUserMessage(content)])
+        ),
+        setMessages,
         reload: vi.fn(),
         stop: vi.fn(),
         status: 'ready',
@@ -81,18 +96,22 @@ function SendFirstMessageOnLayout() {
 
 function SendMessageOnLayout({
   message,
+  conversationId = 'chat-1',
+  initialMessages = [],
   model,
   systemPrompt
 }: {
   message?: string
+  conversationId?: string
+  initialMessages?: ThreadMessage[]
   model: string
   systemPrompt: string
 }) {
   const chat = useMeshChat({
-    conversationId: 'chat-1',
+    conversationId,
     model,
     systemPrompt,
-    initialMessages: []
+    initialMessages
   })
 
   useLayoutEffect(() => {
@@ -107,6 +126,7 @@ function SendMessageOnLayout({
 describe('useMeshChat', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    useChatMockState.reset()
   })
 
   it('sends the default system prompt with the first message in a new chat', async () => {
@@ -143,5 +163,47 @@ describe('useMeshChat', () => {
     expect(body.model).toBe('model-b')
     expect(body.input[0]).toEqual({ role: 'system', content: 'prompt-b' })
     expect(body.input[1]).toEqual({ role: 'user', content: 'Use latest values' })
+  })
+
+  it('resets the underlying chat messages before a fresh conversation can send', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(createSSEStream(['data: [DONE]\n']), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const oldThread: ThreadMessage[] = [
+      {
+        id: 'old-user',
+        messageRole: 'user',
+        timestamp: '2026-05-13T00:00:00.000Z',
+        body: 'Old Windows via Tailscale question'
+      },
+      {
+        id: 'old-assistant',
+        messageRole: 'assistant',
+        timestamp: '2026-05-13T00:00:01.000Z',
+        body: 'Old answer that must not leak'
+      }
+    ]
+
+    const { rerender } = render(
+      <SendMessageOnLayout conversationId="old-chat" initialMessages={oldThread} model="mesh" systemPrompt="" />
+    )
+
+    rerender(
+      <SendMessageOnLayout
+        conversationId="fresh-chat"
+        initialMessages={[]}
+        message="Only answer this fresh prompt"
+        model="mesh"
+        systemPrompt=""
+      />
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    const request = fetchMock.mock.calls[0]?.[1]
+    const body = JSON.parse(String(request?.body)) as { input: Array<{ role: string; content: string }> }
+
+    expect(body.input).toEqual([{ role: 'user', content: 'Only answer this fresh prompt' }])
+    expect(JSON.stringify(body.input)).not.toContain('Windows via Tailscale')
   })
 })

--- a/crates/mesh-llm-ui/src/features/chat/api/use-chat.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/use-chat.ts
@@ -1,4 +1,4 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { useChat } from '@tanstack/ai-react'
 import type { UseChatReturn } from '@tanstack/ai-react'
 import type { ThreadMessage } from '@/features/app-tabs/types'
@@ -50,7 +50,7 @@ export function useMeshChat({
   const hydratedMessages = useMemo(() => threadMessagesToUIMessages(initialMessages), [initialMessages])
   const chat = useChat({ id: conversationId, connection, initialMessages: hydratedMessages })
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const conversationChanged = previousConversationIdRef.current !== conversationId
     previousConversationIdRef.current = conversationId
 

--- a/crates/mesh-llm-ui/src/features/chat/components/composer/ChatComposer.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/composer/ChatComposer.tsx
@@ -217,7 +217,9 @@ export function ChatComposer({
             </Button>
           )}
           <Button
-            onMouseDown={(e) => e.preventDefault()}
+            onPointerDown={(event) => {
+              if (event.pointerType === 'mouse') event.preventDefault()
+            }}
             onClick={onSubmit}
             data-testid="chat-send"
             disabled={!canChat || (!input.trim() && pendingAttachments.length === 0) || !!attachmentPreparationMessage}

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
@@ -105,6 +105,7 @@ const chatMock = vi.hoisted(() => {
       content: string | MultimodalContent
       model: string
       systemPrompt: string
+      priorBodies: string[]
     }>,
     reloadCalls: [] as string[],
     hookConversationIds: [] as string[],
@@ -277,7 +278,15 @@ vi.mock('@/features/chat/api/use-chat', async () => {
         return {
           messages,
           sendMessage: vi.fn(async (content: string | MultimodalContent) => {
-            chatMock.sendCalls.push({ conversationId, content, model, systemPrompt })
+            chatMock.sendCalls.push({
+              conversationId,
+              content,
+              model,
+              systemPrompt,
+              priorBodies: messagesRef.current.map((message) =>
+                message.parts.map((part) => (part.type === 'text' ? part.content : '')).join('')
+              )
+            })
             const body =
               typeof content === 'string'
                 ? content
@@ -892,6 +901,30 @@ describe('ChatPage', () => {
         'Retried assistant reply'
       ])
     })
+  })
+
+  it('sends follow-up prompts with same-conversation history', async () => {
+    const user = userEvent.setup()
+    chatMock.sendStatus = 'ready'
+    chatMock.sendAssistantText = 'First answer'
+
+    renderChatPage({ mode: 'live' })
+
+    await user.type(screen.getByLabelText('Prompt'), 'Remember alpha')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => expect(chatMock.sendCalls).toHaveLength(1))
+    const conversationId = chatMock.sendCalls[0]?.conversationId
+    expect(conversationId).toBeTruthy()
+
+    chatMock.sendAssistantText = 'Second answer'
+    await user.type(screen.getByLabelText('Prompt'), 'What did I ask you to remember?')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+
+    await waitFor(() => expect(chatMock.sendCalls).toHaveLength(2))
+
+    expect(chatMock.sendCalls[1]?.conversationId).toBe(conversationId)
+    expect(chatMock.sendCalls[1]?.priorBodies).toEqual(['Remember alpha', 'First answer'])
   })
 
   it('renders streamed thinking separately, formats final markdown, and persists the raw assistant body', async () => {

--- a/crates/mesh-mixture-of-agents/src/arbiter.rs
+++ b/crates/mesh-mixture-of-agents/src/arbiter.rs
@@ -155,10 +155,7 @@ pub fn arbitrate(outputs: &[WorkerOutput], has_tools: bool) -> Decision {
 
     if !answers.is_empty() {
         // Pick the highest-confidence answer
-        let best = answers
-            .iter()
-            .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
-            .unwrap();
+        let best = best_answer_output(outputs).expect("answers is not empty");
 
         // If confidence is low and there's critique, reducer
         if best.confidence < 0.5 && !critiques.is_empty() {
@@ -189,6 +186,7 @@ pub fn try_early_decision(
     total_workers: usize,
     total_finished: usize,
     has_tools: bool,
+    answer_priority_pending: bool,
 ) -> Option<Decision> {
     if outputs.is_empty() {
         // All workers finished but none succeeded
@@ -215,6 +213,9 @@ pub fn try_early_decision(
         let failed_count = total_finished - outputs.len();
         let majority_failed = failed_count > 0 && failed_count >= total_workers / 2;
         if !majority_failed {
+            return None;
+        }
+        if answer_priority_pending && single_output_would_return_answer(&outputs[0], has_tools) {
             return None;
         }
         // Majority failed — return the sole survivor
@@ -244,7 +245,7 @@ pub fn try_early_decision(
     };
     if let Some((cluster_size, best)) = agreeing_cluster {
         let majority = cluster_size * 2 >= answers.len();
-        if majority && best.confidence >= 0.5 {
+        if majority && best.confidence >= 0.5 && !answer_priority_pending {
             tracing::info!(
                 "moa: early exit — {}/{} workers agree on answer (conf={:.2}), {} still pending",
                 cluster_size,
@@ -474,6 +475,34 @@ fn single_output_decision(output: &WorkerOutput, has_tools: bool) -> Decision {
     }
 }
 
+fn single_output_would_return_answer(output: &WorkerOutput, has_tools: bool) -> bool {
+    !matches!(
+        single_output_decision(output, has_tools),
+        Decision::ToolCall { .. }
+    )
+}
+
+pub(crate) fn best_answer_output(outputs: &[WorkerOutput]) -> Option<&WorkerOutput> {
+    outputs
+        .iter()
+        .filter(|o| is_usable_answer(o))
+        .max_by(|a, b| answer_rank_score(a).total_cmp(&answer_rank_score(b)))
+}
+
+fn answer_rank_score(output: &WorkerOutput) -> f32 {
+    output.confidence + answer_role_bias(output.role)
+}
+
+fn answer_role_bias(role: crate::worker::WorkerRole) -> f32 {
+    match role {
+        crate::worker::WorkerRole::Reducer => 0.20,
+        crate::worker::WorkerRole::Strong => 0.15,
+        crate::worker::WorkerRole::Generalist => 0.10,
+        crate::worker::WorkerRole::Specialist => 0.05,
+        crate::worker::WorkerRole::Fast => 0.0,
+    }
+}
+
 fn is_usable_answer(output: &WorkerOutput) -> bool {
     output.kind == OutputKind::Answer
         && !crate::normalize::is_silent_reply_sentinel(&output.payload)
@@ -523,6 +552,19 @@ mod tests {
     }
 
     #[test]
+    fn answer_arbitration_biases_toward_strong_when_close() {
+        let mut fast = make_output(OutputKind::Answer, 0.86, "fast weaker answer");
+        fast.role = WorkerRole::Fast;
+        let mut strong = make_output(OutputKind::Answer, 0.75, "stronger model answer");
+        strong.role = WorkerRole::Strong;
+
+        match arbitrate(&[fast, strong], false) {
+            Decision::Answer(text) => assert_eq!(text, "stronger model answer"),
+            other => panic!("expected Answer, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn unanimous_tool_proposal() {
         let outputs = vec![
             make_tool_output(0.8, "read_file", serde_json::json!({"path": "a.rs"})),
@@ -564,7 +606,7 @@ mod tests {
     fn early_decision_none_with_one_of_three() {
         let outputs = vec![make_output(OutputKind::Answer, 0.9, "Paris")];
         // 1 of 3 — too early to decide
-        assert!(try_early_decision(&outputs, 3, outputs.len(), false).is_none());
+        assert!(try_early_decision(&outputs, 3, outputs.len(), false, false).is_none());
     }
 
     #[test]
@@ -574,10 +616,24 @@ mod tests {
             make_output(OutputKind::Answer, 0.9, "Paris is the capital"),
         ];
         // 2 of 3 agree — early exit
-        match try_early_decision(&outputs, 3, outputs.len(), false) {
+        match try_early_decision(&outputs, 3, outputs.len(), false, false) {
             Some(Decision::Answer(text)) => assert!(text.contains("Paris")),
             other => panic!("expected early Answer, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn early_answer_decision_waits_for_pending_strong_worker() {
+        let outputs = vec![
+            make_output(OutputKind::Answer, 0.8, "Paris"),
+            make_output(OutputKind::Answer, 0.9, "Paris is the capital"),
+        ];
+
+        let res = try_early_decision(&outputs, 3, outputs.len(), false, true);
+        assert!(
+            res.is_none(),
+            "answer early-exit must not bypass a pending strong worker"
+        );
     }
 
     #[test]
@@ -586,7 +642,7 @@ mod tests {
             make_tool_output(0.8, "read_file", serde_json::json!({"path": "a.rs"})),
             make_tool_output(0.7, "read_file", serde_json::json!({"path": "a.rs"})),
         ];
-        match try_early_decision(&outputs, 3, outputs.len(), true) {
+        match try_early_decision(&outputs, 3, outputs.len(), true, false) {
             Some(Decision::ToolCall { name, .. }) => assert_eq!(name, "read_file"),
             other => panic!("expected early ToolCall, got {other:?}"),
         }
@@ -598,7 +654,7 @@ mod tests {
             make_tool_output(0.7, "read_file", serde_json::json!({})),
             make_output(OutputKind::Answer, 0.8, "I know the answer"),
         ];
-        match try_early_decision(&outputs, 3, outputs.len(), true) {
+        match try_early_decision(&outputs, 3, outputs.len(), true, false) {
             Some(Decision::NeedsReducer { .. }) => {}
             other => panic!("expected early NeedsReducer, got {other:?}"),
         }
@@ -614,7 +670,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.9, "The capital of France is Paris"),
             make_output(OutputKind::Answer, 0.8, "The capital of France is Berlin"),
         ];
-        let res = try_early_decision(&outputs, 3, outputs.len(), false);
+        let res = try_early_decision(&outputs, 3, outputs.len(), false, false);
         assert!(
             res.is_none(),
             "disagreeing answers should not trigger early-exit, got {res:?}"
@@ -630,7 +686,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.7, "Paris"),
             make_output(OutputKind::Answer, 0.9, "Paris is the capital of France"),
         ];
-        match try_early_decision(&outputs, 3, outputs.len(), false) {
+        match try_early_decision(&outputs, 3, outputs.len(), false, false) {
             // Representative picks the most complete (most tokens) member.
             Some(Decision::Answer(text)) => {
                 let lower = text.to_lowercase();
@@ -653,7 +709,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.8, "Paris is the capital"),
             make_output(OutputKind::Answer, 0.6, "I think it's Lyon"),
         ];
-        match try_early_decision(&outputs, 4, outputs.len(), false) {
+        match try_early_decision(&outputs, 4, outputs.len(), false, false) {
             Some(Decision::Answer(text)) => assert!(
                 text.to_lowercase().contains("paris"),
                 "should pick from the agreeing cluster, got {text:?}"
@@ -673,7 +729,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.9, "The capital of France is Berlin"),
             make_output(OutputKind::Answer, 0.5, "The capital of France is Madrid"),
         ];
-        let res = try_early_decision(&outputs, 4, outputs.len(), false);
+        let res = try_early_decision(&outputs, 4, outputs.len(), false, false);
         assert!(
             res.is_none(),
             "three disagreeing answers should not early-exit, got {res:?}"
@@ -689,7 +745,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.9, "You should use grep"),
             make_output(OutputKind::Answer, 0.8, "You should not use grep"),
         ];
-        let res = try_early_decision(&outputs, 3, outputs.len(), false);
+        let res = try_early_decision(&outputs, 3, outputs.len(), false, false);
         assert!(
             res.is_none(),
             "affirmative vs negated answer should not cluster, got {res:?}"
@@ -704,7 +760,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.9, "Do that"),
             make_output(OutputKind::Answer, 0.8, "Don't do that"),
         ];
-        let res = try_early_decision(&outputs, 3, outputs.len(), false);
+        let res = try_early_decision(&outputs, 3, outputs.len(), false, false);
         assert!(
             res.is_none(),
             "affirmative vs negated should not cluster, got {res:?}"
@@ -718,7 +774,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.9, "42"),
             make_output(OutputKind::Answer, 0.8, "The answer is 42"),
         ];
-        match try_early_decision(&outputs, 3, outputs.len(), false) {
+        match try_early_decision(&outputs, 3, outputs.len(), false, false) {
             Some(Decision::Answer(text)) => assert!(text.contains("42")),
             other => panic!("expected numeric agreement, got {other:?}"),
         }
@@ -729,7 +785,7 @@ mod tests {
         // 1 success out of 3, other 2 failed — should return the single answer
         let outputs = vec![make_output(OutputKind::Answer, 0.8, "Paris")];
         // total_workers=3, total_finished=3 (1 success + 2 failures), remaining=0
-        match try_early_decision(&outputs, 3, 3, false) {
+        match try_early_decision(&outputs, 3, 3, false, false) {
             Some(Decision::Answer(text)) => assert!(text.contains("Paris")),
             other => panic!("expected early Answer for sole survivor, got {other:?}"),
         }
@@ -742,7 +798,7 @@ mod tests {
             make_output(OutputKind::Answer, 0.4, "could be Paris"),
         ];
         // Both answers but low confidence — should wait for more
-        assert!(try_early_decision(&outputs, 3, outputs.len(), false).is_none());
+        assert!(try_early_decision(&outputs, 3, outputs.len(), false, false).is_none());
     }
 
     #[test]
@@ -785,7 +841,7 @@ mod tests {
         // 1 success, 3 failures, 1 still pending — majority failed, return sole survivor
         let outputs = vec![make_output(OutputKind::Answer, 0.8, "Paris")];
         // total_workers=5, total_finished=4 (1 success + 3 failures), remaining=1
-        match try_early_decision(&outputs, 5, 4, false) {
+        match try_early_decision(&outputs, 5, 4, false, false) {
             Some(Decision::Answer(text)) => assert!(text.contains("Paris")),
             other => {
                 panic!("expected early Answer for sole survivor (majority failed), got {other:?}")
@@ -798,7 +854,7 @@ mod tests {
         // 1 success, 1 failure, 3 still pending — minority failed, wait for more
         let outputs = vec![make_output(OutputKind::Answer, 0.8, "Paris")];
         // total_workers=5, total_finished=2 (1 success + 1 failure), remaining=3
-        assert!(try_early_decision(&outputs, 5, 2, false).is_none());
+        assert!(try_early_decision(&outputs, 5, 2, false, false).is_none());
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/arbiter.rs
+++ b/crates/mesh-mixture-of-agents/src/arbiter.rs
@@ -482,15 +482,24 @@ fn single_output_would_return_answer(output: &WorkerOutput, has_tools: bool) -> 
     )
 }
 
+const ANSWER_ROLE_BIAS_TIE_EPSILON: f32 = 0.001;
+
 pub(crate) fn best_answer_output(outputs: &[WorkerOutput]) -> Option<&WorkerOutput> {
     outputs
         .iter()
         .filter(|o| is_usable_answer(o))
-        .max_by(|a, b| answer_rank_score(a).total_cmp(&answer_rank_score(b)))
+        .max_by(|a, b| compare_answer_rank(a, b))
 }
 
-fn answer_rank_score(output: &WorkerOutput) -> f32 {
-    output.confidence + answer_role_bias(output.role)
+fn compare_answer_rank(a: &WorkerOutput, b: &WorkerOutput) -> std::cmp::Ordering {
+    let confidence_gap = (a.confidence - b.confidence).abs();
+    if confidence_gap > ANSWER_ROLE_BIAS_TIE_EPSILON {
+        return a.confidence.total_cmp(&b.confidence);
+    }
+
+    answer_role_bias(a.role)
+        .total_cmp(&answer_role_bias(b.role))
+        .then_with(|| a.confidence.total_cmp(&b.confidence))
 }
 
 fn answer_role_bias(role: crate::worker::WorkerRole) -> f32 {
@@ -552,14 +561,27 @@ mod tests {
     }
 
     #[test]
-    fn answer_arbitration_biases_toward_strong_when_close() {
+    fn answer_arbitration_biases_toward_strong_when_confidence_ties() {
         let mut fast = make_output(OutputKind::Answer, 0.86, "fast weaker answer");
         fast.role = WorkerRole::Fast;
-        let mut strong = make_output(OutputKind::Answer, 0.75, "stronger model answer");
+        let mut strong = make_output(OutputKind::Answer, 0.86, "stronger model answer");
         strong.role = WorkerRole::Strong;
 
         match arbitrate(&[fast, strong], false) {
             Decision::Answer(text) => assert_eq!(text, "stronger model answer"),
+            other => panic!("expected Answer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn answer_arbitration_keeps_confidence_primary() {
+        let mut fast = make_output(OutputKind::Answer, 0.90, "high confidence answer");
+        fast.role = WorkerRole::Fast;
+        let mut strong = make_output(OutputKind::Answer, 0.76, "strong lower confidence answer");
+        strong.role = WorkerRole::Strong;
+
+        match arbitrate(&[fast, strong], false) {
+            Decision::Answer(text) => assert_eq!(text, "high confidence answer"),
             other => panic!("expected Answer, got {other:?}"),
         }
     }

--- a/crates/mesh-mixture-of-agents/src/backend.rs
+++ b/crates/mesh-mixture-of-agents/src/backend.rs
@@ -123,6 +123,9 @@ impl ModelBackend for HttpBackend {
             body.as_object_mut()
                 .unwrap()
                 .insert("tools".to_string(), tools.clone());
+            body.as_object_mut()
+                .unwrap()
+                .insert("parallel_tool_calls".to_string(), json!(false));
         }
         apply_enable_thinking(&mut body, sampling.enable_thinking);
 
@@ -160,6 +163,8 @@ pub struct ModelEntry {
     /// Index into the backends vec.  Multiple models can share a backend
     /// (e.g. all models behind the same proxy) or each have their own.
     pub backend_index: usize,
+    /// Total model parameter count in billions, when advertised by the mesh.
+    pub parameter_count_b: Option<f64>,
 }
 
 // ─── Backend call + text extraction ──────────────────────────────────
@@ -276,7 +281,9 @@ fn extract_text_from_response(resp: &Value) -> Result<String, String> {
         let name = tc
             .pointer("/function/name")
             .and_then(|n| n.as_str())
-            .unwrap_or("unknown");
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .ok_or_else(|| "malformed tool call: missing function.name".to_string())?;
         let args = tc
             .pointer("/function/arguments")
             .and_then(|a| a.as_str())
@@ -362,6 +369,59 @@ mod tests {
         let resp: Value = serde_json::json!({"choices": []});
         let err = extract_text_from_response(&resp).unwrap_err();
         assert!(err.contains("missing choices"));
+    }
+
+    #[test]
+    fn extract_text_keeps_only_first_native_tool_call() {
+        let resp: Value = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "exec",
+                                "arguments": "{\"command\":\"pwd\"}"
+                            }
+                        },
+                        {
+                            "type": "function",
+                            "function": {
+                                "name": "read",
+                                "arguments": "{\"path\":\"README.md\"}"
+                            }
+                        }
+                    ]
+                }
+            }]
+        });
+
+        let text = extract_text_from_response(&resp).expect("tool proposal text");
+
+        assert!(text.contains("tool: exec"), "{text}");
+        assert!(text.contains("arguments: {\"command\":\"pwd\"}"), "{text}");
+        assert!(!text.contains("tool: read"), "{text}");
+    }
+
+    #[test]
+    fn extract_text_rejects_empty_native_tool_call_name() {
+        let resp: Value = serde_json::json!({
+            "choices": [{
+                "message": {
+                    "tool_calls": [{
+                        "type": "function",
+                        "function": {
+                            "name": "",
+                            "arguments": "{}"
+                        }
+                    }]
+                }
+            }]
+        });
+
+        let err = extract_text_from_response(&resp).unwrap_err();
+
+        assert!(err.contains("missing function.name"), "{err}");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -28,6 +28,10 @@ const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
 const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
 const TOOL_RESULT_TEXT_PREVIEW_CHARS: usize = 1_600;
 const TOOL_RESULT_WEB_SEARCH_MAX_RESULTS: usize = 6;
+const TOOL_RESULT_WEB_SEARCH_TITLE_MAX_CHARS: usize = 120;
+const TOOL_RESULT_WEB_SEARCH_SNIPPET_MAX_CHARS: usize = 200;
+const TOOL_RESULT_WEB_SEARCH_URL_MAX_CHARS: usize = 120;
+const TOOL_RESULT_WEB_SEARCH_ROW_MAX_CHARS: usize = 320;
 
 /// Packed context ready to send to a worker.
 pub struct PackedContext {
@@ -625,9 +629,17 @@ fn compact_web_search_result(
         let Some(result) = result.as_object() else {
             continue;
         };
-        let title = clean_json_string_field(result, "title").unwrap_or_else(|| "Untitled".into());
-        let url = clean_json_string_field(result, "url").unwrap_or_default();
-        let snippet = clean_json_string_field(result, "snippet").unwrap_or_default();
+        let title = clean_json_string_field(result, "title")
+            .map(|value| truncate_tool_result_field(&value, TOOL_RESULT_WEB_SEARCH_TITLE_MAX_CHARS))
+            .unwrap_or_else(|| "Untitled".into());
+        let url = clean_json_string_field(result, "url")
+            .map(|value| truncate_tool_result_field(&value, TOOL_RESULT_WEB_SEARCH_URL_MAX_CHARS))
+            .unwrap_or_default();
+        let snippet = clean_json_string_field(result, "snippet")
+            .map(|value| {
+                truncate_tool_result_field(&value, TOOL_RESULT_WEB_SEARCH_SNIPPET_MAX_CHARS)
+            })
+            .unwrap_or_default();
         let mut row = format!("{}. {title}", idx + 1);
         if !snippet.is_empty() {
             row.push_str(": ");
@@ -638,10 +650,22 @@ fn compact_web_search_result(
             row.push_str(&url);
             row.push(')');
         }
-        lines.push(row);
+        lines.push(truncate_tool_result_field(
+            &row,
+            TOOL_RESULT_WEB_SEARCH_ROW_MAX_CHARS,
+        ));
     }
 
     (lines.len() > 3).then(|| lines.join("\n"))
+}
+
+fn truncate_tool_result_field(value: &str, max_bytes: usize) -> String {
+    let truncated = crate::worker::truncate_chars(value, max_bytes);
+    if truncated.len() == value.len() {
+        truncated.to_string()
+    } else {
+        format!("{truncated}...")
+    }
 }
 
 fn push_clean_json_field(
@@ -1376,7 +1400,10 @@ mod tests {
                 {
                     "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"title\">>>\nSource: Web Search\n---\nLatest and Breaking News - The Sydney Morning Herald\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"title\">>>",
                     "url": "https://www.smh.com.au/breaking-news",
-                    "snippet": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"snippet\">>>\nSource: Web Search\n---\nThe future of Australian swimming has arrived.\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"snippet\">>>"
+                    "snippet": format!(
+                        "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"snippet\">>>\nSource: Web Search\n---\nThe future of Australian swimming has arrived. {}\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"snippet\">>>",
+                        "noise ".repeat(200)
+                    )
                 }
             ]
         })
@@ -1390,6 +1417,10 @@ mod tests {
         assert!(
             compacted.find("Search results:").unwrap() < compacted.find("Latest").unwrap(),
             "result rows should be explicit and easy for the reducer to read: {compacted}"
+        );
+        assert!(
+            compacted.lines().all(|line| line.len() <= 360),
+            "web_search result rows should stay bounded: {compacted}"
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -7,8 +7,8 @@
 //! and varies the depth per role:
 //!
 //! - Fast:       system prompt + recent dialog + optional tool names
-//! - Specialist: system prompt + last 4 msgs + optional tool summaries/schemas
-//! - Strong:     system prompt + last 10 msgs + optional full tool schemas
+//! - Specialist: system prompt + recent dialog + optional tool summaries/schemas
+//! - Strong:     system prompt + deeper recent dialog + optional full tool schemas
 //! - Reducer:    system prompt + recent transcript + worker outputs + optional full tool schemas
 
 use crate::normalize::WorkerOutput;
@@ -17,9 +17,18 @@ use crate::worker::WorkerRole;
 use serde_json::{Value, json};
 
 const TOOL_RESULT_CONTEXT_WINDOW: usize = 10;
-const FAST_CONTEXT_WINDOW: usize = 4;
-const SPECIALIST_CONTEXT_WINDOW: usize = 4;
-const REDUCER_CONTEXT_WINDOW: usize = 8;
+const FAST_TOOL_CONTEXT_WINDOW: usize = 4;
+const FAST_PLAIN_CONTEXT_WINDOW: usize = 8;
+const SPECIALIST_TOOL_CONTEXT_WINDOW: usize = 4;
+const SPECIALIST_PLAIN_CONTEXT_WINDOW: usize = 12;
+const STRONG_TOOL_CONTEXT_WINDOW: usize = 10;
+const STRONG_PLAIN_CONTEXT_WINDOW: usize = 32;
+const REDUCER_TOOL_CONTEXT_WINDOW: usize = 8;
+const REDUCER_PLAIN_CONTEXT_WINDOW: usize = 32;
+const FAST_PLAIN_CONTEXT_MAX_BYTES: usize = 8 * 1024;
+const SPECIALIST_PLAIN_CONTEXT_MAX_BYTES: usize = 12 * 1024;
+const STRONG_PLAIN_CONTEXT_MAX_BYTES: usize = 32 * 1024;
+const REDUCER_PLAIN_CONTEXT_MAX_BYTES: usize = 32 * 1024;
 const TOOL_EVIDENCE_MAX_RESULTS: usize = 8;
 const TOOL_EVIDENCE_MAX_RESULT_CHARS: usize = 800;
 const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
@@ -155,7 +164,15 @@ fn system_with_tool_summaries(
 fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String]) -> PackedContext {
     let system = system_with_tool_names(session, has_tools, selected_tool_names);
     let mut messages = vec![json!({"role": "system", "content": system})];
-    append_recent_dialog_messages(&mut messages, session, FAST_CONTEXT_WINDOW);
+    let (window, max_bytes) = if has_tools {
+        (FAST_TOOL_CONTEXT_WINDOW, None)
+    } else {
+        (
+            FAST_PLAIN_CONTEXT_WINDOW,
+            Some(FAST_PLAIN_CONTEXT_MAX_BYTES),
+        )
+    };
+    append_recent_dialog_messages(&mut messages, session, window, max_bytes);
 
     // Per-request sessions: the caller owns the multi-turn loop and
     // sends the full history each request. Continuation context lives
@@ -169,7 +186,7 @@ fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String])
 }
 
 // ── Specialist worker ────────────────────────────────────────────────
-// System prompt + last 4 messages + tool name+description summaries.
+// System prompt + recent messages + tool name+description summaries.
 
 fn pack_specialist(
     session: &Session,
@@ -180,7 +197,15 @@ fn pack_specialist(
 
     let mut messages = vec![json!({"role": "system", "content": system})];
 
-    append_recent_dialog_messages(&mut messages, session, SPECIALIST_CONTEXT_WINDOW);
+    let (window, max_bytes) = if has_tools {
+        (SPECIALIST_TOOL_CONTEXT_WINDOW, None)
+    } else {
+        (
+            SPECIALIST_PLAIN_CONTEXT_WINDOW,
+            Some(SPECIALIST_PLAIN_CONTEXT_MAX_BYTES),
+        )
+    };
+    append_recent_dialog_messages(&mut messages, session, window, max_bytes);
 
     PackedContext {
         messages,
@@ -189,8 +214,13 @@ fn pack_specialist(
     }
 }
 
-fn append_recent_dialog_messages(messages: &mut Vec<Value>, session: &Session, window: usize) {
-    let recent = session.recent_messages(window);
+fn append_recent_dialog_messages(
+    messages: &mut Vec<Value>,
+    session: &Session,
+    window: usize,
+    max_bytes: Option<usize>,
+) {
+    let recent = bounded_recent_messages(session.recent_messages(window), max_bytes, true);
     for msg in &recent {
         if plain_dialog_message_for_compact_context(msg) {
             messages.push(msg.clone());
@@ -217,7 +247,7 @@ fn append_current_user_if_missing(messages: &mut Vec<Value>, session: &Session) 
 }
 
 // ── Strong worker ────────────────────────────────────────────────────
-// System prompt + last 10 messages + full tool schemas forwarded natively.
+// System prompt + deeper recent history + full tool schemas forwarded natively.
 // This worker gets the deepest context and the actual tool definitions so
 // it can produce native tool_calls if the backend supports it.
 
@@ -232,7 +262,15 @@ fn pack_strong(
 
     // Deep recent history — include tool result messages too since this
     // worker gets full tool schemas and can understand the context
-    let recent = session.recent_messages(10);
+    let (window, max_bytes) = if has_tools {
+        (STRONG_TOOL_CONTEXT_WINDOW, None)
+    } else {
+        (
+            STRONG_PLAIN_CONTEXT_WINDOW,
+            Some(STRONG_PLAIN_CONTEXT_MAX_BYTES),
+        )
+    };
+    let recent = bounded_recent_messages(session.recent_messages(window), max_bytes, true);
     for msg in &recent {
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
         if role != "system" && !role.is_empty() {
@@ -308,24 +346,62 @@ pub fn pack_for_reducer_selected(
     let tools = selected_tools(session, has_tools, selected_tool_names);
 
     let mut messages = vec![json!({"role": "system", "content": system_parts.join("\n")})];
-    messages.extend(reducer_recent_transcript_messages(session));
+    messages.extend(reducer_recent_transcript_messages(session, has_tools));
     append_current_user_if_missing(&mut messages, session);
 
     (messages, tools)
 }
 
-fn reducer_recent_transcript_messages(session: &Session) -> Vec<Value> {
+fn reducer_recent_transcript_messages(session: &Session, has_tools: bool) -> Vec<Value> {
     let all = session.messages();
     let Some(last_user_idx) = all.iter().rposition(|msg| message_role(msg) == "user") else {
         return Vec::new();
     };
 
-    let start_idx = last_user_idx.saturating_sub(REDUCER_CONTEXT_WINDOW);
-    all[start_idx..last_user_idx]
+    let (window, max_bytes) = if has_tools {
+        (REDUCER_TOOL_CONTEXT_WINDOW, None)
+    } else {
+        (
+            REDUCER_PLAIN_CONTEXT_WINDOW,
+            Some(REDUCER_PLAIN_CONTEXT_MAX_BYTES),
+        )
+    };
+    let start_idx = last_user_idx.saturating_sub(window);
+    let recent = bounded_recent_messages(all[start_idx..last_user_idx].to_vec(), max_bytes, false);
+    recent
         .iter()
         .filter(|msg| reducer_can_replay_message(msg))
         .cloned()
         .collect()
+}
+
+fn bounded_recent_messages(
+    messages: Vec<Value>,
+    max_bytes: Option<usize>,
+    keep_latest_when_oversized: bool,
+) -> Vec<Value> {
+    let Some(max_bytes) = max_bytes else {
+        return messages;
+    };
+    let mut selected_rev = Vec::new();
+    let mut used = 0usize;
+    for message in messages.into_iter().rev() {
+        let cost = estimated_message_context_bytes(&message);
+        let can_keep_oversized_latest = keep_latest_when_oversized && selected_rev.is_empty();
+        if !can_keep_oversized_latest && used.saturating_add(cost) > max_bytes {
+            break;
+        }
+        used = used.saturating_add(cost);
+        selected_rev.push(message);
+    }
+    selected_rev.reverse();
+    selected_rev
+}
+
+fn estimated_message_context_bytes(message: &Value) -> usize {
+    serde_json::to_string(message)
+        .map(|encoded| encoded.len())
+        .unwrap_or(0)
 }
 
 fn reducer_can_replay_message(msg: &Value) -> bool {
@@ -976,6 +1052,10 @@ mod tests {
             .to_string()
     }
 
+    fn serialized_messages(messages: &[Value]) -> String {
+        serde_json::to_string(messages).unwrap()
+    }
+
     // ── pack_for_worker: shape contract per role ─────────────────────
 
     #[test]
@@ -1180,6 +1260,62 @@ mod tests {
         );
         let last = packed.messages.last().unwrap();
         assert_eq!(last.get("content").and_then(|c| c.as_str()), Some("final"));
+    }
+
+    #[test]
+    fn plain_chat_strong_worker_keeps_earlier_same_chat_topic() {
+        let mut msgs = vec![
+            system_msg("Agent ST."),
+            user_msg("How do I run Windows commands over Tailscale from my Mac?"),
+            assistant_msg("We discussed using a reachable Windows host over Tailscale."),
+        ];
+        for i in 0..12 {
+            msgs.push(user_msg(&format!("follow-up topic {i}")));
+            msgs.push(assistant_msg(&format!("follow-up answer {i}")));
+        }
+        msgs.push(user_msg("What did we discuss earlier in this chat?"));
+        let s = session_with(&msgs, None);
+
+        let packed = pack_for_worker(&s, WorkerRole::Strong, false);
+        let body = serialized_messages(&packed.messages);
+
+        assert!(
+            body.contains("Windows commands over Tailscale"),
+            "plain-chat strong worker should retain earlier same-chat topics, got {body}",
+        );
+        assert!(
+            body.contains("What did we discuss earlier"),
+            "current user turn must still be present, got {body}",
+        );
+    }
+
+    #[test]
+    fn plain_chat_strong_worker_drops_oversized_prior_blob_before_current() {
+        let oversized_prior = format!(
+            "OVERSIZED_STRONG_PRIOR_{}",
+            "x".repeat(STRONG_PLAIN_CONTEXT_MAX_BYTES + 1024)
+        );
+        let s = session_with(
+            &[
+                system_msg("Agent ST."),
+                user_msg("Read this large pasted result."),
+                assistant_msg(&oversized_prior),
+                user_msg("What should I do next?"),
+            ],
+            None,
+        );
+
+        let packed = pack_for_worker(&s, WorkerRole::Strong, false);
+        let body = serialized_messages(&packed.messages);
+
+        assert!(
+            body.contains("What should I do next?"),
+            "current user turn must still be present, got {body}",
+        );
+        assert!(
+            !body.contains("OVERSIZED_STRONG_PRIOR_"),
+            "plain-chat strong context should not carry an oversized prior blob, got {body}",
+        );
     }
 
     #[test]
@@ -1670,6 +1806,70 @@ keep this",
                 .and_then(|message| message.get("content"))
                 .and_then(Value::as_str),
             Some("What were the two questions above in this same conversation?"),
+        );
+    }
+
+    #[test]
+    fn plain_chat_reducer_keeps_earlier_same_chat_topic_beyond_short_tail() {
+        let mut msgs = vec![
+            system_msg("Agent R."),
+            user_msg("How do I run Windows commands over Tailscale from my Mac?"),
+            assistant_msg("We discussed using a reachable Windows host over Tailscale."),
+        ];
+        for i in 0..12 {
+            msgs.push(user_msg(&format!("follow-up topic {i}")));
+            msgs.push(assistant_msg(&format!("follow-up answer {i}")));
+        }
+        msgs.push(user_msg("What did we discuss earlier in this chat?"));
+        let s = session_with(&msgs, None);
+        let outputs = vec![
+            worker_out("fast", "I only see the latest question."),
+            worker_out("strong", "Earlier history mentioned Windows and Tailscale."),
+        ];
+
+        let (messages, _tools) = pack_for_reducer(&s, &outputs, "history disagreement", false);
+        let body = serialized_messages(&messages);
+
+        assert!(
+            body.contains("Windows commands over Tailscale"),
+            "plain-chat reducer should retain earlier same-chat topics, got {body}",
+        );
+        assert!(
+            body.contains("What did we discuss earlier"),
+            "current user turn must still be present, got {body}",
+        );
+    }
+
+    #[test]
+    fn plain_chat_reducer_drops_oversized_prior_blob_before_current() {
+        let oversized_prior = format!(
+            "OVERSIZED_REDUCER_PRIOR_{}",
+            "x".repeat(REDUCER_PLAIN_CONTEXT_MAX_BYTES + 1024)
+        );
+        let s = session_with(
+            &[
+                system_msg("Agent R."),
+                user_msg("Read this large pasted result."),
+                assistant_msg(&oversized_prior),
+                user_msg("What should I do next?"),
+            ],
+            None,
+        );
+        let outputs = vec![
+            worker_out("fast", "Answer the current question only."),
+            worker_out("strong", "Do not replay the huge prior blob."),
+        ];
+
+        let (messages, _tools) = pack_for_reducer(&s, &outputs, "history disagreement", false);
+        let body = serialized_messages(&messages);
+
+        assert!(
+            body.contains("What should I do next?"),
+            "current user turn must still be present, got {body}",
+        );
+        assert!(
+            !body.contains("OVERSIZED_REDUCER_PRIOR_"),
+            "plain-chat reducer context should not carry an oversized prior blob, got {body}",
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -612,13 +612,25 @@ fn first_user_task_text(session: &Session) -> Option<String> {
     session
         .messages()
         .iter()
+        .rev()
         .find_map(|message| {
-            (message_role(message) == "user" && !user_message_looks_like_tool_response(message))
-                .then(|| message_text_content(message))
-                .flatten()
+            (message_role(message) == "user"
+                && !user_message_looks_like_tool_response(message)
+                && !user_message_looks_like_runtime_info(message))
+            .then(|| message_text_content(message))
+            .flatten()
         })
         .map(|text| text.trim().to_string())
         .filter(|text| !text.is_empty())
+}
+
+fn user_message_looks_like_runtime_info(message: &Value) -> bool {
+    message_text_content(message).is_some_and(|text| {
+        let trimmed = text.trim_start();
+        trimmed.starts_with("<info-msg>")
+            || trimmed.starts_with("<environment_context>")
+            || trimmed.starts_with("<system-reminder>")
+    })
 }
 
 fn user_message_looks_like_tool_response(message: &Value) -> bool {
@@ -705,10 +717,16 @@ fn tool_evidence_message(session: &Session) -> Option<Value> {
 }
 
 fn compact_tool_message(msg: &Value) -> Value {
-    if message_role(msg) != "tool" {
-        return msg.clone();
+    match message_role(msg) {
+        "tool" => compact_role_tool_message(msg),
+        "user" if user_message_looks_like_tool_response(msg) => {
+            compact_user_tool_response_message(msg)
+        }
+        _ => msg.clone(),
     }
+}
 
+fn compact_role_tool_message(msg: &Value) -> Value {
     let Some(content) = msg.get("content").and_then(Value::as_str) else {
         return msg.clone();
     };
@@ -722,6 +740,96 @@ fn compact_tool_message(msg: &Value) -> Value {
         obj.insert("content".to_string(), Value::String(compacted));
     }
     compact
+}
+
+fn compact_user_tool_response_message(msg: &Value) -> Value {
+    let Some(parts) = msg.get("content").and_then(Value::as_array) else {
+        return msg.clone();
+    };
+
+    let mut changed = false;
+    let compact_parts = parts
+        .iter()
+        .map(|part| {
+            if !content_part_looks_like_tool_response(part) {
+                return part.clone();
+            }
+            let Some(text) = tool_response_part_text(part) else {
+                return part.clone();
+            };
+            changed = true;
+            json!({
+                "type": "text",
+                "text": format!("Tool result:\n{}", compact_tool_result_text(&text)),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    if !changed {
+        return msg.clone();
+    }
+
+    let mut compact = msg.clone();
+    if let Some(obj) = compact.as_object_mut() {
+        obj.insert("content".to_string(), Value::Array(compact_parts));
+    }
+    compact
+}
+
+fn tool_response_part_text(part: &Value) -> Option<String> {
+    content_text_fields(part)
+        .or_else(|| part.get("output").and_then(value_text_content))
+        .or_else(|| {
+            part.pointer("/toolResult/value/content")
+                .and_then(content_array_text)
+        })
+        .or_else(|| {
+            part.pointer("/toolResult/value/structuredContent/stdout")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            part.pointer("/toolResult/value/structuredContent/stderr")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .or_else(|| {
+            part.pointer("/toolResult/value")
+                .and_then(value_text_content)
+        })
+        .or_else(|| {
+            part.pointer("/tool_result/content")
+                .and_then(value_text_content)
+        })
+}
+
+fn value_text_content(value: &Value) -> Option<String> {
+    if let Some(text) = value.as_str() {
+        return Some(text.to_string());
+    }
+    if let Some(text) = content_array_text(value) {
+        return Some(text);
+    }
+    value.as_object()?;
+    serde_json::to_string(value).ok()
+}
+
+fn content_array_text(value: &Value) -> Option<String> {
+    let parts = value.as_array()?;
+    let text = parts
+        .iter()
+        .filter_map(content_text_fields)
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn content_text_fields(part: &Value) -> Option<String> {
+    part.get("text")
+        .and_then(Value::as_str)
+        .or_else(|| part.get("input_text").and_then(Value::as_str))
+        .or_else(|| part.get("output_text").and_then(Value::as_str))
+        .map(str::to_string)
 }
 
 fn compact_tool_result_text(result: &str) -> String {
@@ -1738,7 +1846,10 @@ mod tests {
 
     #[test]
     fn tool_result_reducer_anchors_original_task_when_latest_user_is_tool_wrapper() {
-        let mut messages = vec![user_msg("Implement src/smoke_calc.py so the tests pass.")];
+        let mut messages = vec![
+            user_msg("Old chat about Windows and Tailscale."),
+            user_msg("Implement src/smoke_calc.py so the tests pass."),
+        ];
         for idx in 0..8 {
             let id = format!("call_tree_{idx}");
             messages.push(assistant_tool_msg(
@@ -1786,6 +1897,10 @@ mod tests {
             "task anchor should preserve the real agent task, got {body}",
         );
         assert!(
+            !body.contains("Old chat about Windows and Tailscale"),
+            "task anchor should prefer the active task over older chat, got {body}",
+        );
+        assert!(
             body.contains("NotImplementedError"),
             "latest tool result should remain visible, got {body}",
         );
@@ -1793,7 +1908,11 @@ mod tests {
 
     #[test]
     fn tool_worker_context_anchors_original_task_after_user_tool_wrappers() {
-        let mut messages = vec![user_msg("Implement src/smoke_calc.py so the tests pass.")];
+        let mut messages = vec![
+            user_msg("Old chat about Windows and Tailscale."),
+            user_msg("Implement src/smoke_calc.py so the tests pass."),
+            user_msg("<info-msg>\nWorking directory: /tmp/project\n</info-msg>"),
+        ];
         for idx in 0..8 {
             let id = format!("call_{idx}");
             messages.push(assistant_tool_msg(
@@ -1818,6 +1937,33 @@ mod tests {
         assert!(
             body.contains("Implement src/smoke_calc.py so the tests pass."),
             "tool worker task anchor should preserve the real task, got {body}",
+        );
+        assert!(
+            !body.contains("Old chat about Windows and Tailscale"),
+            "tool worker anchor should prefer the active task over older chat, got {body}",
+        );
+    }
+
+    #[test]
+    fn user_wrapped_tool_result_is_compacted_for_reducer() {
+        let huge_result = "x".repeat(TOOL_RESULT_RAW_MAX_CHARS + 500);
+        let messages = vec![
+            user_msg("Read the large output."),
+            assistant_tool_msg("call_read", "read", json!({"path": "large.txt"})),
+            user_tool_response_msg("call_read", &huge_result),
+        ];
+        let s = session_with(&messages, Some(tools_two()));
+
+        let (messages, _tools) = pack_for_tool_result_turn(&s, true);
+        let body = serialized_messages(&messages);
+
+        assert!(
+            body.contains("Tool result compacted"),
+            "user-wrapped tool result should be compacted, got {body}",
+        );
+        assert!(
+            !body.contains(&huge_result),
+            "full nested user-wrapped tool result should not leak, got {body}",
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -6,10 +6,10 @@
 //! synthetic "you are a worker" envelope.  It augments with a short preamble
 //! and varies the depth per role:
 //!
-//! - Fast:       system prompt + last user msg + optional tool names
+//! - Fast:       system prompt + recent dialog + optional tool names
 //! - Specialist: system prompt + last 4 msgs + optional tool summaries/schemas
 //! - Strong:     system prompt + last 10 msgs + optional full tool schemas
-//! - Reducer:    system prompt + worker outputs + optional full tool schemas
+//! - Reducer:    system prompt + recent transcript + worker outputs + optional full tool schemas
 
 use crate::normalize::WorkerOutput;
 use crate::session::Session;
@@ -17,6 +17,9 @@ use crate::worker::WorkerRole;
 use serde_json::{Value, json};
 
 const TOOL_RESULT_CONTEXT_WINDOW: usize = 10;
+const FAST_CONTEXT_WINDOW: usize = 4;
+const SPECIALIST_CONTEXT_WINDOW: usize = 4;
+const REDUCER_CONTEXT_WINDOW: usize = 8;
 const TOOL_EVIDENCE_MAX_RESULTS: usize = 8;
 const TOOL_EVIDENCE_MAX_RESULT_CHARS: usize = 800;
 const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
@@ -70,10 +73,11 @@ Respond with your best answer or tool call. Be direct.]";
 fn augmented_system_prompt_for_mode(session: &Session, include_tool_guidance: bool) -> String {
     match session.system_prompt() {
         Some(sp) => {
+            let prompt = strip_silent_reply_sections(&sp);
             let prompt = if include_tool_guidance {
-                sp
+                prompt
             } else {
-                strip_tool_guidance_sections(&sp)
+                strip_tool_guidance_sections(&prompt)
             };
             format!("{MOA_PREAMBLE}\n\n{prompt}")
         }
@@ -81,14 +85,20 @@ fn augmented_system_prompt_for_mode(session: &Session, include_tool_guidance: bo
     }
 }
 
-fn strip_tool_guidance_sections(prompt: &str) -> String {
-    const STRIPPED_HEADINGS: &[&str] = &["## Tooling", "## Tool Call Style"];
+fn strip_silent_reply_sections(prompt: &str) -> String {
+    strip_markdown_sections(prompt, &["## Silent Replies"])
+}
 
+fn strip_tool_guidance_sections(prompt: &str) -> String {
+    strip_markdown_sections(prompt, &["## Tooling", "## Tool Call Style"])
+}
+
+fn strip_markdown_sections(prompt: &str, stripped_headings: &[&str]) -> String {
     let mut out = Vec::new();
     let mut skipping = false;
     for line in prompt.lines() {
         if line.starts_with("## ") {
-            skipping = STRIPPED_HEADINGS
+            skipping = stripped_headings
                 .iter()
                 .any(|heading| line.trim() == *heading);
         }
@@ -133,22 +143,20 @@ fn system_with_tool_summaries(
 }
 
 // ── Fast worker ──────────────────────────────────────────────────────
-// System prompt + last user message + tool names only.
+// System prompt + recent dialog + tool names only.
 // Smallest context, quickest to respond.
 
 fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String]) -> PackedContext {
     let system = system_with_tool_names(session, has_tools, selected_tool_names);
-    let user_text = session.last_user_text();
+    let mut messages = vec![json!({"role": "system", "content": system})];
+    append_recent_dialog_messages(&mut messages, session, FAST_CONTEXT_WINDOW);
 
     // Per-request sessions: the caller owns the multi-turn loop and
     // sends the full history each request. Continuation context lives
-    // in `session.messages()`; this path intentionally trims to just
-    // the last user message to keep the fast worker's context small.
+    // in `session.messages()`. Keep this context small, but do not
+    // isolate follow-up questions from the visible same-chat history.
     PackedContext {
-        messages: vec![
-            json!({"role": "system", "content": system}),
-            json!({"role": "user", "content": user_text}),
-        ],
+        messages,
         max_tokens: 256,
         tools: None, // Fast worker doesn't get tool schemas — just names
     }
@@ -166,30 +174,41 @@ fn pack_specialist(
 
     let mut messages = vec![json!({"role": "system", "content": system})];
 
-    // Recent messages — skip system (already included), skip raw tool results
-    // (they'd confuse models that don't have the tool_call context)
-    let recent = session.recent_messages(4);
-    for msg in &recent {
-        let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
-        if role == "user" || (role == "assistant" && msg.get("tool_calls").is_none()) {
-            messages.push(msg.clone());
-        }
-    }
-
-    // Ensure the last message is the current user turn
-    let user_text = session.last_user_text();
-    if messages
-        .last()
-        .and_then(|m| m.get("content").and_then(|c| c.as_str()))
-        != Some(&user_text)
-    {
-        messages.push(json!({"role": "user", "content": user_text}));
-    }
+    append_recent_dialog_messages(&mut messages, session, SPECIALIST_CONTEXT_WINDOW);
 
     PackedContext {
         messages,
         max_tokens: 512,
         tools: selected_tools(session, has_tools, selected_tool_names),
+    }
+}
+
+fn append_recent_dialog_messages(messages: &mut Vec<Value>, session: &Session, window: usize) {
+    let recent = session.recent_messages(window);
+    for msg in &recent {
+        if plain_dialog_message_for_compact_context(msg) {
+            messages.push(msg.clone());
+        }
+    }
+    append_current_user_if_missing(messages, session);
+}
+
+fn plain_dialog_message_for_compact_context(msg: &Value) -> bool {
+    match message_role(msg) {
+        "user" => true,
+        "assistant" => msg.get("tool_calls").is_none(),
+        _ => false,
+    }
+}
+
+fn append_current_user_if_missing(messages: &mut Vec<Value>, session: &Session) {
+    let user_text = session.last_user_text();
+    if messages
+        .last()
+        .and_then(|m| m.get("content").and_then(Value::as_str))
+        != Some(&user_text)
+    {
+        messages.push(json!({"role": "user", "content": user_text}));
     }
 }
 
@@ -293,13 +312,33 @@ pub fn pack_for_reducer_selected(
 
     let tools = selected_tools(session, has_tools, selected_tool_names);
 
-    (
-        vec![
-            json!({"role": "system", "content": system_parts.join("\n")}),
-            json!({"role": "user", "content": user_text}),
-        ],
-        tools,
-    )
+    let mut messages = vec![json!({"role": "system", "content": system_parts.join("\n")})];
+    messages.extend(reducer_recent_transcript_messages(session));
+    messages.push(json!({"role": "user", "content": user_text}));
+
+    (messages, tools)
+}
+
+fn reducer_recent_transcript_messages(session: &Session) -> Vec<Value> {
+    let all = session.messages();
+    let Some(last_user_idx) = all.iter().rposition(|msg| message_role(msg) == "user") else {
+        return Vec::new();
+    };
+
+    let start_idx = last_user_idx.saturating_sub(REDUCER_CONTEXT_WINDOW);
+    all[start_idx..last_user_idx]
+        .iter()
+        .filter(|msg| reducer_can_replay_message(msg))
+        .cloned()
+        .collect()
+}
+
+fn reducer_can_replay_message(msg: &Value) -> bool {
+    match message_role(msg) {
+        "user" => true,
+        "assistant" => msg.get("tool_calls").is_none(),
+        _ => false,
+    }
 }
 
 fn selected_tools(
@@ -806,7 +845,7 @@ mod tests {
     // ── pack_for_worker: shape contract per role ─────────────────────
 
     #[test]
-    fn fast_worker_has_system_user_only_no_tools() {
+    fn fast_worker_has_recent_dialog_no_native_tools() {
         let s = session_with(
             &[
                 system_msg("You are a helpful assistant."),
@@ -823,19 +862,14 @@ mod tests {
             packed.tools.is_none(),
             "fast worker must not receive tool schemas"
         );
-        assert_eq!(packed.messages.len(), 2, "fast = system + last user only");
         assert_eq!(
             packed.messages[0].get("role").and_then(|r| r.as_str()),
             Some("system"),
         );
-        assert_eq!(
-            packed.messages[1].get("role").and_then(|r| r.as_str()),
-            Some("user"),
-        );
-        assert_eq!(
-            packed.messages[1].get("content").and_then(|c| c.as_str()),
-            Some("second"),
-            "fast worker sees only the LAST user message",
+        let body = serde_json::to_string(&packed.messages).unwrap();
+        assert!(
+            body.contains("first") && body.contains("first reply") && body.contains("second"),
+            "fast worker should see a compact recent dialog, got {body}",
         );
 
         // Tool *names* appear in system prompt; full schemas do not.
@@ -1254,6 +1288,36 @@ keep this";
         assert!(!stripped.contains("tool-call policy goes here"));
     }
 
+    #[test]
+    fn tool_context_strips_silent_reply_sections() {
+        let s = session_with(
+            &[
+                system_msg(
+                    "\
+You are helpful.
+## Silent Replies
+When you have nothing to say, respond with ONLY: NO_REPLY
+## Safety
+keep this",
+                ),
+                user_msg("Run the requested command."),
+            ],
+            Some(tools_two()),
+        );
+        let packed = pack_for_worker(&s, WorkerRole::Strong, true);
+        let sys = system_text(&packed.messages);
+
+        assert!(sys.contains("You are helpful."));
+        assert!(sys.contains("## Safety"));
+        assert!(sys.contains("keep this"));
+        assert!(!sys.contains("NO_REPLY"), "{sys}");
+        assert!(!sys.contains("Silent Replies"), "{sys}");
+        assert!(
+            packed.tools.is_some(),
+            "tool schemas should still be present"
+        );
+    }
+
     // ── pack_for_reducer: includes reason + worker outputs ───────────
 
     fn worker_out(model: &str, payload: &str) -> WorkerOutput {
@@ -1304,6 +1368,43 @@ keep this";
         assert_eq!(
             last.get("content").and_then(|c| c.as_str()),
             Some("which is bigger, 7^3 or 350?"),
+        );
+    }
+
+    #[test]
+    fn reducer_context_preserves_same_chat_recent_history_before_current_turn() {
+        let s = session_with(
+            &[
+                system_msg("Agent R."),
+                user_msg("How do I run commands on Windows via Tailscale from a Mac?"),
+                assistant_msg(
+                    "Use a reachable Windows host and run the command over the mesh or SSH tunnel.",
+                ),
+                user_msg("What were the two questions above in this same conversation?"),
+            ],
+            None,
+        );
+        let outputs = vec![
+            worker_out("fast", "Only two questions are visible in this request."),
+            worker_out("strong", "Earlier history mentioned Windows via Tailscale."),
+        ];
+        let (messages, _tools) = pack_for_reducer(&s, &outputs, "history disagreement", false);
+
+        let transcript = serde_json::to_string(&messages).unwrap();
+        assert!(
+            transcript.contains("Windows via Tailscale"),
+            "reducer should see recent same-chat history, got {transcript}",
+        );
+        assert!(
+            transcript.contains("What were the two questions above"),
+            "reducer should still receive the current user turn, got {transcript}",
+        );
+        assert_eq!(
+            messages
+                .last()
+                .and_then(|message| message.get("content"))
+                .and_then(Value::as_str),
+            Some("What were the two questions above in this same conversation?"),
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -26,6 +26,8 @@ const TOOL_RESULT_RAW_MAX_CHARS: usize = 2_400;
 const TOOL_RESULT_JSON_MAX_SCALARS: usize = 48;
 const TOOL_RESULT_JSON_MAX_ARRAY_ITEMS: usize = 12;
 const TOOL_RESULT_SCALAR_MAX_CHARS: usize = 180;
+const TOOL_RESULT_TEXT_PREVIEW_CHARS: usize = 1_600;
+const TOOL_RESULT_WEB_SEARCH_MAX_RESULTS: usize = 6;
 
 /// Packed context ready to send to a worker.
 pub struct PackedContext {
@@ -548,12 +550,17 @@ fn compact_tool_message(msg: &Value) -> Value {
 }
 
 fn compact_tool_result_text(result: &str) -> String {
-    if result.len() <= TOOL_RESULT_RAW_MAX_CHARS {
-        return result.to_string();
+    if let Ok(json) = serde_json::from_str::<Value>(result) {
+        if let Some(compacted) = compact_external_json_tool_result(result.len(), &json) {
+            return compacted;
+        }
+        if result.len() > TOOL_RESULT_RAW_MAX_CHARS {
+            return compact_json_tool_result(result.len(), &json);
+        }
     }
 
-    if let Ok(json) = serde_json::from_str::<Value>(result) {
-        return compact_json_tool_result(result.len(), &json);
+    if result.len() <= TOOL_RESULT_RAW_MAX_CHARS {
+        return result.to_string();
     }
 
     format!(
@@ -562,6 +569,117 @@ fn compact_tool_result_text(result: &str) -> String {
         result.len(),
         crate::worker::truncate_chars(result, TOOL_RESULT_RAW_MAX_CHARS - 96)
     )
+}
+
+fn compact_external_json_tool_result(original_len: usize, value: &Value) -> Option<String> {
+    let map = value.as_object()?;
+    let source = map
+        .get("externalContent")
+        .and_then(|external| external.get("source"))
+        .and_then(Value::as_str)?;
+
+    match source {
+        "web_fetch" => compact_web_fetch_result(original_len, map),
+        "web_search" => compact_web_search_result(original_len, map),
+        _ => None,
+    }
+}
+
+fn compact_web_fetch_result(
+    original_len: usize,
+    map: &serde_json::Map<String, Value>,
+) -> Option<String> {
+    let text = map.get("text").and_then(Value::as_str)?;
+    let mut lines = vec![format!(
+        "Tool result compacted from {original_len} chars; original was web_fetch JSON."
+    )];
+    push_clean_json_field("Title", "title", map, &mut lines);
+    push_clean_json_field("URL", "url", map, &mut lines);
+    push_clean_json_field("Status", "status", map, &mut lines);
+
+    let preview = clean_external_tool_text(text);
+    if preview.is_empty() {
+        return None;
+    }
+    lines.push("Fetched content preview:".to_string());
+    lines.push(crate::worker::truncate_chars(&preview, TOOL_RESULT_TEXT_PREVIEW_CHARS).to_string());
+    Some(lines.join("\n"))
+}
+
+fn compact_web_search_result(
+    original_len: usize,
+    map: &serde_json::Map<String, Value>,
+) -> Option<String> {
+    let results = map.get("results").and_then(Value::as_array)?;
+    let mut lines = vec![format!(
+        "Tool result compacted from {original_len} chars; original was web_search JSON."
+    )];
+    push_clean_json_field("Query", "query", map, &mut lines);
+    lines.push("Search results:".to_string());
+
+    for (idx, result) in results
+        .iter()
+        .take(TOOL_RESULT_WEB_SEARCH_MAX_RESULTS)
+        .enumerate()
+    {
+        let Some(result) = result.as_object() else {
+            continue;
+        };
+        let title = clean_json_string_field(result, "title").unwrap_or_else(|| "Untitled".into());
+        let url = clean_json_string_field(result, "url").unwrap_or_default();
+        let snippet = clean_json_string_field(result, "snippet").unwrap_or_default();
+        let mut row = format!("{}. {title}", idx + 1);
+        if !snippet.is_empty() {
+            row.push_str(": ");
+            row.push_str(&snippet);
+        }
+        if !url.is_empty() {
+            row.push_str(" (");
+            row.push_str(&url);
+            row.push(')');
+        }
+        lines.push(row);
+    }
+
+    (lines.len() > 3).then(|| lines.join("\n"))
+}
+
+fn push_clean_json_field(
+    label: &str,
+    key: &str,
+    map: &serde_json::Map<String, Value>,
+    lines: &mut Vec<String>,
+) {
+    let Some(value) = clean_json_string_field(map, key) else {
+        return;
+    };
+    if !value.is_empty() {
+        lines.push(format!("{label}: {value}"));
+    }
+}
+
+fn clean_json_string_field(map: &serde_json::Map<String, Value>, key: &str) -> Option<String> {
+    let value = map.get(key)?;
+    value
+        .as_str()
+        .map(clean_external_tool_text)
+        .or_else(|| scalar_to_string(value).map(|scalar| scalar.trim_matches('"').to_string()))
+}
+
+fn clean_external_tool_text(text: &str) -> String {
+    let body = unwrap_external_content_body(text).unwrap_or(text);
+    body.trim().to_string()
+}
+
+fn unwrap_external_content_body(text: &str) -> Option<&str> {
+    let marker_start = text.rfind("<<<EXTERNAL_UNTRUSTED_CONTENT")?;
+    let after_marker = &text[marker_start..];
+    let separator = after_marker.find("---")?;
+    let mut body = after_marker.get(separator + 3..)?.trim_start_matches('\n');
+    if let Some(end) = body.find("<<<END_EXTERNAL_UNTRUSTED_CONTENT") {
+        body = &body[..end];
+    }
+    Some(body.trim())
 }
 
 fn compact_json_tool_result(original_len: usize, value: &Value) -> String {
@@ -699,6 +817,9 @@ fn is_scalar(value: &Value) -> bool {
 const PREFERRED_JSON_KEYS: &[&str] = &[
     "number",
     "title",
+    "text",
+    "content",
+    "snippet",
     "name",
     "full_name",
     "state",
@@ -1209,6 +1330,66 @@ mod tests {
         assert!(
             !content.contains(&"x".repeat(512)),
             "large noisy fields should not be forwarded raw"
+        );
+    }
+
+    #[test]
+    fn web_fetch_tool_result_prefers_fetched_text_over_wrapper_keys() {
+        let result = json!({
+            "url": "https://www.smh.com.au",
+            "finalUrl": "https://www.smh.com.au",
+            "status": 200,
+            "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"title\">>>\nSource: Web Fetch\n---\nAustralian Breaking News Headlines & World News Online\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"title\">>>",
+            "externalContent": {
+                "untrusted": true,
+                "source": "web_fetch",
+                "wrapped": true
+            },
+            "text": "SECURITY NOTICE: external content.\n\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"body\">>>\nSource: Web Fetch\n---\n### World Cup of chaos\nThe World Cup returns to North America.\n\n### Modi wants more of Australia's uranium\nAustralia and India struck a historic deal.\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"body\">>>"
+        })
+        .to_string();
+
+        let compacted = compact_tool_result_text(&result);
+
+        assert!(compacted.contains("original was web_fetch JSON"));
+        assert!(compacted.contains("Fetched content preview:"));
+        assert!(compacted.contains("World Cup of chaos"));
+        assert!(compacted.contains("Modi wants more of Australia's uranium"));
+        assert!(
+            !compacted.contains("\"finalUrl\""),
+            "wrapper JSON keys should not dominate reducer context: {compacted}"
+        );
+    }
+
+    #[test]
+    fn web_search_tool_result_compacts_to_result_rows() {
+        let result = json!({
+            "query": "headlines from www.smh.com.au",
+            "provider": "duckduckgo",
+            "externalContent": {
+                "untrusted": true,
+                "source": "web_search",
+                "provider": "duckduckgo",
+                "wrapped": true
+            },
+            "results": [
+                {
+                    "title": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"title\">>>\nSource: Web Search\n---\nLatest and Breaking News - The Sydney Morning Herald\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"title\">>>",
+                    "url": "https://www.smh.com.au/breaking-news",
+                    "snippet": "\n<<<EXTERNAL_UNTRUSTED_CONTENT id=\"snippet\">>>\nSource: Web Search\n---\nThe future of Australian swimming has arrived.\n<<<END_EXTERNAL_UNTRUSTED_CONTENT id=\"snippet\">>>"
+                }
+            ]
+        })
+        .to_string();
+
+        let compacted = compact_tool_result_text(&result);
+
+        assert!(compacted.contains("original was web_search JSON"));
+        assert!(compacted.contains("Latest and Breaking News"));
+        assert!(compacted.contains("Australian swimming"));
+        assert!(
+            compacted.find("Search results:").unwrap() < compacted.find("Latest").unwrap(),
+            "result rows should be explicit and easy for the reducer to read: {compacted}"
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -202,13 +202,11 @@ fn plain_dialog_message_for_compact_context(msg: &Value) -> bool {
 }
 
 fn append_current_user_if_missing(messages: &mut Vec<Value>, session: &Session) {
-    let user_text = session.last_user_text();
-    if messages
-        .last()
-        .and_then(|m| m.get("content").and_then(Value::as_str))
-        != Some(&user_text)
-    {
-        messages.push(json!({"role": "user", "content": user_text}));
+    let Some(last_user) = session.last_user_message() else {
+        return;
+    };
+    if messages.last() != Some(last_user) {
+        messages.push(last_user.clone());
     }
 }
 
@@ -236,14 +234,7 @@ fn pack_strong(
         }
     }
 
-    let user_text = session.last_user_text();
-    if messages
-        .last()
-        .and_then(|m| m.get("content").and_then(|c| c.as_str()))
-        != Some(&user_text)
-    {
-        messages.push(json!({"role": "user", "content": user_text}));
-    }
+    append_current_user_if_missing(&mut messages, session);
 
     // Forward the real tool schemas — the strong worker can produce native
     // tool_calls through the OpenAI API
@@ -280,8 +271,6 @@ pub fn pack_for_reducer_selected(
     has_tools: bool,
     selected_tool_names: &[String],
 ) -> (Vec<Value>, Option<Value>) {
-    let user_text = session.last_user_text();
-
     let mut system_parts = vec![
         augmented_system_prompt_for_mode(session, has_tools),
         String::new(),
@@ -314,7 +303,7 @@ pub fn pack_for_reducer_selected(
 
     let mut messages = vec![json!({"role": "system", "content": system_parts.join("\n")})];
     messages.extend(reducer_recent_transcript_messages(session));
-    messages.push(json!({"role": "user", "content": user_text}));
+    append_current_user_if_missing(&mut messages, session);
 
     (messages, tools)
 }
@@ -920,6 +909,70 @@ mod tests {
         let last = packed.messages.last().unwrap();
         assert_eq!(last.get("role").and_then(|r| r.as_str()), Some("user"));
         assert_eq!(last.get("content").and_then(|c| c.as_str()), Some("m3"));
+    }
+
+    #[test]
+    fn worker_context_preserves_raw_current_user_message() {
+        let current_user = json!({
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "use this structured prompt"},
+                {"type": "text", "text": "without rebuilding it"},
+            ],
+        });
+        let s = session_with(
+            &[
+                system_msg("Agent SP."),
+                assistant_msg("ready"),
+                current_user.clone(),
+            ],
+            None,
+        );
+
+        for role in [WorkerRole::Fast, WorkerRole::Specialist, WorkerRole::Strong] {
+            let packed = pack_for_worker(&s, role, false);
+            let user_messages = packed
+                .messages
+                .iter()
+                .filter(|msg| msg.get("role").and_then(Value::as_str) == Some("user"))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                user_messages.len(),
+                1,
+                "{role:?} should not append a stringified duplicate current user message: {:?}",
+                packed.messages,
+            );
+            assert_eq!(user_messages[0], &current_user);
+        }
+    }
+
+    #[test]
+    fn reducer_context_preserves_raw_current_user_message() {
+        let current_user = json!({
+            "role": "user",
+            "content": [{"type": "input_text", "text": "structured final request"}],
+        });
+        let s = session_with(
+            &[
+                user_msg("earlier"),
+                assistant_msg("earlier reply"),
+                current_user.clone(),
+            ],
+            None,
+        );
+        let outputs = vec![WorkerOutput {
+            model: "worker-a".into(),
+            kind: OutputKind::Answer,
+            payload: "candidate answer".into(),
+            tool_name: None,
+            tool_arguments: None,
+            confidence: 0.4,
+            role: WorkerRole::Fast,
+            elapsed_ms: 10,
+        }];
+
+        let (messages, _tools) = pack_for_reducer(&s, &outputs, "conflict", false);
+        assert_eq!(messages.last(), Some(&current_user));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -41,6 +41,7 @@ const TOOL_RESULT_WEB_SEARCH_TITLE_MAX_CHARS: usize = 120;
 const TOOL_RESULT_WEB_SEARCH_SNIPPET_MAX_CHARS: usize = 200;
 const TOOL_RESULT_WEB_SEARCH_URL_MAX_CHARS: usize = 120;
 const TOOL_RESULT_WEB_SEARCH_ROW_MAX_CHARS: usize = 320;
+const TOOL_TASK_ANCHOR_MAX_CHARS: usize = 2_000;
 
 /// Packed context ready to send to a worker.
 pub struct PackedContext {
@@ -172,7 +173,7 @@ fn pack_fast(session: &Session, has_tools: bool, selected_tool_names: &[String])
             Some(FAST_PLAIN_CONTEXT_MAX_BYTES),
         )
     };
-    append_recent_dialog_messages(&mut messages, session, window, max_bytes);
+    append_recent_dialog_messages(&mut messages, session, window, max_bytes, has_tools);
 
     // Per-request sessions: the caller owns the multi-turn loop and
     // sends the full history each request. Continuation context lives
@@ -205,7 +206,7 @@ fn pack_specialist(
             Some(SPECIALIST_PLAIN_CONTEXT_MAX_BYTES),
         )
     };
-    append_recent_dialog_messages(&mut messages, session, window, max_bytes);
+    append_recent_dialog_messages(&mut messages, session, window, max_bytes, has_tools);
 
     PackedContext {
         messages,
@@ -219,8 +220,12 @@ fn append_recent_dialog_messages(
     session: &Session,
     window: usize,
     max_bytes: Option<usize>,
+    include_tool_task_anchor: bool,
 ) {
     let recent = bounded_recent_messages(session.recent_messages(window), max_bytes, true);
+    if include_tool_task_anchor {
+        append_tool_task_anchor_if_missing(messages, session, &recent);
+    }
     for msg in &recent {
         if plain_dialog_message_for_compact_context(msg) {
             messages.push(msg.clone());
@@ -271,6 +276,9 @@ fn pack_strong(
         )
     };
     let recent = bounded_recent_messages(session.recent_messages(window), max_bytes, true);
+    if has_tools {
+        append_tool_task_anchor_if_missing(&mut messages, session, &recent);
+    }
     for msg in &recent {
         let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("");
         if role != "system" && !role.is_empty() {
@@ -562,20 +570,107 @@ pub fn pack_for_tool_result_turn_selected(
                 .any(|msg| message_role(msg) == "user")
         });
 
+    let mut transcript = Vec::new();
     if let Some(user_idx) = prefix_user_idx {
-        messages.push(all[user_idx].clone());
+        transcript.push(all[user_idx].clone());
     }
 
     for msg in &all[start_idx..] {
         let role = message_role(msg);
         if role != "system" && !role.is_empty() {
-            messages.push(compact_tool_message(msg));
+            transcript.push(compact_tool_message(msg));
         }
     }
+    append_tool_task_anchor_if_missing(&mut messages, session, &transcript);
+    messages.extend(transcript);
 
     let tools = selected_tools(session, has_tools, selected_tool_names);
 
     (messages, tools)
+}
+
+fn append_tool_task_anchor_if_missing(
+    messages: &mut Vec<Value>,
+    session: &Session,
+    visible_messages: &[Value],
+) {
+    let Some(task) = first_user_task_text(session) else {
+        return;
+    };
+    if messages_contain_text(visible_messages, &task) {
+        return;
+    }
+
+    let task = truncate_with_ellipsis(&task, TOOL_TASK_ANCHOR_MAX_CHARS);
+    messages.push(json!({
+        "role": "system",
+        "content": format!("Original user task for this tool loop:\n{task}"),
+    }));
+}
+
+fn first_user_task_text(session: &Session) -> Option<String> {
+    session
+        .messages()
+        .iter()
+        .find_map(|message| {
+            (message_role(message) == "user" && !user_message_looks_like_tool_response(message))
+                .then(|| message_text_content(message))
+                .flatten()
+        })
+        .map(|text| text.trim().to_string())
+        .filter(|text| !text.is_empty())
+}
+
+fn user_message_looks_like_tool_response(message: &Value) -> bool {
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .is_some_and(|parts| parts.iter().all(content_part_looks_like_tool_response))
+}
+
+fn content_part_looks_like_tool_response(part: &Value) -> bool {
+    matches!(
+        part.get("type").and_then(Value::as_str),
+        Some("toolResponse" | "tool_result" | "tool_call_output" | "function_call_output")
+    ) || part.get("toolResult").is_some()
+        || part.get("tool_result").is_some()
+        || part.get("tool_call_id").is_some()
+        || part.get("call_id").is_some()
+}
+
+fn messages_contain_text(messages: &[Value], needle: &str) -> bool {
+    messages
+        .iter()
+        .filter_map(message_text_content)
+        .any(|text| text.contains(needle))
+}
+
+fn message_text_content(message: &Value) -> Option<String> {
+    let content = message.get("content")?;
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+    let parts = content.as_array()?;
+    let text = parts
+        .iter()
+        .filter_map(|part| {
+            part.get("text")
+                .and_then(Value::as_str)
+                .or_else(|| part.get("input_text").and_then(Value::as_str))
+                .or_else(|| part.get("output_text").and_then(Value::as_str))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
+}
+
+fn truncate_with_ellipsis(text: &str, max_bytes: usize) -> String {
+    let truncated = crate::worker::truncate_chars(text, max_bytes);
+    if truncated.len() == text.len() {
+        truncated.to_string()
+    } else {
+        format!("{truncated}...")
+    }
 }
 
 fn tool_evidence_message(session: &Session) -> Option<Value> {
@@ -998,6 +1093,22 @@ mod tests {
     }
     fn tool_result_msg(id: &str, text: &str) -> Value {
         json!({"role": "tool", "tool_call_id": id, "content": text})
+    }
+    fn user_tool_response_msg(id: &str, text: &str) -> Value {
+        json!({
+            "role": "user",
+            "content": [{
+                "type": "toolResponse",
+                "id": id,
+                "toolResult": {
+                    "status": "success",
+                    "value": {
+                        "content": [{"type": "text", "text": text}],
+                        "isError": false,
+                    },
+                },
+            }],
+        })
     }
     fn tools_two() -> Value {
         json!([
@@ -1622,6 +1733,91 @@ mod tests {
         assert_ne!(
             roles[3], "tool",
             "bounded recent tail must not start with a bare tool message",
+        );
+    }
+
+    #[test]
+    fn tool_result_reducer_anchors_original_task_when_latest_user_is_tool_wrapper() {
+        let mut messages = vec![user_msg("Implement src/smoke_calc.py so the tests pass.")];
+        for idx in 0..8 {
+            let id = format!("call_tree_{idx}");
+            messages.push(assistant_tool_msg(
+                &id,
+                "tree",
+                json!({"path": format!("dir{idx}")}),
+            ));
+            messages.push(user_tool_response_msg(
+                &id,
+                &format!("tree result {idx}: src/smoke_calc.py"),
+            ));
+        }
+        messages.push(assistant_tool_msg(
+            "call_read",
+            "read_file",
+            json!({"path": "src/smoke_calc.py"}),
+        ));
+        messages.push(tool_result_msg(
+            "call_read",
+            "raise NotImplementedError(\"ci smoke fixture\")",
+        ));
+        let s = session_with(&messages, Some(tools_two()));
+
+        let recent_without_anchor =
+            s.recent_messages(TOOL_RESULT_CONTEXT_WINDOW)
+                .iter()
+                .any(|msg| {
+                    message_text_content(msg)
+                        .is_some_and(|text| text.contains("Implement src/smoke_calc.py"))
+                });
+        assert!(
+            !recent_without_anchor,
+            "test must push the original task outside the bounded recent tail",
+        );
+
+        let (messages, _tools) = pack_for_tool_result_turn(&s, true);
+        let body = serialized_messages(&messages);
+
+        assert!(
+            body.contains("Original user task for this tool loop"),
+            "tool-result context should add a bounded task anchor, got {body}",
+        );
+        assert!(
+            body.contains("Implement src/smoke_calc.py so the tests pass."),
+            "task anchor should preserve the real agent task, got {body}",
+        );
+        assert!(
+            body.contains("NotImplementedError"),
+            "latest tool result should remain visible, got {body}",
+        );
+    }
+
+    #[test]
+    fn tool_worker_context_anchors_original_task_after_user_tool_wrappers() {
+        let mut messages = vec![user_msg("Implement src/smoke_calc.py so the tests pass.")];
+        for idx in 0..8 {
+            let id = format!("call_{idx}");
+            messages.push(assistant_tool_msg(
+                &id,
+                "tree",
+                json!({"path": format!("dir{idx}")}),
+            ));
+            messages.push(user_tool_response_msg(
+                &id,
+                &format!("tree result {idx}: src/smoke_calc.py"),
+            ));
+        }
+        let s = session_with(&messages, Some(tools_two()));
+
+        let packed = pack_for_worker(&s, WorkerRole::Strong, true);
+        let body = serialized_messages(&packed.messages);
+
+        assert!(
+            body.contains("Original user task for this tool loop"),
+            "tool worker context should anchor the original task, got {body}",
+        );
+        assert!(
+            body.contains("Implement src/smoke_calc.py so the tests pass."),
+            "tool worker task anchor should preserve the real task, got {body}",
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/fanout.rs
+++ b/crates/mesh-mixture-of-agents/src/fanout.rs
@@ -55,35 +55,14 @@ pub(crate) async fn gather_workers_incremental(
     let dispatched_at = Instant::now();
     let grace_enabled = grace_mode != GraceMode::Disabled && !first_answer_grace.is_zero();
 
-    // Grace eligibility: once the grace window has elapsed and a qualifying
-    // partial decision exists, ship it instead of waiting for the slow tail.
-    // Answer grace handles ordinary chat, including tool-enabled clients that
-    // attach schemas to every request. Tool grace handles obvious tool-intent
-    // prompts, but only when a worker has actually proposed a valid tool.
-    let grace_eligible = |outs: &[WorkerOutput]| -> bool {
-        if !grace_enabled {
-            return false;
-        }
-        match grace_mode {
-            GraceMode::Disabled => false,
-            GraceMode::Answer => outs.iter().any(|o| {
-                o.kind == normalize::OutputKind::Answer && o.confidence >= GRACE_MIN_CONFIDENCE
-            }),
-            GraceMode::Tool => outs.iter().any(|o| {
-                o.kind == normalize::OutputKind::ToolProposal
-                    && o.tool_name.is_some()
-                    && o.confidence >= TOOL_GRACE_MIN_CONFIDENCE
-            }),
-        }
-    };
-
     loop {
-        let grace_remaining = if grace_eligible(&outputs) {
+        let answer_priority_pending = answer_priority_worker_pending(dispatched, &summaries);
+        let armed = grace_eligible(&outputs, grace_enabled, grace_mode, answer_priority_pending);
+        let grace_remaining = if armed {
             first_answer_grace.saturating_sub(dispatched_at.elapsed())
         } else {
             Duration::from_secs(60 * 60)
         };
-        let armed = grace_eligible(&outputs);
 
         let join_result = tokio::select! {
             biased;
@@ -135,9 +114,15 @@ pub(crate) async fn gather_workers_incremental(
                 });
                 outputs.push(normalized);
 
-                if let Some(decision) =
-                    arbiter::try_early_decision(&outputs, total_workers, total_finished, has_tools)
-                {
+                let answer_priority_pending =
+                    answer_priority_worker_pending(dispatched, &summaries);
+                if let Some(decision) = arbiter::try_early_decision(
+                    &outputs,
+                    total_workers,
+                    total_finished,
+                    has_tools,
+                    answer_priority_pending,
+                ) {
                     drain_after_early_exit(join_set, &mut summaries).await;
                     reconcile_dispatched(dispatched, &mut summaries);
                     return (outputs, summaries, Some(decision));
@@ -161,9 +146,15 @@ pub(crate) async fn gather_workers_incremental(
                     confidence: None,
                 });
 
-                if let Some(decision) =
-                    arbiter::try_early_decision(&outputs, total_workers, total_finished, has_tools)
-                {
+                let answer_priority_pending =
+                    answer_priority_worker_pending(dispatched, &summaries);
+                if let Some(decision) = arbiter::try_early_decision(
+                    &outputs,
+                    total_workers,
+                    total_finished,
+                    has_tools,
+                    answer_priority_pending,
+                ) {
                     drain_after_early_exit(join_set, &mut summaries).await;
                     reconcile_dispatched(dispatched, &mut summaries);
                     return (outputs, summaries, Some(decision));
@@ -184,16 +175,53 @@ pub(crate) async fn gather_workers_incremental(
     (outputs, summaries, None)
 }
 
+fn grace_eligible(
+    outs: &[WorkerOutput],
+    grace_enabled: bool,
+    grace_mode: GraceMode,
+    answer_priority_pending: bool,
+) -> bool {
+    if !grace_enabled {
+        return false;
+    }
+    match grace_mode {
+        GraceMode::Disabled => false,
+        GraceMode::Answer => {
+            !answer_priority_pending
+                && outs.iter().any(|o| {
+                    o.kind == normalize::OutputKind::Answer && o.confidence >= GRACE_MIN_CONFIDENCE
+                })
+        }
+        GraceMode::Tool => outs.iter().any(|o| {
+            o.kind == normalize::OutputKind::ToolProposal
+                && o.tool_name.is_some()
+                && o.confidence >= TOOL_GRACE_MIN_CONFIDENCE
+        }),
+    }
+}
+
+fn answer_priority_worker_pending(
+    dispatched: &[DispatchedWorker],
+    summaries: &[WorkerSummary],
+) -> bool {
+    dispatched.iter().any(|worker| {
+        answer_priority_role(worker.role)
+            && !summaries
+                .iter()
+                .any(|summary| summary.model == worker.model)
+    })
+}
+
+fn answer_priority_role(role: WorkerRole) -> bool {
+    matches!(
+        role,
+        WorkerRole::Strong | WorkerRole::Generalist | WorkerRole::Reducer
+    )
+}
+
 fn grace_answer_decision(outputs: &[WorkerOutput]) -> arbiter::Decision {
-    let answer = outputs
-        .iter()
-        .filter(|o| o.kind == normalize::OutputKind::Answer)
-        .max_by(|a, b| {
-            a.confidence
-                .partial_cmp(&b.confidence)
-                .unwrap_or(std::cmp::Ordering::Equal)
-        })
-        .expect("answer grace requires at least one Answer");
+    let answer =
+        arbiter::best_answer_output(outputs).expect("answer grace requires at least one Answer");
     let answer_count = outputs
         .iter()
         .filter(|o| o.kind == normalize::OutputKind::Answer)
@@ -357,7 +385,7 @@ mod tests {
             spawn_worker(
                 &mut js,
                 "slow2",
-                WorkerRole::Strong,
+                WorkerRole::Specialist,
                 5_000,
                 Ok(answer_text("agreed", 0.6)),
             ),
@@ -410,7 +438,7 @@ mod tests {
             spawn_worker(
                 &mut js,
                 "slow2",
-                WorkerRole::Strong,
+                WorkerRole::Specialist,
                 200,
                 Ok(answer_text("agreed", 0.6)),
             ),
@@ -435,6 +463,50 @@ mod tests {
         );
         assert_eq!(outputs.len(), 1, "grace should leave the slow tail pending");
         assert!(matches!(decision, Some(arbiter::Decision::Answer(_))));
+    }
+
+    #[tokio::test]
+    async fn answer_grace_waits_for_pending_strong_worker() {
+        let mut js = tokio::task::JoinSet::new();
+        let dispatched = vec![
+            spawn_worker(
+                &mut js,
+                "fast",
+                WorkerRole::Fast,
+                10,
+                Ok(answer_text("same answer", 0.8)),
+            ),
+            spawn_worker(
+                &mut js,
+                "strong",
+                WorkerRole::Strong,
+                180,
+                Ok(answer_text("same answer with stronger detail", 0.7)),
+            ),
+        ];
+
+        let started = std::time::Instant::now();
+        let (outputs, _summaries, decision) = gather_workers_incremental(
+            &mut js,
+            &dispatched,
+            false,
+            &[],
+            None,
+            Duration::from_millis(40),
+            GraceMode::Answer,
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(150),
+            "answer grace must wait for the strong worker; got {elapsed:?}"
+        );
+        assert_eq!(outputs.len(), 2);
+        match decision.expect("strong + fast agreement should early-decide") {
+            arbiter::Decision::Answer(text) => assert!(text.contains("same answer")),
+            other => panic!("expected answer decision, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -653,8 +725,8 @@ mod tests {
             ),
             spawn_worker(
                 &mut js,
-                "slow_strong",
-                WorkerRole::Strong,
+                "slow_specialist",
+                WorkerRole::Specialist,
                 5_000,
                 Ok(answer_text("Ready", 0.5)),
             ),
@@ -716,7 +788,7 @@ mod tests {
             spawn_worker(
                 &mut js,
                 "w_slow",
-                WorkerRole::Strong,
+                WorkerRole::Specialist,
                 5_000,
                 Ok(answer_text("slow_low", 0.4)),
             ),

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -1106,18 +1106,7 @@ async fn resolve_decision(
 // ─── Response builders ───────────────────────────────────────────────
 
 fn best_answer(outputs: &[WorkerOutput]) -> String {
-    outputs
-        .iter()
-        .filter(|o| {
-            matches!(o.kind, normalize::OutputKind::Answer)
-                && !normalize::is_silent_reply_sentinel(&o.payload)
-        })
-        // `total_cmp` is total over all f32 (including NaN/Inf); `partial_cmp`
-        // can return `None` on NaN, which would panic on `unwrap`.
-        // `normalize_worker_output` now sanitizes non-finite confidences
-        // before they reach here, but using `total_cmp` keeps this site
-        // panic-free even if a future caller skips the normalizer.
-        .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
+    arbiter::best_answer_output(outputs)
         .map(|o| o.payload.clone())
         .unwrap_or_default()
 }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -234,6 +234,8 @@ async fn handle_query(
 ) -> TurnResult {
     let assignments = worker::assign_roles(&config.models);
     let grace_mode = grace_mode_for_turn(session, has_tools);
+    let tools_available_for_response = has_tools
+        && (!tools_explicitly_disabled(&session.last_user_text()) || forced_tool.is_some());
     let query_uses_tools = forced_tool.is_some() || matches!(grace_mode, GraceMode::Tool);
     let selected_tool_names = if let Some(tool) = forced_tool {
         vec![tool.name.clone()]
@@ -323,7 +325,7 @@ async fn handle_query(
             session,
             decision,
             outputs: &outputs,
-            has_tools: query_uses_tools,
+            has_tools: tools_available_for_response,
             selected_tool_names: &selected_tool_names,
             forced_tool,
             allowed_tools,
@@ -355,17 +357,27 @@ fn grace_mode_for_turn(session: &Session, has_tools: bool) -> GraceMode {
     if !has_tools {
         return GraceMode::Answer;
     }
-    if looks_like_tool_intent(&session.last_user_text()) {
+    let text = session.last_user_text();
+    if tools_explicitly_disabled(&text) {
+        return GraceMode::Answer;
+    }
+    let text_lc = text.to_ascii_lowercase();
+    if !explicitly_requested_tool_names(&session.tool_names(), &text_lc).is_empty()
+        || looks_like_tool_intent_lc(&text_lc)
+    {
         GraceMode::Tool
     } else {
         GraceMode::Answer
     }
 }
 
-fn looks_like_tool_intent(text: &str) -> bool {
-    let text = text.to_ascii_lowercase();
-    if contains_any(
-        &text,
+fn tools_explicitly_disabled(text: &str) -> bool {
+    tools_explicitly_disabled_lc(&text.to_ascii_lowercase())
+}
+
+fn tools_explicitly_disabled_lc(text: &str) -> bool {
+    contains_any(
+        text,
         &[
             "no tool",
             "without tool",
@@ -378,10 +390,10 @@ fn looks_like_tool_intent(text: &str) -> bool {
             "no lookup",
             "without lookup",
         ],
-    ) {
-        return false;
-    }
+    )
+}
 
+fn looks_like_tool_intent_lc(text: &str) -> bool {
     let tool_intent_phrases = [
         "use a tool",
         "using a tool",
@@ -401,6 +413,8 @@ fn looks_like_tool_intent(text: &str) -> bool {
         "folder",
         "list ",
         "run ",
+        "run:",
+        "exec",
         "execute",
         "terminal",
         "shell",
@@ -1623,6 +1637,27 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn explicit_tool_name_uses_tool_grace() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Use the exec tool exactly once to run: printf ok",
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "read"}},
+                {"type": "function", "function": {"name": "exec"}}
+            ])),
+        );
+
+        assert_eq!(grace_mode_for_turn(&session, true), GraceMode::Tool);
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[]),
+            vec!["exec".to_string()]
+        );
+    }
+
+    #[test]
     fn negated_web_prompt_uses_answer_grace() {
         let mut session = Session::new();
         session.ingest(
@@ -1631,6 +1666,21 @@ mod response_builder_tests {
                 "content": "Plain check with no web lookup: reply OK",
             })],
             &Some(serde_json::json!([{"type": "function", "function": {"name": "web_search"}}])),
+        );
+        assert_eq!(grace_mode_for_turn(&session, true), GraceMode::Answer);
+    }
+
+    #[test]
+    fn negated_explicit_tool_prompt_uses_answer_grace() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Do not use tools; explain what the exec tool does.",
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "exec"}}
+            ])),
         );
         assert_eq!(grace_mode_for_turn(&session, true), GraceMode::Answer);
     }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -965,18 +965,28 @@ fn recover_tool_result_response(
             MOA_ERR_NO_USABLE_ANSWER,
         ),
         arbiter::Decision::Answer(text) => chat_response(&final_answer_text(session, &text)),
-        arbiter::Decision::NeedsReducer { .. } => recovery_best_output_response(session, outputs),
+        arbiter::Decision::NeedsReducer { .. } => {
+            recovery_best_output_response(session, has_tools, outputs)
+        }
     }
 }
 
-fn recovery_best_output_response(session: &Session, outputs: &[WorkerOutput]) -> Value {
-    if let Some(tool) = outputs
-        .iter()
-        .filter(|output| {
-            output.kind == normalize::OutputKind::ToolProposal && output.tool_name.is_some()
+fn recovery_best_output_response(
+    session: &Session,
+    has_tools: bool,
+    outputs: &[WorkerOutput],
+) -> Value {
+    let tool = has_tools
+        .then(|| {
+            outputs
+                .iter()
+                .filter(|output| {
+                    output.kind == normalize::OutputKind::ToolProposal && output.tool_name.is_some()
+                })
+                .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
         })
-        .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
-    {
+        .flatten();
+    if let Some(tool) = tool {
         return tool_proposal_response(tool, true);
     }
 
@@ -1317,9 +1327,15 @@ fn strict_output_requested(session: &Session) -> bool {
     session
         .messages()
         .iter()
-        .filter(|message| message.get("role").and_then(Value::as_str) == Some("user"))
-        .filter_map(message_text)
-        .any(|text| strict_output_requested_lc(&text.to_ascii_lowercase()))
+        .rev()
+        .find_map(|message| {
+            (message.get("role").and_then(Value::as_str) == Some("user")
+                && !user_message_looks_like_tool_response(message)
+                && !user_message_looks_like_runtime_info(message))
+            .then(|| message_text(message))
+            .flatten()
+        })
+        .is_some_and(|text| strict_output_requested_lc(&text.to_ascii_lowercase()))
 }
 
 fn strict_output_requested_lc(text: &str) -> bool {
@@ -1336,6 +1352,32 @@ fn strict_output_requested_lc(text: &str) -> bool {
             "no markdown",
         ],
     )
+}
+
+fn user_message_looks_like_tool_response(message: &Value) -> bool {
+    message
+        .get("content")
+        .and_then(Value::as_array)
+        .is_some_and(|parts| parts.iter().all(content_part_looks_like_tool_response))
+}
+
+fn content_part_looks_like_tool_response(part: &Value) -> bool {
+    matches!(
+        part.get("type").and_then(Value::as_str),
+        Some("toolResponse" | "tool_result" | "tool_call_output" | "function_call_output")
+    ) || part.get("toolResult").is_some()
+        || part.get("tool_result").is_some()
+        || part.get("tool_call_id").is_some()
+        || part.get("call_id").is_some()
+}
+
+fn user_message_looks_like_runtime_info(message: &Value) -> bool {
+    message_text(message).is_some_and(|text| {
+        let trimmed = text.trim_start();
+        trimmed.starts_with("<info-msg>")
+            || trimmed.starts_with("<environment_context>")
+            || trimmed.starts_with("<system-reminder>")
+    })
 }
 
 fn unwrap_markdown_fence(text: &str) -> &str {
@@ -1652,6 +1694,59 @@ mod response_builder_tests {
         assert_eq!(final_answer_text(&session, answer), answer);
     }
 
+    #[test]
+    fn strict_output_repair_ignores_stale_prior_user_directive() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                json!({
+                    "role": "user",
+                    "content": "Answer exactly these lines with no extra text:\nCODEWORD=<value>"
+                }),
+                json!({
+                    "role": "assistant",
+                    "content": "CODEWORD=old"
+                }),
+                json!({
+                    "role": "user",
+                    "content": "Now explain what happened in prose."
+                }),
+            ],
+            &None,
+        );
+        let answer = "The required values are:\nCODEWORD=signal-7429";
+
+        assert_eq!(final_answer_text(&session, answer), answer);
+    }
+
+    #[test]
+    fn strict_output_repair_survives_user_tool_wrappers() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                json!({
+                    "role": "user",
+                    "content": "Answer exactly these lines with no Markdown and no extra text:\nCODEWORD=<value>"
+                }),
+                json!({
+                    "role": "user",
+                    "content": [{
+                        "type": "toolResponse",
+                        "toolResult": {
+                            "status": "success",
+                            "value": {"content": [{"type": "text", "text": "CODEWORD=signal-7429"}]},
+                        },
+                    }]
+                }),
+            ],
+            &None,
+        );
+
+        let repaired = final_answer_text(&session, "Here:\nCODEWORD=signal-7429\nDone.");
+
+        assert_eq!(repaired, "CODEWORD=signal-7429");
+    }
+
     fn tool_proposal(payload: &str) -> WorkerOutput {
         WorkerOutput {
             kind: normalize::OutputKind::ToolProposal,
@@ -1693,6 +1788,27 @@ mod response_builder_tests {
         assert_eq!(
             resp.pointer("/error/code").and_then(Value::as_str),
             Some(MOA_ERR_NO_USABLE_ANSWER)
+        );
+    }
+
+    #[test]
+    fn recovery_best_output_respects_disabled_tools() {
+        let session = Session::new();
+        let outputs = vec![
+            tool_proposal("Need to read."),
+            answer("fallback", 0.4, "Final answer."),
+        ];
+
+        let resp = recovery_best_output_response(&session, false, &outputs);
+
+        assert!(
+            resp.pointer("/choices/0/message/tool_calls").is_none(),
+            "disabled recovery must not emit tool_calls: {resp}"
+        );
+        assert_eq!(
+            resp.pointer("/choices/0/message/content")
+                .and_then(Value::as_str),
+            Some("Final answer.")
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -911,10 +911,13 @@ fn repeated_same_tool_results(session: &Session) -> Option<(String, usize)> {
     last.result.as_ref()?;
 
     let tool_name = last.function_name.as_str();
+    let arguments = &last.arguments;
     let count = calls
         .iter()
         .rev()
-        .take_while(|call| call.function_name == tool_name && call.result.is_some())
+        .take_while(|call| {
+            call.function_name == tool_name && call.arguments == *arguments && call.result.is_some()
+        })
         .count();
 
     (count >= SAME_TOOL_FORCE_ANSWER_THRESHOLD).then(|| (tool_name.to_string(), count))
@@ -1121,6 +1124,13 @@ fn tool_proposal_response(output: &WorkerOutput, has_tools: bool) -> Value {
     if let (true, Some(name)) = (has_tools, output.tool_name.as_ref()) {
         let args = output.tool_arguments.as_ref().unwrap_or(&Value::Null);
         return tool_call_response(name, args);
+    }
+
+    if output.tool_name.is_some() {
+        return error_response(
+            "MoA selected a tool call, but tools are disabled for this turn",
+            MOA_ERR_NO_USABLE_ANSWER,
+        );
     }
 
     if output.payload.trim().is_empty() || normalize::is_silent_reply_sentinel(&output.payload) {
@@ -1344,15 +1354,22 @@ mod response_builder_tests {
 
     #[test]
     fn tool_proposal_response_does_not_emit_tool_call_when_tools_disabled() {
-        let resp = tool_proposal_response(&tool_proposal("I need to read README.md."), false);
+        let resp = tool_proposal_response(
+            &tool_proposal(r#"<|tool_call>call:read_file{path:<|"|>README.md<|"|>}<tool_call|>"#),
+            false,
+        );
         assert!(
             resp.pointer("/choices/0/message/tool_calls").is_none(),
             "disabled tools must not leak tool_calls: {resp}"
         );
         assert_eq!(
-            resp.pointer("/choices/0/message/content")
+            resp.pointer("/choices/0/finish_reason")
                 .and_then(Value::as_str),
-            Some("I need to read README.md.")
+            Some("error")
+        );
+        assert_eq!(
+            resp.pointer("/error/code").and_then(Value::as_str),
+            Some(MOA_ERR_NO_USABLE_ANSWER)
         );
     }
 
@@ -1785,6 +1802,27 @@ mod response_builder_tests {
     }
 
     #[test]
+    fn same_tool_different_arguments_do_not_force_answer() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({"role": "user", "content": "inspect project"}),
+                tool_call_msg_with_args("call_1", "tree", serde_json::json!({"path": "."})),
+                tool_result_msg("call_1", "root tree"),
+                tool_call_msg_with_args("call_2", "tree", serde_json::json!({"path": "facts/"})),
+                tool_result_msg("call_2", "facts tree"),
+                tool_call_msg_with_args("call_3", "tree", serde_json::json!({"path": "src/"})),
+                tool_result_msg("call_3", "src tree"),
+            ],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "tree"}}
+            ])),
+        );
+
+        assert_eq!(repeated_same_tool_results(&session), None);
+    }
+
+    #[test]
     fn repair_tool_result_answer_preserves_short_json_values_on_recall() {
         let mut session = Session::new();
         session.ingest(
@@ -1844,13 +1882,17 @@ mod response_builder_tests {
     }
 
     fn tool_call_msg(id: &str, name: &str) -> Value {
+        tool_call_msg_with_args(id, name, serde_json::json!({"query": "x"}))
+    }
+
+    fn tool_call_msg_with_args(id: &str, name: &str, arguments: Value) -> Value {
         serde_json::json!({
             "role": "assistant",
             "content": null,
             "tool_calls": [{
                 "id": id,
                 "type": "function",
-                "function": {"name": name, "arguments": "{\"query\":\"x\"}"}
+                "function": {"name": name, "arguments": arguments.to_string()}
             }]
         })
     }

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -453,6 +453,10 @@ fn selected_tool_names_for_turn(session: &Session, allowed_tools: &[String]) -> 
         }
     }
 
+    if selected.is_empty() && looks_like_tool_intent_lc(&text) {
+        return available;
+    }
+
     with_recent_tool_chain_names(session, &available, selected)
 }
 
@@ -792,21 +796,24 @@ async fn handle_tool_result(
                     "MoA reducer returned no usable answer",
                     MOA_ERR_NO_USABLE_ANSWER,
                 ),
-                _ => chat_response(&repair_tool_result_answer(session, &reduced.payload)),
+                _ => chat_response(&final_answer_text(session, &reduced.payload)),
             };
             (name, true, body)
         }
         None => {
             let err = last_err.unwrap_or_else(|| "no reducer candidates".into());
             tracing::warn!("moa: all {attempts} reducer candidates failed");
-            (
-                candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
-                false,
-                error_response(
-                    &format!("Reducer failed (tried {attempts}): {err}"),
-                    MOA_ERR_ALL_REDUCERS_FAILED,
-                ),
-            )
+            return recover_tool_result_with_workers(ToolResultRecovery {
+                config,
+                session,
+                has_tools,
+                allowed_tools,
+                reducer_name: candidates.first().map(|c| c.0.clone()).unwrap_or_default(),
+                reducer_attempts: attempts,
+                reducer_error: err,
+                start,
+            })
+            .await;
         }
     };
 
@@ -825,6 +832,155 @@ async fn handle_tool_result(
         turn_kind: TurnKind::ToolResult,
         elapsed_ms: start.elapsed().as_millis() as u64,
     }
+}
+
+struct ToolResultRecovery<'a> {
+    config: &'a GatewayConfig,
+    session: &'a Session,
+    has_tools: bool,
+    allowed_tools: &'a [String],
+    reducer_name: String,
+    reducer_attempts: u32,
+    reducer_error: String,
+    start: Instant,
+}
+
+async fn recover_tool_result_with_workers(request: ToolResultRecovery<'_>) -> TurnResult {
+    let ToolResultRecovery {
+        config,
+        session,
+        has_tools,
+        allowed_tools,
+        reducer_name,
+        reducer_attempts,
+        reducer_error,
+        start,
+    } = request;
+
+    tracing::warn!(
+        "moa: reducer recovery fanout after {reducer_attempts} failed attempt(s): {reducer_error}"
+    );
+
+    let assignments = worker::assign_roles(&config.models);
+    let mut selected_tool_names = selected_tool_names_for_turn(session, allowed_tools);
+    if has_tools && selected_tool_names.is_empty() {
+        selected_tool_names = allowed_tools.to_vec();
+    }
+
+    let mut join_set = tokio::task::JoinSet::new();
+    let mut dispatched = Vec::with_capacity(assignments.len());
+    let enable_thinking = config.enable_thinking;
+
+    for assignment in &assignments {
+        let packed = context::pack_for_worker_selected(
+            session,
+            assignment.role,
+            has_tools,
+            &selected_tool_names,
+        );
+        let model_name = assignment.model_name.clone();
+        let role = assignment.role;
+        let backend = config.backends[assignment.backend_index].clone();
+        let timeout = config.worker_timeout;
+
+        dispatched.push(fanout::DispatchedWorker {
+            model: model_name.clone(),
+            role,
+        });
+
+        join_set.spawn(async move {
+            let t0 = Instant::now();
+            let result = call_backend(
+                &*backend,
+                &model_name,
+                &packed.messages,
+                packed.tools.as_ref(),
+                packed.max_tokens,
+                timeout,
+                SamplingParams::worker().with_thinking(enable_thinking),
+            )
+            .await;
+            let elapsed = t0.elapsed().as_millis() as u64;
+            (model_name, role, result, elapsed)
+        });
+    }
+
+    let (outputs, mut summaries, early_decision) = gather_workers_incremental(
+        &mut join_set,
+        &dispatched,
+        has_tools,
+        allowed_tools,
+        session.tools(),
+        config.first_answer_grace,
+        if has_tools {
+            GraceMode::Tool
+        } else {
+            GraceMode::Answer
+        },
+    )
+    .await;
+
+    summaries.insert(
+        0,
+        WorkerSummary {
+            model: reducer_name,
+            role: WorkerRole::Reducer,
+            succeeded: false,
+            elapsed_ms: config.reducer_timeout.as_millis() as u64,
+            output_kind: None,
+            confidence: None,
+        },
+    );
+
+    let response_body = recover_tool_result_response(session, has_tools, &outputs, early_decision);
+    TurnResult {
+        response_body,
+        worker_summaries: summaries,
+        reducer_used: true,
+        reducer_attempts,
+        turn_kind: TurnKind::ToolResult,
+        elapsed_ms: start.elapsed().as_millis() as u64,
+    }
+}
+
+fn recover_tool_result_response(
+    session: &Session,
+    has_tools: bool,
+    outputs: &[WorkerOutput],
+    early_decision: Option<arbiter::Decision>,
+) -> Value {
+    if outputs.is_empty() {
+        return error_response(
+            "Reducer failed and MoA recovery workers produced no usable output",
+            MOA_ERR_ALL_REDUCERS_FAILED,
+        );
+    }
+
+    match early_decision.unwrap_or_else(|| arbiter::arbitrate(outputs, has_tools)) {
+        arbiter::Decision::ToolCall { name, arguments } if has_tools => {
+            tool_call_response(&name, &arguments)
+        }
+        arbiter::Decision::ToolCall { .. } => error_response(
+            "MoA recovery selected a tool call, but tools are disabled for this turn",
+            MOA_ERR_NO_USABLE_ANSWER,
+        ),
+        arbiter::Decision::Answer(text) => chat_response(&final_answer_text(session, &text)),
+        arbiter::Decision::NeedsReducer { .. } => recovery_best_output_response(session, outputs),
+    }
+}
+
+fn recovery_best_output_response(session: &Session, outputs: &[WorkerOutput]) -> Value {
+    if let Some(tool) = outputs
+        .iter()
+        .filter(|output| {
+            output.kind == normalize::OutputKind::ToolProposal && output.tool_name.is_some()
+        })
+        .max_by(|a, b| a.confidence.total_cmp(&b.confidence))
+    {
+        return tool_proposal_response(tool, true);
+    }
+
+    fallback_worker_response(session, outputs)
 }
 
 fn repair_tool_result_answer(session: &Session, answer: &str) -> String {
@@ -984,7 +1140,7 @@ async fn resolve_decision(
                     0,
                 )
             } else {
-                (chat_response(&text), false, 0)
+                (chat_response(&final_answer_text(session, &text)), false, 0)
             }
         }
         arbiter::Decision::ToolCall { name, arguments } => {
@@ -1067,7 +1223,7 @@ async fn resolve_decision(
                                 attempts,
                             )
                         } else {
-                            (fallback_worker_response(outputs), true, attempts)
+                            (fallback_worker_response(session, outputs), true, attempts)
                         }
                     }
                     _ => {
@@ -1078,7 +1234,11 @@ async fn resolve_decision(
                                 attempts,
                             )
                         } else {
-                            (chat_response(&reduced.payload), true, attempts)
+                            (
+                                chat_response(&final_answer_text(session, &reduced.payload)),
+                                true,
+                                attempts,
+                            )
                         }
                     }
                 },
@@ -1095,7 +1255,7 @@ async fn resolve_decision(
                             attempts,
                         )
                     } else {
-                        (fallback_worker_response(outputs), false, attempts)
+                        (fallback_worker_response(session, outputs), false, attempts)
                     }
                 }
             }
@@ -1111,7 +1271,7 @@ fn best_answer(outputs: &[WorkerOutput]) -> String {
         .unwrap_or_default()
 }
 
-fn fallback_worker_response(outputs: &[WorkerOutput]) -> Value {
+fn fallback_worker_response(session: &Session, outputs: &[WorkerOutput]) -> Value {
     let answer = best_answer(outputs);
     if answer.is_empty() {
         error_response(
@@ -1119,8 +1279,118 @@ fn fallback_worker_response(outputs: &[WorkerOutput]) -> Value {
             MOA_ERR_NO_USABLE_ANSWER,
         )
     } else {
-        chat_response(&answer)
+        chat_response(&final_answer_text(session, &answer))
     }
+}
+
+fn final_answer_text(session: &Session, answer: &str) -> String {
+    let strict = repair_strict_output_answer(session, answer);
+    repair_tool_result_answer(session, &strict)
+}
+
+fn repair_strict_output_answer(session: &Session, answer: &str) -> String {
+    if !strict_output_requested(session) {
+        return answer.to_string();
+    }
+
+    let unwrapped = unwrap_markdown_fence(answer.trim());
+    let lines: Vec<&str> = unwrapped.lines().map(str::trim_end).collect();
+    let Some(start_idx) = lines
+        .iter()
+        .position(|line| line_looks_like_key_value(line))
+    else {
+        return unwrapped.to_string();
+    };
+    let end_idx = lines[start_idx..]
+        .iter()
+        .position(|line| !line_looks_like_key_value(line))
+        .map_or(lines.len(), |offset| start_idx + offset);
+
+    if start_idx == 0 && end_idx == lines.len() {
+        unwrapped.to_string()
+    } else {
+        lines[start_idx..end_idx].join("\n")
+    }
+}
+
+fn strict_output_requested(session: &Session) -> bool {
+    session
+        .messages()
+        .iter()
+        .filter(|message| message.get("role").and_then(Value::as_str) == Some("user"))
+        .filter_map(message_text)
+        .any(|text| strict_output_requested_lc(&text.to_ascii_lowercase()))
+}
+
+fn strict_output_requested_lc(text: &str) -> bool {
+    contains_any(
+        text,
+        &[
+            "answer exactly",
+            "respond exactly",
+            "reply exactly",
+            "output exactly",
+            "return exactly",
+            "no extra text",
+            "only output",
+            "no markdown",
+        ],
+    )
+}
+
+fn unwrap_markdown_fence(text: &str) -> &str {
+    let mut lines = text.lines();
+    let Some(first) = lines.next() else {
+        return text;
+    };
+    if !first.trim_start().starts_with("```") {
+        return text;
+    }
+    let Some(last_start) = text.rfind("```") else {
+        return text;
+    };
+    if last_start == 0 || !text[last_start..].trim().starts_with("```") {
+        return text;
+    }
+    let body_start = first.len() + 1;
+    text.get(body_start..last_start)
+        .map(str::trim)
+        .unwrap_or(text)
+}
+
+fn line_looks_like_key_value(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some((key, value)) = trimmed.split_once('=') else {
+        return false;
+    };
+    let key = key.trim();
+    let value = value.trim();
+    !key.is_empty()
+        && !value.is_empty()
+        && key.len() <= 64
+        && key
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-'))
+}
+
+fn message_text(message: &Value) -> Option<String> {
+    let content = message.get("content")?;
+    if let Some(text) = content.as_str() {
+        return Some(text.to_string());
+    }
+
+    let parts = content.as_array()?;
+    let text = parts
+        .iter()
+        .filter_map(|part| {
+            part.get("text")
+                .and_then(Value::as_str)
+                .or_else(|| part.get("input_text").and_then(Value::as_str))
+                .or_else(|| part.get("output_text").and_then(Value::as_str))
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    (!text.is_empty()).then_some(text)
 }
 
 fn tool_proposal_response(output: &WorkerOutput, has_tools: bool) -> Value {
@@ -1320,7 +1590,8 @@ mod response_builder_tests {
     #[test]
     fn fallback_worker_response_errors_when_only_silent_sentinel_remains() {
         let outputs = vec![answer("a", 0.99, "NO_REPLY")];
-        let resp = fallback_worker_response(&outputs);
+        let session = Session::new();
+        let resp = fallback_worker_response(&session, &outputs);
         assert_eq!(
             resp.pointer("/error/code").and_then(Value::as_str),
             Some(MOA_ERR_NO_USABLE_ANSWER)
@@ -1330,6 +1601,55 @@ mod response_builder_tests {
                 .and_then(Value::as_str),
             Some("error")
         );
+    }
+
+    #[test]
+    fn strict_output_repair_strips_preface_before_key_value_lines() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                json!({
+                    "role": "user",
+                    "content": "Answer exactly these lines with no Markdown and no extra text:\nCODEWORD=<value>\nCHECKSUM=<value>"
+                }),
+                json!({
+                    "role": "user",
+                    "content": "<info-msg>\nWorking directory: /tmp/project\n</info-msg>"
+                }),
+            ],
+            &None,
+        );
+
+        let repaired = final_answer_text(
+            &session,
+            "The required values are:\nCODEWORD=signal-7429\nCHECKSUM=FS-319-DELTA\nThanks",
+        );
+
+        assert_eq!(repaired, "CODEWORD=signal-7429\nCHECKSUM=FS-319-DELTA");
+    }
+
+    #[test]
+    fn strict_output_repair_unwraps_markdown_fence() {
+        let mut session = Session::new();
+        session.ingest(
+            &[json!({
+                "role": "user",
+                "content": "Output exactly one line, no markdown:\nRESULT=<value>"
+            })],
+            &None,
+        );
+
+        let repaired = final_answer_text(&session, "```text\nRESULT=ok\n```");
+
+        assert_eq!(repaired, "RESULT=ok");
+    }
+
+    #[test]
+    fn strict_output_repair_leaves_normal_answers_alone() {
+        let session = Session::new();
+        let answer = "The required values are:\nCODEWORD=signal-7429";
+
+        assert_eq!(final_answer_text(&session, answer), answer);
     }
 
     fn tool_proposal(payload: &str) -> WorkerOutput {
@@ -1794,6 +2114,60 @@ mod response_builder_tests {
         assert_eq!(
             selected_tool_names_for_turn(&session, &[]),
             vec!["exec".to_string(), "read".to_string()]
+        );
+    }
+
+    #[test]
+    fn broad_tool_intent_keeps_unknown_agent_tools_available() {
+        let mut session = Session::new();
+        session.ingest(
+            &[serde_json::json!({
+                "role": "user",
+                "content": "Inspect the repository, read files, edit src/smoke_calc.py, and run the tests."
+            })],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "tree"}},
+                {"type": "function", "function": {"name": "developer__text_editor"}},
+                {"type": "function", "function": {"name": "developer__shell"}}
+            ])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[]),
+            vec![
+                "tree".to_string(),
+                "developer__text_editor".to_string(),
+                "developer__shell".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn broad_agent_tool_loop_does_not_collapse_to_recent_tool_only() {
+        let mut session = Session::new();
+        session.ingest(
+            &[
+                serde_json::json!({
+                    "role": "user",
+                    "content": "Inspect the repository, read files, edit src/smoke_calc.py, and run the tests."
+                }),
+                tool_call_msg("call_tree", "tree"),
+                tool_result_msg("call_tree", "src\nsrc/smoke_calc.py\ntests"),
+            ],
+            &Some(serde_json::json!([
+                {"type": "function", "function": {"name": "tree"}},
+                {"type": "function", "function": {"name": "developer__text_editor"}},
+                {"type": "function", "function": {"name": "developer__shell"}}
+            ])),
+        );
+
+        assert_eq!(
+            selected_tool_names_for_turn(&session, &[]),
+            vec![
+                "tree".to_string(),
+                "developer__text_editor".to_string(),
+                "developer__shell".to_string()
+            ]
         );
     }
 

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -874,6 +874,22 @@ mod tests {
     }
 
     #[test]
+    fn minimax_namespaced_tool_call_block_uses_guardrail_rescue() {
+        let raw = r#"<minimax:tool_call>
+<invoke name="shell">
+<parameter name="command">cat src/smoke_calc.py</parameter>
+</invoke>
+</minimax:tool_call>"#;
+        let out = normalize_worker_output(raw, "minimax", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("shell"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["command"],
+            "cat src/smoke_calc.py"
+        );
+    }
+
+    #[test]
     fn xml_tag_tool_call_uses_guardrail_rescue() {
         let raw = r#"<tool_call>
 <exec>printf ok > /tmp/out</exec>"#;

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -846,6 +846,59 @@ mod tests {
     }
 
     #[test]
+    fn call_colon_tool_call_uses_guardrail_rescue() {
+        let raw = r#"<tool_call>call:exec{command: "printf ok > /tmp/out"}<tool_call>"#;
+        let out = normalize_worker_output(raw, "mesh-worker", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("exec"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["command"],
+            "printf ok > /tmp/out"
+        );
+    }
+
+    #[test]
+    fn openclaw_tool_call_block_uses_guardrail_rescue() {
+        let raw = r#"[TOOL_CALL]
+{tool => "exec", args => {
+  --command "printf ok > /tmp/out"
+}}
+[/TOOL_CALL]"#;
+        let out = normalize_worker_output(raw, "mesh-worker", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("exec"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["command"],
+            "printf ok > /tmp/out"
+        );
+    }
+
+    #[test]
+    fn xml_tag_tool_call_uses_guardrail_rescue() {
+        let raw = r#"<tool_call>
+<exec>printf ok > /tmp/out</exec>"#;
+        let out = normalize_worker_output(raw, "mesh-worker", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("exec"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["command"],
+            "printf ok > /tmp/out"
+        );
+    }
+
+    #[test]
+    fn named_object_tool_call_uses_guardrail_rescue() {
+        let raw = r#"<tool_call>exec{command:"printf ok > /tmp/out"}<tool_call>"#;
+        let out = normalize_worker_output(raw, "mesh-worker", WorkerRole::Fast, 100);
+        assert_eq!(out.kind, OutputKind::ToolProposal);
+        assert_eq!(out.tool_name.as_deref(), Some("exec"));
+        assert_eq!(
+            out.tool_arguments.expect("args")["command"],
+            "printf ok > /tmp/out"
+        );
+    }
+
+    #[test]
     fn normalize_worker_output_rescues_tool_calls_after_thinking_strip() {
         let raw =
             r#"<think>I should inspect the file first.</think>read_file({"path":"README.md"})"#;

--- a/crates/mesh-mixture-of-agents/src/reducer.rs
+++ b/crates/mesh-mixture-of-agents/src/reducer.rs
@@ -23,21 +23,18 @@ use std::time::Duration;
 /// running a stale binary that 502s on tool calls) doesn't take down
 /// the whole reducer step.
 pub(crate) fn reducer_candidates(config: &GatewayConfig) -> Vec<(String, usize)> {
-    let mut big = Vec::new();
-    let mut small = Vec::new();
-    for m in &config.models {
-        let entry = (m.name.clone(), m.backend_index);
-        if worker::is_single_digit_b_name(&m.name) {
-            small.push(entry);
-        } else {
-            big.push(entry);
-        }
-    }
-    big.extend(small);
+    let mut sorted = config.models.clone();
+    sorted.sort_by(worker::compare_model_strength);
+
+    // Strongest first, then progressively smaller/weaker fallbacks.
     // Intentionally allow returning empty: hedged_reducer_call's empty-input
     // path surfaces the right error. A fake ("unknown", 0) entry would call
     // backend_index=0 with a bogus model name and mask real bugs.
-    big
+    sorted
+        .into_iter()
+        .rev()
+        .map(|m| (m.name, m.backend_index))
+        .collect()
 }
 
 /// Successful hedged-reducer outcome.
@@ -255,6 +252,52 @@ mod tests {
     use async_trait::async_trait;
     use serde_json::json;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn test_config(models: Vec<crate::ModelEntry>) -> GatewayConfig {
+        GatewayConfig {
+            backends: Vec::new(),
+            models,
+            worker_timeout: Duration::from_secs(1),
+            hedge_delay: Duration::from_millis(10),
+            reducer_timeout: Duration::from_secs(1),
+            first_answer_grace: Duration::ZERO,
+            enable_thinking: None,
+        }
+    }
+
+    fn model(
+        name: &str,
+        backend_index: usize,
+        parameter_count_b: Option<f64>,
+    ) -> crate::ModelEntry {
+        crate::ModelEntry {
+            name: name.into(),
+            backend_index,
+            parameter_count_b,
+        }
+    }
+
+    #[test]
+    fn reducer_candidates_use_parameter_metadata_for_strength_order() {
+        let config = test_config(vec![
+            model("unknown-big-name", 0, None),
+            model("looks-70B-but-small", 1, Some(7.0)),
+            model("looks-7B-but-large", 2, Some(32.0)),
+            model("plain-70B", 3, Some(70.0)),
+        ]);
+
+        let candidates = reducer_candidates(&config);
+
+        assert_eq!(
+            candidates,
+            vec![
+                ("plain-70B".to_string(), 3),
+                ("looks-7B-but-large".to_string(), 2),
+                ("unknown-big-name".to_string(), 0),
+                ("looks-70B-but-small".to_string(), 1),
+            ]
+        );
+    }
 
     #[derive(Clone)]
     enum FakeBehavior {

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -151,9 +151,17 @@ impl Session {
                         .and_then(|c| c.as_str())
                         .unwrap_or("")
                         .to_string();
-                    if let Some(pending) =
-                        self.pending_tools.iter_mut().find(|p| p.call_id == call_id)
+                    if let Some(idx) = self
+                        .pending_tools
+                        .iter()
+                        .rposition(|p| p.call_id == call_id && p.result.is_none())
+                        .or_else(|| {
+                            self.pending_tools
+                                .iter()
+                                .rposition(|p| p.call_id == call_id)
+                        })
                     {
+                        let pending = &mut self.pending_tools[idx];
                         pending.result = Some(content);
                         tracing::info!(
                             "moa session: tool result received for {}({})",
@@ -408,6 +416,41 @@ mod tests {
             ])),
         );
         assert_eq!(s.tool_names(), vec!["read_file", "web_search"]);
+    }
+
+    #[test]
+    fn repeated_tool_call_ids_pair_with_latest_unresolved_call() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "first"}),
+                json!({
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_repeat",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"old\"}"}
+                    }]
+                }),
+                json!({"role": "tool", "tool_call_id": "call_repeat", "content": "old result"}),
+                json!({"role": "user", "content": "again"}),
+                json!({
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_repeat",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"new\"}"}
+                    }]
+                }),
+                json!({"role": "tool", "tool_call_id": "call_repeat", "content": "new result"}),
+            ],
+            &None,
+        );
+
+        let pending = s.pending_tool_calls();
+        assert_eq!(pending.len(), 2);
+        assert_eq!(pending[0].result.as_deref(), Some("old result"));
+        assert_eq!(pending[1].result.as_deref(), Some("new result"));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/session.rs
+++ b/crates/mesh-mixture-of-agents/src/session.rs
@@ -155,11 +155,6 @@ impl Session {
                         .pending_tools
                         .iter()
                         .rposition(|p| p.call_id == call_id && p.result.is_none())
-                        .or_else(|| {
-                            self.pending_tools
-                                .iter()
-                                .rposition(|p| p.call_id == call_id)
-                        })
                     {
                         let pending = &mut self.pending_tools[idx];
                         pending.result = Some(content);
@@ -234,6 +229,14 @@ impl Session {
             .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
             .and_then(extract_text_content)
             .unwrap_or_default()
+    }
+
+    /// The last user message in its original wire shape.
+    pub fn last_user_message(&self) -> Option<&Value> {
+        self.messages
+            .iter()
+            .rev()
+            .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
     }
 
     /// System prompt (first system message).
@@ -451,6 +454,31 @@ mod tests {
         assert_eq!(pending.len(), 2);
         assert_eq!(pending[0].result.as_deref(), Some("old result"));
         assert_eq!(pending[1].result.as_deref(), Some("new result"));
+    }
+
+    #[test]
+    fn duplicate_tool_result_id_does_not_overwrite_resolved_call() {
+        let mut s = Session::new();
+        s.ingest(
+            &[
+                json!({"role": "user", "content": "first"}),
+                json!({
+                    "role": "assistant",
+                    "tool_calls": [{
+                        "id": "call_repeat",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{\"path\":\"old\"}"}
+                    }]
+                }),
+                json!({"role": "tool", "tool_call_id": "call_repeat", "content": "old result"}),
+                json!({"role": "tool", "tool_call_id": "call_repeat", "content": "late duplicate"}),
+            ],
+            &None,
+        );
+
+        let pending = s.pending_tool_calls();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].result.as_deref(), Some("old result"));
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/worker.rs
+++ b/crates/mesh-mixture-of-agents/src/worker.rs
@@ -54,17 +54,18 @@ pub fn assign_roles(models: &[ModelEntry]) -> Vec<Assignment> {
 
     // Reorder by capacity tier so role assignment lines up with model
     // capability instead of arbitrary list order:
-    //   - "small tier"  = names advertising a single-digit billion-param
-    //                     count (1B-9B), e.g. Qwen3-8B, Qwen2.5-3B
-    //   - "big tier"    = everything else: multi-digit B (31B, 70B) or
-    //                     names that don't encode a size at all
-    //                     (MiniMax-M2.5, Coder-Next, fine-tune tags)
+    //   - "small tier"  = advertised <10B metadata, or names advertising
+    //                     a single-digit billion-param count (1B-9B)
+    //   - "big tier"    = advertised >=10B metadata, or names that don't
+    //                     encode a size at all (MiniMax-M2.5, Coder-Next,
+    //                     fine-tune tags)
     //
     // This mirrors the same heuristic `pick_model_classified` uses in the
     // main router so MoA's reducer/strong worker matches what `auto` would
-    // pick.
+    // pick. Within a tier, known parameter counts sort from smaller to
+    // larger so the strong/reducer role prefers the largest known model.
     let mut sorted: Vec<ModelEntry> = models.to_vec();
-    sorted.sort_by_key(|m| !is_single_digit_b_name(&m.name));
+    sorted.sort_by(compare_model_strength);
     // After sort: small-tier first, big-tier last. That way:
     //   first  = fast       (smallest model)
     //   middle = specialist
@@ -143,6 +144,36 @@ pub(crate) fn is_single_digit_b_name(name: &str) -> bool {
     false
 }
 
+fn compare_model_strength(left: &ModelEntry, right: &ModelEntry) -> std::cmp::Ordering {
+    let left_big = !is_small_parameter_model(left);
+    let right_big = !is_small_parameter_model(right);
+    left_big
+        .cmp(&right_big)
+        .then_with(|| model_strength_value(left).total_cmp(&model_strength_value(right)))
+        .then_with(|| left.name.cmp(&right.name))
+}
+
+fn is_small_parameter_model(model: &ModelEntry) -> bool {
+    model
+        .parameter_count_b
+        .filter(|count| count.is_finite())
+        .map(|count| count < 10.0)
+        .unwrap_or_else(|| is_single_digit_b_name(&model.name))
+}
+
+fn model_strength_value(model: &ModelEntry) -> f64 {
+    model
+        .parameter_count_b
+        .filter(|count| count.is_finite() && *count > 0.0)
+        .unwrap_or_else(|| {
+            if is_single_digit_b_name(&model.name) {
+                9.0
+            } else {
+                10.0
+            }
+        })
+}
+
 /// Truncate `text` so the returned slice is at most `max_bytes` long,
 /// honouring UTF-8 char boundaries (never panics, unlike `&text[..N]`).
 pub fn truncate_chars(text: &str, max_bytes: usize) -> &str {
@@ -209,6 +240,14 @@ pub fn extract_thinking(text: &str) -> String {
 mod tests {
     use super::*;
 
+    fn model(name: &str, backend_index: usize, parameter_count_b: Option<f64>) -> ModelEntry {
+        ModelEntry {
+            name: name.into(),
+            backend_index,
+            parameter_count_b,
+        }
+    }
+
     #[test]
     fn truncate_chars_shorter_than_limit_is_passthrough() {
         assert_eq!(truncate_chars("hello", 100), "hello");
@@ -244,16 +283,7 @@ mod tests {
 
     #[test]
     fn assign_two_models() {
-        let models = vec![
-            ModelEntry {
-                name: "small".into(),
-                backend_index: 0,
-            },
-            ModelEntry {
-                name: "big".into(),
-                backend_index: 1,
-            },
-        ];
+        let models = vec![model("small", 0, None), model("big", 1, None)];
         let assignments = assign_roles(&models);
         assert_eq!(assignments.len(), 2);
         assert_eq!(assignments[0].role, WorkerRole::Fast);
@@ -263,18 +293,9 @@ mod tests {
     #[test]
     fn assign_three_models() {
         let models = vec![
-            ModelEntry {
-                name: "small".into(),
-                backend_index: 0,
-            },
-            ModelEntry {
-                name: "mid".into(),
-                backend_index: 1,
-            },
-            ModelEntry {
-                name: "big".into(),
-                backend_index: 2,
-            },
+            model("small", 0, None),
+            model("mid", 1, None),
+            model("big", 2, None),
         ];
         let assignments = assign_roles(&models);
         assert_eq!(assignments.len(), 3);
@@ -289,22 +310,10 @@ mod tests {
         // MiniMax (no digit) and Qwen3-32B (multi-digit) belong in the
         // big tier; Qwen2.5-3B and Qwen3-8B belong in the small tier.
         let models = vec![
-            ModelEntry {
-                name: "MiniMax-M2.5".into(),
-                backend_index: 0,
-            },
-            ModelEntry {
-                name: "unsloth/Qwen3-32B-GGUF:Q4_K_M".into(),
-                backend_index: 1,
-            },
-            ModelEntry {
-                name: "Qwen3-8B".into(),
-                backend_index: 2,
-            },
-            ModelEntry {
-                name: "Qwen2.5-3B".into(),
-                backend_index: 3,
-            },
+            model("MiniMax-M2.5", 0, None),
+            model("unsloth/Qwen3-32B-GGUF:Q4_K_M", 1, None),
+            model("Qwen3-8B", 2, None),
+            model("Qwen2.5-3B", 3, None),
         ];
         let assignments = assign_roles(&models);
         assert_eq!(assignments.len(), 4);
@@ -322,6 +331,38 @@ mod tests {
             "strong should be big-tier, got {}",
             assignments[3].model_name
         );
+    }
+
+    #[test]
+    fn assign_roles_prefers_largest_known_model_as_strong() {
+        let models = vec![
+            model("unknown-big-name", 0, None),
+            model("misleading-7B-name", 1, Some(32.0)),
+            model("plain-70B", 2, Some(70.0)),
+            model("Qwen3-8B", 3, Some(8.0)),
+        ];
+
+        let assignments = assign_roles(&models);
+
+        assert_eq!(assignments[0].role, WorkerRole::Fast);
+        assert_eq!(assignments[0].model_name, "Qwen3-8B");
+        assert_eq!(assignments[3].role, WorkerRole::Strong);
+        assert_eq!(assignments[3].model_name, "plain-70B");
+    }
+
+    #[test]
+    fn advertised_parameters_override_name_size_tier() {
+        let models = vec![
+            model("looks-70B-but-small", 0, Some(7.0)),
+            model("looks-7B-but-large", 1, Some(32.0)),
+        ];
+
+        let assignments = assign_roles(&models);
+
+        assert_eq!(assignments[0].role, WorkerRole::Fast);
+        assert_eq!(assignments[0].model_name, "looks-70B-but-small");
+        assert_eq!(assignments[1].role, WorkerRole::Strong);
+        assert_eq!(assignments[1].model_name, "looks-7B-but-large");
     }
 
     #[test]

--- a/crates/mesh-mixture-of-agents/src/worker.rs
+++ b/crates/mesh-mixture-of-agents/src/worker.rs
@@ -144,7 +144,7 @@ pub(crate) fn is_single_digit_b_name(name: &str) -> bool {
     false
 }
 
-fn compare_model_strength(left: &ModelEntry, right: &ModelEntry) -> std::cmp::Ordering {
+pub(crate) fn compare_model_strength(left: &ModelEntry, right: &ModelEntry) -> std::cmp::Ordering {
     let left_big = !is_small_parameter_model(left);
     let right_big = !is_small_parameter_model(right);
     left_big

--- a/crates/mesh-mixture-of-agents/tests/sim_all_workers_fail.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_all_workers_fail.rs
@@ -74,14 +74,17 @@ fn three_failing_backends() -> moa::GatewayConfig {
         moa::ModelEntry {
             name: "alpha-3b".into(),
             backend_index: 0,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "beta-13b".into(),
             backend_index: 1,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "gamma-32b".into(),
             backend_index: 2,
+            parameter_count_b: None,
         },
     ];
 

--- a/crates/mesh-mixture-of-agents/tests/sim_enable_thinking_propagation.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_enable_thinking_propagation.rs
@@ -86,14 +86,17 @@ fn build_config(
             moa::ModelEntry {
                 name: "test-fast".into(),
                 backend_index: 0,
+                parameter_count_b: None,
             },
             moa::ModelEntry {
                 name: "test-specialist".into(),
                 backend_index: 0,
+                parameter_count_b: None,
             },
             moa::ModelEntry {
                 name: "test-strong".into(),
                 backend_index: 0,
+                parameter_count_b: None,
             },
         ],
         worker_timeout: Duration::from_secs(5),

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_call_text_not_passed_as_content.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_call_text_not_passed_as_content.rs
@@ -74,14 +74,17 @@ fn config_with_three_workers_returning(text: &str) -> moa::GatewayConfig {
         moa::ModelEntry {
             name: "worker-a-3b".into(),
             backend_index: 0,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "worker-b-13b".into(),
             backend_index: 1,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "worker-c-32b".into(),
             backend_index: 2,
+            parameter_count_b: None,
         },
     ];
 

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -122,6 +122,92 @@ fn config_with_three_recording_workers() -> (
     (config, fast, mid, strong)
 }
 
+struct ReducerFailWorkerToolBackend {
+    calls: AtomicUsize,
+    reducer_calls: AtomicUsize,
+    worker_calls: AtomicUsize,
+}
+
+impl ReducerFailWorkerToolBackend {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls: AtomicUsize::new(0),
+            reducer_calls: AtomicUsize::new(0),
+            worker_calls: AtomicUsize::new(0),
+        })
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn reducer_calls(&self) -> usize {
+        self.reducer_calls.load(Ordering::SeqCst)
+    }
+
+    fn worker_calls(&self) -> usize {
+        self.worker_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl moa::ModelBackend for ReducerFailWorkerToolBackend {
+    async fn chat_completion(
+        &self,
+        _model: &str,
+        _messages: &[Value],
+        _tools: Option<&Value>,
+        _max_tokens: u32,
+        _timeout: Duration,
+        sampling: moa::SamplingParams,
+    ) -> Result<Value, String> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        if sampling.temperature < 0.5 {
+            self.reducer_calls.fetch_add(1, Ordering::SeqCst);
+            return Err("remote timeout after 60s".to_string());
+        }
+
+        self.worker_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(json!({
+            "choices": [{
+                "message": {
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_shell",
+                        "type": "function",
+                        "function": {
+                            "name": "shell",
+                            "arguments": "{\"command\":\"cat facts/signal.md\"}"
+                        }
+                    }]
+                }
+            }]
+        }))
+    }
+}
+
+fn config_with_reducer_fail_worker_tool() -> (moa::GatewayConfig, Arc<ReducerFailWorkerToolBackend>)
+{
+    let backend = ReducerFailWorkerToolBackend::new();
+    let backends: Vec<Arc<dyn moa::ModelBackend>> = vec![backend.clone()];
+    let models = vec![moa::ModelEntry {
+        name: "agent-13b".into(),
+        backend_index: 0,
+        parameter_count_b: Some(13.0),
+    }];
+
+    let config = moa::GatewayConfig {
+        backends,
+        models,
+        worker_timeout: Duration::from_secs(2),
+        hedge_delay: Duration::from_millis(5),
+        reducer_timeout: Duration::from_secs(2),
+        first_answer_grace: Duration::ZERO,
+        enable_thinking: None,
+    };
+    (config, backend)
+}
+
 fn read_file_tool() -> Value {
     json!([{
         "type": "function",
@@ -135,6 +221,35 @@ fn read_file_tool() -> Value {
             }
         }
     }])
+}
+
+fn shell_and_tree_tools() -> Value {
+    json!([
+        {
+            "type": "function",
+            "function": {
+                "name": "tree",
+                "description": "List files",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"path": {"type": "string"}},
+                    "required": ["path"],
+                }
+            }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "shell",
+                "description": "Run a shell command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"command": {"type": "string"}},
+                    "required": ["command"],
+                }
+            }
+        }
+    ])
 }
 
 #[tokio::test]
@@ -246,6 +361,48 @@ async fn trailing_user_after_unsynthesised_tool_result_classifies_as_tool_result
         mid.calls(),
         strong.calls()
     );
+}
+
+#[tokio::test]
+async fn tool_result_reducer_timeout_recovers_with_worker_tool_call() {
+    // Live Goose regression: a mesh peer can time out every reducer candidate
+    // on a tool-result turn. MoA should make one compact recovery fanout and
+    // return a usable tool call instead of surfacing the timeout to the agent.
+    let (config, backend) = config_with_reducer_fail_worker_tool();
+
+    let body = json!({
+        "model": "mesh",
+        "tools": shell_and_tree_tools(),
+        "messages": [
+            {"role": "user", "content": "Inspect the repository, read files, edit src/smoke_calc.py, and run the tests."},
+            {
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_tree",
+                    "type": "function",
+                    "function": {"name": "tree", "arguments": "{\"path\":\".\"}"}
+                }]
+            },
+            {"role": "tool", "tool_call_id": "call_tree", "content": "facts/\n  signal.md\nsrc/\n  smoke_calc.py\n"},
+        ],
+        "max_tokens": 64,
+    });
+
+    let result = moa::handle_turn(&config, &body).await;
+
+    assert_eq!(result.turn_kind, moa::TurnKind::ToolResult);
+    assert!(result.reducer_used);
+    assert_eq!(result.reducer_attempts, 1);
+    assert_eq!(backend.reducer_calls(), 1);
+    assert_eq!(backend.worker_calls(), 1);
+    assert_eq!(backend.calls(), 2);
+
+    let tool_name = result
+        .response_body
+        .pointer("/choices/0/message/tool_calls/0/function/name")
+        .and_then(Value::as_str);
+    assert_eq!(tool_name, Some("shell"));
 }
 
 #[tokio::test]

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -162,6 +162,9 @@ impl moa::ModelBackend for ReducerFailWorkerToolBackend {
         sampling: moa::SamplingParams,
     ) -> Result<Value, String> {
         self.calls.fetch_add(1, Ordering::SeqCst);
+        // Test double: reducer calls use low-temperature sampling, while
+        // worker calls use a higher temperature. Treat low-temperature calls
+        // as reducer timeouts so recovery can be exercised deterministically.
         if sampling.temperature < 0.5 {
             self.reducer_calls.fetch_add(1, Ordering::SeqCst);
             return Err("remote timeout after 60s".to_string());

--- a/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_tool_result_routes_to_reducer.rs
@@ -96,14 +96,17 @@ fn config_with_three_recording_workers() -> (
         moa::ModelEntry {
             name: "fast-3b".into(),
             backend_index: 0,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "mid-13b".into(),
             backend_index: 1,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "strong-32b".into(),
             backend_index: 2,
+            parameter_count_b: None,
         },
     ];
 

--- a/crates/mesh-mixture-of-agents/tests/sim_worker_accounting.rs
+++ b/crates/mesh-mixture-of-agents/tests/sim_worker_accounting.rs
@@ -88,10 +88,12 @@ fn four_workers_two_fast_consensus() -> moa::GatewayConfig {
         moa::ModelEntry {
             name: "fast-a-3b".into(),
             backend_index: 0,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "fast-b-3b".into(),
             backend_index: 1,
+            parameter_count_b: None,
         },
         // The two big-tier models — one of them will be picked as
         // `Strong`. They are deliberately slow so the early-exit path
@@ -99,10 +101,12 @@ fn four_workers_two_fast_consensus() -> moa::GatewayConfig {
         moa::ModelEntry {
             name: "slow-a-32b".into(),
             backend_index: 2,
+            parameter_count_b: None,
         },
         moa::ModelEntry {
             name: "slow-b-32b".into(),
             backend_index: 3,
+            parameter_count_b: None,
         },
     ];
 

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -445,11 +445,19 @@ fn translate_responses_conversation_item(item: &Value) -> Result<Value, OpenAiEr
     }
 }
 
+fn translate_responses_standalone_input_item(item: &Value) -> Result<Value, OpenAiError> {
+    let content = translate_responses_message_content(item)?;
+    Ok(serde_json::json!({
+        "role": "user",
+        "content": content,
+    }))
+}
+
 fn translate_responses_function_call_item(
     object: &Map<String, Value>,
 ) -> Result<Value, OpenAiError> {
-    let call_id = non_empty_response_string(object, &["call_id", "tool_call_id", "id"])
-        .ok_or_else(|| {
+    let call_id =
+        non_empty_response_string(object, &["call_id", "tool_call_id"]).ok_or_else(|| {
             OpenAiError::invalid_request("responses function_call is missing call_id")
         })?;
     let name = non_empty_response_string(object, &["name"]).ok_or_else(|| {
@@ -518,7 +526,13 @@ fn translate_responses_input_to_messages(input: &Value) -> Result<Vec<Value>, Op
             if items.iter().any(responses_input_item_is_conversation_item) {
                 items
                     .iter()
-                    .map(translate_responses_conversation_item)
+                    .map(|item| {
+                        if responses_input_item_is_conversation_item(item) {
+                            translate_responses_conversation_item(item)
+                        } else {
+                            translate_responses_standalone_input_item(item)
+                        }
+                    })
                     .collect()
             } else {
                 let content = translate_responses_message_content(input)?;
@@ -1540,6 +1554,32 @@ mod tests {
     }
 
     #[test]
+    fn normalize_responses_function_call_requires_call_id_not_item_id() {
+        let mut body = json!({
+            "model": "qwen",
+            "input": [
+                {"role": "user", "content": "look up the codeword"},
+                {
+                    "type": "function_call",
+                    "id": "item_call_123",
+                    "name": "lookup_fixture_fact",
+                    "arguments": "{\"key\":\"codeword\"}"
+                }
+            ]
+        });
+
+        let err = normalize_openai_compat_request("/v1/responses", &mut body)
+            .expect_err("item id must not be treated as a function call id");
+
+        assert_eq!(err.status().as_u16(), 400);
+        assert!(
+            err.to_string().contains("missing call_id"),
+            "unexpected error: {err}",
+        );
+        assert!(body.get("messages").is_none());
+    }
+
+    #[test]
     fn normalize_responses_tool_result_requires_call_id_not_item_id() {
         let mut body = json!({
             "model": "qwen",
@@ -1562,6 +1602,30 @@ mod tests {
             "unexpected error: {err}",
         );
         assert!(body.get("messages").is_none());
+    }
+
+    #[test]
+    fn normalize_responses_preserves_plain_blocks_in_mixed_input_arrays() {
+        let mut body = json!({
+            "model": "qwen",
+            "input": [
+                {"role": "user", "content": "first turn"},
+                {"type": "input_text", "text": "plain follow-up block"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_lookup",
+                    "name": "lookup_fixture_fact",
+                    "arguments": "{\"key\":\"codeword\"}"
+                }
+            ]
+        });
+        normalize_openai_compat_request("/v1/responses", &mut body).unwrap();
+
+        let messages = body["messages"].as_array().expect("messages");
+        assert_eq!(messages[0]["content"], "first turn");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[1]["content"], "plain follow-up block");
+        assert_eq!(messages[2]["tool_calls"][0]["id"], "call_lookup");
     }
 
     #[test]

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -292,7 +292,7 @@ fn translate_responses_content_item(item: &Value) -> Result<Value, OpenAiError> 
     let item_type = object.get("type").and_then(Value::as_str).unwrap_or("text");
 
     match item_type {
-        "input_text" | "text" => {
+        "input_text" | "output_text" | "text" => {
             let text = object
                 .get("text")
                 .and_then(Value::as_str)
@@ -1431,6 +1431,21 @@ mod tests {
         assert_eq!(body["messages"][0]["role"], "system");
         assert_eq!(body["messages"][1]["role"], "user");
         assert_eq!(body["messages"][1]["content"], "hello");
+    }
+
+    #[test]
+    fn normalize_responses_accepts_output_text_input_blocks() {
+        let mut body = json!({
+            "model": "qwen",
+            "input": [{
+                "role": "user",
+                "content": [{"type": "output_text", "text": "retry this request"}]
+            }]
+        });
+        normalize_openai_compat_request("/v1/responses", &mut body).unwrap();
+
+        assert_eq!(body["messages"][0]["role"], "user");
+        assert_eq!(body["messages"][0]["content"], "retry this request");
     }
 
     #[test]

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -418,6 +418,96 @@ fn translate_responses_input_message(message: &Value) -> Result<Map<String, Valu
     ]))
 }
 
+fn responses_input_item_is_conversation_item(item: &Value) -> bool {
+    let Some(object) = item.as_object() else {
+        return false;
+    };
+    object.contains_key("role")
+        || object.contains_key("content")
+        || matches!(
+            object.get("type").and_then(Value::as_str),
+            Some("function_call" | "function_call_output" | "tool_call_output" | "tool_result")
+        )
+}
+
+fn translate_responses_conversation_item(item: &Value) -> Result<Value, OpenAiError> {
+    let Some(object) = item.as_object() else {
+        return Err(OpenAiError::unsupported(
+            "unsupported /v1/responses conversation item shape",
+        ));
+    };
+    match object.get("type").and_then(Value::as_str) {
+        Some("function_call") => translate_responses_function_call_item(object),
+        Some("function_call_output" | "tool_call_output" | "tool_result") => {
+            translate_responses_tool_result_item(object)
+        }
+        _ => translate_responses_input_message(item).map(Value::Object),
+    }
+}
+
+fn translate_responses_function_call_item(
+    object: &Map<String, Value>,
+) -> Result<Value, OpenAiError> {
+    let call_id = non_empty_response_string(object, &["call_id", "tool_call_id", "id"])
+        .ok_or_else(|| {
+            OpenAiError::invalid_request("responses function_call is missing call_id")
+        })?;
+    let name = non_empty_response_string(object, &["name"]).ok_or_else(|| {
+        OpenAiError::invalid_request("responses function_call is missing function name")
+    })?;
+    let arguments = response_item_text_field(object, &["arguments"]).unwrap_or_default();
+
+    Ok(serde_json::json!({
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{
+            "id": call_id,
+            "type": "function",
+            "function": {
+                "name": name,
+                "arguments": arguments,
+            },
+        }],
+    }))
+}
+
+fn translate_responses_tool_result_item(object: &Map<String, Value>) -> Result<Value, OpenAiError> {
+    let call_id = non_empty_response_string(object, &["call_id", "tool_call_id", "id"])
+        .ok_or_else(|| {
+            OpenAiError::invalid_request("responses function_call_output is missing call_id")
+        })?;
+    let content =
+        response_item_text_field(object, &["output", "content", "text"]).unwrap_or_default();
+
+    Ok(serde_json::json!({
+        "role": "tool",
+        "tool_call_id": call_id,
+        "content": content,
+    }))
+}
+
+fn non_empty_response_string(object: &Map<String, Value>, fields: &[&str]) -> Option<String> {
+    fields.iter().find_map(|field| {
+        object
+            .get(*field)
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn response_item_text_field(object: &Map<String, Value>, fields: &[&str]) -> Option<String> {
+    fields.iter().find_map(|field| {
+        let value = object.get(*field)?;
+        value.as_str().map(ToOwned::to_owned).or_else(|| {
+            serde_json::to_string(value)
+                .ok()
+                .filter(|text| !text.is_empty())
+        })
+    })
+}
+
 fn translate_responses_input_to_messages(input: &Value) -> Result<Vec<Value>, OpenAiError> {
     match input {
         Value::String(text) => Ok(vec![serde_json::json!({
@@ -425,16 +515,10 @@ fn translate_responses_input_to_messages(input: &Value) -> Result<Vec<Value>, Op
             "content": text,
         })]),
         Value::Array(items) => {
-            let looks_like_messages = items.iter().all(|item| {
-                item.as_object()
-                    .map(|object| object.contains_key("role") || object.contains_key("content"))
-                    .unwrap_or(false)
-            });
-            if looks_like_messages {
+            if items.iter().any(responses_input_item_is_conversation_item) {
                 items
                     .iter()
-                    .map(translate_responses_input_message)
-                    .map(|result| result.map(Value::Object))
+                    .map(translate_responses_conversation_item)
                     .collect()
             } else {
                 let content = translate_responses_message_content(input)?;
@@ -524,6 +608,74 @@ fn translate_openai_responses_input(object: &mut Map<String, Value>) -> Result<b
     Ok(changed)
 }
 
+fn normalize_responses_tool_shapes(object: &mut Map<String, Value>) -> bool {
+    let mut changed = false;
+
+    if let Some(Value::Array(tools)) = object.get_mut("tools") {
+        for tool in tools {
+            if let Some(normalized) = responses_function_tool_to_chat_shape(tool) {
+                *tool = Value::Object(normalized);
+                changed = true;
+            }
+        }
+    }
+
+    if let Some(tool_choice) = object.get_mut("tool_choice")
+        && let Some(normalized) = responses_function_tool_choice_to_chat_shape(tool_choice)
+    {
+        *tool_choice = normalized;
+        changed = true;
+    }
+
+    changed
+}
+
+fn responses_function_tool_to_chat_shape(tool: &Value) -> Option<Map<String, Value>> {
+    let object = tool.as_object()?;
+    if object.contains_key("function")
+        || object.get("type").and_then(Value::as_str) != Some("function")
+    {
+        return None;
+    }
+    let name = object.get("name").and_then(Value::as_str)?;
+    if name.trim().is_empty() {
+        return None;
+    }
+
+    let mut outer = object.clone();
+    let mut function = Map::new();
+    for key in ["name", "description", "parameters", "strict"] {
+        if let Some(value) = outer.remove(key) {
+            function.insert(key.to_string(), value);
+        }
+    }
+    outer.insert("function".to_string(), Value::Object(function));
+    Some(outer)
+}
+
+fn responses_function_tool_choice_to_chat_shape(tool_choice: &Value) -> Option<Value> {
+    let object = tool_choice.as_object()?;
+    if object.contains_key("function")
+        || object.get("type").and_then(Value::as_str) != Some("function")
+    {
+        return None;
+    }
+    let name = object.get("name").and_then(Value::as_str)?;
+    if name.trim().is_empty() {
+        return None;
+    }
+
+    let mut outer = object.clone();
+    outer.remove("name");
+    outer.insert(
+        "function".to_string(),
+        serde_json::json!({
+            "name": name,
+        }),
+    );
+    Some(Value::Object(outer))
+}
+
 fn responses_conversation_cache_key(value: &Value) -> Option<String> {
     if let Some(id) = value.as_str() {
         return Some(id.to_string());
@@ -560,6 +712,7 @@ pub fn normalize_openai_compat_request(
             .and_then(Value::as_bool)
             .unwrap_or(false);
         changed |= translate_openai_responses_input(object)?;
+        changed |= normalize_responses_tool_shapes(object);
         rewritten_path = Some(rewrite_path_preserving_query(path, "/v1/chat/completions"));
         response_adapter = if is_stream {
             ResponseAdapterMode::OpenAiResponsesStream
@@ -1300,6 +1453,75 @@ mod tests {
         assert_eq!(body["response_format"]["type"], "json_schema");
         assert_eq!(body["logprobs"], true);
         assert_eq!(body["top_logprobs"], 3);
+    }
+
+    #[test]
+    fn normalize_responses_converts_function_tools_to_chat_shape() {
+        let mut body = json!({
+            "model": "qwen",
+            "input": "call a tool",
+            "tools": [{
+                "type": "function",
+                "name": "lookup",
+                "description": "Lookup a key",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"key": {"type": "string"}},
+                    "required": ["key"]
+                },
+                "strict": true
+            }],
+            "tool_choice": {"type": "function", "name": "lookup"}
+        });
+        normalize_openai_compat_request("/v1/responses", &mut body).unwrap();
+
+        assert_eq!(body["tools"][0]["type"], "function");
+        assert_eq!(body["tools"][0]["function"]["name"], "lookup");
+        assert_eq!(body["tools"][0]["function"]["description"], "Lookup a key");
+        assert_eq!(body["tools"][0]["function"]["parameters"]["type"], "object");
+        assert_eq!(body["tools"][0]["function"]["strict"], true);
+        assert!(body["tools"][0].get("name").is_none());
+        assert_eq!(body["tool_choice"]["type"], "function");
+        assert_eq!(body["tool_choice"]["function"]["name"], "lookup");
+        assert!(body["tool_choice"].get("name").is_none());
+    }
+
+    #[test]
+    fn normalize_responses_converts_function_call_outputs_to_chat_tool_messages() {
+        let mut body = json!({
+            "model": "qwen",
+            "input": [
+                {"role": "user", "content": "look up the codeword"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_lookup",
+                    "name": "lookup_fixture_fact",
+                    "arguments": "{\"key\":\"codeword\"}"
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_lookup",
+                    "output": "{\"value\":\"signal-7429\"}"
+                }
+            ]
+        });
+        normalize_openai_compat_request("/v1/responses", &mut body).unwrap();
+
+        let messages = body["messages"].as_array().expect("messages");
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[1]["tool_calls"][0]["id"], "call_lookup");
+        assert_eq!(
+            messages[1]["tool_calls"][0]["function"]["name"],
+            "lookup_fixture_fact"
+        );
+        assert_eq!(
+            messages[1]["tool_calls"][0]["function"]["arguments"],
+            "{\"key\":\"codeword\"}"
+        );
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "call_lookup");
+        assert_eq!(messages[2]["content"], "{\"value\":\"signal-7429\"}");
     }
 
     #[test]

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -472,8 +472,8 @@ fn translate_responses_function_call_item(
 }
 
 fn translate_responses_tool_result_item(object: &Map<String, Value>) -> Result<Value, OpenAiError> {
-    let call_id = non_empty_response_string(object, &["call_id", "tool_call_id", "id"])
-        .ok_or_else(|| {
+    let call_id =
+        non_empty_response_string(object, &["call_id", "tool_call_id"]).ok_or_else(|| {
             OpenAiError::invalid_request("responses function_call_output is missing call_id")
         })?;
     let content =
@@ -1522,6 +1522,31 @@ mod tests {
         assert_eq!(messages[2]["role"], "tool");
         assert_eq!(messages[2]["tool_call_id"], "call_lookup");
         assert_eq!(messages[2]["content"], "{\"value\":\"signal-7429\"}");
+    }
+
+    #[test]
+    fn normalize_responses_tool_result_requires_call_id_not_item_id() {
+        let mut body = json!({
+            "model": "qwen",
+            "input": [
+                {"role": "user", "content": "look up the codeword"},
+                {
+                    "type": "function_call_output",
+                    "id": "item_output_123",
+                    "output": "{\"value\":\"signal-7429\"}"
+                }
+            ]
+        });
+
+        let err = normalize_openai_compat_request("/v1/responses", &mut body)
+            .expect_err("item id must not be treated as a tool call id");
+
+        assert_eq!(err.status().as_u16(), 400);
+        assert!(
+            err.to_string().contains("missing call_id"),
+            "unexpected error: {err}",
+        );
+        assert!(body.get("messages").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This stabilizes the `mesh` MoA virtual model for agent clients without copying the old oversized branch:

- Advertise real context for public aliases and for virtual `mesh`, and filter MoA workers by required context with a small fallback only for unknown tiny prompts.
- Preserve recent same-chat context in MoA worker/reducer prompts so a follow-up question can refer to earlier turns in the same conversation.
- Normalize Responses API tools and function-call outputs into chat shape, and emit proper Responses SSE lifecycle events for both text and function-call streams.
- Harden MoA tool loops around malformed/empty native tool calls, repeated tool IDs, repeated same-tool repair, and disabled-tools output.
- Bias MoA strong/reducer role assignment toward larger known models using existing advertised `parameter_count_b` metadata after context eligibility.
- Update recommended small auto packs toward Gemma-4-E4B and fix mobile console double-tap behavior.

## Protocol

No mesh wire/protobuf schema change. This consumes existing served model descriptors/runtime context metadata and keeps mixed-version gossip additive.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mesh-mixture-of-agents --all-targets`
- `cargo test -p openai-frontend --lib`
- `cargo test -p mesh-llm-host-runtime --lib` (`1448 passed, 0 failed, 8 ignored`)
- `cargo clippy -p openai-frontend -p mesh-mixture-of-agents -p mesh-llm-host-runtime -p mesh-llm-client -p mesh-llm-node -p mesh-llm --all-targets -- -D warnings`
- `pnpm run typecheck`
- `pnpm test -- src/features/chat/api/use-chat.test.tsx`
- `pnpm exec prettier --check src/components/ui/tooltip.tsx src/features/chat/api/use-chat.ts src/features/chat/api/use-chat.test.tsx src/features/chat/components/composer/ChatComposer.tsx`
- `pnpm exec eslint src/components/ui/tooltip.tsx src/features/chat/api/use-chat.ts src/features/chat/api/use-chat.test.tsx src/features/chat/components/composer/ChatComposer.tsx --max-warnings=0`
- `just build`

Live validation against rebuilt `./target/debug/mesh-llm serve` with local Qwen3-4B-128K + Gemma-4-E4B:

- `/v1/models` advertises both concrete models at `context_length: 131072` and virtual `mesh` at `context_length: 131072`; concrete metadata includes `parameter_count_b` (`4.0`, `7.5`).
- Console `/api/responses` same-chat Windows/Tailscale follow-up returned the earlier same-chat phrase in both non-streaming and streaming modes.
- Direct `/v1/responses` emitted a native `function_call`, accepted `function_call_output`, and returned `signal-7429`; streaming tool calls emitted `response.function_call_arguments.*` lifecycle events.
- `python3 scripts/qa-agent-tool-call-reliability.py --base-url http://127.0.0.1:9337/v1 --models mesh --attempts 3 --output target/agent-tool-call-reliability/m4-final-after-bias/results.jsonl` passed `12/12` phases.
- Goose: `GOOSE_PROVIDER=openai OPENAI_HOST=http://127.0.0.1:9337 OPENAI_API_KEY=mesh GOOSE_MODEL=mesh goose run ...` called shell once and returned `moa-goose-ok`.
- OpenClaw on mini via reverse SSH tunnel:
  - Plain Responses path returned `moa-claw-ok`, with `contextTokens: 131072`.
  - Exec-tool path made one `exec` call, zero failures, and returned `moa-claw-tool-ok`, with `contextTokens: 131072`.

UI note: the console change is behavioral for touch/pointer handling and conversation reset timing; no visual layout changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gemma-4-E4B model added to catalogs and selected as the mid‑tier default (8–24GB).
  * Responses API: richer streaming lifecycle events and deterministic progress-then-keepalive behavior.

* **Bug Fixes**
  * Improved context discovery for public model aliases.
  * Prevented late tool-result overwrites; chat state resets correctly when switching conversations.

* **Improvements**
  * MOA context reserve for tool usage; parallel tool calls disabled when tools present.
  * Role assignment now uses advertised parameter counts; broader tool-call parsing/rescue.

* **Tests**
  * Expanded unit and integration coverage for new behaviors and regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->