### PR TITLE
Add bounded direct path repair

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/direct_path.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_path.rs
@@ -1,0 +1,449 @@
+//! Direct UDP path maintenance for mesh peers.
+//!
+//! This module keeps direct-path repair close to the iroh/mesh layer. It is
+//! deliberately targeted: one peer per tick, per-peer cooldowns on both sender
+//! and receiver, and no gossip fanout.
+
+use super::*;
+use crate::protocol::{STREAM_DIRECT_PATH_REQUEST, ValidateControlFrame};
+
+pub(super) const DIRECT_PATH_MAINTENANCE_CHECK_SECS: u64 = 30;
+pub(super) const DIRECT_PATH_REPAIR_GRACE_SECS: u64 = 15;
+pub(super) const DIRECT_PATH_REPAIR_COOLDOWN_SECS: u64 = 120;
+pub(super) const DIRECT_PATH_REQUEST_COOLDOWN_SECS: u64 = 120;
+const DIRECT_PATH_REQUEST_TIMEOUT_SECS: u64 = 10;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DirectPathRepairReason {
+    RelaySelected,
+    UnknownSelected,
+}
+
+impl DirectPathRepairReason {
+    fn label(self) -> &'static str {
+        match self {
+            Self::RelaySelected => "selected path is relay",
+            Self::UnknownSelected => "selected path is unknown",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct DirectPathPeerHealth {
+    pub(super) non_direct_since: Option<std::time::Instant>,
+    pub(super) last_request_at: Option<std::time::Instant>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct DirectPathObservation {
+    pub(super) peer_id: EndpointId,
+    pub(super) snapshot: heartbeat::RelayPathSnapshot,
+    pub(super) has_direct_candidate: bool,
+}
+
+#[derive(Default)]
+pub(super) struct DirectPathMaintenanceController {
+    peer_health: HashMap<EndpointId, DirectPathPeerHealth>,
+}
+
+impl DirectPathMaintenanceController {
+    pub(super) fn plan_request<I>(
+        &mut self,
+        observations: I,
+        now: std::time::Instant,
+        inflight_requests: u64,
+    ) -> Option<(EndpointId, DirectPathRepairReason)>
+    where
+        I: IntoIterator<Item = DirectPathObservation>,
+    {
+        let mut observations: Vec<DirectPathObservation> = observations.into_iter().collect();
+        observations.sort_by_key(|observation| endpoint_id_hex(observation.peer_id));
+
+        if observations.is_empty() {
+            self.peer_health.clear();
+            return None;
+        }
+
+        let active_peers: std::collections::HashSet<EndpointId> = observations
+            .iter()
+            .map(|observation| observation.peer_id)
+            .collect();
+        self.peer_health
+            .retain(|peer_id, _| active_peers.contains(peer_id));
+
+        if inflight_requests > 0 {
+            for observation in observations {
+                self.observe_peer(observation, now);
+            }
+            return None;
+        }
+
+        for observation in observations {
+            let health = self.observe_peer(observation, now);
+            if let Some(reason) = direct_path_repair_reason(health, observation, now) {
+                return Some((observation.peer_id, reason));
+            }
+        }
+
+        None
+    }
+
+    fn observe_peer(
+        &mut self,
+        observation: DirectPathObservation,
+        now: std::time::Instant,
+    ) -> &DirectPathPeerHealth {
+        let health = self.peer_health.entry(observation.peer_id).or_default();
+        match (observation.snapshot.kind, observation.has_direct_candidate) {
+            (heartbeat::SelectedPathKind::Direct, _) | (_, false) => {
+                health.non_direct_since = None;
+            }
+            (heartbeat::SelectedPathKind::Relay | heartbeat::SelectedPathKind::Unknown, true) => {
+                if health.non_direct_since.is_none() {
+                    health.non_direct_since = Some(now);
+                }
+            }
+        }
+        health
+    }
+
+    pub(super) fn record_request_attempt(&mut self, peer_id: EndpointId, now: std::time::Instant) {
+        self.peer_health.entry(peer_id).or_default().last_request_at = Some(now);
+    }
+
+    #[cfg(test)]
+    pub(super) fn peer_health(&self, peer_id: EndpointId) -> Option<&DirectPathPeerHealth> {
+        self.peer_health.get(&peer_id)
+    }
+}
+
+pub(super) fn direct_path_repair_reason(
+    health: &DirectPathPeerHealth,
+    observation: DirectPathObservation,
+    now: std::time::Instant,
+) -> Option<DirectPathRepairReason> {
+    if !observation.has_direct_candidate
+        || observation.snapshot.kind == heartbeat::SelectedPathKind::Direct
+    {
+        return None;
+    }
+    if health.last_request_at.is_some_and(|last| {
+        now.duration_since(last) < std::time::Duration::from_secs(DIRECT_PATH_REPAIR_COOLDOWN_SECS)
+    }) {
+        return None;
+    }
+    if !health.non_direct_since.is_some_and(|started| {
+        now.duration_since(started) >= std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS)
+    }) {
+        return None;
+    }
+    match observation.snapshot.kind {
+        heartbeat::SelectedPathKind::Relay => Some(DirectPathRepairReason::RelaySelected),
+        heartbeat::SelectedPathKind::Unknown => Some(DirectPathRepairReason::UnknownSelected),
+        heartbeat::SelectedPathKind::Direct => None,
+    }
+}
+
+fn endpoint_addr_has_direct_candidate(addr: &EndpointAddr) -> bool {
+    addr.addrs
+        .iter()
+        .any(|candidate| matches!(candidate, TransportAddr::Ip(_)))
+}
+
+pub(super) fn endpoint_addr_with_previously_advertised_direct_candidates(
+    mut requested: EndpointAddr,
+    advertised: &EndpointAddr,
+) -> Option<EndpointAddr> {
+    if requested.id != advertised.id {
+        return None;
+    }
+    requested.addrs.retain(|candidate| {
+        matches!(candidate, TransportAddr::Ip(_)) && advertised.addrs.contains(candidate)
+    });
+    endpoint_addr_has_direct_candidate(&requested).then_some(requested)
+}
+
+impl Node {
+    /// Start bounded mesh-level direct path maintenance.
+    ///
+    /// This is not gossip-driven. Each tick selects at most one admitted peer
+    /// whose selected path is non-direct while a direct UDP candidate exists,
+    /// then sends a targeted request asking that peer to dial our current
+    /// advertised endpoint address. The receiver has its own per-peer cooldown.
+    pub fn start_direct_path_maintenance(&self) {
+        let node = self.clone();
+        tokio::spawn(async move {
+            let mut controller = DirectPathMaintenanceController::default();
+
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(
+                    DIRECT_PATH_MAINTENANCE_CHECK_SECS,
+                ))
+                .await;
+
+                let now = std::time::Instant::now();
+                let observations = node.direct_path_observations().await;
+                let inflight_requests = node.inflight_requests();
+                let Some((peer_id, reason)) =
+                    controller.plan_request(observations, now, inflight_requests)
+                else {
+                    continue;
+                };
+
+                controller.record_request_attempt(peer_id, now);
+                let _ = node.request_direct_path_from_peer(peer_id, reason).await;
+            }
+        });
+    }
+
+    async fn direct_path_observations(&self) -> Vec<DirectPathObservation> {
+        let state = self.state.lock().await;
+        state
+            .peers
+            .iter()
+            .filter_map(|(peer_id, peer)| {
+                let conn = state.connections.get(peer_id)?;
+                Some(DirectPathObservation {
+                    peer_id: *peer_id,
+                    snapshot: heartbeat::selected_path_snapshot(conn),
+                    has_direct_candidate: endpoint_addr_has_direct_candidate(&peer.addr),
+                })
+            })
+            .collect()
+    }
+
+    async fn request_direct_path_from_peer(
+        &self,
+        peer_id: EndpointId,
+        reason: DirectPathRepairReason,
+    ) -> bool {
+        let Some(conn) = self.direct_path_request_connection(peer_id).await else {
+            return false;
+        };
+        let Some(request) = self.build_direct_path_request(peer_id) else {
+            return false;
+        };
+
+        tracing::debug!(
+            peer = %peer_id.fmt_short(),
+            reason = reason.label(),
+            "Direct path maintenance requesting reverse dial"
+        );
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(DIRECT_PATH_REQUEST_TIMEOUT_SECS),
+            send_direct_path_request(conn, request),
+        )
+        .await;
+        log_direct_path_request_result(peer_id, result)
+    }
+
+    fn build_direct_path_request(
+        &self,
+        peer_id: EndpointId,
+    ) -> Option<crate::proto::node::DirectPathRequest> {
+        let Ok(serialized_addr) = serde_json::to_vec(&self.endpoint_addr_for_advertisement())
+        else {
+            tracing::debug!(
+                peer = %peer_id.fmt_short(),
+                "Direct path maintenance could not serialize local endpoint address"
+            );
+            return None;
+        };
+        Some(crate::proto::node::DirectPathRequest {
+            requester_id: self.endpoint.id().as_bytes().to_vec(),
+            r#gen: NODE_PROTOCOL_GENERATION,
+            serialized_addr,
+        })
+    }
+
+    async fn direct_path_request_connection(&self, peer_id: EndpointId) -> Option<Connection> {
+        let state = self.state.lock().await;
+        state.connections.get(&peer_id).cloned()
+    }
+
+    pub(super) fn spawn_direct_path_request_stream(
+        &self,
+        remote: EndpointId,
+        recv: iroh::endpoint::RecvStream,
+    ) {
+        let node = self.clone();
+        tokio::spawn(async move {
+            if let Err(error) = node.handle_direct_path_request_stream(remote, recv).await {
+                tracing::debug!(
+                    "Direct path request from {} failed: {error}",
+                    remote.fmt_short()
+                );
+            }
+        });
+    }
+
+    async fn handle_direct_path_request_stream(
+        &self,
+        remote: EndpointId,
+        mut recv: iroh::endpoint::RecvStream,
+    ) -> Result<()> {
+        let frame = self.read_direct_path_request(remote, &mut recv).await?;
+        let addr: EndpointAddr = serde_json::from_slice(&frame.serialized_addr)
+            .context("direct path request endpoint address is invalid")?;
+        anyhow::ensure!(
+            addr.id == remote,
+            "direct path request endpoint id does not match QUIC peer"
+        );
+        let Some(addr) = self.direct_path_request_addr_for_peer(remote, addr).await else {
+            tracing::debug!(
+                peer = %remote.fmt_short(),
+                "Direct path request ignored because no known direct candidate was supplied"
+            );
+            return Ok(());
+        };
+        if !self.record_direct_path_request(remote).await {
+            tracing::debug!(
+                peer = %remote.fmt_short(),
+                "Direct path request ignored due to cooldown"
+            );
+            return Ok(());
+        }
+        self.dial_direct_path_request_peer(remote, addr).await;
+        Ok(())
+    }
+}
+
+async fn send_direct_path_request(
+    conn: Connection,
+    request: crate::proto::node::DirectPathRequest,
+) -> Result<()> {
+    let (mut send, _) = conn.open_bi().await?;
+    send.write_all(&[STREAM_DIRECT_PATH_REQUEST]).await?;
+    write_len_prefixed(&mut send, &request.encode_to_vec()).await?;
+    let _ = send.finish();
+    Ok(())
+}
+
+fn log_direct_path_request_result(
+    peer_id: EndpointId,
+    result: Result<Result<()>, tokio::time::error::Elapsed>,
+) -> bool {
+    match result {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            tracing::debug!(
+                peer = %peer_id.fmt_short(),
+                error = %error,
+                "Direct path maintenance request failed"
+            );
+            false
+        }
+        Err(_) => {
+            tracing::debug!(
+                peer = %peer_id.fmt_short(),
+                "Direct path maintenance request timed out"
+            );
+            false
+        }
+    }
+}
+
+impl Node {
+    async fn read_direct_path_request(
+        &self,
+        remote: EndpointId,
+        recv: &mut iroh::endpoint::RecvStream,
+    ) -> Result<crate::proto::node::DirectPathRequest> {
+        let proto_buf = read_len_prefixed(recv).await?;
+        let frame = crate::proto::node::DirectPathRequest::decode(proto_buf.as_slice())
+            .context("DirectPathRequest decode error")?;
+        frame
+            .validate_frame()
+            .map_err(|error| anyhow::anyhow!("DirectPathRequest validation error: {error}"))?;
+        anyhow::ensure!(
+            frame.requester_id.as_slice() == remote.as_bytes(),
+            "DirectPathRequest requester_id does not match QUIC peer"
+        );
+        Ok(frame)
+    }
+
+    async fn direct_path_request_addr_for_peer(
+        &self,
+        remote: EndpointId,
+        requested: EndpointAddr,
+    ) -> Option<EndpointAddr> {
+        let state = self.state.lock().await;
+        let peer = state.peers.get(&remote).filter(|peer| peer.admitted)?;
+        endpoint_addr_with_previously_advertised_direct_candidates(requested, &peer.addr)
+    }
+
+    async fn record_direct_path_request(&self, remote: EndpointId) -> bool {
+        let mut state = self.state.lock().await;
+        let now = std::time::Instant::now();
+        if state
+            .direct_path_request_last_at
+            .get(&remote)
+            .is_some_and(|last| {
+                now.duration_since(*last)
+                    < std::time::Duration::from_secs(DIRECT_PATH_REQUEST_COOLDOWN_SECS)
+            })
+        {
+            return false;
+        }
+        state.direct_path_request_last_at.insert(remote, now);
+        true
+    }
+
+    async fn dial_direct_path_request_peer(&self, remote: EndpointId, addr: EndpointAddr) {
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(DIRECT_PATH_REQUEST_TIMEOUT_SECS),
+            connect_mesh(&self.endpoint, addr),
+        )
+        .await;
+        match result {
+            Ok(Ok(conn)) => {
+                self.install_direct_path_request_connection(remote, conn)
+                    .await;
+            }
+            Ok(Err(error)) => {
+                tracing::debug!(
+                    peer = %remote.fmt_short(),
+                    error = %error,
+                    "Direct path request reverse dial failed"
+                );
+            }
+            Err(_) => {
+                tracing::debug!(
+                    peer = %remote.fmt_short(),
+                    "Direct path request reverse dial timed out"
+                );
+            }
+        }
+    }
+
+    async fn install_direct_path_request_connection(&self, remote: EndpointId, conn: Connection) {
+        self.capture_connection_event(ConnectionCaptureEvent {
+            event: "peer_connection_opened",
+            remote,
+            direction: "outbound",
+            phase: "direct_path_request",
+            protocol: Some(connection_protocol(&conn)),
+            path_type: None,
+            rtt_ms: None,
+            admitted_peer: Some(true),
+            reason: Some("reverse_dial"),
+        });
+        self.capture_selected_connection_path(remote, &conn, "direct_path_request_path");
+        {
+            let mut state = self.state.lock().await;
+            state.connections.insert(remote, conn.clone());
+        }
+        let node = self.clone();
+        let conn_for_dispatch = conn.clone();
+        tokio::spawn(async move {
+            node.dispatch_streams(conn_for_dispatch, remote).await;
+        });
+        if let Err(error) = self.initiate_gossip_inner(conn, remote, false).await {
+            tracing::debug!(
+                peer = %remote.fmt_short(),
+                error = %error,
+                "Direct path request gossip after reverse dial failed"
+            );
+        }
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_path.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_path.rs
@@ -202,6 +202,9 @@ impl Node {
             .peers
             .iter()
             .filter_map(|(peer_id, peer)| {
+                if !peer.is_admitted() {
+                    return None;
+                }
                 let conn = state.connections.get(peer_id)?;
                 Some(DirectPathObservation {
                     peer_id: *peer_id,

--- a/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/heartbeat.rs
@@ -976,6 +976,9 @@ impl Node {
         state
             .peer_down_rejections
             .retain(|_, ts| ts.elapsed().as_secs() < PEER_DOWN_REPORTER_COOLDOWN_SECS);
+        state.direct_path_request_last_at.retain(|_, ts| {
+            ts.elapsed().as_secs() < super::direct_path::DIRECT_PATH_REQUEST_COOLDOWN_SECS
+        });
         expired_dead_peers
     }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -1,9 +1,9 @@
 //! Mesh membership via iroh QUIC connections.
 //!
 //! Mesh control traffic uses QUIC ALPN `mesh-llm/1` and multiplexes bi-streams
-//! by first byte. Mesh-owned subsystem streams use `STREAM_SUBPROTOCOL` on the
-//! admitted mesh connection; Skippy activation transport remains on the
-//! latency-sensitive `skippy-stage/2` ALPN.
+//! by first byte. Latency-sensitive and path-maintenance flows keep dedicated
+//! stream bytes. Skippy activation transport remains on the latency-sensitive
+//! `skippy-stage/2` ALPN.
 
 pub use mesh_llm_types::mesh::{
     DEMAND_TTL_SECS, MAX_SPLIT_RTT_MS, ModelDemand, ModelRuntimeDescriptor, ModelSourceKind,
@@ -541,17 +541,22 @@ fn endpoint_addr_has_public_ipv4(addr: &EndpointAddr) -> bool {
 }
 
 // Host-network Docker and CNI bridges commonly reuse the same 172.* addresses
-// on every host. When a node selects a bind IP, only advertise that direct IP
-// while preserving relay and public candidates for non-LAN reachability.
+// on every host. When a node selects a bind IP, only advertise that direct IP.
+// Public discovery keeps public candidates for non-LAN reachability; LAN-only
+// discovery strips them so peers try the selected lab interface directly.
 fn filter_endpoint_addr_for_bind_ip(
     mut addr: EndpointAddr,
     bind_ip: Option<IpAddr>,
+    preserve_public_ipv4_candidates: bool,
 ) -> EndpointAddr {
     let Some(bind_ip) = bind_ip else {
         return addr;
     };
     addr.addrs.retain(|candidate| match candidate {
-        TransportAddr::Ip(socket) => socket.ip() == bind_ip || is_public_ipv4_candidate(socket),
+        TransportAddr::Ip(socket) => {
+            socket.ip() == bind_ip
+                || (preserve_public_ipv4_candidates && is_public_ipv4_candidate(socket))
+        }
         _ => true,
     });
     addr
@@ -2238,6 +2243,7 @@ pub struct Node {
     endpoint_secret_key: SecretKey,
     public_addr: Option<std::net::SocketAddr>,
     quic_bind: QuicBindSelection,
+    relay_policy: RelayPolicy,
     owner_keypair: Option<crate::crypto::OwnerKeypair>,
     local_mesh_requirements: crate::MeshRequirements,
     state: Arc<Mutex<MeshState>>,
@@ -2452,6 +2458,9 @@ struct MeshState {
     /// (target was still reachable). Used to suppress repeated false reports
     /// from unreliable reporters (e.g. relay-partitioned nodes).
     peer_down_rejections: HashMap<(EndpointId, EndpointId), std::time::Instant>,
+    /// Last accepted direct-path dial-back request per peer. This keeps path
+    /// maintenance targeted even if a peer repeatedly asks us to reverse-dial.
+    direct_path_request_last_at: HashMap<EndpointId, std::time::Instant>,
     seen_plugin_messages: HashMap<String, std::time::Instant>,
     seen_plugin_message_order: VecDeque<(std::time::Instant, String)>,
     /// Last policy-rejection status per peer — used to suppress duplicate log lines.
@@ -3718,6 +3727,7 @@ impl Node {
             endpoint_secret_key: secret_key.clone(),
             public_addr,
             quic_bind,
+            relay_policy: relay.policy,
             owner_keypair,
             local_mesh_requirements,
             state: Arc::new(Mutex::new(MeshState {
@@ -3726,6 +3736,7 @@ impl Node {
                 remote_tunnel_maps: HashMap::new(),
                 dead_peers: HashMap::new(),
                 peer_down_rejections: HashMap::new(),
+                direct_path_request_last_at: HashMap::new(),
                 seen_plugin_messages: HashMap::new(),
                 seen_plugin_message_order: VecDeque::new(),
                 policy_rejected_peers: HashMap::new(),
@@ -3878,6 +3889,7 @@ impl Node {
             endpoint_secret_key: secret_key,
             public_addr: None,
             quic_bind: QuicBindSelection::default(),
+            relay_policy: RelayPolicy::DefaultPublic,
             owner_keypair: None,
             local_mesh_requirements: crate::MeshRequirements::unrestricted(),
             state: Arc::new(Mutex::new(MeshState {
@@ -3886,6 +3898,7 @@ impl Node {
                 remote_tunnel_maps: HashMap::new(),
                 dead_peers: HashMap::new(),
                 peer_down_rejections: HashMap::new(),
+                direct_path_request_last_at: HashMap::new(),
                 seen_plugin_messages: HashMap::new(),
                 seen_plugin_message_order: VecDeque::new(),
                 policy_rejected_peers: HashMap::new(),
@@ -4512,7 +4525,11 @@ impl Node {
         {
             addr.addrs.insert(TransportAddr::Ip(pub_addr));
         }
-        addr = filter_endpoint_addr_for_bind_ip(addr, self.quic_bind.ip);
+        addr = filter_endpoint_addr_for_bind_ip(
+            addr,
+            self.quic_bind.ip,
+            self.relay_policy.uses_relay(),
+        );
         let mesh_id = self.mesh_id.lock().await.clone();
         let policy_hash = self.mesh_policy_hash.lock().await.clone();
         let policy = self.genesis_policy.lock().await.clone();
@@ -4650,7 +4667,11 @@ impl Node {
     fn endpoint_addr_for_advertisement(&self) -> EndpointAddr {
         let mut addr = self.endpoint.addr();
         if self.quic_bind.ip.is_some() {
-            addr = filter_endpoint_addr_for_bind_ip(addr, self.quic_bind.ip);
+            addr = filter_endpoint_addr_for_bind_ip(
+                addr,
+                self.quic_bind.ip,
+                self.relay_policy.uses_relay(),
+            );
         }
         addr
     }
@@ -7214,6 +7235,7 @@ impl Node {
             STREAM_ROUTE_REQUEST => self.spawn_route_request_stream(remote, protocol, send, recv),
             STREAM_PEER_DOWN => self.spawn_peer_down_stream(remote, recv),
             STREAM_PEER_LEAVING => self.spawn_peer_leaving_stream(remote, recv),
+            STREAM_DIRECT_PATH_REQUEST => self.spawn_direct_path_request_stream(remote, recv),
             STREAM_PLUGIN_CHANNEL => self.spawn_plugin_channel_stream(remote, send, recv),
             STREAM_PLUGIN_BULK_TRANSFER => self.spawn_plugin_bulk_stream(remote, send, recv),
             STREAM_PLUGIN_MESH_STREAM => self.spawn_plugin_mesh_stream(remote, send, recv),
@@ -10350,6 +10372,7 @@ pub fn save_node_key_to_path(path: &std::path::Path, key: &SecretKey) -> Result<
 }
 
 mod artifact_transfer_io;
+mod direct_path;
 mod gossip;
 mod heartbeat;
 mod plugin_streams;

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -3889,7 +3889,7 @@ impl Node {
             endpoint_secret_key: secret_key,
             public_addr: None,
             quic_bind: QuicBindSelection::default(),
-            relay_policy: RelayPolicy::DefaultPublic,
+            relay_policy: RelayPolicy::Disabled,
             owner_keypair: None,
             local_mesh_requirements: crate::MeshRequirements::unrestricted(),
             state: Arc::new(Mutex::new(MeshState {
@@ -4528,7 +4528,7 @@ impl Node {
         addr = filter_endpoint_addr_for_bind_ip(
             addr,
             self.quic_bind.ip,
-            self.relay_policy.uses_relay(),
+            self.relay_policy.uses_raw_stun(),
         );
         let mesh_id = self.mesh_id.lock().await.clone();
         let policy_hash = self.mesh_policy_hash.lock().await.clone();
@@ -4670,7 +4670,7 @@ impl Node {
             addr = filter_endpoint_addr_for_bind_ip(
                 addr,
                 self.quic_bind.ip,
-                self.relay_policy.uses_relay(),
+                self.relay_policy.uses_raw_stun(),
             );
         }
         addr

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1,3 +1,8 @@
+use super::direct_path::{
+    DIRECT_PATH_REPAIR_COOLDOWN_SECS, DIRECT_PATH_REPAIR_GRACE_SECS,
+    DirectPathMaintenanceController, DirectPathObservation, DirectPathRepairReason,
+    endpoint_addr_with_previously_advertised_direct_candidates,
+};
 use super::heartbeat::{
     HeartbeatFailurePolicy, HomeRelayStatusTransition, RELAY_DEGRADED_RTT_MS,
     RELAY_MISSING_GRACE_SECS, RELAY_ONLY_RECONNECT_SECS, RELAY_RECONNECT_COOLDOWN_SECS,
@@ -223,7 +228,7 @@ fn endpoint_addr_filter_for_bind_ip_keeps_selected_ip_relay_and_public_candidate
         "https://relay.example.com".parse().unwrap(),
     ));
 
-    let filtered = filter_endpoint_addr_for_bind_ip(addr, Some("10.1.2.3".parse().unwrap()));
+    let filtered = filter_endpoint_addr_for_bind_ip(addr, Some("10.1.2.3".parse().unwrap()), true);
     let ip_addrs: HashSet<_> = filtered
         .addrs
         .iter()
@@ -238,6 +243,40 @@ fn endpoint_addr_filter_for_bind_ip_keeps_selected_ip_relay_and_public_candidate
     assert!(!ip_addrs.contains("172.23.0.1:47916"));
     assert!(!ip_addrs.contains("100.107.22.123:47916"));
     assert!(!ip_addrs.contains("192.168.1.20:47916"));
+    assert!(
+        filtered
+            .addrs
+            .iter()
+            .any(|addr| matches!(addr, iroh::TransportAddr::Relay(_)))
+    );
+}
+
+#[test]
+fn endpoint_addr_filter_for_lan_only_bind_ip_strips_public_candidates() {
+    let mut addr = EndpointAddr {
+        id: make_test_endpoint_id(0x42),
+        addrs: Default::default(),
+    };
+    addr.addrs
+        .insert(iroh::TransportAddr::Ip("10.1.2.3:47916".parse().unwrap()));
+    addr.addrs.insert(iroh::TransportAddr::Ip(
+        "35.199.1.10:47916".parse().unwrap(),
+    ));
+    addr.addrs.insert(iroh::TransportAddr::Relay(
+        "https://relay.example.com".parse().unwrap(),
+    ));
+
+    let filtered = filter_endpoint_addr_for_bind_ip(addr, Some("10.1.2.3".parse().unwrap()), false);
+    let ip_addrs: HashSet<_> = filtered
+        .addrs
+        .iter()
+        .filter_map(|addr| match addr {
+            iroh::TransportAddr::Ip(socket) => Some(socket.to_string()),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(ip_addrs, HashSet::from(["10.1.2.3:47916".to_string()]));
     assert!(
         filtered
             .addrs
@@ -326,6 +365,7 @@ async fn make_test_node_with_requirements(
         endpoint_secret_key,
         public_addr: None,
         quic_bind: QuicBindSelection::default(),
+        relay_policy: RelayPolicy::DefaultPublic,
         owner_keypair: None,
         local_mesh_requirements,
         state: Arc::new(Mutex::new(MeshState {
@@ -334,6 +374,7 @@ async fn make_test_node_with_requirements(
             remote_tunnel_maps: HashMap::new(),
             dead_peers: HashMap::new(),
             peer_down_rejections: HashMap::new(),
+            direct_path_request_last_at: HashMap::new(),
             seen_plugin_messages: HashMap::new(),
             seen_plugin_message_order: VecDeque::new(),
             policy_rejected_peers: HashMap::new(),
@@ -3111,6 +3152,130 @@ fn relay_reconnect_controller_applies_cooldown_after_attempt_and_prunes_gone_pee
     assert!(
         controller.peer_health(peer).is_none(),
         "controller should prune peers that are no longer active"
+    );
+}
+
+#[test]
+fn direct_path_maintenance_requires_candidate_and_grace_period() {
+    let now = std::time::Instant::now();
+    let peer = make_test_endpoint_id(31);
+    let mut controller = DirectPathMaintenanceController::default();
+    let relay_observation = DirectPathObservation {
+        peer_id: peer,
+        snapshot: RelayPathSnapshot {
+            kind: SelectedPathKind::Relay,
+            rtt_ms: Some(200),
+        },
+        has_direct_candidate: true,
+    };
+
+    assert_eq!(
+        controller.plan_request([relay_observation], now, 0),
+        None,
+        "first non-direct observation starts the grace timer"
+    );
+    assert_eq!(
+        controller.plan_request(
+            [relay_observation],
+            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 2),
+            0,
+        ),
+        Some((peer, DirectPathRepairReason::RelaySelected))
+    );
+
+    let mut no_candidate_controller = DirectPathMaintenanceController::default();
+    assert_eq!(
+        no_candidate_controller.plan_request(
+            [DirectPathObservation {
+                has_direct_candidate: false,
+                ..relay_observation
+            }],
+            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1),
+            0,
+        ),
+        None,
+        "without a direct candidate there is nothing useful to request"
+    );
+}
+
+#[test]
+fn direct_path_maintenance_cooldown_and_inflight_suppress_requests() {
+    let now = std::time::Instant::now();
+    let peer = make_test_endpoint_id(32);
+    let mut controller = DirectPathMaintenanceController::default();
+    let observation = DirectPathObservation {
+        peer_id: peer,
+        snapshot: RelayPathSnapshot {
+            kind: SelectedPathKind::Unknown,
+            rtt_ms: None,
+        },
+        has_direct_candidate: true,
+    };
+
+    assert_eq!(controller.plan_request([observation], now, 1), None);
+    assert!(
+        controller
+            .peer_health(peer)
+            .and_then(|health| health.non_direct_since)
+            .is_some(),
+        "active requests suppress repair but still record path state"
+    );
+
+    let ready_at = now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1);
+    assert_eq!(
+        controller.plan_request([observation], ready_at, 0),
+        Some((peer, DirectPathRepairReason::UnknownSelected))
+    );
+    controller.record_request_attempt(peer, ready_at);
+    assert_eq!(
+        controller.plan_request(
+            [observation],
+            ready_at + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_COOLDOWN_SECS - 1),
+            0,
+        ),
+        None,
+        "cooldown prevents repeated reverse-dial requests"
+    );
+}
+
+#[test]
+fn direct_path_request_keeps_only_previously_advertised_direct_candidates() {
+    let peer_id = make_test_endpoint_id(33);
+    let advertised_direct = TransportAddr::Ip("10.0.0.7:47916".parse().unwrap());
+    let unadvertised_direct = TransportAddr::Ip("10.0.0.99:47916".parse().unwrap());
+    let advertised_relay = TransportAddr::Relay("https://relay.example.com".parse().unwrap());
+
+    let mut advertised = EndpointAddr {
+        id: peer_id,
+        addrs: Default::default(),
+    };
+    advertised.addrs.insert(advertised_direct.clone());
+    advertised.addrs.insert(advertised_relay.clone());
+
+    let mut requested = EndpointAddr {
+        id: peer_id,
+        addrs: Default::default(),
+    };
+    requested.addrs.insert(advertised_direct.clone());
+    requested.addrs.insert(unadvertised_direct.clone());
+    requested.addrs.insert(advertised_relay.clone());
+
+    let filtered =
+        endpoint_addr_with_previously_advertised_direct_candidates(requested, &advertised)
+            .expect("the previously advertised direct candidate should be kept");
+    assert!(filtered.addrs.contains(&advertised_direct));
+    assert!(!filtered.addrs.contains(&unadvertised_direct));
+    assert!(!filtered.addrs.contains(&advertised_relay));
+
+    let mut unknown_only = EndpointAddr {
+        id: peer_id,
+        addrs: Default::default(),
+    };
+    unknown_only.addrs.insert(unadvertised_direct);
+    assert!(
+        endpoint_addr_with_previously_advertised_direct_candidates(unknown_only, &advertised)
+            .is_none(),
+        "requests with only unknown direct candidates must not trigger reverse dials"
     );
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests.rs
@@ -1,8 +1,3 @@
-use super::direct_path::{
-    DIRECT_PATH_REPAIR_COOLDOWN_SECS, DIRECT_PATH_REPAIR_GRACE_SECS,
-    DirectPathMaintenanceController, DirectPathObservation, DirectPathRepairReason,
-    endpoint_addr_with_previously_advertised_direct_candidates,
-};
 use super::heartbeat::{
     HeartbeatFailurePolicy, HomeRelayStatusTransition, RELAY_DEGRADED_RTT_MS,
     RELAY_MISSING_GRACE_SECS, RELAY_ONLY_RECONNECT_SECS, RELAY_RECONNECT_COOLDOWN_SECS,
@@ -18,6 +13,8 @@ use serial_test::serial;
 use skippy_protocol::proto::stage as skippy_stage_proto;
 use std::collections::{HashMap, HashSet};
 use tokio::sync::{mpsc, watch};
+
+mod direct_path;
 
 #[test]
 fn quic_bind_addr_uses_explicit_port_on_all_platforms() {
@@ -3152,130 +3149,6 @@ fn relay_reconnect_controller_applies_cooldown_after_attempt_and_prunes_gone_pee
     assert!(
         controller.peer_health(peer).is_none(),
         "controller should prune peers that are no longer active"
-    );
-}
-
-#[test]
-fn direct_path_maintenance_requires_candidate_and_grace_period() {
-    let now = std::time::Instant::now();
-    let peer = make_test_endpoint_id(31);
-    let mut controller = DirectPathMaintenanceController::default();
-    let relay_observation = DirectPathObservation {
-        peer_id: peer,
-        snapshot: RelayPathSnapshot {
-            kind: SelectedPathKind::Relay,
-            rtt_ms: Some(200),
-        },
-        has_direct_candidate: true,
-    };
-
-    assert_eq!(
-        controller.plan_request([relay_observation], now, 0),
-        None,
-        "first non-direct observation starts the grace timer"
-    );
-    assert_eq!(
-        controller.plan_request(
-            [relay_observation],
-            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 2),
-            0,
-        ),
-        Some((peer, DirectPathRepairReason::RelaySelected))
-    );
-
-    let mut no_candidate_controller = DirectPathMaintenanceController::default();
-    assert_eq!(
-        no_candidate_controller.plan_request(
-            [DirectPathObservation {
-                has_direct_candidate: false,
-                ..relay_observation
-            }],
-            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1),
-            0,
-        ),
-        None,
-        "without a direct candidate there is nothing useful to request"
-    );
-}
-
-#[test]
-fn direct_path_maintenance_cooldown_and_inflight_suppress_requests() {
-    let now = std::time::Instant::now();
-    let peer = make_test_endpoint_id(32);
-    let mut controller = DirectPathMaintenanceController::default();
-    let observation = DirectPathObservation {
-        peer_id: peer,
-        snapshot: RelayPathSnapshot {
-            kind: SelectedPathKind::Unknown,
-            rtt_ms: None,
-        },
-        has_direct_candidate: true,
-    };
-
-    assert_eq!(controller.plan_request([observation], now, 1), None);
-    assert!(
-        controller
-            .peer_health(peer)
-            .and_then(|health| health.non_direct_since)
-            .is_some(),
-        "active requests suppress repair but still record path state"
-    );
-
-    let ready_at = now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1);
-    assert_eq!(
-        controller.plan_request([observation], ready_at, 0),
-        Some((peer, DirectPathRepairReason::UnknownSelected))
-    );
-    controller.record_request_attempt(peer, ready_at);
-    assert_eq!(
-        controller.plan_request(
-            [observation],
-            ready_at + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_COOLDOWN_SECS - 1),
-            0,
-        ),
-        None,
-        "cooldown prevents repeated reverse-dial requests"
-    );
-}
-
-#[test]
-fn direct_path_request_keeps_only_previously_advertised_direct_candidates() {
-    let peer_id = make_test_endpoint_id(33);
-    let advertised_direct = TransportAddr::Ip("10.0.0.7:47916".parse().unwrap());
-    let unadvertised_direct = TransportAddr::Ip("10.0.0.99:47916".parse().unwrap());
-    let advertised_relay = TransportAddr::Relay("https://relay.example.com".parse().unwrap());
-
-    let mut advertised = EndpointAddr {
-        id: peer_id,
-        addrs: Default::default(),
-    };
-    advertised.addrs.insert(advertised_direct.clone());
-    advertised.addrs.insert(advertised_relay.clone());
-
-    let mut requested = EndpointAddr {
-        id: peer_id,
-        addrs: Default::default(),
-    };
-    requested.addrs.insert(advertised_direct.clone());
-    requested.addrs.insert(unadvertised_direct.clone());
-    requested.addrs.insert(advertised_relay.clone());
-
-    let filtered =
-        endpoint_addr_with_previously_advertised_direct_candidates(requested, &advertised)
-            .expect("the previously advertised direct candidate should be kept");
-    assert!(filtered.addrs.contains(&advertised_direct));
-    assert!(!filtered.addrs.contains(&unadvertised_direct));
-    assert!(!filtered.addrs.contains(&advertised_relay));
-
-    let mut unknown_only = EndpointAddr {
-        id: peer_id,
-        addrs: Default::default(),
-    };
-    unknown_only.addrs.insert(unadvertised_direct);
-    assert!(
-        endpoint_addr_with_previously_advertised_direct_candidates(unknown_only, &advertised)
-            .is_none(),
-        "requests with only unknown direct candidates must not trigger reverse dials"
     );
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/direct_path.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/direct_path.rs
@@ -1,0 +1,132 @@
+use super::super::direct_path::{
+    DIRECT_PATH_REPAIR_COOLDOWN_SECS, DIRECT_PATH_REPAIR_GRACE_SECS,
+    DirectPathMaintenanceController, DirectPathObservation, DirectPathRepairReason,
+    endpoint_addr_with_previously_advertised_direct_candidates,
+};
+use super::super::heartbeat::{RelayPathSnapshot, SelectedPathKind};
+use super::make_test_endpoint_id;
+use iroh::{EndpointAddr, TransportAddr};
+
+#[test]
+fn direct_path_maintenance_requires_candidate_and_grace_period() {
+    let now = std::time::Instant::now();
+    let peer = make_test_endpoint_id(31);
+    let mut controller = DirectPathMaintenanceController::default();
+    let relay_observation = DirectPathObservation {
+        peer_id: peer,
+        snapshot: RelayPathSnapshot {
+            kind: SelectedPathKind::Relay,
+            rtt_ms: Some(200),
+        },
+        has_direct_candidate: true,
+    };
+
+    assert_eq!(
+        controller.plan_request([relay_observation], now, 0),
+        None,
+        "first non-direct observation starts the grace timer"
+    );
+    assert_eq!(
+        controller.plan_request(
+            [relay_observation],
+            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 2),
+            0,
+        ),
+        Some((peer, DirectPathRepairReason::RelaySelected))
+    );
+
+    let mut no_candidate_controller = DirectPathMaintenanceController::default();
+    assert_eq!(
+        no_candidate_controller.plan_request(
+            [DirectPathObservation {
+                has_direct_candidate: false,
+                ..relay_observation
+            }],
+            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1),
+            0,
+        ),
+        None,
+        "without a direct candidate there is nothing useful to request"
+    );
+}
+
+#[test]
+fn direct_path_maintenance_cooldown_and_inflight_suppress_requests() {
+    let now = std::time::Instant::now();
+    let peer = make_test_endpoint_id(32);
+    let mut controller = DirectPathMaintenanceController::default();
+    let observation = DirectPathObservation {
+        peer_id: peer,
+        snapshot: RelayPathSnapshot {
+            kind: SelectedPathKind::Unknown,
+            rtt_ms: None,
+        },
+        has_direct_candidate: true,
+    };
+
+    assert_eq!(controller.plan_request([observation], now, 1), None);
+    assert!(
+        controller
+            .peer_health(peer)
+            .and_then(|health| health.non_direct_since)
+            .is_some(),
+        "active requests suppress repair but still record path state"
+    );
+
+    let ready_at = now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1);
+    assert_eq!(
+        controller.plan_request([observation], ready_at, 0),
+        Some((peer, DirectPathRepairReason::UnknownSelected))
+    );
+    controller.record_request_attempt(peer, ready_at);
+    assert_eq!(
+        controller.plan_request(
+            [observation],
+            ready_at + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_COOLDOWN_SECS - 1),
+            0,
+        ),
+        None,
+        "cooldown prevents repeated reverse-dial requests"
+    );
+}
+
+#[test]
+fn direct_path_request_keeps_only_previously_advertised_direct_candidates() {
+    let peer_id = make_test_endpoint_id(33);
+    let advertised_direct = TransportAddr::Ip("10.0.0.7:47916".parse().unwrap());
+    let unadvertised_direct = TransportAddr::Ip("10.0.0.99:47916".parse().unwrap());
+    let advertised_relay = TransportAddr::Relay("https://relay.example.com".parse().unwrap());
+
+    let mut advertised = EndpointAddr {
+        id: peer_id,
+        addrs: Default::default(),
+    };
+    advertised.addrs.insert(advertised_direct.clone());
+    advertised.addrs.insert(advertised_relay.clone());
+
+    let mut requested = EndpointAddr {
+        id: peer_id,
+        addrs: Default::default(),
+    };
+    requested.addrs.insert(advertised_direct.clone());
+    requested.addrs.insert(unadvertised_direct.clone());
+    requested.addrs.insert(advertised_relay.clone());
+
+    let filtered =
+        endpoint_addr_with_previously_advertised_direct_candidates(requested, &advertised)
+            .expect("the previously advertised direct candidate should be kept");
+    assert!(filtered.addrs.contains(&advertised_direct));
+    assert!(!filtered.addrs.contains(&unadvertised_direct));
+    assert!(!filtered.addrs.contains(&advertised_relay));
+
+    let mut unknown_only = EndpointAddr {
+        id: peer_id,
+        addrs: Default::default(),
+    };
+    unknown_only.addrs.insert(unadvertised_direct);
+    assert!(
+        endpoint_addr_with_previously_advertised_direct_candidates(unknown_only, &advertised)
+            .is_none(),
+        "requests with only unknown direct candidates must not trigger reverse dials"
+    );
+}

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -38,11 +38,13 @@ pub(crate) const STREAM_CONFIG_SUBSCRIBE: u8 = 0x0b;
 /// keep 0x0c reserved so old wire values are not accidentally reused.
 pub(crate) const STREAM_CONFIG_PUSH: u8 = 0x0c;
 pub(crate) const STREAM_SUBPROTOCOL: u8 = 0x0d;
+pub(crate) const STREAM_DIRECT_PATH_REQUEST: u8 = 0x0e;
 const _: () = {
     let _ = ALPN_CONTROL_V1;
     let _ = STREAM_CONFIG_SUBSCRIBE;
     let _ = STREAM_CONFIG_PUSH;
     let _ = STREAM_SUBPROTOCOL;
+    let _ = STREAM_DIRECT_PATH_REQUEST;
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -270,6 +272,23 @@ impl ValidateControlFrame for crate::proto::node::PeerLeaving {
             return Err(ControlFrameError::InvalidEndpointId {
                 got: self.peer_id.len(),
             });
+        }
+        Ok(())
+    }
+}
+
+impl ValidateControlFrame for crate::proto::node::DirectPathRequest {
+    fn validate_frame(&self) -> Result<(), ControlFrameError> {
+        if self.r#gen != NODE_PROTOCOL_GENERATION {
+            return Err(ControlFrameError::BadGeneration { got: self.r#gen });
+        }
+        if self.requester_id.len() != 32 {
+            return Err(ControlFrameError::InvalidEndpointId {
+                got: self.requester_id.len(),
+            });
+        }
+        if self.serialized_addr.is_empty() {
+            return Err(ControlFrameError::InvalidEndpointId { got: 0 });
         }
         Ok(())
     }

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -67,6 +67,7 @@ pub(crate) enum ControlFrameError {
     InvalidSenderId {
         got: usize,
     },
+    MissingDirectPathAddress,
     MissingHttpPort,
     MissingControlOwnerId,
     InvalidConfigHashLength {
@@ -118,6 +119,9 @@ impl std::fmt::Display for ControlFrameError {
             }
             ControlFrameError::InvalidSenderId { got } => {
                 write!(f, "invalid sender_id length: expected 32, got {}", got)
+            }
+            ControlFrameError::MissingDirectPathAddress => {
+                write!(f, "direct path request missing endpoint address")
             }
             ControlFrameError::MissingHttpPort => {
                 write!(f, "HOST-role peer annotation missing http_port")
@@ -288,7 +292,7 @@ impl ValidateControlFrame for crate::proto::node::DirectPathRequest {
             });
         }
         if self.serialized_addr.is_empty() {
-            return Err(ControlFrameError::InvalidEndpointId { got: 0 });
+            return Err(ControlFrameError::MissingDirectPathAddress);
         }
         Ok(())
     }

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -5765,6 +5765,7 @@ pub(crate) async fn run_plugin_mcp(options: &RuntimeOptions) -> Result<()> {
         .await;
     node.start_heartbeat();
     node.start_rtt_refresh();
+    node.start_direct_path_maintenance();
     start_relay_health_monitor_for_discovery_mode(&node, options.mesh_discovery_mode);
     join_mesh_for_mcp(options, &node).await?;
 
@@ -6132,6 +6133,7 @@ async fn build_run_auto_node_setup(
     node.set_available_models(local_models.clone()).await;
     node.start_heartbeat();
     node.start_rtt_refresh();
+    node.start_direct_path_maintenance();
     start_relay_health_monitor_for_discovery_mode(&node, options.mesh_discovery_mode);
 
     if !is_client {

--- a/crates/mesh-llm-protocol/proto/node.proto
+++ b/crates/mesh-llm-protocol/proto/node.proto
@@ -352,6 +352,13 @@ message PeerLeaving {
   uint32 gen = 2;      // must equal NODE_PROTOCOL_GENERATION; rejected otherwise
 }
 
+// Stream 0x0e — Direct Path Request
+message DirectPathRequest {
+  bytes requester_id = 1;      // exactly 32 bytes; must match the QUIC sender identity
+  uint32 gen = 2;              // must equal NODE_PROTOCOL_GENERATION; rejected otherwise
+  bytes serialized_addr = 3;   // JSON-serialized EndpointAddr the receiver should try to dial
+}
+
 // Shared enum
 enum NodeRole {
   NODE_ROLE_UNSPECIFIED = 0;

--- a/crates/mesh-llm-protocol/src/proto/node.rs
+++ b/crates/mesh-llm-protocol/src/proto/node.rs
@@ -462,6 +462,19 @@ pub struct PeerLeaving {
     #[prost(uint32, tag = "2")]
     pub r#gen: u32,
 }
+/// Stream 0x0e — Direct Path Request
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct DirectPathRequest {
+    /// exactly 32 bytes; must match the QUIC sender identity
+    #[prost(bytes = "vec", tag = "1")]
+    pub requester_id: ::prost::alloc::vec::Vec<u8>,
+    /// must equal NODE_PROTOCOL_GENERATION; rejected otherwise
+    #[prost(uint32, tag = "2")]
+    pub r#gen: u32,
+    /// JSON-serialized EndpointAddr the receiver should try to dial
+    #[prost(bytes = "vec", tag = "3")]
+    pub serialized_addr: ::prost::alloc::vec::Vec<u8>,
+}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NodeConfigSnapshot {
     /// config schema version (currently 1)

--- a/crates/mesh-llm-protocol/src/protocol/mod.rs
+++ b/crates/mesh-llm-protocol/src/protocol/mod.rs
@@ -31,6 +31,7 @@ pub const STREAM_CONFIG_SUBSCRIBE: u8 = 0x0b;
 /// keep 0x0c reserved so old wire values are not accidentally reused.
 pub const STREAM_CONFIG_PUSH: u8 = 0x0c;
 pub const STREAM_SUBPROTOCOL: u8 = 0x0d;
+pub const STREAM_DIRECT_PATH_REQUEST: u8 = 0x0e;
 const _: () = {
     let _ = STREAM_CONFIG_SUBSCRIBE;
     let _ = STREAM_CONFIG_PUSH;
@@ -240,6 +241,25 @@ impl ValidateControlFrame for crate::proto::node::PeerLeaving {
             return Err(ControlFrameError::InvalidEndpointId {
                 got: self.peer_id.len(),
             });
+        }
+        Ok(())
+    }
+}
+
+impl ValidateControlFrame for crate::proto::node::DirectPathRequest {
+    fn validate_frame(&self) -> Result<(), ControlFrameError> {
+        if self.r#gen != NODE_PROTOCOL_GENERATION {
+            return Err(ControlFrameError::BadGeneration { got: self.r#gen });
+        }
+        if self.requester_id.len() != 32 {
+            return Err(ControlFrameError::InvalidEndpointId {
+                got: self.requester_id.len(),
+            });
+        }
+        if self.serialized_addr.is_empty() {
+            return Err(ControlFrameError::DecodeError(
+                "direct path request missing endpoint address".to_string(),
+            ));
         }
         Ok(())
     }
@@ -738,6 +758,7 @@ mod tests {
         assert_eq!(STREAM_CONFIG_SUBSCRIBE, 0x0b);
         assert_eq!(STREAM_CONFIG_PUSH, 0x0c);
         assert_eq!(STREAM_SUBPROTOCOL, 0x0d);
+        assert_eq!(STREAM_DIRECT_PATH_REQUEST, 0x0e);
     }
 
     #[test]

--- a/crates/mesh-llm-protocol/src/protocol/mod.rs
+++ b/crates/mesh-llm-protocol/src/protocol/mod.rs
@@ -50,6 +50,7 @@ pub enum ControlFrameError {
     BadGeneration { got: u32 },
     InvalidEndpointId { got: usize },
     InvalidSenderId { got: usize },
+    MissingDirectPathAddress,
     MissingHttpPort,
     MissingOwnerId,
     MissingControlOwnerId,
@@ -88,6 +89,9 @@ impl std::fmt::Display for ControlFrameError {
             }
             ControlFrameError::InvalidSenderId { got } => {
                 write!(f, "invalid sender_id length: expected 32, got {}", got)
+            }
+            ControlFrameError::MissingDirectPathAddress => {
+                write!(f, "direct path request missing endpoint address")
             }
             ControlFrameError::MissingHttpPort => {
                 write!(f, "HOST-role peer annotation missing http_port")
@@ -257,9 +261,7 @@ impl ValidateControlFrame for crate::proto::node::DirectPathRequest {
             });
         }
         if self.serialized_addr.is_empty() {
-            return Err(ControlFrameError::DecodeError(
-                "direct path request missing endpoint address".to_string(),
-            ));
+            return Err(ControlFrameError::MissingDirectPathAddress);
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Adds a targeted mesh-level direct-path repair flow for peers whose selected iroh path has fallen back to relay or is unknown even though a direct UDP candidate is available.

The repair path uses a dedicated mesh stream byte (`0x0e`) and a `DirectPathRequest` frame. It does not use `STREAM_SUBPROTOCOL`, does not gossip, and only asks one peer per maintenance tick to reverse-dial the requester’s current advertised endpoint address.

## Why

In private/mDNS lab meshes, one side may need the other side to initiate the UDP attempt for iroh to converge on a direct path. The previous behavior could sit on relay/unknown path state even when a usable LAN candidate existed. This keeps the fix close to mesh networking and iroh connection management without adding broad discovery chatter.

This follows the iroh layering model: iroh authenticates the endpoint reached by a dial, while mesh-llm constrains which peer-advertised candidates this mesh-level repair path is allowed to hand to iroh.

## Flow Diagram

```mermaid
sequenceDiagram
    autonumber
    participant A as Node A maintenance loop
    participant Conn as Existing mesh QUIC connection
    participant B as Node B mesh dispatcher
    participant Iroh as iroh endpoint

    Note over A,B: Existing admitted mesh connection is already alive
    A->>A: Observe selected path = relay/unknown<br/>and peer has direct UDP candidate
    A->>A: Apply grace period, one-at-a-time gate,<br/>sender cooldown, inflight suppression
    A->>Conn: Open bi stream with byte 0x0e
    Conn->>B: DirectPathRequest{requester_id, gen, EndpointAddr}
    B->>B: Validate generation, requester id,<br/>admitted peer, known direct candidate, receiver cooldown
    B->>Iroh: Dial A using only previously advertised direct candidates
    Iroh-->>B: New QUIC connection if endpoint identity verifies
    B->>B: Install connection, dispatch streams,<br/>initiate gossip
```

## Security / Layering Note

This is only reachable from an already-admitted mesh peer over an existing QUIC connection. iroh still verifies the remote endpoint identity during the reverse dial; a candidate cannot produce an accepted connection unless the remote proves it owns the requested endpoint id.

mesh-llm still has to authorize candidate eligibility before handing addresses to iroh. Otherwise this repair frame could become a new low-rate UDP egress primitive where an admitted peer asks us to try socket candidates that did not come through normal mesh membership. To keep the repair path aligned with iroh’s design, the receiver intersects the requested `EndpointAddr` with that peer’s already-known membership address and keeps only previously advertised direct IP candidates. Unknown candidates and relay candidates in the request are ignored before any dial attempt or receiver cooldown is recorded.

## Details

- Adds bounded direct-path maintenance with grace period, one-at-a-time planning, sender cooldown, receiver cooldown, and request timeout.
- Adds `DirectPathRequest` to the mesh protocol surface and validates generation/requester identity.
- Wires `STREAM_DIRECT_PATH_REQUEST = 0x0e` into the mesh stream dispatcher.
- In LAN-only/mDNS mode, strips public/STUN candidates when a bind IP is selected so advertised addresses point peers at the intended lab interface.
- Adds focused tests for LAN-only candidate filtering, direct-path maintenance throttling, and rejecting unadvertised direct candidates in repair requests.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo test -p mesh-llm-host-runtime endpoint_addr_filter --lib`
- `cargo test -p mesh-llm-host-runtime direct_path_maintenance --lib`
- `cargo test -p mesh-llm-host-runtime direct_path --lib`
- `cargo test -p mesh-llm-protocol control_plane_messages_constants_are_stable --lib`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-protocol --all-targets -- -D warnings`
- `just build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic direct peer-to-peer path maintenance to discover and establish direct connections, reducing relay use when possible.

* **Bug Fixes / Reliability**
  * Improved request validation and cooldown handling to avoid stale or malformed direct-path requests and reduce unnecessary retries.

* **Documentation**
  * Clarified stream multiplexing behavior and transport activation details.

* **Tests**
  * Added unit tests covering maintenance planning, request cooldowns, and candidate filtering.

* **Chores**
  * Added protocol support and configuration hooks for direct-path management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


