### PR TITLE
Require explicit native runtime version selection

### DIFF
--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -1,17 +1,17 @@
+mod formatters;
+
 use anyhow::Result;
-use mesh_llm_native_runtime::{
-    HostRuntimeProfile, NativeRuntimePruneMode, NativeRuntimeResolver, RuntimeSelection,
-};
+use mesh_llm_native_runtime::{NativeRuntimePruneMode, NativeRuntimeResolver, RuntimeSelection};
 use mesh_llm_runtime_install::{
     CURRENT_MESH_VERSION, NativeRuntimeDownloadProgressCallback, NativeRuntimeInstallOptions,
-    NativeRuntimeInstallStatus, NativeRuntimeManifestOptions, host_runtime_profile,
-    install_native_runtime, load_release_manifest, native_runtime_cache,
+    NativeRuntimeManifestOptions, host_runtime_profile, install_native_runtime,
+    load_release_manifest, native_runtime_cache,
 };
-use serde::Serialize;
-use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
+
+use formatters::{AvailableRuntimeRow, NativeRuntimeDoctorReport, runtime_native_formatter};
 
 #[derive(Clone, Copy, Debug, Default)]
 pub struct NativeRuntimeConfigSelection<'a> {
@@ -37,6 +37,7 @@ pub async fn run_native_runtime_list(
     let mesh_version = configured.mesh_version_or_current();
     let selection = RuntimeSelection::parse(configured.selection)?;
     let cache = native_runtime_cache(cache_dir)?;
+    let formatter = runtime_native_formatter(json_output);
     if available {
         print_configured_selector(configured, json_output);
         if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
@@ -66,34 +67,26 @@ pub async fn run_native_runtime_list(
                     .iter()
                     .find(|candidate| candidate.artifact.id == artifact.id);
                 let supported = evaluation.is_some_and(|candidate| candidate.compatible);
-                json!({
-                    "id": artifact.id,
-                    "mesh_version": artifact.mesh_version.as_deref(),
-                    "skippy_abi": artifact.skippy_abi,
-                    "backend": artifact.backend.kind.to_string(),
-                    "os": artifact.platform.os,
-                    "arch": artifact.platform.arch,
-                    "supported": supported,
-                    "rejection_reasons": evaluation.map(|candidate| &candidate.rejection_reasons),
-                    "url": artifact.url.as_deref(),
-                })
+                AvailableRuntimeRow {
+                    id: artifact.id.clone(),
+                    mesh_version: artifact.mesh_version.clone(),
+                    skippy_abi: artifact.skippy_abi.clone(),
+                    backend: artifact.backend.kind.to_string(),
+                    os: artifact.platform.os.clone(),
+                    arch: artifact.platform.arch.clone(),
+                    supported,
+                    rejection_reasons: evaluation
+                        .map(|candidate| candidate.rejection_reasons.clone())
+                        .unwrap_or_default(),
+                    url: artifact.url.clone(),
+                }
             })
             .collect::<Vec<_>>();
-        if json_output {
-            println!("{}", serde_json::to_string_pretty(&rows)?);
-        } else {
-            print_available_runtimes(&rows);
-        }
-        return Ok(());
+        return formatter.render_available(&rows);
     }
 
     let installed = cache.installed()?;
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&installed)?);
-    } else {
-        print_installed_runtimes(&installed, cache.root());
-    }
-    Ok(())
+    formatter.render_installed(&installed, cache.root())
 }
 
 pub async fn run_native_runtime_install(
@@ -122,7 +115,8 @@ pub async fn run_native_runtime_install(
         },
         json_output,
     );
-    let outcome = install_native_runtime(NativeRuntimeInstallOptions {
+    let formatter = runtime_native_formatter(json_output);
+    let outcome = match install_native_runtime(NativeRuntimeInstallOptions {
         mesh_version: configured.mesh_version_or_current().to_string(),
         skippy_abi_version: configured.skippy_abi_version.map(ToString::to_string),
         selection,
@@ -132,45 +126,15 @@ pub async fn run_native_runtime_install(
         progress: cli_download_progress(json_output),
         ..Default::default()
     })
-    .await?;
-    match outcome.status {
-        NativeRuntimeInstallStatus::AlreadyInstalled => {
-            if json_output {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&json!({
-                        "status": "already_installed",
-                        "runtime": outcome.runtime,
-                        "resolution": outcome.resolution,
-                    }))?
-                );
-            } else {
-                eprintln!(
-                    "✅ Native runtime already installed: {}",
-                    outcome.runtime.native_runtime_id
-                );
-                eprintln!("   path: {}", outcome.runtime.path.display());
-            }
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            formatter.render_install_error(&error)?;
+            return Err(error);
         }
-        NativeRuntimeInstallStatus::Installed => {
-            if json_output {
-                println!(
-                    "{}",
-                    serde_json::to_string_pretty(&json!({
-                        "status": "installed",
-                        "runtime": outcome.runtime,
-                        "resolution": outcome.resolution,
-                    }))?
-                );
-            } else {
-                eprintln!("✅ Installed {}", outcome.runtime.native_runtime_id);
-                eprintln!("   version: {}", outcome.runtime.mesh_version);
-                eprintln!("   flavor: {}", outcome.runtime.flavor);
-                eprintln!("   path: {}", outcome.runtime.path.display());
-            }
-        }
-    }
-    Ok(())
+    };
+    formatter.render_install(&outcome)
 }
 
 fn print_configured_selector(configured: NativeRuntimeConfigSelection<'_>, json_output: bool) {
@@ -298,21 +262,7 @@ pub fn run_native_runtime_remove(
     let version = mesh_version.unwrap_or(CURRENT_MESH_VERSION);
     let cache = native_runtime_cache(cache_dir)?;
     let removed = cache.remove(version, native_runtime_id)?;
-    if json_output {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&json!({
-                "mesh_version": version,
-                "native_runtime_id": native_runtime_id,
-                "removed": removed,
-            }))?
-        );
-    } else if removed {
-        eprintln!("✅ Removed native runtime {native_runtime_id} for MeshLLM {version}");
-    } else {
-        eprintln!("🔎 Native runtime {native_runtime_id} for MeshLLM {version} was not installed");
-    }
-    Ok(())
+    runtime_native_formatter(json_output).render_remove(native_runtime_id, version, removed)
 }
 
 pub fn run_native_runtime_prune(
@@ -329,20 +279,7 @@ pub fn run_native_runtime_prune(
     };
     let cache = native_runtime_cache(cache_dir)?;
     let plan = cache.prune(version, mode)?;
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&plan)?);
-    } else if plan.remove_dirs.is_empty() {
-        eprintln!("✅ Native runtime cache already pruned");
-    } else {
-        eprintln!(
-            "✅ Pruned {} native runtime cache version(s)",
-            plan.remove_dirs.len()
-        );
-        for dir in plan.remove_dirs {
-            eprintln!("   removed: {}", dir.display());
-        }
-    }
-    Ok(())
+    runtime_native_formatter(json_output).render_prune(&plan)
 }
 
 pub fn run_native_runtime_doctor(
@@ -392,130 +329,5 @@ pub fn run_native_runtime_doctor(
         selected_version_installed_count: selected_version_runtimes.len(),
     };
 
-    if json_output {
-        println!("{}", serde_json::to_string_pretty(&report)?);
-    } else {
-        print_doctor_report(&report);
-    }
-    Ok(())
-}
-
-#[derive(Serialize)]
-struct NativeRuntimeDoctorReport {
-    running_mesh_version: String,
-    selected_mesh_version: String,
-    configured_skippy_abi: Option<String>,
-    configured_selection: Option<String>,
-    host: HostRuntimeProfile,
-    cache_path: PathBuf,
-    selected_runtime_id: Option<String>,
-    selected_runtime_flavor: Option<String>,
-    selected_runtime_path: Option<PathBuf>,
-    installed_count: usize,
-    selected_version_installed_count: usize,
-}
-
-fn print_available_runtimes(rows: &[serde_json::Value]) {
-    if rows.is_empty() {
-        println!("📦 No native runtime manifest entries found");
-        println!("   Pass --manifest or --bundle-dir to inspect available runtimes.");
-        return;
-    }
-    println!("📦 Available native runtimes");
-    for row in rows {
-        let status = if row["supported"].as_bool().unwrap_or(false) {
-            "compatible"
-        } else {
-            "not compatible"
-        };
-        println!(
-            "  - {} {} ({}, {}/{})",
-            row["id"].as_str().unwrap_or("unknown"),
-            status,
-            row["backend"].as_str().unwrap_or("unknown"),
-            row["os"].as_str().unwrap_or("unknown"),
-            row["arch"].as_str().unwrap_or("unknown")
-        );
-        if let Some(reasons) = row["rejection_reasons"].as_array()
-            && !reasons.is_empty()
-        {
-            for reason in reasons {
-                println!("    reason: {}", compact_json(reason));
-            }
-        }
-    }
-}
-
-fn compact_json(value: &serde_json::Value) -> String {
-    serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
-}
-
-fn print_installed_runtimes(
-    installed: &[mesh_llm_native_runtime::InstalledNativeRuntime],
-    cache_root: &Path,
-) {
-    if installed.is_empty() {
-        println!("📦 No native runtimes installed");
-        println!("   cache: {}", cache_root.display());
-        return;
-    }
-    println!("📦 Installed native runtimes");
-    println!("   cache: {}", cache_root.display());
-    for runtime in installed {
-        println!(
-            "  - {} {} ({})",
-            runtime.native_runtime_id, runtime.mesh_version, runtime.flavor
-        );
-        println!("    path: {}", runtime.path.display());
-    }
-}
-
-fn print_doctor_report(report: &NativeRuntimeDoctorReport) {
-    println!("🩺 MeshLLM doctor");
-    println!();
-    println!("Native runtime:");
-    println!("  running MeshLLM version: {}", report.running_mesh_version);
-    println!(
-        "  selected runtime version: {}",
-        report.selected_mesh_version
-    );
-    if report.selected_mesh_version != report.running_mesh_version {
-        println!("  status: native runtime version is pinned by config");
-    }
-    if let Some(skippy_abi) = &report.configured_skippy_abi {
-        println!("  configured Skippy ABI: {skippy_abi}");
-    }
-    if let Some(selection) = &report.configured_selection {
-        println!("  configured selection: {selection}");
-    }
-    println!("  cache: {}", report.cache_path.display());
-    println!("  host: {}/{}", report.host.os, report.host.arch);
-    let flavors = report
-        .host
-        .available_flavors
-        .iter()
-        .map(ToString::to_string)
-        .collect::<Vec<_>>()
-        .join(", ");
-    println!("  detected flavors: {flavors}");
-    match &report.selected_runtime_id {
-        Some(id) => {
-            println!("  selected: {id}");
-            if let Some(flavor) = &report.selected_runtime_flavor {
-                println!("  flavor: {flavor}");
-            }
-            if let Some(path) = &report.selected_runtime_path {
-                println!("  path: {}", path.display());
-            }
-        }
-        None => {
-            println!("  selected: none");
-            println!("  status: no native runtime installed for selected MeshLLM version");
-        }
-    }
-    println!("  installed: {}", report.installed_count);
-    println!(
-        "  installed for selected version: {}",
-        report.selected_version_installed_count
-    );
+    runtime_native_formatter(json_output).render_doctor(&report)
 }

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -18,14 +18,21 @@ pub async fn run_native_runtime_list(
     manifest_path: Option<&Path>,
     bundle_dirs: &[PathBuf],
     cache_dir: Option<&Path>,
+    mesh_version: Option<&str>,
+    skippy_abi_version: Option<&str>,
     json_output: bool,
 ) -> Result<()> {
+    let mesh_version = mesh_version.unwrap_or(CURRENT_MESH_VERSION);
+    let skippy_abi_version = skippy_abi_version
+        .map(ToString::to_string)
+        .unwrap_or_else(mesh_llm_runtime_install::current_skippy_abi_version);
     let cache = native_runtime_cache(cache_dir)?;
     if available {
         if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
             eprintln!("🔎 Loading native runtime release manifest");
         }
         let manifest = load_release_manifest(NativeRuntimeManifestOptions {
+            mesh_version: mesh_version.to_string(),
             manifest_path: manifest_path.map(Path::to_path_buf),
             bundle_dirs: bundle_dirs.to_vec(),
             ..Default::default()
@@ -33,14 +40,11 @@ pub async fn run_native_runtime_list(
         .await?;
         let profile = host_runtime_profile();
         let cache = native_runtime_cache(cache_dir)?;
-        let resolution = NativeRuntimeResolver::new(
-            CURRENT_MESH_VERSION,
-            profile.clone(),
-            manifest.clone(),
-            cache,
-        )
-        .resolve(&RuntimeSelection::Recommended)
-        .ok();
+        let resolution =
+            NativeRuntimeResolver::new(mesh_version, profile.clone(), manifest.clone(), cache)
+                .with_skippy_abi_version(skippy_abi_version)
+                .resolve(&RuntimeSelection::Recommended)
+                .ok();
         let rows = manifest
             .artifacts
             .iter()
@@ -87,6 +91,8 @@ pub async fn run_native_runtime_install(
     manifest_path: Option<&Path>,
     bundle_dirs: &[PathBuf],
     cache_dir: Option<&Path>,
+    mesh_version: Option<&str>,
+    skippy_abi_version: Option<&str>,
     json_output: bool,
 ) -> Result<()> {
     let selection = RuntimeSelection::parse(requested_runtime)?;
@@ -97,6 +103,10 @@ pub async fn run_native_runtime_install(
         eprintln!("🔎 Detecting host runtime profile");
     }
     let outcome = install_native_runtime(NativeRuntimeInstallOptions {
+        mesh_version: mesh_version.unwrap_or(CURRENT_MESH_VERSION).to_string(),
+        skippy_abi_version: skippy_abi_version
+            .map(ToString::to_string)
+            .unwrap_or_else(mesh_llm_runtime_install::current_skippy_abi_version),
         selection,
         manifest_path: manifest_path.map(Path::to_path_buf),
         bundle_dirs: bundle_dirs.to_vec(),

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -13,21 +13,32 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NativeRuntimeConfigSelection<'a> {
+    pub mesh_version: Option<&'a str>,
+    pub skippy_abi_version: Option<&'a str>,
+    pub selection: Option<&'a str>,
+}
+
+impl<'a> NativeRuntimeConfigSelection<'a> {
+    fn mesh_version_or_current(self) -> &'a str {
+        self.mesh_version.unwrap_or(CURRENT_MESH_VERSION)
+    }
+}
+
 pub async fn run_native_runtime_list(
     available: bool,
     manifest_path: Option<&Path>,
     bundle_dirs: &[PathBuf],
     cache_dir: Option<&Path>,
-    mesh_version: Option<&str>,
-    skippy_abi_version: Option<&str>,
+    configured: NativeRuntimeConfigSelection<'_>,
     json_output: bool,
 ) -> Result<()> {
-    let mesh_version = mesh_version.unwrap_or(CURRENT_MESH_VERSION);
-    let skippy_abi_version = skippy_abi_version
-        .map(ToString::to_string)
-        .unwrap_or_else(mesh_llm_runtime_install::current_skippy_abi_version);
+    let mesh_version = configured.mesh_version_or_current();
+    let selection = RuntimeSelection::parse(configured.selection)?;
     let cache = native_runtime_cache(cache_dir)?;
     if available {
+        print_configured_selector(configured, json_output);
         if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
             eprintln!("🔎 Loading native runtime release manifest");
         }
@@ -40,21 +51,20 @@ pub async fn run_native_runtime_list(
         .await?;
         let profile = host_runtime_profile();
         let cache = native_runtime_cache(cache_dir)?;
-        let resolution =
+        let mut resolver =
             NativeRuntimeResolver::new(mesh_version, profile.clone(), manifest.clone(), cache)
-                .with_skippy_abi_version(skippy_abi_version)
-                .resolve(&RuntimeSelection::Recommended)
-                .ok();
+                .with_bundle_dirs(bundle_dirs.to_vec());
+        if let Some(skippy_abi_version) = configured.skippy_abi_version {
+            resolver = resolver.with_skippy_abi_version(skippy_abi_version);
+        }
+        let evaluated = resolver.evaluate(&selection)?;
         let rows = manifest
             .artifacts
             .iter()
             .map(|artifact| {
-                let evaluation = resolution.as_ref().and_then(|resolution| {
-                    resolution
-                        .evaluated
-                        .iter()
-                        .find(|candidate| candidate.artifact.id == artifact.id)
-                });
+                let evaluation = evaluated
+                    .iter()
+                    .find(|candidate| candidate.artifact.id == artifact.id);
                 let supported = evaluation.is_some_and(|candidate| candidate.compatible);
                 json!({
                     "id": artifact.id,
@@ -91,22 +101,30 @@ pub async fn run_native_runtime_install(
     manifest_path: Option<&Path>,
     bundle_dirs: &[PathBuf],
     cache_dir: Option<&Path>,
-    mesh_version: Option<&str>,
-    skippy_abi_version: Option<&str>,
+    configured: NativeRuntimeConfigSelection<'_>,
     json_output: bool,
 ) -> Result<()> {
-    let selection = RuntimeSelection::parse(requested_runtime)?;
+    let configured_selection = requested_runtime
+        .is_none()
+        .then_some(configured.selection)
+        .flatten();
+    let selection = RuntimeSelection::parse(requested_runtime.or(configured_selection))?;
     if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
         eprintln!("🔎 Loading native runtime release manifest");
     }
     if !json_output {
         eprintln!("🔎 Detecting host runtime profile");
     }
+    print_configured_selector(
+        NativeRuntimeConfigSelection {
+            selection: configured_selection,
+            ..configured
+        },
+        json_output,
+    );
     let outcome = install_native_runtime(NativeRuntimeInstallOptions {
-        mesh_version: mesh_version.unwrap_or(CURRENT_MESH_VERSION).to_string(),
-        skippy_abi_version: skippy_abi_version
-            .map(ToString::to_string)
-            .unwrap_or_else(mesh_llm_runtime_install::current_skippy_abi_version),
+        mesh_version: configured.mesh_version_or_current().to_string(),
+        skippy_abi_version: configured.skippy_abi_version.map(ToString::to_string),
         selection,
         manifest_path: manifest_path.map(Path::to_path_buf),
         bundle_dirs: bundle_dirs.to_vec(),
@@ -153,6 +171,21 @@ pub async fn run_native_runtime_install(
         }
     }
     Ok(())
+}
+
+fn print_configured_selector(configured: NativeRuntimeConfigSelection<'_>, json_output: bool) {
+    if json_output || configured.mesh_version.is_none() {
+        return;
+    }
+    let mesh_version = configured.mesh_version_or_current();
+    eprintln!("🔒 Using native runtime selector from config");
+    eprintln!("   mesh version: {mesh_version}");
+    if let Some(skippy_abi_version) = configured.skippy_abi_version {
+        eprintln!("   Skippy ABI: {skippy_abi_version}");
+    }
+    if let Some(configured_selection) = configured.selection {
+        eprintln!("   selection: {configured_selection}");
+    }
 }
 
 struct DownloadProgress {
@@ -312,27 +345,51 @@ pub fn run_native_runtime_prune(
     Ok(())
 }
 
-pub fn run_native_runtime_doctor(json_output: bool) -> Result<()> {
+pub fn run_native_runtime_doctor(
+    mesh_version: Option<&str>,
+    skippy_abi_version: Option<&str>,
+    configured_selection: Option<&str>,
+    json_output: bool,
+) -> Result<()> {
     let cache = native_runtime_cache(None)?;
     let profile = host_runtime_profile();
     let installed = cache.installed()?;
-    let current_version_runtimes = installed
+    let selected_mesh_version = mesh_version.unwrap_or(CURRENT_MESH_VERSION);
+    let runtime_selection = RuntimeSelection::parse(configured_selection)?;
+    let selected_version_runtimes = installed
         .iter()
-        .filter(|runtime| runtime.mesh_version == CURRENT_MESH_VERSION)
+        .filter(|runtime| runtime.mesh_version == selected_mesh_version)
         .collect::<Vec<_>>();
-    let selected = current_version_runtimes
+    let installed_artifacts = selected_version_runtimes
         .iter()
-        .max_by_key(|runtime| runtime.manifest.runtime.backend.kind.default_rank());
+        .map(|runtime| runtime.manifest.runtime.clone())
+        .collect::<Vec<_>>();
+    let selected_candidate = mesh_llm_native_runtime::select_native_runtime_from_artifacts(
+        &installed_artifacts,
+        &profile,
+        selected_mesh_version,
+        skippy_abi_version,
+        &runtime_selection,
+    );
+    let selected = selected_candidate.as_ref().and_then(|candidate| {
+        selected_version_runtimes.iter().find(|runtime| {
+            runtime.native_runtime_id == candidate.artifact.id
+                && runtime.manifest.runtime.skippy_abi == candidate.artifact.skippy_abi
+        })
+    });
 
     let report = NativeRuntimeDoctorReport {
-        mesh_version: CURRENT_MESH_VERSION.to_string(),
+        running_mesh_version: CURRENT_MESH_VERSION.to_string(),
+        selected_mesh_version: selected_mesh_version.to_string(),
+        configured_skippy_abi: skippy_abi_version.map(ToString::to_string),
+        configured_selection: configured_selection.map(ToString::to_string),
         host: profile,
         cache_path: cache.root().to_path_buf(),
         selected_runtime_id: selected.map(|runtime| runtime.native_runtime_id.clone()),
         selected_runtime_flavor: selected.map(|runtime| runtime.flavor.clone()),
         selected_runtime_path: selected.map(|runtime| runtime.path.clone()),
         installed_count: installed.len(),
-        current_version_installed_count: current_version_runtimes.len(),
+        selected_version_installed_count: selected_version_runtimes.len(),
     };
 
     if json_output {
@@ -345,14 +402,17 @@ pub fn run_native_runtime_doctor(json_output: bool) -> Result<()> {
 
 #[derive(Serialize)]
 struct NativeRuntimeDoctorReport {
-    mesh_version: String,
+    running_mesh_version: String,
+    selected_mesh_version: String,
+    configured_skippy_abi: Option<String>,
+    configured_selection: Option<String>,
     host: HostRuntimeProfile,
     cache_path: PathBuf,
     selected_runtime_id: Option<String>,
     selected_runtime_flavor: Option<String>,
     selected_runtime_path: Option<PathBuf>,
     installed_count: usize,
-    current_version_installed_count: usize,
+    selected_version_installed_count: usize,
 }
 
 fn print_available_runtimes(rows: &[serde_json::Value]) {
@@ -376,7 +436,18 @@ fn print_available_runtimes(rows: &[serde_json::Value]) {
             row["os"].as_str().unwrap_or("unknown"),
             row["arch"].as_str().unwrap_or("unknown")
         );
+        if let Some(reasons) = row["rejection_reasons"].as_array()
+            && !reasons.is_empty()
+        {
+            for reason in reasons {
+                println!("    reason: {}", compact_json(reason));
+            }
+        }
     }
+}
+
+fn compact_json(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| value.to_string())
 }
 
 fn print_installed_runtimes(
@@ -403,7 +474,20 @@ fn print_doctor_report(report: &NativeRuntimeDoctorReport) {
     println!("🩺 MeshLLM doctor");
     println!();
     println!("Native runtime:");
-    println!("  mesh version: {}", report.mesh_version);
+    println!("  running MeshLLM version: {}", report.running_mesh_version);
+    println!(
+        "  selected runtime version: {}",
+        report.selected_mesh_version
+    );
+    if report.selected_mesh_version != report.running_mesh_version {
+        println!("  status: native runtime version is pinned by config");
+    }
+    if let Some(skippy_abi) = &report.configured_skippy_abi {
+        println!("  configured Skippy ABI: {skippy_abi}");
+    }
+    if let Some(selection) = &report.configured_selection {
+        println!("  configured selection: {selection}");
+    }
     println!("  cache: {}", report.cache_path.display());
     println!("  host: {}/{}", report.host.os, report.host.arch);
     let flavors = report
@@ -426,12 +510,12 @@ fn print_doctor_report(report: &NativeRuntimeDoctorReport) {
         }
         None => {
             println!("  selected: none");
-            println!("  status: no native runtime installed for this MeshLLM version");
+            println!("  status: no native runtime installed for selected MeshLLM version");
         }
     }
     println!("  installed: {}", report.installed_count);
     println!(
-        "  installed for current version: {}",
-        report.current_version_installed_count
+        "  installed for selected version: {}",
+        report.selected_version_installed_count
     );
 }

--- a/crates/mesh-llm-commands/src/runtime_native/formatters.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/formatters.rs
@@ -1,0 +1,367 @@
+use anyhow::{Error, Result};
+use mesh_llm_native_runtime::{
+    CachePrunePlan, CandidateRejection, HostRuntimeProfile, InstalledNativeRuntime,
+};
+use mesh_llm_runtime_install::{NativeRuntimeInstallOutcome, NativeRuntimeInstallStatus};
+use serde::Serialize;
+use serde_json::json;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct AvailableRuntimeRow {
+    pub(crate) id: String,
+    pub(crate) mesh_version: Option<String>,
+    pub(crate) skippy_abi: String,
+    pub(crate) backend: String,
+    pub(crate) os: String,
+    pub(crate) arch: String,
+    pub(crate) supported: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(crate) rejection_reasons: Vec<CandidateRejection>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) url: Option<String>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct NativeRuntimeDoctorReport {
+    pub(crate) running_mesh_version: String,
+    pub(crate) selected_mesh_version: String,
+    pub(crate) configured_skippy_abi: Option<String>,
+    pub(crate) configured_selection: Option<String>,
+    pub(crate) host: HostRuntimeProfile,
+    pub(crate) cache_path: PathBuf,
+    pub(crate) selected_runtime_id: Option<String>,
+    pub(crate) selected_runtime_flavor: Option<String>,
+    pub(crate) selected_runtime_path: Option<PathBuf>,
+    pub(crate) installed_count: usize,
+    pub(crate) selected_version_installed_count: usize,
+}
+
+pub(crate) trait RuntimeNativeFormatter {
+    fn render_available(&self, rows: &[AvailableRuntimeRow]) -> Result<()>;
+    fn render_installed(
+        &self,
+        installed: &[InstalledNativeRuntime],
+        cache_root: &Path,
+    ) -> Result<()>;
+    fn render_install(&self, outcome: &NativeRuntimeInstallOutcome) -> Result<()>;
+    fn render_install_error(&self, error: &Error) -> Result<()>;
+    fn render_remove(
+        &self,
+        native_runtime_id: &str,
+        mesh_version: &str,
+        removed: bool,
+    ) -> Result<()>;
+    fn render_prune(&self, plan: &CachePrunePlan) -> Result<()>;
+    fn render_doctor(&self, report: &NativeRuntimeDoctorReport) -> Result<()>;
+}
+
+pub(crate) struct HumanFormatter;
+pub(crate) struct JsonFormatter;
+
+pub(crate) fn runtime_native_formatter(json_output: bool) -> Box<dyn RuntimeNativeFormatter> {
+    if json_output {
+        Box::new(JsonFormatter)
+    } else {
+        Box::new(HumanFormatter)
+    }
+}
+
+impl RuntimeNativeFormatter for HumanFormatter {
+    fn render_available(&self, rows: &[AvailableRuntimeRow]) -> Result<()> {
+        print_available_human(rows);
+        Ok(())
+    }
+
+    fn render_installed(
+        &self,
+        installed: &[InstalledNativeRuntime],
+        cache_root: &Path,
+    ) -> Result<()> {
+        print_installed_human(installed, cache_root);
+        Ok(())
+    }
+
+    fn render_install(&self, outcome: &NativeRuntimeInstallOutcome) -> Result<()> {
+        print_install_human(outcome);
+        Ok(())
+    }
+
+    fn render_install_error(&self, error: &Error) -> Result<()> {
+        eprintln!("❌ Native runtime install failed");
+        eprintln!("   Reason: {error}");
+        eprintln!("   Try: mesh-llm runtime list --available");
+        Ok(())
+    }
+
+    fn render_remove(
+        &self,
+        native_runtime_id: &str,
+        mesh_version: &str,
+        removed: bool,
+    ) -> Result<()> {
+        if removed {
+            eprintln!("✅ Removed native runtime {native_runtime_id} for MeshLLM {mesh_version}");
+        } else {
+            eprintln!(
+                "🔎 Native runtime {native_runtime_id} for MeshLLM {mesh_version} was not installed"
+            );
+        }
+        Ok(())
+    }
+
+    fn render_prune(&self, plan: &CachePrunePlan) -> Result<()> {
+        if plan.remove_dirs.is_empty() {
+            eprintln!("✅ Native runtime cache already pruned");
+        } else {
+            eprintln!(
+                "✅ Pruned {} native runtime cache version(s)",
+                plan.remove_dirs.len()
+            );
+            for dir in &plan.remove_dirs {
+                eprintln!("   removed: {}", dir.display());
+            }
+        }
+        Ok(())
+    }
+
+    fn render_doctor(&self, report: &NativeRuntimeDoctorReport) -> Result<()> {
+        print_doctor_human(report);
+        Ok(())
+    }
+}
+
+impl RuntimeNativeFormatter for JsonFormatter {
+    fn render_available(&self, rows: &[AvailableRuntimeRow]) -> Result<()> {
+        print_json(rows)
+    }
+
+    fn render_installed(
+        &self,
+        installed: &[InstalledNativeRuntime],
+        _cache_root: &Path,
+    ) -> Result<()> {
+        print_json(installed)
+    }
+
+    fn render_install(&self, outcome: &NativeRuntimeInstallOutcome) -> Result<()> {
+        print_json(&json!({
+            "status": install_status_label(outcome.status.clone()),
+            "runtime": outcome.runtime,
+            "resolution": outcome.resolution,
+        }))
+    }
+
+    fn render_install_error(&self, error: &Error) -> Result<()> {
+        print_json(&json!({
+            "status": "error",
+            "error": {
+                "type": "native_runtime_install_failed",
+                "message": error.to_string(),
+                "context": error.chain().skip(1).map(ToString::to_string).collect::<Vec<_>>(),
+            },
+        }))
+    }
+
+    fn render_remove(
+        &self,
+        native_runtime_id: &str,
+        mesh_version: &str,
+        removed: bool,
+    ) -> Result<()> {
+        print_json(&json!({
+            "mesh_version": mesh_version,
+            "native_runtime_id": native_runtime_id,
+            "removed": removed,
+        }))
+    }
+
+    fn render_prune(&self, plan: &CachePrunePlan) -> Result<()> {
+        print_json(plan)
+    }
+
+    fn render_doctor(&self, report: &NativeRuntimeDoctorReport) -> Result<()> {
+        print_json(report)
+    }
+}
+
+fn print_json(value: &(impl Serialize + ?Sized)) -> Result<()> {
+    println!("{}", serde_json::to_string_pretty(value)?);
+    Ok(())
+}
+
+fn install_status_label(status: NativeRuntimeInstallStatus) -> &'static str {
+    match status {
+        NativeRuntimeInstallStatus::AlreadyInstalled => "already_installed",
+        NativeRuntimeInstallStatus::Installed => "installed",
+    }
+}
+
+fn print_available_human(rows: &[AvailableRuntimeRow]) {
+    if rows.is_empty() {
+        println!("📦 No native runtime manifest entries found");
+        println!("   Pass --manifest or --bundle-dir to inspect available runtimes.");
+        return;
+    }
+    println!("📦 Available native runtimes");
+    for row in rows {
+        let marker = if row.supported { "✅" } else { "⚠️" };
+        let status = if row.supported {
+            "compatible"
+        } else {
+            "not compatible"
+        };
+        println!(
+            "  - {marker} {} {status} ({}, {}/{})",
+            row.id, row.backend, row.os, row.arch
+        );
+        if let Some(mesh_version) = row.mesh_version.as_deref() {
+            println!(
+                "    MeshLLM: {mesh_version}; Skippy ABI: {}",
+                row.skippy_abi
+            );
+        } else {
+            println!("    MeshLLM: unspecified; Skippy ABI: {}", row.skippy_abi);
+        }
+        for reason in &row.rejection_reasons {
+            println!("    reason: {}", format_rejection(reason));
+        }
+    }
+}
+
+fn print_installed_human(installed: &[InstalledNativeRuntime], cache_root: &Path) {
+    if installed.is_empty() {
+        println!("📦 No native runtimes installed");
+        println!("   cache: {}", cache_root.display());
+        return;
+    }
+    println!("📦 Installed native runtimes");
+    println!("   cache: {}", cache_root.display());
+    for runtime in installed {
+        println!(
+            "  - ✅ {} {} ({})",
+            runtime.native_runtime_id, runtime.mesh_version, runtime.flavor
+        );
+        println!("    path: {}", runtime.path.display());
+    }
+}
+
+fn print_install_human(outcome: &NativeRuntimeInstallOutcome) {
+    match outcome.status {
+        NativeRuntimeInstallStatus::AlreadyInstalled => {
+            eprintln!(
+                "✅ Native runtime already installed: {}",
+                outcome.runtime.native_runtime_id
+            );
+            eprintln!("   version: {}", outcome.runtime.mesh_version);
+            eprintln!("   flavor: {}", outcome.runtime.flavor);
+            eprintln!("   path: {}", outcome.runtime.path.display());
+        }
+        NativeRuntimeInstallStatus::Installed => {
+            eprintln!("✅ Installed {}", outcome.runtime.native_runtime_id);
+            eprintln!("   version: {}", outcome.runtime.mesh_version);
+            eprintln!("   flavor: {}", outcome.runtime.flavor);
+            eprintln!("   path: {}", outcome.runtime.path.display());
+        }
+    }
+}
+
+fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
+    println!("🩺 MeshLLM doctor");
+    println!();
+    println!("Native runtime:");
+    println!("  running MeshLLM version: {}", report.running_mesh_version);
+    println!(
+        "  selected runtime version: {}",
+        report.selected_mesh_version
+    );
+    if report.selected_mesh_version != report.running_mesh_version {
+        println!("  status: native runtime version is pinned by config");
+    }
+    if let Some(skippy_abi) = &report.configured_skippy_abi {
+        println!("  configured Skippy ABI: {skippy_abi}");
+    }
+    if let Some(selection) = &report.configured_selection {
+        println!("  configured selection: {selection}");
+    }
+    println!("  cache: {}", report.cache_path.display());
+    println!("  host: {}/{}", report.host.os, report.host.arch);
+    let flavors = report
+        .host
+        .available_flavors
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    println!("  detected flavors: {flavors}");
+    match &report.selected_runtime_id {
+        Some(id) => {
+            println!("  selected: {id}");
+            if let Some(flavor) = &report.selected_runtime_flavor {
+                println!("  flavor: {flavor}");
+            }
+            if let Some(path) = &report.selected_runtime_path {
+                println!("  path: {}", path.display());
+            }
+        }
+        None => {
+            println!("  selected: none");
+            println!("  status: no native runtime installed for selected MeshLLM version");
+        }
+    }
+    println!("  installed: {}", report.installed_count);
+    println!(
+        "  installed for selected version: {}",
+        report.selected_version_installed_count
+    );
+}
+
+fn format_rejection(reason: &CandidateRejection) -> String {
+    match reason {
+        CandidateRejection::MeshVersionMismatch { expected, actual } => {
+            format!("MeshLLM version mismatch: expected {expected}, found {actual}")
+        }
+        CandidateRejection::SkippyAbiMismatch { expected, actual } => {
+            format!("Skippy ABI mismatch: expected {expected}, found {actual}")
+        }
+        CandidateRejection::OsMismatch { expected, actual } => {
+            format!("OS mismatch: expected {expected}, artifact is for {actual}")
+        }
+        CandidateRejection::ArchMismatch { expected, actual } => {
+            format!("CPU architecture mismatch: expected {expected}, artifact is for {actual}")
+        }
+        CandidateRejection::TargetTripleMismatch { expected, actual } => {
+            format!("target triple mismatch: expected {expected}, host is {actual}")
+        }
+        CandidateRejection::BackendNotSupported { backend } => {
+            format!("backend {backend} is not supported on this host")
+        }
+        CandidateRejection::CudaProfileMissing => {
+            "CUDA runtime requires CUDA, but no CUDA profile was detected".to_string()
+        }
+        CandidateRejection::CudaToolkitMajorMismatch { required } => {
+            format!("CUDA toolkit mismatch: runtime requires CUDA {required}")
+        }
+        CandidateRejection::CudaGpuArchUnsupported { supported } => {
+            format!(
+                "CUDA GPU architecture unsupported: runtime supports {}",
+                supported.join(", ")
+            )
+        }
+        CandidateRejection::RocmProfileMissing => {
+            "ROCm runtime requires ROCm, but no ROCm profile was detected".to_string()
+        }
+        CandidateRejection::RocmGpuArchUnsupported { supported } => {
+            format!(
+                "ROCm GPU architecture unsupported: runtime supports {}",
+                supported.join(", ")
+            )
+        }
+        CandidateRejection::VulkanProfileMissing => {
+            "Vulkan runtime requires Vulkan, but no Vulkan profile was detected".to_string()
+        }
+        CandidateRejection::SelectionMismatch { selection } => {
+            format!("selection mismatch: requested {selection}")
+        }
+    }
+}

--- a/crates/mesh-llm-config/src/lib.rs
+++ b/crates/mesh-llm-config/src/lib.rs
@@ -99,15 +99,16 @@ connect_timeout_secs = 0
     }
 
     #[test]
-    fn native_runtime_override_requires_explicit_mesh_version_and_abi() {
+    fn native_runtime_override_accepts_mesh_version_with_optional_abi_and_selection() {
         let config = parse_config_toml(
             r#"
 [runtime.native_runtime]
 mesh_version = "0.68.0"
 skippy_abi = "0.1.25"
+selection = "exact:meshllm-native-runtime-linux-x86_64-cuda12"
 "#,
         )
-        .expect("complete native runtime selector should parse");
+        .expect("native runtime selector should parse");
 
         assert_eq!(
             config.runtime.native_runtime.mesh_version.as_deref(),
@@ -117,18 +118,30 @@ skippy_abi = "0.1.25"
             config.runtime.native_runtime.skippy_abi.as_deref(),
             Some("0.1.25")
         );
+        assert_eq!(
+            config.runtime.native_runtime.selection.as_deref(),
+            Some("exact:meshllm-native-runtime-linux-x86_64-cuda12")
+        );
+
+        parse_config_toml(
+            r#"
+[runtime.native_runtime]
+mesh_version = "0.68.0"
+"#,
+        )
+        .expect("mesh-version-only native runtime selector should parse");
 
         let err = parse_config_toml(
             r#"
 [runtime.native_runtime]
-mesh_version = "0.68.0"
+selection = "cuda12"
 "#,
         )
         .expect_err("partial native runtime selector should fail validation");
 
         assert!(
             err.to_string().contains(
-                "runtime.native_runtime override must set both mesh_version and skippy_abi"
+                "runtime.native_runtime override must set mesh_version when skippy_abi or selection is set"
             ),
             "unexpected validation error: {err}"
         );

--- a/crates/mesh-llm-config/src/lib.rs
+++ b/crates/mesh-llm-config/src/lib.rs
@@ -99,6 +99,42 @@ connect_timeout_secs = 0
     }
 
     #[test]
+    fn native_runtime_override_requires_explicit_mesh_version_and_abi() {
+        let config = parse_config_toml(
+            r#"
+[runtime.native_runtime]
+mesh_version = "0.68.0"
+skippy_abi = "0.1.25"
+"#,
+        )
+        .expect("complete native runtime selector should parse");
+
+        assert_eq!(
+            config.runtime.native_runtime.mesh_version.as_deref(),
+            Some("0.68.0")
+        );
+        assert_eq!(
+            config.runtime.native_runtime.skippy_abi.as_deref(),
+            Some("0.1.25")
+        );
+
+        let err = parse_config_toml(
+            r#"
+[runtime.native_runtime]
+mesh_version = "0.68.0"
+"#,
+        )
+        .expect_err("partial native runtime selector should fail validation");
+
+        assert!(
+            err.to_string().contains(
+                "runtime.native_runtime override must set both mesh_version and skippy_abi"
+            ),
+            "unexpected validation error: {err}"
+        );
+    }
+
+    #[test]
     fn config_store_add_model_preserves_existing_fields() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("config.toml");
@@ -607,6 +643,7 @@ gpu_id = "pci:0000:65:00.0"
             ("OwnerControlConfig", 1),
             ("GpuConfig", 1),
             ("RuntimeConfig", 1),
+            ("NativeRuntimeConfig", 1),
             ("MeshRequirementsConfig", 1),
             ("ModelConfigEntry", 1),
             ("ModelFitConfig", 2),
@@ -628,6 +665,7 @@ gpu_id = "pci:0000:65:00.0"
             "MeshRequirementsConfig",
             "OwnerControlConfig",
             "RuntimeConfig",
+            "NativeRuntimeConfig",
             "TelemetryConfig",
             "TelemetryMetricsConfig",
             "ModelConfigDefaults",

--- a/crates/mesh-llm-config/src/model.rs
+++ b/crates/mesh-llm-config/src/model.rs
@@ -71,6 +71,8 @@ pub struct RuntimeConfig {
     pub reconcile_model_targets: bool,
     #[serde(default)]
     pub reconcile_model_target_demand_upgrades: bool,
+    #[serde(default)]
+    pub native_runtime: NativeRuntimeConfig,
     #[serde(default = "default_model_target_demand_upgrade_min_requests")]
     pub model_target_demand_upgrade_min_requests: u64,
     #[serde(default = "default_model_target_demand_upgrade_max_age_secs")]
@@ -82,12 +84,21 @@ impl Default for RuntimeConfig {
         Self {
             reconcile_model_targets: false,
             reconcile_model_target_demand_upgrades: false,
+            native_runtime: NativeRuntimeConfig::default(),
             model_target_demand_upgrade_min_requests:
                 DEFAULT_MODEL_TARGET_DEMAND_UPGRADE_MIN_REQUESTS,
             model_target_demand_upgrade_max_age_secs:
                 DEFAULT_MODEL_TARGET_DEMAND_UPGRADE_MAX_AGE_SECS,
         }
     }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+pub struct NativeRuntimeConfig {
+    #[serde(default)]
+    pub mesh_version: Option<String>,
+    #[serde(default)]
+    pub skippy_abi: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/mesh-llm-config/src/model.rs
+++ b/crates/mesh-llm-config/src/model.rs
@@ -99,6 +99,8 @@ pub struct NativeRuntimeConfig {
     pub mesh_version: Option<String>,
     #[serde(default)]
     pub skippy_abi: Option<String>,
+    #[serde(default)]
+    pub selection: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/mesh-llm-config/src/model/built_in_schema.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema.rs
@@ -141,6 +141,14 @@ fn build_built_in_config_schema() -> ConfigSchema {
             ConfigValueSchema::Boolean,
         ),
         runtime_setting(
+            "runtime.native_runtime.mesh_version",
+            ConfigValueSchema::String,
+        ),
+        runtime_setting(
+            "runtime.native_runtime.skippy_abi",
+            ConfigValueSchema::String,
+        ),
+        runtime_setting(
             "runtime.model_target_demand_upgrade_min_requests",
             ConfigValueSchema::Integer,
         ),

--- a/crates/mesh-llm-config/src/model/built_in_schema.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema.rs
@@ -140,12 +140,16 @@ fn build_built_in_config_schema() -> ConfigSchema {
             "runtime.reconcile_model_target_demand_upgrades",
             ConfigValueSchema::Boolean,
         ),
-        runtime_setting(
+        native_runtime_setting(
             "runtime.native_runtime.mesh_version",
             ConfigValueSchema::String,
         ),
-        runtime_setting(
+        native_runtime_setting(
             "runtime.native_runtime.skippy_abi",
+            ConfigValueSchema::String,
+        ),
+        native_runtime_setting(
+            "runtime.native_runtime.selection",
             ConfigValueSchema::String,
         ),
         runtime_setting(
@@ -896,6 +900,17 @@ fn runtime_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSetting
     let mut setting = basic_setting(path, value_schema);
     setting.control_surfaces = vec![ConfigControlSurface::ConfigFile, ConfigControlSurface::Api];
     setting.apply_mode = ConfigApplyMode::DynamicValidationOnly;
+    setting
+}
+
+fn native_runtime_setting(path: &str, value_schema: ConfigValueSchema) -> ConfigSettingSchema {
+    let mut setting = basic_setting(path, value_schema);
+    setting.control_surfaces = vec![ConfigControlSurface::ConfigFile, ConfigControlSurface::Api];
+    setting.apply_mode = ConfigApplyMode::DynamicValidationOnly;
+    setting.restart_scope = ConfigRestartScope::ProcessRestart;
+    setting.description = Some(
+        "Native runtime selection is read before dynamic runtime libraries are loaded.".into(),
+    );
     setting
 }
 

--- a/crates/mesh-llm-config/src/validate.rs
+++ b/crates/mesh-llm-config/src/validate.rs
@@ -82,6 +82,9 @@ pub fn validate_config_diagnostics(config: &MeshConfig) -> Vec<ConfigDiagnostic>
     if let Err(diagnostic) = validate_telemetry_config(&config.telemetry) {
         diagnostics.push(diagnostic);
     }
+    if let Err(diagnostic) = validate_runtime_config(&config.runtime) {
+        diagnostics.push(diagnostic);
+    }
     if let Err(diagnostic) = validate_plugin_entries(&config.plugins) {
         diagnostics.push(diagnostic);
     }
@@ -113,6 +116,30 @@ pub fn validate_config_diagnostics(config: &MeshConfig) -> Vec<ConfigDiagnostic>
     }
 
     diagnostics
+}
+
+fn validate_runtime_config(config: &RuntimeConfig) -> DiagnosticResult {
+    let mesh_version = config.native_runtime.mesh_version.as_deref();
+    let skippy_abi = config.native_runtime.skippy_abi.as_deref();
+    if mesh_version.is_some() != skippy_abi.is_some() {
+        return Err(validation_diagnostic(
+            "runtime.native_runtime",
+            "runtime.native_runtime override must set both mesh_version and skippy_abi",
+        ));
+    }
+    if matches!(mesh_version, Some(value) if value.trim().is_empty()) {
+        return Err(validation_diagnostic(
+            "runtime.native_runtime.mesh_version",
+            "runtime.native_runtime.mesh_version must not be empty",
+        ));
+    }
+    if matches!(skippy_abi, Some(value) if value.trim().is_empty()) {
+        return Err(validation_diagnostic(
+            "runtime.native_runtime.skippy_abi",
+            "runtime.native_runtime.skippy_abi must not be empty",
+        ));
+    }
+    Ok(())
 }
 
 pub fn validate_config_diagnostics_with_plugin_schemas<F>(

--- a/crates/mesh-llm-config/src/validate.rs
+++ b/crates/mesh-llm-config/src/validate.rs
@@ -121,10 +121,11 @@ pub fn validate_config_diagnostics(config: &MeshConfig) -> Vec<ConfigDiagnostic>
 fn validate_runtime_config(config: &RuntimeConfig) -> DiagnosticResult {
     let mesh_version = config.native_runtime.mesh_version.as_deref();
     let skippy_abi = config.native_runtime.skippy_abi.as_deref();
-    if mesh_version.is_some() != skippy_abi.is_some() {
+    let selection = config.native_runtime.selection.as_deref();
+    if mesh_version.is_none() && (skippy_abi.is_some() || selection.is_some()) {
         return Err(validation_diagnostic(
             "runtime.native_runtime",
-            "runtime.native_runtime override must set both mesh_version and skippy_abi",
+            "runtime.native_runtime override must set mesh_version when skippy_abi or selection is set",
         ));
     }
     if matches!(mesh_version, Some(value) if value.trim().is_empty()) {
@@ -137,6 +138,12 @@ fn validate_runtime_config(config: &RuntimeConfig) -> DiagnosticResult {
         return Err(validation_diagnostic(
             "runtime.native_runtime.skippy_abi",
             "runtime.native_runtime.skippy_abi must not be empty",
+        ));
+    }
+    if matches!(selection, Some(value) if value.trim().is_empty()) {
+        return Err(validation_diagnostic(
+            "runtime.native_runtime.selection",
+            "runtime.native_runtime.selection must not be empty",
         ));
     }
     Ok(())

--- a/crates/mesh-llm-ffi/src/lib.rs
+++ b/crates/mesh-llm-ffi/src/lib.rs
@@ -1016,9 +1016,7 @@ fn runtime_install_options(
         mesh_version: options
             .mesh_version
             .unwrap_or_else(|| mesh_llm_sdk::native_runtime::CURRENT_MESH_VERSION.to_string()),
-        skippy_abi_version: options
-            .skippy_abi_version
-            .unwrap_or_else(mesh_llm_sdk::native_runtime::current_skippy_abi_version),
+        skippy_abi_version: options.skippy_abi_version,
         selection: mesh_llm_sdk::native_runtime::RuntimeSelection::parse(Some(
             options.selection.as_str(),
         ))

--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -39,6 +39,7 @@ pub use mesh::requirements::{
 };
 
 use anyhow::Result;
+use std::path::Path;
 
 pub const BUILD_VERSION: &str = mesh_llm_build_info::BUILD_VERSION;
 pub const RELEASE_VERSION: &str = mesh_llm_build_info::RELEASE_VERSION;
@@ -58,7 +59,7 @@ pub async fn run_runtime(
     explicit_surface: Option<RuntimeSurface>,
     legacy_warning: Option<String>,
 ) -> Result<()> {
-    initialize_host_runtime().await?;
+    initialize_host_runtime_with_config(options.config.as_deref()).await?;
     run_runtime_initialized(options, explicit_surface, legacy_warning).await
 }
 
@@ -71,13 +72,38 @@ pub async fn run_runtime_initialized(
 }
 
 pub async fn initialize_host_runtime() -> Result<()> {
+    initialize_host_runtime_with_config(None).await
+}
+
+pub async fn initialize_host_runtime_with_config(config_path: Option<&Path>) -> Result<()> {
     #[cfg(feature = "dynamic-native-runtime")]
-    if let Some(runtime) = system::native_runtime::try_load_installed_native_runtime().await? {
-        tracing::info!(
-            native_runtime_id = %runtime.native_runtime_id,
-            libraries = ?runtime.libraries,
-            "Loaded MeshLLM native runtime"
-        );
+    {
+        let config = plugin::load_config(config_path)?;
+        let startup_selection = match (
+            config.runtime.native_runtime.mesh_version,
+            config.runtime.native_runtime.skippy_abi,
+        ) {
+            (Some(mesh_version), Some(skippy_abi)) => {
+                system::native_runtime::NativeRuntimeStartupSelection::explicit(
+                    mesh_version,
+                    skippy_abi,
+                )
+            }
+            _ => system::native_runtime::NativeRuntimeStartupSelection::current(),
+        };
+        if let Some(runtime) =
+            system::native_runtime::try_load_installed_native_runtime(startup_selection).await?
+        {
+            tracing::info!(
+                native_runtime_id = %runtime.native_runtime_id,
+                libraries = ?runtime.libraries,
+                "Loaded MeshLLM native runtime"
+            );
+        }
+    }
+    #[cfg(not(feature = "dynamic-native-runtime"))]
+    {
+        let _ = config_path;
     }
     Ok(())
 }

--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -79,17 +79,19 @@ pub async fn initialize_host_runtime_with_config(config_path: Option<&Path>) -> 
     #[cfg(feature = "dynamic-native-runtime")]
     {
         let config = plugin::load_config(config_path)?;
-        let startup_selection = match (
-            config.runtime.native_runtime.mesh_version,
-            config.runtime.native_runtime.skippy_abi,
-        ) {
-            (Some(mesh_version), Some(skippy_abi)) => {
+        let native_runtime = config.runtime.native_runtime;
+        let startup_selection = match native_runtime.mesh_version {
+            Some(mesh_version) => {
+                let runtime_selection = mesh_llm_native_runtime::RuntimeSelection::parse(
+                    native_runtime.selection.as_deref(),
+                )?;
                 system::native_runtime::NativeRuntimeStartupSelection::explicit(
                     mesh_version,
-                    skippy_abi,
+                    native_runtime.skippy_abi,
+                    runtime_selection,
                 )
             }
-            _ => system::native_runtime::NativeRuntimeStartupSelection::current(),
+            None => system::native_runtime::NativeRuntimeStartupSelection::current(),
         };
         if let Some(runtime) =
             system::native_runtime::try_load_installed_native_runtime(startup_selection).await?

--- a/crates/mesh-llm-host-runtime/src/plugin/config.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/config.rs
@@ -14,12 +14,12 @@ pub use mesh_llm_config::{
     ConfigDiagnosticSeverity, ConfigEditor, ConfigStore, FlashAttentionType, GpuAssignment,
     GpuConfig, HardwareConfig, IntegerOrString, LocalServingNodeConfig, MeshConfig,
     MeshRequirementsConfig, ModelConfigDefaults, ModelConfigEditor, ModelConfigEntry,
-    ModelDefaultsEditor, ModelFitConfig, ModelRuntimeKind, MultimodalConfig, OwnerControlConfig,
-    PluginConfigEditor, PluginConfigEntry, PluginStartupConfig, PrefixCacheConfig, ReasoningBudget,
-    ReasoningEnabled, RequestDefaultsConfig, ReservedObjectConfig, SkippyConfig, SpeculativeConfig,
-    StringOrStringList, TelemetryConfig, TelemetryMetricsConfig, TensorSplitConfig,
-    ThroughputConfig, config_path, config_to_toml, parse_config_toml as base_parse_config_toml,
-    validate_config_with_plugin_schemas,
+    ModelDefaultsEditor, ModelFitConfig, ModelRuntimeKind, MultimodalConfig, NativeRuntimeConfig,
+    OwnerControlConfig, PluginConfigEditor, PluginConfigEntry, PluginStartupConfig,
+    PrefixCacheConfig, ReasoningBudget, ReasoningEnabled, RequestDefaultsConfig,
+    ReservedObjectConfig, SkippyConfig, SpeculativeConfig, StringOrStringList, TelemetryConfig,
+    TelemetryMetricsConfig, TensorSplitConfig, ThroughputConfig, config_path, config_to_toml,
+    parse_config_toml as base_parse_config_toml, validate_config_with_plugin_schemas,
 };
 use mesh_llm_plugin::MeshVisibility;
 use std::collections::BTreeMap;

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -6,7 +6,7 @@ mod dynamic {
     use anyhow::{Context, Result};
     use mesh_llm_native_runtime::{
         HostRuntimeProfile, NativeRuntimeArtifact, NativeRuntimeCache, NativeRuntimeLoadPlan,
-        NativeRuntimeReleaseManifest, RuntimeSelection, select_native_runtime,
+        NativeRuntimeReleaseManifest, RuntimeSelection, select_native_runtime_for_skippy_abi,
     };
     use std::{future::Future, path::PathBuf};
 
@@ -32,13 +32,38 @@ mod dynamic {
         pub(crate) source: NativeRuntimePlanSource,
     }
 
-    pub(crate) async fn try_load_installed_native_runtime() -> Result<Option<LoadedNativeRuntime>> {
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct NativeRuntimeStartupSelection {
+        pub(crate) mesh_version: String,
+        pub(crate) skippy_abi: String,
+    }
+
+    impl NativeRuntimeStartupSelection {
+        pub(crate) fn current() -> Self {
+            Self {
+                mesh_version: crate::RELEASE_VERSION.to_string(),
+                skippy_abi: crate::system::native_runtime_install::current_skippy_abi_version(),
+            }
+        }
+
+        pub(crate) fn explicit(mesh_version: String, skippy_abi: String) -> Self {
+            Self {
+                mesh_version,
+                skippy_abi,
+            }
+        }
+    }
+
+    pub(crate) async fn try_load_installed_native_runtime(
+        startup_selection: NativeRuntimeStartupSelection,
+    ) -> Result<Option<LoadedNativeRuntime>> {
         try_load_installed_native_runtime_with(
             skippy_runtime::native_runtime_loaded,
             default_native_runtime_cache,
             host_runtime_profile,
             default_install_options,
             default_install_executor,
+            startup_selection,
             |libraries| {
                 unsafe { skippy_runtime::load_native_runtime_libraries(libraries) }
                     .map_err(anyhow::Error::from)
@@ -61,6 +86,7 @@ mod dynamic {
         profile: ProfileFn,
         install_options: InstallOptionsFn,
         install_executor: InstallExecutorFn,
+        startup_selection: NativeRuntimeStartupSelection,
         load_libraries: LoadLibrariesFn,
     ) -> Result<Option<LoadedNativeRuntime>>
     where
@@ -80,6 +106,7 @@ mod dynamic {
             profile,
             install_options,
             install_executor,
+            startup_selection,
         )
         .await?
         else {
@@ -109,6 +136,7 @@ mod dynamic {
         profile: ProfileFn,
         install_options: InstallOptionsFn,
         install_executor: InstallExecutorFn,
+        startup_selection: NativeRuntimeStartupSelection,
     ) -> Result<Option<NativeRuntimeStartupLoadPlan>>
     where
         CacheFn: Fn() -> Result<NativeRuntimeCache>,
@@ -123,13 +151,16 @@ mod dynamic {
             &cache,
             &profile,
             crate::BUILD_VERSION,
-            crate::RELEASE_VERSION,
+            &startup_selection.mesh_version,
+            &startup_selection.skippy_abi,
             &RuntimeSelection::Recommended,
         )? {
             return Ok(Some(plan));
         }
 
         let mut options = install_options();
+        options.mesh_version = startup_selection.mesh_version.clone();
+        options.skippy_abi_version = startup_selection.skippy_abi.clone();
         if options.cache_dir.is_none() {
             options.cache_dir = Some(cache.root().to_path_buf());
         }
@@ -170,7 +201,8 @@ mod dynamic {
         cache: &NativeRuntimeCache,
         profile: &HostRuntimeProfile,
         build_version: &str,
-        release_version: &str,
+        target_mesh_version: &str,
+        target_skippy_abi: &str,
         selection: &RuntimeSelection,
     ) -> Result<Option<NativeRuntimeStartupLoadPlan>> {
         let installed = cache.installed()?;
@@ -178,21 +210,22 @@ mod dynamic {
             return Ok(None);
         }
         let initial_cache_version =
-            startup_native_runtime_cache_version(build_version, release_version);
+            startup_native_runtime_cache_version(build_version, target_mesh_version);
         let manifest = NativeRuntimeReleaseManifest {
             mesh_version: initial_cache_version.to_string(),
-            skippy_abi: installed
-                .first()
-                .map(|runtime| runtime.manifest.runtime.skippy_abi.clone())
-                .unwrap_or_default(),
+            skippy_abi: target_skippy_abi.to_string(),
             artifacts: installed
                 .iter()
                 .map(|runtime| runtime.manifest.runtime.clone())
                 .collect(),
         };
-        let Some(candidate) =
-            select_native_runtime(&manifest, profile, initial_cache_version, selection)
-        else {
+        let Some(candidate) = select_native_runtime_for_skippy_abi(
+            &manifest,
+            profile,
+            initial_cache_version,
+            &manifest.skippy_abi,
+            selection,
+        ) else {
             return Ok(None);
         };
         load_plan_from_candidate(cache, &manifest, candidate.artifact)
@@ -339,6 +372,7 @@ mod dynamic {
                 &HostRuntimeProfile::current_without_gpu_probe(),
                 sha_build_version,
                 release_version,
+                "0.1.25",
                 &RuntimeSelection::Recommended,
             )
             .unwrap()
@@ -358,7 +392,32 @@ mod dynamic {
         }
 
         #[test]
-        fn selected_artifact_mesh_version_wins_over_release_fallback() {
+        fn explicit_runtime_version_can_select_other_mesh_version() {
+            let temp = tempfile::tempdir().unwrap();
+            let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+            let runtime_id = "meshllm-native-runtime-test-cpu";
+            let artifact_mesh_version = "0.69.0";
+            let runtime_dir = cache.runtime_dir(artifact_mesh_version, runtime_id);
+            write_runtime(&runtime_dir, artifact_mesh_version, runtime_id);
+
+            let plan = resolve_installed_native_runtime_plan(
+                &cache,
+                &HostRuntimeProfile::current_without_gpu_probe(),
+                "0.68.0+gAB131C.dirty",
+                artifact_mesh_version,
+                "0.1.25",
+                &RuntimeSelection::Recommended,
+            )
+            .unwrap()
+            .expect("expected cached runtime plan");
+
+            assert_eq!(plan.cache_mesh_version, artifact_mesh_version);
+            assert_eq!(plan.root, runtime_dir);
+            assert_eq!(plan.source, NativeRuntimePlanSource::CacheHit);
+        }
+
+        #[test]
+        fn default_startup_plan_rejects_other_mesh_version() {
             let temp = tempfile::tempdir().unwrap();
             let cache = NativeRuntimeCache::new(temp.path().join("cache"));
             let runtime_id = "meshllm-native-runtime-test-cpu";
@@ -372,14 +431,12 @@ mod dynamic {
                 &HostRuntimeProfile::current_without_gpu_probe(),
                 "0.68.0+gAB131C.dirty",
                 release_version,
+                "0.1.25",
                 &RuntimeSelection::Recommended,
             )
-            .unwrap()
-            .expect("expected cached runtime plan");
+            .unwrap();
 
-            assert_eq!(plan.cache_mesh_version, artifact_mesh_version);
-            assert_eq!(plan.root, runtime_dir);
-            assert_eq!(plan.source, NativeRuntimePlanSource::CacheHit);
+            assert!(plan.is_none());
         }
 
         #[test]
@@ -468,6 +525,10 @@ mod dynamic {
                         }
                     }
                 },
+                NativeRuntimeStartupSelection::explicit(
+                    release_version.to_string(),
+                    "0.1.25".to_string(),
+                ),
                 {
                     let load_calls = Arc::clone(&load_calls);
                     move |libraries| {
@@ -495,7 +556,7 @@ mod dynamic {
             let cache = NativeRuntimeCache::new(temp.path().join("cache"));
             let bundle_dir = temp.path().join("bundle");
             let runtime_id = "meshllm-native-runtime-test-cpu";
-            let manifest_mesh_version = "0.69.0";
+            let manifest_mesh_version = "0.68.0";
             write_runtime(&bundle_dir, manifest_mesh_version, runtime_id);
 
             let install_calls = Arc::new(Mutex::new(Vec::<NativeRuntimeInstallOptions>::new()));
@@ -533,6 +594,7 @@ mod dynamic {
                         }
                     }
                 },
+                NativeRuntimeStartupSelection::explicit("0.68.0".to_string(), "0.1.25".to_string()),
                 {
                     let load_calls = Arc::clone(&load_calls);
                     move |libraries| {
@@ -585,6 +647,7 @@ mod dynamic {
                         }
                     }
                 },
+                NativeRuntimeStartupSelection::explicit("0.68.0".to_string(), "0.1.25".to_string()),
                 {
                     let load_calls = Arc::clone(&load_calls);
                     move |_| {
@@ -607,6 +670,6 @@ mod dynamic {
 pub(crate) use dynamic::*;
 
 #[cfg(not(feature = "dynamic-native-runtime"))]
-pub(crate) fn try_load_installed_native_runtime() -> anyhow::Result<Option<()>> {
+pub(crate) fn try_load_installed_native_runtime(_: bool) -> anyhow::Result<Option<()>> {
     Ok(None)
 }

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -6,7 +6,7 @@ mod dynamic {
     use anyhow::{Context, Result};
     use mesh_llm_native_runtime::{
         HostRuntimeProfile, NativeRuntimeArtifact, NativeRuntimeCache, NativeRuntimeLoadPlan,
-        NativeRuntimeReleaseManifest, RuntimeSelection, select_native_runtime_for_skippy_abi,
+        NativeRuntimeReleaseManifest, RuntimeSelection,
     };
     use std::{future::Future, path::PathBuf};
 
@@ -35,21 +35,30 @@ mod dynamic {
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub(crate) struct NativeRuntimeStartupSelection {
         pub(crate) mesh_version: String,
-        pub(crate) skippy_abi: String,
+        pub(crate) skippy_abi: Option<String>,
+        pub(crate) runtime_selection: RuntimeSelection,
     }
 
     impl NativeRuntimeStartupSelection {
         pub(crate) fn current() -> Self {
             Self {
                 mesh_version: crate::RELEASE_VERSION.to_string(),
-                skippy_abi: crate::system::native_runtime_install::current_skippy_abi_version(),
+                skippy_abi: Some(
+                    crate::system::native_runtime_install::current_skippy_abi_version(),
+                ),
+                runtime_selection: RuntimeSelection::Recommended,
             }
         }
 
-        pub(crate) fn explicit(mesh_version: String, skippy_abi: String) -> Self {
+        pub(crate) fn explicit(
+            mesh_version: String,
+            skippy_abi: Option<String>,
+            runtime_selection: RuntimeSelection,
+        ) -> Self {
             Self {
                 mesh_version,
                 skippy_abi,
+                runtime_selection,
             }
         }
     }
@@ -152,8 +161,8 @@ mod dynamic {
             &profile,
             crate::BUILD_VERSION,
             &startup_selection.mesh_version,
-            &startup_selection.skippy_abi,
-            &RuntimeSelection::Recommended,
+            startup_selection.skippy_abi.as_deref(),
+            &startup_selection.runtime_selection,
         )? {
             return Ok(Some(plan));
         }
@@ -161,6 +170,7 @@ mod dynamic {
         let mut options = install_options();
         options.mesh_version = startup_selection.mesh_version.clone();
         options.skippy_abi_version = startup_selection.skippy_abi.clone();
+        options.selection = startup_selection.runtime_selection.clone();
         if options.cache_dir.is_none() {
             options.cache_dir = Some(cache.root().to_path_buf());
         }
@@ -202,7 +212,7 @@ mod dynamic {
         profile: &HostRuntimeProfile,
         build_version: &str,
         target_mesh_version: &str,
-        target_skippy_abi: &str,
+        target_skippy_abi: Option<&str>,
         selection: &RuntimeSelection,
     ) -> Result<Option<NativeRuntimeStartupLoadPlan>> {
         let installed = cache.installed()?;
@@ -213,17 +223,17 @@ mod dynamic {
             startup_native_runtime_cache_version(build_version, target_mesh_version);
         let manifest = NativeRuntimeReleaseManifest {
             mesh_version: initial_cache_version.to_string(),
-            skippy_abi: target_skippy_abi.to_string(),
+            skippy_abi: target_skippy_abi.unwrap_or_default().to_string(),
             artifacts: installed
                 .iter()
                 .map(|runtime| runtime.manifest.runtime.clone())
                 .collect(),
         };
-        let Some(candidate) = select_native_runtime_for_skippy_abi(
-            &manifest,
+        let Some(candidate) = mesh_llm_native_runtime::select_native_runtime_from_artifacts(
+            &manifest.artifacts,
             profile,
             initial_cache_version,
-            &manifest.skippy_abi,
+            target_skippy_abi,
             selection,
         ) else {
             return Ok(None);
@@ -290,6 +300,9 @@ mod dynamic {
     fn default_install_options() -> NativeRuntimeInstallOptions {
         NativeRuntimeInstallOptions {
             mesh_version: crate::RELEASE_VERSION.to_string(),
+            skippy_abi_version: Some(
+                crate::system::native_runtime_install::current_skippy_abi_version(),
+            ),
             selection: RuntimeSelection::Recommended,
             ..Default::default()
         }
@@ -314,13 +327,21 @@ mod dynamic {
         };
 
         fn write_runtime(dir: &Path, version: &str, id: &str) {
+            write_runtime_with_manifest_mesh_version(dir, Some(version), id);
+        }
+
+        fn write_runtime_without_mesh_version(dir: &Path, id: &str) {
+            write_runtime_with_manifest_mesh_version(dir, None, id);
+        }
+
+        fn write_runtime_with_manifest_mesh_version(dir: &Path, version: Option<&str>, id: &str) {
             let library_rel_path = test_library_rel_path();
             fs::create_dir_all(dir.join(library_rel_path.parent().unwrap())).unwrap();
             fs::write(dir.join(&library_rel_path), b"native runtime").unwrap();
             let manifest = NativeRuntimeManifest {
                 runtime: NativeRuntimeArtifact {
                     id: id.to_string(),
-                    mesh_version: Some(version.to_string()),
+                    mesh_version: version.map(ToString::to_string),
                     skippy_abi: "0.1.25".to_string(),
                     platform: NativeRuntimePlatform {
                         os: std::env::consts::OS.to_string(),
@@ -372,7 +393,7 @@ mod dynamic {
                 &HostRuntimeProfile::current_without_gpu_probe(),
                 sha_build_version,
                 release_version,
-                "0.1.25",
+                Some("0.1.25"),
                 &RuntimeSelection::Recommended,
             )
             .unwrap()
@@ -405,7 +426,7 @@ mod dynamic {
                 &HostRuntimeProfile::current_without_gpu_probe(),
                 "0.68.0+gAB131C.dirty",
                 artifact_mesh_version,
-                "0.1.25",
+                Some("0.1.25"),
                 &RuntimeSelection::Recommended,
             )
             .unwrap()
@@ -431,7 +452,29 @@ mod dynamic {
                 &HostRuntimeProfile::current_without_gpu_probe(),
                 "0.68.0+gAB131C.dirty",
                 release_version,
-                "0.1.25",
+                Some("0.1.25"),
+                &RuntimeSelection::Recommended,
+            )
+            .unwrap();
+
+            assert!(plan.is_none());
+        }
+
+        #[test]
+        fn startup_plan_rejects_installed_runtime_without_mesh_version() {
+            let temp = tempfile::tempdir().unwrap();
+            let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+            let runtime_id = "meshllm-native-runtime-test-cpu";
+            let release_version = "0.68.0";
+            let runtime_dir = cache.runtime_dir("unknown", runtime_id);
+            write_runtime_without_mesh_version(&runtime_dir, runtime_id);
+
+            let plan = resolve_installed_native_runtime_plan(
+                &cache,
+                &HostRuntimeProfile::current_without_gpu_probe(),
+                "0.68.0+gAB131C.dirty",
+                release_version,
+                Some("0.1.25"),
                 &RuntimeSelection::Recommended,
             )
             .unwrap();
@@ -527,7 +570,8 @@ mod dynamic {
                 },
                 NativeRuntimeStartupSelection::explicit(
                     release_version.to_string(),
-                    "0.1.25".to_string(),
+                    Some("0.1.25".to_string()),
+                    RuntimeSelection::Recommended,
                 ),
                 {
                     let load_calls = Arc::clone(&load_calls);
@@ -594,7 +638,11 @@ mod dynamic {
                         }
                     }
                 },
-                NativeRuntimeStartupSelection::explicit("0.68.0".to_string(), "0.1.25".to_string()),
+                NativeRuntimeStartupSelection::explicit(
+                    "0.68.0".to_string(),
+                    Some("0.1.25".to_string()),
+                    RuntimeSelection::Recommended,
+                ),
                 {
                     let load_calls = Arc::clone(&load_calls);
                     move |libraries| {
@@ -610,6 +658,10 @@ mod dynamic {
             let recorded_options = install_calls.lock().unwrap();
             assert_eq!(recorded_options.len(), 1);
             assert_eq!(recorded_options[0].mesh_version, "0.68.0");
+            assert_eq!(
+                recorded_options[0].skippy_abi_version.as_deref(),
+                Some("0.1.25")
+            );
             assert_eq!(recorded_options[0].cache_dir.as_deref(), Some(cache.root()));
             assert_eq!(runtime.native_runtime_id, runtime_id);
             assert_eq!(
@@ -647,7 +699,11 @@ mod dynamic {
                         }
                     }
                 },
-                NativeRuntimeStartupSelection::explicit("0.68.0".to_string(), "0.1.25".to_string()),
+                NativeRuntimeStartupSelection::explicit(
+                    "0.68.0".to_string(),
+                    Some("0.1.25".to_string()),
+                    RuntimeSelection::Recommended,
+                ),
                 {
                     let load_calls = Arc::clone(&load_calls);
                     move |_| {
@@ -670,6 +726,6 @@ mod dynamic {
 pub(crate) use dynamic::*;
 
 #[cfg(not(feature = "dynamic-native-runtime"))]
-pub(crate) fn try_load_installed_native_runtime(_: bool) -> anyhow::Result<Option<()>> {
+pub(crate) fn try_load_installed_native_runtime() -> anyhow::Result<Option<()>> {
     Ok(None)
 }

--- a/crates/mesh-llm-native-runtime/src/lib.rs
+++ b/crates/mesh-llm-native-runtime/src/lib.rs
@@ -26,5 +26,5 @@ pub use manifest::{
 pub use resolver::{
     CandidateEvaluation, CandidateRejection, NativeRuntimeResolution, NativeRuntimeResolver,
     NativeRuntimeSource, RuntimeSelection, select_native_runtime,
-    select_native_runtime_for_skippy_abi,
+    select_native_runtime_for_skippy_abi, select_native_runtime_from_artifacts,
 };

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -20,6 +20,7 @@ pub enum RuntimeSelection {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CandidateRejection {
+    MeshVersionMismatch { expected: String, actual: String },
     SkippyAbiMismatch { expected: String, actual: String },
     OsMismatch { expected: String, actual: String },
     ArchMismatch { expected: String, actual: String },
@@ -131,7 +132,13 @@ impl NativeRuntimeResolver {
             .skippy_abi
             .as_deref()
             .unwrap_or(self.release_manifest.skippy_abi.as_str());
-        let evaluated = evaluate_candidates(&artifacts, &self.profile, expected_abi, selection);
+        let evaluated = evaluate_candidates(
+            &artifacts,
+            &self.profile,
+            &self.mesh_version,
+            expected_abi,
+            selection,
+        );
         let Some(selected) = best_candidate(&evaluated) else {
             bail!(
                 "no compatible native runtime found for Skippy ABI {} on {}/{}",
@@ -151,8 +158,12 @@ impl NativeRuntimeResolver {
         let mut seen = BTreeSet::new();
         let mut artifacts = Vec::new();
         for artifact in &self.release_manifest.artifacts {
-            seen.insert(artifact_key(artifact));
-            artifacts.push(artifact.clone());
+            let artifact = artifact_with_manifest_mesh_version(
+                artifact,
+                self.release_manifest.mesh_version.as_str(),
+            );
+            seen.insert(artifact_key(&artifact));
+            artifacts.push(artifact);
         }
         for dir in &self.bundle_dirs {
             let manifest = crate::NativeRuntimeManifest::read_from_dir(dir)?;
@@ -207,13 +218,13 @@ fn artifact_key(artifact: &NativeRuntimeArtifact) -> String {
 pub fn select_native_runtime(
     release_manifest: &NativeRuntimeReleaseManifest,
     profile: &HostRuntimeProfile,
-    _mesh_version: &str,
+    mesh_version: &str,
     selection: &RuntimeSelection,
 ) -> Option<CandidateEvaluation> {
     select_native_runtime_for_skippy_abi(
         release_manifest,
         profile,
-        _mesh_version,
+        mesh_version,
         &release_manifest.skippy_abi,
         selection,
     )
@@ -222,34 +233,63 @@ pub fn select_native_runtime(
 pub fn select_native_runtime_for_skippy_abi(
     release_manifest: &NativeRuntimeReleaseManifest,
     profile: &HostRuntimeProfile,
-    _mesh_version: &str,
+    mesh_version: &str,
     skippy_abi: &str,
     selection: &RuntimeSelection,
 ) -> Option<CandidateEvaluation> {
-    let evaluated =
-        evaluate_candidates(&release_manifest.artifacts, profile, skippy_abi, selection);
+    let artifacts = release_manifest
+        .artifacts
+        .iter()
+        .map(|artifact| {
+            artifact_with_manifest_mesh_version(artifact, release_manifest.mesh_version.as_str())
+        })
+        .collect::<Vec<_>>();
+    let evaluated = evaluate_candidates(&artifacts, profile, mesh_version, skippy_abi, selection);
     best_candidate(&evaluated).cloned()
 }
 
 fn evaluate_candidates(
     artifacts: &[NativeRuntimeArtifact],
     profile: &HostRuntimeProfile,
+    mesh_version: &str,
     skippy_abi: &str,
     selection: &RuntimeSelection,
 ) -> Vec<CandidateEvaluation> {
     artifacts
         .iter()
-        .map(|artifact| evaluate_artifact(artifact, profile, skippy_abi, selection))
+        .map(|artifact| evaluate_artifact(artifact, profile, mesh_version, skippy_abi, selection))
         .collect()
+}
+
+fn artifact_with_manifest_mesh_version(
+    artifact: &NativeRuntimeArtifact,
+    manifest_mesh_version: &str,
+) -> NativeRuntimeArtifact {
+    let mut artifact = artifact.clone();
+    if artifact.mesh_version.is_none() {
+        artifact.mesh_version = Some(manifest_mesh_version.to_string());
+    }
+    artifact
 }
 
 fn evaluate_artifact(
     artifact: &NativeRuntimeArtifact,
     profile: &HostRuntimeProfile,
+    mesh_version: &str,
     skippy_abi: &str,
     selection: &RuntimeSelection,
 ) -> CandidateEvaluation {
     let mut reasons = Vec::new();
+    if artifact.mesh_version.as_deref() != Some(mesh_version) {
+        let actual = artifact
+            .mesh_version
+            .clone()
+            .unwrap_or_else(|| "unspecified".to_string());
+        reasons.push(CandidateRejection::MeshVersionMismatch {
+            expected: mesh_version.to_string(),
+            actual,
+        });
+    }
     if artifact.skippy_abi != skippy_abi {
         reasons.push(CandidateRejection::SkippyAbiMismatch {
             expected: skippy_abi.to_string(),
@@ -542,7 +582,29 @@ mod tests {
     }
 
     #[test]
-    fn mesh_version_mismatch_does_not_reject_matching_skippy_abi_candidate() {
+    fn mesh_version_mismatch_rejects_matching_skippy_abi_candidate() {
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: "0.67.0".to_string(),
+            skippy_abi: "0.1.25".to_string(),
+            artifacts: vec![NativeRuntimeArtifact {
+                mesh_version: Some("0.67.0".to_string()),
+                ..cuda_runtime("meshllm-runtime-linux-x86_64-cuda12", 12, &["sm_90"])
+            }],
+        };
+        assert!(
+            select_native_runtime_for_skippy_abi(
+                &manifest,
+                &profile(),
+                "0.68.0",
+                "0.1.25",
+                &RuntimeSelection::Recommended,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn explicit_mesh_version_and_skippy_abi_select_matching_candidate() {
         let manifest = NativeRuntimeReleaseManifest {
             mesh_version: "0.67.0".to_string(),
             skippy_abi: "0.1.25".to_string(),
@@ -554,7 +616,7 @@ mod tests {
         let selected = select_native_runtime_for_skippy_abi(
             &manifest,
             &profile(),
-            "0.68.0",
+            "0.67.0",
             "0.1.25",
             &RuntimeSelection::Recommended,
         )

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -127,18 +127,8 @@ impl NativeRuntimeResolver {
     }
 
     pub fn resolve(&self, selection: &RuntimeSelection) -> Result<NativeRuntimeResolution> {
-        let artifacts = self.candidate_artifacts()?;
-        let expected_abi = self
-            .skippy_abi
-            .as_deref()
-            .unwrap_or(self.release_manifest.skippy_abi.as_str());
-        let evaluated = evaluate_candidates(
-            &artifacts,
-            &self.profile,
-            &self.mesh_version,
-            expected_abi,
-            selection,
-        );
+        let evaluated = self.evaluate(selection)?;
+        let expected_abi = self.expected_skippy_abi();
         let Some(selected) = best_candidate(&evaluated) else {
             bail!(
                 "no compatible native runtime found for Skippy ABI {} on {}/{}",
@@ -152,6 +142,23 @@ impl NativeRuntimeResolver {
             selected: selected.artifact.clone(),
             evaluated,
         })
+    }
+
+    pub fn evaluate(&self, selection: &RuntimeSelection) -> Result<Vec<CandidateEvaluation>> {
+        let artifacts = self.candidate_artifacts()?;
+        Ok(evaluate_candidates(
+            &artifacts,
+            &self.profile,
+            &self.mesh_version,
+            Some(self.expected_skippy_abi()),
+            selection,
+        ))
+    }
+
+    fn expected_skippy_abi(&self) -> &str {
+        self.skippy_abi
+            .as_deref()
+            .unwrap_or(self.release_manifest.skippy_abi.as_str())
     }
 
     fn candidate_artifacts(&self) -> Result<Vec<NativeRuntimeArtifact>> {
@@ -195,7 +202,7 @@ impl NativeRuntimeResolver {
             let Ok(manifest) = crate::NativeRuntimeManifest::read_from_dir(dir) else {
                 continue;
             };
-            if manifest.runtime.id == artifact.id {
+            if artifact_identity_matches(&manifest.runtime, artifact) {
                 return Ok(NativeRuntimeSource::Bundle { path: dir.clone() });
             }
         }
@@ -212,7 +219,12 @@ fn parse_cuda_major(value: &str) -> Option<u32> {
 }
 
 fn artifact_key(artifact: &NativeRuntimeArtifact) -> String {
-    artifact.id.clone()
+    format!(
+        "{}\0{}\0{}",
+        artifact.id,
+        artifact.mesh_version.as_deref().unwrap_or_default(),
+        artifact.skippy_abi
+    )
 }
 
 pub fn select_native_runtime(
@@ -244,7 +256,24 @@ pub fn select_native_runtime_for_skippy_abi(
             artifact_with_manifest_mesh_version(artifact, release_manifest.mesh_version.as_str())
         })
         .collect::<Vec<_>>();
-    let evaluated = evaluate_candidates(&artifacts, profile, mesh_version, skippy_abi, selection);
+    let evaluated = evaluate_candidates(
+        &artifacts,
+        profile,
+        mesh_version,
+        Some(skippy_abi),
+        selection,
+    );
+    best_candidate(&evaluated).cloned()
+}
+
+pub fn select_native_runtime_from_artifacts(
+    artifacts: &[NativeRuntimeArtifact],
+    profile: &HostRuntimeProfile,
+    mesh_version: &str,
+    skippy_abi: Option<&str>,
+    selection: &RuntimeSelection,
+) -> Option<CandidateEvaluation> {
+    let evaluated = evaluate_candidates(artifacts, profile, mesh_version, skippy_abi, selection);
     best_candidate(&evaluated).cloned()
 }
 
@@ -252,7 +281,7 @@ fn evaluate_candidates(
     artifacts: &[NativeRuntimeArtifact],
     profile: &HostRuntimeProfile,
     mesh_version: &str,
-    skippy_abi: &str,
+    skippy_abi: Option<&str>,
     selection: &RuntimeSelection,
 ) -> Vec<CandidateEvaluation> {
     artifacts
@@ -276,7 +305,7 @@ fn evaluate_artifact(
     artifact: &NativeRuntimeArtifact,
     profile: &HostRuntimeProfile,
     mesh_version: &str,
-    skippy_abi: &str,
+    skippy_abi: Option<&str>,
     selection: &RuntimeSelection,
 ) -> CandidateEvaluation {
     let mut reasons = Vec::new();
@@ -290,7 +319,9 @@ fn evaluate_artifact(
             actual,
         });
     }
-    if artifact.skippy_abi != skippy_abi {
+    if let Some(skippy_abi) = skippy_abi
+        && artifact.skippy_abi != skippy_abi
+    {
         reasons.push(CandidateRejection::SkippyAbiMismatch {
             expected: skippy_abi.to_string(),
             actual: artifact.skippy_abi.clone(),
@@ -332,6 +363,15 @@ fn evaluate_artifact(
         rank: artifact.rank + artifact.backend.kind.default_rank(),
         rejection_reasons: reasons,
     }
+}
+
+fn artifact_identity_matches(
+    candidate: &NativeRuntimeArtifact,
+    selected: &NativeRuntimeArtifact,
+) -> bool {
+    candidate.id == selected.id
+        && candidate.mesh_version.as_deref() == selected.mesh_version.as_deref()
+        && candidate.skippy_abi == selected.skippy_abi
 }
 
 fn evaluate_backend_requirements(
@@ -663,5 +703,42 @@ mod tests {
             resolution.source,
             NativeRuntimeSource::Bundle { .. }
         ));
+    }
+
+    #[test]
+    fn stale_bundle_with_same_id_does_not_satisfy_selected_artifact() {
+        let bundle = tempfile::tempdir().unwrap();
+        let cache_root = tempfile::tempdir().unwrap();
+        let runtime_id = "meshllm-runtime-linux-x86_64-cpu";
+        let stale_bundle_artifact = NativeRuntimeArtifact {
+            mesh_version: Some("0.67.0".to_string()),
+            ..artifact(runtime_id, NativeRuntimeBackend::cpu())
+        };
+        NativeRuntimeManifest {
+            runtime: stale_bundle_artifact,
+        }
+        .write_to_dir(bundle.path())
+        .unwrap();
+
+        let resolution = NativeRuntimeResolver::new(
+            "0.68.0",
+            HostRuntimeProfile {
+                available_flavors: BTreeSet::from([NativeRuntimeBackendKind::Cpu]),
+                cuda: None,
+                ..profile()
+            },
+            NativeRuntimeReleaseManifest {
+                mesh_version: "0.68.0".to_string(),
+                skippy_abi: "0.1.25".to_string(),
+                artifacts: vec![artifact(runtime_id, NativeRuntimeBackend::cpu())],
+            },
+            NativeRuntimeCache::new(cache_root.path()),
+        )
+        .with_bundle_dirs(vec![bundle.path().to_path_buf()])
+        .with_skippy_abi_version("0.1.25")
+        .resolve(&RuntimeSelection::Recommended)
+        .unwrap();
+
+        assert!(matches!(resolution.source, NativeRuntimeSource::Missing));
     }
 }

--- a/crates/mesh-llm-nodejs/src/lib.rs
+++ b/crates/mesh-llm-nodejs/src/lib.rs
@@ -711,8 +711,7 @@ fn parse_native_runtime_install_options(
     Ok(mesh_llm_sdk::native_runtime::NativeRuntimeInstallOptions {
         mesh_version: optional_string(&value, "meshVersion")
             .unwrap_or_else(|| mesh_llm_sdk::native_runtime::CURRENT_MESH_VERSION.to_string()),
-        skippy_abi_version: optional_string(&value, "skippyAbiVersion")
-            .unwrap_or_else(mesh_llm_sdk::native_runtime::current_skippy_abi_version),
+        skippy_abi_version: optional_string(&value, "skippyAbiVersion"),
         selection: mesh_llm_sdk::native_runtime::RuntimeSelection::parse(
             optional_string(&value, "selection").as_deref(),
         )

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -53,7 +53,7 @@ pub struct NativeRuntimeManifestOptions {
 #[derive(Clone)]
 pub struct NativeRuntimeInstallOptions {
     pub mesh_version: String,
-    pub skippy_abi_version: String,
+    pub skippy_abi_version: Option<String>,
     pub selection: RuntimeSelection,
     pub manifest_path: Option<PathBuf>,
     pub manifest_url: Option<String>,
@@ -94,7 +94,7 @@ impl Default for NativeRuntimeInstallOptions {
     fn default() -> Self {
         Self {
             mesh_version: CURRENT_MESH_VERSION.to_string(),
-            skippy_abi_version: current_skippy_abi_version(),
+            skippy_abi_version: None,
             selection: RuntimeSelection::Recommended,
             manifest_path: None,
             manifest_url: None,
@@ -209,6 +209,10 @@ pub async fn install_native_runtime(
     if manifest.artifacts.is_empty() {
         bail!("no native runtime manifest entries found");
     }
+    let skippy_abi_version = options
+        .skippy_abi_version
+        .clone()
+        .unwrap_or_else(|| manifest.skippy_abi.clone());
     let cache = native_runtime_cache(options.cache_dir.as_deref())?;
     let resolution = NativeRuntimeResolver::new(
         &options.mesh_version,
@@ -216,7 +220,7 @@ pub async fn install_native_runtime(
         manifest,
         cache.clone(),
     )
-    .with_skippy_abi_version(options.skippy_abi_version.clone())
+    .with_skippy_abi_version(skippy_abi_version)
     .with_bundle_dirs(options.bundle_dirs.clone())
     .resolve(&options.selection)?;
     install_resolved_runtime(&cache, resolution, &options).await

--- a/crates/mesh-llm/src/commands/doctor.rs
+++ b/crates/mesh-llm/src/commands/doctor.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use mesh_llm_cli::DoctorCommand;
+use mesh_llm_host_runtime::command_support::plugin::load_config;
 use mesh_llm_host_runtime::command_support::runtime_instances::{
     LocalInstanceSnapshot, runtime_root, scan_local_instances,
 };
@@ -38,6 +39,7 @@ const SKIPPY_DIAGNOSTIC_ENDPOINTS: &[(&str, &str, &str)] = &[
 
 pub(crate) async fn dispatch_doctor_command(
     command: Option<&DoctorCommand>,
+    config_path: Option<&Path>,
     json_output: bool,
 ) -> Result<()> {
     match command {
@@ -47,7 +49,16 @@ pub(crate) async fn dispatch_doctor_command(
             json,
             output_dir,
         }) => run_split_doctor(model_ref, *port, *json, output_dir.as_deref()).await,
-        None => mesh_llm_commands::runtime_native::run_native_runtime_doctor(json_output),
+        None => {
+            let config = load_config(config_path)?;
+            let native_runtime = config.runtime.native_runtime;
+            mesh_llm_commands::runtime_native::run_native_runtime_doctor(
+                native_runtime.mesh_version.as_deref(),
+                native_runtime.skippy_abi.as_deref(),
+                native_runtime.selection.as_deref(),
+                json_output,
+            )
+        }
     }
 }
 

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -51,7 +51,9 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             dispatch_runtime_command(command.as_ref(), cli.config.as_deref()).await
         }
         Command::Config { command } => dispatch_config_command(cli, command),
-        Command::Doctor { command, json } => dispatch_doctor_command(command.as_ref(), *json).await,
+        Command::Doctor { command, json } => {
+            dispatch_doctor_command(command.as_ref(), cli.config.as_deref(), *json).await
+        }
         Command::Load { name, port } => run_load(name, *port).await,
         Command::Unload { name, port } => run_drop(name, *port).await,
         Command::Status { port } => run_status(*port).await,

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -47,7 +47,9 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             mesh_llm_commands::gpus::dispatch_gpu_command(*json, command.as_ref())?;
             Ok(())
         }
-        Command::Runtime { command } => dispatch_runtime_command(command.as_ref()).await,
+        Command::Runtime { command } => {
+            dispatch_runtime_command(command.as_ref(), cli.config.as_deref()).await
+        }
         Command::Config { command } => dispatch_config_command(cli, command),
         Command::Doctor { command, json } => dispatch_doctor_command(command.as_ref(), *json).await,
         Command::Load { name, port } => run_load(name, *port).await,

--- a/crates/mesh-llm/src/commands/runtime.rs
+++ b/crates/mesh-llm/src/commands/runtime.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 
 use mesh_llm_cli::MeshGuardrailCliMode;
 use mesh_llm_cli::runtime::RuntimeCommand;
+use mesh_llm_commands::runtime_native::NativeRuntimeConfigSelection;
 use mesh_llm_host_runtime::command_support::plugin::{MeshConfig, load_config};
 
 pub(crate) async fn dispatch_runtime_command(
@@ -19,18 +20,17 @@ pub(crate) async fn dispatch_runtime_command(
             cache_dir,
             json,
         }) => {
-            let selector = native_runtime_config_selector(config_path)?;
+            let selector = if *available {
+                native_runtime_config_selector(config_path)?
+            } else {
+                None
+            };
             mesh_llm_commands::runtime_native::run_native_runtime_list(
                 *available,
                 manifest.as_deref(),
                 bundle_dirs,
                 cache_dir.as_deref(),
-                selector
-                    .as_ref()
-                    .map(|selector| selector.mesh_version.as_str()),
-                selector
-                    .as_ref()
-                    .map(|selector| selector.skippy_abi.as_str()),
+                native_runtime_command_selection(selector.as_ref()),
                 *json,
             )
             .await
@@ -48,12 +48,7 @@ pub(crate) async fn dispatch_runtime_command(
                 manifest.as_deref(),
                 bundle_dirs,
                 cache_dir.as_deref(),
-                selector
-                    .as_ref()
-                    .map(|selector| selector.mesh_version.as_str()),
-                selector
-                    .as_ref()
-                    .map(|selector| selector.skippy_abi.as_str()),
+                native_runtime_command_selection(selector.as_ref()),
                 *json,
             )
             .await
@@ -74,12 +69,23 @@ pub(crate) async fn dispatch_runtime_command(
             mesh_version,
             cache_dir,
             json,
-        }) => mesh_llm_commands::runtime_native::run_native_runtime_prune(
-            *active_only,
-            mesh_version.as_deref(),
-            cache_dir.as_deref(),
-            *json,
-        ),
+        }) => {
+            let selector = if mesh_version.is_none() {
+                native_runtime_config_selector(config_path)?
+            } else {
+                None
+            };
+            mesh_llm_commands::runtime_native::run_native_runtime_prune(
+                *active_only,
+                mesh_version.as_deref().or_else(|| {
+                    selector
+                        .as_ref()
+                        .map(|selector| selector.mesh_version.as_str())
+                }),
+                cache_dir.as_deref(),
+                *json,
+            )
+        }
         Some(RuntimeCommand::Status { port }) => run_status(*port).await,
         Some(RuntimeCommand::Bootstrap { port, json }) => run_control_bootstrap(*port, *json).await,
         Some(RuntimeCommand::GetConfig {
@@ -110,25 +116,32 @@ pub(crate) async fn dispatch_runtime_command(
 
 struct NativeRuntimeConfigSelector {
     mesh_version: String,
-    skippy_abi: String,
+    skippy_abi: Option<String>,
+    selection: Option<String>,
 }
 
 fn native_runtime_config_selector(
     config_path: Option<&Path>,
 ) -> Result<Option<NativeRuntimeConfigSelector>> {
     let config = load_config(config_path)?;
-    Ok(
-        match (
-            config.runtime.native_runtime.mesh_version,
-            config.runtime.native_runtime.skippy_abi,
-        ) {
-            (Some(mesh_version), Some(skippy_abi)) => Some(NativeRuntimeConfigSelector {
-                mesh_version,
-                skippy_abi,
-            }),
-            _ => None,
-        },
-    )
+    Ok(match config.runtime.native_runtime.mesh_version {
+        Some(mesh_version) => Some(NativeRuntimeConfigSelector {
+            mesh_version,
+            skippy_abi: config.runtime.native_runtime.skippy_abi,
+            selection: config.runtime.native_runtime.selection,
+        }),
+        None => None,
+    })
+}
+
+fn native_runtime_command_selection<'a>(
+    selector: Option<&'a NativeRuntimeConfigSelector>,
+) -> NativeRuntimeConfigSelection<'a> {
+    NativeRuntimeConfigSelection {
+        mesh_version: selector.map(|selector| selector.mesh_version.as_str()),
+        skippy_abi_version: selector.and_then(|selector| selector.skippy_abi.as_deref()),
+        selection: selector.and_then(|selector| selector.selection.as_deref()),
+    }
 }
 
 pub(crate) async fn run_set_mesh_guardrails(

--- a/crates/mesh-llm/src/commands/runtime.rs
+++ b/crates/mesh-llm/src/commands/runtime.rs
@@ -6,7 +6,10 @@ use mesh_llm_cli::MeshGuardrailCliMode;
 use mesh_llm_cli::runtime::RuntimeCommand;
 use mesh_llm_host_runtime::command_support::plugin::{MeshConfig, load_config};
 
-pub(crate) async fn dispatch_runtime_command(command: Option<&RuntimeCommand>) -> Result<()> {
+pub(crate) async fn dispatch_runtime_command(
+    command: Option<&RuntimeCommand>,
+    config_path: Option<&Path>,
+) -> Result<()> {
     match command {
         Some(RuntimeCommand::List {
             available,
@@ -16,11 +19,18 @@ pub(crate) async fn dispatch_runtime_command(command: Option<&RuntimeCommand>) -
             cache_dir,
             json,
         }) => {
+            let selector = native_runtime_config_selector(config_path)?;
             mesh_llm_commands::runtime_native::run_native_runtime_list(
                 *available,
                 manifest.as_deref(),
                 bundle_dirs,
                 cache_dir.as_deref(),
+                selector
+                    .as_ref()
+                    .map(|selector| selector.mesh_version.as_str()),
+                selector
+                    .as_ref()
+                    .map(|selector| selector.skippy_abi.as_str()),
                 *json,
             )
             .await
@@ -32,11 +42,18 @@ pub(crate) async fn dispatch_runtime_command(command: Option<&RuntimeCommand>) -
             cache_dir,
             json,
         }) => {
+            let selector = native_runtime_config_selector(config_path)?;
             mesh_llm_commands::runtime_native::run_native_runtime_install(
                 runtime.as_deref(),
                 manifest.as_deref(),
                 bundle_dirs,
                 cache_dir.as_deref(),
+                selector
+                    .as_ref()
+                    .map(|selector| selector.mesh_version.as_str()),
+                selector
+                    .as_ref()
+                    .map(|selector| selector.skippy_abi.as_str()),
                 *json,
             )
             .await
@@ -89,6 +106,29 @@ pub(crate) async fn dispatch_runtime_command(command: Option<&RuntimeCommand>) -
         }
         None => run_status(3131).await,
     }
+}
+
+struct NativeRuntimeConfigSelector {
+    mesh_version: String,
+    skippy_abi: String,
+}
+
+fn native_runtime_config_selector(
+    config_path: Option<&Path>,
+) -> Result<Option<NativeRuntimeConfigSelector>> {
+    let config = load_config(config_path)?;
+    Ok(
+        match (
+            config.runtime.native_runtime.mesh_version,
+            config.runtime.native_runtime.skippy_abi,
+        ) {
+            (Some(mesh_version), Some(skippy_abi)) => Some(NativeRuntimeConfigSelector {
+                mesh_version,
+                skippy_abi,
+            }),
+            _ => None,
+        },
+    )
 }
 
 pub(crate) async fn run_set_mesh_guardrails(

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -34,7 +34,7 @@ async fn run_cli_entrypoint() -> anyhow::Result<()> {
     if commands::dispatch(&cli).await? {
         return Ok(());
     }
-    mesh_llm_host_runtime::initialize_host_runtime().await?;
+    mesh_llm_host_runtime::initialize_host_runtime_with_config(cli.config.as_deref()).await?;
     mesh_llm_tui::output::OutputManager::init_global(
         cli.log_format,
         mesh_llm_host_runtime::console_session_mode_for_runtime_surface(explicit_surface),

--- a/docs/design/NATIVE_RUNTIMES.md
+++ b/docs/design/NATIVE_RUNTIMES.md
@@ -326,6 +326,20 @@ installs the recommended compatible native runtime from the release manifest,
 an explicit manifest, or bundle directories. Explicit backend policy or runtime ID
 arguments are overrides for advanced users, CI, and prepared images.
 
+Advanced users can pin runtime resolution in `~/.mesh-llm/config.toml`:
+
+```toml
+[runtime.native_runtime]
+mesh_version = "0.68.0"
+selection = "exact:meshllm-native-runtime-linux-x86_64-cuda12"
+```
+
+`skippy_abi` may also be supplied for strict ABI selection; when omitted,
+install resolves the ABI from the selected release manifest. The configured
+`mesh_version` is honored by startup, `runtime install`, `runtime list
+--available`, `runtime prune`, and `mesh-llm doctor`, so autoupdate pruning does
+not remove a manually pinned runtime version.
+
 Selected-runtime diagnostics belong in `mesh-llm doctor`, not in a separate
 `mesh-llm runtime doctor` command. Doctor output should include the active
 MeshLLM version, selected native runtime ID, backend lane, runtime path,

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -237,6 +237,42 @@ collect_runtime_libraries() {
         '
 }
 
+rewrite_macos_runtime_paths() {
+    case "$TARGET_TRIPLE" in
+        *apple-darwin) ;;
+        *) return 0 ;;
+    esac
+    if ! command -v install_name_tool >/dev/null 2>&1; then
+        echo "install_name_tool is required to package macOS native runtimes" >&2
+        exit 1
+    fi
+    if ! command -v otool >/dev/null 2>&1; then
+        echo "otool is required to package macOS native runtimes" >&2
+        exit 1
+    fi
+
+    local rel_path library name dep dep_name candidate candidate_name
+    for rel_path in "${library_paths[@]}"; do
+        library="$stage_dir/$rel_path"
+        name="$(basename "$library")"
+        install_name_tool -id "@rpath/$name" "$library" 2>/dev/null || true
+        install_name_tool -add_rpath "@loader_path" "$library" 2>/dev/null || true
+    done
+
+    for rel_path in "${library_paths[@]}"; do
+        library="$stage_dir/$rel_path"
+        while IFS= read -r dep; do
+            dep_name="$(basename "$dep")"
+            for candidate in "${library_paths[@]}"; do
+                candidate_name="$(basename "$candidate")"
+                if [[ "$dep_name" == "$candidate_name" && "$dep" != "@rpath/$candidate_name" ]]; then
+                    install_name_tool -change "$dep" "@rpath/$candidate_name" "$library"
+                fi
+            done
+        done < <(otool -L "$library" | awk 'NR > 1 { print $1 }')
+    done
+}
+
 if [[ -z "$TARGET_TRIPLE" ]]; then
     TARGET_TRIPLE="$(default_target_triple)"
 fi
@@ -291,6 +327,8 @@ for library in "${runtime_libraries[@]}"; do
     cp "$library" "$stage_dir/lib/$name"
     library_paths+=("lib/$name")
 done
+
+rewrite_macos_runtime_paths
 
 primary_library="lib/$primary_name"
 primary_sha="$(sha256_file "$stage_dir/$primary_library")"

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -255,8 +255,13 @@ rewrite_macos_runtime_paths() {
     for rel_path in "${library_paths[@]}"; do
         library="$stage_dir/$rel_path"
         name="$(basename "$library")"
-        install_name_tool -id "@rpath/$name" "$library" 2>/dev/null || true
-        install_name_tool -add_rpath "@loader_path" "$library" 2>/dev/null || true
+        install_name_tool -id "@rpath/$name" "$library"
+        if ! otool -l "$library" | awk '
+            $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+            in_rpath && $1 == "path" { print $2; in_rpath = 0 }
+        ' | grep -qx '@loader_path'; then
+            install_name_tool -add_rpath "@loader_path" "$library"
+        fi
     done
 
     for rel_path in "${library_paths[@]}"; do

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -136,7 +136,46 @@ if library_sha256:
             f"library_sha256 mismatch for {primary_library}: {actual} != {library_sha256}"
         )
 PY
+    verify_macos_runtime_paths "$artifact_dir" "$manifest"
     echo "verified native runtime artifact: $artifact_dir"
+}
+
+verify_macos_runtime_paths() {
+    local artifact_dir="$1"
+    local manifest="$2"
+    if ! find "$artifact_dir" -type f -name '*.dylib' -print -quit | grep -q .; then
+        return 0
+    fi
+    if ! command -v otool >/dev/null 2>&1; then
+        echo "otool is required to verify macOS native runtime dylibs" >&2
+        exit 1
+    fi
+    python3 - "$artifact_dir" "$manifest" <<'PY'
+import json
+import os
+import subprocess
+import sys
+
+artifact_dir, manifest_path = sys.argv[1:3]
+with open(manifest_path, encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+libraries = manifest["runtime"]["libraries"]
+library_names = {os.path.basename(path) for path in libraries}
+for rel_path in libraries:
+    if not rel_path.endswith(".dylib"):
+        continue
+    path = os.path.join(artifact_dir, rel_path)
+    load_output = subprocess.check_output(["otool", "-L", path], text=True)
+    deps = [line.split()[0] for line in load_output.splitlines()[1:] if line.strip()]
+    for dep in deps:
+        if os.path.basename(dep) in library_names and dep.startswith("/"):
+            raise SystemExit(f"{rel_path} depends on absolute packaged dylib path: {dep}")
+
+    link_output = subprocess.check_output(["otool", "-l", path], text=True)
+    if "@loader_path" not in link_output:
+        raise SystemExit(f"{rel_path} is missing @loader_path LC_RPATH")
+PY
 }
 
 if [[ "$#" -lt 1 ]]; then

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -143,7 +143,7 @@ PY
 verify_macos_runtime_paths() {
     local artifact_dir="$1"
     local manifest="$2"
-    if ! find "$artifact_dir" -type f -name '*.dylib' -print -quit | grep -q .; then
+    if ! find -L "$artifact_dir" -type f -name '*.dylib' -print -quit | grep -q .; then
         return 0
     fi
     if ! command -v otool >/dev/null 2>&1; then
@@ -173,7 +173,18 @@ for rel_path in libraries:
             raise SystemExit(f"{rel_path} depends on absolute packaged dylib path: {dep}")
 
     link_output = subprocess.check_output(["otool", "-l", path], text=True)
-    if "@loader_path" not in link_output:
+    has_loader_path_rpath = False
+    in_rpath = False
+    for line in link_output.splitlines():
+        fields = line.split()
+        if fields[:2] == ["cmd", "LC_RPATH"]:
+            in_rpath = True
+            continue
+        if in_rpath and fields[:1] == ["path"]:
+            if len(fields) > 1 and fields[1] == "@loader_path":
+                has_loader_path_rpath = True
+            in_rpath = False
+    if not has_loader_path_rpath:
         raise SystemExit(f"{rel_path} is missing @loader_path LC_RPATH")
 PY
 }


### PR DESCRIPTION
MeshLLM now pairs native runtimes with an explicit MeshLLM version and Skippy ABI instead of accepting any cached runtime with a matching ABI.

## What changed

- Native runtime resolution now rejects stale cached runtime artifacts when their `mesh_version` does not match the selected MeshLLM runtime version.
- Startup defaults to the running binary's MeshLLM release version and current Skippy ABI.
- Added an explicit config override:

```toml
[runtime.native_runtime]
mesh_version = "0.68.0"
skippy_abi = "0.1.25"
```

- `mesh-llm runtime install` and `mesh-llm runtime list --available` use the same explicit selector from config.
- macOS native runtime packaging now rewrites local dylib dependencies to packaged `@rpath/...` names and adds `@loader_path`; package verification now catches absolute packaged-dylib dependencies and missing `@loader_path`.

## Why

Upgrading from a MeshLLM version without separate native runtimes could leave an old cached runtime, such as `0.68.0`, selected by a newer binary. On macOS, that stale runtime could then fail during `dlopen` because packaged dylibs still referenced build-tree paths for sibling llama libraries.

## Runtime install scenarios

| Scenario | Behavior |
|---|---|
| Fresh install, no config | Installs the recommended native runtime for the new MeshLLM release, then prunes with the current release active. |
| Upgrade, no config | The new binary installs the new release runtime; old cached runtimes are rejected by `mesh_version` mismatch and pruned. |
| Startup, matching runtime already cached | Loads the cached runtime directly; no install attempt. |
| Startup, no compatible cached runtime | Attempts a one-shot install for the selected version; if install fails, continues without a dynamic native runtime. |
| Config pins only `mesh_version` | Install derives ABI from that release manifest; startup, prune, and doctor target that version. |
| Config pins `mesh_version` + `skippy_abi` | Resolver requires both exact MeshLLM version and ABI. |
| Config pins `selection` | Startup, install, list, and doctor use that selection, e.g. `cuda12` or `exact:...`. |
| CLI runs `runtime install cuda12` with config selection | CLI positional selection wins for that install invocation. |
| Upgrade while pinned to old version | New binary honors the pin; `runtime prune --active-only` keeps the pinned version instead of pruning it away. |
| Explicit `runtime prune --mesh-version X` | Explicit CLI version wins over config. |
| Bad config has `skippy_abi` or `selection` without `mesh_version` | Config validation fails. |
| `runtime list --installed` with bad config | Still lists cache; it does not load config. |
| `runtime list --available` with no compatible runtime | Prints each artifact plus rejection reasons. |
| Cached runtime manifest omits `mesh_version` | Rejected; it is not rewritten to the selected version. |
| Bundle has same runtime ID but wrong version/ABI | Not used as source for the selected artifact. |
| `mesh-llm doctor` with pin | Shows running version, selected runtime version, configured ABI/selection, and pinned status. |

## Validation

- `cargo check -p mesh-llm`
- `cargo test -p mesh-llm-native-runtime --lib`
- `cargo test -p mesh-llm-config --lib`
- `cargo test -p mesh-llm-host-runtime --features dynamic-native-runtime --lib system::native_runtime`
- `bash -n scripts/package-native-runtime.sh`
- `bash -n scripts/verify-native-runtime-package.sh`
- `cargo fmt --all -- --check`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --features dynamic-native-runtime --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `[runtime.native_runtime]` settings to pin native `mesh_version`, `skippy_abi`, and `selection` for native runtime resolution.
  * Native runtime list/install/remove/prune/doctor now render via consistent human/JSON output, including more detailed doctor reporting for pinned versions.
* **Bug Fixes**
  * Native runtime resolution now rejects candidates with mismatched mesh versions (in addition to ABI/compat checks).
  * Install no longer implicitly fills `skippy_abi_version` when not provided.
  * macOS packaging now rewrites staged library paths/dependencies and enforces `@loader_path` in verification.
* **Tests / Documentation**
  * Added config parsing/validation tests and updated the native runtimes pinning documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
