### PR TITLE
[codex] Use sccache for Rust build scripts

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -94,6 +94,15 @@ EOF
     echo "Using Rust linker: $(command -v ld.lld)"
 }
 
+configure_rust_cache() {
+    if [[ -n "${RUSTC_WRAPPER:-}" ]]; then
+        echo "Using Rust compiler wrapper: $RUSTC_WRAPPER"
+    elif command -v sccache >/dev/null 2>&1; then
+        export RUSTC_WRAPPER="$(command -v sccache)"
+        echo "Using Rust compiler wrapper: $RUSTC_WRAPPER"
+    fi
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --clean)
@@ -265,6 +274,7 @@ if [[ "$CLEAN" -eq 1 ]]; then
 fi
 
 configure_lld_linker
+configure_rust_cache
 
 echo "Preparing patched llama.cpp ABI checkout..."
 LLAMA_WORKDIR="$LLAMA_DIR" "$SCRIPT_DIR/prepare-llama.sh" "${MESH_LLM_LLAMA_PIN_SHA:-pinned}"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -129,6 +129,15 @@ EOF
     esac
 }
 
+configure_rust_cache() {
+    if [[ -n "${RUSTC_WRAPPER:-}" ]]; then
+        echo "Using Rust compiler wrapper: $RUSTC_WRAPPER"
+    elif command -v sccache >/dev/null 2>&1; then
+        export RUSTC_WRAPPER="$(command -v sccache)"
+        echo "Using Rust compiler wrapper: $RUSTC_WRAPPER"
+    fi
+}
+
 os_name="$(uname -s)"
 case "$os_name" in
     Darwin)
@@ -155,6 +164,7 @@ if [[ -z "${LLAMA_STAGE_BUILD_DIR:-}" ]]; then
 fi
 
 configure_lld_linker
+configure_rust_cache
 
 if [[ "$DYNAMIC_NATIVE_RUNTIME" == "1" ]]; then
     echo "Skipping embedded llama.cpp ABI build; release binary will load native runtimes dynamically."


### PR DESCRIPTION
## Summary

Local Linux and release builds now automatically use `sccache` for Rust compilation when it is installed, matching the existing macOS and Windows behavior. The scripts still respect an explicitly configured `RUSTC_WRAPPER`, so callers can override or disable the wrapper as needed.

## Impact

This should improve repeated Rust build times for `just build` on Linux and `just release-build` on Linux/macOS without changing the llama.cpp C/C++ sccache wiring.

## Validation

- `bash -n scripts/build-linux.sh`
- `bash -n scripts/build-release.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to accelerate compilation times for both Linux and release builds by implementing compiler caching when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->