### PR TITLE
fix(skippy): Metal shutdown race in Skippy runtime

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -3640,7 +3640,7 @@ impl Node {
                 .store(true, std::sync::atomic::Ordering::Release);
             lifecycle.shutdown.notify_waiters();
             let _ = lifecycle.task.await;
-            drop(lifecycle.endpoint);
+            lifecycle.endpoint.close().await;
         }
     }
 

--- a/crates/skippy-server/src/binary_transport/decode_batcher.rs
+++ b/crates/skippy-server/src/binary_transport/decode_batcher.rs
@@ -5,7 +5,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         mpsc as std_mpsc,
     },
-    thread,
+    thread::{self, JoinHandle},
     time::Instant,
 };
 
@@ -24,6 +24,7 @@ struct DecodeFrameBatcherShared {
     ready: Condvar,
     max_batch_size: usize,
     owner_count: AtomicUsize,
+    worker: Mutex<Option<JoinHandle<()>>>,
 }
 
 #[derive(Default)]
@@ -58,9 +59,13 @@ impl DecodeFrameBatcher {
             ready: Condvar::new(),
             max_batch_size: max_batch_size.max(1),
             owner_count: AtomicUsize::new(1),
+            worker: Mutex::new(None),
         });
         let worker = Arc::downgrade(&shared);
-        thread::spawn(move || DecodeFrameBatcherShared::run_worker(worker));
+        let worker = thread::spawn(move || DecodeFrameBatcherShared::run_worker(worker));
+        if let Ok(mut slot) = shared.worker.lock() {
+            *slot = Some(worker);
+        }
         Self { shared }
     }
 
@@ -103,6 +108,13 @@ impl Drop for DecodeFrameBatcher {
         if let Ok(mut state) = self.shared.state.lock() {
             state.stopping = true;
             self.shared.ready.notify_all();
+        }
+        let worker = match self.shared.worker.lock() {
+            Ok(mut worker) => worker.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+        if let Some(worker) = worker {
+            let _ = worker.join();
         }
     }
 }

--- a/crates/skippy-server/src/frontend/decode_batcher.rs
+++ b/crates/skippy-server/src/frontend/decode_batcher.rs
@@ -5,7 +5,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
         mpsc as std_mpsc,
     },
-    thread,
+    thread::{self, JoinHandle},
     time::Instant,
 };
 
@@ -22,6 +22,7 @@ struct DecodeBatcherShared {
     ready: Condvar,
     max_batch_size: usize,
     owner_count: AtomicUsize,
+    worker: Mutex<Option<JoinHandle<()>>>,
 }
 
 #[derive(Default)]
@@ -55,9 +56,13 @@ impl DecodeBatcher {
             ready: Condvar::new(),
             max_batch_size: max_batch_size.max(1),
             owner_count: AtomicUsize::new(1),
+            worker: Mutex::new(None),
         });
         let worker = Arc::downgrade(&shared);
-        thread::spawn(move || DecodeBatcherShared::run_worker(worker));
+        let worker = thread::spawn(move || DecodeBatcherShared::run_worker(worker));
+        if let Ok(mut slot) = shared.worker.lock() {
+            *slot = Some(worker);
+        }
         Self { shared }
     }
 
@@ -98,6 +103,13 @@ impl Drop for DecodeBatcher {
         if let Ok(mut state) = self.shared.state.lock() {
             state.stopping = true;
             self.shared.ready.notify_all();
+        }
+        let worker = match self.shared.worker.lock() {
+            Ok(mut worker) => worker.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+        if let Some(worker) = worker {
+            let _ = worker.join();
         }
     }
 }


### PR DESCRIPTION
## Summary

- Join the Skippy frontend and binary-transport decode batcher worker threads when the final batcher owner drops.
- Explicitly close the iroh control endpoint during mesh node shutdown instead of dropping it.

## Root Cause

The Metal shutdown segfault was consistent with native llama/ggml teardown racing a detached decode-batcher worker. The batcher workers could temporarily upgrade their weak shared state and hold an `Arc<Mutex<RuntimeState>>` after the final public batcher handle was dropped. That lets `StageModel` / `RuntimeState` ownership survive past the shutdown path and race process teardown, leaving ggml Metal residency resources populated when the Metal device is freed.

The iroh log line was a separate shutdown hygiene issue: the control listener endpoint was dropped without calling `Endpoint::close`.

## Impact

Shutdown now waits for the decode-batcher workers to observe the stop signal and exit before the final batcher owner releases shutdown ownership. This keeps Rust-side runtime ownership ordered ahead of native Metal teardown and removes the ungraceful iroh endpoint drop.

## Validation

- `cargo fmt --all --check`
- `cargo check -p mesh-llm`
- `cargo test -p skippy-server --lib`
- `cargo test -p skippy-protocol --lib`
- `cargo test -p mesh-llm-host-runtime --lib inference::skippy`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`

Live Metal shutdown reproduction was not rerun after the patch in this PR pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shutdown sequence to ensure all background resources and threads are properly terminated before the application exits, preventing potential resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->