### PR TITLE
fix(website): fix visual regressions

### DIFF
--- a/website/src/assets/hero-viz.js
+++ b/website/src/assets/hero-viz.js
@@ -784,6 +784,8 @@
       if (child.tagName.toLowerCase() !== 'defs') child.remove();
     });
     var defs = svg.querySelector('defs') || el('defs', {}, svg);
+    var meshGridPattern = defs.querySelector('#mesh-grid');
+    if (meshGridPattern) meshGridPattern.setAttribute('patternTransform', 'translate(18 18)');
 
     var bg = el('g', { class: 'mesh-bg' }, svg);
     var bgPlane = el('rect', { class: 'mesh-grid-plane', width: roundSvg(layout.width), height: roundSvg(layout.height), fill: 'url(#mesh-grid)' }, bg);

--- a/website/src/assets/model-slicing.js
+++ b/website/src/assets/model-slicing.js
@@ -70,6 +70,8 @@
   var STAGE_INTRO_PROGRESS = 0.16;
   // Leaves the final slice of the stage as a settled hold after the aperture closes.
   var STAGE_ANIMATION_END_PROGRESS = 0.955;
+  var APERTURE_OPEN_START = 0.245;
+  var APERTURE_OPEN_END = 0.380;
   var APERTURE_CLOSE_START = 1.095;
   var APERTURE_CLOSE_END = 1.153;
   var APERTURE_FADE_START = 1.125;
@@ -78,6 +80,7 @@
   var APERTURE_WORKBENCH_EXIT_END = 1.148;
   var APERTURE_RING_RETURN_END = 1.125;
   var APERTURE_SCRUBBER_EXIT_END = 1.142;
+  var DESKTOP_APERTURE_ENTRY_SCROLL_FACTOR = 0.5;
   var TITLE_SNAP_LEAD_START_PROGRESS = 0.035;
   var TITLE_SNAP_FORWARD_PROGRESS = 0.085;
   var TITLE_SNAP_REVERSE_PROGRESS = 0.065;
@@ -329,6 +332,16 @@
 
     delete sectionVarCache[name];
     section.style.removeProperty(name);
+  }
+
+  function syncHeroChromeMetrics() {
+    var chromeHeight = nav ? nav.getBoundingClientRect().height : 0;
+
+    if (!chromeHeight) chromeHeight = 64;
+
+    chromeHeight = Math.round(chromeHeight * 100) / 100;
+    setVar('--hero-initial-chrome', chromeHeight + 'px');
+    setVar('--hero-sticky-top', chromeHeight + 'px');
   }
 
   function syncCompletedGridClip() {
@@ -972,12 +985,54 @@
     return cachedApertureMaxRadius;
   }
 
-  function stageProgressFromScrollProgress(progress) {
+  function linearStageProgressFromScrollProgress(progress) {
     return clamp((progress - STAGE_INTRO_PROGRESS) / (STAGE_ANIMATION_END_PROGRESS - STAGE_INTRO_PROGRESS), 0, 1) * SCRUBBER_END;
   }
 
-  function scrollProgressFromStageProgress(progress) {
+  function linearScrollProgressFromStageProgress(progress) {
     return STAGE_INTRO_PROGRESS + (clamp(progress, 0, SCRUBBER_END) / SCRUBBER_END) * (STAGE_ANIMATION_END_PROGRESS - STAGE_INTRO_PROGRESS);
+  }
+
+  function useDesktopApertureEntryTiming() {
+    return !useTouchScrollProfile();
+  }
+
+  function desktopApertureEntryScrollProgress() {
+    return linearScrollProgressFromStageProgress(APERTURE_OPEN_START);
+  }
+
+  function desktopApertureEntryTargetScrollProgress() {
+    return STAGE_INTRO_PROGRESS + (desktopApertureEntryScrollProgress() - STAGE_INTRO_PROGRESS) * DESKTOP_APERTURE_ENTRY_SCROLL_FACTOR;
+  }
+
+  function stageProgressFromScrollProgress(progress) {
+    var clampedProgress = clamp(progress, 0, 1);
+    var apertureEntryTarget;
+
+    if (!useDesktopApertureEntryTiming()) return linearStageProgressFromScrollProgress(clampedProgress);
+    if (clampedProgress <= STAGE_INTRO_PROGRESS) return 0;
+
+    apertureEntryTarget = desktopApertureEntryTargetScrollProgress();
+    if (clampedProgress <= apertureEntryTarget) {
+      return lerp(0, APERTURE_OPEN_START, ramp(clampedProgress, STAGE_INTRO_PROGRESS, apertureEntryTarget));
+    }
+
+    return lerp(APERTURE_OPEN_START, SCRUBBER_END, ramp(clampedProgress, apertureEntryTarget, STAGE_ANIMATION_END_PROGRESS));
+  }
+
+  function scrollProgressFromStageProgress(progress) {
+    var clampedProgress = clamp(progress, 0, SCRUBBER_END);
+    var apertureEntryTarget;
+
+    if (!useDesktopApertureEntryTiming()) return linearScrollProgressFromStageProgress(clampedProgress);
+    if (clampedProgress <= 0) return STAGE_INTRO_PROGRESS;
+
+    apertureEntryTarget = desktopApertureEntryTargetScrollProgress();
+    if (clampedProgress <= APERTURE_OPEN_START) {
+      return lerp(STAGE_INTRO_PROGRESS, apertureEntryTarget, ramp(clampedProgress, 0, APERTURE_OPEN_START));
+    }
+
+    return lerp(apertureEntryTarget, STAGE_ANIMATION_END_PROGRESS, ramp(clampedProgress, APERTURE_OPEN_START, SCRUBBER_END));
   }
 
   function modelShrinkProgressFromPlacement(stageProgress, phaseLocal) {
@@ -998,7 +1053,7 @@
 
   function setChromeProgress(progress, stageProgress) {
     var navOut = ramp(progress, 0.015, 0.18);
-    var navReturn = easeOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END));
+    var navReturn = stageProgress >= SCRUBBER_END ? 1 : 0;
     var navHidden = navOut * (1 - navReturn);
     var footerOut = ramp(stageProgress, FOOTER_CLEAR_START_STAGE_PROGRESS, FOOTER_CLEAR_END_STAGE_PROGRESS);
     var heroReady = document.body.classList.contains('is-hero-complete') || !document.body.classList.contains('home-intro');
@@ -1045,11 +1100,11 @@
     progress = clamp(progress, 0, SCRUBBER_END);
     var stageProgress = stageProgressFromScrollProgress(progress);
     var server;
-    var apertureOpen = ramp(stageProgress, 0.245, 0.380);
+    var apertureOpen = ramp(stageProgress, APERTURE_OPEN_START, APERTURE_OPEN_END);
     var apertureCloseRaw = ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END);
     var apertureClose = fastCloseEase(apertureCloseRaw);
     var aperture = clamp(apertureOpen - apertureClose, 0, 1);
-    var apertureFadeIn = easeOut(ramp(stageProgress, 0.245, 0.292));
+    var apertureFadeIn = easeOut(ramp(stageProgress, APERTURE_OPEN_START, 0.292));
     var apertureFadeOut = easeInOut(ramp(stageProgress, APERTURE_FADE_START, APERTURE_FADE_END));
     var light = clamp(apertureFadeIn - apertureFadeOut, 0, 1);
     var closeDetailFade = easeOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_DETAIL_FADE_END));
@@ -1058,7 +1113,7 @@
     var heroGrid = 1 - (heroGridRetreat * 0.46);
     var apertureRadius;
     var ringOpacity = clamp(ramp(stageProgress, 0.235, 0.270) - ramp(stageProgress, 0.365, 0.430) + ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_RING_RETURN_END) - ramp(stageProgress, APERTURE_FADE_START, APERTURE_CLOSE_END), 0, 1);
-    var meshZoom = clamp(ramp(stageProgress, 0.165, 0.380) - easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END)), 0, 1);
+    var meshZoom = clamp(ramp(stageProgress, 0.165, APERTURE_OPEN_END) - easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END)), 0, 1);
     var meshScale = lerp(1, 1.115, easeInOut(meshZoom));
     var scrubberEnter = ramp(stageProgress, 0.360, 0.435);
     var scrubberExit = easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_SCRUBBER_EXIT_END));
@@ -1133,7 +1188,10 @@
 
     if (!reduceMotion) {
       document.body.classList.toggle('is-stage2-active', stageProgress > 0.002 && stageProgress < SCRUBBER_END);
+      document.body.classList.toggle('is-stage2-aperture-active', stageProgress >= APERTURE_CLOSE_START && stageProgress < SCRUBBER_END);
       document.body.classList.toggle('is-stage2-complete', stageProgress >= SCRUBBER_END);
+    } else {
+      document.body.classList.remove('is-stage2-aperture-active');
     }
 
     if (stageProgress >= SCRUBBER_END - 0.01) syncCompletedGridClip();
@@ -1379,6 +1437,7 @@
   }
 
   function handleGeometryChange() {
+    syncHeroChromeMetrics();
     invalidateGeometry();
     syncCompletedGridClip();
     requestUpdate(true);
@@ -2797,6 +2856,7 @@
     }
 
     initTimeline();
+    syncHeroChromeMetrics();
     initStage2Layout();
     initSliceTimeline();
     renderStage2NodeIcons();

--- a/website/src/assets/site.css
+++ b/website/src/assets/site.css
@@ -4968,6 +4968,7 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   --stage2-aperture-radial-pos: 50% 50%;
   --stage2-aperture-grid-y-pos: 0px 17px;
   --stage2-aperture-grid-x-pos: 17px 0px;
+
   content: "";
   position: absolute;
   inset: 0;

--- a/website/src/assets/site.css
+++ b/website/src/assets/site.css
@@ -906,6 +906,10 @@ nav.top {
   -webkit-backdrop-filter: blur(16px) saturate(140%);
   background: rgba(8,9,11,0.72);
   border-bottom: 1px solid var(--line);
+  transition:
+    opacity 420ms cubic-bezier(0.22, 1, 0.36, 1),
+    transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: opacity, transform;
 }
 .js body.home-intro nav.top,
 .js body.home-intro .hero-footer {
@@ -4958,16 +4962,21 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
 }
 
 .stage2-workspace::before {
+  --stage2-aperture-radial-bg: radial-gradient(circle at var(--stage2-aperture-x, 50%) var(--stage2-aperture-y, 42%), rgba(59, 130, 246, var(--stage2-aperture-blue-alpha, 0.08)), transparent 34%);
+  --stage2-aperture-grid-y-bg: linear-gradient(rgba(9, 9, 11, var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px);
+  --stage2-aperture-grid-x-bg: linear-gradient(90deg, rgba(9, 9, 11, var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px);
+  --stage2-aperture-radial-pos: 50% 50%;
+  --stage2-aperture-grid-y-pos: 0px 17px;
+  --stage2-aperture-grid-x-pos: 17px 0px;
   content: "";
   position: absolute;
   inset: 0;
   z-index: 0;
   pointer-events: none;
   background:
-    radial-gradient(circle at var(--stage2-aperture-x, 50%) var(--stage2-aperture-y, 42%), rgba(59,130,246,var(--stage2-aperture-blue-alpha, 0.08)), transparent 34%),
-    linear-gradient(rgba(9,9,11,var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(9,9,11,var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px);
-  background-size: auto, 34px 34px, 34px 34px;
+    var(--stage2-aperture-radial-bg) var(--stage2-aperture-radial-pos) / auto no-repeat,
+    var(--stage2-aperture-grid-y-bg) var(--stage2-aperture-grid-y-pos) / 34px 34px repeat,
+    var(--stage2-aperture-grid-x-bg) var(--stage2-aperture-grid-x-pos) / 34px 34px repeat;
   mask-image: linear-gradient(to bottom, #000 0%, #000 var(--stage2-grid-mask-solid, 78%), transparent var(--stage2-grid-mask-end, 100%));
   -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 var(--stage2-grid-mask-solid, 78%), transparent var(--stage2-grid-mask-end, 100%));
 }
@@ -6043,12 +6052,14 @@ body.is-stage2-complete .hero-stage-sticky {
 }
 
 section.hero.stage2-scroll::after {
+  --stage2-hero-grid-y-pos: 0px 0px;
+  --stage2-hero-grid-x-pos: 18px 0px;
   top: -60px;
   bottom: 0;
   opacity: 0.92;
-  background-image:
-    linear-gradient(rgba(255,255,255,0.068) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255,255,255,0.068) 1px, transparent 1px);
+  background:
+    linear-gradient(rgba(255,255,255,0.068) 1px, transparent 1px) var(--stage2-hero-grid-y-pos) / 36px 36px repeat,
+    linear-gradient(90deg, rgba(255,255,255,0.068) 1px, transparent 1px) var(--stage2-hero-grid-x-pos) / 36px 36px repeat;
   mask-image: linear-gradient(to bottom, #000 0%, #000 86%, transparent 100%);
   -webkit-mask-image: linear-gradient(to bottom, #000 0%, #000 86%, transparent 100%);
 }
@@ -6111,10 +6122,6 @@ section.hero.stage2-scroll.is-stage2-footer-cleared .hero-footer {
   transform: translateY(168px) !important;
 }
 
-body.is-stage2-active nav.top {
-  transition: none;
-}
-
 body.is-stage2-complete nav.top {
   opacity: 1 !important;
   pointer-events: auto !important;
@@ -6122,6 +6129,12 @@ body.is-stage2-complete nav.top {
 }
 
 body.is-stage2-active section.hero.stage2-scroll::before {
+  --stage2-aperture-active-radial-bg: radial-gradient(circle at var(--stage2-aperture-x, 50%) calc(var(--stage2-aperture-y, 42%) + var(--hero-sticky-top)), rgba(59, 130, 246, var(--stage2-aperture-blue-alpha, 0.08)), transparent 34%);
+  --stage2-aperture-active-grid-y-bg: linear-gradient(rgba(9, 9, 11, var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px);
+  --stage2-aperture-active-grid-x-bg: linear-gradient(90deg, rgba(9, 9, 11, var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px);
+  --stage2-aperture-active-radial-pos: 50% 50%;
+  --stage2-aperture-active-grid-y-pos: 0px 17px;
+  --stage2-aperture-active-grid-x-pos: 17px 0px;
   top: 0;
   left: 0;
   width: 100vw;
@@ -6130,11 +6143,10 @@ body.is-stage2-active section.hero.stage2-scroll::before {
   z-index: 4;
   opacity: var(--stage2-light-opacity);
   background:
-    radial-gradient(circle at var(--stage2-aperture-x, 50%) calc(var(--stage2-aperture-y, 42%) + var(--hero-sticky-top)), rgba(59,130,246,var(--stage2-aperture-blue-alpha, 0.08)), transparent 34%),
-    linear-gradient(rgba(9,9,11,var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(9,9,11,var(--stage2-aperture-grid-alpha, 0.045)) 1px, transparent 1px),
+    var(--stage2-aperture-active-radial-bg) var(--stage2-aperture-active-radial-pos) / auto no-repeat,
+    var(--stage2-aperture-active-grid-y-bg) var(--stage2-aperture-active-grid-y-pos) / 34px 34px repeat,
+    var(--stage2-aperture-active-grid-x-bg) var(--stage2-aperture-active-grid-x-pos) / 34px 34px repeat,
     #fbfaf7;
-  background-size: auto, 34px 34px, 34px 34px, auto;
   clip-path: circle(var(--stage2-aperture-radius) at var(--stage2-aperture-x) calc(var(--stage2-aperture-y) + var(--hero-sticky-top)));
   -webkit-clip-path: circle(var(--stage2-aperture-radius) at var(--stage2-aperture-x) calc(var(--stage2-aperture-y) + var(--hero-sticky-top)));
 }
@@ -6384,6 +6396,10 @@ body.is-stage2-active .stage2-aperture-ring {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  nav.top {
+    transition: none;
+  }
+
   .title-reveal,
   .title-reveal.is-title-revealing,
   .title-reveal.is-title-revealed {


### PR DESCRIPTION
There was a white line in the middle of the site after recent changes
tweaks the opening aperture start so it's not so long
fixed the nav appearing the middle of the white screen mode white the split is being demonstrated 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted hero mesh grid positioning for a cleaner background alignment
  * Refined navigation transitions with reduced-motion support for smoother/accessible behavior
  * Polished aperture, overlay and mesh-zoom visuals for stage‑2 hero/workspace
* **New Features**
  * Improved desktop vs. touch scroll timing for aperture entry and stage progress
  * Header geometry is now synced to layout so overlays and animations align more reliably
<!-- end of auto-generated comment: release notes by coderabbit.ai -->