### PR TITLE
[codex] upgrade iroh to 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,19 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ahash"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
-dependencies = [
- "cfg-if 1.0.4",
- "getrandom 0.3.4",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,7 +170,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1041,7 +1028,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1437,12 +1424,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if 1.0.4",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.2",
  "fiat-crypto 0.3.0",
@@ -1570,7 +1557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1754,7 +1741,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1840,11 +1827,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "ed25519",
  "rand_core 0.10.0",
  "serde",
@@ -1938,7 +1925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3154,9 +3141,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
 dependencies = [
  "axum",
  "backon",
@@ -3192,7 +3179,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "smallvec",
  "strum 0.28.0",
@@ -3203,36 +3189,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
+checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.2",
  "ed25519-dalek",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
+checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3242,8 +3224,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.2",
  "rustls",
  "simple-dns",
  "strum 0.28.0",
@@ -3254,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -3277,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3289,11 +3271,10 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
 dependencies = [
- "ahash",
  "blake3",
  "bytes",
  "cfg_aliases",
@@ -4464,9 +4445,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -4474,9 +4455,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4506,9 +4487,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -4604,19 +4585,22 @@ checksum = "f0efe882e02d206d8d279c20eb40e03baf7cb5136a1476dc084a324fbc3ec42d"
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
  "netlink-packet-route 0.29.0",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -4649,9 +4633,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -4688,14 +4672,15 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
+checksum = "8487d26d691cd98d5c17b2adb4b1fd4b31cccc820da1eac827d483295d7bb94a"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -4703,7 +4688,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -4777,9 +4762,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
+checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4799,9 +4784,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
+checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -4827,9 +4812,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
+checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4930,7 +4915,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5760,9 +5745,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aec2a8809e3f7dba624776bb223da9fed49c413c60b3bef21aadcb67a5e35944"
+checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
 dependencies = [
  "base64",
  "bytes",
@@ -6092,7 +6077,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6664,7 +6649,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6757,7 +6742,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6778,7 +6763,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7032,7 +7017,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7806,7 +7791,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9152,7 +9137,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10020,18 +10005,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -22,7 +22,7 @@ host-io = ["mesh-llm-identity/host-io"]
 # model-artifact, iroh, tokio, prost, bytes, rustls, quinn, serde, serde_json, thiserror, anyhow,
 # tracing, sha2, ed25519-dalek, hex, uuid, url, http, base64, async-trait, httparse
 # (httparse is a transitive dep of iroh; not in forbidden list)
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0"
 mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.68.0", default-features = false }
 mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.68.0" }
 mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.68.0" }
@@ -43,7 +43,7 @@ hex = "0.4"
 sha2 = "0.10"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["rand_core"] }
+ed25519-dalek = { version = "=3.0.0-rc.0", features = ["rand_core"] }
 crypto_box = "0.9"
 rand = "0.10"
 base64 = "0.22"

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0"
 json5 = "1.3.1"
 mesh-llm-build-info.workspace = true
 mesh-llm-cli = { path = "../mesh-llm-cli", version = "0.68.0" }

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -57,7 +57,7 @@ skippy-coordinator = { path = "../skippy-coordinator", version = "0.68.0"  }
 skippy-runtime = { path = "../skippy-runtime", version = "0.68.0"  }
 skippy-server = { path = "../skippy-server", version = "0.68.0"  }
 skippy-topology = { path = "../skippy-topology", version = "0.68.0"  }
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
@@ -83,7 +83,7 @@ futures-util = "0.3"
 semver = "1"
 sha2 = "0.10"
 tar = "0.4"
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["rand_core"] }
+ed25519-dalek = { version = "=3.0.0-rc.0", features = ["rand_core"] }
 crypto_box = "0.9"
 chacha20poly1305 = "0.10"
 argon2 = "0.5"
@@ -119,5 +119,5 @@ mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = 
 # with AccessConfig::Restricted, then build a real iroh::Endpoint from our
 # relay_map_from_urls output and verify --relay-auth tokens reach the relay
 # on the WebSocket upgrade (and that the wrong token is rejected).
-iroh = { version = "1.0.0-rc.0", features = ["test-utils"] }
-iroh-relay = { version = "1.0.0-rc.0", features = ["server", "test-utils"] }
+iroh = { version = "1.0.0", features = ["test-utils"] }
+iroh-relay = { version = "1.0.0", features = ["server", "test-utils"] }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -708,11 +708,11 @@ mod relay_map_tests {
 }
 
 /// End-to-end regression tests for `--relay-auth` against a real in-process
-/// iroh-relay running [`iroh_relay::server::AccessConfig::Restricted`].
+/// iroh-relay running a custom [`iroh_relay::server::AccessControl`].
 ///
 /// These tests do not go through the full `Node::start` path — they exercise
 /// `relay_map_from_urls` (the new wiring) plus the iroh `Endpoint` builder
-/// the same way `bind_mesh_endpoint` does, with `ca_roots_config` overridden
+/// the same way `bind_mesh_endpoint` does, with `ca_tls_config` overridden
 /// for the relay's self-signed test cert. The contract being defended is:
 ///
 ///  1. A token configured for a gated relay URL reaches iroh as
@@ -730,25 +730,31 @@ mod gated_relay_e2e_tests {
     use iroh::Watcher;
     use iroh::endpoint::{Endpoint, RelayMode, presets};
     use iroh::test_utils::run_relay_server_with_access;
-    use iroh_relay::server::{Access, AccessConfig};
-    use iroh_relay::tls::CaRootsConfig;
+    use iroh_relay::server::{Access, AccessControl, AllowAll, ClientRequest};
+    use iroh_relay::tls::CaTlsConfig;
     use std::collections::HashMap;
+    use std::sync::Arc;
     use std::time::Duration;
+
+    #[derive(Debug)]
+    struct TokenAccess(&'static str);
+
+    impl AccessControl for TokenAccess {
+        async fn on_connect(&self, request: &ClientRequest) -> Access {
+            if request.auth_token().as_deref() == Some(self.0) {
+                Access::Allow
+            } else {
+                Access::Deny { reason: None }
+            }
+        }
+    }
 
     /// Spawn an in-process iroh-relay that only admits `expected_token`.
     /// Returns (relay_url_string, drop-guard server).
     async fn spawn_gated_relay(
         expected_token: &'static str,
     ) -> (String, iroh_relay::server::Server) {
-        let access = AccessConfig::Restricted(Box::new(move |request| {
-            Box::pin(async move {
-                if request.auth_token().as_deref() == Some(expected_token) {
-                    Access::Allow
-                } else {
-                    Access::Deny
-                }
-            })
-        }));
+        let access = Arc::new(TokenAccess(expected_token));
         let (_relay_map, relay_url, server) = run_relay_server_with_access(false, access)
             .await
             .expect("spawn gated relay");
@@ -768,7 +774,7 @@ mod gated_relay_e2e_tests {
                 relay_urls,
                 relay_auths,
             )))
-            .ca_roots_config(CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await
             .expect("endpoint bind")
@@ -854,7 +860,7 @@ mod gated_relay_e2e_tests {
         // Spin up a second, fully-open relay to stand in for a public iroh
         // relay sharing the same map.
         let (_public_map, public_url, _public) =
-            run_relay_server_with_access(false, AccessConfig::Everyone)
+            run_relay_server_with_access(false, Arc::new(AllowAll))
                 .await
                 .expect("spawn public relay");
         let public_url = public_url.to_string();

--- a/crates/mesh-llm-identity/Cargo.toml
+++ b/crates/mesh-llm-identity/Cargo.toml
@@ -19,7 +19,7 @@ chacha20poly1305 = "0.10"
 chrono = { version = "0.4", features = ["serde"] }
 crypto_box = "0.9"
 dirs = { version = "6.0.0", optional = true }
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["rand_core"] }
+ed25519-dalek = { version = "=3.0.0-rc.0", features = ["rand_core"] }
 hex = "0.4"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust", "vendored"], optional = true }
 rand = "0.10"

--- a/crates/mesh-llm-protocol/Cargo.toml
+++ b/crates/mesh-llm-protocol/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 anyhow.workspace = true
 hex = "0.4"
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0"
 prost = "0.14"
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/mesh-llm-routing/Cargo.toml
+++ b/crates/mesh-llm-routing/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["llm", "mesh", "routing", "inference"]
 categories = ["network-programming"]
 
 [dependencies]
-iroh = "1.0.0-rc.0"
+iroh = "1.0.0"

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 publish = false
 
 [dependencies]
-ed25519-dalek = { version = "=3.0.0-pre.7", features = ["rand_core"] }
+ed25519-dalek = { version = "=3.0.0-rc.0", features = ["rand_core"] }
 getrandom = "0.3"
 hex = "0.4"
 mesh-llm-system = { path = "../../crates/mesh-llm-system" }


### PR DESCRIPTION
## Summary

- Upgrade direct `iroh` and `iroh-relay` pins from `1.0.0-rc.0` to `1.0.0`.
- Align exact `ed25519-dalek` pins with the version required by `iroh 1.0.0`.
- Update the gated relay regression test for the stable `iroh-relay` `AccessControl` API and `ca_tls_config` naming.

## Impact

This moves mesh networking dependencies from the iroh 1.0 release candidate to the stable 1.0 line while keeping the existing relay-auth behavior covered by the in-process relay test.

## Validation

- `cargo check -p mesh-llm`
- `cargo check -p mesh-llm-host-runtime --tests`
- `cargo check -p mesh-llm-client --tests`
- `cargo check -p mesh-llm-identity --tests`
- `cargo check -p xtask`
- `cargo fmt --all --check`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-client --all-targets -- -D warnings`
- `cargo clippy -p xtask -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core messaging infrastructure dependencies from release candidates to the stable 1.0.0 release version
  * Upgraded cryptographic signature and verification dependencies to release candidate versions across multiple components and development tools
  * Refactored relay API integration to align with updated authentication control and certificate verification implementation patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->