### PR TITLE
Salvage safe bits from reverted MoA PR (#820)

### DIFF
--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -40,6 +40,19 @@
     "mmproj": null
   },
   {
+    "name": "Gemma-4-E4B-it-Q4_K_M",
+    "file": "gemma-4-E4B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
+    "size": "4.6GB",
+    "description": "Gemma 4 E4B instruction model, strong mini-class default",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+    }
+  },
+  {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
     "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
     "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",

--- a/crates/mesh-client/src/network/nostr.rs
+++ b/crates/mesh-client/src/network/nostr.rs
@@ -445,7 +445,7 @@ pub fn auto_model_pack(vram_gb: f64) -> Vec<String> {
         },
         Pack {
             min_vram: 8.0,
-            models: &["Qwen3-8B-Q4_K_M"],
+            models: &["Gemma-4-E4B-it-Q4_K_M"],
         },
         Pack {
             min_vram: 0.0,
@@ -510,13 +510,13 @@ mod auto_pack_tests {
     #[test]
     fn pack_8gb_single_model() {
         let pack = auto_model_pack(8.0);
-        assert_eq!(pack, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(pack, vec!["Gemma-4-E4B-it-Q4_K_M"]);
     }
 
     #[test]
     fn pack_16gb_single() {
         let pack = auto_model_pack(16.0);
-        assert_eq!(pack, vec!["Qwen3-8B-Q4_K_M"]);
+        assert_eq!(pack, vec!["Gemma-4-E4B-it-Q4_K_M"]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -1852,6 +1852,24 @@ impl PeerInfo {
     }
 
     pub fn advertised_context_length(&self, model: &str) -> Option<u32> {
+        self.advertised_context_length_for_runtime_model(model)
+            .or_else(|| {
+                self.served_model_descriptors
+                    .iter()
+                    .filter(|descriptor| {
+                        let runtime_name = descriptor.identity.model_name.as_str();
+                        runtime_name != model
+                            && self.public_model_id_for_routable_model(runtime_name) == model
+                    })
+                    .find_map(|descriptor| {
+                        self.advertised_context_length_for_runtime_model(
+                            &descriptor.identity.model_name,
+                        )
+                    })
+            })
+    }
+
+    fn advertised_context_length_for_runtime_model(&self, model: &str) -> Option<u32> {
         self.served_model_runtime
             .iter()
             .find(|runtime| runtime.model_name == model)

--- a/crates/mesh-llm-host-runtime/src/network/nostr.rs
+++ b/crates/mesh-llm-host-runtime/src/network/nostr.rs
@@ -1242,7 +1242,7 @@ fn model_tiers() -> Vec<(String, f64)> {
 ///
 /// Tiers:
 ///   <8GB:    Qwen3-4B (2.5G)
-///   8-24GB:  Qwen3-8B (5G)
+///   8-24GB:  Gemma-4-E4B-it (4.6G)
 ///   24-50GB: Qwen3.5-27B (17G) — vision + text
 ///   50-63GB: GLM-4.7-Flash (18G) — fast, tool calling
 ///   63-179GB: Qwen3-Coder-Next (48G) — frontier coder ~85B
@@ -1294,7 +1294,7 @@ pub fn auto_model_pack(vram_gb: f64) -> Vec<String> {
         },
         Pack {
             min_vram: 8.0,
-            models: vec![catalog_ref("Qwen3-8B-Q4_K_M")],
+            models: vec![catalog_ref("Gemma-4-E4B-it-Q4_K_M")],
         },
         Pack {
             min_vram: 0.0,
@@ -1408,13 +1408,13 @@ mod auto_pack_tests {
     #[test]
     fn pack_8gb_single_model() {
         let pack = auto_model_pack(8.0);
-        assert_single_pack_model(&pack, "Qwen3-8B-Q4_K_M");
+        assert_single_pack_model(&pack, "Gemma-4-E4B-it-Q4_K_M");
     }
 
     #[test]
     fn pack_16gb_single() {
         let pack = auto_model_pack(16.0);
-        assert_single_pack_model(&pack, "Qwen3-8B-Q4_K_M");
+        assert_single_pack_model(&pack, "Gemma-4-E4B-it-Q4_K_M");
     }
 
     #[test]

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -40,6 +40,19 @@
     "mmproj": null
   },
   {
+    "name": "Gemma-4-E4B-it-Q4_K_M",
+    "file": "gemma-4-E4B-it-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
+    "size": "4.6GB",
+    "description": "Gemma 4 E4B instruction model, strong mini-class default",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-F16.gguf",
+      "url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/mmproj-F16.gguf"
+    }
+  },
+  {
     "name": "Qwen2.5-Coder-7B-Instruct-Q4_K_M",
     "file": "Qwen2.5-Coder-7B-Instruct-Q4_K_M.gguf",
     "url": "https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF/resolve/main/qwen2.5-coder-7b-instruct-q4_k_m.gguf",

--- a/crates/mesh-llm-ui/src/components/ui/tooltip.tsx
+++ b/crates/mesh-llm-ui/src/components/ui/tooltip.tsx
@@ -1,4 +1,5 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip'
+import { useSyncExternalStore } from 'react'
 import type { ReactElement, ReactNode } from 'react'
 
 // eslint-disable-next-line react-refresh/only-export-components -- re-exports of Radix UI components for convenience
@@ -38,7 +39,36 @@ type TooltipProps = {
   side?: RadixTooltip.TooltipContentProps['side']
 }
 
+const TOUCH_TOOLTIP_QUERY = '(hover: none), (pointer: coarse)'
+
+function tooltipShouldBeDisabledForTouch() {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false
+  return window.matchMedia(TOUCH_TOOLTIP_QUERY).matches
+}
+
+function subscribeToTouchTooltipChanges(onStoreChange: () => void) {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return () => {}
+
+  const mediaQuery = window.matchMedia(TOUCH_TOOLTIP_QUERY)
+  const handleChange = () => onStoreChange()
+
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }
+
+  mediaQuery.addListener(handleChange)
+  return () => mediaQuery.removeListener(handleChange)
+}
+
+function useTooltipDisabledForTouch() {
+  return useSyncExternalStore(subscribeToTouchTooltipChanges, tooltipShouldBeDisabledForTouch, () => false)
+}
+
 export function Tooltip({ children, content, side = 'top' }: TooltipProps) {
+  const disabledForTouch = useTooltipDisabledForTouch()
+  if (disabledForTouch) return children
+
   return (
     <RadixTooltip.Provider delayDuration={250} skipDelayDuration={120}>
       <RadixTooltip.Root>


### PR DESCRIPTION
Re-applies the isolated, low-risk improvements from #820 without the MoA fanout/context changes that hung the `mesh` route (reverted in #823).

## What users get
- **New model recommendation**: `Gemma-4-E4B-it` added to the catalog (with vision mmproj) and used as the **8–24GB auto-pack default** instead of Qwen3-8B — a stronger mini-class default.
- **Context length fix**: peers now correctly report advertised context length when the routable (public) model name differs from the served runtime model name.
- **Touch tooltips**: hover tooltips are disabled on touch / coarse-pointer devices so they don't get stuck open.

## What was deliberately left out
The MoA pieces suspected of causing the `mesh`-route hang are **not** included:
- `mesh-mixture-of-agents/src/*` (context, fanout, worker, arbiter, reducer, session, normalize)
- `network/openai/moa_gateway/*` (context_budget, context_selection, progress)
- `openai-frontend/responses.rs`, `network/openai/transport.rs`
- `mesh-llm-guardrails/src/rescue.rs` (wired into the MoA tool-call path)

These need a real multi-node retest (the hang only reproduced against the live relay-heavy mesh, not CI sim tests) before re-merging.

## Validation
- `cargo check -p mesh-llm-host-runtime -p mesh-llm-client -p mesh-llm-node` — clean
- `cargo test --lib auto_pack` (host + client) — green
- UI `npm run typecheck` — clean

## Background
#820 was reverted in #823 after it hung the `mesh`/MoA route in production (verified via Fly v85 works / v86 hangs); console is currently on the v85 rollback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemma-4-E4B-it-Q4_K_M model to available options.
  * Improved automatic model selection for 8–24GB VRAM systems.

* **Bug Fixes**
  * Fixed tooltip rendering on touch-based devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->