### PR TITLE
Fix Windows install on PowerShell 5.1 (irm | iex and missing checksum sidecar)

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,8 +1,7 @@
 param(
     [switch]$PreRelease,
     [string]$InstallDir = $env:MESH_LLM_INSTALL_DIR,
-    [ValidateSet("cpu", "cuda", "cuda-blackwell", "rocm", "vulkan")]
-    [string]$Flavor = $env:MESH_LLM_INSTALL_FLAVOR,
+    [string]$Flavor,
     [switch]$NoPathUpdate,
     [switch]$Help
 )
@@ -25,6 +24,10 @@ if (Test-Truthy $env:MESH_LLM_INSTALL_PRERELEASE) {
 }
 
 $RequireChecksum = Test-Truthy $env:MESH_LLM_REQUIRE_CHECKSUM
+
+if (-not $Flavor -and $env:MESH_LLM_INSTALL_FLAVOR) {
+    $Flavor = $env:MESH_LLM_INSTALL_FLAVOR
+}
 
 if (-not $InstallDir) {
     $localAppData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $HOME "AppData\Local" }
@@ -305,7 +308,14 @@ function Test-MissingChecksumResponse {
 
     $response = $ErrorRecord.Exception.Response
     if (-not $response) {
-        return $false
+        # Windows PowerShell 5.1 follows the GitHub release redirect and then,
+        # on a 404 target, surfaces the failure as a response-less WebException
+        # ("The request was aborted: The connection was closed unexpectedly.")
+        # rather than a clean 404 HttpWebResponse. Treat a response-less
+        # WebException as a missing sidecar so the warn-and-continue path
+        # remains reachable on 5.1. A genuinely required checksum is still
+        # enforced by the caller via $RequireSidecar.
+        return $ErrorRecord.Exception -is [System.Net.WebException]
     }
 
     $statusCode = [int]$response.StatusCode


### PR DESCRIPTION
Windows users can now install mesh-llm with the documented one-liner, and the install no longer dies when a release has no checksum sidecar.

## What you can now do

On a stock Windows box (Windows PowerShell 5.1, the default), the documented command now works end to end:

```powershell
irm https://meshllm.cloud/install.ps1 | iex
```

Previously this failed immediately with a `ValidateSetFailure` before any install logic ran, and even when invoked as a downloaded `.ps1` it then hard-failed on releases that ship no `.sha256` sidecar.

## Bugs fixed

1. **`irm | iex` threw before running.** The `$Flavor` parameter had `[ValidateSet(...)]` with an env-var default. Under `Invoke-Expression`, a `[ValidateSet][string]` parameter is initialised to `""`, which is immediately validated against the set, is not a member, and throws `ValidateSetFailure`. The `[ValidateSet]` is removed from the param; flavor values are still validated in `Choose-Flavor` against `Get-SupportedFlavors`, and `MESH_LLM_INSTALL_FLAVOR` is now resolved in the body. Behaviour for an explicit/invalid `-Flavor` is unchanged (still throws `unsupported Windows flavor`).

2. **Hard failure on a missing checksum sidecar (PowerShell 5.1).** When a release has no `<archive>.sha256`, `Invoke-WebRequest` on Windows PowerShell 5.1 follows the GitHub `releases/latest/download` redirect and, on the 404 target, surfaces a response-less `WebException` (`The request was aborted: The connection was closed unexpectedly.`) rather than a clean 404. `Test-MissingChecksumResponse` returned `$false` for that, so the intended warn-and-continue path was unreachable and the install died with `could not download checksum sidecar`. A response-less `WebException` is now treated as a missing sidecar. `MESH_LLM_REQUIRE_CHECKSUM=1` still hard-fails on a missing sidecar via the caller.

This keeps the existing installer policy: verify when the sidecar exists, warn and continue when it is missing, and fail only when a checksum is explicitly required.

## Validation

Tested end to end on a Windows 11 desktop (Intel i5-12400F, Windows PowerShell 5.1) reached over Tailscale, against the current published release (which has no sidecars):

- Before: `irm | iex` failed with `ValidateSetFailure`; running the file failed with `could not download checksum sidecar`.
- After: detects the `cuda` flavor, downloads the bundle, warns `Checksum sidecar not found; continuing without archive verification`, extracts, updates the user `Path`, and prints `mesh-llm 0.71.0`.

Example output:

```
Installing flavor: cuda
Release channel: stable
Downloading https://github.com/Mesh-LLM/mesh-llm/releases/latest/download/mesh-llm-x86_64-pc-windows-msvc-cuda.zip
WARNING: Checksum sidecar not found; continuing without archive verification: ...zip.sha256
Added C:\Users\sshuser\AppData\Local\mesh-llm\bin to your user Path.
Installed mesh-llm-x86_64-pc-windows-msvc-cuda.zip to C:\Users\sshuser\AppData\Local\mesh-llm\bin
mesh-llm 0.71.0
```

Note: this PR only fixes installation. A separate issue tracks a runtime crash (`STATUS_ILLEGAL_INSTRUCTION 0xC000001D`) on CPUs without AVX-512 once inference runs; that is a build-flag fix in the native runtime, addressed separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation script compatibility with older Windows PowerShell versions
  * Enhanced checksum validation detection for legacy system environments

* **Chores**
  * Refined installation parameter handling for improved consistency and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->