### PR TITLE
fix(console): render thinking traces as markdown

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
@@ -233,7 +233,7 @@ describe('MessageRow', () => {
     expect(screen.getByText('Thinking trace').closest('[data-thinking-state="complete"]')).toHaveTextContent(
       'Thinking trace'
     )
-    expect(screen.getByText('Check geography facts before answering.')).toHaveClass('select-text')
+    expect(screen.getByText('Check geography facts before answering.').closest('.select-text')).toBeInTheDocument()
     expect(screen.getByText('The capital of France is Paris.').closest('.select-text')).toBeInTheDocument()
   })
 
@@ -287,6 +287,30 @@ describe('MessageRow', () => {
     expect(screen.getByText('Paris').closest('.select-text')).toBeInTheDocument()
   })
 
+  it('formats thinking trace text as markdown', () => {
+    render(
+      <MessageRow
+        messageRole="assistant"
+        body={'<think>1. **Analyze input**\n   - Check the `route`\n   - Keep it *brief*</think> Final response.'}
+        timestamp="12:11"
+        model="Qwen3-8B"
+      />
+    )
+
+    const thinkingTrace = screen.getByText('Thinking trace').closest('[data-thinking-state="complete"]')
+
+    expect(thinkingTrace).toBeInstanceOf(HTMLElement)
+    const thinkingTraceElement = thinkingTrace as HTMLElement
+
+    expect(screen.queryByText(/\*\*Analyze input\*\*/)).not.toBeInTheDocument()
+    expect(within(thinkingTraceElement).getByText('Analyze input').tagName.toLowerCase()).toBe('strong')
+    expect(within(thinkingTraceElement).getByText('route').tagName.toLowerCase()).toBe('code')
+    expect(within(thinkingTraceElement).getByText('brief').tagName.toLowerCase()).toBe('em')
+    expect(thinkingTraceElement.querySelector('ol')).toHaveClass('list-decimal')
+    expect(thinkingTraceElement.querySelector('ul')).toHaveClass('list-disc')
+    expect(screen.getByText('Final response.')).toBeInTheDocument()
+  })
+
   it('renders assistant markdown tables with semantic compact cell styling', () => {
     render(
       <MessageRow
@@ -338,7 +362,7 @@ describe('MessageRow', () => {
     )
 
     expect(container.querySelector('.whitespace-pre-wrap')).not.toBeInTheDocument()
-    expect(screen.getByText('First item').parentElement).toHaveClass('[&>span]:my-0', '[&>span]:inline')
+    expect(screen.getByText('First item').parentElement).toHaveClass('marker:text-fg-faint', '[&>p]:my-0')
   })
 
   it('marks an open thinking segment as in progress while streaming', () => {
@@ -353,7 +377,7 @@ describe('MessageRow', () => {
     )
 
     expect(screen.getByText('Thinking').closest('[data-thinking-state="active"]')).toHaveTextContent('Thinking')
-    expect(screen.getByText('Checking the current capital from memory')).toHaveClass('select-text')
+    expect(screen.getByText('Checking the current capital from memory').closest('.select-text')).toBeInTheDocument()
     expect(screen.getByText('Streaming response...')).toBeInTheDocument()
   })
 
@@ -371,7 +395,9 @@ describe('MessageRow', () => {
     const thinkingContainer = screen.getByText('Thinking').closest('[data-thinking-state="active"]')
 
     expect(thinkingContainer).toHaveTextContent('The user asked for a long story, so plan the structure first.')
-    expect(screen.getByText('The user asked for a long story, so plan the structure first.')).toHaveClass('select-text')
+    expect(
+      screen.getByText('The user asked for a long story, so plan the structure first.').closest('.select-text')
+    ).toBeInTheDocument()
     expect(screen.getByText('Streaming response...')).toBeInTheDocument()
   })
 

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
@@ -220,7 +220,7 @@ describe('MessageRow', () => {
     expect(streamingControlRow).toHaveClass('mt-3', 'block')
   })
 
-  it('separates closed thinking traces from final assistant response text', () => {
+  it('separates closed thinking from final assistant response text', () => {
     render(
       <MessageRow
         messageRole="assistant"
@@ -230,9 +230,7 @@ describe('MessageRow', () => {
       />
     )
 
-    expect(screen.getByText('Thinking trace').closest('[data-thinking-state="complete"]')).toHaveTextContent(
-      'Thinking trace'
-    )
+    expect(screen.getByText('Thinking').closest('[data-thinking-state="complete"]')).toHaveTextContent('Thinking')
     expect(screen.getByText('Check geography facts before answering.').closest('.select-text')).toBeInTheDocument()
     expect(screen.getByText('The capital of France is Paris.').closest('.select-text')).toBeInTheDocument()
   })
@@ -247,7 +245,7 @@ describe('MessageRow', () => {
       />
     )
 
-    expect(screen.getByText('Thinking trace').closest('[data-thinking-state="complete"]')).toHaveTextContent(
+    expect(screen.getByText('Thinking').closest('[data-thinking-state="complete"]')).toHaveTextContent(
       'The user asked a simple factual question.'
     )
     expect(screen.getByText('The capital of France is Paris.')).toBeInTheDocument()
@@ -263,7 +261,7 @@ describe('MessageRow', () => {
       />
     )
 
-    expect(screen.getByText('Thinking trace').closest('[data-thinking-state="complete"]')).toHaveTextContent(
+    expect(screen.getByText('Thinking').closest('[data-thinking-state="complete"]')).toHaveTextContent(
       'Check whether the prompt is a test.'
     )
     expect(screen.getByText('Test received!').closest('.select-text')).toBeInTheDocument()
@@ -287,7 +285,7 @@ describe('MessageRow', () => {
     expect(screen.getByText('Paris').closest('.select-text')).toBeInTheDocument()
   })
 
-  it('formats thinking trace text as markdown', () => {
+  it('formats thinking text as markdown', () => {
     render(
       <MessageRow
         messageRole="assistant"
@@ -297,7 +295,7 @@ describe('MessageRow', () => {
       />
     )
 
-    const thinkingTrace = screen.getByText('Thinking trace').closest('[data-thinking-state="complete"]')
+    const thinkingTrace = screen.getByText('Thinking').closest('[data-thinking-state="complete"]')
 
     expect(thinkingTrace).toBeInstanceOf(HTMLElement)
     const thinkingTraceElement = thinkingTrace as HTMLElement

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
@@ -75,9 +75,22 @@ function AttachmentIcon({ kind }: { kind: MessageAttachmentAction['kind'] }) {
   return <FileIcon className="size-3.5" aria-hidden={true} />
 }
 
-function AssistantMarkdown({ text, linksEnabled }: { text: string; linksEnabled: boolean }) {
+function AssistantMarkdown({
+  text,
+  linksEnabled,
+  variant = 'default'
+}: {
+  text: string
+  linksEnabled: boolean
+  variant?: 'default' | 'thinking'
+}) {
   return (
-    <div className="block select-text break-words [&_code]:rounded-[calc(var(--radius)-2px)] [&_code]:bg-panel-strong [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.93em] [&_em]:text-fg-dim [&_strong]:font-semibold [&_strong]:text-foreground">
+    <div
+      className={cn(
+        'block select-text break-words [&_code]:rounded-[calc(var(--radius)-2px)] [&_code]:bg-panel-strong [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.93em] [&_em]:text-fg-dim [&_strong]:font-semibold [&_strong]:text-foreground',
+        variant === 'thinking' && '[&_strong]:text-fg-muted'
+      )}
+    >
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={{
@@ -138,19 +151,12 @@ function AssistantMarkdown({ text, linksEnabled }: { text: string; linksEnabled:
           li(props) {
             const { node, ...itemProps } = props
             void node
-            return (
-              <li {...itemProps} className="my-0.5 block pl-1">
-                <span aria-hidden={true} className="mr-2 text-fg-faint">
-                  •
-                </span>
-                <span className="inline [&>span]:my-0 [&>span]:inline">{itemProps.children}</span>
-              </li>
-            )
+            return <li {...itemProps} className="my-0.5 pl-1 marker:text-fg-faint [&>p]:my-0" />
           },
           ol(props) {
             const { node, ...listProps } = props
             void node
-            return <ol {...listProps} className="my-2 block list-none pl-4" />
+            return <ol {...listProps} className="my-2 list-decimal pl-5" />
           },
           p(props) {
             const { node, ...paragraphProps } = props
@@ -220,7 +226,7 @@ function AssistantMarkdown({ text, linksEnabled }: { text: string; linksEnabled:
           ul(props) {
             const { node, ...listProps } = props
             void node
-            return <ul {...listProps} className="my-2 block list-none pl-4" />
+            return <ul {...listProps} className="my-2 list-disc pl-5" />
           }
         }}
       >
@@ -269,7 +275,7 @@ function AssistantMessageContent({
                 )}
                 <span>{active ? 'Thinking' : 'Thinking trace'}</span>
               </span>
-              <span className="block select-text whitespace-pre-wrap break-words">{segment.text}</span>
+              <AssistantMarkdown text={segment.text} linksEnabled={linksEnabled} variant="thinking" />
             </div>
           )
         }

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
@@ -273,7 +273,7 @@ function AssistantMessageContent({
                 ) : (
                   <BrainCircuit className="size-3" aria-hidden={true} strokeWidth={1.7} />
                 )}
-                <span>{active ? 'Thinking' : 'Thinking trace'}</span>
+                <span>Thinking</span>
               </span>
               <AssistantMarkdown text={segment.text} linksEnabled={linksEnabled} variant="thinking" />
             </div>

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
@@ -904,7 +904,7 @@ describe('ChatPage', () => {
     await user.type(screen.getByLabelText('Prompt'), 'Show final answer formatting')
     await user.click(screen.getByRole('button', { name: 'Send' }))
 
-    expect(await screen.findByText('Thinking trace')).toBeInTheDocument()
+    expect(await screen.findByText('Thinking')).toBeInTheDocument()
     expect(screen.getByText('Reasoning text.')).toBeInTheDocument()
 
     const paris = screen.getByText('Paris')

--- a/crates/mesh-llm-ui/src/features/developer/playground/areas/ChatComponentsArea.tsx
+++ b/crates/mesh-llm-ui/src/features/developer/playground/areas/ChatComponentsArea.tsx
@@ -290,7 +290,7 @@ export function ChatComponentsArea({ state }: { state: DeveloperPlaygroundState 
 
               <PlaygroundPanel
                 title="Message row states"
-                description="Queue removal, streaming stop, stopped stats, error copy, markdown, thinking traces, and attachment actions are visible without sending a live request."
+                description="Queue removal, streaming stop, stopped stats, error copy, markdown, thinking content, and attachment actions are visible without sending a live request."
               >
                 <div className="space-y-4">
                   <MessageRow


### PR DESCRIPTION
## Original problem

Thinking trace content in the React chat UI rendered as pre-wrapped plain text, so markdown markers like `**bold**`, ordered steps, nested bullets, inline code, and emphasis appeared raw inside reasoning traces. Final assistant responses already rendered through markdown, so the trace panel looked inconsistent and harder to scan.

## Diagnostics

The issue was isolated to `MessageRow.tsx`: normal assistant segments used `AssistantMarkdown`, while thinking segments used a raw `span` with `whitespace-pre-wrap`.

Screenshot of the fixed thinking trace:

![Thinking trace markdown fix](https://files.catbox.moe/we7509.png)

## Fix

- Render thinking trace segments through the existing assistant markdown renderer.
- Keep trace-specific muted styling for bold text so the reasoning panel stays visually secondary to the final answer.
- Restore semantic ordered and unordered list rendering so numbered reasoning steps and nested bullets format correctly.
- Add regression coverage for bold, inline code, italics, ordered lists, nested bullets, and hidden raw markdown markers inside thinking traces.

No protocol or compatibility impact; this is UI-only rendering behavior.

## Validation

- [x] `pnpm prettier --check src/features/chat/components/MessageRow.tsx src/features/chat/components/MessageRow.test.tsx`
- [x] `pnpm vitest run src/features/chat/components/MessageRow.test.tsx`
- [x] `just build`
- [x] Browser check in the developer playground confirmed the thinking trace DOM includes `strong`, `code`, `em`, `ol`, and `ul` nodes, with no raw `**` visible.
- [x] UI changes include screenshot above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced markdown rendering for thinking content with support for lists, text emphasis, code formatting, and improved visual styling
  * Simplified thinking content presentation in the chat interface

* **Bug Fixes**
  * Improved text selection behavior and CSS styling for thinking segments to ensure consistent appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->