### PR TITLE
Fix native runtime startup initialization

### DIFF
--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -49,7 +49,7 @@ pub use runtime::{
 };
 
 pub async fn run() -> Result<()> {
-    initialize_host_runtime()?;
+    initialize_host_runtime().await?;
     runtime::run().await
 }
 
@@ -58,7 +58,7 @@ pub async fn run_runtime(
     explicit_surface: Option<RuntimeSurface>,
     legacy_warning: Option<String>,
 ) -> Result<()> {
-    initialize_host_runtime()?;
+    initialize_host_runtime().await?;
     run_runtime_initialized(options, explicit_surface, legacy_warning).await
 }
 
@@ -70,9 +70,9 @@ pub async fn run_runtime_initialized(
     runtime::run_cli(options, explicit_surface, legacy_warning).await
 }
 
-pub fn initialize_host_runtime() -> Result<()> {
+pub async fn initialize_host_runtime() -> Result<()> {
     #[cfg(feature = "dynamic-native-runtime")]
-    if let Some(runtime) = system::native_runtime::try_load_installed_native_runtime()? {
+    if let Some(runtime) = system::native_runtime::try_load_installed_native_runtime().await? {
         tracing::info!(
             native_runtime_id = %runtime.native_runtime_id,
             libraries = ?runtime.libraries,

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -8,7 +8,7 @@ mod dynamic {
         HostRuntimeProfile, NativeRuntimeArtifact, NativeRuntimeCache, NativeRuntimeLoadPlan,
         NativeRuntimeReleaseManifest, RuntimeSelection, select_native_runtime,
     };
-    use std::path::PathBuf;
+    use std::{future::Future, path::PathBuf};
 
     #[derive(Clone, Debug)]
     pub(crate) struct LoadedNativeRuntime {
@@ -32,7 +32,7 @@ mod dynamic {
         pub(crate) source: NativeRuntimePlanSource,
     }
 
-    pub(crate) fn try_load_installed_native_runtime() -> Result<Option<LoadedNativeRuntime>> {
+    pub(crate) async fn try_load_installed_native_runtime() -> Result<Option<LoadedNativeRuntime>> {
         try_load_installed_native_runtime_with(
             skippy_runtime::native_runtime_loaded,
             default_native_runtime_cache,
@@ -44,14 +44,16 @@ mod dynamic {
                     .map_err(anyhow::Error::from)
             },
         )
+        .await
     }
 
-    fn try_load_installed_native_runtime_with<
+    async fn try_load_installed_native_runtime_with<
         NativeRuntimeLoadedFn,
         CacheFn,
         ProfileFn,
         InstallOptionsFn,
         InstallExecutorFn,
+        InstallFuture,
         LoadLibrariesFn,
     >(
         native_runtime_loaded: NativeRuntimeLoadedFn,
@@ -66,7 +68,8 @@ mod dynamic {
         CacheFn: Fn() -> Result<NativeRuntimeCache>,
         ProfileFn: Fn() -> HostRuntimeProfile,
         InstallOptionsFn: Fn() -> NativeRuntimeInstallOptions,
-        InstallExecutorFn: Fn(NativeRuntimeInstallOptions) -> Result<NativeRuntimeInstallOutcome>,
+        InstallExecutorFn: Fn(NativeRuntimeInstallOptions) -> InstallFuture,
+        InstallFuture: Future<Output = Result<NativeRuntimeInstallOutcome>>,
         LoadLibrariesFn: Fn(&[PathBuf]) -> Result<()>,
     {
         if native_runtime_loaded() {
@@ -77,7 +80,8 @@ mod dynamic {
             profile,
             install_options,
             install_executor,
-        )?
+        )
+        .await?
         else {
             return Ok(None);
         };
@@ -94,11 +98,12 @@ mod dynamic {
         }))
     }
 
-    fn resolve_startup_native_runtime_plan_with<
+    async fn resolve_startup_native_runtime_plan_with<
         CacheFn,
         ProfileFn,
         InstallOptionsFn,
         InstallExecutorFn,
+        InstallFuture,
     >(
         cache: CacheFn,
         profile: ProfileFn,
@@ -109,7 +114,8 @@ mod dynamic {
         CacheFn: Fn() -> Result<NativeRuntimeCache>,
         ProfileFn: Fn() -> HostRuntimeProfile,
         InstallOptionsFn: Fn() -> NativeRuntimeInstallOptions,
-        InstallExecutorFn: Fn(NativeRuntimeInstallOptions) -> Result<NativeRuntimeInstallOutcome>,
+        InstallExecutorFn: Fn(NativeRuntimeInstallOptions) -> InstallFuture,
+        InstallFuture: Future<Output = Result<NativeRuntimeInstallOutcome>>,
     {
         let cache = cache()?;
         let profile = profile();
@@ -134,7 +140,7 @@ mod dynamic {
             "No compatible installed MeshLLM native runtime found; attempting one-shot startup install"
         );
 
-        let install_result = install_executor(options.clone());
+        let install_result = install_executor(options.clone()).await;
         match install_result {
             Ok(outcome) => {
                 let load_plan = outcome.runtime.load_plan()?;
@@ -256,14 +262,10 @@ mod dynamic {
         }
     }
 
-    fn default_install_executor(
+    async fn default_install_executor(
         options: NativeRuntimeInstallOptions,
     ) -> Result<NativeRuntimeInstallOutcome> {
-        tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .context("build native runtime startup install executor")?
-            .block_on(crate::system::native_runtime_install::install_native_runtime(options))
+        crate::system::native_runtime_install::install_native_runtime(options).await
     }
 
     #[cfg(test)]
@@ -439,8 +441,8 @@ mod dynamic {
             assert!(plan.is_none());
         }
 
-        #[test]
-        fn cache_hit_skips_install_and_loads_cached_runtime_once() {
+        #[tokio::test]
+        async fn cache_hit_skips_install_and_loads_cached_runtime_once() {
             let temp = tempfile::tempdir().unwrap();
             let cache = NativeRuntimeCache::new(temp.path().join("cache"));
             let runtime_id = "meshllm-native-runtime-test-cpu";
@@ -459,8 +461,11 @@ mod dynamic {
                 {
                     let install_calls = Arc::clone(&install_calls);
                     move |_| {
-                        *install_calls.lock().unwrap() += 1;
-                        anyhow::bail!("install should not run on cache hit")
+                        let install_calls = Arc::clone(&install_calls);
+                        async move {
+                            *install_calls.lock().unwrap() += 1;
+                            anyhow::bail!("install should not run on cache hit")
+                        }
                     }
                 },
                 {
@@ -471,6 +476,7 @@ mod dynamic {
                     }
                 },
             )
+            .await
             .unwrap()
             .expect("expected cached runtime to load");
 
@@ -483,8 +489,8 @@ mod dynamic {
             assert_eq!(load_calls.lock().unwrap().as_slice(), &[runtime.libraries]);
         }
 
-        #[test]
-        fn cache_miss_installs_once_and_loads_post_install_runtime() {
+        #[tokio::test]
+        async fn cache_miss_installs_once_and_loads_post_install_runtime() {
             let temp = tempfile::tempdir().unwrap();
             let cache = NativeRuntimeCache::new(temp.path().join("cache"));
             let bundle_dir = temp.path().join("bundle");
@@ -505,18 +511,26 @@ mod dynamic {
                     let bundle_dir = bundle_dir.clone();
                     let cache = cache.clone();
                     move |mut options| {
-                        install_calls.lock().unwrap().push(options.clone());
-                        let source = options.bundle_dirs.pop().unwrap_or(bundle_dir.clone());
-                        let runtime = cache.install_from_dir(&source)?;
-                        Ok(NativeRuntimeInstallOutcome {
-                            status: crate::system::native_runtime_install::NativeRuntimeInstallStatus::Installed,
-                            runtime,
-                            resolution: mesh_llm_native_runtime::NativeRuntimeResolution {
-                                source: mesh_llm_native_runtime::NativeRuntimeSource::Bundle { path: source },
-                                selected: NativeRuntimeManifest::read_from_dir(&bundle_dir)?.runtime,
-                                evaluated: Vec::new(),
-                            },
-                        })
+                        let install_calls = Arc::clone(&install_calls);
+                        let bundle_dir = bundle_dir.clone();
+                        let cache = cache.clone();
+                        async move {
+                            install_calls.lock().unwrap().push(options.clone());
+                            let source = options.bundle_dirs.pop().unwrap_or(bundle_dir.clone());
+                            let runtime = cache.install_from_dir(&source)?;
+                            Ok(NativeRuntimeInstallOutcome {
+                                status: crate::system::native_runtime_install::NativeRuntimeInstallStatus::Installed,
+                                runtime,
+                                resolution: mesh_llm_native_runtime::NativeRuntimeResolution {
+                                    source: mesh_llm_native_runtime::NativeRuntimeSource::Bundle {
+                                        path: source,
+                                    },
+                                    selected: NativeRuntimeManifest::read_from_dir(&bundle_dir)?
+                                        .runtime,
+                                    evaluated: Vec::new(),
+                                },
+                            })
+                        }
                     }
                 },
                 {
@@ -527,6 +541,7 @@ mod dynamic {
                     }
                 },
             )
+            .await
             .unwrap()
             .expect("expected installed runtime to load");
 
@@ -546,8 +561,8 @@ mod dynamic {
             assert_eq!(load_calls.lock().unwrap().as_slice(), &[runtime.libraries]);
         }
 
-        #[test]
-        fn cache_miss_install_failure_returns_none_without_retry() {
+        #[tokio::test]
+        async fn cache_miss_install_failure_returns_none_without_retry() {
             let temp = tempfile::tempdir().unwrap();
             let cache = NativeRuntimeCache::new(temp.path().join("cache"));
             let install_calls = Arc::new(Mutex::new(Vec::<NativeRuntimeInstallOptions>::new()));
@@ -561,10 +576,13 @@ mod dynamic {
                 {
                     let install_calls = Arc::clone(&install_calls);
                     move |options| {
-                        install_calls.lock().unwrap().push(options);
-                        anyhow::bail!(
-                            "no compatible native runtime found for Skippy ABI 0.1.25 on test/test"
-                        )
+                        let install_calls = Arc::clone(&install_calls);
+                        async move {
+                            install_calls.lock().unwrap().push(options);
+                            anyhow::bail!(
+                                "no compatible native runtime found for Skippy ABI 0.1.25 on test/test"
+                            )
+                        }
                     }
                 },
                 {
@@ -575,6 +593,7 @@ mod dynamic {
                     }
                 },
             )
+            .await
             .unwrap();
 
             assert!(runtime.is_none());

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -31,10 +31,10 @@ async fn run_cli_entrypoint() -> anyhow::Result<()> {
     );
     let explicit_surface = normalized_args.explicit_surface.map(map_runtime_surface);
 
-    mesh_llm_host_runtime::initialize_host_runtime()?;
     if commands::dispatch(&cli).await? {
         return Ok(());
     }
+    mesh_llm_host_runtime::initialize_host_runtime().await?;
     mesh_llm_tui::output::OutputManager::init_global(
         cli.log_format,
         mesh_llm_host_runtime::console_session_mode_for_runtime_surface(explicit_surface),


### PR DESCRIPTION
## Summary

MeshLLM can now install or load the dynamic native runtime from inside the existing async process runtime without panicking, and CLI-only commands no longer preload host runtime state before dispatch.

This fixes the root cause behind the release smoke panic:

```text
Cannot start a runtime from within a runtime
```

## Details

- Makes host runtime initialization async so native-runtime startup install awaits the existing Tokio runtime instead of creating a nested runtime and calling `block_on`.
- Dispatches `mesh-llm` CLI subcommands before startup native-runtime initialization, so commands like `mesh-llm runtime install` do not first trigger implicit startup install/load behavior.
- Updates the dynamic native-runtime unit tests to cover async cache-hit, cache-miss install, and install-failure startup paths.

## Why CI missed this

The failing path was a cache-miss startup/install path under the `dynamic-native-runtime` release feature. The problematic code only panicked when it needed to run the async installer from inside the already-running `mesh-llm` Tokio runtime. A compatible cache hit skips that installer and would not expose the bug.

The release smoke hit this exact shape by staging a release binary and invoking native runtime installation in an isolated release workflow environment. Existing PR checks compile the dynamic runtime feature, but they did not assert the shipped binary can run `runtime install` or perform startup native-runtime install from an empty cache under the release smoke layout.

A follow-up CI hardening would be an isolated-cache smoke step that runs `mesh-llm runtime install --bundle-dir ... --cache-dir $(mktemp -d)` and a startup load/install check with `MESH_LLM_NATIVE_RUNTIME_CACHE_DIR` pointed at an empty directory.

## Validation

- `cargo test -p mesh-llm-host-runtime --features dynamic-native-runtime --lib native_runtime`
- `cargo check -p mesh-llm --bin mesh-llm --features dynamic-native-runtime`
- `cargo clippy -p mesh-llm --bin mesh-llm --features dynamic-native-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm --bin mesh-llm`
- `rustfmt --edition 2024 --check crates/mesh-llm/src/lib.rs crates/mesh-llm-host-runtime/src/lib.rs crates/mesh-llm-host-runtime/src/system/native_runtime.rs`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Host runtime initialization now operates asynchronously, enabling smoother startup and better system resource utilization
  * Native runtime loading refactored to use async operations for more efficient handling of initialization tasks
  * System bootstrap sequence improved through elimination of blocking operations during runtime setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->