### PR TITLE
fix: mobile chat enhancements

### DIFF
--- a/crates/mesh-llm-ui/index.html
+++ b/crates/mesh-llm-ui/index.html
@@ -14,6 +14,7 @@
     <meta name="theme-color" content="#fbfaf7" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#171b24" media="(prefers-color-scheme: dark)" />
     <meta name="description" content="MeshLLM clean-room app UI" />
+    <link rel="manifest" href="/manifest.json" />
     <script>
       ;(() => {
         const defaults = {

--- a/crates/mesh-llm-ui/src/app/layout/RootLayout.tsx
+++ b/crates/mesh-llm-ui/src/app/layout/RootLayout.tsx
@@ -16,6 +16,7 @@ import { useStatusQuery } from '@/features/network/api/use-status-query'
 import { useUIPreferences } from '@/features/shell/hooks/useUiPreferences'
 import { SHELL_HARNESS } from '@/features/app-tabs/data'
 import { env, hrefWithBasePath, stripBasePath } from '@/lib/env'
+import { cn } from '@/lib/cn'
 import { useDataMode } from '@/lib/data-mode'
 import { useBooleanFeatureFlag } from '@/lib/feature-flags'
 import type { ShellHarnessData, AppTab } from '@/features/app-tabs/types'
@@ -137,7 +138,7 @@ export function RootLayout({ data = SHELL_HARNESS }: RootLayoutProps = {}) {
     <>
       <HeadContent />
       <LiveStatusConnector />
-      <div className="flex h-dvh flex-col overflow-hidden">
+      <div className={cn('flex h-dvh flex-col overflow-hidden', activeTab === 'chat' && 'route-chat')}>
         <TopNav
           enabledTabs={enabledTabs}
           tab={visibleActiveTab}

--- a/crates/mesh-llm-ui/src/components/ui/useLoadingGhostShimmer.ts
+++ b/crates/mesh-llm-ui/src/components/ui/useLoadingGhostShimmer.ts
@@ -1,33 +1,38 @@
 import { useEffect, useRef, type RefObject } from 'react'
-import { animate, createScope, stagger, type Scope } from 'animejs'
 
 const LOADING_GHOST_SHIMMER_SELECTOR = '[data-loading-ghost-shimmer]'
 
 export function useLoadingGhostShimmer<TElement extends HTMLElement>(rootRef: RefObject<TElement | null>) {
-  const scopeRef = useRef<Scope | null>(null)
+  const animationsRef = useRef<Animation[]>([])
 
   useEffect(() => {
     const prefersReducedMotion =
       typeof window !== 'undefined' &&
       typeof window.matchMedia === 'function' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (prefersReducedMotion) return undefined
+    const root = rootRef.current
+    if (prefersReducedMotion || !root || typeof Element.prototype.animate !== 'function') return undefined
 
-    scopeRef.current = createScope({ root: rootRef }).add(() => {
-      animate(LOADING_GHOST_SHIMMER_SELECTOR, {
-        translateX: ['-130%', '260%'],
-        opacity: [0, 0.42, 0],
-        duration: 2400,
-        delay: stagger(70),
-        loop: true,
-        loopDelay: 280,
-        ease: 'inOutSine'
-      })
-    })
+    const shimmerElements = Array.from(root.querySelectorAll<HTMLElement>(LOADING_GHOST_SHIMMER_SELECTOR))
+    animationsRef.current = shimmerElements.map((element, index) =>
+      element.animate(
+        [
+          { opacity: 0, transform: 'translateX(-130%)' },
+          { opacity: 0.42, offset: 0.5, transform: 'translateX(65%)' },
+          { opacity: 0, transform: 'translateX(260%)' }
+        ],
+        {
+          delay: index * 70,
+          duration: 2400,
+          easing: 'ease-in-out',
+          iterations: Number.POSITIVE_INFINITY
+        }
+      )
+    )
 
     return () => {
-      scopeRef.current?.revert()
-      scopeRef.current = null
+      animationsRef.current.forEach((animation) => animation.cancel())
+      animationsRef.current = []
     }
   }, [rootRef])
 }

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
@@ -19,7 +19,18 @@ describe('MessageRow', () => {
     const article = container.querySelector('article')
 
     expect(article).toBeInTheDocument()
-    expect(article).toHaveClass('relative', '-mx-2', 'mb-5', 'block', 'w-[calc(100%+16px)]', 'select-none')
+    expect(article).toHaveClass(
+      'chat-message-row',
+      'relative',
+      '-mx-1',
+      'mb-4',
+      'block',
+      'w-[calc(100%+8px)]',
+      'sm:-mx-2',
+      'sm:mb-5',
+      'sm:w-[calc(100%+16px)]',
+      'select-none'
+    )
     expect(article).not.toHaveClass('focus-visible:outline-accent')
     expect(article).toHaveTextContent('Static response from the mesh')
     expect(container.querySelector('button')).not.toBeInTheDocument()
@@ -84,7 +95,18 @@ describe('MessageRow', () => {
     const article = container.querySelector('article')
     const button = screen.getByRole('button', { name: 'Inspect mesh route' })
 
-    expect(article).toHaveClass('relative', '-mx-2', 'mb-5', 'block', 'w-[calc(100%+16px)]', 'select-none')
+    expect(article).toHaveClass(
+      'chat-message-row',
+      'relative',
+      '-mx-1',
+      'mb-4',
+      'block',
+      'w-[calc(100%+8px)]',
+      'sm:-mx-2',
+      'sm:mb-5',
+      'sm:w-[calc(100%+16px)]',
+      'select-none'
+    )
     expect(button).not.toHaveClass('w-[calc(100%+16px)]')
     expect(article).toHaveTextContent('Inspectable response from the mesh')
 

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties } from 'react'
+import { memo, type CSSProperties } from 'react'
 import {
   BrainCircuit,
   Eye,
@@ -75,7 +75,15 @@ function AttachmentIcon({ kind }: { kind: MessageAttachmentAction['kind'] }) {
   return <FileIcon className="size-3.5" aria-hidden={true} />
 }
 
-function AssistantMarkdown({ text, linksEnabled }: { text: string; linksEnabled: boolean }) {
+// Memoized so historical assistant messages skip re-parsing markdown on every
+// streaming token flush; props are scalars, so the shallow compare is exact.
+const AssistantMarkdown = memo(function AssistantMarkdown({
+  text,
+  linksEnabled
+}: {
+  text: string
+  linksEnabled: boolean
+}) {
   return (
     <div className="block select-text break-words [&_code]:rounded-[calc(var(--radius)-2px)] [&_code]:bg-panel-strong [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.93em] [&_em]:text-fg-dim [&_strong]:font-semibold [&_strong]:text-foreground">
       <ReactMarkdown
@@ -228,9 +236,9 @@ function AssistantMarkdown({ text, linksEnabled }: { text: string; linksEnabled:
       </ReactMarkdown>
     </div>
   )
-}
+})
 
-function AssistantMessageContent({
+const AssistantMessageContent = memo(function AssistantMessageContent({
   body,
   linksEnabled,
   streaming
@@ -282,9 +290,9 @@ function AssistantMessageContent({
       })}
     </div>
   )
-}
+})
 
-export function MessageRow({
+function MessageRowImpl({
   messageRole,
   body,
   timestamp,
@@ -315,7 +323,7 @@ export function MessageRow({
   const routeMetadata = showRouteMetadata && ((isUser && routeNode) || (isResponse && route))
   const displayModel = isQueued ? 'Queued' : model
   const rowClassName =
-    'relative -mx-2 mb-5 block w-[calc(100%+16px)] select-none rounded-[var(--radius-lg)] border-0 bg-transparent px-2 py-1 text-left transition-[background,box-shadow] duration-150'
+    'chat-message-row relative -mx-1 mb-4 block w-[calc(100%+8px)] select-none rounded-[var(--radius-lg)] border-0 bg-transparent px-1 py-1 text-left transition-[background,box-shadow] duration-150 sm:-mx-2 sm:mb-5 sm:w-[calc(100%+16px)] sm:px-2'
   const rowStyle: CSSProperties = {
     ...(inspected ? { background: 'color-mix(in oklab, var(--color-accent) 4%, transparent)' } : {})
   }
@@ -325,8 +333,7 @@ export function MessageRow({
       ? '1px solid var(--color-bad)'
       : isQueued
         ? '1px solid color-mix(in oklab, var(--color-fg-faint) 42%, var(--color-border))'
-        : '1px solid var(--color-accent)',
-    padding: '8px 12px 8px 14px'
+        : '1px solid var(--color-accent)'
   }
   const errorContentStyle: CSSProperties = {
     ...userContentStyle,
@@ -408,9 +415,11 @@ export function MessageRow({
         ) : null}
       </div>
       <div
-        className="block select-text text-[length:var(--density-type-body-lg)] leading-[1.55]"
+        className={cn(
+          'block select-text text-[length:var(--density-type-body-lg)] leading-[1.55]',
+          isUser || isError ? 'py-1.5 pl-3 sm:pl-3.5' : 'px-0 py-2 sm:px-4 sm:py-3'
+        )}
         style={{
-          padding: isUser || isError ? '6px 0 6px 14px' : '12px 16px',
           background: 'transparent',
           border: isUser || isError ? '0 solid transparent' : '1px solid transparent',
           maxWidth: isUser || isError ? 720 : 'none'
@@ -466,7 +475,7 @@ export function MessageRow({
     </div>
   ) : isUser ? (
     <div
-      className={cn('relative block', hasAttachmentActions && 'flex items-center justify-between gap-4')}
+      className={cn('relative block px-3 py-2 sm:px-3 sm:py-2', hasAttachmentActions && 'flex items-center justify-between gap-4')}
       style={userContentStyle}
     >
       <div className="min-w-0">{messageContent}</div>
@@ -515,3 +524,39 @@ export function MessageRow({
     </article>
   )
 }
+
+function sameAttachments(prev: MessageAttachmentAction[] | undefined, next: MessageAttachmentAction[] | undefined) {
+  const prevAttachments = prev ?? []
+  const nextAttachments = next ?? []
+  if (prevAttachments.length !== nextAttachments.length) return false
+  return prevAttachments.every((attachment, index) => {
+    const nextAttachment = nextAttachments[index]
+    return (
+      attachment.id === nextAttachment.id &&
+      attachment.label === nextAttachment.label &&
+      attachment.kind === nextAttachment.kind &&
+      attachment.fileName === nextAttachment.fileName
+    )
+  })
+}
+
+function sameMessageRowProps(prev: MessageRowProps, next: MessageRowProps) {
+  return (
+    prev.messageRole === next.messageRole &&
+    prev.body === next.body &&
+    prev.timestamp === next.timestamp &&
+    prev.model === next.model &&
+    prev.state === next.state &&
+    prev.route === next.route &&
+    prev.tokens === next.tokens &&
+    prev.inspectLabel === next.inspectLabel &&
+    prev.inspected === next.inspected &&
+    prev.routeNode === next.routeNode &&
+    prev.showRouteMetadata === next.showRouteMetadata &&
+    prev.tokPerSec === next.tokPerSec &&
+    prev.ttft === next.ttft &&
+    sameAttachments(prev.attachments, next.attachments)
+  )
+}
+
+export const MessageRow = memo(MessageRowImpl, sameMessageRowProps)

--- a/crates/mesh-llm-ui/src/features/chat/components/messages/MarkdownMessage.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/messages/MarkdownMessage.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
 import remarkGfm from 'remark-gfm'
@@ -7,7 +8,7 @@ import { cn } from '@/lib/utils'
 import { KaTeXBlock } from '@/features/chat/components/messages/KaTeXBlock'
 import { MermaidBlock } from '@/features/chat/components/messages/MermaidBlock'
 
-export function MarkdownMessage({ content, streaming }: { content: string; streaming?: boolean }) {
+function MarkdownMessageImpl({ content, streaming }: { content: string; streaming?: boolean }) {
   return (
     <div
       className={cn(
@@ -53,3 +54,5 @@ export function MarkdownMessage({ content, streaming }: { content: string; strea
     </div>
   )
 }
+
+export const MarkdownMessage = memo(MarkdownMessageImpl)

--- a/crates/mesh-llm-ui/src/features/chat/layouts/ChatLayout.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/layouts/ChatLayout.tsx
@@ -177,14 +177,14 @@ export function ChatLayout({
     >
       {showDesktopSidebar ? <div className="min-h-0 min-w-0 overflow-hidden [&>*]:h-full">{sidebar}</div> : null}
       <section className="panel-shell flex min-h-0 min-w-0 select-none flex-col overflow-hidden rounded-[var(--radius-lg)] border border-border bg-panel">
-        <header className="flex min-h-[58px] flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b border-border-soft px-4 py-2 md:flex-nowrap">
-          <div className="flex min-w-0 shrink-0 flex-col justify-center">
+        <header className="flex min-h-[48px] flex-wrap items-center justify-between gap-x-3 gap-y-1.5 border-b border-border-soft px-3 py-2 sm:min-h-[58px] sm:gap-x-4 sm:gap-y-2 sm:px-4 md:flex-nowrap">
+          <div className="flex min-w-0 flex-1 flex-col justify-center sm:shrink-0 sm:flex-none">
             {subtitle ? (
               <>
                 <span className="text-[length:var(--density-type-label)] font-medium uppercase tracking-[0.08em] text-fg-faint">
                   {title}
                 </span>
-                <h1 className="truncate text-[length:var(--density-type-title)] font-semibold leading-snug tracking-[-0.01em]">
+                <h1 className="truncate text-[length:var(--density-type-control-lg)] font-semibold leading-snug tracking-[-0.01em] sm:text-[length:var(--density-type-title)]">
                   {subtitle}
                 </h1>
               </>
@@ -197,7 +197,7 @@ export function ChatLayout({
         <div className="flex min-h-0 flex-1 flex-col">
           <div
             ref={messageListRef}
-            className="chat-message-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-4 py-4 sm:px-[26px] sm:py-5"
+            className="chat-message-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 py-3 sm:px-[26px] sm:py-5"
             data-testid="chat-message-list"
             onPointerDown={handleMessageAreaPointerDown}
           >

--- a/crates/mesh-llm-ui/src/features/network/api/use-status-stream.ts
+++ b/crates/mesh-llm-ui/src/features/network/api/use-status-stream.ts
@@ -6,6 +6,7 @@ import { env } from '@/lib/env'
 
 const MIN_BACKOFF = 1000
 const MAX_BACKOFF = 15_000
+const MIN_STATUS_COMMIT_MS = 500
 
 export function useStatusStream(options?: { enabled?: boolean }) {
   const queryClient = useQueryClient()
@@ -13,6 +14,9 @@ export function useStatusStream(options?: { enabled?: boolean }) {
   const esRef = useRef<EventSource | null>(null)
   const backoffRef = useRef<number>(MIN_BACKOFF)
   const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const commitTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+  const lastCommitRef = useRef(0)
+  const pendingStatusRef = useRef<StatusPayload | undefined>(undefined)
 
   useEffect(() => {
     if (!enabled) return
@@ -22,6 +26,35 @@ export function useStatusStream(options?: { enabled?: boolean }) {
       if (timerRef.current === undefined) return
       clearTimeout(timerRef.current)
       timerRef.current = undefined
+    }
+
+    function clearCommitTimer() {
+      if (commitTimerRef.current === undefined) return
+      clearTimeout(commitTimerRef.current)
+      commitTimerRef.current = undefined
+    }
+
+    function flushPendingStatus() {
+      if (!active || pendingStatusRef.current === undefined) return
+      queryClient.setQueryData(statusKeys.detail(), pendingStatusRef.current)
+      pendingStatusRef.current = undefined
+      lastCommitRef.current = Date.now()
+    }
+
+    function scheduleStatusCommit(payload: StatusPayload) {
+      pendingStatusRef.current = payload
+      const elapsed = Date.now() - lastCommitRef.current
+      if (elapsed >= MIN_STATUS_COMMIT_MS) {
+        clearCommitTimer()
+        flushPendingStatus()
+        return
+      }
+
+      if (commitTimerRef.current !== undefined) return
+      commitTimerRef.current = setTimeout(() => {
+        commitTimerRef.current = undefined
+        flushPendingStatus()
+      }, MIN_STATUS_COMMIT_MS - elapsed)
     }
 
     function closeEventSource() {
@@ -61,8 +94,7 @@ export function useStatusStream(options?: { enabled?: boolean }) {
       es.onmessage = (event: MessageEvent) => {
         if (!active) return
         try {
-          const payload = JSON.parse(event.data as string) as StatusPayload
-          queryClient.setQueryData(statusKeys.detail(), payload)
+          scheduleStatusCommit(JSON.parse(event.data as string) as StatusPayload)
         } catch (_) {
           void _
         }
@@ -83,6 +115,8 @@ export function useStatusStream(options?: { enabled?: boolean }) {
     return () => {
       active = false
       clearReconnectTimer()
+      clearCommitTimer()
+      pendingStatusRef.current = undefined
       closeEventSource()
     }
   }, [queryClient, enabled])

--- a/crates/mesh-llm-ui/src/features/shell/components/TopNav.tsx
+++ b/crates/mesh-llm-ui/src/features/shell/components/TopNav.tsx
@@ -729,7 +729,7 @@ function UtilityActions({
 
 export function TopNav(props: TopNavProps) {
   return (
-    <header className="surface-chrome sticky top-0 z-30 flex flex-nowrap items-center gap-[var(--topnav-gap)] border-b border-border-soft px-[var(--topnav-pad-x)] py-[var(--topnav-pad-y)]">
+    <header className="surface-chrome sticky top-0 z-30 flex flex-nowrap items-center gap-[var(--topnav-gap)] border-b border-border-soft px-[var(--topnav-pad-x)] pb-[var(--topnav-pad-y)] pt-[calc(var(--topnav-pad-y)+var(--topnav-safe-pad-top,0px))]">
       <BrandCluster version={props.version} renderLogo={props.renderLogo} brand={props.brand} />
       <PrimaryTabs
         enabledTabs={props.enabledTabs}

--- a/crates/mesh-llm-ui/src/styles/globals.css
+++ b/crates/mesh-llm-ui/src/styles/globals.css
@@ -77,6 +77,7 @@
   --chat-layout-height: calc(100dvh - 180px);
   --topnav-pad-x: 24px;
   --topnav-pad-y: 10px;
+  --topnav-safe-pad-top: 0px;
   --topnav-gap: 10px;
   --brand-margin-end: 14px;
   --brand-gap: 8px;
@@ -1254,6 +1255,11 @@ textarea:focus-visible,
   background-clip: padding-box;
 }
 
+.chat-message-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 160px;
+}
+
 .mesh-canvas {
   background-color: oklch(from var(--color-background) calc(l - 0.02) c h);
   background-image: radial-gradient(color-mix(in oklch, var(--color-border), transparent 30%) 1px, transparent 1px);
@@ -1372,6 +1378,7 @@ textarea:focus-visible,
     --shell-pad-x: 12px;
     --shell-pad-top: 12px;
     --shell-pad-bottom: 28px;
+    --topnav-safe-pad-top: env(safe-area-inset-top, 0px);
     --shell-zoom: 1;
     --topnav-pad-x: 12px;
     --topnav-pad-y: 9px;
@@ -1397,6 +1404,20 @@ textarea:focus-visible,
 
   .density-shell {
     zoom: 1;
+  }
+
+  .route-chat .density-shell {
+    --shell-pad-top: 8px;
+    --shell-pad-bottom: 0px;
+  }
+
+  .route-chat footer {
+    display: none;
+  }
+
+  .surface-chrome,
+  .surface-overlay {
+    backdrop-filter: none;
   }
 }
 


### PR DESCRIPTION
A smattering of things for web app performance: 

Mobile chat/top spacing and safe-area handling
More compact chat header/padding on phones
Hide footer on mobile chat to give the transcript/composer more room
Memoized chat message rendering so old messages don’t re-render during streaming
Added content-visibility for chat rows
Changed loading shimmer from animejs to Web Animations API
Throttled live status SSE cache writes
Disabled expensive backdrop blur on mobile


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added web app manifest support for better app installation experience.
  * Added safe-area inset handling for devices with notches or rounded corners.

* **Improvements**
  * Optimized chat message rendering performance through component memoization.
  * Improved loading animation efficiency using modern browser APIs.
  * Implemented batching for status updates to reduce unnecessary refreshes.

* **Style**
  * Refined chat layout spacing and header styling across different screen sizes.
  * Updated navigation padding to accommodate safe-area insets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->