### PR TITLE
model-hf: clean up broken hf_hub cache symlinks after model deletion (#877)

### DIFF
--- a/crates/model-hf/src/store/delete.rs
+++ b/crates/model-hf/src/store/delete.rs
@@ -439,10 +439,11 @@ pub async fn delete_model_by_identifier_with_catalog(
         // symlink_metadata succeeds for real files AND broken symlinks;
         // exists() returns false for broken symlinks. Combined they identify
         // symlinks whose blob target no longer exists.
-        if std::fs::symlink_metadata(path).is_ok() && !path.exists() {
-            if std::fs::remove_file(path).is_ok() {
-                prune_empty_ancestors(path, &hf_cache_root);
-            }
+        if std::fs::symlink_metadata(path).is_ok()
+            && !path.exists()
+            && std::fs::remove_file(path).is_ok()
+        {
+            prune_empty_ancestors(path, &hf_cache_root);
         }
     }
 

--- a/crates/model-hf/src/store/delete.rs
+++ b/crates/model-hf/src/store/delete.rs
@@ -439,11 +439,21 @@ pub async fn delete_model_by_identifier_with_catalog(
         // symlink_metadata succeeds for real files AND broken symlinks;
         // exists() returns false for broken symlinks. Combined they identify
         // symlinks whose blob target no longer exists.
-        if std::fs::symlink_metadata(path).is_ok()
-            && !path.exists()
-            && std::fs::remove_file(path).is_ok()
-        {
-            prune_empty_ancestors(path, &hf_cache_root);
+        if std::fs::symlink_metadata(path).is_ok() && !path.exists() {
+            match std::fs::remove_file(path) {
+                Ok(()) => {
+                    prune_empty_ancestors(path, &hf_cache_root);
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    prune_empty_ancestors(path, &hf_cache_root);
+                }
+                Err(e) => {
+                    bail!(
+                        "Failed to remove stale cache symlink {}: {e}",
+                        path.display()
+                    );
+                }
+            }
         }
     }
 

--- a/crates/model-hf/src/store/delete.rs
+++ b/crates/model-hf/src/store/delete.rs
@@ -428,6 +428,24 @@ pub async fn delete_model_by_identifier_with_catalog(
         }
     }
 
+    // Clean up stale hf_hub cache symlinks that became broken when their blob
+    // targets were deleted (collect_delete_paths canonicalizes symlinks to
+    // blob paths, so the original symlinks in snapshots/<hash>/ are not
+    // cleaned up by the blob-deletion loop above). Without this cleanup the
+    // hf_hub cache still reports the revision as "ready" on re-download but
+    // the actual files are gone, causing a "No such file" error.
+    let hf_cache_root = huggingface_hub_cache_dir();
+    for path in &resolved_paths {
+        // symlink_metadata succeeds for real files AND broken symlinks;
+        // exists() returns false for broken symlinks. Combined they identify
+        // symlinks whose blob target no longer exists.
+        if std::fs::symlink_metadata(path).is_ok() && !path.exists() {
+            if std::fs::remove_file(path).is_ok() {
+                prune_empty_ancestors(path, &hf_cache_root);
+            }
+        }
+    }
+
     Ok(DeleteResult {
         deleted_paths,
         reclaimed_bytes,

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -175,6 +175,7 @@ mesh-llm models download mlx-community/SmolLM-135M-8bit
 Switches:
 
 - `--draft`: also download the recommended draft model (if available).
+- `--direct`: download the exact HuggingFace GGUF file directly, bypassing catalog layer-package resolution.
 - `--json`: machine-readable output.
 
 ### `models certify`

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -175,7 +175,6 @@ mesh-llm models download mlx-community/SmolLM-135M-8bit
 Switches:
 
 - `--draft`: also download the recommended draft model (if available).
-- `--direct`: download the exact HuggingFace GGUF file directly, bypassing catalog layer-package resolution.
 - `--json`: machine-readable output.
 
 ### `models certify`


### PR DESCRIPTION
Fixes #877.

## Problem
After deleting a layer-package model via `mesh-llm models delete`, re-downloading the same model fails with:
```
Ready meshllm/.../model-package.json
No such file or directory: read package manifest
```

## Root Cause
The delete flow (`delete_model_by_identifier_with_catalog`) calls `collect_delete_paths` which canonicalizes hf_hub cache symlinks (`snapshots/<hash>/file.gguf` → `blobs/<sha256>`) to their blob targets. The blob-deletion loop:
1. Removes the blob file
2. Calls `prune_empty_ancestors` starting from the blob directory

But `blobs/` is never empty (other blobs exist), so the snapshot directory at `snapshots/<hash>/` — which still contains broken symlinks — is never pruned. On re-download, hf_hub cache finds the `CachedRevisionInfo` pointing to the still-present snapshot path, reports "Ready", and the downloader attempts to read the non-existent file.

## Fix
After the blob-deletion loop, iterate the original `resolved_paths` (pre-canonicalization symlink paths), detect broken symlinks (`symlink_metadata().is_ok() && !path.exists()`), remove them, and prune empty ancestors up to the hf cache root. This ensures the snapshot directory is properly cleaned so hf_hub initiates a fresh download on re-request.

## Verification
- `cargo check -p model-hf` passes
- `cargo test -p model-hf --lib` — all 34 tests pass
- `cargo test -p model-resolver --lib` — all 29 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved model deletion cleanup by detecting and removing broken Hugging Face Hub cache symlinks, and pruning resulting empty cache directories to prevent stale cache entries and reduce follow-up file-not-found errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->