### PR TITLE
feat: add config schema control surface

### DIFF
--- a/.agents/skills/config-settings-management/SKILL.md
+++ b/.agents/skills/config-settings-management/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: config-settings-management
+description: Use this skill when adding, renaming, removing, validating, or exposing mesh-llm config settings, including built-in settings, plugin config schemas, owner-control apply behavior, CLI validation, and UI configuration surfaces.
+metadata:
+  short-description: Keep mesh-llm config settings complete
+---
+
+# config-settings-management
+
+Use this skill before changing any setting that appears in
+`~/.mesh-llm/config.toml`, the owner-control configuration API, the runtime
+configuration UI, or an installed plugin's `config_schema`.
+
+## Mental Model
+
+Config settings are not just struct fields. A complete setting has:
+
+- A persisted TOML shape in `crates/mesh-llm-config/src/model.rs`.
+- Authoring/editor support in `crates/mesh-llm-config/src/authoring.rs` when
+  code needs to create or mutate it.
+- Built-in schema metadata in
+  `crates/mesh-llm-config/src/model/built_in_schema.rs` when it is a core
+  mesh-llm setting.
+- Validation diagnostics in `crates/mesh-llm-config/src/validate.rs`, with
+  stable `ConfigPath` and canonical path metadata.
+- Runtime schema aggregation/export in
+  `crates/mesh-llm-host-runtime/src/config_schema.rs`.
+- Owner-control apply behavior in
+  `crates/mesh-llm-host-runtime/src/runtime/config_state.rs` when it can be
+  changed dynamically.
+- API/protocol conversion coverage in `crates/mesh-llm-host-runtime/src/api/`,
+  `crates/mesh-llm-host-runtime/src/protocol/`, and
+  `crates/mesh-llm-protocol/proto/node.proto` when it crosses process or node
+  boundaries.
+- UI adapter and fixture coverage under
+  `crates/mesh-llm-ui/src/features/configuration/` and
+  `crates/mesh-llm-host-runtime/tests/fixtures/`.
+
+## Built-In Settings Checklist
+
+When adding or removing a built-in setting:
+
+- Update `MeshConfig` or the owning nested config struct in
+  `crates/mesh-llm-config/src/model.rs`.
+- Update defaults and editor helpers in `authoring.rs` if generated configs,
+  tests, or command flows need to write the setting.
+- Add, rename, or remove the corresponding descriptor in
+  `model/built_in_schema.rs`. Include owner, value schema, support state,
+  control surfaces, apply mode, restart scope, visibility, constraints, aliases,
+  and description.
+- Update validation in `validate.rs`. Prefer structured `ConfigDiagnostic`
+  helpers over plain string errors.
+- Preserve compatibility with existing TOML when possible. Use aliases and
+  warnings for renamed keys; reserve `version = 1` bumps for actual incompatible
+  persisted config format changes.
+- Update schema fixtures and UI adapter expectations when exported schema JSON
+  changes.
+- Run `mesh-llm config validate --config-path <fixture> --json` for at least one
+  valid and one invalid representative file.
+
+## Plugin Settings Checklist
+
+Plugin settings are install-time schemas, not hard-coded built-in settings.
+
+- The plugin manifest owns its schema through `config_schema` in
+  `crates/mesh-llm-plugin/src/manifest.rs` and
+  `crates/mesh-llm-plugin/proto/plugin.proto`.
+- Keep `schema_version` at
+  `mesh_llm_config::SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION` unless the schema
+  format itself becomes incompatible. Tightening validation of existing v1
+  fields such as `required`, type, enum, object, array, or constraints does not
+  by itself require a schema version bump.
+- Host-side installed plugin schema loading and strict validation live in
+  `crates/mesh-llm-host-runtime/src/plugin/config.rs` and
+  `crates/mesh-llm-config/src/plugin_validation.rs`.
+- Required plugin settings must be rejected even when `[plugin.settings]` is
+  absent.
+- Missing or unavailable schemas should reject custom settings, but plugin
+  entries without custom settings should remain loadable when possible.
+- `allow_unvalidated_config` should produce warnings, not silently drop
+  diagnostics from success responses.
+
+## Owner-Control And UI
+
+- Dynamic apply behavior belongs in
+  `crates/mesh-llm-host-runtime/src/runtime/config_state.rs`.
+- The management API should return diagnostics for both rejected applies and
+  successful applies with warnings.
+- Protobuf changes must be additive unless explicitly approved as breaking.
+  Older nodes and clients should ignore unknown fields.
+- The UI should consume exported schema metadata instead of duplicating setting
+  ownership, labels, constraints, or apply behavior.
+- Snapshot fixtures in `crates/mesh-llm-host-runtime/tests/fixtures/` are the
+  cross-check between Rust schema export and the TypeScript adapter.
+
+## Validation
+
+Run cargo commands serially. For config-surface changes, start with:
+
+```bash
+cargo test -p mesh-llm-config --lib
+cargo test -p mesh-llm-host-runtime --lib schema_export
+cargo test -p mesh-llm-host-runtime --lib runtime_config
+cargo test -p mesh-llm-host-runtime --lib plugin_config
+cargo test -p mesh-llm-plugin --lib
+cargo test -p mesh-llm-plugin-manager --lib
+cargo test -p mesh-llm-cli config_validate --lib
+cargo test -p mesh-llm config_validate --lib
+cargo check -p mesh-llm
+cargo clippy -p mesh-llm-config -p mesh-llm-plugin -p mesh-llm-plugin-manager -p mesh-llm-host-runtime -p mesh-llm-cli -p mesh-llm --all-targets -- -D warnings
+```
+
+Also run the UI checks when the schema export or adapter changes:
+
+```bash
+cd crates/mesh-llm-ui
+npm test -- --run src/features/configuration/api/config-adapter.test.ts
+npm run typecheck
+```
+
+Use the repo build gate before publishing broad changes:
+
+```bash
+just build
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,6 +3861,7 @@ dependencies = [
  "json5",
  "mesh-llm-build-info",
  "mesh-llm-cli",
+ "mesh-llm-config",
  "mesh-llm-identity",
  "mesh-llm-native-runtime",
  "mesh-llm-plugin-manager",
@@ -3879,6 +3880,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "toml 0.9.12+spec-1.1.0",
  "url",
  "zeroize",
 ]

--- a/crates/mesh-client/tests/control_plane_client.rs
+++ b/crates/mesh-client/tests/control_plane_client.rs
@@ -178,6 +178,7 @@ async fn spawn_success_server(
                                         config_hash: vec![0x44; 32],
                                         error: None,
                                         apply_mode: ConfigApplyMode::Staged as i32,
+                                        diagnostics: Vec::new(),
                                     },
                                 ),
                                 refresh_inventory: None,

--- a/crates/mesh-llm-cli/src/lib.rs
+++ b/crates/mesh-llm-cli/src/lib.rs
@@ -10,8 +10,8 @@ pub mod shell;
 pub use mesh_llm_events::LogFormat;
 
 pub use parser::{
-    AuthCommand, BinaryFlavor, Cli, Command, DiscoveryScope, DoctorCommand, GpuCommand,
-    MeshDiscoveryMode, MeshGuardrailCliMode, NormalizedRuntimeArgs, PluginCommand, RuntimeSurface,
-    SkillAgentArg, SkillCommand, TrustCommand, TrustPolicy, legacy_runtime_surface_warning,
-    normalize_runtime_surface_args, validate_discovery_mode_args,
+    AuthCommand, BinaryFlavor, Cli, Command, ConfigCommand, DiscoveryScope, DoctorCommand,
+    GpuCommand, MeshDiscoveryMode, MeshGuardrailCliMode, NormalizedRuntimeArgs, PluginCommand,
+    RuntimeSurface, SkillAgentArg, SkillCommand, TrustCommand, TrustPolicy,
+    legacy_runtime_surface_warning, normalize_runtime_surface_args, validate_discovery_mode_args,
 };

--- a/crates/mesh-llm-cli/src/parser.rs
+++ b/crates/mesh-llm-cli/src/parser.rs
@@ -707,6 +707,11 @@ pub enum Command {
         #[command(subcommand)]
         command: Option<RuntimeCommand>,
     },
+    /// Inspect and validate mesh-llm configuration files.
+    Config {
+        #[command(subcommand)]
+        command: ConfigCommand,
+    },
     /// Diagnose local mesh, runtime, and split-readiness problems.
     Doctor {
         /// Print machine-readable JSON for the default doctor report.
@@ -915,6 +920,19 @@ pub enum Command {
     /// Run a CLI command contributed by a configured plugin.
     #[command(external_subcommand)]
     ExternalPlugin(Vec<OsString>),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommand {
+    /// Validate a config TOML file without starting a node.
+    Validate {
+        /// Config TOML path to validate. Defaults to --config, MESH_LLM_CONFIG, or ~/.mesh-llm/config.toml.
+        #[arg(long = "config-path")]
+        config_path: Option<PathBuf>,
+        /// Print machine-readable JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -1520,6 +1538,27 @@ mod tests {
             }
             other => panic!("unexpected command for {args:?}: {other:?}"),
         }
+    }
+
+    #[test]
+    fn config_validate_command_parses_config_path_and_json() {
+        let cli = Cli::parse_from([
+            "mesh-llm",
+            "config",
+            "validate",
+            "--config-path",
+            "mesh.toml",
+            "--json",
+        ]);
+
+        let Some(Command::Config {
+            command: ConfigCommand::Validate { config_path, json },
+        }) = cli.command
+        else {
+            panic!("expected config validate command");
+        };
+        assert_eq!(config_path, Some(PathBuf::from("mesh.toml")));
+        assert!(json);
     }
 
     #[test]

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -24,6 +24,7 @@ iroh = "1.0.0-rc.0"
 json5 = "1.3.1"
 mesh-llm-build-info.workspace = true
 mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.68.0" }
+mesh-llm-config = { path = "../mesh-llm-config", version = "0.68.0" }
 mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.68.0" }
 mesh-llm-plugin-manager = { path = "../mesh-llm-plugin-manager", version = "0.68.0" }
 mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.68.0", features = ["host-io"] }
@@ -39,6 +40,7 @@ serde_json.workspace = true
 serde_yaml = "0.9"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
+toml = "0.9"
 url = "2"
 zeroize = { version = "1", features = ["derive"] }
 

--- a/crates/mesh-llm-commands/src/config.rs
+++ b/crates/mesh-llm-commands/src/config.rs
@@ -1,0 +1,369 @@
+use anyhow::{Context, Result, bail};
+use mesh_llm_cli::Cli;
+use mesh_llm_config::{
+    ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticSchemaSource, ConfigDiagnosticSeverity,
+    ConfigDiagnosticSource, ConfigPath, MeshConfig, PluginConfigSchema, PluginObjectPropertySchema,
+    PluginSchemaAvailability, PluginSettingConstraint, PluginSettingSchema, PluginValueKind,
+    PluginValueSchema, SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION, config_path,
+    validate_config_diagnostics_with_plugin_schemas,
+};
+use mesh_llm_plugin_manager::{
+    InstalledPluginConfigSchema, InstalledPluginConstraint, InstalledPluginMetadata,
+    InstalledPluginObjectProperty, InstalledPluginValueKind, InstalledPluginValueSchema,
+    PluginStore, default_store_root,
+};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug)]
+struct ConfigFileValidation {
+    path: PathBuf,
+    diagnostics: Vec<ConfigDiagnostic>,
+}
+
+pub fn run_config_validate(
+    cli: &Cli,
+    config_path_override: Option<&Path>,
+    json: bool,
+) -> Result<()> {
+    let selected_path = config_path_override.or(cli.config.as_deref());
+    let resolved_path = config_path(selected_path).ok();
+
+    match validate_config_file(selected_path) {
+        Ok(validation) => handle_validation_result(validation.path, validation.diagnostics, json),
+        Err(err) => {
+            print_validation_load_error(resolved_path.as_deref(), &err, json)?;
+            Err(err).context("config validation failed")
+        }
+    }
+}
+
+fn validate_config_file(override_path: Option<&Path>) -> Result<ConfigFileValidation> {
+    let path = config_path(override_path)?;
+    if !path.exists() {
+        bail!(
+            "Failed to read config file {}: file does not exist",
+            path.display()
+        );
+    }
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read config {}", path.display()))?;
+    let config: MeshConfig =
+        toml::from_str(&raw).with_context(|| format!("Invalid config {}", path.display()))?;
+    let diagnostics =
+        validate_config_diagnostics_with_plugin_schemas(&config, Some(&raw), plugin_schema);
+    Ok(ConfigFileValidation { path, diagnostics })
+}
+
+fn plugin_schema(plugin_name: &str) -> PluginSchemaAvailability {
+    let Ok(root) = default_store_root() else {
+        return PluginSchemaAvailability::NotInstalled;
+    };
+    let store = PluginStore::new(root);
+    let Ok(metadata) = store.load_optional(plugin_name) else {
+        return PluginSchemaAvailability::NotInstalled;
+    };
+    let Some(metadata) = metadata else {
+        return PluginSchemaAvailability::NotInstalled;
+    };
+    plugin_schema_from_metadata(&metadata)
+}
+
+fn plugin_schema_from_metadata(metadata: &InstalledPluginMetadata) -> PluginSchemaAvailability {
+    let Some(schema) = metadata
+        .manifest
+        .as_ref()
+        .and_then(|manifest| manifest.config_schema.as_ref())
+    else {
+        return PluginSchemaAvailability::MissingSchema;
+    };
+
+    if schema.schema_version != SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION {
+        return PluginSchemaAvailability::UnsupportedVersion {
+            version: schema.schema_version,
+        };
+    }
+
+    PluginSchemaAvailability::Available(plugin_schema_from_installed(schema))
+}
+
+fn plugin_schema_from_installed(schema: &InstalledPluginConfigSchema) -> PluginConfigSchema {
+    PluginConfigSchema {
+        plugin_name: schema.plugin_name.clone(),
+        schema_version: schema.schema_version,
+        allow_unvalidated_config: schema.allow_unvalidated_config,
+        settings: schema
+            .settings
+            .iter()
+            .map(|setting| PluginSettingSchema {
+                key: setting.key.clone(),
+                value_schema: plugin_value_schema_from_installed(&setting.value_schema),
+                required: setting.required,
+                default_json: setting.default_json.clone(),
+                constraints: setting
+                    .constraints
+                    .iter()
+                    .map(plugin_constraint_from_installed)
+                    .collect(),
+                description: setting.description.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn plugin_value_schema_from_installed(schema: &InstalledPluginValueSchema) -> PluginValueSchema {
+    PluginValueSchema {
+        kind: match schema.kind {
+            InstalledPluginValueKind::Boolean => PluginValueKind::Boolean,
+            InstalledPluginValueKind::Integer => PluginValueKind::Integer,
+            InstalledPluginValueKind::Float => PluginValueKind::Float,
+            InstalledPluginValueKind::String => PluginValueKind::String,
+            InstalledPluginValueKind::Path => PluginValueKind::Path,
+            InstalledPluginValueKind::Url => PluginValueKind::Url,
+            InstalledPluginValueKind::Enum => PluginValueKind::Enum,
+            InstalledPluginValueKind::Array => PluginValueKind::Array,
+            InstalledPluginValueKind::Object => PluginValueKind::Object,
+        },
+        enum_values: schema.enum_values.clone(),
+        items: schema
+            .items
+            .as_deref()
+            .map(plugin_value_schema_from_installed)
+            .map(Box::new),
+        object_properties: schema
+            .object_properties
+            .iter()
+            .map(plugin_object_property_from_installed)
+            .collect(),
+        allow_additional_properties: schema.allow_additional_properties,
+    }
+}
+
+fn plugin_object_property_from_installed(
+    property: &InstalledPluginObjectProperty,
+) -> PluginObjectPropertySchema {
+    PluginObjectPropertySchema {
+        key: property.key.clone(),
+        value_schema: plugin_value_schema_from_installed(&property.value_schema),
+        required: property.required,
+        description: property.description.clone(),
+    }
+}
+
+fn plugin_constraint_from_installed(
+    constraint: &InstalledPluginConstraint,
+) -> PluginSettingConstraint {
+    match constraint {
+        InstalledPluginConstraint::NonEmpty => PluginSettingConstraint::NonEmpty,
+        InstalledPluginConstraint::Positive => PluginSettingConstraint::Positive,
+        InstalledPluginConstraint::Range { min, max } => PluginSettingConstraint::Range {
+            min: min.clone(),
+            max: max.clone(),
+        },
+        InstalledPluginConstraint::AllowedValues { values } => {
+            PluginSettingConstraint::AllowedValues {
+                values: values.clone(),
+            }
+        }
+        InstalledPluginConstraint::Requires { key } => {
+            PluginSettingConstraint::Requires { key: key.clone() }
+        }
+    }
+}
+
+fn handle_validation_result(
+    path: PathBuf,
+    diagnostics: Vec<ConfigDiagnostic>,
+    json: bool,
+) -> Result<()> {
+    let report = ConfigValidateReport::from_diagnostics(path, diagnostics);
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        print_human_report(&report);
+    }
+
+    if report.ok {
+        Ok(())
+    } else {
+        bail!("config validation failed")
+    }
+}
+
+fn print_validation_load_error(path: Option<&Path>, err: &anyhow::Error, json: bool) -> Result<()> {
+    let report = ConfigValidateReport::from_error(path.map(Path::to_path_buf), err.to_string());
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+
+    let path = report.path.as_deref().unwrap_or("<unresolved>");
+    println!("Config invalid: {path}");
+    println!("  error: {err}");
+    Ok(())
+}
+
+fn print_human_report(report: &ConfigValidateReport) {
+    let path = report.path.as_deref().unwrap_or("<unresolved>");
+    if report.ok {
+        println!("Config valid: {path}");
+    } else {
+        println!("Config invalid: {path}");
+    }
+
+    for diagnostic in &report.diagnostics {
+        print_human_diagnostic(diagnostic);
+    }
+}
+
+fn print_human_diagnostic(diagnostic: &ConfigDiagnosticPayload) {
+    let path = diagnostic
+        .path
+        .as_deref()
+        .map(|path| format!(" at {path}"))
+        .unwrap_or_default();
+    println!(
+        "  {} {:?}{}: {}",
+        severity_label(diagnostic.severity),
+        diagnostic.code,
+        path,
+        diagnostic.message
+    );
+    if let Some(help) = diagnostic.help.as_deref() {
+        println!("    help: {help}");
+    }
+}
+
+const fn severity_label(severity: ConfigDiagnosticSeverity) -> &'static str {
+    match severity {
+        ConfigDiagnosticSeverity::Error => "error",
+        ConfigDiagnosticSeverity::Warning => "warning",
+        ConfigDiagnosticSeverity::Info => "info",
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConfigValidateReport {
+    ok: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+    diagnostics: Vec<ConfigDiagnosticPayload>,
+}
+
+impl ConfigValidateReport {
+    fn from_diagnostics(path: PathBuf, diagnostics: Vec<ConfigDiagnostic>) -> Self {
+        let ok = !diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity == ConfigDiagnosticSeverity::Error);
+        Self {
+            ok,
+            path: Some(path.display().to_string()),
+            error: None,
+            diagnostics: diagnostics
+                .iter()
+                .map(ConfigDiagnosticPayload::from)
+                .collect(),
+        }
+    }
+
+    fn from_error(path: Option<PathBuf>, error: String) -> Self {
+        Self {
+            ok: false,
+            path: path.map(|path| path.display().to_string()),
+            error: Some(error),
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConfigDiagnosticPayload {
+    code: ConfigDiagnosticCode,
+    severity: ConfigDiagnosticSeverity,
+    source: ConfigDiagnosticSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_source: Option<ConfigDiagnosticSchemaSource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canonical_path: Option<String>,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    help: Option<String>,
+}
+
+impl From<&ConfigDiagnostic> for ConfigDiagnosticPayload {
+    fn from(diagnostic: &ConfigDiagnostic) -> Self {
+        Self {
+            code: diagnostic.code,
+            severity: diagnostic.severity,
+            source: diagnostic.source,
+            schema_source: diagnostic.schema_source,
+            path: diagnostic.path.as_ref().map(ConfigPath::render),
+            canonical_path: diagnostic.canonical_path.as_ref().map(ConfigPath::render),
+            message: diagnostic.message.clone(),
+            help: diagnostic.help.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_validate_report_keeps_warning_only_diagnostics_successful() {
+        let diagnostic = ConfigDiagnostic::warning(
+            ConfigDiagnosticCode::LegacyUnvalidatedConfig,
+            ConfigDiagnosticSource::Plugin,
+            "plugin accepts unvalidated settings",
+        )
+        .at_path(plugin_settings_path("flash-moe"));
+
+        let report =
+            ConfigValidateReport::from_diagnostics(PathBuf::from("config.toml"), vec![diagnostic]);
+
+        assert!(report.ok);
+        assert_eq!(
+            report.diagnostics[0].path.as_deref(),
+            Some("plugin[\"flash-moe\"].settings")
+        );
+    }
+
+    #[test]
+    fn config_validate_report_marks_error_diagnostics_invalid() {
+        let diagnostic = ConfigDiagnostic::error(
+            ConfigDiagnosticCode::MissingRequiredValue,
+            ConfigDiagnosticSource::Schema,
+            "required plugin setting is missing",
+        )
+        .at_path(plugin_settings_path("flash-moe"));
+
+        let report =
+            ConfigValidateReport::from_diagnostics(PathBuf::from("config.toml"), vec![diagnostic]);
+
+        assert!(!report.ok);
+    }
+
+    #[test]
+    fn config_validate_error_report_serializes_stable_json_shape() {
+        let report = ConfigValidateReport::from_error(
+            Some(PathBuf::from("/tmp/config.toml")),
+            "failed to parse config TOML".to_string(),
+        );
+        let json = serde_json::to_value(report).unwrap();
+
+        assert_eq!(json["ok"], false);
+        assert_eq!(json["path"], "/tmp/config.toml");
+        assert_eq!(json["error"], "failed to parse config TOML");
+        assert_eq!(json["diagnostics"].as_array().unwrap().len(), 0);
+    }
+
+    fn plugin_settings_path(plugin_name: &str) -> ConfigPath {
+        let mut path = ConfigPath::field("plugin");
+        path.push_key(plugin_name).push_field("settings");
+        path
+    }
+}

--- a/crates/mesh-llm-commands/src/lib.rs
+++ b/crates/mesh-llm-commands/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod agent_cli;
 pub mod auth;
 pub mod benchmark;
+pub mod config;
 pub mod gpus;
 pub mod model_package;
 pub mod plugin;

--- a/crates/mesh-llm-config/src/authoring.rs
+++ b/crates/mesh-llm-config/src/authoring.rs
@@ -1,6 +1,9 @@
 use crate::{
-    GpuAssignment, HardwareConfig, MeshConfig, ModelConfigDefaults, ModelConfigEntry,
-    ModelFitConfig, MultimodalConfig, PluginConfigEntry, RequestDefaultsConfig, ThroughputConfig,
+    ConfigAliasMode, ConfigApplyMode, ConfigConstraint, ConfigControlSurface, ConfigPath,
+    ConfigPathAlias, ConfigRestartScope, ConfigSchema, ConfigSettingOwner, ConfigSettingSchema,
+    ConfigSupportState, ConfigValueSchema, ConfigVisibility, GpuAssignment, HardwareConfig,
+    MeshConfig, ModelConfigDefaults, ModelConfigEntry, ModelFitConfig, MultimodalConfig,
+    PluginConfigEntry, RequestDefaultsConfig, ThroughputConfig,
 };
 use anyhow::{Result, bail};
 use mesh_llm_types::runtime::ModelRuntimeKind;
@@ -17,6 +20,109 @@ pub struct LocalServingNodeConfig {
     pub owner_control_bind: Option<SocketAddr>,
     pub owner_control_advertise_addr: Option<SocketAddr>,
     pub gpu_assignment: Option<GpuAssignment>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ConfigSchemaBuilder {
+    settings: Vec<ConfigSettingSchema>,
+}
+
+impl ConfigSchemaBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn setting(&mut self, setting: ConfigSettingSchema) -> &mut Self {
+        self.settings.push(setting);
+        self
+    }
+
+    pub fn build(self) -> ConfigSchema {
+        ConfigSchema {
+            settings: self.settings,
+        }
+    }
+}
+
+pub fn built_in_config_schema() -> ConfigSchema {
+    ConfigSchema {
+        settings: crate::built_in_config_settings(),
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ConfigSettingSchemaBuilder {
+    setting: ConfigSettingSchema,
+}
+
+impl ConfigSettingSchemaBuilder {
+    pub fn new(path: ConfigPath, value_schema: ConfigValueSchema) -> Self {
+        Self {
+            setting: ConfigSettingSchema {
+                path,
+                alias_policy: Default::default(),
+                owner: ConfigSettingOwner::BuiltIn,
+                value_schema,
+                support: ConfigSupportState::Supported,
+                control_surfaces: Vec::new(),
+                apply_mode: ConfigApplyMode::StaticOnLoad,
+                restart_scope: ConfigRestartScope::None,
+                visibility: ConfigVisibility::User,
+                constraints: Vec::new(),
+                description: None,
+            },
+        }
+    }
+
+    pub fn owner(&mut self, owner: ConfigSettingOwner) -> &mut Self {
+        self.setting.owner = owner;
+        self
+    }
+
+    pub fn support(&mut self, support: ConfigSupportState) -> &mut Self {
+        self.setting.support = support;
+        self
+    }
+
+    pub fn control_surface(&mut self, surface: ConfigControlSurface) -> &mut Self {
+        self.setting.control_surfaces.push(surface);
+        self
+    }
+
+    pub fn apply_mode(&mut self, apply_mode: ConfigApplyMode) -> &mut Self {
+        self.setting.apply_mode = apply_mode;
+        self
+    }
+
+    pub fn restart_scope(&mut self, restart_scope: ConfigRestartScope) -> &mut Self {
+        self.setting.restart_scope = restart_scope;
+        self
+    }
+
+    pub fn visibility(&mut self, visibility: ConfigVisibility) -> &mut Self {
+        self.setting.visibility = visibility;
+        self
+    }
+
+    pub fn description(&mut self, description: impl Into<String>) -> &mut Self {
+        self.setting.description = Some(description.into());
+        self
+    }
+
+    pub fn alias(&mut self, alias: ConfigPathAlias) -> &mut Self {
+        self.setting.alias_policy.mode = ConfigAliasMode::CanonicalWithLegacyAliases;
+        self.setting.alias_policy.aliases.push(alias);
+        self
+    }
+
+    pub fn constraint(&mut self, constraint: ConfigConstraint) -> &mut Self {
+        self.setting.constraints.push(constraint);
+        self
+    }
+
+    pub fn build(self) -> ConfigSettingSchema {
+        self.setting
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -181,6 +287,7 @@ impl ConfigEditor {
                     command: None,
                     args: Vec::new(),
                     url: None,
+                    settings: Default::default(),
                     startup: Default::default(),
                 });
                 self.config.plugins.len() - 1
@@ -411,4 +518,64 @@ fn normalize_non_empty(value: &str, label: &str) -> Result<String> {
         bail!("{label} cannot be empty");
     }
     Ok(value.to_string())
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+    use crate::{ConfigPathAliasKind, ConfigVisibility};
+
+    #[test]
+    fn schema_setting_builder_populates_control_surface_metadata() {
+        let mut setting = ConfigSettingSchemaBuilder::new(
+            ConfigPath::from_fields(["owner_control", "bind"]),
+            ConfigValueSchema::SocketAddr,
+        );
+        setting
+            .owner(ConfigSettingOwner::BuiltIn)
+            .support(ConfigSupportState::Supported)
+            .control_surface(ConfigControlSurface::ConfigFile)
+            .control_surface(ConfigControlSurface::OwnerControl)
+            .apply_mode(ConfigApplyMode::DynamicApply)
+            .restart_scope(ConfigRestartScope::ProcessRestart)
+            .visibility(ConfigVisibility::Advanced)
+            .description("Owner control listener bind address")
+            .constraint(ConfigConstraint::NonEmpty)
+            .alias(ConfigPathAlias {
+                path: ConfigPath::from_fields(["owner_control", "listen"]),
+                kind: ConfigPathAliasKind::LegacyKey,
+                note: Some("legacy naming preserved for diagnostics".into()),
+            });
+
+        let built = setting.build();
+
+        assert_eq!(built.path.render(), "owner_control.bind");
+        assert_eq!(
+            built.alias_policy.mode,
+            ConfigAliasMode::CanonicalWithLegacyAliases
+        );
+        assert_eq!(built.alias_policy.aliases.len(), 1);
+        assert_eq!(built.control_surfaces.len(), 2);
+        assert_eq!(built.apply_mode, ConfigApplyMode::DynamicApply);
+        assert_eq!(built.restart_scope, ConfigRestartScope::ProcessRestart);
+        assert_eq!(built.visibility, ConfigVisibility::Advanced);
+    }
+
+    #[test]
+    fn schema_builder_collects_settings() {
+        let mut schema = ConfigSchemaBuilder::new();
+        let mut setting = ConfigSettingSchemaBuilder::new(
+            ConfigPath::from_fields(["telemetry", "endpoint"]),
+            ConfigValueSchema::String,
+        );
+        setting
+            .owner(ConfigSettingOwner::BuiltIn)
+            .control_surface(ConfigControlSurface::ConfigFile);
+        schema.setting(setting.build());
+
+        let built = schema.build();
+
+        assert_eq!(built.settings.len(), 1);
+        assert_eq!(built.settings[0].path.render(), "telemetry.endpoint");
+    }
 }

--- a/crates/mesh-llm-config/src/diagnostic.rs
+++ b/crates/mesh-llm-config/src/diagnostic.rs
@@ -1,0 +1,180 @@
+use crate::ConfigPath;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigDiagnosticSeverity {
+    #[default]
+    Error,
+    Warning,
+    Info,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigDiagnosticSource {
+    #[default]
+    Validation,
+    Schema,
+    Plugin,
+    Compatibility,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigDiagnosticSchemaSource {
+    BuiltIn,
+    Engine,
+    Plugin,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigDiagnosticCode {
+    InvalidValue,
+    MissingRequiredValue,
+    UnsupportedField,
+    RejectedField,
+    AliasApplied,
+    MisplacedField,
+    UnknownField,
+    SchemaUnavailable,
+    LegacyUnvalidatedConfig,
+    UnsupportedSchemaVersion,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ConfigDiagnostic {
+    pub code: ConfigDiagnosticCode,
+    pub severity: ConfigDiagnosticSeverity,
+    pub source: ConfigDiagnosticSource,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_source: Option<ConfigDiagnosticSchemaSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<ConfigPath>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub canonical_path: Option<ConfigPath>,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub help: Option<String>,
+}
+
+impl ConfigDiagnostic {
+    pub fn new(
+        code: ConfigDiagnosticCode,
+        severity: ConfigDiagnosticSeverity,
+        source: ConfigDiagnosticSource,
+        message: impl Into<String>,
+    ) -> Self {
+        Self {
+            code,
+            severity,
+            source,
+            schema_source: None,
+            path: None,
+            canonical_path: None,
+            message: message.into(),
+            help: None,
+        }
+    }
+
+    pub fn error(
+        code: ConfigDiagnosticCode,
+        source: ConfigDiagnosticSource,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(code, ConfigDiagnosticSeverity::Error, source, message)
+    }
+
+    pub fn warning(
+        code: ConfigDiagnosticCode,
+        source: ConfigDiagnosticSource,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::new(code, ConfigDiagnosticSeverity::Warning, source, message)
+    }
+
+    pub fn at_path(mut self, path: ConfigPath) -> Self {
+        self.path = Some(path);
+        self
+    }
+
+    pub fn with_schema_source(mut self, schema_source: ConfigDiagnosticSchemaSource) -> Self {
+        self.schema_source = Some(schema_source);
+        self
+    }
+
+    pub fn with_canonical_path(mut self, canonical_path: ConfigPath) -> Self {
+        self.canonical_path = Some(canonical_path);
+        self
+    }
+
+    pub fn with_help(mut self, help: impl Into<String>) -> Self {
+        self.help = Some(help.into());
+        self
+    }
+
+    pub fn legacy_message(&self) -> &str {
+        &self.message
+    }
+}
+
+pub fn invalid_value_diagnostic(path: ConfigPath, message: impl Into<String>) -> ConfigDiagnostic {
+    ConfigDiagnostic::error(
+        ConfigDiagnosticCode::InvalidValue,
+        ConfigDiagnosticSource::Validation,
+        message,
+    )
+    .with_schema_source(ConfigDiagnosticSchemaSource::BuiltIn)
+    .at_path(path)
+}
+
+pub fn unsupported_field_diagnostic(
+    path: ConfigPath,
+    message: impl Into<String>,
+) -> ConfigDiagnostic {
+    ConfigDiagnostic::error(
+        ConfigDiagnosticCode::UnsupportedField,
+        ConfigDiagnosticSource::Schema,
+        message,
+    )
+    .with_schema_source(ConfigDiagnosticSchemaSource::BuiltIn)
+    .at_path(path.clone())
+    .with_canonical_path(path)
+}
+
+pub fn rejected_field_diagnostic(path: ConfigPath, message: impl Into<String>) -> ConfigDiagnostic {
+    ConfigDiagnostic::error(
+        ConfigDiagnosticCode::RejectedField,
+        ConfigDiagnosticSource::Schema,
+        message,
+    )
+    .with_schema_source(ConfigDiagnosticSchemaSource::BuiltIn)
+    .at_path(path.clone())
+    .with_canonical_path(path)
+}
+
+pub fn alias_diagnostic(
+    used_path: ConfigPath,
+    canonical_path: ConfigPath,
+    message: impl Into<String>,
+) -> ConfigDiagnostic {
+    ConfigDiagnostic::warning(
+        ConfigDiagnosticCode::AliasApplied,
+        ConfigDiagnosticSource::Compatibility,
+        message,
+    )
+    .with_schema_source(ConfigDiagnosticSchemaSource::BuiltIn)
+    .at_path(used_path)
+    .with_canonical_path(canonical_path)
+}
+
+pub(crate) type DiagnosticResult = std::result::Result<(), ConfigDiagnostic>;
+
+pub fn legacy_validation_error_text(diagnostics: &[ConfigDiagnostic]) -> String {
+    diagnostics
+        .iter()
+        .map(ConfigDiagnostic::legacy_message)
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/crates/mesh-llm-config/src/lib.rs
+++ b/crates/mesh-llm-config/src/lib.rs
@@ -1,23 +1,38 @@
 mod authoring;
+mod diagnostic;
 mod model;
 mod plugin_validation;
 mod store;
 mod validate;
 
 pub use authoring::{
-    ConfigEditor, LocalServingNodeConfig, ModelConfigEditor, ModelDefaultsEditor,
-    PluginConfigEditor,
+    ConfigEditor, ConfigSchemaBuilder, ConfigSettingSchemaBuilder, LocalServingNodeConfig,
+    ModelConfigEditor, ModelDefaultsEditor, PluginConfigEditor, built_in_config_schema,
 };
 pub use model::*;
+pub use plugin_validation::{
+    PluginConfigSchema, PluginObjectPropertySchema, PluginSchemaAvailability,
+    PluginSettingConstraint, PluginSettingSchema, PluginValueKind, PluginValueSchema,
+    SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION,
+};
 pub use store::{ConfigStore, config_path, config_to_toml, load_config, parse_config_toml};
-pub use validate::validate_config;
+pub use validate::{
+    ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticSchemaSource, ConfigDiagnosticSeverity,
+    ConfigDiagnosticSource, alias_diagnostic, built_in_support_diagnostic,
+    canonical_builtin_diagnostic_path, invalid_value_diagnostic, legacy_validation_error_text,
+    rejected_field_diagnostic, unsupported_field_diagnostic, validate_config,
+    validate_config_diagnostics, validate_config_diagnostics_with_plugin_schemas,
+    validate_config_with_plugin_schemas,
+};
 
 #[cfg(test)]
 mod tests {
     use super::{
         ConfigStore, GpuAssignment, LocalServingNodeConfig, MeshConfig, ModelRuntimeKind,
-        parse_config_toml, validate_config,
+        built_in_config_schema, canonicalize_built_in_config_identifier, parse_config_toml,
+        validate_config,
     };
+    use std::collections::{BTreeMap, BTreeSet};
     use std::fs;
     use tempfile::TempDir;
 
@@ -312,5 +327,442 @@ gpu_id = "pci:0000:65:00.0"
 
         assert!(toml.contains("gpu_id = \"pci:0000:65:00.0\""));
         parse_config_toml(&toml).unwrap();
+    }
+
+    #[test]
+    fn built_in_schema_exhaustiveness() {
+        let schema = built_in_config_schema();
+        let canonical_paths: BTreeSet<_> = schema
+            .settings
+            .iter()
+            .map(|setting| setting.path.render())
+            .collect();
+        assert_eq!(
+            canonical_paths.len(),
+            schema.settings.len(),
+            "duplicate canonical paths in built-in schema"
+        );
+
+        assert_eq!(
+            schema.settings.len(),
+            canonical_public_field_count(),
+            "built-in schema count drifted from model-owned config leaf inventory"
+        );
+
+        for required in [
+            "version",
+            "gpu.assignment",
+            "owner_control.bind",
+            "telemetry.prompt_shape_metrics",
+            "defaults.model_fit.ctx_size",
+            "defaults.hardware.rpc_backend",
+            "models.<model-ref>.hardware.device",
+            "models.<model-ref>.throughput.sleep_idle_seconds",
+            "models.<model-ref>.request_defaults.json_schema",
+            "plugin.<plugin-name>.startup.connect_timeout_secs",
+        ] {
+            assert!(
+                canonical_paths.contains(required),
+                "missing built-in schema descriptor for {required}"
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_path_aliases() {
+        let cases = [
+            ("models[0].gpu_id", "models.<model-ref>.hardware.device"),
+            (
+                "models[0].ctx_size",
+                "models.<model-ref>.model_fit.ctx_size",
+            ),
+            (
+                "models[0].parallel",
+                "models.<model-ref>.throughput.parallel",
+            ),
+            ("models[0].mmproj", "models.<model-ref>.multimodal.mmproj"),
+            ("defaults.gpu_id", "defaults.hardware.device"),
+            ("defaults.ctx_size", "defaults.model_fit.ctx_size"),
+            ("defaults.parallel", "defaults.throughput.parallel"),
+            ("defaults.mmproj", "defaults.multimodal.mmproj"),
+            (
+                "plugin[0].startup.connect_timeout_secs",
+                "plugin.<plugin-name>.startup.connect_timeout_secs",
+            ),
+        ];
+
+        for (alias, canonical) in cases {
+            assert_eq!(
+                canonicalize_built_in_config_identifier(alias).as_deref(),
+                Some(canonical),
+                "alias `{alias}` should resolve to canonical `{canonical}`"
+            );
+        }
+    }
+
+    #[test]
+    fn authoring_mutators_remain_schema_classified() {
+        let canonical_paths: BTreeSet<_> = built_in_config_schema()
+            .settings
+            .into_iter()
+            .map(|setting| setting.path.render())
+            .collect();
+        let tracked = BTreeMap::from([
+            ("ConfigEditor::set_version", vec!["version"]),
+            ("ConfigEditor::set_gpu_assignment", vec!["gpu.assignment"]),
+            ("ConfigEditor::set_gpu_parallel", vec!["gpu.parallel"]),
+            (
+                "ConfigEditor::set_owner_control_bind",
+                vec!["owner_control.bind"],
+            ),
+            (
+                "ConfigEditor::set_owner_control_advertise_addr",
+                vec!["owner_control.advertise_addr"],
+            ),
+            (
+                "ConfigEditor::set_default_runtime",
+                vec!["defaults.hardware.model_runtime"],
+            ),
+            (
+                "ConfigEditor::clear_default_runtime",
+                vec!["defaults.hardware.model_runtime"],
+            ),
+            (
+                "ConfigEditor::set_default_device",
+                vec!["defaults.hardware.device"],
+            ),
+            (
+                "ConfigEditor::clear_default_device",
+                vec!["defaults.hardware.device"],
+            ),
+            (
+                "ConfigEditor::set_default_context_size",
+                vec!["defaults.model_fit.ctx_size"],
+            ),
+            (
+                "ConfigEditor::configure_local_serving_node",
+                vec![
+                    "version",
+                    "gpu.assignment",
+                    "owner_control.bind",
+                    "owner_control.advertise_addr",
+                    "models.<model-ref>.hardware.model_runtime",
+                    "models.<model-ref>.hardware.device",
+                    "models.<model-ref>.model_fit.ctx_size",
+                    "models.<model-ref>.throughput.parallel",
+                    "models.<model-ref>.multimodal.mmproj",
+                ],
+            ),
+            (
+                "ConfigEditor::enable_builtin_plugin",
+                vec!["plugin.<plugin-name>.enabled"],
+            ),
+            (
+                "ConfigEditor::disable_plugin",
+                vec!["plugin.<plugin-name>.enabled"],
+            ),
+            (
+                "ConfigEditor::upsert_external_plugin",
+                vec![
+                    "plugin.<plugin-name>.enabled",
+                    "plugin.<plugin-name>.command",
+                    "plugin.<plugin-name>.args",
+                ],
+            ),
+            (
+                "ModelDefaultsEditor::runtime",
+                vec!["defaults.hardware.model_runtime"],
+            ),
+            (
+                "ModelDefaultsEditor::clear_runtime",
+                vec!["defaults.hardware.model_runtime"],
+            ),
+            (
+                "ModelDefaultsEditor::device",
+                vec!["defaults.hardware.device"],
+            ),
+            (
+                "ModelDefaultsEditor::clear_device",
+                vec!["defaults.hardware.device"],
+            ),
+            (
+                "ModelDefaultsEditor::context_size",
+                vec!["defaults.model_fit.ctx_size"],
+            ),
+            (
+                "ModelDefaultsEditor::parallel",
+                vec!["defaults.throughput.parallel"],
+            ),
+            (
+                "ModelConfigEditor::runtime",
+                vec!["models.<model-ref>.hardware.model_runtime"],
+            ),
+            (
+                "ModelConfigEditor::clear_runtime",
+                vec!["models.<model-ref>.hardware.model_runtime"],
+            ),
+            (
+                "ModelConfigEditor::device",
+                vec!["models.<model-ref>.hardware.device"],
+            ),
+            (
+                "ModelConfigEditor::clear_device",
+                vec!["models.<model-ref>.hardware.device"],
+            ),
+            (
+                "ModelConfigEditor::context_size",
+                vec!["models.<model-ref>.model_fit.ctx_size"],
+            ),
+            (
+                "ModelConfigEditor::parallel",
+                vec!["models.<model-ref>.throughput.parallel"],
+            ),
+            (
+                "ModelConfigEditor::cache_types",
+                vec![
+                    "models.<model-ref>.model_fit.cache_type_k",
+                    "models.<model-ref>.model_fit.cache_type_v",
+                ],
+            ),
+            (
+                "ModelConfigEditor::max_tokens",
+                vec!["models.<model-ref>.request_defaults.max_tokens"],
+            ),
+            (
+                "ModelConfigEditor::temperature",
+                vec!["models.<model-ref>.request_defaults.temperature"],
+            ),
+            (
+                "ModelConfigEditor::mmproj",
+                vec!["models.<model-ref>.multimodal.mmproj"],
+            ),
+            (
+                "PluginConfigEditor::enabled",
+                vec!["plugin.<plugin-name>.enabled"],
+            ),
+            (
+                "PluginConfigEditor::command",
+                vec!["plugin.<plugin-name>.command"],
+            ),
+            (
+                "PluginConfigEditor::args",
+                vec!["plugin.<plugin-name>.args"],
+            ),
+            ("PluginConfigEditor::url", vec!["plugin.<plugin-name>.url"]),
+            (
+                "PluginConfigEditor::connect_timeout_secs",
+                vec!["plugin.<plugin-name>.startup.connect_timeout_secs"],
+            ),
+            (
+                "PluginConfigEditor::init_timeout_secs",
+                vec!["plugin.<plugin-name>.startup.init_timeout_secs"],
+            ),
+            (
+                "PluginConfigEditor::optional",
+                vec!["plugin.<plugin-name>.startup.optional"],
+            ),
+            (
+                "PluginConfigEditor::lazy_start",
+                vec!["plugin.<plugin-name>.startup.lazy_start"],
+            ),
+        ]);
+        let ignored = BTreeSet::from([
+            "ConfigEditor::new",
+            "ConfigEditor::into_config",
+            "ConfigEditor::config",
+            "ConfigEditor::defaults",
+            "ConfigEditor::upsert_model",
+            "ConfigEditor::remove_model",
+            "ConfigEditor::model_refs",
+            "ConfigEditor::upsert_plugin",
+            "ModelConfigEditor::model_ref",
+            "PluginConfigEditor::name",
+        ]);
+        let actual = authoring_public_methods();
+        let expected = tracked
+            .keys()
+            .map(|name| (*name).to_string())
+            .chain(ignored.iter().map(|name| (*name).to_string()))
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            actual, expected,
+            "authoring public method inventory drifted; classify new mutators against the schema registry"
+        );
+
+        for (method, paths) in tracked {
+            for path in paths {
+                assert!(
+                    canonical_paths.contains(path),
+                    "authoring method {method} references unclassified canonical path {path}"
+                );
+            }
+        }
+    }
+
+    fn canonical_public_field_count() -> usize {
+        let source = include_str!("model.rs");
+        let occurrences = [
+            ("MeshConfig", 1usize),
+            ("OwnerControlConfig", 1),
+            ("GpuConfig", 1),
+            ("RuntimeConfig", 1),
+            ("MeshRequirementsConfig", 1),
+            ("ModelConfigEntry", 1),
+            ("ModelFitConfig", 2),
+            ("PrefixCacheConfig", 2),
+            ("HardwareConfig", 2),
+            ("ThroughputConfig", 2),
+            ("SkippyConfig", 2),
+            ("SpeculativeConfig", 2),
+            ("RequestDefaultsConfig", 2),
+            ("MultimodalConfig", 2),
+            ("AdvancedServerConfig", 2),
+            ("TelemetryConfig", 1),
+            ("TelemetryMetricsConfig", 1),
+            ("PluginConfigEntry", 1),
+            ("PluginStartupConfig", 1),
+        ];
+        let nested = [
+            "GpuConfig",
+            "MeshRequirementsConfig",
+            "OwnerControlConfig",
+            "RuntimeConfig",
+            "TelemetryConfig",
+            "TelemetryMetricsConfig",
+            "ModelConfigDefaults",
+            "ModelConfigEntry",
+            "ModelFitConfig",
+            "PrefixCacheConfig",
+            "HardwareConfig",
+            "ThroughputConfig",
+            "SkippyConfig",
+            "SpeculativeConfig",
+            "RequestDefaultsConfig",
+            "MultimodalConfig",
+            "AdvancedConfig",
+            "AdvancedServerConfig",
+            "PluginConfigEntry",
+            "PluginStartupConfig",
+        ];
+        let ignored = [
+            "extra",
+            "gpu_id_from_legacy_shim",
+            "models",
+            "plugins",
+            "settings",
+        ];
+
+        occurrences
+            .iter()
+            .map(|(name, multiplier)| {
+                let leafs = extract_struct_fields(source, name)
+                    .into_iter()
+                    .filter(|(field, ty)| {
+                        !ignored.contains(&field.as_str())
+                            && !is_legacy_flat_model_field(name, field)
+                            && !nested
+                                .iter()
+                                .any(|nested_ty| contains_nested_type(ty, nested_ty))
+                    })
+                    .count();
+                leafs * multiplier
+            })
+            .sum()
+    }
+
+    fn extract_struct_fields(source: &str, struct_name: &str) -> Vec<(String, String)> {
+        let marker = format!("pub struct {struct_name} {{");
+        let start = source
+            .find(&marker)
+            .unwrap_or_else(|| panic!("struct {struct_name} not found in model.rs"));
+        let body = &source[start + marker.len()..];
+        let end = body.find("\n}").expect("struct body terminator");
+
+        body[..end]
+            .lines()
+            .filter_map(|line| {
+                let line = line.trim();
+                line.strip_prefix("pub ")
+                    .and_then(|line| line.split_once(':'))
+                    .map(|(field, ty)| {
+                        (
+                            field.trim().to_string(),
+                            ty.trim().trim_end_matches(',').to_string(),
+                        )
+                    })
+            })
+            .collect()
+    }
+
+    fn contains_nested_type(type_name: &str, nested: &str) -> bool {
+        type_name == nested
+            || type_name == format!("Option<{nested}>")
+            || type_name == format!("Vec<{nested}>")
+    }
+
+    fn authoring_public_methods() -> BTreeSet<String> {
+        let source = include_str!("authoring.rs");
+        let mut methods = BTreeSet::new();
+
+        for (impl_name, marker) in [
+            ("ConfigEditor", "impl ConfigEditor {"),
+            ("ModelDefaultsEditor", "impl ModelDefaultsEditor<'_> {"),
+            ("ModelConfigEditor", "impl ModelConfigEditor<'_> {"),
+            ("PluginConfigEditor", "impl PluginConfigEditor<'_> {"),
+        ] {
+            let body = impl_body(source, marker);
+            for line in body.lines() {
+                let line = line.trim_start();
+                if let Some(signature) = line.strip_prefix("pub fn ") {
+                    let name = signature
+                        .split_once('(')
+                        .map(|(name, _)| name)
+                        .expect("public function signature should contain '('");
+                    methods.insert(format!("{impl_name}::{name}"));
+                }
+            }
+        }
+
+        methods
+    }
+
+    fn impl_body<'a>(source: &'a str, marker: &str) -> &'a str {
+        let start = source
+            .find(marker)
+            .unwrap_or_else(|| panic!("impl marker `{marker}` not found in authoring.rs"));
+        let body_start = start + marker.len();
+        let mut depth = 1usize;
+
+        for (offset, ch) in source[body_start..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &source[body_start..body_start + offset];
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        panic!("impl marker `{marker}` did not terminate");
+    }
+
+    fn is_legacy_flat_model_field(struct_name: &str, field: &str) -> bool {
+        struct_name == "ModelConfigEntry"
+            && matches!(
+                field,
+                "mmproj"
+                    | "ctx_size"
+                    | "gpu_id"
+                    | "parallel"
+                    | "cache_type_k"
+                    | "cache_type_v"
+                    | "batch"
+                    | "ubatch"
+                    | "flash_attention"
+            )
     }
 }

--- a/crates/mesh-llm-config/src/model.rs
+++ b/crates/mesh-llm-config/src/model.rs
@@ -1,3 +1,13 @@
+mod built_in_schema;
+mod schema_types;
+
+pub use built_in_schema::{
+    BuiltInConfigPathResolution, built_in_config_schema_descriptor, built_in_config_settings,
+    canonicalize_built_in_config_identifier, canonicalize_built_in_config_path,
+    resolve_built_in_config_identifier, resolve_built_in_config_path,
+};
+pub use schema_types::*;
+
 pub use mesh_llm_types::runtime::ModelRuntimeKind;
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Serialize};
@@ -978,6 +988,8 @@ pub struct PluginConfigEntry {
     /// Optional URL passed to the plugin as `MESH_LLM_PLUGIN_URL`.
     #[serde(default)]
     pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub settings: BTreeMap<String, toml::Value>,
     #[serde(default, skip_serializing_if = "PluginStartupConfig::is_default")]
     pub startup: PluginStartupConfig,
 }

--- a/crates/mesh-llm-config/src/model/built_in_schema.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema.rs
@@ -1,0 +1,1097 @@
+use super::*;
+use std::sync::OnceLock;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuiltInConfigPathResolution {
+    pub requested_path: ConfigPath,
+    pub normalized_path: ConfigPath,
+    pub canonical_path: ConfigPath,
+    pub matched_alias: Option<ConfigPath>,
+    pub support: ConfigSupportState,
+}
+
+impl BuiltInConfigPathResolution {
+    pub fn canonical_identifier(&self) -> String {
+        self.canonical_path.render()
+    }
+
+    pub fn used_legacy_alias(&self) -> bool {
+        self.matched_alias.is_some()
+    }
+}
+
+pub fn built_in_config_settings() -> Vec<ConfigSettingSchema> {
+    built_in_config_schema_cache().settings.clone()
+}
+
+pub fn built_in_config_schema_descriptor(path: &ConfigPath) -> Option<ConfigSettingSchema> {
+    let normalized = path.normalize_builtin_layout();
+    built_in_config_schema_cache()
+        .settings
+        .iter()
+        .find(|setting| setting.path == normalized)
+        .cloned()
+}
+
+pub fn resolve_built_in_config_path(path: &ConfigPath) -> Option<BuiltInConfigPathResolution> {
+    let requested_path = path.clone();
+    let normalized_path = path.normalize_builtin_layout();
+
+    for setting in &built_in_config_schema_cache().settings {
+        if setting.path == normalized_path {
+            return Some(BuiltInConfigPathResolution {
+                requested_path,
+                normalized_path,
+                canonical_path: setting.path.clone(),
+                matched_alias: None,
+                support: setting.support,
+            });
+        }
+        if let Some(alias) = setting
+            .alias_policy
+            .aliases
+            .iter()
+            .find(|alias| alias.path == normalized_path)
+        {
+            return Some(BuiltInConfigPathResolution {
+                requested_path,
+                normalized_path,
+                canonical_path: setting.path.clone(),
+                matched_alias: Some(alias.path.clone()),
+                support: setting.support,
+            });
+        }
+    }
+
+    None
+}
+
+pub fn resolve_built_in_config_identifier(rendered: &str) -> Option<BuiltInConfigPathResolution> {
+    let parsed = ConfigPath::parse_rendered(rendered).ok()?;
+    resolve_built_in_config_path(&parsed)
+}
+
+pub fn canonicalize_built_in_config_path(path: &ConfigPath) -> Option<ConfigPath> {
+    resolve_built_in_config_path(path).map(|resolution| resolution.canonical_path)
+}
+
+pub fn canonicalize_built_in_config_identifier(rendered: &str) -> Option<String> {
+    resolve_built_in_config_identifier(rendered).map(|resolution| resolution.canonical_identifier())
+}
+
+fn built_in_config_schema_cache() -> &'static ConfigSchema {
+    static SCHEMA: OnceLock<ConfigSchema> = OnceLock::new();
+    SCHEMA.get_or_init(build_built_in_config_schema)
+}
+
+fn build_built_in_config_schema() -> ConfigSchema {
+    let mut settings = vec![
+        top_level_setting("version", ConfigValueSchema::Integer),
+        top_level_setting("gpu.assignment", string_enum(["auto", "pinned"])),
+        top_level_setting("gpu.parallel", ConfigValueSchema::Integer),
+        top_level_setting(
+            "mesh_requirements.min_node_version",
+            ConfigValueSchema::String,
+        ),
+        top_level_setting(
+            "mesh_requirements.max_node_version",
+            ConfigValueSchema::String,
+        ),
+        top_level_setting(
+            "mesh_requirements.min_protocol_version",
+            ConfigValueSchema::Integer,
+        ),
+        top_level_setting(
+            "mesh_requirements.max_protocol_version",
+            ConfigValueSchema::Integer,
+        ),
+        top_level_setting(
+            "mesh_requirements.require_release_attestation",
+            ConfigValueSchema::Boolean,
+        ),
+        top_level_setting(
+            "mesh_requirements.release_signer_keys",
+            ConfigValueSchema::Array {
+                items: Box::new(ConfigValueSchema::String),
+            },
+        ),
+        owner_control_setting("owner_control.bind", ConfigValueSchema::SocketAddr),
+        owner_control_setting(
+            "owner_control.advertise_addr",
+            ConfigValueSchema::SocketAddr,
+        ),
+        telemetry_setting("telemetry.enabled", ConfigValueSchema::Boolean),
+        telemetry_setting("telemetry.service_name", ConfigValueSchema::String),
+        telemetry_setting("telemetry.endpoint", ConfigValueSchema::String),
+        telemetry_setting("telemetry.headers", ConfigValueSchema::Object),
+        telemetry_setting("telemetry.export_interval_secs", ConfigValueSchema::Integer),
+        telemetry_setting("telemetry.queue_size", ConfigValueSchema::Integer),
+        unsupported_setting(
+            "telemetry.prompt_shape_metrics",
+            ConfigValueSchema::Boolean,
+            "Prompt-shape telemetry is intentionally disabled until the telemetry surface is reviewed.",
+        ),
+        telemetry_setting("telemetry.metrics.endpoint", ConfigValueSchema::String),
+        runtime_setting(
+            "runtime.reconcile_model_targets",
+            ConfigValueSchema::Boolean,
+        ),
+        runtime_setting(
+            "runtime.reconcile_model_target_demand_upgrades",
+            ConfigValueSchema::Boolean,
+        ),
+        runtime_setting(
+            "runtime.model_target_demand_upgrade_min_requests",
+            ConfigValueSchema::Integer,
+        ),
+        runtime_setting(
+            "runtime.model_target_demand_upgrade_max_age_secs",
+            ConfigValueSchema::Integer,
+        ),
+    ];
+
+    settings.extend(model_defaults_settings());
+    settings.extend(model_entry_settings());
+    settings.extend(plugin_entry_settings());
+
+    ConfigSchema { settings }
+}
+
+fn model_defaults_settings() -> Vec<ConfigSettingSchema> {
+    let mut settings = Vec::new();
+    settings.extend(model_fit_settings(
+        "defaults.model_fit",
+        &[
+            flat_alias("defaults.ctx_size"),
+            flat_alias("defaults.batch"),
+            flat_alias("defaults.ubatch"),
+            flat_alias("defaults.cache_type_k"),
+            flat_alias("defaults.cache_type_v"),
+            flat_alias("defaults.flash_attention"),
+        ],
+    ));
+    settings.extend(hardware_settings(
+        "defaults.hardware",
+        &[flat_alias("defaults.gpu_id")],
+    ));
+    settings.extend(throughput_settings(
+        "defaults.throughput",
+        &[flat_alias("defaults.parallel")],
+    ));
+    settings.extend(skippy_settings("defaults.skippy"));
+    settings.extend(speculative_settings("defaults.speculative"));
+    settings.extend(request_defaults_settings("defaults.request_defaults"));
+    settings.extend(multimodal_settings(
+        "defaults.multimodal",
+        &[flat_alias("defaults.mmproj")],
+    ));
+    settings.extend(advanced_settings("defaults.advanced"));
+    settings
+}
+
+fn model_entry_settings() -> Vec<ConfigSettingSchema> {
+    let model_prefix = format!("models.{CANONICAL_MODEL_REF_SEGMENT}");
+    let mut settings = vec![basic_setting(
+        &format!("{model_prefix}.model"),
+        ConfigValueSchema::String,
+    )];
+    settings.extend(model_fit_settings(
+        &format!("{model_prefix}.model_fit"),
+        &[
+            flat_alias(&format!("{model_prefix}.ctx_size")),
+            flat_alias(&format!("{model_prefix}.batch")),
+            flat_alias(&format!("{model_prefix}.ubatch")),
+            flat_alias(&format!("{model_prefix}.cache_type_k")),
+            flat_alias(&format!("{model_prefix}.cache_type_v")),
+            flat_alias(&format!("{model_prefix}.flash_attention")),
+        ],
+    ));
+    settings.extend(hardware_settings(
+        &format!("{model_prefix}.hardware"),
+        &[flat_alias(&format!("{model_prefix}.gpu_id"))],
+    ));
+    settings.extend(throughput_settings(
+        &format!("{model_prefix}.throughput"),
+        &[flat_alias(&format!("{model_prefix}.parallel"))],
+    ));
+    settings.extend(skippy_settings(&format!("{model_prefix}.skippy")));
+    settings.extend(speculative_settings(&format!("{model_prefix}.speculative")));
+    settings.extend(request_defaults_settings(&format!(
+        "{model_prefix}.request_defaults"
+    )));
+    settings.extend(multimodal_settings(
+        &format!("{model_prefix}.multimodal"),
+        &[flat_alias(&format!("{model_prefix}.mmproj"))],
+    ));
+    settings.extend(advanced_settings(&format!("{model_prefix}.advanced")));
+    settings
+}
+
+fn plugin_entry_settings() -> Vec<ConfigSettingSchema> {
+    let plugin_prefix = format!("plugin.{CANONICAL_PLUGIN_NAME_SEGMENT}");
+    vec![
+        plugin_setting(&format!("{plugin_prefix}.name"), ConfigValueSchema::String),
+        plugin_setting(
+            &format!("{plugin_prefix}.enabled"),
+            ConfigValueSchema::Boolean,
+        ),
+        plugin_setting(
+            &format!("{plugin_prefix}.command"),
+            ConfigValueSchema::String,
+        ),
+        plugin_setting(
+            &format!("{plugin_prefix}.args"),
+            ConfigValueSchema::Array {
+                items: Box::new(ConfigValueSchema::String),
+            },
+        ),
+        plugin_setting(&format!("{plugin_prefix}.url"), ConfigValueSchema::String),
+        plugin_setting(
+            &format!("{plugin_prefix}.startup.connect_timeout_secs"),
+            ConfigValueSchema::Integer,
+        ),
+        plugin_setting(
+            &format!("{plugin_prefix}.startup.init_timeout_secs"),
+            ConfigValueSchema::Integer,
+        ),
+        plugin_setting(
+            &format!("{plugin_prefix}.startup.optional"),
+            ConfigValueSchema::Boolean,
+        ),
+        plugin_setting(
+            &format!("{plugin_prefix}.startup.lazy_start"),
+            ConfigValueSchema::Boolean,
+        ),
+    ]
+}
+
+fn model_fit_settings(
+    prefix: &str,
+    legacy_aliases: &[ConfigPathAlias],
+) -> Vec<ConfigSettingSchema> {
+    let mut settings = vec![
+        basic_setting(&format!("{prefix}.ctx_size"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.batch"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.ubatch"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.cache_type_k"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.cache_type_v"), ConfigValueSchema::String),
+        basic_setting(
+            &format!("{prefix}.kv_cache_policy"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.kv_offload"), bool_or_auto_schema()),
+        basic_setting(&format!("{prefix}.kv_unified"), bool_or_auto_schema()),
+        basic_setting(
+            &format!("{prefix}.cache_ram_mib"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.cache_idle_slots"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(&format!("{prefix}.prompt_cache"), bool_or_auto_schema()),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.enabled"),
+            ConfigValueSchema::Boolean,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.max_entries"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.max_bytes"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.min_tokens"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.shared_stride_tokens"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.shared_record_limit"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefix_cache.payload_mode"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.keep_tokens"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.context_shift"), bool_or_auto_schema()),
+        basic_setting(&format!("{prefix}.swa_full"), ConfigValueSchema::Boolean),
+        basic_setting(
+            &format!("{prefix}.checkpoint_interval"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.checkpoint_count"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.lookup_cache_static"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.lookup_cache_dynamic"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.flash_attention"),
+            ConfigValueSchema::String,
+        ),
+    ];
+
+    if !legacy_aliases.is_empty() {
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.ctx_size"),
+            &legacy_aliases[0..1],
+        );
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.batch"),
+            &legacy_aliases[1..2],
+        );
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.ubatch"),
+            &legacy_aliases[2..3],
+        );
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.cache_type_k"),
+            &legacy_aliases[3..4],
+        );
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.cache_type_v"),
+            &legacy_aliases[4..5],
+        );
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.flash_attention"),
+            &legacy_aliases[5..6],
+        );
+    }
+
+    settings
+}
+
+fn hardware_settings(
+    prefix: &str,
+    legacy_device_aliases: &[ConfigPathAlias],
+) -> Vec<ConfigSettingSchema> {
+    let mut settings = vec![
+        basic_setting(
+            &format!("{prefix}.model_runtime"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.device"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.gpu_layers"), integer_or_auto_schema()),
+        basic_setting(
+            &format!("{prefix}.stage_layer_start"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.stage_layer_end"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(&format!("{prefix}.placement"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.tensor_split"), tensor_split_schema()),
+        basic_setting(&format!("{prefix}.split_mode"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.main_gpu"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.cpu_moe"), bool_or_auto_schema()),
+        basic_setting(&format!("{prefix}.n_cpu_moe"), ConfigValueSchema::Integer),
+        rejected_setting(
+            &format!("{prefix}.rpc_backend"),
+            ConfigValueSchema::Object,
+            "The legacy rpc_backend escape hatch is explicitly unsupported by the embedded runtime.",
+        ),
+        basic_setting(
+            &format!("{prefix}.fit_target_mib"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.safety_margin_gb"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(&format!("{prefix}.fit_context"), bool_or_auto_schema()),
+        basic_setting(&format!("{prefix}.model_path"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.hf_repo"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.hf_file"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.mmproj"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.mmproj_offload"), bool_or_auto_schema()),
+        basic_setting(
+            &format!("{prefix}.lora_adapters"),
+            ConfigValueSchema::Array {
+                items: Box::new(ConfigValueSchema::String),
+            },
+        ),
+        basic_setting(
+            &format!("{prefix}.control_vectors"),
+            ConfigValueSchema::Array {
+                items: Box::new(ConfigValueSchema::String),
+            },
+        ),
+        basic_setting(
+            &format!("{prefix}.check_tensors"),
+            ConfigValueSchema::Boolean,
+        ),
+        basic_setting(&format!("{prefix}.mmap"), bool_or_auto_schema()),
+        basic_setting(&format!("{prefix}.mlock"), ConfigValueSchema::Boolean),
+        basic_setting(&format!("{prefix}.direct_io"), ConfigValueSchema::Boolean),
+        basic_setting(&format!("{prefix}.repack"), ConfigValueSchema::Boolean),
+        basic_setting(&format!("{prefix}.op_offload"), ConfigValueSchema::Boolean),
+        basic_setting(
+            &format!("{prefix}.no_host_buffer"),
+            ConfigValueSchema::Boolean,
+        ),
+        basic_setting(&format!("{prefix}.warmup"), bool_or_auto_schema()),
+    ];
+
+    if !legacy_device_aliases.is_empty() {
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.device"),
+            legacy_device_aliases,
+        );
+    }
+
+    settings
+}
+
+fn throughput_settings(
+    prefix: &str,
+    legacy_parallel_aliases: &[ConfigPathAlias],
+) -> Vec<ConfigSettingSchema> {
+    let mut settings = vec![
+        basic_setting(&format!("{prefix}.parallel"), ConfigValueSchema::Integer),
+        basic_setting(
+            &format!("{prefix}.continuous_batching"),
+            bool_or_auto_schema(),
+        ),
+        basic_setting(&format!("{prefix}.threads"), ConfigValueSchema::Integer),
+        basic_setting(
+            &format!("{prefix}.threads_batch"),
+            ConfigValueSchema::Integer,
+        ),
+        rejected_setting(
+            &format!("{prefix}.threads_http"),
+            ConfigValueSchema::Integer,
+            "Dedicated HTTP worker tuning is rejected on the current embedded runtime path.",
+        ),
+        basic_setting(&format!("{prefix}.priority"), integer_or_string_schema()),
+        basic_setting(
+            &format!("{prefix}.poll"),
+            bool_or_string_enum(["auto", "busy", "sleep"]),
+        ),
+        basic_setting(&format!("{prefix}.cpu_affinity"), string_or_list_schema()),
+        basic_setting(&format!("{prefix}.numa"), ConfigValueSchema::String),
+        basic_setting(
+            &format!("{prefix}.slot_prompt_similarity"),
+            ConfigValueSchema::Float,
+        ),
+        rejected_setting(
+            &format!("{prefix}.sleep_idle_seconds"),
+            ConfigValueSchema::Integer,
+            "The sleep-idle tuning knob is documented as rejected and must never become a live exported identifier.",
+        ),
+        basic_setting(
+            &format!("{prefix}.tuning_profile"),
+            ConfigValueSchema::String,
+        ),
+    ];
+
+    if !legacy_parallel_aliases.is_empty() {
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.parallel"),
+            legacy_parallel_aliases,
+        );
+    }
+
+    settings
+}
+
+fn skippy_settings(prefix: &str) -> Vec<ConfigSettingSchema> {
+    vec![
+        basic_setting(
+            &format!("{prefix}.stage_model_path"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.stage_role"), ConfigValueSchema::String),
+        basic_setting(
+            &format!("{prefix}.stage_topology"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.activation_wire_dtype"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.binary_stage_transport"),
+            ConfigValueSchema::String,
+        ),
+        rejected_setting(
+            &format!("{prefix}.openai_frontend_mode"),
+            ConfigValueSchema::Object,
+            "OpenAI frontend override wiring is intentionally rejected on the built-in schema surface.",
+        ),
+        basic_setting(
+            &format!("{prefix}.lifecycle_startup_timeout_ms"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.lifecycle_readiness_interval_ms"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.lifecycle_health_interval_ms"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefill_chunking"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefill_chunk_size"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefill_chunk_schedule"),
+            ConfigValueSchema::String,
+        ),
+    ]
+}
+
+fn speculative_settings(prefix: &str) -> Vec<ConfigSettingSchema> {
+    vec![
+        basic_setting(&format!("{prefix}.mode"), ConfigValueSchema::String),
+        basic_setting(
+            &format!("{prefix}.draft_model_path"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_hf_repo"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_hf_file"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_selection_policy"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.pairing_fault"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_max_tokens"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_min_tokens"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_acceptance_threshold"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_split_probability"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_gpu_layers"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(&format!("{prefix}.draft_device"), ConfigValueSchema::String),
+        basic_setting(
+            &format!("{prefix}.draft_threads"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_cache_type_k"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.draft_cache_type_v"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.ngram_min"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.ngram_max"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.spec_default"), bool_or_auto_schema()),
+    ]
+}
+
+fn request_defaults_settings(prefix: &str) -> Vec<ConfigSettingSchema> {
+    vec![
+        basic_setting(&format!("{prefix}.max_tokens"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.stop"), string_or_list_schema()),
+        basic_setting(&format!("{prefix}.temperature"), ConfigValueSchema::Float),
+        basic_setting(&format!("{prefix}.top_p"), ConfigValueSchema::Float),
+        basic_setting(&format!("{prefix}.top_k"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.min_p"), ConfigValueSchema::Float),
+        basic_setting(&format!("{prefix}.typical_p"), ConfigValueSchema::Float),
+        basic_setting(&format!("{prefix}.top_nsigma"), ConfigValueSchema::Float),
+        basic_setting(
+            &format!("{prefix}.dynatemp_range"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.dynatemp_exponent"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.repeat_penalty"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.repeat_last_n"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.presence_penalty"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.frequency_penalty"),
+            ConfigValueSchema::Float,
+        ),
+        unwired_setting(
+            &format!("{prefix}.dry"),
+            ConfigValueSchema::Object,
+            "Reserved sampler object accepted for compatibility but not wired into the current runtime.",
+        ),
+        unwired_setting(
+            &format!("{prefix}.xtc"),
+            ConfigValueSchema::Object,
+            "Reserved sampler object accepted for compatibility but not wired into the current runtime.",
+        ),
+        unwired_setting(
+            &format!("{prefix}.adaptive"),
+            ConfigValueSchema::Object,
+            "Reserved sampler object accepted for compatibility but not wired into the current runtime.",
+        ),
+        basic_setting(
+            &format!("{prefix}.mirostat_mode"),
+            integer_or_string_enum(["disabled", "1", "2"]),
+        ),
+        basic_setting(
+            &format!("{prefix}.mirostat_entropy"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.mirostat_learning_rate"),
+            ConfigValueSchema::Float,
+        ),
+        basic_setting(
+            &format!("{prefix}.samplers"),
+            ConfigValueSchema::Array {
+                items: Box::new(ConfigValueSchema::String),
+            },
+        ),
+        basic_setting(
+            &format!("{prefix}.sampler_sequence"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.seed"), ConfigValueSchema::Integer),
+        basic_setting(&format!("{prefix}.logit_bias"), ConfigValueSchema::Object),
+        basic_setting(&format!("{prefix}.ignore_eos"), ConfigValueSchema::Boolean),
+        rejected_setting(
+            &format!("{prefix}.backend_sampling"),
+            ConfigValueSchema::Object,
+            "Backend-owned sampler blocks are explicitly rejected from the built-in control surface.",
+        ),
+        basic_setting(
+            &format!("{prefix}.reasoning_format"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.reasoning_enabled"),
+            bool_or_string_enum(["auto", "off", "on"]),
+        ),
+        basic_setting(
+            &format!("{prefix}.reasoning_budget"),
+            integer_or_string_enum(["auto", "low", "medium", "high"]),
+        ),
+        basic_setting(
+            &format!("{prefix}.chat_template"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(
+            &format!("{prefix}.chat_template_file"),
+            ConfigValueSchema::String,
+        ),
+        basic_setting(&format!("{prefix}.jinja"), ConfigValueSchema::Boolean),
+        basic_setting(
+            &format!("{prefix}.chat_template_kwargs"),
+            ConfigValueSchema::Object,
+        ),
+        basic_setting(
+            &format!("{prefix}.skip_chat_parsing"),
+            ConfigValueSchema::Boolean,
+        ),
+        basic_setting(
+            &format!("{prefix}.prefill_assistant"),
+            ConfigValueSchema::Object,
+        ),
+        basic_setting(
+            &format!("{prefix}.system_prompt"),
+            ConfigValueSchema::String,
+        ),
+        rejected_setting(
+            &format!("{prefix}.grammar"),
+            ConfigValueSchema::Object,
+            "Grammar injection is explicitly rejected on the built-in config surface.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.json_schema"),
+            ConfigValueSchema::Object,
+            "JSON schema response shaping is intentionally rejected until a stable runtime contract exists.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.logprobs"),
+            ConfigValueSchema::Object,
+            "Logprobs request defaults are explicitly rejected from persisted config.",
+        ),
+    ]
+}
+
+fn multimodal_settings(
+    prefix: &str,
+    legacy_mmproj_aliases: &[ConfigPathAlias],
+) -> Vec<ConfigSettingSchema> {
+    let mut settings = vec![
+        basic_setting(&format!("{prefix}.mmproj"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.mmproj_url"), ConfigValueSchema::String),
+        basic_setting(&format!("{prefix}.mmproj_offload"), bool_or_auto_schema()),
+        basic_setting(
+            &format!("{prefix}.image_min_tokens"),
+            ConfigValueSchema::Integer,
+        ),
+        basic_setting(
+            &format!("{prefix}.image_max_tokens"),
+            ConfigValueSchema::Integer,
+        ),
+        rejected_setting(
+            &format!("{prefix}.embeddings"),
+            ConfigValueSchema::Object,
+            "Built-in multimodal embeddings controls are explicitly rejected from persisted config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.reranking"),
+            ConfigValueSchema::Object,
+            "Built-in reranking controls are explicitly rejected from persisted config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.pooling"),
+            ConfigValueSchema::Object,
+            "Built-in pooling controls are explicitly rejected from persisted config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.vocoder"),
+            ConfigValueSchema::Object,
+            "Built-in vocoder controls are explicitly rejected from persisted config.",
+        ),
+    ];
+
+    if !legacy_mmproj_aliases.is_empty() {
+        apply_aliases(
+            &mut settings,
+            &format!("{prefix}.mmproj"),
+            legacy_mmproj_aliases,
+        );
+    }
+
+    settings
+}
+
+fn advanced_settings(prefix: &str) -> Vec<ConfigSettingSchema> {
+    vec![
+        rejected_setting(
+            &format!("{prefix}.server.host"),
+            ConfigValueSchema::String,
+            "Server host overrides are explicitly rejected from persisted model config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.server.port"),
+            ConfigValueSchema::Integer,
+            "Server port overrides are explicitly rejected from persisted model config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.server.reuse_port"),
+            ConfigValueSchema::Boolean,
+            "reuse_port overrides are explicitly rejected from persisted model config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.server.timeout"),
+            ConfigValueSchema::Integer,
+            "Server timeout overrides are explicitly rejected from persisted model config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.server.metrics"),
+            ConfigValueSchema::Boolean,
+            "Server metrics overrides are explicitly rejected from persisted model config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.server.slots"),
+            ConfigValueSchema::Boolean,
+            "Server slot overrides are explicitly rejected from persisted model config.",
+        ),
+        rejected_setting(
+            &format!("{prefix}.server.props"),
+            ConfigValueSchema::Boolean,
+            "Server props overrides are explicitly rejected from persisted model config.",
+        ),
+        basic_setting(&format!("{prefix}.server.alias"), ConfigValueSchema::String),
+        rejected_setting(
+            &format!("{prefix}.server.api_prefix"),
+            ConfigValueSchema::String,
+            "API prefix overrides are explicitly rejected from persisted model config.",
+        ),
+    ]
+}
+
+fn top_level_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.visibility = if path == "version" {
+        ConfigVisibility::Internal
+    } else {
+        ConfigVisibility::Advanced
+    };
+    setting
+}
+
+fn owner_control_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.control_surfaces = vec![
+        ConfigControlSurface::ConfigFile,
+        ConfigControlSurface::OwnerControl,
+    ];
+    setting.apply_mode = ConfigApplyMode::DynamicApply;
+    setting.restart_scope = ConfigRestartScope::ProcessRestart;
+    setting
+}
+
+fn telemetry_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.control_surfaces = vec![ConfigControlSurface::ConfigFile, ConfigControlSurface::Api];
+    setting
+}
+
+fn runtime_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.control_surfaces = vec![ConfigControlSurface::ConfigFile, ConfigControlSurface::Api];
+    setting.apply_mode = ConfigApplyMode::DynamicValidationOnly;
+    setting
+}
+
+fn plugin_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.control_surfaces = vec![
+        ConfigControlSurface::ConfigFile,
+        ConfigControlSurface::PluginManifest,
+    ];
+    setting.restart_scope = ConfigRestartScope::ProcessRestart;
+    setting
+}
+
+fn basic_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    ConfigSettingSchema {
+        path: schema_path(path),
+        alias_policy: ConfigAliasPolicy::default(),
+        owner: ConfigSettingOwner::BuiltIn,
+        value_schema,
+        support: ConfigSupportState::Supported,
+        control_surfaces: vec![ConfigControlSurface::ConfigFile],
+        apply_mode: ConfigApplyMode::StaticOnLoad,
+        restart_scope: ConfigRestartScope::ModelReload,
+        visibility: ConfigVisibility::Advanced,
+        constraints: Vec::new(),
+        description: Some(path.to_string()),
+    }
+}
+
+fn unsupported_setting(
+    path: &str,
+    value_schema: ConfigValueSchema,
+    description: &str,
+) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.support = ConfigSupportState::Unsupported;
+    setting.restart_scope = ConfigRestartScope::None;
+    setting.description = Some(description.to_string());
+    setting
+}
+
+fn rejected_setting(
+    path: &str,
+    value_schema: ConfigValueSchema,
+    description: &str,
+) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.support = ConfigSupportState::Rejected;
+    setting.restart_scope = ConfigRestartScope::None;
+    setting.description = Some(description.to_string());
+    setting
+}
+
+fn unwired_setting(
+    path: &str,
+    value_schema: ConfigValueSchema,
+    description: &str,
+) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.support = ConfigSupportState::Unwired;
+    setting.description = Some(description.to_string());
+    setting
+}
+
+fn schema_path(path: &str) -> ConfigPath {
+    ConfigPath::parse_rendered(path).expect("static schema path should parse")
+}
+
+fn flat_alias(path: &str) -> ConfigPathAlias {
+    ConfigPathAlias {
+        path: schema_path(path),
+        kind: ConfigPathAliasKind::LegacyLayout,
+        note: Some("legacy flattened TOML field".into()),
+    }
+}
+
+fn string_enum<const N: usize>(values: [&str; N]) -> ConfigValueSchema {
+    ConfigValueSchema::Enum {
+        values: values.into_iter().map(str::to_string).collect(),
+    }
+}
+
+fn one_of<const N: usize>(variants: [ConfigValueSchema; N]) -> ConfigValueSchema {
+    ConfigValueSchema::OneOf {
+        variants: variants.into_iter().collect(),
+    }
+}
+
+fn bool_or_auto_schema() -> ConfigValueSchema {
+    bool_or_string_enum(["auto", "true", "false"])
+}
+
+fn bool_or_string_enum<const N: usize>(values: [&str; N]) -> ConfigValueSchema {
+    one_of([ConfigValueSchema::Boolean, string_enum(values)])
+}
+
+fn integer_or_auto_schema() -> ConfigValueSchema {
+    integer_or_string_enum(["auto"])
+}
+
+fn integer_or_string_schema() -> ConfigValueSchema {
+    one_of([ConfigValueSchema::Integer, ConfigValueSchema::String])
+}
+
+fn integer_or_string_enum<const N: usize>(values: [&str; N]) -> ConfigValueSchema {
+    one_of([ConfigValueSchema::Integer, string_enum(values)])
+}
+
+fn string_or_list_schema() -> ConfigValueSchema {
+    one_of([
+        ConfigValueSchema::String,
+        ConfigValueSchema::Array {
+            items: Box::new(ConfigValueSchema::String),
+        },
+    ])
+}
+
+fn tensor_split_schema() -> ConfigValueSchema {
+    one_of([
+        ConfigValueSchema::Array {
+            items: Box::new(ConfigValueSchema::Float),
+        },
+        ConfigValueSchema::String,
+    ])
+}
+
+fn apply_aliases(
+    settings: &mut [ConfigSettingSchema],
+    canonical_path: &str,
+    aliases: &[ConfigPathAlias],
+) {
+    if let Some(setting) = settings
+        .iter_mut()
+        .find(|setting| setting.path.render() == canonical_path)
+    {
+        setting.alias_policy.mode = ConfigAliasMode::CanonicalWithLegacyAliases;
+        setting.alias_policy.aliases.extend_from_slice(aliases);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn built_in_schema_preserves_union_typed_fields() {
+        for path in [
+            "models.<model-ref>.model_fit.kv_offload",
+            "models.<model-ref>.model_fit.kv_unified",
+            "models.<model-ref>.model_fit.prompt_cache",
+            "models.<model-ref>.model_fit.context_shift",
+            "models.<model-ref>.hardware.cpu_moe",
+            "models.<model-ref>.hardware.fit_context",
+            "models.<model-ref>.hardware.mmproj_offload",
+            "models.<model-ref>.hardware.mmap",
+            "models.<model-ref>.hardware.warmup",
+            "models.<model-ref>.throughput.continuous_batching",
+            "models.<model-ref>.speculative.spec_default",
+            "models.<model-ref>.multimodal.mmproj_offload",
+        ] {
+            assert_eq!(schema_value(path), bool_or_auto_schema());
+        }
+
+        assert_eq!(
+            schema_value("models.<model-ref>.hardware.gpu_layers"),
+            integer_or_auto_schema()
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.hardware.tensor_split"),
+            tensor_split_schema()
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.throughput.priority"),
+            integer_or_string_schema()
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.throughput.poll"),
+            bool_or_string_enum(["auto", "busy", "sleep"])
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.throughput.cpu_affinity"),
+            string_or_list_schema()
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.request_defaults.stop"),
+            string_or_list_schema()
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.request_defaults.mirostat_mode"),
+            integer_or_string_enum(["disabled", "1", "2"])
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.request_defaults.reasoning_enabled"),
+            bool_or_string_enum(["auto", "off", "on"])
+        );
+        assert_eq!(
+            schema_value("models.<model-ref>.request_defaults.reasoning_budget"),
+            integer_or_string_enum(["auto", "low", "medium", "high"])
+        );
+    }
+
+    fn schema_value(path: &str) -> ConfigValueSchema {
+        built_in_config_schema_descriptor(&schema_path(path))
+            .expect("schema setting should exist")
+            .value_schema
+    }
+}

--- a/crates/mesh-llm-config/src/model/schema_types.rs
+++ b/crates/mesh-llm-config/src/model/schema_types.rs
@@ -1,0 +1,405 @@
+use serde::{Deserialize, Serialize};
+use std::iter::Peekable;
+use std::str::Chars;
+
+pub const CANONICAL_MODEL_REF_SEGMENT: &str = "<model-ref>";
+pub const CANONICAL_PLUGIN_NAME_SEGMENT: &str = "<plugin-name>";
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ConfigSchema {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub settings: Vec<ConfigSettingSchema>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ConfigSettingSchema {
+    pub path: ConfigPath,
+    #[serde(default)]
+    pub alias_policy: ConfigAliasPolicy,
+    pub owner: ConfigSettingOwner,
+    pub value_schema: ConfigValueSchema,
+    pub support: ConfigSupportState,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub control_surfaces: Vec<ConfigControlSurface>,
+    pub apply_mode: ConfigApplyMode,
+    pub restart_scope: ConfigRestartScope,
+    pub visibility: ConfigVisibility,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<ConfigConstraint>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ConfigPath {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub segments: Vec<ConfigPathSegment>,
+}
+
+impl ConfigPath {
+    pub fn root() -> Self {
+        Self::default()
+    }
+
+    pub fn field(name: impl Into<String>) -> Self {
+        let mut path = Self::root();
+        path.push_field(name);
+        path
+    }
+
+    pub fn from_fields<I, S>(fields: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut path = Self::root();
+        for field in fields {
+            path.push_field(field);
+        }
+        path
+    }
+
+    pub fn push_field(&mut self, name: impl Into<String>) -> &mut Self {
+        self.segments
+            .push(ConfigPathSegment::Field { name: name.into() });
+        self
+    }
+
+    pub fn push_index(&mut self, index: usize) -> &mut Self {
+        self.segments.push(ConfigPathSegment::Index { index });
+        self
+    }
+
+    pub fn push_key(&mut self, name: impl Into<String>) -> &mut Self {
+        self.segments
+            .push(ConfigPathSegment::Key { name: name.into() });
+        self
+    }
+
+    pub fn render(&self) -> String {
+        let mut rendered = String::new();
+        for segment in &self.segments {
+            match segment {
+                ConfigPathSegment::Field { name } => {
+                    if !rendered.is_empty() {
+                        rendered.push('.');
+                    }
+                    rendered.push_str(name);
+                }
+                ConfigPathSegment::Index { index } => {
+                    rendered.push('[');
+                    rendered.push_str(&index.to_string());
+                    rendered.push(']');
+                }
+                ConfigPathSegment::Key { name } => {
+                    rendered.push('[');
+                    rendered.push_str(&format!("{name:?}"));
+                    rendered.push(']');
+                }
+            }
+        }
+        rendered
+    }
+
+    pub fn parse_rendered(rendered: &str) -> Result<Self, String> {
+        let mut path = Self::root();
+        let mut chars = rendered.chars().peekable();
+        let mut field = String::new();
+
+        while let Some(ch) = chars.next() {
+            match ch {
+                '.' => {
+                    if field.is_empty() {
+                        if path.segments.is_empty() {
+                            return Err(format!("invalid config path `{rendered}`"));
+                        }
+                        continue;
+                    }
+                    path.push_field(std::mem::take(&mut field));
+                }
+                '[' => {
+                    if !field.is_empty() {
+                        path.push_field(std::mem::take(&mut field));
+                    }
+                    match chars.peek().copied() {
+                        Some('"') => {
+                            path.push_key(parse_rendered_key(&mut chars, rendered)?);
+                        }
+                        Some(next) if next.is_ascii_digit() => {
+                            let mut index = String::new();
+                            while let Some(next) = chars.peek().copied() {
+                                if next == ']' {
+                                    break;
+                                }
+                                if !next.is_ascii_digit() {
+                                    return Err(format!("invalid config path `{rendered}`"));
+                                }
+                                index.push(next);
+                                chars.next();
+                            }
+                            if chars.next() != Some(']') || index.is_empty() {
+                                return Err(format!("invalid config path `{rendered}`"));
+                            }
+                            let index = index
+                                .parse::<usize>()
+                                .map_err(|_| format!("invalid config path `{rendered}`"))?;
+                            path.push_index(index);
+                        }
+                        _ => return Err(format!("invalid config path `{rendered}`")),
+                    }
+                }
+                other => field.push(other),
+            }
+        }
+
+        if !field.is_empty() {
+            path.push_field(field);
+        }
+
+        Ok(path)
+    }
+
+    pub fn normalize_builtin_layout(&self) -> Self {
+        let mut normalized = Self::root();
+        let root_field = self.segments.first().and_then(|segment| match segment {
+            ConfigPathSegment::Field { name } => Some(name.as_str()),
+            _ => None,
+        });
+
+        for (index, segment) in self.segments.iter().enumerate() {
+            match (root_field, index, segment) {
+                (Some("models"), 1, ConfigPathSegment::Index { .. }) => {
+                    normalized.push_field(CANONICAL_MODEL_REF_SEGMENT);
+                }
+                (Some("plugin"), 1, ConfigPathSegment::Index { .. }) => {
+                    normalized.push_field(CANONICAL_PLUGIN_NAME_SEGMENT);
+                }
+                _ => normalized.segments.push(segment.clone()),
+            }
+        }
+
+        normalized
+    }
+}
+
+fn parse_rendered_key(chars: &mut Peekable<Chars<'_>>, rendered: &str) -> Result<String, String> {
+    if chars.next() != Some('"') {
+        return Err(format!("invalid config path `{rendered}`"));
+    }
+
+    let mut key = String::new();
+    while let Some(next) = chars.next() {
+        match next {
+            '"' => {
+                if chars.next() != Some(']') {
+                    return Err(format!("invalid config path `{rendered}`"));
+                }
+                return Ok(key);
+            }
+            '\\' => key.push(parse_rendered_escape(chars, rendered)?),
+            other => key.push(other),
+        }
+    }
+
+    Err(format!("invalid config path `{rendered}`"))
+}
+
+fn parse_rendered_escape(chars: &mut Peekable<Chars<'_>>, rendered: &str) -> Result<char, String> {
+    match chars.next() {
+        Some('"') => Ok('"'),
+        Some('\\') => Ok('\\'),
+        Some('n') => Ok('\n'),
+        Some('r') => Ok('\r'),
+        Some('t') => Ok('\t'),
+        Some('0') => Ok('\0'),
+        Some('u') => parse_rendered_unicode_escape(chars, rendered),
+        _ => Err(format!("invalid config path `{rendered}`")),
+    }
+}
+
+fn parse_rendered_unicode_escape(
+    chars: &mut Peekable<Chars<'_>>,
+    rendered: &str,
+) -> Result<char, String> {
+    if chars.next() != Some('{') {
+        return Err(format!("invalid config path `{rendered}`"));
+    }
+
+    let mut codepoint = String::new();
+    for next in chars.by_ref() {
+        match next {
+            '}' => {
+                let codepoint = u32::from_str_radix(&codepoint, 16)
+                    .map_err(|_| format!("invalid config path `{rendered}`"))?;
+                return char::from_u32(codepoint)
+                    .ok_or_else(|| format!("invalid config path `{rendered}`"));
+            }
+            hex if hex.is_ascii_hexdigit() => codepoint.push(hex),
+            _ => return Err(format!("invalid config path `{rendered}`")),
+        }
+    }
+
+    Err(format!("invalid config path `{rendered}`"))
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConfigPathSegment {
+    Field { name: String },
+    Index { index: usize },
+    Key { name: String },
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ConfigAliasPolicy {
+    #[serde(default)]
+    pub mode: ConfigAliasMode,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<ConfigPathAlias>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ConfigPathAlias {
+    pub path: ConfigPath,
+    pub kind: ConfigPathAliasKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigAliasMode {
+    #[default]
+    CanonicalOnly,
+    CanonicalWithLegacyAliases,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigPathAliasKind {
+    #[default]
+    LegacyKey,
+    LegacyLayout,
+    LegacySection,
+    LegacyShim,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigSettingOwner {
+    #[default]
+    BuiltIn,
+    Engine,
+    Plugin,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConfigValueSchema {
+    Boolean,
+    Integer,
+    Float,
+    String,
+    SocketAddr,
+    Enum { values: Vec<String> },
+    OneOf { variants: Vec<ConfigValueSchema> },
+    Array { items: Box<ConfigValueSchema> },
+    Object,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigSupportState {
+    #[default]
+    Supported,
+    Experimental,
+    DeprecatedAlias,
+    Unwired,
+    Unsupported,
+    Rejected,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigControlSurface {
+    ConfigFile,
+    Cli,
+    OwnerControl,
+    Api,
+    Ui,
+    PluginManifest,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigApplyMode {
+    #[default]
+    StaticOnLoad,
+    DynamicValidationOnly,
+    DynamicApply,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigRestartScope {
+    #[default]
+    None,
+    ModelReload,
+    ProcessRestart,
+    MeshRestart,
+}
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigVisibility {
+    #[default]
+    User,
+    Advanced,
+    Hidden,
+    Internal,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConfigConstraint {
+    NonEmpty,
+    Positive,
+    Range {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        min: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max: Option<String>,
+    },
+    Requires {
+        path: ConfigPath,
+    },
+    AllowedValues {
+        values: Vec<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rendered_accepts_canonical_placeholder_path() {
+        let rendered = "models.<model-ref>.hardware.device";
+        let path = ConfigPath::parse_rendered(rendered).expect("canonical path should parse");
+
+        assert_eq!(path.render(), rendered);
+    }
+
+    #[test]
+    fn parse_rendered_roundtrips_rendered_key_escapes() {
+        let mut path = ConfigPath::field("plugin");
+        path.push_key("plugin.with\nquote\"backslash\\escape\u{1b}");
+        path.push_field("settings");
+
+        let rendered = path.render();
+        let parsed = ConfigPath::parse_rendered(&rendered).expect("rendered key should parse");
+
+        assert_eq!(parsed, path);
+        assert_eq!(parsed.render(), rendered);
+    }
+}

--- a/crates/mesh-llm-config/src/plugin_validation.rs
+++ b/crates/mesh-llm-config/src/plugin_validation.rs
@@ -1,20 +1,865 @@
-use anyhow::{Result, bail};
-
 use crate::PluginConfigEntry;
+use crate::model::ConfigPath;
+use crate::validate::{
+    ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticSchemaSource, ConfigDiagnosticSeverity,
+    ConfigDiagnosticSource, DiagnosticResult, validation_diagnostic,
+};
+use std::collections::{BTreeMap, BTreeSet};
+use toml::Value;
 
-pub(crate) fn validate_plugin_entries(entries: &[PluginConfigEntry]) -> Result<()> {
+pub const SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PluginSchemaAvailability {
+    Available(PluginConfigSchema),
+    NotInstalled,
+    MissingSchema,
+    UnsupportedVersion { version: u32 },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PluginConfigSchema {
+    pub plugin_name: String,
+    pub schema_version: u32,
+    pub allow_unvalidated_config: bool,
+    pub settings: Vec<PluginSettingSchema>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PluginSettingSchema {
+    pub key: String,
+    pub value_schema: PluginValueSchema,
+    pub required: bool,
+    pub default_json: Option<String>,
+    pub constraints: Vec<PluginSettingConstraint>,
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PluginValueSchema {
+    pub kind: PluginValueKind,
+    pub enum_values: Vec<String>,
+    pub items: Option<Box<PluginValueSchema>>,
+    pub object_properties: Vec<PluginObjectPropertySchema>,
+    pub allow_additional_properties: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PluginObjectPropertySchema {
+    pub key: String,
+    pub value_schema: PluginValueSchema,
+    pub required: bool,
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PluginValueKind {
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Path,
+    Url,
+    Enum,
+    Array,
+    Object,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PluginSettingConstraint {
+    NonEmpty,
+    Positive,
+    Range {
+        min: Option<String>,
+        max: Option<String>,
+    },
+    AllowedValues {
+        values: Vec<String>,
+    },
+    Requires {
+        key: String,
+    },
+}
+
+pub(crate) fn validate_plugin_entries(entries: &[PluginConfigEntry]) -> DiagnosticResult {
     for (index, entry) in entries.iter().enumerate() {
         validate_plugin_startup(entry, index)?;
     }
     Ok(())
 }
 
-fn validate_plugin_startup(entry: &PluginConfigEntry, index: usize) -> Result<()> {
+pub(crate) fn validate_plugin_entries_strict<F>(
+    entries: &[PluginConfigEntry],
+    raw_toml: Option<&str>,
+    mut schema_for_plugin: F,
+) -> Vec<ConfigDiagnostic>
+where
+    F: FnMut(&str) -> PluginSchemaAvailability,
+{
+    let mut diagnostics = plugin_misplaced_key_diagnostics(raw_toml);
+
+    for entry in entries {
+        let has_custom_settings = !entry.settings.is_empty();
+        let settings_path = plugin_settings_path(&entry.name);
+        match schema_for_plugin(&entry.name) {
+            PluginSchemaAvailability::Available(schema) => {
+                if schema.schema_version != SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION {
+                    diagnostics.push(plugin_diagnostic(
+                        ConfigDiagnosticCode::UnsupportedSchemaVersion,
+                        ConfigDiagnosticSeverity::Error,
+                        settings_path,
+                        format!(
+                            "plugin '{}' declares unsupported config schema_version {}; expected {}",
+                            entry.name, schema.schema_version, SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION
+                        ),
+                    ));
+                    continue;
+                }
+                if schema.allow_unvalidated_config {
+                    if has_custom_settings {
+                        diagnostics.push(plugin_diagnostic(
+                            ConfigDiagnosticCode::LegacyUnvalidatedConfig,
+                            ConfigDiagnosticSeverity::Warning,
+                            settings_path,
+                            format!(
+                                "plugin '{}' allows legacy unvalidated config; custom settings are accepted without schema checks",
+                                entry.name
+                            ),
+                        ));
+                    }
+                    continue;
+                }
+                diagnostics.extend(validate_plugin_settings_against_schema(entry, &schema));
+            }
+            PluginSchemaAvailability::NotInstalled => {
+                if has_custom_settings {
+                    diagnostics.push(plugin_diagnostic(
+                        ConfigDiagnosticCode::SchemaUnavailable,
+                        ConfigDiagnosticSeverity::Error,
+                        settings_path,
+                        format!(
+                            "plugin '{}' is not installed, so custom settings cannot be validated in strict mode",
+                            entry.name
+                        ),
+                    ));
+                }
+            }
+            PluginSchemaAvailability::MissingSchema => {
+                if has_custom_settings {
+                    diagnostics.push(plugin_diagnostic(
+                        ConfigDiagnosticCode::SchemaUnavailable,
+                        ConfigDiagnosticSeverity::Error,
+                        settings_path,
+                        format!(
+                            "plugin '{}' does not expose install-time config schema metadata, so custom settings cannot be validated in strict mode",
+                            entry.name
+                        ),
+                    ));
+                }
+            }
+            PluginSchemaAvailability::UnsupportedVersion { version } => {
+                diagnostics.push(plugin_diagnostic(
+                    ConfigDiagnosticCode::UnsupportedSchemaVersion,
+                    ConfigDiagnosticSeverity::Error,
+                    settings_path,
+                    format!(
+                        "plugin '{}' declares unsupported config schema_version {}; expected {}",
+                        entry.name, version, SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION
+                    ),
+                ));
+            }
+        }
+    }
+
+    diagnostics
+}
+
+fn validate_plugin_startup(entry: &PluginConfigEntry, index: usize) -> DiagnosticResult {
     if matches!(entry.startup.connect_timeout_secs, Some(0)) {
-        bail!("plugin[{index}].startup.connect_timeout_secs must be at least 1 when set");
+        return Err(validation_diagnostic(
+            &format!("plugin[{index}].startup.connect_timeout_secs"),
+            format!("plugin[{index}].startup.connect_timeout_secs must be at least 1 when set"),
+        ));
     }
     if matches!(entry.startup.init_timeout_secs, Some(0)) {
-        bail!("plugin[{index}].startup.init_timeout_secs must be at least 1 when set");
+        return Err(validation_diagnostic(
+            &format!("plugin[{index}].startup.init_timeout_secs"),
+            format!("plugin[{index}].startup.init_timeout_secs must be at least 1 when set"),
+        ));
     }
     Ok(())
+}
+
+fn validate_plugin_settings_against_schema(
+    entry: &PluginConfigEntry,
+    schema: &PluginConfigSchema,
+) -> Vec<ConfigDiagnostic> {
+    let mut diagnostics = Vec::new();
+    let schema_by_key = schema
+        .settings
+        .iter()
+        .map(|setting| (setting.key.as_str(), setting))
+        .collect::<BTreeMap<_, _>>();
+
+    for key in entry.settings.keys() {
+        if !schema_by_key.contains_key(key.as_str()) {
+            diagnostics.push(plugin_diagnostic(
+                ConfigDiagnosticCode::UnknownField,
+                ConfigDiagnosticSeverity::Error,
+                plugin_setting_path(&entry.name, [key.as_str()]),
+                format!(
+                    "plugin '{}' does not declare custom setting '{}' in [[plugin]].settings",
+                    entry.name, key
+                ),
+            ));
+        }
+    }
+
+    for setting in &schema.settings {
+        let Some(value) = entry.settings.get(&setting.key) else {
+            if setting.required {
+                diagnostics.push(plugin_diagnostic(
+                    ConfigDiagnosticCode::MissingRequiredValue,
+                    ConfigDiagnosticSeverity::Error,
+                    plugin_setting_path(&entry.name, [setting.key.as_str()]),
+                    format!(
+                        "plugin '{}' requires [[plugin]].settings.{} to be set",
+                        entry.name, setting.key
+                    ),
+                ));
+            }
+            continue;
+        };
+
+        validate_plugin_value(
+            &entry.name,
+            &[setting.key.as_str()],
+            value,
+            &setting.value_schema,
+            &setting.constraints,
+            &entry.settings,
+            &mut diagnostics,
+        );
+    }
+
+    diagnostics
+}
+
+fn validate_plugin_value(
+    plugin_name: &str,
+    path_segments: &[&str],
+    value: &Value,
+    schema: &PluginValueSchema,
+    constraints: &[PluginSettingConstraint],
+    root_settings: &BTreeMap<String, Value>,
+    diagnostics: &mut Vec<ConfigDiagnostic>,
+) {
+    if let Err(message) = validate_plugin_value_kind(value, schema) {
+        diagnostics.push(plugin_diagnostic(
+            ConfigDiagnosticCode::InvalidValue,
+            ConfigDiagnosticSeverity::Error,
+            plugin_setting_path(plugin_name, path_segments.iter().copied()),
+            message,
+        ));
+        return;
+    }
+
+    for constraint in constraints {
+        if let Err(message) = validate_plugin_constraint(value, constraint, root_settings) {
+            diagnostics.push(plugin_diagnostic(
+                ConfigDiagnosticCode::InvalidValue,
+                ConfigDiagnosticSeverity::Error,
+                plugin_setting_path(plugin_name, path_segments.iter().copied()),
+                message,
+            ));
+        }
+    }
+
+    match (&schema.kind, value) {
+        (PluginValueKind::Array, Value::Array(items)) => {
+            if let Some(item_schema) = schema.items.as_deref() {
+                for (index, item) in items.iter().enumerate() {
+                    let index_segment = index.to_string();
+                    let mut nested = path_segments.to_vec();
+                    nested.push(index_segment.as_str());
+                    validate_plugin_value(
+                        plugin_name,
+                        &nested,
+                        item,
+                        item_schema,
+                        &[],
+                        root_settings,
+                        diagnostics,
+                    );
+                }
+            }
+        }
+        (PluginValueKind::Object, Value::Table(table)) => {
+            let object_schema = schema
+                .object_properties
+                .iter()
+                .map(|property| (property.key.as_str(), property))
+                .collect::<BTreeMap<_, _>>();
+
+            for key in table.keys() {
+                if !schema.allow_additional_properties && !object_schema.contains_key(key.as_str())
+                {
+                    diagnostics.push(plugin_diagnostic(
+                        ConfigDiagnosticCode::UnknownField,
+                        ConfigDiagnosticSeverity::Error,
+                        plugin_setting_path(
+                            plugin_name,
+                            path_segments.iter().copied().chain([key.as_str()]),
+                        ),
+                        format!(
+                            "plugin '{}' does not allow object property '{}' here",
+                            plugin_name, key
+                        ),
+                    ));
+                }
+            }
+
+            for property in &schema.object_properties {
+                let Some(property_value) = table.get(&property.key) else {
+                    if property.required {
+                        diagnostics.push(plugin_diagnostic(
+                            ConfigDiagnosticCode::MissingRequiredValue,
+                            ConfigDiagnosticSeverity::Error,
+                            plugin_setting_path(
+                                plugin_name,
+                                path_segments.iter().copied().chain([property.key.as_str()]),
+                            ),
+                            format!(
+                                "plugin '{}' requires object property '{}' here",
+                                plugin_name, property.key
+                            ),
+                        ));
+                    }
+                    continue;
+                };
+
+                let mut nested = path_segments.to_vec();
+                nested.push(property.key.as_str());
+                validate_plugin_value(
+                    plugin_name,
+                    &nested,
+                    property_value,
+                    &property.value_schema,
+                    &[],
+                    root_settings,
+                    diagnostics,
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
+fn validate_plugin_value_kind(value: &Value, schema: &PluginValueSchema) -> Result<(), String> {
+    match schema.kind {
+        PluginValueKind::Boolean if value.is_bool() => Ok(()),
+        PluginValueKind::Integer if value.as_integer().is_some() => Ok(()),
+        PluginValueKind::Float if numeric_value(value).is_some() => Ok(()),
+        PluginValueKind::String | PluginValueKind::Path if value.as_str().is_some() => Ok(()),
+        PluginValueKind::Url => {
+            let Some(raw) = value.as_str() else {
+                return Err("expected URL string".into());
+            };
+            if raw.contains("://") {
+                Ok(())
+            } else {
+                Err(format!("expected valid URL, got {raw:?}"))
+            }
+        }
+        PluginValueKind::Enum => {
+            let Some(raw) = value.as_str() else {
+                return Err("expected enum string".into());
+            };
+            if schema.enum_values.iter().any(|candidate| candidate == raw) {
+                Ok(())
+            } else {
+                Err(format!(
+                    "expected one of: {}",
+                    schema.enum_values.join(", ")
+                ))
+            }
+        }
+        PluginValueKind::Array if value.as_array().is_some() => Ok(()),
+        PluginValueKind::Object if value.as_table().is_some() => Ok(()),
+        PluginValueKind::Boolean => Err("expected boolean".into()),
+        PluginValueKind::Integer => Err("expected integer".into()),
+        PluginValueKind::Float => Err("expected number".into()),
+        PluginValueKind::String => Err("expected string".into()),
+        PluginValueKind::Path => Err("expected path string".into()),
+        PluginValueKind::Array => Err("expected array".into()),
+        PluginValueKind::Object => Err("expected object/table".into()),
+    }
+}
+
+fn validate_plugin_constraint(
+    value: &Value,
+    constraint: &PluginSettingConstraint,
+    root_settings: &BTreeMap<String, Value>,
+) -> Result<(), String> {
+    match constraint {
+        PluginSettingConstraint::NonEmpty => {
+            let valid = match value {
+                Value::String(inner) => !inner.trim().is_empty(),
+                Value::Array(inner) => !inner.is_empty(),
+                Value::Table(inner) => !inner.is_empty(),
+                _ => true,
+            };
+            if valid {
+                Ok(())
+            } else {
+                Err("must not be empty".into())
+            }
+        }
+        PluginSettingConstraint::Positive => {
+            let Some(number) = numeric_value(value) else {
+                return Err("must be numeric to apply positive constraint".into());
+            };
+            if number > 0.0 {
+                Ok(())
+            } else {
+                Err("must be greater than 0".into())
+            }
+        }
+        PluginSettingConstraint::Range { min, max } => {
+            let Some(number) = numeric_value(value) else {
+                return Err("must be numeric to apply range constraint".into());
+            };
+            if let Some(min) = parse_optional_constraint_number("min", min.as_deref())?
+                && number < min
+            {
+                return Err(format!("must be at least {}", render_number(min)));
+            }
+            if let Some(max) = parse_optional_constraint_number("max", max.as_deref())?
+                && number > max
+            {
+                return Err(format!("must be at most {}", render_number(max)));
+            }
+            Ok(())
+        }
+        PluginSettingConstraint::AllowedValues { values } => {
+            let Some(raw) = value.as_str() else {
+                return Err("must be string-like to apply allowed-values constraint".into());
+            };
+            if values.iter().any(|candidate| candidate == raw) {
+                Ok(())
+            } else {
+                Err(format!("expected one of: {}", values.join(", ")))
+            }
+        }
+        PluginSettingConstraint::Requires { key } => {
+            if root_settings.contains_key(key) {
+                Ok(())
+            } else {
+                Err(format!("requires [[plugin]].settings.{key} to also be set"))
+            }
+        }
+    }
+}
+
+fn plugin_misplaced_key_diagnostics(raw_toml: Option<&str>) -> Vec<ConfigDiagnostic> {
+    let Some(raw_toml) = raw_toml else {
+        return Vec::new();
+    };
+    let Ok(parsed) = toml::from_str::<Value>(raw_toml) else {
+        return Vec::new();
+    };
+    let Some(plugin_entries) = parsed.get("plugin").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    let allowed_top_level = BTreeSet::from([
+        "name", "enabled", "command", "args", "url", "startup", "settings",
+    ]);
+    let allowed_startup = BTreeSet::from([
+        "connect_timeout_secs",
+        "init_timeout_secs",
+        "optional",
+        "lazy_start",
+    ]);
+
+    let mut diagnostics = Vec::new();
+    for (index, item) in plugin_entries.iter().enumerate() {
+        let Some(table) = item.as_table() else {
+            continue;
+        };
+        let plugin_name = table
+            .get("name")
+            .and_then(Value::as_str)
+            .unwrap_or("<plugin>")
+            .to_string();
+
+        for key in table.keys() {
+            if allowed_top_level.contains(key.as_str()) {
+                continue;
+            }
+            diagnostics.push(
+                plugin_diagnostic(
+                    ConfigDiagnosticCode::MisplacedField,
+                    ConfigDiagnosticSeverity::Error,
+                    plugin_setting_path(&plugin_name, [key.as_str()]),
+                    format!(
+                        "plugin[{index}].{key} is a custom plugin setting in a host-owned location; move it under [[plugin]].settings.{key}"
+                    ),
+                )
+                .at_path(ConfigPath::parse_rendered(&format!("plugin[{index}].{key}")).unwrap_or_default()),
+            );
+        }
+
+        if let Some(startup) = table.get("startup").and_then(Value::as_table) {
+            for key in startup.keys() {
+                if allowed_startup.contains(key.as_str()) {
+                    continue;
+                }
+                diagnostics.push(
+                    plugin_diagnostic(
+                        ConfigDiagnosticCode::MisplacedField,
+                        ConfigDiagnosticSeverity::Error,
+                        plugin_setting_path(&plugin_name, [key.as_str()]),
+                        format!(
+                            "plugin[{index}].startup.{key} is not a host-owned startup key; plugin custom settings must live under [[plugin]].settings.{key}"
+                        ),
+                    )
+                    .at_path(
+                        ConfigPath::parse_rendered(&format!("plugin[{index}].startup.{key}"))
+                            .unwrap_or_default(),
+                    ),
+                );
+            }
+        }
+    }
+
+    diagnostics
+}
+
+fn plugin_diagnostic(
+    code: ConfigDiagnosticCode,
+    severity: ConfigDiagnosticSeverity,
+    path: ConfigPath,
+    message: impl Into<String>,
+) -> ConfigDiagnostic {
+    ConfigDiagnostic::new(code, severity, ConfigDiagnosticSource::Plugin, message)
+        .with_schema_source(ConfigDiagnosticSchemaSource::Plugin)
+        .at_path(path.clone())
+        .with_canonical_path(path)
+}
+
+fn plugin_settings_path(plugin_name: &str) -> ConfigPath {
+    ConfigPath::from_fields(["plugin", plugin_name, "settings"])
+}
+
+fn plugin_setting_path<'a>(
+    plugin_name: &str,
+    segments: impl IntoIterator<Item = &'a str>,
+) -> ConfigPath {
+    let mut path = plugin_settings_path(plugin_name);
+    for segment in segments {
+        path.push_field(segment);
+    }
+    path
+}
+
+fn numeric_value(value: &Value) -> Option<f64> {
+    value
+        .as_float()
+        .or_else(|| value.as_integer().map(|integer| integer as f64))
+}
+
+fn parse_optional_constraint_number(
+    bound_name: &str,
+    raw: Option<&str>,
+) -> Result<Option<f64>, String> {
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+    raw.parse::<f64>()
+        .map(Some)
+        .map_err(|_| format!("range constraint {bound_name} bound must be numeric, got {raw:?}"))
+}
+
+fn render_number(value: f64) -> String {
+    if value.fract() == 0.0 {
+        format!("{value:.0}")
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> PluginConfigSchema {
+        PluginConfigSchema {
+            plugin_name: "blackboard".into(),
+            schema_version: SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION,
+            allow_unvalidated_config: false,
+            settings: vec![
+                PluginSettingSchema {
+                    key: "retention_days".into(),
+                    value_schema: PluginValueSchema {
+                        kind: PluginValueKind::Integer,
+                        enum_values: Vec::new(),
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: true,
+                    default_json: Some("14".into()),
+                    constraints: vec![PluginSettingConstraint::Range {
+                        min: Some("1".into()),
+                        max: Some("365".into()),
+                    }],
+                    description: None,
+                },
+                PluginSettingSchema {
+                    key: "mode".into(),
+                    value_schema: PluginValueSchema {
+                        kind: PluginValueKind::Enum,
+                        enum_values: vec!["strict".into(), "relaxed".into()],
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: false,
+                    default_json: Some("\"strict\"".into()),
+                    constraints: Vec::new(),
+                    description: None,
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn strict_plugin_validation_reports_misplaced_and_unknown_keys() {
+        let config: crate::MeshConfig = toml::from_str(
+            r#"
+[[plugin]]
+name = "blackboard"
+retention_days = 14
+
+[plugin.settings]
+mode = "strict"
+unknown = true
+"#,
+        )
+        .unwrap();
+
+        let diagnostics = validate_plugin_entries_strict(
+            &config.plugins,
+            Some(
+                r#"
+[[plugin]]
+name = "blackboard"
+retention_days = 14
+
+[plugin.settings]
+mode = "strict"
+unknown = true
+"#,
+            ),
+            |_| PluginSchemaAvailability::Available(schema()),
+        );
+
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ConfigDiagnosticCode::MisplacedField)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == ConfigDiagnosticCode::UnknownField)
+        );
+    }
+
+    #[test]
+    fn strict_plugin_validation_rejects_required_settings_when_settings_table_is_absent() {
+        let raw = r#"
+[[plugin]]
+name = "blackboard"
+"#;
+        let config: crate::MeshConfig = toml::from_str(raw).unwrap();
+
+        let diagnostics = validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+            PluginSchemaAvailability::Available(schema())
+        });
+
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == ConfigDiagnosticCode::MissingRequiredValue
+                && diagnostic
+                    .canonical_path
+                    .as_ref()
+                    .map(ConfigPath::render)
+                    .as_deref()
+                    == Some("plugin.blackboard.settings.retention_days")
+        }));
+    }
+
+    #[test]
+    fn strict_plugin_validation_rejects_malformed_range_bound() {
+        let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+retention_days = 14
+"#;
+        let config: crate::MeshConfig = toml::from_str(raw).unwrap();
+        let mut malformed_schema = schema();
+        malformed_schema.settings[0].constraints = vec![PluginSettingConstraint::Range {
+            min: Some("low".into()),
+            max: Some("365".into()),
+        }];
+
+        let diagnostics = validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+            PluginSchemaAvailability::Available(malformed_schema.clone())
+        });
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, ConfigDiagnosticCode::InvalidValue);
+        assert_eq!(diagnostics[0].severity, ConfigDiagnosticSeverity::Error);
+        assert_eq!(
+            diagnostics[0]
+                .canonical_path
+                .as_ref()
+                .map(ConfigPath::render),
+            Some("plugin.blackboard.settings.retention_days".to_string())
+        );
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("range constraint min bound must be numeric")
+        );
+    }
+
+    #[test]
+    fn strict_plugin_validation_rejects_missing_install_time_schema_metadata() {
+        let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+retention_days = 14
+"#;
+        let config: crate::MeshConfig = toml::from_str(raw).unwrap();
+
+        let diagnostics = validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+            PluginSchemaAvailability::MissingSchema
+        });
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, ConfigDiagnosticCode::SchemaUnavailable);
+        assert_eq!(diagnostics[0].severity, ConfigDiagnosticSeverity::Error);
+        assert_eq!(
+            diagnostics[0]
+                .canonical_path
+                .as_ref()
+                .map(ConfigPath::render),
+            Some("plugin.blackboard.settings".to_string())
+        );
+    }
+
+    #[test]
+    fn strict_plugin_validation_rejects_uninstalled_plugins_with_custom_settings() {
+        let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+retention_days = 14
+"#;
+        let config: crate::MeshConfig = toml::from_str(raw).unwrap();
+
+        let diagnostics = validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+            PluginSchemaAvailability::NotInstalled
+        });
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, ConfigDiagnosticCode::SchemaUnavailable);
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("custom settings cannot be validated in strict mode")
+        );
+    }
+
+    #[test]
+    fn strict_plugin_validation_only_allows_unbounded_settings_via_legacy_escape_hatch() {
+        let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+retention_days = 14
+unknown = true
+"#;
+        let config: crate::MeshConfig = toml::from_str(raw).unwrap();
+        let mut legacy_schema = schema();
+        legacy_schema.allow_unvalidated_config = true;
+
+        let diagnostics = validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+            PluginSchemaAvailability::Available(legacy_schema.clone())
+        });
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            ConfigDiagnosticCode::LegacyUnvalidatedConfig
+        );
+        assert_eq!(diagnostics[0].severity, ConfigDiagnosticSeverity::Warning);
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("allows legacy unvalidated config")
+        );
+    }
+
+    #[test]
+    fn strict_plugin_validation_rejects_unsupported_schema_version_boundaries() {
+        let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+retention_days = 14
+"#;
+        let config: crate::MeshConfig = toml::from_str(raw).unwrap();
+
+        let mut mismatched_schema = schema();
+        mismatched_schema.schema_version = SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION + 1;
+        let available_diagnostics =
+            validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+                PluginSchemaAvailability::Available(mismatched_schema.clone())
+            });
+        let unavailable_diagnostics =
+            validate_plugin_entries_strict(&config.plugins, Some(raw), |_| {
+                PluginSchemaAvailability::UnsupportedVersion {
+                    version: SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION + 2,
+                }
+            });
+
+        assert_eq!(
+            available_diagnostics[0].code,
+            ConfigDiagnosticCode::UnsupportedSchemaVersion
+        );
+        assert!(
+            available_diagnostics[0]
+                .message
+                .contains("unsupported config schema_version")
+        );
+        assert_eq!(
+            unavailable_diagnostics[0].code,
+            ConfigDiagnosticCode::UnsupportedSchemaVersion
+        );
+        assert!(
+            unavailable_diagnostics[0]
+                .message
+                .contains(&format!("{}", SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION + 2))
+        );
+    }
 }

--- a/crates/mesh-llm-config/src/validate.rs
+++ b/crates/mesh-llm-config/src/validate.rs
@@ -1,63 +1,197 @@
+pub(crate) use crate::diagnostic::DiagnosticResult;
+pub use crate::diagnostic::{
+    ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticSchemaSource, ConfigDiagnosticSeverity,
+    ConfigDiagnosticSource, alias_diagnostic, invalid_value_diagnostic,
+    legacy_validation_error_text, rejected_field_diagnostic, unsupported_field_diagnostic,
+};
 use crate::model::{merge_hardware, merge_model_fit, merge_multimodal, merge_throughput};
-use crate::plugin_validation::validate_plugin_entries;
+use crate::plugin_validation::{
+    PluginSchemaAvailability, validate_plugin_entries, validate_plugin_entries_strict,
+};
 use crate::*;
-use anyhow::{Result, bail};
+use anyhow::Result;
 use semver::{BuildMetadata, Version};
 
-pub fn validate_config(config: &MeshConfig) -> Result<()> {
+fn parsed_config_path(raw_path: &str) -> Option<ConfigPath> {
+    ConfigPath::parse_rendered(raw_path).ok()
+}
+
+pub(crate) fn validation_diagnostic(
+    raw_path: &str,
+    message: impl Into<String>,
+) -> ConfigDiagnostic {
+    let message = message.into();
+    if let Some(diagnostic) = built_in_support_diagnostic(raw_path, message.clone()) {
+        return diagnostic;
+    }
+
+    let mut diagnostic = ConfigDiagnostic::error(
+        ConfigDiagnosticCode::InvalidValue,
+        ConfigDiagnosticSource::Validation,
+        message,
+    );
+    diagnostic.path = parsed_config_path(raw_path);
+    diagnostic
+}
+
+pub fn validate_config_diagnostics(config: &MeshConfig) -> Vec<ConfigDiagnostic> {
+    let mut diagnostics = Vec::new();
+
     if let Some(version) = config.version
         && version != 1
     {
-        bail!("unsupported config version {version}; expected version = 1");
+        diagnostics.push(validation_diagnostic(
+            "version",
+            format!("unsupported config version {version}; expected version = 1"),
+        ));
     }
     if let Some(bind) = config.owner_control.bind
         && bind.port() == 0
         && !bind.ip().is_loopback()
     {
-        bail!("owner_control.bind must use a concrete port when binding a non-loopback address");
+        diagnostics.push(validation_diagnostic(
+            "owner_control.bind",
+            "owner_control.bind must use a concrete port when binding a non-loopback address",
+        ));
     }
     if let Some(advertise_addr) = config.owner_control.advertise_addr {
         if advertise_addr.port() == 0 {
-            bail!("owner_control.advertise_addr must use a concrete port");
+            diagnostics.push(validation_diagnostic(
+                "owner_control.advertise_addr",
+                "owner_control.advertise_addr must use a concrete port",
+            ));
         }
         if advertise_addr.ip().is_unspecified() {
-            bail!("owner_control.advertise_addr must not use an unspecified IP address");
+            diagnostics.push(validation_diagnostic(
+                "owner_control.advertise_addr",
+                "owner_control.advertise_addr must not use an unspecified IP address",
+            ));
         }
     }
     if let Some(parallel) = config.gpu.parallel
         && parallel < 1
     {
-        bail!("gpu.parallel must be at least 1, got {parallel}");
+        diagnostics.push(validation_diagnostic(
+            "gpu.parallel",
+            format!("gpu.parallel must be at least 1, got {parallel}"),
+        ));
     }
-    validate_mesh_requirements_config(&config.mesh_requirements)?;
-    validate_telemetry_config(&config.telemetry)?;
-    validate_plugin_entries(&config.plugins)?;
+    if let Err(diagnostic) = validate_mesh_requirements_config(&config.mesh_requirements) {
+        diagnostics.push(diagnostic);
+    }
+    if let Err(diagnostic) = validate_telemetry_config(&config.telemetry) {
+        diagnostics.push(diagnostic);
+    }
+    if let Err(diagnostic) = validate_plugin_entries(&config.plugins) {
+        diagnostics.push(diagnostic);
+    }
     let defaults_hardware = config
         .defaults
         .as_ref()
         .and_then(|defaults| defaults.hardware.as_ref());
-    if let Some(defaults) = &config.defaults {
-        validate_model_defaults(defaults, "defaults", config.gpu.assignment)?;
+    if let Some(defaults) = &config.defaults
+        && let Err(diagnostic) =
+            validate_model_defaults(defaults, "defaults", config.gpu.assignment)
+    {
+        diagnostics.push(diagnostic);
     }
     for (index, model) in config.models.iter().enumerate() {
         if model.model.trim().is_empty() {
-            bail!("models[{index}].model must not be empty");
+            diagnostics.push(validation_diagnostic(
+                &format!("models[{index}].model"),
+                format!("models[{index}].model must not be empty"),
+            ));
         }
-        validate_model_entry(
+        if let Err(diagnostic) = validate_model_entry(
             model,
             &format!("models[{index}]"),
             config.gpu.assignment,
             defaults_hardware,
-        )?;
+        ) {
+            diagnostics.push(diagnostic);
+        }
     }
-    Ok(())
+
+    diagnostics
+}
+
+pub fn validate_config_diagnostics_with_plugin_schemas<F>(
+    config: &MeshConfig,
+    raw_toml: Option<&str>,
+    schema_for_plugin: F,
+) -> Vec<ConfigDiagnostic>
+where
+    F: FnMut(&str) -> PluginSchemaAvailability,
+{
+    let mut diagnostics = validate_config_diagnostics(config);
+    diagnostics.extend(validate_plugin_entries_strict(
+        &config.plugins,
+        raw_toml,
+        schema_for_plugin,
+    ));
+    diagnostics
+}
+
+pub fn canonical_builtin_diagnostic_path(raw_path: &str) -> Option<ConfigPath> {
+    canonicalize_built_in_config_identifier(raw_path)
+        .and_then(|path| ConfigPath::parse_rendered(&path).ok())
+}
+
+pub fn built_in_support_diagnostic(
+    raw_path: &str,
+    message: impl Into<String>,
+) -> Option<ConfigDiagnostic> {
+    let resolution = resolve_built_in_config_identifier(raw_path)?;
+    let message = message.into();
+    let mut diagnostic = match resolution.support {
+        ConfigSupportState::Rejected => {
+            rejected_field_diagnostic(resolution.canonical_path.clone(), message)
+        }
+        ConfigSupportState::Unsupported | ConfigSupportState::Unwired => {
+            unsupported_field_diagnostic(resolution.canonical_path.clone(), message)
+        }
+        _ => invalid_value_diagnostic(resolution.canonical_path.clone(), message),
+    };
+    diagnostic.path = Some(resolution.requested_path);
+    diagnostic.canonical_path = Some(resolution.canonical_path);
+    diagnostic.schema_source = Some(ConfigDiagnosticSchemaSource::BuiltIn);
+    Some(diagnostic)
+}
+
+pub fn validate_config(config: &MeshConfig) -> Result<()> {
+    let diagnostics = validate_config_diagnostics(config);
+    if diagnostics.is_empty() {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!(legacy_validation_error_text(&diagnostics)))
+    }
+}
+
+pub fn validate_config_with_plugin_schemas<F>(
+    config: &MeshConfig,
+    raw_toml: Option<&str>,
+    schema_for_plugin: F,
+) -> Result<()>
+where
+    F: FnMut(&str) -> PluginSchemaAvailability,
+{
+    let diagnostics =
+        validate_config_diagnostics_with_plugin_schemas(config, raw_toml, schema_for_plugin);
+    let has_errors = diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == ConfigDiagnosticSeverity::Error);
+    if has_errors {
+        Err(anyhow::anyhow!(legacy_validation_error_text(&diagnostics)))
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_model_defaults(
     defaults: &ModelConfigDefaults,
     base_path: &str,
     gpu_assignment: GpuAssignment,
-) -> Result<()> {
+) -> DiagnosticResult {
     if let Some(model_fit) = &defaults.model_fit {
         validate_model_fit(model_fit, &format!("{base_path}.model_fit"))?;
     }
@@ -96,7 +230,7 @@ fn validate_model_entry(
     base_path: &str,
     gpu_assignment: GpuAssignment,
     defaults_hardware: Option<&HardwareConfig>,
-) -> Result<()> {
+) -> DiagnosticResult {
     let model_fit = merge_model_fit(
         model.model_fit.clone(),
         model.ctx_size,
@@ -169,9 +303,12 @@ fn validate_gpu_assignment_constraints(
     legacy_gpu_id: Option<&str>,
     device_path: &str,
     gpu_assignment: GpuAssignment,
-) -> Result<()> {
+) -> DiagnosticResult {
     if matches!(gpu_assignment, GpuAssignment::Auto) && legacy_gpu_id.is_some() {
-        bail!("{device_path} must not be set when gpu.assignment = \"auto\"");
+        return Err(validation_diagnostic(
+            device_path,
+            format!("{device_path} must not be set when gpu.assignment = \"auto\""),
+        ));
     }
     if matches!(gpu_assignment, GpuAssignment::Pinned) {
         match hardware
@@ -180,23 +317,29 @@ fn validate_gpu_assignment_constraints(
         {
             Some(device) if !device.trim().is_empty() && !device.eq_ignore_ascii_case("auto") => {}
             _ => {
-                bail!(
-                    "{device_path} must be set to a non-empty value when gpu.assignment = \"pinned\""
-                );
+                return Err(validation_diagnostic(
+                    device_path,
+                    format!(
+                        "{device_path} must be set to a non-empty value when gpu.assignment = \"pinned\""
+                    ),
+                ));
             }
         }
     }
     Ok(())
 }
 
-fn validate_model_fit(config: &ModelFitConfig, base_path: &str) -> Result<()> {
+fn validate_model_fit(config: &ModelFitConfig, base_path: &str) -> DiagnosticResult {
     validate_optional_positive_u32(config.ctx_size, &format!("{base_path}.ctx_size"))?;
     validate_optional_positive_u32(config.batch, &format!("{base_path}.batch"))?;
     validate_optional_positive_u32(config.ubatch, &format!("{base_path}.ubatch"))?;
     if let (Some(batch), Some(ubatch)) = (config.batch, config.ubatch)
         && ubatch > batch
     {
-        bail!("{base_path}.ubatch must be less than or equal to {base_path}.batch");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.ubatch"),
+            format!("{base_path}.ubatch must be less than or equal to {base_path}.batch"),
+        ));
     }
     validate_optional_non_empty(
         config.cache_type_k.as_deref(),
@@ -231,7 +374,10 @@ fn validate_model_fit(config: &ModelFitConfig, base_path: &str) -> Result<()> {
         && cache_idle_slots > 0
         && matches!(config.prompt_cache, Some(BoolOrAuto::Bool(false)))
     {
-        bail!("{base_path}.cache_idle_slots requires {base_path}.prompt_cache = true");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.cache_idle_slots"),
+            format!("{base_path}.cache_idle_slots requires {base_path}.prompt_cache = true"),
+        ));
     }
     if let Some(prefix_cache) = &config.prefix_cache {
         validate_prefix_cache(prefix_cache, &format!("{base_path}.prefix_cache"))?;
@@ -239,7 +385,10 @@ fn validate_model_fit(config: &ModelFitConfig, base_path: &str) -> Result<()> {
     if let (Some(keep_tokens), Some(ctx_size)) = (config.keep_tokens, config.ctx_size)
         && keep_tokens > ctx_size
     {
-        bail!("{base_path}.keep_tokens must be less than or equal to {base_path}.ctx_size");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.keep_tokens"),
+            format!("{base_path}.keep_tokens must be less than or equal to {base_path}.ctx_size"),
+        ));
     }
     validate_optional_positive_u32(
         config.checkpoint_interval,
@@ -260,7 +409,7 @@ fn validate_model_fit(config: &ModelFitConfig, base_path: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_prefix_cache(config: &PrefixCacheConfig, base_path: &str) -> Result<()> {
+fn validate_prefix_cache(config: &PrefixCacheConfig, base_path: &str) -> DiagnosticResult {
     if config.enabled == Some(false) {
         return Ok(());
     }
@@ -288,20 +437,31 @@ fn validate_hardware(
     config: &HardwareConfig,
     base_path: &str,
     gpu_assignment: GpuAssignment,
-) -> Result<()> {
+) -> DiagnosticResult {
     if let Some(device) = &config.device {
         validate_non_empty(device, &format!("{base_path}.device"))?;
         if matches!(gpu_assignment, GpuAssignment::Pinned) && device.eq_ignore_ascii_case("auto") {
-            bail!("{base_path}.device must not be \"auto\" when gpu.assignment = \"pinned\"");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.device"),
+                format!("{base_path}.device must not be \"auto\" when gpu.assignment = \"pinned\""),
+            ));
         }
     }
     if let Some(gpu_layers) = &config.gpu_layers {
         match gpu_layers {
             IntegerOrString::Integer(value) if *value >= -1 && *value <= i64::from(i32::MAX) => {}
             IntegerOrString::Integer(value) if *value > i64::from(i32::MAX) => {
-                bail!("{base_path}.gpu_layers must be at most {}", i32::MAX)
+                return Err(validation_diagnostic(
+                    &format!("{base_path}.gpu_layers"),
+                    format!("{base_path}.gpu_layers must be at most {}", i32::MAX),
+                ));
             }
-            IntegerOrString::Integer(_) => bail!("{base_path}.gpu_layers must be at least -1"),
+            IntegerOrString::Integer(_) => {
+                return Err(validation_diagnostic(
+                    &format!("{base_path}.gpu_layers"),
+                    format!("{base_path}.gpu_layers must be at least -1"),
+                ));
+            }
             IntegerOrString::String(value) => {
                 validate_allowed(value, &["auto"], &format!("{base_path}.gpu_layers"))?
             }
@@ -309,14 +469,29 @@ fn validate_hardware(
     }
     match (config.stage_layer_start, config.stage_layer_end) {
         (Some(start), Some(end)) if end <= start => {
-            bail!("{base_path}.stage_layer_end must be greater than {base_path}.stage_layer_start");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.stage_layer_end"),
+                format!(
+                    "{base_path}.stage_layer_end must be greater than {base_path}.stage_layer_start"
+                ),
+            ));
         }
-        (Some(_), None) => bail!(
-            "{base_path}.stage_layer_end must be set when {base_path}.stage_layer_start is set"
-        ),
-        (None, Some(_)) => bail!(
-            "{base_path}.stage_layer_start must be set when {base_path}.stage_layer_end is set"
-        ),
+        (Some(_), None) => {
+            return Err(validation_diagnostic(
+                &format!("{base_path}.stage_layer_end"),
+                format!(
+                    "{base_path}.stage_layer_end must be set when {base_path}.stage_layer_start is set"
+                ),
+            ));
+        }
+        (None, Some(_)) => {
+            return Err(validation_diagnostic(
+                &format!("{base_path}.stage_layer_start"),
+                format!(
+                    "{base_path}.stage_layer_start must be set when {base_path}.stage_layer_end is set"
+                ),
+            ));
+        }
         _ => {}
     }
     validate_optional_enum(
@@ -329,7 +504,12 @@ fn validate_hardware(
             TensorSplitConfig::Ratios(ratios) => {
                 for ratio in ratios {
                     if *ratio < 0.0 {
-                        bail!("{base_path}.tensor_split must contain only non-negative ratios");
+                        return Err(validation_diagnostic(
+                            &format!("{base_path}.tensor_split"),
+                            format!(
+                                "{base_path}.tensor_split must contain only non-negative ratios"
+                            ),
+                        ));
                     }
                 }
             }
@@ -347,7 +527,10 @@ fn validate_hardware(
         validate_bool_or_auto(Some(value), &format!("{base_path}.cpu_moe"))?;
     }
     if config.rpc_backend.is_some() {
-        bail!("{base_path}.rpc_backend is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.rpc_backend"),
+            format!("{base_path}.rpc_backend is documented-rejected and must not be set"),
+        ));
     }
     if let Some(fit_context) = &config.fit_context {
         validate_bool_or_auto(Some(fit_context), &format!("{base_path}.fit_context"))?;
@@ -381,11 +564,14 @@ fn validate_hardware(
     Ok(())
 }
 
-fn validate_throughput(config: &ThroughputConfig, base_path: &str) -> Result<()> {
+fn validate_throughput(config: &ThroughputConfig, base_path: &str) -> DiagnosticResult {
     if let Some(parallel) = config.parallel
         && parallel < 1
     {
-        bail!("{base_path}.parallel must be at least 1, got {parallel}");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.parallel"),
+            format!("{base_path}.parallel must be at least 1, got {parallel}"),
+        ));
     }
     validate_bool_or_auto(
         config.continuous_batching.as_ref(),
@@ -393,7 +579,10 @@ fn validate_throughput(config: &ThroughputConfig, base_path: &str) -> Result<()>
     )?;
     // `0` is a canonical auto/default sentinel for threads and threads_batch.
     if config.threads_http.is_some() {
-        bail!("{base_path}.threads_http is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.threads_http"),
+            format!("{base_path}.threads_http is documented-rejected and must not be set"),
+        ));
     }
     if let Some(BoolOrString::String(value)) = &config.poll {
         validate_allowed(
@@ -416,10 +605,16 @@ fn validate_throughput(config: &ThroughputConfig, base_path: &str) -> Result<()>
     if let Some(slot_prompt_similarity) = config.slot_prompt_similarity
         && slot_prompt_similarity < 0.0
     {
-        bail!("{base_path}.slot_prompt_similarity must be non-negative");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.slot_prompt_similarity"),
+            format!("{base_path}.slot_prompt_similarity must be non-negative"),
+        ));
     }
     if config.sleep_idle_seconds.is_some() {
-        bail!("{base_path}.sleep_idle_seconds is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.sleep_idle_seconds"),
+            format!("{base_path}.sleep_idle_seconds is documented-rejected and must not be set"),
+        ));
     }
     validate_optional_enum(
         config.tuning_profile.as_deref(),
@@ -429,7 +624,7 @@ fn validate_throughput(config: &ThroughputConfig, base_path: &str) -> Result<()>
     Ok(())
 }
 
-fn validate_skippy(config: &SkippyConfig, base_path: &str) -> Result<()> {
+fn validate_skippy(config: &SkippyConfig, base_path: &str) -> DiagnosticResult {
     validate_optional_non_empty(
         config.stage_model_path.as_deref(),
         &format!("{base_path}.stage_model_path"),
@@ -452,7 +647,10 @@ fn validate_skippy(config: &SkippyConfig, base_path: &str) -> Result<()> {
         &format!("{base_path}.binary_stage_transport"),
     )?;
     if config.openai_frontend_mode.is_some() {
-        bail!("{base_path}.openai_frontend_mode is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.openai_frontend_mode"),
+            format!("{base_path}.openai_frontend_mode is documented-rejected and must not be set"),
+        ));
     }
     validate_optional_positive_u64(
         config.lifecycle_startup_timeout_ms,
@@ -482,16 +680,19 @@ fn validate_skippy(config: &SkippyConfig, base_path: &str) -> Result<()> {
                     .filter(|value| *value > 0)
                     .is_none()
             {
-                bail!(
-                    "{base_path}.prefill_chunk_schedule must contain only comma-separated positive integers"
-                );
+                return Err(validation_diagnostic(
+                    &format!("{base_path}.prefill_chunk_schedule"),
+                    format!(
+                        "{base_path}.prefill_chunk_schedule must contain only comma-separated positive integers"
+                    ),
+                ));
             }
         }
     }
     Ok(())
 }
 
-fn validate_speculative(config: &SpeculativeConfig, base_path: &str) -> Result<()> {
+fn validate_speculative(config: &SpeculativeConfig, base_path: &str) -> DiagnosticResult {
     validate_optional_enum(
         config.mode.as_deref(),
         &["auto", "disabled", "draft", "ngram"],
@@ -526,9 +727,12 @@ fn validate_speculative(config: &SpeculativeConfig, base_path: &str) -> Result<(
     if let (Some(min), Some(max)) = (config.draft_min_tokens, config.draft_max_tokens)
         && min > max
     {
-        bail!(
-            "{base_path}.draft_min_tokens must be less than or equal to {base_path}.draft_max_tokens"
-        );
+        return Err(validation_diagnostic(
+            &format!("{base_path}.draft_min_tokens"),
+            format!(
+                "{base_path}.draft_min_tokens must be less than or equal to {base_path}.draft_max_tokens"
+            ),
+        ));
     }
     validate_probability(
         config.draft_acceptance_threshold,
@@ -541,7 +745,10 @@ fn validate_speculative(config: &SpeculativeConfig, base_path: &str) -> Result<(
     if let Some(gpu_layers) = config.draft_gpu_layers
         && gpu_layers < -1
     {
-        bail!("{base_path}.draft_gpu_layers must be at least -1");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.draft_gpu_layers"),
+            format!("{base_path}.draft_gpu_layers must be at least -1"),
+        ));
     }
     validate_optional_non_empty(
         config.draft_device.as_deref(),
@@ -561,7 +768,10 @@ fn validate_speculative(config: &SpeculativeConfig, base_path: &str) -> Result<(
     if let (Some(min), Some(max)) = (config.ngram_min, config.ngram_max)
         && max < min
     {
-        bail!("{base_path}.ngram_max must be greater than or equal to {base_path}.ngram_min");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.ngram_max"),
+            format!("{base_path}.ngram_max must be greater than or equal to {base_path}.ngram_min"),
+        ));
     }
     validate_bool_or_auto(
         config.spec_default.as_ref(),
@@ -572,14 +782,17 @@ fn validate_speculative(config: &SpeculativeConfig, base_path: &str) -> Result<(
         && config.draft_hf_repo.is_none()
         && config.draft_selection_policy.is_none()
     {
-        bail!(
-            "{base_path}.draft_selection_policy must be set when {base_path}.mode = \"draft\" and no explicit draft model source is configured"
-        );
+        return Err(validation_diagnostic(
+            &format!("{base_path}.draft_selection_policy"),
+            format!(
+                "{base_path}.draft_selection_policy must be set when {base_path}.mode = \"draft\" and no explicit draft model source is configured"
+            ),
+        ));
     }
     Ok(())
 }
 
-fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) -> Result<()> {
+fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) -> DiagnosticResult {
     validate_optional_positive_u32(config.max_tokens, &format!("{base_path}.max_tokens"))?;
     if let Some(stop) = &config.stop {
         match stop {
@@ -596,7 +809,10 @@ fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) ->
     if let Some(top_k) = config.top_k
         && top_k < 0
     {
-        bail!("{base_path}.top_k must be greater than or equal to 0");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.top_k"),
+            format!("{base_path}.top_k must be greater than or equal to 0"),
+        ));
     }
     validate_probability(config.min_p, &format!("{base_path}.min_p"))?;
     validate_probability(config.typical_p, &format!("{base_path}.typical_p"))?;
@@ -616,7 +832,10 @@ fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) ->
     if let Some(repeat_last_n) = config.repeat_last_n
         && repeat_last_n < -1
     {
-        bail!("{base_path}.repeat_last_n must be greater than or equal to -1");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.repeat_last_n"),
+            format!("{base_path}.repeat_last_n must be greater than or equal to -1"),
+        ));
     }
     validate_non_negative_f64(
         config.presence_penalty,
@@ -634,7 +853,12 @@ fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) ->
                 &["disabled", "1", "2"],
                 &format!("{base_path}.mirostat_mode"),
             )?,
-            _ => bail!("{base_path}.mirostat_mode must be one of: disabled, 1, 2"),
+            _ => {
+                return Err(validation_diagnostic(
+                    &format!("{base_path}.mirostat_mode"),
+                    format!("{base_path}.mirostat_mode must be one of: disabled, 1, 2"),
+                ));
+            }
         }
     }
     validate_positive_f64(
@@ -653,7 +877,10 @@ fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) ->
         &format!("{base_path}.sampler_sequence"),
     )?;
     if config.backend_sampling.is_some() {
-        bail!("{base_path}.backend_sampling is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.backend_sampling"),
+            format!("{base_path}.backend_sampling is documented-rejected and must not be set"),
+        ));
     }
     validate_optional_enum(
         config.reasoning_format.as_deref(),
@@ -693,13 +920,22 @@ fn validate_request_defaults(config: &RequestDefaultsConfig, base_path: &str) ->
         &format!("{base_path}.system_prompt"),
     )?;
     if config.grammar.is_some() {
-        bail!("{base_path}.grammar is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.grammar"),
+            format!("{base_path}.grammar is documented-rejected and must not be set"),
+        ));
     }
     if config.json_schema.is_some() {
-        bail!("{base_path}.json_schema is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.json_schema"),
+            format!("{base_path}.json_schema is documented-rejected and must not be set"),
+        ));
     }
     if config.logprobs.is_some() {
-        bail!("{base_path}.logprobs is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.logprobs"),
+            format!("{base_path}.logprobs is documented-rejected and must not be set"),
+        ));
     }
     Ok(())
 }
@@ -709,28 +945,36 @@ fn validate_multimodal_pair(
     multimodal: Option<&MultimodalConfig>,
     hardware_path: &str,
     multimodal_path: &str,
-) -> Result<()> {
+) -> DiagnosticResult {
     if let (Some(hardware), Some(multimodal)) = (hardware, multimodal) {
         if let (Some(hardware_mmproj), Some(multimodal_mmproj)) =
             (hardware.mmproj.as_deref(), multimodal.mmproj.as_deref())
             && hardware_mmproj != multimodal_mmproj
         {
-            bail!("{multimodal_path}.mmproj must match {hardware_path}.mmproj when both are set");
+            return Err(validation_diagnostic(
+                &format!("{multimodal_path}.mmproj"),
+                format!(
+                    "{multimodal_path}.mmproj must match {hardware_path}.mmproj when both are set"
+                ),
+            ));
         }
         if let (Some(hardware_offload), Some(multimodal_offload)) = (
             hardware.mmproj_offload.as_ref(),
             multimodal.mmproj_offload.as_ref(),
         ) && hardware_offload != multimodal_offload
         {
-            bail!(
-                "{multimodal_path}.mmproj_offload must match {hardware_path}.mmproj_offload when both are set"
-            );
+            return Err(validation_diagnostic(
+                &format!("{multimodal_path}.mmproj_offload"),
+                format!(
+                    "{multimodal_path}.mmproj_offload must match {hardware_path}.mmproj_offload when both are set"
+                ),
+            ));
         }
     }
     Ok(())
 }
 
-fn validate_multimodal(config: &MultimodalConfig, base_path: &str) -> Result<()> {
+fn validate_multimodal(config: &MultimodalConfig, base_path: &str) -> DiagnosticResult {
     validate_optional_non_empty(config.mmproj.as_deref(), &format!("{base_path}.mmproj"))?;
     validate_optional_non_empty(
         config.mmproj_url.as_deref(),
@@ -743,50 +987,89 @@ fn validate_multimodal(config: &MultimodalConfig, base_path: &str) -> Result<()>
     if let (Some(min), Some(max)) = (config.image_min_tokens, config.image_max_tokens)
         && min > max
     {
-        bail!(
-            "{base_path}.image_min_tokens must be less than or equal to {base_path}.image_max_tokens"
-        );
+        return Err(validation_diagnostic(
+            &format!("{base_path}.image_min_tokens"),
+            format!(
+                "{base_path}.image_min_tokens must be less than or equal to {base_path}.image_max_tokens"
+            ),
+        ));
     }
     if config.embeddings.is_some() {
-        bail!("{base_path}.embeddings is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.embeddings"),
+            format!("{base_path}.embeddings is documented-rejected and must not be set"),
+        ));
     }
     if config.reranking.is_some() {
-        bail!("{base_path}.reranking is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.reranking"),
+            format!("{base_path}.reranking is documented-rejected and must not be set"),
+        ));
     }
     if config.pooling.is_some() {
-        bail!("{base_path}.pooling is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.pooling"),
+            format!("{base_path}.pooling is documented-rejected and must not be set"),
+        ));
     }
     if config.vocoder.is_some() {
-        bail!("{base_path}.vocoder is documented-rejected and must not be set");
+        return Err(validation_diagnostic(
+            &format!("{base_path}.vocoder"),
+            format!("{base_path}.vocoder is documented-rejected and must not be set"),
+        ));
     }
     Ok(())
 }
 
-fn validate_advanced(config: &AdvancedConfig, base_path: &str) -> Result<()> {
+fn validate_advanced(config: &AdvancedConfig, base_path: &str) -> DiagnosticResult {
     if let Some(server) = &config.server {
         if server.host.is_some() {
-            bail!("{base_path}.server.host is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.host"),
+                format!("{base_path}.server.host is documented-rejected and must not be set"),
+            ));
         }
         if server.port.is_some() {
-            bail!("{base_path}.server.port is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.port"),
+                format!("{base_path}.server.port is documented-rejected and must not be set"),
+            ));
         }
         if server.reuse_port.is_some() {
-            bail!("{base_path}.server.reuse_port is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.reuse_port"),
+                format!("{base_path}.server.reuse_port is documented-rejected and must not be set"),
+            ));
         }
         if server.timeout.is_some() {
-            bail!("{base_path}.server.timeout is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.timeout"),
+                format!("{base_path}.server.timeout is documented-rejected and must not be set"),
+            ));
         }
         if server.metrics.is_some() {
-            bail!("{base_path}.server.metrics is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.metrics"),
+                format!("{base_path}.server.metrics is documented-rejected and must not be set"),
+            ));
         }
         if server.slots.is_some() {
-            bail!("{base_path}.server.slots is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.slots"),
+                format!("{base_path}.server.slots is documented-rejected and must not be set"),
+            ));
         }
         if server.props.is_some() {
-            bail!("{base_path}.server.props is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.props"),
+                format!("{base_path}.server.props is documented-rejected and must not be set"),
+            ));
         }
         if server.api_prefix.is_some() {
-            bail!("{base_path}.server.api_prefix is documented-rejected and must not be set");
+            return Err(validation_diagnostic(
+                &format!("{base_path}.server.api_prefix"),
+                format!("{base_path}.server.api_prefix is documented-rejected and must not be set"),
+            ));
         }
         validate_optional_non_empty(
             server.alias.as_deref(),
@@ -796,89 +1079,113 @@ fn validate_advanced(config: &AdvancedConfig, base_path: &str) -> Result<()> {
     Ok(())
 }
 
-fn validate_optional_positive_u32(value: Option<u32>, path: &str) -> Result<()> {
+fn validate_optional_positive_u32(value: Option<u32>, path: &str) -> DiagnosticResult {
     if value == Some(0) {
-        bail!("{path} must be at least 1 when set");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be at least 1 when set"),
+        ));
     }
     Ok(())
 }
 
-fn validate_optional_positive_u64(value: Option<u64>, path: &str) -> Result<()> {
+fn validate_optional_positive_u64(value: Option<u64>, path: &str) -> DiagnosticResult {
     if value == Some(0) {
-        bail!("{path} must be at least 1 when set");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be at least 1 when set"),
+        ));
     }
     Ok(())
 }
 
-fn validate_optional_positive_usize(value: Option<usize>, path: &str) -> Result<()> {
+fn validate_optional_positive_usize(value: Option<usize>, path: &str) -> DiagnosticResult {
     if value == Some(0) {
-        bail!("{path} must be at least 1 when set");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be at least 1 when set"),
+        ));
     }
     Ok(())
 }
 
-fn validate_optional_non_empty(value: Option<&str>, path: &str) -> Result<()> {
+fn validate_optional_non_empty(value: Option<&str>, path: &str) -> DiagnosticResult {
     if let Some(value) = value {
         validate_non_empty(value, path)?;
     }
     Ok(())
 }
 
-fn validate_non_empty(value: &str, path: &str) -> Result<()> {
+fn validate_non_empty(value: &str, path: &str) -> DiagnosticResult {
     if value.trim().is_empty() {
-        bail!("{path} must not be empty when set");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must not be empty when set"),
+        ));
     }
     Ok(())
 }
 
-fn validate_optional_enum(value: Option<&str>, allowed: &[&str], path: &str) -> Result<()> {
+fn validate_optional_enum(value: Option<&str>, allowed: &[&str], path: &str) -> DiagnosticResult {
     if let Some(value) = value {
         validate_allowed(value, allowed, path)?;
     }
     Ok(())
 }
 
-fn validate_allowed(value: &str, allowed: &[&str], path: &str) -> Result<()> {
+fn validate_allowed(value: &str, allowed: &[&str], path: &str) -> DiagnosticResult {
     validate_non_empty(value, path)?;
     if !allowed
         .iter()
         .any(|candidate| value.eq_ignore_ascii_case(candidate))
     {
-        bail!("{path} must be one of: {}", allowed.join(", "));
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be one of: {}", allowed.join(", ")),
+        ));
     }
     Ok(())
 }
 
-fn validate_bool_or_auto(value: Option<&BoolOrAuto>, path: &str) -> Result<()> {
+fn validate_bool_or_auto(value: Option<&BoolOrAuto>, path: &str) -> DiagnosticResult {
     if let Some(BoolOrAuto::String(value)) = value {
         validate_allowed(value, &["auto"], path)?;
     }
     Ok(())
 }
 
-fn validate_probability(value: Option<f64>, path: &str) -> Result<()> {
+fn validate_probability(value: Option<f64>, path: &str) -> DiagnosticResult {
     if let Some(value) = value
         && !(0.0..=1.0).contains(&value)
     {
-        bail!("{path} must be between 0.0 and 1.0");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be between 0.0 and 1.0"),
+        ));
     }
     Ok(())
 }
 
-fn validate_non_negative_f64(value: Option<f64>, path: &str) -> Result<()> {
+fn validate_non_negative_f64(value: Option<f64>, path: &str) -> DiagnosticResult {
     if let Some(value) = value
         && value < 0.0
     {
-        bail!("{path} must be greater than or equal to 0.0");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be greater than or equal to 0.0"),
+        ));
     }
     Ok(())
 }
 
-fn validate_positive_f64(value: Option<f64>, path: &str) -> Result<()> {
+fn validate_positive_f64(value: Option<f64>, path: &str) -> DiagnosticResult {
     if let Some(value) = value
         && value <= 0.0
     {
-        bail!("{path} must be greater than 0.0");
+        return Err(validation_diagnostic(
+            path,
+            format!("{path} must be greater than 0.0"),
+        ));
     }
     Ok(())
 }
@@ -888,94 +1195,110 @@ fn validate_hf_pair(
     file: Option<&str>,
     repo_path: &str,
     file_path: &str,
-) -> Result<()> {
+) -> DiagnosticResult {
     validate_optional_non_empty(repo, repo_path)?;
     validate_optional_non_empty(file, file_path)?;
     match (repo, file) {
-        (Some(_), None) => bail!("{file_path} must be set when {repo_path} is set"),
-        (None, Some(_)) => bail!("{repo_path} must be set when {file_path} is set"),
+        (Some(_), None) => Err(validation_diagnostic(
+            file_path,
+            format!("{file_path} must be set when {repo_path} is set"),
+        )),
+        (None, Some(_)) => Err(validation_diagnostic(
+            repo_path,
+            format!("{repo_path} must be set when {file_path} is set"),
+        )),
         _ => Ok(()),
     }
 }
 
-fn validate_string_list(values: &[String], path: &str) -> Result<()> {
+fn validate_string_list(values: &[String], path: &str) -> DiagnosticResult {
     for value in values {
         validate_non_empty(value, path)?;
     }
     Ok(())
 }
 
-fn validate_mesh_requirements_config(config: &MeshRequirementsConfig) -> Result<()> {
+fn validate_mesh_requirements_config(config: &MeshRequirementsConfig) -> DiagnosticResult {
     let min_node_version = config
         .min_node_version
         .as_deref()
-        .map(parse_node_version)
+        .map(|value| parse_node_version(value, "mesh_requirements.min_node_version"))
         .transpose()?;
     let max_node_version = config
         .max_node_version
         .as_deref()
-        .map(parse_node_version)
+        .map(|value| parse_node_version(value, "mesh_requirements.max_node_version"))
         .transpose()?;
     if let (Some(min), Some(max)) = (&min_node_version, &max_node_version)
         && version_precedence_cmp(min, max).is_gt()
     {
-        bail!(
-            "mesh_requirements.min_node_version must be less than or equal to mesh_requirements.max_node_version"
-        );
+        return Err(validation_diagnostic(
+            "mesh_requirements.min_node_version",
+            "mesh_requirements.min_node_version must be less than or equal to mesh_requirements.max_node_version",
+        ));
     }
 
     if let (Some(min), Some(max)) = (config.min_protocol_version, config.max_protocol_version)
         && min > max
     {
-        bail!(
-            "mesh_requirements.min_protocol_version must be less than or equal to mesh_requirements.max_protocol_version"
-        );
+        return Err(validation_diagnostic(
+            "mesh_requirements.min_protocol_version",
+            "mesh_requirements.min_protocol_version must be less than or equal to mesh_requirements.max_protocol_version",
+        ));
     }
 
     for signer_key in &config.release_signer_keys {
-        validate_release_signer_key_shape(signer_key)?;
+        validate_release_signer_key_shape(signer_key, "mesh_requirements.release_signer_keys")?;
     }
     if config.require_release_attestation && config.release_signer_keys.is_empty() {
-        bail!(
-            "mesh_requirements.require_release_attestation is true but mesh_requirements.release_signer_keys is empty; certified-build admission is not remote runtime attestation, so trust must be anchored in at least one release signer key"
-        );
+        return Err(validation_diagnostic(
+            "mesh_requirements.require_release_attestation",
+            "mesh_requirements.require_release_attestation is true but mesh_requirements.release_signer_keys is empty; certified-build admission is not remote runtime attestation, so trust must be anchored in at least one release signer key",
+        ));
     }
 
     Ok(())
 }
 
-fn parse_node_version(raw: &str) -> Result<Version> {
+fn parse_node_version(raw: &str, path: &str) -> std::result::Result<Version, ConfigDiagnostic> {
     let normalized = raw.trim();
     if normalized.is_empty() {
-        bail!(
-            "mesh_requirements node version bounds must be valid semver strings (an optional leading 'v' is allowed)"
-        );
+        return Err(validation_diagnostic(
+            path,
+            "mesh_requirements node version bounds must be valid semver strings (an optional leading 'v' is allowed)",
+        ));
     }
     let normalized = normalized
         .strip_prefix('v')
         .or_else(|| normalized.strip_prefix('V'))
         .unwrap_or(normalized);
     Version::parse(normalized).map_err(|_| {
-        anyhow::anyhow!(
-            "mesh_requirements node version bounds must be valid semver strings (an optional leading 'v' is allowed)"
+        validation_diagnostic(
+            path,
+            "mesh_requirements node version bounds must be valid semver strings (an optional leading 'v' is allowed)",
         )
     })
 }
 
-fn validate_release_signer_key_shape(raw: &str) -> Result<()> {
+fn validate_release_signer_key_shape(raw: &str, path: &str) -> DiagnosticResult {
     let normalized = raw.trim();
     if normalized.is_empty() {
-        bail!("mesh_requirements.release_signer_keys entries must not be empty");
+        return Err(validation_diagnostic(
+            path,
+            "mesh_requirements.release_signer_keys entries must not be empty",
+        ));
     }
     let Some(encoded) = normalized.strip_prefix("ed25519:") else {
-        bail!(
-            "mesh_requirements.release_signer_keys entries must be of the form 'ed25519:<64-character-hex-public-key>'"
-        );
+        return Err(validation_diagnostic(
+            path,
+            "mesh_requirements.release_signer_keys entries must be of the form 'ed25519:<64-character-hex-public-key>'",
+        ));
     };
     if encoded.len() != 64 || !encoded.chars().all(|ch| ch.is_ascii_hexdigit()) {
-        bail!(
-            "mesh_requirements.release_signer_keys entries must be of the form 'ed25519:<64-character-hex-public-key>'"
-        );
+        return Err(validation_diagnostic(
+            path,
+            "mesh_requirements.release_signer_keys entries must be of the form 'ed25519:<64-character-hex-public-key>'",
+        ));
     }
     Ok(())
 }
@@ -988,39 +1311,233 @@ fn version_precedence_cmp(left: &Version, right: &Version) -> std::cmp::Ordering
     left.cmp(&right)
 }
 
-fn validate_telemetry_config(config: &TelemetryConfig) -> Result<()> {
+fn validate_telemetry_config(config: &TelemetryConfig) -> DiagnosticResult {
     if let Some(service_name) = &config.service_name
         && service_name.trim().is_empty()
     {
-        bail!("telemetry.service_name must not be empty when set");
+        return Err(validation_diagnostic(
+            "telemetry.service_name",
+            "telemetry.service_name must not be empty when set",
+        ));
     }
     if let Some(endpoint) = &config.endpoint
         && endpoint.trim().is_empty()
     {
-        bail!("telemetry.endpoint must not be empty when set");
+        return Err(validation_diagnostic(
+            "telemetry.endpoint",
+            "telemetry.endpoint must not be empty when set",
+        ));
     }
     if let Some(endpoint) = &config.metrics.endpoint
         && endpoint.trim().is_empty()
     {
-        bail!("telemetry.metrics.endpoint must not be empty when set");
+        return Err(validation_diagnostic(
+            "telemetry.metrics.endpoint",
+            "telemetry.metrics.endpoint must not be empty when set",
+        ));
     }
     for key in config.headers.keys() {
         if key.trim().is_empty() {
-            bail!("telemetry.headers keys must not be empty");
+            return Err(validation_diagnostic(
+                "telemetry.headers",
+                "telemetry.headers keys must not be empty",
+            ));
         }
     }
     if let Some(export_interval_secs) = config.export_interval_secs
         && export_interval_secs < 1
     {
-        bail!("telemetry.export_interval_secs must be at least 1");
+        return Err(validation_diagnostic(
+            "telemetry.export_interval_secs",
+            "telemetry.export_interval_secs must be at least 1",
+        ));
     }
     if let Some(queue_size) = config.queue_size
         && queue_size < 1
     {
-        bail!("telemetry.queue_size must be at least 1");
+        return Err(validation_diagnostic(
+            "telemetry.queue_size",
+            "telemetry.queue_size must be at least 1",
+        ));
     }
     if config.prompt_shape_metrics {
-        bail!("telemetry.prompt_shape_metrics is not supported yet and must remain false");
+        return Err(validation_diagnostic(
+            "telemetry.prompt_shape_metrics",
+            "telemetry.prompt_shape_metrics is not supported yet and must remain false",
+        ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+
+    #[test]
+    fn schema_diagnostic_constructors_preserve_paths_and_legacy_message() {
+        let used_path = ConfigPath::from_fields(["models", "gpu_id"]);
+        let canonical_path = ConfigPath::from_fields(["models", "hardware", "device"]);
+        let diagnostic = alias_diagnostic(
+            used_path.clone(),
+            canonical_path.clone(),
+            "legacy gpu_id alias resolved to models.hardware.device",
+        )
+        .with_help("Use models.hardware.device for new config writes.");
+
+        assert_eq!(diagnostic.severity, ConfigDiagnosticSeverity::Warning);
+        assert_eq!(diagnostic.code, ConfigDiagnosticCode::AliasApplied);
+        assert_eq!(
+            diagnostic.schema_source,
+            Some(ConfigDiagnosticSchemaSource::BuiltIn)
+        );
+        assert_eq!(diagnostic.path, Some(used_path));
+        assert_eq!(diagnostic.canonical_path, Some(canonical_path));
+        assert_eq!(
+            diagnostic.legacy_message(),
+            "legacy gpu_id alias resolved to models.hardware.device"
+        );
+        assert_eq!(
+            diagnostic.help.as_deref(),
+            Some("Use models.hardware.device for new config writes.")
+        );
+    }
+
+    #[test]
+    fn schema_diagnostics_round_trip_via_toml() {
+        let diagnostic = rejected_field_diagnostic(
+            ConfigPath::from_fields(["defaults", "request_defaults", "json_schema"]),
+            "defaults.request_defaults.json_schema is documented-rejected and must not be set",
+        );
+
+        let encoded = toml::to_string(&diagnostic).expect("diagnostic should serialize");
+        let decoded: ConfigDiagnostic =
+            toml::from_str(&encoded).expect("diagnostic should deserialize");
+
+        assert_eq!(decoded, diagnostic);
+    }
+
+    #[test]
+    fn schema_diagnostic_helpers_cover_validation_and_support_cases() {
+        let invalid = invalid_value_diagnostic(
+            ConfigPath::from_fields(["gpu", "parallel"]),
+            "gpu.parallel must be at least 1, got 0",
+        );
+        let unsupported = unsupported_field_diagnostic(
+            ConfigPath::from_fields(["runtime", "sleep_idle_seconds"]),
+            "runtime.sleep_idle_seconds is not supported",
+        );
+
+        assert_eq!(invalid.code, ConfigDiagnosticCode::InvalidValue);
+        assert_eq!(invalid.severity, ConfigDiagnosticSeverity::Error);
+        assert_eq!(
+            invalid.schema_source,
+            Some(ConfigDiagnosticSchemaSource::BuiltIn)
+        );
+        assert_eq!(unsupported.code, ConfigDiagnosticCode::UnsupportedField);
+        assert_eq!(
+            unsupported.canonical_path.as_ref().map(ConfigPath::render),
+            Some("runtime.sleep_idle_seconds".to_string())
+        );
+    }
+
+    #[test]
+    fn canonical_path_aliases_use_stable_built_in_identifier() {
+        assert_eq!(
+            canonical_builtin_diagnostic_path("models[0].gpu_id")
+                .as_ref()
+                .map(ConfigPath::render),
+            Some("models.<model-ref>.hardware.device".to_string())
+        );
+
+        let diagnostic = built_in_support_diagnostic(
+            "models[0].gpu_id",
+            "legacy gpu_id should report the canonical device path",
+        )
+        .expect("legacy built-in alias should resolve");
+
+        assert_eq!(
+            diagnostic.path.as_ref().map(ConfigPath::render),
+            Some("models[0].gpu_id".to_string())
+        );
+        assert_eq!(
+            diagnostic.canonical_path.as_ref().map(ConfigPath::render),
+            Some("models.<model-ref>.hardware.device".to_string())
+        );
+    }
+
+    #[test]
+    fn structured_diagnostics_report_canonical_path_for_alias_backed_invalid_input() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+
+[gpu]
+assignment = "auto"
+
+[[models]]
+model = "Qwen3-4B-Q4_K_M"
+gpu_id = "metal:0"
+"#,
+        )
+        .expect("config should parse before validation");
+
+        let diagnostics = validate_config_diagnostics(&config);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| {
+                diagnostic.canonical_path.as_ref().map(ConfigPath::render)
+                    == Some("models.<model-ref>.hardware.device".to_string())
+            })
+            .expect("legacy gpu_id path should yield a canonical device diagnostic");
+
+        assert_eq!(diagnostic.code, ConfigDiagnosticCode::InvalidValue);
+        assert_eq!(diagnostic.severity, ConfigDiagnosticSeverity::Error);
+        assert_eq!(
+            diagnostic.schema_source,
+            Some(ConfigDiagnosticSchemaSource::BuiltIn)
+        );
+        assert_eq!(
+            diagnostic.path.as_ref().map(ConfigPath::render),
+            Some("models[0].hardware.device".to_string())
+        );
+        assert_eq!(
+            diagnostic.canonical_path.as_ref().map(ConfigPath::render),
+            Some("models.<model-ref>.hardware.device".to_string())
+        );
+        assert_eq!(
+            diagnostic.message,
+            "models[0].hardware.device must not be set when gpu.assignment = \"auto\""
+        );
+    }
+
+    #[test]
+    fn legacy_validation_errors_derive_compatible_string_messages() {
+        let config: MeshConfig = toml::from_str(
+            r#"
+version = 1
+
+[[plugin]]
+name = "metrics"
+command = "mesh-llm-plugin-metrics"
+
+[plugin.startup]
+connect_timeout_secs = 0
+"#,
+        )
+        .expect("config should parse before validation");
+
+        let diagnostics = validate_config_diagnostics(&config);
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            legacy_validation_error_text(&diagnostics),
+            "plugin[0].startup.connect_timeout_secs must be at least 1 when set"
+        );
+
+        let err =
+            validate_config(&config).expect_err("legacy validation surface should still fail");
+        assert_eq!(
+            err.to_string(),
+            "plugin[0].startup.connect_timeout_secs must be at least 1 when set"
+        );
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/api/routes/control_apply_diagnostics.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/control_apply_diagnostics.rs
@@ -1,0 +1,102 @@
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(super) struct LocalControlApplyDiagnosticPayload {
+    code: String,
+    severity: String,
+    source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema_source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    canonical_path: Option<String>,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    help: Option<String>,
+}
+
+pub(super) fn local_control_apply_diagnostic_payload(
+    diagnostic: &mesh_client::proto::node::ConfigDiagnostic,
+) -> LocalControlApplyDiagnosticPayload {
+    let diagnostic = crate::protocol::convert::proto_config_diagnostic_to_local(diagnostic);
+    LocalControlApplyDiagnosticPayload {
+        code: control_diagnostic_code_label(diagnostic.code),
+        severity: control_diagnostic_severity_label(diagnostic.severity),
+        source: control_diagnostic_source_label(diagnostic.source),
+        schema_source: diagnostic
+            .schema_source
+            .map(control_diagnostic_schema_source_label),
+        path: diagnostic.path.map(|path| path.render()),
+        canonical_path: diagnostic.canonical_path.map(|path| path.render()),
+        message: diagnostic.message,
+        help: diagnostic.help,
+    }
+}
+
+pub(super) fn local_control_apply_diagnostic_payload_from_local(
+    diagnostic: &mesh_llm_config::ConfigDiagnostic,
+) -> LocalControlApplyDiagnosticPayload {
+    LocalControlApplyDiagnosticPayload {
+        code: control_diagnostic_code_label(diagnostic.code),
+        severity: control_diagnostic_severity_label(diagnostic.severity),
+        source: control_diagnostic_source_label(diagnostic.source),
+        schema_source: diagnostic
+            .schema_source
+            .map(control_diagnostic_schema_source_label),
+        path: diagnostic.path.clone().map(|path| path.render()),
+        canonical_path: diagnostic.canonical_path.clone().map(|path| path.render()),
+        message: diagnostic.message.clone(),
+        help: diagnostic.help.clone(),
+    }
+}
+
+fn control_diagnostic_code_label(value: mesh_llm_config::ConfigDiagnosticCode) -> String {
+    match value {
+        mesh_llm_config::ConfigDiagnosticCode::InvalidValue => "invalid_value",
+        mesh_llm_config::ConfigDiagnosticCode::MissingRequiredValue => "missing_required_value",
+        mesh_llm_config::ConfigDiagnosticCode::UnsupportedField => "unsupported_field",
+        mesh_llm_config::ConfigDiagnosticCode::RejectedField => "rejected_field",
+        mesh_llm_config::ConfigDiagnosticCode::AliasApplied => "alias_applied",
+        mesh_llm_config::ConfigDiagnosticCode::MisplacedField => "misplaced_field",
+        mesh_llm_config::ConfigDiagnosticCode::UnknownField => "unknown_field",
+        mesh_llm_config::ConfigDiagnosticCode::SchemaUnavailable => "schema_unavailable",
+        mesh_llm_config::ConfigDiagnosticCode::LegacyUnvalidatedConfig => {
+            "legacy_unvalidated_config"
+        }
+        mesh_llm_config::ConfigDiagnosticCode::UnsupportedSchemaVersion => {
+            "unsupported_schema_version"
+        }
+    }
+    .to_string()
+}
+
+fn control_diagnostic_severity_label(value: mesh_llm_config::ConfigDiagnosticSeverity) -> String {
+    match value {
+        mesh_llm_config::ConfigDiagnosticSeverity::Error => "error",
+        mesh_llm_config::ConfigDiagnosticSeverity::Warning => "warning",
+        mesh_llm_config::ConfigDiagnosticSeverity::Info => "info",
+    }
+    .to_string()
+}
+
+fn control_diagnostic_source_label(value: mesh_llm_config::ConfigDiagnosticSource) -> String {
+    match value {
+        mesh_llm_config::ConfigDiagnosticSource::Validation => "validation",
+        mesh_llm_config::ConfigDiagnosticSource::Schema => "schema",
+        mesh_llm_config::ConfigDiagnosticSource::Plugin => "plugin",
+        mesh_llm_config::ConfigDiagnosticSource::Compatibility => "compatibility",
+    }
+    .to_string()
+}
+
+fn control_diagnostic_schema_source_label(
+    value: mesh_llm_config::ConfigDiagnosticSchemaSource,
+) -> String {
+    match value {
+        mesh_llm_config::ConfigDiagnosticSchemaSource::BuiltIn => "built_in",
+        mesh_llm_config::ConfigDiagnosticSchemaSource::Engine => "engine",
+        mesh_llm_config::ConfigDiagnosticSchemaSource::Plugin => "plugin",
+    }
+    .to_string()
+}

--- a/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/mod.rs
@@ -1,4 +1,5 @@
 mod chat;
+mod control_apply_diagnostics;
 mod diagnostics;
 mod discover;
 mod mcp;

--- a/crates/mesh-llm-host-runtime/src/api/routes/runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/runtime.rs
@@ -3,13 +3,19 @@ use super::super::{
     http::{respond_error, respond_json, respond_runtime_error},
     status::decode_runtime_model_path,
 };
+use super::control_apply_diagnostics::{
+    LocalControlApplyDiagnosticPayload, local_control_apply_diagnostic_payload,
+    local_control_apply_diagnostic_payload_from_local,
+};
 use crate::crypto::{
     OwnerKeychainLoadError, keystore_metadata, load_keystore, load_owner_keypair_from_keychain,
 };
+use crate::plugin::validate_config_diagnostics_with_installed_plugin_schemas;
 use mesh_client::{
     ClientBuilder, ControlPlaneBootstrapOptions, ControlPlaneClientError, ControlPlaneConnection,
     InviteToken, OwnerControlRemoteError,
 };
+use mesh_llm_config::{ConfigDiagnosticSeverity, legacy_validation_error_text};
 use mesh_llm_node::serving::{UnloadOptions, UnloadTarget};
 use openai_frontend::GuardrailMode;
 use serde::{Deserialize, Serialize};
@@ -108,6 +114,13 @@ struct ApplyConfigRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct RawApplyConfigRequest {
+    endpoint: Option<String>,
+    expected_revision: u64,
+    config: serde_json::Value,
+}
+
+#[derive(Debug, Deserialize)]
 struct OpenAiGuardrailsModeRequest {
     mode: String,
 }
@@ -130,6 +143,8 @@ struct LocalControlApplyPayload {
     apply_mode: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    diagnostics: Vec<LocalControlApplyDiagnosticPayload>,
 }
 
 #[derive(Debug, Serialize)]
@@ -217,14 +232,50 @@ async fn handle_control_apply_config(
     if !ensure_loopback_control_caller(stream).await? {
         return Ok(());
     }
-    let request: ApplyConfigRequest = match serde_json::from_str(body) {
+    let raw_request: RawApplyConfigRequest = match serde_json::from_str(body) {
         Ok(request) => request,
         Err(_) => return respond_error(stream, 400, "Invalid JSON body").await,
+    };
+    let raw_config_toml = toml::to_string(&raw_request.config).ok();
+    let request = ApplyConfigRequest {
+        endpoint: raw_request.endpoint,
+        expected_revision: raw_request.expected_revision,
+        config: match serde_json::from_value(raw_request.config) {
+            Ok(config) => config,
+            Err(_) => return respond_error(stream, 400, "Invalid JSON body").await,
+        },
     };
     let endpoint = match required_control_endpoint(request.endpoint) {
         Ok(endpoint) => endpoint,
         Err(error) => return respond_control_error(stream, error).await,
     };
+    let diagnostics = validate_config_diagnostics_with_installed_plugin_schemas(
+        &request.config,
+        raw_config_toml.as_deref(),
+    );
+    if diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == ConfigDiagnosticSeverity::Error)
+    {
+        return respond_json(
+            stream,
+            200,
+            &LocalControlApplyPayload {
+                success: false,
+                current_revision: request.expected_revision,
+                config_hash: hex::encode(crate::protocol::convert::canonical_config_hash(
+                    &crate::protocol::convert::mesh_config_to_proto(&request.config),
+                )),
+                apply_mode: "unspecified".to_string(),
+                error: Some(legacy_validation_error_text(&diagnostics)),
+                diagnostics: diagnostics
+                    .iter()
+                    .map(local_control_apply_diagnostic_payload_from_local)
+                    .collect(),
+            },
+        )
+        .await;
+    }
     match connect_owner_control_client(state, &endpoint).await {
         Ok(client) => {
             let result = client
@@ -245,6 +296,11 @@ async fn handle_control_apply_config(
                             config_hash: hex::encode(response.config_hash),
                             apply_mode: control_apply_mode_label(response.apply_mode),
                             error: response.error,
+                            diagnostics: response
+                                .diagnostics
+                                .iter()
+                                .map(local_control_apply_diagnostic_payload)
+                                .collect(),
                         },
                     )
                     .await

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -23,6 +23,8 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};
 
+mod apply_config_diagnostics;
+
 fn qwen_coder_remote_catalog_entry() -> crate::models::remote_catalog::CatalogEntry {
     use crate::models::remote_catalog::{
         CatalogCurated, CatalogEntry, CatalogSource, CatalogVariant,
@@ -1267,6 +1269,7 @@ async fn control_plane_api_apply_config_uses_full_mesh_config_contract() {
             config_hash: vec![0xab; 32],
             error: None,
             apply_mode: ConfigApplyMode::Staged as i32,
+            diagnostics: Vec::new(),
         },
     ))
     .await;

--- a/crates/mesh-llm-host-runtime/src/api/tests/apply_config_diagnostics.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/apply_config_diagnostics.rs
@@ -1,0 +1,227 @@
+use super::*;
+
+struct HomeEnvGuard {
+    original_home: Option<std::ffi::OsString>,
+}
+
+impl HomeEnvGuard {
+    fn set(home: &std::path::Path) -> Self {
+        let original_home = std::env::var_os("HOME");
+        unsafe { std::env::set_var("HOME", home) };
+        Self { original_home }
+    }
+}
+
+impl Drop for HomeEnvGuard {
+    fn drop(&mut self) {
+        match &self.original_home {
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn control_plane_api_apply_config_serializes_structured_diagnostics() {
+    let temp = tempfile::tempdir().unwrap();
+    let _home_guard = HomeEnvGuard::set(temp.path());
+    let owner = OwnerKeypair::generate();
+    let keystore_path = default_keystore_path().unwrap();
+    save_keystore(&keystore_path, &owner, None, true).unwrap();
+
+    let OwnerControlApplyTestServer {
+        endpoint_token,
+        task: control_task,
+        received_apply: _,
+    } = spawn_owner_control_apply_test_server(OwnerControlApplyTestResponse::Success(
+        OwnerControlApplyConfigResponse {
+            success: false,
+            current_revision: 7,
+            config_hash: vec![0xcd; 32],
+            error: Some(
+                "models[0].request_defaults.reasoning_format must be one of: auto, none, deepseek, deepseek-legacy, hidden"
+                    .to_string(),
+            ),
+            apply_mode: ConfigApplyMode::Unspecified as i32,
+            diagnostics: vec![mesh_client::proto::node::ConfigDiagnostic {
+                code: mesh_client::proto::node::ConfigDiagnosticCode::InvalidValue as i32,
+                severity: mesh_client::proto::node::ConfigDiagnosticSeverity::Error as i32,
+                source: mesh_client::proto::node::ConfigDiagnosticSource::Validation as i32,
+                schema_source: Some(
+                    mesh_client::proto::node::ConfigDiagnosticSchemaSource::BuiltIn as i32,
+                ),
+                path: Some("models[0].request_defaults.reasoning_format".to_string()),
+                canonical_path: Some(
+                    "models.<model-ref>.request_defaults.reasoning_format".to_string(),
+                ),
+                message:
+                    "models[0].request_defaults.reasoning_format must be one of: auto, none, deepseek, deepseek-legacy, hidden"
+                        .to_string(),
+                help: Some("choose one of the supported reasoning formats".to_string()),
+            }],
+        },
+    ))
+    .await;
+    let state = build_test_mesh_api().await;
+    state.set_owner_key_path(Some(keystore_path)).await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let apply_request_body = json!({
+        "endpoint": endpoint_token,
+        "expected_revision": 7,
+        "config": full_mesh_config_fixture(),
+    })
+    .to_string();
+    let apply_response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/apply-config", &apply_request_body),
+    )
+    .await;
+    let apply_body = json_body(&apply_response);
+
+    assert_eq!(apply_body["success"], false, "response: {apply_response}");
+    assert_eq!(apply_body["current_revision"], 7);
+    assert_eq!(apply_body["apply_mode"], "unspecified");
+    assert_eq!(
+        apply_body["error"],
+        "models[0].request_defaults.reasoning_format must be one of: auto, none, deepseek, deepseek-legacy, hidden"
+    );
+    assert_eq!(apply_body["diagnostics"][0]["code"], "invalid_value");
+    assert_eq!(apply_body["diagnostics"][0]["severity"], "error");
+    assert_eq!(apply_body["diagnostics"][0]["source"], "validation");
+    assert_eq!(apply_body["diagnostics"][0]["schema_source"], "built_in");
+    assert_eq!(
+        apply_body["diagnostics"][0]["path"],
+        "models[0].request_defaults.reasoning_format"
+    );
+    assert_eq!(
+        apply_body["diagnostics"][0]["help"],
+        "choose one of the supported reasoning formats"
+    );
+
+    handle.await.unwrap().unwrap();
+    control_task.await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn control_plane_api_apply_config_serializes_success_warning_diagnostics() {
+    let temp = tempfile::tempdir().unwrap();
+    let _home_guard = HomeEnvGuard::set(temp.path());
+    let owner = OwnerKeypair::generate();
+    let keystore_path = default_keystore_path().unwrap();
+    save_keystore(&keystore_path, &owner, None, true).unwrap();
+
+    let OwnerControlApplyTestServer {
+        endpoint_token,
+        task: control_task,
+        received_apply: _,
+    } = spawn_owner_control_apply_test_server(OwnerControlApplyTestResponse::Success(
+        OwnerControlApplyConfigResponse {
+            success: true,
+            current_revision: 8,
+            config_hash: vec![0xef; 32],
+            error: None,
+            apply_mode: ConfigApplyMode::Staged as i32,
+            diagnostics: vec![mesh_client::proto::node::ConfigDiagnostic {
+                code: mesh_client::proto::node::ConfigDiagnosticCode::LegacyUnvalidatedConfig
+                    as i32,
+                severity: mesh_client::proto::node::ConfigDiagnosticSeverity::Warning as i32,
+                source: mesh_client::proto::node::ConfigDiagnosticSource::Plugin as i32,
+                schema_source: Some(
+                    mesh_client::proto::node::ConfigDiagnosticSchemaSource::Plugin as i32,
+                ),
+                path: Some("plugin.blackboard.settings".to_string()),
+                canonical_path: Some("plugin.blackboard.settings".to_string()),
+                message:
+                    "plugin 'blackboard' allows legacy unvalidated config; custom settings are accepted without schema checks"
+                        .to_string(),
+                help: None,
+            }],
+        },
+    ))
+    .await;
+    let state = build_test_mesh_api().await;
+    state.set_owner_key_path(Some(keystore_path)).await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let apply_request_body = json!({
+        "endpoint": endpoint_token,
+        "expected_revision": 7,
+        "config": full_mesh_config_fixture(),
+    })
+    .to_string();
+    let apply_response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/apply-config", &apply_request_body),
+    )
+    .await;
+    let apply_body = json_body(&apply_response);
+
+    assert_eq!(apply_body["success"], true, "response: {apply_response}");
+    assert_eq!(apply_body["current_revision"], 8);
+    assert_eq!(apply_body["apply_mode"], "staged");
+    assert_eq!(apply_body["error"], serde_json::Value::Null);
+    assert_eq!(
+        apply_body["diagnostics"][0]["code"],
+        "legacy_unvalidated_config"
+    );
+    assert_eq!(apply_body["diagnostics"][0]["severity"], "warning");
+    assert_eq!(apply_body["diagnostics"][0]["source"], "plugin");
+    assert_eq!(apply_body["diagnostics"][0]["schema_source"], "plugin");
+    assert_eq!(
+        apply_body["diagnostics"][0]["canonical_path"],
+        "plugin.blackboard.settings"
+    );
+
+    handle.await.unwrap().unwrap();
+    control_task.await.unwrap();
+}
+
+#[tokio::test]
+#[serial]
+async fn control_plane_api_apply_config_preserves_misplaced_plugin_key_diagnostics() {
+    let state = build_test_mesh_api().await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+
+    let apply_request_body = json!({
+        "endpoint": "control://ignored",
+        "expected_revision": 7,
+        "config": {
+            "version": 1,
+            "plugin": [
+                {
+                    "name": "blackboard",
+                    "retention_days": 14,
+                    "settings": {
+                        "mode": "strict"
+                    }
+                }
+            ]
+        }
+    })
+    .to_string();
+    let apply_response = send_management_request(
+        addr,
+        management_post_request("/api/runtime/control/apply-config", &apply_request_body),
+    )
+    .await;
+    let apply_body = json_body(&apply_response);
+
+    assert!(
+        apply_response.starts_with("HTTP/1.1 200"),
+        "response: {apply_response}"
+    );
+    assert_eq!(apply_body["success"], false);
+    assert_eq!(apply_body["apply_mode"], "unspecified");
+    assert!(
+        apply_body["diagnostics"]
+            .as_array()
+            .expect("diagnostics should be an array")
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "misplaced_field")
+    );
+
+    handle.await.unwrap().unwrap();
+}

--- a/crates/mesh-llm-host-runtime/src/command_support.rs
+++ b/crates/mesh-llm-host-runtime/src/command_support.rs
@@ -60,6 +60,14 @@ pub mod plugin {
     pub use crate::runtime::load_resolved_plugins;
 }
 
+pub mod config {
+    pub use crate::plugin::{config_path, validate_config_file};
+    pub use mesh_llm_config::{
+        ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticSchemaSource,
+        ConfigDiagnosticSeverity, ConfigDiagnosticSource, ConfigPath,
+    };
+}
+
 pub mod runtime_instances {
     pub use crate::runtime::instance::{LocalInstanceSnapshot, runtime_root, scan_local_instances};
 }

--- a/crates/mesh-llm-host-runtime/src/config_schema.rs
+++ b/crates/mesh-llm-host-runtime/src/config_schema.rs
@@ -1,0 +1,716 @@
+use anyhow::Context;
+use mesh_llm_config::{
+    ConfigAliasPolicy, ConfigApplyMode, ConfigConstraint, ConfigControlSurface, ConfigPath,
+    ConfigRestartScope, ConfigSchema, ConfigSettingOwner, ConfigSettingSchema, ConfigSupportState,
+    ConfigValueSchema, ConfigVisibility, built_in_config_schema,
+};
+use mesh_llm_plugin_manager::{
+    InstalledPluginApplyMode, InstalledPluginConfigSchema, InstalledPluginConstraint,
+    InstalledPluginMetadata, InstalledPluginRestartScope, InstalledPluginValueKind,
+    InstalledPluginValueSchema, InstalledPluginVisibility, PluginStore, default_store_root,
+};
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AggregatedConfigSchema {
+    settings_by_path: BTreeMap<ConfigPath, AggregatedConfigSchemaEntry>,
+}
+
+impl AggregatedConfigSchema {
+    pub fn get(&self, path: &ConfigPath) -> Option<&AggregatedConfigSchemaEntry> {
+        self.settings_by_path.get(path)
+    }
+
+    pub fn settings_by_path(&self) -> &BTreeMap<ConfigPath, AggregatedConfigSchemaEntry> {
+        &self.settings_by_path
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&ConfigPath, &AggregatedConfigSchemaEntry)> {
+        self.settings_by_path.iter()
+    }
+
+    pub fn export_reference(&self) -> ConfigSchemaReference {
+        ConfigSchemaReference {
+            settings: self
+                .settings_by_path
+                .values()
+                .map(ConfigSchemaReferenceEntry::from)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ConfigSchemaReference {
+    pub settings: Vec<ConfigSchemaReferenceEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct ConfigSchemaReferenceEntry {
+    pub canonical_path: String,
+    pub owner: ConfigSettingOwner,
+    pub source: ConfigSchemaReferenceSource,
+    pub support: ConfigSupportState,
+    pub control_surfaces: Vec<ConfigControlSurface>,
+    pub apply_mode: ConfigApplyMode,
+    pub restart_scope: ConfigRestartScope,
+    pub visibility: ConfigVisibility,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl From<&AggregatedConfigSchemaEntry> for ConfigSchemaReferenceEntry {
+    fn from(value: &AggregatedConfigSchemaEntry) -> Self {
+        Self {
+            canonical_path: value.setting.path.render(),
+            owner: value.setting.owner,
+            source: ConfigSchemaReferenceSource::from(&value.source),
+            support: value.setting.support,
+            control_surfaces: value.setting.control_surfaces.clone(),
+            apply_mode: value.setting.apply_mode,
+            restart_scope: value.setting.restart_scope,
+            visibility: value.setting.visibility,
+            description: value.setting.description.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ConfigSchemaReferenceSource {
+    BuiltIn,
+    Engine {
+        engine_id: String,
+    },
+    Plugin {
+        plugin_name: String,
+        allow_unvalidated_config: bool,
+    },
+}
+
+impl From<&AggregatedConfigSchemaSource> for ConfigSchemaReferenceSource {
+    fn from(value: &AggregatedConfigSchemaSource) -> Self {
+        match value {
+            AggregatedConfigSchemaSource::BuiltIn => Self::BuiltIn,
+            AggregatedConfigSchemaSource::Engine { engine_id } => Self::Engine {
+                engine_id: engine_id.clone(),
+            },
+            AggregatedConfigSchemaSource::Plugin {
+                plugin_name,
+                allow_unvalidated_config,
+            } => Self::Plugin {
+                plugin_name: plugin_name.clone(),
+                allow_unvalidated_config: *allow_unvalidated_config,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AggregatedConfigSchemaEntry {
+    pub setting: ConfigSettingSchema,
+    pub source: AggregatedConfigSchemaSource,
+    pub unknown_policy: AggregatedConfigUnknownPolicy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AggregatedConfigSchemaSource {
+    BuiltIn,
+    Engine {
+        engine_id: String,
+    },
+    Plugin {
+        plugin_name: String,
+        allow_unvalidated_config: bool,
+    },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AggregatedConfigUnknownPolicy {
+    Reject,
+    PreserveWithDiagnostics,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EngineConfigSchemaDescriptor {
+    pub engine_id: String,
+    pub schema: ConfigSchema,
+}
+
+#[derive(Debug)]
+pub enum AggregatedConfigSchemaError {
+    DuplicatePath {
+        path: ConfigPath,
+        existing_source: AggregatedConfigSchemaSource,
+        incoming_source: AggregatedConfigSchemaSource,
+    },
+    PluginStore(anyhow::Error),
+}
+
+impl fmt::Display for AggregatedConfigSchemaError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DuplicatePath {
+                path,
+                existing_source,
+                incoming_source,
+            } => write!(
+                f,
+                "duplicate aggregated config schema path '{}' from {:?}; already registered by {:?}",
+                path.render(),
+                incoming_source,
+                existing_source
+            ),
+            Self::PluginStore(error) => write!(
+                f,
+                "failed to load installed plugin schema metadata: {error}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AggregatedConfigSchemaError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DuplicatePath { .. } => None,
+            Self::PluginStore(error) => Some(error.as_ref()),
+        }
+    }
+}
+
+pub fn aggregate_runtime_config_schema(
+    engine_schemas: impl IntoIterator<Item = EngineConfigSchemaDescriptor>,
+) -> Result<AggregatedConfigSchema, AggregatedConfigSchemaError> {
+    let root = default_store_root().map_err(AggregatedConfigSchemaError::PluginStore)?;
+    let installed_plugins = PluginStore::new(root)
+        .list()
+        .context("list installed plugins")
+        .map_err(AggregatedConfigSchemaError::PluginStore)?;
+    aggregate_config_schema_sources(engine_schemas, installed_plugins)
+}
+
+pub fn export_runtime_config_schema_reference(
+    engine_schemas: impl IntoIterator<Item = EngineConfigSchemaDescriptor>,
+) -> Result<ConfigSchemaReference, AggregatedConfigSchemaError> {
+    aggregate_runtime_config_schema(engine_schemas).map(|schema| schema.export_reference())
+}
+
+pub fn aggregate_config_schema_sources(
+    engine_schemas: impl IntoIterator<Item = EngineConfigSchemaDescriptor>,
+    installed_plugins: impl IntoIterator<Item = InstalledPluginMetadata>,
+) -> Result<AggregatedConfigSchema, AggregatedConfigSchemaError> {
+    let mut settings_by_path = BTreeMap::new();
+
+    for setting in built_in_config_schema().settings {
+        register_setting(
+            &mut settings_by_path,
+            setting,
+            AggregatedConfigSchemaSource::BuiltIn,
+            AggregatedConfigUnknownPolicy::Reject,
+        )?;
+    }
+
+    for engine in engine_schemas {
+        let source = AggregatedConfigSchemaSource::Engine {
+            engine_id: engine.engine_id,
+        };
+        for setting in engine.schema.settings {
+            register_setting(
+                &mut settings_by_path,
+                setting,
+                source.clone(),
+                AggregatedConfigUnknownPolicy::PreserveWithDiagnostics,
+            )?;
+        }
+    }
+
+    for plugin in installed_plugins {
+        let Some(schema) = plugin
+            .manifest
+            .as_ref()
+            .and_then(|manifest| manifest.config_schema.as_ref())
+        else {
+            continue;
+        };
+
+        let source = AggregatedConfigSchemaSource::Plugin {
+            plugin_name: schema.plugin_name.clone(),
+            allow_unvalidated_config: schema.allow_unvalidated_config,
+        };
+
+        for setting in plugin_settings_from_installed_schema(schema) {
+            register_setting(
+                &mut settings_by_path,
+                setting,
+                source.clone(),
+                AggregatedConfigUnknownPolicy::Reject,
+            )?;
+        }
+    }
+
+    Ok(AggregatedConfigSchema { settings_by_path })
+}
+
+fn register_setting(
+    settings_by_path: &mut BTreeMap<ConfigPath, AggregatedConfigSchemaEntry>,
+    mut setting: ConfigSettingSchema,
+    source: AggregatedConfigSchemaSource,
+    unknown_policy: AggregatedConfigUnknownPolicy,
+) -> Result<(), AggregatedConfigSchemaError> {
+    setting.path = setting.path.normalize_builtin_layout();
+
+    if let Some(existing) = settings_by_path.get(&setting.path) {
+        return Err(AggregatedConfigSchemaError::DuplicatePath {
+            path: setting.path.clone(),
+            existing_source: existing.source.clone(),
+            incoming_source: source,
+        });
+    }
+
+    settings_by_path.insert(
+        setting.path.clone(),
+        AggregatedConfigSchemaEntry {
+            setting,
+            source,
+            unknown_policy,
+        },
+    );
+    Ok(())
+}
+
+fn plugin_settings_from_installed_schema(
+    schema: &InstalledPluginConfigSchema,
+) -> Vec<ConfigSettingSchema> {
+    schema
+        .settings
+        .iter()
+        .map(|setting| ConfigSettingSchema {
+            path: ConfigPath::from_fields([
+                "plugin",
+                schema.plugin_name.as_str(),
+                "settings",
+                setting.key.as_str(),
+            ]),
+            alias_policy: ConfigAliasPolicy::default(),
+            owner: ConfigSettingOwner::Plugin,
+            value_schema: plugin_value_schema_from_installed(&setting.value_schema),
+            support: ConfigSupportState::Supported,
+            control_surfaces: vec![
+                ConfigControlSurface::ConfigFile,
+                ConfigControlSurface::OwnerControl,
+                ConfigControlSurface::PluginManifest,
+            ],
+            apply_mode: plugin_apply_mode_from_installed(setting.apply_mode),
+            restart_scope: plugin_restart_scope_from_installed(setting.restart_scope),
+            visibility: plugin_visibility_from_installed(setting.visibility),
+            constraints: setting
+                .constraints
+                .iter()
+                .map(plugin_constraint_from_installed)
+                .collect(),
+            description: setting.description.clone(),
+        })
+        .collect()
+}
+
+fn plugin_value_schema_from_installed(schema: &InstalledPluginValueSchema) -> ConfigValueSchema {
+    match schema.kind {
+        InstalledPluginValueKind::Boolean => ConfigValueSchema::Boolean,
+        InstalledPluginValueKind::Integer => ConfigValueSchema::Integer,
+        InstalledPluginValueKind::Float => ConfigValueSchema::Float,
+        InstalledPluginValueKind::String => ConfigValueSchema::String,
+        InstalledPluginValueKind::Path => ConfigValueSchema::String,
+        InstalledPluginValueKind::Url => ConfigValueSchema::String,
+        InstalledPluginValueKind::Enum => ConfigValueSchema::Enum {
+            values: schema.enum_values.clone(),
+        },
+        InstalledPluginValueKind::Array => ConfigValueSchema::Array {
+            items: Box::new(
+                schema
+                    .items
+                    .as_deref()
+                    .map(plugin_value_schema_from_installed)
+                    .unwrap_or(ConfigValueSchema::String),
+            ),
+        },
+        InstalledPluginValueKind::Object => ConfigValueSchema::Object,
+    }
+}
+
+fn plugin_constraint_from_installed(constraint: &InstalledPluginConstraint) -> ConfigConstraint {
+    match constraint {
+        InstalledPluginConstraint::NonEmpty => ConfigConstraint::NonEmpty,
+        InstalledPluginConstraint::Positive => ConfigConstraint::Positive,
+        InstalledPluginConstraint::Range { min, max } => ConfigConstraint::Range {
+            min: min.clone(),
+            max: max.clone(),
+        },
+        InstalledPluginConstraint::AllowedValues { values } => ConfigConstraint::AllowedValues {
+            values: values.clone(),
+        },
+        InstalledPluginConstraint::Requires { key } => ConfigConstraint::Requires {
+            path: ConfigPath::field(key.clone()),
+        },
+    }
+}
+
+fn plugin_apply_mode_from_installed(mode: InstalledPluginApplyMode) -> ConfigApplyMode {
+    match mode {
+        InstalledPluginApplyMode::StaticOnLoad => ConfigApplyMode::StaticOnLoad,
+        InstalledPluginApplyMode::DynamicValidationOnly => ConfigApplyMode::DynamicValidationOnly,
+        InstalledPluginApplyMode::DynamicApply => ConfigApplyMode::DynamicApply,
+    }
+}
+
+fn plugin_restart_scope_from_installed(scope: InstalledPluginRestartScope) -> ConfigRestartScope {
+    match scope {
+        InstalledPluginRestartScope::None => ConfigRestartScope::None,
+        InstalledPluginRestartScope::ModelReload => ConfigRestartScope::ModelReload,
+        InstalledPluginRestartScope::ProcessRestart
+        | InstalledPluginRestartScope::PluginProcess => ConfigRestartScope::ProcessRestart,
+        InstalledPluginRestartScope::MeshRestart => ConfigRestartScope::MeshRestart,
+    }
+}
+
+fn plugin_visibility_from_installed(visibility: InstalledPluginVisibility) -> ConfigVisibility {
+    match visibility {
+        InstalledPluginVisibility::User => ConfigVisibility::User,
+        InstalledPluginVisibility::Advanced => ConfigVisibility::Advanced,
+        InstalledPluginVisibility::Hidden => ConfigVisibility::Hidden,
+        InstalledPluginVisibility::Internal => ConfigVisibility::Internal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mesh_llm_config::{ConfigSchemaBuilder, ConfigSettingSchemaBuilder};
+    use mesh_llm_plugin_manager::{
+        InstalledPluginConfigSchema, InstalledPluginManifestMetadata,
+        InstalledPluginObjectProperty, InstalledPluginSettingSchema,
+    };
+    use serde::Serialize;
+    use std::path::PathBuf;
+
+    const CONFIG_SCHEMA_REFERENCE_FIXTURE: &str =
+        include_str!("../tests/fixtures/config_schema_reference.json");
+    const CONFIG_SCHEMA_DEFAULTS_UI_FIXTURE: &str =
+        include_str!("../tests/fixtures/config_schema_defaults_ui_reference.json");
+
+    #[derive(Serialize)]
+    struct DefaultsUiSchemaReference {
+        settings: Vec<DefaultsUiSchemaReferenceEntry>,
+    }
+
+    #[derive(Serialize)]
+    struct DefaultsUiSchemaReferenceEntry {
+        canonical_path: String,
+        support: ConfigSupportState,
+        source: ConfigSchemaReferenceSource,
+    }
+
+    #[test]
+    fn aggregated_config_schema_sources() {
+        let mut engine_schema = ConfigSchemaBuilder::new();
+        let mut engine_setting = ConfigSettingSchemaBuilder::new(
+            ConfigPath::from_fields(["defaults", "engine", "vllm", "temperature"]),
+            ConfigValueSchema::Float,
+        );
+        engine_setting.owner(ConfigSettingOwner::Engine);
+        engine_schema.setting(engine_setting.build());
+
+        let aggregated = aggregate_config_schema_sources(
+            [EngineConfigSchemaDescriptor {
+                engine_id: "vllm".into(),
+                schema: engine_schema.build(),
+            }],
+            [installed_plugin_metadata(
+                "blackboard",
+                vec![InstalledPluginSettingSchema {
+                    key: "retention_days".into(),
+                    value_schema: InstalledPluginValueSchema {
+                        kind: InstalledPluginValueKind::Integer,
+                        enum_values: Vec::new(),
+                        items: None,
+                        object_properties: vec![InstalledPluginObjectProperty {
+                            key: "unused".into(),
+                            value_schema: InstalledPluginValueSchema {
+                                kind: InstalledPluginValueKind::String,
+                                enum_values: Vec::new(),
+                                items: None,
+                                object_properties: Vec::new(),
+                                allow_additional_properties: false,
+                            },
+                            required: false,
+                            description: None,
+                        }],
+                        allow_additional_properties: false,
+                    },
+                    required: true,
+                    default_json: Some("14".into()),
+                    constraints: vec![InstalledPluginConstraint::Range {
+                        min: Some("1".into()),
+                        max: Some("365".into()),
+                    }],
+                    apply_mode: InstalledPluginApplyMode::DynamicApply,
+                    restart_scope: InstalledPluginRestartScope::PluginProcess,
+                    visibility: InstalledPluginVisibility::Advanced,
+                    description: Some("Retention period in days".into()),
+                }],
+            )],
+        )
+        .expect("schema aggregation should succeed");
+
+        let built_in = aggregated
+            .get(&ConfigPath::field("version"))
+            .expect("built-in version setting should be present");
+        assert_eq!(built_in.source, AggregatedConfigSchemaSource::BuiltIn);
+        assert_eq!(
+            built_in.unknown_policy,
+            AggregatedConfigUnknownPolicy::Reject
+        );
+
+        let engine = aggregated
+            .get(&ConfigPath::from_fields([
+                "defaults",
+                "engine",
+                "vllm",
+                "temperature",
+            ]))
+            .expect("engine setting should be present");
+        assert_eq!(
+            engine.source,
+            AggregatedConfigSchemaSource::Engine {
+                engine_id: "vllm".into(),
+            }
+        );
+        assert_eq!(
+            engine.unknown_policy,
+            AggregatedConfigUnknownPolicy::PreserveWithDiagnostics
+        );
+
+        let plugin = aggregated
+            .get(&ConfigPath::from_fields([
+                "plugin",
+                "blackboard",
+                "settings",
+                "retention_days",
+            ]))
+            .expect("plugin setting should be present under canonical plugin path");
+        assert_eq!(
+            plugin.source,
+            AggregatedConfigSchemaSource::Plugin {
+                plugin_name: "blackboard".into(),
+                allow_unvalidated_config: false,
+            }
+        );
+        assert_eq!(plugin.unknown_policy, AggregatedConfigUnknownPolicy::Reject);
+        assert_eq!(plugin.setting.owner, ConfigSettingOwner::Plugin);
+        assert_eq!(
+            plugin.setting.path.render(),
+            "plugin.blackboard.settings.retention_days"
+        );
+    }
+
+    #[test]
+    fn aggregated_schema_duplicate_paths() {
+        let mut duplicate_schema = ConfigSchemaBuilder::new();
+        let mut duplicate_setting = ConfigSettingSchemaBuilder::new(
+            ConfigPath::field("version"),
+            ConfigValueSchema::Integer,
+        );
+        duplicate_setting.owner(ConfigSettingOwner::Engine);
+        duplicate_schema.setting(duplicate_setting.build());
+
+        let error = aggregate_config_schema_sources(
+            [EngineConfigSchemaDescriptor {
+                engine_id: "vllm".into(),
+                schema: duplicate_schema.build(),
+            }],
+            Vec::<InstalledPluginMetadata>::new(),
+        )
+        .expect_err("duplicate canonical paths should fail deterministically");
+
+        match error {
+            AggregatedConfigSchemaError::DuplicatePath {
+                path,
+                existing_source,
+                incoming_source,
+            } => {
+                assert_eq!(path.render(), "version");
+                assert_eq!(existing_source, AggregatedConfigSchemaSource::BuiltIn);
+                assert_eq!(
+                    incoming_source,
+                    AggregatedConfigSchemaSource::Engine {
+                        engine_id: "vllm".into(),
+                    }
+                );
+            }
+            other => panic!("unexpected aggregation error: {other}"),
+        }
+    }
+
+    #[test]
+    fn schema_export_snapshot() {
+        let mut engine_schema = ConfigSchemaBuilder::new();
+        let mut engine_setting = ConfigSettingSchemaBuilder::new(
+            ConfigPath::from_fields(["defaults", "engine", "vllm", "temperature"]),
+            ConfigValueSchema::Float,
+        );
+        engine_setting.owner(ConfigSettingOwner::Engine);
+        engine_setting.control_surface(ConfigControlSurface::Api);
+        engine_setting.control_surface(ConfigControlSurface::OwnerControl);
+        engine_setting.apply_mode(ConfigApplyMode::DynamicApply);
+        engine_setting.restart_scope(ConfigRestartScope::None);
+        engine_setting.visibility(ConfigVisibility::Advanced);
+        engine_setting.description("Engine temperature override.");
+        engine_schema.setting(engine_setting.build());
+
+        let exported = aggregate_config_schema_sources(
+            [EngineConfigSchemaDescriptor {
+                engine_id: "vllm".into(),
+                schema: engine_schema.build(),
+            }],
+            [installed_plugin_metadata(
+                "blackboard",
+                vec![InstalledPluginSettingSchema {
+                    key: "retention_days".into(),
+                    value_schema: InstalledPluginValueSchema {
+                        kind: InstalledPluginValueKind::Integer,
+                        enum_values: Vec::new(),
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: true,
+                    default_json: Some("14".into()),
+                    constraints: vec![InstalledPluginConstraint::Range {
+                        min: Some("1".into()),
+                        max: Some("365".into()),
+                    }],
+                    apply_mode: InstalledPluginApplyMode::DynamicApply,
+                    restart_scope: InstalledPluginRestartScope::PluginProcess,
+                    visibility: InstalledPluginVisibility::Advanced,
+                    description: Some("Retention period in days".into()),
+                }],
+            )],
+        )
+        .expect("schema aggregation should succeed")
+        .export_reference();
+
+        let filtered = ConfigSchemaReference {
+            settings: exported
+                .settings
+                .into_iter()
+                .filter(|entry| {
+                    matches!(
+                        entry.canonical_path.as_str(),
+                        "version"
+                            | "telemetry.prompt_shape_metrics"
+                            | "defaults.request_defaults.dry"
+                            | "defaults.engine.vllm.temperature"
+                            | "plugin.blackboard.settings.retention_days"
+                    )
+                })
+                .collect(),
+        };
+        let actual = serde_json::to_string_pretty(&filtered)
+            .expect("schema reference export should serialize to json");
+        let expected = CONFIG_SCHEMA_REFERENCE_FIXTURE.trim();
+
+        assert_eq!(actual, expected, "schema export snapshot drifted\n{actual}");
+    }
+
+    #[test]
+    fn schema_export_omits_plugins_without_install_time_schema() {
+        let exported = aggregate_config_schema_sources(
+            Vec::<EngineConfigSchemaDescriptor>::new(),
+            [InstalledPluginMetadata {
+                name: "blackboard".into(),
+                source_repository: "mesh-llm/blackboard".into(),
+                installed_version: "0.1.0".into(),
+                target_triple: "aarch64-apple-darwin".into(),
+                downloaded_asset_name: "blackboard.tar.gz".into(),
+                install_path: PathBuf::from("/tmp/blackboard"),
+                enabled: true,
+                manifest: Some(InstalledPluginManifestMetadata {
+                    config_schema: None,
+                }),
+                last_protocol_version: None,
+                last_status: None,
+                last_error: None,
+            }],
+        )
+        .expect("schema aggregation should succeed")
+        .export_reference();
+
+        assert!(exported.settings.iter().all(|entry| {
+            !entry
+                .canonical_path
+                .starts_with("plugin.blackboard.settings.")
+        }));
+    }
+
+    #[test]
+    fn defaults_ui_schema_export_snapshot() {
+        let exported = aggregate_config_schema_sources(
+            Vec::<EngineConfigSchemaDescriptor>::new(),
+            Vec::<InstalledPluginMetadata>::new(),
+        )
+        .expect("schema aggregation should succeed")
+        .export_reference();
+
+        let filtered = DefaultsUiSchemaReference {
+            settings: exported
+                .settings
+                .into_iter()
+                .filter(|entry| {
+                    entry.source == ConfigSchemaReferenceSource::BuiltIn
+                        && entry.support == ConfigSupportState::Supported
+                        && entry.canonical_path.starts_with("defaults.")
+                })
+                .map(|entry| DefaultsUiSchemaReferenceEntry {
+                    canonical_path: entry.canonical_path,
+                    support: entry.support,
+                    source: entry.source,
+                })
+                .collect(),
+        };
+        let actual = serde_json::to_string_pretty(&filtered)
+            .expect("defaults ui schema reference should serialize to json");
+        let expected = CONFIG_SCHEMA_DEFAULTS_UI_FIXTURE.trim();
+
+        assert_eq!(
+            actual, expected,
+            "defaults UI schema export snapshot drifted\n{actual}"
+        );
+    }
+
+    fn installed_plugin_metadata(
+        plugin_name: &str,
+        settings: Vec<InstalledPluginSettingSchema>,
+    ) -> InstalledPluginMetadata {
+        InstalledPluginMetadata {
+            name: plugin_name.into(),
+            source_repository: format!("mesh-llm/{plugin_name}"),
+            installed_version: "0.1.0".into(),
+            target_triple: "aarch64-apple-darwin".into(),
+            downloaded_asset_name: format!("{plugin_name}.tar.gz"),
+            install_path: PathBuf::from(format!("/tmp/{plugin_name}")),
+            enabled: true,
+            manifest: Some(InstalledPluginManifestMetadata {
+                config_schema: Some(InstalledPluginConfigSchema {
+                    plugin_name: plugin_name.into(),
+                    schema_version: mesh_llm_plugin_manager::SUPPORTED_PLUGIN_SCHEMA_VERSION,
+                    allow_unvalidated_config: false,
+                    settings,
+                }),
+            }),
+            last_protocol_version: None,
+            last_status: None,
+            last_error: None,
+        }
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -3,6 +3,7 @@
 mod api;
 mod capture;
 pub mod command_support;
+pub mod config_schema;
 pub mod crypto;
 pub mod discovery;
 pub mod inference;

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -8610,36 +8610,24 @@ impl Node {
                 revision,
                 hash,
                 apply_mode,
+                diagnostics,
             } => {
                 if apply_mode == ConfigApplyMode::Staged {
                     let _ = self.config_revision_tx.send(revision);
                 }
-                crate::proto::node::OwnerControlEnvelope {
-                    r#gen: NODE_PROTOCOL_GENERATION,
-                    handshake: None,
-                    request: None,
-                    response: Some(crate::proto::node::OwnerControlResponse {
-                        request_id,
-                        get_config: None,
-                        watch_config: None,
-                        apply_config: Some(crate::proto::node::OwnerControlApplyConfigResponse {
-                            success: true,
-                            current_revision: revision,
-                            config_hash: hash.to_vec(),
-                            error: None,
-                            apply_mode: match apply_mode {
-                                ConfigApplyMode::Staged => {
-                                    crate::proto::node::ConfigApplyMode::Staged as i32
-                                }
-                                ConfigApplyMode::Noop => {
-                                    crate::proto::node::ConfigApplyMode::Noop as i32
-                                }
-                            },
-                        }),
-                        refresh_inventory: None,
-                    }),
-                    error: None,
-                }
+                owner_control_response::apply_response_envelope(
+                    request_id,
+                    crate::proto::node::OwnerControlApplyConfigResponse {
+                        success: true,
+                        current_revision: revision,
+                        config_hash: hash.to_vec(),
+                        error: None,
+                        apply_mode: owner_control_response::proto_apply_mode(apply_mode),
+                        diagnostics: owner_control_response::config_diagnostics_to_proto(
+                            &diagnostics,
+                        ),
+                    },
+                )
             }
             ApplyResult::RevisionConflict { current_revision } => owner_control_error_envelope(
                 crate::proto::node::OwnerControlErrorCode::RevisionConflict,
@@ -8651,49 +8639,49 @@ impl Node {
                 revision,
                 hash,
                 error,
+                diagnostics,
             } => {
                 let _ = self.config_revision_tx.send(revision);
-                crate::proto::node::OwnerControlEnvelope {
-                    r#gen: NODE_PROTOCOL_GENERATION,
-                    handshake: None,
-                    request: None,
-                    response: Some(crate::proto::node::OwnerControlResponse {
-                        request_id,
-                        get_config: None,
-                        watch_config: None,
-                        apply_config: Some(crate::proto::node::OwnerControlApplyConfigResponse {
-                            success: false,
-                            current_revision: revision,
-                            config_hash: hash.to_vec(),
-                            error: Some(error),
-                            apply_mode: crate::proto::node::ConfigApplyMode::Staged as i32,
-                        }),
-                        refresh_inventory: None,
-                    }),
-                    error: None,
-                }
+                owner_control_response::apply_response_envelope(
+                    request_id,
+                    crate::proto::node::OwnerControlApplyConfigResponse {
+                        success: false,
+                        current_revision: revision,
+                        config_hash: hash.to_vec(),
+                        error: Some(error),
+                        apply_mode: crate::proto::node::ConfigApplyMode::Staged as i32,
+                        diagnostics: owner_control_response::config_diagnostics_to_proto(
+                            &diagnostics,
+                        ),
+                    },
+                )
             }
-            ApplyResult::ValidationError(error) | ApplyResult::PersistError(error) => {
-                crate::proto::node::OwnerControlEnvelope {
-                    r#gen: NODE_PROTOCOL_GENERATION,
-                    handshake: None,
-                    request: None,
-                    response: Some(crate::proto::node::OwnerControlResponse {
-                        request_id,
-                        get_config: None,
-                        watch_config: None,
-                        apply_config: Some(crate::proto::node::OwnerControlApplyConfigResponse {
-                            success: false,
-                            current_revision,
-                            config_hash: current_hash.to_vec(),
-                            error: Some(error),
-                            apply_mode: crate::proto::node::ConfigApplyMode::Unspecified as i32,
-                        }),
-                        refresh_inventory: None,
-                    }),
-                    error: None,
-                }
+            ApplyResult::ValidationError { error, diagnostics } => {
+                owner_control_response::apply_response_envelope(
+                    request_id,
+                    crate::proto::node::OwnerControlApplyConfigResponse {
+                        success: false,
+                        current_revision,
+                        config_hash: current_hash.to_vec(),
+                        error: Some(error),
+                        apply_mode: crate::proto::node::ConfigApplyMode::Unspecified as i32,
+                        diagnostics: owner_control_response::config_diagnostics_to_proto(
+                            &diagnostics,
+                        ),
+                    },
+                )
             }
+            ApplyResult::PersistError(error) => owner_control_response::apply_response_envelope(
+                request_id,
+                crate::proto::node::OwnerControlApplyConfigResponse {
+                    success: false,
+                    current_revision,
+                    config_hash: current_hash.to_vec(),
+                    error: Some(error),
+                    apply_mode: crate::proto::node::ConfigApplyMode::Unspecified as i32,
+                    diagnostics: Vec::new(),
+                },
+            ),
         };
         self.send_owner_control_envelope(send, envelope).await
     }
@@ -10375,6 +10363,7 @@ mod artifact_transfer_io;
 mod direct_path;
 mod gossip;
 mod heartbeat;
+mod owner_control_response;
 mod plugin_streams;
 pub(crate) mod requirements;
 pub use gossip::backfill_legacy_descriptors;

--- a/crates/mesh-llm-host-runtime/src/mesh/owner_control_response.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/owner_control_response.rs
@@ -1,0 +1,39 @@
+use mesh_llm_protocol::proto::node;
+use mesh_llm_protocol::protocol::NODE_PROTOCOL_GENERATION;
+
+use crate::runtime::config_state::ConfigApplyMode;
+
+pub(super) fn apply_response_envelope(
+    request_id: u64,
+    apply_config: node::OwnerControlApplyConfigResponse,
+) -> node::OwnerControlEnvelope {
+    node::OwnerControlEnvelope {
+        r#gen: NODE_PROTOCOL_GENERATION,
+        handshake: None,
+        request: None,
+        response: Some(node::OwnerControlResponse {
+            request_id,
+            get_config: None,
+            watch_config: None,
+            apply_config: Some(apply_config),
+            refresh_inventory: None,
+        }),
+        error: None,
+    }
+}
+
+pub(super) fn config_diagnostics_to_proto(
+    diagnostics: &[mesh_llm_config::ConfigDiagnostic],
+) -> Vec<node::ConfigDiagnostic> {
+    diagnostics
+        .iter()
+        .map(crate::protocol::convert::config_diagnostic_to_proto)
+        .collect()
+}
+
+pub(super) fn proto_apply_mode(apply_mode: ConfigApplyMode) -> i32 {
+    match apply_mode {
+        ConfigApplyMode::Staged => node::ConfigApplyMode::Staged as i32,
+        ConfigApplyMode::Noop => node::ConfigApplyMode::Noop as i32,
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/plugin/config.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/config.rs
@@ -1,6 +1,7 @@
 use super::installed::{
     ConfiguredExternalPlugin, append_installed_plugins, configured_external_plugin_spec,
 };
+use super::schema_validation::strict_plugin_schema_availability;
 use super::{BLOBSTORE_PLUGIN_ID, PluginStartupOptions, PluginSummary};
 use crate::{
     MeshRequirementRejectReason, MeshRequirements, NodeVersionBounds, ProtocolGenerationBounds,
@@ -9,18 +10,82 @@ use crate::{
 use anyhow::{Context, Result, bail};
 #[allow(unused_imports)]
 pub use mesh_llm_config::{
-    AdvancedConfig, AdvancedServerConfig, BoolOrAuto, BoolOrString, ConfigEditor, ConfigStore,
-    FlashAttentionType, GpuAssignment, GpuConfig, HardwareConfig, IntegerOrString,
-    LocalServingNodeConfig, MeshConfig, MeshRequirementsConfig, ModelConfigDefaults,
-    ModelConfigEditor, ModelConfigEntry, ModelDefaultsEditor, ModelFitConfig, ModelRuntimeKind,
-    MultimodalConfig, OwnerControlConfig, PluginConfigEditor, PluginConfigEntry,
-    PluginStartupConfig, PrefixCacheConfig, ReasoningBudget, ReasoningEnabled,
-    RequestDefaultsConfig, ReservedObjectConfig, SkippyConfig, SpeculativeConfig,
+    AdvancedConfig, AdvancedServerConfig, BoolOrAuto, BoolOrString, ConfigDiagnostic,
+    ConfigDiagnosticSeverity, ConfigEditor, ConfigStore, FlashAttentionType, GpuAssignment,
+    GpuConfig, HardwareConfig, IntegerOrString, LocalServingNodeConfig, MeshConfig,
+    MeshRequirementsConfig, ModelConfigDefaults, ModelConfigEditor, ModelConfigEntry,
+    ModelDefaultsEditor, ModelFitConfig, ModelRuntimeKind, MultimodalConfig, OwnerControlConfig,
+    PluginConfigEditor, PluginConfigEntry, PluginStartupConfig, PrefixCacheConfig, ReasoningBudget,
+    ReasoningEnabled, RequestDefaultsConfig, ReservedObjectConfig, SkippyConfig, SpeculativeConfig,
     StringOrStringList, TelemetryConfig, TelemetryMetricsConfig, TensorSplitConfig,
-    ThroughputConfig, config_path, config_to_toml, load_config, parse_config_toml, validate_config,
+    ThroughputConfig, config_path, config_to_toml, parse_config_toml as base_parse_config_toml,
+    validate_config_with_plugin_schemas,
 };
 use mesh_llm_plugin::MeshVisibility;
 use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug)]
+pub struct ConfigFileValidation {
+    pub path: PathBuf,
+    pub diagnostics: Vec<ConfigDiagnostic>,
+}
+
+pub fn load_config(override_path: Option<&Path>) -> Result<MeshConfig> {
+    let path = config_path(override_path)?;
+    if !path.exists() {
+        return Ok(MeshConfig::default());
+    }
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read config {}", path.display()))?;
+    parse_config_toml(&raw).with_context(|| format!("Invalid config {}", path.display()))
+}
+
+pub fn parse_config_toml(raw: &str) -> Result<MeshConfig> {
+    let config = base_parse_config_toml(raw)?;
+    validate_config_with_installed_plugin_schemas(&config, Some(raw))?;
+    Ok(config)
+}
+
+pub fn validate_config_file(override_path: Option<&Path>) -> Result<ConfigFileValidation> {
+    let path = config_path(override_path)?;
+    if !path.exists() {
+        bail!(
+            "Failed to read config file {}: file does not exist",
+            path.display()
+        );
+    }
+    let raw = std::fs::read_to_string(&path)
+        .with_context(|| format!("Failed to read config {}", path.display()))?;
+    let config = base_parse_config_toml(&raw)
+        .with_context(|| format!("Invalid config {}", path.display()))?;
+    let diagnostics =
+        validate_config_diagnostics_with_installed_plugin_schemas(&config, Some(&raw));
+    Ok(ConfigFileValidation { path, diagnostics })
+}
+
+#[cfg(test)]
+fn validate_config(config: &MeshConfig) -> Result<()> {
+    validate_config_with_installed_plugin_schemas(config, None)
+}
+
+pub(crate) fn validate_config_with_installed_plugin_schemas(
+    config: &MeshConfig,
+    raw_toml: Option<&str>,
+) -> Result<()> {
+    validate_config_with_plugin_schemas(config, raw_toml, strict_plugin_schema_availability)
+}
+
+pub(crate) fn validate_config_diagnostics_with_installed_plugin_schemas(
+    config: &MeshConfig,
+    raw_toml: Option<&str>,
+) -> Vec<mesh_llm_config::ConfigDiagnostic> {
+    mesh_llm_config::validate_config_diagnostics_with_plugin_schemas(
+        config,
+        raw_toml,
+        strict_plugin_schema_availability,
+    )
+}
 
 pub(crate) fn mesh_requirements_config_to_runtime(
     config: &MeshRequirementsConfig,
@@ -288,7 +353,16 @@ pub fn bundled_cli_plugin_spec(_name: &str) -> Result<Option<ExternalPluginSpec>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::plugin::schema_validation::plugin_schema_availability_from_store_root;
+    use mesh_llm_config::{ConfigDiagnosticCode, validate_config_diagnostics_with_plugin_schemas};
+    use mesh_llm_plugin_manager::{
+        InstalledPluginApplyMode, InstalledPluginConfigSchema, InstalledPluginConstraint,
+        InstalledPluginManifestMetadata, InstalledPluginMetadata, InstalledPluginRestartScope,
+        InstalledPluginSettingSchema, InstalledPluginValueKind, InstalledPluginValueSchema,
+        InstalledPluginVisibility, PluginStore,
+    };
     use std::collections::BTreeSet;
+    use tempfile::TempDir;
 
     const FULL_SURFACE_VALID_FIXTURE: &str =
         include_str!("../../tests/fixtures/skippy_full_surface_valid.toml");
@@ -346,6 +420,114 @@ mod tests {
         }
     }
 
+    fn installed_plugin_metadata(
+        name: &str,
+        schema: Option<InstalledPluginConfigSchema>,
+    ) -> InstalledPluginMetadata {
+        InstalledPluginMetadata {
+            name: name.to_string(),
+            source_repository: format!("https://github.com/mesh-llm/{name}"),
+            installed_version: "v1.0.0".to_string(),
+            target_triple: std::env::consts::ARCH.to_string(),
+            downloaded_asset_name: format!("{name}.tar.gz"),
+            install_path: std::env::temp_dir().join(format!("mesh-llm-plugin-{name}")),
+            enabled: true,
+            manifest: Some(InstalledPluginManifestMetadata {
+                config_schema: schema,
+            }),
+            last_protocol_version: Some(1),
+            last_status: Some("installed".to_string()),
+            last_error: None,
+        }
+    }
+
+    fn blackboard_schema(
+        allow_unvalidated_config: bool,
+        schema_version: u32,
+    ) -> InstalledPluginConfigSchema {
+        InstalledPluginConfigSchema {
+            plugin_name: "blackboard".to_string(),
+            schema_version,
+            allow_unvalidated_config,
+            settings: vec![
+                InstalledPluginSettingSchema {
+                    key: "retention_days".to_string(),
+                    value_schema: InstalledPluginValueSchema {
+                        kind: InstalledPluginValueKind::Integer,
+                        enum_values: Vec::new(),
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: true,
+                    default_json: Some("14".to_string()),
+                    constraints: vec![InstalledPluginConstraint::Range {
+                        min: Some("1".to_string()),
+                        max: Some("365".to_string()),
+                    }],
+                    apply_mode: InstalledPluginApplyMode::DynamicValidationOnly,
+                    restart_scope: InstalledPluginRestartScope::PluginProcess,
+                    visibility: InstalledPluginVisibility::User,
+                    description: Some("Retention window".to_string()),
+                },
+                InstalledPluginSettingSchema {
+                    key: "mode".to_string(),
+                    value_schema: InstalledPluginValueSchema {
+                        kind: InstalledPluginValueKind::Enum,
+                        enum_values: vec!["strict".to_string(), "relaxed".to_string()],
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: false,
+                    default_json: Some("\"strict\"".to_string()),
+                    constraints: Vec::new(),
+                    apply_mode: InstalledPluginApplyMode::DynamicValidationOnly,
+                    restart_scope: InstalledPluginRestartScope::PluginProcess,
+                    visibility: InstalledPluginVisibility::User,
+                    description: Some("Conflict mode".to_string()),
+                },
+            ],
+        }
+    }
+
+    fn with_plugin_store<F>(metadata: &[InstalledPluginMetadata], test: F)
+    where
+        F: FnOnce(&Path),
+    {
+        let temp = TempDir::new().unwrap();
+        let store = PluginStore::new(temp.path());
+        for entry in metadata {
+            store.save(entry).unwrap();
+        }
+
+        test(temp.path());
+    }
+
+    fn parse_config_toml_with_plugin_store(raw: &str, store_root: &Path) -> Result<MeshConfig> {
+        let config = base_parse_config_toml(raw)?;
+        validate_config_with_plugin_schemas(&config, Some(raw), |plugin_name| {
+            plugin_schema_availability_from_store_root(store_root, plugin_name)
+        })?;
+        Ok(config)
+    }
+
+    fn validate_config_with_plugin_store(config: &MeshConfig, store_root: &Path) -> Result<()> {
+        validate_config_with_plugin_schemas(config, None, |plugin_name| {
+            plugin_schema_availability_from_store_root(store_root, plugin_name)
+        })
+    }
+
+    fn plugin_config_diagnostics_with_plugin_store(
+        config: &MeshConfig,
+        raw_toml: Option<&str>,
+        store_root: &Path,
+    ) -> Vec<ConfigDiagnostic> {
+        validate_config_diagnostics_with_plugin_schemas(config, raw_toml, |plugin_name| {
+            plugin_schema_availability_from_store_root(store_root, plugin_name)
+        })
+    }
+
     #[test]
     fn parse_unified_config_keeps_plugins_and_models() {
         let config: MeshConfig = toml::from_str(
@@ -400,6 +582,174 @@ command = "/tmp/demo"
         assert_eq!(config.models[1].gpu_id, None);
         assert_eq!(config.plugins.len(), 1);
         assert_eq!(config.plugins[0].name, "demo");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn plugin_config_roundtrip() {
+        with_plugin_store(
+            &[installed_plugin_metadata(
+                "blackboard",
+                Some(blackboard_schema(
+                    false,
+                    mesh_llm_config::SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION,
+                )),
+            )],
+            |store_root| {
+                let raw = r#"
+version = 1
+
+[[plugin]]
+name = "blackboard"
+enabled = true
+command = "mesh-blackboard-plugin"
+
+[plugin.settings]
+retention_days = 14
+mode = "strict"
+"#;
+
+                let config = parse_config_toml_with_plugin_store(raw, store_root)
+                    .expect("strict plugin config should parse");
+                assert_eq!(
+                    config.plugins[0].settings["retention_days"].as_integer(),
+                    Some(14)
+                );
+                assert_eq!(config.plugins[0].settings["mode"].as_str(), Some("strict"));
+
+                let rendered = config_to_toml(&config).expect("settings should serialize");
+                let reparsed = parse_config_toml_with_plugin_store(&rendered, store_root)
+                    .expect("rendered config should reparse");
+                validate_config_with_plugin_store(&reparsed, store_root)
+                    .expect("strict plugin config should validate");
+                assert_eq!(
+                    reparsed.plugins[0].settings["retention_days"].as_integer(),
+                    Some(14)
+                );
+                assert_eq!(
+                    reparsed.plugins[0].settings["mode"].as_str(),
+                    Some("strict")
+                );
+            },
+        );
+
+        with_plugin_store(
+            &[installed_plugin_metadata(
+                "blackboard",
+                Some(blackboard_schema(
+                    true,
+                    mesh_llm_config::SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION,
+                )),
+            )],
+            |store_root| {
+                let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+arbitrary = "kept"
+"#;
+                let config = base_parse_config_toml(raw).unwrap();
+                let diagnostics =
+                    plugin_config_diagnostics_with_plugin_store(&config, Some(raw), store_root);
+                assert!(diagnostics.iter().any(|diagnostic| {
+                    diagnostic.code == ConfigDiagnosticCode::LegacyUnvalidatedConfig
+                        && diagnostic.severity == ConfigDiagnosticSeverity::Warning
+                }));
+            },
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn plugin_config_validation_failures() {
+        with_plugin_store(
+            &[installed_plugin_metadata(
+                "blackboard",
+                Some(blackboard_schema(
+                    false,
+                    mesh_llm_config::SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION,
+                )),
+            )],
+            |store_root| {
+                let raw = r#"
+[[plugin]]
+name = "blackboard"
+retention_days = 14
+
+[plugin.settings]
+mode = "mystery"
+unknown = true
+"#;
+
+                let config = base_parse_config_toml(raw).unwrap();
+                let diagnostics =
+                    plugin_config_diagnostics_with_plugin_store(&config, Some(raw), store_root);
+
+                assert!(
+                    diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic.code == ConfigDiagnosticCode::MisplacedField)
+                );
+                assert!(
+                    diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic.code == ConfigDiagnosticCode::UnknownField)
+                );
+                assert!(diagnostics.iter().any(
+                    |diagnostic| diagnostic.code == ConfigDiagnosticCode::MissingRequiredValue
+                ));
+                assert!(
+                    diagnostics
+                        .iter()
+                        .any(|diagnostic| diagnostic.code == ConfigDiagnosticCode::InvalidValue)
+                );
+            },
+        );
+
+        with_plugin_store(&[], |store_root| {
+            let raw = r#"
+[[plugin]]
+name = "missing-plugin"
+
+[plugin.settings]
+flag = true
+"#;
+            let config = base_parse_config_toml(raw).unwrap();
+            let diagnostics =
+                plugin_config_diagnostics_with_plugin_store(&config, Some(raw), store_root);
+            assert!(
+                diagnostics
+                    .iter()
+                    .any(|diagnostic| diagnostic.code == ConfigDiagnosticCode::SchemaUnavailable)
+            );
+        });
+
+        with_plugin_store(
+            &[installed_plugin_metadata(
+                "blackboard",
+                Some(blackboard_schema(
+                    false,
+                    mesh_llm_config::SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION + 1,
+                )),
+            )],
+            |store_root| {
+                let raw = r#"
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+retention_days = 30
+"#;
+                let config = base_parse_config_toml(raw).unwrap();
+                let diagnostics =
+                    plugin_config_diagnostics_with_plugin_store(&config, Some(raw), store_root);
+                assert!(
+                    diagnostics.iter().any(|diagnostic| diagnostic.code
+                        == ConfigDiagnosticCode::UnsupportedSchemaVersion)
+                );
+            },
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/plugin/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/mod.rs
@@ -2,6 +2,7 @@ mod config;
 mod installed;
 pub(crate) mod mcp;
 mod runtime;
+mod schema_validation;
 pub(crate) mod stapler;
 mod startup;
 mod support;
@@ -32,7 +33,6 @@ use url::Url;
 
 #[allow(unused_imports)]
 pub use self::config::ExternalPluginSpec;
-pub(crate) use self::config::validate_config;
 #[allow(unused_imports)]
 pub(crate) use self::config::{
     BoolOrAuto, HardwareConfig, IntegerOrString, ModelConfigDefaults, ModelFitConfig,
@@ -46,7 +46,7 @@ pub use self::config::{
     ModelRuntimeKind, OwnerControlConfig, PluginConfigEditor, PluginConfigEntry, PluginHostMode,
     PluginStartupConfig, ResolvedPlugins, TelemetryConfig, TelemetryMetricsConfig,
     bundled_cli_plugin_spec, config_path, config_to_toml, load_config, parse_config_toml,
-    resolve_plugins,
+    resolve_plugins, validate_config_file,
 };
 #[cfg(test)]
 pub(crate) use self::config::{
@@ -56,7 +56,7 @@ pub(crate) use self::config::{
 };
 pub(crate) use self::config::{
     mesh_requirements_config_from_runtime, mesh_requirements_config_to_runtime,
-    mesh_requirements_validation_error,
+    mesh_requirements_validation_error, validate_config_diagnostics_with_installed_plugin_schemas,
 };
 use self::runtime::ExternalPlugin;
 pub use self::startup::{PluginStartupOptions, PluginStartupSummary};
@@ -1957,6 +1957,7 @@ mod tests {
                 command: Some("mesh-llm-plugin-demo".into()),
                 args: vec!["--stdio".into()],
                 url: None,
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             defaults: None,
@@ -1980,6 +1981,7 @@ mod tests {
                 command: Some("mesh-llm-plugin-metrics".into()),
                 args: Vec::new(),
                 url: None,
+                settings: Default::default(),
                 startup: PluginStartupConfig {
                     connect_timeout_secs: Some(75),
                     init_timeout_secs: Some(90),
@@ -2013,6 +2015,7 @@ mod tests {
                 command: None,
                 args: Vec::new(),
                 url: None,
+                settings: Default::default(),
                 startup: PluginStartupConfig {
                     optional: true,
                     ..PluginStartupConfig::default()
@@ -2060,6 +2063,7 @@ mod tests {
                 command: None,
                 args: Vec::new(),
                 url: None,
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             defaults: None,
@@ -2079,6 +2083,7 @@ mod tests {
                 command: Some("endpoint-plugin".into()),
                 args: Vec::new(),
                 url: Some("http://gpu-box:8000/v1".into()),
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             defaults: None,
@@ -2103,6 +2108,7 @@ mod tests {
                 command: Some("/opt/plugins/endpoint-plugin".into()),
                 args: vec!["--verbose".into()],
                 url: None,
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             defaults: None,
@@ -2126,6 +2132,7 @@ mod tests {
                 command: None,
                 args: Vec::new(),
                 url: Some("http://gpu-box:8000/v1".into()),
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             defaults: None,
@@ -2159,6 +2166,7 @@ mod tests {
                 command: Some("/tmp/demo".into()),
                 args: vec!["--flag".into()],
                 url: None,
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             defaults: None,

--- a/crates/mesh-llm-host-runtime/src/plugin/schema_validation.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/schema_validation.rs
@@ -1,0 +1,133 @@
+use mesh_llm_config::{
+    PluginConfigSchema, PluginObjectPropertySchema, PluginSchemaAvailability,
+    PluginSettingConstraint, PluginSettingSchema, PluginValueKind, PluginValueSchema,
+};
+use mesh_llm_plugin_manager::{
+    InstalledPluginConfigSchema, InstalledPluginConstraint, InstalledPluginMetadata,
+    InstalledPluginObjectProperty, InstalledPluginValueKind, InstalledPluginValueSchema,
+    PluginStore, default_store_root,
+};
+use std::path::Path;
+
+pub(crate) fn strict_plugin_schema_availability(plugin_name: &str) -> PluginSchemaAvailability {
+    let Ok(root) = default_store_root() else {
+        return PluginSchemaAvailability::NotInstalled;
+    };
+    plugin_schema_availability_from_store_root(&root, plugin_name)
+}
+
+pub(crate) fn plugin_schema_availability_from_store_root(
+    root: &Path,
+    plugin_name: &str,
+) -> PluginSchemaAvailability {
+    let store = PluginStore::new(root);
+    let Ok(metadata) = store.load_optional(plugin_name) else {
+        return PluginSchemaAvailability::NotInstalled;
+    };
+    let Some(metadata) = metadata else {
+        return PluginSchemaAvailability::NotInstalled;
+    };
+    plugin_schema_from_metadata(&metadata)
+}
+
+fn plugin_schema_from_metadata(metadata: &InstalledPluginMetadata) -> PluginSchemaAvailability {
+    let Some(schema) = metadata
+        .manifest
+        .as_ref()
+        .and_then(|manifest| manifest.config_schema.as_ref())
+    else {
+        return PluginSchemaAvailability::MissingSchema;
+    };
+
+    if schema.schema_version != mesh_llm_config::SUPPORTED_PLUGIN_CONFIG_SCHEMA_VERSION {
+        return PluginSchemaAvailability::UnsupportedVersion {
+            version: schema.schema_version,
+        };
+    }
+
+    PluginSchemaAvailability::Available(plugin_schema_from_installed(schema))
+}
+
+fn plugin_schema_from_installed(schema: &InstalledPluginConfigSchema) -> PluginConfigSchema {
+    PluginConfigSchema {
+        plugin_name: schema.plugin_name.clone(),
+        schema_version: schema.schema_version,
+        allow_unvalidated_config: schema.allow_unvalidated_config,
+        settings: schema
+            .settings
+            .iter()
+            .map(|setting| PluginSettingSchema {
+                key: setting.key.clone(),
+                value_schema: plugin_value_schema_from_installed(&setting.value_schema),
+                required: setting.required,
+                default_json: setting.default_json.clone(),
+                constraints: setting
+                    .constraints
+                    .iter()
+                    .map(plugin_constraint_from_installed)
+                    .collect(),
+                description: setting.description.clone(),
+            })
+            .collect(),
+    }
+}
+
+fn plugin_value_schema_from_installed(schema: &InstalledPluginValueSchema) -> PluginValueSchema {
+    PluginValueSchema {
+        kind: match schema.kind {
+            InstalledPluginValueKind::Boolean => PluginValueKind::Boolean,
+            InstalledPluginValueKind::Integer => PluginValueKind::Integer,
+            InstalledPluginValueKind::Float => PluginValueKind::Float,
+            InstalledPluginValueKind::String => PluginValueKind::String,
+            InstalledPluginValueKind::Path => PluginValueKind::Path,
+            InstalledPluginValueKind::Url => PluginValueKind::Url,
+            InstalledPluginValueKind::Enum => PluginValueKind::Enum,
+            InstalledPluginValueKind::Array => PluginValueKind::Array,
+            InstalledPluginValueKind::Object => PluginValueKind::Object,
+        },
+        enum_values: schema.enum_values.clone(),
+        items: schema
+            .items
+            .as_deref()
+            .map(plugin_value_schema_from_installed)
+            .map(Box::new),
+        object_properties: schema
+            .object_properties
+            .iter()
+            .map(plugin_object_property_from_installed)
+            .collect(),
+        allow_additional_properties: schema.allow_additional_properties,
+    }
+}
+
+fn plugin_object_property_from_installed(
+    property: &InstalledPluginObjectProperty,
+) -> PluginObjectPropertySchema {
+    PluginObjectPropertySchema {
+        key: property.key.clone(),
+        value_schema: plugin_value_schema_from_installed(&property.value_schema),
+        required: property.required,
+        description: property.description.clone(),
+    }
+}
+
+fn plugin_constraint_from_installed(
+    constraint: &InstalledPluginConstraint,
+) -> PluginSettingConstraint {
+    match constraint {
+        InstalledPluginConstraint::NonEmpty => PluginSettingConstraint::NonEmpty,
+        InstalledPluginConstraint::Positive => PluginSettingConstraint::Positive,
+        InstalledPluginConstraint::Range { min, max } => PluginSettingConstraint::Range {
+            min: min.clone(),
+            max: max.clone(),
+        },
+        InstalledPluginConstraint::AllowedValues { values } => {
+            PluginSettingConstraint::AllowedValues {
+                values: values.clone(),
+            }
+        }
+        InstalledPluginConstraint::Requires { key } => {
+            PluginSettingConstraint::Requires { key: key.clone() }
+        }
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/protocol/config_diagnostic.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/config_diagnostic.rs
@@ -1,0 +1,213 @@
+use mesh_llm_config::{
+    ConfigDiagnostic, ConfigDiagnosticCode, ConfigDiagnosticSchemaSource, ConfigDiagnosticSeverity,
+    ConfigDiagnosticSource, ConfigPath,
+};
+
+pub(crate) fn config_diagnostic_to_proto(
+    diagnostic: &ConfigDiagnostic,
+) -> crate::proto::node::ConfigDiagnostic {
+    crate::proto::node::ConfigDiagnostic {
+        code: match diagnostic.code {
+            ConfigDiagnosticCode::InvalidValue => {
+                crate::proto::node::ConfigDiagnosticCode::InvalidValue as i32
+            }
+            ConfigDiagnosticCode::MissingRequiredValue => {
+                crate::proto::node::ConfigDiagnosticCode::MissingRequiredValue as i32
+            }
+            ConfigDiagnosticCode::UnsupportedField => {
+                crate::proto::node::ConfigDiagnosticCode::UnsupportedField as i32
+            }
+            ConfigDiagnosticCode::RejectedField => {
+                crate::proto::node::ConfigDiagnosticCode::RejectedField as i32
+            }
+            ConfigDiagnosticCode::AliasApplied => {
+                crate::proto::node::ConfigDiagnosticCode::AliasApplied as i32
+            }
+            ConfigDiagnosticCode::MisplacedField => {
+                crate::proto::node::ConfigDiagnosticCode::MisplacedField as i32
+            }
+            ConfigDiagnosticCode::UnknownField => {
+                crate::proto::node::ConfigDiagnosticCode::UnknownField as i32
+            }
+            ConfigDiagnosticCode::SchemaUnavailable => {
+                crate::proto::node::ConfigDiagnosticCode::SchemaUnavailable as i32
+            }
+            ConfigDiagnosticCode::LegacyUnvalidatedConfig => {
+                crate::proto::node::ConfigDiagnosticCode::LegacyUnvalidatedConfig as i32
+            }
+            ConfigDiagnosticCode::UnsupportedSchemaVersion => {
+                crate::proto::node::ConfigDiagnosticCode::UnsupportedSchemaVersion as i32
+            }
+        },
+        severity: match diagnostic.severity {
+            ConfigDiagnosticSeverity::Error => {
+                crate::proto::node::ConfigDiagnosticSeverity::Error as i32
+            }
+            ConfigDiagnosticSeverity::Warning => {
+                crate::proto::node::ConfigDiagnosticSeverity::Warning as i32
+            }
+            ConfigDiagnosticSeverity::Info => {
+                crate::proto::node::ConfigDiagnosticSeverity::Info as i32
+            }
+        },
+        source: match diagnostic.source {
+            ConfigDiagnosticSource::Validation => {
+                crate::proto::node::ConfigDiagnosticSource::Validation as i32
+            }
+            ConfigDiagnosticSource::Schema => {
+                crate::proto::node::ConfigDiagnosticSource::Schema as i32
+            }
+            ConfigDiagnosticSource::Plugin => {
+                crate::proto::node::ConfigDiagnosticSource::Plugin as i32
+            }
+            ConfigDiagnosticSource::Compatibility => {
+                crate::proto::node::ConfigDiagnosticSource::Compatibility as i32
+            }
+        },
+        schema_source: diagnostic
+            .schema_source
+            .map(|schema_source| match schema_source {
+                ConfigDiagnosticSchemaSource::BuiltIn => {
+                    crate::proto::node::ConfigDiagnosticSchemaSource::BuiltIn as i32
+                }
+                ConfigDiagnosticSchemaSource::Engine => {
+                    crate::proto::node::ConfigDiagnosticSchemaSource::Engine as i32
+                }
+                ConfigDiagnosticSchemaSource::Plugin => {
+                    crate::proto::node::ConfigDiagnosticSchemaSource::Plugin as i32
+                }
+            }),
+        path: diagnostic.path.as_ref().map(ConfigPath::render),
+        canonical_path: diagnostic.canonical_path.as_ref().map(ConfigPath::render),
+        message: diagnostic.message.clone(),
+        help: diagnostic.help.clone(),
+    }
+}
+
+pub(crate) fn proto_config_diagnostic_to_local(
+    diagnostic: &crate::proto::node::ConfigDiagnostic,
+) -> ConfigDiagnostic {
+    let mut local = ConfigDiagnostic::new(
+        match crate::proto::node::ConfigDiagnosticCode::try_from(diagnostic.code)
+            .unwrap_or(crate::proto::node::ConfigDiagnosticCode::InvalidValue)
+        {
+            crate::proto::node::ConfigDiagnosticCode::MissingRequiredValue => {
+                ConfigDiagnosticCode::MissingRequiredValue
+            }
+            crate::proto::node::ConfigDiagnosticCode::UnsupportedField => {
+                ConfigDiagnosticCode::UnsupportedField
+            }
+            crate::proto::node::ConfigDiagnosticCode::RejectedField => {
+                ConfigDiagnosticCode::RejectedField
+            }
+            crate::proto::node::ConfigDiagnosticCode::AliasApplied => {
+                ConfigDiagnosticCode::AliasApplied
+            }
+            crate::proto::node::ConfigDiagnosticCode::MisplacedField => {
+                ConfigDiagnosticCode::MisplacedField
+            }
+            crate::proto::node::ConfigDiagnosticCode::UnknownField => {
+                ConfigDiagnosticCode::UnknownField
+            }
+            crate::proto::node::ConfigDiagnosticCode::SchemaUnavailable => {
+                ConfigDiagnosticCode::SchemaUnavailable
+            }
+            crate::proto::node::ConfigDiagnosticCode::LegacyUnvalidatedConfig => {
+                ConfigDiagnosticCode::LegacyUnvalidatedConfig
+            }
+            crate::proto::node::ConfigDiagnosticCode::UnsupportedSchemaVersion => {
+                ConfigDiagnosticCode::UnsupportedSchemaVersion
+            }
+            crate::proto::node::ConfigDiagnosticCode::InvalidValue
+            | crate::proto::node::ConfigDiagnosticCode::Unspecified => {
+                ConfigDiagnosticCode::InvalidValue
+            }
+        },
+        match crate::proto::node::ConfigDiagnosticSeverity::try_from(diagnostic.severity)
+            .unwrap_or(crate::proto::node::ConfigDiagnosticSeverity::Error)
+        {
+            crate::proto::node::ConfigDiagnosticSeverity::Warning => {
+                ConfigDiagnosticSeverity::Warning
+            }
+            crate::proto::node::ConfigDiagnosticSeverity::Info => ConfigDiagnosticSeverity::Info,
+            crate::proto::node::ConfigDiagnosticSeverity::Error
+            | crate::proto::node::ConfigDiagnosticSeverity::Unspecified => {
+                ConfigDiagnosticSeverity::Error
+            }
+        },
+        match crate::proto::node::ConfigDiagnosticSource::try_from(diagnostic.source)
+            .unwrap_or(crate::proto::node::ConfigDiagnosticSource::Validation)
+        {
+            crate::proto::node::ConfigDiagnosticSource::Schema => ConfigDiagnosticSource::Schema,
+            crate::proto::node::ConfigDiagnosticSource::Plugin => ConfigDiagnosticSource::Plugin,
+            crate::proto::node::ConfigDiagnosticSource::Compatibility => {
+                ConfigDiagnosticSource::Compatibility
+            }
+            crate::proto::node::ConfigDiagnosticSource::Validation
+            | crate::proto::node::ConfigDiagnosticSource::Unspecified => {
+                ConfigDiagnosticSource::Validation
+            }
+        },
+        diagnostic.message.clone(),
+    );
+    local.schema_source = diagnostic.schema_source.and_then(|schema_source| {
+        match crate::proto::node::ConfigDiagnosticSchemaSource::try_from(schema_source)
+            .unwrap_or(crate::proto::node::ConfigDiagnosticSchemaSource::Unspecified)
+        {
+            crate::proto::node::ConfigDiagnosticSchemaSource::BuiltIn => {
+                Some(ConfigDiagnosticSchemaSource::BuiltIn)
+            }
+            crate::proto::node::ConfigDiagnosticSchemaSource::Engine => {
+                Some(ConfigDiagnosticSchemaSource::Engine)
+            }
+            crate::proto::node::ConfigDiagnosticSchemaSource::Plugin => {
+                Some(ConfigDiagnosticSchemaSource::Plugin)
+            }
+            crate::proto::node::ConfigDiagnosticSchemaSource::Unspecified => None,
+        }
+    });
+    local.path = diagnostic
+        .path
+        .as_deref()
+        .and_then(|path| ConfigPath::parse_rendered(path).ok());
+    local.canonical_path = diagnostic
+        .canonical_path
+        .as_deref()
+        .and_then(|path| ConfigPath::parse_rendered(path).ok());
+    local.help = diagnostic.help.clone();
+    local
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_diagnostic_proto_roundtrip_preserves_structured_fields() {
+        let canonical_path = "models.<model-ref>.hardware.device";
+        let parsed_canonical_path =
+            ConfigPath::parse_rendered(canonical_path).expect("canonical path should parse");
+        assert_eq!(parsed_canonical_path.render(), canonical_path);
+
+        let diagnostic = ConfigDiagnostic::warning(
+            ConfigDiagnosticCode::AliasApplied,
+            ConfigDiagnosticSource::Compatibility,
+            "legacy alias accepted",
+        )
+        .with_schema_source(ConfigDiagnosticSchemaSource::BuiltIn)
+        .at_path(ConfigPath::parse_rendered("models[0].gpu_id").expect("valid path"))
+        .with_canonical_path(parsed_canonical_path)
+        .with_help("use models.<model-ref>.hardware.device instead");
+
+        let proto = config_diagnostic_to_proto(&diagnostic);
+        assert_eq!(proto.canonical_path.as_deref(), Some(canonical_path));
+
+        let roundtripped = proto_config_diagnostic_to_local(&proto);
+
+        assert_eq!(roundtripped, diagnostic);
+        assert_eq!(
+            roundtripped.canonical_path.as_ref().map(ConfigPath::render),
+            Some(canonical_path.to_string())
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -2,6 +2,9 @@
 use crate::mesh::RouteEntry;
 use crate::mesh::{ModelDemand, NodeRole, PeerAnnouncement, RoutingTable};
 use crate::protocol::NODE_PROTOCOL_GENERATION;
+pub(crate) use crate::protocol::config_diagnostic::{
+    config_diagnostic_to_proto, proto_config_diagnostic_to_local,
+};
 use anyhow::{Context, Result};
 use iroh::{EndpointAddr, EndpointId};
 use std::collections::{HashMap, HashSet};
@@ -1057,6 +1060,7 @@ fn legacy_proto_config_to_mesh(
             command: p.command.clone(),
             args: p.args.clone(),
             url: None,
+            settings: Default::default(),
             startup: Default::default(),
         })
         .collect();

--- a/crates/mesh-llm-host-runtime/src/protocol/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/mod.rs
@@ -4,6 +4,7 @@
 use crate::mesh::NodeRole;
 use crate::mesh::PeerAnnouncement;
 
+pub(crate) mod config_diagnostic;
 pub(crate) mod convert;
 use anyhow::Result;
 pub(crate) use convert::*;
@@ -2048,6 +2049,7 @@ alias = "model-alias"
                 command: Some("mesh-llm".to_string()),
                 args: vec!["--plugin".to_string()],
                 url: None,
+                settings: Default::default(),
                 startup: Default::default(),
             }],
             extra: Default::default(),

--- a/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/config_state.rs
@@ -1,8 +1,12 @@
 use anyhow::Result;
+use mesh_llm_config::{ConfigDiagnostic, ConfigDiagnosticSeverity, legacy_validation_error_text};
 use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
-use crate::plugin::{ConfigStore, MeshConfig, load_config, validate_config};
+use crate::plugin::{
+    ConfigStore, MeshConfig, config_to_toml, load_config,
+    validate_config_diagnostics_with_installed_plugin_schemas,
+};
 use crate::protocol::convert::{canonical_config_hash, mesh_config_to_proto};
 
 /// Mirrors the `ConfigApplyMode` proto enum; kept in the domain layer so
@@ -21,6 +25,7 @@ pub(crate) enum ApplyResult {
         revision: u64,
         hash: [u8; 32],
         apply_mode: ConfigApplyMode,
+        diagnostics: Vec<ConfigDiagnostic>,
     },
     RevisionConflict {
         current_revision: u64,
@@ -29,8 +34,12 @@ pub(crate) enum ApplyResult {
         revision: u64,
         hash: [u8; 32],
         error: String,
+        diagnostics: Vec<ConfigDiagnostic>,
     },
-    ValidationError(String),
+    ValidationError {
+        error: String,
+        diagnostics: Vec<ConfigDiagnostic>,
+    },
     PersistError(String),
 }
 
@@ -165,8 +174,19 @@ impl ConfigState {
     }
 
     pub(crate) fn apply(&mut self, new_config: MeshConfig, expected_revision: u64) -> ApplyResult {
-        if let Err(e) = validate_config(&new_config) {
-            return ApplyResult::ValidationError(e.to_string());
+        let raw_toml = config_to_toml(&new_config).ok();
+        let diagnostics = validate_config_diagnostics_with_installed_plugin_schemas(
+            &new_config,
+            raw_toml.as_deref(),
+        );
+        if diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity == ConfigDiagnosticSeverity::Error)
+        {
+            return ApplyResult::ValidationError {
+                error: legacy_validation_error_text(&diagnostics),
+                diagnostics,
+            };
         }
 
         if expected_revision != self.revision {
@@ -184,6 +204,7 @@ impl ConfigState {
                 revision: self.revision,
                 hash: self.config_hash,
                 apply_mode: ConfigApplyMode::Noop,
+                diagnostics,
             };
         }
 
@@ -204,6 +225,7 @@ impl ConfigState {
                 error: format!(
                     "failed to write revision sidecar: {e}; config persisted and in-memory revision advanced, but on-disk revision tracking may be stale"
                 ),
+                diagnostics,
             };
         }
 
@@ -216,6 +238,7 @@ impl ConfigState {
             revision: self.revision,
             hash: self.config_hash,
             apply_mode: ConfigApplyMode::Staged,
+            diagnostics,
         }
     }
 }
@@ -224,6 +247,11 @@ impl ConfigState {
 mod tests {
     use super::*;
     use crate::plugin::{GpuAssignment, GpuConfig, MeshConfig};
+    use mesh_llm_config::ConfigDiagnosticCode;
+    use mesh_llm_plugin_manager::{
+        InstalledPluginConfigSchema, InstalledPluginManifestMetadata, InstalledPluginMetadata,
+        PluginStore, SUPPORTED_PLUGIN_SCHEMA_VERSION,
+    };
 
     const FULL_SURFACE_VALID_FIXTURE: &str =
         include_str!("../../tests/fixtures/skippy_full_surface_valid.toml");
@@ -251,6 +279,64 @@ mod tests {
             plugins: vec![],
             extra: Default::default(),
         }
+    }
+
+    fn installed_plugin_metadata(
+        name: &str,
+        schema: Option<InstalledPluginConfigSchema>,
+    ) -> InstalledPluginMetadata {
+        InstalledPluginMetadata {
+            name: name.to_string(),
+            source_repository: format!("https://github.com/mesh-llm/{name}"),
+            installed_version: "v1.0.0".to_string(),
+            target_triple: std::env::consts::ARCH.to_string(),
+            downloaded_asset_name: format!("{name}.tar.gz"),
+            install_path: std::env::temp_dir().join(format!("mesh-llm-plugin-{name}")),
+            enabled: true,
+            manifest: Some(InstalledPluginManifestMetadata {
+                config_schema: schema,
+            }),
+            last_protocol_version: Some(1),
+            last_status: Some("installed".to_string()),
+            last_error: None,
+        }
+    }
+
+    fn legacy_unvalidated_schema(plugin_name: &str) -> InstalledPluginConfigSchema {
+        InstalledPluginConfigSchema {
+            plugin_name: plugin_name.to_string(),
+            schema_version: SUPPORTED_PLUGIN_SCHEMA_VERSION,
+            allow_unvalidated_config: true,
+            settings: Vec::new(),
+        }
+    }
+
+    fn with_plugin_store(metadata: &[InstalledPluginMetadata], test: impl FnOnce()) {
+        struct PluginDirRestoreGuard {
+            previous: Option<std::ffi::OsString>,
+        }
+
+        impl Drop for PluginDirRestoreGuard {
+            fn drop(&mut self) {
+                if let Some(previous) = self.previous.take() {
+                    unsafe { std::env::set_var("MESH_LLM_PLUGIN_DIR", previous) };
+                } else {
+                    unsafe { std::env::remove_var("MESH_LLM_PLUGIN_DIR") };
+                }
+            }
+        }
+
+        let temp = tempfile::TempDir::new().expect("plugin store temp dir");
+        let store = PluginStore::new(temp.path());
+        for entry in metadata {
+            store.save(entry).expect("save plugin metadata");
+        }
+
+        let previous = std::env::var_os("MESH_LLM_PLUGIN_DIR");
+        let _restore_plugin_dir = PluginDirRestoreGuard { previous };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("MESH_LLM_PLUGIN_DIR", temp.path()) };
+        test();
     }
 
     fn representative_nested_config() -> MeshConfig {
@@ -399,9 +485,11 @@ alias = "model-alias"
                 revision,
                 hash: _,
                 apply_mode,
+                diagnostics,
             } => {
                 assert_eq!(revision, 1);
                 assert_eq!(apply_mode, ConfigApplyMode::Staged);
+                assert!(diagnostics.is_empty());
             }
             other => panic!("expected Applied, got {other:?}"),
         }
@@ -647,9 +735,11 @@ reasoning_format = "qwen"
                 revision,
                 hash,
                 apply_mode,
+                diagnostics,
             } => {
                 assert_eq!(revision, 1);
                 assert_eq!(apply_mode, ConfigApplyMode::Staged);
+                assert!(diagnostics.is_empty());
                 hash
             }
             other => panic!("expected Applied, got {other:?}"),
@@ -722,6 +812,107 @@ reasoning_format = "mystery"
         );
 
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn runtime_config_diagnostics_transport() {
+        let dir = test_dir();
+        let config_path = dir.join("config.toml");
+        let mut state = ConfigState::load(&config_path).expect("load");
+        let invalid: MeshConfig = toml::from_str(
+            r#"version = 1
+
+[gpu]
+assignment = "auto"
+
+[[models]]
+model = "Qwen3-8B-Q4_K_M"
+
+[models.request_defaults]
+reasoning_format = "mystery"
+"#,
+        )
+        .expect("invalid fixture should still deserialize");
+
+        match state.apply(invalid, 0) {
+            ApplyResult::ValidationError { error, diagnostics } => {
+                assert!(
+                    error.contains(
+                        "models[0].request_defaults.reasoning_format must be one of: auto, none, deepseek, deepseek-legacy, hidden"
+                    ),
+                    "unexpected legacy error: {error}"
+                );
+                assert!(diagnostics.iter().any(|diagnostic| {
+                    diagnostic.severity == ConfigDiagnosticSeverity::Error
+                        && diagnostic
+                            .message
+                            .contains("reasoning_format must be one of")
+                        && diagnostic
+                            .path
+                            .as_ref()
+                            .map(|path| path.render())
+                            .as_deref()
+                            == Some("models[0].request_defaults.reasoning_format")
+                        && diagnostic.help.is_none()
+                }));
+            }
+            other => panic!("expected ValidationError, got {other:?}"),
+        }
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn runtime_config_success_preserves_warning_diagnostics() {
+        with_plugin_store(
+            &[installed_plugin_metadata(
+                "blackboard",
+                Some(legacy_unvalidated_schema("blackboard")),
+            )],
+            || {
+                let dir = test_dir();
+                let config_path = dir.join("config.toml");
+                let mut state = ConfigState::load(&config_path).expect("load");
+                let config: MeshConfig = toml::from_str(
+                    r#"
+version = 1
+
+[[plugin]]
+name = "blackboard"
+
+[plugin.settings]
+arbitrary = "kept"
+"#,
+                )
+                .expect("legacy plugin config should deserialize");
+
+                match state.apply(config, 0) {
+                    ApplyResult::Applied {
+                        revision,
+                        apply_mode,
+                        diagnostics,
+                        ..
+                    } => {
+                        assert_eq!(revision, 1);
+                        assert_eq!(apply_mode, ConfigApplyMode::Staged);
+                        assert!(diagnostics.iter().any(|diagnostic| {
+                            diagnostic.code == ConfigDiagnosticCode::LegacyUnvalidatedConfig
+                                && diagnostic.severity == ConfigDiagnosticSeverity::Warning
+                                && diagnostic
+                                    .canonical_path
+                                    .as_ref()
+                                    .map(|path| path.render())
+                                    .as_deref()
+                                    == Some("plugin.blackboard.settings")
+                        }));
+                    }
+                    other => panic!("expected Applied with warning diagnostics, got {other:?}"),
+                }
+
+                std::fs::remove_dir_all(&dir).ok();
+            },
+        );
     }
 
     #[test]
@@ -920,9 +1111,11 @@ temperature = 0.2
                 revision,
                 hash,
                 apply_mode,
+                diagnostics,
             } => {
                 assert_eq!(revision, 1);
                 assert_eq!(apply_mode, ConfigApplyMode::Staged);
+                assert!(diagnostics.is_empty());
                 hash
             }
             other => panic!("expected Applied, got {other:?}"),

--- a/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_defaults_ui_reference.json
+++ b/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_defaults_ui_reference.json
@@ -1,0 +1,928 @@
+{
+  "settings": [
+    {
+      "canonical_path": "defaults.advanced.server.alias",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.check_tensors",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.control_vectors",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.cpu_moe",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.device",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.direct_io",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.fit_context",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.fit_target_mib",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.gpu_layers",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.hf_file",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.hf_repo",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.lora_adapters",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.main_gpu",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.mlock",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.mmap",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.mmproj",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.mmproj_offload",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.model_path",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.model_runtime",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.n_cpu_moe",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.no_host_buffer",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.op_offload",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.placement",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.repack",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.safety_margin_gb",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.split_mode",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.stage_layer_end",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.stage_layer_start",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.tensor_split",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.hardware.warmup",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.batch",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.cache_idle_slots",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.cache_ram_mib",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.cache_type_k",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.cache_type_v",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.checkpoint_count",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.checkpoint_interval",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.context_shift",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.ctx_size",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.flash_attention",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.keep_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.kv_cache_policy",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.kv_offload",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.kv_unified",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.lookup_cache_dynamic",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.lookup_cache_static",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.enabled",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.max_bytes",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.max_entries",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.min_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.payload_mode",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.shared_record_limit",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prefix_cache.shared_stride_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.prompt_cache",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.swa_full",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.model_fit.ubatch",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.multimodal.image_max_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.multimodal.image_min_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.multimodal.mmproj",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.multimodal.mmproj_offload",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.multimodal.mmproj_url",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.chat_template",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.chat_template_file",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.chat_template_kwargs",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.dynatemp_exponent",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.dynatemp_range",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.frequency_penalty",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.ignore_eos",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.jinja",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.logit_bias",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.max_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.min_p",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.mirostat_entropy",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.mirostat_learning_rate",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.mirostat_mode",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.prefill_assistant",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.presence_penalty",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.reasoning_budget",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.reasoning_enabled",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.reasoning_format",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.repeat_last_n",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.repeat_penalty",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.sampler_sequence",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.samplers",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.seed",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.skip_chat_parsing",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.stop",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.system_prompt",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.temperature",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.top_k",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.top_nsigma",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.top_p",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.request_defaults.typical_p",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.activation_wire_dtype",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.binary_stage_transport",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.lifecycle_health_interval_ms",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.lifecycle_readiness_interval_ms",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.lifecycle_startup_timeout_ms",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.prefill_chunk_schedule",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.prefill_chunk_size",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.prefill_chunking",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.stage_model_path",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.stage_role",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.skippy.stage_topology",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_acceptance_threshold",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_cache_type_k",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_cache_type_v",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_device",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_gpu_layers",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_hf_file",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_hf_repo",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_max_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_min_tokens",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_model_path",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_selection_policy",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_split_probability",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.draft_threads",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.mode",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.ngram_max",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.ngram_min",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.pairing_fault",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.speculative.spec_default",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.continuous_batching",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.cpu_affinity",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.numa",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.parallel",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.poll",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.priority",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.slot_prompt_similarity",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.threads",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.threads_batch",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
+      "canonical_path": "defaults.throughput.tuning_profile",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    }
+  ]
+}

--- a/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_reference.json
+++ b/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_reference.json
@@ -1,0 +1,85 @@
+{
+  "settings": [
+    {
+      "canonical_path": "defaults.engine.vllm.temperature",
+      "owner": "engine",
+      "source": {
+        "kind": "engine",
+        "engine_id": "vllm"
+      },
+      "support": "supported",
+      "control_surfaces": [
+        "api",
+        "owner_control"
+      ],
+      "apply_mode": "dynamic_apply",
+      "restart_scope": "none",
+      "visibility": "advanced",
+      "description": "Engine temperature override."
+    },
+    {
+      "canonical_path": "defaults.request_defaults.dry",
+      "owner": "built_in",
+      "source": {
+        "kind": "built_in"
+      },
+      "support": "unwired",
+      "control_surfaces": [
+        "config_file"
+      ],
+      "apply_mode": "static_on_load",
+      "restart_scope": "model_reload",
+      "visibility": "advanced",
+      "description": "Reserved sampler object accepted for compatibility but not wired into the current runtime."
+    },
+    {
+      "canonical_path": "plugin.blackboard.settings.retention_days",
+      "owner": "plugin",
+      "source": {
+        "kind": "plugin",
+        "plugin_name": "blackboard",
+        "allow_unvalidated_config": false
+      },
+      "support": "supported",
+      "control_surfaces": [
+        "config_file",
+        "owner_control",
+        "plugin_manifest"
+      ],
+      "apply_mode": "dynamic_apply",
+      "restart_scope": "process_restart",
+      "visibility": "advanced",
+      "description": "Retention period in days"
+    },
+    {
+      "canonical_path": "telemetry.prompt_shape_metrics",
+      "owner": "built_in",
+      "source": {
+        "kind": "built_in"
+      },
+      "support": "unsupported",
+      "control_surfaces": [
+        "config_file"
+      ],
+      "apply_mode": "static_on_load",
+      "restart_scope": "none",
+      "visibility": "advanced",
+      "description": "Prompt-shape telemetry is intentionally disabled until the telemetry surface is reviewed."
+    },
+    {
+      "canonical_path": "version",
+      "owner": "built_in",
+      "source": {
+        "kind": "built_in"
+      },
+      "support": "supported",
+      "control_surfaces": [
+        "config_file"
+      ],
+      "apply_mode": "static_on_load",
+      "restart_scope": "model_reload",
+      "visibility": "internal",
+      "description": "version"
+    }
+  ]
+}

--- a/crates/mesh-llm-plugin-manager/src/archive.rs
+++ b/crates/mesh-llm-plugin-manager/src/archive.rs
@@ -6,14 +6,25 @@ use std::{
 use anyhow::{Context, Result, bail};
 use flate2::read::GzDecoder;
 
-use crate::target::ArchiveExt;
+use crate::{
+    store::{InstalledPluginManifestMetadata, SUPPORTED_PLUGIN_SCHEMA_VERSION},
+    target::ArchiveExt,
+};
+
+const PACKAGED_MANIFEST_FILE: &str = "plugin-manifest.json";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExtractedPluginArchive {
+    pub install_path: PathBuf,
+    pub manifest: Option<InstalledPluginManifestMetadata>,
+}
 
 pub fn extract_plugin_archive(
     archive_path: &Path,
     archive_ext: ArchiveExt,
     plugin_name: &str,
     install_dir: &Path,
-) -> Result<PathBuf> {
+) -> Result<ExtractedPluginArchive> {
     let staging = tempfile::Builder::new()
         .prefix("mesh-plugin-extract-")
         .tempdir()
@@ -26,11 +37,57 @@ pub fn extract_plugin_archive(
 
     let extracted_root = find_plugin_root(staging.path(), plugin_name)?;
     validate_plugin_root(&extracted_root, plugin_name)?;
+    let manifest = load_packaged_manifest(&extracted_root, plugin_name)?;
     let final_dir = install_dir.join(plugin_name);
     fs::create_dir_all(install_dir)
         .with_context(|| format!("create plugin install dir {}", install_dir.display()))?;
     replace_plugin_dir(&extracted_root, &final_dir, plugin_name)?;
-    Ok(final_dir)
+    Ok(ExtractedPluginArchive {
+        install_path: final_dir,
+        manifest,
+    })
+}
+
+fn load_packaged_manifest(
+    plugin_dir: &Path,
+    plugin_name: &str,
+) -> Result<Option<InstalledPluginManifestMetadata>> {
+    let manifest_path = plugin_dir.join(PACKAGED_MANIFEST_FILE);
+    if !manifest_path.exists() {
+        return Ok(None);
+    }
+
+    let contents = fs::read(&manifest_path)
+        .with_context(|| format!("read packaged plugin manifest {}", manifest_path.display()))?;
+    let manifest: InstalledPluginManifestMetadata = serde_json::from_slice(&contents)
+        .with_context(|| format!("parse packaged plugin manifest {}", manifest_path.display()))?;
+    validate_packaged_manifest(&manifest, plugin_name)?;
+    Ok(Some(manifest))
+}
+
+fn validate_packaged_manifest(
+    manifest: &InstalledPluginManifestMetadata,
+    plugin_name: &str,
+) -> Result<()> {
+    let Some(schema) = &manifest.config_schema else {
+        return Ok(());
+    };
+    if schema.plugin_name != plugin_name {
+        bail!(
+            "plugin manifest schema name '{}' does not match installed plugin '{}'",
+            schema.plugin_name,
+            plugin_name
+        );
+    }
+    if schema.schema_version != SUPPORTED_PLUGIN_SCHEMA_VERSION {
+        bail!(
+            "plugin config schema version {} is unsupported for '{}'; supported version is {}",
+            schema.schema_version,
+            plugin_name,
+            SUPPORTED_PLUGIN_SCHEMA_VERSION
+        );
+    }
+    Ok(())
 }
 
 fn replace_plugin_dir(from: &Path, to: &Path, plugin_name: &str) -> Result<()> {
@@ -162,6 +219,11 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
+    use crate::store::{
+        InstalledPluginApplyMode, InstalledPluginConfigSchema, InstalledPluginConstraint,
+        InstalledPluginRestartScope, InstalledPluginSettingSchema, InstalledPluginValueKind,
+        InstalledPluginValueSchema, InstalledPluginVisibility,
+    };
 
     fn write_tar_gz(archive_path: &Path, plugin_name: &str, files: &[(&str, &[u8])]) -> Result<()> {
         let archive_file = fs::File::create(archive_path)?;
@@ -210,5 +272,55 @@ mod tests {
             fs::read_to_string(existing.join("old-version.txt")).unwrap(),
             "keep me"
         );
+    }
+
+    #[test]
+    fn unsupported_plugin_schema_version() {
+        let temp = TempDir::new().unwrap();
+        let install_dir = temp.path().join("installed");
+        let archive_path = temp.path().join("demo.tar.gz");
+        let executable_name = format!("demo{}", std::env::consts::EXE_SUFFIX);
+        let manifest = serde_json::to_vec_pretty(&InstalledPluginManifestMetadata {
+            config_schema: Some(InstalledPluginConfigSchema {
+                plugin_name: "demo".to_string(),
+                schema_version: SUPPORTED_PLUGIN_SCHEMA_VERSION + 1,
+                allow_unvalidated_config: false,
+                settings: vec![InstalledPluginSettingSchema {
+                    key: "mode".to_string(),
+                    value_schema: InstalledPluginValueSchema {
+                        kind: InstalledPluginValueKind::String,
+                        enum_values: Vec::new(),
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: false,
+                    default_json: Some("\"strict\"".to_string()),
+                    constraints: vec![InstalledPluginConstraint::AllowedValues {
+                        values: vec!["strict".to_string(), "relaxed".to_string()],
+                    }],
+                    apply_mode: InstalledPluginApplyMode::StaticOnLoad,
+                    restart_scope: InstalledPluginRestartScope::PluginProcess,
+                    visibility: InstalledPluginVisibility::User,
+                    description: None,
+                }],
+            }),
+        })
+        .unwrap();
+        write_tar_gz(
+            &archive_path,
+            "demo",
+            &[
+                ("plugin.toml", b"name = \"demo\""),
+                (executable_name.as_str(), b""),
+                (PACKAGED_MANIFEST_FILE, manifest.as_slice()),
+            ],
+        )
+        .unwrap();
+
+        let error = extract_plugin_archive(&archive_path, ArchiveExt::TarGz, "demo", &install_dir)
+            .expect_err("unsupported schema version should fail install-time extraction");
+
+        assert!(error.to_string().contains("unsupported"));
     }
 }

--- a/crates/mesh-llm-plugin-manager/src/install.rs
+++ b/crates/mesh-llm-plugin-manager/src/install.rs
@@ -5,7 +5,7 @@ use futures_util::StreamExt;
 use reqwest::Client;
 
 use crate::{
-    archive::extract_plugin_archive,
+    archive::{ExtractedPluginArchive, extract_plugin_archive},
     catalog::PluginCatalog,
     github::{GitHubReleaseAsset, GitHubReleaseClient},
     select_plugin_asset,
@@ -203,7 +203,7 @@ async fn install_resolved_plugin(
     progress.report(PluginProgressEvent::Extracting {
         asset: asset.name.clone(),
     });
-    let install_path = extract_plugin_archive(
+    let extracted = extract_plugin_archive(
         &archive_path,
         options.target.archive_ext(),
         &resolved.plugin_name,
@@ -211,25 +211,14 @@ async fn install_resolved_plugin(
     )?;
     let _ = fs::remove_file(&archive_path);
 
-    let metadata = InstalledPluginMetadata {
-        name: resolved.plugin_name.clone(),
-        source_repository: resolved.source.url(),
-        installed_version: release.tag_name.clone(),
-        target_triple: options.target.triple().to_string(),
-        downloaded_asset_name: asset.name.clone(),
-        install_path,
-        enabled: current
-            .as_ref()
-            .map(|metadata| metadata.enabled)
-            .unwrap_or(true),
-        last_protocol_version: current
-            .as_ref()
-            .and_then(|metadata| metadata.last_protocol_version),
-        last_status: current
-            .as_ref()
-            .and_then(|metadata| metadata.last_status.clone()),
-        last_error: None,
-    };
+    let metadata = build_installed_metadata(
+        &resolved,
+        &release.tag_name,
+        asset,
+        &options.target,
+        extracted,
+        current.as_ref(),
+    );
     PluginStore::new(&options.store_root).save(&metadata)?;
 
     if let Some(current) = current {
@@ -249,6 +238,29 @@ async fn install_resolved_plugin(
         metadata,
         changed: true,
     })
+}
+
+fn build_installed_metadata(
+    resolved: &ResolvedInstallSource,
+    release_tag: &str,
+    asset: &GitHubReleaseAsset,
+    target: &PluginTarget,
+    extracted: ExtractedPluginArchive,
+    current: Option<&InstalledPluginMetadata>,
+) -> InstalledPluginMetadata {
+    InstalledPluginMetadata {
+        name: resolved.plugin_name.clone(),
+        source_repository: resolved.source.url(),
+        installed_version: release_tag.to_string(),
+        target_triple: target.triple().to_string(),
+        downloaded_asset_name: asset.name.clone(),
+        install_path: extracted.install_path,
+        enabled: current.map(|metadata| metadata.enabled).unwrap_or(true),
+        manifest: extracted.manifest,
+        last_protocol_version: current.and_then(|metadata| metadata.last_protocol_version),
+        last_status: current.and_then(|metadata| metadata.last_status.clone()),
+        last_error: None,
+    }
 }
 
 async fn download_asset(
@@ -294,4 +306,119 @@ async fn download_asset(
         asset: asset.name.clone(),
     });
     Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use flate2::{Compression, write::GzEncoder};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::ArchiveExt;
+    use crate::store::{
+        InstalledPluginApplyMode, InstalledPluginConfigSchema, InstalledPluginConstraint,
+        InstalledPluginManifestMetadata, InstalledPluginRestartScope, InstalledPluginSettingSchema,
+        InstalledPluginValueKind, InstalledPluginValueSchema, InstalledPluginVisibility,
+        SUPPORTED_PLUGIN_SCHEMA_VERSION,
+    };
+
+    fn write_tar_gz(archive_path: &Path, plugin_name: &str, files: &[(&str, &[u8])]) -> Result<()> {
+        let archive_file = fs::File::create(archive_path)?;
+        let encoder = GzEncoder::new(archive_file, Compression::default());
+        let mut archive = tar::Builder::new(encoder);
+        for (relative_path, contents) in files {
+            let path = format!("{plugin_name}/{relative_path}");
+            let mut header = tar::Header::new_gnu();
+            header.set_size(contents.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            archive.append_data(&mut header, path, *contents)?;
+        }
+        archive.finish()?;
+        archive.into_inner()?.finish()?;
+        Ok(())
+    }
+
+    #[test]
+    fn install_plugin_schema_roundtrip() {
+        let temp = TempDir::new().unwrap();
+        let install_root = temp.path().join("installed");
+        let store_root = temp.path().join("store");
+        let archive_path = temp.path().join("demo.tar.gz");
+        let executable_name = format!("demo{}", std::env::consts::EXE_SUFFIX);
+        let packaged_manifest = serde_json::to_vec_pretty(&InstalledPluginManifestMetadata {
+            config_schema: Some(InstalledPluginConfigSchema {
+                plugin_name: "demo".to_string(),
+                schema_version: SUPPORTED_PLUGIN_SCHEMA_VERSION,
+                allow_unvalidated_config: false,
+                settings: vec![InstalledPluginSettingSchema {
+                    key: "retention_days".to_string(),
+                    value_schema: InstalledPluginValueSchema {
+                        kind: InstalledPluginValueKind::Integer,
+                        enum_values: Vec::new(),
+                        items: None,
+                        object_properties: Vec::new(),
+                        allow_additional_properties: false,
+                    },
+                    required: true,
+                    default_json: Some("14".to_string()),
+                    constraints: vec![InstalledPluginConstraint::Range {
+                        min: Some("1".to_string()),
+                        max: Some("365".to_string()),
+                    }],
+                    apply_mode: InstalledPluginApplyMode::DynamicValidationOnly,
+                    restart_scope: InstalledPluginRestartScope::PluginProcess,
+                    visibility: InstalledPluginVisibility::User,
+                    description: Some("How long to retain entries.".to_string()),
+                }],
+            }),
+        })
+        .unwrap();
+        write_tar_gz(
+            &archive_path,
+            "demo",
+            &[
+                ("plugin.toml", b"name = \"demo\""),
+                (executable_name.as_str(), b""),
+                ("plugin-manifest.json", packaged_manifest.as_slice()),
+            ],
+        )
+        .unwrap();
+
+        let extracted =
+            extract_plugin_archive(&archive_path, ArchiveExt::TarGz, "demo", &install_root)
+                .expect("archive should extract");
+        let resolved = ResolvedInstallSource {
+            plugin_name: "demo".to_string(),
+            source: GitHubPluginSource::from_url("https://github.com/mesh-llm/demo").unwrap(),
+            version: None,
+        };
+        let asset = GitHubReleaseAsset {
+            name: "demo-v1.0.0-aarch64-apple-darwin.tar.gz".to_string(),
+            browser_download_url: "https://example.invalid/demo.tar.gz".to_string(),
+            size: Some(123),
+        };
+
+        let metadata = build_installed_metadata(
+            &resolved,
+            "v1.0.0",
+            &asset,
+            &PluginTarget::from_os_arch("macos", "aarch64").unwrap(),
+            extracted,
+            None,
+        );
+        let store = PluginStore::new(&store_root);
+        store.save(&metadata).unwrap();
+        let loaded = store.load("demo").unwrap();
+
+        let schema = loaded
+            .manifest
+            .and_then(|manifest| manifest.config_schema)
+            .expect("stored schema");
+        assert_eq!(schema.schema_version, SUPPORTED_PLUGIN_SCHEMA_VERSION);
+        assert_eq!(schema.settings[0].key, "retention_days");
+        assert_eq!(schema.settings[0].default_json.as_deref(), Some("14"));
+    }
 }

--- a/crates/mesh-llm-plugin-manager/src/lib.rs
+++ b/crates/mesh-llm-plugin-manager/src/lib.rs
@@ -21,5 +21,11 @@ pub use mesh_llm_skills::{
 };
 pub use skills::{PluginSkillInstallOptions, discover_plugin_skills, install_available_skills};
 pub use source_ref::{GitHubPluginSource, PluginInstallRef, PluginVersion, parse_install_ref};
-pub use store::{InstalledPluginMetadata, PluginStore, default_store_root};
+pub use store::{
+    InstalledPluginApplyMode, InstalledPluginConfigSchema, InstalledPluginConstraint,
+    InstalledPluginManifestMetadata, InstalledPluginMetadata, InstalledPluginObjectProperty,
+    InstalledPluginRestartScope, InstalledPluginSettingSchema, InstalledPluginValueKind,
+    InstalledPluginValueSchema, InstalledPluginVisibility, PluginStore,
+    SUPPORTED_PLUGIN_SCHEMA_VERSION, default_store_root,
+};
 pub use target::{ArchiveExt, PluginTarget, UnsupportedTarget};

--- a/crates/mesh-llm-plugin-manager/src/skills.rs
+++ b/crates/mesh-llm-plugin-manager/src/skills.rs
@@ -125,6 +125,7 @@ mod tests {
             downloaded_asset_name: format!("{name}-x86_64-unknown-linux-gnu.tar.gz"),
             install_path,
             enabled: true,
+            manifest: None,
             last_protocol_version: None,
             last_status: None,
             last_error: None,

--- a/crates/mesh-llm-plugin-manager/src/store.rs
+++ b/crates/mesh-llm-plugin-manager/src/store.rs
@@ -9,6 +9,123 @@ use serde::{Deserialize, Serialize};
 use crate::source_ref::is_valid_name;
 
 const METADATA_FILE: &str = "plugin-install.json";
+pub const SUPPORTED_PLUGIN_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledPluginManifestMetadata {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub config_schema: Option<InstalledPluginConfigSchema>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledPluginConfigSchema {
+    pub plugin_name: String,
+    pub schema_version: u32,
+    #[serde(default)]
+    pub allow_unvalidated_config: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub settings: Vec<InstalledPluginSettingSchema>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledPluginSettingSchema {
+    pub key: String,
+    pub value_schema: InstalledPluginValueSchema,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub default_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub constraints: Vec<InstalledPluginConstraint>,
+    pub apply_mode: InstalledPluginApplyMode,
+    pub restart_scope: InstalledPluginRestartScope,
+    pub visibility: InstalledPluginVisibility,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledPluginValueSchema {
+    pub kind: InstalledPluginValueKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub enum_values: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub items: Option<Box<InstalledPluginValueSchema>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub object_properties: Vec<InstalledPluginObjectProperty>,
+    #[serde(default)]
+    pub allow_additional_properties: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InstalledPluginObjectProperty {
+    pub key: String,
+    pub value_schema: InstalledPluginValueSchema,
+    #[serde(default)]
+    pub required: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstalledPluginValueKind {
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Path,
+    Url,
+    Enum,
+    Array,
+    Object,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstalledPluginApplyMode {
+    StaticOnLoad,
+    DynamicValidationOnly,
+    DynamicApply,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstalledPluginRestartScope {
+    None,
+    ModelReload,
+    ProcessRestart,
+    MeshRestart,
+    PluginProcess,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InstalledPluginVisibility {
+    User,
+    Advanced,
+    Hidden,
+    Internal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum InstalledPluginConstraint {
+    NonEmpty,
+    Positive,
+    Range {
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        min: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        max: Option<String>,
+    },
+    AllowedValues {
+        values: Vec<String>,
+    },
+    Requires {
+        key: String,
+    },
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InstalledPluginMetadata {
@@ -19,6 +136,8 @@ pub struct InstalledPluginMetadata {
     pub downloaded_asset_name: String,
     pub install_path: PathBuf,
     pub enabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub manifest: Option<InstalledPluginManifestMetadata>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub last_protocol_version: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -185,6 +304,33 @@ mod tests {
             downloaded_asset_name: "blackboard-v1.0.0-aarch64-apple-darwin.tar.gz".to_string(),
             install_path: PathBuf::from("/tmp/plugins/blackboard"),
             enabled: true,
+            manifest: Some(InstalledPluginManifestMetadata {
+                config_schema: Some(InstalledPluginConfigSchema {
+                    plugin_name: name.to_string(),
+                    schema_version: SUPPORTED_PLUGIN_SCHEMA_VERSION,
+                    allow_unvalidated_config: false,
+                    settings: vec![InstalledPluginSettingSchema {
+                        key: "retention_days".to_string(),
+                        value_schema: InstalledPluginValueSchema {
+                            kind: InstalledPluginValueKind::Integer,
+                            enum_values: Vec::new(),
+                            items: None,
+                            object_properties: Vec::new(),
+                            allow_additional_properties: false,
+                        },
+                        required: true,
+                        default_json: Some("14".to_string()),
+                        constraints: vec![InstalledPluginConstraint::Range {
+                            min: Some("1".to_string()),
+                            max: Some("365".to_string()),
+                        }],
+                        apply_mode: InstalledPluginApplyMode::DynamicValidationOnly,
+                        restart_scope: InstalledPluginRestartScope::PluginProcess,
+                        visibility: InstalledPluginVisibility::User,
+                        description: Some("How long to retain entries.".to_string()),
+                    }],
+                }),
+            }),
             last_protocol_version: Some(2),
             last_status: Some("running".to_string()),
             last_error: None,
@@ -202,6 +348,14 @@ mod tests {
         let loaded = store.load("blackboard").unwrap();
         assert_eq!(loaded.name, "blackboard");
         assert!(loaded.enabled);
+        assert_eq!(
+            loaded
+                .manifest
+                .as_ref()
+                .and_then(|manifest| manifest.config_schema.as_ref())
+                .map(|schema| schema.schema_version),
+            Some(SUPPORTED_PLUGIN_SCHEMA_VERSION)
+        );
         assert_eq!(loaded.last_protocol_version, Some(2));
 
         let listed = store.list().unwrap();

--- a/crates/mesh-llm-plugin/build.rs
+++ b/crates/mesh-llm-plugin/build.rs
@@ -28,7 +28,9 @@ fn compile_proto() {
     // TODO: Audit that the environment access only happens in single-threaded code.
     unsafe { std::env::set_var("PROTOC", protoc) };
 
-    prost_build::Config::new()
+    let mut config = prost_build::Config::new();
+    config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
+    config
         .compile_protos(&["proto/plugin.proto"], &["proto"])
         .expect("compile plugin proto");
 }

--- a/crates/mesh-llm-plugin/proto/plugin.proto
+++ b/crates/mesh-llm-plugin/proto/plugin.proto
@@ -185,6 +185,105 @@ message PluginManifest {
   repeated string capabilities = 8;
   repeated MeshChannelManifest mesh_channels = 9;
   repeated MeshEventSubscriptionManifest mesh_event_subscriptions = 10;
+  optional PluginConfigSchemaManifest config_schema = 11;
+}
+
+message PluginConfigSchemaManifest {
+  string plugin_name = 1;
+  uint32 schema_version = 2;
+  bool allow_unvalidated_config = 3;
+  repeated PluginConfigSettingManifest settings = 4;
+}
+
+message PluginConfigSettingManifest {
+  string key = 1;
+  PluginConfigValueSchema value_schema = 2;
+  bool required = 3;
+  optional string default_json = 4;
+  repeated PluginConfigConstraintManifest constraints = 5;
+  PluginConfigApplyMode apply_mode = 6;
+  PluginConfigRestartScope restart_scope = 7;
+  PluginConfigVisibility visibility = 8;
+  optional string description = 9;
+}
+
+message PluginConfigValueSchema {
+  PluginConfigValueKind kind = 1;
+  repeated string enum_values = 2;
+  optional PluginConfigValueSchema items = 3;
+  repeated PluginConfigObjectProperty object_properties = 4;
+  bool allow_additional_properties = 5;
+}
+
+message PluginConfigObjectProperty {
+  string key = 1;
+  PluginConfigValueSchema value_schema = 2;
+  bool required = 3;
+  optional string description = 4;
+}
+
+enum PluginConfigValueKind {
+  PLUGIN_CONFIG_VALUE_KIND_UNSPECIFIED = 0;
+  PLUGIN_CONFIG_VALUE_KIND_BOOLEAN = 1;
+  PLUGIN_CONFIG_VALUE_KIND_INTEGER = 2;
+  PLUGIN_CONFIG_VALUE_KIND_FLOAT = 3;
+  PLUGIN_CONFIG_VALUE_KIND_STRING = 4;
+  PLUGIN_CONFIG_VALUE_KIND_PATH = 5;
+  PLUGIN_CONFIG_VALUE_KIND_URL = 6;
+  PLUGIN_CONFIG_VALUE_KIND_ENUM = 7;
+  PLUGIN_CONFIG_VALUE_KIND_ARRAY = 8;
+  PLUGIN_CONFIG_VALUE_KIND_OBJECT = 9;
+}
+
+enum PluginConfigApplyMode {
+  PLUGIN_CONFIG_APPLY_MODE_UNSPECIFIED = 0;
+  PLUGIN_CONFIG_APPLY_MODE_STATIC_ON_LOAD = 1;
+  PLUGIN_CONFIG_APPLY_MODE_DYNAMIC_VALIDATION_ONLY = 2;
+  PLUGIN_CONFIG_APPLY_MODE_DYNAMIC_APPLY = 3;
+}
+
+enum PluginConfigRestartScope {
+  PLUGIN_CONFIG_RESTART_SCOPE_UNSPECIFIED = 0;
+  PLUGIN_CONFIG_RESTART_SCOPE_NONE = 1;
+  PLUGIN_CONFIG_RESTART_SCOPE_MODEL_RELOAD = 2;
+  PLUGIN_CONFIG_RESTART_SCOPE_PROCESS_RESTART = 3;
+  PLUGIN_CONFIG_RESTART_SCOPE_MESH_RESTART = 4;
+  PLUGIN_CONFIG_RESTART_SCOPE_PLUGIN_PROCESS = 5;
+}
+
+enum PluginConfigVisibility {
+  PLUGIN_CONFIG_VISIBILITY_UNSPECIFIED = 0;
+  PLUGIN_CONFIG_VISIBILITY_USER = 1;
+  PLUGIN_CONFIG_VISIBILITY_ADVANCED = 2;
+  PLUGIN_CONFIG_VISIBILITY_HIDDEN = 3;
+  PLUGIN_CONFIG_VISIBILITY_INTERNAL = 4;
+}
+
+message PluginConfigConstraintManifest {
+  oneof constraint {
+    PluginConfigNonEmptyConstraint non_empty = 1;
+    PluginConfigPositiveConstraint positive = 2;
+    PluginConfigRangeConstraint range = 3;
+    PluginConfigAllowedValuesConstraint allowed_values = 4;
+    PluginConfigRequiresConstraint requires = 5;
+  }
+}
+
+message PluginConfigNonEmptyConstraint {}
+
+message PluginConfigPositiveConstraint {}
+
+message PluginConfigRangeConstraint {
+  optional string min = 1;
+  optional string max = 2;
+}
+
+message PluginConfigAllowedValuesConstraint {
+  repeated string values = 1;
+}
+
+message PluginConfigRequiresConstraint {
+  string key = 1;
 }
 
 message MeshChannelManifest {

--- a/crates/mesh-llm-plugin/src/lib.rs
+++ b/crates/mesh-llm-plugin/src/lib.rs
@@ -51,13 +51,17 @@ pub mod events {
 }
 pub use manifest::{
     CompletionBuilder, EndpointBuilder, HttpBindingBuilder, ManifestEntry, OperationBuilder,
+    PluginConfigObjectPropertyBuilder, PluginConfigSchemaBuilder, PluginConfigSettingBuilder,
     PluginManifestBuilder, PromptBuilder, ResourceBuilder, ResourceTemplateBuilder, capability,
-    completion, http_binding, http_delete, http_get, http_patch, http_post, http_put,
-    mcp_http_endpoint, mcp_stdio_endpoint, mcp_tcp_endpoint, mcp_unix_socket_endpoint,
-    mesh_channel, mesh_event_local_accepting, mesh_event_local_standby, mesh_event_mesh_id_updated,
-    mesh_event_peer_down, mesh_event_peer_up, mesh_event_peer_updated, mesh_event_subscription,
-    openai_http_inference_endpoint, operation, plugin_manifest, prompt_service, resource,
-    resource_template_service,
+    completion, config_array, config_boolean, config_enum, config_float, config_integer,
+    config_object, config_object_property, config_path, config_schema, config_setting,
+    config_string, config_url, constraint_allowed_values, constraint_non_empty,
+    constraint_positive, constraint_range, constraint_requires, http_binding, http_delete,
+    http_get, http_patch, http_post, http_put, mcp_http_endpoint, mcp_stdio_endpoint,
+    mcp_tcp_endpoint, mcp_unix_socket_endpoint, mesh_channel, mesh_event_local_accepting,
+    mesh_event_local_standby, mesh_event_mesh_id_updated, mesh_event_peer_down, mesh_event_peer_up,
+    mesh_event_peer_updated, mesh_event_subscription, openai_http_inference_endpoint, operation,
+    package_manifest_json, plugin_manifest, prompt_service, resource, resource_template_service,
 };
 pub mod mcp {
     pub use crate::dsl::mcp::{

--- a/crates/mesh-llm-plugin/src/manifest.rs
+++ b/crates/mesh-llm-plugin/src/manifest.rs
@@ -1,9 +1,12 @@
 use crate::{helpers::json_string, json_schema_for, proto};
+use anyhow::{Context, Result, anyhow};
 use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug)]
 pub enum ManifestEntry {
     Capability(String),
+    ConfigSchema(proto::PluginConfigSchemaManifest),
     Operation(proto::OperationManifest),
     Resource(proto::ResourceManifest),
     ResourceTemplate(proto::ResourceTemplateManifest),
@@ -41,6 +44,7 @@ impl PluginManifestBuilder {
     fn push(&mut self, item: ManifestEntry) {
         match item {
             ManifestEntry::Capability(capability) => self.manifest.capabilities.push(capability),
+            ManifestEntry::ConfigSchema(schema) => self.manifest.config_schema = Some(schema),
             ManifestEntry::Operation(operation) => self.manifest.operations.push(operation),
             ManifestEntry::Resource(resource) => self.manifest.resources.push(resource),
             ManifestEntry::ResourceTemplate(template) => {
@@ -66,6 +70,538 @@ pub fn plugin_manifest() -> PluginManifestBuilder {
 
 pub fn capability(name: impl Into<String>) -> ManifestEntry {
     ManifestEntry::Capability(name.into())
+}
+
+pub fn config_schema(plugin_name: impl Into<String>) -> PluginConfigSchemaBuilder {
+    PluginConfigSchemaBuilder {
+        inner: proto::PluginConfigSchemaManifest {
+            plugin_name: plugin_name.into(),
+            schema_version: 1,
+            allow_unvalidated_config: false,
+            settings: Vec::new(),
+        },
+    }
+}
+
+pub fn config_setting(
+    key: impl Into<String>,
+    value_schema: proto::PluginConfigValueSchema,
+) -> PluginConfigSettingBuilder {
+    PluginConfigSettingBuilder {
+        inner: proto::PluginConfigSettingManifest {
+            key: key.into(),
+            value_schema: Some(value_schema),
+            required: false,
+            default_json: None,
+            constraints: Vec::new(),
+            apply_mode: proto::PluginConfigApplyMode::StaticOnLoad as i32,
+            restart_scope: proto::PluginConfigRestartScope::None as i32,
+            visibility: proto::PluginConfigVisibility::User as i32,
+            description: None,
+        },
+    }
+}
+
+pub fn config_boolean() -> proto::PluginConfigValueSchema {
+    value_schema(proto::PluginConfigValueKind::Boolean)
+}
+
+pub fn config_integer() -> proto::PluginConfigValueSchema {
+    value_schema(proto::PluginConfigValueKind::Integer)
+}
+
+pub fn config_float() -> proto::PluginConfigValueSchema {
+    value_schema(proto::PluginConfigValueKind::Float)
+}
+
+pub fn config_string() -> proto::PluginConfigValueSchema {
+    value_schema(proto::PluginConfigValueKind::String)
+}
+
+pub fn config_path() -> proto::PluginConfigValueSchema {
+    value_schema(proto::PluginConfigValueKind::Path)
+}
+
+pub fn config_url() -> proto::PluginConfigValueSchema {
+    value_schema(proto::PluginConfigValueKind::Url)
+}
+
+pub fn config_enum<I, S>(values: I) -> proto::PluginConfigValueSchema
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut schema = value_schema(proto::PluginConfigValueKind::Enum);
+    schema.enum_values = values.into_iter().map(Into::into).collect();
+    schema
+}
+
+pub fn config_array(items: proto::PluginConfigValueSchema) -> proto::PluginConfigValueSchema {
+    let mut schema = value_schema(proto::PluginConfigValueKind::Array);
+    schema.items = Some(Box::new(items));
+    schema
+}
+
+pub fn config_object<I>(properties: I) -> proto::PluginConfigValueSchema
+where
+    I: IntoIterator<Item = proto::PluginConfigObjectProperty>,
+{
+    let mut schema = value_schema(proto::PluginConfigValueKind::Object);
+    schema.object_properties = properties.into_iter().collect();
+    schema
+}
+
+pub fn config_object_property(
+    key: impl Into<String>,
+    value_schema: proto::PluginConfigValueSchema,
+) -> PluginConfigObjectPropertyBuilder {
+    PluginConfigObjectPropertyBuilder {
+        inner: proto::PluginConfigObjectProperty {
+            key: key.into(),
+            value_schema: Some(value_schema),
+            required: false,
+            description: None,
+        },
+    }
+}
+
+pub fn constraint_non_empty() -> proto::PluginConfigConstraintManifest {
+    proto::PluginConfigConstraintManifest {
+        constraint: Some(
+            proto::plugin_config_constraint_manifest::Constraint::NonEmpty(
+                proto::PluginConfigNonEmptyConstraint {},
+            ),
+        ),
+    }
+}
+
+pub fn constraint_positive() -> proto::PluginConfigConstraintManifest {
+    proto::PluginConfigConstraintManifest {
+        constraint: Some(
+            proto::plugin_config_constraint_manifest::Constraint::Positive(
+                proto::PluginConfigPositiveConstraint {},
+            ),
+        ),
+    }
+}
+
+pub fn constraint_range(
+    min: Option<impl Into<String>>,
+    max: Option<impl Into<String>>,
+) -> proto::PluginConfigConstraintManifest {
+    proto::PluginConfigConstraintManifest {
+        constraint: Some(proto::plugin_config_constraint_manifest::Constraint::Range(
+            proto::PluginConfigRangeConstraint {
+                min: min.map(Into::into),
+                max: max.map(Into::into),
+            },
+        )),
+    }
+}
+
+pub fn constraint_allowed_values<I, S>(values: I) -> proto::PluginConfigConstraintManifest
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    proto::PluginConfigConstraintManifest {
+        constraint: Some(
+            proto::plugin_config_constraint_manifest::Constraint::AllowedValues(
+                proto::PluginConfigAllowedValuesConstraint {
+                    values: values.into_iter().map(Into::into).collect(),
+                },
+            ),
+        ),
+    }
+}
+
+pub fn constraint_requires(key: impl Into<String>) -> proto::PluginConfigConstraintManifest {
+    proto::PluginConfigConstraintManifest {
+        constraint: Some(
+            proto::plugin_config_constraint_manifest::Constraint::Requires(
+                proto::PluginConfigRequiresConstraint { key: key.into() },
+            ),
+        ),
+    }
+}
+
+pub fn package_manifest_json(manifest: &proto::PluginManifest) -> Result<String> {
+    let packaged = PackagedPluginManifest::try_from(manifest)?;
+    Ok(serde_json::to_string_pretty(&packaged)?)
+}
+
+fn value_schema(kind: proto::PluginConfigValueKind) -> proto::PluginConfigValueSchema {
+    proto::PluginConfigValueSchema {
+        kind: kind as i32,
+        enum_values: Vec::new(),
+        items: None,
+        object_properties: Vec::new(),
+        allow_additional_properties: false,
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+struct PackagedPluginManifest {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    config_schema: Option<PackagedPluginConfigSchema>,
+}
+
+impl TryFrom<&proto::PluginManifest> for PackagedPluginManifest {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &proto::PluginManifest) -> Result<Self> {
+        let config_schema = value
+            .config_schema
+            .as_ref()
+            .map(PackagedPluginConfigSchema::try_from)
+            .transpose()?;
+
+        Ok(Self { config_schema })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct PackagedPluginConfigSchema {
+    plugin_name: String,
+    schema_version: u32,
+    #[serde(default)]
+    allow_unvalidated_config: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    settings: Vec<PackagedPluginSetting>,
+}
+
+impl TryFrom<&proto::PluginConfigSchemaManifest> for PackagedPluginConfigSchema {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &proto::PluginConfigSchemaManifest) -> Result<Self> {
+        let settings = value
+            .settings
+            .iter()
+            .map(PackagedPluginSetting::try_from)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            plugin_name: value.plugin_name.clone(),
+            schema_version: value.schema_version,
+            allow_unvalidated_config: value.allow_unvalidated_config,
+            settings,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct PackagedPluginSetting {
+    key: String,
+    value_schema: PackagedPluginValueSchema,
+    #[serde(default)]
+    required: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    default_json: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    constraints: Vec<PackagedPluginConstraint>,
+    apply_mode: PackagedPluginApplyMode,
+    restart_scope: PackagedPluginRestartScope,
+    visibility: PackagedPluginVisibility,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    description: Option<String>,
+}
+
+impl TryFrom<&proto::PluginConfigSettingManifest> for PackagedPluginSetting {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &proto::PluginConfigSettingManifest) -> Result<Self> {
+        let value_schema = value.value_schema.as_ref().ok_or_else(|| {
+            anyhow!(
+                "plugin config setting `{}` is missing value_schema",
+                value.key
+            )
+        })?;
+        let constraints = value
+            .constraints
+            .iter()
+            .enumerate()
+            .map(|(index, constraint)| {
+                PackagedPluginConstraint::try_from(constraint).with_context(|| {
+                    format!(
+                        "plugin config setting `{}` has invalid constraint #{}",
+                        value.key,
+                        index + 1
+                    )
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            key: value.key.clone(),
+            value_schema: PackagedPluginValueSchema::try_from(value_schema).with_context(|| {
+                format!(
+                    "plugin config setting `{}` has invalid value_schema",
+                    value.key
+                )
+            })?,
+            required: value.required,
+            default_json: value.default_json.clone(),
+            constraints,
+            apply_mode: PackagedPluginApplyMode::try_from_i32(value.apply_mode).with_context(
+                || {
+                    format!(
+                        "plugin config setting `{}` has invalid apply_mode",
+                        value.key
+                    )
+                },
+            )?,
+            restart_scope: PackagedPluginRestartScope::try_from_i32(value.restart_scope)
+                .with_context(|| {
+                    format!(
+                        "plugin config setting `{}` has invalid restart_scope",
+                        value.key
+                    )
+                })?,
+            visibility: PackagedPluginVisibility::try_from_i32(value.visibility).with_context(
+                || {
+                    format!(
+                        "plugin config setting `{}` has invalid visibility",
+                        value.key
+                    )
+                },
+            )?,
+            description: value.description.clone(),
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct PackagedPluginValueSchema {
+    kind: PackagedPluginValueKind,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    enum_values: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    items: Option<Box<PackagedPluginValueSchema>>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    object_properties: Vec<PackagedPluginObjectProperty>,
+    #[serde(default)]
+    allow_additional_properties: bool,
+}
+
+impl TryFrom<&proto::PluginConfigValueSchema> for PackagedPluginValueSchema {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &proto::PluginConfigValueSchema) -> Result<Self> {
+        let items = value
+            .items
+            .as_ref()
+            .map(|items| PackagedPluginValueSchema::try_from(items.as_ref()).map(Box::new))
+            .transpose()
+            .context("array items schema is invalid")?;
+        let object_properties = value
+            .object_properties
+            .iter()
+            .map(PackagedPluginObjectProperty::try_from)
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self {
+            kind: PackagedPluginValueKind::try_from_i32(value.kind)?,
+            enum_values: value.enum_values.clone(),
+            items,
+            object_properties,
+            allow_additional_properties: value.allow_additional_properties,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+struct PackagedPluginObjectProperty {
+    key: String,
+    value_schema: PackagedPluginValueSchema,
+    #[serde(default)]
+    required: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    description: Option<String>,
+}
+
+impl TryFrom<&proto::PluginConfigObjectProperty> for PackagedPluginObjectProperty {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &proto::PluginConfigObjectProperty) -> Result<Self> {
+        let value_schema = value.value_schema.as_ref().ok_or_else(|| {
+            anyhow!(
+                "plugin config object property `{}` is missing value_schema",
+                value.key
+            )
+        })?;
+
+        Ok(Self {
+            key: value.key.clone(),
+            value_schema: PackagedPluginValueSchema::try_from(value_schema).with_context(|| {
+                format!(
+                    "plugin config object property `{}` has invalid value_schema",
+                    value.key
+                )
+            })?,
+            required: value.required,
+            description: value.description.clone(),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum PackagedPluginValueKind {
+    Boolean,
+    Integer,
+    Float,
+    String,
+    Path,
+    Url,
+    Enum,
+    Array,
+    Object,
+}
+
+impl PackagedPluginValueKind {
+    fn try_from_i32(value: i32) -> Result<Self> {
+        let kind = match proto::PluginConfigValueKind::try_from(value)
+            .map_err(|_| anyhow!("unknown plugin config value kind `{value}`"))?
+        {
+            proto::PluginConfigValueKind::Boolean => Self::Boolean,
+            proto::PluginConfigValueKind::Integer => Self::Integer,
+            proto::PluginConfigValueKind::Float => Self::Float,
+            proto::PluginConfigValueKind::String => Self::String,
+            proto::PluginConfigValueKind::Path => Self::Path,
+            proto::PluginConfigValueKind::Url => Self::Url,
+            proto::PluginConfigValueKind::Enum => Self::Enum,
+            proto::PluginConfigValueKind::Array => Self::Array,
+            proto::PluginConfigValueKind::Object => Self::Object,
+            proto::PluginConfigValueKind::Unspecified => {
+                return Err(anyhow!("plugin config value kind is unspecified"));
+            }
+        };
+        Ok(kind)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum PackagedPluginApplyMode {
+    StaticOnLoad,
+    DynamicValidationOnly,
+    DynamicApply,
+}
+
+impl PackagedPluginApplyMode {
+    fn try_from_i32(value: i32) -> Result<Self> {
+        let mode = match proto::PluginConfigApplyMode::try_from(value)
+            .map_err(|_| anyhow!("unknown plugin config apply mode `{value}`"))?
+        {
+            proto::PluginConfigApplyMode::StaticOnLoad => Self::StaticOnLoad,
+            proto::PluginConfigApplyMode::DynamicValidationOnly => Self::DynamicValidationOnly,
+            proto::PluginConfigApplyMode::DynamicApply => Self::DynamicApply,
+            proto::PluginConfigApplyMode::Unspecified => {
+                return Err(anyhow!("plugin config apply mode is unspecified"));
+            }
+        };
+        Ok(mode)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum PackagedPluginRestartScope {
+    None,
+    ModelReload,
+    ProcessRestart,
+    MeshRestart,
+    PluginProcess,
+}
+
+impl PackagedPluginRestartScope {
+    fn try_from_i32(value: i32) -> Result<Self> {
+        let scope = match proto::PluginConfigRestartScope::try_from(value)
+            .map_err(|_| anyhow!("unknown plugin config restart scope `{value}`"))?
+        {
+            proto::PluginConfigRestartScope::None => Self::None,
+            proto::PluginConfigRestartScope::ModelReload => Self::ModelReload,
+            proto::PluginConfigRestartScope::ProcessRestart => Self::ProcessRestart,
+            proto::PluginConfigRestartScope::MeshRestart => Self::MeshRestart,
+            proto::PluginConfigRestartScope::PluginProcess => Self::PluginProcess,
+            proto::PluginConfigRestartScope::Unspecified => {
+                return Err(anyhow!("plugin config restart scope is unspecified"));
+            }
+        };
+        Ok(scope)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum PackagedPluginVisibility {
+    User,
+    Advanced,
+    Hidden,
+    Internal,
+}
+
+impl PackagedPluginVisibility {
+    fn try_from_i32(value: i32) -> Result<Self> {
+        let visibility = match proto::PluginConfigVisibility::try_from(value)
+            .map_err(|_| anyhow!("unknown plugin config visibility `{value}`"))?
+        {
+            proto::PluginConfigVisibility::User => Self::User,
+            proto::PluginConfigVisibility::Advanced => Self::Advanced,
+            proto::PluginConfigVisibility::Hidden => Self::Hidden,
+            proto::PluginConfigVisibility::Internal => Self::Internal,
+            proto::PluginConfigVisibility::Unspecified => {
+                return Err(anyhow!("plugin config visibility is unspecified"));
+            }
+        };
+        Ok(visibility)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum PackagedPluginConstraint {
+    NonEmpty,
+    Positive,
+    Range {
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        min: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        max: Option<String>,
+    },
+    AllowedValues {
+        values: Vec<String>,
+    },
+    Requires {
+        key: String,
+    },
+}
+
+impl PackagedPluginConstraint {
+    fn try_from(value: &proto::PluginConfigConstraintManifest) -> Result<Self> {
+        match value
+            .constraint
+            .as_ref()
+            .ok_or_else(|| anyhow!("plugin config constraint is empty"))?
+        {
+            proto::plugin_config_constraint_manifest::Constraint::NonEmpty(_) => Ok(Self::NonEmpty),
+            proto::plugin_config_constraint_manifest::Constraint::Positive(_) => Ok(Self::Positive),
+            proto::plugin_config_constraint_manifest::Constraint::Range(range) => Ok(Self::Range {
+                min: range.min.clone(),
+                max: range.max.clone(),
+            }),
+            proto::plugin_config_constraint_manifest::Constraint::AllowedValues(values) => {
+                Ok(Self::AllowedValues {
+                    values: values.values.clone(),
+                })
+            }
+            proto::plugin_config_constraint_manifest::Constraint::Requires(requires) => {
+                Ok(Self::Requires {
+                    key: requires.key.clone(),
+                })
+            }
+        }
+    }
 }
 
 pub fn mesh_channel(name: impl Into<String>) -> ManifestEntry {
@@ -103,6 +639,111 @@ pub fn mesh_event_mesh_id_updated() -> ManifestEntry {
 impl From<proto::MeshChannelManifest> for ManifestEntry {
     fn from(value: proto::MeshChannelManifest) -> Self {
         Self::MeshChannel(value)
+    }
+}
+
+impl From<proto::PluginConfigSchemaManifest> for ManifestEntry {
+    fn from(value: proto::PluginConfigSchemaManifest) -> Self {
+        Self::ConfigSchema(value)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PluginConfigSchemaBuilder {
+    inner: proto::PluginConfigSchemaManifest,
+}
+
+impl PluginConfigSchemaBuilder {
+    pub fn schema_version(mut self, schema_version: u32) -> Self {
+        self.inner.schema_version = schema_version;
+        self
+    }
+
+    pub fn allow_unvalidated_config(mut self, allow_unvalidated_config: bool) -> Self {
+        self.inner.allow_unvalidated_config = allow_unvalidated_config;
+        self
+    }
+
+    pub fn setting<T: Into<proto::PluginConfigSettingManifest>>(mut self, setting: T) -> Self {
+        self.inner.settings.push(setting.into());
+        self
+    }
+}
+
+impl From<PluginConfigSchemaBuilder> for ManifestEntry {
+    fn from(value: PluginConfigSchemaBuilder) -> Self {
+        Self::ConfigSchema(value.inner)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PluginConfigSettingBuilder {
+    inner: proto::PluginConfigSettingManifest,
+}
+
+impl PluginConfigSettingBuilder {
+    pub fn required(mut self, required: bool) -> Self {
+        self.inner.required = required;
+        self
+    }
+
+    pub fn default_value<T: Serialize>(mut self, value: &T) -> Self {
+        self.inner.default_json = json_string(value).ok();
+        self
+    }
+
+    pub fn constraint(mut self, constraint: proto::PluginConfigConstraintManifest) -> Self {
+        self.inner.constraints.push(constraint);
+        self
+    }
+
+    pub fn apply_mode(mut self, apply_mode: proto::PluginConfigApplyMode) -> Self {
+        self.inner.apply_mode = apply_mode as i32;
+        self
+    }
+
+    pub fn restart_scope(mut self, restart_scope: proto::PluginConfigRestartScope) -> Self {
+        self.inner.restart_scope = restart_scope as i32;
+        self
+    }
+
+    pub fn visibility(mut self, visibility: proto::PluginConfigVisibility) -> Self {
+        self.inner.visibility = visibility as i32;
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
+        self
+    }
+}
+
+impl From<PluginConfigSettingBuilder> for proto::PluginConfigSettingManifest {
+    fn from(value: PluginConfigSettingBuilder) -> Self {
+        value.inner
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PluginConfigObjectPropertyBuilder {
+    inner: proto::PluginConfigObjectProperty,
+}
+
+impl PluginConfigObjectPropertyBuilder {
+    pub fn required(mut self, required: bool) -> Self {
+        self.inner.required = required;
+        self
+    }
+
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.inner.description = Some(description.into());
+        self
+    }
+}
+
+impl From<PluginConfigObjectPropertyBuilder> for proto::PluginConfigObjectProperty {
+    fn from(value: PluginConfigObjectPropertyBuilder) -> Self {
+        value.inner
     }
 }
 
@@ -567,6 +1208,24 @@ mod tests {
         echoed: String,
     }
 
+    fn manifest_with_setting(setting: proto::PluginConfigSettingManifest) -> proto::PluginManifest {
+        proto::PluginManifest {
+            config_schema: Some(proto::PluginConfigSchemaManifest {
+                plugin_name: "demo".into(),
+                schema_version: 1,
+                settings: vec![setting],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn error_chain_contains(error: &anyhow::Error, needle: &str) -> bool {
+        error
+            .chain()
+            .any(|cause| cause.to_string().contains(needle))
+    }
+
     #[test]
     fn macro_builds_manifest_entries() {
         let manifest = crate::plugin_manifest![
@@ -699,5 +1358,110 @@ mod tests {
         assert_eq!(manifest.resources.len(), 1);
         assert_eq!(manifest.prompts.len(), 1);
         assert_eq!(manifest.completions.len(), 1);
+    }
+
+    #[test]
+    fn manifest_can_embed_packaged_config_schema() {
+        let manifest = crate::plugin_manifest![
+            config_schema("demo")
+                .setting(
+                    config_setting("retention_days", config_integer())
+                        .required(true)
+                        .default_value(&14)
+                        .constraint(constraint_range(Some("1"), Some("365")))
+                        .apply_mode(proto::PluginConfigApplyMode::DynamicValidationOnly)
+                        .restart_scope(proto::PluginConfigRestartScope::PluginProcess)
+                        .description("How long to retain entries."),
+                )
+                .setting(
+                    config_setting("mode", config_enum(["strict", "relaxed"]))
+                        .default_value(&"strict")
+                        .constraint(constraint_allowed_values(["strict", "relaxed"])),
+                )
+        ];
+
+        let schema = manifest.config_schema.expect("config schema");
+        assert_eq!(schema.plugin_name, "demo");
+        assert_eq!(schema.schema_version, 1);
+        assert_eq!(schema.settings.len(), 2);
+        assert_eq!(schema.settings[0].default_json.as_deref(), Some("14"));
+    }
+
+    #[test]
+    fn packaged_manifest_json_includes_config_schema() {
+        let manifest = crate::plugin_manifest![
+            config_schema("demo")
+                .allow_unvalidated_config(true)
+                .setting(config_setting("legacy", config_boolean()).default_value(&true))
+        ];
+
+        let encoded = package_manifest_json(&manifest).expect("manifest json");
+        let decoded: PackagedPluginManifest =
+            serde_json::from_str(&encoded).expect("manifest should deserialize");
+
+        let schema = decoded.config_schema.expect("config schema");
+        assert!(schema.allow_unvalidated_config);
+        assert_eq!(schema.settings[0].key, "legacy");
+    }
+
+    #[test]
+    fn packaged_manifest_json_rejects_missing_setting_value_schema() {
+        let setting = proto::PluginConfigSettingManifest {
+            key: "broken".into(),
+            value_schema: None,
+            apply_mode: proto::PluginConfigApplyMode::StaticOnLoad as i32,
+            restart_scope: proto::PluginConfigRestartScope::None as i32,
+            visibility: proto::PluginConfigVisibility::User as i32,
+            ..Default::default()
+        };
+
+        let error = package_manifest_json(&manifest_with_setting(setting))
+            .expect_err("missing value_schema should fail packaging");
+
+        assert!(
+            error_chain_contains(&error, "missing value_schema"),
+            "{error}"
+        );
+        assert!(error_chain_contains(&error, "broken"), "{error}");
+    }
+
+    #[test]
+    fn packaged_manifest_json_rejects_empty_constraint_payload() {
+        let mut setting: proto::PluginConfigSettingManifest =
+            config_setting("mode", config_string()).into();
+        setting
+            .constraints
+            .push(proto::PluginConfigConstraintManifest { constraint: None });
+
+        let error = package_manifest_json(&manifest_with_setting(setting))
+            .expect_err("empty constraint should fail packaging");
+
+        assert!(
+            error_chain_contains(&error, "invalid constraint #1"),
+            "{error}"
+        );
+        assert!(
+            error_chain_contains(&error, "constraint is empty"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn packaged_manifest_json_rejects_unknown_enum_discriminants() {
+        let mut setting: proto::PluginConfigSettingManifest =
+            config_setting("mode", config_string()).into();
+        setting.apply_mode = 99_999;
+
+        let error = package_manifest_json(&manifest_with_setting(setting))
+            .expect_err("unknown apply mode should fail packaging");
+
+        assert!(
+            error_chain_contains(&error, "invalid apply_mode"),
+            "{error}"
+        );
+        assert!(
+            error_chain_contains(&error, "unknown plugin config apply mode"),
+            "{error}"
+        );
     }
 }

--- a/crates/mesh-llm-protocol/proto/node.proto
+++ b/crates/mesh-llm-protocol/proto/node.proto
@@ -418,6 +418,53 @@ enum ConfigApplyMode {
   CONFIG_APPLY_MODE_NOOP = 3;
 }
 
+enum ConfigDiagnosticSeverity {
+  CONFIG_DIAGNOSTIC_SEVERITY_UNSPECIFIED = 0;
+  CONFIG_DIAGNOSTIC_SEVERITY_ERROR = 1;
+  CONFIG_DIAGNOSTIC_SEVERITY_WARNING = 2;
+  CONFIG_DIAGNOSTIC_SEVERITY_INFO = 3;
+}
+
+enum ConfigDiagnosticSource {
+  CONFIG_DIAGNOSTIC_SOURCE_UNSPECIFIED = 0;
+  CONFIG_DIAGNOSTIC_SOURCE_VALIDATION = 1;
+  CONFIG_DIAGNOSTIC_SOURCE_SCHEMA = 2;
+  CONFIG_DIAGNOSTIC_SOURCE_PLUGIN = 3;
+  CONFIG_DIAGNOSTIC_SOURCE_COMPATIBILITY = 4;
+}
+
+enum ConfigDiagnosticSchemaSource {
+  CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_UNSPECIFIED = 0;
+  CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_BUILT_IN = 1;
+  CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_ENGINE = 2;
+  CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_PLUGIN = 3;
+}
+
+enum ConfigDiagnosticCode {
+  CONFIG_DIAGNOSTIC_CODE_UNSPECIFIED = 0;
+  CONFIG_DIAGNOSTIC_CODE_INVALID_VALUE = 1;
+  CONFIG_DIAGNOSTIC_CODE_MISSING_REQUIRED_VALUE = 2;
+  CONFIG_DIAGNOSTIC_CODE_UNSUPPORTED_FIELD = 3;
+  CONFIG_DIAGNOSTIC_CODE_REJECTED_FIELD = 4;
+  CONFIG_DIAGNOSTIC_CODE_ALIAS_APPLIED = 5;
+  CONFIG_DIAGNOSTIC_CODE_MISPLACED_FIELD = 6;
+  CONFIG_DIAGNOSTIC_CODE_UNKNOWN_FIELD = 7;
+  CONFIG_DIAGNOSTIC_CODE_SCHEMA_UNAVAILABLE = 8;
+  CONFIG_DIAGNOSTIC_CODE_LEGACY_UNVALIDATED_CONFIG = 9;
+  CONFIG_DIAGNOSTIC_CODE_UNSUPPORTED_SCHEMA_VERSION = 10;
+}
+
+message ConfigDiagnostic {
+  ConfigDiagnosticCode code = 1;
+  ConfigDiagnosticSeverity severity = 2;
+  ConfigDiagnosticSource source = 3;
+  optional ConfigDiagnosticSchemaSource schema_source = 4;
+  optional string path = 5;
+  optional string canonical_path = 6;
+  string message = 7;
+  optional string help = 8;
+}
+
 message OwnerControlEnvelope {
   uint32 gen = 1;                         // must equal NODE_PROTOCOL_GENERATION
   OwnerControlHandshake handshake = 2;
@@ -505,6 +552,7 @@ message OwnerControlApplyConfigResponse {
   bytes config_hash = 3;
   optional string error = 4;
   ConfigApplyMode apply_mode = 5;
+  repeated ConfigDiagnostic diagnostics = 6;
 }
 
 message OwnerControlRefreshInventoryRequest {

--- a/crates/mesh-llm-protocol/src/proto/node.rs
+++ b/crates/mesh-llm-protocol/src/proto/node.rs
@@ -656,6 +656,27 @@ pub struct OwnerControlApplyConfigResponse {
     pub error: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(enumeration = "ConfigApplyMode", tag = "5")]
     pub apply_mode: i32,
+    #[prost(message, repeated, tag = "6")]
+    pub diagnostics: ::prost::alloc::vec::Vec<ConfigDiagnostic>,
+}
+#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
+pub struct ConfigDiagnostic {
+    #[prost(enumeration = "ConfigDiagnosticCode", tag = "1")]
+    pub code: i32,
+    #[prost(enumeration = "ConfigDiagnosticSeverity", tag = "2")]
+    pub severity: i32,
+    #[prost(enumeration = "ConfigDiagnosticSource", tag = "3")]
+    pub source: i32,
+    #[prost(enumeration = "ConfigDiagnosticSchemaSource", optional, tag = "4")]
+    pub schema_source: ::core::option::Option<i32>,
+    #[prost(string, optional, tag = "5")]
+    pub path: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "6")]
+    pub canonical_path: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, tag = "7")]
+    pub message: ::prost::alloc::string::String,
+    #[prost(string, optional, tag = "8")]
+    pub help: ::core::option::Option<::prost::alloc::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OwnerControlRefreshInventoryRequest {
@@ -1006,6 +1027,142 @@ impl ConfigApplyMode {
             "CONFIG_APPLY_MODE_STAGED" => Some(Self::Staged),
             "CONFIG_APPLY_MODE_LIVE" => Some(Self::Live),
             "CONFIG_APPLY_MODE_NOOP" => Some(Self::Noop),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ConfigDiagnosticSeverity {
+    Unspecified = 0,
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+}
+impl ConfigDiagnosticSeverity {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CONFIG_DIAGNOSTIC_SEVERITY_UNSPECIFIED",
+            Self::Error => "CONFIG_DIAGNOSTIC_SEVERITY_ERROR",
+            Self::Warning => "CONFIG_DIAGNOSTIC_SEVERITY_WARNING",
+            Self::Info => "CONFIG_DIAGNOSTIC_SEVERITY_INFO",
+        }
+    }
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CONFIG_DIAGNOSTIC_SEVERITY_UNSPECIFIED" => Some(Self::Unspecified),
+            "CONFIG_DIAGNOSTIC_SEVERITY_ERROR" => Some(Self::Error),
+            "CONFIG_DIAGNOSTIC_SEVERITY_WARNING" => Some(Self::Warning),
+            "CONFIG_DIAGNOSTIC_SEVERITY_INFO" => Some(Self::Info),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ConfigDiagnosticSource {
+    Unspecified = 0,
+    Validation = 1,
+    Schema = 2,
+    Plugin = 3,
+    Compatibility = 4,
+}
+impl ConfigDiagnosticSource {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CONFIG_DIAGNOSTIC_SOURCE_UNSPECIFIED",
+            Self::Validation => "CONFIG_DIAGNOSTIC_SOURCE_VALIDATION",
+            Self::Schema => "CONFIG_DIAGNOSTIC_SOURCE_SCHEMA",
+            Self::Plugin => "CONFIG_DIAGNOSTIC_SOURCE_PLUGIN",
+            Self::Compatibility => "CONFIG_DIAGNOSTIC_SOURCE_COMPATIBILITY",
+        }
+    }
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CONFIG_DIAGNOSTIC_SOURCE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CONFIG_DIAGNOSTIC_SOURCE_VALIDATION" => Some(Self::Validation),
+            "CONFIG_DIAGNOSTIC_SOURCE_SCHEMA" => Some(Self::Schema),
+            "CONFIG_DIAGNOSTIC_SOURCE_PLUGIN" => Some(Self::Plugin),
+            "CONFIG_DIAGNOSTIC_SOURCE_COMPATIBILITY" => Some(Self::Compatibility),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ConfigDiagnosticSchemaSource {
+    Unspecified = 0,
+    BuiltIn = 1,
+    Engine = 2,
+    Plugin = 3,
+}
+impl ConfigDiagnosticSchemaSource {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_UNSPECIFIED",
+            Self::BuiltIn => "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_BUILT_IN",
+            Self::Engine => "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_ENGINE",
+            Self::Plugin => "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_PLUGIN",
+        }
+    }
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_BUILT_IN" => Some(Self::BuiltIn),
+            "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_ENGINE" => Some(Self::Engine),
+            "CONFIG_DIAGNOSTIC_SCHEMA_SOURCE_PLUGIN" => Some(Self::Plugin),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum ConfigDiagnosticCode {
+    Unspecified = 0,
+    InvalidValue = 1,
+    MissingRequiredValue = 2,
+    UnsupportedField = 3,
+    RejectedField = 4,
+    AliasApplied = 5,
+    MisplacedField = 6,
+    UnknownField = 7,
+    SchemaUnavailable = 8,
+    LegacyUnvalidatedConfig = 9,
+    UnsupportedSchemaVersion = 10,
+}
+impl ConfigDiagnosticCode {
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            Self::Unspecified => "CONFIG_DIAGNOSTIC_CODE_UNSPECIFIED",
+            Self::InvalidValue => "CONFIG_DIAGNOSTIC_CODE_INVALID_VALUE",
+            Self::MissingRequiredValue => "CONFIG_DIAGNOSTIC_CODE_MISSING_REQUIRED_VALUE",
+            Self::UnsupportedField => "CONFIG_DIAGNOSTIC_CODE_UNSUPPORTED_FIELD",
+            Self::RejectedField => "CONFIG_DIAGNOSTIC_CODE_REJECTED_FIELD",
+            Self::AliasApplied => "CONFIG_DIAGNOSTIC_CODE_ALIAS_APPLIED",
+            Self::MisplacedField => "CONFIG_DIAGNOSTIC_CODE_MISPLACED_FIELD",
+            Self::UnknownField => "CONFIG_DIAGNOSTIC_CODE_UNKNOWN_FIELD",
+            Self::SchemaUnavailable => "CONFIG_DIAGNOSTIC_CODE_SCHEMA_UNAVAILABLE",
+            Self::LegacyUnvalidatedConfig => "CONFIG_DIAGNOSTIC_CODE_LEGACY_UNVALIDATED_CONFIG",
+            Self::UnsupportedSchemaVersion => "CONFIG_DIAGNOSTIC_CODE_UNSUPPORTED_SCHEMA_VERSION",
+        }
+    }
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CONFIG_DIAGNOSTIC_CODE_UNSPECIFIED" => Some(Self::Unspecified),
+            "CONFIG_DIAGNOSTIC_CODE_INVALID_VALUE" => Some(Self::InvalidValue),
+            "CONFIG_DIAGNOSTIC_CODE_MISSING_REQUIRED_VALUE" => Some(Self::MissingRequiredValue),
+            "CONFIG_DIAGNOSTIC_CODE_UNSUPPORTED_FIELD" => Some(Self::UnsupportedField),
+            "CONFIG_DIAGNOSTIC_CODE_REJECTED_FIELD" => Some(Self::RejectedField),
+            "CONFIG_DIAGNOSTIC_CODE_ALIAS_APPLIED" => Some(Self::AliasApplied),
+            "CONFIG_DIAGNOSTIC_CODE_MISPLACED_FIELD" => Some(Self::MisplacedField),
+            "CONFIG_DIAGNOSTIC_CODE_UNKNOWN_FIELD" => Some(Self::UnknownField),
+            "CONFIG_DIAGNOSTIC_CODE_SCHEMA_UNAVAILABLE" => Some(Self::SchemaUnavailable),
+            "CONFIG_DIAGNOSTIC_CODE_LEGACY_UNVALIDATED_CONFIG" => {
+                Some(Self::LegacyUnvalidatedConfig)
+            }
+            "CONFIG_DIAGNOSTIC_CODE_UNSUPPORTED_SCHEMA_VERSION" => {
+                Some(Self::UnsupportedSchemaVersion)
+            }
             _ => None,
         }
     }

--- a/crates/mesh-llm-protocol/src/protocol/mod.rs
+++ b/crates/mesh-llm-protocol/src/protocol/mod.rs
@@ -847,6 +847,7 @@ mod tests {
                     config_hash: vec![0x99; 32],
                     error: None,
                     apply_mode: ConfigApplyMode::Live as i32,
+                    diagnostics: Vec::new(),
                 }),
                 refresh_inventory: None,
             }),

--- a/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.test.ts
@@ -1,12 +1,32 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import {
   adaptStatusToConfiguration,
+  configurationDefaultsSchemaPathEntries,
   createConfigurationDefaultsValuesFromMeshConfig,
   mergeConfigurationDefaultsIntoMeshConfig,
   runtimeControlApplyErrorMessage,
   type RuntimeControlMeshConfig
 } from '@/features/configuration/api/config-adapter'
 import type { MeshModelRaw, StatusPayload } from '@/lib/api/types'
+
+const DEFAULTS_SCHEMA_REFERENCE = JSON.parse(
+  readFileSync(
+    resolve(
+      dirname(fileURLToPath(import.meta.url)),
+      '../../../../../mesh-llm-host-runtime/tests/fixtures/config_schema_defaults_ui_reference.json'
+    ),
+    'utf8'
+  )
+) as {
+  settings: Array<{
+    canonical_path: string
+    support: string
+    source: { kind: string }
+  }>
+}
 
 const STATUS_PAYLOAD: StatusPayload = {
   node_id: 'self',
@@ -291,5 +311,60 @@ describe('adaptStatusToConfiguration', () => {
         error: { code: 'control_unavailable' }
       })
     ).toBe('control unavailable')
+
+    expect(
+      runtimeControlApplyErrorMessage({
+        success: false,
+        current_revision: 7,
+        config_hash: 'abc123',
+        apply_mode: 'unspecified',
+        diagnostics: [
+          {
+            code: 'invalid_value',
+            severity: 'error',
+            source: 'validation',
+            path: 'models[0].request_defaults.reasoning_format',
+            canonical_path: 'models.<model-ref>.request_defaults.reasoning_format',
+            message: 'reasoning_format must be one of: auto, none, deepseek, deepseek-legacy, hidden',
+            help: 'choose one of the supported reasoning formats'
+          }
+        ]
+      })
+    ).toBe('reasoning_format must be one of: auto, none, deepseek, deepseek-legacy, hidden')
+  })
+
+  it('projects every configuration defaults control onto a supported built-in schema path', () => {
+    const schemaByPath = new Map(DEFAULTS_SCHEMA_REFERENCE.settings.map((entry) => [entry.canonical_path, entry]))
+    const seenPaths = new Set<string>()
+
+    for (const projection of configurationDefaultsSchemaPathEntries()) {
+      expect(
+        seenPaths.has(projection.canonicalPath),
+        `duplicate defaults schema path ${projection.canonicalPath}`
+      ).toBe(false)
+      seenPaths.add(projection.canonicalPath)
+
+      const schemaEntry = schemaByPath.get(projection.canonicalPath)
+      expect(
+        schemaEntry,
+        `missing exported schema row for ${projection.id} -> ${projection.canonicalPath}`
+      ).toBeDefined()
+      expect(schemaEntry?.support).toBe('supported')
+      expect(schemaEntry?.source.kind).toBe('built_in')
+    }
+  })
+
+  it('keeps canonical nested defaults paths for alias-prone and rejected controls', () => {
+    const projections = new Map(
+      configurationDefaultsSchemaPathEntries().map((entry) => [entry.id, entry.canonicalPath])
+    )
+
+    expect(projections.get('parallel-slots')).toBe('defaults.throughput.parallel')
+    expect(projections.get('llamacpp-flavor')).toBe('defaults.hardware.model_runtime')
+    expect(projections.get('hardware-device')).toBe('defaults.hardware.device')
+    expect(projections.get('ctx-size')).toBe('defaults.model_fit.ctx_size')
+    expect(projections.get('server-alias')).toBe('defaults.advanced.server.alias')
+    expect(Array.from(projections.values())).not.toContain('defaults.request_defaults.json_schema')
+    expect(Array.from(projections.values())).not.toContain('defaults.hardware.rpc_backend')
   })
 })

--- a/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts
@@ -50,11 +50,31 @@ export type RuntimeControlApplyResponse = {
   config_hash: string
   apply_mode: string
   error?: unknown
+  diagnostics?: RuntimeControlDiagnostic[]
+}
+
+export type RuntimeControlDiagnostic = {
+  code: string
+  severity: string
+  source: string
+  schema_source?: string
+  path?: string
+  canonical_path?: string
+  message: string
+  help?: string
+}
+
+export type ConfigurationDefaultsSchemaPathEntry = {
+  id: string
+  canonicalPath: string
 }
 
 export function runtimeControlApplyErrorMessage(response: RuntimeControlApplyResponse | null | undefined) {
   if (!response) return undefined
-  return runtimeControlErrorMessage(response.error)
+  return (
+    runtimeControlErrorMessage(response.error) ??
+    response.diagnostics?.find((diagnostic) => diagnostic.severity === 'error')?.message
+  )
 }
 
 function runtimeControlErrorMessage(error: unknown): string | undefined {
@@ -154,6 +174,13 @@ function resolveControlDefaultsPath(setting: ConfigurationDefaultsSetting): stri
   const sectionPath = parseDefaultsSectionPath(setting.tomlSection ?? categorySection?.tomlSection)
 
   return [...sectionPath, key]
+}
+
+export function configurationDefaultsSchemaPathEntries(): ConfigurationDefaultsSchemaPathEntry[] {
+  return CONFIGURATION_DEFAULTS.settings.map((setting) => ({
+    id: setting.id,
+    canonicalPath: ['defaults', ...resolveControlDefaultsPath(setting)].join('.')
+  }))
 }
 
 function overlayDefaultsValues(

--- a/crates/mesh-llm/src/commands/config.rs
+++ b/crates/mesh-llm/src/commands/config.rs
@@ -1,0 +1,10 @@
+use anyhow::Result;
+use mesh_llm_cli::{Cli, ConfigCommand};
+
+pub(crate) fn dispatch_config_command(cli: &Cli, command: &ConfigCommand) -> Result<()> {
+    match command {
+        ConfigCommand::Validate { config_path, json } => {
+            mesh_llm_commands::config::run_config_validate(cli, config_path.as_deref(), *json)
+        }
+    }
+}

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod config;
 mod discover;
 mod doctor;
 mod download;
@@ -8,6 +9,7 @@ mod runtime;
 use anyhow::Result;
 use mesh_llm_cli::{Cli, Command};
 
+use self::config::dispatch_config_command;
 use self::discover::{DiscoverOptions, run_discover, run_stop};
 use self::doctor::dispatch_doctor_command;
 use self::download::dispatch_download_command;
@@ -46,6 +48,7 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             Ok(())
         }
         Command::Runtime { command } => dispatch_runtime_command(command.as_ref()).await,
+        Command::Config { command } => dispatch_config_command(cli, command),
         Command::Doctor { command, json } => dispatch_doctor_command(command.as_ref(), *json).await,
         Command::Load { name, port } => run_load(name, *port).await,
         Command::Unload { name, port } => run_drop(name, *port).await,

--- a/crates/mesh-llm/src/commands/plugin_cli.rs
+++ b/crates/mesh-llm/src/commands/plugin_cli.rs
@@ -277,6 +277,7 @@ mod tests {
             downloaded_asset_name: "demo.tar.gz".to_string(),
             install_path,
             enabled: true,
+            manifest: None,
             last_protocol_version: None,
             last_status: None,
             last_error: None,

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -253,6 +253,48 @@ Switches:
 
 Use this to inspect local GPU identity and capacity, including per-device VRAM, unified-memory state, and cached benchmark-derived bandwidth when present.
 
+### `config validate`
+
+Use this to validate a mesh-llm config file before starting a node or applying
+the file through owner-control.
+
+Usage:
+
+```bash
+mesh-llm config validate
+mesh-llm config validate --config-path ~/.mesh-llm/config.toml
+mesh-llm config validate --config-path ./mesh.toml --json
+```
+
+Switches:
+
+- `--config-path <CONFIG_PATH>`: config TOML file to validate. If omitted,
+  mesh-llm uses the global `--config` path, then `MESH_LLM_CONFIG`, then
+  `~/.mesh-llm/config.toml`.
+- `--json`: print a machine-readable validation report.
+
+The JSON report uses this shape:
+
+```json
+{
+  "ok": false,
+  "path": "./mesh.toml",
+  "diagnostics": [
+    {
+      "code": "missing_required_value",
+      "severity": "error",
+      "source": "schema",
+      "path": "plugin[\"example\"].settings.api_key",
+      "message": "required plugin setting is missing"
+    }
+  ]
+}
+```
+
+Validation checks built-in settings and installed plugin config schemas. Warning
+diagnostics are printed but do not make the command fail; error diagnostics and
+TOML load/parse failures exit nonzero.
+
 
 ### `load`
 


### PR DESCRIPTION
## What users can do now

This adds a configuration schema and validation surface for mesh-llm settings. Operators can inspect and validate config files without starting a node:

```bash
mesh-llm config validate --config-path ~/.mesh-llm/config.toml
mesh-llm config validate --config-path ./mesh.toml --json
```

The JSON form reports a stable `{ ok, path, diagnostics }` shape for automation, and exits nonzero when validation finds errors. Warning-only diagnostics remain successful so migration and compatibility warnings can be surfaced without blocking a valid config.

The owner-control apply path now returns structured diagnostics for both rejected changes and successful changes with warnings. The runtime configuration UI consumes exported schema metadata instead of duplicating the setting inventory by hand.

## How the config schema works

The config model now has first-class schema metadata for built-in settings:

- canonical `ConfigPath` values and aliases
- setting owner and support state
- value type, constraints, visibility, and restart/apply behavior
- control surfaces such as config file, owner-control, and UI
- structured `ConfigDiagnostic` values with rendered paths and canonical paths

The host runtime aggregates built-in settings, engine schema sources, and installed plugin schemas into an exported runtime schema. Snapshot fixtures keep the exported shape stable for the TypeScript configuration adapter.

Config file `version = 1` remains unchanged. These changes add metadata, stricter diagnostics, and control-surface wiring; they do not introduce an incompatible persisted config format.

## How this interconnects with plugins

Plugins can now ship install-time `config_schema` metadata in their manifest. The plugin manager stores that schema, and host-runtime validation uses the installed schema when reading or applying config.

The plugin schema path covers:

- scalar, enum, array, and object setting shapes
- required settings and defaults
- constraints
- schema availability and unsupported schema-version diagnostics
- legacy `allow_unvalidated_config` warnings

Required plugin settings are now enforced even when a `[plugin.settings]` table is absent. Missing schemas reject custom plugin settings, while plugin entries without custom settings can remain loadable where possible.

Plugin config schema version remains `1`; this PR enforces the existing v1 contract rather than changing the plugin schema format.

## How developers add or remove settings now

For built-in mesh-llm settings, update the config model and its schema descriptor together:

1. Change the owning config struct in `crates/mesh-llm-config/src/model.rs`.
2. Update authoring/editor helpers in `crates/mesh-llm-config/src/authoring.rs` if generated or mutated configs need the setting.
3. Add or remove the descriptor in `crates/mesh-llm-config/src/model/built_in_schema.rs`.
4. Add validation diagnostics in `crates/mesh-llm-config/src/validate.rs`.
5. Update dynamic apply behavior in `crates/mesh-llm-host-runtime/src/runtime/config_state.rs` when the setting can be applied without restart.
6. Update schema export/API/protocol/UI fixtures when the setting crosses those surfaces.
7. Run `mesh-llm config validate --config-path <fixture> --json` against representative valid and invalid files.

For plugin settings, add or update the plugin manifest `config_schema`; do not hard-code plugin settings into the built-in schema. Bump plugin schema version only if the schema format becomes incompatible, not when tightening enforcement of existing v1 fields.

This also adds `.agents/skills/config-settings-management/SKILL.md` so future agents have a concrete checklist before adding, removing, renaming, or refactoring config settings.

## Validation

Already run locally:

```bash
cargo fmt --all -- --check
cargo test -p mesh-llm-config --lib
cargo test -p mesh-llm-host-runtime --lib plugin_config
cargo test -p mesh-llm-host-runtime --lib runtime_config
cargo test -p mesh-llm-plugin-manager --lib
cargo test -p mesh-llm-plugin --lib
cargo test -p mesh-llm-host-runtime --lib schema_export
cargo test -p mesh-llm-cli config_validate_command_parses_config_path_and_json --lib
cargo test -p mesh-llm config_validate --lib
cargo check -p mesh-llm
cargo clippy -p mesh-llm-config -p mesh-llm-plugin -p mesh-llm-plugin-manager -p mesh-llm-host-runtime -p mesh-llm --all-targets -- -D warnings
cargo clippy -p mesh-llm-cli -p mesh-llm-host-runtime -p mesh-llm --all-targets -- -D warnings
just build
```

Manual CLI checks:

```bash
cargo run -p mesh-llm -- config validate --config-path crates/mesh-llm-host-runtime/tests/fixtures/skippy_full_surface_valid.toml --json
cargo run -p mesh-llm -- config validate --config-path crates/mesh-llm-host-runtime/tests/fixtures/skippy_full_surface_invalid.toml --json
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `mesh-llm config validate` with human-readable or JSON output (`--config-path`, `--json`).
  * Introduced structured configuration diagnostics across validation, apply flows, and API responses (multiple warnings/errors supported).
  * Enabled strict installed-plugin config schema validation with diagnostics for misplaced/unknown keys and missing required settings.
  * Added runtime configuration schema aggregation/export to power UI/tooling.
* **Documentation**
  * Documented `mesh-llm config validate` and added the config-settings-management skill guide.
* **Tests**
  * Expanded API/contract tests and JSON fixtures to verify diagnostics payloads and schema defaults/projections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->