### PR TITLE
fix: chat IDs issue on insecure origins

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/lib/chat-storage.ts
+++ b/crates/mesh-llm-ui/src/features/chat/lib/chat-storage.ts
@@ -7,6 +7,7 @@ import {
   type ChatStorageScope
 } from '@/features/chat/api/chat-storage'
 import type { ChatConversation, ChatMessage, ChatState } from '@/features/chat/lib/chat-types'
+import { createBrowserId } from '@/lib/api/browser-id'
 export type { ChatState as ChatStateExported } from '@/features/chat/lib/chat-types'
 export { MAX_CHAT_CONVERSATIONS, loadChatState, saveChatState, trimThreadMessages, type ChatStorageScope }
 
@@ -27,7 +28,7 @@ export function chatToConversation(chat: {
 
 export function createConversation(): ChatConversation {
   return {
-    id: crypto.randomUUID(),
+    id: createBrowserId('conversation'),
     title: 'New chat',
     subtitle: '',
     createdAt: Date.now(),

--- a/crates/mesh-llm-ui/src/lib/api/browser-id.test.ts
+++ b/crates/mesh-llm-ui/src/lib/api/browser-id.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createBrowserId } from '@/lib/api/browser-id'
+
+describe('createBrowserId', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('uses crypto.randomUUID when it is available', () => {
+    vi.stubGlobal('crypto', { randomUUID: () => 'uuid-123' })
+
+    expect(createBrowserId('request')).toBe('uuid-123')
+  })
+
+  it('falls back when crypto.randomUUID is unavailable', () => {
+    vi.stubGlobal('crypto', {})
+    vi.spyOn(Date, 'now').mockReturnValue(1_718_000_000_000)
+    vi.spyOn(Math, 'random').mockReturnValue(0.25)
+
+    expect(createBrowserId('request')).toBe('request-lx8kuby8-9')
+  })
+})

--- a/crates/mesh-llm-ui/src/lib/api/browser-id.ts
+++ b/crates/mesh-llm-ui/src/lib/api/browser-id.ts
@@ -1,3 +1,10 @@
+/**
+ * Creates an opaque browser-side ID.
+ *
+ * Secure contexts return a standard UUID from `crypto.randomUUID()` and ignore
+ * the prefix. The prefix is applied only in fallback contexts where
+ * `crypto.randomUUID()` is unavailable, such as non-secure HTTP origins.
+ */
 export function createBrowserId(prefix = 'id'): string {
   if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
     return crypto.randomUUID()

--- a/crates/mesh-llm-ui/src/lib/api/browser-id.ts
+++ b/crates/mesh-llm-ui/src/lib/api/browser-id.ts
@@ -1,0 +1,7 @@
+export function createBrowserId(prefix = 'id'): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID()
+  }
+
+  return `${prefix}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/crates/mesh-llm-ui/src/lib/api/client-id.ts
+++ b/crates/mesh-llm-ui/src/lib/api/client-id.ts
@@ -1,9 +1,11 @@
+import { createBrowserId } from '@/lib/api/browser-id'
+
 const CLIENT_ID_KEY = 'mesh-llm:client-id'
 
 export function getClientId(): string {
   let id = localStorage.getItem(CLIENT_ID_KEY)
   if (!id) {
-    id = crypto.randomUUID()
+    id = createBrowserId('client')
     localStorage.setItem(CLIENT_ID_KEY, id)
   }
   return id

--- a/crates/mesh-llm-ui/src/lib/api/request-id.ts
+++ b/crates/mesh-llm-ui/src/lib/api/request-id.ts
@@ -1,3 +1,5 @@
+import { createBrowserId } from '@/lib/api/browser-id'
+
 export function generateRequestId(): string {
-  return crypto.randomUUID()
+  return createBrowserId('request')
 }


### PR DESCRIPTION
## Summary
- Add a browser-safe ID helper that falls back when `crypto.randomUUID` is unavailable
- Use it for chat request IDs, client IDs, and legacy chat conversation creation
- Cover both native `randomUUID` and fallback behavior with a focused Vitest test

## Root Cause
The chat send path creates client and request IDs before posting to `/api/responses`. On non-secure HTTP origins such as `http://lemony29.patio51.com:3131`, browsers can expose `crypto` without `crypto.randomUUID`, so the UI threw before the request reached the backend.

## Validation
- `pnpm exec vitest run src/lib/api/browser-id.test.ts src/features/chat/api/mesh-connection.test.ts src/features/chat/api/upload-attachment.test.ts`
- `just build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved generation of browser-scoped identifiers for client, request, and new chat conversations, using `crypto.randomUUID()` when available and a deterministic fallback when not.

* **Tests**
  * Added automated coverage to verify identifier generation behavior both with `crypto.randomUUID()` present and with the fallback path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->