### PR TITLE
Add package writer progress output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7436,6 +7436,7 @@ dependencies = [
  "model-artifact",
  "model-hf",
  "model-ref",
+ "ratatui",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/skippy-model-package/Cargo.toml
+++ b/crates/skippy-model-package/Cargo.toml
@@ -12,6 +12,7 @@ skippy-runtime = { path = "../skippy-runtime" }
 model-artifact = { path = "../model-artifact" }
 model-hf = { path = "../model-hf" }
 model-ref = { path = "../model-ref" }
+ratatui = "0.30"
 serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"

--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -18,6 +18,9 @@ use skippy_ffi::TensorRole;
 use skippy_runtime::{ModelInfo, TensorInfo, write_gguf_from_parts};
 
 mod preflight;
+mod progress;
+
+use progress::{PackageProgress, format_bytes};
 
 #[derive(Debug, Parser)]
 #[command(name = "skippy-model-package")]
@@ -499,7 +502,9 @@ fn write_package(
     let layer_count = layer_count(tensors)?;
     let activation_width = activation_width(&input.model_path)?;
     let source_sha256 = file_sha256(&input.model_path)?;
+    let mut progress = PackageProgress::new(3 + layer_count as usize + projectors.len() + 1);
 
+    progress.start_step("shared/metadata.gguf")?;
     let metadata = write_package_artifact(
         &source,
         tensors,
@@ -514,6 +519,8 @@ fn write_package(
         &out_dir,
         &artifact_hook,
     )?;
+    progress.finish_step(&artifact_progress_detail(&metadata))?;
+    progress.start_step("shared/embeddings.gguf")?;
     let embeddings = write_package_artifact(
         &source,
         tensors,
@@ -528,6 +535,8 @@ fn write_package(
         &out_dir,
         &artifact_hook,
     )?;
+    progress.finish_step(&artifact_progress_detail(&embeddings))?;
+    progress.start_step("shared/output.gguf")?;
     let output = write_package_artifact(
         &source,
         tensors,
@@ -542,10 +551,12 @@ fn write_package(
         &out_dir,
         &artifact_hook,
     )?;
+    progress.finish_step(&artifact_progress_detail(&output))?;
 
     let mut layers = Vec::new();
     for layer_index in 0..layer_count {
         let relative = PathBuf::from(format!("layers/layer-{layer_index:03}.gguf"));
+        progress.start_step(&relative.display().to_string())?;
         let artifact = write_package_artifact(
             &source,
             tensors,
@@ -560,6 +571,7 @@ fn write_package(
             &out_dir,
             &artifact_hook,
         )?;
+        progress.finish_step(&artifact_progress_detail(&artifact))?;
         layers.push(PackageLayer {
             layer_index,
             path: artifact.path,
@@ -570,13 +582,14 @@ fn write_package(
         });
     }
 
-    let projectors = projectors
-        .iter()
-        .enumerate()
-        .map(|(index, projector)| {
-            copy_projector_artifact(projector, index, &out_dir, &artifact_hook)
-        })
-        .collect::<Result<Vec<_>>>()?;
+    let mut package_projectors = Vec::new();
+    for (index, projector) in projectors.iter().enumerate() {
+        progress.start_step(&projector.display().to_string())?;
+        let package_projector =
+            copy_projector_artifact(projector, index, &out_dir, &artifact_hook)?;
+        progress.finish_step(&projector_progress_detail(&package_projector))?;
+        package_projectors.push(package_projector);
+    }
 
     let manifest = PackageManifest {
         schema_version: 1,
@@ -599,7 +612,7 @@ fn write_package(
             embeddings,
             output,
         },
-        projectors,
+        projectors: package_projectors,
         layers,
         skippy_abi_version: format!(
             "{}.{}.{}",
@@ -614,9 +627,34 @@ fn write_package(
     };
 
     let manifest_path = out_dir.join("model-package.json");
+    progress.start_step("model-package.json")?;
     write_json_file(&manifest_path, &manifest)?;
+    let manifest_bytes = fs::metadata(&manifest_path)
+        .with_context(|| format!("read manifest metadata {}", manifest_path.display()))?
+        .len();
+    progress.finish_step(&format!(
+        "model-package.json {}",
+        format_bytes(manifest_bytes)
+    ))?;
+    progress.finish()?;
     println!("{}", serde_json::to_string_pretty(&manifest)?);
     Ok(())
+}
+
+fn artifact_progress_detail(artifact: &PackageArtifact) -> String {
+    format!(
+        "{} {}",
+        artifact.path,
+        format_bytes(artifact.artifact_bytes)
+    )
+}
+
+fn projector_progress_detail(projector: &PackageProjector) -> String {
+    format!(
+        "{} {}",
+        projector.path,
+        format_bytes(projector.artifact_bytes)
+    )
 }
 
 fn resolve_package_input(model: String, explicit: ExplicitSourceIdentity) -> Result<PackageInput> {

--- a/crates/skippy-model-package/src/progress.rs
+++ b/crates/skippy-model-package/src/progress.rs
@@ -1,0 +1,165 @@
+use std::env;
+use std::io::{IsTerminal, Write};
+
+use anyhow::{Context, Result};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    widgets::{LineGauge, Widget},
+};
+
+const GAUGE_WIDTH: u16 = 72;
+
+pub(crate) struct PackageProgress {
+    total: usize,
+    completed: usize,
+    interactive: bool,
+    enabled: bool,
+}
+
+impl PackageProgress {
+    pub(crate) fn new(total: usize) -> Self {
+        Self {
+            total,
+            completed: 0,
+            interactive: std::io::stderr().is_terminal(),
+            enabled: progress_enabled(),
+        }
+    }
+
+    pub(crate) fn start_step(&mut self, detail: &str) -> Result<()> {
+        if self.enabled && self.interactive {
+            self.draw("writing", detail)?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn finish_step(&mut self, detail: &str) -> Result<()> {
+        if self.completed < self.total {
+            self.completed += 1;
+        }
+        if !self.enabled {
+            return Ok(());
+        }
+        if self.interactive {
+            self.draw("wrote", detail)?;
+        } else {
+            eprintln!(
+                "package progress: {}/{} wrote {}",
+                self.completed, self.total, detail
+            );
+        }
+        Ok(())
+    }
+
+    pub(crate) fn finish(&self) -> Result<()> {
+        if self.enabled && self.interactive {
+            eprintln!();
+            std::io::stderr()
+                .flush()
+                .context("flush package progress finish")?;
+        }
+        Ok(())
+    }
+
+    fn draw(&self, verb: &str, detail: &str) -> Result<()> {
+        eprint!("\r\x1b[2K{} {}", self.render_gauge(verb), detail);
+        std::io::stderr()
+            .flush()
+            .context("flush package progress")?;
+        Ok(())
+    }
+
+    fn render_gauge(&self, verb: &str) -> String {
+        render_inline_gauge(
+            ratio_complete(self.completed, self.total),
+            &format!(
+                "package {:>5.1}% [{}/{}] {verb}",
+                percent_complete(self.completed, self.total),
+                self.completed,
+                self.total
+            ),
+        )
+    }
+}
+
+pub(crate) fn format_bytes(bytes: u64) -> String {
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let mut value = bytes as f64;
+    let mut unit = 0usize;
+    while value >= 1024.0 && unit + 1 < UNITS.len() {
+        value /= 1024.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        format!("{bytes} {}", UNITS[unit])
+    } else {
+        format!("{value:.1} {}", UNITS[unit])
+    }
+}
+
+fn progress_enabled() -> bool {
+    env::var("SKIPPY_MODEL_PACKAGE_PROGRESS")
+        .map(|value| value != "0" && !value.eq_ignore_ascii_case("false"))
+        .unwrap_or(true)
+}
+
+fn percent_complete(completed: usize, total: usize) -> f64 {
+    ratio_complete(completed, total) * 100.0
+}
+
+fn ratio_complete(completed: usize, total: usize) -> f64 {
+    if total == 0 {
+        1.0
+    } else {
+        (completed as f64 / total as f64).clamp(0.0, 1.0)
+    }
+}
+
+fn render_inline_gauge(ratio: f64, label: &str) -> String {
+    let area = Rect::new(0, 0, GAUGE_WIDTH, 1);
+    let mut buffer = Buffer::empty(area);
+    LineGauge::default()
+        .ratio(ratio.clamp(0.0, 1.0))
+        .label(label)
+        .filled_symbol("=")
+        .unfilled_symbol("-")
+        .render(area, &mut buffer);
+    buffer
+        .content()
+        .iter()
+        .map(|cell| cell.symbol())
+        .collect::<String>()
+        .trim_end()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{format_bytes, render_inline_gauge};
+
+    #[test]
+    fn inline_gauge_renders_label_and_progress() {
+        let line = render_inline_gauge(0.5, "package 50.0% [5/10] wrote");
+
+        assert!(line.starts_with("package 50.0% [5/10] wrote "));
+        assert!(line.contains('='));
+        assert!(line.contains('-'));
+    }
+
+    #[test]
+    fn inline_gauge_clamps_ratio() {
+        let line = render_inline_gauge(2.0, "done");
+
+        assert!(line.starts_with("done "));
+        assert!(line.contains('='));
+        assert!(!line.contains('-'));
+    }
+
+    #[test]
+    fn format_bytes_uses_binary_units() {
+        assert_eq!(format_bytes(512), "512 B");
+        assert_eq!(format_bytes(1536), "1.5 KiB");
+        assert_eq!(format_bytes(5 * 1024 * 1024), "5.0 MiB");
+    }
+}


### PR DESCRIPTION
## Summary

`skippy-model-package write-package` now reports deterministic package-writing progress while it builds layer package repos. The progress advances at artifact boundaries: shared metadata, embeddings, output, each layer GGUF, projector artifacts, and the final `model-package.json`.

The interactive renderer uses Ratatui's inline `LineGauge` instead of a bespoke progress bar, so this stays aligned with the terminal UI dependency already used by the project.

## Output Preview

Interactive terminals redraw one stderr line while work is active. These examples are simulated from the actual Ratatui `LineGauge` renderer configured by this PR:

```text
package  30.1% [25/83] writing ============----------------------------- layers/layer-022.gguf
package  31.3% [26/83] wrote =============------------------------------ layers/layer-022.gguf 4.4 GiB
```

For the GLM-5.1 Q3_K_M-plus layer package, the expected step count is:

```text
3 shared artifacts + 79 layers + 1 manifest = 83 steps
```

A representative full progression looks like:

```text
package   0.0% [0/83] writing ------------------------------------------ shared/metadata.gguf
package   1.2% [1/83] wrote -------------------------------------------- shared/metadata.gguf 9.0 MiB
package   2.4% [2/83] wrote =------------------------------------------- shared/embeddings.gguf 973.2 MiB
package   3.6% [3/83] wrote =------------------------------------------- shared/output.gguf 1.8 GiB
package   3.6% [3/83] writing =----------------------------------------- layers/layer-000.gguf
package   4.8% [4/83] wrote ==------------------------------------------ layers/layer-000.gguf 208.0 MiB
package  50.6% [42/83] wrote =====================---------------------- layers/layer-038.gguf 4.4 GiB
package  98.8% [82/83] wrote ==========================================- layers/layer-078.gguf 4.5 GiB
package  98.8% [82/83] writing ========================================- model-package.json
package 100.0% [83/83] wrote =========================================== model-package.json 62.7 KiB
```

Non-interactive logs emit one line per completed step instead of terminal redraws:

```text
package progress: 42/83 wrote layers/layer-038.gguf 4.4 GiB
```

Progress output can be disabled with:

```bash
SKIPPY_MODEL_PACKAGE_PROGRESS=0 skippy-model-package write-package ...
```

## Validation

```bash
cargo check -p skippy-model-package
cargo test -p skippy-model-package --bin skippy-model-package
cargo clippy -p skippy-model-package --bin skippy-model-package -- -D warnings
```
