### PR TITLE
Support GLM DSA IndexShare layers

### DIFF
--- a/third_party/llama.cpp/patches/0110-Support-GLM-DSA-IndexShare-layers.patch
+++ b/third_party/llama.cpp/patches/0110-Support-GLM-DSA-IndexShare-layers.patch
@@ -1,0 +1,92 @@
+From ab74aa4a59b3e49b5f83de0763d651c1eda18ce7 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Mon, 22 Jun 2026 10:54:53 +1000
+Subject: [PATCH 110/110] Support GLM DSA IndexShare layers
+
+---
+ src/llama-graph.cpp       |  2 ++
+ src/models/deepseek32.cpp | 16 +++++++++++++++-
+ src/models/glm-dsa.cpp    | 12 ++++++------
+ 3 files changed, 23 insertions(+), 7 deletions(-)
+
+diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
+index 64d38fc4..d79bda76 100644
+--- a/src/llama-graph.cpp
++++ b/src/llama-graph.cpp
+@@ -2639,6 +2639,8 @@ ggml_tensor * llm_graph_context::build_attn(
+ 
+     const auto & kq_mask = inp->get_kq_mask_mla();
+ 
++    GGML_ASSERT(top_k != nullptr);
++
+     // prepare new kq mask - starts filled with -INFINITY
+     ggml_tensor * kq_mask_all = ggml_fill(ctx0, kq_mask, -INFINITY);
+ 
+diff --git a/src/models/deepseek32.cpp b/src/models/deepseek32.cpp
+index 9a20e2ce..2cc13491 100644
+--- a/src/models/deepseek32.cpp
++++ b/src/models/deepseek32.cpp
+@@ -202,6 +202,8 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+ 
+     ggml_tensor * inp_out_ids = build_inp_out_ids();
+ 
++    ggml_tensor * shared_top_k = nullptr;
++
+     for (int il = 0; il < n_layer; ++il) {
+         ggml_tensor * inpSA = inpL;
+ 
+@@ -219,8 +221,15 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+ 
+             ggml_tensor * top_k = nullptr;
+ 
++            const bool has_indexer =
++                model.layers[il].indexer_attn_q_b &&
++                model.layers[il].indexer_attn_k &&
++                model.layers[il].indexer_k_norm &&
++                model.layers[il].indexer_k_norm_b &&
++                model.layers[il].indexer_proj;
++
+             // lightning indexer
+-            {
++            if (has_indexer) {
+                 ggml_tensor * indexer_q = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_q_b, qr);
+                 cb(indexer_q, "indexer_q", il);
+ 
+@@ -343,6 +352,11 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+                 uint32_t n_top_k = indexer_score->ne[0] < n_indexer_top_k ? indexer_score->ne[0] : n_indexer_top_k;
+                 top_k = ggml_cont(ctx0, ggml_top_k(ctx0, indexer_score, n_top_k));
+                 cb(top_k, "top_k", il);
++                shared_top_k = top_k;
++            } else {
++                GGML_ASSERT(shared_top_k != nullptr && "DSA IndexShare layer requires a previous top-k");
++                top_k = shared_top_k;
++                cb(top_k, "top_k_shared", il);
+             }
+ 
+             ggml_tensor * q = ggml_mul_mat(ctx0, model.layers[il].wq_b, qr);
+diff --git a/src/models/glm-dsa.cpp b/src/models/glm-dsa.cpp
+index d7067347..8162f641 100644
+--- a/src/models/glm-dsa.cpp
++++ b/src/models/glm-dsa.cpp
+@@ -95,12 +95,12 @@ void llama_model_glm_dsa::load_arch_tensors(llama_model_loader &) {
+ 
+         layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, flags);
+ 
+-        // DSA indexer
+-        layer.indexer_k_norm   = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "weight", i), {hparams.indexer_head_size}, flags);
+-        layer.indexer_k_norm_b = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "bias",   i), {hparams.indexer_head_size}, flags);
+-        layer.indexer_proj     = create_tensor(tn(LLM_TENSOR_INDEXER_PROJ,     "weight", i), {n_embd, hparams.indexer_n_head}, flags);
+-        layer.indexer_attn_k   = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_K,   "weight", i), {n_embd, hparams.indexer_head_size}, flags);
+-        layer.indexer_attn_q_b = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_Q_B, "weight", i), {q_lora_rank, hparams.indexer_n_head * hparams.indexer_head_size}, flags);
++        // GLM DSA uses lightning indexer tensors only on sparse layers.
++        layer.indexer_k_norm   = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "weight", i), {hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
++        layer.indexer_k_norm_b = create_tensor(tn(LLM_TENSOR_INDEXER_K_NORM,   "bias",   i), {hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
++        layer.indexer_proj     = create_tensor(tn(LLM_TENSOR_INDEXER_PROJ,     "weight", i), {n_embd, hparams.indexer_n_head}, flags | TENSOR_NOT_REQUIRED);
++        layer.indexer_attn_k   = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_K,   "weight", i), {n_embd, hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
++        layer.indexer_attn_q_b = create_tensor(tn(LLM_TENSOR_INDEXER_ATTN_Q_B, "weight", i), {q_lora_rank, hparams.indexer_n_head * hparams.indexer_head_size}, flags | TENSOR_NOT_REQUIRED);
+         if (i < (int) hparams.n_layer_dense_lead) {
+             layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, flags);
+             layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, flags);
+-- 
+2.54.0 (Apple Git-156)
+


### PR DESCRIPTION
## Summary
- add the GLM DSA IndexShare llama.cpp patch to the mesh-llm patch queue
- mark GLM DSA indexer tensors optional so layers without local indexer weights can load
- reuse the previous sparse-layer top-k for IndexShare layers and assert that attention receives one

## Validation
- LLAMA_WORKDIR="/tmp/mesh-llm-llama.bTs460" scripts/prepare-llama.sh pinned

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GLM DSA layer handling to properly support sparse attention configurations and improved tensor requirement validation.

* **Performance**
  * Optimized tensor allocation by making indexer tensors conditional rather than required for all layers, reducing memory overhead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->