### PR TITLE
chore: Hide unavailable website install options

### DIFF
--- a/website/src/_includes/components/cta-terminal.njk
+++ b/website/src/_includes/components/cta-terminal.njk
@@ -7,8 +7,8 @@
     </div>
     <div class="cta-terminal-tabs" role="tablist" aria-label="Install methods">
       <button class="active" type="button" role="tab" aria-selected="true" data-install-method="curl" data-install-copy="curl -fsSL https://meshllm.cloud/install.sh | bash">curl</button>
-      <button type="button" role="tab" aria-selected="false" data-install-method="brew" data-install-copy="brew install mesh-llm/tap/mesh-llm">brew</button>
-      <button type="button" role="tab" aria-selected="false" data-install-method="cargo" data-install-copy="cargo install mesh-llm">cargo</button>
+      <button type="button" role="tab" aria-selected="false" hidden aria-hidden="true" data-install-unavailable="true" data-install-method="brew" data-install-copy="brew install mesh-llm/tap/mesh-llm">brew</button>
+      <button type="button" role="tab" aria-selected="false" hidden aria-hidden="true" data-install-unavailable="true" data-install-method="cargo" data-install-copy="cargo install mesh-llm">cargo</button>
     </div>
     <div class="cta-terminal-meta">~ &middot; zsh &middot; mesh-llm</div>
     <button class="cta-copy" type="button" data-copy-text="curl -fsSL https://meshllm.cloud/install.sh | bash" aria-label="Copy install command">COPY</button>


### PR DESCRIPTION
## Summary

Hide the public website's brew and cargo install options while keeping their tab markup and command templates in place for a future re-enable.

Only the curl installer is currently usable. Brew and cargo should stay hidden until the `mesh-agent-images` repo is finished enough to publish and support those package paths.

## Screenshot

![mesh-llm-website-install-options-hidden.png](https://github.com/user-attachments/assets/0debf67b-a242-4f13-b1da-f9586f6264c6)

## Validation

- `npm ci`
- `just website-build`
- Browser screenshot verified the CTA shows only `curl`, with `brew` and `cargo` present but hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Brew and cargo installation method tabs are now hidden from the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->