### PR TITLE
Clarify Skippy prompt cache reuse

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::inference::skippy::{SkippyPackageIdentity, SkippyTelemetryOptions, StageWireDType};
 use crate::plugin::{MeshConfig, ReasoningBudget, RequestDefaultsConfig};
 use serde_json::Value;
-use skippy_protocol::{LoadMode, StageKvCachePayload};
+use skippy_protocol::{LoadMode, StageKvCacheMode, StageKvCachePayload};
 use skippy_server::{EmbeddedReasoningEnabled, EmbeddedReasoningFormat};
 use std::{
     io::Write,
@@ -622,6 +622,32 @@ fn family_policy_beats_builtin_wire_dtype_when_config_is_unset() {
     .unwrap();
 
     assert_eq!(resolved.skippy.activation_wire_dtype, StageWireDType::F32);
+}
+
+#[test]
+fn family_policy_wires_prefix_cache_by_default_for_supported_models() {
+    let model_file = temp_model_file();
+    let resolved = resolve_skippy_config(SkippyConfigResolveRequest {
+        mesh_config: &MeshConfig::default(),
+        model_id: "Qwen/Qwen3-0.6B:Q4_K_M",
+        model_path: model_file.path(),
+        model_bytes: 4 * 1024 * 1024 * 1024,
+        allocatable_memory_bytes: None,
+        request_defaults: None,
+    })
+    .expect("config should resolve");
+
+    let stage_config = resolved
+        .to_stage_config(Some(fake_package_identity(24)), LoadMode::RuntimeSlice)
+        .expect("stage config should build");
+    let kv_cache = stage_config
+        .kv_cache
+        .expect("supported family should enable prefix cache by default");
+
+    assert_eq!(kv_cache.mode, StageKvCacheMode::LookupRecord);
+    assert_eq!(kv_cache.payload, StageKvCachePayload::ResidentKv);
+    assert!(kv_cache.max_entries > 0);
+    assert!(kv_cache.max_bytes > 0);
 }
 
 #[test]

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1159,12 +1159,25 @@ fn prompt_cache_retention_label(retention: openai_frontend::PromptCacheRetention
     }
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 struct GenerationCacheStats {
+    status: &'static str,
     cached_prompt_tokens: u32,
     matched_prefix_tokens: u32,
     suffix_prefill_tokens: u32,
     hit_kind: Option<&'static str>,
+}
+
+impl Default for GenerationCacheStats {
+    fn default() -> Self {
+        Self {
+            status: "disabled",
+            cached_prompt_tokens: 0,
+            matched_prefix_tokens: 0,
+            suffix_prefill_tokens: 0,
+            hit_kind: None,
+        }
+    }
 }
 
 struct ChainPrefixRestore {
@@ -2051,6 +2064,7 @@ where
         Ok(GeneratedText {
             prompt_tokens: saturating_u32(prompt_token_count),
             completion_tokens: saturating_u32(self.completion_tokens),
+            cache_status: cache_stats.status,
             cached_prompt_tokens: cache_stats.cached_prompt_tokens,
             matched_prefix_tokens: cache_stats.matched_prefix_tokens,
             suffix_prefill_tokens: cache_stats.suffix_prefill_tokens,
@@ -2067,6 +2081,7 @@ where
 struct GeneratedText {
     prompt_tokens: u32,
     completion_tokens: u32,
+    cache_status: &'static str,
     cached_prompt_tokens: u32,
     matched_prefix_tokens: u32,
     suffix_prefill_tokens: u32,

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -70,6 +70,9 @@ impl StageOpenAiBackend {
             }
             if prefill_token_count > 0 {
                 let prefill_tokens = &request.prompt_token_ids[..prefill_token_count];
+                if self.kv.is_some() {
+                    cache_stats.status = "miss";
+                }
                 if request.max_tokens > 0 && request.draft.is_none() {
                     let current = *request
                         .prompt_token_ids
@@ -91,6 +94,7 @@ impl StageOpenAiBackend {
                         cache_stats.matched_prefix_tokens =
                             saturating_u32(request.prompt_token_ids.len());
                         cache_stats.suffix_prefill_tokens = 0;
+                        cache_stats.status = "hit";
                         cache_stats.hit_kind = Some("chain_exact_replay");
                         fused_first_decode = Some(cached);
                     } else if let Some(cached) = self
@@ -108,6 +112,7 @@ impl StageOpenAiBackend {
                         cache_stats.matched_prefix_tokens =
                             saturating_u32(request.prompt_token_ids.len());
                         cache_stats.suffix_prefill_tokens = 0;
+                        cache_stats.status = "hit";
                         cache_stats.hit_kind = Some("chain_full_prompt_first_token");
                         fused_first_decode = Some(cached);
                     } else if let Some(fused) = self.try_restore_embedded_split_prefill_and_decode(
@@ -124,6 +129,7 @@ impl StageOpenAiBackend {
                         cache_stats.cached_prompt_tokens = saturating_u32(prefill_token_count);
                         cache_stats.matched_prefix_tokens = saturating_u32(prefill_token_count);
                         cache_stats.suffix_prefill_tokens = 0;
+                        cache_stats.status = "hit";
                         cache_stats.hit_kind = Some("chain_fused_exact_prefix");
                         fused_first_decode = Some(fused);
                     }
@@ -149,6 +155,7 @@ impl StageOpenAiBackend {
                             .len()
                             .saturating_sub(prefill_chain_restored_tokens),
                     );
+                    cache_stats.status = "hit";
                     cache_stats.hit_kind = Some("chain_prefix");
                 }
                 let mut pos_start = prefill_chain_restored_tokens.min(prefill_tokens.len());

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -150,6 +150,7 @@ impl StageOpenAiBackend {
             "llama_stage.completion_token_count".to_string(),
             json!(output.completion_tokens),
         );
+        summary_attrs.insert("skippy.kv.status".to_string(), json!(output.cache_status));
         summary_attrs.insert(
             "skippy.kv.cached_prompt_tokens".to_string(),
             json!(output.cached_prompt_tokens),
@@ -162,9 +163,10 @@ impl StageOpenAiBackend {
             "skippy.kv.suffix_prefill_tokens".to_string(),
             json!(output.suffix_prefill_tokens),
         );
-        if let Some(hit_kind) = output.cache_hit_kind {
-            summary_attrs.insert("skippy.kv.hit_kind".to_string(), json!(hit_kind));
-        }
+        summary_attrs.insert(
+            "skippy.kv.hit_kind".to_string(),
+            json!(output.cache_hit_kind.unwrap_or("none")),
+        );
         summary_attrs.insert(
             "llama_stage.detokenize_ms".to_string(),
             json!(output.detokenize_ms),

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -25,6 +25,7 @@ impl StageOpenAiBackend {
                 let runtime_lock_hold_timer = PhaseTimer::start();
                 let runtime_sessions_before = runtime.session_stats();
                 if let Some(kv) = self.kv.as_ref() {
+                    cache_stats.status = "miss";
                     let base = self.local_kv_message_base(&session_id, request.ids);
                     let kv_identity_timer = PhaseTimer::start();
                     let identities = kv.lookup_identities(&self.config, &base, 0, prefill_tokens);
@@ -33,6 +34,7 @@ impl StageOpenAiBackend {
                     match kv.restore_exact_state(&mut runtime, &session_id, &identities) {
                         Ok(Some(restored)) => {
                             restored_prefill = true;
+                            cache_stats.status = "hit";
                             cache_stats.hit_kind = Some("exact_prefix");
                             let mut attrs = self.openai_attrs(request.ids);
                             attrs.insert("skippy.kv.decision".to_string(), json!("exact_hit"));
@@ -90,6 +92,7 @@ impl StageOpenAiBackend {
                         ) {
                             Ok(Some(restored)) => {
                                 restored_prefill = true;
+                                cache_stats.status = "hit";
                                 cache_stats.hit_kind = Some("resident_prefix");
                                 let mut attrs = self.openai_attrs(request.ids);
                                 attrs.insert(

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::kv_integration::PrefillKvIdentity;
 use async_trait::async_trait;
 use std::io::Cursor;
 use std::{
@@ -124,6 +125,158 @@ fn prefix_cache_test_base() -> MessageBase {
         chat_template_id: Some("template".to_string()),
         seq: Some(1),
     }
+}
+
+fn prefix_cache_base_with_request(request_id: &str, session_id: &str) -> MessageBase {
+    MessageBase {
+        request_id: request_id.to_string(),
+        session_id: session_id.to_string(),
+        ..prefix_cache_test_base()
+    }
+}
+
+fn seed_resident_prefix(kv: &KvStageIntegration, identity: &PrefillKvIdentity) {
+    let token_count = identity.identity.token_count;
+    let mut cache = kv.resident.lock().expect("resident cache lock poisoned");
+    let allocation = cache
+        .allocate_for_record(&identity.page_id, token_count, token_count, |_| Ok(()))
+        .expect("synthetic resident prefix should allocate");
+    assert!(allocation.should_retain);
+    cache.commit_record(
+        identity.page_id.clone(),
+        allocation.seq_id,
+        token_count,
+        token_count,
+    );
+}
+
+#[test]
+fn openai_cache_stats_default_to_disabled() {
+    let stats = GenerationCacheStats::default();
+
+    assert_eq!(stats.status, "disabled");
+    assert_eq!(stats.cached_prompt_tokens, 0);
+    assert_eq!(stats.matched_prefix_tokens, 0);
+    assert_eq!(stats.suffix_prefill_tokens, 0);
+    assert_eq!(stats.hit_kind, None);
+}
+
+#[test]
+fn cache_identity_reuses_repeated_prompts_without_client_cache_key() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let first_request = prefix_cache_base_with_request("request-a", "session-a");
+    let second_request = prefix_cache_base_with_request("request-b", "session-b");
+    let tokens = (0..1024).collect::<Vec<_>>();
+
+    let recorded = kv.prefill_identity(&config, &first_request, 0, &tokens);
+    let looked_up = kv.prefill_identity(&config, &second_request, 0, &tokens);
+
+    assert_eq!(recorded.page_id, looked_up.page_id);
+    assert_eq!(
+        recorded.identity.prefix_hash,
+        looked_up.identity.prefix_hash
+    );
+    assert_ne!(recorded.identity.session_id, looked_up.identity.session_id);
+
+    seed_resident_prefix(&kv, &recorded);
+    let hit = kv
+        .probe_resident_prefix(&looked_up)
+        .expect("repeated prompt should hit without a client cache key");
+    assert_eq!(hit.page_id, recorded.page_id);
+    assert_eq!(hit.token_count, tokens.len());
+}
+
+#[test]
+fn cache_identity_namespaces_explicit_prompt_cache_keys() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let tokens = (0..1024).collect::<Vec<_>>();
+    let mut default_namespace = prefix_cache_test_base();
+    default_namespace.chat_template_id = None;
+    let mut explicit_namespace = prefix_cache_test_base();
+    explicit_namespace.chat_template_id = Some("openai:prompt_cache_key:tenant-a".to_string());
+
+    let default_identity = kv.prefill_identity(&config, &default_namespace, 0, &tokens);
+    let explicit_identity = kv.prefill_identity(&config, &explicit_namespace, 0, &tokens);
+
+    assert_ne!(default_identity.page_id, explicit_identity.page_id);
+    assert_ne!(
+        default_identity.identity.prefix_hash,
+        explicit_identity.identity.prefix_hash
+    );
+}
+
+#[test]
+fn disabled_cache_config_has_no_stage_integration() {
+    let config = StageConfig {
+        kv_cache: Some(StageKvCacheConfig {
+            mode: StageKvCacheMode::Disabled,
+            ..prefix_cache_test_config()
+                .kv_cache
+                .expect("test cache config")
+        }),
+        ..prefix_cache_test_config()
+    };
+
+    let kv = KvStageIntegration::from_config(&config).unwrap();
+
+    assert!(kv.is_none());
+}
+
+#[test]
+fn cold_resident_prefix_lookup_misses_before_recording() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let identity = kv.prefill_identity(
+        &config,
+        &prefix_cache_test_base(),
+        0,
+        &(0..1024).collect::<Vec<_>>(),
+    );
+
+    assert!(kv.probe_resident_prefix(&identity).is_none());
+}
+
+#[test]
+fn resident_prefix_cache_hits_shared_prefix_grid() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let base = prefix_cache_test_base();
+    let recorded_tokens = (0..2214).collect::<Vec<_>>();
+    let mut lookup_tokens = recorded_tokens.clone();
+    lookup_tokens.extend(100_000..100_017);
+    let record_plan = super::prefix_cache::stage0_full_prefill_record_identities(
+        &kv,
+        &config,
+        &base,
+        &recorded_tokens,
+    );
+    let lookup_plan = kv.lookup_identities(&config, &base, 0, &lookup_tokens);
+    let recorded_shared = record_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("record plan should include shared grid prefix");
+    let lookup_shared = lookup_plan
+        .iter()
+        .find(|identity| identity.identity.token_count == 2176)
+        .expect("lookup plan should probe shared grid prefix");
+
+    seed_resident_prefix(&kv, recorded_shared);
+    let hit = kv
+        .probe_resident_prefix(lookup_shared)
+        .expect("different-tail prompt should hit shared prefix grid");
+
+    assert_eq!(hit.page_id, recorded_shared.page_id);
+    assert_eq!(hit.token_count, 2176);
 }
 
 #[test]
@@ -854,6 +1007,7 @@ fn chat_response_from_parsed_message_separates_reasoning_content() {
     let output = GeneratedText {
         prompt_tokens: 4,
         completion_tokens: 7,
+        cache_status: "disabled",
         cached_prompt_tokens: 0,
         matched_prefix_tokens: 0,
         suffix_prefill_tokens: 0,

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Use this hub to find project guides that are not owned by a single Rust crate.
 | [skippy/FAMILY_CERTIFY.md](skippy/FAMILY_CERTIFY.md) | Certification workflow for new families |
 | [skippy/TOPOLOGY_PLANNER.md](skippy/TOPOLOGY_PLANNER.md) | Stage topology planning behavior |
 | [skippy/CONFIGURATION.md](skippy/CONFIGURATION.md) | Authoritative operator matrix for Skippy config keys and rejection boundaries |
+| [skippy/PROMPT_CACHE.md](skippy/PROMPT_CACHE.md) | OpenAI prompt-prefix cache behavior, defaults, telemetry, and benchmark flow |
 | [skippy/DATA_FLOW.md](skippy/DATA_FLOW.md) | Stage data flow and transport details |
 | [skippy/LLAMA_PARITY.md](skippy/LLAMA_PARITY.md) | Remaining llama.cpp parity queue |
 | [specs/layer-package-repos.md](specs/layer-package-repos.md) | Manifest schema and package artifact rules |

--- a/docs/skippy/PROMPT_CACHE.md
+++ b/docs/skippy/PROMPT_CACHE.md
@@ -1,0 +1,109 @@
+# Skippy OpenAI Prompt Cache
+
+Skippy OpenAI serving has an automatic prompt-prefix cache for normal text
+generation. The cache is intended to provide the same operator-facing outcome
+as llama-server prompt reuse: repeated prompts, and prompts with a long shared
+prefix, avoid recomputing the whole prefix on later requests.
+
+## llama-server Reference Behavior
+
+llama-server keeps prompt state in serving slots. With `cache_prompt` enabled,
+each request compares its prompt tokens with the selected slot and reuses the
+longest common prefix already resident in that slot. With `--cache-ram`,
+llama-server can also save idle slot state into a RAM prompt cache and reload
+the closest reusable prompt state later. No client cache key is required for
+the common case.
+
+Important llama-server properties:
+
+- `cache_prompt` controls per-request prompt reuse.
+- `--cache-ram N` enables RAM prompt-cache storage.
+- idle slots may be saved to the prompt cache and cleared.
+- later requests choose reusable state by prompt similarity or cache lookup.
+- reported timings include cached versus processed prompt tokens.
+
+## Skippy Behavior
+
+Skippy uses the stage KV integration rather than llama-server slots. When a
+stage has `kv_cache.mode = "lookup-record"`, Skippy records prompt-prefix
+state after prefill and probes that state before later OpenAI chat/completion
+requests. A client `prompt_cache_key` is optional; ordinary requests without a
+key share the default namespace and can hit automatically.
+
+Skippy records exact prompt-prefix identities and a small shared-prefix grid.
+The exact path covers identical prompts. The shared-prefix path covers prompts
+whose common prefix falls on the configured stride, such as a stable system
+prompt or tool schema followed by different user tails. This is not arbitrary
+llama-server LCP slot selection; it is deterministic prefix identity probing.
+
+Skippy reports cache state in OpenAI usage and telemetry:
+
+- `usage.prompt_tokens_details.cached_tokens` is the OpenAI-compatible cached
+  prompt token count.
+- `stage.openai_generation_summary` emits `skippy.kv.status`, one of
+  `disabled`, `miss`, or `hit`.
+- The same summary emits `skippy.kv.cached_prompt_tokens`,
+  `skippy.kv.matched_prefix_tokens`, `skippy.kv.suffix_prefill_tokens`, and
+  `skippy.kv.hit_kind`. The hit kind is `none` for disabled or missed cache
+  lookups.
+
+## mesh-llm Defaults
+
+mesh-llm wires Skippy prefix cache through family policy. For supported model
+families, generated `StageConfig` values receive a bounded cache config with
+`mode = "lookup-record"` and a production payload such as `resident-kv` or
+`kv-recurrent`. This applies to normal mesh-llm embedded Skippy serving without
+requiring users to send `prompt_cache_key`.
+
+The default is conditional, not universal:
+
+- unsupported or unknown families may leave `kv_cache` unset.
+- raw `skippy-server serve-openai` leaves cache off unless the stage config or
+  `SKIPPY_KV_CACHE`/`SKIPPY_PREFIX_CACHE` enables it.
+- operators can disable cache with `model_fit.prompt_cache = false` or
+  `model_fit.prefix_cache.enabled = false`.
+- recurrent-state families use `kv-recurrent` rather than `resident-kv` when
+  the family policy requires it.
+
+## Benchmarking
+
+Use `evals/skippy-openai-cache-matrix.py` to compare cold and warm behavior
+across native llama-server and Skippy OpenAI endpoints. The script records four
+rows:
+
+- cold native: llama-server with request cache disabled.
+- cold Skippy: Skippy endpoint started with prefix cache disabled.
+- warm native: llama-server with request cache enabled.
+- warm Skippy: Skippy endpoint started with prefix cache enabled.
+
+The report is intended to prove cache behavior before comparing timing. Each
+row includes a verdict, observed cache statuses, prompt tokens, cacheable
+prefix tokens, cached tokens, suffix/uncached prefix tokens, and cache
+efficiency. For Skippy OpenAI chat generation, the cacheable prefix excludes
+the final current token that drives decode, so `cacheable = prompt_tokens - 1`.
+
+Example:
+
+```bash
+python3 evals/skippy-openai-cache-matrix.py \
+  --llama-cold-base-url http://127.0.0.1:8081 \
+  --llama-warm-base-url http://127.0.0.1:8082 \
+  --skippy-cold-base-url http://127.0.0.1:9337/v1 \
+  --skippy-warm-base-url http://127.0.0.1:9447/v1 \
+  --model Qwen/Qwen3-0.6B:Q4_K_M \
+  --output-dir target/skippy-openai-cache-matrix/local
+```
+
+Start the cold native endpoint with `--cache-ram 0`. Start the warm native
+endpoint with `--cache-ram N` or the llama-server default prompt-cache setting.
+
+The default benchmark pattern is `exact`, so the warmup and measured request
+use the same prompt. To exercise Skippy's shared-prefix grid against
+llama-server's LCP reuse, add `--pattern shared-prefix`. By default, the script
+exits non-zero when either warm row reports zero cached tokens; use
+`--allow-missing-warm-cache` only for exploratory timing runs where the endpoint
+does not expose cached-token counts.
+
+The cold Skippy endpoint should use a config with no `kv_cache` or with
+`kv_cache.mode = "disabled"`. The warm Skippy endpoint should use mesh-llm
+family defaults or an explicit `lookup-record` prefix cache.

--- a/evals/skippy-openai-cache-matrix.py
+++ b/evals/skippy-openai-cache-matrix.py
@@ -1,0 +1,568 @@
+#!/usr/bin/env python3
+"""Compare native llama-server and Skippy OpenAI prompt-cache behavior.
+
+The runner attaches to already-running endpoints. Skippy cache mode is a stage
+configuration choice, so pass separate cold and warm Skippy endpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import time
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BenchRequest:
+    shared_prefix: str
+    measured_tail: str
+    warmup_tail: str
+    pattern: str
+
+
+def http_json(
+    url: str,
+    payload: dict[str, Any],
+    api_key: str | None,
+    timeout: float,
+) -> dict[str, Any]:
+    headers = {"content-type": "application/json"}
+    if api_key:
+        headers["authorization"] = f"Bearer {api_key}"
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def elapsed_request(
+    url: str,
+    payload: dict[str, Any],
+    api_key: str | None,
+    timeout: float,
+) -> tuple[dict[str, Any], float]:
+    started = time.monotonic()
+    response = http_json(url, payload, api_key, timeout)
+    return response, (time.monotonic() - started) * 1000.0
+
+
+def llama_payload(prompt: str, max_tokens: int, cache_prompt: bool) -> dict[str, Any]:
+    return {
+        "prompt": prompt,
+        "n_predict": max_tokens,
+        "temperature": 0,
+        "top_k": 1,
+        "cache_prompt": cache_prompt,
+    }
+
+
+def skippy_payload(
+    model: str,
+    shared_prefix: str,
+    tail: str,
+    max_tokens: int,
+) -> dict[str, Any]:
+    return {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": shared_prefix},
+            {"role": "user", "content": tail},
+        ],
+        "temperature": 0,
+        "top_p": 1,
+        "max_tokens": max_tokens,
+    }
+
+
+def prompt_text(request: BenchRequest, tail: str) -> str:
+    return f"System prefix:\n{request.shared_prefix}\n\nUser request:\n{tail}\n"
+
+
+def cached_tokens_from_skippy(response: dict[str, Any]) -> int:
+    usage = response.get("usage") or {}
+    details = usage.get("prompt_tokens_details") or {}
+    value = details.get("cached_tokens", 0)
+    return int(value) if isinstance(value, (int, float)) else 0
+
+
+def prompt_tokens_from_skippy(response: dict[str, Any]) -> int:
+    usage = response.get("usage") or {}
+    value = usage.get("prompt_tokens", 0)
+    return int(value) if isinstance(value, (int, float)) else 0
+
+
+def cache_tokens_from_llama(response: dict[str, Any]) -> int:
+    timings = response.get("timings") or {}
+    for key in ("cache_n", "tokens_cached"):
+        value = timings.get(key)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def prompt_tokens_from_llama(response: dict[str, Any]) -> int:
+    timings = response.get("timings") or {}
+    for key in ("prompt_n", "tokens_evaluated"):
+        value = timings.get(key)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def total_prompt_tokens_from_llama(response: dict[str, Any]) -> int:
+    processed = prompt_tokens_from_llama(response)
+    cached = cache_tokens_from_llama(response)
+    return processed + cached
+
+
+def cacheable_prefix_tokens(prompt_tokens: int, backend: str) -> int:
+    if backend == "skippy-openai":
+        return max(prompt_tokens - 1, 0)
+    return prompt_tokens
+
+
+def cache_status(cache_mode: str, cached_tokens: int) -> str:
+    if "disabled" in cache_mode or "false" in cache_mode:
+        return "disabled"
+    if cached_tokens > 0:
+        return "hit"
+    return "miss"
+
+
+def hit_kind(backend: str, status: str) -> str:
+    if status != "hit":
+        return "none"
+    if backend == "llama-server":
+        return "llama_prompt_cache"
+    return "usage_cached_tokens"
+
+
+def cache_observation(
+    backend: str,
+    cache_mode: str,
+    prompt_tokens: int,
+    cached_tokens: int,
+) -> dict[str, Any]:
+    cacheable_tokens = cacheable_prefix_tokens(prompt_tokens, backend)
+    status = cache_status(cache_mode, cached_tokens)
+    uncached_tokens = max(cacheable_tokens - cached_tokens, 0)
+    efficiency = (cached_tokens / cacheable_tokens) if cacheable_tokens else 0.0
+    return {
+        "cache_status": status,
+        "hit_kind": hit_kind(backend, status),
+        "cacheable_prefix_tokens": cacheable_tokens,
+        "cached_tokens": cached_tokens,
+        "suffix_prefill_tokens": uncached_tokens,
+        "cache_efficiency": efficiency,
+    }
+
+
+def run_observation(
+    backend: str,
+    cache_mode: str,
+    elapsed_ms: float,
+    prompt_tokens: int,
+    cached_tokens: int,
+    run: int | None = None,
+) -> dict[str, Any]:
+    observation = {
+        "elapsed_ms": elapsed_ms,
+        "prompt_tokens": prompt_tokens,
+        **cache_observation(backend, cache_mode, prompt_tokens, cached_tokens),
+    }
+    if run is not None:
+        observation = {"run": run, **observation}
+    return observation
+
+
+def median(values: list[float]) -> float | None:
+    return statistics.median(values) if values else None
+
+
+def summarize_row(
+    name: str,
+    backend: str,
+    cache_mode: str,
+    runs: list[dict[str, Any]],
+    warmup: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    elapsed = [
+        float(run["elapsed_ms"])
+        for run in runs
+        if isinstance(run.get("elapsed_ms"), (int, float))
+    ]
+    cached = [
+        int(run["cached_tokens"])
+        for run in runs
+        if isinstance(run.get("cached_tokens"), (int, float))
+    ]
+    prompt_tokens = [
+        int(run["prompt_tokens"])
+        for run in runs
+        if isinstance(run.get("prompt_tokens"), (int, float))
+    ]
+    cacheable_tokens = [
+        int(run["cacheable_prefix_tokens"])
+        for run in runs
+        if isinstance(run.get("cacheable_prefix_tokens"), (int, float))
+    ]
+    suffix_prefill = [
+        int(run["suffix_prefill_tokens"])
+        for run in runs
+        if isinstance(run.get("suffix_prefill_tokens"), (int, float))
+    ]
+    efficiencies = [
+        float(run["cache_efficiency"])
+        for run in runs
+        if isinstance(run.get("cache_efficiency"), (int, float))
+    ]
+    max_prompt_tokens = max(prompt_tokens) if prompt_tokens else 0
+    max_cacheable_tokens = max(cacheable_tokens) if cacheable_tokens else 0
+    min_cached_tokens = min(cached) if cached else 0
+    max_cached_tokens = max(cached) if cached else 0
+    max_suffix_prefill_tokens = max(suffix_prefill) if suffix_prefill else 0
+    max_prompt_ratio = (max_cached_tokens / max_prompt_tokens) if max_prompt_tokens else 0.0
+    min_cache_efficiency = min(efficiencies) if efficiencies else 0.0
+    max_cache_efficiency = max(efficiencies) if efficiencies else 0.0
+    statuses = sorted({str(run.get("cache_status", "unknown")) for run in runs})
+    verdict = cache_verdict(cache_mode, cached)
+    return {
+        "name": name,
+        "backend": backend,
+        "cache_mode": cache_mode,
+        "warmup": warmup,
+        "runs": runs,
+        "verdict": verdict,
+        "cache_statuses": statuses,
+        "median_elapsed_ms": median(elapsed),
+        "mean_cached_tokens": (sum(cached) / len(cached)) if cached else 0,
+        "min_cached_tokens": min_cached_tokens,
+        "max_cached_tokens": max_cached_tokens,
+        "max_prompt_tokens": max_prompt_tokens,
+        "max_cacheable_prefix_tokens": max_cacheable_tokens,
+        "max_suffix_prefill_tokens": max_suffix_prefill_tokens,
+        "max_prompt_cached_ratio": max_prompt_ratio,
+        "min_cache_efficiency": min_cache_efficiency,
+        "max_cache_efficiency": max_cache_efficiency,
+    }
+
+
+def cache_verdict(cache_mode: str, cached_tokens: list[int]) -> str:
+    if "disabled" in cache_mode or "false" in cache_mode:
+        return (
+            "PASS disabled/no-cache"
+            if all(cached == 0 for cached in cached_tokens)
+            else "FAIL disabled cached"
+        )
+    if cached_tokens and all(cached > 0 for cached in cached_tokens):
+        return "PASS all-hit"
+    return "FAIL missed-hit"
+
+
+def format_range(min_value: int | float, max_value: int | float, suffix: str = "") -> str:
+    if min_value == max_value:
+        return f"{min_value}{suffix}"
+    return f"{min_value}{suffix}-{max_value}{suffix}"
+
+
+def format_percent_range(min_value: float, max_value: float) -> str:
+    if min_value == max_value:
+        return f"{min_value:.1%}"
+    return f"{min_value:.1%}-{max_value:.1%}"
+
+
+def run_llama_row(
+    base_url: str,
+    request: BenchRequest,
+    repeats: int,
+    max_tokens: int,
+    cache_prompt: bool,
+    timeout: float,
+    warmup: bool,
+) -> dict[str, Any]:
+    base_url = base_url.rstrip("/")
+    url = f"{base_url}/completion"
+    backend = "llama-server"
+    mode = "warm" if cache_prompt else "cold"
+    cache_mode = "cache_prompt=true" if cache_prompt else "cache_prompt=false"
+    warmup_result = None
+    if warmup:
+        response, elapsed_ms = elapsed_request(
+            url,
+            llama_payload(prompt_text(request, request.warmup_tail), max_tokens, cache_prompt),
+            None,
+            timeout,
+        )
+        warmup_result = run_observation(
+            backend,
+            cache_mode,
+            elapsed_ms,
+            total_prompt_tokens_from_llama(response),
+            cache_tokens_from_llama(response),
+        )
+
+    runs = []
+    payload = llama_payload(prompt_text(request, request.measured_tail), max_tokens, cache_prompt)
+    for index in range(repeats):
+        response, elapsed_ms = elapsed_request(url, payload, None, timeout)
+        runs.append(
+            run_observation(
+                backend,
+                cache_mode,
+                elapsed_ms,
+                total_prompt_tokens_from_llama(response),
+                cache_tokens_from_llama(response),
+                run=index + 1,
+            )
+        )
+    return summarize_row(
+        f"{mode} native",
+        backend,
+        cache_mode,
+        runs,
+        warmup_result,
+    )
+
+
+def run_skippy_row(
+    base_url: str,
+    model: str,
+    request: BenchRequest,
+    repeats: int,
+    max_tokens: int,
+    api_key: str | None,
+    timeout: float,
+    warmup: bool,
+    name: str,
+    cache_mode: str,
+) -> dict[str, Any]:
+    base_url = base_url.rstrip("/")
+    url = f"{base_url}/chat/completions"
+    backend = "skippy-openai"
+    warmup_result = None
+    if warmup:
+        response, elapsed_ms = elapsed_request(
+            url,
+            skippy_payload(model, request.shared_prefix, request.warmup_tail, max_tokens),
+            api_key,
+            timeout,
+        )
+        warmup_result = run_observation(
+            backend,
+            cache_mode,
+            elapsed_ms,
+            prompt_tokens_from_skippy(response),
+            cached_tokens_from_skippy(response),
+        )
+
+    runs = []
+    payload = skippy_payload(model, request.shared_prefix, request.measured_tail, max_tokens)
+    for index in range(repeats):
+        response, elapsed_ms = elapsed_request(url, payload, api_key, timeout)
+        runs.append(
+            run_observation(
+                backend,
+                cache_mode,
+                elapsed_ms,
+                prompt_tokens_from_skippy(response),
+                cached_tokens_from_skippy(response),
+                run=index + 1,
+            )
+        )
+    return summarize_row(name, backend, cache_mode, runs, warmup_result)
+
+
+def markdown_report(rows: list[dict[str, Any]]) -> str:
+    lines = [
+        "| Mode | Verdict | Warmup | Statuses | Cache mode | Median ms | Prompt | Cacheable | Cached | Suffix/uncached | Prompt ratio | Cache efficiency |",
+        "| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        median_ms = row.get("median_elapsed_ms")
+        prompt_ratio = row.get("max_prompt_cached_ratio")
+        min_efficiency = row.get("min_cache_efficiency")
+        max_efficiency = row.get("max_cache_efficiency")
+        warmup = row.get("warmup") or {}
+        warmup_status = warmup.get("cache_status", "none")
+        lines.append(
+            "| {name} | {verdict} | {warmup} | {statuses} | `{cache_mode}` | {median_ms} | {prompt} | {cacheable} | {cached} | {suffix} | {prompt_ratio} | {efficiency} |".format(
+                name=row["name"],
+                verdict=row["verdict"],
+                warmup=warmup_status,
+                statuses=", ".join(row["cache_statuses"]),
+                cache_mode=row["cache_mode"],
+                median_ms=f"{median_ms:.1f}" if isinstance(median_ms, (int, float)) else "n/a",
+                prompt=row["max_prompt_tokens"],
+                cacheable=row["max_cacheable_prefix_tokens"],
+                cached=format_range(row["min_cached_tokens"], row["max_cached_tokens"]),
+                suffix=row["max_suffix_prefill_tokens"],
+                prompt_ratio=(
+                    f"{prompt_ratio:.1%}"
+                    if isinstance(prompt_ratio, (int, float))
+                    else "n/a"
+                ),
+                efficiency=(
+                    format_percent_range(min_efficiency, max_efficiency)
+                    if isinstance(min_efficiency, (int, float))
+                    and isinstance(max_efficiency, (int, float))
+                    else "n/a"
+                ),
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_request(prefix_repetitions: int, pattern: str) -> BenchRequest:
+    prefix = "Skippy prompt cache benchmark shared prefix. " * prefix_repetitions
+    measured_tail = "Measure the reusable prefix and answer with the word measured."
+    warmup_tail = measured_tail
+    if pattern == "shared-prefix":
+        warmup_tail = "Warm the reusable prefix and answer with the word warmup."
+    return BenchRequest(
+        shared_prefix=prefix,
+        warmup_tail=warmup_tail,
+        measured_tail=measured_tail,
+        pattern=pattern,
+    )
+
+
+def require_warm_cache(rows: list[dict[str, Any]]) -> None:
+    warm_rows = [row for row in rows if row["name"] in {"warm native", "warm Skippy"}]
+    failures = [
+        row["name"]
+        for row in warm_rows
+        if not isinstance(row.get("max_cached_tokens"), int)
+        or row["max_cached_tokens"] <= 0
+    ]
+    if failures:
+        joined = ", ".join(failures)
+        raise SystemExit(f"warm cache proof failed: {joined} reported zero cached tokens")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--llama-base-url",
+        help="Use one llama-server endpoint for both native rows; prefer separate cold/warm URLs for strict comparisons",
+    )
+    parser.add_argument(
+        "--llama-cold-base-url",
+        help="llama-server endpoint started with prompt cache disabled, for example --cache-ram 0",
+    )
+    parser.add_argument(
+        "--llama-warm-base-url",
+        help="llama-server endpoint started with prompt cache enabled, for example --cache-ram N",
+    )
+    parser.add_argument("--skippy-cold-base-url", required=True)
+    parser.add_argument("--skippy-warm-base-url", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--api-key")
+    parser.add_argument("--prefix-repetitions", type=int, default=256)
+    parser.add_argument(
+        "--pattern",
+        choices=("exact", "shared-prefix"),
+        default="exact",
+        help="exact repeats the whole prompt; shared-prefix warms a common prefix with a different tail",
+    )
+    parser.add_argument("--max-tokens", type=int, default=16)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--timeout", type=float, default=120.0)
+    parser.add_argument(
+        "--allow-missing-warm-cache",
+        action="store_true",
+        help="write timing results even if warm rows report zero cached tokens",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("target/skippy-openai-cache-matrix"),
+    )
+    args = parser.parse_args()
+
+    if args.prefix_repetitions <= 0:
+        raise SystemExit("--prefix-repetitions must be positive")
+    if args.repeats <= 0:
+        raise SystemExit("--repeats must be positive")
+    if args.max_tokens <= 0:
+        raise SystemExit("--max-tokens must be positive")
+    llama_cold_base_url = args.llama_cold_base_url or args.llama_base_url
+    llama_warm_base_url = args.llama_warm_base_url or args.llama_base_url
+    if not llama_cold_base_url or not llama_warm_base_url:
+        raise SystemExit(
+            "pass --llama-cold-base-url and --llama-warm-base-url, or pass --llama-base-url"
+        )
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    request = build_request(args.prefix_repetitions, args.pattern)
+    rows = [
+        run_llama_row(
+            llama_cold_base_url,
+            request,
+            args.repeats,
+            args.max_tokens,
+            cache_prompt=False,
+            timeout=args.timeout,
+            warmup=False,
+        ),
+        run_skippy_row(
+            args.skippy_cold_base_url,
+            args.model,
+            request,
+            args.repeats,
+            args.max_tokens,
+            args.api_key,
+            args.timeout,
+            warmup=False,
+            name="cold Skippy",
+            cache_mode="prefix-cache-disabled",
+        ),
+        run_llama_row(
+            llama_warm_base_url,
+            request,
+            args.repeats,
+            args.max_tokens,
+            cache_prompt=True,
+            timeout=args.timeout,
+            warmup=True,
+        ),
+        run_skippy_row(
+            args.skippy_warm_base_url,
+            args.model,
+            request,
+            args.repeats,
+            args.max_tokens,
+            args.api_key,
+            args.timeout,
+            warmup=True,
+            name="warm Skippy",
+            cache_mode="prefix-cache-enabled",
+        ),
+    ]
+    result = {
+        "model": args.model,
+        "pattern": request.pattern,
+        "prefix_repetitions": args.prefix_repetitions,
+        "max_tokens": args.max_tokens,
+        "repeats": args.repeats,
+        "rows": rows,
+    }
+    (args.output_dir / "cache-matrix.json").write_text(json.dumps(result, indent=2) + "\n")
+    (args.output_dir / "cache-matrix.md").write_text(markdown_report(rows))
+    print(markdown_report(rows))
+    print(f"Wrote {args.output_dir / 'cache-matrix.json'}")
+    print(f"Wrote {args.output_dir / 'cache-matrix.md'}")
+    if not args.allow_missing_warm_cache:
+        require_warm_cache(rows)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

This PR makes Skippy's normal OpenAI prompt-cache behavior explicit, observable, tested, and benchmarkable against llama-server.

- Documents how llama-server prompt cache reuse works versus Skippy's stage KV prefix-cache model.
- Documents the important default: mesh-llm enables Skippy prefix cache automatically for supported family-policy paths, while raw `skippy-server serve-openai` still needs explicit config/env.
- Adds request-summary telemetry for every OpenAI generation request: `skippy.kv.status`, `skippy.kv.cached_prompt_tokens`, `skippy.kv.matched_prefix_tokens`, `skippy.kv.suffix_prefill_tokens`, and `skippy.kv.hit_kind`.
- Strengthens tests for cold miss, repeated prompt reuse without client cache keys, shared-prefix grid hits, disabled cache config, and mesh-llm family-policy default wiring.
- Adds `evals/skippy-openai-cache-matrix.py`, a focused four-way benchmark runner for cold/warm llama-server and cold/warm Skippy OpenAI endpoints.

## Why this is materially better than before

Before this change, Skippy had cache machinery, but ordinary OpenAI serving was hard to reason about from the outside: it was unclear when cache was enabled by mesh-llm defaults, whether repeated requests could hit without a client cache key, and whether warm Skippy behavior could be compared directly with llama-server prompt-cache behavior.

After this change, that story is concrete:

- Operators can tell whether a request was `disabled`, `miss`, or `hit` from telemetry instead of inferring from latency.
- Cached, matched-prefix, and suffix-prefill token counts are reported consistently, so warm reuse is visible in the same request summary that already carries generation timing.
- The tests prove repeated prompts and shared-prefix prompts can reuse state automatically without requiring `prompt_cache_key`.
- The resolver test proves supported mesh-llm Skippy family-policy paths wire `lookup-record` prefix cache by default.
- The benchmark runner now produces an assertive cache-behavior matrix: verdicts, warmup state, measured statuses, prompt tokens, cacheable prefix tokens, cached-token ranges, suffix/uncached prefix tokens, and cache efficiency. Timing remains in the report, but no longer has to be the proof.

Local benchmark evidence from the new matrix runner:

| Mode | Verdict | Warmup | Statuses | Cache mode | Median ms | Prompt | Cacheable | Cached | Suffix/uncached | Prompt ratio | Cache efficiency |
| --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| cold native | PASS disabled/no-cache | none | disabled | `cache_prompt=false` | 102.9 | 94 | 94 | 0 | 94 | 0.0% | 0.0% |
| cold Skippy | PASS disabled/no-cache | none | disabled | `prefix-cache-disabled` | 112.4 | 98 | 97 | 0 | 97 | 0.0% | 0.0% |
| warm native | PASS all-hit | miss | hit | `cache_prompt=true` | 6.8 | 94 | 94 | 93 | 1 | 98.9% | 98.9% |
| warm Skippy | PASS all-hit | miss | hit | `prefix-cache-enabled` | 15.3 | 98 | 97 | 94-95 | 3 | 96.9% | 96.9%-97.9% |

This makes the important behavior visible: warm Skippy is hitting on every measured run and reusing 94-95 of 97 cacheable prefix tokens, while the cold Skippy row remains disabled/no-cache.

## Validation

- `cargo test -p skippy-server --lib frontend::tests:: -- --nocapture`
- `cargo test -p skippy-server --lib`
- `cargo test -p mesh-llm-host-runtime --lib "inference::skippy::resolver::tests"`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `python3 -m py_compile evals/skippy-openai-cache-matrix.py`
- `python3 evals/skippy-openai-cache-matrix.py --help`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt-prefix cache status tracking now reported in generation responses and telemetry
  * Resident prefix cache with cross-session identity reuse support
  * Cache benchmarking tool for performance evaluation

* **Documentation**
  * Added comprehensive prompt-cache documentation covering behavior, defaults, and benchmarking guidance

* **Tests**
  * Expanded cache testing coverage including cold/warm scenarios, namespace isolation, and cache-disabled modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->