### PR TITLE
fix(website): reduce CPU-heavy homepage motion

### DIFF
--- a/website/src/_includes/components/document-head.njk
+++ b/website/src/_includes/components/document-head.njk
@@ -1,5 +1,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="color-scheme" content="dark">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 {% set pageTitle %}{{ title }}{% if title != site.title %} - {{ site.title }}{% endif %}{% endset %}
 {% set pageDescription = description or site.description %}
 {% set canonicalUrl = site.url + page.url %}

--- a/website/src/_includes/sections/hero.njk
+++ b/website/src/_includes/sections/hero.njk
@@ -169,7 +169,12 @@
 
     <div class="stage2-aperture-ring" aria-hidden="true"></div>
 
-    <div class="stage2-scrubber" aria-label="Stage 2 sequence scrubber">
+    <button class="stage2-debug-toggle" type="button" role="switch" aria-checked="false" aria-label="Toggle stage 2 timeline scrubber" hidden>
+      <span>Timeline</span>
+      <i aria-hidden="true"></i>
+    </button>
+
+    <div class="stage2-scrubber" aria-label="Stage 2 sequence scrubber" aria-hidden="true">
       <div class="stage2-scrubber-meta" aria-live="polite">
         <span class="stage2-phase-name">phase 1</span>
         <span class="stage2-phase-index">01 / 08</span>

--- a/website/src/_includes/sections/hero.njk
+++ b/website/src/_includes/sections/hero.njk
@@ -184,7 +184,7 @@
         <span class="stage2-scrubber-majors"></span>
         <span class="stage2-scrubber-thumb"></span>
       </div>
-      <input class="stage2-scrubber-input" type="range" min="0" max="1000" value="0" aria-label="Stage 2 sequence position" aria-valuemin="0" aria-valuemax="1000" aria-valuenow="0">
+      <input class="stage2-scrubber-input" type="range" min="0" max="1000" value="0" aria-label="Stage 2 sequence position" aria-valuemin="0" aria-valuemax="1000" aria-valuenow="0" disabled tabindex="-1">
     </div>
   </div>
 </section>

--- a/website/src/assets/hero-viz.js
+++ b/website/src/assets/hero-viz.js
@@ -22,8 +22,14 @@
   var SUBTITLE_CHAR_IN_DURATION = 150;
   var SUBTITLE_DOT_LERP = 0.84;
   var SUBTITLE_DOT_SNAP = 0.35;
+  var SUBTITLE_LOOP_DELAY = 2400;
+  var SUBTITLE_LOOP_RETRY_DELAY = 900;
+  var SUBTITLE_LOOP_FRAME_BUDGET = 48;
+  var SUBTITLE_LOOP_PERF_COOLDOWN = 2600;
   var NODE_PLATE_RATIO = 0.48;
   var NODE_ICON_DIAMETER_RATIO = 0.576;
+  var SVG_MOTION_EVENT = 'mesh:hero-viz:svg-motion';
+  var SVG_MOTION_CLASS = 'is-svg-motion-active';
   var reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   var isSafari = /^((?!chrome|android|crios|fxios).)*safari/i.test(window.navigator.userAgent);
 
@@ -204,7 +210,9 @@
 
   var routes = [
     { edge: 'e2', source: '#60a5fa', target: '#22c55e', delay: 0, duration: 4800 },
+    { edge: 'e3', source: '#93c5fd', target: '#22c55e', delay: 1200, duration: 5200 },
     { edge: 'e5', source: '#22c55e', target: '#a5b4fc', delay: 2600, duration: 5600 },
+    { edge: 'e4', source: '#22c55e', target: '#38bdf8', delay: 3900, duration: 4600 },
     { edge: 'e7', source: '#22c55e', target: '#86efac', delay: 5200, duration: 5400 },
   ];
 
@@ -899,7 +907,7 @@
     routes.forEach(function (route) {
       var edge = edges.filter(function (item) { return item.id === route.edge; })[0];
       route.path = edge.path;
-      route.packet = el('circle', { class: 'ambient-packet', r: 3.5, fill: route.source, opacity: 0 }, packetGroup);
+      route.packet = el('circle', { class: 'ambient-packet', 'data-route-edge': route.edge, r: 3.5, fill: route.source, opacity: 0 }, packetGroup);
     });
 
     var tokenCount = viz.querySelectorAll('.stream-token').length;
@@ -1323,10 +1331,166 @@
     setCharsTyped(parts.all);
     setSubtitleDotResting(scene);
     if (scene.subtitle) scene.subtitle.classList.add('is-visible');
+    scene.subtitleLoopIndex = 0;
   }
 
   function scheduleTitleStep(callback, delay) {
     window.setTimeout(callback, delay);
+  }
+
+  function subtitleLoopBaseActive(scene) {
+    var rect;
+    var titleStyle;
+    var subtitleStyle;
+    var section;
+
+    if (!scene || !scene.title || !scene.subtitle || reduceMotion || document.hidden) return false;
+    if (!scene.titleLoopStarted || scene.subtitleLoopAnimating || scene.subtitleLoopMeasuring) return false;
+    if (scene.subtitleLoopMotionActive === false) return false;
+
+    section = scene.title.closest('[data-stage2-scroll]');
+    if (section && section.classList.contains('is-stage2-final-hook-visible')) return false;
+
+    rect = scene.title.getBoundingClientRect();
+    if (rect.bottom <= 0 || rect.top >= window.innerHeight || rect.right <= 0 || rect.left >= window.innerWidth) return false;
+
+    titleStyle = window.getComputedStyle(scene.title);
+    subtitleStyle = window.getComputedStyle(scene.subtitle);
+    return Number.parseFloat(titleStyle.opacity || '1') > 0.08 && Number.parseFloat(subtitleStyle.opacity || '1') > 0.08;
+  }
+
+  function subtitleLoopPerfDelay(scene) {
+    var now = window.performance ? window.performance.now() : Date.now();
+    var blockedUntil = scene.subtitleLoopPerfBlockedUntil || 0;
+    return Math.max(0, blockedUntil - now);
+  }
+
+  function clearSubtitleLoopTimer(scene) {
+    if (!scene || !scene.subtitleLoopTimer) return;
+    window.clearTimeout(scene.subtitleLoopTimer);
+    scene.subtitleLoopTimer = null;
+  }
+
+  function scheduleSubtitleLoop(scene, animate, delay) {
+    if (!scene || scene.subtitleLoopTimer || scene.subtitleLoopAnimating || scene.subtitleLoopMeasuring) return;
+    if (!subtitleLoopBaseActive(scene)) return;
+
+    delay = Math.max(0, delay || SUBTITLE_LOOP_DELAY);
+    scene.subtitleLoopTimer = window.setTimeout(function () {
+      scene.subtitleLoopTimer = null;
+      advanceSubtitleLoop(scene, animate);
+    }, delay);
+  }
+
+  function syncSubtitleLoop(scene, animate, delay) {
+    var perfDelay;
+
+    if (!subtitleLoopBaseActive(scene)) {
+      clearSubtitleLoopTimer(scene);
+      return;
+    }
+
+    perfDelay = subtitleLoopPerfDelay(scene);
+    scheduleSubtitleLoop(scene, animate, perfDelay > 0 ? perfDelay + 80 : delay);
+  }
+
+  function requestSubtitleLoopSync(scene, animate, delay) {
+    if (!scene || scene.subtitleLoopSyncRaf) return;
+
+    scene.subtitleLoopSyncRaf = window.requestAnimationFrame(function () {
+      scene.subtitleLoopSyncRaf = null;
+      syncSubtitleLoop(scene, animate, delay || SUBTITLE_LOOP_RETRY_DELAY);
+    });
+  }
+
+  function measureSubtitleLoopFrame(scene, onComplete) {
+    var firstFrame;
+
+    if (!window.requestAnimationFrame) {
+      onComplete(true);
+      return;
+    }
+
+    scene.subtitleLoopMeasuring = true;
+    window.requestAnimationFrame(function (first) {
+      firstFrame = first;
+      window.requestAnimationFrame(function (second) {
+        var delta = second - firstFrame;
+        var now = window.performance ? window.performance.now() : Date.now();
+        scene.subtitleLoopMeasuring = false;
+
+        if (delta > SUBTITLE_LOOP_FRAME_BUDGET) {
+          scene.subtitleLoopPerfBlockedUntil = now + SUBTITLE_LOOP_PERF_COOLDOWN;
+          onComplete(false);
+          return;
+        }
+
+        onComplete(true);
+      });
+    });
+  }
+
+  function rotateSubtitleLoop(scene, animate) {
+    var nextIndex;
+
+    if (!subtitleLoopBaseActive(scene)) return;
+
+    nextIndex = ((scene.subtitleLoopIndex || 0) + 1) % TITLE_PHRASES.length;
+    scene.subtitleLoopAnimating = true;
+
+    eraseSubtitleDynamic(scene, animate, function () {
+      revealSubtitleDynamic(scene, animate, TITLE_PHRASES[nextIndex], function () {
+        scene.subtitleLoopIndex = nextIndex;
+        scene.subtitleLoopAnimating = false;
+        syncSubtitleLoop(scene, animate, SUBTITLE_LOOP_DELAY);
+      });
+    });
+  }
+
+  function advanceSubtitleLoop(scene, animate) {
+    var perfDelay;
+
+    if (!subtitleLoopBaseActive(scene)) return;
+
+    perfDelay = subtitleLoopPerfDelay(scene);
+    if (perfDelay > 0) {
+      scheduleSubtitleLoop(scene, animate, perfDelay + 80);
+      return;
+    }
+
+    measureSubtitleLoopFrame(scene, function (allowed) {
+      if (!allowed) {
+        syncSubtitleLoop(scene, animate, SUBTITLE_LOOP_PERF_COOLDOWN);
+        return;
+      }
+
+      rotateSubtitleLoop(scene, animate);
+    });
+  }
+
+  function installSubtitleLoopGates(scene, animate) {
+    if (scene.subtitleLoopGatesInstalled) return;
+    scene.subtitleLoopGatesInstalled = true;
+    scene.subtitleLoopMotionActive = true;
+
+    window.addEventListener(SVG_MOTION_EVENT, function (event) {
+      scene.subtitleLoopMotionActive = !event.detail || event.detail.active !== false;
+      syncSubtitleLoop(scene, animate, SUBTITLE_LOOP_RETRY_DELAY);
+    });
+
+    document.addEventListener('visibilitychange', function () {
+      syncSubtitleLoop(scene, animate, SUBTITLE_LOOP_RETRY_DELAY);
+    });
+
+    window.addEventListener('scroll', function () {
+      requestSubtitleLoopSync(scene, animate);
+    }, { passive: true });
+    window.addEventListener('resize', function () {
+      requestSubtitleLoopSync(scene, animate);
+    });
+    window.addEventListener('pageshow', function () {
+      requestSubtitleLoopSync(scene, animate, SUBTITLE_LOOP_RETRY_DELAY);
+    });
   }
 
   function startTitleHeadingSequence(scene, animate) {
@@ -1366,22 +1530,11 @@
   function startTitleLoop(scene, animate) {
     if (!scene.title || reduceMotion || scene.titleLoopStarted) return;
 
-    var index = 0;
     scene.titleLoopStarted = true;
     scene.title.classList.add('is-visible', 'is-settled');
-
-    function scheduleNext() {
-      scene.titleLoopTimer = window.setTimeout(cycle, 1750);
-    }
-
-    function cycle() {
-      eraseSubtitleDynamic(scene, animate, function () {
-        index = (index + 1) % TITLE_PHRASES.length;
-        revealSubtitleDynamic(scene, animate, TITLE_PHRASES[index], scheduleNext);
-      });
-    }
-
-    scene.titleLoopTimer = window.setTimeout(cycle, 1750);
+    setSubtitleFinal(scene);
+    installSubtitleLoopGates(scene, animate);
+    syncSubtitleLoop(scene, animate, SUBTITLE_LOOP_DELAY);
   }
 
   function activateFinalState(scene) {
@@ -1436,38 +1589,119 @@
     });
   }
 
-  function initAmbient(scene, animate) {
-    animate(edges.map(function (edge) { return edge.path; }), {
+  function quietAmbient(scene) {
+    routes.forEach(function (route) {
+      if (route.packet) route.packet.setAttribute('opacity', 0);
+    });
+    if (scene.target && scene.target.halo) {
+      scene.target.halo.setAttribute('r', scene.target.r * 1.08);
+      scene.target.halo.setAttribute('opacity', 0.24);
+    }
+  }
+
+  function pauseAnimation(animation) {
+    if (animation && typeof animation.pause === 'function') animation.pause();
+  }
+
+  function resumeAnimation(animation) {
+    if (animation && typeof animation.resume === 'function') {
+      animation.resume();
+    } else if (animation && typeof animation.play === 'function') {
+      animation.play();
+    }
+  }
+
+  function createAmbientAnimations(scene, animate) {
+    var animations = [];
+
+    animations.push(animate(edges.map(function (edge) { return edge.path; }), {
       strokeDashoffset: [0, -20],
       duration: 5400,
       loop: true,
       ease: 'linear',
-    });
+      autoplay: false,
+    }));
 
-    animate(scene.target.halo, {
+    animations.push(animate(scene.target.halo, {
       r: [scene.target.r, scene.target.r * 1.26, scene.target.r],
       opacity: [0.2, 0.34, 0.2],
       duration: 2400,
       loop: true,
       ease: 'inOutQuad',
-    });
+      autoplay: false,
+    }));
 
     routes.forEach(function (route) {
       var state = { p: 0 };
-      animate(state, {
+      animations.push(animate(state, {
         p: [0, 1],
         duration: route.duration,
         delay: route.delay,
         loopDelay: 3200,
         loop: true,
         ease: 'inOut(3)',
+        autoplay: false,
         onUpdate: function () {
           var opacity = state.p < 0.14 ? state.p / 0.14 : state.p > 0.86 ? (1 - state.p) / 0.14 : 0.66;
           route.packet.setAttribute('opacity', Math.max(0, opacity));
           setPacketOnPath(route.packet, route.path, state.p, route.source, route.target);
         },
-      });
+      }));
     });
+
+    return animations;
+  }
+
+  function createSvgMotionSwitch(viz, scene, animate) {
+    var animations = null;
+    var ready = false;
+    var requestedActive = true;
+    var active = false;
+
+    function ensureAnimations() {
+      if (!animations) animations = createAmbientAnimations(scene, animate);
+    }
+
+    function setMotionActive(nextActive) {
+      nextActive = Boolean(nextActive);
+      if (active === nextActive) return;
+
+      active = nextActive;
+      viz.classList.toggle(SVG_MOTION_CLASS, active);
+
+      if (active) {
+        ensureAnimations();
+        animations.forEach(resumeAnimation);
+      } else {
+        if (animations) animations.forEach(pauseAnimation);
+        quietAmbient(scene);
+      }
+    }
+
+    function sync() {
+      if (!ready) {
+        active = false;
+        viz.classList.remove(SVG_MOTION_CLASS);
+        return;
+      }
+      setMotionActive(ready && requestedActive && !reduceMotion);
+    }
+
+    window.addEventListener(SVG_MOTION_EVENT, function (event) {
+      requestedActive = !event.detail || event.detail.active !== false;
+      sync();
+    });
+
+    return {
+      ready: function () {
+        ready = true;
+        sync();
+      },
+      stop: function () {
+        requestedActive = false;
+        sync();
+      },
+    };
   }
 
   function addReturnPacket(tl, packet, path, position) {
@@ -1564,10 +1798,11 @@
     var panelCollapseStart = TOKEN_START + (scene.tokens.length - 1) * TOKEN_STAGGER + Math.max(TOKEN_DURATION, RETURN_PACKET_DURATION) + PANEL_COLLAPSE_DELAY;
     var stableStateStart = panelCollapseStart + 620;
     var stableStarted = false;
+    var svgMotion = createSvgMotionSwitch(viz, scene, animate);
     function beginStableState() {
       if (stableStarted) return;
       stableStarted = true;
-      initAmbient(scene, animate);
+      svgMotion.ready();
       startSubtitleIntroSequence(scene, animate);
     }
 

--- a/website/src/assets/model-slicing.js
+++ b/website/src/assets/model-slicing.js
@@ -10,9 +10,15 @@
   var heroViz = null;
   var heroTitle = null;
   var heroFooter = null;
+  var modelBlock = null;
+  var phaseTitleSplit = null;
+  var phaseTitleNodes = null;
+  var phaseTitlePlace = null;
+  var finalHook = null;
   var finalHookLines = [];
   var finalHookBiggerWords = [];
   var finalHookPulseTimeline = null;
+  var finalHookPulseTimer = null;
   var finalHookWordAnimationPlayed = false;
   var finalHookPreviousStageProgress = 0;
   var serverPlate = null;
@@ -30,8 +36,11 @@
   var layoutClearTimers = [];
   var phaseName = null;
   var phaseIndex = null;
+  var scrubberDebugToggle = null;
   var scrubInput = null;
   var phasePanels = [];
+  var nodeSlotsById = {};
+  var nodeColorsById = {};
   var timeline = null;
   var scrollObserver = null;
   var timelineState = { progress: 0 };
@@ -49,6 +58,11 @@
   var cachedServer = null;
   var cachedApertureMaxRadius = null;
   var cachedMeshGeometry = null;
+  var cachedStickyMetrics = null;
+  var cachedHeroVizOrigin = null;
+  var heroVizTransformCache = '';
+  var cachedScrollBounds = null;
+  var cachedFlightLayerRect = null;
   var cachedTitleSnapY = null;
   var currentMeshGeometryScale = 1;
   var currentMeshGeometryOriginX = 0;
@@ -58,12 +72,17 @@
   var placementStarted = false;
   var placementMotionActive = false;
   var placementSettleBarrier = false;
+  var idleSourceLayerClearTimer = null;
+  var meshNodeTransformClearTimer = null;
+  var settledLayerTransformClearTimer = null;
   var isScrubbing = false;
   var scrubberPointerId = null;
   var latestScrollProgress = 0;
   var usesScrollObserver = false;
   var manualStageSeekActive = false;
   var manualStageSeekScrollY = 0;
+  var scrubberDebugView = false;
+  var scrubberDebugVisible = false;
   var titleSnapState = { progress: 0 };
   var titleSnapTarget = 0;
   var titleSnapPrimed = false;
@@ -72,53 +91,74 @@
   var titleScrollProgress = 0;
   var titleFadeProgress = 0;
   var heroVizStableRequested = false;
-  var STAGE_INTRO_PROGRESS = 0.16;
+  var heroSvgMotionActive = null;
+  var heroSvgMotionResumeTimer = null;
+  var apertureSettledActive = null;
+  var apertureVisualImmediateSeek = false;
+  var apertureVisual = {
+    radius: 0,
+    ringOpacity: 0,
+    targetAperture: 0,
+    targetRadius: 0,
+    targetRingOpacity: 0,
+    serverRadius: 34,
+    maxRadius: 1200,
+    initialized: false,
+    lastFrameTime: 0,
+    raf: null,
+  };
+  var STAGE_INTRO_PROGRESS = 0.04;
   // Leaves the final slice of the stage as a settled hold after the aperture closes.
-  var STAGE_ANIMATION_END_PROGRESS = 0.955;
-  var APERTURE_OPEN_START = 0.245;
-  var APERTURE_OPEN_END = 0.380;
-  var APERTURE_CLOSE_START = 1.095;
+  var STAGE_ANIMATION_END_PROGRESS = 0.86;
+  var APERTURE_OPEN_START = 0.190;
+  var APERTURE_OPEN_END = 0.310;
+  var APERTURE_CLOSE_START = 1.075;
   var APERTURE_CLOSE_END = 1.153;
-  var APERTURE_FADE_START = 1.125;
-  var APERTURE_FADE_END = 1.155;
+  var APERTURE_FADE_START = 1.132;
+  var APERTURE_FADE_END = 1.158;
   var APERTURE_DETAIL_FADE_END = 1.146;
   var APERTURE_WORKBENCH_EXIT_END = 1.148;
   var APERTURE_RING_RETURN_END = 1.125;
-  var APERTURE_SCRUBBER_EXIT_END = 1.142;
-  var DESKTOP_APERTURE_ENTRY_SCROLL_FACTOR = 0.5;
-  var FINAL_HOOK_FADE_START = 1.136;
-  var FINAL_HOOK_FADE_END = 1.153;
-  var FINAL_HOOK_PULSE_TRIGGER_PROGRESS = 1.154;
+  var DESKTOP_APERTURE_ENTRY_SCROLL_FACTOR = 0.34;
+  var FINAL_HOOK_FADE_START = 1.108;
+  var FINAL_HOOK_FADE_END = 1.140;
+  var FINAL_HOOK_PULSE_TRIGGER_PROGRESS = 1.142;
   var FINAL_HOOK_PULSE_SCALE = 1.1125;
   var FINAL_HOOK_PULSE_DURATION = 920;
   var FINAL_HOOK_PULSE_PEAK_DURATION = 310;
   var FINAL_HOOK_PULSE_GAP = 1500;
-  var TITLE_SNAP_LEAD_START_PROGRESS = 0.035;
-  var TITLE_SNAP_FORWARD_PROGRESS = 0.085;
-  var TITLE_SNAP_REVERSE_PROGRESS = 0.065;
-  var TOUCH_LANDSCAPE_TITLE_SNAP_REVERSE_PROGRESS = 0.155;
+  var FINAL_HOOK_PULSE_IDLE_DELAY = 1100;
+  var HERO_SVG_MOTION_RESUME_DELAY = 900;
+  var SCRUBBER_DEBUG_VIEW_STORAGE_KEY = 'meshStage2DebugView';
+  var SCRUBBER_DEBUG_VISIBLE_STORAGE_KEY = 'meshStage2DebugScrubberVisible';
+  var TITLE_SNAP_LEAD_START_PROGRESS = 0.012;
+  var TITLE_SNAP_FORWARD_PROGRESS = 0.045;
+  var TITLE_SNAP_REVERSE_PROGRESS = 0.045;
+  var TOUCH_LANDSCAPE_TITLE_SNAP_REVERSE_PROGRESS = 0.105;
   var TITLE_SNAP_LEAD_PROGRESS = 0;
   var TITLE_SNAP_Y = -570;
-  var TITLE_CLEAR_START_STAGE_PROGRESS = 0.205;
-  var TITLE_CLEAR_END_STAGE_PROGRESS = 0.245;
-  var FOOTER_CLEAR_START_STAGE_PROGRESS = 0.245;
-  var FOOTER_CLEAR_END_STAGE_PROGRESS = 0.405;
+  var TITLE_CLEAR_START_STAGE_PROGRESS = 0.160;
+  var TITLE_CLEAR_END_STAGE_PROGRESS = 0.215;
+  var FOOTER_CLEAR_START_STAGE_PROGRESS = 0.205;
+  var FOOTER_CLEAR_END_STAGE_PROGRESS = 0.325;
 
   var PHASES = [
-    { id: 'phase-1', label: 'materialize model', start: 0.385, end: 0.465, apply: applyPhaseOne },
-    { id: 'phase-2', label: 'slice layers', start: 0.465, end: 0.575, apply: applyPhaseTwo },
-    { id: 'phase-3', label: 'compact model', start: 0.575, end: 0.655, apply: applyPhaseThree },
-    { id: 'phase-4', label: 'materialize nodes', start: 0.655, end: 0.775, apply: applyPhaseFour },
-    { id: 'phase-5', label: 'distribute layers', start: 0.775, end: 0.955, apply: applyPhaseFive },
-    { id: 'phase-6', label: 'lock split', start: 0.955, end: 1.015, apply: applyPhaseSix },
-    { id: 'phase-7', label: 'align nodes', start: 1.015, end: 1.095, apply: applyPhaseSeven },
-    { id: 'phase-8', label: 'aperture close', start: 1.095, end: 1.155, apply: applyPhaseEight },
+    { id: 'phase-1', label: 'materialize model', start: 0.230, end: 0.325, apply: applyPhaseOne },
+    { id: 'phase-2', label: 'slice layers', start: 0.325, end: 0.450, apply: applyPhaseTwo },
+    { id: 'phase-3', label: 'compact model', start: 0.450, end: 0.545, apply: applyPhaseThree },
+    { id: 'phase-4', label: 'materialize nodes', start: 0.545, end: 0.675, apply: applyPhaseFour },
+    { id: 'phase-5', label: 'distribute layers', start: 0.675, end: 0.895, apply: applyPhaseFive },
+    { id: 'phase-6', label: 'lock split', start: 0.895, end: 0.975, apply: applyPhaseSix },
+    { id: 'phase-7', label: 'align nodes', start: 0.985, end: 1.075, apply: applyPhaseSeven },
+    { id: 'phase-8', label: 'aperture close', start: 1.075, end: 1.155, apply: applyPhaseEight },
   ];
   var SHRINK_PHASE_INDEX = 2;
   var NODE_PHASE_INDEX = 3;
   var MESH_PHASE_INDEX = 4;
   var LOCK_PHASE_INDEX = 5;
   var ALIGN_PHASE_INDEX = 6;
+  var MODEL_DETAIL_REVEAL_START = PHASES[0].start + 0.002;
+  var MODEL_DETAIL_REVEAL_END = PHASES[0].start + 0.028;
   var SCRUBBER_START = PHASES[0].start;
   var SCRUBBER_END = PHASES[PHASES.length - 1].end;
   var LEARN_MORE_TARGET_PROGRESS = SCRUBBER_END;
@@ -150,10 +190,24 @@
   var PLACEMENT_LAYER_WINDOW = 0.095;
   var PLACEMENT_LAYER_END = PLACEMENT_LAYER_START + PLACEMENT_LAYER_WINDOW * 10;
   var PLACEMENT_PROGRESS_EPSILON = 0.001;
-  var SCROLL_SMOOTH_SYNC = 0.9;
-  var SCROLL_SMOOTH_STEP = 0.181;
+  var PLACEMENT_EXTRACT_HOLD = 0.18;
+  var SCROLL_SMOOTH_SYNC = 0.94;
+  var SCROLL_SMOOTH_STEP = 0.42;
+  var SCROLL_SMOOTH_JUMP_THRESHOLD = 0.018;
   var TOUCH_SCROLL_SMOOTH_SYNC = 1;
   var TOUCH_SCROLL_SMOOTH_STEP = 0.44;
+  var USE_ANIME_SCROLL_OBSERVER = true;
+  var APERTURE_OPEN_SMOOTH_MS = 115;
+  var APERTURE_CLOSE_SMOOTH_MS = 92;
+  var APERTURE_RING_SMOOTH_MS = 88;
+  var APERTURE_RADIUS_OPEN_MAX_STEP = 82;
+  var APERTURE_RADIUS_CLOSE_MAX_STEP = 96;
+  var APERTURE_RADIUS_EPSILON = 0.45;
+  var APERTURE_RING_EPSILON = 0.003;
+  var APERTURE_SETTLED_BUFFER = 0.018;
+  var CSS_NUMBER_QUANTUM = 1000;
+  var CSS_PX_QUANTUM = 10;
+  var CSS_PERCENT_QUANTUM = 20;
   var TOUCH_MODEL_MIN_SCALE = 0.018;
   var TOUCH_PLACEMENT_SNAP_PROGRESS = 0.12;
 
@@ -173,13 +227,24 @@
     return useTouchScrollProfile() ? TOUCH_SCROLL_SMOOTH_STEP : SCROLL_SMOOTH_STEP;
   }
 
+  function stickyMetrics() {
+    if (cachedStickyMetrics) return cachedStickyMetrics;
+
+    cachedStickyMetrics = {
+      width: sticky ? sticky.clientWidth : window.innerWidth,
+      height: sticky ? sticky.clientHeight : window.innerHeight,
+    };
+    return cachedStickyMetrics;
+  }
+
   function useLiteStage2Motion() {
     return useTouchScrollProfile();
   }
 
   function useTouchLandscapeStage() {
-    var width = sticky ? sticky.clientWidth : window.innerWidth;
-    var height = sticky ? sticky.clientHeight : window.innerHeight;
+    var metrics = stickyMetrics();
+    var width = metrics.width;
+    var height = metrics.height;
     return useTouchScrollProfile() && width > height;
   }
 
@@ -188,35 +253,41 @@
   }
 
   function useLandscapeStage() {
-    var width = sticky ? sticky.clientWidth : window.innerWidth;
-    var height = sticky ? sticky.clientHeight : window.innerHeight;
+    var metrics = stickyMetrics();
+    var width = metrics.width;
+    var height = metrics.height;
     return width > height;
   }
 
   function landscapeVizStageY() {
+    var metrics = stickyMetrics();
     if (!sticky || !useLandscapeStage()) return 0;
-    return clamp(sticky.clientHeight * 0.18, 150, 190);
+    return clamp(metrics.height * 0.18, 150, 190);
   }
 
   function shortLandscapeVizBaseY() {
-    if (!sticky || !useLandscapeStage() || sticky.clientHeight > 480) return 0;
-    return -clamp(sticky.clientHeight * 0.32, 90, 120);
+    var metrics = stickyMetrics();
+    if (!sticky || !useLandscapeStage() || metrics.height > 480) return 0;
+    return -clamp(metrics.height * 0.32, 90, 120);
   }
 
   function usePhonePortraitStage() {
-    var width = sticky ? sticky.clientWidth : window.innerWidth;
-    var height = sticky ? sticky.clientHeight : window.innerHeight;
+    var metrics = stickyMetrics();
+    var width = metrics.width;
+    var height = metrics.height;
     return width <= 640 && height > width;
   }
 
   function phonePortraitVizStageY() {
+    var metrics = stickyMetrics();
     if (!sticky || !usePhonePortraitStage()) return 0;
-    return clamp(sticky.clientHeight * 0.16, 96, 150);
+    return clamp(metrics.height * 0.16, 96, 150);
   }
 
   function phonePortraitTitleLift() {
+    var metrics = stickyMetrics();
     if (!sticky || !usePhonePortraitStage()) return 0;
-    return clamp(sticky.clientHeight * 0.055, 34, 58);
+    return clamp(metrics.height * 0.055, 34, 58);
   }
 
   function heroVizStageY() {
@@ -336,8 +407,28 @@
     return clamp(value, 0, 1);
   }
 
+  function quantizeNumber(value, quantum) {
+    if (!Number.isFinite(value)) return value;
+    return Math.round(value * quantum) / quantum;
+  }
+
+  function normalizeCssValue(value) {
+    var numeric;
+
+    if (typeof value === 'number') return String(quantizeNumber(value, CSS_NUMBER_QUANTUM));
+    if (typeof value !== 'string') return value;
+
+    numeric = Number.parseFloat(value);
+    if (!Number.isFinite(numeric)) return value;
+    if (/^-?\d*\.?\d+px$/.test(value)) return quantizeNumber(numeric, CSS_PX_QUANTUM) + 'px';
+    if (/^-?\d*\.?\d+%$/.test(value)) return quantizeNumber(numeric, CSS_PERCENT_QUANTUM) + '%';
+    if (/^-?\d*\.?\d+$/.test(value)) return String(quantizeNumber(numeric, CSS_NUMBER_QUANTUM));
+
+    return value;
+  }
+
   function setVar(name, value) {
-    var nextValue = typeof value === 'number' ? String(Math.round(value * 10000) / 10000) : value;
+    var nextValue = normalizeCssValue(value);
 
     if (sectionVarCache[name] === nextValue) return;
     sectionVarCache[name] = nextValue;
@@ -351,6 +442,105 @@
     section.style.removeProperty(name);
   }
 
+  function apertureVisualStep(deltaMs, durationMs) {
+    if (durationMs <= 0) return 1;
+    return 1 - Math.exp(-Math.max(0, deltaMs) / durationMs);
+  }
+
+  function writeApertureVisual() {
+    var apertureScale;
+
+    setVar('--stage2-aperture-ring-opacity', apertureVisual.ringOpacity);
+    setVar('--stage2-aperture-max-radius', Math.round(apertureVisual.maxRadius * 100) / 100 + 'px');
+
+    apertureScale = apertureVisual.maxRadius > 0 ? clamp(apertureVisual.radius / apertureVisual.maxRadius, 0, 1) : 0;
+
+    setVar('--stage2-aperture-radius', Math.round(apertureVisual.radius * 100) / 100 + 'px');
+    setVar('--stage2-aperture-scale', Math.round(apertureScale * 10000) / 10000);
+    setVar('--stage2-aperture-inverse-scale', apertureScale > 0.001 ? Math.round((1 / apertureScale) * 10000) / 10000 : 1);
+  }
+
+  function apertureVisualSettled() {
+    return Math.abs(apertureVisual.targetRadius - apertureVisual.radius) < APERTURE_RADIUS_EPSILON
+      && Math.abs(apertureVisual.targetRingOpacity - apertureVisual.ringOpacity) < APERTURE_RING_EPSILON;
+  }
+
+  function snapApertureVisualToTarget() {
+    apertureVisual.radius = apertureVisual.targetRadius;
+    apertureVisual.ringOpacity = apertureVisual.targetRingOpacity;
+    apertureVisual.lastFrameTime = 0;
+    writeApertureVisual();
+  }
+
+  function advanceApertureVisual(now) {
+    var deltaMs;
+    var radiusDuration;
+    var radiusStep;
+    var radiusDelta;
+    var radiusMaxStep;
+    var ringStep;
+
+    deltaMs = apertureVisual.lastFrameTime ? clamp(now - apertureVisual.lastFrameTime, 0, 64) : 16;
+    apertureVisual.lastFrameTime = now;
+    radiusDuration = apertureVisual.targetRadius >= apertureVisual.radius
+      ? APERTURE_OPEN_SMOOTH_MS
+      : APERTURE_CLOSE_SMOOTH_MS;
+    radiusStep = apertureVisualStep(deltaMs, radiusDuration);
+    ringStep = apertureVisualStep(deltaMs, APERTURE_RING_SMOOTH_MS);
+    radiusDelta = (apertureVisual.targetRadius - apertureVisual.radius) * radiusStep;
+    radiusMaxStep = apertureVisual.targetRadius >= apertureVisual.radius
+      ? APERTURE_RADIUS_OPEN_MAX_STEP
+      : APERTURE_RADIUS_CLOSE_MAX_STEP;
+
+    apertureVisual.radius += clamp(radiusDelta, -radiusMaxStep, radiusMaxStep);
+    apertureVisual.ringOpacity += (apertureVisual.targetRingOpacity - apertureVisual.ringOpacity) * ringStep;
+
+    if (apertureVisualSettled()) {
+      snapApertureVisualToTarget();
+      return false;
+    }
+
+    writeApertureVisual();
+    return true;
+  }
+
+  function scheduleApertureVisual() {
+    if (apertureVisual.raf) return;
+    apertureVisual.raf = window.requestAnimationFrame(function renderApertureVisual(now) {
+      apertureVisual.raf = null;
+      if (advanceApertureVisual(now)) scheduleApertureVisual();
+    });
+  }
+
+  function resetApertureVisual() {
+    if (apertureVisual.raf) window.cancelAnimationFrame(apertureVisual.raf);
+    apertureVisual.raf = null;
+    apertureVisual.initialized = false;
+    apertureVisual.lastFrameTime = 0;
+  }
+
+  function syncApertureVisual(targetAperture, targetRingOpacity, server, maxRadius, immediate) {
+    apertureVisual.targetAperture = clamp(targetAperture, 0, 1);
+    apertureVisual.targetRingOpacity = clamp(targetRingOpacity, 0, 1);
+    apertureVisual.serverRadius = Math.max(1, server && server.radius ? server.radius : 34);
+    apertureVisual.maxRadius = Math.max(1, maxRadius || apertureVisual.maxRadius);
+    apertureVisual.targetRadius = lerp(
+      apertureVisual.serverRadius * 1.14,
+      apertureVisual.maxRadius,
+      easeInOut(apertureVisual.targetAperture)
+    );
+
+    if (!apertureVisual.initialized || immediate || reduceMotion) {
+      apertureVisual.initialized = true;
+      if (apertureVisual.raf) window.cancelAnimationFrame(apertureVisual.raf);
+      apertureVisual.raf = null;
+      snapApertureVisualToTarget();
+      return;
+    }
+
+    if (advanceApertureVisual(performance.now())) scheduleApertureVisual();
+  }
+
   function syncHeroChromeMetrics() {
     var chromeHeight = nav ? nav.getBoundingClientRect().height : 0;
 
@@ -362,8 +552,10 @@
   }
 
   function syncCompletedGridClip() {
+    var bounds;
     if (!section) return;
-    var heroBottom = section.getBoundingClientRect().bottom;
+    bounds = scrollBounds();
+    var heroBottom = bounds.bottom - window.scrollY;
     var clipBottom = clamp(heroBottom, 0, window.innerHeight);
     setVar('--stage2-grid-clip-bottom', Math.round(clipBottom) + 'px');
   }
@@ -376,6 +568,83 @@
       completedGridClipRaf = null;
       syncCompletedGridClip();
     });
+  }
+
+  function isHeroInViewport() {
+    var bounds;
+    var scrollY;
+
+    if (!section) return false;
+
+    bounds = scrollBounds();
+    scrollY = window.scrollY || window.pageYOffset || 0;
+    return bounds.bottom > scrollY && bounds.start < scrollY + window.innerHeight;
+  }
+
+  function clearHeroSvgMotionResume() {
+    if (!heroSvgMotionResumeTimer) return;
+    window.clearTimeout(heroSvgMotionResumeTimer);
+    heroSvgMotionResumeTimer = null;
+  }
+
+  function setHeroSvgMotionActive(active, stageProgress) {
+    if (heroSvgMotionActive === active) return;
+    heroSvgMotionActive = active;
+    window.dispatchEvent(new CustomEvent('mesh:hero-viz:svg-motion', {
+      detail: {
+        active: active,
+        stageProgress: stageProgress,
+      },
+    }));
+  }
+
+  function canRunHeroSvgMotion(stageProgress) {
+    var apertureOpen = stageProgress >= APERTURE_OPEN_START && stageProgress < APERTURE_CLOSE_END;
+    return !reduceMotion && !apertureOpen && isHeroInViewport();
+  }
+
+  function syncHeroSvgMotion(stageProgress) {
+    var active = canRunHeroSvgMotion(stageProgress);
+    var deferCloseResume = active
+      && stageProgress >= APERTURE_CLOSE_END
+      && stageProgress < SCRUBBER_END;
+
+    if (!active) {
+      clearHeroSvgMotionResume();
+      setHeroSvgMotionActive(false, stageProgress);
+      return;
+    }
+
+    if (deferCloseResume && heroSvgMotionActive !== true) {
+      if (!heroSvgMotionResumeTimer) {
+        heroSvgMotionResumeTimer = window.setTimeout(function () {
+          var nextStageProgress;
+
+          heroSvgMotionResumeTimer = null;
+          nextStageProgress = stageProgressFromScrollProgress(latestScrollProgress);
+          if (canRunHeroSvgMotion(nextStageProgress)) {
+            setHeroSvgMotionActive(true, nextStageProgress);
+          }
+        }, HERO_SVG_MOTION_RESUME_DELAY);
+      }
+      return;
+    }
+
+    clearHeroSvgMotionResume();
+    setHeroSvgMotionActive(true, stageProgress);
+  }
+
+  function isApertureSettledState(stageProgress, aperture) {
+    return !reduceMotion
+      && aperture > 0.995
+      && stageProgress > APERTURE_OPEN_END + APERTURE_SETTLED_BUFFER
+      && stageProgress < APERTURE_CLOSE_START - APERTURE_SETTLED_BUFFER;
+  }
+
+  function syncApertureSettledState(settled) {
+    if (apertureSettledActive === settled) return;
+    apertureSettledActive = settled;
+    section.classList.toggle('is-stage2-aperture-settled', settled);
   }
 
   function readSectionNumber(name, fallback) {
@@ -415,12 +684,43 @@
     return 'translateX(-50%) translateY(' + stageY + 'px) scale(' + meshScale + ')';
   }
 
-  function applyHeroVizTransform(meshScale, syncGeometry) {
+  function writeHeroVizTransform(stageY, meshScale) {
+    var transform = heroVizTransform(stageY, meshScale);
+
+    if (heroVizTransformCache === transform) return;
+    heroVizTransformCache = transform;
+    heroViz.style.transform = transform;
+  }
+
+  function syncHeroVizOrigin() {
     var heroVizLeft;
     var originX;
     var originY;
     var server;
+    var origin;
 
+    if (cachedHeroVizOrigin) {
+      currentMeshGeometryOriginX = cachedHeroVizOrigin.x;
+      currentMeshGeometryOriginY = cachedHeroVizOrigin.y;
+      return;
+    }
+
+    if (!cachedServer) writeHeroVizTransform(currentHeroVizStageY, 1);
+
+    server = syncServerGeometry();
+    heroVizLeft = heroViz.offsetLeft - heroViz.offsetWidth / 2;
+    originX = server.baseX - heroVizLeft;
+    originY = server.baseY - heroViz.offsetTop;
+    origin = Math.round(originX * 100) / 100 + 'px ' + Math.round(originY * 100) / 100 + 'px';
+
+    cachedHeroVizOrigin = { x: server.baseX, y: server.baseY };
+    currentMeshGeometryOriginX = cachedHeroVizOrigin.x;
+    currentMeshGeometryOriginY = cachedHeroVizOrigin.y;
+
+    if (heroViz.style.transformOrigin !== origin) heroViz.style.transformOrigin = origin;
+  }
+
+  function applyHeroVizTransform(meshScale, syncGeometry) {
     if (!heroViz) return;
     syncGeometry = syncGeometry !== false;
 
@@ -428,23 +728,12 @@
     currentHeroVizStageY = Math.round(lerp(heroVizBaseStageY(), heroVizStageY(), titleSnapState.progress));
 
     if (!syncGeometry) {
-      heroViz.style.transform = heroVizTransform(currentHeroVizStageY, meshScale);
+      writeHeroVizTransform(currentHeroVizStageY, meshScale);
       return;
     }
 
-    if (!cachedServer) {
-      heroViz.style.transform = heroVizTransform(currentHeroVizStageY, 1);
-    }
-    server = syncServerGeometry();
-    heroVizLeft = heroViz.offsetLeft - heroViz.offsetWidth / 2;
-    originX = server.baseX - heroVizLeft;
-    originY = server.baseY - heroViz.offsetTop;
-    currentMeshGeometryOriginX = server.baseX;
-    currentMeshGeometryOriginY = server.baseY;
-    heroViz.style.transformOrigin = Math.round(originX * 100) / 100 + 'px ' + Math.round(originY * 100) / 100 + 'px';
-    heroViz.style.transform = heroVizTransform(currentHeroVizStageY, meshScale);
-    syncServerGeometry();
-    syncMeshGeometry();
+    syncHeroVizOrigin();
+    writeHeroVizTransform(currentHeroVizStageY, meshScale);
   }
 
   function cancelTitleSnapAnimation() {
@@ -589,6 +878,39 @@
     return Math.round(snapped * (scrubberTickCount - 1)) * 4 + 'px';
   }
 
+  function readStoredFlag(key) {
+    try {
+      return window.localStorage && window.localStorage.getItem(key) === '1';
+    } catch (_error) {
+      return false;
+    }
+  }
+
+  function writeStoredFlag(key, enabled) {
+    try {
+      if (!window.localStorage) return;
+      if (enabled) {
+        window.localStorage.setItem(key, '1');
+      } else {
+        window.localStorage.removeItem(key);
+      }
+    } catch (_error) {
+      // Private browsing can reject localStorage writes.
+    }
+  }
+
+  function queryFlag(name) {
+    var value;
+
+    try {
+      value = new URLSearchParams(window.location.search).get(name);
+    } catch (_error) {
+      return false;
+    }
+
+    return value === '1' || value === 'true' || value === '';
+  }
+
   function phaseForProgress(progress) {
     var i;
 
@@ -608,8 +930,9 @@
   }
 
   function phaseTitleModelOffset(titleOpacity) {
-    var width = window.innerWidth || (sticky ? sticky.clientWidth : 1440);
-    var height = window.innerHeight || (sticky ? sticky.clientHeight : 900);
+    var metrics = stickyMetrics();
+    var width = window.innerWidth || metrics.width || 1440;
+    var height = window.innerHeight || metrics.height || 900;
     var offset = 64;
 
     if (height <= 480 && width > height) {
@@ -705,10 +1028,13 @@
   }
 
   function setFinalHookWordGlow(word, state) {
+    var sweep;
+
     if (!word || !state) return;
+    sweep = 12 + clamp(state.sweep, 0, 1) * 76;
     word.style.setProperty('--stage2-final-word-glow', String(Math.round(state.glow * 1000) / 1000));
     word.style.setProperty('--stage2-final-word-core', String(Math.round(state.core * 1000) / 1000));
-    word.style.setProperty('--stage2-final-word-glow-x', Math.round(state.sweep * 100) + '%');
+    word.style.setProperty('--stage2-final-word-glow-x', Math.round(sweep * 100) / 100 + '%');
     word.style.setProperty('--stage2-final-word-glow-stretch', String(Math.round(state.stretch * 1000) / 1000));
   }
 
@@ -730,6 +1056,10 @@
 
   function resetFinalHookWordPulse() {
     finalHookWordAnimationPlayed = false;
+    if (finalHookPulseTimer) {
+      window.clearTimeout(finalHookPulseTimer);
+      finalHookPulseTimer = null;
+    }
     clearFinalHookPulseTimeline();
     if (window.anime && typeof window.anime.remove === 'function') {
       window.anime.remove(finalHookBiggerWords);
@@ -749,7 +1079,7 @@
         { to: FINAL_HOOK_PULSE_SCALE, duration: FINAL_HOOK_PULSE_PEAK_DURATION, ease: riseEase },
         { to: 1, duration: releaseDuration, ease: releaseEase },
       ],
-      '--stage2-final-word-glow-x': ['0%', '100%'],
+      '--stage2-final-word-glow-x': ['12%', '88%'],
       '--stage2-final-word-glow': [
         { to: 1, duration: FINAL_HOOK_PULSE_PEAK_DURATION, ease: riseEase },
         { to: 0, duration: releaseDuration, ease: releaseEase },
@@ -810,13 +1140,26 @@
     finalHookPulseTimeline.play();
   }
 
+  function queueFinalHookWordPulseTimeline() {
+    if (finalHookWordAnimationPlayed || finalHookPulseTimer) return;
+
+    finalHookPulseTimer = window.setTimeout(function () {
+      finalHookPulseTimer = null;
+      playFinalHookWordPulseTimeline();
+    }, FINAL_HOOK_PULSE_IDLE_DELAY);
+  }
+
   function syncFinalHookWordPulse(stageProgress) {
     var crossedForward = finalHookPreviousStageProgress < FINAL_HOOK_PULSE_TRIGGER_PROGRESS && stageProgress >= FINAL_HOOK_PULSE_TRIGGER_PROGRESS;
 
     if (crossedForward) {
-      playFinalHookWordPulseTimeline();
+      queueFinalHookWordPulseTimeline();
     } else if (stageProgress < FINAL_HOOK_PULSE_TRIGGER_PROGRESS - 0.012) {
       finalHookWordAnimationPlayed = false;
+      if (finalHookPulseTimer) {
+        window.clearTimeout(finalHookPulseTimer);
+        finalHookPulseTimer = null;
+      }
     }
 
     if (stageProgress <= FINAL_HOOK_FADE_START - 0.02) resetFinalHookWordPulse();
@@ -824,24 +1167,27 @@
   }
 
   function setStage2TitleProgress(stageProgress) {
-    var split = titlePresence(stageProgress, 0.486, 0.522, 0.622, 0.662);
-    var nodes = titlePresence(stageProgress, 0.666, 0.704, 0.754, 0.810);
-    var place = titlePresence(stageProgress, 0.794, 0.836, 0.948, 1.012);
+    var split = titlePresence(stageProgress, 0.342, 0.382, 0.456, 0.512);
+    var nodes = titlePresence(stageProgress, 0.565, 0.606, 0.668, 0.728);
+    var place = titlePresence(stageProgress, 0.720, 0.766, 0.910, 0.992);
     var phaseTitle = Math.max(split, nodes, place);
+    var lockOffsetRelease = easeOutQuart(ramp(stageProgress, PHASES[LOCK_PHASE_INDEX].start - 0.018, PHASES[LOCK_PHASE_INDEX].start + 0.018));
+    var modelTitleOffset = phaseTitleModelOffset(phaseTitle) * (1 - lockOffsetRelease);
     var final = easeOut(ramp(stageProgress, FINAL_HOOK_FADE_START, FINAL_HOOK_FADE_END));
 
-    setVar('--stage2-title-split-opacity', Math.round(split * 10000) / 10000);
-    setVar('--stage2-title-nodes-opacity', Math.round(nodes * 10000) / 10000);
-    setVar('--stage2-title-place-opacity', Math.round(place * 10000) / 10000);
-    setVar('--stage2-title-final-opacity', Math.round(final * 10000) / 10000);
-    setVar('--stage2-title-model-offset', phaseTitleModelOffset(phaseTitle) + 'px');
+    setElementVar(phaseTitleSplit, '--stage2-title-opacity', split);
+    setElementVar(phaseTitleNodes, '--stage2-title-opacity', nodes);
+    setElementVar(phaseTitlePlace, '--stage2-title-opacity', place);
+    setElementVar(finalHook, '--stage2-title-final-opacity', final);
+    setElementVar(modelBlock, '--stage2-title-model-offset', modelTitleOffset + 'px');
     syncFinalHookWordPulse(stageProgress);
     if (section) section.classList.toggle('is-stage2-final-hook-visible', final > 0.02);
   }
 
   function modelTargetSize() {
-    var width = sticky ? sticky.clientWidth : window.innerWidth;
-    var height = window.innerHeight || (sticky ? sticky.clientHeight : 720);
+    var metrics = stickyMetrics();
+    var width = metrics.width || window.innerWidth;
+    var height = window.innerHeight || metrics.height || 720;
 
     if (width <= 640) {
       return {
@@ -957,6 +1303,11 @@
     var lock = Math.max(lockMark, lockText, lockRoute);
 
     setVar('--stage2-phase-6', progress);
+    if (context.progress >= context.phase.start) {
+      settleAllPlacementTargets();
+      setVar('--stage2-placement-progress', 1);
+    }
+
     if (!isPlacementSettled()) {
       setVar('--stage2-lock-card-progress', 0);
       setVar('--stage2-lock-progress', 0);
@@ -975,7 +1326,6 @@
     setVar('--stage2-lock-text-progress', clamp(lockText, 0, 1));
     setVar('--stage2-lock-route-progress', clamp(lockRoute, 0, 1));
     setVar('--stage2-lock-node-progress', clamp(lockNodes, 0, 1));
-    if (context.progress >= context.phase.start) setVar('--stage2-placement-progress', 1);
   }
 
   function applyPhaseSeven(context) {
@@ -1002,11 +1352,13 @@
   function applyPhaseScaffold(stageProgress) {
     PHASES.forEach(function (phase, index) {
       var localProgress = phaseProgress(phase, stageProgress);
-      var panel = section.querySelector('[data-stage2-phase-panel="' + phase.id + '"]');
+      var panel = phasePanels[index] || null;
+      var panelActive = index === activePhase;
 
-      if (panel) {
-        panel.style.opacity = String(index === activePhase ? 1 : 0);
-        panel.style.pointerEvents = 'none';
+      if (panel && panel.__stage2PanelActive !== panelActive) {
+        panel.__stage2PanelActive = panelActive;
+        panel.style.opacity = panelActive ? '1' : '0';
+        if (panel.style.pointerEvents !== 'none') panel.style.pointerEvents = 'none';
       }
 
       phase.apply({
@@ -1028,7 +1380,13 @@
     cachedServer = null;
     cachedApertureMaxRadius = null;
     cachedMeshGeometry = null;
+    cachedStickyMetrics = null;
+    cachedHeroVizOrigin = null;
+    heroVizTransformCache = '';
+    cachedScrollBounds = null;
+    cachedFlightLayerRect = null;
     cachedTitleSnapY = null;
+    resetApertureVisual();
   }
 
   function setElementVar(element, name, value) {
@@ -1036,7 +1394,7 @@
 
     if (!element) return;
 
-    nextValue = typeof value === 'number' ? String(Math.round(value * 10000) / 10000) : value;
+    nextValue = normalizeCssValue(value);
     element.__stage2VarCache = element.__stage2VarCache || {};
     if (element.__stage2VarCache[name] === nextValue) return;
     element.__stage2VarCache[name] = nextValue;
@@ -1051,20 +1409,26 @@
   }
 
   function nodeCardSize(id, scale) {
-    var width = sticky ? sticky.clientWidth : window.innerWidth;
+    var width = stickyMetrics().width || window.innerWidth;
     var mobile = width <= 640;
     var compact = width <= 900;
-    var baseWidth = mobile ? 116 : compact ? 132 : 152;
-    var baseHeight = mobile ? 86 : compact ? 100 : 116;
-    var capacityBoost = id === 'server' ? 30 : id === 'cloud' ? 16 : id === 'workstation' ? 10 : 0;
+    var baseWidth = mobile ? 104 : compact ? 132 : 152;
+    var baseHeight = mobile ? 78 : compact ? 100 : 116;
+    var capacityBoost = id === 'server'
+      ? mobile ? 18 : 30
+      : id === 'cloud'
+        ? mobile ? 10 : 16
+        : id === 'workstation'
+          ? mobile ? 6 : 10
+          : 0;
     var layerCount = nodeTargetLayerCount(id);
-    var rowHeight = mobile ? 22 : 24;
-    var rowGap = 5;
-    var hostChrome = mobile ? 84 : 96;
+    var rowHeight = mobile ? 18 : 24;
+    var rowGap = mobile ? 4 : 5;
+    var hostChrome = mobile ? 68 : 96;
     var requiredHeight = hostChrome + (layerCount * rowHeight) + (Math.max(0, layerCount - 1) * rowGap);
 
     return {
-      width: Math.max(Math.round((baseWidth + capacityBoost) * scale), mobile ? 112 : 124),
+      width: Math.max(Math.round((baseWidth + capacityBoost) * scale), mobile ? 98 : 124),
       height: Math.max(Math.round((baseHeight + capacityBoost * 0.42) * scale), requiredHeight),
     };
   }
@@ -1078,7 +1442,7 @@
   }
 
   function nodeCardOffset(id) {
-    var width = sticky ? sticky.clientWidth : window.innerWidth;
+    var width = stickyMetrics().width || window.innerWidth;
     var factor = width <= 640 ? 0.46 : width <= 900 ? 0.72 : 1;
     var offset = NODE_CARD_OFFSETS[id] || { x: 0, y: 0 };
     var serverReturn = id === 'server' ? readSectionNumber('--stage2-server-return-progress', 0) : 0;
@@ -1100,8 +1464,28 @@
     item.radius = item.baseRadius * scale;
   }
 
+  function clampNodeCardTarget(item, x, y) {
+    var metrics = stickyMetrics();
+    var width = metrics.width || window.innerWidth;
+    var height = metrics.height || window.innerHeight;
+    var margin = width <= 640 ? 14 : width <= 900 ? 18 : 0;
+    var halfWidth;
+    var halfHeight;
+
+    if (!margin || !item || !item.size) return { x: x, y: y };
+
+    halfWidth = item.size.width / 2;
+    halfHeight = item.size.height / 2;
+
+    return {
+      x: clamp(x, margin + halfWidth, width - margin - halfWidth),
+      y: clamp(y, margin + halfHeight, height - margin - halfHeight),
+    };
+  }
+
   function writeMeshNodeGeometry(id, item) {
     var offset;
+    var cardTarget;
     var cardX;
     var cardY;
     var scale;
@@ -1115,6 +1499,9 @@
     offset = nodeCardOffset(id);
     cardX = item.x + offset.x;
     cardY = item.y + offset.y;
+    cardTarget = clampNodeCardTarget(item, cardX, cardY);
+    cardX = cardTarget.x;
+    cardY = cardTarget.y;
 
     setElementVar(item.stage2Node, '--stage2-node-x', Math.round(item.x * 100) / 100 + 'px');
     setElementVar(item.stage2Node, '--stage2-node-y', Math.round(item.y * 100) / 100 + 'px');
@@ -1224,7 +1611,7 @@
   function maxRadiusFrom(point) {
     if (cachedApertureMaxRadius !== null) return cachedApertureMaxRadius;
 
-    var w = sticky ? sticky.clientWidth : window.innerWidth;
+    var w = stickyMetrics().width || window.innerWidth;
     var h = sticky ? sticky.clientHeight : window.innerHeight;
     var corners = [
       [0, 0],
@@ -1350,11 +1737,15 @@
     var nodeShapeProgress;
     var nodePositionProgress;
     var nodeContentOpacity;
+    var nodeIconShapeFade;
+    var nodeCloseIconFade;
     var nodeIconOpacity;
     var modelShrinkProgress;
+    var modelDetailProgress;
     var serverReturnProgress;
+    var heroVizDim;
+    var heroVizOpacity;
     var apertureMaxRadius;
-    var apertureScale;
 
     progress = clamp(progress, 0, SCRUBBER_END);
     var stageProgress = stageProgressFromScrollProgress(progress);
@@ -1363,22 +1754,17 @@
     var apertureCloseRaw = ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END);
     var apertureClose = fastCloseEase(apertureCloseRaw);
     var aperture = clamp(apertureOpen - apertureClose, 0, 1);
-    var apertureFadeIn = easeOut(ramp(stageProgress, APERTURE_OPEN_START, 0.292));
+    var apertureFadeIn = easeOut(ramp(stageProgress, APERTURE_OPEN_START, 0.246));
     var apertureFadeOut = easeInOut(ramp(stageProgress, APERTURE_FADE_START, APERTURE_FADE_END));
     var light = clamp(apertureFadeIn - apertureFadeOut, 0, 1);
     var closeDetailFade = easeOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_DETAIL_FADE_END));
-    var workbench = clamp(ramp(stageProgress, 0.360, 0.435) - easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_WORKBENCH_EXIT_END)), 0, 1);
+    var workbench = clamp(ramp(stageProgress, 0.212, 0.292) - easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_WORKBENCH_EXIT_END)), 0, 1);
     var heroGridRetreat = easeInOut(ramp(stageProgress, PHASES[LOCK_PHASE_INDEX].end, APERTURE_CLOSE_END));
     var heroGrid = 1 - (heroGridRetreat * 0.46);
-    var apertureRadius;
-    var ringOpacity = clamp(ramp(stageProgress, 0.235, 0.270) - ramp(stageProgress, 0.365, 0.430) + ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_RING_RETURN_END) - ramp(stageProgress, APERTURE_FADE_START, APERTURE_CLOSE_END), 0, 1);
+    var apertureSettled = isApertureSettledState(stageProgress, aperture);
+    var ringOpacity = clamp(ramp(stageProgress, 0.188, 0.232) - ramp(stageProgress, 0.286, 0.350) + ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_RING_RETURN_END) - ramp(stageProgress, APERTURE_FADE_START, APERTURE_CLOSE_END), 0, 1);
     var meshZoom = clamp(ramp(stageProgress, 0.165, APERTURE_OPEN_END) - easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END)), 0, 1);
     var meshScale = lerp(1, 1.115, easeInOut(meshZoom));
-    var scrubberEnter = ramp(stageProgress, 0.360, 0.435);
-    var scrubberExit = easeInOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_SCRUBBER_EXIT_END));
-    var scrubberPresence = clamp(scrubberEnter - scrubberExit, 0, 1);
-    var scrubberEnterY = (1 - scrubberEnter) * 16;
-    var scrubberExitY = scrubberExit * 112;
     shrinkPhaseProgress = phaseProgress(PHASES[SHRINK_PHASE_INDEX], stageProgress);
     meshPhaseProgress = phaseProgress(PHASES[NODE_PHASE_INDEX], stageProgress);
     alignPhaseProgress = phaseProgress(PHASES[ALIGN_PHASE_INDEX], stageProgress);
@@ -1388,13 +1774,15 @@
     nodeShapeProgress = easeInOut(ramp(meshPhaseProgress, 0.30, 0.58)) * (1 - easeInOut(ramp(alignPhaseProgress, 0.28, 0.56)));
     nodePositionProgress = easeInOut(ramp(meshPhaseProgress, 0.40, 0.66)) * (1 - easeInOut(ramp(alignPhaseProgress, 0.58, 0.92)));
     nodeContentOpacity = nodeShapeProgress * easeOutQuart(ramp(meshPhaseProgress, 0.52, 0.70)) * (1 - easeOutQuart(ramp(alignPhaseProgress, 0.04, 0.24)));
-    nodeIconOpacity = nodeRevealProgress * (1 - nodeShapeProgress) * (1 - closeDetailFade);
+    nodeIconShapeFade = easeInOut(ramp(meshPhaseProgress, 0.66, 0.90)) * (1 - easeOutQuart(ramp(alignPhaseProgress, 0.04, 0.24)));
+    nodeCloseIconFade = easeOut(ramp(stageProgress, APERTURE_FADE_START, APERTURE_DETAIL_FADE_END));
+    nodeIconOpacity = nodeRevealProgress * (1 - nodeIconShapeFade) * (1 - (nodeCloseIconFade * 0.55));
+    modelDetailProgress = easeOut(ramp(stageProgress, MODEL_DETAIL_REVEAL_START, MODEL_DETAIL_REVEAL_END));
 
     setStage2TitleProgress(stageProgress);
     setVar('--stage2-p', stageProgress);
     setVar('--stage2-pct', Math.round((stageProgress / SCRUBBER_END) * 10000) / 100 + '%');
     setVar('--stage2-scrubber-pct', Math.round(scrubberProgressFromProgress(stageProgress) * 10000) / 100 + '%');
-    setVar('--stage2-aperture-ring-opacity', ringOpacity);
     setVar('--stage2-light-opacity', light);
     setVar('--stage2-workbench-opacity', workbench);
     setVar('--stage2-aperture-detail-fade', closeDetailFade);
@@ -1404,32 +1792,38 @@
     setVar('--stage2-node-content-opacity', nodeContentOpacity);
     setVar('--stage2-node-icon-opacity', nodeIconOpacity);
     setVar('--stage2-model-shrink-progress', modelShrinkProgress);
+    setVar('--stage2-model-detail-opacity', modelDetailProgress);
     setVar('--stage2-server-return-progress', serverReturnProgress);
-    setVar('--stage2-scrubber-y', Math.round((scrubberEnterY + scrubberExitY) * 100) / 100 + 'px');
-    setVar('--stage2-scrubber-opacity', scrubberPresence);
-    syncScrubberAccessibility(scrubberPresence);
     syncPlacedLayerAccessibility(nodeShapeProgress);
+    heroVizDim = clamp(
+      easeOut(ramp(stageProgress, APERTURE_OPEN_START - 0.012, APERTURE_OPEN_END))
+      - easeOut(ramp(stageProgress, APERTURE_CLOSE_START, APERTURE_CLOSE_END)),
+      0,
+      1
+    );
+    heroVizOpacity = lerp(1, 0.18, heroVizDim);
+    setVar('--stage2-hero-opacity', heroVizOpacity);
     setVar('--stage2-grid-opacity', heroGrid);
     setVar('--stage2-grid-mask-solid', Math.round(lerp(78, 28, heroGridRetreat) * 100) / 100 + '%');
     setVar('--stage2-grid-mask-end', Math.round(lerp(100, 38, heroGridRetreat) * 100) / 100 + '%');
     setVar('--stage2-aperture-blue-alpha', lerp(0.08, 0.014, closeDetailFade));
     setVar('--stage2-aperture-grid-alpha', lerp(0.045, 0.006, closeDetailFade));
-    if (!heroVizStableRequested && stageProgress >= APERTURE_CLOSE_END) {
+    if (!heroVizStableRequested && stageProgress >= APERTURE_OPEN_START) {
       heroVizStableRequested = true;
       window.dispatchEvent(new CustomEvent('mesh:hero-viz:stable'));
     }
-    section.classList.toggle('is-stage2-scrubbable', scrubberPresence > 0.12);
-
     setChromeProgress(progress, stageProgress);
     applyHeroVizTransform(meshScale);
     server = syncServerGeometry();
     apertureMaxRadius = maxRadiusFrom(server);
-    apertureRadius = lerp(server.radius * 1.14, apertureMaxRadius, easeInOut(aperture));
-    apertureScale = apertureMaxRadius > 0 ? clamp(apertureRadius / apertureMaxRadius, 0, 1) : 0;
-    setVar('--stage2-aperture-radius', Math.round(apertureRadius * 100) / 100 + 'px');
-    setVar('--stage2-aperture-max-radius', Math.round(apertureMaxRadius * 100) / 100 + 'px');
-    setVar('--stage2-aperture-scale', Math.round(apertureScale * 10000) / 10000);
-    setVar('--stage2-aperture-inverse-scale', apertureScale > 0.001 ? Math.round((1 / apertureScale) * 10000) / 10000 : 1);
+    syncApertureVisual(
+      aperture,
+      ringOpacity,
+      server,
+      apertureMaxRadius,
+      apertureVisualImmediateSeek || isScrubbing
+    );
+    syncApertureSettledState(apertureSettled);
 
     syncMeshGeometry();
     clearMeshNodeLayoutTransforms();
@@ -1447,38 +1841,47 @@
     }
 
     if (!reduceMotion) {
+      var stageComplete = stageProgress >= SCRUBBER_END;
+      var wasStageComplete = document.body.classList.contains('is-stage2-complete');
       document.body.classList.toggle('is-stage2-active', stageProgress > 0.002 && stageProgress < SCRUBBER_END);
       document.body.classList.toggle('is-stage2-aperture-active', stageProgress >= APERTURE_CLOSE_START && stageProgress < SCRUBBER_END);
-      document.body.classList.toggle('is-stage2-complete', stageProgress >= SCRUBBER_END);
+      document.body.classList.toggle('is-stage2-complete', stageComplete);
+      if (stageComplete && !wasStageComplete) syncCompletedGridClip();
     } else {
       document.body.classList.remove('is-stage2-aperture-active');
     }
+    syncHeroSvgMotion(stageProgress);
+  }
 
-    if (stageProgress >= SCRUBBER_END - 0.01) syncCompletedGridClip();
+  function scrollBounds() {
+    if (cachedScrollBounds) return cachedScrollBounds;
+
+    cachedScrollBounds = {
+      start: section.offsetTop,
+      range: Math.max(1, section.offsetHeight - window.innerHeight),
+      bottom: section.offsetTop + section.offsetHeight,
+    };
+    return cachedScrollBounds;
   }
 
   function progressFromScroll() {
-    var start = section.offsetTop;
-    var range = Math.max(1, section.offsetHeight - window.innerHeight);
-    return clamp((window.scrollY - start) / range, 0, 1);
+    var bounds = scrollBounds();
+    return clamp((window.scrollY - bounds.start) / bounds.range, 0, 1);
   }
 
   function scrollToProgress(progress) {
-    var start = section.offsetTop;
-    var range = Math.max(1, section.offsetHeight - window.innerHeight);
-    window.scrollTo({ top: start + range * scrollProgressFromStageProgress(progress), behavior: 'auto' });
+    var bounds = scrollBounds();
+    window.scrollTo({ top: bounds.start + bounds.range * scrollProgressFromStageProgress(progress), behavior: 'auto' });
   }
 
   function scrollTopForScrollProgress(progress) {
-    var start = section.offsetTop;
-    var range = Math.max(1, section.offsetHeight - window.innerHeight);
-    return start + range * clamp(progress, 0, 1);
+    var bounds = scrollBounds();
+    return bounds.start + bounds.range * clamp(progress, 0, 1);
   }
 
   function scrollTopForStageProgress(progress) {
-    var start = section.offsetTop;
-    var range = Math.max(1, section.offsetHeight - window.innerHeight);
-    return start + range * scrollProgressFromStageProgress(progress);
+    var bounds = scrollBounds();
+    return bounds.start + bounds.range * scrollProgressFromStageProgress(progress);
   }
 
   function forceInstantScrollBehavior() {
@@ -1622,6 +2025,7 @@
 
   function seekStageProgressImmediate(progress) {
     var scrollProgress = scrollProgressFromStageProgress(progress);
+    var previousImmediateAperture = apertureVisualImmediateSeek;
 
     cancelScrollSmoothing();
     if (window.anime && window.anime.remove) window.anime.remove(smoothState);
@@ -1631,39 +2035,49 @@
     smoothState.progress = scrollProgress;
     timelineState.progress = scrollProgress;
     beginManualStageSeekOverride();
-    applyProgress(scrollProgress);
+    apertureVisualImmediateSeek = true;
+    try {
+      applyProgress(scrollProgress);
+    } finally {
+      apertureVisualImmediateSeek = previousImmediateAperture;
+    }
   }
 
-  function seek(progress) {
-    progress = clamp(progress, 0, 1);
+  function seek(progress, immediateAperture) {
+    var previousImmediateAperture = apertureVisualImmediateSeek;
 
-    if (timeline && timeline.seek) {
-      try {
-        timeline.seek(progress * 1000);
-      } catch (_error) {
-        applyProgress(progress);
-      }
-    } else {
+    progress = clamp(progress, 0, 1);
+    apertureVisualImmediateSeek = Boolean(immediateAperture);
+    timelineState.progress = progress;
+
+    try {
       applyProgress(progress);
+    } finally {
+      apertureVisualImmediateSeek = previousImmediateAperture;
     }
   }
 
   function smoothTo(progress, immediate) {
     var delta;
+    var incomingDelta;
     var snap;
 
     progress = clamp(progress, 0, 1);
+    incomingDelta = Math.abs(progress - latestScrollProgress);
     latestScrollProgress = progress;
 
-    if (immediate || reduceMotion || useTouchScrollProfile() || !window.anime || !window.anime.animate) {
+    if (
+      immediate
+      || reduceMotion
+      || useTouchScrollProfile()
+      || scrollSmoothStep() >= 1
+      || (!scrollSmoothRaf && incomingDelta < SCROLL_SMOOTH_JUMP_THRESHOLD)
+    ) {
       cancelScrollSmoothing();
-      if (window.anime && window.anime.remove) window.anime.remove(smoothState);
       smoothState.progress = progress;
-      seek(progress);
+      seek(progress, immediate || isScrubbing);
       return;
     }
-
-    if (window.anime.remove) window.anime.remove(smoothState);
 
     if (scrollSmoothRaf) return;
 
@@ -1681,6 +2095,7 @@
       snap = smoothState.progress > latestScrollProgress && latestScrollProgress === 0 ? -0.0001 : snap;
       smoothState.progress = clamp(smoothState.progress + delta * scrollSmoothStep() + snap, 0, 1);
       seek(smoothState.progress);
+      if (Math.abs(latestScrollProgress - smoothState.progress) < 0.0006) return;
       scrollSmoothRaf = window.requestAnimationFrame(renderSmoothedProgress);
     }
 
@@ -1778,6 +2193,7 @@
       var impact = easeOutQuart(ramp(layerLocal, 0.02, 0.34)) * (1 - easeOutQuart(ramp(layerLocal, 0.42, 0.92)));
       var residue = easeOutQuart(ramp(layerLocal, 0.34, 0.68)) * (1 - easeOutQuart(ramp(layerLocal, 0.88, 1.34)));
       var cutFront = easeOutQuart(ramp(layerLocal, 0.02, 0.58));
+      var layerCutterOpacity = cutterVisible && index === cutIndex ? 1 : 0;
       var shear = useLiteStage2Motion() ? 0 : impact * (index % 2 === 0 ? -1 : 1) * 1.8;
 
       setElementVar(layer, '--stage2-layer-slice-progress', String(Math.round(release * 10000) / 10000));
@@ -1785,6 +2201,9 @@
       setElementVar(layer, '--stage2-layer-cut-energy', String(Math.round(impact * 10000) / 10000));
       setElementVar(layer, '--stage2-layer-cut-residue', String(Math.round(residue * 10000) / 10000));
       setElementVar(layer, '--stage2-layer-cut-front', String(Math.round(cutFront * 10000) / 10000));
+      setElementVar(layer, '--stage2-layer-cutter-opacity', String(layerCutterOpacity));
+      setElementVar(layer, '--stage2-layer-cutter-left', String(Math.round(cutterLeft * 10000) / 10000));
+      setElementVar(layer, '--stage2-layer-cutter-right', String(Math.round(cutterRight * 10000) / 10000));
       setElementVar(layer, '--stage2-layer-cut-shear', Math.round(shear * 100) / 100 + 'px');
       setElementVar(layer, '--stage2-layer-cut-skew', Math.round(shear * -0.32 * 100) / 100 + 'deg');
       if (layer.parentElement === tensorStack) cumulativeGap += layerGap;
@@ -1792,17 +2211,7 @@
 
     setVar('--stage2-stack-extra-height', Math.round(cumulativeGap * 100) / 100 + 'px');
 
-    if (useLiteStage2Motion()) {
-      cancelSliceCutterRetarget();
-      setVar('--stage2-cutter-y', cutterY + '%');
-      return;
-    }
-
-    if (retargetSliceCutter(cutIndex)) {
-      if (!isScrubbing) scheduleSliceCutterRetarget(cutIndex);
-      return;
-    }
-
+    cancelSliceCutterRetarget();
     setVar('--stage2-cutter-y', cutterY + '%');
   }
 
@@ -1832,28 +2241,16 @@
   function syncSliceTimeline(progress) {
     progress = clamp(progress, 0, 1);
     sliceTimelineState.progress = progress;
-
-    if (sliceTimeline && typeof sliceTimeline.seek === 'function') {
-      try {
-        sliceTimeline.seek(progress * 1000, true);
-        paintSliceTimeline(progress);
-      } catch (_error) {
-        paintSliceTimeline(progress);
-      }
-      return;
-    }
-
+    sliceTimelinePainted = true;
     paintSliceTimeline(progress);
   }
 
   function syncLayerCompaction(stageProgress) {
     var phaseLocal = phaseProgress(PHASES[SHRINK_PHASE_INDEX], stageProgress);
-    var placementPhaseStarted = stageProgress >= PHASES[MESH_PHASE_INDEX].start;
 
     modelLayers.forEach(function (layer, index) {
       var compact = phaseLocal > 0 ? easeOutQuart(ramp(phaseLocal, 0.04 + index * 0.035, 0.18 + index * 0.035)) : 0;
       if (layer.getAttribute('data-stage2-assigned-node')) compact = 1;
-      else if (placementPhaseStarted && !layer.classList.contains('is-stage2-layer-in-flight')) compact = 0;
       setElementVar(layer, '--stage2-layer-compact-progress', String(Math.round(compact * 10000) / 10000));
     });
   }
@@ -1898,8 +2295,17 @@
 
   function clearMeshNodeLayoutTransforms() {
     meshNodes.forEach(function (node) {
-      node.style.transform = '';
-      node.style.translate = '';
+      if (node.style.transform) node.style.transform = '';
+      if (node.style.translate) node.style.translate = '';
+    });
+  }
+
+  function cancelLayoutTimer(timerId) {
+    if (!timerId) return;
+
+    window.clearTimeout(timerId);
+    layoutClearTimers = layoutClearTimers.filter(function (candidate) {
+      return candidate !== timerId;
     });
   }
 
@@ -1908,6 +2314,9 @@
       window.clearTimeout(timerId);
     });
     layoutClearTimers = [];
+    idleSourceLayerClearTimer = null;
+    meshNodeTransformClearTimer = null;
+    settledLayerTransformClearTimer = null;
   }
 
   function scheduleLayoutClear(callback, delay) {
@@ -1919,6 +2328,7 @@
     }, Math.max(0, delay || 0));
 
     layoutClearTimers.push(timerId);
+    return timerId;
   }
 
   function hasActivePlacementSourceMotion() {
@@ -1933,31 +2343,46 @@
 
     modelLayers.forEach(function (layer) {
       if (layer.getAttribute('data-stage2-assigned-node')) return;
-      layer.style.transform = '';
-      layer.style.translate = '';
+      if (layer.style.transform) layer.style.transform = '';
+      setLayerTranslate(layer, '');
     });
   }
 
   function scheduleIdleSourceLayerTransformClear() {
     clearIdleSourceLayerTransforms();
-    scheduleLayoutClear(clearIdleSourceLayerTransforms, 40);
+    if (idleSourceLayerClearTimer) return;
+
+    idleSourceLayerClearTimer = scheduleLayoutClear(function () {
+      idleSourceLayerClearTimer = null;
+      clearIdleSourceLayerTransforms();
+    }, 40);
   }
 
   function clearSettledLayerTransforms() {
     modelLayers.forEach(function (layer) {
-      layer.style.transform = '';
-      layer.style.translate = '';
+      if (layer.classList.contains('is-stage2-layer-in-flight')) return;
+      if (layer.style.transform) layer.style.transform = '';
+      setLayerTranslate(layer, '');
     });
   }
 
   function scheduleSettledLayerTransformClear(duration) {
     var delay = Number(duration) || 0;
-    scheduleLayoutClear(clearSettledLayerTransforms, delay + 50);
+
+    cancelLayoutTimer(settledLayerTransformClearTimer);
+    settledLayerTransformClearTimer = scheduleLayoutClear(function () {
+      settledLayerTransformClearTimer = null;
+      clearSettledLayerTransforms();
+    }, delay + 50);
   }
 
   function scheduleMeshNodeTransformClear(duration) {
     clearMeshNodeLayoutTransforms();
-    scheduleLayoutClear(clearMeshNodeLayoutTransforms, Math.max(0, duration || 0) + 40);
+    cancelLayoutTimer(meshNodeTransformClearTimer);
+    meshNodeTransformClearTimer = scheduleLayoutClear(function () {
+      meshNodeTransformClearTimer = null;
+      clearMeshNodeLayoutTransforms();
+    }, Math.max(0, duration || 0) + 40);
   }
 
   function runLayoutMutation(mutation, options) {
@@ -1997,52 +2422,51 @@
   }
 
   function slotForNode(nodeId) {
-    return section.querySelector('[data-stage2-node-slots="' + nodeId + '"]');
+    if (!nodeSlotsById[nodeId]) {
+      nodeSlotsById[nodeId] = section.querySelector('[data-stage2-node-slots="' + nodeId + '"]');
+    }
+    return nodeSlotsById[nodeId] || null;
   }
 
   function colorForNode(nodeId) {
-    var node = nodeId && section.querySelector('[data-stage2-node="' + nodeId + '"]');
-    var color;
-
-    if (!node) return '';
-    color = window.getComputedStyle(node).getPropertyValue('--stage2-node-color').trim();
-    return color || '';
+    return nodeColorsById[nodeId] || '';
   }
 
   function layerIdFor(layer) {
     return layer ? layer.getAttribute('data-stage2-model-layer') : '';
   }
 
+  function clearLayerInteractiveAttrs(layer) {
+    if (layer.hasAttribute('aria-disabled')) layer.removeAttribute('aria-disabled');
+    if (layer.hasAttribute('aria-label')) layer.removeAttribute('aria-label');
+    if (layer.hasAttribute('title')) layer.removeAttribute('title');
+    if (layer.hasAttribute('tabindex')) layer.removeAttribute('tabindex');
+  }
+
+  function setLayerState(layer, state) {
+    if (layer.getAttribute('data-stage2-layer-state') !== state) {
+      layer.setAttribute('data-stage2-layer-state', state);
+    }
+  }
+
   function setLayerSourceSemantics(layer) {
-    layer.removeAttribute('aria-disabled');
-    layer.removeAttribute('aria-label');
-    layer.removeAttribute('title');
-    layer.removeAttribute('tabindex');
-    layer.setAttribute('data-stage2-layer-state', 'source');
+    clearLayerInteractiveAttrs(layer);
+    setLayerState(layer, 'source');
   }
 
   function setLayerPlacedSemantics(layer, nodeId) {
-    layer.removeAttribute('aria-disabled');
-    layer.removeAttribute('aria-label');
-    layer.removeAttribute('title');
-    layer.removeAttribute('tabindex');
-    layer.setAttribute('data-stage2-layer-state', 'placed');
+    clearLayerInteractiveAttrs(layer);
+    setLayerState(layer, 'placed');
   }
 
   function setLayerReducedSemantics(layer, nodeId) {
-    layer.removeAttribute('aria-disabled');
-    layer.removeAttribute('aria-label');
-    layer.removeAttribute('title');
-    layer.removeAttribute('tabindex');
-    layer.setAttribute('data-stage2-layer-state', 'summary');
+    clearLayerInteractiveAttrs(layer);
+    setLayerState(layer, 'summary');
   }
 
   function setLayerCollapsedSemantics(layer, nodeId) {
-    layer.removeAttribute('aria-disabled');
-    layer.removeAttribute('aria-label');
-    layer.removeAttribute('title');
-    layer.removeAttribute('tabindex');
-    layer.setAttribute('data-stage2-layer-state', 'collapsed');
+    clearLayerInteractiveAttrs(layer);
+    setLayerState(layer, 'collapsed');
   }
 
   function syncPlacedLayerAccessibility(nodeCardProgress) {
@@ -2061,15 +2485,56 @@
     });
   }
 
-  function syncScrubberAccessibility(scrubberPresence) {
+  function syncScrubberAccessibility() {
     var scrubber = section.querySelector('.stage2-scrubber');
-    var isVisible = scrubberPresence > 0.12;
 
-    if (scrubber) scrubber.setAttribute('aria-hidden', isVisible ? 'false' : 'true');
+    if (scrubber) scrubber.setAttribute('aria-hidden', scrubberDebugVisible ? 'false' : 'true');
     if (!scrubInput) return;
 
-    scrubInput.disabled = !isVisible;
-    scrubInput.tabIndex = isVisible ? 0 : -1;
+    scrubInput.disabled = !scrubberDebugVisible;
+    scrubInput.tabIndex = scrubberDebugVisible ? 0 : -1;
+  }
+
+  function setScrubberDebugVisible(enabled, persist) {
+    var scrubber = section.querySelector('.stage2-scrubber');
+
+    scrubberDebugVisible = scrubberDebugView && Boolean(enabled);
+    document.body.classList.toggle('is-stage2-debug-scrubber-visible', scrubberDebugVisible);
+    section.classList.toggle('is-stage2-scrubbable', scrubberDebugVisible);
+
+    if (scrubberDebugToggle) scrubberDebugToggle.setAttribute('aria-checked', scrubberDebugVisible ? 'true' : 'false');
+    if (persist) writeStoredFlag(SCRUBBER_DEBUG_VISIBLE_STORAGE_KEY, scrubberDebugVisible);
+    if (!scrubberDebugVisible) {
+      isScrubbing = false;
+      scrubberPointerId = null;
+      if (scrubber) scrubber.classList.remove('is-scrubbing');
+    }
+    syncScrubberAccessibility();
+  }
+
+  function setScrubberDebugView(enabled, persist) {
+    scrubberDebugView = Boolean(enabled);
+    document.body.classList.toggle('is-stage2-debug-view', scrubberDebugView);
+    if (scrubberDebugToggle) scrubberDebugToggle.hidden = !scrubberDebugView;
+    if (persist) writeStoredFlag(SCRUBBER_DEBUG_VIEW_STORAGE_KEY, scrubberDebugView);
+    setScrubberDebugVisible(scrubberDebugView && scrubberDebugVisible, false);
+  }
+
+  function initScrubberDebugControls() {
+    var visibleByQuery = queryFlag('stage2Scrubber') || queryFlag('scrubber');
+    var viewByQuery = visibleByQuery || queryFlag('stage2Debug');
+
+    scrubberDebugToggle = section.querySelector('.stage2-debug-toggle');
+    scrubberDebugView = viewByQuery || readStoredFlag(SCRUBBER_DEBUG_VIEW_STORAGE_KEY);
+    scrubberDebugVisible = visibleByQuery || readStoredFlag(SCRUBBER_DEBUG_VISIBLE_STORAGE_KEY);
+
+    setScrubberDebugView(scrubberDebugView, false);
+    setScrubberDebugVisible(scrubberDebugVisible, false);
+
+    if (!scrubberDebugToggle) return;
+    scrubberDebugToggle.addEventListener('click', function () {
+      setScrubberDebugVisible(!scrubberDebugVisible, true);
+    });
   }
 
   function insertLayerInTensorOrder(layer) {
@@ -2128,14 +2593,62 @@
     if (!layoutRoot) return null;
 
     stage2FlightLayer = layoutRoot.querySelector('[data-stage2-flight-layer]');
-    if (stage2FlightLayer) return stage2FlightLayer;
+    if (stage2FlightLayer) {
+      cachedFlightLayerRect = null;
+      return stage2FlightLayer;
+    }
 
     stage2FlightLayer = document.createElement('div');
     stage2FlightLayer.className = 'stage2-flight-layer';
     stage2FlightLayer.setAttribute('data-stage2-flight-layer', 'true');
     stage2FlightLayer.setAttribute('aria-hidden', 'true');
     layoutRoot.appendChild(stage2FlightLayer);
+    cachedFlightLayerRect = null;
     return stage2FlightLayer;
+  }
+
+  function flightLayerRectFor(flightLayer) {
+    if (!flightLayer) return { left: 0, top: 0 };
+    if (!cachedFlightLayerRect) cachedFlightLayerRect = flightLayer.getBoundingClientRect();
+    return cachedFlightLayerRect;
+  }
+
+  function setLayerTranslate(layer, value) {
+    value = value || '';
+    if (!layer || layer.__stage2Translate === value) return;
+
+    layer.__stage2Translate = value;
+    layer.style.translate = value;
+  }
+
+  function setLayerFlightMotion(layer, x, y) {
+    if (!layer) return;
+
+    setElementVar(layer, '--stage2-flight-x', Math.round(x * 100) / 100 + 'px');
+    setElementVar(layer, '--stage2-flight-y', Math.round(y * 100) / 100 + 'px');
+  }
+
+  function setLayerFlightSize(layer, width) {
+    if (!layer || !Number.isFinite(width)) return;
+
+    layer.style.width = Math.round(width * 100) / 100 + 'px';
+  }
+
+  function applyLayerFlightBox(layer, left, top, width, height) {
+    if (!layer) return;
+
+    layer.style.position = 'absolute';
+    layer.style.left = Math.round(left * 100) / 100 + 'px';
+    layer.style.top = Math.round(top * 100) / 100 + 'px';
+    layer.style.width = Math.round(width * 100) / 100 + 'px';
+    layer.style.height = Math.round(height * 100) / 100 + 'px';
+    layer.style.minHeight = Math.round(height * 100) / 100 + 'px';
+    layer.style.marginTop = '0px';
+    layer.style.transform = 'translate3d(var(--stage2-flight-x, 0px), calc(var(--stage2-flight-y, 0px) + var(--stage2-flight-lift-y, 0px)), 0)';
+    layer.style.transformOrigin = '0 0';
+    setLayerTranslate(layer, 'none');
+    layer.style.willChange = 'transform';
+    setLayerFlightMotion(layer, 0, 0);
   }
 
   function clearLayerFlightStyles(layer) {
@@ -2145,16 +2658,17 @@
     layer.style.top = '';
     layer.style.width = '';
     layer.style.height = '';
+    layer.style.minHeight = '';
     layer.style.marginTop = '';
     layer.style.transform = '';
-    layer.style.translate = '';
+    layer.style.transformOrigin = '';
+    setLayerTranslate(layer, '');
     layer.style.willChange = '';
-    clearElementVar(layer, '--stage2-flight-shadow-y');
-    clearElementVar(layer, '--stage2-flight-shadow-blur');
-    clearElementVar(layer, '--stage2-flight-shadow-spread');
-    clearElementVar(layer, '--stage2-flight-shadow-alpha');
+    clearElementVar(layer, '--stage2-flight-x');
+    clearElementVar(layer, '--stage2-flight-y');
     clearElementVar(layer, '--stage2-flight-lift-y');
-    clearElementVar(layer, '--stage2-flight-scale');
+    clearElementVar(layer, '--stage2-layer-extract-progress');
+    clearElementVar(layer, '--stage2-layer-highlight-progress');
   }
 
   function clearLayerPlacementStyles(layer) {
@@ -2168,17 +2682,31 @@
   }
 
   function setLayerFlightVisuals(layer, progress) {
-    var crisp = easeInOut(progress);
-    var lift = 1 - easeOutQuart(progress);
+    var travel = placementTravelProgress(progress);
+    var liftY = -4 * Math.sin(travel * Math.PI);
+    var extract = easeOutQuart(ramp(progress, 0, 0.38));
+    var highlight = easeInOut(ramp(progress, 0.06, 0.34));
 
     if (!layer) return;
 
-    setElementVar(layer, '--stage2-flight-shadow-y', Math.round(lerp(24, 2, crisp) * 100) / 100 + 'px');
-    setElementVar(layer, '--stage2-flight-shadow-blur', Math.round(lerp(30, 3, crisp) * 100) / 100 + 'px');
-    setElementVar(layer, '--stage2-flight-shadow-spread', Math.round(lerp(-5, 0, crisp) * 100) / 100 + 'px');
-    setElementVar(layer, '--stage2-flight-shadow-alpha', String(Math.round(lerp(0.24, 0.08, crisp) * 10000) / 10000));
-    setElementVar(layer, '--stage2-flight-lift-y', Math.round(lerp(-5, 0, crisp) * lift * 100) / 100 + 'px');
-    setElementVar(layer, '--stage2-flight-scale', String(Math.round(lerp(1.012, 1, crisp) * 10000) / 10000));
+    setElementVar(layer, '--stage2-flight-lift-y', Math.round(liftY * 100) / 100 + 'px');
+    setElementVar(layer, '--stage2-layer-extract-progress', String(Math.round(extract * 10000) / 10000));
+    setElementVar(layer, '--stage2-layer-highlight-progress', String(Math.round(highlight * 10000) / 10000));
+  }
+
+  function setLayerFlightFrame(layer, state, progress) {
+    var eased;
+
+    if (!layer || !state) return;
+
+    eased = placementTravelProgress(progress);
+    setLayerFlightMotion(
+      layer,
+      lerp(0, state.toLeft - state.fromLeft, eased),
+      lerp(0, state.toTop - state.fromTop, eased)
+    );
+    setLayerFlightSize(layer, lerp(state.fromWidth, state.toWidth, eased));
+    setLayerFlightVisuals(layer, progress);
   }
 
   function hasActiveLayerFlight() {
@@ -2373,24 +2901,24 @@
   function clearSourceMagazineMotion() {
     modelLayers.forEach(function (layer) {
       if (layer.parentElement !== tensorStack) return;
-      layer.style.translate = '';
+      setLayerTranslate(layer, '');
     });
   }
 
   function createPlacementReservation(layer, fromRect) {
     var reservation;
-    var layerStyle;
+    var layerGap;
 
     if (!layer || layer.parentElement !== tensorStack) return null;
 
-    layerStyle = window.getComputedStyle(layer);
+    layerGap = layer.style.getPropertyValue('--stage2-layer-gap-before') || '0px';
     reservation = document.createElement('div');
     reservation.className = 'stage2-layer-slot-reservation';
     reservation.setAttribute('data-stage2-placement-reservation', layerIdFor(layer));
     reservation.style.flex = '0 0 ' + Math.round(fromRect.height * 100) / 100 + 'px';
     reservation.style.height = Math.round(fromRect.height * 100) / 100 + 'px';
     reservation.style.minHeight = Math.round(fromRect.height * 100) / 100 + 'px';
-    reservation.style.marginTop = layerStyle.marginTop;
+    reservation.style.marginTop = layerGap;
 
     tensorStack.insertBefore(reservation, layer);
     return reservation;
@@ -2422,7 +2950,7 @@
 
     modelLayers.forEach(function (layer, index) {
       if (layer.parentElement !== tensorStack) return;
-      layer.style.translate = index > sourceIndex ? '0 ' + offset + 'px' : '';
+      setLayerTranslate(layer, index > sourceIndex ? '0 ' + offset + 'px' : '');
     });
   }
 
@@ -2473,6 +3001,10 @@
     return clamp(progress, 0, 1);
   }
 
+  function placementTravelProgress(progress) {
+    return easeInOut(ramp(progress, PLACEMENT_EXTRACT_HOLD, 1));
+  }
+
   function restoreSettledSourceLayersBeforeActivePlacement(phaseLocal, flightLayer) {
     var restored = false;
 
@@ -2516,6 +3048,8 @@
     var fromTop;
     var toLeft;
     var toTop;
+    var targetX;
+    var targetY;
 
     if (!layer || !fromRect) return;
 
@@ -2524,17 +3058,23 @@
 
     toRect = options && options.toRect ? options.toRect : layer.getBoundingClientRect();
     targetParent = layer.parentElement;
-    flightRect = flightLayer.getBoundingClientRect();
+    flightRect = flightLayerRectFor(flightLayer);
     fromLeft = fromRect.left - flightRect.left;
     fromTop = fromRect.top - flightRect.top;
     toLeft = toRect.left - flightRect.left;
     toTop = toRect.top - flightRect.top;
+    targetX = toLeft - fromLeft;
+    targetY = toTop - fromTop;
 
     if (window.anime && window.anime.remove && layer.__stage2MoveState) {
       window.anime.remove(layer.__stage2MoveState);
     }
 
-    if (Math.abs(fromLeft - toLeft) < 0.5 && Math.abs(fromTop - toTop) < 0.5) {
+    if (
+      Math.abs(fromLeft - toLeft) < 0.5
+      && Math.abs(fromTop - toTop) < 0.5
+      && Math.abs(fromRect.width - toRect.width) < 0.5
+    ) {
       clearLayerFlightStyles(layer);
       layer.__stage2MoveState = null;
       requestPlacementContinuation();
@@ -2542,10 +3082,9 @@
     }
 
     state = {
-      left: fromLeft,
-      top: fromTop,
+      x: 0,
+      y: 0,
       width: fromRect.width,
-      height: fromRect.height,
       visualProgress: 0,
     };
     layer.__stage2MoveState = state;
@@ -2553,15 +3092,7 @@
     flightLayer.appendChild(layer);
     setLayerFlightVisuals(layer, 0);
     layer.classList.add('is-stage2-layer-in-flight');
-    layer.style.position = 'absolute';
-    layer.style.left = Math.round(fromLeft * 100) / 100 + 'px';
-    layer.style.top = Math.round(fromTop * 100) / 100 + 'px';
-    layer.style.width = Math.round(fromRect.width * 100) / 100 + 'px';
-    layer.style.height = Math.round(fromRect.height * 100) / 100 + 'px';
-    layer.style.marginTop = '0px';
-    layer.style.transform = 'translate3d(0, var(--stage2-flight-lift-y, 0px), 0) scale(var(--stage2-flight-scale, 1))';
-    layer.style.translate = 'none';
-    layer.style.willChange = 'left, top, width, height, transform, box-shadow';
+    applyLayerFlightBox(layer, fromLeft, fromTop, fromRect.width, fromRect.height);
 
     if (!window.anime || typeof window.anime.animate !== 'function' || !duration) {
       settleLayerInMoveTarget(layer, targetParent);
@@ -2573,20 +3104,17 @@
     }
 
     window.anime.animate(state, {
-      left: toLeft,
-      top: toTop,
+      x: targetX,
+      y: targetY,
       width: toRect.width,
-      height: fromRect.height,
       visualProgress: 1,
       duration: duration,
       delay: delay || 0,
       ease: ease,
       onUpdate: function () {
         if (layer.__stage2MoveState !== state) return;
-        layer.style.left = Math.round(state.left * 100) / 100 + 'px';
-        layer.style.top = Math.round(state.top * 100) / 100 + 'px';
-        layer.style.width = Math.round(state.width * 100) / 100 + 'px';
-        layer.style.height = Math.round(state.height * 100) / 100 + 'px';
+        setLayerFlightMotion(layer, state.x, state.y);
+        setLayerFlightSize(layer, state.width);
         setLayerFlightVisuals(layer, state.visualProgress);
       },
       onComplete: function () {
@@ -2648,17 +3176,13 @@
       hasActiveTransition = true;
 
       progress = placementProgressForLayer(i, phaseLocal);
-      eased = easeInOut(progress);
+      eased = placementTravelProgress(progress);
 
-      layer.style.left = Math.round(lerp(state.fromLeft, state.toLeft, eased) * 100) / 100 + 'px';
-      layer.style.top = Math.round(lerp(state.fromTop, state.toTop, eased) * 100) / 100 + 'px';
-      layer.style.width = Math.round(lerp(state.fromWidth, state.toWidth, eased) * 100) / 100 + 'px';
-      layer.style.height = Math.round(state.fromHeight * 100) / 100 + 'px';
-      setLayerFlightVisuals(layer, progress);
+      setLayerFlightFrame(layer, state, progress);
 
       if (typeof state.sourceIndex === 'number') {
         if (manualStageSeekActive) clearSourceMagazineMotion();
-        else applySourceMagazineMotion(state.sourceIndex, state.sourceStep, progress);
+        else applySourceMagazineMotion(state.sourceIndex, state.sourceStep, eased);
       }
 
       if (progress >= 1) {
@@ -2680,7 +3204,6 @@
         return;
       } else {
         placementMotionActive = true;
-        rebuildLayerAssignments();
         return;
       }
     }
@@ -2721,8 +3244,10 @@
         continue;
       }
 
-      flightRect = flightLayer.getBoundingClientRect();
-      settleLayerPlacementState(layer, tensorStack, null);
+      flightRect = flightLayerRectFor(flightLayer);
+      if (currentNode || layer.parentElement !== tensorStack) {
+        settleLayerPlacementState(layer, tensorStack, null);
+      }
       fromRect = layer.getBoundingClientRect();
       syncSourceLayerHeightFromRect(fromRect);
       sourceStep = sourceStepForLayer(i, fromRect);
@@ -2741,15 +3266,7 @@
 
       flightLayer.appendChild(layer);
       setLayerFlightVisuals(layer, progress);
-      layer.style.position = 'absolute';
-      layer.style.left = Math.round(fromLeft * 100) / 100 + 'px';
-      layer.style.top = Math.round(fromTop * 100) / 100 + 'px';
-      layer.style.width = Math.round(fromRect.width * 100) / 100 + 'px';
-      layer.style.height = Math.round(fromRect.height * 100) / 100 + 'px';
-      layer.style.marginTop = '0px';
-      layer.style.transform = 'translate3d(0, var(--stage2-flight-lift-y, 0px), 0) scale(var(--stage2-flight-scale, 1))';
-      layer.style.translate = 'none';
-      layer.style.willChange = 'left, top, width, height, transform, box-shadow';
+      applyLayerFlightBox(layer, fromLeft, fromTop, fromRect.width, fromRect.height);
       layer.classList.add('is-stage2-layer-in-flight');
 
       layer.__stage2PlacementData = {
@@ -2768,14 +3285,10 @@
         reservation: reservation,
       };
 
-      eased = easeInOut(progress);
-      layer.style.left = Math.round(lerp(fromLeft, toLeft, eased) * 100) / 100 + 'px';
-      layer.style.top = Math.round(lerp(fromTop, toTop, eased) * 100) / 100 + 'px';
-      layer.style.width = Math.round(lerp(fromRect.width, toWidth, eased) * 100) / 100 + 'px';
-      layer.style.height = Math.round(fromRect.height * 100) / 100 + 'px';
-      setLayerFlightVisuals(layer, progress);
+      eased = placementTravelProgress(progress);
+      setLayerFlightFrame(layer, layer.__stage2PlacementData, progress);
       if (manualStageSeekActive) clearSourceMagazineMotion();
-      else applySourceMagazineMotion(i, sourceStep, progress);
+      else applySourceMagazineMotion(i, sourceStep, eased);
 
       hasActiveTransition = true;
       cancelLayoutClearTimers();
@@ -2846,7 +3359,7 @@
       },
     }, 0);
 
-    if (window.anime.onScroll) {
+    if (USE_ANIME_SCROLL_OBSERVER && window.anime.onScroll) {
       try {
         scrollObserver = window.anime.onScroll({
           target: section,
@@ -2956,7 +3469,7 @@
     }
 
     function setScrubberFromClientX(clientX, immediate) {
-      if (!track) return;
+      if (!track || !scrubberDebugVisible) return;
       scheduleScrubberProgress(progressFromClientX(clientX), immediate);
     }
 
@@ -2970,12 +3483,14 @@
 
     if (scrubInput) {
       scrubInput.addEventListener('input', function () {
+        if (!scrubberDebugVisible) return;
         scheduleScrubberProgress(Number(scrubInput.value) / 1000, false);
       });
     }
 
     if (scrubber && window.PointerEvent) {
       scrubber.addEventListener('pointerdown', function (event) {
+        if (!scrubberDebugVisible) return;
         if (event.button !== undefined && event.button !== 0) return;
 
         isScrubbing = true;
@@ -3076,9 +3591,16 @@
   }
 
   function lockCompletedStageAtAnchor(target) {
+    var previousImmediateAperture = apertureVisualImmediateSeek;
+
     scrollToAnchorTarget(target);
     beginManualStageSeekOverride();
-    applyProgress(1);
+    apertureVisualImmediateSeek = true;
+    try {
+      applyProgress(1);
+    } finally {
+      apertureVisualImmediateSeek = previousImmediateAperture;
+    }
   }
 
   function initLearnMore() {
@@ -3129,9 +3651,20 @@
       scrubToPhaseTwo: function () {
         scrubToStageProgress(LEARN_MORE_TARGET_PROGRESS);
       },
+      setDebugView: function (enabled) {
+        setScrubberDebugView(Boolean(enabled), true);
+        return scrubberDebugView;
+      },
+      setTimelineScrubber: function (enabled) {
+        if (enabled && !scrubberDebugView) setScrubberDebugView(true, true);
+        setScrubberDebugVisible(Boolean(enabled), true);
+        return scrubberDebugVisible;
+      },
       debug: function () {
         return {
           hasLayout: Boolean(stage2Layout),
+          debugView: scrubberDebugView,
+          timelineScrubber: scrubberDebugVisible,
           assignments: Object.assign({}, layerAssignments),
           placedCount: modelLayers.filter(function (layer) {
             return Boolean(layer.getAttribute('data-stage2-assigned-node'));
@@ -3150,6 +3683,11 @@
     heroViz = section.querySelector('.hero-viz');
     heroTitle = section.querySelector('.hero-title-loop');
     heroFooter = section.querySelector('.hero-footer');
+    modelBlock = section.querySelector('.stage2-model-block');
+    phaseTitleSplit = section.querySelector('.stage2-phase-title--split');
+    phaseTitleNodes = section.querySelector('.stage2-phase-title--nodes');
+    phaseTitlePlace = section.querySelector('.stage2-phase-title--place');
+    finalHook = section.querySelector('.stage2-final-hook');
     finalHookLines = Array.prototype.slice.call(section.querySelectorAll('[data-stage2-final-line]'));
     serverPlate = section.querySelector('.hero-viz [data-node-id="server"] .node-plate');
     tensorStack = section.querySelector('[data-stage2-tensor-stack]');
@@ -3158,6 +3696,15 @@
     phaseName = section.querySelector('.stage2-phase-name');
     phaseIndex = section.querySelector('.stage2-phase-index');
     phasePanels = Array.prototype.slice.call(section.querySelectorAll('.stage2-phase-panel'));
+    nodeSlotsById = {};
+    nodeColorsById = {};
+    meshNodes.forEach(function (node) {
+      var nodeId = node.getAttribute('data-stage2-node');
+
+      if (!nodeId) return;
+      nodeSlotsById[nodeId] = section.querySelector('[data-stage2-node-slots="' + nodeId + '"]');
+      nodeColorsById[nodeId] = (node.style.getPropertyValue('--stage2-node-color') || '').trim();
+    });
 
     if (!reduceMotion && typeof window.anime === 'undefined') {
       window.requestAnimationFrame(init);
@@ -3171,6 +3718,7 @@
     initFinalHookWords();
     renderStage2NodeIcons();
     initScrubber();
+    initScrubberDebugControls();
     initLayerInteractions();
     initLearnMore();
     exposeStage2DebugControls();
@@ -3187,7 +3735,7 @@
       setVar('--stage2-lock-route-progress', 1);
       setVar('--stage2-lock-node-progress', 1);
       applyReducedStaticPlacement();
-      syncScrubberAccessibility(0);
+      setScrubberDebugVisible(false, false);
       document.body.classList.remove('is-stage2-active');
       section.classList.add('is-stage2-reduced-summary');
       section.classList.remove('is-stage2-title-cleared', 'is-stage2-footer-cleared');

--- a/website/src/assets/model-slicing.js
+++ b/website/src/assets/model-slicing.js
@@ -90,6 +90,7 @@
   var titleSnapRaf = null;
   var titleScrollProgress = 0;
   var titleFadeProgress = 0;
+  var currentStageProgress = 0;
   var heroVizStableRequested = false;
   var heroSvgMotionActive = null;
   var heroSvgMotionResumeTimer = null;
@@ -108,8 +109,8 @@
     raf: null,
   };
   var STAGE_INTRO_PROGRESS = 0.04;
-  // Leaves the final slice of the stage as a settled hold after the aperture closes.
-  var STAGE_ANIMATION_END_PROGRESS = 0.86;
+  // Leaves a short settled hold after the aperture closes without making the hero feel stuck.
+  var STAGE_ANIMATION_END_PROGRESS = 0.92;
   var APERTURE_OPEN_START = 0.190;
   var APERTURE_OPEN_END = 0.310;
   var APERTURE_CLOSE_START = 1.075;
@@ -442,6 +443,19 @@
     section.style.removeProperty(name);
   }
 
+  function setInlineStyle(element, property, value) {
+    var nextValue;
+
+    if (!element) return;
+
+    nextValue = value == null ? '' : String(value);
+    element.__stage2InlineStyleCache = element.__stage2InlineStyleCache || {};
+    if (element.__stage2InlineStyleCache[property] === nextValue) return;
+
+    element.__stage2InlineStyleCache[property] = nextValue;
+    element.style[property] = nextValue;
+  }
+
   function apertureVisualStep(deltaMs, durationMs) {
     if (durationMs <= 0) return 1;
     return 1 - Math.exp(-Math.max(0, deltaMs) / durationMs);
@@ -621,7 +635,7 @@
           var nextStageProgress;
 
           heroSvgMotionResumeTimer = null;
-          nextStageProgress = stageProgressFromScrollProgress(latestScrollProgress);
+          nextStageProgress = stageProgressFromScrollProgress(progressFromScroll());
           if (canRunHeroSvgMotion(nextStageProgress)) {
             setHeroSvgMotionActive(true, nextStageProgress);
           }
@@ -676,7 +690,7 @@
     if (!heroTitle) return;
     var y = Math.round(titleSnapY() * titleSnapState.progress);
     var shrink = lerp(1, 0.965, animeEase('outSine', easeOut)(titleFadeProgress));
-    heroTitle.style.transform = 'translateY(' + y + 'px) scale(' + Math.round(shrink * 10000) / 10000 + ')';
+    setInlineStyle(heroTitle, 'transform', 'translateY(' + y + 'px) scale(' + Math.round(shrink * 10000) / 10000 + ')');
     applyHeroVizTransform(currentMeshGeometryScale || 1, false);
   }
 
@@ -851,7 +865,7 @@
     titleFadeProgress = easeOut(titleOut);
     section.classList.toggle('is-stage2-title-cleared', titleFadeProgress > 0.985);
     syncTitleSnap(titleProgress);
-    heroTitle.style.opacity = String(Math.round((1 - titleFadeProgress) * 10000) / 10000);
+    setInlineStyle(heroTitle, 'opacity', String(Math.round((1 - titleFadeProgress) * 10000) / 10000));
     applyTitleSnapTransform();
   }
 
@@ -1714,17 +1728,17 @@
     section.classList.toggle('is-stage2-footer-cleared', footerOut > 0.985);
 
     if (nav) {
-      nav.style.opacity = String(1 - navHidden);
-      nav.style.transform = 'translateY(' + Math.round(-88 * navHidden) + 'px)';
-      nav.style.pointerEvents = navHidden > 0.92 ? 'none' : '';
+      setInlineStyle(nav, 'opacity', String(Math.round((1 - navHidden) * 10000) / 10000));
+      setInlineStyle(nav, 'transform', 'translateY(' + Math.round(-88 * navHidden) + 'px)');
+      setInlineStyle(nav, 'pointerEvents', navHidden > 0.92 ? 'none' : '');
     }
 
     syncTitleFromProgress(progress, stageProgress);
 
     if (heroFooter) {
-      heroFooter.style.opacity = String(1 - footerOut);
-      heroFooter.style.transform = 'translateY(' + Math.round(168 * easeOut(footerOut)) + 'px)';
-      heroFooter.style.pointerEvents = footerOut > 0.8 ? 'none' : '';
+      setInlineStyle(heroFooter, 'opacity', String(Math.round((1 - footerOut) * 10000) / 10000));
+      setInlineStyle(heroFooter, 'transform', 'translateY(' + Math.round(168 * easeOut(footerOut)) + 'px)');
+      setInlineStyle(heroFooter, 'pointerEvents', footerOut > 0.8 ? 'none' : '');
     }
   }
 
@@ -1780,9 +1794,8 @@
     modelDetailProgress = easeOut(ramp(stageProgress, MODEL_DETAIL_REVEAL_START, MODEL_DETAIL_REVEAL_END));
 
     setStage2TitleProgress(stageProgress);
-    setVar('--stage2-p', stageProgress);
-    setVar('--stage2-pct', Math.round((stageProgress / SCRUBBER_END) * 10000) / 100 + '%');
-    setVar('--stage2-scrubber-pct', Math.round(scrubberProgressFromProgress(stageProgress) * 10000) / 100 + '%');
+    currentStageProgress = stageProgress;
+    if (scrubberDebugVisible) setVar('--stage2-scrubber-pct', Math.round(scrubberProgressFromProgress(stageProgress) * 10000) / 100 + '%');
     setVar('--stage2-light-opacity', light);
     setVar('--stage2-workbench-opacity', workbench);
     setVar('--stage2-aperture-detail-fade', closeDetailFade);
@@ -1994,7 +2007,7 @@
     token = scrubScrollToken;
 
     from = window.scrollY;
-    fromStage = Number.parseFloat(section.style.getPropertyValue('--stage2-p')) || stageProgressFromScrollProgress(progressFromScroll());
+    fromStage = currentStageProgress || stageProgressFromScrollProgress(progressFromScroll());
     to = scrollTopForStageProgress(progress);
     distance = Math.abs(to - from);
     referenceDistance = options && options.referenceDistance ? Math.max(1, Math.abs(options.referenceDistance)) : 0;
@@ -2508,6 +2521,8 @@
       isScrubbing = false;
       scrubberPointerId = null;
       if (scrubber) scrubber.classList.remove('is-scrubbing');
+    } else {
+      setVar('--stage2-scrubber-pct', Math.round(scrubberProgressFromProgress(currentStageProgress) * 10000) / 100 + '%');
     }
     syncScrubberAccessibility();
   }
@@ -2815,7 +2830,7 @@
     if (raf) return;
     raf = window.requestAnimationFrame(function () {
       raf = null;
-      stageProgress = readSectionNumber('--stage2-p', stageProgressFromScrollProgress(latestScrollProgress));
+      stageProgress = currentStageProgress || stageProgressFromScrollProgress(latestScrollProgress);
       applyProgress(scrollProgressFromStageProgress(stageProgress));
     });
   }
@@ -3740,18 +3755,18 @@
       section.classList.add('is-stage2-reduced-summary');
       section.classList.remove('is-stage2-title-cleared', 'is-stage2-footer-cleared');
       if (nav) {
-        nav.style.opacity = '';
-        nav.style.transform = '';
-        nav.style.pointerEvents = '';
+        setInlineStyle(nav, 'opacity', '');
+        setInlineStyle(nav, 'transform', '');
+        setInlineStyle(nav, 'pointerEvents', '');
       }
       if (heroTitle) {
-        heroTitle.style.opacity = '';
-        heroTitle.style.transform = '';
+        setInlineStyle(heroTitle, 'opacity', '');
+        setInlineStyle(heroTitle, 'transform', '');
       }
       if (heroFooter) {
-        heroFooter.style.opacity = '';
-        heroFooter.style.transform = '';
-        heroFooter.style.pointerEvents = '';
+        setInlineStyle(heroFooter, 'opacity', '');
+        setInlineStyle(heroFooter, 'transform', '');
+        setInlineStyle(heroFooter, 'pointerEvents', '');
       }
       return;
     }

--- a/website/src/assets/plugin-architecture.js
+++ b/website/src/assets/plugin-architecture.js
@@ -9,6 +9,7 @@
   var IN_VIEW_DELAY = 650;
   var DRAW_DELAY = 520;
   var DRAW_DURATION = 820;
+  var MOTION_ACTIVE_CLASS = "is-motion-active";
 
   var desktopMedia = window.matchMedia(DESKTOP_QUERY);
   var reduceMotion = window.matchMedia(REDUCE_QUERY);
@@ -71,8 +72,12 @@
   }
 
   function clearDiagram(diagram) {
+    if (diagram.__pluginArchitectureTimeline && typeof diagram.__pluginArchitectureTimeline.pause === "function") {
+      diagram.__pluginArchitectureTimeline.pause();
+    }
+    diagram.__pluginArchitectureTimeline = null;
     getAllSvgs(diagram).forEach(clearSvg);
-    diagram.classList.remove("is-clicked");
+    diagram.classList.remove("is-clicked", MOTION_ACTIVE_CLASS);
     delete diagram.dataset.pluginArchitectureState;
   }
 
@@ -232,9 +237,42 @@
 
     timeline.call(function () {
       diagram.dataset.pluginArchitectureState = "complete";
+      diagram.__pluginArchitectureTimeline = null;
+      if (diagram.__pluginArchitectureObserver) {
+        diagram.__pluginArchitectureObserver.disconnect();
+        diagram.__pluginArchitectureObserver = null;
+      }
     }, drawAt + DRAW_DURATION + 340);
 
     return timeline;
+  }
+
+  function pauseTimeline(timeline) {
+    if (timeline && typeof timeline.pause === "function") timeline.pause();
+  }
+
+  function resumeTimeline(timeline) {
+    if (timeline && typeof timeline.resume === "function") {
+      timeline.resume();
+    } else if (timeline && typeof timeline.play === "function") {
+      timeline.play();
+    }
+  }
+
+  function pauseDiagram(diagram) {
+    if (diagram.dataset.pluginArchitectureState !== "running") return;
+
+    pauseTimeline(diagram.__pluginArchitectureTimeline);
+    diagram.classList.remove(MOTION_ACTIVE_CLASS);
+    diagram.dataset.pluginArchitectureState = "paused";
+  }
+
+  function resumeDiagram(diagram) {
+    if (diagram.dataset.pluginArchitectureState !== "paused") return;
+
+    diagram.dataset.pluginArchitectureState = "running";
+    diagram.classList.add(MOTION_ACTIVE_CLASS);
+    resumeTimeline(diagram.__pluginArchitectureTimeline);
   }
 
   function animateDiagram(diagram) {
@@ -259,6 +297,8 @@
     }
 
     diagram.dataset.pluginArchitectureState = "running";
+    diagram.__pluginArchitectureTimeline = timeline;
+    diagram.classList.add(MOTION_ACTIVE_CLASS);
     timeline.play();
   }
 
@@ -276,8 +316,11 @@
         if (!entry.isIntersecting) {
           window.clearTimeout(startTimer);
           startTimer = null;
+          pauseDiagram(diagram);
           return;
         }
+
+        resumeDiagram(diagram);
 
         if (startTimer || diagram.dataset.pluginArchitectureState === "running" || diagram.classList.contains("is-clicked")) {
           return;
@@ -285,12 +328,12 @@
 
         startTimer = window.setTimeout(function () {
           startTimer = null;
-          observer.disconnect();
           animateDiagram(diagram);
         }, IN_VIEW_DELAY);
       });
     }, { threshold: 0.38 });
 
+    diagram.__pluginArchitectureObserver = observer;
     observer.observe(diagram);
   }
 
@@ -300,7 +343,7 @@
       toArray(document.querySelectorAll(DIAGRAM_SELECTOR)).forEach(function (diagram) {
         if (diagram.classList.contains("is-clicked")) {
           setSeated(diagram);
-        } else if (diagram.dataset.pluginArchitectureState !== "running") {
+        } else if (diagram.dataset.pluginArchitectureState !== "running" && diagram.dataset.pluginArchitectureState !== "paused") {
           clearDiagram(diagram);
         }
       });

--- a/website/src/assets/plugin-architecture.js
+++ b/website/src/assets/plugin-architecture.js
@@ -242,6 +242,7 @@
         diagram.__pluginArchitectureObserver.disconnect();
         diagram.__pluginArchitectureObserver = null;
       }
+      diagram.classList.remove(MOTION_ACTIVE_CLASS);
     }, drawAt + DRAW_DURATION + 340);
 
     return timeline;

--- a/website/src/assets/site.css
+++ b/website/src/assets/site.css
@@ -1180,7 +1180,7 @@ body:not(.docs-body)::after {
   z-index: 60;
   height: env(safe-area-inset-bottom);
   pointer-events: none;
-  background: #08090b;
+  background: var(--background);
 }
 .js body.home-intro {
   --page-atmosphere-opacity: 0;

--- a/website/src/assets/site.css
+++ b/website/src/assets/site.css
@@ -60,7 +60,11 @@
 }
 
 * { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+html {
+  min-height: 100%;
+  scroll-behavior: smooth;
+  background: var(--background);
+}
 body {
   margin: 0;
   overflow-x: hidden;
@@ -381,6 +385,14 @@ td strong { color: var(--text); }
 .catalog .table-card td {
   overflow: hidden;
   padding: 12px 10px;
+}
+.catalog .table-card th.col-size,
+.catalog .table-card .size-cell {
+  text-align: center;
+}
+.catalog .table-card .size-cell .badge {
+  justify-content: center;
+  margin-top: 6px;
 }
 .catalog .table-card .links-cell { text-align: right; }
 .catalog .table-card td:nth-child(5),
@@ -787,10 +799,13 @@ td strong { color: var(--text); }
   .doc pre { margin-left: -2px; margin-right: -2px; padding: 14px; font-size: 12px; }
   .doc .code-copy-frame { margin-left: -2px; margin-right: -2px; }
   .doc .code-copy-frame pre { margin-left: 0; margin-right: 0; padding-right: 72px; }
+  .catalog .table-card .col-ref { display: none; }
+  .catalog .table-card .col-model { width: 68%; }
+  .catalog .table-card .col-size { width: 32%; }
   table { min-width: 760px; }
 }
 
-@media (max-width: 374px) {
+@media (max-width: 399px) {
   .catalog .table-card {
     display: grid;
     gap: 12px;
@@ -854,6 +869,7 @@ td strong { color: var(--text); }
   .catalog .table-card td,
   .catalog .table-card td.col-run,
   .catalog .table-card td.col-package,
+  .catalog .table-card td.col-ref,
   .catalog .table-card td.col-links {
     display: block;
     width: auto;
@@ -903,6 +919,7 @@ td strong { color: var(--text); }
     font-family: var(--mono);
     font-size: 11px;
     letter-spacing: 0.02em;
+    text-align: left;
     white-space: nowrap;
   }
 
@@ -927,6 +944,7 @@ td strong { color: var(--text); }
 
   .catalog .table-card .size-cell .badge {
     min-height: 20px;
+    margin-top: 0;
     padding-inline: 6px;
     border-radius: 5px;
     font-family: var(--mono);
@@ -1115,8 +1133,13 @@ td strong { color: var(--text); }
   --radius-xl:    20px;
 }
 *, *::before, *::after { box-sizing: border-box; }
-html { scroll-behavior: smooth; }
+html {
+  min-height: 100%;
+  scroll-behavior: smooth;
+  background: var(--bg);
+}
 body {
+  min-height: 100%;
   margin: 0;
   overflow-x: hidden;
   background: var(--bg);
@@ -1146,6 +1169,18 @@ body::before {
   opacity: var(--page-atmosphere-opacity, 1);
   transition: opacity 0.8s cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 0;
+}
+
+body:not(.docs-body)::after {
+  content: "";
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 60;
+  height: env(safe-area-inset-bottom);
+  pointer-events: none;
+  background: #08090b;
 }
 .js body.home-intro {
   --page-atmosphere-opacity: 0;
@@ -1186,6 +1221,13 @@ nav.top {
     opacity 420ms cubic-bezier(0.22, 1, 0.36, 1),
     transform 420ms cubic-bezier(0.22, 1, 0.36, 1);
   will-change: opacity, transform;
+}
+
+body.is-stage2-active:not(.is-stage2-complete) nav.top {
+  opacity: 0 !important;
+  pointer-events: none !important;
+  transform: translateY(-100%) !important;
+  border-bottom: 0 !important;
 }
 .js body.home-intro nav.top,
 .js body.home-intro .hero-footer {
@@ -2244,6 +2286,9 @@ h2.title .title-line {
   stroke-linejoin: round;
   stroke-dasharray: 7 9;
   vector-effect: non-scaling-stroke;
+  animation: none;
+}
+.topology.is-motion-active .topology-map.is-active .topology-edge {
   animation: topology-dash 18s linear infinite;
 }
 .topology-edge--active {
@@ -2333,6 +2378,9 @@ h2.title .title-line {
   background: linear-gradient(180deg, rgba(15,25,40,0.98), rgba(7,10,15,0.98));
   box-shadow: 0 0 0 0 rgba(96,165,250,0.1), 0 0 18px rgba(59,130,246,0.12);
   text-align: center;
+  animation: none;
+}
+.topology.is-motion-active .topology-map.is-active .mesh-core {
   animation: topology-core-breathe 4.8s ease-in-out infinite;
 }
 .mesh-core > span {
@@ -2631,6 +2679,9 @@ h2.title .title-line {
   .topology-map--split .topology-edge--return {
     stroke: rgba(34,197,94,0.5);
     stroke-dasharray: 4 10;
+    animation: none;
+  }
+  .topology.is-motion-active .topology-map--split.is-active .topology-edge--return {
     animation: topology-return-flow 5.6s linear infinite;
   }
   .topology-map--split .split-client,
@@ -3327,6 +3378,9 @@ h2.title .title-line {
     stroke: rgba(34,197,94,0.62);
     stroke-dasharray: 4 9;
     stroke-linejoin: round;
+    animation: none;
+  }
+  .topology.is-motion-active .topology-map--split.is-active .topology-edge--mobile-return {
     animation: topology-return-flow 4.8s linear infinite;
   }
   .topology .mesh-node,
@@ -5383,16 +5437,18 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   border-radius: calc(10px - (var(--stage2-lock-card-progress, 0) * 2px));
   background: transparent;
   color: #18181b;
-  opacity: calc(var(--stage2-model-opacity, 0) * (1 - var(--stage2-collapse-progress, 0)));
+  opacity: max(0.001, calc(var(--stage2-model-opacity, 0) * (1 - var(--stage2-collapse-progress, 0))));
   transform:
+    translateZ(0)
     translate(-50%, -50%)
     translateY(calc(var(--stage2-model-y, 22px) + var(--stage2-title-model-offset, 0px) + (var(--stage2-model-shrink-progress, 0) * 210px)))
     scale(var(--stage2-model-scale, 1))
     scale(calc(1 - (var(--stage2-collapse-progress, 0) * 0.08)));
   transform-origin: center;
   filter: blur(var(--stage2-model-blur, 7px));
-  contain: layout;
-  will-change: transform, opacity, filter;
+  backface-visibility: hidden;
+  contain: layout paint;
+  will-change: transform, opacity;
 }
 
 .stage2-model-shell {
@@ -5406,16 +5462,12 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   padding: clamp(14px, calc(2vw + (var(--stage2-lock-card-progress, 0) * 12px)), 34px);
   overflow: hidden;
   border-radius: inherit;
-  background:
-    linear-gradient(135deg, rgba(34,197,94,calc(var(--stage2-lock-card-progress, 0) * 0.13)), rgba(34,197,94,0) calc(38% + (var(--stage2-lock-card-progress, 0) * 12%))),
-    linear-gradient(90deg, rgba(59,130,246,calc(var(--stage2-lock-route-progress, 0) * 0.055)), rgba(59,130,246,0) 38%),
-    linear-gradient(180deg, rgba(255,255,255,1), rgba(247,248,251,0.98));
-  box-shadow:
-    0 calc(12px - (var(--stage2-lock-card-progress, 0) * 2px)) 0 rgba(9,9,11,0.1),
-    0 0 0 1px rgba(39,39,42,calc(0.16 - (var(--stage2-lock-card-progress, 0) * 0.03)));
-  opacity: calc(1 - (var(--stage2-collapse-progress, 0) * 0.72));
+  background: transparent;
+  box-shadow: none;
+  opacity: 1;
   transform: scale(calc(1 - (var(--stage2-placement-progress, 0) * 0.018)));
   transform-origin: center;
+  backface-visibility: hidden;
 }
 
 .stage2-model-lock {
@@ -5614,9 +5666,35 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   content: "";
   position: absolute;
   inset: 0;
+  z-index: 0;
   border-radius: inherit;
-  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.88), inset 0 -1px 0 rgba(39,39,42,0.08);
+  background:
+    linear-gradient(135deg, rgba(34,197,94,calc(var(--stage2-lock-card-progress, 0) * 0.13)), rgba(34,197,94,0) calc(38% + (var(--stage2-lock-card-progress, 0) * 12%))),
+    linear-gradient(90deg, rgba(59,130,246,calc(var(--stage2-lock-route-progress, 0) * 0.055)), rgba(59,130,246,0) 38%),
+    linear-gradient(180deg, rgba(255,255,255,1), rgba(247,248,251,0.98));
+  box-shadow:
+    0 calc(12px - (var(--stage2-lock-card-progress, 0) * 2px)) 0 rgba(9,9,11,0.1),
+    0 0 0 1px rgba(39,39,42,calc(0.16 - (var(--stage2-lock-card-progress, 0) * 0.03))),
+    inset 0 0 0 1px rgba(255,255,255,0.88),
+    inset 0 -1px 0 rgba(39,39,42,0.08);
+  opacity: max(
+    var(--stage2-lock-card-progress, 0),
+    calc(
+      var(--stage2-model-detail-opacity, 1)
+      * (1 - (var(--stage2-collapse-progress, 0) * 0.72))
+    )
+  );
   pointer-events: none;
+}
+
+section.hero.stage2-scroll[data-stage2-phase="phase-1"] .stage2-model-shell::before {
+  background: rgba(255,255,255,0.94);
+  box-shadow: 0 0 0 1px rgba(39,39,42,0.12);
+}
+
+section.hero.stage2-scroll[data-stage2-phase="phase-1"] .stage2-model-header,
+section.hero.stage2-scroll[data-stage2-phase="phase-1"] .stage2-model-metrics {
+  opacity: 1;
 }
 
 .stage2-model-header,
@@ -5633,7 +5711,7 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   gap: 16px;
   max-height: max(0px, calc((1 - (var(--stage2-model-shrink-progress, 0) * 2.2)) * 68px));
   overflow: hidden;
-  opacity: max(0, calc((1 - (var(--stage2-model-shrink-progress, 0) * 2.6)) * (1 - (var(--stage2-placement-progress, 0) * 0.78))));
+  opacity: calc(var(--stage2-model-detail-opacity, 1) * max(0, calc((1 - (var(--stage2-model-shrink-progress, 0) * 2.6)) * (1 - (var(--stage2-placement-progress, 0) * 0.78)))));
 }
 
 .stage2-model-header strong {
@@ -5687,7 +5765,7 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   margin: 0;
   max-height: max(0px, calc((1 - (var(--stage2-model-shrink-progress, 0) * 2.2)) * 54px));
   overflow: hidden;
-  opacity: max(0, calc((1 - (var(--stage2-model-shrink-progress, 0) * 2.6)) * (1 - (var(--stage2-placement-progress, 0) * 0.86))));
+  opacity: calc(var(--stage2-model-detail-opacity, 1) * max(0, calc((1 - (var(--stage2-model-shrink-progress, 0) * 2.6)) * (1 - (var(--stage2-placement-progress, 0) * 0.86)))));
 }
 
 .stage2-model-metrics div {
@@ -5737,18 +5815,24 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
 }
 
 .stage2-model-layer.is-stage2-layer-in-flight {
-  grid-template-columns: 8px minmax(22px, 0.18fr) minmax(0, 1fr);
+  --stage2-layer-extract-progress: 0;
+  --stage2-layer-highlight-progress: 0;
+  grid-template-columns: 12px minmax(30px, 0.26fr) minmax(0, 1fr) minmax(38px, 0.36fr);
+  background:
+    linear-gradient(90deg, rgba(34,197,94,calc(var(--stage2-layer-highlight-progress, 0) * 0.18)), rgba(255,255,255,0) 32%),
+    color-mix(in srgb, var(--stage2-active-layer-color, var(--stage2-layer-node-color, #3b82f6)) calc(var(--stage2-layer-highlight-progress, 0) * 12%), #ffffff);
   opacity: 1;
   pointer-events: none;
   z-index: 10;
+  transform-origin: 0 0;
+  backface-visibility: hidden;
+  will-change: transform;
   box-shadow:
-    inset 0 0 0 1px rgba(59,130,246,0.34),
-    0 var(--stage2-flight-shadow-y, 24px) var(--stage2-flight-shadow-blur, 30px) var(--stage2-flight-shadow-spread, -5px) rgba(9,9,11,var(--stage2-flight-shadow-alpha, 0.24)),
-    0 calc(var(--stage2-flight-shadow-y, 24px) * 0.34) calc(var(--stage2-flight-shadow-blur, 30px) * 0.34) rgba(59,130,246,0.12);
+    inset 0 0 0 1px color-mix(in srgb, var(--stage2-active-layer-color, var(--stage2-layer-node-color, #3b82f6)) calc(var(--stage2-layer-highlight-progress, 0) * 44%), rgba(39,39,42,0.14)),
+    0 0 calc(var(--stage2-layer-highlight-progress, 0) * 18px) color-mix(in srgb, var(--stage2-active-layer-color, var(--stage2-layer-node-color, #3b82f6)) 28%, transparent);
   transition: none;
 }
 
-.stage2-model-layer.is-stage2-layer-in-flight .stage2-layer-param,
 .stage2-model-layer[data-stage2-assigned-node] .stage2-layer-param {
   display: none;
 }
@@ -5765,6 +5849,9 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   --stage2-layer-cut-energy: 0;
   --stage2-layer-cut-front: 0;
   --stage2-layer-cut-residue: 0;
+  --stage2-layer-cutter-opacity: 0;
+  --stage2-layer-cutter-left: 0;
+  --stage2-layer-cutter-right: 1;
   --stage2-layer-cut-shear: 0px;
   --stage2-layer-cut-skew: 0deg;
   appearance: none;
@@ -5791,7 +5878,7 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
     inset 0 0 0 calc(var(--stage2-layer-cut-energy, 0) * 0.7px) rgba(59,130,246,0.2),
     0 0 calc(var(--stage2-layer-cut-energy, 0) * 10px) rgba(59,130,246,0.1);
   cursor: default;
-  opacity: calc(1 - (var(--stage2-placement-progress, 0) * 0.46));
+  opacity: 1;
   transform:
     translateX(var(--stage2-layer-cut-shear, 0px))
     skewX(var(--stage2-layer-cut-skew, 0deg))
@@ -5824,18 +5911,22 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
 }
 
 .stage2-model-layer::after {
-  inset: 1px;
-  border-radius: inherit;
+  left: clamp(6px, 1.05vw, 10px);
+  right: clamp(6px, 1.05vw, 10px);
+  top: auto;
+  bottom: 0;
+  height: 3px;
+  border-radius: 999px;
   background:
-    linear-gradient(90deg, rgba(59,130,246,0.08), rgba(255,255,255,0) 12%),
-    linear-gradient(180deg, rgba(59,130,246,0.1), rgba(255,255,255,0) 18%, rgba(255,255,255,0) 82%, rgba(59,130,246,0.06));
+    linear-gradient(90deg, rgba(59,130,246,0), rgba(37,99,235,0.95) 16%, rgba(255,255,255,1) 48%, rgba(147,197,253,1) 55%, rgba(34,197,94,0.72) 68%, rgba(37,99,235,0.9) 86%, rgba(59,130,246,0));
   box-shadow:
-    inset 0 0 0 calc(var(--stage2-layer-cut-energy, 0) * 0.7px) rgba(59,130,246,0.18),
-    inset 0 1px 0 rgba(59,130,246,calc(var(--stage2-layer-cut-energy, 0) * 0.2)),
-    inset 0 -1px 0 rgba(34,197,94,calc(var(--stage2-layer-cut-residue, 0) * 0.08));
-  opacity: calc((var(--stage2-layer-cut-energy, 0) * 0.24) + (var(--stage2-layer-cut-residue, 0) * 0.06));
-  transform: none;
-  transform-origin: center;
+    0 0 0 1px rgba(37,99,235,0.34),
+    0 0 calc(12px + (var(--stage2-layer-cut-energy, 0) * 18px)) rgba(37,99,235,0.58),
+    0 0 calc(6px + (var(--stage2-layer-cut-energy, 0) * 22px)) rgba(34,197,94,0.24);
+  clip-path: inset(0 calc((1 - var(--stage2-layer-cutter-right, 1)) * 100%) 0 calc(var(--stage2-layer-cutter-left, 0) * 100%));
+  opacity: calc(var(--stage2-layer-cutter-opacity, 0) * (0.44 + (var(--stage2-layer-cut-energy, 0) * 0.56)));
+  transform: translateY(50%);
+  transform-origin: left center;
 }
 
 .stage2-layer-handle,
@@ -5865,6 +5956,7 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
 .stage2-model-layer:nth-child(10) { border-bottom-left-radius: 6px; border-bottom-right-radius: 6px; }
 
 .stage2-slice-cutter {
+  display: none;
   position: absolute;
   left: 10px;
   right: 10px;
@@ -5900,7 +5992,6 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   height: calc(16px + (var(--stage2-cutter-energy, 0) * 14px));
   background: linear-gradient(90deg, rgba(37,99,235,0), rgba(37,99,235,0.28) 36%, rgba(34,197,94,0.2) 55%, rgba(37,99,235,0));
   opacity: calc(0.58 + (var(--stage2-cutter-energy, 0) * 0.32));
-  filter: blur(6px);
   transform: translateY(-50%);
 }
 
@@ -5950,17 +6041,30 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
 }
 
 .stage2-model-layer[data-stage2-assigned-node].is-stage2-layer-in-flight {
-  background: color-mix(in srgb, var(--stage2-active-layer-color) 10%, #ffffff);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--stage2-active-layer-color) calc(var(--stage2-layer-highlight-progress, 0) * 18%), transparent), transparent 34%),
+    color-mix(in srgb, var(--stage2-active-layer-color) calc(var(--stage2-layer-highlight-progress, 0) * 10%), #ffffff);
   box-shadow:
-    inset 0 0 0 1px color-mix(in srgb, var(--stage2-active-layer-color) 34%, rgba(59,130,246,0.18)),
-    0 var(--stage2-flight-shadow-y, 24px) var(--stage2-flight-shadow-blur, 30px) var(--stage2-flight-shadow-spread, -5px) rgba(9,9,11,var(--stage2-flight-shadow-alpha, 0.24)),
-    0 calc(var(--stage2-flight-shadow-y, 24px) * 0.34) calc(var(--stage2-flight-shadow-blur, 30px) * 0.34) color-mix(in srgb, var(--stage2-active-layer-color) 16%, transparent);
-  opacity: calc(var(--stage2-node-content-opacity, 0) * var(--stage2-layer-placed-opacity, 1));
+    inset 0 0 0 1px color-mix(in srgb, var(--stage2-active-layer-color) calc(var(--stage2-layer-highlight-progress, 0) * 46%), rgba(39,39,42,0.14)),
+    0 0 calc(var(--stage2-layer-highlight-progress, 0) * 18px) color-mix(in srgb, var(--stage2-active-layer-color) 28%, transparent);
+  opacity: 1;
 }
 
 .stage2-model-layer[data-stage2-layer-state="source"] .stage2-layer-bars,
 .stage2-model-layer[data-stage2-layer-state="source"] .stage2-layer-param {
   opacity: calc(1 - (var(--stage2-layer-compact-progress, 0) * 0.78));
+}
+
+.stage2-model-layer.is-stage2-layer-in-flight .stage2-layer-bars {
+  opacity: calc((1 - (var(--stage2-layer-compact-progress, 0) * 0.78)) + (var(--stage2-layer-extract-progress, 0) * 0.18));
+  transform: scaleX(calc(1 - (var(--stage2-layer-extract-progress, 0) * 0.08)));
+  transform-origin: left center;
+}
+
+.stage2-model-layer.is-stage2-layer-in-flight .stage2-layer-param,
+.stage2-model-layer[data-stage2-assigned-node].is-stage2-layer-in-flight .stage2-layer-param {
+  display: block;
+  opacity: calc((1 - (var(--stage2-layer-compact-progress, 0) * 0.78)) * (1 - (var(--stage2-layer-extract-progress, 0) * 0.6)));
 }
 
 .stage2-layer-bars i:nth-child(2n) {
@@ -6155,6 +6259,63 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   opacity: var(--stage2-lock-node-progress, var(--stage2-lock-check-progress, 0));
 }
 
+.stage2-debug-toggle {
+  position: absolute;
+  right: clamp(16px, 3vw, 38px);
+  bottom: clamp(18px, 4.5vh, 42px);
+  z-index: 13;
+  display: none;
+  align-items: center;
+  gap: 9px;
+  min-height: 34px;
+  padding: 5px 6px 5px 11px;
+  border: 1px solid rgba(255,255,255,0.12);
+  border-radius: 999px;
+  background: rgba(9,9,11,0.78);
+  color: #f4f4f5;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0;
+  box-shadow: 0 12px 30px rgba(0,0,0,0.24);
+  cursor: pointer;
+}
+
+.stage2-debug-toggle i {
+  position: relative;
+  display: block;
+  width: 30px;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(255,255,255,0.18);
+  box-shadow: inset 0 0 0 1px rgba(255,255,255,0.08);
+}
+
+.stage2-debug-toggle i::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  top: 3px;
+  width: 12px;
+  height: 12px;
+  border-radius: inherit;
+  background: #f4f4f5;
+  transition: transform 0.16s ease, background 0.16s ease;
+}
+
+.stage2-debug-toggle[aria-checked="true"] i {
+  background: rgba(59,130,246,0.72);
+}
+
+.stage2-debug-toggle[aria-checked="true"] i::after {
+  background: #ffffff;
+  transform: translateX(12px);
+}
+
+body.is-stage2-debug-view .stage2-debug-toggle {
+  display: inline-flex;
+}
+
 .stage2-scrubber {
   position: absolute;
   left: 50%;
@@ -6162,7 +6323,7 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   z-index: 12;
   width: min(336px, calc(100vw - 58px));
   min-height: 58px;
-  transform: translateX(-50%) translateY(var(--stage2-scrubber-y, 16px));
+  transform: translateX(-50%);
   display: grid;
   gap: 8px;
   align-items: center;
@@ -6173,7 +6334,8 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   color: #f4f4f5;
   box-shadow: 0 16px 32px rgba(0,0,0,0.22);
   cursor: grab;
-  opacity: calc(var(--stage2-scrubber-opacity, 0) * 0.92);
+  opacity: 0;
+  pointer-events: none;
   user-select: none;
   -webkit-user-select: none;
 }
@@ -6270,6 +6432,11 @@ html:has(> body.docs-body)::-webkit-scrollbar-corner,
   touch-action: none;
 }
 
+body.is-stage2-debug-scrubber-visible .stage2-scroll .stage2-scrubber {
+  opacity: 0.92;
+  pointer-events: auto;
+}
+
 .stage2-scrubber:hover {
   cursor: grab;
 }
@@ -6307,8 +6474,6 @@ section.hero.stage2-scroll {
   --stage2-p: 0;
   --stage2-pct: 0%;
   --stage2-scrubber-pct: 0%;
-  --stage2-scrubber-y: 16px;
-  --stage2-scrubber-opacity: 0;
   --stage2-scrubber-tick-step: 4px;
   --stage2-aperture-x: 50%;
   --stage2-aperture-y: 42%;
@@ -6344,6 +6509,7 @@ section.hero.stage2-scroll {
   --stage2-model-width: 8px;
   --stage2-model-height: 8px;
   --stage2-model-shrink-progress: 0;
+  --stage2-model-detail-opacity: 0;
   --stage2-server-return-progress: 0;
   --stage2-stack-extra-height: 0px;
   --stage2-model-y: 22px;
@@ -6370,19 +6536,26 @@ section.hero.stage2-scroll {
   --stage2-title-place-opacity: 0;
   --stage2-title-final-opacity: 0;
   --stage2-title-model-offset: 0px;
-  min-height: 4000svh;
+  --stage2-viewport-height: 100svh;
+  min-height: 1800svh;
   max-width: none;
   padding: 0;
   margin: 0;
   background: #09090b;
 }
 
+@supports (height: 100dvh) {
+  section.hero.stage2-scroll {
+    --stage2-viewport-height: 100dvh;
+  }
+}
+
 .hero-stage-sticky {
   position: sticky;
   top: var(--hero-sticky-top);
   z-index: 1;
-  height: calc(100svh - var(--hero-initial-chrome));
-  min-height: calc(100svh - var(--hero-initial-chrome));
+  height: calc(var(--stage2-viewport-height) - var(--hero-initial-chrome));
+  min-height: calc(var(--stage2-viewport-height) - var(--hero-initial-chrome));
   overflow: hidden;
   isolation: isolate;
 }
@@ -6447,11 +6620,24 @@ body.is-stage2-complete section.hero.stage2-scroll {
   background-image: none;
 }
 
+body.is-stage2-active:not(.is-stage2-complete) section.hero.stage2-scroll .hero-viz {
+  opacity: var(--stage2-hero-opacity, 1) !important;
+  mask-image: none !important;
+  -webkit-mask-image: none !important;
+  transition: none;
+  will-change: auto;
+}
+
+body.is-stage2-active:not(.is-stage2-complete) section.hero.stage2-scroll .hero-viz * {
+  filter: none !important;
+  mix-blend-mode: normal !important;
+}
+
 body.is-stage2-complete section.hero.stage2-scroll::after {
   position: fixed;
   top: -60px;
   bottom: auto;
-  height: calc(var(--stage2-grid-clip-bottom, 100svh) + 60px);
+  height: calc(var(--stage2-grid-clip-bottom, var(--stage2-viewport-height)) + 60px);
 }
 
 section.hero.stage2-scroll .hero-viz {
@@ -6491,8 +6677,9 @@ section.hero.stage2-scroll .hero-viz .mesh-node {
 .stage2-final-hook {
   position: absolute;
   inset: 0;
-  z-index: 3;
+  z-index: 8;
   width: 100%;
+  overflow: visible;
   opacity: var(--stage2-title-final-opacity, 0);
   pointer-events: none;
   transition: none;
@@ -6525,19 +6712,18 @@ section.hero.stage2-scroll .hero-viz .mesh-node {
   display: block;
   width: max-content;
   max-width: calc(100vw - 2rem);
+  overflow: visible;
   white-space: nowrap;
   transform:
     translate3d(-50%, calc((1 - var(--stage2-title-final-opacity, 0)) * var(--stage2-final-line-rise, 0.34em)), 0)
     scale(calc(0.965 + (var(--stage2-title-final-opacity, 0) * 0.035)));
-  filter:
-    blur(calc((1 - var(--stage2-title-final-opacity, 0)) * 5px))
-    saturate(calc(1 + (var(--stage2-title-final-opacity, 0) * 0.4)));
   transform-origin: 50% 58%;
-  will-change: transform, filter;
+  will-change: transform;
 }
 
 .stage2-final-hook .stage2-final-word {
   display: inline-block;
+  overflow: visible;
   transform-origin: 50% 62%;
   will-change: transform;
 }
@@ -6551,14 +6737,11 @@ section.hero.stage2-scroll .hero-viz .mesh-node {
   z-index: 0;
   margin-inline: 0.035em;
   color: #f8fbff;
-  filter:
-    brightness(calc(1 + (var(--stage2-final-word-core, 0) * 0.2)))
-    saturate(calc(1 + (var(--stage2-final-word-glow, 0) * 0.38)));
   text-shadow:
     0 0 2px rgba(255,255,255,0.84),
     0 0 calc(10px + (var(--stage2-final-word-glow, 0) * 16px)) rgba(125,211,252,calc(0.16 + (var(--stage2-final-word-glow, 0) * 0.36))),
     0 0 calc(30px + (var(--stage2-final-word-glow, 0) * 32px)) rgba(34,197,94,calc(0.08 + (var(--stage2-final-word-glow, 0) * 0.2)));
-  will-change: transform, filter, text-shadow;
+  will-change: transform, text-shadow;
 }
 
 .stage2-final-hook [data-stage2-final-keyword="bigger"]::before,
@@ -6570,25 +6753,24 @@ section.hero.stage2-scroll .hero-viz .mesh-node {
 }
 
 .stage2-final-hook [data-stage2-final-keyword="bigger"]::before {
-  inset: -0.24em -0.34em -0.2em;
+  inset: -0.3em -0.5em -0.25em;
   z-index: -1;
-  border-radius: 999px;
   background:
     radial-gradient(
       ellipse at var(--stage2-final-word-glow-x, 50%) 54%,
-      rgba(226,248,255,0.82) 0%,
-      rgba(125,211,252,0.46) 18%,
-      rgba(34,197,94,0.22) 42%,
-      transparent 72%
-    );
-  opacity: calc(var(--stage2-final-word-glow, 0) * 0.92);
-  filter: blur(calc(8px + (var(--stage2-final-word-glow, 0) * 12px)));
+      rgba(226,248,255,0.45) 0%,
+      rgba(125,211,252,0.16) 8%,
+      rgba(34,197,94,0.04) 16%,
+      transparent 28%
+  );
+  opacity: calc(var(--stage2-final-word-glow, 0) * 0.68);
+  filter: blur(5px);
   transform:
     translate3d(0, 0, 0)
-    scaleX(var(--stage2-final-word-glow-stretch, 1))
+    scaleX(calc(var(--stage2-final-word-glow-stretch, 1) * 1.08))
     scaleY(calc(0.72 + (var(--stage2-final-word-core, 0) * 0.22)));
   transform-origin: var(--stage2-final-word-glow-x, 50%) 55%;
-  will-change: opacity, filter, transform;
+  will-change: opacity, transform, filter;
 }
 
 .stage2-final-hook [data-stage2-final-keyword="bigger"]::after {
@@ -6606,9 +6788,8 @@ section.hero.stage2-scroll .hero-viz .mesh-node {
       rgba(255,255,255,0.88) 48%,
       rgba(125,211,252,0.24) 64%,
       transparent 100%
-    );
+  );
   opacity: calc(var(--stage2-final-word-core, 0) * 0.58);
-  filter: blur(5px);
   transform: translateX(-50%) skewX(-13deg);
   will-change: left, opacity;
 }
@@ -6691,36 +6872,62 @@ body.is-stage2-active section.hero.stage2-scroll::before {
   -webkit-clip-path: circle(var(--stage2-aperture-radius) at var(--stage2-aperture-x) calc(var(--stage2-aperture-y) + var(--hero-sticky-top)));
 }
 
+body.is-stage2-active section.hero.stage2-scroll.is-stage2-aperture-settled::before {
+  opacity: 1;
+  background: #fbfaf7;
+  clip-path: none;
+  -webkit-clip-path: none;
+}
+
 .stage2-aperture-portal {
   position: absolute;
-  left: var(--stage2-aperture-px);
-  top: var(--stage2-aperture-py);
+  left: 0;
+  top: 0;
   z-index: 4;
-  width: calc(var(--stage2-aperture-max-radius) * 2);
-  height: calc(var(--stage2-aperture-max-radius) * 2);
-  overflow: hidden;
-  border-radius: 50%;
+  width: 100vw;
+  height: calc(var(--stage2-viewport-height) - var(--hero-initial-chrome));
+  overflow: visible;
+  border-radius: 0;
   opacity: var(--stage2-light-opacity);
-  transform: translate(-50%, -50%) scale(var(--stage2-aperture-scale));
-  transform-origin: 50% 50%;
+  clip-path: circle(var(--stage2-aperture-radius) at var(--stage2-aperture-px) var(--stage2-aperture-py));
+  -webkit-clip-path: circle(var(--stage2-aperture-radius) at var(--stage2-aperture-px) var(--stage2-aperture-py));
   pointer-events: none;
   transition: none;
-  contain: layout paint style;
-  will-change: transform, opacity;
+  contain: paint;
+  will-change: clip-path, opacity;
+}
+
+.stage2-scroll.is-stage2-aperture-settled .stage2-aperture-portal {
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: calc(var(--stage2-viewport-height) - var(--hero-initial-chrome));
+  overflow: hidden;
+  border-radius: 0;
+  clip-path: none;
+  -webkit-clip-path: none;
 }
 
 .stage2-aperture-portal .stage2-workspace {
-  left: calc(var(--stage2-aperture-max-radius) - var(--stage2-aperture-px));
-  top: calc(var(--stage2-aperture-max-radius) - var(--stage2-aperture-py));
+  left: 0;
+  top: 0;
   right: auto;
   bottom: auto;
   width: 100vw;
-  height: calc(100svh - var(--hero-initial-chrome));
+  height: calc(var(--stage2-viewport-height) - var(--hero-initial-chrome));
   opacity: 1;
-  transform: scale(var(--stage2-aperture-inverse-scale));
-  transform-origin: var(--stage2-aperture-px) var(--stage2-aperture-py);
+  transform: none;
   transition: none;
-  will-change: transform;
+}
+
+.stage2-scroll.is-stage2-aperture-settled .stage2-aperture-portal .stage2-workspace {
+  left: 0;
+  top: 0;
+  right: auto;
+  bottom: auto;
+  width: 100vw;
+  height: calc(var(--stage2-viewport-height) - var(--hero-initial-chrome));
+  transform: none;
 }
 
 .stage2-aperture-ring {
@@ -6742,6 +6949,10 @@ body.is-stage2-active section.hero.stage2-scroll::before {
   will-change: transform, opacity;
 }
 
+.stage2-scroll.is-stage2-aperture-settled .stage2-aperture-ring {
+  opacity: 0;
+}
+
 body.is-stage2-active .stage2-aperture-ring {
   position: fixed;
   top: calc(var(--hero-sticky-top) + var(--stage2-aperture-y));
@@ -6749,18 +6960,17 @@ body.is-stage2-active .stage2-aperture-ring {
 
 .stage2-scroll .stage2-scrubber {
   position: absolute;
-  opacity: calc(var(--stage2-scrubber-opacity, 0) * 0.92);
   pointer-events: none;
   transition: none;
 }
 
-.stage2-scroll.is-stage2-scrubbable .stage2-scrubber {
+body.is-stage2-debug-scrubber-visible .stage2-scroll.is-stage2-scrubbable .stage2-scrubber {
   pointer-events: auto;
 }
 
 @media (max-width: 900px) {
   section.hero.stage2-scroll {
-    min-height: 3100svh;
+    min-height: 1500svh;
   }
 
   .stage2-model-header strong {
@@ -6774,7 +6984,7 @@ body.is-stage2-active .stage2-aperture-ring {
 
 @media (max-width: 640px) {
   section.hero.stage2-scroll {
-    min-height: 3200svh;
+    min-height: 1180svh;
   }
 
   .stage2-final-hook {
@@ -6918,7 +7128,7 @@ body.is-stage2-active .stage2-aperture-ring {
 
 @media (pointer: coarse) {
   section.hero.stage2-scroll {
-    min-height: 2200svh;
+    min-height: 1100svh;
   }
   @media (min-width: 641px) {
     section.hero.stage2-scroll .hero-viz svg {
@@ -6959,7 +7169,7 @@ body.is-stage2-active .stage2-aperture-ring {
   }
 
   .stage2-model-layer::after {
-    opacity: calc(var(--stage2-layer-cut-energy, 0) * 0.48);
+    opacity: calc(var(--stage2-layer-cutter-opacity, 0) * 0.56);
   }
 
   .stage2-slice-cutter {
@@ -6978,7 +7188,13 @@ body.is-stage2-active .stage2-aperture-ring {
 
 @media (pointer: coarse) and (max-width: 640px) {
   section.hero.stage2-scroll {
-    min-height: 1850svh;
+    min-height: 880svh;
+  }
+}
+
+@media (pointer: coarse) and (max-width: 640px) and (max-height: 720px) {
+  section.hero.stage2-scroll {
+    min-height: 760svh;
   }
 }
 
@@ -7126,6 +7342,7 @@ body.is-stage2-active .stage2-aperture-ring {
   }
 
   .stage2-scroll .stage2-scrubber,
+  .stage2-debug-toggle,
   .stage2-aperture-ring {
     display: none;
   }
@@ -7168,6 +7385,9 @@ body.is-stage2-active .stage2-aperture-ring {
     --stage2-layer-cut-energy: 0;
     --stage2-layer-cut-front: 0;
     --stage2-layer-cut-residue: 0;
+    --stage2-layer-cutter-opacity: 0;
+    --stage2-layer-cutter-left: 0;
+    --stage2-layer-cutter-right: 1;
     --stage2-layer-cut-shear: 0px;
     --stage2-layer-cut-skew: 0deg;
   }

--- a/website/src/assets/title-reveal.js
+++ b/website/src/assets/title-reveal.js
@@ -67,6 +67,7 @@
 
   function queueReveal(title) {
     if (!title || title.classList.contains('is-title-revealed') || title.classList.contains('is-title-revealing')) return;
+    if (document.body.classList.contains('is-stage2-active')) return;
     if (revealTimers.has(title)) return;
 
     revealTimers.set(title, window.setTimeout(function () {
@@ -127,7 +128,10 @@
   }
 
   function revealVisibleHiddenTitles() {
-    if (document.body.classList.contains('is-stage2-active')) return;
+    if (document.body.classList.contains('is-stage2-active')) {
+      titles.forEach(cancelQueuedReveal);
+      return;
+    }
 
     titles.forEach(function (title) {
       if (title.classList.contains('is-title-revealed')) {

--- a/website/src/assets/title-reveal.js
+++ b/website/src/assets/title-reveal.js
@@ -127,6 +127,8 @@
   }
 
   function revealVisibleHiddenTitles() {
+    if (document.body.classList.contains('is-stage2-active')) return;
+
     titles.forEach(function (title) {
       if (title.classList.contains('is-title-revealed')) {
         cancelQueuedReveal(title);

--- a/website/src/assets/topology-switcher.js
+++ b/website/src/assets/topology-switcher.js
@@ -6,6 +6,7 @@
   var PANEL_SELECTOR = "[data-topology-panel]";
   var MAP_SELECTOR = "[data-topology-map]";
   var REDUCE_QUERY = "(prefers-reduced-motion: reduce)";
+  var MOTION_ACTIVE_CLASS = "is-motion-active";
 
   var reduceMotion = window.matchMedia(REDUCE_QUERY);
 
@@ -112,6 +113,35 @@
     });
   }
 
+  function bindMotionVisibility(root) {
+    if (reduceMotion.matches) {
+      root.classList.remove(MOTION_ACTIVE_CLASS);
+      return;
+    }
+
+    if (!("IntersectionObserver" in window)) {
+      root.classList.add(MOTION_ACTIVE_CLASS);
+      return;
+    }
+
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        root.classList.toggle(MOTION_ACTIVE_CLASS, entry.isIntersecting);
+      });
+    }, {
+      rootMargin: "180px 0px",
+      threshold: 0.01,
+    });
+
+    observer.observe(root);
+
+    if (reduceMotion.addEventListener) {
+      reduceMotion.addEventListener("change", function (event) {
+        root.classList.toggle(MOTION_ACTIVE_CLASS, !event.matches);
+      });
+    }
+  }
+
   function init(root) {
     var tabs = toArray(root.querySelectorAll(TAB_SELECTOR));
     if (!tabs.length) return;
@@ -123,6 +153,7 @@
     });
 
     bindKeyboard(root, tabs);
+    bindMotionVisibility(root);
     setMode(root, root.getAttribute("data-topology-active") || "route");
   }
 

--- a/website/src/assets/topology-switcher.js
+++ b/website/src/assets/topology-switcher.js
@@ -114,19 +114,26 @@
   }
 
   function bindMotionVisibility(root) {
-    if (reduceMotion.matches) {
-      root.classList.remove(MOTION_ACTIVE_CLASS);
-      return;
+    var isVisible = false;
+
+    function sync() {
+      if (reduceMotion.matches) {
+        root.classList.remove(MOTION_ACTIVE_CLASS);
+      } else {
+        root.classList.toggle(MOTION_ACTIVE_CLASS, isVisible);
+      }
     }
 
     if (!("IntersectionObserver" in window)) {
-      root.classList.add(MOTION_ACTIVE_CLASS);
+      isVisible = true;
+      sync();
       return;
     }
 
     var observer = new IntersectionObserver(function (entries) {
       entries.forEach(function (entry) {
-        root.classList.toggle(MOTION_ACTIVE_CLASS, entry.isIntersecting);
+        isVisible = entry.isIntersecting;
+        sync();
       });
     }, {
       rootMargin: "180px 0px",
@@ -136,9 +143,7 @@
     observer.observe(root);
 
     if (reduceMotion.addEventListener) {
-      reduceMotion.addEventListener("change", function (event) {
-        root.classList.toggle(MOTION_ACTIVE_CLASS, !event.matches);
-      });
+      reduceMotion.addEventListener("change", sync);
     }
   }
 


### PR DESCRIPTION
## Summary

* gate SVG motion by visibility
* polish animation segments
* perf-tune to 60 FPS target

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dark-mode meta tags and mobile status bar styling.
  * Introduced a motion-aware hero animation system with Stage 2 timeline debug toggle and safer, accessibility-friendly scrubber behavior.

* **Improvements**
  * Enhanced reduced-motion and visibility-based pause/resume behavior for diagram animations.
  * Refined Stage 2 hero/aperture visuals, animation timing, and scrubber visibility/input gating for smoother, more consistent rendering.

* **Bug Fixes**
  * Prevented title reveal behavior while Stage 2 is active.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->