### PR TITLE
chore: upgrade iroh to 1.0.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1041,7 +1041,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1570,7 +1570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1754,7 +1754,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1938,7 +1938,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3154,9 +3154,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
 dependencies = [
  "axum",
  "backon",
@@ -3208,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
+checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
 dependencies = [
  "curve25519-dalek 5.0.0-pre.6",
  "data-encoding",
@@ -3230,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
+checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3289,9 +3289,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
 dependencies = [
  "ahash",
  "blake3",
@@ -4686,9 +4686,9 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
+checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4775,9 +4775,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
+checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4797,9 +4797,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
+checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -4825,9 +4825,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.0"
+version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
+checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4928,7 +4928,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5758,9 +5758,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec2a8809e3f7dba624776bb223da9fed49c413c60b3bef21aadcb67a5e35944"
+checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
 dependencies = [
  "base64",
  "bytes",
@@ -6090,7 +6090,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6662,7 +6662,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6755,7 +6755,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6776,7 +6776,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7030,7 +7030,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7802,7 +7802,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9148,7 +9148,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -22,7 +22,7 @@ host-io = ["mesh-llm-identity/host-io"]
 # model-artifact, iroh, tokio, prost, bytes, rustls, quinn, serde, serde_json, thiserror, anyhow,
 # tracing, sha2, ed25519-dalek, hex, uuid, url, http, base64, async-trait, httparse
 # (httparse is a transitive dep of iroh; not in forbidden list)
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0-rc.1"
 mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.68.0", default-features = false }
 mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.68.0" }
 mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.68.0" }

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0-rc.1"
 json5 = "1.3.1"
 mesh-llm-build-info.workspace = true
 mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.68.0" }

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -57,7 +57,7 @@ skippy-coordinator = { path = "../skippy-coordinator", version = "0.68.0"  }
 skippy-runtime = { path = "../skippy-runtime", version = "0.68.0"  }
 skippy-server = { path = "../skippy-server", version = "0.68.0"  }
 skippy-topology = { path = "../skippy-topology", version = "0.68.0"  }
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0-rc.1"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
@@ -119,5 +119,5 @@ mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = 
 # with AccessConfig::Restricted, then build a real iroh::Endpoint from our
 # relay_map_from_urls output and verify --relay-auth tokens reach the relay
 # on the WebSocket upgrade (and that the wrong token is rejected).
-iroh = { version = "1.0.0-rc.0", features = ["test-utils"] }
-iroh-relay = { version = "1.0.0-rc.0", features = ["server", "test-utils"] }
+iroh = { version = "1.0.0-rc.1", features = ["test-utils"] }
+iroh-relay = { version = "1.0.0-rc.1", features = ["server", "test-utils"] }

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -116,7 +116,7 @@ tempfile = "3"
 serial_test = "3"
 mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = "0.68.0"  }
 # Used by the gated-relay regression test to spawn an in-process iroh-relay
-# with AccessConfig::Restricted, then build a real iroh::Endpoint from our
+# with a restricted AccessControl, then build a real iroh::Endpoint from our
 # relay_map_from_urls output and verify --relay-auth tokens reach the relay
 # on the WebSocket upgrade (and that the wrong token is rejected).
 iroh = { version = "1.0.0-rc.1", features = ["test-utils"] }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -387,7 +387,8 @@ pub struct QuicBindSelection {
 /// Relay map plus per-relay bearer tokens for gated iroh-relays.
 ///
 /// `urls` is the relay map; `auths` is a sparse map of relay URL -> bearer
-/// token used when registering with relays running `AccessConfig::Restricted`.
+/// token used when registering with relays running a restricted
+/// [`iroh_relay::server::AccessControl`].
 /// Public relays in the same map continue to register without auth.
 #[derive(Clone, Copy, Debug)]
 pub struct RelayConfig<'a> {
@@ -614,10 +615,10 @@ mod relay_policy_tests {
 /// are passed to `iroh::RelayConfig::with_auth_token` which sends them as
 /// `Authorization: Bearer <token>` on the WebSocket upgrade. Relays not present
 /// in the map register unauthenticated, which is the correct behavior for
-/// public (`AccessConfig::Everyone`) relays.
+/// public (`AllowAll`) relays.
 ///
-/// This is the wire-up that lets a gated iroh-relay (e.g. one running
-/// `AccessConfig::Restricted` with NIP-98 admission) admit this node while
+/// This is the wire-up that lets a gated iroh-relay (e.g. one running a
+/// custom `AccessControl` with NIP-98 admission) admit this node while
 /// public relays in the same map continue to work normally.
 fn relay_map_from_urls(
     urls: &[String],
@@ -708,7 +709,7 @@ mod relay_map_tests {
 }
 
 /// End-to-end regression tests for `--relay-auth` against a real in-process
-/// iroh-relay running [`iroh_relay::server::AccessConfig::Restricted`].
+/// iroh-relay running a restricted [`iroh_relay::server::AccessControl`].
 ///
 /// These tests do not go through the full `Node::start` path — they exercise
 /// `relay_map_from_urls` (the new wiring) plus the iroh `Endpoint` builder
@@ -730,25 +731,34 @@ mod gated_relay_e2e_tests {
     use iroh::Watcher;
     use iroh::endpoint::{Endpoint, RelayMode, presets};
     use iroh::test_utils::run_relay_server_with_access;
-    use iroh_relay::server::{Access, AccessConfig};
+    use iroh_relay::server::{Access, AccessControl, AllowAll, ClientRequest};
     use iroh_relay::tls::CaRootsConfig;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::Duration;
+
+    /// Token-checking [`AccessControl`] for gated-relay tests.
+    #[derive(Debug)]
+    struct TokenAccess {
+        expected_token: &'static str,
+    }
+
+    impl AccessControl for TokenAccess {
+        async fn on_connect(&self, request: &ClientRequest) -> Access {
+            if request.auth_token().as_deref() == Some(self.expected_token) {
+                Access::Allow
+            } else {
+                Access::Deny { reason: None }
+            }
+        }
+    }
 
     /// Spawn an in-process iroh-relay that only admits `expected_token`.
     /// Returns (relay_url_string, drop-guard server).
     async fn spawn_gated_relay(
         expected_token: &'static str,
     ) -> (String, iroh_relay::server::Server) {
-        let access = AccessConfig::Restricted(Box::new(move |request| {
-            Box::pin(async move {
-                if request.auth_token().as_deref() == Some(expected_token) {
-                    Access::Allow
-                } else {
-                    Access::Deny
-                }
-            })
-        }));
+        let access = Arc::new(TokenAccess { expected_token });
         let (_relay_map, relay_url, server) = run_relay_server_with_access(false, access)
             .await
             .expect("spawn gated relay");
@@ -854,7 +864,7 @@ mod gated_relay_e2e_tests {
         // Spin up a second, fully-open relay to stand in for a public iroh
         // relay sharing the same map.
         let (_public_map, public_url, _public) =
-            run_relay_server_with_access(false, AccessConfig::Everyone)
+            run_relay_server_with_access(false, Arc::new(AllowAll))
                 .await
                 .expect("spawn public relay");
         let public_url = public_url.to_string();

--- a/crates/mesh-llm-protocol/Cargo.toml
+++ b/crates/mesh-llm-protocol/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 anyhow.workspace = true
 hex = "0.4"
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0-rc.1"
 prost = "0.14"
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/mesh-llm-routing/Cargo.toml
+++ b/crates/mesh-llm-routing/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["llm", "mesh", "routing", "inference"]
 categories = ["network-programming"]
 
 [dependencies]
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0-rc.1"


### PR DESCRIPTION
Bumps iroh (and its companions iroh-relay, iroh-base, iroh-dns, iroh-metrics) from `1.0.0-rc.0` to `1.0.0-rc.1`.

## Changes

- No source code changes required — the rc.1 API is fully compatible with rc.0 for the surface we use.
- Transitive bumps: `netwatch` 0.17.0 → 0.18.0, `portmapper` 0.17.0 → 0.18.0.

## Validation

- `cargo check -p mesh-llm` clean
- Tested `mesh-llm client --auto` against the public mesh: discovery joined, models listed, inference via `model: mesh` completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the `iroh` dependency version across multiple crates to the latest compatible release candidate.
* **Documentation**
  * Refreshed relay authorization notes to match the current access-control terminology and behavior.
* **Tests**
  * Updated gated-relay end-to-end and mixed-relay test setup to use the newer access-control approach for bearer-token authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->