### PR TITLE
[draft] Preserve GLM native MTP n=1 gains through Skippy

### DIFF
--- a/docs/design/GLM_NATIVE_MTP_SKIPPY.md
+++ b/docs/design/GLM_NATIVE_MTP_SKIPPY.md
@@ -1,0 +1,121 @@
+# GLM Native MTP Through Skippy
+
+## Objective
+
+Preserve the proven GLM-4.7 Flash native-MTP `n=1` speedup through Skippy before
+attempting wider speculative windows or GLM-5.1.
+
+This is intentionally narrower than speculative pipeline decoding. Native MTP is
+the proposer; Skippy still owns staged target verification, rollback, cache
+state, and user-visible serving.
+
+## Current Evidence
+
+GLM-4.7 Flash native MTP works in the patched llama.cpp serving path when
+`--spec-type draft-mtp --spec-draft-n-max 1` is used.
+
+Latest b2d6 rebench, run on 2026-06-15 with
+`jamesdumay/GLM-4.7-Flash-MTP-GGUF`:
+
+| Run | Requests | Avg decode tok/s | Speedup | Acceptance |
+|---|---:|---:|---:|---:|
+| baseline | 8 | 43.66 | 1.00x | n/a |
+| MTP `n=1` | 8 | 60.09 | 1.38x | 67.2% |
+| MTP `n=2` | 8 | 48.80 | 1.12x | 38.6% |
+| MTP `n=3` | 8 | 34.16 | 0.78x | 21.7% |
+
+Earlier 2026-06-11 evidence showed the same shape:
+
+| Run | Requests | Avg decode tok/s | Speedup | Acceptance |
+|---|---:|---:|---:|---:|
+| baseline | 8 | 41.33 | 1.00x | n/a |
+| MTP `n=1` | 8 | 60.84 | 1.47x | 67.2% |
+| MTP `n=2` | 8 | 44.07 | 1.07x | 38.6% |
+| MTP `n=3` | 8 | 36.06 | 0.87x | 21.7% |
+
+The drafted/accepted token counts are identical across both SPEED-Bench runs.
+The smaller b2d6 headline speedup comes from a faster non-MTP baseline, not from
+a lower-quality MTP proposer.
+
+Experiment artifacts:
+
+- `lab-experiments/jianyang/phase-4/iteration-2.md`
+- `lab-experiments/jianyang/benchmarks/speed-bench/results/20260615T080125Z-b2d6-mtp`
+
+## Decision
+
+Skippy should target native MTP `n=1` first.
+
+`n=2` and `n=3` should stay disabled by default for GLM-4.7 Flash. `n=2` is too
+thin and workload-sensitive to justify as a default. `n=3` is a clear
+regression because acceptance collapses faster than verification amortization
+improves.
+
+## PR Scope
+
+The first implementation PR should:
+
+- keep GLM MTP as a proposer sidecar, not a trunk layer;
+- keep Skippy trunk stage ranges bounded to transformer layers only;
+- wire one native-MTP proposed token into Skippy target verification;
+- preserve byte-identical output versus non-MTP baseline under greedy sampling;
+- record drafted, accepted, rejected, acceptance-rate, proposer latency,
+  verifier latency, and visible tok/s metrics; and
+- expose `n=1` as the only supported GLM native-MTP setting.
+
+## Non-Goals
+
+This first PR should not attempt:
+
+- GLM-5.1 native MTP serving;
+- multi-token speculative windows beyond `n=1`;
+- external draft-model speculation;
+- speculative pipeline decoding;
+- multi-host performance claims before single-node parity is proven; or
+- turning MTP blocks into ordinary Skippy trunk stages.
+
+## Acceptance Gates
+
+Before promotion from draft, the implementation must show:
+
+1. GLM-4.7 Flash baseline and Skippy native-MTP output are byte-identical for a
+   fixed greedy prompt.
+2. Accepted draft tokens are nonzero.
+3. Skippy native-MTP `n=1` beats Skippy baseline on the same SPEED-Bench corpus.
+4. `n=2` and `n=3` remain disabled or explicitly experimental.
+5. Benchmark artifacts are recorded in `lab-experiments`.
+
+## Validation Plan
+
+Minimum local validation:
+
+```bash
+scripts/prepare-llama.sh pinned
+just build
+cargo test -p skippy-ffi --lib
+cargo test -p skippy-runtime --lib
+```
+
+Then run GLM-4.7 Flash native-MTP checks:
+
+```bash
+# Native llama.cpp reference
+RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-native-mtp" \
+LLAMA_DIR=/path/to/patched/llama.cpp \
+/Users/jdumay/code/lab-experiments/jianyang/benchmarks/speed-bench/run-glm47-mtp-speed-bench.sh
+```
+
+The Skippy implementation should add an equivalent focused runner for the
+Skippy native-MTP path and record its results beside the native llama.cpp
+reference.
+
+## Open Implementation Questions
+
+- Which Skippy runtime owns the MTP proposer context: final stage, coordinator,
+  or a dedicated sidecar?
+- What is the smallest ABI surface needed to pass the target hidden state into
+  the proposer without exposing wider SPD state?
+- Can the `n=1` path reuse existing staged verification trim/checkpoint APIs, or
+  does it need a simpler single-token rollback path?
+- Which metric names should become stable telemetry versus benchmark-only
+  fields?


### PR DESCRIPTION
This draft PR establishes the implementation contract for carrying the proven GLM-4.7 Flash native-MTP `n=1` speedup through Skippy split serving.

It does not implement the runtime path yet. The goal is to lock the evidence, scope, non-goals, and acceptance gates before changing the staged llama.cpp ABI or Skippy runtime behavior.

## Evidence

Latest b2d6 rebench on 2026-06-15 with `jamesdumay/GLM-4.7-Flash-MTP-GGUF`:

| Run | Requests | Avg decode tok/s | Speedup | Acceptance |
|---|---:|---:|---:|---:|
| baseline | 8 | 43.66 | 1.00x | n/a |
| MTP `n=1` | 8 | 60.09 | 1.38x | 67.2% |
| MTP `n=2` | 8 | 48.80 | 1.12x | 38.6% |
| MTP `n=3` | 8 | 34.16 | 0.78x | 21.7% |

Earlier 2026-06-11 evidence showed the same shape: `n=1` wins, `n=2` is thin, and `n=3` regresses. The drafted/accepted token counts match across both runs, so the b2d6 patches preserve the native MTP win but do not materially improve it.

Lab evidence was recorded in `lab-experiments` commit `3a0ae3e`:

- `jianyang/phase-4/iteration-2.md`
- `jianyang/benchmarks/speed-bench/results/20260615T080125Z-b2d6-mtp`

## Scope

This PR proposes the first implementation lane:

- keep GLM MTP as a proposer sidecar, not a trunk layer;
- keep Skippy trunk stage ranges bounded to transformer layers only;
- wire one native-MTP proposed token into Skippy target verification;
- preserve byte-identical output versus non-MTP baseline under greedy sampling;
- record drafted, accepted, rejected, acceptance-rate, proposer latency, verifier latency, and visible tok/s metrics; and
- expose `n=1` as the only supported GLM native-MTP setting.

## Non-goals

- GLM-5.1 native MTP serving.
- Multi-token speculative windows beyond `n=1`.
- External draft-model speculation.
- Speculative pipeline decoding.
- Multi-host performance claims before single-node parity is proven.
- Treating MTP blocks as ordinary Skippy trunk stages.

## Acceptance gates

Before this draft can become an implementation PR, the implementation should show:

1. GLM-4.7 Flash baseline and Skippy native-MTP output are byte-identical for a fixed greedy prompt.
2. Accepted draft tokens are nonzero.
3. Skippy native-MTP `n=1` beats Skippy baseline on the same SPEED-Bench corpus.
4. `n=2` and `n=3` remain disabled or explicitly experimental.
5. Benchmark artifacts are recorded in `lab-experiments`.

## Validation

For this planning PR:

- `git diff --cached --check`
- ASCII scan of `docs/design/GLM_NATIVE_MTP_SKIPPY.md`
- Native llama.cpp b2d6 SPEED-Bench rebench recorded in `lab-experiments`

No mesh-llm build or Rust tests were run because this PR only adds documentation.
