### PR TITLE
[codex] Keep model chat and thinking behavior in llama

### DIFF
--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -30,7 +30,6 @@ use openai_frontend::{
     MessageContentPart, ModelId, ModelObject, OpenAiBackend, OpenAiError, OpenAiErrorKind,
     OpenAiHookPolicy, OpenAiRequestContext, OpenAiResult, PrefillHookSignals, ReasoningEffort,
     StreamingGuardrailMode, Usage, apply_chat_hook_outcome, chat_mesh_hooks_enabled,
-    normalize_reasoning_template_options,
 };
 use serde::Serialize;
 use serde_json::{Value, json};
@@ -1517,9 +1516,9 @@ fn tool_calls_requested(request: &ChatCompletionRequest) -> bool {
 
 fn chat_output_parser_required(
     request: &ChatCompletionRequest,
-    template_options: &ChatTemplateOptions,
+    _template_options: &ChatTemplateOptions,
 ) -> bool {
-    tool_calls_requested(request) || template_options.enable_thinking == Some(true)
+    tool_calls_requested(request)
 }
 
 fn chat_response_from_generated_text(

--- a/crates/skippy-server/src/frontend/request.rs
+++ b/crates/skippy-server/src/frontend/request.rs
@@ -8,8 +8,6 @@ struct SharedRequestFields<'a> {
     temperature: &'a mut Option<f32>,
     top_p: &'a mut Option<f32>,
     stop: &'a mut Option<openai_frontend::StopSequence>,
-    reasoning: &'a mut Option<openai_frontend::ReasoningConfig>,
-    reasoning_effort: &'a mut Option<openai_frontend::ReasoningEffort>,
     extra: &'a mut std::collections::BTreeMap<String, serde_json::Value>,
 }
 
@@ -26,8 +24,6 @@ pub(super) fn apply_chat_request_defaults(
             temperature: &mut request.temperature,
             top_p: &mut request.top_p,
             stop: &mut request.stop,
-            reasoning: &mut request.reasoning,
-            reasoning_effort: &mut request.reasoning_effort,
             extra: &mut request.extra,
         },
         defaults,
@@ -47,8 +43,6 @@ pub(super) fn apply_completion_request_defaults(
             temperature: &mut request.temperature,
             top_p: &mut request.top_p,
             stop: &mut request.stop,
-            reasoning: &mut request.reasoning,
-            reasoning_effort: &mut request.reasoning_effort,
             extra: &mut request.extra,
         },
         defaults,
@@ -172,8 +166,6 @@ fn apply_shared_request_defaults(
         temperature,
         top_p,
         stop,
-        reasoning,
-        reasoning_effort,
         extra,
     } = fields;
     if presence_penalty.is_none() {
@@ -219,86 +211,6 @@ fn apply_shared_request_defaults(
     ) {
         extra.insert("repeat_last_n".to_string(), serde_json::json!(value));
     }
-    apply_reasoning_defaults(reasoning, reasoning_effort, extra, defaults);
-}
-
-fn apply_reasoning_defaults(
-    reasoning: &mut Option<openai_frontend::ReasoningConfig>,
-    reasoning_effort: &mut Option<openai_frontend::ReasoningEffort>,
-    extra: &mut std::collections::BTreeMap<String, serde_json::Value>,
-    defaults: &EmbeddedOpenAiRequestDefaults,
-) {
-    if explicit_reasoning_toggle_present(reasoning.as_ref(), *reasoning_effort, extra) {
-        return;
-    }
-
-    match defaults.reasoning_enabled {
-        Some(EmbeddedReasoningEnabled::Disabled) => {
-            reasoning.get_or_insert_with(Default::default).enabled = Some(false);
-            return;
-        }
-        Some(EmbeddedReasoningEnabled::Enabled) => {
-            reasoning.get_or_insert_with(Default::default).enabled = Some(true);
-        }
-        Some(EmbeddedReasoningEnabled::Auto) | None => {}
-    }
-
-    match defaults.reasoning_format {
-        Some(EmbeddedReasoningFormat::None) => {
-            reasoning.get_or_insert_with(Default::default).enabled = Some(false);
-            return;
-        }
-        Some(EmbeddedReasoningFormat::Deepseek)
-        | Some(EmbeddedReasoningFormat::DeepseekLegacy)
-        | Some(EmbeddedReasoningFormat::Hidden) => {
-            reasoning.get_or_insert_with(Default::default).enabled = Some(true);
-        }
-        Some(EmbeddedReasoningFormat::Auto) | None => {}
-    }
-
-    if explicit_reasoning_budget_present(reasoning.as_ref(), *reasoning_effort, extra) {
-        return;
-    }
-
-    match defaults.reasoning_budget {
-        Some(EmbeddedReasoningBudget::Tokens(value)) => {
-            reasoning.get_or_insert_with(Default::default).max_tokens = Some(value);
-        }
-        Some(EmbeddedReasoningBudget::Effort(value)) => {
-            reasoning.get_or_insert_with(Default::default).effort = Some(value);
-        }
-        Some(EmbeddedReasoningBudget::Auto) | None => {}
-    }
-}
-
-fn explicit_reasoning_toggle_present(
-    reasoning: Option<&openai_frontend::ReasoningConfig>,
-    reasoning_effort: Option<openai_frontend::ReasoningEffort>,
-    extra: &std::collections::BTreeMap<String, serde_json::Value>,
-) -> bool {
-    reasoning.is_some_and(|value| value.enabled.is_some() || value.effort.is_some())
-        || reasoning_effort.is_some()
-        || openai_frontend::THINKING_BOOLEAN_ALIASES
-            .iter()
-            .any(|field| !extra_value_is_omitted(extra, field))
-        || extra
-            .get("chat_template_kwargs")
-            .and_then(Value::as_object)
-            .is_some_and(|object| {
-                openai_frontend::THINKING_BOOLEAN_ALIASES
-                    .iter()
-                    .any(|field| object.get(*field).is_some_and(|value| !value.is_null()))
-            })
-}
-
-fn explicit_reasoning_budget_present(
-    reasoning: Option<&openai_frontend::ReasoningConfig>,
-    reasoning_effort: Option<openai_frontend::ReasoningEffort>,
-    extra: &std::collections::BTreeMap<String, serde_json::Value>,
-) -> bool {
-    reasoning.is_some_and(|value| value.max_tokens.is_some() || value.effort.is_some())
-        || reasoning_effort.is_some()
-        || !extra_value_is_omitted(extra, "thinking_budget")
 }
 
 fn extra_value_is_omitted(
@@ -345,17 +257,9 @@ pub(super) fn completion_sampling_config(
 }
 
 pub(super) fn chat_template_options(
-    request: &ChatCompletionRequest,
+    _request: &ChatCompletionRequest,
 ) -> OpenAiResult<ChatTemplateOptions> {
-    let reasoning_options = normalize_reasoning_template_options(
-        request.reasoning.as_ref(),
-        request.reasoning_effort,
-        &request.extra,
-    )?;
-    Ok(ChatTemplateOptions {
-        enable_thinking: reasoning_options.enable_thinking,
-        ..ChatTemplateOptions::default()
-    })
+    Ok(ChatTemplateOptions::default())
 }
 
 pub(super) fn ensure_chat_runtime_features_supported(

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -980,25 +980,10 @@ fn plain_chat_does_not_require_chat_output_parser() {
 }
 
 #[test]
-fn tools_and_enabled_thinking_require_chat_output_parser() {
+fn tools_require_chat_output_parser() {
     assert!(chat_output_parser_required(
         &tool_request(),
         &ChatTemplateOptions::default(),
-    ));
-
-    let request: ChatCompletionRequest = serde_json::from_value(json!({
-        "model": "test",
-        "messages": [{"role": "user", "content": "think"}],
-        "reasoning": {"enabled": true}
-    }))
-    .unwrap();
-
-    assert!(chat_output_parser_required(
-        &request,
-        &ChatTemplateOptions {
-            enable_thinking: Some(true),
-            ..ChatTemplateOptions::default()
-        },
     ));
 }
 
@@ -1904,15 +1889,9 @@ fn request_defaults_fill_omitted_chat_fields_only() {
     assert_eq!(sampling.logit_bias.len(), 2);
     assert_eq!(
         chat_template_options(&request).unwrap().enable_thinking,
-        Some(true)
+        None
     );
-    assert_eq!(
-        request
-            .reasoning
-            .as_ref()
-            .and_then(|value| value.max_tokens),
-        Some(256)
-    );
+    assert_eq!(request.reasoning, None);
     assert_eq!(
         GenerationTokenLimit::from_request(request.effective_max_tokens(), 64),
         GenerationTokenLimit::Default(64)
@@ -2000,7 +1979,7 @@ fn explicit_chat_request_values_override_request_defaults() {
     assert_eq!(sampling.logit_bias.len(), 1);
     assert_eq!(
         chat_template_options(&request).unwrap().enable_thinking,
-        Some(false)
+        None
     );
     assert_eq!(
         GenerationTokenLimit::from_request(request.effective_max_tokens(), 64),
@@ -2069,31 +2048,7 @@ fn request_defaults_do_not_make_structured_output_or_logprobs_executable() {
 }
 
 #[test]
-fn deepseek_legacy_request_default_enables_chat_template_thinking() {
-    let mut request: ChatCompletionRequest = serde_json::from_value(json!({
-        "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
-        "messages": [{"role": "user", "content": "hello"}]
-    }))
-    .unwrap();
-
-    let defaults = EmbeddedOpenAiRequestDefaults {
-        reasoning_format: Some(EmbeddedReasoningFormat::DeepseekLegacy),
-        ..EmbeddedOpenAiRequestDefaults::default()
-    };
-    apply_chat_request_defaults(&mut request, &defaults);
-
-    assert_eq!(
-        request.reasoning.as_ref().and_then(|value| value.enabled),
-        Some(true)
-    );
-    assert_eq!(
-        chat_template_options(&request).unwrap().enable_thinking,
-        Some(true)
-    );
-}
-
-#[test]
-fn canonical_reasoning_disabled_turns_off_chat_template_thinking() {
+fn canonical_reasoning_does_not_override_chat_template_thinking() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}],
@@ -2102,11 +2057,11 @@ fn canonical_reasoning_disabled_turns_off_chat_template_thinking() {
     .unwrap();
 
     let options = chat_template_options(&request).unwrap();
-    assert_eq!(options.enable_thinking, Some(false));
+    assert_eq!(options.enable_thinking, None);
 }
 
 #[test]
-fn reasoning_effort_none_turns_off_chat_template_thinking() {
+fn reasoning_effort_does_not_override_chat_template_thinking() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}],
@@ -2115,11 +2070,11 @@ fn reasoning_effort_none_turns_off_chat_template_thinking() {
     .unwrap();
 
     let options = chat_template_options(&request).unwrap();
-    assert_eq!(options.enable_thinking, Some(false));
+    assert_eq!(options.enable_thinking, None);
 }
 
 #[test]
-fn top_level_reasoning_effort_none_turns_off_chat_template_thinking() {
+fn top_level_reasoning_effort_does_not_override_chat_template_thinking() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}],
@@ -2128,11 +2083,11 @@ fn top_level_reasoning_effort_none_turns_off_chat_template_thinking() {
     .unwrap();
 
     let options = chat_template_options(&request).unwrap();
-    assert_eq!(options.enable_thinking, Some(false));
+    assert_eq!(options.enable_thinking, None);
 }
 
 #[test]
-fn provider_enable_thinking_overrides_canonical_reasoning() {
+fn provider_enable_thinking_does_not_override_chat_template_thinking() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}],
@@ -2142,11 +2097,11 @@ fn provider_enable_thinking_overrides_canonical_reasoning() {
     .unwrap();
 
     let options = chat_template_options(&request).unwrap();
-    assert_eq!(options.enable_thinking, Some(true));
+    assert_eq!(options.enable_thinking, None);
 }
 
 #[test]
-fn chat_template_kwargs_enable_thinking_is_supported() {
+fn chat_template_kwargs_enable_thinking_does_not_override_template() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}],
@@ -2155,11 +2110,11 @@ fn chat_template_kwargs_enable_thinking_is_supported() {
     .unwrap();
 
     let options = chat_template_options(&request).unwrap();
-    assert_eq!(options.enable_thinking, Some(false));
+    assert_eq!(options.enable_thinking, None);
 }
 
 #[test]
-fn thinking_boolean_aliases_are_supported() {
+fn thinking_boolean_aliases_do_not_override_chat_template_thinking() {
     for field in openai_frontend::THINKING_BOOLEAN_ALIASES {
         let request: ChatCompletionRequest = serde_json::from_value(json!({
             "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
@@ -2169,7 +2124,7 @@ fn thinking_boolean_aliases_are_supported() {
         .unwrap();
         assert_eq!(
             chat_template_options(&request).unwrap().enable_thinking,
-            Some(false),
+            None,
             "top-level alias {field}"
         );
 
@@ -2181,14 +2136,14 @@ fn thinking_boolean_aliases_are_supported() {
         .unwrap();
         assert_eq!(
             chat_template_options(&request).unwrap().enable_thinking,
-            Some(false),
+            None,
             "chat_template_kwargs alias {field}"
         );
     }
 }
 
 #[test]
-fn reasoning_max_tokens_enables_and_zero_budget_disables_thinking() {
+fn reasoning_budget_does_not_override_chat_template_thinking() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}],
@@ -2197,7 +2152,7 @@ fn reasoning_max_tokens_enables_and_zero_budget_disables_thinking() {
     .unwrap();
     assert_eq!(
         chat_template_options(&request).unwrap().enable_thinking,
-        Some(true)
+        None
     );
 
     let request: ChatCompletionRequest = serde_json::from_value(json!({
@@ -2209,7 +2164,7 @@ fn reasoning_max_tokens_enables_and_zero_budget_disables_thinking() {
     .unwrap();
     assert_eq!(
         chat_template_options(&request).unwrap().enable_thinking,
-        Some(false)
+        None
     );
 }
 

--- a/third_party/llama.cpp/patches/0109-Add-GLM-chat-template-fallback.patch
+++ b/third_party/llama.cpp/patches/0109-Add-GLM-chat-template-fallback.patch
@@ -1,0 +1,140 @@
+From 172b08455f464992f347f2b09fd7c9666920aa5b Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sun, 21 Jun 2026 19:35:13 +1000
+Subject: [PATCH 109/109] Add GLM chat template fallback
+
+---
+ common/chat.cpp | 111 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 111 insertions(+)
+
+diff --git a/common/chat.cpp b/common/chat.cpp
+index ded8440e..69ab8805 100644
+--- a/common/chat.cpp
++++ b/common/chat.cpp
+@@ -611,6 +611,113 @@ std::string common_chat_format_example(const struct common_chat_templates *
+     "  {{- '<|im_start|>assistant\n' -}}\n"                                               \
+     "{%- endif -%}"
+ 
++// Fallback copied from the official zai-org/GLM-4.7-Flash chat_template.jinja.
++// In particular, the generation-prompt branch that emits a leading </think>
++// when enable_thinking=false is upstream GLM template behavior, not skippy policy.
++static const char * GLM_4_7_FALLBACK_TEMPLATE_SRC = R"jinja([gMASK]<sop>
++{%- if tools -%}
++<|system|>
++# Tools
++
++You may call one or more functions to assist with the user query.
++
++You are provided with function signatures within <tools></tools> XML tags:
++<tools>
++{% for tool in tools %}
++{{ tool | tojson(ensure_ascii=False) }}
++{% endfor %}
++</tools>
++
++For each function call, output the function name and arguments within the following XML format:
++<tool_call>{function-name}<arg_key>{arg-key-1}</arg_key><arg_value>{arg-value-1}</arg_value><arg_key>{arg-key-2}</arg_key><arg_value>{arg-value-2}</arg_value>...</tool_call>{%- endif -%}
++{%- macro visible_text(content) -%}
++    {%- if content is string -%}
++        {{- content }}
++    {%- elif content is iterable and content is not mapping -%}
++        {%- for item in content -%}
++            {%- if item is mapping and item.type == 'text' -%}
++                {{- item.text }}
++            {%- elif item is string -%}
++                {{- item }}
++            {%- endif -%}
++        {%- endfor -%}
++    {%- else -%}
++        {{- content }}
++    {%- endif -%}
++{%- endmacro -%}
++{%- set ns = namespace(last_user_index=-1) %}
++{%- for m in messages %}
++    {%- if m.role == 'user' %}
++        {% set ns.last_user_index = loop.index0 -%}
++    {%- endif %}
++{%- endfor %}
++{% for m in messages %}
++{%- if m.role == 'user' -%}<|user|>{{ visible_text(m.content) }}
++{%- elif m.role == 'assistant' -%}
++<|assistant|>
++{%- set reasoning_content = '' %}
++{%- set content = visible_text(m.content) %}
++{%- if m.reasoning_content is string %}
++    {%- set reasoning_content = m.reasoning_content %}
++{%- else %}
++    {%- if '</think>' in content %}
++        {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
++        {%- set content = content.split('</think>')[-1].lstrip('\n') %}
++    {%- endif %}
++{%- endif %}
++{%- if ((clear_thinking is defined and not clear_thinking) or loop.index0 > ns.last_user_index) and reasoning_content -%}
++{{ '<think>' + reasoning_content.strip() +  '</think>'}}
++{%- else -%}
++{{ '</think>' }}
++{%- endif -%}
++{%- if content.strip() -%}
++{{ content.strip() }}
++{%- endif -%}
++{% if m.tool_calls %}
++{% for tc in m.tool_calls %}
++{%- if tc.function %}
++    {%- set tc = tc.function %}
++{%- endif %}
++{{- '<tool_call>' + tc.name -}}
++{% set _args = tc.arguments %}{% for k, v in _args.items() %}<arg_key>{{ k }}</arg_key><arg_value>{{ v | tojson(ensure_ascii=False) if v is not string else v }}</arg_value>{% endfor %}</tool_call>{% endfor %}
++{% endif %}
++{%- elif m.role == 'tool' -%}
++{%- if m.content is string -%}
++{%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
++    {{- '<|observation|>' }}
++{%- endif %}
++{{- '<tool_response>' }}
++{{- m.content }}
++{{- '</tool_response>' }}
++{%- else -%}
++<|observation|>{% for tr in m.content %}
++<tool_response>{{ tr.output if tr.output is defined else tr }}</tool_response>{% endfor -%}
++{% endif -%}
++{%- elif m.role == 'system' -%}
++<|system|>{{ visible_text(m.content) }}
++{%- endif -%}
++{%- endfor -%}
++{%- if add_generation_prompt -%}
++    <|assistant|>{{- '</think>' if (enable_thinking is defined and not enable_thinking) else '<think>' -}}
++{%- endif -%})jinja";
++
++static std::string common_chat_vocab_piece(const struct llama_vocab * vocab, llama_token token) {
++    return token == LLAMA_TOKEN_NULL ? std::string() : common_token_to_piece(vocab, token, true);
++}
++
++static bool common_chat_model_has_glm4_vocab(const struct llama_model * model) {
++    if (model == nullptr) {
++        return false;
++    }
++    const auto * vocab = llama_model_get_vocab(model);
++    if (vocab == nullptr) {
++        return false;
++    }
++    return common_chat_vocab_piece(vocab, llama_vocab_bos(vocab)) == "[gMASK]" &&
++           common_chat_vocab_piece(vocab, llama_vocab_eos(vocab)) == "<|endoftext|>" &&
++           common_chat_vocab_piece(vocab, llama_vocab_eot(vocab)) == "<|user|>";
++}
++
+ void common_chat_templates_free(struct common_chat_templates * tmpls) {
+     delete tmpls;
+ }
+@@ -675,6 +779,10 @@ common_chat_templates_ptr common_chat_templates_init(const struct llama_model *
+     } else {
+         default_template_src = chat_template_override;
+     }
++    if (default_template_src.empty() && template_tool_use_src.empty() && common_chat_model_has_glm4_vocab(model)) {
++        LOG_DBG("%s: using built-in GLM 4.7 fallback chat template\n", __func__);
++        default_template_src = GLM_4_7_FALLBACK_TEMPLATE_SRC;
++    }
+     if (default_template_src.empty() || default_template_src == "chatml") {
+         if (!template_tool_use_src.empty()) {
+             default_template_src = template_tool_use_src;
+-- 
+2.54.0 (Apple Git-156)


### PR DESCRIPTION
## Summary
- Moves the missing-template fallback into llama.cpp by adding a patch-queue fallback for GLM-style GGUFs that expose GLM tokenizer markers but omit `tokenizer.chat_template`.
- Keeps model-family chat control behavior in llama by consuming llama chat-template metadata (`additional_stops`) rather than adding Skippy fallback stops.
- Removes Skippy-side thinking inference from OpenAI/provider aliases (`reasoning`, `reasoning_effort`, `thinking_budget`, `enable_thinking`, `chat_template_kwargs`). Skippy now leaves `enable_thinking` unset so llama/model template defaults decide.

## Why
Skippy should not maintain parallel model-family policy for chat templates, stop tokens, or chain-of-thought/thinking behavior. Those semantics belong in llama's chat-template/parser layer, where they can be tied to model metadata, tokenizer markers, template capabilities, and parser metadata.

The observed bug was GLM 4.7 Flash: the GGUF advertises GLM tokenizer markers/EOG tokens but has no `tokenizer.chat_template`, so llama's common chat path fell back to ChatML. That rendered conversations with the wrong control tokens and could let generation continue past the expected GLM turn boundary.

The fix adds the concrete GLM fallback in llama, while removing the broader Skippy-side behavior that tried to infer thinking policy from request-shaped fields.

## Behavior
For GGUFs matching the GLM vocabulary signature:
- BOS token renders as `[gMASK]`
- EOS token renders as `<|endoftext|>`
- EOT token renders as `<|user|>`

llama now selects the built-in GLM fallback template before falling back to ChatML.

The fallback template follows the official `zai-org/GLM-4.7-Flash` chat template, including the `enable_thinking=false` generation prompt branch that emits a leading `</think>`. That is upstream GLM template behavior, not a Skippy workaround.

Skippy still:
- forwards chat messages, tools, and tool choice into llama's chat-template ABI
- consumes llama's `additional_stops` metadata
- uses llama's chat parser for tool-call parsing
- maps llama parser `reasoning_content` into OpenAI responses when llama provides it

Skippy no longer:
- adds model-family fallback stops
- converts OpenAI/provider reasoning aliases into `enable_thinking`
- requires chat-output parsing just because Skippy inferred thinking was enabled

## Thinking / CoT Ownership
Thinking behavior stays llama-owned in this path:
- Skippy passes `enable_thinking: None`, so the ABI sends `override_enable_thinking=false`.
- llama/model chat templates decide whether thinking is enabled, disabled, opened, or closed.
- If llama's parser returns `reasoning_content`, Skippy maps it into the OpenAI response; Skippy does not parse `<think>` tags itself.

## Validation
- `LLAMA_WORKDIR=$(mktemp -d /tmp/mesh-llm-llama.XXXXXX) scripts/prepare-llama.sh pinned`
- `just build`
- `cargo test -p skippy-server --lib`
- `cargo check -p skippy-server`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`

## Protocol
No mesh protocol changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic GLM 4.7 chat template fallback detection for improved model compatibility.

* **Changes**
  * Output parsing now activates only for tool requests.
  * Simplified chat template thinking behavior configuration.
  * Removed embedded reasoning field processing from request defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->