### PR TITLE
Fix Windows binary crashing (STATUS_ILLEGAL_INSTRUCTION) on CPUs without AVX-512

### DIFF
--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -977,6 +977,19 @@ Invoke-InRepo {
         "-DGGML_HIP=OFF",
         "-DGGML_VULKAN=OFF",
         "-DGGML_OPENMP=ON",
+        # Do not optimize for the build runner's CPU. windows-2025 runners can
+        # expose AVX-512 / AVX-VNNI / BMI2 that consumer desktops (e.g. Alder
+        # Lake i5/i7) lack; a GGML_NATIVE build then crashes with
+        # STATUS_ILLEGAL_INSTRUCTION (0xC000001D) on those machines the moment a
+        # ggml compute kernel runs. Pin GGML_NATIVE=OFF (matching the Linux and
+        # macOS builds in scripts/build-llama.sh) and select a portable AVX2
+        # baseline, which every x86-64 CPU since ~2013 supports. On MSVC, F16C
+        # and FMA are implied by AVX2.
+        "-DGGML_NATIVE=OFF",
+        "-DGGML_AVX=ON",
+        "-DGGML_AVX2=ON",
+        "-DGGML_AVX512=OFF",
+        "-DGGML_BMI2=OFF",
         "-DBUILD_SHARED_LIBS=OFF",
         "-DLLAMA_CURL=OFF",
         "-DLLAMA_BUILD_EXAMPLES=OFF",

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -147,10 +147,32 @@ function New-ZipArchive {
     )
 }
 
+function Get-Sha256Hex {
+    param([string]$Path)
+
+    # Use the .NET SHA-256 API directly instead of Get-FileHash. Under
+    # `powershell -NoProfile` on the CI runners, Microsoft.PowerShell.Utility
+    # module autoloading does not always resolve Get-FileHash, which caused
+    # release bundling to fail with CommandNotFoundException. The .NET API is
+    # always available regardless of module autoloading.
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $stream = [System.IO.File]::OpenRead($Path)
+        try {
+            $bytes = $sha256.ComputeHash($stream)
+        } finally {
+            $stream.Dispose()
+        }
+    } finally {
+        $sha256.Dispose()
+    }
+    return [System.BitConverter]::ToString($bytes).Replace("-", "").ToLowerInvariant()
+}
+
 function New-ChecksumSidecar {
     param([string]$Path)
 
-    $hash = (Get-FileHash -Path $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+    $hash = Get-Sha256Hex $Path
     $name = Split-Path -Leaf $Path
     Set-Content -Path "$Path.sha256" -Value "$hash  $name" -NoNewline
 }


### PR DESCRIPTION
## What this fixes

Windows users on CPUs without AVX-512 — which includes **all Intel consumer
desktops from 11th–14th gen (Alder/Raptor Lake), e.g. the i5/i7-12xxx/13xxx** —
got an immediate hard crash (`STATUS_ILLEGAL_INSTRUCTION`, `0xC000001D`) the
moment inference actually ran. The binary would load a model, then die at
compute-graph / KV-cache allocation. After this change the Windows release
binaries run on those machines.

## Root cause

`scripts/build-windows.ps1` did not set `GGML_NATIVE`, while the Linux/macOS
path in `scripts/build-llama.sh` does set `GGML_NATIVE=OFF`. With `GGML_NATIVE`
unset and the build not cross-compiling, llama.cpp defaults `GGML_NATIVE=ON`,
so ggml-cpu was compiled for the **build runner's** CPU. The `windows-2025`
runners expose AVX-512, so the shipped binary contained AVX-512 instructions
with no runtime CPU-feature guard. Disassembly of the released
`mesh-llm.exe` showed **8,257 AVX-512 (`zmm`) instructions** baked into the
compute path.

## The fix

- `scripts/build-windows.ps1`: pin `GGML_NATIVE=OFF` (matching Linux/macOS) and
  select a portable **AVX2** baseline (`GGML_AVX2=ON`, `GGML_AVX512=OFF`,
  `GGML_BMI2=OFF`). AVX2/FMA/F16C are supported by every x86-64 CPU since ~2013.
- `scripts/package-release.ps1`: compute release-archive SHA-256 checksums via
  the .NET `SHA256` API instead of `Get-FileHash`. Under `powershell -NoProfile`
  on the runners, `Get-FileHash` failed to autoload (`CommandNotFoundException`),
  which broke release bundling and prevented `.sha256` sidecars from being
  generated. (This is the same sidecar the installer fix in #828 consumes.)

## Validation

Built a canary CUDA bundle for sm_89 from this branch and ran it on a real
**RTX 4060 + Intel i5-12400F** (no AVX-512):

- Original release binary: crashes `0xC000001D` right after
  `load_tensors: CPU_Mapped model buffer size`.
- This branch's binary: compiles ggml-cpu with `/arch:AVX2`
  (`GGML_AVX2;GGML_FMA;GGML_F16C`, no AVX-512), loads the model onto the GPU,
  reaches `mesh-llm runtime ready`, and **returns a real chat completion**
  (`"Hello! How can I help you today?"`) with the process still alive after.
- Checksum fix verified: release bundle builds and emits valid `.sha256`
  sidecars (digest matches the archive).

## Notes

- AVX-512 is intentionally fused off on consumer Alder/Raptor Lake, so this hit
  a large share of Windows desktops, not an edge case.
- Follow-up worth filing separately: a CPU-only node reports
  `local_capacity_gb=0.0` (VRAM-based) and refuses to run even a 0.5 GB model
  locally, forcing a split. CPU nodes should size local capacity from system RAM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Windows binary build compatibility by adjusting processor optimization settings to prevent illegal instruction exceptions on certain consumer CPU models while maintaining robust performance baselines for modern AVX2-compatible systems.

* **Chores**
  * Streamlined release package creation process with updated checksum generation methodology for enhanced accuracy and distribution consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->