### PR TITLE
[codex] Correct metrics-server storage docs

### DIFF
--- a/.agents/skills/metrics-server/SKILL.md
+++ b/.agents/skills/metrics-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: metrics-server
-description: Use this skill when working on benchmark telemetry ingest, metrics-server run lifecycle, OTLP collection, DuckDB storage, benchmark report export, or separating telemetry/reporting ownership from staged runtime servers.
+description: Use this skill when working on benchmark telemetry ingest, metrics-server run lifecycle, OTLP collection, SQLite storage, benchmark report export, or separating telemetry/reporting ownership from staged runtime servers.
 metadata:
   short-description: Work on benchmark telemetry and reports
 ---
@@ -16,7 +16,7 @@ report export.
 cargo build -p metrics-server
 
 target/debug/metrics-server serve \
-  --db /tmp/metrics.duckdb \
+  --db /tmp/metrics.sqlite \
   --http-addr 127.0.0.1:18080 \
   --otlp-grpc-addr 127.0.0.1:14317
 ```

--- a/.agents/skills/skippy-metrics/SKILL.md
+++ b/.agents/skills/skippy-metrics/SKILL.md
@@ -14,7 +14,7 @@ benchmark/report integration.
 
 `crates/skippy-metrics` owns shared attribute names. Stage servers may emit
 OTLP/telemetry, but request-path serving must not block on telemetry export.
-`crates/metrics-server` owns benchmark/debug telemetry ingest, DuckDB storage,
+`crates/metrics-server` owns benchmark/debug telemetry ingest, SQLite storage,
 run lifecycle, and canonical report export.
 
 Mesh API runtime status is not a telemetry dump. Keep public runtime status

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -56,7 +56,7 @@ Bring over these skippy crates:
 | `skippy-server` | Stage transport and OpenAI driver code to refactor into embeddable APIs |
 | `skippy-topology` | Layer topology planning and family/split policy |
 | `skippy-metrics` | Runtime telemetry helpers |
-| `metrics-server` | Benchmark/debug OTLP ingest, run lifecycle, DuckDB storage, and report export |
+| `metrics-server` | Benchmark/debug OTLP ingest, run lifecycle, SQLite storage, and report export |
 | `openai-frontend` | Shared OpenAI-compatible request/response, streaming, responses API compatibility, structured-output, tool-call, logprob, and backend contract |
 | `skippy-model-package` | Later package tooling for producing layer packages |
 
@@ -153,7 +153,7 @@ Current branch status:
   behind the backend selector. The next replacement step is multi-peer stage
   topology planning and activation transport, after which the legacy
   `llama-server`/`rpc-server` startup path can be retired.
-- `metrics-server` is in the workspace with OTLP ingest, DuckDB-backed run
+- `metrics-server` is in the workspace with OTLP ingest, SQLite-backed run
   lifecycle/report export, `just metrics-server` recipes, and agent workflow
   documentation.
 
@@ -575,13 +575,13 @@ work can keep the same measure/debug loop:
 mesh/skippy stage runtime
     -. best-effort OTLP summaries .->
 metrics-server
-    -> metrics.duckdb
+    -> metrics.sqlite
     -> report.json
 ```
 
 `metrics-server` is not on the request path. Mesh and skippy stages must keep
 running if telemetry export is unavailable, slow, or drops events. The server
-owns benchmark/debug ingest, run lifecycle, DuckDB storage, and report export;
+owns benchmark/debug ingest, run lifecycle, SQLite storage, and report export;
 stage runtime code owns only best-effort emission and stable `skippy-metrics`
 names.
 


### PR DESCRIPTION
## Summary

Correct stale metrics-server documentation and agent skill text so they describe the current SQLite-backed storage path instead of DuckDB.

## Why

`metrics-server` now uses `rusqlite` and defaults to `metrics.sqlite`, but several Skippy docs and skills still referred to DuckDB storage or showed a `metrics.duckdb` path. That made live benchmark runs confusing because a file could be named `.duckdb` while actually containing a SQLite database.

## Changed

- Update `docs/SKIPPY.md` to describe metrics-server as SQLite-backed and show `metrics.sqlite` in the debug workflow.
- Update `.agents/skills/metrics-server` to use SQLite terminology and `/tmp/metrics.sqlite` in the example command.
- Update `.agents/skills/skippy-metrics` ownership text to say SQLite storage.

## Validation

- Ran a focused search confirming no remaining metrics-server DuckDB references in `docs/SKIPPY.md`, metrics-server skills, or `crates/metrics-server`.
- Left the `crates/skippy-bench/README.md` DuckDB mention intact because it refers to the separate benchmark corpus parquet sampler, not metrics-server storage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify that the metrics-server database backend uses SQLite instead of DuckDB for storing and reporting debug and benchmark telemetry. Changes applied to skill descriptions, ownership guidelines, crate scope documentation, and metrics debug workflow references to reflect SQLite-backed storage architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->