### PR TITLE
Add direct quantized layer package workflow

### DIFF
--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -1189,16 +1189,22 @@ fn write_package_artifact(
     );
     let path = out_dir.join(&spec.relative_path);
     write_stage_artifact(source, &stage, &path)?;
+    let relative_path = spec.relative_path.display().to_string();
+    run_artifact_hook(artifact_hook, &path, &relative_path)?;
+    let artifact_info = ModelInfo::open(&path)
+        .with_context(|| format!("open package artifact {}", path.display()))?;
+    let artifact_tensors = artifact_info
+        .tensors()
+        .with_context(|| format!("read package artifact tensors {}", path.display()))?;
     let metadata = fs::metadata(&path)
         .with_context(|| format!("read artifact metadata {}", path.display()))?;
     let artifact = PackageArtifact {
-        path: spec.relative_path.display().to_string(),
-        tensor_count: stage.tensor_count,
-        tensor_bytes: stage.tensor_bytes,
+        path: relative_path,
+        tensor_count: artifact_tensors.len(),
+        tensor_bytes: artifact_tensors.iter().map(|tensor| tensor.byte_size).sum(),
         artifact_bytes: metadata.len(),
         sha256: file_sha256(&path)?,
     };
-    run_artifact_hook(artifact_hook, &path, &artifact.path)?;
     Ok(artifact)
 }
 

--- a/crates/skippy-quantize/README.md
+++ b/crates/skippy-quantize/README.md
@@ -406,10 +406,10 @@ Important quantization flags:
 ## Recipes
 
 Top-level quantization modes intentionally mirror the pinned llama.cpp quant
-table. Custom profile labels such as `UD-Q3_K_S` and `Q4_K_XL` are accepted as
-recipe aliases when paired with `--tensor-type-file`. They resolve to the
-corresponding base llama quant for backend execution while preserving the recipe
-label in default output and sidecar names.
+table. Custom profile names such as `Q2_K-MTP-Q8`, `UD-Q3_K_S`, or `Q4_K_XL`
+belong in artifact names such as `--target-prefix` and `--output-basename`, not
+in `--quant`. Pass the base llama quant with `--quant` and express any
+per-tensor policy with `--tensor-type-file` or repeated `--tensor-type`.
 
 The tensor recipe format is one override per line:
 

--- a/crates/skippy-quantize/README.md
+++ b/crates/skippy-quantize/README.md
@@ -426,6 +426,51 @@ skippy-quantize list-quants --json
 skippy-quantize list-tensor-types --json
 ```
 
+## BF16 to layer package
+
+For lab workflows, keep one reusable split BF16 GGUF artifact as the durable
+source of truth, then build quantized layer packages from it. The quantized
+GGUF shards can be treated as disposable staging once the package preflight
+passes:
+
+```bash
+skippy-quantize quantize-layer-package \
+  --source /Users/lab/glm52-work/bf16-gguf \
+  --source-prefix BF16 \
+  --target /Users/lab/glm52-work/quantized \
+  --target-prefix Q2_K-MTP-Q8 \
+  --manifest /Users/lab/glm52-work/work/q2-k-mtp-q8-package/quant-manifest.json \
+  --package-dir /Users/lab/glm52-work/packages/GLM-5.2-Q2_K-MTP-Q8-layers \
+  --package-model-id meshllm/GLM-5.2-Q2_K-MTP-Q8-GGUF:Q2_K-MTP-Q8 \
+  --package-source-repo meshllm/GLM-5.2-Q2_K-MTP-Q8-GGUF \
+  --package-source-revision local \
+  --work-dir /Users/lab/glm52-work/work/q2-k-mtp-q8-package/native-work \
+  --spool-dir /Users/lab/glm52-work/work/q2-k-mtp-q8-package/spool \
+  --record-dir /Users/lab/glm52-work/work/q2-k-mtp-q8-package/records \
+  --json-event-file /Users/lab/glm52-work/work/q2-k-mtp-q8-package/status.json \
+  --quant Q2_K \
+  --tensor-type-file /Users/lab/glm52-work/recipes/glm-5.2-q2-k-mtp-q8.tensor-types.txt \
+  --output-basename GLM-5.2-Q2_K-MTP-Q8 \
+  --stages 2 \
+  --replace-package \
+  --watchdog-seconds 120
+```
+
+Build prerequisites:
+
+```bash
+just skippy-quantize-standalone-release-build
+cargo build --release --locked -p skippy-model-package
+```
+
+The command validates the source split, writes the package artifacts from the
+BF16 GGUF source, quantizes each artifact in place, then runs package preflight.
+It does not materialize a complete quantized GGUF repo first. By default, the
+temporary quant scratch directory is deleted after package preflight passes;
+pass `--keep-quant` to retain it. It does not pass `--max-memory` to
+quantization because the unpatched llama API quant backend does not expose a
+memory-budget knob.
+
 ## Validation
 
 Useful checks:

--- a/crates/skippy-quantize/src/direct_quantize.rs
+++ b/crates/skippy-quantize/src/direct_quantize.rs
@@ -413,12 +413,13 @@ mod tests {
     }
 
     #[test]
-    fn parses_recipe_quant_label_for_direct_quantize() {
-        let parsed = parse_direct_quantize_positionals(&["UD-Q3_K_S".to_string()]).unwrap();
+    fn rejects_profile_quant_label_for_direct_quantize() {
+        let error = parse_direct_quantize_positionals(&["UD-Q3_K_S".to_string()]).unwrap_err();
 
-        assert_eq!(parsed.output, None);
-        assert_eq!(parsed.quant.base_quant(), QuantType::Q3KS);
-        assert_eq!(parsed.quant.output_name(), "UD-Q3_K_S");
+        assert!(
+            error.to_string().contains("custom tensor-type recipes"),
+            "profile labels should not be accepted as quant modes: {error}"
+        );
     }
 
     #[test]
@@ -611,12 +612,9 @@ mod tests {
             PathBuf::from("ggml-model-Q2_K_S.gguf")
         );
         assert_eq!(
-            default_output_path(
-                Path::new("/repo/BF16/model.gguf"),
-                &"UD-Q3_K_S".parse::<QuantSpec>().unwrap()
-            )
-            .unwrap(),
-            PathBuf::from("/repo/BF16/ggml-model-UD-Q3_K_S.gguf")
+            default_output_path(Path::new("/repo/BF16/model.gguf"), &QuantType::Q3KS.into())
+                .unwrap(),
+            PathBuf::from("/repo/BF16/ggml-model-Q3_K_S.gguf")
         );
     }
 

--- a/crates/skippy-quantize/src/gguf_template.rs
+++ b/crates/skippy-quantize/src/gguf_template.rs
@@ -50,6 +50,7 @@ pub(crate) fn metadata_from_hf_config_with_options(
     ];
     push_common_llm_metadata(&mut metadata, arch, &config, options)?;
     push_attention_metadata(&mut metadata, arch, &config)?;
+    push_glm_dsa_indexer_metadata(&mut metadata, arch, &config)?;
     push_moe_metadata(&mut metadata, arch, &config);
     push_tokenizer_metadata(&mut metadata, source, &config)?;
     if options.include_mtp {
@@ -220,6 +221,38 @@ fn push_attention_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Valu
     Ok(())
 }
 
+fn push_glm_dsa_indexer_metadata(
+    metadata: &mut Vec<GgufKv>,
+    arch: &str,
+    config: &Value,
+) -> Result<()> {
+    if arch != "glm-dsa" {
+        return Ok(());
+    }
+    push_required_first_u32(
+        metadata,
+        arch,
+        "attention.indexer.head_count",
+        config,
+        &["index_n_heads", "indexer_n_head"],
+    )?;
+    push_required_first_u32(
+        metadata,
+        arch,
+        "attention.indexer.key_length",
+        config,
+        &["index_head_dim", "indexer_head_size"],
+    )?;
+    push_required_first_u32(
+        metadata,
+        arch,
+        "attention.indexer.top_k",
+        config,
+        &["index_topk", "indexer_top_k"],
+    )?;
+    Ok(())
+}
+
 fn push_moe_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Value) {
     push_first_u32(
         metadata,
@@ -269,6 +302,26 @@ fn push_moe_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Value) {
     if let Some(norm) = optional_bool(config, "norm_topk_prob") {
         metadata.push(GgufKv::bool(&format!("{arch}.expert_weights_norm"), norm));
     }
+}
+
+fn push_required_first_u32(
+    metadata: &mut Vec<GgufKv>,
+    arch: &str,
+    gguf_suffix: &str,
+    config: &Value,
+    config_keys: &[&str],
+) -> Result<()> {
+    for config_key in config_keys {
+        if let Some(value) = optional_u32(config, config_key) {
+            ensure!(
+                value > 0,
+                "config value {config_key:?} must be greater than zero"
+            );
+            metadata.push(GgufKv::u32(&format!("{arch}.{gguf_suffix}"), value));
+            return Ok(());
+        }
+    }
+    anyhow::bail!("config missing one of {config_keys:?}")
 }
 
 fn push_first_u32(
@@ -434,6 +487,68 @@ mod tests {
             matches!(
                 kv,
                 GgufKv::U32 { key, .. } if key == "deepseek2.nextn_predict_layers"
+            )
+        }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn builds_glm_dsa_indexer_metadata_from_config() {
+        let root = unique_temp_dir();
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("config.json"),
+            r#"{
+              "model_type": "glm_moe_dsa",
+              "vocab_size": 154880,
+              "max_position_embeddings": 1048576,
+              "hidden_size": 6144,
+              "intermediate_size": 12288,
+              "num_hidden_layers": 78,
+              "num_nextn_predict_layers": 1,
+              "num_attention_heads": 64,
+              "num_key_value_heads": 64,
+              "qk_nope_head_dim": 192,
+              "qk_rope_head_dim": 64,
+              "v_head_dim": 256,
+              "q_lora_rank": 2048,
+              "kv_lora_rank": 512,
+              "index_n_heads": 32,
+              "index_head_dim": 128,
+              "index_topk": 2048,
+              "n_routed_experts": 256,
+              "num_experts_per_tok": 8,
+              "n_shared_experts": 1,
+              "moe_intermediate_size": 2048,
+              "first_k_dense_replace": 3,
+              "routed_scaling_factor": 2.5,
+              "norm_topk_prob": true,
+              "rms_norm_eps": 1e-5
+            }"#,
+        )
+        .unwrap();
+
+        let metadata = metadata_from_hf_config(&root, 3).unwrap();
+
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.indexer.head_count" && *value == 32
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.indexer.key_length" && *value == 128
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.indexer.top_k" && *value == 2048
             )
         }));
         fs::remove_dir_all(root).unwrap();

--- a/crates/skippy-quantize/src/gguf_writer.rs
+++ b/crates/skippy-quantize/src/gguf_writer.rs
@@ -131,7 +131,8 @@ fn prepare_raw_safetensors_gguf(
         source.display()
     );
     let total_tensor_count = tensors.len();
-    let tensors = select_split_tensors(tensors, options.split)?;
+    let mut tensors = select_split_tensors(tensors, options.split)?;
+    assign_gguf_offsets(&mut tensors)?;
     let metadata = options
         .metadata
         .clone()
@@ -161,10 +162,9 @@ fn select_split_tensors(
     );
     let split_index =
         usize::try_from(split.split_index).context("split_index does not fit usize")?;
-    let split_count =
-        usize::try_from(split.split_count).context("split_count does not fit usize")?;
-    let start = (split_index - 1) * total_tensors / split_count;
-    let end = split_index * total_tensors / split_count;
+    let boundaries = byte_balanced_split_boundaries(&tensors, split)?;
+    let start = boundaries[split_index - 1];
+    let end = boundaries[split_index];
     ensure!(
         start < end,
         "split {} of {} would contain no tensors",
@@ -176,6 +176,63 @@ fn select_split_tensors(
         .enumerate()
         .filter_map(|(index, tensor)| (start <= index && index < end).then_some(tensor))
         .collect())
+}
+
+fn byte_balanced_split_boundaries(
+    tensors: &[TensorSource],
+    split: GgufSplit,
+) -> Result<Vec<usize>> {
+    split.validate()?;
+    let split_count =
+        usize::try_from(split.split_count).context("split_count does not fit usize")?;
+    ensure!(
+        split_count <= tensors.len(),
+        "split_count {} cannot exceed tensor count {}",
+        split.split_count,
+        tensors.len()
+    );
+    let total_bytes = tensors
+        .iter()
+        .try_fold(0_u128, |acc, tensor| {
+            acc.checked_add(tensor.byte_len as u128)
+        })
+        .context("split tensor byte total overflow")?;
+    let mut boundaries = vec![0_usize];
+    let mut accumulated = 0_u128;
+    for (index, tensor) in tensors.iter().enumerate() {
+        accumulated = accumulated
+            .checked_add(tensor.byte_len as u128)
+            .context("split tensor byte total overflow")?;
+        let remaining_tensors = tensors.len() - (index + 1);
+        let remaining_splits = split_count - boundaries.len();
+        if boundaries.len() < split_count && remaining_tensors >= remaining_splits {
+            let target = total_bytes
+                .checked_mul(boundaries.len() as u128)
+                .context("split target byte overflow")?
+                / split_count as u128;
+            if accumulated >= target {
+                boundaries.push(index + 1);
+            }
+        }
+    }
+    while boundaries.len() < split_count {
+        let next = boundaries.last().copied().unwrap_or(0) + 1;
+        boundaries.push(next);
+    }
+    boundaries.push(tensors.len());
+    Ok(boundaries)
+}
+
+fn assign_gguf_offsets(tensors: &mut [TensorSource]) -> Result<()> {
+    let mut offset = 0_u64;
+    for tensor in tensors {
+        offset = align_to(offset, GGUF_ALIGNMENT);
+        tensor.gguf_offset = offset;
+        offset = offset
+            .checked_add(tensor.byte_len)
+            .with_context(|| format!("GGUF data offset overflow after {}", tensor.name))?;
+    }
+    Ok(())
 }
 
 fn split_metadata(
@@ -269,14 +326,6 @@ fn collect_tensor_sources(
         tensors.push(group.into_tensor_source()?);
     }
     tensors.sort_by(|a, b| a.name.cmp(&b.name));
-    let mut offset = 0_u64;
-    for tensor in &mut tensors {
-        offset = align_to(offset, GGUF_ALIGNMENT);
-        tensor.gguf_offset = offset;
-        offset = offset
-            .checked_add(tensor.byte_len)
-            .with_context(|| format!("GGUF data offset overflow after {}", tensor.name))?;
-    }
     Ok(tensors)
 }
 

--- a/crates/skippy-quantize/src/gguf_writer_tests.rs
+++ b/crates/skippy-quantize/src/gguf_writer_tests.rs
@@ -687,6 +687,55 @@ fn writes_only_selected_split_with_split_metadata() {
     assert_eq!(parsed.metadata_count, 4);
     assert_eq!(parsed.tensors[0].name, "c.weight");
     assert_eq!(parsed.tensors[1].name, "d.weight");
+    assert_eq!(parsed.tensors[0].absolute_offset, parsed.data_start);
+    assert_eq!(
+        &bytes[parsed.tensors[0].absolute_offset..parsed.tensors[0].absolute_offset + 4],
+        &[3, 0, 0, 0]
+    );
+    assert_eq!(
+        &bytes[parsed.tensors[1].absolute_offset..parsed.tensors[1].absolute_offset + 4],
+        &[4, 0, 0, 0]
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn native_splits_are_byte_balanced_not_tensor_count_balanced() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[
+            ("a.weight", "F32", &[64], &[1; 256]),
+            ("b.weight", "F32", &[1], &[2, 0, 0, 0]),
+            ("c.weight", "F32", &[1], &[3, 0, 0, 0]),
+            ("d.weight", "F32", &[1], &[4, 0, 0, 0]),
+        ],
+    );
+    let output = root.join("split.gguf");
+
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 64,
+            metadata: None,
+            tensor_name_map: TensorNameMap::Raw,
+            split: Some(GgufSplit {
+                split_index: 1,
+                split_count: 2,
+            }),
+            output_type: None,
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+
+    let bytes = fs::read(&output).unwrap();
+    let parsed = parse_test_gguf(&bytes);
+    assert_eq!(parsed.tensor_count, 1);
+    assert_eq!(parsed.tensors[0].name, "a.weight");
+    assert_eq!(parsed.tensors[0].absolute_offset, parsed.data_start);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -727,6 +776,7 @@ fn keeps_rank_one_f32_tensor_as_f32_for_bf16_output() {
 struct ParsedGguf {
     tensor_count: u64,
     metadata_count: u64,
+    data_start: usize,
     tensors: Vec<ParsedTensor>,
 }
 
@@ -800,6 +850,7 @@ fn parse_test_gguf(bytes: &[u8]) -> ParsedGguf {
     ParsedGguf {
         tensor_count,
         metadata_count,
+        data_start,
         tensors: tensors
             .into_iter()
             .map(|(name, dims, ggml_type, relative_offset)| ParsedTensor {

--- a/crates/skippy-quantize/src/main.rs
+++ b/crates/skippy-quantize/src/main.rs
@@ -778,6 +778,7 @@ fn write_layer_package_quant_hook(
     if let Some(nthreads) = runner.nthreads {
         script.push_str(&format!(" --nthreads {nthreads}"));
     }
+    append_optional_tensor_type_file(&mut script, args.init.tensor_type_file.as_deref());
     if runner.allow_requantize {
         script.push_str(" --allow-requantize");
     }
@@ -804,6 +805,12 @@ fn write_layer_package_quant_hook(
     fs::write(&hook, script).with_context(|| format!("write hook {}", hook.display()))?;
     make_executable(&hook)?;
     Ok(hook)
+}
+
+fn append_optional_tensor_type_file(script: &mut String, tensor_type_file: Option<&Path>) {
+    if let Some(path) = tensor_type_file {
+        script.push_str(&format!(" --tensor-type-file {}", shell_quote(path)));
+    }
 }
 
 fn run_skippy_model_package_write(
@@ -1473,4 +1480,24 @@ fn print_dry_run_complete(json: bool, kind: &str) -> Result<()> {
         ));
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::append_optional_tensor_type_file;
+
+    #[test]
+    fn layer_package_hook_forwards_tensor_type_file() {
+        let mut script = String::new();
+
+        append_optional_tensor_type_file(
+            &mut script,
+            Some(Path::new("/tmp/recipes/glm 5.2 q2.tensor-types.txt")),
+        );
+
+        assert!(script.contains("--tensor-type-file"));
+        assert!(script.contains("'/tmp/recipes/glm 5.2 q2.tensor-types.txt'"));
+    }
 }

--- a/crates/skippy-quantize/src/main.rs
+++ b/crates/skippy-quantize/src/main.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command as ProcessCommand;
 use std::time::Instant;
 
 use anyhow::{Context, Result, ensure};
@@ -97,6 +98,7 @@ enum Command {
     Convert(DirectConvertArgs),
     PlanConvert(PlanConvertArgs),
     Quantize(DirectQuantizeArgs),
+    QuantizeLayerPackage(QuantizeLayerPackageArgs),
     ConvertJob(ConvertJobArgs),
     QuantJob(QuantJobArgs),
     Status(StatusArgs),
@@ -197,6 +199,34 @@ struct QuantJobRunArgs {
     verify_on_complete: bool,
     #[command(flatten)]
     verify_load: VerifyLoadArgs,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Debug, Parser)]
+struct QuantizeLayerPackageArgs {
+    #[command(flatten)]
+    init: InitQuantArgs,
+    #[command(flatten)]
+    runner: QuantRunnerArgs,
+    #[arg(long)]
+    package_dir: PathBuf,
+    #[arg(long)]
+    package_model_id: String,
+    #[arg(long)]
+    package_source_repo: String,
+    #[arg(long)]
+    package_source_revision: String,
+    #[arg(long)]
+    package_source_file: Option<String>,
+    #[arg(long, default_value = "target/release/skippy-model-package")]
+    skippy_model_package_bin: PathBuf,
+    #[arg(long)]
+    stages: Option<usize>,
+    #[arg(long)]
+    keep_quant: bool,
+    #[arg(long)]
+    replace_package: bool,
     #[arg(long)]
     json: bool,
 }
@@ -461,6 +491,7 @@ fn main() -> Result<()> {
         Command::Convert(args) => run_direct_convert(args),
         Command::PlanConvert(args) => run_plan_convert(args),
         Command::Quantize(args) => run_direct_quantize(args),
+        Command::QuantizeLayerPackage(args) => quantize_layer_package(args),
         Command::ConvertJob(args) => convert_job(args),
         Command::QuantJob(args) => quant_job(args),
         Command::Status(args) => run_status_command(&args.manifest, args.json),
@@ -643,6 +674,222 @@ fn quant_job(args: QuantJobArgs) -> Result<()> {
         })?;
         print_verify_on_complete(&manifest_path, verify_options)
     })
+}
+
+fn quantize_layer_package(args: QuantizeLayerPackageArgs) -> Result<()> {
+    ensure!(
+        args.init.window_size == 1,
+        "quantize-layer-package currently requires --window-size 1"
+    );
+    ensure!(
+        !args.runner.dry_run,
+        "quantize-layer-package does not support --dry-run; use quant-job --preflight-only first"
+    );
+    ensure!(
+        !args.runner.print_only,
+        "quantize-layer-package does not support --print-only; use quant-job --preflight-only first"
+    );
+    ensure!(
+        args.skippy_model_package_bin.is_file(),
+        "missing skippy-model-package binary {}; build it with `cargo build --release --locked -p skippy-model-package` or pass --skippy-model-package-bin",
+        args.skippy_model_package_bin.display()
+    );
+    if args.package_dir.exists() {
+        ensure!(
+            args.replace_package,
+            "package dir already exists: {}; pass --replace-package to overwrite it",
+            args.package_dir.display()
+        );
+        fs::remove_dir_all(&args.package_dir)
+            .with_context(|| format!("remove package dir {}", args.package_dir.display()))?;
+    }
+
+    let manifest = quant_manifest_from_args(&args.init)?;
+    let manifest_path = args.init.manifest.clone();
+    let runner = prepare_quant_runner(args.runner.clone())?;
+    with_manifest_lock(&manifest_path, || {
+        ensure_manifest(&manifest_path, &manifest)?;
+        let hook = write_layer_package_quant_hook(&args, &runner)?;
+        write_and_preflight_layer_package(&args, &manifest, &hook)?;
+        if !args.keep_quant {
+            remove_dir_if_exists(&manifest.target)?;
+            print_path_event("🧹", "Cleaned quant scratch", &manifest.target);
+        }
+        Ok(())
+    })
+}
+
+fn write_and_preflight_layer_package(
+    args: &QuantizeLayerPackageArgs,
+    manifest: &Manifest,
+    hook: &Path,
+) -> Result<()> {
+    let first_source_shard = find_first_shard(
+        &manifest.source,
+        manifest
+            .source_prefix
+            .as_deref()
+            .context("quantize manifest is missing source_prefix")?,
+    )?;
+    run_skippy_model_package_write(args, &first_source_shard, hook)?;
+    run_skippy_model_package_preflight(args)
+}
+
+fn write_layer_package_quant_hook(
+    args: &QuantizeLayerPackageArgs,
+    runner: &QuantRunnerArgs,
+) -> Result<PathBuf> {
+    let hook_dir = runner.work_dir.join("layer-package-hook");
+    fs::create_dir_all(&hook_dir)
+        .with_context(|| format!("create hook directory {}", hook_dir.display()))?;
+    fs::create_dir_all(&args.init.target)
+        .with_context(|| format!("create quant scratch {}", args.init.target.display()))?;
+    let hook = hook_dir.join("quantize-package-artifact.sh");
+    let current_exe = std::env::current_exe().context("resolve current skippy-quantize path")?;
+    let hook_work_dir = args.init.target.join("hook-work");
+    let hook_spool_dir = args.init.target.join("hook-spool");
+    let hook_record_dir = args.init.target.join("hook-records");
+    let hook_status_file = args.init.target.join("hook-status.json");
+    let mut script = String::new();
+    script.push_str("#!/usr/bin/env bash\nset -euo pipefail\n");
+    script.push_str("case \"${SKIPPY_PACKAGE_ARTIFACT_RELATIVE_PATH:-}\" in\n");
+    script.push_str("  shared/metadata.gguf) exit 0 ;;\n");
+    script.push_str("esac\n");
+    script.push_str("artifact=\"${SKIPPY_PACKAGE_ARTIFACT_PATH:?}\"\n");
+    script.push_str("tmp=\"${artifact}.quant-tmp.gguf\"\n");
+    script.push_str("single_source=\"${artifact}.quant-src\"\n");
+    script.push_str("rm -rf \"$single_source\" \"$tmp\"\n");
+    script.push_str("mkdir -p \"$single_source\"\n");
+    script.push_str("ln -s \"$artifact\" \"$single_source/model.gguf\"\n");
+    script.push_str(&format!(
+        "{} quantize --backend {} --source-prefix '' --target-prefix '' --work-dir {} --spool-dir {} --record-dir {} --json-event-file {} --json-event-interval-seconds {} --json-event-window {} --no-verify-on-complete",
+        shell_quote(&current_exe),
+        runner.backend.as_str(),
+        shell_quote(&hook_work_dir),
+        shell_quote(&hook_spool_dir),
+        shell_quote(&hook_record_dir),
+        shell_quote(&hook_status_file),
+        runner.json_event_interval_seconds,
+        runner.json_event_window,
+    ));
+    if let Some(watchdog_seconds) = runner.watchdog_seconds {
+        script.push_str(&format!(" --watchdog-seconds {watchdog_seconds}"));
+    }
+    if let Some(nthreads) = runner.nthreads {
+        script.push_str(&format!(" --nthreads {nthreads}"));
+    }
+    if runner.allow_requantize {
+        script.push_str(" --allow-requantize");
+    }
+    if runner.pure {
+        script.push_str(" --pure");
+    }
+    if runner.leave_output_tensor {
+        script.push_str(" --leave-output-tensor");
+    }
+    for library in &runner.native_runtime_libraries {
+        script.push_str(&format!(
+            " --native-runtime-library {}",
+            shell_quote(library)
+        ));
+    }
+    script.push_str(" \"$single_source/model.gguf\" \"$tmp\" ");
+    script.push_str(&shell_quote(args.init.quant.output_name()));
+    script.push('\n');
+    script.push_str("rm -rf \"$single_source\"\n");
+    script.push_str("if [[ ! -f \"$tmp\" && -f \"${tmp%.gguf}-00001-of-00001.gguf\" ]]; then\n");
+    script.push_str("  tmp=\"${tmp%.gguf}-00001-of-00001.gguf\"\n");
+    script.push_str("fi\n");
+    script.push_str("mv \"$tmp\" \"$artifact\"\n");
+    fs::write(&hook, script).with_context(|| format!("write hook {}", hook.display()))?;
+    make_executable(&hook)?;
+    Ok(hook)
+}
+
+fn run_skippy_model_package_write(
+    args: &QuantizeLayerPackageArgs,
+    first_source_shard: &Path,
+    hook: &Path,
+) -> Result<()> {
+    print_path_event("📦", "Writing layer package", &args.package_dir);
+    let source_file = args.package_source_file.clone().unwrap_or_else(|| {
+        let file_name = first_source_shard
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or("model.gguf");
+        format!("{}/{}", args.init.source_prefix, file_name)
+    });
+    let status = ProcessCommand::new(&args.skippy_model_package_bin)
+        .arg("write-package")
+        .arg(first_source_shard)
+        .arg("--out-dir")
+        .arg(&args.package_dir)
+        .arg("--after-artifact-command")
+        .arg(hook)
+        .arg("--model-id")
+        .arg(&args.package_model_id)
+        .arg("--source-repo")
+        .arg(&args.package_source_repo)
+        .arg("--source-revision")
+        .arg(&args.package_source_revision)
+        .arg("--source-file")
+        .arg(source_file)
+        .status()
+        .with_context(|| {
+            format!(
+                "run {} write-package",
+                args.skippy_model_package_bin.display()
+            )
+        })?;
+    ensure!(
+        status.success(),
+        "{} write-package failed with status {status}",
+        args.skippy_model_package_bin.display()
+    );
+    Ok(())
+}
+
+fn shell_quote(path: impl AsRef<Path>) -> String {
+    let raw = path.as_ref().display().to_string();
+    format!("'{}'", raw.replace('\'', "'\\''"))
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mut permissions = fs::metadata(path)
+        .with_context(|| format!("read permissions {}", path.display()))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions)
+        .with_context(|| format!("set executable permissions {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn run_skippy_model_package_preflight(args: &QuantizeLayerPackageArgs) -> Result<()> {
+    print_path_event("✅", "Preflighting layer package", &args.package_dir);
+    let mut command = ProcessCommand::new(&args.skippy_model_package_bin);
+    command
+        .arg("preflight")
+        .arg(&args.package_dir)
+        .arg("--verify-sha256");
+    if let Some(stages) = args.stages {
+        command.arg("--stages").arg(stages.to_string());
+    }
+    let status = command
+        .status()
+        .with_context(|| format!("run {} preflight", args.skippy_model_package_bin.display()))?;
+    ensure!(
+        status.success(),
+        "{} preflight failed with status {status}",
+        args.skippy_model_package_bin.display()
+    );
+    Ok(())
 }
 
 fn quant_manifest_from_args(args: &InitQuantArgs) -> Result<Manifest> {

--- a/crates/skippy-quantize/src/main.rs
+++ b/crates/skippy-quantize/src/main.rs
@@ -779,6 +779,7 @@ fn write_layer_package_quant_hook(
         script.push_str(&format!(" --nthreads {nthreads}"));
     }
     append_optional_tensor_type_file(&mut script, args.init.tensor_type_file.as_deref());
+    append_override_kv_args(&mut script, &runner.override_kv);
     if runner.allow_requantize {
         script.push_str(" --allow-requantize");
     }
@@ -810,6 +811,12 @@ fn write_layer_package_quant_hook(
 fn append_optional_tensor_type_file(script: &mut String, tensor_type_file: Option<&Path>) {
     if let Some(path) = tensor_type_file {
         script.push_str(&format!(" --tensor-type-file {}", shell_quote(path)));
+    }
+}
+
+fn append_override_kv_args(script: &mut String, overrides: &[String]) {
+    for override_kv in overrides {
+        script.push_str(&format!(" --override-kv {}", shell_quote_str(override_kv)));
     }
 }
 
@@ -857,7 +864,10 @@ fn run_skippy_model_package_write(
 }
 
 fn shell_quote(path: impl AsRef<Path>) -> String {
-    let raw = path.as_ref().display().to_string();
+    shell_quote_str(&path.as_ref().display().to_string())
+}
+
+fn shell_quote_str(raw: &str) -> String {
     format!("'{}'", raw.replace('\'', "'\\''"))
 }
 
@@ -1486,7 +1496,7 @@ fn print_dry_run_complete(json: bool, kind: &str) -> Result<()> {
 mod tests {
     use std::path::Path;
 
-    use super::append_optional_tensor_type_file;
+    use super::{append_optional_tensor_type_file, append_override_kv_args};
 
     #[test]
     fn layer_package_hook_forwards_tensor_type_file() {
@@ -1499,5 +1509,17 @@ mod tests {
 
         assert!(script.contains("--tensor-type-file"));
         assert!(script.contains("'/tmp/recipes/glm 5.2 q2.tensor-types.txt'"));
+    }
+
+    #[test]
+    fn layer_package_hook_forwards_metadata_overrides() {
+        let mut script = String::new();
+
+        append_override_kv_args(
+            &mut script,
+            &["glm-dsa.attention.indexer.head_count=int:32".to_string()],
+        );
+
+        assert!(script.contains("--override-kv 'glm-dsa.attention.indexer.head_count=int:32'"));
     }
 }

--- a/crates/skippy-quantize/src/native_quantize.rs
+++ b/crates/skippy-quantize/src/native_quantize.rs
@@ -491,6 +491,33 @@ mod tests {
     }
 
     #[test]
+    fn passes_explicit_tensor_type_file_to_command() {
+        let root = unique_temp_dir();
+        fs::create_dir_all(&root).unwrap();
+        let recipe = root.join("glm-5.2-q2-k-mtp-q8.tensor-types.txt");
+        fs::write(&recipe, "(^|\\.)nextn\\.=Q8_0").unwrap();
+        let args = native_args();
+        let manifest = manifest(Some(recipe.clone()));
+
+        let command = build_native_quantize_command(
+            &args,
+            &manifest,
+            Path::new("/tmp/in/model-00001-of-00002.gguf"),
+            Path::new("/tmp/out/model-q2-mtp-q8"),
+            SplitWindow {
+                first_split: 1,
+                last_split: 2,
+            },
+        )
+        .unwrap();
+
+        assert!(command.contains(&"--tensor-type-file".to_string()));
+        assert!(command.contains(&recipe.display().to_string()));
+        assert!(!command.contains(&"(^|\\.)nextn\\.=Q8_0".to_string()));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
     fn builds_skippy_abi_quantize_command_label() {
         let mut args = native_args();
         args.backend = BackendKind::SkippyAbi;
@@ -582,6 +609,38 @@ mod tests {
         assert_eq!(inputs.tensor_overrides.len(), 3);
         assert_eq!(inputs.prune_layers, vec![1, 2, -1]);
         assert_eq!(inputs.kv_overrides.len(), 4);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn appends_tensor_type_file_entries_after_explicit_overrides() {
+        let root = unique_temp_dir();
+        fs::create_dir_all(&root).unwrap();
+        let recipe = root.join("glm-5.2-q2-k-mtp-q8.tensor-types.txt");
+        fs::write(
+            &recipe,
+            "^token_embd\\.weight$=Q8_0\n(^|\\.)nextn\\.=Q8_0\n",
+        )
+        .unwrap();
+        let mut args = native_args();
+        args.tensor_type = vec!["nextn\\.pre_projection\\.weight=F16".to_string()];
+        let manifest = manifest(Some(recipe));
+
+        let inputs = NativeQuantizeInputs::build(&args, &manifest).unwrap();
+
+        assert_eq!(inputs.tensor_overrides.len(), 4);
+        assert_eq!(
+            inputs._tensor_patterns[0].to_str().unwrap(),
+            "nextn\\.pre_projection\\.weight"
+        );
+        assert_eq!(
+            inputs._tensor_patterns[1].to_str().unwrap(),
+            "^token_embd\\.weight$"
+        );
+        assert_eq!(
+            inputs._tensor_patterns[2].to_str().unwrap(),
+            "(^|\\.)nextn\\."
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/skippy-quantize/src/type_catalog.rs
+++ b/crates/skippy-quantize/src/type_catalog.rs
@@ -14,14 +14,6 @@ pub(crate) struct TypeCatalogArgs {
 #[derive(Debug, Serialize)]
 struct QuantCatalog {
     whole_model_quant_modes: Vec<&'static str>,
-    known_recipe_labels: Vec<KnownRecipeLabel>,
-}
-
-#[derive(Debug, Serialize)]
-struct KnownRecipeLabel {
-    label: &'static str,
-    base_quant: &'static str,
-    note: &'static str,
 }
 
 #[derive(Debug, Serialize)]
@@ -34,41 +26,18 @@ pub(crate) fn list_quants(args: TypeCatalogArgs) -> Result<()> {
         .iter()
         .map(|quant| quant.as_llama_name())
         .collect::<Vec<_>>();
-    let labels = known_recipe_labels();
     if args.json {
         print_json_pretty(&QuantCatalog {
             whole_model_quant_modes: names,
-            known_recipe_labels: labels,
         })?;
     } else {
         print_success("Whole-model quant modes");
         for name in names {
             println!("   • {name}");
         }
-        print_info("Known recipe labels");
-        for label in labels {
-            println!(
-                "   • {} -> {} ({})",
-                label.label, label.base_quant, label.note
-            );
-        }
+        print_info("Use --tensor-type-file for custom tensor recipes");
     }
     Ok(())
-}
-
-fn known_recipe_labels() -> Vec<KnownRecipeLabel> {
-    vec![
-        KnownRecipeLabel {
-            label: "UD-Q3_K_S",
-            base_quant: "Q3_K_S",
-            note: "custom dynamic tensor-type recipe; pass the recipe with --tensor-type-file",
-        },
-        KnownRecipeLabel {
-            label: "Q4_K_XL",
-            base_quant: "Q4_K_M",
-            note: "custom high-quality tensor-type recipe; pass the recipe with --tensor-type-file",
-        },
-    ]
 }
 
 pub(crate) fn list_tensor_types(args: TypeCatalogArgs) -> Result<()> {
@@ -97,6 +66,5 @@ mod tests {
     fn catalogs_are_not_empty() {
         assert!(!QuantType::ALL.is_empty());
         assert!(!TensorType::ALL.is_empty());
-        assert!(!known_recipe_labels().is_empty());
     }
 }

--- a/crates/skippy-quantize/src/types.rs
+++ b/crates/skippy-quantize/src/types.rs
@@ -82,29 +82,14 @@ pub enum QuantType {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QuantSpec {
     base_quant: QuantType,
-    recipe_label: Option<&'static str>,
 }
 
 impl FromStr for QuantSpec {
     type Err = String;
 
     fn from_str(raw: &str) -> std::result::Result<Self, Self::Err> {
-        if let Ok(base_quant) = raw.parse::<QuantType>() {
-            return Ok(Self {
-                base_quant,
-                recipe_label: None,
-            });
-        }
-        let normalized = normalize_type_name(raw);
-        let (base_quant, recipe_label) = match normalized.as_str() {
-            "UDQ3KS" => (QuantType::Q3KS, "UD-Q3_K_S"),
-            "Q4KXL" => (QuantType::Q4KM, "Q4_K_XL"),
-            _ => return Err(unsupported_quant_type_error(raw, &normalized)),
-        };
-        Ok(Self {
-            base_quant,
-            recipe_label: Some(recipe_label),
-        })
+        let base_quant = raw.parse::<QuantType>()?;
+        Ok(Self { base_quant })
     }
 }
 
@@ -114,31 +99,20 @@ impl QuantSpec {
     }
 
     pub fn output_name(&self) -> &'static str {
-        self.recipe_label
-            .unwrap_or_else(|| self.base_quant.as_llama_name())
+        self.base_quant.as_llama_name()
     }
 
     pub fn validate_recipe_requirements(
         &self,
-        has_tensor_type_file: bool,
+        _has_tensor_type_file: bool,
     ) -> std::result::Result<(), String> {
-        if let Some(label) = self.recipe_label
-            && !has_tensor_type_file
-        {
-            return Err(format!(
-                "{label} is a tensor-type recipe label; pass --tensor-type-file with the recipe"
-            ));
-        }
         Ok(())
     }
 }
 
 impl From<QuantType> for QuantSpec {
     fn from(base_quant: QuantType) -> Self {
-        Self {
-            base_quant,
-            recipe_label: None,
-        }
+        Self { base_quant }
     }
 }
 
@@ -581,6 +555,13 @@ fn unsupported_quant_type_error(raw: &str, normalized: &str) -> String {
                 with --tensor-type-file for the XL recipe"
             .to_string();
     }
+    if normalized.ends_with("MTPQ8") {
+        return format!(
+            "unsupported quant type {raw:?}: MTP-Q8 is a custom artifact profile, \
+             not a whole-model quant mode; pass the base quant with --quant and \
+             the tensor policy with --tensor-type-file"
+        );
+    }
     format!("unsupported quant type {raw:?}")
 }
 
@@ -651,17 +632,10 @@ mod tests {
     }
 
     #[test]
-    fn parses_recipe_quant_specs() {
-        let ud = "UD-Q3_K_S".parse::<QuantSpec>().unwrap();
-        assert_eq!(ud.base_quant(), QuantType::Q3KS);
-        assert_eq!(ud.output_name(), "UD-Q3_K_S");
-        assert!(ud.validate_recipe_requirements(true).is_ok());
-        assert!(ud.validate_recipe_requirements(false).is_err());
-
-        let xl = "Q4_K_XL".parse::<QuantSpec>().unwrap();
-        assert_eq!(xl.base_quant(), QuantType::Q4KM);
-        assert_eq!(xl.output_name(), "Q4_K_XL");
-
+    fn parses_quant_specs_from_llama_quant_names() {
+        assert!("UD-Q3_K_S".parse::<QuantSpec>().is_err());
+        assert!("Q4_K_XL".parse::<QuantSpec>().is_err());
+        assert!("Q2_K-MTP-Q8".parse::<QuantSpec>().is_err());
         let regular = "Q4_K_M".parse::<QuantSpec>().unwrap();
         assert_eq!(regular.base_quant(), QuantType::Q4KM);
         assert_eq!(regular.output_name(), "Q4_K_M");

--- a/crates/skippy-quantize/tests/direct_quantize_cli.rs
+++ b/crates/skippy-quantize/tests/direct_quantize_cli.rs
@@ -108,7 +108,7 @@ fn direct_quantize_preflight_supports_current_directory_no_output_shape() {
 }
 
 #[test]
-fn direct_quantize_preflight_accepts_recipe_quant_label_with_tensor_file() {
+fn direct_quantize_preflight_accepts_base_quant_with_tensor_file() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();
     fs::write(root.join("model.gguf"), b"source shard").unwrap();
@@ -125,7 +125,7 @@ fn direct_quantize_preflight_accepts_recipe_quant_label_with_tensor_file() {
             "--preflight-only",
             "--json",
             "model.gguf",
-            "UD-Q3_K_S",
+            "Q3_K_S",
         ])
         .output()
         .expect("skippy-quantize command should run");
@@ -137,15 +137,15 @@ fn direct_quantize_preflight_accepts_recipe_quant_label_with_tensor_file() {
         .as_str()
         .expect("manifest_path should be a string");
     assert!(
-        manifest_path.ends_with(".ggml-model-UD-Q3_K_S.UD-Q3_K_S.skippy-quantize.json"),
-        "recipe quant label should drive output and sidecar names, got {manifest_path}"
+        manifest_path.ends_with(".ggml-model-Q3_K_S.Q3_K_S.skippy-quantize.json"),
+        "base quant should drive output and sidecar names, got {manifest_path}"
     );
 
     fs::remove_dir_all(root).unwrap();
 }
 
 #[test]
-fn direct_quantize_preflight_rejects_recipe_quant_label_without_tensor_file() {
+fn direct_quantize_preflight_rejects_profile_quant_label() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();
     fs::write(root.join("model.gguf"), b"source shard").unwrap();
@@ -166,12 +166,12 @@ fn direct_quantize_preflight_rejects_recipe_quant_label_without_tensor_file() {
 
     assert!(
         !output.status.success(),
-        "preflight should reject missing recipe"
+        "preflight should reject custom profile labels as quant modes"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("pass --tensor-type-file"),
-        "error should explain missing tensor recipe, got: {stderr}"
+        stderr.contains("custom tensor-type recipes"),
+        "error should explain profile labels are not quant modes, got: {stderr}"
     );
 
     fs::remove_dir_all(root).unwrap();


### PR DESCRIPTION
## Summary
- add direct BF16/FP16 GGUF -> quantized Skippy layer package flow to skippy-quantize
- require custom quant profiles to be expressed via tensor recipes, not baked --quant aliases
- forward tensor recipe files and metadata overrides into package quant hooks, including GLM-DSA indexer metadata

## Validation
- cargo fmt -p skippy-quantize
- cargo test -p skippy-quantize
- cargo clippy -p skippy-quantize --all-targets -- -D warnings

## Lab proof
- GLM-5.2 Q2_K with MTP/indexer tensors held at Q8 is currently being packaged from the local BF16 GGUF artifact using this flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `quantize-layer-package` CLI subcommand for generating and quantizing layer packages from BF16 source files.
  * Implemented byte-balanced GGUF tensor splitting for improved distribution across splits.
  * Added GLM-DSA attention indexer metadata support.

* **Documentation**
  * Updated guidance: custom quantization profiles now belong in artifact naming via `--target-prefix` / `--output-basename`, not in the `--quant` flag.
  * Added "BF16 to layer package" recipes subsection with workflow examples.

* **Bug Fixes**
  * Artifact metadata now calculated from post-quantization files rather than pre-quantization values.
  * Removed support for recipe-style quant labels; users must specify base quant and custom tensor policies via `--tensor-type-file`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->