### PR TITLE
fix release build version stamping and smoke runtime install

### DIFF
--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -52,6 +52,12 @@ stamp_build_version() {
         return 0
     fi
 
+    if [[ "${MESH_LLM_BUILD_PROFILE:-debug}" == "release" ]]; then
+        export MESH_LLM_BUILD_VERSION="$release_version"
+        echo "Using release MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
+        return 0
+    fi
+
     if ! sha="$(git -C "$REPO_ROOT" rev-parse --short=6 HEAD 2>/dev/null)"; then
         echo "Warning: unable to derive build version; git SHA unavailable." >&2
         unset MESH_LLM_BUILD_VERSION || true

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -46,6 +46,12 @@ stamp_build_version() {
         return 0
     fi
 
+    if [[ "$build_profile" == "release" ]]; then
+        export MESH_LLM_BUILD_VERSION="$release_version"
+        echo "Using release MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
+        return 0
+    fi
+
     if ! sha="$(git -C "$REPO_ROOT" rev-parse --short=6 HEAD 2>/dev/null)"; then
         echo "Warning: unable to derive build version; git SHA unavailable." >&2
         unset MESH_LLM_BUILD_VERSION || true

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,9 +21,6 @@ append_rustflag() {
 stamp_build_version() {
     local release_version=""
     local pkgid=""
-    local sha=""
-    local dirty_suffix=""
-    local status_output=""
 
     if [[ -n "${MESH_LLM_BUILD_VERSION:-}" ]]; then
         echo "Using preset MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
@@ -42,24 +39,9 @@ stamp_build_version() {
         return 0
     fi
 
-    if ! sha="$(git -C "$REPO_ROOT" rev-parse --short=6 HEAD 2>/dev/null)"; then
-        echo "Warning: unable to derive build version; git SHA unavailable." >&2
-        unset MESH_LLM_BUILD_VERSION || true
-        return 0
-    fi
-    sha="$(printf '%s' "$sha" | tr '[:lower:]' '[:upper:]')"
-
-    if ! status_output="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=all 2>/dev/null)"; then
-        echo "Warning: unable to derive build version; git status unavailable." >&2
-        unset MESH_LLM_BUILD_VERSION || true
-        return 0
-    fi
-    if [[ -n "$status_output" ]]; then
-        dirty_suffix=".dirty"
-    fi
-
-    export MESH_LLM_BUILD_VERSION="${release_version}+g${sha}${dirty_suffix}"
-    echo "Derived MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
+    export MESH_LLM_BUILD_VERSION="$release_version"
+    echo "Using release MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
+    return 0
 }
 
 configure_lld_linker() {

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -218,6 +218,12 @@ function Set-BuildVersionStamp {
         return
     }
 
+    if ($buildProfile -eq "release") {
+        $env:MESH_LLM_BUILD_VERSION = $releaseVersion
+        Write-Host "Using release MESH_LLM_BUILD_VERSION: $($env:MESH_LLM_BUILD_VERSION)"
+        return
+    }
+
     $sha = $null
     try {
         $sha = (& git -C $repoRoot rev-parse --short=6 HEAD 2>$null).Trim()

--- a/scripts/ci-install-native-runtime.sh
+++ b/scripts/ci-install-native-runtime.sh
@@ -24,9 +24,41 @@ native_runtime_dir="$(scripts/ci-prepare-native-runtime.sh "$OUT_DIR" "$BACKEND"
 echo "Installing CI native runtime:" >&2
 echo "  runtime: $native_runtime_dir" >&2
 echo "  cache:   $RUNTIME_CACHE" >&2
-MESH_LLM_NATIVE_RUNTIME_CACHE_DIR="$RUNTIME_CACHE" \
-    "$MESH_LLM" runtime install \
-        --bundle-dir "$native_runtime_dir" \
-        --cache-dir "$RUNTIME_CACHE" >&2
+python3 - "$native_runtime_dir" "$RUNTIME_CACHE" <<'PY'
+import json
+import shutil
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+cache = Path(sys.argv[2])
+manifest_path = source / "manifest.json"
+
+with manifest_path.open("r", encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+runtime = manifest["runtime"]
+runtime_id = runtime["id"]
+mesh_version = runtime.get("mesh_version") or "unknown"
+libraries = runtime.get("libraries") or []
+if not runtime_id.strip():
+    raise SystemExit(f"native runtime id is empty in {manifest_path}")
+if not mesh_version.strip():
+    raise SystemExit(f"native runtime mesh_version is empty in {manifest_path}")
+if not libraries:
+    raise SystemExit(f"native runtime libraries are empty in {manifest_path}")
+
+for library in libraries:
+    library_path = source / library
+    if not library_path.is_file():
+        raise SystemExit(f"native runtime library is missing: {library_path}")
+
+target = cache / mesh_version / runtime_id
+if target.exists():
+    shutil.rmtree(target)
+target.parent.mkdir(parents=True, exist_ok=True)
+shutil.copytree(source, target)
+print(f"Installed CI native runtime: {target}", file=sys.stderr)
+PY
 
 printf '%s\n' "$RUNTIME_CACHE"


### PR DESCRIPTION
## Summary

Fix the release failures exposed by the workflow-dispatch release run:

- release-profile build scripts now stamp `MESH_LLM_BUILD_VERSION` to the plain Cargo package version instead of deriving `+g<sha>[.dirty]` metadata
- CI smoke native-runtime setup now installs the freshly built runtime bundle directly into the native-runtime cache layout instead of invoking `mesh-llm runtime install`

## Root Cause

PR #831 introduced separate build/display identity and release identity, but the release build scripts still derived SHA-bearing build versions. In `workflow_dispatch` release jobs, `scripts/release-version.sh` mutates tracked manifests before the build, so Windows release binaries reported versions like `0.72.0-rc2+g7E9D61.dirty`; `package-release.ps1` correctly rejected those artifacts because release bundles must report `0.72.0-rc2` exactly.

The smoke failure was separate: `scripts/ci-install-native-runtime.sh` used the just-built `mesh-llm` binary to run `runtime install`. That command runs inside the binary's Tokio runtime and tripped the nested-runtime guard before inference could start.

## Validation

- `bash -n scripts/build-release.sh scripts/build-linux.sh scripts/ci-install-native-runtime.sh`
- `zsh -n scripts/build-mac.sh`
- `git diff --check`
- `cargo run -p xtask -- repo-consistency release-targets`
- local fixture check that the CI native-runtime installer writes `cache/<mesh_version>/<runtime_id>/manifest.json` and the runtime library


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release builds now generate simplified version numbers without build-specific identifiers, providing cleaner and more predictable version strings.
  * Build system has been optimized across all supported platforms for consistent release behavior.
  * Runtime installation mechanism has been refactored for improved efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->