### PR TITLE
Add GLM 4.7 SPD sidecar acceleration

### DIFF
--- a/SPD_SKIPPY_PROJECT.md
+++ b/SPD_SKIPPY_PROJECT.md
@@ -1,0 +1,394 @@
+# SPD for Skippy Project Handoff
+
+This branch captures the current public proof and next implementation steps for
+running Speculative Pipeline Decoding (SPD) in Skippy.
+
+It intentionally excludes private lab hosts, credentials, local IPs, and
+machine-specific notes. Use it as a research/implementation handoff that another
+engineer can reproduce from open models, open data, and the checked-in scripts.
+
+## Source Paper
+
+Paper: **Speculative Pipeline Decoding: Higher-Accuracy and Zero-Bubble
+Speculation via Pipeline Parallelism**
+
+- arXiv: `https://arxiv.org/abs/2605.30852`
+- Reference code: `https://github.com/yuyijiong/speculative_pipeline_decoding`
+
+The core idea is to combine pipeline parallel target-model execution with a
+trained speculation module. The target model is partitioned into `n` pipeline
+stages. While the target pipeline is processing one token per stage, the SPD
+head consumes selected intermediate hidden states from the pipeline and proposes
+future draft token(s). The target model still verifies the draft tokens, so with
+verification enabled the output follows the base model's decoding path.
+
+## Why This Matters for Skippy
+
+Skippy already splits a model across staged runtimes. Ordinary split decoding is
+sensitive to stage and network latency because each generated token must traverse
+the full stage chain before the next target token is known.
+
+SPD is interesting because it can fill the pipeline and amortize that stage/hop
+latency across accepted speculative work. The quality question is whether the
+sidecar head accepts enough tokens. The engineering question is whether Skippy
+can expose the required hidden-state taps and verify proposals without breaking
+target-model equivalence.
+
+Headline current result: the pretrained `Qwen/Qwen3.5-4B` SPD head accepted
+`1230 / 1536` draft flags on the local reference eval, with equivalent accept
+length `2.4704` and token-weighted theoretical gain `163.39%`. Feeding that
+same real trace into a four-stage Skippy latency model with `4ms` per stage
+estimated `9.882x` SPD-vs-serial split throughput at `0ms` hop, `8.117x` at
+`10ms` hop, and `7.752x` at `25ms` hop.
+
+## What Works Today
+
+### 1. Real Small-Model Training Proof
+
+`evals/spd/hf_train_eval_qwen06.py` trains a real SPD head using the paper's
+reference code.
+
+Recorded local proof:
+
+| Model | Training data | Head | Generated tokens | Accepted flags | Acceptance | Equivalent accept length | Theoretical gain |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `Qwen/Qwen3-0.6B` | `HuggingFaceH4/ultrachat_200k`, split `train_sft`, first 1024 rows | 4 spec layers, 2 stages | 1536 | 326 / 1536 | 0.5628 | 1.1257 | 12.67% |
+
+This proves the train/eval/export path. It is not the high-gain target.
+
+### 2. Strong Modest-Model Acceptance Signal
+
+The author-published `Qwen3.5-4B_s4_l4.pt` SPD head evaluates well with the
+reference verifier.
+
+Recorded local proof:
+
+| Model | Head | Generated tokens | Accepted flags | Acceptance | Equivalent accept length | Theoretical gain |
+| --- | --- | ---: | ---: | ---: | ---: | ---: |
+| `Qwen/Qwen3.5-4B` | pretrained, 4 stages / 4 spec layers | 1536 | 1230 / 1536 | 0.6176 | 2.4704 | 163.39% |
+
+Per-dataset theoretical gains from the same run:
+
+| Dataset | Acceptance | Equivalent accept length | Theoretical gain |
+| --- | ---: | ---: | ---: |
+| MT-Bench | 0.4918 | 1.9673 | 98.42% |
+| HumanEval | 0.8797 | 3.5189 | 254.18% |
+| GSM8K | 0.5926 | 2.3704 | 137.58% |
+
+This is the main reason to keep pursuing SPD for Skippy.
+
+### 3. Trace-Based Skippy Latency Model
+
+`evals/spd/simulate_latency.py` consumes real per-sample SPD eval traces and
+models split-stage latency. It does not invent acceptance.
+
+Recorded Qwen3.5-4B trace with four target stages at `4ms,4ms,4ms,4ms`:
+
+| Hop ms | Serial split tok/s | SPD pipeline tok/s | SPD vs serial split | Paper-like gain | P50 serial ms | P50 SPD ms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0 | 62.50 | 617.61 | 9.882x | 2.470x | 1024.00 | 106.50 |
+| 1 | 52.63 | 494.09 | 9.388x | 2.470x | 1216.00 | 133.12 |
+| 5 | 32.26 | 274.49 | 8.509x | 2.470x | 1984.00 | 239.62 |
+| 10 | 21.74 | 176.46 | 8.117x | 2.470x | 2944.00 | 372.75 |
+| 25 | 10.99 | 85.19 | 7.752x | 2.470x | 5824.00 | 772.12 |
+
+The paper-like gain is from the SPD trace itself. The Skippy comparison models
+ordinary split serving as requiring each generated token to traverse all
+stages/hops before the next target token is known.
+
+### 4. Rust Manifest Validation
+
+`crates/skippy-runtime/src/spd.rs` adds a manifest parser and validator for SPD
+head artifacts:
+
+- schema: `skippy-spd-head/v1`
+- checkpoint path, byte size, sha256
+- base model path/id
+- checkpoint format/version
+- hidden size
+- vocab size
+- draft vocab size and optional draft token ids
+- number of target stages
+- number of spec layers
+- shallow hidden-layer tap indices
+
+This is validation only. It does not load tensors or run the head.
+
+## What Does Not Work Yet
+
+- Skippy/Rust does not execute the SPD head.
+- The `.pt` checkpoint is not a serving artifact.
+- Skippy does not yet expose live hidden-state taps for SPD.
+- No live Skippy request has used trained SPD proposals.
+- No larger-than-4B head has been trained by us yet.
+
+## Correctness Contract
+
+SPD should be treated as a verified speculative path.
+
+For greedy decoding:
+
+1. SPD proposes a token.
+2. The target model computes the verified logits for that position.
+3. The token is accepted only if it equals the target argmax.
+4. On rejection, Skippy rolls back speculative state and emits the target token.
+
+For sampling:
+
+1. SPD proposes from draft distribution `q`.
+2. Target distribution `p` is computed by the base model.
+3. Standard speculative rejection sampling accepts with the corrected
+   probability and otherwise samples from residual `max(0, p - q)`.
+
+Do not ship unverified/lossy SPD as the default path. Lossy SPD should only be a
+separate explicit experiment because wrong accepted tokens change the future
+context.
+
+## Practical Skippy Hosting Model
+
+Treat the SPD head as a sidecar artifact attached to a Skippy stage topology.
+It should not be exposed as a separate OpenAI model and should not mutate the
+base GGUF/layer-package weights.
+
+Recommended first implementation:
+
+- one SPD sidecar runtime per active Skippy topology/session group
+- host it in one Skippy process first, likely coordinator or final-stage side
+- other stages expose/send selected hidden-state taps
+- SPD proposes token candidates
+- normal Skippy stages verify every emitted token
+
+Distributed SPD execution across all stage nodes may become useful later, but it
+is not the first proof path.
+
+## llama.cpp / Stage Runtime Dependencies
+
+The current proof branch does not require James's GLM/MTP work to reproduce the
+Python SPD results or validate the Rust manifest. The live Skippy path will,
+however, need additional staged-runtime/llama-side capability.
+
+Likely required:
+
+- hidden-state tap export from selected layers/stages, with token position,
+  dtype, shape, and stage ownership metadata
+- enough sideband transport to return those taps to the SPD sidecar without
+  changing ordinary generation output
+- verification support that can run proposed SPD tokens through the real target
+  stages and return the target-model decision
+- rollback/session-trim support for rejected speculative tokens
+- ABI version bumps and Rust `skippy-ffi` mirrors for any new staged-runtime
+  calls
+
+Adjacent work that may help:
+
+- native MTP verification work has similar concerns around speculative proposal,
+  target verification, sideband data, and rollback
+- GLM/MTP branches may contain useful patterns for verifier plumbing, but they
+  are not SPD themselves and should not be merged wholesale just to start SPD
+- package-declared draft speculation work may be useful later for advertising
+  optional SPD artifacts in model/layer packages
+
+First Skippy implementation should add the minimum SPD-specific stage-runtime
+surface needed for Qwen3.5-4B parity: capture required hidden taps, run the SPD
+head, and verify proposed tokens. Pull reusable verifier/rollback patterns from
+MTP work only after confirming they apply cleanly to SPD.
+
+## Artifact Layout Target
+
+Layer packages should eventually support optional SPD artifacts:
+
+```text
+package/
+  manifest.json
+  parts/
+    ...
+  spd/
+    skippy-spd-head.json
+    spd-head.safetensors
+    draft-vocab.json
+```
+
+The manifest must bind the head to:
+
+- base model digest/path
+- tokenizer/vocab identity
+- hidden size
+- split topology
+- stage count
+- layer taps
+- draft vocab
+- head tensor checksum
+
+## Reproduction Commands
+
+### Train Small Qwen3-0.6B Head
+
+```bash
+python evals/spd/hf_train_eval_qwen06.py \
+  --work-dir /tmp/skippy-spd-qwen06-proof \
+  --model-name Qwen/Qwen3-0.6B \
+  --dataset HuggingFaceH4/ultrachat_200k \
+  --dataset-split train_sft \
+  --train-rows 1024 \
+  --eval-rows-per-set 8 \
+  --num-stages 2 \
+  --num-spec-layers 4 \
+  --max-length 256 \
+  --max-new-tokens 64 \
+  --draft-top-k 4 \
+  --device mps \
+  --upload-repo ''
+```
+
+Use `--device cuda` on a CUDA host.
+
+### Evaluate Pretrained Qwen3.5-4B Head
+
+```bash
+python evals/spd/hf_train_eval_qwen06.py \
+  --work-dir /tmp/skippy-spd-qwen35-4b-pretrained-s4l4 \
+  --model-name Qwen/Qwen3.5-4B \
+  --spec-head-repo yuyijiong/speculative_pipeline_decoding \
+  --spec-head-file Qwen3.5-4B_s4_l4.pt \
+  --manifest-base-model-path Qwen/Qwen3.5-4B \
+  --skip-train \
+  --device mps \
+  --eval-rows-per-set 8 \
+  --max-new-tokens 64 \
+  --draft-top-k 4 \
+  --upload-repo ''
+```
+
+### Simulate Split Latency From Trace
+
+```bash
+python evals/spd/simulate_latency.py \
+  --raw /tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/eval/raw/pipeline_eval__train__speculation_head_final__nt24__per_sample.jsonl \
+  --stage-ms 4,4,4,4 \
+  --hop-ms 0,1,5,10,25
+```
+
+## Engineering Next Steps
+
+### Milestone 1: Tensor Export
+
+Goal: produce a Rust-serving artifact from the `.pt` checkpoint.
+
+Tasks:
+
+1. Add/export a `safetensors` writer for the SPD checkpoint.
+2. Preserve tensor names, shapes, dtype, draft vocab ids, and config.
+3. Extend `skippy-spd-head.json` to reference the serving checkpoint.
+4. Add a small shape/checksum inspection command or test fixture.
+
+Exit criteria:
+
+- Qwen3.5-4B SPD head exports deterministically.
+- Rust can validate the manifest and enumerate expected tensors.
+
+### Milestone 2: Rust Forward Pass Parity
+
+Goal: Rust computes the same draft candidates as Python for recorded inputs.
+
+Tasks:
+
+1. Record hidden-state tap fixtures from Python reference execution.
+2. Implement the Qwen3.5-4B SPD head forward pass in Rust.
+3. Compare Rust top-k draft candidates against Python top-k on the same hidden
+   states.
+4. Add focused tests with small fixture tensors.
+
+Exit criteria:
+
+- Rust top-k proposals match Python within tolerance on recorded fixtures.
+- No Skippy serving integration is required for this milestone.
+
+### Milestone 3: Skippy Hidden-State Taps
+
+Goal: Skippy can expose the hidden states the SPD head needs.
+
+Tasks:
+
+1. Identify the target layer taps from `skippy-spd-head.json`.
+2. Add a hidden-state sideband/tap path in the staged runtime.
+3. Validate dtype, shape, token position, and stage ownership.
+4. Write a correctness test that compares tapped hidden states against a known
+   reference for a small prompt.
+
+Exit criteria:
+
+- Skippy can capture the required taps for a live prompt without changing
+  normal generation output.
+
+### Milestone 4: Live Verified SPD in Skippy
+
+Goal: Skippy uses SPD proposals during generation and verifies every token.
+
+Tasks:
+
+1. Wire SPD proposal generation into `skippy-server`.
+2. Feed proposals into the existing target verification path.
+3. Roll back speculative KV/session state on rejection.
+4. Emit metrics for proposals, accepted tokens, rejected tokens, equivalent
+   accept length, and decode-loop steps.
+5. Run ordinary split serving and SPD serving against the same prompts.
+
+Exit criteria:
+
+- Greedy outputs match ordinary target-model decoding.
+- Acceptance and equivalent accept length are non-zero and close to reference
+  trace behavior.
+- Latency improves under injected hop/stage delay.
+
+### Milestone 5: Larger-Model Training Proof
+
+Goal: prove the SPD head generation pipeline scales beyond the pretrained 4B
+artifact.
+
+Recommended first target:
+
+- a larger Qwen-family model with architecture/tokenizer support close to the
+  reference implementation
+- avoid custom huge MoE targets for the first scaling proof
+
+Tasks:
+
+1. Train with open conversation data mix.
+2. Keep draft vocab capped at 32k or 50k.
+3. Evaluate on the same MT-Bench/HumanEval/GSM8K prompt sets.
+4. Record acceptance, equivalent accept length, and latency simulation.
+5. Publish only artifact manifests, scripts, and aggregate metrics unless model
+   licensing allows the trained head to be shared.
+
+Exit criteria:
+
+- Larger-model head reaches useful equivalent accept length.
+- Training process and artifact production are reproducible by another engineer.
+
+## Branch Scope
+
+This branch should stay focused on SPD proof and handoff material:
+
+- `SPD_SKIPPY_PROJECT.md`
+- `evals/spd/`
+- `crates/skippy-runtime/src/spd.rs`
+- minimal module export from `skippy-runtime`
+
+Avoid mixing in unrelated MTP, GLM, packaging, branch-reconciliation, or private
+lab automation work. Those can be inputs later, but the purpose of this branch
+is to make the SPD path clear and reproducible.
+
+## Validation
+
+Run:
+
+```bash
+python3 -m py_compile evals/spd/hf_train_eval_qwen06.py evals/spd/simulate_latency.py
+cargo fmt --all -- --check
+cargo test -p skippy-runtime spd
+cargo clippy -p skippy-runtime --all-targets -- -D warnings
+```
+
+Before publishing or handing off, run the repo's normal secret scan and also
+check the diff for private hostnames, private IPs, access tokens, credentials,
+and absolute developer-machine paths.

--- a/SPD_SKIPPY_PROJECT.md
+++ b/SPD_SKIPPY_PROJECT.md
@@ -96,7 +96,7 @@ The paper-like gain is from the SPD trace itself. The Skippy comparison models
 ordinary split serving as requiring each generated token to traverse all
 stages/hops before the next target token is known.
 
-### 4. Rust Manifest Validation
+### 4. Rust Serving Artifact Validation
 
 `crates/skippy-runtime/src/spd.rs` adds a manifest parser and validator for SPD
 head artifacts:
@@ -111,13 +111,18 @@ head artifacts:
 - number of target stages
 - number of spec layers
 - shallow hidden-layer tap indices
+- optional safetensors serving checkpoint path, size, checksum, tensor count,
+  and dtype
 
-This is validation only. It does not load tensors or run the head.
+`evals/spd/export_spd_head.py` exports the reference `.pt` checkpoint into
+`spd-head.safetensors` and updates the manifest with a `serving_checkpoint`
+section. This is still validation only: Skippy can inspect the serving artifact
+but does not run the SPD head yet.
 
 ## What Does Not Work Yet
 
 - Skippy/Rust does not execute the SPD head.
-- The `.pt` checkpoint is not a serving artifact.
+- Skippy/Rust does not load tensor values into an executable SPD head yet.
 - Skippy does not yet expose live hidden-state taps for SPD.
 - No live Skippy request has used trained SPD proposals.
 - No larger-than-4B head has been trained by us yet.
@@ -259,6 +264,15 @@ python evals/spd/hf_train_eval_qwen06.py \
   --upload-repo ''
 ```
 
+### Export Serving Checkpoint
+
+```bash
+python evals/spd/export_spd_head.py \
+  --checkpoint /tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/train/speculation_head_final.pt \
+  --manifest /tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/train/skippy-spd-head.json \
+  --base-model-path Qwen/Qwen3.5-4B
+```
+
 ### Simulate Split Latency From Trace
 
 ```bash
@@ -276,15 +290,25 @@ Goal: produce a Rust-serving artifact from the `.pt` checkpoint.
 
 Tasks:
 
-1. Add/export a `safetensors` writer for the SPD checkpoint.
-2. Preserve tensor names, shapes, dtype, draft vocab ids, and config.
-3. Extend `skippy-spd-head.json` to reference the serving checkpoint.
-4. Add a small shape/checksum inspection command or test fixture.
+1. Add/export a `safetensors` writer for the SPD checkpoint. Done in
+   `evals/spd/export_spd_head.py`.
+2. Preserve tensor names, shapes, dtype, draft vocab ids, and config. Done via
+   the safetensors file and `skippy-spd-head.json`.
+3. Extend `skippy-spd-head.json` to reference the serving checkpoint. Done with
+   the optional `serving_checkpoint` section.
+4. Add a small shape/checksum inspection command or test fixture. Done in
+   `skippy-runtime` tests.
 
 Exit criteria:
 
 - Qwen3.5-4B SPD head exports deterministically.
 - Rust can validate the manifest and enumerate expected tensors.
+- To validate a local exported head through Rust, set
+  `SKIPPY_SPD_MANIFEST=/tmp/.../train/skippy-spd-head.json` and run:
+
+```bash
+cargo test -p skippy-runtime validates_external_manifest_when_skippy_spd_manifest_is_set
+```
 
 ### Milestone 2: Rust Forward Pass Parity
 
@@ -383,7 +407,7 @@ is to make the SPD path clear and reproducible.
 Run:
 
 ```bash
-python3 -m py_compile evals/spd/hf_train_eval_qwen06.py evals/spd/simulate_latency.py
+python3 -m py_compile evals/spd/hf_train_eval_qwen06.py evals/spd/simulate_latency.py evals/spd/export_spd_head.py
 cargo fmt --all -- --check
 cargo test -p skippy-runtime spd
 cargo clippy -p skippy-runtime --all-targets -- -D warnings

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -27,6 +27,7 @@ use tokio::sync::mpsc;
 mod devices;
 pub mod package;
 mod runtime_events;
+pub mod spd;
 
 pub const MAX_LOGIT_BIAS: usize = 256;
 pub const GGML_TYPE_F16: u32 = 1;

--- a/crates/skippy-runtime/src/spd.rs
+++ b/crates/skippy-runtime/src/spd.rs
@@ -1,0 +1,378 @@
+use std::{
+    fs,
+    path::{Component, Path, PathBuf},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+pub const SPD_HEAD_MANIFEST_SCHEMA: &str = "skippy-spd-head/v1";
+pub const TORCH_SPD_HEAD_FORMAT_V10: &str = "torch-speculation-head-v10";
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpdHeadManifest {
+    pub schema: String,
+    pub checkpoint: SpdHeadCheckpoint,
+    pub source: SpdHeadSource,
+    pub topology: SpdHeadTopology,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpdHeadCheckpoint {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpdHeadSource {
+    pub format: String,
+    pub reference_repo: Option<String>,
+    pub base_model_path: String,
+    pub model_type: Option<String>,
+    pub checkpoint_version: u32,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpdHeadTopology {
+    pub hidden_size: u32,
+    pub vocab_size: u32,
+    pub draft_vocab_size: u32,
+    pub num_stages: u32,
+    pub num_spec_layers: u32,
+    pub trained_with_use_deepest: bool,
+    pub shallow_hidden_layer_indices: Vec<Vec<u32>>,
+    pub spec_init_from_base_layers: Option<Vec<u32>>,
+    pub draft_token_ids: Option<Vec<u32>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpdHeadRuntimeProfile<'a> {
+    pub base_model_path: Option<&'a str>,
+    pub hidden_size: u32,
+    pub vocab_size: u32,
+    pub num_stages: u32,
+}
+
+impl SpdHeadManifest {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let manifest: Self = serde_json::from_slice(
+            &fs::read(path)
+                .with_context(|| format!("read SPD head manifest {}", path.display()))?,
+        )
+        .with_context(|| format!("parse SPD head manifest {}", path.display()))?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        if self.schema != SPD_HEAD_MANIFEST_SCHEMA {
+            bail!(
+                "unsupported SPD head manifest schema {}; expected {}",
+                self.schema,
+                SPD_HEAD_MANIFEST_SCHEMA
+            );
+        }
+        if self.source.format != TORCH_SPD_HEAD_FORMAT_V10 || self.source.checkpoint_version != 10 {
+            bail!(
+                "unsupported SPD head format {} version {}; expected {} version 10",
+                self.source.format,
+                self.source.checkpoint_version,
+                TORCH_SPD_HEAD_FORMAT_V10
+            );
+        }
+        if self.source.base_model_path.trim().is_empty() {
+            bail!("SPD head manifest base_model_path must not be empty");
+        }
+        self.checkpoint.validate()?;
+        self.topology.validate()?;
+        Ok(())
+    }
+
+    pub fn checkpoint_path(&self, manifest_path: impl AsRef<Path>) -> Result<PathBuf> {
+        let manifest_path = manifest_path.as_ref();
+        let base = manifest_path
+            .parent()
+            .with_context(|| format!("resolve parent for {}", manifest_path.display()))?;
+        Ok(base.join(safe_relative_manifest_path(&self.checkpoint.path)?))
+    }
+
+    pub fn verify_checkpoint(&self, manifest_path: impl AsRef<Path>) -> Result<()> {
+        let checkpoint_path = self.checkpoint_path(manifest_path)?;
+        let metadata = fs::metadata(&checkpoint_path).with_context(|| {
+            format!("read SPD checkpoint metadata {}", checkpoint_path.display())
+        })?;
+        if metadata.len() != self.checkpoint.bytes {
+            bail!(
+                "SPD checkpoint byte size mismatch for {}: expected {}, got {}",
+                checkpoint_path.display(),
+                self.checkpoint.bytes,
+                metadata.len()
+            );
+        }
+        let actual = file_sha256(&checkpoint_path)?;
+        if actual != self.checkpoint.sha256 {
+            bail!(
+                "SPD checkpoint checksum mismatch for {}: expected {}, got {}",
+                checkpoint_path.display(),
+                self.checkpoint.sha256,
+                actual
+            );
+        }
+        Ok(())
+    }
+
+    pub fn ensure_runtime_compatible(&self, profile: &SpdHeadRuntimeProfile<'_>) -> Result<()> {
+        match profile.base_model_path {
+            Some(base_model_path) if self.source.base_model_path != base_model_path => {
+                bail!(
+                    "SPD head was trained for base model {}; runtime model is {}",
+                    self.source.base_model_path,
+                    base_model_path
+                )
+            }
+            _ => {}
+        }
+        if self.topology.hidden_size != profile.hidden_size {
+            bail!(
+                "SPD head hidden_size {} does not match runtime hidden_size {}",
+                self.topology.hidden_size,
+                profile.hidden_size
+            );
+        }
+        if self.topology.vocab_size != profile.vocab_size {
+            bail!(
+                "SPD head vocab_size {} does not match runtime vocab_size {}",
+                self.topology.vocab_size,
+                profile.vocab_size
+            );
+        }
+        if self.topology.num_stages != profile.num_stages {
+            bail!(
+                "SPD head num_stages {} does not match runtime num_stages {}",
+                self.topology.num_stages,
+                profile.num_stages
+            );
+        }
+        Ok(())
+    }
+}
+
+impl SpdHeadCheckpoint {
+    fn validate(&self) -> Result<()> {
+        let _ = safe_relative_manifest_path(&self.path)?;
+        if self.bytes == 0 {
+            bail!("SPD checkpoint bytes must be greater than zero");
+        }
+        validate_sha256_digest("SPD checkpoint sha256", &self.sha256)
+    }
+}
+
+impl SpdHeadTopology {
+    fn validate(&self) -> Result<()> {
+        if self.hidden_size == 0 {
+            bail!("SPD head hidden_size must be greater than zero");
+        }
+        if self.vocab_size == 0 {
+            bail!("SPD head vocab_size must be greater than zero");
+        }
+        if self.draft_vocab_size == 0 || self.draft_vocab_size > self.vocab_size {
+            bail!(
+                "SPD head draft_vocab_size {} must be in 1..={}",
+                self.draft_vocab_size,
+                self.vocab_size
+            );
+        }
+        if self.num_stages == 0 {
+            bail!("SPD head num_stages must be greater than zero");
+        }
+        if self.num_spec_layers == 0 {
+            bail!("SPD head num_spec_layers must be greater than zero");
+        }
+        if self.shallow_hidden_layer_indices.len() != self.num_stages as usize {
+            bail!(
+                "SPD head shallow_hidden_layer_indices length {} must match num_stages {}",
+                self.shallow_hidden_layer_indices.len(),
+                self.num_stages
+            );
+        }
+        for (stage, indices) in self.shallow_hidden_layer_indices.iter().enumerate() {
+            validate_sorted_unique_indices(
+                &format!("shallow_hidden_layer_indices[{stage}]"),
+                indices,
+            )?;
+        }
+        match &self.spec_init_from_base_layers {
+            Some(indices) if indices.len() != self.num_spec_layers as usize => {
+                bail!(
+                    "SPD head spec_init_from_base_layers length {} must match num_spec_layers {}",
+                    indices.len(),
+                    self.num_spec_layers
+                )
+            }
+            _ => {}
+        }
+        if let Some(ids) = &self.draft_token_ids {
+            if ids.len() != self.draft_vocab_size as usize {
+                bail!(
+                    "SPD head draft_token_ids length {} must match draft_vocab_size {}",
+                    ids.len(),
+                    self.draft_vocab_size
+                );
+            }
+            validate_sorted_unique_indices("draft_token_ids", ids)?;
+            if ids.iter().any(|id| *id >= self.vocab_size) {
+                bail!(
+                    "SPD head draft_token_ids must all be less than vocab_size {}",
+                    self.vocab_size
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_sorted_unique_indices(label: &str, values: &[u32]) -> Result<()> {
+    if values.is_empty() {
+        bail!("SPD head {label} must not be empty");
+    }
+    if values.windows(2).any(|pair| pair[0] >= pair[1]) {
+        bail!("SPD head {label} must be sorted and unique");
+    }
+    Ok(())
+}
+
+fn validate_sha256_digest(label: &str, value: &str) -> Result<()> {
+    if value.len() != 64 || !value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        bail!("{label} must be a 64-character hex digest");
+    }
+    Ok(())
+}
+
+fn safe_relative_manifest_path(path: &str) -> Result<PathBuf> {
+    let path = Path::new(path);
+    if path.as_os_str().is_empty() || path.is_absolute() {
+        bail!("SPD checkpoint path must be a non-empty relative path");
+    }
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => {}
+            _ => bail!(
+                "SPD checkpoint path must not contain prefix, root, dot, or parent components"
+            ),
+        }
+    }
+    Ok(path.to_path_buf())
+}
+
+fn file_sha256(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("open SPD checkpoint for hashing {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)
+        .with_context(|| format!("hash SPD checkpoint {}", path.display()))?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_manifest() -> SpdHeadManifest {
+        SpdHeadManifest {
+            schema: SPD_HEAD_MANIFEST_SCHEMA.to_string(),
+            checkpoint: SpdHeadCheckpoint {
+                path: "speculation_head_final.pt".to_string(),
+                sha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    .to_string(),
+                bytes: 4,
+            },
+            source: SpdHeadSource {
+                format: TORCH_SPD_HEAD_FORMAT_V10.to_string(),
+                reference_repo: Some("https://example.invalid/spd.git".to_string()),
+                base_model_path: "Qwen/Qwen3-0.6B".to_string(),
+                model_type: Some("qwen3".to_string()),
+                checkpoint_version: 10,
+            },
+            topology: SpdHeadTopology {
+                hidden_size: 1024,
+                vocab_size: 10,
+                draft_vocab_size: 3,
+                num_stages: 2,
+                num_spec_layers: 1,
+                trained_with_use_deepest: true,
+                shallow_hidden_layer_indices: vec![vec![0, 7, 14], vec![0, 14]],
+                spec_init_from_base_layers: Some(vec![20]),
+                draft_token_ids: Some(vec![1, 3, 5]),
+            },
+        }
+    }
+
+    #[test]
+    fn validates_reference_manifest_shape() {
+        valid_manifest().validate().unwrap();
+    }
+
+    #[test]
+    fn rejects_draft_vocab_size_mismatch() {
+        let mut manifest = valid_manifest();
+        manifest.topology.draft_token_ids = Some(vec![1, 3]);
+        let error = manifest.validate().unwrap_err().to_string();
+        assert!(error.contains("draft_token_ids length"));
+    }
+
+    #[test]
+    fn rejects_unsafe_checkpoint_path() {
+        let mut manifest = valid_manifest();
+        manifest.checkpoint.path = "../speculation_head_final.pt".to_string();
+        let error = manifest.validate().unwrap_err().to_string();
+        assert!(error.contains("parent components"));
+    }
+
+    #[test]
+    fn verifies_checkpoint_checksum_relative_to_manifest() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkpoint = temp.path().join("speculation_head_final.pt");
+        fs::write(&checkpoint, b"head").unwrap();
+        let sha256 = file_sha256(&checkpoint).unwrap();
+
+        let mut manifest = valid_manifest();
+        manifest.checkpoint.sha256 = sha256;
+        manifest.checkpoint.bytes = 4;
+        let manifest_path = temp.path().join("skippy-spd-head.json");
+        fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let parsed = SpdHeadManifest::from_path(&manifest_path).unwrap();
+        parsed.verify_checkpoint(&manifest_path).unwrap();
+    }
+
+    #[test]
+    fn checks_runtime_compatibility_profile() {
+        let manifest = valid_manifest();
+        manifest
+            .ensure_runtime_compatible(&SpdHeadRuntimeProfile {
+                base_model_path: Some("Qwen/Qwen3-0.6B"),
+                hidden_size: 1024,
+                vocab_size: 10,
+                num_stages: 2,
+            })
+            .unwrap();
+    }
+
+    #[test]
+    fn rejects_runtime_profile_mismatch() {
+        let manifest = valid_manifest();
+        let error = manifest
+            .ensure_runtime_compatible(&SpdHeadRuntimeProfile {
+                base_model_path: Some("Qwen/Qwen3-1.7B"),
+                hidden_size: 1024,
+                vocab_size: 10,
+                num_stages: 2,
+            })
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("trained for base model"));
+    }
+}

--- a/crates/skippy-runtime/src/spd.rs
+++ b/crates/skippy-runtime/src/spd.rs
@@ -55,6 +55,8 @@ pub struct SpdHeadTopology {
     pub vocab_size: u32,
     pub draft_vocab_size: u32,
     pub num_stages: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage_layer_boundaries: Option<Vec<u32>>,
     pub num_spec_layers: u32,
     pub trained_with_use_deepest: bool,
     pub shallow_hidden_layer_indices: Vec<Vec<u32>>,
@@ -455,6 +457,16 @@ impl SpdHeadTopology {
         if self.num_stages == 0 {
             bail!("SPD head num_stages must be greater than zero");
         }
+        if let Some(boundaries) = &self.stage_layer_boundaries {
+            if boundaries.len() != self.num_stages as usize {
+                bail!(
+                    "SPD head stage_layer_boundaries length {} must match num_stages {}",
+                    boundaries.len(),
+                    self.num_stages
+                );
+            }
+            validate_sorted_unique_indices("stage_layer_boundaries", boundaries)?;
+        }
         if self.num_spec_layers == 0 {
             bail!("SPD head num_spec_layers must be greater than zero");
         }
@@ -647,6 +659,7 @@ mod tests {
                 vocab_size: 10,
                 draft_vocab_size: 3,
                 num_stages: 2,
+                stage_layer_boundaries: Some(vec![7, 14]),
                 num_spec_layers: 1,
                 trained_with_use_deepest: true,
                 shallow_hidden_layer_indices: vec![vec![0, 7, 14], vec![0, 14]],
@@ -709,6 +722,14 @@ mod tests {
         manifest.topology.draft_token_ids = Some(vec![1, 3]);
         let error = manifest.validate().unwrap_err().to_string();
         assert!(error.contains("draft_token_ids length"));
+    }
+
+    #[test]
+    fn rejects_stage_layer_boundary_count_mismatch() {
+        let mut manifest = valid_manifest();
+        manifest.topology.stage_layer_boundaries = Some(vec![7]);
+        let error = manifest.validate().unwrap_err().to_string();
+        assert!(error.contains("stage_layer_boundaries length"));
     }
 
     #[test]

--- a/crates/skippy-runtime/src/spd.rs
+++ b/crates/skippy-runtime/src/spd.rs
@@ -1,5 +1,7 @@
 use std::{
+    collections::BTreeMap,
     fs,
+    io::Read,
     path::{Component, Path, PathBuf},
 };
 
@@ -9,11 +11,14 @@ use sha2::{Digest, Sha256};
 
 pub const SPD_HEAD_MANIFEST_SCHEMA: &str = "skippy-spd-head/v1";
 pub const TORCH_SPD_HEAD_FORMAT_V10: &str = "torch-speculation-head-v10";
+pub const SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1: &str = "safetensors-spd-head-v1";
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct SpdHeadManifest {
     pub schema: String,
     pub checkpoint: SpdHeadCheckpoint,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serving_checkpoint: Option<SpdHeadServingCheckpoint>,
     pub source: SpdHeadSource,
     pub topology: SpdHeadTopology,
 }
@@ -23,6 +28,16 @@ pub struct SpdHeadCheckpoint {
     pub path: String,
     pub sha256: String,
     pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpdHeadServingCheckpoint {
+    pub path: String,
+    pub sha256: String,
+    pub bytes: u64,
+    pub format: String,
+    pub tensor_count: u32,
+    pub dtype: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -53,6 +68,21 @@ pub struct SpdHeadRuntimeProfile<'a> {
     pub hidden_size: u32,
     pub vocab_size: u32,
     pub num_stages: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpdSafetensorsIndex {
+    pub tensors: BTreeMap<String, SpdSafetensorsTensor>,
+    pub metadata: BTreeMap<String, String>,
+    pub data_start: u64,
+    pub data_len: u64,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct SpdSafetensorsTensor {
+    pub dtype: String,
+    pub shape: Vec<u64>,
+    pub data_offsets: [u64; 2],
 }
 
 impl SpdHeadManifest {
@@ -87,6 +117,9 @@ impl SpdHeadManifest {
             bail!("SPD head manifest base_model_path must not be empty");
         }
         self.checkpoint.validate()?;
+        if let Some(serving_checkpoint) = &self.serving_checkpoint {
+            serving_checkpoint.validate()?;
+        }
         self.topology.validate()?;
         Ok(())
     }
@@ -99,27 +132,100 @@ impl SpdHeadManifest {
         Ok(base.join(safe_relative_manifest_path(&self.checkpoint.path)?))
     }
 
+    pub fn serving_checkpoint_path(&self, manifest_path: impl AsRef<Path>) -> Result<PathBuf> {
+        let serving_checkpoint = self
+            .serving_checkpoint
+            .as_ref()
+            .context("SPD manifest does not include a serving checkpoint")?;
+        let manifest_path = manifest_path.as_ref();
+        let base = manifest_path
+            .parent()
+            .with_context(|| format!("resolve parent for {}", manifest_path.display()))?;
+        Ok(base.join(safe_relative_manifest_path(&serving_checkpoint.path)?))
+    }
+
     pub fn verify_checkpoint(&self, manifest_path: impl AsRef<Path>) -> Result<()> {
         let checkpoint_path = self.checkpoint_path(manifest_path)?;
-        let metadata = fs::metadata(&checkpoint_path).with_context(|| {
-            format!("read SPD checkpoint metadata {}", checkpoint_path.display())
-        })?;
-        if metadata.len() != self.checkpoint.bytes {
-            bail!(
-                "SPD checkpoint byte size mismatch for {}: expected {}, got {}",
-                checkpoint_path.display(),
-                self.checkpoint.bytes,
-                metadata.len()
-            );
+        verify_checkpoint_artifact(
+            "SPD checkpoint",
+            &checkpoint_path,
+            self.checkpoint.bytes,
+            &self.checkpoint.sha256,
+        )
+    }
+
+    pub fn verify_serving_checkpoint(
+        &self,
+        manifest_path: impl AsRef<Path>,
+    ) -> Result<SpdSafetensorsIndex> {
+        let serving_checkpoint = self
+            .serving_checkpoint
+            .as_ref()
+            .context("SPD manifest does not include a serving checkpoint")?;
+        let path = self.serving_checkpoint_path(manifest_path)?;
+        verify_checkpoint_artifact(
+            "SPD serving checkpoint",
+            &path,
+            serving_checkpoint.bytes,
+            &serving_checkpoint.sha256,
+        )?;
+        let index = SpdSafetensorsIndex::from_path(&path)?;
+        serving_checkpoint.validate_index(&index)?;
+        Ok(index)
+    }
+
+    pub fn serving_checkpoint_index(
+        &self,
+        manifest_path: impl AsRef<Path>,
+    ) -> Result<SpdSafetensorsIndex> {
+        let serving_checkpoint = self
+            .serving_checkpoint
+            .as_ref()
+            .context("SPD manifest does not include a serving checkpoint")?;
+        let index = SpdSafetensorsIndex::from_path(self.serving_checkpoint_path(manifest_path)?)?;
+        serving_checkpoint.validate_index(&index)?;
+        Ok(index)
+    }
+
+    pub fn ensure_serving_checkpoint_for_runtime(
+        &self,
+        manifest_path: impl AsRef<Path>,
+    ) -> Result<SpdSafetensorsIndex> {
+        let index = self.verify_serving_checkpoint(manifest_path)?;
+        self.ensure_serving_tensor_shapes(&index)?;
+        Ok(index)
+    }
+
+    fn ensure_serving_tensor_shapes(&self, index: &SpdSafetensorsIndex) -> Result<()> {
+        let hidden_size = self.topology.hidden_size as u64;
+        for (stage, indices) in self
+            .topology
+            .shallow_hidden_layer_indices
+            .iter()
+            .enumerate()
+        {
+            let expected_width = hidden_size
+                .checked_mul(indices.len() as u64)
+                .context("SPD stage projection width overflow")?;
+            index.ensure_tensor_shape(
+                &format!("stage_projs.{stage}.weight"),
+                &[hidden_size, expected_width],
+            )?;
         }
-        let actual = file_sha256(&checkpoint_path)?;
-        if actual != self.checkpoint.sha256 {
-            bail!(
-                "SPD checkpoint checksum mismatch for {}: expected {}, got {}",
-                checkpoint_path.display(),
-                self.checkpoint.sha256,
-                actual
-            );
+        index.ensure_tensor_shape("g0_proj.weight", &[hidden_size, hidden_size])?;
+        index.ensure_tensor_shape(
+            "lm_head.weight",
+            &[self.topology.draft_vocab_size as u64, hidden_size],
+        )?;
+        for layer in 0..self.topology.num_spec_layers {
+            index.ensure_tensor_shape(
+                &format!("spec_layers.{layer}.input_layernorm.weight"),
+                &[hidden_size],
+            )?;
+            index.ensure_tensor_shape(
+                &format!("spec_layers.{layer}.post_attention_layernorm.weight"),
+                &[hidden_size],
+            )?;
         }
         Ok(())
     }
@@ -167,6 +273,167 @@ impl SpdHeadCheckpoint {
             bail!("SPD checkpoint bytes must be greater than zero");
         }
         validate_sha256_digest("SPD checkpoint sha256", &self.sha256)
+    }
+}
+
+impl SpdHeadServingCheckpoint {
+    fn validate(&self) -> Result<()> {
+        let _ = safe_relative_manifest_path(&self.path)?;
+        if self.bytes == 0 {
+            bail!("SPD serving checkpoint bytes must be greater than zero");
+        }
+        if self.format != SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1 {
+            bail!(
+                "unsupported SPD serving checkpoint format {}; expected {}",
+                self.format,
+                SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1
+            );
+        }
+        if self.tensor_count == 0 {
+            bail!("SPD serving checkpoint tensor_count must be greater than zero");
+        }
+        if self.dtype.trim().is_empty() {
+            bail!("SPD serving checkpoint dtype must not be empty");
+        }
+        validate_sha256_digest("SPD serving checkpoint sha256", &self.sha256)
+    }
+
+    fn validate_index(&self, index: &SpdSafetensorsIndex) -> Result<()> {
+        if index.tensors.len() != self.tensor_count as usize {
+            bail!(
+                "SPD serving checkpoint tensor_count mismatch: expected {}, got {}",
+                self.tensor_count,
+                index.tensors.len()
+            );
+        }
+        if self.dtype != "mixed"
+            && index
+                .tensors
+                .values()
+                .any(|tensor| tensor.dtype != self.dtype)
+        {
+            bail!(
+                "SPD serving checkpoint dtype mismatch: expected all tensors to be {}",
+                self.dtype
+            );
+        }
+        match index.metadata.get("format") {
+            Some(format) if format != SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1 => {
+                bail!(
+                    "SPD serving checkpoint metadata format {}; expected {}",
+                    format,
+                    SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1
+                );
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+impl SpdSafetensorsIndex {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref();
+        let mut file = fs::File::open(path)
+            .with_context(|| format!("open SPD safetensors checkpoint {}", path.display()))?;
+        let file_len = file
+            .metadata()
+            .with_context(|| format!("stat SPD safetensors checkpoint {}", path.display()))?
+            .len();
+        let mut header_len_bytes = [0_u8; 8];
+        file.read_exact(&mut header_len_bytes)
+            .with_context(|| format!("read SPD safetensors header length {}", path.display()))?;
+        let header_len = u64::from_le_bytes(header_len_bytes);
+        if header_len == 0 {
+            bail!("SPD safetensors header must not be empty");
+        }
+        if header_len > file_len.saturating_sub(8) {
+            bail!(
+                "SPD safetensors header length {} exceeds file length {}",
+                header_len,
+                file_len
+            );
+        }
+        let header_len_usize =
+            usize::try_from(header_len).context("SPD safetensors header is too large")?;
+        let mut header = vec![0_u8; header_len_usize];
+        file.read_exact(&mut header)
+            .with_context(|| format!("read SPD safetensors header {}", path.display()))?;
+        Self::from_header_bytes(&header, 8 + header_len, file_len)
+    }
+
+    fn from_header_bytes(header: &[u8], data_start: u64, file_len: u64) -> Result<Self> {
+        if data_start > file_len {
+            bail!("SPD safetensors data section starts past end of file");
+        }
+        let data_len = file_len - data_start;
+        let mut metadata = BTreeMap::new();
+        let mut tensors = BTreeMap::new();
+        let value: serde_json::Value =
+            serde_json::from_slice(header).context("parse SPD safetensors header JSON")?;
+        let serde_json::Value::Object(entries) = value else {
+            bail!("SPD safetensors header must be a JSON object");
+        };
+
+        for (name, value) in entries {
+            if name == "__metadata__" {
+                metadata =
+                    serde_json::from_value(value).context("parse SPD safetensors metadata map")?;
+                continue;
+            }
+            if name.trim().is_empty() {
+                bail!("SPD safetensors tensor names must not be empty");
+            }
+            let tensor: SpdSafetensorsTensor = serde_json::from_value(value)
+                .with_context(|| format!("parse SPD safetensors tensor metadata {name}"))?;
+            tensor.validate(&name, data_len)?;
+            tensors.insert(name, tensor);
+        }
+        validate_safetensors_ranges(&tensors, data_len)?;
+        Ok(Self {
+            tensors,
+            metadata,
+            data_start,
+            data_len,
+        })
+    }
+
+    pub fn ensure_tensor_shape(&self, name: &str, expected_shape: &[u64]) -> Result<()> {
+        let tensor = self
+            .tensors
+            .get(name)
+            .with_context(|| format!("SPD serving checkpoint is missing tensor {name}"))?;
+        if tensor.shape != expected_shape {
+            bail!(
+                "SPD serving checkpoint tensor {name} shape mismatch: expected {:?}, got {:?}",
+                expected_shape,
+                tensor.shape
+            );
+        }
+        Ok(())
+    }
+}
+
+impl SpdSafetensorsTensor {
+    fn validate(&self, name: &str, data_len: u64) -> Result<()> {
+        let [start, end] = self.data_offsets;
+        if start > end || end > data_len {
+            bail!(
+                "SPD safetensors tensor {name} has invalid data offsets {:?} for data length {}",
+                self.data_offsets,
+                data_len
+            );
+        }
+        let expected_bytes = tensor_byte_len(&self.dtype, &self.shape)
+            .with_context(|| format!("validate SPD safetensors tensor {name}"))?;
+        if end - start != expected_bytes {
+            bail!(
+                "SPD safetensors tensor {name} byte length mismatch: offsets describe {}, shape/dtype describe {}",
+                end - start,
+                expected_bytes
+            );
+        }
+        Ok(())
     }
 }
 
@@ -234,6 +501,84 @@ impl SpdHeadTopology {
     }
 }
 
+fn verify_checkpoint_artifact(
+    label: &str,
+    path: &Path,
+    expected_bytes: u64,
+    expected_sha256: &str,
+) -> Result<()> {
+    let metadata =
+        fs::metadata(path).with_context(|| format!("read {label} metadata {}", path.display()))?;
+    if metadata.len() != expected_bytes {
+        bail!(
+            "{label} byte size mismatch for {}: expected {}, got {}",
+            path.display(),
+            expected_bytes,
+            metadata.len()
+        );
+    }
+    let actual = file_sha256(path)?;
+    if actual != expected_sha256 {
+        bail!(
+            "{label} checksum mismatch for {}: expected {}, got {}",
+            path.display(),
+            expected_sha256,
+            actual
+        );
+    }
+    Ok(())
+}
+
+fn validate_safetensors_ranges(
+    tensors: &BTreeMap<String, SpdSafetensorsTensor>,
+    data_len: u64,
+) -> Result<()> {
+    let mut ranges: Vec<(&str, [u64; 2])> = tensors
+        .iter()
+        .map(|(name, tensor)| (name.as_str(), tensor.data_offsets))
+        .collect();
+    ranges.sort_by_key(|(_, [start, _])| *start);
+    let mut previous_end = 0;
+    for (name, [start, end]) in ranges {
+        if start < previous_end {
+            bail!("SPD safetensors tensor {name} overlaps a previous tensor range");
+        }
+        if start > previous_end {
+            bail!("SPD safetensors tensor {name} leaves a gap before its data range");
+        }
+        previous_end = end;
+    }
+    if previous_end != data_len {
+        bail!(
+            "SPD safetensors tensor data ends at {}, but data section is {} bytes",
+            previous_end,
+            data_len
+        );
+    }
+    Ok(())
+}
+
+fn tensor_byte_len(dtype: &str, shape: &[u64]) -> Result<u64> {
+    let element_bytes = safetensors_dtype_size(dtype)?;
+    let elements = shape.iter().try_fold(1_u64, |acc, dimension| {
+        acc.checked_mul(*dimension)
+            .context("SPD safetensors tensor shape element count overflow")
+    })?;
+    elements
+        .checked_mul(element_bytes)
+        .context("SPD safetensors tensor byte length overflow")
+}
+
+fn safetensors_dtype_size(dtype: &str) -> Result<u64> {
+    match dtype {
+        "BOOL" | "I8" | "U8" => Ok(1),
+        "F16" | "BF16" | "I16" | "U16" => Ok(2),
+        "F32" | "I32" | "U32" => Ok(4),
+        "F64" | "I64" | "U64" => Ok(8),
+        _ => bail!("unsupported SPD safetensors dtype {dtype}"),
+    }
+}
+
 fn validate_sorted_unique_indices(label: &str, values: &[u32]) -> Result<()> {
     if values.is_empty() {
         bail!("SPD head {label} must not be empty");
@@ -289,6 +634,7 @@ mod tests {
                     .to_string(),
                 bytes: 4,
             },
+            serving_checkpoint: None,
             source: SpdHeadSource {
                 format: TORCH_SPD_HEAD_FORMAT_V10.to_string(),
                 reference_repo: Some("https://example.invalid/spd.git".to_string()),
@@ -308,6 +654,48 @@ mod tests {
                 draft_token_ids: Some(vec![1, 3, 5]),
             },
         }
+    }
+
+    fn valid_manifest_with_serving_checkpoint() -> SpdHeadManifest {
+        let mut manifest = valid_manifest();
+        manifest.serving_checkpoint = Some(SpdHeadServingCheckpoint {
+            path: "spd-head.safetensors".to_string(),
+            sha256: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_string(),
+            bytes: 0,
+            format: SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1.to_string(),
+            tensor_count: 6,
+            dtype: "F32".to_string(),
+        });
+        manifest
+    }
+
+    fn write_test_safetensors(path: &Path, tensors: &[(&str, &str, &[u64])]) {
+        let mut header_entries = serde_json::Map::new();
+        let mut data = Vec::new();
+        for (name, dtype, shape) in tensors {
+            let start = data.len() as u64;
+            let bytes = tensor_byte_len(dtype, shape).unwrap();
+            data.resize(data.len() + bytes as usize, 0);
+            let end = data.len() as u64;
+            header_entries.insert(
+                (*name).to_string(),
+                serde_json::json!({
+                    "dtype": dtype,
+                    "shape": shape,
+                    "data_offsets": [start, end],
+                }),
+            );
+        }
+        header_entries.insert(
+            "__metadata__".to_string(),
+            serde_json::json!({"format": SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1}),
+        );
+        let header = serde_json::to_vec(&serde_json::Value::Object(header_entries)).unwrap();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&header);
+        bytes.extend_from_slice(&data);
+        fs::write(path, bytes).unwrap();
     }
 
     #[test]
@@ -346,6 +734,118 @@ mod tests {
 
         let parsed = SpdHeadManifest::from_path(&manifest_path).unwrap();
         parsed.verify_checkpoint(&manifest_path).unwrap();
+    }
+
+    #[test]
+    fn verifies_serving_checkpoint_checksum_and_shapes() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkpoint = temp.path().join("spd-head.safetensors");
+        write_test_safetensors(
+            &checkpoint,
+            &[
+                ("stage_projs.0.weight", "F32", &[1024, 3072]),
+                ("stage_projs.1.weight", "F32", &[1024, 2048]),
+                ("g0_proj.weight", "F32", &[1024, 1024]),
+                ("lm_head.weight", "F32", &[3, 1024]),
+                ("spec_layers.0.input_layernorm.weight", "F32", &[1024]),
+                (
+                    "spec_layers.0.post_attention_layernorm.weight",
+                    "F32",
+                    &[1024],
+                ),
+            ],
+        );
+        let sha256 = file_sha256(&checkpoint).unwrap();
+
+        let mut manifest = valid_manifest_with_serving_checkpoint();
+        let serving_checkpoint = manifest.serving_checkpoint.as_mut().unwrap();
+        serving_checkpoint.sha256 = sha256;
+        serving_checkpoint.bytes = fs::metadata(&checkpoint).unwrap().len();
+        let manifest_path = temp.path().join("skippy-spd-head.json");
+        fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let parsed = SpdHeadManifest::from_path(&manifest_path).unwrap();
+        let index = parsed
+            .ensure_serving_checkpoint_for_runtime(&manifest_path)
+            .unwrap();
+        assert_eq!(index.tensors.len(), 6);
+        assert_eq!(
+            index.metadata.get("format").unwrap(),
+            SPD_SERVING_CHECKPOINT_FORMAT_SAFETENSORS_V1
+        );
+    }
+
+    #[test]
+    fn rejects_serving_checkpoint_shape_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let checkpoint = temp.path().join("spd-head.safetensors");
+        write_test_safetensors(
+            &checkpoint,
+            &[
+                ("stage_projs.0.weight", "F32", &[1024, 2048]),
+                ("stage_projs.1.weight", "F32", &[1024, 2048]),
+                ("g0_proj.weight", "F32", &[1024, 1024]),
+                ("lm_head.weight", "F32", &[3, 1024]),
+                ("spec_layers.0.input_layernorm.weight", "F32", &[1024]),
+                (
+                    "spec_layers.0.post_attention_layernorm.weight",
+                    "F32",
+                    &[1024],
+                ),
+            ],
+        );
+        let sha256 = file_sha256(&checkpoint).unwrap();
+
+        let mut manifest = valid_manifest_with_serving_checkpoint();
+        let serving_checkpoint = manifest.serving_checkpoint.as_mut().unwrap();
+        serving_checkpoint.sha256 = sha256;
+        serving_checkpoint.bytes = fs::metadata(&checkpoint).unwrap().len();
+        let manifest_path = temp.path().join("skippy-spd-head.json");
+        fs::write(&manifest_path, serde_json::to_vec(&manifest).unwrap()).unwrap();
+
+        let parsed = SpdHeadManifest::from_path(&manifest_path).unwrap();
+        let error = parsed
+            .ensure_serving_checkpoint_for_runtime(&manifest_path)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("stage_projs.0.weight shape mismatch"));
+    }
+
+    #[test]
+    fn rejects_safetensors_byte_length_mismatch() {
+        let header = serde_json::json!({
+            "bad.weight": {
+                "dtype": "F32",
+                "shape": [2_u64, 2_u64],
+                "data_offsets": [0_u64, 12_u64],
+            }
+        });
+        let header = serde_json::to_vec(&header).unwrap();
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+        bytes.extend_from_slice(&header);
+        bytes.extend_from_slice(&[0_u8; 12]);
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("bad.safetensors");
+        fs::write(&path, bytes).unwrap();
+
+        let error = SpdSafetensorsIndex::from_path(&path)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("byte length mismatch"));
+    }
+
+    #[test]
+    fn validates_external_manifest_when_skippy_spd_manifest_is_set() {
+        let Ok(manifest_path) = std::env::var("SKIPPY_SPD_MANIFEST") else {
+            return;
+        };
+        let manifest_path = PathBuf::from(manifest_path);
+        let manifest = SpdHeadManifest::from_path(&manifest_path).unwrap();
+        let index = manifest
+            .ensure_serving_checkpoint_for_runtime(&manifest_path)
+            .unwrap();
+        assert!(index.tensors.contains_key("lm_head.weight"));
     }
 
     #[test]

--- a/docs/design/GLM47_SPD_EXECUTION_PLAN.md
+++ b/docs/design/GLM47_SPD_EXECUTION_PLAN.md
@@ -87,6 +87,11 @@ The success criterion is artifact flow, not acceptance quality:
 - optional `spd-head.safetensors` after export
 - Rust SPD manifest validation
 
+The initial tiny GLM 4.7 smoke passed and the artifacts are stored in the
+private Hugging Face model repo `meshllm/skippy-spd-glm47-train-smoke`. The
+repo contains the manifest, serving safetensors export, and original reference
+checkpoint for reproducing the Skippy SPD manifest and serving-artifact path.
+
 ## Phase 5: Train And Evaluate SPD
 
 Build a GLM tokenizer-specific draft vocabulary. Do not reuse Qwen draft vocab.

--- a/docs/design/GLM47_SPD_EXECUTION_PLAN.md
+++ b/docs/design/GLM47_SPD_EXECUTION_PLAN.md
@@ -45,6 +45,9 @@ integration gaps:
 - add GLM model metadata inspection
 - support explicit non-uniform `stage_layer_boundaries`
 - derive GLM hidden-state tap rows from those boundaries
+- generate a small GLM-tokenizer draft vocabulary for training smoke runs
+- patch the reference trainer so explicit tap rows can bypass equal-stage
+  assumptions
 - write manifest-compatible GLM SPD smoke artifacts
 - validate the smoke manifest through `skippy-runtime`
 - keep the smoke artifacts clearly separate from trained weights
@@ -66,7 +69,25 @@ After the GLM code path exists, establish the vanilla GLM baseline:
 
 This baseline is the only performance comparison target for SPD.
 
-## Phase 4: Train And Evaluate SPD
+## Phase 4: Training Smoke
+
+Before a model-quality run, run a tiny real training smoke:
+
+- frozen local GLM 4.7 base model
+- explicit stage boundaries `15,31,47`
+- derived hidden tap rows `0,15,31,47;0,15,31;0,15`
+- small generated GLM-tokenizer draft vocab
+- a few rows from the training corpus
+- `--skip-eval` unless the training checkpoint is produced successfully
+
+The success criterion is artifact flow, not acceptance quality:
+
+- `speculation_head_final.pt`
+- `skippy-spd-head.json`
+- optional `spd-head.safetensors` after export
+- Rust SPD manifest validation
+
+## Phase 5: Train And Evaluate SPD
 
 Build a GLM tokenizer-specific draft vocabulary. Do not reuse Qwen draft vocab.
 Start with 32k tokens, then try 50k if vocab coverage limits acceptance.
@@ -80,7 +101,7 @@ Compare exactly two paths:
 - vanilla GLM target decode
 - GLM target decode with verified SPD sidecar
 
-## Phase 5: Serving Decision
+## Phase 6: Serving Decision
 
 Only wire the trained SPD head into live Skippy if it is materially faster than
 vanilla GLM while preserving target-equivalent verified output.

--- a/docs/design/GLM47_SPD_EXECUTION_PLAN.md
+++ b/docs/design/GLM47_SPD_EXECUTION_PLAN.md
@@ -1,0 +1,100 @@
+# GLM 4.7 SPD Execution Plan
+
+This plan combines the local GLM 4.7 checkpoint, the GLM llama.cpp/Skippy work
+on `feat/jianyang-glm-llama-patches`, the Skippy SPD proof handoff in PR #859,
+and the reference implementation at `yuyijiong/speculative_pipeline_decoding`.
+
+The goal is to train a GLM 4.7 SPD sidecar model and benchmark vanilla GLM
+decode against GLM decode with the verified SPD sidecar enabled.
+
+## Scope
+
+This effort is about trained SPD, not native GLM MTP performance. The GLM MTP
+branch is useful as implementation scaffolding because it carries GLM
+llama.cpp/Skippy support, hidden-state exposure, verification, sampler, and
+rollback work. It should not be used as a competing benchmark lane.
+
+PR #859 is the SPD training, export, manifest, and latency-model handoff. The
+reference SPD repo remains the training/evaluation source for the sidecar head.
+
+## Phase 1: Inspect GLM
+
+Inspect the local checkpoint before training or benchmarking:
+
+- architecture and `model_type`
+- tokenizer identity and chat template presence
+- `num_hidden_layers`
+- `hidden_size`
+- vocab size
+- any GLM-specific auxiliary tensors preserved by llama.cpp patches
+
+The local `zai-org/GLM-4.7-Flash` snapshot reports:
+
+- architecture: `Glm4MoeLiteForCausalLM`
+- model type: `glm4_moe_lite`
+- target layers: `47`
+- hidden size: `2048`
+- vocab size: `154880`
+- auxiliary layer-47 tensors: `eh_proj`, `enorm`, `hnorm`
+
+## Phase 2: Frontload Code Risk
+
+Before long GPU training jobs, make the GLM SPD path executable enough to expose
+integration gaps:
+
+- add GLM model metadata inspection
+- support explicit non-uniform `stage_layer_boundaries`
+- derive GLM hidden-state tap rows from those boundaries
+- write manifest-compatible GLM SPD smoke artifacts
+- validate the smoke manifest through `skippy-runtime`
+- keep the smoke artifacts clearly separate from trained weights
+
+`evals/spd/glm47_frontload.py` owns this first executable surface. The default
+GLM 4.7 Flash topology uses stage boundaries `15,31,47`, matching the 47-layer
+target model without relying on equal layer division.
+
+## Phase 3: Baseline
+
+After the GLM code path exists, establish the vanilla GLM baseline:
+
+1. Run vanilla GLM decode from the local checkpoint or Skippy package.
+2. Freeze prompts, generation settings, tokenizer, temperature, max tokens, and
+   hardware.
+3. Record throughput, latency distribution, generated token counts, and output
+   text.
+4. If using Skippy, validate vanilla split correctness against non-split GLM.
+
+This baseline is the only performance comparison target for SPD.
+
+## Phase 4: Train And Evaluate SPD
+
+Build a GLM tokenizer-specific draft vocabulary. Do not reuse Qwen draft vocab.
+Start with 32k tokens, then try 50k if vocab coverage limits acceptance.
+
+Train only the SPD sidecar head against the frozen GLM base model. Evaluate with
+verification enabled and record accepted draft flags, acceptance rate,
+equivalent accept length, theoretical gain, summaries, and raw traces.
+
+Compare exactly two paths:
+
+- vanilla GLM target decode
+- GLM target decode with verified SPD sidecar
+
+## Phase 5: Serving Decision
+
+Only wire the trained SPD head into live Skippy if it is materially faster than
+vanilla GLM while preserving target-equivalent verified output.
+
+Serving integration then needs:
+
+- Rust safetensors loading for the SPD head
+- GLM SPD forward pass for the recorded topology
+- Skippy hidden-state taps or transport
+- Python/Rust proposal parity on fixed taps
+- verified proposal generation
+- rollback/session trim for rejected proposals
+- SPD metrics for draft, accept, reject, proposal time, verification time, and
+  end-to-end throughput
+
+If the trained sidecar is weak, keep the result as research evidence and do not
+wire it into serving.

--- a/docs/design/GLM47_SPD_EXECUTION_PLAN.md
+++ b/docs/design/GLM47_SPD_EXECUTION_PLAN.md
@@ -4,8 +4,9 @@ This plan combines the local GLM 4.7 checkpoint, the GLM llama.cpp/Skippy work
 on `feat/jianyang-glm-llama-patches`, the Skippy SPD proof handoff in PR #859,
 and the reference implementation at `yuyijiong/speculative_pipeline_decoding`.
 
-The goal is to train a GLM 4.7 SPD sidecar model and benchmark vanilla GLM
-decode against GLM decode with the verified SPD sidecar enabled.
+The goal is to train a GLM 4.7 SPD sidecar model and use the Speedy benchmark
+to compare vanilla GLM decode against GLM decode with the verified SPD sidecar
+enabled.
 
 ## Scope
 
@@ -56,15 +57,16 @@ integration gaps:
 GLM 4.7 Flash topology uses stage boundaries `15,31,47`, matching the 47-layer
 target model without relying on equal layer division.
 
-## Phase 3: Baseline
+## Phase 3: Speedy Baseline
 
 After the GLM code path exists, establish the vanilla GLM baseline:
 
-1. Run vanilla GLM decode from the local checkpoint or Skippy package.
-2. Freeze prompts, generation settings, tokenizer, temperature, max tokens, and
-   hardware.
-3. Record throughput, latency distribution, generated token counts, and output
-   text.
+1. Run the Speedy benchmark against vanilla GLM decode from the local checkpoint
+   or Skippy package.
+2. Freeze Speedy prompt set, generation settings, tokenizer, temperature, max
+   tokens, hardware, and runtime build.
+3. Record Speedy throughput, latency distribution, generated token counts, and
+   output text.
 4. If using Skippy, validate vanilla split correctness against non-split GLM.
 
 This baseline is the only performance comparison target for SPD.
@@ -103,13 +105,14 @@ equivalent accept length, theoretical gain, summaries, and raw traces.
 
 Compare exactly two paths:
 
-- vanilla GLM target decode
-- GLM target decode with verified SPD sidecar
+- Speedy benchmark on vanilla GLM target decode
+- Speedy benchmark on GLM target decode with verified SPD sidecar
 
 ## Phase 6: Serving Decision
 
-Only wire the trained SPD head into live Skippy if it is materially faster than
-vanilla GLM while preserving target-equivalent verified output.
+Only wire the trained SPD head into live Skippy if the Speedy benchmark shows
+it is materially faster than vanilla GLM while preserving target-equivalent
+verified output.
 
 Serving integration then needs:
 

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -1,0 +1,190 @@
+# Skippy SPD Proof Notes
+
+This directory is the public, reproducible handoff for the Skippy Speculative
+Pipeline Decoding (SPD) proof.
+
+SPD is treated here as a separate trained sidecar head. It proposes draft tokens
+from selected target-model hidden states; the target model still verifies every
+accepted token. The work in this directory proves the training/evaluation path
+and records the artifact contract Skippy needs before serving the head from
+Rust.
+
+## What Works
+
+- A real SPD head can be trained locally for `Qwen/Qwen3-0.6B` with the paper's
+  reference implementation.
+- A real pretrained SPD head for `Qwen/Qwen3.5-4B` reaches high acceptance on
+  local eval prompts.
+- Real per-sample SPD eval traces can be fed into a Skippy split-stage latency
+  model to estimate how much pipeline bubble/activation-hop latency SPD can
+  hide.
+- `skippy-runtime` can parse and validate the SPD head manifest/checkpoint
+  binding. It does not execute the head yet.
+
+## What Does Not Work Yet
+
+- Skippy/Rust does not yet run the SPD head forward pass.
+- Skippy does not yet expose the live hidden-state taps required by the head.
+- No live Skippy generation request has used trained SPD proposals yet.
+- The `.pt` checkpoint is a proof/training artifact, not the intended serving
+  format.
+
+## Open Training Data
+
+The local Qwen3-0.6B proof uses:
+
+- dataset: `HuggingFaceH4/ultrachat_200k`
+- split: `train_sft`
+- rows: first `1024` rows for the recorded local proof
+
+The reference SPD repository lists the intended training corpus family as:
+
+- UltraChat-200k
+- ShareGPT
+- SmolTalk
+- SmolTalk-Chinese
+
+MT-Bench, HumanEval, and GSM8K prompts are used here only for evaluation.
+
+## Reproduce Qwen3-0.6B Training
+
+This is the smallest useful proof that the training path and artifact shape
+work. It trains a real head from open data.
+
+```bash
+python evals/spd/hf_train_eval_qwen06.py \
+  --work-dir /tmp/skippy-spd-qwen06-proof \
+  --model-name Qwen/Qwen3-0.6B \
+  --dataset HuggingFaceH4/ultrachat_200k \
+  --dataset-split train_sft \
+  --train-rows 1024 \
+  --eval-rows-per-set 8 \
+  --num-stages 2 \
+  --num-spec-layers 4 \
+  --max-length 256 \
+  --max-new-tokens 64 \
+  --draft-top-k 4 \
+  --device mps \
+  --upload-repo ''
+```
+
+Use `--device cuda` on a GPU host. The runner also supports HF Jobs, but that is
+only a convenience wrapper; the proof is ordinary Python plus open data.
+
+Recorded local result:
+
+| Model | Head | Eval draft top-k | Generated tokens | Accepted flags | Acceptance | Equivalent accept length | Theoretical gain |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `Qwen/Qwen3-0.6B` | locally trained, 4 spec layers | 4 | 1536 | 326 / 1536 | 0.5628 | 1.1257 | 12.67% |
+
+This proves the training/export path, but it is not the high-gain target.
+
+## Reproduce Qwen3.5-4B Pretrained Head Eval
+
+This is the strongest current model-quality signal. It uses an author-published
+SPD head and evaluates it locally against the reference verifier.
+
+```bash
+python evals/spd/hf_train_eval_qwen06.py \
+  --work-dir /tmp/skippy-spd-qwen35-4b-pretrained-s4l4 \
+  --model-name Qwen/Qwen3.5-4B \
+  --spec-head-repo yuyijiong/speculative_pipeline_decoding \
+  --spec-head-file Qwen3.5-4B_s4_l4.pt \
+  --manifest-base-model-path Qwen/Qwen3.5-4B \
+  --skip-train \
+  --device mps \
+  --eval-rows-per-set 8 \
+  --max-new-tokens 64 \
+  --draft-top-k 4 \
+  --upload-repo ''
+```
+
+Use `--device cuda` on a GPU host. The first run downloads the base model and
+the SPD head.
+
+Recorded local result:
+
+| Model | Head | Eval draft top-k | Generated tokens | Accepted flags | Acceptance | Equivalent accept length | Theoretical gain |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `Qwen/Qwen3.5-4B` | pretrained, 4 stages / 4 spec layers | 4 | 1536 | 1230 / 1536 | 0.6176 | 2.4704 | 163.39% |
+
+Per-dataset theoretical gains from the same run:
+
+| Dataset | Acceptance | Equivalent accept length | Theoretical gain |
+| --- | ---: | ---: | ---: |
+| MT-Bench | 0.4918 | 1.9673 | 98.42% |
+| HumanEval | 0.8797 | 3.5189 | 254.18% |
+| GSM8K | 0.5926 | 2.3704 | 137.58% |
+
+## Latency Simulation From Real Traces
+
+`simulate_latency.py` consumes the raw `eval/raw/*per_sample.jsonl` file emitted
+by the reference evaluator. It does not invent acceptance; it uses the real
+`new_tokens`, `decode_loop_steps`, and accepted-flag counters from the run.
+
+```bash
+python evals/spd/simulate_latency.py \
+  --raw /tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/eval/raw/pipeline_eval__train__speculation_head_final__nt24__per_sample.jsonl \
+  --stage-ms 4,4,4,4 \
+  --hop-ms 0,1,5,10,25
+```
+
+Recorded Qwen3.5-4B trace with a four-stage `4ms,4ms,4ms,4ms` model:
+
+| Hop ms | Serial split tok/s | SPD pipeline tok/s | SPD vs serial split | Paper-like gain | P50 serial ms | P50 SPD ms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 0 | 62.50 | 617.61 | 9.882x | 2.470x | 1024.00 | 106.50 |
+| 1 | 52.63 | 494.09 | 9.388x | 2.470x | 1216.00 | 133.12 |
+| 5 | 32.26 | 274.49 | 8.509x | 2.470x | 1984.00 | 239.62 |
+| 10 | 21.74 | 176.46 | 8.117x | 2.470x | 2944.00 | 372.75 |
+| 25 | 10.99 | 85.19 | 7.752x | 2.470x | 5824.00 | 772.12 |
+
+The `paper-like gain` column is based on the SPD trace alone. The `SPD vs serial
+split` column models a Skippy-specific comparison where ordinary split serving
+must traverse every stage/hop for each generated token before the next target
+token is known.
+
+## Artifact Contract
+
+The proof runner writes:
+
+- `train/speculation_head_final.pt`
+- `train/skippy-spd-head.json`
+- `eval/raw/*.jsonl`
+- `eval/summary/*.json`
+
+The manifest schema is `skippy-spd-head/v1`. It binds a head checkpoint to:
+
+- base model path/id
+- checkpoint format/version
+- checkpoint byte size and sha256
+- hidden size
+- base vocab size
+- draft vocab size and optional draft token ids
+- number of target stages
+- number of spec layers
+- shallow hidden-layer tap indices
+
+Rust validation lives in `crates/skippy-runtime/src/spd.rs`.
+
+## Next Engineering Steps
+
+1. Export `.pt` to a Rust-serving format, probably `safetensors` first.
+2. Add a tensor loader for the SPD head weights and draft vocab mapping.
+3. Implement the Qwen3.5-4B SPD forward pass in Rust for the recorded topology.
+4. Capture Skippy hidden-state taps and compare Rust top-k proposals to the
+   Python reference on the same taps.
+5. Wire live proposal generation into `skippy-server`.
+6. Verify every accepted token through the normal target stages.
+7. Benchmark against ordinary split serving with both injected hop latency and a
+   real multi-node topology.
+
+## Next Research Steps
+
+1. Train a head for a larger Qwen-family model to prove scaling beyond the
+   pretrained 4B artifact.
+2. Keep the draft vocab capped at 32k or 50k first.
+3. Record acceptance, equivalent accept length, and latency simulation from the
+   same eval prompts.
+4. Only after that, evaluate custom large MoE targets. Very large MoE models
+   need activation-capture support and are not the right first scaling proof.

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -91,6 +91,39 @@ layer-47 auxiliary tensors `eh_proj`, `enorm`, and `hnorm`. Because 47 target
 layers do not divide evenly into the old equal-stage assumptions, GLM SPD
 manifests carry explicit `stage_layer_boundaries`.
 
+### GLM Training Smoke Command
+
+After the frontload smoke passes, run a tiny real training smoke with a
+tokenizer-specific draft vocab. This is not a model-quality run; it verifies
+that the reference trainer can load GLM, accept the non-uniform tap topology,
+produce a real `speculation_head_final.pt`, and write a Skippy manifest.
+
+```bash
+python evals/spd/hf_train_eval_qwen06.py \
+  --work-dir /tmp/skippy-spd-glm47-train-smoke \
+  --model-name /path/to/GLM-4.7-Flash \
+  --dataset HuggingFaceH4/ultrachat_200k \
+  --dataset-split train_sft \
+  --train-rows 8 \
+  --skip-eval \
+  --num-stages 3 \
+  --stage-layer-boundaries 15,31,47 \
+  --num-spec-layers 1 \
+  --max-length 128 \
+  --batch-size 1 \
+  --gradient-accumulation-steps 1 \
+  --build-draft-vocab-size 1024 \
+  --draft-vocab-json '' \
+  --device cuda \
+  --upload-repo ''
+```
+
+`--stage-layer-boundaries` derives the reference trainer's
+`--shallow_hidden_layer_indices` as `0,15,31,47;0,15,31;0,15`. You can override
+that directly with `--shallow-hidden-layer-indices` when testing another tap
+layout. `--build-draft-vocab-size` builds a GLM-tokenizer draft vocab from the
+loaded training rows and passes the generated JSON into the reference trainer.
+
 ## Reproduce Qwen3-0.6B Training
 
 This is the smallest useful proof that the training path and artifact shape

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -47,6 +47,50 @@ The reference SPD repository lists the intended training corpus family as:
 
 MT-Bench, HumanEval, and GSM8K prompts are used here only for evaluation.
 
+## GLM 4.7 Frontload Smoke Path
+
+`glm47_frontload.py` inspects a local GLM 4.7 checkpoint and writes a tiny
+manifest-compatible SPD smoke artifact before any long training run. This is
+for frontloading integration risk: GLM model metadata, non-uniform stage
+boundaries, hidden-state tap rows, and Rust manifest validation. The generated
+weights are shape fixtures, not a trained SPD head.
+
+The default local checkpoint path points at the cached `zai-org/GLM-4.7-Flash`
+snapshot when present. Override it with `--model-path` on another machine.
+
+```bash
+python evals/spd/glm47_frontload.py \
+  --model-path /path/to/GLM-4.7-Flash \
+  --work-dir /tmp/skippy-spd-glm47-frontload \
+  --num-stages 3 \
+  --stage-layer-boundaries 15,31,47 \
+  --num-spec-layers 1 \
+  --draft-vocab-size 8 \
+  --write-smoke-artifacts
+```
+
+The command writes:
+
+- `glm47-spd-frontload.json` — checkpoint inspection and derived topology
+- `speculation_head_final.pt` — placeholder provenance file
+- `spd-head.safetensors` — tiny Rust-readable serving shape fixture
+- `skippy-spd-head.json` — manifest with `stage_layer_boundaries`
+
+Validate the smoke manifest without building native llama.cpp:
+
+```bash
+SKIPPY_SPD_MANIFEST=/tmp/skippy-spd-glm47-frontload/glm47-spd-frontload/skippy-spd-head.json \
+  cargo test -p skippy-runtime --features dynamic-native-runtime \
+  validates_external_manifest_when_skippy_spd_manifest_is_set
+```
+
+The inspected local GLM 4.7 Flash checkpoint currently reports
+`model_type = glm4_moe_lite`, architecture `Glm4MoeLiteForCausalLM`,
+`num_hidden_layers = 47`, `hidden_size = 2048`, `vocab_size = 154880`, and
+layer-47 auxiliary tensors `eh_proj`, `enorm`, and `hnorm`. Because 47 target
+layers do not divide evenly into the old equal-stage assumptions, GLM SPD
+manifests carry explicit `stage_layer_boundaries`.
+
 ## Reproduce Qwen3-0.6B Training
 
 This is the smallest useful proof that the training path and artifact shape

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -19,15 +19,16 @@ Rust.
   model to estimate how much pipeline bubble/activation-hop latency SPD can
   hide.
 - `skippy-runtime` can parse and validate the SPD head manifest/checkpoint
-  binding. It does not execute the head yet.
+  binding, including a Rust-readable safetensors serving checkpoint. It does
+  not execute the head yet.
 
 ## What Does Not Work Yet
 
 - Skippy/Rust does not yet run the SPD head forward pass.
 - Skippy does not yet expose the live hidden-state taps required by the head.
 - No live Skippy generation request has used trained SPD proposals yet.
-- The `.pt` checkpoint is a proof/training artifact, not the intended serving
-  format.
+- The `.pt` checkpoint is a proof/training artifact. Export it to
+  `spd-head.safetensors` before Rust-side serving work.
 
 ## Open Training Data
 
@@ -144,11 +145,35 @@ split` column models a Skippy-specific comparison where ordinary split serving
 must traverse every stage/hop for each generated token before the next target
 token is known.
 
+## Export the Serving Checkpoint
+
+After training or downloading a reference SPD head, export the PyTorch
+checkpoint to a Rust-readable serving artifact:
+
+```bash
+python evals/spd/export_spd_head.py \
+  --checkpoint /tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/train/speculation_head_final.pt \
+  --manifest /tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/train/skippy-spd-head.json \
+  --base-model-path Qwen/Qwen3.5-4B
+```
+
+The exporter writes `spd-head.safetensors` next to the manifest and adds an
+optional `serving_checkpoint` section to `skippy-spd-head.json`. The original
+`.pt` checkpoint remains referenced for provenance.
+
+Validate an exported local head through Rust with:
+
+```bash
+SKIPPY_SPD_MANIFEST=/tmp/skippy-spd-qwen35-4b-pretrained-s4l4/artifacts/<run-id>/train/skippy-spd-head.json \
+  cargo test -p skippy-runtime validates_external_manifest_when_skippy_spd_manifest_is_set
+```
+
 ## Artifact Contract
 
 The proof runner writes:
 
 - `train/speculation_head_final.pt`
+- `train/spd-head.safetensors` after export
 - `train/skippy-spd-head.json`
 - `eval/raw/*.jsonl`
 - `eval/summary/*.json`
@@ -164,19 +189,20 @@ The manifest schema is `skippy-spd-head/v1`. It binds a head checkpoint to:
 - number of target stages
 - number of spec layers
 - shallow hidden-layer tap indices
+- optional safetensors serving checkpoint path, size, checksum, tensor count,
+  and dtype
 
 Rust validation lives in `crates/skippy-runtime/src/spd.rs`.
 
 ## Next Engineering Steps
 
-1. Export `.pt` to a Rust-serving format, probably `safetensors` first.
-2. Add a tensor loader for the SPD head weights and draft vocab mapping.
-3. Implement the Qwen3.5-4B SPD forward pass in Rust for the recorded topology.
-4. Capture Skippy hidden-state taps and compare Rust top-k proposals to the
+1. Add a tensor loader for the SPD head weights and draft vocab mapping.
+2. Implement the Qwen3.5-4B SPD forward pass in Rust for the recorded topology.
+3. Capture Skippy hidden-state taps and compare Rust top-k proposals to the
    Python reference on the same taps.
-5. Wire live proposal generation into `skippy-server`.
-6. Verify every accepted token through the normal target stages.
-7. Benchmark against ordinary split serving with both injected hop latency and a
+4. Wire live proposal generation into `skippy-server`.
+5. Verify every accepted token through the normal target stages.
+6. Benchmark against ordinary split serving with both injected hop latency and a
    real multi-node topology.
 
 ## Next Research Steps

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -124,6 +124,12 @@ that directly with `--shallow-hidden-layer-indices` when testing another tap
 layout. `--build-draft-vocab-size` builds a GLM-tokenizer draft vocab from the
 loaded training rows and passes the generated JSON into the reference trainer.
 
+The first GLM 4.7 smoke artifact is uploaded to the private Hugging Face model
+repo `meshllm/skippy-spd-glm47-train-smoke`. It contains the Skippy manifest,
+the Rust-readable `spd-head.safetensors` export, the original reference
+`speculation_head_final.pt`, and a smoke-focused model card. This artifact is
+for training/export/manifest validation only, not production-quality decoding.
+
 ## Reproduce Qwen3-0.6B Training
 
 This is the smallest useful proof that the training path and artifact shape

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -115,7 +115,7 @@ python evals/spd/hf_train_eval_qwen06.py \
   --build-draft-vocab-size 1024 \
   --draft-vocab-json '' \
   --device cuda \
-  --upload-repo ''
+  --upload-repo none
 ```
 
 `--stage-layer-boundaries` derives the reference trainer's
@@ -143,7 +143,7 @@ python evals/spd/hf_train_eval_qwen06.py \
   --max-new-tokens 64 \
   --draft-top-k 4 \
   --device mps \
-  --upload-repo ''
+  --upload-repo none
 ```
 
 Use `--device cuda` on a GPU host. The runner also supports HF Jobs, but that is
@@ -174,7 +174,7 @@ python evals/spd/hf_train_eval_qwen06.py \
   --eval-rows-per-set 8 \
   --max-new-tokens 64 \
   --draft-top-k 4 \
-  --upload-repo ''
+  --upload-repo none
 ```
 
 Use `--device cuda` on a GPU host. The first run downloads the base model and

--- a/evals/spd/README.md
+++ b/evals/spd/README.md
@@ -285,8 +285,9 @@ Rust validation lives in `crates/skippy-runtime/src/spd.rs`.
    Python reference on the same taps.
 4. Wire live proposal generation into `skippy-server`.
 5. Verify every accepted token through the normal target stages.
-6. Benchmark against ordinary split serving with both injected hop latency and a
-   real multi-node topology.
+6. Use the Speedy benchmark for the final vanilla target versus verified
+   target+SPD sidecar comparison; keep latency simulation as supporting
+   analysis only.
 
 ## Next Research Steps
 

--- a/evals/spd/export_spd_head.py
+++ b/evals/spd/export_spd_head.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "safetensors>=0.5.0",
+#   "torch>=2.8.0",
+# ]
+# ///
+"""Export a reference SPD PyTorch checkpoint into a Skippy serving artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+SERVING_FORMAT = "safetensors-spd-head-v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Export an SPD .pt checkpoint to a Rust-readable safetensors artifact"
+    )
+    parser.add_argument("--checkpoint", required=True, help="Input speculation_head_final.pt")
+    parser.add_argument("--manifest", required=True, help="Input skippy-spd-head.json")
+    parser.add_argument(
+        "--manifest-out",
+        default="",
+        help="Manifest to write. Defaults to updating --manifest in place.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default="",
+        help="Output directory. Defaults to the manifest output directory.",
+    )
+    parser.add_argument("--out-name", default="spd-head.safetensors")
+    parser.add_argument(
+        "--dtype",
+        choices=("keep", "bfloat16", "float16", "float32"),
+        default="keep",
+        help="Tensor dtype for the serving artifact.",
+    )
+    parser.add_argument(
+        "--base-model-path",
+        default="",
+        help="Optional manifest base_model_path override, for portable public manifests.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    checkpoint_path = Path(args.checkpoint)
+    manifest_path = Path(args.manifest)
+    manifest_out = Path(args.manifest_out) if args.manifest_out else manifest_path
+    out_dir = Path(args.out_dir) if args.out_dir else manifest_out.parent
+    output_path = out_dir / args.out_name
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    tensors, checkpoint_config = load_tensors(checkpoint_path, args.dtype)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    from safetensors.torch import save_file
+
+    dtype_label = common_dtype_label(tensors)
+    metadata = {
+        "format": SERVING_FORMAT,
+        "source_checkpoint_sha256": manifest["checkpoint"]["sha256"],
+        "source_format": manifest["source"]["format"],
+        "tensor_count": str(len(tensors)),
+        "dtype": dtype_label,
+    }
+    base_model_path = args.base_model_path.strip()
+    if base_model_path:
+        manifest["source"]["base_model_path"] = base_model_path
+    metadata["base_model_path"] = manifest["source"]["base_model_path"]
+
+    save_file(tensors, output_path, metadata=metadata)
+
+    manifest["serving_checkpoint"] = {
+        "path": manifest_relative_path(output_path, manifest_out.parent),
+        "sha256": file_sha256(output_path),
+        "bytes": output_path.stat().st_size,
+        "format": SERVING_FORMAT,
+        "tensor_count": len(tensors),
+        "dtype": dtype_label,
+    }
+    if checkpoint_config.get("version") is not None:
+        manifest["source"]["checkpoint_version"] = int(checkpoint_config["version"])
+
+    manifest_out.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "serving_checkpoint": str(output_path),
+                "manifest": str(manifest_out),
+                "format": SERVING_FORMAT,
+                "tensor_count": len(tensors),
+                "dtype": dtype_label,
+                "bytes": output_path.stat().st_size,
+                "sha256": manifest["serving_checkpoint"]["sha256"],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def load_tensors(checkpoint_path: Path, dtype: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    import torch
+
+    try:
+        checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=False)
+    except TypeError:
+        checkpoint = torch.load(checkpoint_path, map_location="cpu")
+
+    if not isinstance(checkpoint, dict):
+        raise RuntimeError(f"{checkpoint_path} must contain a dict checkpoint")
+
+    state_dict = checkpoint.get("state_dict") or checkpoint.get("model_state_dict")
+    if state_dict is None:
+        state_dict = checkpoint
+    if not isinstance(state_dict, dict):
+        raise RuntimeError(f"{checkpoint_path} does not contain a state dict")
+
+    target_dtype = {
+        "keep": None,
+        "bfloat16": torch.bfloat16,
+        "float16": torch.float16,
+        "float32": torch.float32,
+    }[dtype]
+
+    tensors: dict[str, Any] = {}
+    for name in sorted(state_dict):
+        value = state_dict[name]
+        if not torch.is_tensor(value):
+            continue
+        tensor = value.detach().cpu().contiguous()
+        if target_dtype is not None:
+            tensor = tensor.to(target_dtype)
+        tensors[name] = tensor
+
+    if not tensors:
+        raise RuntimeError(f"{checkpoint_path} did not contain any tensors")
+    config = checkpoint.get("config") if isinstance(checkpoint.get("config"), dict) else {}
+    return tensors, config
+
+
+def common_dtype_label(tensors: dict[str, Any]) -> str:
+    import torch
+
+    labels = {
+        torch.bfloat16: "BF16",
+        torch.float16: "F16",
+        torch.float32: "F32",
+        torch.float64: "F64",
+        torch.int64: "I64",
+        torch.int32: "I32",
+        torch.int16: "I16",
+        torch.int8: "I8",
+        torch.uint8: "U8",
+        torch.bool: "BOOL",
+    }
+    seen = {labels.get(tensor.dtype, str(tensor.dtype)) for tensor in tensors.values()}
+    if len(seen) == 1:
+        return next(iter(seen))
+    return "mixed"
+
+
+def manifest_relative_path(path: Path, manifest_dir: Path) -> str:
+    resolved_path = path.resolve()
+    resolved_manifest_dir = manifest_dir.resolve()
+    try:
+        relative = resolved_path.relative_to(resolved_manifest_dir)
+    except ValueError as exc:
+        raise RuntimeError(
+            f"{path} must be inside the manifest directory {manifest_dir}"
+        ) from exc
+    if any(part in ("", ".", "..") for part in relative.parts):
+        raise RuntimeError(f"unsafe manifest-relative path: {relative}")
+    return relative.as_posix()
+
+
+def file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/spd/glm47_frontload.py
+++ b/evals/spd/glm47_frontload.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Frontload GLM 4.7 SPD integration checks.
+
+This utility is intentionally lightweight: it inspects a local GLM checkpoint,
+derives SPD topology metadata for non-uniform Skippy stage boundaries, and can
+write tiny manifest-compatible smoke artifacts. The smoke artifacts validate the
+Skippy SPD manifest and serving-checkpoint shape contract; they are not trained
+weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import struct
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REFERENCE_REPO = "https://github.com/yuyijiong/speculative_pipeline_decoding.git"
+DEFAULT_GLM47_FLASH_SNAPSHOT = (
+    Path.home()
+    / ".cache/huggingface/hub/models--zai-org--GLM-4.7-Flash/"
+    / "snapshots/7dd20894a642a0aa287e9827cb1a1f7f91386b67"
+)
+SMOKE_CHECKPOINT_FORMAT = "torch-speculation-head-v10"
+SERVING_FORMAT = "safetensors-spd-head-v1"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Inspect and frontload GLM 4.7 SPD metadata")
+    parser.add_argument(
+        "--model-path",
+        default=str(DEFAULT_GLM47_FLASH_SNAPSHOT),
+        help="Local GLM checkpoint directory containing config.json.",
+    )
+    parser.add_argument("--work-dir", default="/tmp/skippy-spd-glm47-frontload")
+    parser.add_argument("--reference-repo", default=REFERENCE_REPO)
+    parser.add_argument(
+        "--patch-reference",
+        action="store_true",
+        help="Clone and patch the SPD reference repo's model-type allowlist for GLM.",
+    )
+    parser.add_argument(
+        "--write-smoke-artifacts",
+        action="store_true",
+        help="Write tiny manifest-compatible SPD smoke artifacts.",
+    )
+    parser.add_argument("--num-stages", type=int, default=3)
+    parser.add_argument(
+        "--stage-layer-boundaries",
+        default="",
+        help="Comma-separated target layer end indices, e.g. 15,31,47.",
+    )
+    parser.add_argument("--num-spec-layers", type=int, default=1)
+    parser.add_argument("--draft-vocab-size", type=int, default=8)
+    parser.add_argument("--out-name", default="glm47-spd-frontload")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    model_path = Path(args.model_path).expanduser().resolve()
+    work_dir = Path(args.work_dir).expanduser().resolve()
+    out_dir = work_dir / args.out_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    inspection = inspect_checkpoint(model_path)
+    boundaries = resolve_stage_boundaries(
+        args.stage_layer_boundaries,
+        num_stages=args.num_stages,
+        num_layers=inspection["num_hidden_layers"],
+    )
+    hidden_indices = derive_hidden_tap_indices(boundaries)
+    topology = {
+        "hidden_size": inspection["hidden_size"],
+        "vocab_size": inspection["vocab_size"],
+        "draft_vocab_size": args.draft_vocab_size,
+        "num_stages": len(boundaries),
+        "stage_layer_boundaries": boundaries,
+        "num_spec_layers": args.num_spec_layers,
+        "trained_with_use_deepest": False,
+        "shallow_hidden_layer_indices": hidden_indices,
+        "spec_init_from_base_layers": None,
+        "draft_token_ids": list(range(args.draft_vocab_size)),
+    }
+
+    report = {
+        "model_path": str(model_path),
+        "inspected_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "checkpoint": inspection,
+        "topology": topology,
+        "notes": [
+            "Smoke artifacts are shape-contract fixtures, not trained SPD weights.",
+            "Stage boundaries are target layer end indices.",
+            "Hidden-state indices follow Hugging Face convention: 0 is embeddings, k is output after layer k-1.",
+        ],
+    }
+    report_path = out_dir / "glm47-spd-frontload.json"
+    write_json(report_path, report)
+
+    if args.patch_reference:
+        reference_dir = work_dir / "speculative_pipeline_decoding"
+        clone_reference(args.reference_repo, reference_dir)
+        patch_reference_for_glm(reference_dir)
+
+    if args.write_smoke_artifacts:
+        write_smoke_artifacts(
+            out_dir=out_dir,
+            model_path=model_path,
+            inspection=inspection,
+            topology=topology,
+            reference_repo=args.reference_repo,
+        )
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+
+
+def inspect_checkpoint(model_path: Path) -> dict[str, Any]:
+    config_path = model_path / "config.json"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"GLM config.json not found: {config_path}")
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    weight_map = read_weight_map(model_path)
+    auxiliary_tensors = sorted(
+        name
+        for name in weight_map
+        if any(part in name.lower() for part in ("eh_proj", "enorm", "hnorm", "nextn", "mtp"))
+    )
+    return {
+        "architectures": config.get("architectures", []),
+        "model_type": config.get("model_type"),
+        "hidden_size": positive_int(config, "hidden_size"),
+        "vocab_size": positive_int(config, "vocab_size"),
+        "num_hidden_layers": positive_int(config, "num_hidden_layers"),
+        "num_nextn_predict_layers": int(config.get("num_nextn_predict_layers") or 0),
+        "num_attention_heads": config.get("num_attention_heads"),
+        "num_key_value_heads": config.get("num_key_value_heads"),
+        "rope_theta": config.get("rope_theta"),
+        "tokenizer": inspect_tokenizer(model_path),
+        "weight_shards": len({shard for shard in weight_map.values()}),
+        "tensor_count": len(weight_map),
+        "auxiliary_tensors": auxiliary_tensors,
+    }
+
+
+def read_weight_map(model_path: Path) -> dict[str, str]:
+    index_path = model_path / "model.safetensors.index.json"
+    if not index_path.is_file():
+        return {}
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    weight_map = index.get("weight_map") or {}
+    if not isinstance(weight_map, dict):
+        raise RuntimeError(f"invalid weight_map in {index_path}")
+    return {str(k): str(v) for k, v in weight_map.items()}
+
+
+def inspect_tokenizer(model_path: Path) -> dict[str, Any]:
+    tokenizer_config = model_path / "tokenizer_config.json"
+    if not tokenizer_config.is_file():
+        return {}
+    config = json.loads(tokenizer_config.read_text(encoding="utf-8"))
+    return {
+        "tokenizer_class": config.get("tokenizer_class"),
+        "model_max_length": config.get("model_max_length"),
+        "has_chat_template": bool(config.get("chat_template") or (model_path / "chat_template.jinja").is_file()),
+    }
+
+
+def positive_int(config: dict[str, Any], key: str) -> int:
+    value = int(config.get(key) or 0)
+    if value <= 0:
+        raise RuntimeError(f"config field {key!r} must be a positive integer")
+    return value
+
+
+def resolve_stage_boundaries(value: str, *, num_stages: int, num_layers: int) -> list[int]:
+    if value.strip():
+        boundaries = [int(part.strip()) for part in value.split(",") if part.strip()]
+    elif num_layers == 47 and num_stages == 3:
+        boundaries = [15, 31, 47]
+    else:
+        boundaries = [
+            round(num_layers * (stage + 1) / num_stages) for stage in range(num_stages)
+        ]
+    if not boundaries:
+        raise RuntimeError("stage_layer_boundaries must not be empty")
+    if boundaries[-1] != num_layers:
+        raise RuntimeError(
+            f"last stage boundary must equal num_hidden_layers={num_layers}, got {boundaries[-1]}"
+        )
+    if any(left >= right for left, right in zip(boundaries, boundaries[1:])):
+        raise RuntimeError(f"stage boundaries must be strictly increasing: {boundaries}")
+    return boundaries
+
+
+def derive_hidden_tap_indices(boundaries: list[int]) -> list[list[int]]:
+    rows: list[list[int]] = []
+    for depth in range(len(boundaries), 0, -1):
+        rows.append([0, *boundaries[:depth]])
+    return rows
+
+
+def clone_reference(repo_url: str, dest: Path) -> None:
+    if dest.exists():
+        print(f"reference repo already exists: {dest}", file=sys.stderr)
+        return
+    run(["git", "clone", "--depth", "1", repo_url, str(dest)])
+
+
+def patch_reference_for_glm(reference_dir: Path) -> None:
+    pipeline_model = reference_dir / "pipeline_model.py"
+    replace_once(
+        pipeline_model,
+        'supported = {"qwen3", "qwen3_moe", "qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text", "llama"}',
+        'supported = {"qwen3", "qwen3_moe", "qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text", "llama", "glm4_moe_lite"}',
+    )
+
+
+def replace_once(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        if new in text:
+            return
+        raise RuntimeError(f"expected text not found in {path}: {old[:80]!r}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def write_smoke_artifacts(
+    *,
+    out_dir: Path,
+    model_path: Path,
+    inspection: dict[str, Any],
+    topology: dict[str, Any],
+    reference_repo: str,
+) -> None:
+    checkpoint_path = out_dir / "speculation_head_final.pt"
+    checkpoint_payload = {
+        "note": "GLM SPD frontload placeholder; not a torch training checkpoint.",
+        "config": checkpoint_config(model_path, inspection, topology),
+    }
+    checkpoint_path.write_text(json.dumps(checkpoint_payload, indent=2, sort_keys=True) + "\n")
+    serving_path = out_dir / "spd-head.safetensors"
+    write_smoke_safetensors(serving_path, topology)
+    manifest = {
+        "schema": "skippy-spd-head/v1",
+        "checkpoint": {
+            "path": checkpoint_path.name,
+            "sha256": file_sha256(checkpoint_path),
+            "bytes": checkpoint_path.stat().st_size,
+        },
+        "serving_checkpoint": {
+            "path": serving_path.name,
+            "sha256": file_sha256(serving_path),
+            "bytes": serving_path.stat().st_size,
+            "format": SERVING_FORMAT,
+            "tensor_count": smoke_tensor_count(topology),
+            "dtype": "F32",
+        },
+        "source": {
+            "format": SMOKE_CHECKPOINT_FORMAT,
+            "reference_repo": reference_repo,
+            "base_model_path": str(model_path),
+            "model_type": inspection["model_type"],
+            "checkpoint_version": 10,
+        },
+        "topology": topology,
+    }
+    write_json(out_dir / "skippy-spd-head.json", manifest)
+
+
+def checkpoint_config(
+    model_path: Path,
+    inspection: dict[str, Any],
+    topology: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "version": 10,
+        "base_model_path": str(model_path),
+        "model_type": inspection["model_type"],
+        **topology,
+    }
+
+
+def write_smoke_safetensors(path: Path, topology: dict[str, Any]) -> None:
+    hidden = int(topology["hidden_size"])
+    tensors: list[tuple[str, str, list[int]]] = []
+    for stage, indices in enumerate(topology["shallow_hidden_layer_indices"]):
+        tensors.append((f"stage_projs.{stage}.weight", "F32", [hidden, hidden * len(indices)]))
+    tensors.append(("g0_proj.weight", "F32", [hidden, hidden]))
+    tensors.append(("lm_head.weight", "F32", [int(topology["draft_vocab_size"]), hidden]))
+    for layer in range(int(topology["num_spec_layers"])):
+        tensors.append((f"spec_layers.{layer}.input_layernorm.weight", "F32", [hidden]))
+        tensors.append((f"spec_layers.{layer}.post_attention_layernorm.weight", "F32", [hidden]))
+
+    header_entries: dict[str, Any] = {
+        "__metadata__": {
+            "format": SERVING_FORMAT,
+            "purpose": "glm47-spd-frontload-smoke",
+        }
+    }
+    data_len = 0
+    for name, dtype, shape in tensors:
+        byte_len = tensor_byte_len(dtype, shape)
+        header_entries[name] = {
+            "dtype": dtype,
+            "shape": shape,
+            "data_offsets": [data_len, data_len + byte_len],
+        }
+        data_len += byte_len
+    header = json.dumps(header_entries, sort_keys=True, separators=(",", ":")).encode()
+    with path.open("wb") as handle:
+        handle.write(struct.pack("<Q", len(header)))
+        handle.write(header)
+        handle.truncate(8 + len(header) + data_len)
+
+
+def smoke_tensor_count(topology: dict[str, Any]) -> int:
+    return len(topology["shallow_hidden_layer_indices"]) + 2 + 2 * int(topology["num_spec_layers"])
+
+
+def tensor_byte_len(dtype: str, shape: list[int]) -> int:
+    sizes = {"F32": 4}
+    elements = 1
+    for dimension in shape:
+        elements *= int(dimension)
+    return elements * sizes[dtype]
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {path}", file=sys.stderr)
+
+
+def file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def run(cmd: list[str]) -> None:
+    print("+", " ".join(cmd), file=sys.stderr)
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/spd/hf_train_eval_qwen06.py
+++ b/evals/spd/hf_train_eval_qwen06.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "accelerate>=1.0.0",
+#   "datasets>=3.0.0",
+#   "huggingface_hub>=0.30.0",
+#   "numpy",
+#   "pyarrow",
+#   "setproctitle",
+#   "torch>=2.8.0",
+#   "tqdm",
+#   "transformers>=5.6.0",
+# ]
+# ///
+"""Train and evaluate a small SPD speculation head on Hugging Face Jobs.
+
+This is intentionally a proof runner, not serving code. It produces a real
+`speculation_head_final.pt` from the reference SPD implementation, evaluates it,
+and uploads the checkpoint + eval summaries to a private HF model repo by
+default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+
+REFERENCE_REPO = "https://github.com/yuyijiong/speculative_pipeline_decoding.git"
+DEFAULT_MODEL = "Qwen/Qwen3-0.6B"
+DEFAULT_DATASET = "HuggingFaceH4/ultrachat_200k"
+DEFAULT_DATASET_SPLIT = "train_sft"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a real Qwen3-0.6B SPD head proof job")
+    parser.add_argument("--work-dir", default="/tmp/skippy-spd-qwen06-proof")
+    parser.add_argument("--reference-repo", default=REFERENCE_REPO)
+    parser.add_argument("--model-name", default=DEFAULT_MODEL)
+    parser.add_argument("--dataset", default=DEFAULT_DATASET)
+    parser.add_argument("--dataset-split", default=DEFAULT_DATASET_SPLIT)
+    parser.add_argument("--train-rows", type=int, default=1024)
+    parser.add_argument("--eval-rows-per-set", type=int, default=8)
+    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--num-spec-layers", type=int, default=1)
+    parser.add_argument("--epochs", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--gradient-accumulation-steps", type=int, default=8)
+    parser.add_argument(
+        "--learning-rate",
+        type=float,
+        default=1e-5,
+        help="Learning rate for the speculation head trainer.",
+    )
+    parser.add_argument("--max-length", type=int, default=512)
+    parser.add_argument("--max-new-tokens", type=int, default=64)
+    parser.add_argument("--draft-top-k", type=int, default=1)
+    parser.add_argument("--attn-implementation", default="sdpa")
+    parser.add_argument(
+        "--device",
+        choices=("auto", "cuda", "mps", "cpu"),
+        default="auto",
+        help="Device for local/reference execution. HF GPU jobs can leave this as auto.",
+    )
+    parser.add_argument(
+        "--draft-vocab-json",
+        default="draft_vocab/ultrachat_qwen3_0.6b_top_32k.json",
+        help="Path inside the reference repo; empty disables reduced draft vocab.",
+    )
+    parser.add_argument(
+        "--upload-repo",
+        default="auto",
+        help="HF model repo for artifacts. Use 'auto' for <user>/skippy-spd-qwen06-proof.",
+    )
+    parser.add_argument("--public", action="store_true", help="Create upload repo as public")
+    parser.add_argument(
+        "--spec-head-path",
+        default="",
+        help="Existing speculation_head checkpoint to evaluate instead of training.",
+    )
+    parser.add_argument(
+        "--spec-head-repo",
+        default="",
+        help="HF model repo containing an existing speculation_head checkpoint.",
+    )
+    parser.add_argument(
+        "--spec-head-file",
+        default="",
+        help="Filename inside --spec-head-repo for an existing speculation_head checkpoint.",
+    )
+    parser.add_argument(
+        "--manifest-base-model-path",
+        default="",
+        help="Override the base_model_path written to the Skippy SPD manifest.",
+    )
+    parser.add_argument("--skip-train", action="store_true")
+    parser.add_argument("--skip-eval", action="store_true")
+    return parser.parse_args()
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    print("+", " ".join(cmd), flush=True)
+    subprocess.run(cmd, cwd=str(cwd) if cwd else None, env=env, check=True)
+
+
+def clone_reference(repo_url: str, dest: Path) -> None:
+    if dest.exists():
+        print(f"reference repo already exists: {dest}", flush=True)
+        return
+    run(["git", "clone", "--depth", "1", repo_url, str(dest)])
+
+
+def patch_reference_for_proof(reference_dir: Path) -> None:
+    write_qwen3_nonthink_template(reference_dir / "qwen3-nonthink-template")
+    replace_once(
+        reference_dir / "train.py",
+        '        report_to="wandb",\n',
+        "        report_to=[],\n",
+    )
+    patch_reference_for_transformers(reference_dir)
+
+
+def write_qwen3_nonthink_template(path: Path) -> None:
+    path.write_text(
+        """{%- for message in messages %}
+{%- if message['role'] == 'system' %}
+<|im_start|>system
+{{ message['content'] }}<|im_end|>
+{%- elif message['role'] == 'user' %}
+<|im_start|>user
+{{ message['content'] }}<|im_end|>
+{%- elif message['role'] == 'assistant' %}
+{% generation %}<|im_start|>assistant
+{{ message['content'] }}<|im_end|>{% endgeneration %}
+{%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+<|im_start|>assistant
+{%- endif %}
+""",
+        encoding="utf-8",
+    )
+
+
+def patch_reference_for_transformers(reference_dir: Path) -> None:
+    patch_reference_linear_cache_import(reference_dir / "pipeline_linear_cache.py")
+    replace_once(
+        reference_dir / "pipeline_model.py",
+        '            "cache_position": cache_position,\n',
+        "",
+    )
+
+
+def patch_reference_linear_cache_import(path: Path) -> None:
+    replace_once(
+        path,
+        '''from transformers.cache_utils import (
+    LinearAttentionAndFullAttentionLayer,
+    LinearAttentionCacheLayerMixin,
+    LinearAttentionLayer,
+)
+''',
+        '''from transformers.cache_utils import LinearAttentionCacheLayerMixin, LinearAttentionLayer
+
+try:
+    from transformers.cache_utils import LinearAttentionAndFullAttentionLayer
+except ImportError:
+    class LinearAttentionAndFullAttentionLayer(LinearAttentionLayer):
+        """Compatibility placeholder for Transformers 4.x without hybrid linear caches."""
+
+        pass
+
+''',
+    )
+
+
+def patch_reference_for_device(reference_dir: Path, device: str) -> None:
+    if device == "auto":
+        return
+    patch_train_for_device(reference_dir / "train.py")
+    patch_eval_for_device(reference_dir / "eval.py")
+    patch_pipeline_inference_for_device(reference_dir / "pipeline_inference.py")
+
+
+def replace_once(path: Path, old: str, new: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    if old not in text:
+        if new in text:
+            return
+        raise RuntimeError(f"expected text not found in {path}: {old[:80]!r}")
+    path.write_text(text.replace(old, new, 1), encoding="utf-8")
+
+
+def patch_train_for_device(path: Path) -> None:
+    replace_once(
+        path,
+        '    device_map: Any = {"": local_rank} if torch.cuda.is_available() else "cpu"\n',
+        '''    spd_device = os.environ.get("SPD_DEVICE", "auto").lower()
+    if spd_device == "mps":
+        device_map: Any = {"": "mps"}
+    elif spd_device == "cpu":
+        device_map = "cpu"
+    elif spd_device == "cuda":
+        device_map = {"": local_rank}
+    else:
+        device_map = {"": local_rank} if torch.cuda.is_available() else "cpu"
+
+''',
+    )
+    replace_once(
+        path,
+        "        torch_dtype=torch.bfloat16,\n",
+        '''        torch_dtype=(
+            torch.float32 if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else torch.bfloat16
+        ),
+''',
+    )
+    replace_once(
+        path,
+        "        bf16=True,\n        fp16=False,\n",
+        '''        bf16=torch.cuda.is_available(),
+        fp16=False,
+''',
+    )
+
+
+def patch_eval_for_device(path: Path) -> None:
+    for _ in range(2):
+        replace_once(
+            path,
+            '''        dtype=torch.bfloat16,
+        device_map={"": 0} if torch.cuda.is_available() else None,
+        attn_implementation="flash_attention_2",
+''',
+            '''        dtype=torch.float16 if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else torch.bfloat16,
+        device_map={"": "mps"} if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else ({"": 0} if torch.cuda.is_available() else None),
+        attn_implementation=os.environ.get("SPD_ATTN_IMPLEMENTATION", "sdpa"),
+''',
+        )
+    replace_once(
+        path,
+        '    map_loc = "cuda"\n',
+        '    map_loc = "mps" if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else ("cuda" if torch.cuda.is_available() else "cpu")\n',
+    )
+
+
+def patch_pipeline_inference_for_device(path: Path) -> None:
+    replace_once(
+        path,
+        '''        dtype=dtype,
+        device_map={"":0},
+        trust_remote_code=True,
+''',
+        '''        dtype=torch.float16 if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else dtype,
+        device_map={"": "mps"} if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else {"": 0},
+        trust_remote_code=True,
+''',
+    )
+    replace_once(
+        path,
+        '    map_loc = "cuda" if torch.cuda.is_available() else "cpu"\n',
+        '    map_loc = "mps" if os.environ.get("SPD_DEVICE", "auto").lower() == "mps" else ("cuda" if torch.cuda.is_available() else "cpu")\n',
+    )
+
+
+def load_training_rows(dataset_name: str, split: str, limit: int) -> list[dict[str, Any]]:
+    from datasets import load_dataset
+
+    wanted = max(1, int(limit))
+    split_expr = f"{split}[:{wanted}]"
+    print(f"loading training data: {dataset_name} {split_expr}", flush=True)
+    try:
+        ds = load_dataset(dataset_name, split=split_expr)
+    except Exception:
+        fallback = f"train[:{wanted}]"
+        print(f"failed to load split {split_expr!r}; trying {fallback!r}", flush=True)
+        ds = load_dataset(dataset_name, split=fallback)
+
+    rows: list[dict[str, Any]] = []
+    for row in ds:
+        messages = row.get("messages") or row.get("conversations")
+        if not messages:
+            continue
+        normalized = []
+        for message in messages:
+            role = message.get("role") or message.get("from")
+            content = message.get("content") or message.get("value")
+            if role is None or content is None:
+                normalized = []
+                break
+            if role == "human":
+                role = "user"
+            if role == "gpt":
+                role = "assistant"
+            normalized.append({"role": str(role), "content": str(content)})
+        if normalized:
+            rows.append({"messages": normalized})
+    if not rows:
+        raise RuntimeError(f"no usable messages/conversations rows found in {dataset_name}")
+    return rows[:wanted]
+
+
+def write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, ensure_ascii=False) + "\n")
+    print(f"wrote {len(rows)} rows -> {path}", flush=True)
+
+
+def create_mini_eval_data(reference_dir: Path, out_dir: Path, rows_per_set: int) -> None:
+    source_root = reference_dir / "eval_data"
+    for name in ("mt_bench", "humaneval", "gsm8k"):
+        source = source_root / name / "question.jsonl"
+        dest_dir = out_dir / name
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        dest = dest_dir / "question.jsonl"
+        copied = 0
+        with source.open("r", encoding="utf-8") as src, dest.open("w", encoding="utf-8") as dst:
+            for line in src:
+                if copied >= rows_per_set:
+                    break
+                if line.strip():
+                    dst.write(line)
+                    copied += 1
+        print(f"mini eval {name}: {copied} rows -> {dest}", flush=True)
+
+
+def train_head(args: argparse.Namespace, reference_dir: Path, train_jsonl: Path, train_dir: Path) -> Path:
+    cmd = [
+        sys.executable,
+        "train.py",
+        "--model_name",
+        args.model_name,
+        "--data_path",
+        str(train_jsonl),
+        "--num_stages",
+        str(args.num_stages),
+        "--num_spec_layers",
+        str(args.num_spec_layers),
+        "--epochs",
+        str(args.epochs),
+        "--batch_size",
+        str(args.batch_size),
+        "--gradient_accumulation_steps",
+        str(args.gradient_accumulation_steps),
+        "--lr",
+        str(args.learning_rate),
+        "--max_length",
+        str(args.max_length),
+        "--max_length_overflow",
+        "truncate",
+        "--min_length",
+        "10",
+        "--num_proc",
+        "2",
+        "--attn_implementation",
+        args.attn_implementation,
+        "--output_dir",
+        str(train_dir),
+    ]
+    if args.draft_vocab_json:
+        cmd.extend(["--draft_vocab_json", str(reference_dir / args.draft_vocab_json)])
+    started = time.perf_counter()
+    run(cmd, cwd=reference_dir, env=reference_env(args))
+    elapsed = time.perf_counter() - started
+    ckpt = train_dir / "speculation_head_final.pt"
+    if not ckpt.is_file():
+        raise FileNotFoundError(f"training did not produce {ckpt}")
+    print(f"training complete in {elapsed / 60.0:.2f} min: {ckpt}", flush=True)
+    write_skippy_spd_manifest(args, ckpt, train_dir / "skippy-spd-head.json")
+    return ckpt
+
+
+def prepare_existing_spec_head(args: argparse.Namespace, train_dir: Path) -> Path | None:
+    local_path = args.spec_head_path.strip()
+    repo = args.spec_head_repo.strip()
+    filename = args.spec_head_file.strip()
+    if not local_path and not repo and not filename:
+        return None
+    if local_path and (repo or filename):
+        raise RuntimeError("--spec-head-path cannot be combined with --spec-head-repo/file")
+    if bool(repo) != bool(filename):
+        raise RuntimeError("--spec-head-repo and --spec-head-file must be set together")
+
+    if repo:
+        from huggingface_hub import hf_hub_download
+
+        source = Path(hf_hub_download(repo_id=repo, filename=filename, repo_type="model"))
+    else:
+        source = Path(local_path).expanduser().resolve()
+    if not source.is_file():
+        raise FileNotFoundError(f"speculation head checkpoint not found: {source}")
+
+    train_dir.mkdir(parents=True, exist_ok=True)
+    dest = train_dir / "speculation_head_final.pt"
+    if source.resolve() != dest.resolve():
+        if dest.exists():
+            dest.unlink()
+        try:
+            os.link(source, dest)
+        except OSError:
+            shutil.copy2(source, dest)
+    write_skippy_spd_manifest(args, dest, train_dir / "skippy-spd-head.json")
+    print(f"prepared existing speculation head -> {dest}", flush=True)
+    return dest
+
+
+def file_sha256(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def write_skippy_spd_manifest(args: argparse.Namespace, ckpt: Path, manifest_path: Path) -> None:
+    import torch
+
+    try:
+        checkpoint = torch.load(ckpt, map_location="cpu", weights_only=False)
+    except TypeError:
+        checkpoint = torch.load(ckpt, map_location="cpu")
+    config = checkpoint.get("config") if isinstance(checkpoint, dict) else None
+    if not isinstance(config, dict):
+        raise RuntimeError(f"{ckpt} does not contain a config dict")
+
+    draft_token_ids = config.get("draft_token_ids")
+    manifest_base_model_path = args.manifest_base_model_path.strip()
+    if not manifest_base_model_path:
+        manifest_base_model_path = config.get("base_model_path") or args.model_name
+
+    manifest = {
+        "schema": "skippy-spd-head/v1",
+        "checkpoint": {
+            "path": ckpt.name,
+            "sha256": file_sha256(ckpt),
+            "bytes": ckpt.stat().st_size,
+        },
+        "source": {
+            "format": "torch-speculation-head-v10",
+            "reference_repo": args.reference_repo,
+            "base_model_path": manifest_base_model_path,
+            "model_type": config.get("model_type"),
+            "checkpoint_version": int(config.get("version", 0)),
+        },
+        "topology": {
+            "hidden_size": int(config["hidden_size"]),
+            "vocab_size": int(config["vocab_size"]),
+            "draft_vocab_size": int(config.get("draft_vocab_size", config["vocab_size"])),
+            "num_stages": int(config["num_stages"]),
+            "num_spec_layers": int(config["num_spec_layers"]),
+            "trained_with_use_deepest": bool(config.get("trained_with_use_deepest", False)),
+            "shallow_hidden_layer_indices": config["shallow_hidden_layer_indices"],
+            "spec_init_from_base_layers": config.get("spec_init_from_base_layers"),
+            "draft_token_ids": draft_token_ids,
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote Skippy SPD manifest -> {manifest_path}", flush=True)
+
+
+def evaluate_head(
+    args: argparse.Namespace,
+    reference_dir: Path,
+    ckpt: Path,
+    eval_data: Path,
+    eval_dir: Path,
+) -> None:
+    cmd = [
+        sys.executable,
+        "eval.py",
+        "--spec_head_ckpt",
+        str(ckpt),
+        "--base_model_path",
+        args.model_name,
+        "--data_dir",
+        str(eval_data),
+        "--output_dir",
+        str(eval_dir),
+        "--gpus",
+        "0",
+        "--max_new_tokens",
+        str(args.max_new_tokens),
+        "--temperature",
+        "0.0",
+        "--draft_top_k",
+        str(args.draft_top_k),
+        "--no-baseline",
+    ]
+    started = time.perf_counter()
+    run(cmd, cwd=reference_dir, env=reference_env(args))
+    elapsed = time.perf_counter() - started
+    print(f"eval complete in {elapsed / 60.0:.2f} min", flush=True)
+
+
+def print_eval_summary(eval_dir: Path) -> None:
+    summary_dir = eval_dir / "summary"
+    if not summary_dir.is_dir():
+        print(f"no eval summary dir found: {summary_dir}", flush=True)
+        return
+    for path in sorted(summary_dir.glob("*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            obj = json.load(handle)
+        print(f"summary: {path}", flush=True)
+        overall = obj.get("overall") or {}
+        if not overall and obj.get("results"):
+            overall = obj["results"][0].get("overall", {})
+        interesting = {
+            key: overall.get(key)
+            for key in (
+                "acceptance_rate",
+                "equivalent_accept_length",
+                "theoretical_speedup",
+                "new_tokens",
+                "decode_loop_steps",
+            )
+            if key in overall
+        }
+        print(json.dumps(interesting or overall, indent=2, sort_keys=True), flush=True)
+
+
+def resolve_upload_repo(value: str) -> str | None:
+    value = (value or "").strip()
+    if not value:
+        return None
+    if value != "auto":
+        return value
+    from huggingface_hub import HfApi
+
+    who = HfApi().whoami()
+    name = who.get("name")
+    if not name:
+        raise RuntimeError("could not resolve HF username for --upload-repo auto")
+    return f"{name}/skippy-spd-qwen06-proof"
+
+
+def upload_artifacts(upload_repo: str | None, artifact_dir: Path, *, public: bool) -> None:
+    if upload_repo is None:
+        print(f"no upload repo configured; artifacts remain at {artifact_dir}", flush=True)
+        return
+    from huggingface_hub import HfApi
+
+    api = HfApi()
+    api.create_repo(upload_repo, repo_type="model", private=not public, exist_ok=True)
+    api.upload_folder(
+        repo_id=upload_repo,
+        repo_type="model",
+        folder_path=str(artifact_dir),
+        path_in_repo=f"runs/{artifact_dir.name}",
+    )
+    print(f"uploaded artifacts to hf://models/{upload_repo}/runs/{artifact_dir.name}", flush=True)
+
+
+def reference_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    if args.device != "auto":
+        env["SPD_DEVICE"] = args.device
+    env["SPD_ATTN_IMPLEMENTATION"] = args.attn_implementation
+    return env
+
+
+def main() -> None:
+    args = parse_args()
+    work_dir = Path(args.work_dir).resolve()
+    reference_dir = work_dir / "speculative_pipeline_decoding"
+    artifact_dir = work_dir / "artifacts" / time.strftime("%Y%m%d-%H%M%S")
+    data_dir = work_dir / "data"
+    train_dir = artifact_dir / "train"
+    eval_dir = artifact_dir / "eval"
+    mini_eval_dir = data_dir / "mini_eval_data"
+    train_jsonl = data_dir / "train_conversations.jsonl"
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    clone_reference(args.reference_repo, reference_dir)
+    patch_reference_for_proof(reference_dir)
+    patch_reference_for_device(reference_dir, args.device)
+
+    existing_ckpt = prepare_existing_spec_head(args, train_dir)
+    if existing_ckpt is not None:
+        ckpt = existing_ckpt
+    elif not args.skip_train:
+        rows = load_training_rows(args.dataset, args.dataset_split, args.train_rows)
+        write_jsonl(train_jsonl, rows)
+        ckpt = train_head(args, reference_dir, train_jsonl, train_dir)
+    else:
+        ckpt = train_dir / "speculation_head_final.pt"
+        if not ckpt.is_file():
+            raise FileNotFoundError(f"--skip-train requires existing checkpoint at {ckpt}")
+
+    if not args.skip_eval:
+        if mini_eval_dir.exists():
+            shutil.rmtree(mini_eval_dir)
+        create_mini_eval_data(reference_dir, mini_eval_dir, args.eval_rows_per_set)
+        evaluate_head(args, reference_dir, ckpt, mini_eval_dir, eval_dir)
+        print_eval_summary(eval_dir)
+
+    upload_repo = resolve_upload_repo(args.upload_repo)
+    upload_artifacts(upload_repo, artifact_dir, public=args.public)
+
+
+if __name__ == "__main__":
+    main()

--- a/evals/spd/hf_train_eval_qwen06.py
+++ b/evals/spd/hf_train_eval_qwen06.py
@@ -595,6 +595,23 @@ def file_sha256(path: Path) -> str:
     return hasher.hexdigest()
 
 
+def resolve_manifest_model_type(config: dict[str, Any], model_name: str) -> str | None:
+    model_type = config.get("model_type")
+    if isinstance(model_type, str) and model_type:
+        return model_type
+
+    try:
+        from transformers import AutoConfig
+
+        base_config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
+    except Exception as exc:  # noqa: BLE001
+        print(f"warning: could not resolve base model_type for manifest: {exc}", flush=True)
+        return None
+
+    model_type = getattr(base_config, "model_type", None)
+    return model_type if isinstance(model_type, str) and model_type else None
+
+
 def write_skippy_spd_manifest(args: argparse.Namespace, ckpt: Path, manifest_path: Path) -> None:
     import torch
 
@@ -625,7 +642,7 @@ def write_skippy_spd_manifest(args: argparse.Namespace, ckpt: Path, manifest_pat
             "format": "torch-speculation-head-v10",
             "reference_repo": args.reference_repo,
             "base_model_path": manifest_base_model_path,
-            "model_type": config.get("model_type"),
+            "model_type": resolve_manifest_model_type(config, args.model_name),
             "checkpoint_version": int(config.get("version", 0)),
         },
         "topology": {

--- a/evals/spd/hf_train_eval_qwen06.py
+++ b/evals/spd/hf_train_eval_qwen06.py
@@ -724,7 +724,7 @@ def print_eval_summary(eval_dir: Path) -> None:
 
 def resolve_upload_repo(value: str) -> str | None:
     value = (value or "").strip()
-    if not value:
+    if not value or value.lower() in {"none", "off", "false", "disabled"}:
         return None
     if value != "auto":
         return value

--- a/evals/spd/hf_train_eval_qwen06.py
+++ b/evals/spd/hf_train_eval_qwen06.py
@@ -458,6 +458,7 @@ def write_skippy_spd_manifest(args: argparse.Namespace, ckpt: Path, manifest_pat
             "vocab_size": int(config["vocab_size"]),
             "draft_vocab_size": int(config.get("draft_vocab_size", config["vocab_size"])),
             "num_stages": int(config["num_stages"]),
+            "stage_layer_boundaries": config.get("stage_layer_boundaries"),
             "num_spec_layers": int(config["num_spec_layers"]),
             "trained_with_use_deepest": bool(config.get("trained_with_use_deepest", False)),
             "shallow_hidden_layer_indices": config["shallow_hidden_layer_indices"],

--- a/evals/spd/hf_train_eval_qwen06.py
+++ b/evals/spd/hf_train_eval_qwen06.py
@@ -13,7 +13,7 @@
 #   "transformers>=5.6.0",
 # ]
 # ///
-"""Train and evaluate a small SPD speculation head on Hugging Face Jobs.
+"""Train and evaluate an SPD speculation head on Hugging Face Jobs or locally.
 
 This is intentionally a proof runner, not serving code. It produces a real
 `speculation_head_final.pt` from the reference SPD implementation, evaluates it,
@@ -42,7 +42,7 @@ DEFAULT_DATASET_SPLIT = "train_sft"
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run a real Qwen3-0.6B SPD head proof job")
+    parser = argparse.ArgumentParser(description="Run a real SPD head proof or smoke job")
     parser.add_argument("--work-dir", default="/tmp/skippy-spd-qwen06-proof")
     parser.add_argument("--reference-repo", default=REFERENCE_REPO)
     parser.add_argument("--model-name", default=DEFAULT_MODEL)
@@ -51,6 +51,22 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--train-rows", type=int, default=1024)
     parser.add_argument("--eval-rows-per-set", type=int, default=8)
     parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument(
+        "--stage-layer-boundaries",
+        default="",
+        help=(
+            "Comma-separated target layer end indices for non-uniform topologies, "
+            "for example 15,31,47 for GLM 4.7 Flash."
+        ),
+    )
+    parser.add_argument(
+        "--shallow-hidden-layer-indices",
+        default="",
+        help=(
+            "Explicit semicolon-separated HF hidden-state tap rows for [g_n..g_1]. "
+            "Overrides --stage-layer-boundaries when set."
+        ),
+    )
     parser.add_argument("--num-spec-layers", type=int, default=1)
     parser.add_argument("--epochs", type=int, default=1)
     parser.add_argument("--batch-size", type=int, default=1)
@@ -74,7 +90,21 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--draft-vocab-json",
         default="draft_vocab/ultrachat_qwen3_0.6b_top_32k.json",
-        help="Path inside the reference repo; empty disables reduced draft vocab.",
+        help=(
+            "Draft vocab JSON path. Relative paths are resolved inside the reference repo; "
+            "absolute paths are passed through. Empty disables reduced draft vocab."
+        ),
+    )
+    parser.add_argument(
+        "--build-draft-vocab-size",
+        type=int,
+        default=0,
+        help="Build a tokenizer-specific draft vocab from the loaded train rows before training.",
+    )
+    parser.add_argument(
+        "--draft-vocab-out",
+        default="",
+        help="Output JSON for --build-draft-vocab-size. Defaults under the artifact data dir.",
     )
     parser.add_argument(
         "--upload-repo",
@@ -127,6 +157,7 @@ def patch_reference_for_proof(reference_dir: Path) -> None:
         "        report_to=[],\n",
     )
     patch_reference_for_transformers(reference_dir)
+    patch_reference_for_glm_training_smoke(reference_dir)
 
 
 def write_qwen3_nonthink_template(path: Path) -> None:
@@ -157,6 +188,37 @@ def patch_reference_for_transformers(reference_dir: Path) -> None:
         reference_dir / "pipeline_model.py",
         '            "cache_position": cache_position,\n',
         "",
+    )
+
+
+def patch_reference_for_glm_training_smoke(reference_dir: Path) -> None:
+    patch_pipeline_model_for_glm(reference_dir / "pipeline_model.py")
+
+
+def patch_pipeline_model_for_glm(path: Path) -> None:
+    replace_once(
+        path,
+        'supported = {"qwen3", "qwen3_moe", "qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text", "llama"}',
+        'supported = {"qwen3", "qwen3_moe", "qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text", "llama", "glm4_moe_lite"}',
+    )
+    replace_once(
+        path,
+        '''        if self.num_layers % self.num_stages != 0:
+            raise ValueError(
+                f"num_layers ({self.num_layers}) must be divisible by num_stages ({self.num_stages})"
+            )
+        self.layers_per_stage = self.num_layers // self.num_stages
+''',
+        '''        if self.num_layers % self.num_stages != 0:
+            if shallow_hidden_layer_indices is None:
+                raise ValueError(
+                    f"num_layers ({self.num_layers}) must be divisible by num_stages ({self.num_stages}) "
+                    "unless shallow_hidden_layer_indices supplies an explicit non-uniform topology"
+                )
+            self.layers_per_stage = max(1, (self.num_layers + self.num_stages - 1) // self.num_stages)
+        else:
+            self.layers_per_stage = self.num_layers // self.num_stages
+''',
     )
 
 
@@ -335,6 +397,113 @@ def create_mini_eval_data(reference_dir: Path, out_dir: Path, rows_per_set: int)
         print(f"mini eval {name}: {copied} rows -> {dest}", flush=True)
 
 
+def parse_stage_layer_boundaries(value: str) -> list[int] | None:
+    value = (value or "").strip()
+    if not value:
+        return None
+    boundaries = [int(part.strip()) for part in value.split(",") if part.strip()]
+    if not boundaries:
+        raise RuntimeError("--stage-layer-boundaries must not be empty when set")
+    if any(left >= right for left, right in zip(boundaries, boundaries[1:])):
+        raise RuntimeError(f"--stage-layer-boundaries must be strictly increasing: {boundaries}")
+    return boundaries
+
+
+def derive_hidden_tap_indices(boundaries: list[int]) -> list[list[int]]:
+    rows: list[list[int]] = []
+    for depth in range(len(boundaries), 0, -1):
+        rows.append([0, *boundaries[:depth]])
+    return rows
+
+
+def hidden_tap_rows_arg(args: argparse.Namespace) -> str:
+    explicit = args.shallow_hidden_layer_indices.strip()
+    if explicit:
+        return explicit
+    boundaries = parse_stage_layer_boundaries(args.stage_layer_boundaries)
+    if boundaries is None:
+        return ""
+    if len(boundaries) != args.num_stages:
+        raise RuntimeError(
+            f"--stage-layer-boundaries has {len(boundaries)} entries but --num-stages is {args.num_stages}"
+        )
+    return ";".join(",".join(str(index) for index in row) for row in derive_hidden_tap_indices(boundaries))
+
+
+def resolve_draft_vocab_path(reference_dir: Path, value: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return reference_dir / path
+
+
+def build_draft_vocab_json(
+    *,
+    args: argparse.Namespace,
+    rows: list[dict[str, Any]],
+    output_path: Path,
+    vocab_size: int,
+) -> Path:
+    from collections import Counter
+
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model_name, trust_remote_code=True)
+    counts: Counter[int] = Counter()
+    for row in rows:
+        text = row_text_for_vocab(tokenizer, row.get("messages") or [])
+        if not text:
+            continue
+        counts.update(int(token_id) for token_id in tokenizer.encode(text, add_special_tokens=False))
+    for token_id in (
+        getattr(tokenizer, "eos_token_id", None),
+        getattr(tokenizer, "pad_token_id", None),
+        getattr(tokenizer, "bos_token_id", None),
+    ):
+        if token_id is not None:
+            counts[int(token_id)] += 1
+    if not counts:
+        raise RuntimeError("could not build draft vocab: no tokens counted")
+    token_ids = [
+        token_id
+        for token_id, _ in sorted(counts.items(), key=lambda item: (-item[1], item[0]))[
+            : max(1, int(vocab_size))
+        ]
+    ]
+    token_ids = sorted(set(token_ids))
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output = {
+        "draft_vocab_size": len(token_ids),
+        "token_ids": token_ids,
+        "metadata": {
+            "base_model_path": args.model_name,
+            "source": "hf_train_eval_qwen06.py --build-draft-vocab-size",
+            "train_rows": len(rows),
+            "requested_vocab_size": int(vocab_size),
+        },
+    }
+    output_path.write_text(json.dumps(output, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote draft vocab ({len(token_ids)} ids) -> {output_path}", flush=True)
+    return output_path
+
+
+def row_text_for_vocab(tokenizer: Any, messages: list[dict[str, Any]]) -> str:
+    if not messages:
+        return ""
+    try:
+        rendered = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=False,
+            enable_thinking=False,
+        )
+        if isinstance(rendered, str):
+            return rendered
+    except Exception:
+        pass
+    return "\n".join(str(message.get("content", "")) for message in messages)
+
+
 def train_head(args: argparse.Namespace, reference_dir: Path, train_jsonl: Path, train_dir: Path) -> Path:
     cmd = [
         sys.executable,
@@ -368,8 +537,11 @@ def train_head(args: argparse.Namespace, reference_dir: Path, train_jsonl: Path,
         "--output_dir",
         str(train_dir),
     ]
+    hidden_rows = hidden_tap_rows_arg(args)
+    if hidden_rows:
+        cmd.extend(["--shallow_hidden_layer_indices", hidden_rows])
     if args.draft_vocab_json:
-        cmd.extend(["--draft_vocab_json", str(reference_dir / args.draft_vocab_json)])
+        cmd.extend(["--draft_vocab_json", str(resolve_draft_vocab_path(reference_dir, args.draft_vocab_json))])
     started = time.perf_counter()
     run(cmd, cwd=reference_dir, env=reference_env(args))
     elapsed = time.perf_counter() - started
@@ -435,6 +607,9 @@ def write_skippy_spd_manifest(args: argparse.Namespace, ckpt: Path, manifest_pat
         raise RuntimeError(f"{ckpt} does not contain a config dict")
 
     draft_token_ids = config.get("draft_token_ids")
+    stage_layer_boundaries = config.get("stage_layer_boundaries")
+    if stage_layer_boundaries is None:
+        stage_layer_boundaries = parse_stage_layer_boundaries(args.stage_layer_boundaries)
     manifest_base_model_path = args.manifest_base_model_path.strip()
     if not manifest_base_model_path:
         manifest_base_model_path = config.get("base_model_path") or args.model_name
@@ -458,7 +633,7 @@ def write_skippy_spd_manifest(args: argparse.Namespace, ckpt: Path, manifest_pat
             "vocab_size": int(config["vocab_size"]),
             "draft_vocab_size": int(config.get("draft_vocab_size", config["vocab_size"])),
             "num_stages": int(config["num_stages"]),
-            "stage_layer_boundaries": config.get("stage_layer_boundaries"),
+            "stage_layer_boundaries": stage_layer_boundaries,
             "num_spec_layers": int(config["num_spec_layers"]),
             "trained_with_use_deepest": bool(config.get("trained_with_use_deepest", False)),
             "shallow_hidden_layer_indices": config["shallow_hidden_layer_indices"],
@@ -593,6 +768,20 @@ def main() -> None:
     elif not args.skip_train:
         rows = load_training_rows(args.dataset, args.dataset_split, args.train_rows)
         write_jsonl(train_jsonl, rows)
+        if args.build_draft_vocab_size > 0:
+            draft_vocab_out = (
+                Path(args.draft_vocab_out).expanduser().resolve()
+                if args.draft_vocab_out
+                else data_dir / f"draft_vocab_top_{args.build_draft_vocab_size}.json"
+            )
+            args.draft_vocab_json = str(
+                build_draft_vocab_json(
+                    args=args,
+                    rows=rows,
+                    output_path=draft_vocab_out,
+                    vocab_size=args.build_draft_vocab_size,
+                )
+            )
         ckpt = train_head(args, reference_dir, train_jsonl, train_dir)
     else:
         ckpt = train_dir / "speculation_head_final.pt"

--- a/evals/spd/hf_train_eval_qwen06.py
+++ b/evals/spd/hf_train_eval_qwen06.py
@@ -220,6 +220,68 @@ def patch_pipeline_model_for_glm(path: Path) -> None:
             self.layers_per_stage = self.num_layers // self.num_stages
 ''',
     )
+    replace_once(
+        path,
+        "        self.shallow_hidden_layer_indices = self._normalize_stage_feature_indices(shallow_hidden_layer_indices)\n",
+        """        self.shallow_hidden_layer_indices = self._normalize_stage_feature_indices(shallow_hidden_layer_indices)
+        self.stage_layer_ranges = self._derive_stage_layer_ranges()
+""",
+    )
+    replace_once(
+        path,
+        '''    def _snap_indices_needed(self) -> Set[int]:
+        want: Set[int] = set()
+        for row in self.shallow_hidden_layer_indices:
+            for idx in row:
+                want.add(int(idx))
+        return want
+''',
+        '''    def _snap_indices_needed(self) -> Set[int]:
+        want: Set[int] = set()
+        for row in self.shallow_hidden_layer_indices:
+            for idx in row:
+                want.add(int(idx))
+        return want
+
+    def _derive_stage_layer_ranges(self) -> List[Tuple[int, int]]:
+        rows = self.shallow_hidden_layer_indices
+        deepest_row = tuple(sorted({int(x) for x in rows[0] if int(x) > 0})) if rows else ()
+        if (
+            len(deepest_row) >= self.num_stages
+            and deepest_row[-1] == self.num_layers
+            and all(a < b for a, b in zip(deepest_row, deepest_row[1:]))
+        ):
+            ranges: List[Tuple[int, int]] = []
+            start = 0
+            for end in deepest_row[: self.num_stages]:
+                ranges.append((start, end))
+                start = end
+            return ranges
+
+        ranges = []
+        for stage_idx in range(self.num_stages):
+            start = min(stage_idx * self.layers_per_stage, self.num_layers)
+            end = min((stage_idx + 1) * self.layers_per_stage, self.num_layers)
+            ranges.append((start, end))
+        return ranges
+''',
+    )
+    replace_once(
+        path,
+        '''                start_layer = stage_idx * lps
+                end_layer = (stage_idx + 1) * lps
+''',
+        '''                start_layer, end_layer = self.stage_layer_ranges[stage_idx]
+''',
+    )
+    replace_once(
+        path,
+        '''                start_layer = stage_idx * lps
+                end_layer = (stage_idx + 1) * lps
+''',
+        '''                start_layer, end_layer = self.stage_layer_ranges[stage_idx]
+''',
+    )
 
 
 def patch_reference_linear_cache_import(path: Path) -> None:

--- a/evals/spd/simulate_latency.py
+++ b/evals/spd/simulate_latency.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Simulate split-stage latency from real SPD eval traces.
+
+This is not a serving benchmark. It consumes the per-sample JSONL emitted by the
+reference SPD eval and applies an explicit latency model to its real
+``new_tokens`` and ``decode_loop_steps`` counts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class TraceTotals:
+    samples: int
+    stages: int
+    tokens: int
+    decode_steps: int
+    accepted_flags: int
+    acceptance_flags: int
+
+    @property
+    def pipeline_cycles(self) -> float:
+        return self.decode_steps / max(self.stages, 1)
+
+    @property
+    def aggregate_acceptance_rate(self) -> float:
+        if self.decode_steps == 0:
+            return 0.0
+        return self.tokens / self.decode_steps
+
+    @property
+    def equivalent_accept_length(self) -> float:
+        return self.stages * self.aggregate_acceptance_rate
+
+    @property
+    def paper_theoretical_gain_pct(self) -> float:
+        if self.pipeline_cycles <= 0.0:
+            return 0.0
+        return ((self.tokens / self.pipeline_cycles) - 1.0) * 100.0
+
+
+@dataclass(frozen=True)
+class LatencyScenario:
+    stage_ms: tuple[float, ...]
+    hop_ms: float
+
+    @property
+    def stages(self) -> int:
+        return len(self.stage_ms)
+
+    @property
+    def serial_step_ms(self) -> float:
+        return sum(self.stage_ms) + self.hop_ms * max(self.stages - 1, 0)
+
+    @property
+    def pipeline_slot_ms(self) -> float:
+        if not self.stage_ms:
+            return 0.0
+        slots = []
+        for index, stage_ms in enumerate(self.stage_ms):
+            outgoing_hop = self.hop_ms if index + 1 < self.stages else 0.0
+            slots.append(stage_ms + outgoing_hop)
+        return max(slots)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--raw", required=True, type=Path, help="SPD eval raw per-sample JSONL")
+    parser.add_argument(
+        "--stage-ms",
+        default="4,4",
+        help="Comma-separated per-stage compute latency in ms, e.g. 4,4 or 3,5,6",
+    )
+    parser.add_argument(
+        "--hop-ms",
+        default="0,1,5,10,25",
+        help="Comma-separated inter-stage activation hop latency scenarios in ms",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of the default human table",
+    )
+    return parser.parse_args()
+
+
+def parse_float_list(value: str, label: str) -> tuple[float, ...]:
+    try:
+        parsed = tuple(float(part.strip()) for part in value.split(",") if part.strip())
+    except ValueError as error:
+        raise SystemExit(f"invalid {label}: {value!r}") from error
+    if not parsed:
+        raise SystemExit(f"{label} must contain at least one number")
+    if any(item < 0.0 for item in parsed):
+        raise SystemExit(f"{label} values must be non-negative")
+    return parsed
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as error:
+                raise SystemExit(f"{path}:{line_number}: invalid JSON") from error
+    if not rows:
+        raise SystemExit(f"{path} contains no rows")
+    return rows
+
+
+def trace_totals(rows: list[dict[str, Any]]) -> TraceTotals:
+    stages = {int(row.get("num_stages") or 0) for row in rows}
+    stages.discard(0)
+    if len(stages) != 1:
+        raise SystemExit(f"expected one num_stages value, got {sorted(stages)}")
+    return TraceTotals(
+        samples=len(rows),
+        stages=stages.pop(),
+        tokens=sum(int(row.get("new_tokens") or 0) for row in rows),
+        decode_steps=sum(int(row.get("decode_loop_steps") or 0) for row in rows),
+        accepted_flags=sum(int(row.get("n_accepted") or 0) for row in rows),
+        acceptance_flags=sum(int(row.get("n_acceptance_flags") or 0) for row in rows),
+    )
+
+
+def percentile(values: list[float], pct: float) -> float:
+    if not values:
+        return 0.0
+    values = sorted(values)
+    index = (len(values) - 1) * pct
+    lower = int(index)
+    upper = min(lower + 1, len(values) - 1)
+    fraction = index - lower
+    return values[lower] * (1.0 - fraction) + values[upper] * fraction
+
+
+def simulate(rows: list[dict[str, Any]], totals: TraceTotals, scenario: LatencyScenario) -> dict[str, Any]:
+    if scenario.stages != totals.stages:
+        raise SystemExit(
+            f"--stage-ms has {scenario.stages} stages but trace has {totals.stages} stages"
+        )
+
+    serial_ms_by_sample = [
+        int(row.get("new_tokens") or 0) * scenario.serial_step_ms for row in rows
+    ]
+    spd_ms_by_sample = [
+        (int(row.get("decode_loop_steps") or 0) / totals.stages) * scenario.pipeline_slot_ms
+        for row in rows
+    ]
+    serial_total_ms = sum(serial_ms_by_sample)
+    spd_total_ms = sum(spd_ms_by_sample)
+    paper_like_no_spd_ms = totals.tokens * scenario.pipeline_slot_ms
+
+    return {
+        "stage_ms": list(scenario.stage_ms),
+        "hop_ms": scenario.hop_ms,
+        "serial_step_ms": scenario.serial_step_ms,
+        "pipeline_slot_ms": scenario.pipeline_slot_ms,
+        "paper_like_no_spd_ms": paper_like_no_spd_ms,
+        "serial_split_no_spd_ms": serial_total_ms,
+        "spd_pipeline_ms": spd_total_ms,
+        "spd_vs_paper_like_no_spd": safe_ratio(paper_like_no_spd_ms, spd_total_ms),
+        "spd_vs_serial_split_no_spd": safe_ratio(serial_total_ms, spd_total_ms),
+        "serial_split_tok_s": safe_tok_s(totals.tokens, serial_total_ms),
+        "spd_pipeline_tok_s": safe_tok_s(totals.tokens, spd_total_ms),
+        "serial_request_p50_ms": percentile(serial_ms_by_sample, 0.5),
+        "serial_request_p95_ms": percentile(serial_ms_by_sample, 0.95),
+        "spd_request_p50_ms": percentile(spd_ms_by_sample, 0.5),
+        "spd_request_p95_ms": percentile(spd_ms_by_sample, 0.95),
+        "request_latency_p50_ratio": safe_ratio(
+            percentile(serial_ms_by_sample, 0.5),
+            percentile(spd_ms_by_sample, 0.5),
+        ),
+        "request_latency_p95_ratio": safe_ratio(
+            percentile(serial_ms_by_sample, 0.95),
+            percentile(spd_ms_by_sample, 0.95),
+        ),
+    }
+
+
+def safe_ratio(numerator: float, denominator: float) -> float:
+    if denominator <= 0.0:
+        return 0.0
+    return numerator / denominator
+
+
+def safe_tok_s(tokens: int, total_ms: float) -> float:
+    if total_ms <= 0.0:
+        return 0.0
+    return tokens / (total_ms / 1000.0)
+
+
+def emit_table(totals: TraceTotals, results: list[dict[str, Any]]) -> None:
+    print("Trace")
+    print(f"  samples: {totals.samples}")
+    print(f"  stages: {totals.stages}")
+    print(f"  generated tokens: {totals.tokens}")
+    print(f"  decode loop steps: {totals.decode_steps}")
+    print(f"  accepted draft flags: {totals.accepted_flags}/{totals.acceptance_flags}")
+    print(f"  aggregate acceptance: {totals.aggregate_acceptance_rate:.4f}")
+    print(f"  equivalent accept length: {totals.equivalent_accept_length:.4f}")
+    print(f"  paper theoretical gain: {totals.paper_theoretical_gain_pct:.2f}%")
+    print()
+    print("Latency scenarios")
+    writer = csv.writer(sys.stdout)
+    writer.writerow(
+        [
+            "hop_ms",
+            "slot_ms",
+            "serial_tok_s",
+            "spd_tok_s",
+            "spd_vs_serial",
+            "paper_like_gain",
+            "p50_serial_ms",
+            "p50_spd_ms",
+            "p95_serial_ms",
+            "p95_spd_ms",
+        ]
+    )
+    for result in results:
+        writer.writerow(
+            [
+                f"{result['hop_ms']:.3f}",
+                f"{result['pipeline_slot_ms']:.3f}",
+                f"{result['serial_split_tok_s']:.2f}",
+                f"{result['spd_pipeline_tok_s']:.2f}",
+                f"{result['spd_vs_serial_split_no_spd']:.3f}",
+                f"{result['spd_vs_paper_like_no_spd']:.3f}",
+                f"{result['serial_request_p50_ms']:.2f}",
+                f"{result['spd_request_p50_ms']:.2f}",
+                f"{result['serial_request_p95_ms']:.2f}",
+                f"{result['spd_request_p95_ms']:.2f}",
+            ]
+        )
+
+
+def main() -> None:
+    args = parse_args()
+    rows = load_rows(args.raw)
+    totals = trace_totals(rows)
+    stage_ms = parse_float_list(args.stage_ms, "--stage-ms")
+    hop_values = parse_float_list(args.hop_ms, "--hop-ms")
+    scenarios = [LatencyScenario(stage_ms=stage_ms, hop_ms=hop_ms) for hop_ms in hop_values]
+    results = [simulate(rows, totals, scenario) for scenario in scenarios]
+
+    payload = {
+        "raw": str(args.raw),
+        "totals": {
+            "samples": totals.samples,
+            "stages": totals.stages,
+            "tokens": totals.tokens,
+            "decode_steps": totals.decode_steps,
+            "accepted_flags": totals.accepted_flags,
+            "acceptance_flags": totals.acceptance_flags,
+            "aggregate_acceptance_rate": totals.aggregate_acceptance_rate,
+            "equivalent_accept_length": totals.equivalent_accept_length,
+            "paper_theoretical_gain_pct": totals.paper_theoretical_gain_pct,
+        },
+        "assumptions": {
+            "serial_split_no_spd": (
+                "one generated token traverses every stage and inter-stage hop before the "
+                "next target token is known"
+            ),
+            "spd_pipeline": (
+                "real reference decode_loop_steps are converted to pipeline cycles by "
+                "dividing by num_stages; each cycle costs the slowest stage slot"
+            ),
+            "stage_slot": "stage compute plus outgoing hop, except the final stage has no outgoing hop",
+        },
+        "results": results,
+    }
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        emit_table(totals, results)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/skippy-openai-smoke.sh
+++ b/scripts/skippy-openai-smoke.sh
@@ -36,6 +36,7 @@ DEFAULT_MAX_TOKENS="${DEFAULT_MAX_TOKENS:-2}"
 N_GPU_LAYERS="${N_GPU_LAYERS:-0}"
 RUN_BENCHY="${RUN_BENCHY:-0}"
 KEEP_SERVER="${KEEP_SERVER:-0}"
+SKIP_UNSUPPORTED_SAMPLING_PROBE="${SKIP_UNSUPPORTED_SAMPLING_PROBE:-0}"
 
 SERVER_PID=""
 
@@ -231,29 +232,33 @@ fi
 sampling_json="$(cat "$sampling_response")"
 echo "$sampling_json" | jq -e '.choices[0].finish_reason == "length"' >/dev/null
 
-echo "probing unsupported sampling rejection"
-unsupported_sampling_request="$(jq -cn --arg model "$MODEL_ID" '{
-  model: $model,
-  messages: [{role: "user", content: "Say hi"}],
-  min_p: 0.1,
-  max_tokens: 2
-}')"
-unsupported_sampling_response="${WORK_DIR}/unsupported-sampling-response.json"
-unsupported_sampling_status="$(
-  curl -sS --max-time 10 \
-    -o "$unsupported_sampling_response" \
-    -w '%{http_code}' \
-    "${BASE_URL}/chat/completions" \
-    -H 'content-type: application/json' \
-    -d "$unsupported_sampling_request"
-)"
-if [[ "$unsupported_sampling_status" != "400" ]]; then
-  echo "expected unsupported sampling to return HTTP 400, got ${unsupported_sampling_status}" >&2
-  cat "$unsupported_sampling_response" >&2 || true
-  exit 1
+if [[ "$SKIP_UNSUPPORTED_SAMPLING_PROBE" == "1" ]]; then
+  echo "skipping unsupported sampling rejection probe"
+else
+  echo "probing unsupported sampling rejection"
+  unsupported_sampling_request="$(jq -cn --arg model "$MODEL_ID" '{
+    model: $model,
+    messages: [{role: "user", content: "Say hi"}],
+    min_p: 0.1,
+    max_tokens: 2
+  }')"
+  unsupported_sampling_response="${WORK_DIR}/unsupported-sampling-response.json"
+  unsupported_sampling_status="$(
+    curl -sS --max-time 10 \
+      -o "$unsupported_sampling_response" \
+      -w '%{http_code}' \
+      "${BASE_URL}/chat/completions" \
+      -H 'content-type: application/json' \
+      -d "$unsupported_sampling_request"
+  )"
+  if [[ "$unsupported_sampling_status" != "400" ]]; then
+    echo "expected unsupported sampling to return HTTP 400, got ${unsupported_sampling_status}" >&2
+    cat "$unsupported_sampling_response" >&2 || true
+    exit 1
+  fi
+  unsupported_sampling_json="$(cat "$unsupported_sampling_response")"
+  echo "$unsupported_sampling_json" | jq -e '.error.code == "unsupported_model_feature"' >/dev/null
 fi
-unsupported_sampling_json="$(cat "$unsupported_sampling_response")"
-echo "$unsupported_sampling_json" | jq -e '.error.code == "unsupported_model_feature"' >/dev/null
 
 if [[ "$RUN_BENCHY" == "1" ]]; then
   require_cmd uvx

--- a/scripts/skippy-openai-smoke.sh
+++ b/scripts/skippy-openai-smoke.sh
@@ -1,7 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-LLAMA_BUILD_DIR="${LLAMA_STAGE_BUILD_DIR:-.deps/llama-build/build-stage-abi-static}"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+resolve_llama_build_dir() {
+  if [[ -n "${LLAMA_STAGE_BUILD_DIR:-}" ]]; then
+    printf '%s\n' "$LLAMA_STAGE_BUILD_DIR"
+    return
+  fi
+  if [[ -n "${SKIPPY_LLAMA_BUILD_DIR:-}" ]]; then
+    printf '%s\n' "$SKIPPY_LLAMA_BUILD_DIR"
+    return
+  fi
+  if [[ "$(uname -s)" == "Darwin" && -d "$ROOT/.deps/llama-build/build-stage-abi-metal" ]]; then
+    printf '%s\n' "$ROOT/.deps/llama-build/build-stage-abi-metal"
+    return
+  fi
+  printf '%s\n' "$ROOT/.deps/llama-build/build-stage-abi-static"
+}
+
+LLAMA_BUILD_DIR="$(resolve_llama_build_dir)"
 MODEL_REPO="${MODEL_REPO:-jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF}"
 MODEL_FILE="${MODEL_FILE:-SmolLM2-135M-Instruct.Q4_K_M.gguf}"
 MODEL_SELECTOR="${MODEL_SELECTOR:-Q4_K_M}"
@@ -15,6 +33,7 @@ PORT="${PORT:-9337}"
 BASE_URL="http://${HOST}:${PORT}/v1"
 CTX_SIZE="${CTX_SIZE:-256}"
 DEFAULT_MAX_TOKENS="${DEFAULT_MAX_TOKENS:-2}"
+N_GPU_LAYERS="${N_GPU_LAYERS:-0}"
 RUN_BENCHY="${RUN_BENCHY:-0}"
 KEEP_SERVER="${KEEP_SERVER:-0}"
 
@@ -85,11 +104,11 @@ if [[ -z "$LAYER_END" || "$LAYER_END" == "null" ]]; then
 fi
 
 CONFIG_PATH="${WORK_DIR}/stage-openai-smoke.json"
-python3 - "$CONFIG_PATH" "$MODEL_ID" "$MODEL_PATH" "$LAYER_END" "$CTX_SIZE" <<'PY'
+python3 - "$CONFIG_PATH" "$MODEL_ID" "$MODEL_PATH" "$LAYER_END" "$CTX_SIZE" "$N_GPU_LAYERS" <<'PY'
 import json
 import sys
 
-config_path, model_id, model_path, layer_end, ctx_size = sys.argv[1:]
+config_path, model_id, model_path, layer_end, ctx_size, n_gpu_layers = sys.argv[1:]
 config = {
     "run_id": "openai-smoke",
     "topology_id": "openai-smoke-single-stage",
@@ -100,7 +119,7 @@ config = {
     "layer_start": 0,
     "layer_end": int(layer_end),
     "ctx_size": int(ctx_size),
-    "n_gpu_layers": 0,
+    "n_gpu_layers": int(n_gpu_layers),
     "filter_tensors_on_load": False,
     "load_mode": "runtime-slice",
     "bind_addr": "127.0.0.1:19000",

--- a/third_party/llama.cpp/patches/0101-Return-native-MTP-draft-from-verify-span.patch
+++ b/third_party/llama.cpp/patches/0101-Return-native-MTP-draft-from-verify-span.patch
@@ -1,6 +1,6 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From d5955ba41d54411ea20d6250a9e814bf59b63caf Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
-Date: Tue, 16 Jun 2026 15:30:00 +1000
+Date: Tue, 16 Jun 2026 18:43:54 +1000
 Subject: [PATCH] Return native MTP draft from verify span
 
 ---
@@ -22,12 +22,12 @@ index 063706ef..137910df 100644
  enum skippy_feature {
      SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index ee1dcad5..43dcd07b 100644
+index 119b755d..8f77fd13 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -3959,6 +3959,24 @@ enum skippy_status skippy_verify_tokens_frame_sampled(
-                     sampling,
-                     i);
+@@ -3947,6 +3947,24 @@ enum skippy_status skippy_verify_tokens_frame_sampled(
+         for (int32_t i = 0; i < n_tokens; ++i) {
+             output_tokens[i] = skippy_sample_token_ith(session, sampling, i);
          }
 +        if (output_token_capacity >= token_count + 2 && token_count > 0) {
 +            skippy_native_mtp_draft mtp_draft = {};

--- a/third_party/llama.cpp/patches/0104-Match-server-token-piece-detokenization.patch
+++ b/third_party/llama.cpp/patches/0104-Match-server-token-piece-detokenization.patch
@@ -1,27 +1,17 @@
-From 2f44fb3ccf58b24816203171d62f96f2ea32b97f Mon Sep 17 00:00:00 2001
+From 6aeb4ec5302b6f1cdd5765b7e6091be0ca0fd96f Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
-Date: Tue, 16 Jun 2026 16:48:00 +1000
+Date: Tue, 16 Jun 2026 18:45:27 +1000
 Subject: [PATCH] Match server token-piece detokenization
 
-llama-server reconstructs generated text by appending
-common_token_to_piece() for each sampled token. Skippy's OpenAI frontend
-used the staged ABI detokenize helper, which called full-sequence
-llama_detokenize(). For GLM/GPT-style tokenizers these paths are not
-equivalent: token ids can match while output text loses a token-piece
-leading space.
-
-Build staged detokenized text by appending llama_token_to_piece() for each
-generated token so single-stage Skippy output matches llama-server's
-generated text path.
 ---
- src/skippy.cpp | 43 +++++++++++++++++++++++++++++++------------
- 1 file changed, 31 insertions(+), 12 deletions(-)
+ src/skippy.cpp | 50 ++++++++++++++++++++++++++++++++++++++------------
+ 1 file changed, 38 insertions(+), 12 deletions(-)
 
 diff --git a/src/skippy.cpp b/src/skippy.cpp
-index f6d48cd5..2f44fb3c 100644
+index 50046936..f10e1d5f 100644
 --- a/src/skippy.cpp
 +++ b/src/skippy.cpp
-@@ -4912,22 +4912,41 @@ enum skippy_status skippy_detokenize(
+@@ -4909,21 +4909,47 @@ enum skippy_status skippy_detokenize(
      }
  
      const llama_vocab * vocab = llama_model_get_vocab(model->model);
@@ -82,5 +72,5 @@ index f6d48cd5..2f44fb3c 100644
  }
  
 -- 
-2.39.5
+2.54.0 (Apple Git-156)
 


### PR DESCRIPTION
## Goal

Enable a full GLM 4.7 SPD sidecar workflow: train a sidecar against the frozen GLM base model, evaluate it with target verification enabled, export it as a Skippy-compatible serving artifact, and use the Speedy benchmark to compare verified GLM+SPD decode against vanilla GLM decode under the same prompts, tokenizer, hardware, and generation settings.

This PR is the feature branch for that work. It is expected to accumulate the rest of the implementation, training/eval plumbing, export path, benchmark harness, and serving integration as they land.

## Current Status

The branch now has the GLM metadata/topology frontload, the tiny real training-smoke path, and a validated smoke serving artifact path:

- adds `evals/spd/glm47_frontload.py` to inspect a local GLM 4.7 checkpoint, derive non-uniform stage boundaries/tap metadata, and write tiny manifest-compatible smoke artifacts
- adds optional `stage_layer_boundaries` to the Skippy SPD manifest contract
- carries topology metadata, `model_type`, and serving-checkpoint metadata through the SPD manifest writer
- patches the cloned reference SPD model wrapper to allow `glm4_moe_lite` and to bypass equal-stage assumptions when explicit tap rows are supplied
- adds `--stage-layer-boundaries` and `--shallow-hidden-layer-indices` to the runner
- derives GLM tap rows such as `0,15,31,47;0,15,31;0,15` from `--stage-layer-boundaries 15,31,47`
- adds `--build-draft-vocab-size` to generate a GLM-tokenizer draft vocab from the smoke training rows
- adds explicit upload opt-out values such as `--upload-repo none` for local/lab smoke runs
- documents the GLM 4.7 SPD sidecar workflow, smoke manifest path, and training smoke command

The local checkpoint inspection found `glm4_moe_lite`, `Glm4MoeLiteForCausalLM`, 47 target layers, hidden size 2048, vocab size 154880, and layer-47 auxiliary tensors `eh_proj`, `enorm`, and `hnorm`. The default frontload topology uses explicit stage ends `15,31,47` so GLM is not forced into the old equal-stage assumption.

Tiny real training smoke passed on `micstudio` with the local `zai-org/GLM-4.7-Flash` snapshot, 8 UltraChat rows, MPS, `--stage-layer-boundaries 15,31,47`, `--num-spec-layers 1`, and a generated 1024-token GLM draft vocab. The smoke produced:

- `speculation_head_final.pt`: 520,122,465 bytes, sha256 `c68126aeb48e82973c5390932e607d51b30f0d62f44db2054632cb42a376a145`
- `spd-head.safetensors`: 520,112,968 bytes, 19 tensors, F32, sha256 `88d2e3c2b4e810e7ba3431faf616fb43004186ff843dbc0cfd58f13a02b16f1c`
- `skippy-spd-head.json` with `source.model_type = glm4_moe_lite`, `stage_layer_boundaries = [15,31,47]`, and GLM tap rows `[[0,15,31,47],[0,15,31],[0,15]]`

The smoke sidecar artifacts are uploaded to the private Hugging Face model repo [`meshllm/skippy-spd-glm47-train-smoke`](https://huggingface.co/meshllm/skippy-spd-glm47-train-smoke). The local source copy remains on `micstudio` under `/tmp/skippy-spd-glm47-manifest-refresh/artifacts/20260616-173653/train`.


Vanilla GLM Speedy baseline passed on `micstudio` against `GLM-4.7-Flash-Q4_K_M.gguf` with Metal offload (`N_GPU_LAYERS=-1`), `ctx_size=1024`, `pp=128,512`, `tg=16,32`, `runs=3`, `concurrency=1`, and generation-latency mode. Result file: `/tmp/glm47-speedy-vanilla-baseline/vanilla-glm47-speedy.md`. The baseline measured generation throughput around 77-79 tok/s for tg16/tg32 and prompt processing from 166k to 740k tok/s across the selected prompt sizes.


Tiny GLM SPD reference eval smoke passed on `micstudio` using the existing private smoke sidecar. This is not a live `serve-openai` Speedy run yet; it is the Python reference verifier with `--max-new-tokens 16`, `--draft-top-k 1`, 3 mini eval prompts, and target verification enabled. It produced `acceptance_rate = 0.3556`, `equivalent_accept_length = 1.0667`, and a theoretical throughput gain of `+6.67%`. Raw trace: `/tmp/skippy-spd-glm47-speedy-rows-smoke-rerun/artifacts/20260616-191923/eval/raw/pipeline_eval__train__speculation_head_final__nt3__per_sample.jsonl`.


1k-row GLM SPD reference train/eval now runs end-to-end on `micstudio`, but the resulting sidecar is not yet a useful acceleration candidate. The run trained for 128 steps from 1024 UltraChat rows with `--stage-layer-boundaries 15,31,47`, generated a 4096-token GLM draft vocab, and wrote `speculation_head_final.pt` plus `skippy-spd-head.json` under `/tmp/skippy-spd-glm47-train-1k/artifacts/20260618-154442/train`. The training metrics stayed at zero loss/accuracy, so this result should be treated as a harness/compatibility smoke, not a quality train.

The matching verified Python reference eval completed over 12 mini prompts (`mt_bench`, `humaneval`, `gsm8k`, 4 rows each), 768 generated tokens, and 2268 decode loop steps. It accepted 12 draft flags out of 768, for `acceptance_rate = 0.3386`, `equivalent_accept_length = 1.0159`, and `theoretical_throughput_gain = +1.59%`. Summary: `/tmp/skippy-spd-glm47-train-1k/artifacts/20260618-154442/eval/summary/pipeline_eval__train__speculation_head_final__nt12__summary.json`.

## Remaining Feature Work

This PR should continue until it contains the full GLM 4.7 SPD sidecar feature:

1. GLM 4.7 checkpoint inspection and topology metadata. Done.
2. Frontloaded GLM SPD smoke path and manifest validation. Done.
3. Training-smoke launch plumbing. Done.
4. Tiny real GLM training smoke, serving export, and Rust manifest validation. Done.
5. Vanilla GLM Speedy baseline benchmark. Done.
6. GLM tokenizer-specific production draft vocabulary generation.
7. GLM reference-model/SPD training adaptation for the full run. Reference path now handles explicit GLM stage ranges. Next fix: investigate why the 1k training-smoke reports zero loss/accuracy.
8. Sidecar training against the frozen GLM base model. Initial 1k-row smoke complete, but not production-quality because the trained head shows weak acceptance.
9. Verified evaluation and raw trace capture. Initial 12-prompt reference eval complete; live Speedy comparison remains gated on a better sidecar.
10. Export production sidecar to Rust-readable Skippy serving artifact.
11. Skippy latency simulation from real GLM SPD traces.
12. Speedy side-by-side benchmark: vanilla GLM versus verified GLM+SPD sidecar.
13. Live Skippy integration if the sidecar is materially faster while preserving target-equivalent output.

## Validation

Passed for the current slice:

```bash
python evals/spd/glm47_frontload.py \
  --write-smoke-artifacts \
  --work-dir /tmp/skippy-spd-glm47-frontload \
  --num-stages 3 \
  --num-spec-layers 1 \
  --draft-vocab-size 8

python evals/spd/hf_train_eval_qwen06.py --help

python -m py_compile \
  evals/spd/glm47_frontload.py \
  evals/spd/hf_train_eval_qwen06.py \
  evals/spd/export_spd_head.py

cargo fmt --all -- --check

git diff --check

SKIPPY_SPD_MANIFEST=/tmp/skippy-spd-glm47-frontload/glm47-spd-frontload/skippy-spd-head.json \
  cargo test -p skippy-runtime --features dynamic-native-runtime spd::tests
```

Tiny real GLM smoke passed on `micstudio`:

```bash
python evals/spd/hf_train_eval_qwen06.py \
  --work-dir /tmp/skippy-spd-glm47-train-smoke \
  --model-name /Volumes/models/huggingface/hub/models--zai-org--GLM-4.7-Flash/snapshots/7dd20894a642a0aa287e9827cb1a1f7f91386b67 \
  --dataset HuggingFaceH4/ultrachat_200k \
  --dataset-split train_sft \
  --train-rows 8 \
  --skip-eval \
  --num-stages 3 \
  --stage-layer-boundaries 15,31,47 \
  --num-spec-layers 1 \
  --max-length 128 \
  --batch-size 1 \
  --gradient-accumulation-steps 1 \
  --build-draft-vocab-size 1024 \
  --draft-vocab-json '' \
  --attn-implementation sdpa \
  --device mps
```

The exported real smoke serving artifact passed Rust manifest and safetensors validation:

```bash
SKIPPY_SPD_MANIFEST=/tmp/skippy-spd-glm47-manifest-refresh/artifacts/20260616-173653/train/skippy-spd-head.json \
  cargo test -p skippy-runtime --features dynamic-native-runtime \
  spd::tests::validates_external_manifest_when_skippy_spd_manifest_is_set
```

Uploaded the smoke artifacts to the private org repo:

```bash
hf models info meshllm/skippy-spd-glm47-train-smoke --format json
```

Also passed a reference-clone patch dry run: cloned `yuyijiong/speculative_pipeline_decoding` into `/tmp` and verified the GLM allowlist plus explicit non-uniform topology patch applied.

Vanilla GLM Speedy baseline passed on `micstudio` using the OpenAI-surface Speedy/benchy harness:

```bash
MODEL_PATH=/Volumes/models/huggingface/hub/models--unsloth--GLM-4.7-Flash-GGUF/snapshots/0d32489ecb9db6d2a4fc93bd27ef01519f95474d/GLM-4.7-Flash-Q4_K_M.gguf \
MODEL_ID=GLM-4.7-Flash-Q4_K_M \
TOKENIZER=/Volumes/models/huggingface/hub/models--zai-org--GLM-4.7-Flash/snapshots/7dd20894a642a0aa287e9827cb1a1f7f91386b67 \
CTX_SIZE=1024 \
DEFAULT_MAX_TOKENS=64 \
N_GPU_LAYERS=-1 \
SKIP_UNSUPPORTED_SAMPLING_PROBE=1 \
RUN_BENCHY=1 \
PP="128 512" TG="16 32" RUNS=3 CONCURRENCY=1 \
LATENCY_MODE=generation FORMAT=md \
SAVE_RESULT=/tmp/glm47-speedy-vanilla-baseline/vanilla-glm47-speedy.md \
scripts/skippy-openai-smoke.sh
```

Baseline result:

| model | test | t/s | peak t/s | ttfr (ms) | est_ppt (ms) | e2e_ttft (ms) |
|:--|--:|--:|--:|--:|--:|--:|
| GLM-4.7-Flash-Q4_K_M | pp128 | 166826.91 +/- 10693.93 | | 13.34 +/- 0.05 | 0.77 +/- 0.05 | 153.68 +/- 0.24 |
| GLM-4.7-Flash-Q4_K_M | tg16 | 78.62 +/- 0.05 | 83.86 +/- 0.05 | | | |
| GLM-4.7-Flash-Q4_K_M | pp128 | 522093.85 +/- 0.00 | | 11.79 +/- 0.72 | 0.08 +/- 0.12 | 150.38 +/- 2.98 |
| GLM-4.7-Flash-Q4_K_M | tg32 | 76.80 +/- 1.95 | 79.28 +/- 2.01 | | | |
| GLM-4.7-Flash-Q4_K_M | tg16 | 77.08 +/- 2.58 | 82.22 +/- 2.75 | | | |
| GLM-4.7-Flash-Q4_K_M | pp512 | 740847.88 +/- 6051.45 | | 12.66 +/- 0.84 | 0.46 +/- 0.33 | 298.61 +/- 0.67 |
| GLM-4.7-Flash-Q4_K_M | tg32 | 79.10 +/- 0.47 | 81.65 +/- 0.48 | | | |

The GLM llama patch queue now validates cleanly with:

```bash
LLAMA_WORKDIR=/tmp/mesh-llm-llama-validate-glm47-spd scripts/prepare-llama.sh pinned
```

Tiny GLM SPD reference eval smoke passed with the existing smoke sidecar after patching the reference wrapper to use explicit GLM stage ranges during generation:

```bash
uv run --script evals/spd/hf_train_eval_qwen06.py   --work-dir /tmp/skippy-spd-glm47-speedy-rows-smoke-rerun   --model-name /Volumes/models/huggingface/hub/models--zai-org--GLM-4.7-Flash/snapshots/7dd20894a642a0aa287e9827cb1a1f7f91386b67   --spec-head-path /tmp/skippy-spd-glm47-manifest-refresh/artifacts/20260616-173653/train/speculation_head_final.pt   --manifest-base-model-path /Volumes/models/huggingface/hub/models--zai-org--GLM-4.7-Flash/snapshots/7dd20894a642a0aa287e9827cb1a1f7f91386b67   --skip-train   --eval-rows-per-set 1   --num-stages 3   --stage-layer-boundaries 15,31,47   --num-spec-layers 1   --max-new-tokens 16   --draft-top-k 1   --attn-implementation sdpa   --device mps   --upload-repo none
```

Result: `acceptance_rate=0.3556`, `equivalent_accept_length=1.0667`, `theoretical_throughput_gain=+6.67%`, `48` verified generated tokens, `3/48` accepted draft flags. This is a smoke-quality sidecar eval, not the final live Speedy comparison.


1k-row GLM SPD reference train/eval completed on `micstudio`:

```bash
uv run --script evals/spd/hf_train_eval_qwen06.py \
  --work-dir /tmp/skippy-spd-glm47-train-1k \
  --model-name /Volumes/models/huggingface/hub/models--zai-org--GLM-4.7-Flash/snapshots/7dd20894a642a0aa287e9827cb1a1f7f91386b67 \
  --dataset HuggingFaceH4/ultrachat_200k \
  --dataset-split train_sft \
  --train-rows 1024 \
  --eval-rows-per-set 4 \
  --num-stages 3 \
  --stage-layer-boundaries 15,31,47 \
  --num-spec-layers 1 \
  --epochs 1 \
  --max-length 256 \
  --max-new-tokens 64 \
  --batch-size 1 \
  --gradient-accumulation-steps 8 \
  --learning-rate 1e-5 \
  --build-draft-vocab-size 4096 \
  --draft-vocab-json '' \
  --draft-top-k 1 \
  --attn-implementation sdpa \
  --device mps \
  --upload-repo none
```

Result: `acceptance_rate=0.3386`, `equivalent_accept_length=1.0159`, `theoretical_throughput_gain=+1.59%`, `768` verified generated tokens, `12/768` accepted draft flags. The trainer reported zero loss/accuracy, so this is evidence that the GLM reference harness runs end-to-end, not that the current sidecar is ready for Speedy.

Known validation caveats:

- `cargo test -p skippy-runtime --features dynamic-native-runtime --lib` has one pre-existing dynamic runtime failure: `invalid_selected_backend_device_fails_before_model_open` panics because no native runtime library is loaded. The SPD subset passes.




