### PR TITLE
fix(runtime): support relocating shared libs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,7 +275,7 @@ jobs:
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl lld
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl lld patchelf
 
       - name: Install macOS dependencies
         if: runner.os == 'macOS'

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install Linux SDK dependencies
         if: ${{ runner.os == 'Linux' }}
-        run: sudo apt-get update && sudo apt-get install -y build-essential libdbus-1-dev curl jq lsof lld
+        run: sudo apt-get update && sudo apt-get install -y build-essential libdbus-1-dev curl jq lsof lld patchelf
 
       - name: Install macOS SDK dependencies
         if: ${{ runner.os == 'macOS' }}

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -224,6 +224,11 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
   runs.
 - Linux CPU artifacts feed inference, two-node, native SDK, and Kotlin SDK
   smokes. macOS CPU artifacts feed Swift SDK smokes.
+- Linux native-runtime packaging uses `patchelf` to make packaged shared
+  libraries relocatable with `$ORIGIN`, then verifies them without
+  `LD_LIBRARY_PATH`. Release native-runtime jobs and Linux SDK smoke jobs need
+  `patchelf` because SDK smoke prepares native runtime packages through
+  `scripts/ci-prepare-native-runtime.sh`.
 - Artifact-consuming smokes are additionally gated on the matching CPU producer
   being eligible, so backend-only or cleanup-only PRs skip those jobs natively
   instead of attempting to download an artifact that was never uploaded.

--- a/crates/mesh-llm-native-runtime/README.md
+++ b/crates/mesh-llm-native-runtime/README.md
@@ -238,6 +238,13 @@ scripts/package-native-runtime.sh \
 scripts/verify-native-runtime-package.sh dist/native-runtimes/*.tar.gz
 ```
 
+Linux runtime packages must be relocatable from the installed cache. Packaged
+ELF shared libraries use `$ORIGIN` in their runtime search path so sibling
+libraries under `lib/` resolve without requiring users, CI, or SDK smoke tests to
+set `LD_LIBRARY_PATH`. The package verifier rejects absolute build or CI
+`RPATH`/`RUNPATH` entries and checks packaged Linux dependencies with
+`LD_LIBRARY_PATH` removed from the environment.
+
 CUDA lanes use `MESH_LLM_CUDA_TOOLKIT_MAJOR` to emit IDs such as `cuda12` or
 `cuda13`. `--backend cuda-blackwell` defaults to `cuda13-sm120`.
 

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -278,6 +278,23 @@ rewrite_macos_runtime_paths() {
     done
 }
 
+rewrite_linux_runtime_paths() {
+    case "$TARGET_TRIPLE" in
+        *linux*) ;;
+        *) return 0 ;;
+    esac
+    if ! command -v patchelf >/dev/null 2>&1; then
+        echo "patchelf is required to package Linux native runtimes" >&2
+        exit 1
+    fi
+
+    local rel_path library
+    for rel_path in "${library_paths[@]}"; do
+        library="$stage_dir/$rel_path"
+        patchelf --set-rpath '$ORIGIN' "$library"
+    done
+}
+
 if [[ -z "$TARGET_TRIPLE" ]]; then
     TARGET_TRIPLE="$(default_target_triple)"
 fi
@@ -334,6 +351,7 @@ for library in "${runtime_libraries[@]}"; do
 done
 
 rewrite_macos_runtime_paths
+rewrite_linux_runtime_paths
 
 primary_library="lib/$primary_name"
 primary_sha="$(sha256_file "$stage_dir/$primary_library")"

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -13,6 +13,7 @@ Verifies MeshLLM native runtime artifacts:
   - artifact directory name matches runtime.id
   - all runtime.libraries exist
   - library_sha256 matches the primary library
+  - Linux shared-library RUNPATH/RPATH is relocatable and resolves packaged deps
   - archive checksum sidecar when present
 EOF
 }
@@ -137,6 +138,7 @@ if library_sha256:
         )
 PY
     verify_macos_runtime_paths "$artifact_dir" "$manifest"
+    verify_linux_runtime_paths "$artifact_dir" "$manifest"
     echo "verified native runtime artifact: $artifact_dir"
 }
 
@@ -186,6 +188,106 @@ for rel_path in libraries:
             in_rpath = False
     if not has_loader_path_rpath:
         raise SystemExit(f"{rel_path} is missing @loader_path LC_RPATH")
+PY
+}
+
+verify_linux_runtime_paths() {
+    local artifact_dir="$1"
+    local manifest="$2"
+    if ! python3 - "$manifest" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    manifest = json.load(fh)
+raise SystemExit(0 if manifest["runtime"]["platform"].get("os") == "linux" else 1)
+PY
+    then
+        return 0
+    fi
+    if ! command -v readelf >/dev/null 2>&1; then
+        echo "readelf is required to verify Linux native runtime shared libraries" >&2
+        exit 1
+    fi
+    python3 - "$artifact_dir" "$manifest" <<'PY'
+import json
+import os
+import platform
+import re
+import shutil
+import subprocess
+import sys
+
+artifact_dir, manifest_path = sys.argv[1:3]
+with open(manifest_path, encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+libraries = manifest["runtime"]["libraries"]
+library_names = {os.path.basename(path) for path in libraries}
+artifact_root = os.path.realpath(artifact_dir)
+dynamic_re = re.compile(r"\((NEEDED|RPATH|RUNPATH)\).*\[(.*)\]")
+suspicious_tokens = (
+    "/home/runner/work",
+    ".deps/llama-build",
+    "build-stage-abi",
+)
+
+
+def dynamic_entries(path: str) -> tuple[list[str], list[str]]:
+    output = subprocess.check_output(["readelf", "-d", path], text=True)
+    needed: list[str] = []
+    search_paths: list[str] = []
+    for line in output.splitlines():
+        match = dynamic_re.search(line)
+        if not match:
+            continue
+        tag, value = match.groups()
+        if tag == "NEEDED":
+            needed.append(value)
+        else:
+            search_paths.extend(entry for entry in value.split(":") if entry)
+    return needed, search_paths
+
+
+def verify_ldd_resolution(rel_path: str, needed: list[str]) -> None:
+    packaged_needed = [dep for dep in needed if os.path.basename(dep) in library_names]
+    if not packaged_needed or platform.system() != "Linux":
+        return
+    if shutil.which("ldd") is None:
+        raise SystemExit("ldd is required to verify Linux packaged dependency resolution")
+    path = os.path.join(artifact_dir, rel_path)
+    env = os.environ.copy()
+    env.pop("LD_LIBRARY_PATH", None)
+    output = subprocess.check_output(["ldd", path], env=env, text=True, stderr=subprocess.STDOUT)
+    for dep in packaged_needed:
+        dep_name = os.path.basename(dep)
+        match = re.search(rf"^\s*{re.escape(dep_name)}\s+=>\s+(\S+)", output, re.MULTILINE)
+        if match is None:
+            raise SystemExit(f"{rel_path} ldd output is missing packaged dependency {dep_name}")
+        resolved = match.group(1)
+        if resolved == "not":
+            raise SystemExit(f"{rel_path} does not resolve packaged dependency {dep_name} without LD_LIBRARY_PATH")
+        if not os.path.realpath(resolved).startswith(artifact_root + os.sep):
+            raise SystemExit(
+                f"{rel_path} resolves packaged dependency {dep_name} outside artifact: {resolved}"
+            )
+
+
+for rel_path in libraries:
+    name = os.path.basename(rel_path)
+    if ".so" not in name:
+        continue
+    needed, search_paths = dynamic_entries(os.path.join(artifact_dir, rel_path))
+    packaged_needed = [dep for dep in needed if os.path.basename(dep) in library_names]
+    for entry in search_paths:
+        if any(token in entry for token in suspicious_tokens):
+            raise SystemExit(f"{rel_path} contains build-directory runtime search path: {entry}")
+        if entry.startswith("/"):
+            raise SystemExit(f"{rel_path} contains absolute runtime search path: {entry}")
+    if packaged_needed and not any("$ORIGIN" in entry for entry in search_paths):
+        joined = ", ".join(packaged_needed)
+        raise SystemExit(f"{rel_path} needs packaged libraries ({joined}) but is missing $ORIGIN RPATH/RUNPATH")
+    verify_ldd_resolution(rel_path, needed)
 PY
 }
 


### PR DESCRIPTION
## Summary
- set Linux native-runtime packaged shared libraries to use `$ORIGIN` runtime search paths
- extend the native-runtime package verifier to reject absolute/build RUNPATH/RPATH entries and verify packaged deps without `LD_LIBRARY_PATH`
- add `patchelf` to Linux release and SDK-smoke dependency setup
- document the Linux relocatability contract in native-runtime and CI docs

## Validation
- `bash -n scripts/package-native-runtime.sh && bash -n scripts/verify-native-runtime-package.sh`
- `GIT_MASTER=1 git diff --check`
- workflow/action YAML parse
- `cargo run -p xtask -- repo-consistency release-targets`
- Linux Docker red/green verifier fixture
- Linux amd64 x86_64 CPU package check with `RUNPATH [$ORIGIN]` and `ldd` resolving packaged deps without `LD_LIBRARY_PATH`
- direct Linux amd64 `dlopen` smoke over packaged libraries without `LD_LIBRARY_PATH`

## Caveat
A full `mesh-llm serve --log-format json` smoke against `v0.72.0-rc3` was not run because this checkout is `0.68.0` and no matching Linux binary was present. The verified runtime truth is the package and direct ELF loader chain without `LD_LIBRARY_PATH`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Linux build infrastructure to support improved native runtime packaging and validation.
  * Added dependency installation and validation steps to release and smoke test workflows.

* **Documentation**
  * Updated packaging documentation with Linux native runtime requirements and validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->