### PR TITLE
Add metrics-server healthcheck

### DIFF
--- a/crates/metrics-server/README.md
+++ b/crates/metrics-server/README.md
@@ -32,6 +32,7 @@ stage, and model identifiers for report export and post-run debugging.
 metrics-server serve --db metrics.sqlite
 metrics-server serve --db metrics.sqlite --debug-retain-raw-otlp
 metrics-server emit-fixture --run-id fixture
+curl http://127.0.0.1:18080/health
 ```
 
 ## Responsibilities
@@ -39,6 +40,7 @@ metrics-server emit-fixture --run-id fixture
 - ingest OTLP traces, metrics, and logs
 - accept OTLP/gRPC on `--otlp-grpc-addr`
 - accept OTLP/HTTP protobuf at `/v1/traces`, `/v1/metrics`, and `/v1/logs`
+- expose `/health` for process-level HTTP health checks
 - persist scalar OTLP gauge/sum data points in `metric_points`
 - index data by run/request/session/stage IDs
 - expose run lifecycle HTTP APIs

--- a/crates/metrics-server/src/api.rs
+++ b/crates/metrics-server/src/api.rs
@@ -35,6 +35,10 @@ pub(crate) async fn create_run(
     }))
 }
 
+pub(crate) async fn health() -> Json<Value> {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
 pub(crate) async fn run_status(
     State(state): State<AppState>,
     Path(run_id): Path<String>,

--- a/crates/metrics-server/src/lib.rs
+++ b/crates/metrics-server/src/lib.rs
@@ -24,7 +24,7 @@ pub async fn run() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::{
-        api::otlp_http_traces,
+        api::{health, otlp_http_traces},
         otlp_value::{kv_i64, kv_string},
         server::AppState,
         store::Store,
@@ -136,6 +136,12 @@ mod tests {
                 schema_url: String::new(),
             }],
         }
+    }
+
+    #[tokio::test]
+    async fn health_endpoint_reports_ok() {
+        let response = health().await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[test]

--- a/crates/metrics-server/src/server.rs
+++ b/crates/metrics-server/src/server.rs
@@ -17,8 +17,8 @@ use tokio::net::TcpListener;
 
 use crate::{
     api::{
-        artifacts, create_run, finalize_run, otlp_http_logs, otlp_http_metrics, otlp_http_traces,
-        report_json, run_status,
+        artifacts, create_run, finalize_run, health, otlp_http_logs, otlp_http_metrics,
+        otlp_http_traces, report_json, run_status,
     },
     cli::ServeArgs,
     otlp::OtlpIngest,
@@ -73,6 +73,7 @@ pub(crate) async fn serve(args: ServeArgs) -> Result<()> {
 
 pub(crate) async fn serve_http(state: AppState, addr: SocketAddr) -> Result<()> {
     let app = Router::new()
+        .route("/health", get(health))
         .route("/v1/runs", post(create_run))
         .route("/v1/runs/{run_id}/status", get(run_status))
         .route("/v1/runs/{run_id}/finalize", post(finalize_run))


### PR DESCRIPTION
## Summary

Adds a process-level HTTP healthcheck for `metrics-server` at `GET /health`, returning `200 OK` with `{"status":"ok"}`. This gives deploy and orchestration tooling a simple URL to verify that the metrics-server HTTP listener is alive without touching run lifecycle or OTLP ingest APIs.

## Changes

- Adds the `health` HTTP handler.
- Wires `GET /health` into the metrics-server Axum router.
- Adds a focused unit test for the handler.
- Documents the healthcheck URL in the metrics-server README.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p metrics-server`
- `cargo test -p metrics-server --lib`
- `cargo clippy -p metrics-server --all-targets -- -D warnings`
- `cargo build -p metrics-server`
- Live smoke: `GET http://127.0.0.1:18080/health` returned `{"status":"ok"}`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP health-check endpoint (`/health`) that returns JSON status confirmation. Enables external monitoring systems and orchestration platforms to verify service availability and operational readiness.

* **Documentation**
  * Updated README documentation to describe the health-check endpoint, including sample curl command demonstrating usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->