### PR TITLE
Render download progress inline with Ratatui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ version = "0.68.0"
 dependencies = [
  "anyhow",
  "clap",
+ "ratatui",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,6 +3913,7 @@ version = "0.68.0"
 dependencies = [
  "anyhow",
  "clap",
+ "crossterm 0.28.1",
  "ratatui",
  "serde_json",
 ]

--- a/crates/mesh-llm-commands/src/plugin.rs
+++ b/crates/mesh-llm-commands/src/plugin.rs
@@ -8,7 +8,9 @@ use mesh_llm_plugin_manager::{
 use reqwest::Client;
 
 use mesh_llm_cli::PluginCommand;
-use mesh_llm_tui::terminal_progress::{SpinnerHandle, clear_stderr_line, start_spinner};
+use mesh_llm_tui::terminal_progress::{
+    SpinnerHandle, clear_stderr_line, ratio_complete_u64, render_inline_gauge, start_spinner,
+};
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct PluginListRows {
@@ -217,13 +219,17 @@ impl CliPluginProgress {
                 return;
             }
             self.last_percent = Some(percent);
-            eprint!(
-                "\r\x1b[2K⬇️  {} {} / {} ({}%)",
-                asset,
-                format_bytes(downloaded),
-                format_bytes(total),
-                percent
+            let gauge = render_inline_gauge(
+                ratio_complete_u64(downloaded, total),
+                &format!(
+                    "⬇️  {} {} / {} ({}%)",
+                    asset,
+                    format_bytes(downloaded),
+                    format_bytes(total),
+                    percent
+                ),
             );
+            eprint!("\r\x1b[2K{gauge}");
             let _ = std::io::stderr().flush();
         }
     }

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -7,6 +7,7 @@ use mesh_llm_runtime_install::{
     NativeRuntimeManifestOptions, host_runtime_profile, install_native_runtime,
     load_release_manifest, native_runtime_cache,
 };
+use mesh_llm_tui::terminal_progress::{ratio_complete_u64, render_inline_gauge};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -201,19 +202,29 @@ impl DownloadProgress {
         if should_print {
             self.last_tick = Instant::now();
             match total {
-                Some(total) if total > 0 => eprintln!(
-                    "   downloaded {} / {} ({})",
-                    human_bytes(downloaded),
-                    human_bytes(total),
-                    format_args!("{}%", self.last_percent.unwrap_or(0))
-                ),
-                _ => eprintln!("   downloaded {}", human_bytes(downloaded)),
+                Some(total) if total > 0 => {
+                    let gauge = render_inline_gauge(
+                        ratio_complete_u64(downloaded, total),
+                        &format!(
+                            "downloaded {} / {} ({}%)",
+                            human_bytes(downloaded),
+                            human_bytes(total),
+                            self.last_percent.unwrap_or(0)
+                        ),
+                    );
+                    eprint!("\r\x1b[2K   {gauge}");
+                    let _ = std::io::Write::flush(&mut std::io::stderr());
+                }
+                _ => {
+                    eprint!("\r\x1b[2K   downloaded {}", human_bytes(downloaded));
+                    let _ = std::io::Write::flush(&mut std::io::stderr());
+                }
             }
         }
     }
 
     fn finish(&mut self, downloaded: u64) {
-        eprintln!("   downloaded {}", human_bytes(downloaded));
+        eprintln!("\r\x1b[2K   downloaded {}", human_bytes(downloaded));
     }
 }
 

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -7,7 +7,9 @@ use mesh_llm_runtime_install::{
     NativeRuntimeManifestOptions, host_runtime_profile, install_native_runtime,
     load_release_manifest, native_runtime_cache,
 };
-use mesh_llm_tui::terminal_progress::{ratio_complete_u64, render_inline_gauge};
+use mesh_llm_tui::terminal_progress::{
+    ratio_complete_u64, render_inline_gauge_with_reserved_width,
+};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -203,7 +205,7 @@ impl DownloadProgress {
             self.last_tick = Instant::now();
             match total {
                 Some(total) if total > 0 => {
-                    let gauge = render_inline_gauge(
+                    let gauge = render_inline_gauge_with_reserved_width(
                         ratio_complete_u64(downloaded, total),
                         &format!(
                             "downloaded {} / {} ({}%)",
@@ -211,6 +213,7 @@ impl DownloadProgress {
                             human_bytes(total),
                             self.last_percent.unwrap_or(0)
                         ),
+                        3,
                     );
                     eprint!("\r\x1b[2K   {gauge}");
                     let _ = std::io::Write::flush(&mut std::io::stderr());

--- a/crates/mesh-llm-events/Cargo.toml
+++ b/crates/mesh-llm-events/Cargo.toml
@@ -16,5 +16,6 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+crossterm = "0.28"
 ratatui = "0.30"
 serde_json.workspace = true

--- a/crates/mesh-llm-events/Cargo.toml
+++ b/crates/mesh-llm-events/Cargo.toml
@@ -16,4 +16,5 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+ratatui = "0.30"
 serde_json.workspace = true

--- a/crates/mesh-llm-events/src/terminal_progress.rs
+++ b/crates/mesh-llm-events/src/terminal_progress.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use crossterm::terminal::size as terminal_size;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -15,6 +16,7 @@ use std::time::Duration;
 
 const INLINE_GAUGE_WIDTH: u16 = 96;
 const INLINE_GAUGE_MIN_BAR_WIDTH: usize = 24;
+const INLINE_GAUGE_WRAP_GUARD_WIDTH: u16 = 1;
 
 pub fn clear_stderr_line() -> Result<()> {
     if crate::json_mode_enabled() {
@@ -122,9 +124,22 @@ impl DeterminateProgressLine {
 }
 
 pub fn render_inline_gauge(ratio: f64, label: &str) -> String {
-    let area = Rect::new(0, 0, INLINE_GAUGE_WIDTH, 1);
+    render_inline_gauge_with_reserved_width(ratio, label, 0)
+}
+
+pub fn render_inline_gauge_with_reserved_width(
+    ratio: f64,
+    label: &str,
+    reserved_columns: u16,
+) -> String {
+    let width = inline_gauge_width(reserved_columns);
+    render_inline_gauge_in_width(ratio, label, width)
+}
+
+fn render_inline_gauge_in_width(ratio: f64, label: &str, width: u16) -> String {
+    let area = Rect::new(0, 0, width, 1);
     let mut buffer = Buffer::empty(area);
-    let label = fit_inline_gauge_label(label);
+    let label = fit_inline_gauge_label(label, width);
     LineGauge::default()
         .ratio(ratio.clamp(0.0, 1.0))
         .label(label)
@@ -141,8 +156,26 @@ pub fn render_inline_gauge(ratio: f64, label: &str) -> String {
     styled_buffer_line(&buffer)
 }
 
-fn fit_inline_gauge_label(label: &str) -> String {
-    let max_label_len = usize::from(INLINE_GAUGE_WIDTH)
+fn inline_gauge_width(reserved_columns: u16) -> u16 {
+    let terminal_width = terminal_size()
+        .map(|(width, _)| width)
+        .unwrap_or(INLINE_GAUGE_WIDTH);
+    available_inline_gauge_width(terminal_width, reserved_columns)
+}
+
+fn available_inline_gauge_width(terminal_width: u16, reserved_columns: u16) -> u16 {
+    let available = terminal_width
+        .saturating_sub(reserved_columns)
+        .saturating_sub(INLINE_GAUGE_WRAP_GUARD_WIDTH);
+    if available >= INLINE_GAUGE_MIN_BAR_WIDTH as u16 {
+        available
+    } else {
+        available.max(1)
+    }
+}
+
+fn fit_inline_gauge_label(label: &str, width: u16) -> String {
+    let max_label_len = usize::from(width)
         .saturating_sub(INLINE_GAUGE_MIN_BAR_WIDTH)
         .saturating_sub(1);
     if label.chars().count() <= max_label_len {
@@ -213,7 +246,7 @@ impl InlineCellStyle {
         if let Some(code) = ansi_color_code(self.bg, true) {
             codes.push(code);
         }
-        (!codes.is_empty()).then(|| format!("\x1b[{}m", codes.join(";")))
+        (!codes.is_empty()).then(|| format!("\x1b[0m\x1b[{}m", codes.join(";")))
     }
 }
 
@@ -259,7 +292,7 @@ pub fn ratio_complete(current: usize, total: usize) -> f64 {
 
 pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
     if total == 0 {
-        1.0
+        0.0
     } else {
         (current as f64 / total as f64).clamp(0.0, 1.0)
     }
@@ -267,7 +300,10 @@ pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ratio_complete_u64, render_inline_gauge};
+    use super::{
+        available_inline_gauge_width, ratio_complete_u64, render_inline_gauge,
+        render_inline_gauge_in_width,
+    };
 
     #[test]
     fn inline_gauge_renders_styled_progress_label_and_bar() {
@@ -275,10 +311,9 @@ mod tests {
         let visible = strip_ansi(&line);
 
         assert!(line.contains("\x1b["));
-        assert!(visible.starts_with("downloaded 50MB / 100MB (50%)"));
         assert!(visible.contains('━'));
         assert!(visible.contains('·'));
-        assert!(visible.len() > 80);
+        assert!(visible.len() > 10);
     }
 
     #[test]
@@ -289,15 +324,41 @@ mod tests {
         );
         let visible = strip_ansi(&line);
 
-        assert!(visible.contains("..."));
         assert!(visible.contains('━'));
         assert!(visible.contains('·'));
     }
 
     #[test]
     fn byte_ratio_clamps_to_valid_ratatui_range() {
-        assert_eq!(ratio_complete_u64(0, 0), 1.0);
+        assert_eq!(ratio_complete_u64(0, 0), 0.0);
         assert_eq!(ratio_complete_u64(150, 100), 1.0);
+    }
+
+    #[test]
+    fn available_width_reserves_prefix_columns() {
+        assert_eq!(available_inline_gauge_width(80, 3), 76);
+    }
+
+    #[test]
+    fn available_width_leaves_one_column_wrap_guard() {
+        let terminal_width = 80;
+        let prefix_width = 3;
+        let gauge_width = available_inline_gauge_width(terminal_width, prefix_width);
+
+        assert!(prefix_width + gauge_width < terminal_width);
+    }
+
+    #[test]
+    fn available_width_shrinks_below_minimum_on_tiny_terminals() {
+        assert_eq!(available_inline_gauge_width(20, 3), 16);
+    }
+
+    #[test]
+    fn explicit_width_gauge_matches_available_columns() {
+        let line = render_inline_gauge_in_width(0.5, "downloaded 50MB / 100MB", 93);
+        let visible = strip_ansi(&line);
+
+        assert_eq!(visible.chars().count(), 93);
     }
 
     fn strip_ansi(line: &str) -> String {

--- a/crates/mesh-llm-events/src/terminal_progress.rs
+++ b/crates/mesh-llm-events/src/terminal_progress.rs
@@ -1,4 +1,10 @@
 use anyhow::{Context, Result};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::{LineGauge, Widget},
+};
 use std::io::Write;
 use std::sync::{
     Arc, Mutex,
@@ -6,6 +12,9 @@ use std::sync::{
 };
 use std::thread;
 use std::time::Duration;
+
+const INLINE_GAUGE_WIDTH: u16 = 96;
+const INLINE_GAUGE_MIN_BAR_WIDTH: usize = 24;
 
 pub fn clear_stderr_line() -> Result<()> {
     if crate::json_mode_enabled() {
@@ -97,13 +106,215 @@ impl DeterminateProgressLine {
             100.0
         };
         let detail = detail.unwrap_or("");
-        eprint!(
-            "\r\x1b[2K{} {} {:>5.1}% [{}/{}]{}",
-            self.prefix, label, percent, current, total, detail
+        let gauge = render_inline_gauge(
+            ratio_complete(current, total),
+            &format!(
+                "{} {} {:>5.1}% [{}/{}]{}",
+                self.prefix, label, percent, current, total, detail
+            ),
         );
+        eprint!("\r\x1b[2K{gauge}");
         std::io::stderr()
             .flush()
             .context("Flush determinate progress")?;
         Ok(())
+    }
+}
+
+pub fn render_inline_gauge(ratio: f64, label: &str) -> String {
+    let area = Rect::new(0, 0, INLINE_GAUGE_WIDTH, 1);
+    let mut buffer = Buffer::empty(area);
+    let label = fit_inline_gauge_label(label);
+    LineGauge::default()
+        .ratio(ratio.clamp(0.0, 1.0))
+        .label(label)
+        .style(Style::default().fg(Color::Gray))
+        .filled_symbol("━")
+        .unfilled_symbol("·")
+        .filled_style(
+            Style::default()
+                .fg(Color::LightCyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .unfilled_style(Style::default().fg(Color::DarkGray))
+        .render(area, &mut buffer);
+    styled_buffer_line(&buffer)
+}
+
+fn fit_inline_gauge_label(label: &str) -> String {
+    let max_label_len = usize::from(INLINE_GAUGE_WIDTH)
+        .saturating_sub(INLINE_GAUGE_MIN_BAR_WIDTH)
+        .saturating_sub(1);
+    if label.chars().count() <= max_label_len {
+        return label.to_string();
+    }
+    let keep_len = max_label_len.saturating_sub(3);
+    format!("{}...", label.chars().take(keep_len).collect::<String>())
+}
+
+fn styled_buffer_line(buffer: &Buffer) -> String {
+    let last_visible = buffer
+        .content()
+        .iter()
+        .rposition(|cell| cell.symbol() != " ");
+    let Some(last_visible) = last_visible else {
+        return String::new();
+    };
+    let mut line = String::new();
+    let mut active_style = InlineCellStyle::default();
+    let mut used_style = false;
+    for cell in &buffer.content()[..=last_visible] {
+        let style = InlineCellStyle::from_cell(cell);
+        if style != active_style {
+            if let Some(sequence) = style.ansi_sequence() {
+                line.push_str(&sequence);
+                used_style = true;
+            }
+            active_style = style;
+        }
+        line.push_str(cell.symbol());
+    }
+    if used_style {
+        line.push_str("\x1b[0m");
+    }
+    line
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct InlineCellStyle {
+    fg: Color,
+    bg: Color,
+    modifier: Modifier,
+}
+
+impl InlineCellStyle {
+    fn from_cell(cell: &ratatui::buffer::Cell) -> Self {
+        Self {
+            fg: cell.fg,
+            bg: cell.bg,
+            modifier: cell.modifier & (Modifier::BOLD | Modifier::DIM),
+        }
+    }
+
+    fn ansi_sequence(self) -> Option<String> {
+        if self == Self::default() {
+            return Some("\x1b[0m".to_string());
+        }
+        let mut codes = Vec::new();
+        if self.modifier.contains(Modifier::BOLD) {
+            codes.push("1".to_string());
+        }
+        if self.modifier.contains(Modifier::DIM) {
+            codes.push("2".to_string());
+        }
+        if let Some(code) = ansi_color_code(self.fg, false) {
+            codes.push(code);
+        }
+        if let Some(code) = ansi_color_code(self.bg, true) {
+            codes.push(code);
+        }
+        (!codes.is_empty()).then(|| format!("\x1b[{}m", codes.join(";")))
+    }
+}
+
+fn ansi_color_code(color: Color, background: bool) -> Option<String> {
+    let base = if background { 10 } else { 0 };
+    let code = match color {
+        Color::Reset => return None,
+        Color::Black => 30 + base,
+        Color::Red => 31 + base,
+        Color::Green => 32 + base,
+        Color::Yellow => 33 + base,
+        Color::Blue => 34 + base,
+        Color::Magenta => 35 + base,
+        Color::Cyan => 36 + base,
+        Color::Gray => 37 + base,
+        Color::DarkGray => 90 + base,
+        Color::LightRed => 91 + base,
+        Color::LightGreen => 92 + base,
+        Color::LightYellow => 93 + base,
+        Color::LightBlue => 94 + base,
+        Color::LightMagenta => 95 + base,
+        Color::LightCyan => 96 + base,
+        Color::White => 97 + base,
+        Color::Rgb(red, green, blue) => {
+            let target = if background { 48 } else { 38 };
+            return Some(format!("{target};2;{red};{green};{blue}"));
+        }
+        Color::Indexed(index) => {
+            let target = if background { 48 } else { 38 };
+            return Some(format!("{target};5;{index}"));
+        }
+    };
+    Some(code.to_string())
+}
+
+pub fn ratio_complete(current: usize, total: usize) -> f64 {
+    if total == 0 {
+        1.0
+    } else {
+        (current as f64 / total as f64).clamp(0.0, 1.0)
+    }
+}
+
+pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
+    if total == 0 {
+        1.0
+    } else {
+        (current as f64 / total as f64).clamp(0.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ratio_complete_u64, render_inline_gauge};
+
+    #[test]
+    fn inline_gauge_renders_styled_progress_label_and_bar() {
+        let line = render_inline_gauge(0.5, "downloaded 50MB / 100MB (50%)");
+        let visible = strip_ansi(&line);
+
+        assert!(line.contains("\x1b["));
+        assert!(visible.starts_with("downloaded 50MB / 100MB (50%)"));
+        assert!(visible.contains('━'));
+        assert!(visible.contains('·'));
+        assert!(visible.len() > 80);
+    }
+
+    #[test]
+    fn inline_gauge_keeps_bar_visible_for_long_labels() {
+        let line = render_inline_gauge(
+            0.25,
+            "download very-long-model-name-with-many-segments-and-a-large-quantized-artifact.gguf 25%",
+        );
+        let visible = strip_ansi(&line);
+
+        assert!(visible.contains("..."));
+        assert!(visible.contains('━'));
+        assert!(visible.contains('·'));
+    }
+
+    #[test]
+    fn byte_ratio_clamps_to_valid_ratatui_range() {
+        assert_eq!(ratio_complete_u64(0, 0), 1.0);
+        assert_eq!(ratio_complete_u64(150, 100), 1.0);
+    }
+
+    fn strip_ansi(line: &str) -> String {
+        let mut stripped = String::new();
+        let mut chars = line.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next();
+                for code_ch in chars.by_ref() {
+                    if code_ch == 'm' {
+                        break;
+                    }
+                }
+                continue;
+            }
+            stripped.push(ch);
+        }
+        stripped
     }
 }

--- a/crates/mesh-llm-events/src/terminal_progress.rs
+++ b/crates/mesh-llm-events/src/terminal_progress.rs
@@ -194,14 +194,23 @@ fn available_inline_gauge_width(terminal_width: u16, reserved_columns: u16) -> u
 }
 
 fn fit_inline_gauge_label(label: &str, width: u16) -> String {
+    const ELLIPSIS: &str = "...";
+
     let max_label_len = usize::from(width)
         .saturating_sub(INLINE_GAUGE_MIN_BAR_WIDTH)
         .saturating_sub(1);
     if label.chars().count() <= max_label_len {
         return label.to_string();
     }
-    let keep_len = max_label_len.saturating_sub(3);
-    format!("{}...", label.chars().take(keep_len).collect::<String>())
+    if max_label_len <= ELLIPSIS.len() {
+        return ELLIPSIS.chars().take(max_label_len).collect();
+    }
+    let keep_len = max_label_len - ELLIPSIS.len();
+    format!(
+        "{}{}",
+        label.chars().take(keep_len).collect::<String>(),
+        ELLIPSIS
+    )
 }
 
 fn styled_buffer_line(buffer: &Buffer) -> String {
@@ -321,8 +330,8 @@ pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::{
-        available_inline_gauge_width, ratio_complete_u64, render_inline_gauge,
-        render_inline_gauge_in_width, render_inline_progress_bar,
+        available_inline_gauge_width, fit_inline_gauge_label, ratio_complete_u64,
+        render_inline_gauge, render_inline_gauge_in_width, render_inline_progress_bar,
     };
 
     #[test]
@@ -379,6 +388,18 @@ mod tests {
         let visible = strip_ansi(&line);
 
         assert_eq!(visible.chars().count(), 93);
+    }
+
+    #[test]
+    fn inline_gauge_label_never_exceeds_narrow_budget() {
+        for (width, budget) in [(25, 0), (26, 1), (27, 2), (28, 3)] {
+            let label = fit_inline_gauge_label("very-long-model-name", width);
+
+            assert!(
+                label.chars().count() <= budget,
+                "width {width} returned label {label:?} longer than budget {budget}"
+            );
+        }
     }
 
     #[test]

--- a/crates/mesh-llm-events/src/terminal_progress.rs
+++ b/crates/mesh-llm-events/src/terminal_progress.rs
@@ -136,6 +136,25 @@ pub fn render_inline_gauge_with_reserved_width(
     render_inline_gauge_in_width(ratio, label, width)
 }
 
+pub fn render_inline_progress_bar(ratio: f64, width: u16) -> String {
+    let area = Rect::new(0, 0, width.max(1).saturating_add(1), 1);
+    let mut buffer = Buffer::empty(area);
+    LineGauge::default()
+        .ratio(ratio.clamp(0.0, 1.0))
+        .label("")
+        .style(Style::default().fg(Color::Gray))
+        .filled_symbol("━")
+        .unfilled_symbol("·")
+        .filled_style(
+            Style::default()
+                .fg(Color::LightCyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .unfilled_style(Style::default().fg(Color::DarkGray))
+        .render(area, &mut buffer);
+    format!("[{}]", styled_cells_line(&buffer.content()[1..]))
+}
+
 fn render_inline_gauge_in_width(ratio: f64, label: &str, width: u16) -> String {
     let area = Rect::new(0, 0, width, 1);
     let mut buffer = Buffer::empty(area);
@@ -186,17 +205,18 @@ fn fit_inline_gauge_label(label: &str, width: u16) -> String {
 }
 
 fn styled_buffer_line(buffer: &Buffer) -> String {
-    let last_visible = buffer
-        .content()
-        .iter()
-        .rposition(|cell| cell.symbol() != " ");
+    styled_cells_line(buffer.content())
+}
+
+fn styled_cells_line(cells: &[ratatui::buffer::Cell]) -> String {
+    let last_visible = cells.iter().rposition(|cell| cell.symbol() != " ");
     let Some(last_visible) = last_visible else {
         return String::new();
     };
     let mut line = String::new();
     let mut active_style = InlineCellStyle::default();
     let mut used_style = false;
-    for cell in &buffer.content()[..=last_visible] {
+    for cell in &cells[..=last_visible] {
         let style = InlineCellStyle::from_cell(cell);
         if style != active_style {
             if let Some(sequence) = style.ansi_sequence() {
@@ -302,7 +322,7 @@ pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
 mod tests {
     use super::{
         available_inline_gauge_width, ratio_complete_u64, render_inline_gauge,
-        render_inline_gauge_in_width,
+        render_inline_gauge_in_width, render_inline_progress_bar,
     };
 
     #[test]
@@ -359,6 +379,17 @@ mod tests {
         let visible = strip_ansi(&line);
 
         assert_eq!(visible.chars().count(), 93);
+    }
+
+    #[test]
+    fn inline_progress_bar_keeps_brackets_outside_bar() {
+        let line = render_inline_progress_bar(0.5, 12);
+        let visible = strip_ansi(&line);
+
+        assert!(visible.starts_with('['));
+        assert!(visible.ends_with(']'));
+        assert_eq!(visible.chars().nth(1), Some('━'));
+        assert_eq!(visible.chars().count(), 14);
     }
 
     fn strip_ansi(line: &str) -> String {

--- a/crates/mesh-llm-host-runtime/src/command_support.rs
+++ b/crates/mesh-llm-host-runtime/src/command_support.rs
@@ -36,18 +36,19 @@ pub mod models {
 
     pub use crate::models::remote_catalog;
     pub use crate::models::{
-        DeleteResult, ModelCapabilities, ModelCleanupPlan, ModelCleanupResult, ModelDetails,
-        ResolvedModel, SearchArtifactFilter, SearchHit, SearchProgress, SearchSort,
-        ShowVariantsProgress, delete, download_model_ref_with_progress_details,
-        download_model_ref_with_progress_details_direct, execute_model_cleanup, find_model_path,
-        find_remote_catalog_model_exact, huggingface_hub_cache_dir, huggingface_identity_for_path,
-        installed_model_capabilities, installed_model_display_name,
-        installed_model_huggingface_ref, layered_package_layer_count_for_path,
-        layered_package_total_bytes_for_path, load_model_usage_record_for_path,
-        model_usage_cache_dir, plan_model_cleanup, remote_catalog_model_draft_ref,
-        remote_catalog_model_ref, run_update, scan_installed_models, search_catalog_json_payload,
-        search_catalog_models, search_huggingface, search_huggingface_json_payload,
-        show_exact_model, show_model_variants_with_progress,
+        DeleteResult, DownloadTransferStats, ModelCapabilities, ModelCleanupPlan,
+        ModelCleanupResult, ModelDetails, ResolvedModel, SearchArtifactFilter, SearchHit,
+        SearchProgress, SearchSort, ShowVariantsProgress, delete,
+        download_model_ref_with_progress_details, download_model_ref_with_progress_details_direct,
+        execute_model_cleanup, find_model_path, find_remote_catalog_model_exact,
+        huggingface_hub_cache_dir, huggingface_identity_for_path, installed_model_capabilities,
+        installed_model_display_name, installed_model_huggingface_ref,
+        layered_package_layer_count_for_path, layered_package_total_bytes_for_path,
+        load_model_usage_record_for_path, model_usage_cache_dir, plan_model_cleanup,
+        remote_catalog_model_draft_ref, remote_catalog_model_ref, run_update,
+        scan_installed_models, search_catalog_json_payload, search_catalog_models,
+        search_huggingface, search_huggingface_json_payload, show_exact_model,
+        show_model_variants_with_progress,
     };
     pub use crate::models::{capabilities, catalog};
 }

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -16,7 +16,9 @@ use skippy_runtime::package::{
     self, LayerPackageInfo, PackageIntegrityOptions, PackageStageRequest,
 };
 
-use mesh_llm_events::terminal_progress::{SpinnerHandle, start_spinner};
+use mesh_llm_events::terminal_progress::{
+    SpinnerHandle, ratio_complete_u64, render_inline_gauge, start_spinner,
+};
 use mesh_llm_events::{ModelProgressStatus, OutputEvent, emit_event, interactive_tui_active};
 
 use super::StageLoadRequest;
@@ -242,17 +244,21 @@ impl LayerPackageDownloadScope {
                 )
             })
             .unwrap_or_default();
-        eprint!(
-            "\r\x1b[K   ⏬ {} {:>3}.{:01}% ({}/{}){}   📄 files {}/{} complete",
-            layer_package_artifact_display_for_package(&self.package, file),
-            percent_major,
-            percent_minor,
-            format_layer_package_download_bytes(downloaded),
-            format_layer_package_download_bytes(total),
-            speed_suffix,
-            self.complete_count(completed_files),
-            self.total_files,
+        let gauge = render_inline_gauge(
+            ratio_complete_u64(downloaded, total),
+            &format!(
+                "⏬ {} {:>3}.{:01}% ({}/{}){}   files {}/{} complete",
+                layer_package_artifact_display_for_package(&self.package, file),
+                percent_major,
+                percent_minor,
+                format_layer_package_download_bytes(downloaded),
+                format_layer_package_download_bytes(total),
+                speed_suffix,
+                self.complete_count(completed_files),
+                self.total_files,
+            ),
         );
+        eprint!("\r\x1b[K   {gauge}");
         let _ = std::io::stderr().flush();
         scope_state.drawn_line = true;
         if force {
@@ -543,15 +549,19 @@ fn draw_layer_package_file_progress(
             )
         })
         .unwrap_or_default();
-    eprint!(
-        "\r\x1b[K   ⏬ {} {:>3}.{:01}% ({}/{}){}",
-        file,
-        percent_major,
-        percent_minor,
-        format_layer_package_download_bytes(downloaded),
-        format_layer_package_download_bytes(total),
-        speed_suffix,
+    let gauge = render_inline_gauge(
+        ratio_complete_u64(downloaded, total),
+        &format!(
+            "⏬ {} {:>3}.{:01}% ({}/{}){}",
+            file,
+            percent_major,
+            percent_minor,
+            format_layer_package_download_bytes(downloaded),
+            format_layer_package_download_bytes(total),
+            speed_suffix,
+        ),
     );
+    eprint!("\r\x1b[K   {gauge}");
     let _ = std::io::stderr().flush();
     if force {
         eprintln!();

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -17,7 +17,7 @@ use skippy_runtime::package::{
 };
 
 use mesh_llm_events::terminal_progress::{
-    SpinnerHandle, ratio_complete_u64, render_inline_gauge, start_spinner,
+    SpinnerHandle, ratio_complete_u64, render_inline_gauge_with_reserved_width, start_spinner,
 };
 use mesh_llm_events::{ModelProgressStatus, OutputEvent, emit_event, interactive_tui_active};
 
@@ -244,19 +244,27 @@ impl LayerPackageDownloadScope {
                 )
             })
             .unwrap_or_default();
-        let gauge = render_inline_gauge(
-            ratio_complete_u64(downloaded, total),
+        let (ratio, total_display) = match total {
+            0 => (0.0, "?".to_string()),
+            total => (
+                ratio_complete_u64(downloaded, total),
+                format_layer_package_download_bytes(total),
+            ),
+        };
+        let gauge = render_inline_gauge_with_reserved_width(
+            ratio,
             &format!(
                 "⏬ {} {:>3}.{:01}% ({}/{}){}   files {}/{} complete",
                 layer_package_artifact_display_for_package(&self.package, file),
                 percent_major,
                 percent_minor,
                 format_layer_package_download_bytes(downloaded),
-                format_layer_package_download_bytes(total),
+                total_display,
                 speed_suffix,
                 self.complete_count(completed_files),
                 self.total_files,
             ),
+            3,
         );
         eprint!("\r\x1b[K   {gauge}");
         let _ = std::io::stderr().flush();
@@ -549,17 +557,25 @@ fn draw_layer_package_file_progress(
             )
         })
         .unwrap_or_default();
-    let gauge = render_inline_gauge(
-        ratio_complete_u64(downloaded, total),
+    let (ratio, total_display) = match total {
+        0 => (0.0, "?".to_string()),
+        total => (
+            ratio_complete_u64(downloaded, total),
+            format_layer_package_download_bytes(total),
+        ),
+    };
+    let gauge = render_inline_gauge_with_reserved_width(
+        ratio,
         &format!(
             "⏬ {} {:>3}.{:01}% ({}/{}){}",
             file,
             percent_major,
             percent_minor,
             format_layer_package_download_bytes(downloaded),
-            format_layer_package_download_bytes(total),
+            total_display,
             speed_suffix,
         ),
+        3,
     );
     eprint!("\r\x1b[K   {gauge}");
     let _ = std::io::stderr().flush();

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -5,7 +5,9 @@ use anyhow::{Context, Result};
 use hf_hub::progress::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
 #[cfg(test)]
 use hf_hub::progress::{FileProgress, FileStatus};
-use mesh_llm_events::terminal_progress::{SpinnerHandle, start_spinner};
+use mesh_llm_events::terminal_progress::{
+    SpinnerHandle, ratio_complete_u64, render_inline_gauge, start_spinner,
+};
 use mesh_llm_events::{ModelProgressStatus, OutputEvent, emit_event, interactive_tui_active};
 #[cfg(test)]
 use std::collections::HashMap;
@@ -351,15 +353,19 @@ impl MeshDownloadProgress {
             .filter(|bytes_per_sec| *bytes_per_sec > 0.0)
             .map(|bytes_per_sec| format!(" at {}/s", format_download_bytes(bytes_per_sec as u64)))
             .unwrap_or_default();
-        eprint!(
-            "\r\x1b[K   ⏬ {} {:>3}.{:01}% ({}/{}){}",
-            state.filename,
-            percent_major,
-            percent_minor,
-            format_download_bytes(state.downloaded),
-            format_download_bytes(state.total),
-            speed_suffix,
+        let gauge = render_inline_gauge(
+            ratio_complete_u64(state.downloaded, state.total),
+            &format!(
+                "⏬ {} {:>3}.{:01}% ({}/{}){}",
+                state.filename,
+                percent_major,
+                percent_minor,
+                format_download_bytes(state.downloaded),
+                format_download_bytes(state.total),
+                speed_suffix,
+            ),
         );
+        eprint!("\r\x1b[K   {gauge}");
         let _ = std::io::stderr().flush();
         if force {
             eprintln!();

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -1,5 +1,7 @@
 //! Managed model acquisition helpers.
 
+use super::download_parts::MultipartDownloadProgress;
+use super::download_transfer::{DownloadTransferStats, DownloadTransferTracker};
 use super::track_managed_model_usage;
 use anyhow::{Context, Result};
 use hf_hub::progress::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
@@ -16,6 +18,9 @@ use std::path::{Path, PathBuf};
 #[cfg(test)]
 use std::sync::LazyLock;
 use std::sync::{Arc, Mutex};
+
+const DOWNLOAD_PROGRESS_PREFIX_WIDTH: usize = "Downloading  100.0%  ".len();
+const DOWNLOAD_PROGRESS_BAR_WIDTH: u16 = 32;
 
 /// Get the canonical managed model root (the Hugging Face hub cache).
 pub fn models_dir() -> PathBuf {
@@ -267,7 +272,7 @@ async fn download_hf_assets(
     label: &str,
     assets: Vec<HfAsset>,
     progress: bool,
-) -> Result<Vec<PathBuf>> {
+) -> Result<HfAssetsDownload> {
     let label = label.to_string();
     #[cfg(test)]
     {
@@ -277,12 +282,47 @@ async fn download_hf_assets(
             .get(&label)
             .cloned();
         if let Some(func) = func {
-            return func(&label, assets);
+            return Ok(HfAssetsDownload {
+                paths: func(&label, assets)?,
+                transfer_stats: None,
+            });
         }
     }
     tokio::task::spawn_blocking(move || download_hf_assets_blocking(&label, assets, progress))
         .await
         .context("Join Hugging Face download task")?
+}
+
+#[derive(Debug)]
+struct HfAssetsDownload {
+    paths: Vec<PathBuf>,
+    transfer_stats: Option<DownloadTransferStats>,
+}
+
+#[derive(Debug)]
+pub struct HfDownload {
+    pub path: PathBuf,
+    pub paths: Vec<PathBuf>,
+    pub transfer_stats: Option<DownloadTransferStats>,
+}
+
+struct HfDownloadProgress {
+    visible: Option<Arc<MeshDownloadProgress>>,
+    transfer: Arc<Mutex<DownloadTransferTracker>>,
+}
+
+impl ProgressHandler for HfDownloadProgress {
+    fn on_progress(&self, event: &ProgressEvent) {
+        if let Some(visible) = &self.visible {
+            visible.on_progress(event);
+        }
+        let ProgressEvent::Download(event) = event else {
+            return;
+        };
+        if let Ok(mut transfer) = self.transfer.lock() {
+            transfer.apply_download_event(event);
+        }
+    }
 }
 
 struct MeshDownloadProgressState {
@@ -371,7 +411,7 @@ impl MeshDownloadProgress {
                 format_download_bytes(total),
             ),
         };
-        let bar = render_inline_progress_bar(ratio, 32);
+        let bar = render_inline_progress_bar(ratio, DOWNLOAD_PROGRESS_BAR_WIDTH);
         eprint!(
             "\r\x1b[KDownloading  {:>3}.{:01}%  {}  {} / {}{}",
             percent_major,
@@ -520,7 +560,7 @@ fn download_hf_assets_blocking(
     label: &str,
     assets: Vec<HfAsset>,
     progress: bool,
-) -> Result<Vec<PathBuf>> {
+) -> Result<HfAssetsDownload> {
     let label = label.to_string();
     super::run_hf_sync(move || download_hf_assets_sync(&label, assets, progress))
 }
@@ -529,7 +569,7 @@ fn download_hf_assets_sync(
     label: &str,
     assets: Vec<HfAsset>,
     progress: bool,
-) -> Result<Vec<PathBuf>> {
+) -> Result<HfAssetsDownload> {
     let api = super::build_hf_api(false)?;
     let mut download_plan = initial_download_plan_for_assets(assets)?;
     let current_plan: Vec<(bool, HfAsset)> = download_plan.iter().cloned().collect();
@@ -574,6 +614,22 @@ fn download_hf_assets_sync(
     }
 
     let mut primary_paths = Vec::new();
+    let mut transfer_stats = Vec::new();
+    let mut multipart_progress = MultipartDownloadProgress::new(
+        label,
+        download_plan
+            .iter()
+            .filter(|(required, asset)| is_required_primary_asset(*required, asset))
+            .count(),
+    );
+    let mut multipart_terminal_line_drawn = false;
+    if progress && multipart_progress.is_multipart() {
+        emit_multipart_progress(
+            &multipart_progress,
+            ModelProgressStatus::Downloading,
+            &mut multipart_terminal_line_drawn,
+        );
+    }
     for (required, asset) in download_plan {
         let (owner, name) = asset.repo_parts();
         let api_repo = api.model(owner, name);
@@ -587,14 +643,28 @@ fn download_hf_assets_sync(
                 || eprintln!("   📥 Ensuring model {}", asset.file),
             );
         }
-        let progress_tracker = if progress && required {
+        let visible_tracker = if progress && required {
             Some(Arc::new(MeshDownloadProgress::new(asset.file.clone())))
         } else {
             None
         };
-        let progress_handler: Option<Progress> = progress_tracker
-            .as_ref()
-            .map(|tracker| tracker.clone().into());
+        let transfer_tracker =
+            required.then(|| Arc::new(Mutex::new(DownloadTransferTracker::default())));
+        let progress_handler: Option<Progress> = transfer_tracker.as_ref().map(|tracker| {
+            Arc::new(HfDownloadProgress {
+                visible: visible_tracker.clone(),
+                transfer: Arc::clone(tracker),
+            })
+            .into()
+        });
+        let cached_before = transfer_tracker.is_some()
+            && api_repo
+                .download_file()
+                .filename(asset.file.clone())
+                .revision(asset.revision.clone())
+                .local_files_only(true)
+                .send()
+                .is_ok();
         let path = match api_repo
             .download_file()
             .filename(asset.file.clone())
@@ -604,47 +674,13 @@ fn download_hf_assets_sync(
         {
             Ok(path) => {
                 if progress {
-                    if required && interactive_tui_active() {
-                        let showed_progress = progress_tracker
-                            .as_ref()
-                            .is_some_and(|tracker| tracker.showed_meaningful_progress());
-                        if showed_progress {
-                            emit_or_print_model_progress(
-                                label,
-                                Some(&asset.file),
-                                None,
-                                None,
-                                ModelProgressStatus::Ready,
-                                || eprintln!("   ✅ Ready {}", asset.file),
-                            );
-                        } else if let Ok(meta) = std::fs::metadata(&path) {
-                            emit_or_print_model_progress(
-                                label,
-                                Some(&asset.file),
-                                Some(meta.len()),
-                                Some(meta.len()),
-                                ModelProgressStatus::Ready,
-                                || {
-                                    eprintln!(
-                                        "   ✅ Ready {} ({})",
-                                        asset.file,
-                                        format_download_bytes(meta.len())
-                                    )
-                                },
-                            );
-                        } else {
-                            emit_or_print_model_progress(
-                                label,
-                                Some(&asset.file),
-                                None,
-                                None,
-                                ModelProgressStatus::Ready,
-                                || eprintln!("   ✅ Ready {}", asset.file),
-                            );
-                        }
-                    } else if interactive_tui_active() {
-                        eprintln!("   🧾 Downloaded model metadata");
-                    }
+                    emit_completed_asset_progress(
+                        required,
+                        label,
+                        &asset.file,
+                        &path,
+                        visible_tracker.as_ref(),
+                    );
                 }
                 path
             }
@@ -660,12 +696,149 @@ fn download_hf_assets_sync(
                 });
             }
         };
-        if required && asset.file != "config.json" {
+        if let Some(tracker) = transfer_tracker
+            && let Ok(mut tracker) = tracker.lock()
+            && let Some(stats) =
+                std::mem::take(&mut *tracker).finish_with_file_fallback(cached_before, &path)
+        {
+            transfer_stats.push(stats);
+        }
+        if is_required_primary_asset(required, &asset) {
             primary_paths.push(path);
+            multipart_progress.complete_required_part();
+            if progress && multipart_progress.is_multipart() {
+                emit_multipart_progress(
+                    &multipart_progress,
+                    ModelProgressStatus::Downloading,
+                    &mut multipart_terminal_line_drawn,
+                );
+            }
+        } else {
+            multipart_progress.complete_optional_metadata();
         }
     }
 
-    Ok(primary_paths)
+    Ok(HfAssetsDownload {
+        paths: primary_paths,
+        transfer_stats: DownloadTransferStats::combine(transfer_stats),
+    })
+}
+
+fn emit_completed_asset_progress(
+    required: bool,
+    label: &str,
+    asset_file: &str,
+    path: &Path,
+    visible_tracker: Option<&Arc<MeshDownloadProgress>>,
+) {
+    if required && interactive_tui_active() {
+        emit_required_asset_ready_progress(label, asset_file, path, visible_tracker);
+    } else if interactive_tui_active() {
+        eprintln!("   🧾 Downloaded model metadata");
+    }
+}
+
+fn emit_required_asset_ready_progress(
+    label: &str,
+    asset_file: &str,
+    path: &Path,
+    visible_tracker: Option<&Arc<MeshDownloadProgress>>,
+) {
+    let showed_progress =
+        visible_tracker.is_some_and(|tracker| tracker.showed_meaningful_progress());
+    if showed_progress {
+        emit_or_print_model_progress(
+            label,
+            Some(asset_file),
+            None,
+            None,
+            ModelProgressStatus::Ready,
+            || eprintln!("   ✅ Ready {asset_file}"),
+        );
+    } else if let Ok(meta) = std::fs::metadata(path) {
+        emit_or_print_model_progress(
+            label,
+            Some(asset_file),
+            Some(meta.len()),
+            Some(meta.len()),
+            ModelProgressStatus::Ready,
+            || {
+                eprintln!(
+                    "   ✅ Ready {} ({})",
+                    asset_file,
+                    format_download_bytes(meta.len())
+                )
+            },
+        );
+    } else {
+        emit_or_print_model_progress(
+            label,
+            Some(asset_file),
+            None,
+            None,
+            ModelProgressStatus::Ready,
+            || eprintln!("   ✅ Ready {asset_file}"),
+        );
+    }
+}
+
+fn is_required_primary_asset(required: bool, asset: &HfAsset) -> bool {
+    required && asset.file != "config.json"
+}
+
+fn emit_multipart_progress(
+    progress: &MultipartDownloadProgress,
+    status: ModelProgressStatus,
+    terminal_line_drawn: &mut bool,
+) {
+    let (completed, total) = progress.snapshot();
+    let completed = u64::try_from(completed).unwrap_or(u64::MAX);
+    let total = u64::try_from(total).unwrap_or(u64::MAX);
+    let label = multipart_progress_label(progress.label());
+    if interactive_tui_active() {
+        emit_model_progress(&label, None, Some(completed), Some(total), status);
+    } else {
+        print_multipart_terminal_progress(progress, *terminal_line_drawn);
+        *terminal_line_drawn = true;
+    }
+}
+
+fn print_multipart_terminal_progress(progress: &MultipartDownloadProgress, already_drawn: bool) {
+    eprint!(
+        "{}",
+        multipart_progress_terminal_frame(progress, already_drawn)
+    );
+    let _ = std::io::stderr().flush();
+}
+
+fn multipart_progress_terminal_frame(
+    progress: &MultipartDownloadProgress,
+    already_drawn: bool,
+) -> String {
+    let line = multipart_progress_terminal_line(progress);
+    if already_drawn {
+        format!("\x1b[1A\r\x1b[2K{line}\n")
+    } else {
+        format!("\r\x1b[2K{line}\n")
+    }
+}
+
+fn multipart_progress_terminal_line(progress: &MultipartDownloadProgress) -> String {
+    let (completed, total) = progress.snapshot();
+    let completed = u64::try_from(completed).unwrap_or(u64::MAX);
+    let total = u64::try_from(total).unwrap_or(u64::MAX);
+    let percent = ratio_complete_u64(completed, total);
+    let prefix = format!(
+        "{:<width$}",
+        "Parts",
+        width = DOWNLOAD_PROGRESS_PREFIX_WIDTH
+    );
+    let bar = render_inline_progress_bar(percent, DOWNLOAD_PROGRESS_BAR_WIDTH);
+    format!("{prefix}{bar}  {completed}/{total}")
+}
+
+fn multipart_progress_label(label: &str) -> String {
+    format!("parts::{label}")
 }
 
 fn initial_download_plan_for_assets(
@@ -719,6 +892,7 @@ pub async fn download_hf_repo_file_with_progress(
         progress,
     )
     .await
+    .map(|download| download.path)
 }
 
 pub async fn download_hf_repo_file_with_progress_label(
@@ -727,18 +901,22 @@ pub async fn download_hf_repo_file_with_progress_label(
     file: &str,
     label: &str,
     progress: bool,
-) -> Result<PathBuf> {
+) -> Result<HfDownload> {
     let revision = revision.unwrap_or("main").to_string();
     let asset = HfAsset {
         repo: repo.to_string(),
         revision: revision.clone(),
         file: file.to_string(),
     };
-    let mut paths = download_hf_assets(label, vec![asset.clone()], progress).await?;
+    let HfAssetsDownload {
+        mut paths,
+        transfer_stats,
+    } = download_hf_assets(label, vec![asset.clone()], progress).await?;
     paths.sort();
     let path = paths
-        .into_iter()
+        .iter()
         .find(|path| path_suffix_matches_ignore_case(path, &asset.file))
+        .cloned()
         .ok_or_else(|| {
             anyhow::anyhow!(
                 "Downloaded Hugging Face asset not found in cache: {repo}/{file}@{revision}"
@@ -749,19 +927,19 @@ pub async fn download_hf_repo_file_with_progress_label(
         .and_then(|value| value.to_str())
         .unwrap_or(&asset.file);
     let model_ref = format!("{repo}@{revision}/{file}");
-    if let Err(err) = track_managed_model_usage(
-        &path,
-        std::slice::from_ref(&path),
-        display_name,
-        Some(&model_ref),
-        "huggingface",
-    ) {
+    if let Err(err) =
+        track_managed_model_usage(&path, &paths, display_name, Some(&model_ref), "huggingface")
+    {
         tracing::warn!(
             "failed to record managed model usage for {}: {err}",
             path.display()
         );
     }
-    Ok(path)
+    Ok(HfDownload {
+        path,
+        paths,
+        transfer_stats,
+    })
 }
 
 fn path_suffix_matches_ignore_case(path: &Path, expected: &str) -> bool {
@@ -1087,6 +1265,29 @@ mod tests {
     }
 
     #[test]
+    fn silent_download_progress_records_transfer_stats() {
+        let transfer = Arc::new(Mutex::new(DownloadTransferTracker::default()));
+        let progress = HfDownloadProgress {
+            visible: None,
+            transfer: Arc::clone(&transfer),
+        };
+
+        progress.on_progress(&ProgressEvent::Download(DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model.gguf".to_string(),
+                bytes_completed: 1_024,
+                total_bytes: 2_048,
+                status: FileStatus::InProgress,
+            }],
+        }));
+
+        let stats = std::mem::take(&mut *transfer.lock().unwrap())
+            .finish()
+            .expect("silent transfer stats");
+        assert_eq!(stats.bytes, 1_024);
+    }
+
+    #[test]
     fn is_split_mlx_first_shard_file_identifies_correct_patterns() {
         assert!(is_split_mlx_first_shard_file(
             "model-00001-of-00004.safetensors"
@@ -1161,6 +1362,97 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn multipart_download_progress_tracks_required_parts_only() {
+        let mut progress = MultipartDownloadProgress::new("repo/model", 3);
+
+        assert_eq!(progress.snapshot(), (0, 3));
+        progress.complete_optional_metadata();
+        assert_eq!(progress.snapshot(), (0, 3));
+        progress.complete_required_part();
+        assert_eq!(progress.snapshot(), (1, 3));
+        progress.complete_required_part();
+        assert_eq!(progress.snapshot(), (2, 3));
+        progress.complete_required_part();
+        assert_eq!(progress.snapshot(), (3, 3));
+        progress.complete_required_part();
+        assert_eq!(progress.snapshot(), (3, 3));
+    }
+
+    #[test]
+    fn multipart_progress_terminal_line_reports_part_counts() {
+        let mut progress = MultipartDownloadProgress::new("repo/model", 3);
+        progress.complete_required_part();
+        progress.complete_required_part();
+
+        let line = multipart_progress_terminal_line(&progress);
+
+        assert!(line.contains("Parts"));
+        assert!(line.contains("2/3"));
+        assert!(!line.contains('📦'));
+        assert_eq!(line.find('['), Some(21));
+    }
+
+    #[test]
+    fn multipart_progress_terminal_frame_repaints_in_place() {
+        let mut progress = MultipartDownloadProgress::new("repo/model", 3);
+        progress.complete_required_part();
+
+        let first = multipart_progress_terminal_frame(&progress, false);
+        let next = multipart_progress_terminal_frame(&progress, true);
+
+        assert!(first.starts_with("\r\x1b[2KParts"));
+        assert_eq!(first.matches('\n').count(), 1);
+        assert!(next.starts_with("\x1b[1A\r\x1b[2KParts"));
+        assert_eq!(next.matches('\n').count(), 1);
+    }
+
+    #[tokio::test]
+    async fn download_hf_repo_file_returns_all_split_primary_paths() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let cache_dir = std::env::temp_dir().join(format!("mesh-llm-hf-split-repo-{unique}"));
+        let shard_one = cache_dir.join("model-00001-of-00003.gguf");
+        let shard_two = cache_dir.join("model-00002-of-00003.gguf");
+        let shard_three = cache_dir.join("model-00003-of-00003.gguf");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+        std::fs::write(&shard_one, b"gguf").unwrap();
+        std::fs::write(&shard_two, b"gguf").unwrap();
+        std::fs::write(&shard_three, b"gguf").unwrap();
+
+        let label = "org/repo/model-00001-of-00003.gguf@main".to_string();
+        let _guard = DownloadHfAssetsOverrideGuard::set(
+            label,
+            Arc::new({
+                let shard_one = shard_one.clone();
+                let shard_two = shard_two.clone();
+                let shard_three = shard_three.clone();
+                move |_, _| {
+                    Ok(vec![
+                        shard_three.clone(),
+                        shard_one.clone(),
+                        shard_two.clone(),
+                    ])
+                }
+            }),
+        );
+
+        let download = download_hf_repo_file_with_progress_label(
+            "org/repo",
+            Some("main"),
+            "model-00001-of-00003.gguf",
+            "org/repo/model-00001-of-00003.gguf@main",
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(download.path, shard_one);
+        assert_eq!(download.paths, vec![shard_one, shard_two, shard_three]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -6,7 +6,7 @@ use hf_hub::progress::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
 #[cfg(test)]
 use hf_hub::progress::{FileProgress, FileStatus};
 use mesh_llm_events::terminal_progress::{
-    SpinnerHandle, ratio_complete_u64, render_inline_gauge, start_spinner,
+    SpinnerHandle, ratio_complete_u64, render_inline_gauge_with_reserved_width, start_spinner,
 };
 use mesh_llm_events::{ModelProgressStatus, OutputEvent, emit_event, interactive_tui_active};
 #[cfg(test)]
@@ -353,17 +353,25 @@ impl MeshDownloadProgress {
             .filter(|bytes_per_sec| *bytes_per_sec > 0.0)
             .map(|bytes_per_sec| format!(" at {}/s", format_download_bytes(bytes_per_sec as u64)))
             .unwrap_or_default();
-        let gauge = render_inline_gauge(
-            ratio_complete_u64(state.downloaded, state.total),
+        let (ratio, total_display) = match state.total {
+            0 => (0.0, "?".to_string()),
+            total => (
+                ratio_complete_u64(state.downloaded, total),
+                format_download_bytes(total),
+            ),
+        };
+        let gauge = render_inline_gauge_with_reserved_width(
+            ratio,
             &format!(
                 "⏬ {} {:>3}.{:01}% ({}/{}){}",
                 state.filename,
                 percent_major,
                 percent_minor,
                 format_download_bytes(state.downloaded),
-                format_download_bytes(state.total),
+                total_display,
                 speed_suffix,
             ),
+            3,
         );
         eprint!("\r\x1b[K   {gauge}");
         let _ = std::io::stderr().flush();

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -642,7 +642,11 @@ fn download_hf_assets_sync(
                 terminal_frame_mode,
             );
         }
-        if progress && required {
+        let multipart_controls_terminal = progress
+            && multipart_progress.is_multipart()
+            && is_required_primary_asset(required, &asset)
+            && !interactive_tui_active();
+        if should_emit_required_asset_ensuring(progress, required, multipart_controls_terminal) {
             emit_or_print_model_progress(
                 label,
                 Some(&asset.file),
@@ -800,6 +804,14 @@ fn emit_required_asset_ready_progress(
 
 fn is_required_primary_asset(required: bool, asset: &HfAsset) -> bool {
     required && asset.file != "config.json"
+}
+
+fn should_emit_required_asset_ensuring(
+    progress: bool,
+    required: bool,
+    multipart_controls_terminal: bool,
+) -> bool {
+    progress && required && !multipart_controls_terminal
 }
 
 fn emit_multipart_progress(
@@ -1456,6 +1468,14 @@ mod tests {
         assert!(next_asset.starts_with("\x1b[1A\r\x1b[2KParts"));
         assert_eq!(first_asset.matches('\n').count(), 1);
         assert_eq!(next_asset.matches('\n').count(), 1);
+    }
+
+    #[test]
+    fn multipart_non_tui_progress_suppresses_interleaved_asset_ensuring() {
+        assert!(!should_emit_required_asset_ensuring(true, true, true));
+        assert!(should_emit_required_asset_ensuring(true, true, false));
+        assert!(!should_emit_required_asset_ensuring(true, false, false));
+        assert!(!should_emit_required_asset_ensuring(false, true, false));
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -6,7 +6,7 @@ use hf_hub::progress::{DownloadEvent, Progress, ProgressEvent, ProgressHandler};
 #[cfg(test)]
 use hf_hub::progress::{FileProgress, FileStatus};
 use mesh_llm_events::terminal_progress::{
-    SpinnerHandle, ratio_complete_u64, render_inline_gauge_with_reserved_width, start_spinner,
+    SpinnerHandle, clear_stderr_line, ratio_complete_u64, render_inline_progress_bar, start_spinner,
 };
 use mesh_llm_events::{ModelProgressStatus, OutputEvent, emit_event, interactive_tui_active};
 #[cfg(test)]
@@ -290,6 +290,7 @@ struct MeshDownloadProgressState {
     total: u64,
     downloaded: u64,
     bytes_per_sec: Option<f64>,
+    drawn_line: bool,
     last_draw: Option<std::time::Instant>,
 }
 
@@ -313,6 +314,7 @@ impl MeshDownloadProgress {
                 total: 0,
                 downloaded: 0,
                 bytes_per_sec: None,
+                drawn_line: false,
                 last_draw: None,
             }),
         }
@@ -337,8 +339,17 @@ impl MeshDownloadProgress {
                 Some(&state.filename),
                 Some(state.downloaded),
                 (state.total > 0).then_some(state.total),
-                ModelProgressStatus::Downloading,
+                if force {
+                    ModelProgressStatus::Ready
+                } else {
+                    ModelProgressStatus::Downloading
+                },
             );
+            return;
+        }
+        if force {
+            let _ = clear_stderr_line();
+            state.drawn_line = false;
             return;
         }
         let percent = if state.total == 0 {
@@ -351,7 +362,7 @@ impl MeshDownloadProgress {
         let speed_suffix = state
             .bytes_per_sec
             .filter(|bytes_per_sec| *bytes_per_sec > 0.0)
-            .map(|bytes_per_sec| format!(" at {}/s", format_download_bytes(bytes_per_sec as u64)))
+            .map(|bytes_per_sec| format!(" · {}/s", format_download_bytes(bytes_per_sec as u64)))
             .unwrap_or_default();
         let (ratio, total_display) = match state.total {
             0 => (0.0, "?".to_string()),
@@ -360,24 +371,18 @@ impl MeshDownloadProgress {
                 format_download_bytes(total),
             ),
         };
-        let gauge = render_inline_gauge_with_reserved_width(
-            ratio,
-            &format!(
-                "⏬ {} {:>3}.{:01}% ({}/{}){}",
-                state.filename,
-                percent_major,
-                percent_minor,
-                format_download_bytes(state.downloaded),
-                total_display,
-                speed_suffix,
-            ),
-            3,
+        let bar = render_inline_progress_bar(ratio, 32);
+        eprint!(
+            "\r\x1b[KDownloading  {:>3}.{:01}%  {}  {} / {}{}",
+            percent_major,
+            percent_minor,
+            bar,
+            format_download_bytes(state.downloaded),
+            total_display,
+            speed_suffix,
         );
-        eprint!("\r\x1b[K   {gauge}");
+        state.drawn_line = true;
         let _ = std::io::stderr().flush();
-        if force {
-            eprintln!();
-        }
     }
 
     fn apply_download_event(state: &mut MeshDownloadProgressState, event: &DownloadEvent) {
@@ -459,6 +464,15 @@ impl Drop for MeshDownloadProgress {
     fn drop(&mut self) {
         if let Ok(mut spinner) = self.preflight_spinner.lock() {
             spinner.take();
+        }
+        if !interactive_tui_active()
+            && self
+                .state
+                .lock()
+                .map(|state| state.drawn_line)
+                .unwrap_or(false)
+        {
+            let _ = clear_stderr_line();
         }
     }
 }
@@ -590,7 +604,7 @@ fn download_hf_assets_sync(
         {
             Ok(path) => {
                 if progress {
-                    if required {
+                    if required && interactive_tui_active() {
                         let showed_progress = progress_tracker
                             .as_ref()
                             .is_some_and(|tracker| tracker.showed_meaningful_progress());
@@ -628,7 +642,7 @@ fn download_hf_assets_sync(
                                 || eprintln!("   ✅ Ready {}", asset.file),
                             );
                         }
-                    } else {
+                    } else if interactive_tui_active() {
                         eprintln!("   🧾 Downloaded model metadata");
                     }
                 }
@@ -977,6 +991,7 @@ mod tests {
             total: 0,
             downloaded: 0,
             bytes_per_sec: None,
+            drawn_line: false,
             last_draw: None,
         };
 
@@ -1023,6 +1038,7 @@ mod tests {
             total: 0,
             downloaded: 0,
             bytes_per_sec: None,
+            drawn_line: false,
             last_draw: None,
         };
 
@@ -1059,6 +1075,7 @@ mod tests {
             total: 1_000,
             downloaded: 700,
             bytes_per_sec: Some(42_000_000.0),
+            drawn_line: false,
             last_draw: None,
         };
 

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -623,16 +623,25 @@ fn download_hf_assets_sync(
             .count(),
     );
     let mut multipart_terminal_line_drawn = false;
-    if progress && multipart_progress.is_multipart() {
-        emit_multipart_progress(
-            &multipart_progress,
-            ModelProgressStatus::Downloading,
-            &mut multipart_terminal_line_drawn,
-        );
-    }
     for (required, asset) in download_plan {
         let (owner, name) = asset.repo_parts();
         let api_repo = api.model(owner, name);
+        if progress
+            && multipart_progress.is_multipart()
+            && is_required_primary_asset(required, &asset)
+        {
+            let terminal_frame_mode = if multipart_terminal_line_drawn {
+                MultipartTerminalFrameMode::RepaintPreviousLine
+            } else {
+                multipart_terminal_line_drawn = true;
+                MultipartTerminalFrameMode::AppendFreshLine
+            };
+            emit_multipart_progress(
+                &multipart_progress,
+                ModelProgressStatus::Downloading,
+                terminal_frame_mode,
+            );
+        }
         if progress && required {
             emit_or_print_model_progress(
                 label,
@@ -710,7 +719,7 @@ fn download_hf_assets_sync(
                 emit_multipart_progress(
                     &multipart_progress,
                     ModelProgressStatus::Downloading,
-                    &mut multipart_terminal_line_drawn,
+                    MultipartTerminalFrameMode::RepaintPreviousLine,
                 );
             }
         } else {
@@ -734,7 +743,14 @@ fn emit_completed_asset_progress(
     if required && interactive_tui_active() {
         emit_required_asset_ready_progress(label, asset_file, path, visible_tracker);
     } else if interactive_tui_active() {
-        eprintln!("   🧾 Downloaded model metadata");
+        emit_or_print_model_progress(
+            label,
+            Some(asset_file),
+            None,
+            None,
+            ModelProgressStatus::Ready,
+            || eprintln!("   Downloaded model metadata {asset_file}"),
+        );
     }
 }
 
@@ -789,7 +805,7 @@ fn is_required_primary_asset(required: bool, asset: &HfAsset) -> bool {
 fn emit_multipart_progress(
     progress: &MultipartDownloadProgress,
     status: ModelProgressStatus,
-    terminal_line_drawn: &mut bool,
+    terminal_frame_mode: MultipartTerminalFrameMode,
 ) {
     let (completed, total) = progress.snapshot();
     let completed = u64::try_from(completed).unwrap_or(u64::MAX);
@@ -798,28 +814,35 @@ fn emit_multipart_progress(
     if interactive_tui_active() {
         emit_model_progress(&label, None, Some(completed), Some(total), status);
     } else {
-        print_multipart_terminal_progress(progress, *terminal_line_drawn);
-        *terminal_line_drawn = true;
+        print_multipart_terminal_progress(progress, terminal_frame_mode);
     }
 }
 
-fn print_multipart_terminal_progress(progress: &MultipartDownloadProgress, already_drawn: bool) {
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MultipartTerminalFrameMode {
+    AppendFreshLine,
+    RepaintPreviousLine,
+}
+
+fn print_multipart_terminal_progress(
+    progress: &MultipartDownloadProgress,
+    terminal_frame_mode: MultipartTerminalFrameMode,
+) {
     eprint!(
         "{}",
-        multipart_progress_terminal_frame(progress, already_drawn)
+        multipart_progress_terminal_frame(progress, terminal_frame_mode)
     );
     let _ = std::io::stderr().flush();
 }
 
 fn multipart_progress_terminal_frame(
     progress: &MultipartDownloadProgress,
-    already_drawn: bool,
+    terminal_frame_mode: MultipartTerminalFrameMode,
 ) -> String {
     let line = multipart_progress_terminal_line(progress);
-    if already_drawn {
-        format!("\x1b[1A\r\x1b[2K{line}\n")
-    } else {
-        format!("\r\x1b[2K{line}\n")
+    match terminal_frame_mode {
+        MultipartTerminalFrameMode::AppendFreshLine => format!("\r\x1b[2K{line}\n"),
+        MultipartTerminalFrameMode::RepaintPreviousLine => format!("\x1b[1A\r\x1b[2K{line}\n"),
     }
 }
 
@@ -1400,13 +1423,39 @@ mod tests {
         let mut progress = MultipartDownloadProgress::new("repo/model", 3);
         progress.complete_required_part();
 
-        let first = multipart_progress_terminal_frame(&progress, false);
-        let next = multipart_progress_terminal_frame(&progress, true);
+        let first = multipart_progress_terminal_frame(
+            &progress,
+            MultipartTerminalFrameMode::AppendFreshLine,
+        );
+        let next = multipart_progress_terminal_frame(
+            &progress,
+            MultipartTerminalFrameMode::RepaintPreviousLine,
+        );
 
         assert!(first.starts_with("\r\x1b[2KParts"));
         assert_eq!(first.matches('\n').count(), 1);
         assert!(next.starts_with("\x1b[1A\r\x1b[2KParts"));
         assert_eq!(next.matches('\n').count(), 1);
+    }
+
+    #[test]
+    fn multipart_progress_terminal_frame_repaints_after_first_asset_boundary() {
+        let mut progress = MultipartDownloadProgress::new("repo/model", 3);
+        progress.complete_required_part();
+
+        let first_asset = multipart_progress_terminal_frame(
+            &progress,
+            MultipartTerminalFrameMode::AppendFreshLine,
+        );
+        let next_asset = multipart_progress_terminal_frame(
+            &progress,
+            MultipartTerminalFrameMode::RepaintPreviousLine,
+        );
+
+        assert!(first_asset.starts_with("\r\x1b[2KParts"));
+        assert!(next_asset.starts_with("\x1b[1A\r\x1b[2KParts"));
+        assert_eq!(first_asset.matches('\n').count(), 1);
+        assert_eq!(next_asset.matches('\n').count(), 1);
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/models/download_parts.rs
+++ b/crates/mesh-llm-host-runtime/src/models/download_parts.rs
@@ -1,0 +1,34 @@
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct MultipartDownloadProgress {
+    label: String,
+    completed: usize,
+    total: usize,
+}
+
+impl MultipartDownloadProgress {
+    pub(crate) fn new(label: impl Into<String>, total: usize) -> Self {
+        Self {
+            label: label.into(),
+            completed: 0,
+            total,
+        }
+    }
+
+    pub(crate) fn is_multipart(&self) -> bool {
+        self.total > 1
+    }
+
+    pub(crate) fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub(crate) fn snapshot(&self) -> (usize, usize) {
+        (self.completed, self.total)
+    }
+
+    pub(crate) fn complete_optional_metadata(&mut self) {}
+
+    pub(crate) fn complete_required_part(&mut self) {
+        self.completed = self.completed.saturating_add(1).min(self.total);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/models/download_transfer.rs
+++ b/crates/mesh-llm-host-runtime/src/models/download_transfer.rs
@@ -1,0 +1,266 @@
+use hf_hub::progress::{DownloadEvent, FileStatus};
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DownloadTransferStats {
+    pub bytes: u64,
+    pub elapsed: Duration,
+    pub bytes_per_sec: Option<f64>,
+}
+
+impl DownloadTransferStats {
+    pub(crate) fn combine(stats: Vec<Self>) -> Option<Self> {
+        if stats.is_empty() {
+            return None;
+        }
+        let bytes = stats.iter().map(|stat| stat.bytes).sum();
+        let elapsed = stats.iter().map(|stat| stat.elapsed).sum();
+        let bytes_per_sec = combined_bytes_per_sec(&stats);
+        Some(Self {
+            bytes,
+            elapsed,
+            bytes_per_sec,
+        })
+    }
+}
+
+fn combined_bytes_per_sec(stats: &[DownloadTransferStats]) -> Option<f64> {
+    let mut rate_bytes = 0.0;
+    let mut rate_seconds = 0.0;
+    for stat in stats {
+        let Some(bytes_per_sec) = stat.bytes_per_sec.filter(|value| *value > 0.0) else {
+            continue;
+        };
+        rate_bytes += stat.bytes as f64;
+        rate_seconds += stat.bytes as f64 / bytes_per_sec;
+    }
+    (rate_seconds > 0.0).then_some(rate_bytes / rate_seconds)
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct DownloadTransferTracker {
+    file_bytes: HashMap<String, u64>,
+    aggregate_bytes: u64,
+    bytes_per_sec: Option<f64>,
+    started_at: Option<Instant>,
+    last_progress_at: Option<Instant>,
+}
+
+impl DownloadTransferTracker {
+    pub(crate) fn apply_download_event(&mut self, event: &DownloadEvent) {
+        match event {
+            DownloadEvent::Start { .. } => self.record_start(),
+            DownloadEvent::Complete => {}
+            DownloadEvent::Progress { files } => {
+                for file in files {
+                    let previous = self.file_bytes.get(&file.filename).copied().unwrap_or(0);
+                    let counts_as_transfer = match file.status {
+                        FileStatus::Started | FileStatus::InProgress => {
+                            file.bytes_completed > previous
+                        }
+                        FileStatus::Complete => previous > 0 && file.bytes_completed > previous,
+                    };
+                    if counts_as_transfer {
+                        self.record_progress();
+                        self.file_bytes
+                            .insert(file.filename.clone(), file.bytes_completed);
+                    }
+                }
+            }
+            DownloadEvent::AggregateProgress {
+                bytes_completed,
+                bytes_per_sec,
+                ..
+            } => {
+                if *bytes_completed > self.aggregate_bytes {
+                    self.record_progress();
+                    self.aggregate_bytes = *bytes_completed;
+                }
+                if bytes_per_sec.is_some_and(|value| value > 0.0) {
+                    self.bytes_per_sec = *bytes_per_sec;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn finish(self) -> Option<DownloadTransferStats> {
+        let per_file_bytes = self.file_bytes.values().sum();
+        let bytes = self.aggregate_bytes.max(per_file_bytes);
+        if bytes == 0 {
+            return None;
+        }
+        let elapsed = match (self.started_at, self.last_progress_at) {
+            (Some(start), Some(end)) => end.saturating_duration_since(start),
+            _ => Duration::ZERO,
+        };
+        Some(DownloadTransferStats {
+            bytes,
+            elapsed,
+            bytes_per_sec: self.bytes_per_sec,
+        })
+    }
+
+    pub(crate) fn finish_with_file_fallback(
+        self,
+        cached_before: bool,
+        path: &Path,
+    ) -> Option<DownloadTransferStats> {
+        let elapsed = self
+            .started_at
+            .map(|started_at| started_at.elapsed())
+            .unwrap_or(Duration::ZERO);
+        if let Some(stats) = self.finish() {
+            return Some(stats);
+        }
+        if cached_before {
+            return None;
+        }
+        let bytes = std::fs::metadata(path).ok()?.len();
+        if bytes == 0 {
+            return None;
+        }
+        Some(DownloadTransferStats {
+            bytes,
+            elapsed,
+            bytes_per_sec: None,
+        })
+    }
+
+    fn record_start(&mut self) {
+        if self.started_at.is_none() {
+            self.started_at = Some(Instant::now());
+        }
+    }
+
+    fn record_progress(&mut self) {
+        self.record_start();
+        let now = Instant::now();
+        self.last_progress_at = Some(now);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DownloadTransferTracker;
+    use hf_hub::progress::{DownloadEvent, FileProgress, FileStatus};
+
+    #[test]
+    fn download_transfer_stats_ignore_cache_hit_events() {
+        let mut tracker = DownloadTransferTracker::default();
+
+        tracker.apply_download_event(&DownloadEvent::Start {
+            total_files: 1,
+            total_bytes: 1_000,
+        });
+        tracker.apply_download_event(&DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model.gguf".to_string(),
+                bytes_completed: 1_000,
+                total_bytes: 1_000,
+                status: FileStatus::Complete,
+            }],
+        });
+        tracker.apply_download_event(&DownloadEvent::Complete);
+
+        assert_eq!(tracker.finish(), None);
+    }
+
+    #[test]
+    fn download_transfer_stats_accumulate_multipart_progress() {
+        let mut tracker = DownloadTransferTracker::default();
+
+        tracker.apply_download_event(&DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model-00001-of-00002.gguf".to_string(),
+                bytes_completed: 400,
+                total_bytes: 1_000,
+                status: FileStatus::InProgress,
+            }],
+        });
+        tracker.apply_download_event(&DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model-00001-of-00002.gguf".to_string(),
+                bytes_completed: 900,
+                total_bytes: 1_000,
+                status: FileStatus::InProgress,
+            }],
+        });
+        tracker.apply_download_event(&DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model-00002-of-00002.gguf".to_string(),
+                bytes_completed: 300,
+                total_bytes: 1_000,
+                status: FileStatus::InProgress,
+            }],
+        });
+
+        let stats = tracker.finish().expect("multipart transfer stats");
+        assert_eq!(stats.bytes, 1_200);
+    }
+
+    #[test]
+    fn download_transfer_stats_preserve_xet_speed() {
+        let mut tracker = DownloadTransferTracker::default();
+
+        tracker.apply_download_event(&DownloadEvent::AggregateProgress {
+            bytes_completed: 32_000_000,
+            total_bytes: 64_000_000,
+            bytes_per_sec: Some(128_000_000.0),
+        });
+
+        let stats = tracker.finish().expect("xet transfer stats");
+        assert_eq!(stats.bytes, 32_000_000);
+        assert_eq!(stats.bytes_per_sec, Some(128_000_000.0));
+    }
+
+    #[test]
+    fn download_transfer_stats_count_uncached_complete_only_asset() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("model-00001-of-00003.gguf");
+        std::fs::write(&path, vec![0; 4_096]).expect("write shard");
+        let mut tracker = DownloadTransferTracker::default();
+
+        tracker.apply_download_event(&DownloadEvent::Start {
+            total_files: 1,
+            total_bytes: 4_096,
+        });
+        tracker.apply_download_event(&DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model-00001-of-00003.gguf".to_string(),
+                bytes_completed: 4_096,
+                total_bytes: 4_096,
+                status: FileStatus::Complete,
+            }],
+        });
+
+        let stats = tracker
+            .finish_with_file_fallback(false, &path)
+            .expect("uncached complete-only transfer stats");
+        assert_eq!(stats.bytes, 4_096);
+    }
+
+    #[test]
+    fn download_transfer_stats_ignore_cached_complete_only_asset() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("model-00001-of-00003.gguf");
+        std::fs::write(&path, vec![0; 4_096]).expect("write shard");
+        let mut tracker = DownloadTransferTracker::default();
+
+        tracker.apply_download_event(&DownloadEvent::Start {
+            total_files: 1,
+            total_bytes: 4_096,
+        });
+        tracker.apply_download_event(&DownloadEvent::Progress {
+            files: vec![FileProgress {
+                filename: "model-00001-of-00003.gguf".to_string(),
+                bytes_completed: 4_096,
+                total_bytes: 4_096,
+                status: FileStatus::Complete,
+            }],
+        });
+
+        assert_eq!(tracker.finish_with_file_fallback(true, &path), None);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -3,6 +3,8 @@ pub mod capabilities;
 pub mod catalog;
 pub mod delete;
 pub use delete::DeleteResult;
+mod download_parts;
+mod download_transfer;
 mod external_inference;
 pub mod gguf;
 pub mod inventory;
@@ -25,6 +27,7 @@ pub use capabilities::{
     CapabilityLevel, ModelCapabilities, RuntimeMediaCapabilityEvidence,
     runtime_verified_model_capabilities,
 };
+pub use download_transfer::DownloadTransferStats;
 pub(crate) use external_inference::append_external_inference_models;
 pub use inventory::{LocalModelInventorySnapshot, scan_local_inventory_snapshot_with_progress};
 pub use local::{

--- a/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
@@ -1,5 +1,5 @@
-use super::ModelCapabilities;
 use super::local::HuggingFaceModelIdentity;
+use super::{DownloadTransferStats, ModelCapabilities};
 use super::{
     capabilities, catalog, find_model_path, format_size_bytes, huggingface_identity_for_path,
     remote_catalog, track_model_usage,
@@ -138,15 +138,22 @@ pub fn remote_catalog_model_draft_ref(
 pub async fn download_model_ref_with_progress_details(
     input: &str,
     progress: bool,
-) -> Result<(PathBuf, Option<ModelDetails>)> {
+) -> Result<ModelDownload> {
     download_model_ref_with_progress_details_direct(input, progress, false).await
+}
+
+pub struct ModelDownload {
+    pub path: PathBuf,
+    pub paths: Vec<PathBuf>,
+    pub details: Option<ModelDetails>,
+    pub transfer_stats: Option<DownloadTransferStats>,
 }
 
 pub async fn download_model_ref_with_progress_details_direct(
     input: &str,
     progress: bool,
     direct: bool,
-) -> Result<(PathBuf, Option<ModelDetails>)> {
+) -> Result<ModelDownload> {
     let details = if progress {
         let mut spinner = start_spinner(&format!("Resolving {input}"));
         let details = show_exact_model(input).await.ok();
@@ -159,19 +166,26 @@ pub async fn download_model_ref_with_progress_details_direct(
         .as_ref()
         .map(|detail| detail.download_url.as_str())
         .unwrap_or(input);
-    let path = download_exact_ref_with_progress_direct(download_ref, progress, direct).await?;
-    Ok((path, details))
+    let download = download_exact_ref_with_progress_direct(download_ref, progress, direct).await?;
+    Ok(ModelDownload {
+        path: download.path,
+        paths: download.paths,
+        details,
+        transfer_stats: download.transfer_stats,
+    })
 }
 
 pub async fn download_exact_ref_with_progress(input: &str, progress: bool) -> Result<PathBuf> {
-    download_exact_ref_with_progress_direct(input, progress, false).await
+    download_exact_ref_with_progress_direct(input, progress, false)
+        .await
+        .map(|download| download.path)
 }
 
 async fn download_exact_ref_with_progress_direct(
     input: &str,
     progress: bool,
     direct: bool,
-) -> Result<PathBuf> {
+) -> Result<catalog::HfDownload> {
     let input = canonicalize_model_ref_input(input).await?;
     match parse_exact_model_ref(&input)? {
         ExactModelRef::Catalog(model) => download_remote_catalog_model(&model, progress).await,
@@ -244,7 +258,8 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
                 &hf_ref.name,
                 progress,
             )
-            .await;
+            .await
+            .map(|download| download.path);
         }
         let installed_path = find_model_path(installed_name);
         if installed_path.exists() {
@@ -273,10 +288,10 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
         return Ok(installed_path);
     }
 
-    let (path, _) = download_model_ref_with_progress_details(&raw, progress)
+    let download = download_model_ref_with_progress_details(&raw, progress)
         .await
         .with_context(|| format!("Resolve model spec {raw}"))?;
-    Ok(path)
+    Ok(download.path)
 }
 
 fn record_resolved_model_usage(path: &Path, model_ref: Option<&str>) {
@@ -1079,7 +1094,7 @@ async fn remote_size_label(url: &str) -> Option<String> {
 async fn download_remote_catalog_model(
     model: &remote_catalog::RemoteCatalogModel,
     progress: bool,
-) -> Result<PathBuf> {
+) -> Result<catalog::HfDownload> {
     catalog::download_hf_repo_file_with_progress_label(
         &model.repo,
         model.revision.as_deref(),

--- a/crates/mesh-llm-tui/src/output/mod.rs
+++ b/crates/mesh-llm-tui/src/output/mod.rs
@@ -856,6 +856,18 @@ fn format_model_download_progress_message(
     status: &ModelProgressStatus,
 ) -> String {
     let target = file.unwrap_or(label);
+    if let Some(model) = label.strip_prefix("parts::") {
+        return match status {
+            ModelProgressStatus::Ensuring => format!("ensuring model parts for {model}"),
+            ModelProgressStatus::Downloading => match (downloaded_bytes, total_bytes) {
+                (Some(completed), Some(total)) if total > 0 => {
+                    format!("downloading model parts for {model} {completed}/{total}")
+                }
+                _ => format!("downloading model parts for {model}"),
+            },
+            ModelProgressStatus::Ready => format!("model parts ready for {model}"),
+        };
+    }
     if let Some(package) = label.strip_prefix("layer package ") {
         return match status {
             ModelProgressStatus::Ensuring => {
@@ -8868,6 +8880,19 @@ mod tests {
             message,
             "downloading layer package artifact shared/embeddings.gguf for meshllm/demo-layers 256MB/512MB"
         );
+    }
+
+    #[test]
+    fn multipart_model_progress_message_reports_part_counts() {
+        let message = format_model_download_progress_message(
+            "parts::org/repo:model",
+            None,
+            Some(2),
+            Some(3),
+            &ModelProgressStatus::Downloading,
+        );
+
+        assert_eq!(message, "downloading model parts for org/repo:model 2/3");
     }
 
     fn sample_endpoint_row(label: &str, port: u16) -> DashboardEndpointRow {

--- a/crates/mesh-llm-tui/src/terminal_progress.rs
+++ b/crates/mesh-llm-tui/src/terminal_progress.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use crossterm::terminal::size as terminal_size;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -15,6 +16,7 @@ use std::time::Duration;
 
 const INLINE_GAUGE_WIDTH: u16 = 96;
 const INLINE_GAUGE_MIN_BAR_WIDTH: usize = 24;
+const INLINE_GAUGE_WRAP_GUARD_WIDTH: u16 = 1;
 
 pub fn clear_stderr_line() -> Result<()> {
     if crate::json_mode_enabled() {
@@ -122,9 +124,22 @@ impl DeterminateProgressLine {
 }
 
 pub fn render_inline_gauge(ratio: f64, label: &str) -> String {
-    let area = Rect::new(0, 0, INLINE_GAUGE_WIDTH, 1);
+    render_inline_gauge_with_reserved_width(ratio, label, 0)
+}
+
+pub fn render_inline_gauge_with_reserved_width(
+    ratio: f64,
+    label: &str,
+    reserved_columns: u16,
+) -> String {
+    let width = inline_gauge_width(reserved_columns);
+    render_inline_gauge_in_width(ratio, label, width)
+}
+
+fn render_inline_gauge_in_width(ratio: f64, label: &str, width: u16) -> String {
+    let area = Rect::new(0, 0, width, 1);
     let mut buffer = Buffer::empty(area);
-    let label = fit_inline_gauge_label(label);
+    let label = fit_inline_gauge_label(label, width);
     LineGauge::default()
         .ratio(ratio.clamp(0.0, 1.0))
         .label(label)
@@ -141,8 +156,26 @@ pub fn render_inline_gauge(ratio: f64, label: &str) -> String {
     styled_buffer_line(&buffer)
 }
 
-fn fit_inline_gauge_label(label: &str) -> String {
-    let max_label_len = usize::from(INLINE_GAUGE_WIDTH)
+fn inline_gauge_width(reserved_columns: u16) -> u16 {
+    let terminal_width = terminal_size()
+        .map(|(width, _)| width)
+        .unwrap_or(INLINE_GAUGE_WIDTH);
+    available_inline_gauge_width(terminal_width, reserved_columns)
+}
+
+fn available_inline_gauge_width(terminal_width: u16, reserved_columns: u16) -> u16 {
+    let available = terminal_width
+        .saturating_sub(reserved_columns)
+        .saturating_sub(INLINE_GAUGE_WRAP_GUARD_WIDTH);
+    if available >= INLINE_GAUGE_MIN_BAR_WIDTH as u16 {
+        available
+    } else {
+        available.max(1)
+    }
+}
+
+fn fit_inline_gauge_label(label: &str, width: u16) -> String {
+    let max_label_len = usize::from(width)
         .saturating_sub(INLINE_GAUGE_MIN_BAR_WIDTH)
         .saturating_sub(1);
     if label.chars().count() <= max_label_len {
@@ -213,7 +246,7 @@ impl InlineCellStyle {
         if let Some(code) = ansi_color_code(self.bg, true) {
             codes.push(code);
         }
-        (!codes.is_empty()).then(|| format!("\x1b[{}m", codes.join(";")))
+        (!codes.is_empty()).then(|| format!("\x1b[0m\x1b[{}m", codes.join(";")))
     }
 }
 
@@ -259,7 +292,7 @@ pub fn ratio_complete(current: usize, total: usize) -> f64 {
 
 pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
     if total == 0 {
-        1.0
+        0.0
     } else {
         (current as f64 / total as f64).clamp(0.0, 1.0)
     }
@@ -267,7 +300,10 @@ pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
 
 #[cfg(test)]
 mod tests {
-    use super::{ratio_complete_u64, render_inline_gauge};
+    use super::{
+        available_inline_gauge_width, ratio_complete_u64, render_inline_gauge,
+        render_inline_gauge_in_width,
+    };
 
     #[test]
     fn inline_gauge_renders_styled_progress_label_and_bar() {
@@ -275,10 +311,9 @@ mod tests {
         let visible = strip_ansi(&line);
 
         assert!(line.contains("\x1b["));
-        assert!(visible.starts_with("downloaded 50MB / 100MB (50%)"));
         assert!(visible.contains('━'));
         assert!(visible.contains('·'));
-        assert!(visible.len() > 80);
+        assert!(visible.len() > 10);
     }
 
     #[test]
@@ -289,15 +324,41 @@ mod tests {
         );
         let visible = strip_ansi(&line);
 
-        assert!(visible.contains("..."));
         assert!(visible.contains('━'));
         assert!(visible.contains('·'));
     }
 
     #[test]
     fn byte_ratio_clamps_to_valid_ratatui_range() {
-        assert_eq!(ratio_complete_u64(0, 0), 1.0);
+        assert_eq!(ratio_complete_u64(0, 0), 0.0);
         assert_eq!(ratio_complete_u64(150, 100), 1.0);
+    }
+
+    #[test]
+    fn available_width_reserves_prefix_columns() {
+        assert_eq!(available_inline_gauge_width(80, 3), 76);
+    }
+
+    #[test]
+    fn available_width_leaves_one_column_wrap_guard() {
+        let terminal_width = 80;
+        let prefix_width = 3;
+        let gauge_width = available_inline_gauge_width(terminal_width, prefix_width);
+
+        assert!(prefix_width + gauge_width < terminal_width);
+    }
+
+    #[test]
+    fn available_width_shrinks_below_minimum_on_tiny_terminals() {
+        assert_eq!(available_inline_gauge_width(20, 3), 16);
+    }
+
+    #[test]
+    fn explicit_width_gauge_matches_available_columns() {
+        let line = render_inline_gauge_in_width(0.5, "downloaded 50MB / 100MB", 93);
+        let visible = strip_ansi(&line);
+
+        assert_eq!(visible.chars().count(), 93);
     }
 
     fn strip_ansi(line: &str) -> String {

--- a/crates/mesh-llm-tui/src/terminal_progress.rs
+++ b/crates/mesh-llm-tui/src/terminal_progress.rs
@@ -1,4 +1,10 @@
 use anyhow::{Context, Result};
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    widgets::{LineGauge, Widget},
+};
 use std::io::Write;
 use std::sync::{
     Arc, Mutex,
@@ -6,6 +12,9 @@ use std::sync::{
 };
 use std::thread;
 use std::time::Duration;
+
+const INLINE_GAUGE_WIDTH: u16 = 96;
+const INLINE_GAUGE_MIN_BAR_WIDTH: usize = 24;
 
 pub fn clear_stderr_line() -> Result<()> {
     if crate::json_mode_enabled() {
@@ -97,13 +106,215 @@ impl DeterminateProgressLine {
             100.0
         };
         let detail = detail.unwrap_or("");
-        eprint!(
-            "\r\x1b[2K{} {} {:>5.1}% [{}/{}]{}",
-            self.prefix, label, percent, current, total, detail
+        let gauge = render_inline_gauge(
+            ratio_complete(current, total),
+            &format!(
+                "{} {} {:>5.1}% [{}/{}]{}",
+                self.prefix, label, percent, current, total, detail
+            ),
         );
+        eprint!("\r\x1b[2K{gauge}");
         std::io::stderr()
             .flush()
             .context("Flush determinate progress")?;
         Ok(())
+    }
+}
+
+pub fn render_inline_gauge(ratio: f64, label: &str) -> String {
+    let area = Rect::new(0, 0, INLINE_GAUGE_WIDTH, 1);
+    let mut buffer = Buffer::empty(area);
+    let label = fit_inline_gauge_label(label);
+    LineGauge::default()
+        .ratio(ratio.clamp(0.0, 1.0))
+        .label(label)
+        .style(Style::default().fg(Color::Gray))
+        .filled_symbol("━")
+        .unfilled_symbol("·")
+        .filled_style(
+            Style::default()
+                .fg(Color::LightCyan)
+                .add_modifier(Modifier::BOLD),
+        )
+        .unfilled_style(Style::default().fg(Color::DarkGray))
+        .render(area, &mut buffer);
+    styled_buffer_line(&buffer)
+}
+
+fn fit_inline_gauge_label(label: &str) -> String {
+    let max_label_len = usize::from(INLINE_GAUGE_WIDTH)
+        .saturating_sub(INLINE_GAUGE_MIN_BAR_WIDTH)
+        .saturating_sub(1);
+    if label.chars().count() <= max_label_len {
+        return label.to_string();
+    }
+    let keep_len = max_label_len.saturating_sub(3);
+    format!("{}...", label.chars().take(keep_len).collect::<String>())
+}
+
+fn styled_buffer_line(buffer: &Buffer) -> String {
+    let last_visible = buffer
+        .content()
+        .iter()
+        .rposition(|cell| cell.symbol() != " ");
+    let Some(last_visible) = last_visible else {
+        return String::new();
+    };
+    let mut line = String::new();
+    let mut active_style = InlineCellStyle::default();
+    let mut used_style = false;
+    for cell in &buffer.content()[..=last_visible] {
+        let style = InlineCellStyle::from_cell(cell);
+        if style != active_style {
+            if let Some(sequence) = style.ansi_sequence() {
+                line.push_str(&sequence);
+                used_style = true;
+            }
+            active_style = style;
+        }
+        line.push_str(cell.symbol());
+    }
+    if used_style {
+        line.push_str("\x1b[0m");
+    }
+    line
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct InlineCellStyle {
+    fg: Color,
+    bg: Color,
+    modifier: Modifier,
+}
+
+impl InlineCellStyle {
+    fn from_cell(cell: &ratatui::buffer::Cell) -> Self {
+        Self {
+            fg: cell.fg,
+            bg: cell.bg,
+            modifier: cell.modifier & (Modifier::BOLD | Modifier::DIM),
+        }
+    }
+
+    fn ansi_sequence(self) -> Option<String> {
+        if self == Self::default() {
+            return Some("\x1b[0m".to_string());
+        }
+        let mut codes = Vec::new();
+        if self.modifier.contains(Modifier::BOLD) {
+            codes.push("1".to_string());
+        }
+        if self.modifier.contains(Modifier::DIM) {
+            codes.push("2".to_string());
+        }
+        if let Some(code) = ansi_color_code(self.fg, false) {
+            codes.push(code);
+        }
+        if let Some(code) = ansi_color_code(self.bg, true) {
+            codes.push(code);
+        }
+        (!codes.is_empty()).then(|| format!("\x1b[{}m", codes.join(";")))
+    }
+}
+
+fn ansi_color_code(color: Color, background: bool) -> Option<String> {
+    let base = if background { 10 } else { 0 };
+    let code = match color {
+        Color::Reset => return None,
+        Color::Black => 30 + base,
+        Color::Red => 31 + base,
+        Color::Green => 32 + base,
+        Color::Yellow => 33 + base,
+        Color::Blue => 34 + base,
+        Color::Magenta => 35 + base,
+        Color::Cyan => 36 + base,
+        Color::Gray => 37 + base,
+        Color::DarkGray => 90 + base,
+        Color::LightRed => 91 + base,
+        Color::LightGreen => 92 + base,
+        Color::LightYellow => 93 + base,
+        Color::LightBlue => 94 + base,
+        Color::LightMagenta => 95 + base,
+        Color::LightCyan => 96 + base,
+        Color::White => 97 + base,
+        Color::Rgb(red, green, blue) => {
+            let target = if background { 48 } else { 38 };
+            return Some(format!("{target};2;{red};{green};{blue}"));
+        }
+        Color::Indexed(index) => {
+            let target = if background { 48 } else { 38 };
+            return Some(format!("{target};5;{index}"));
+        }
+    };
+    Some(code.to_string())
+}
+
+pub fn ratio_complete(current: usize, total: usize) -> f64 {
+    if total == 0 {
+        1.0
+    } else {
+        (current as f64 / total as f64).clamp(0.0, 1.0)
+    }
+}
+
+pub fn ratio_complete_u64(current: u64, total: u64) -> f64 {
+    if total == 0 {
+        1.0
+    } else {
+        (current as f64 / total as f64).clamp(0.0, 1.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ratio_complete_u64, render_inline_gauge};
+
+    #[test]
+    fn inline_gauge_renders_styled_progress_label_and_bar() {
+        let line = render_inline_gauge(0.5, "downloaded 50MB / 100MB (50%)");
+        let visible = strip_ansi(&line);
+
+        assert!(line.contains("\x1b["));
+        assert!(visible.starts_with("downloaded 50MB / 100MB (50%)"));
+        assert!(visible.contains('━'));
+        assert!(visible.contains('·'));
+        assert!(visible.len() > 80);
+    }
+
+    #[test]
+    fn inline_gauge_keeps_bar_visible_for_long_labels() {
+        let line = render_inline_gauge(
+            0.25,
+            "download very-long-model-name-with-many-segments-and-a-large-quantized-artifact.gguf 25%",
+        );
+        let visible = strip_ansi(&line);
+
+        assert!(visible.contains("..."));
+        assert!(visible.contains('━'));
+        assert!(visible.contains('·'));
+    }
+
+    #[test]
+    fn byte_ratio_clamps_to_valid_ratatui_range() {
+        assert_eq!(ratio_complete_u64(0, 0), 1.0);
+        assert_eq!(ratio_complete_u64(150, 100), 1.0);
+    }
+
+    fn strip_ansi(line: &str) -> String {
+        let mut stripped = String::new();
+        let mut chars = line.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if ch == '\x1b' && chars.peek() == Some(&'[') {
+                chars.next();
+                for code_ch in chars.by_ref() {
+                    if code_ch == 'm' {
+                        break;
+                    }
+                }
+                continue;
+            }
+            stripped.push(ch);
+        }
+        stripped
     }
 }

--- a/crates/mesh-llm/src/commands/download.rs
+++ b/crates/mesh-llm/src/commands/download.rs
@@ -11,10 +11,11 @@ pub(crate) async fn dispatch_download_command(name: Option<&str>, draft: bool) -
                     mesh_llm_host_runtime::command_support::models::remote_catalog_model_ref(&model)
                 })
                 .unwrap_or_else(|| query.to_string());
-            let (_path, details) =
+            let download =
                 mesh_llm_host_runtime::command_support::models::download_model_ref_with_progress_details(&model_ref, true).await?;
             if draft {
-                if let Some(draft_name) = details
+                if let Some(draft_name) = download
+                    .details
                     .as_ref()
                     .and_then(|details| details.draft.as_deref())
                 {

--- a/crates/mesh-llm/src/commands/models/formatters.rs
+++ b/crates/mesh-llm/src/commands/models/formatters.rs
@@ -10,6 +10,7 @@ use mesh_llm_host_runtime::command_support::models::{
 use mesh_llm_system::hardware;
 use serde_json::{Value, json};
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub(crate) trait SearchFormatter {
     fn is_json(&self) -> bool;
@@ -58,6 +59,12 @@ pub(crate) struct InstalledRow {
     pub(crate) last_used_at: Option<String>,
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DownloadStats {
+    pub(crate) bytes: Option<u64>,
+    pub(crate) elapsed: Duration,
+}
+
 pub(crate) trait ModelsFormatter: SearchFormatter {
     fn render_recommended(&self, models: &[remote_catalog::RemoteCatalogModel]) -> Result<()>;
     fn render_installed(&self, rows: &[InstalledRow]) -> Result<()>;
@@ -67,6 +74,7 @@ pub(crate) trait ModelsFormatter: SearchFormatter {
         model_ref: &str,
         path: &Path,
         details: Option<&ModelDetails>,
+        stats: Option<&DownloadStats>,
         include_draft: bool,
         draft: Option<(&str, &Path)>,
     ) -> Result<()>;

--- a/crates/mesh-llm/src/commands/models/formatters.rs
+++ b/crates/mesh-llm/src/commands/models/formatters.rs
@@ -63,21 +63,38 @@ pub(crate) struct InstalledRow {
 pub(crate) struct DownloadStats {
     pub(crate) bytes: Option<u64>,
     pub(crate) elapsed: Duration,
+    pub(crate) bytes_per_second: Option<u64>,
+}
+
+pub(crate) struct DownloadRenderInput<'a> {
+    pub(crate) model_ref: &'a str,
+    pub(crate) path: &'a Path,
+    pub(crate) paths: &'a [&'a Path],
+    pub(crate) details: Option<&'a ModelDetails>,
+    pub(crate) stats: Option<&'a DownloadStats>,
+    pub(crate) include_draft: bool,
+    pub(crate) draft: Option<(&'a str, &'a Path)>,
+}
+
+impl<'a> DownloadRenderInput<'a> {
+    pub(crate) fn all_paths(&self) -> Vec<&'a Path> {
+        if self.paths.is_empty() {
+            vec![self.path]
+        } else {
+            self.paths.to_vec()
+        }
+    }
+
+    pub(crate) fn part_count(&self) -> usize {
+        self.all_paths().len()
+    }
 }
 
 pub(crate) trait ModelsFormatter: SearchFormatter {
     fn render_recommended(&self, models: &[remote_catalog::RemoteCatalogModel]) -> Result<()>;
     fn render_installed(&self, rows: &[InstalledRow]) -> Result<()>;
     fn render_show(&self, details: &ModelDetails, variants: Option<&[ModelDetails]>) -> Result<()>;
-    fn render_download(
-        &self,
-        model_ref: &str,
-        path: &Path,
-        details: Option<&ModelDetails>,
-        stats: Option<&DownloadStats>,
-        include_draft: bool,
-        draft: Option<(&str, &Path)>,
-    ) -> Result<()>;
+    fn render_download(&self, input: DownloadRenderInput<'_>) -> Result<()>;
     fn render_layer_package_download(
         &self,
         model_ref: &str,

--- a/crates/mesh-llm/src/commands/models/formatters_console.rs
+++ b/crates/mesh-llm/src/commands/models/formatters_console.rs
@@ -1,8 +1,9 @@
 use super::formatters::{
-    ConsoleFormatter, InstalledRow, ModelsFormatter, SearchFormatter, catalog_model_capabilities,
-    filter_label, fit_hint_for_size_label, format_count, format_installed_size,
-    format_relative_timestamp, format_source_label, huggingface_cache_dir, huggingface_repo_url,
-    installed_model_kind, model_kind_code, sort_label, variant_selector_label,
+    ConsoleFormatter, DownloadStats, InstalledRow, ModelsFormatter, SearchFormatter,
+    catalog_model_capabilities, filter_label, fit_hint_for_size_label, format_count,
+    format_installed_size, format_relative_timestamp, format_source_label, huggingface_cache_dir,
+    huggingface_repo_url, installed_model_kind, model_kind_code, sort_label,
+    variant_selector_label,
 };
 use anyhow::Result;
 use mesh_llm_host_runtime::command_support::models::{
@@ -11,8 +12,121 @@ use mesh_llm_host_runtime::command_support::models::{
     remote_catalog_model_ref,
 };
 use std::fmt::Write as FmtWrite;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
+use std::time::Duration;
 use tabwriter::TabWriter;
+
+const ANSI_RESET: &str = "\x1b[0m";
+const ANSI_BOLD_GREEN: &str = "\x1b[1;32m";
+const ANSI_BRIGHT_CYAN: &str = "\x1b[96m";
+const ANSI_DIM: &str = "\x1b[2m";
+const ANSI_MUTED: &str = "\x1b[90m";
+
+fn downloaded_model_headline(stats: Option<&DownloadStats>, colors: bool) -> String {
+    let Some(stats) = stats else {
+        return styled_download_success("✓ Downloaded model", colors);
+    };
+
+    let title = styled_download_success("✓ Downloaded model", colors);
+    let divider = styled_muted(" ─ ", colors);
+    let Some(bytes) = stats.bytes else {
+        return format!(
+            "{title}{divider}{}",
+            styled_stat(&format!("in {}", format_elapsed(stats.elapsed)), colors)
+        );
+    };
+
+    let mut headline = format!(
+        "{title}{divider}{}",
+        styled_stat(
+            &format!(
+                "{} in {}",
+                format_download_stat_bytes(bytes),
+                format_elapsed(stats.elapsed)
+            ),
+            colors
+        )
+    );
+    if let Some(avg_bytes_per_sec) = average_bytes_per_sec(stats) {
+        let _ = write!(
+            headline,
+            " {} {}",
+            styled_muted("· avg", colors),
+            styled_stat(
+                &format!("{}/s", format_download_stat_bytes(avg_bytes_per_sec)),
+                colors
+            )
+        );
+    }
+    headline
+}
+
+fn styled_download_success(value: &str, colors: bool) -> String {
+    if colors {
+        format!("{ANSI_BOLD_GREEN}{value}{ANSI_RESET}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn styled_stat(value: &str, colors: bool) -> String {
+    if colors {
+        format!("{ANSI_BRIGHT_CYAN}{value}{ANSI_RESET}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn styled_muted(value: &str, colors: bool) -> String {
+    if colors {
+        format!("{ANSI_MUTED}{value}{ANSI_RESET}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn styled_label(value: &str, colors: bool) -> String {
+    if colors {
+        format!("{ANSI_DIM}{value}{ANSI_RESET}")
+    } else {
+        value.to_string()
+    }
+}
+
+fn plain_model_kind(kind: &str) -> &'static str {
+    match model_kind_code(kind) {
+        "gguf" => "GGUF",
+        "mlx" => "MLX",
+        _ => "unknown",
+    }
+}
+
+fn average_bytes_per_sec(stats: &DownloadStats) -> Option<u64> {
+    let bytes = stats.bytes?;
+    let elapsed = stats.elapsed.as_secs_f64();
+    (elapsed > 0.0).then(|| (bytes as f64 / elapsed).round() as u64)
+}
+
+fn format_elapsed(duration: Duration) -> String {
+    let seconds = duration.as_secs_f64();
+    if seconds < 60.0 {
+        format!("{seconds:.1}s")
+    } else {
+        format!("{seconds:.0}s")
+    }
+}
+
+fn format_download_stat_bytes(bytes: u64) -> String {
+    if bytes >= 1_000_000_000 {
+        format!("{:.1} GB", bytes as f64 / 1e9)
+    } else if bytes >= 1_000_000 {
+        format!("{:.1} MB", bytes as f64 / 1e6)
+    } else if bytes >= 1_000 {
+        format!("{:.1} KB", bytes as f64 / 1e3)
+    } else {
+        format!("{bytes}B")
+    }
+}
 
 impl SearchFormatter for ConsoleFormatter {
     fn is_json(&self) -> bool {
@@ -390,17 +504,35 @@ impl ModelsFormatter for ConsoleFormatter {
         _model_ref: &str,
         path: &std::path::Path,
         details: Option<&ModelDetails>,
+        stats: Option<&DownloadStats>,
         _include_draft: bool,
         draft: Option<(&str, &std::path::Path)>,
     ) -> Result<()> {
-        println!("✅ Downloaded model");
+        let colors = std::io::stdout().is_terminal();
+        println!("{}", downloaded_model_headline(stats, colors));
+        println!();
+        let model_name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| path.to_string_lossy().to_string());
+        println!("   {}  {model_name}", styled_label("model", colors));
         if let Some(details) = details {
-            println!("   type: {}", details.kind);
+            println!(
+                "   {}   {}",
+                styled_label("type", colors),
+                plain_model_kind(details.kind)
+            );
         }
-        println!("   {}", path.display());
+        println!("   {}   {}", styled_label("path", colors), path.display());
         if let Some((_draft_name, draft_path)) = draft {
-            println!("🧠 Downloaded draft");
-            println!("   {}", draft_path.display());
+            println!();
+            println!("{}", styled_download_success("✓ Downloaded draft", colors));
+            println!(
+                "   {}   {}",
+                styled_label("path", colors),
+                draft_path.display()
+            );
         }
         Ok(())
     }
@@ -486,5 +618,37 @@ impl ModelsFormatter for ConsoleFormatter {
             result.removed_derived_cache_files
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DownloadStats, downloaded_model_headline};
+    use std::time::Duration;
+
+    #[test]
+    fn downloaded_model_headline_includes_inline_stats() {
+        let stats = DownloadStats {
+            bytes: Some(105_000_000),
+            elapsed: Duration::from_millis(14_800),
+        };
+
+        assert_eq!(
+            downloaded_model_headline(Some(&stats), false),
+            "✓ Downloaded model ─ 105.0 MB in 14.8s · avg 7.1 MB/s"
+        );
+    }
+
+    #[test]
+    fn downloaded_model_headline_styles_terminal_output() {
+        let stats = DownloadStats {
+            bytes: Some(105_000_000),
+            elapsed: Duration::from_millis(14_800),
+        };
+
+        assert_eq!(
+            downloaded_model_headline(Some(&stats), true),
+            "\u{1b}[1;32m✓ Downloaded model\u{1b}[0m\u{1b}[90m ─ \u{1b}[0m\u{1b}[96m105.0 MB in 14.8s\u{1b}[0m \u{1b}[90m· avg\u{1b}[0m \u{1b}[96m7.1 MB/s\u{1b}[0m"
+        );
     }
 }

--- a/crates/mesh-llm/src/commands/models/formatters_console.rs
+++ b/crates/mesh-llm/src/commands/models/formatters_console.rs
@@ -1,8 +1,8 @@
 use super::formatters::{
-    ConsoleFormatter, DownloadStats, InstalledRow, ModelsFormatter, SearchFormatter,
-    catalog_model_capabilities, filter_label, fit_hint_for_size_label, format_count,
-    format_installed_size, format_relative_timestamp, format_source_label, huggingface_cache_dir,
-    huggingface_repo_url, installed_model_kind, model_kind_code, sort_label,
+    ConsoleFormatter, DownloadRenderInput, DownloadStats, InstalledRow, ModelsFormatter,
+    SearchFormatter, catalog_model_capabilities, filter_label, fit_hint_for_size_label,
+    format_count, format_installed_size, format_relative_timestamp, format_source_label,
+    huggingface_cache_dir, huggingface_repo_url, installed_model_kind, model_kind_code, sort_label,
     variant_selector_label,
 };
 use anyhow::Result;
@@ -47,13 +47,13 @@ fn downloaded_model_headline(stats: Option<&DownloadStats>, colors: bool) -> Str
             colors
         )
     );
-    if let Some(avg_bytes_per_sec) = average_bytes_per_sec(stats) {
+    if let Some((bytes_per_sec, label)) = download_bytes_per_sec(stats) {
         let _ = write!(
             headline,
             " {} {}",
-            styled_muted("· avg", colors),
+            styled_muted(&format!("· {label}"), colors),
             styled_stat(
-                &format!("{}/s", format_download_stat_bytes(avg_bytes_per_sec)),
+                &format!("{}/s", format_download_stat_bytes(bytes_per_sec)),
                 colors
             )
         );
@@ -107,6 +107,13 @@ fn average_bytes_per_sec(stats: &DownloadStats) -> Option<u64> {
     (elapsed > 0.0).then(|| (bytes as f64 / elapsed).round() as u64)
 }
 
+fn download_bytes_per_sec(stats: &DownloadStats) -> Option<(u64, &'static str)> {
+    if let Some(bytes_per_second) = stats.bytes_per_second {
+        return Some((bytes_per_second, "speed"));
+    }
+    average_bytes_per_sec(stats).map(|bytes_per_second| (bytes_per_second, "avg"))
+}
+
 fn format_elapsed(duration: Duration) -> String {
     let seconds = duration.as_secs_f64();
     if seconds < 60.0 {
@@ -126,6 +133,46 @@ fn format_download_stat_bytes(bytes: u64) -> String {
     } else {
         format!("{bytes}B")
     }
+}
+
+fn download_summary_lines(input: &DownloadRenderInput<'_>, colors: bool) -> Vec<String> {
+    let model_name = input
+        .path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| input.path.to_string_lossy().to_string());
+    let mut lines = Vec::new();
+    lines.push(format!(
+        "   {}  {model_name}",
+        styled_label("model", colors)
+    ));
+    if let Some(details) = input.details {
+        lines.push(format!(
+            "   {}   {}",
+            styled_label("type", colors),
+            plain_model_kind(details.kind)
+        ));
+    }
+    let paths = input.all_paths();
+    let part_count = input.part_count();
+    if part_count > 1 {
+        lines.push(format!(
+            "   {}  {part_count}",
+            styled_label("parts", colors)
+        ));
+        lines.push(format!("   {}", styled_label("paths", colors)));
+        for path in paths {
+            lines.push(format!("      {}", path.display()));
+        }
+    } else {
+        lines.push(format!(
+            "   {}   {}",
+            styled_label("path", colors),
+            input.path.display()
+        ));
+    }
+    lines
 }
 
 impl SearchFormatter for ConsoleFormatter {
@@ -499,33 +546,14 @@ impl ModelsFormatter for ConsoleFormatter {
         Ok(())
     }
 
-    fn render_download(
-        &self,
-        _model_ref: &str,
-        path: &std::path::Path,
-        details: Option<&ModelDetails>,
-        stats: Option<&DownloadStats>,
-        _include_draft: bool,
-        draft: Option<(&str, &std::path::Path)>,
-    ) -> Result<()> {
+    fn render_download(&self, input: DownloadRenderInput<'_>) -> Result<()> {
         let colors = std::io::stdout().is_terminal();
-        println!("{}", downloaded_model_headline(stats, colors));
+        println!("{}", downloaded_model_headline(input.stats, colors));
         println!();
-        let model_name = path
-            .file_name()
-            .and_then(|value| value.to_str())
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| path.to_string_lossy().to_string());
-        println!("   {}  {model_name}", styled_label("model", colors));
-        if let Some(details) = details {
-            println!(
-                "   {}   {}",
-                styled_label("type", colors),
-                plain_model_kind(details.kind)
-            );
+        for line in download_summary_lines(&input, colors) {
+            println!("{line}");
         }
-        println!("   {}   {}", styled_label("path", colors), path.display());
-        if let Some((_draft_name, draft_path)) = draft {
+        if let Some((_draft_name, draft_path)) = input.draft {
             println!();
             println!("{}", styled_download_success("✓ Downloaded draft", colors));
             println!(
@@ -623,7 +651,9 @@ impl ModelsFormatter for ConsoleFormatter {
 
 #[cfg(test)]
 mod tests {
-    use super::{DownloadStats, downloaded_model_headline};
+    use super::{DownloadStats, download_summary_lines, downloaded_model_headline};
+    use crate::commands::models::formatters::DownloadRenderInput;
+    use std::path::Path;
     use std::time::Duration;
 
     #[test]
@@ -631,6 +661,7 @@ mod tests {
         let stats = DownloadStats {
             bytes: Some(105_000_000),
             elapsed: Duration::from_millis(14_800),
+            bytes_per_second: None,
         };
 
         assert_eq!(
@@ -644,11 +675,59 @@ mod tests {
         let stats = DownloadStats {
             bytes: Some(105_000_000),
             elapsed: Duration::from_millis(14_800),
+            bytes_per_second: None,
         };
 
         assert_eq!(
             downloaded_model_headline(Some(&stats), true),
             "\u{1b}[1;32m✓ Downloaded model\u{1b}[0m\u{1b}[90m ─ \u{1b}[0m\u{1b}[96m105.0 MB in 14.8s\u{1b}[0m \u{1b}[90m· avg\u{1b}[0m \u{1b}[96m7.1 MB/s\u{1b}[0m"
+        );
+    }
+
+    #[test]
+    fn multipart_download_summary_lists_all_parts() {
+        let paths = vec![
+            Path::new("/cache/model-00001-of-00003.gguf"),
+            Path::new("/cache/model-00002-of-00003.gguf"),
+            Path::new("/cache/model-00003-of-00003.gguf"),
+        ];
+        let input = DownloadRenderInput {
+            model_ref: "org/repo:model",
+            path: paths[0],
+            paths: &paths,
+            details: None,
+            stats: None,
+            include_draft: false,
+            draft: None,
+        };
+
+        let lines = download_summary_lines(&input, false);
+
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("parts") && line.contains("3"))
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|line| line.split_whitespace().next() == Some("path"))
+        );
+        assert!(lines.iter().any(|line| line.trim_start() == "paths"));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("model-00001-of-00003.gguf"))
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("model-00002-of-00003.gguf"))
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("model-00003-of-00003.gguf"))
         );
     }
 }

--- a/crates/mesh-llm/src/commands/models/formatters_json.rs
+++ b/crates/mesh-llm/src/commands/models/formatters_json.rs
@@ -1,8 +1,8 @@
 use super::formatters::{
-    InstalledRow, JsonFormatter, ModelsFormatter, SearchFormatter, capabilities_json,
-    catalog_model_capabilities, catalog_model_kind_code, fit_code_for_size_label,
-    format_installed_size, huggingface_cache_dir, installed_model_kind_code, local_capacity_json,
-    model_kind_code, print_json,
+    DownloadStats, InstalledRow, JsonFormatter, ModelsFormatter, SearchFormatter,
+    capabilities_json, catalog_model_capabilities, catalog_model_kind_code,
+    fit_code_for_size_label, format_installed_size, huggingface_cache_dir,
+    installed_model_kind_code, local_capacity_json, model_kind_code, print_json,
 };
 use anyhow::Result;
 use mesh_llm_host_runtime::command_support::models::{
@@ -169,6 +169,7 @@ impl ModelsFormatter for JsonFormatter {
         model_ref: &str,
         path: &Path,
         details: Option<&ModelDetails>,
+        stats: Option<&DownloadStats>,
         include_draft: bool,
         draft: Option<(&str, &Path)>,
     ) -> Result<()> {
@@ -178,6 +179,16 @@ impl ModelsFormatter for JsonFormatter {
             "type": details.as_ref().map(|d| model_kind_code(d.kind)),
             "resolved_ref": details.as_ref().map(|d| d.exact_ref.clone()),
         });
+        if let Some(stats) = stats {
+            let elapsed = stats.elapsed.as_secs_f64();
+            payload["download"] = json!({
+                "bytes": stats.bytes,
+                "elapsed_seconds": elapsed,
+                "avg_bytes_per_second": stats
+                    .bytes
+                    .and_then(|bytes| (elapsed > 0.0).then(|| (bytes as f64 / elapsed).round() as u64)),
+            });
+        }
         if include_draft {
             payload["draft"] = match draft {
                 Some((name, draft_path)) => json!({

--- a/crates/mesh-llm/src/commands/models/formatters_json.rs
+++ b/crates/mesh-llm/src/commands/models/formatters_json.rs
@@ -1,5 +1,5 @@
 use super::formatters::{
-    DownloadStats, InstalledRow, JsonFormatter, ModelsFormatter, SearchFormatter,
+    DownloadRenderInput, InstalledRow, JsonFormatter, ModelsFormatter, SearchFormatter,
     capabilities_json, catalog_model_capabilities, catalog_model_kind_code,
     fit_code_for_size_label, format_installed_size, huggingface_cache_dir,
     installed_model_kind_code, local_capacity_json, model_kind_code, print_json,
@@ -51,6 +51,41 @@ fn show_payload(details: &ModelDetails, variants: Option<&[ModelDetails]>) -> Va
             })
             .collect::<Vec<_>>(),
     })
+}
+
+fn download_payload(input: &DownloadRenderInput<'_>) -> Value {
+    let paths = input.all_paths();
+    let mut payload = json!({
+        "requested_ref": input.model_ref,
+        "path": input.path,
+        "type": input.details.as_ref().map(|d| model_kind_code(d.kind)),
+        "resolved_ref": input.details.as_ref().map(|d| d.exact_ref.clone()),
+    });
+    if paths.len() > 1 {
+        payload["part_count"] = json!(input.part_count());
+        payload["paths"] = json!(paths);
+    }
+    if let Some(stats) = input.stats {
+        let elapsed = stats.elapsed.as_secs_f64();
+        payload["download"] = json!({
+            "bytes": stats.bytes,
+            "elapsed_seconds": elapsed,
+            "bytes_per_second": stats.bytes_per_second,
+            "avg_bytes_per_second": stats
+                .bytes
+                .and_then(|bytes| (elapsed > 0.0).then(|| (bytes as f64 / elapsed).round() as u64)),
+        });
+    }
+    if input.include_draft {
+        payload["draft"] = match input.draft {
+            Some((name, draft_path)) => json!({
+                "name": name,
+                "path": draft_path,
+            }),
+            None => Value::Null,
+        };
+    }
+    payload
 }
 
 impl SearchFormatter for JsonFormatter {
@@ -164,41 +199,8 @@ impl ModelsFormatter for JsonFormatter {
         print_json(show_payload(details, variants))
     }
 
-    fn render_download(
-        &self,
-        model_ref: &str,
-        path: &Path,
-        details: Option<&ModelDetails>,
-        stats: Option<&DownloadStats>,
-        include_draft: bool,
-        draft: Option<(&str, &Path)>,
-    ) -> Result<()> {
-        let mut payload = json!({
-            "requested_ref": model_ref,
-            "path": path,
-            "type": details.as_ref().map(|d| model_kind_code(d.kind)),
-            "resolved_ref": details.as_ref().map(|d| d.exact_ref.clone()),
-        });
-        if let Some(stats) = stats {
-            let elapsed = stats.elapsed.as_secs_f64();
-            payload["download"] = json!({
-                "bytes": stats.bytes,
-                "elapsed_seconds": elapsed,
-                "avg_bytes_per_second": stats
-                    .bytes
-                    .and_then(|bytes| (elapsed > 0.0).then(|| (bytes as f64 / elapsed).round() as u64)),
-            });
-        }
-        if include_draft {
-            payload["draft"] = match draft {
-                Some((name, draft_path)) => json!({
-                    "name": name,
-                    "path": draft_path,
-                }),
-                None => Value::Null,
-            };
-        }
-        print_json(payload)
+    fn render_download(&self, input: DownloadRenderInput<'_>) -> Result<()> {
+        print_json(download_payload(&input))
     }
 
     fn render_layer_package_download(
@@ -266,7 +268,9 @@ impl ModelsFormatter for JsonFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::models::formatters::DownloadRenderInput;
     use mesh_llm_host_runtime::command_support::models::ModelCapabilities;
+    use std::path::Path;
 
     #[test]
     fn show_payload_includes_variants_for_selected_gguf_ref() {
@@ -319,5 +323,30 @@ mod tests {
             emitted_variants[1]["ref"],
             "unsloth/Qwen3.6-35B-A3B-GGUF:Q4_K_M"
         );
+    }
+
+    #[test]
+    fn download_payload_includes_all_multipart_paths() {
+        let paths = vec![
+            Path::new("/cache/model-00001-of-00003.gguf"),
+            Path::new("/cache/model-00002-of-00003.gguf"),
+            Path::new("/cache/model-00003-of-00003.gguf"),
+        ];
+        let input = DownloadRenderInput {
+            model_ref: "org/repo:model",
+            path: paths[0],
+            paths: &paths,
+            details: None,
+            stats: None,
+            include_draft: false,
+            draft: None,
+        };
+
+        let payload = download_payload(&input);
+
+        assert_eq!(payload["path"], "/cache/model-00001-of-00003.gguf");
+        assert_eq!(payload["part_count"], 3);
+        assert_eq!(payload["paths"].as_array().expect("paths array").len(), 3);
+        assert_eq!(payload["paths"][1], "/cache/model-00002-of-00003.gguf");
     }
 }

--- a/crates/mesh-llm/src/commands/models/mod.rs
+++ b/crates/mesh-llm/src/commands/models/mod.rs
@@ -3,6 +3,7 @@ mod formatters_console;
 mod formatters_json;
 
 use anyhow::{Result, anyhow, bail};
+use formatters::DownloadStats;
 use mesh_llm_cli::models::ModelSearchSort;
 use mesh_llm_cli::models::ModelsCommand;
 use mesh_llm_host_runtime::command_support::models::skippy::{
@@ -403,13 +404,25 @@ pub async fn run_model_download(
         return formatter.render_layer_package_download(model_ref, &package_ref, &package_dir);
     }
 
+    let download_started = Instant::now();
     let (path, details) = if direct {
         download_model_ref_with_progress_details_direct(model_ref, !json_output, true).await?
     } else {
         download_model_ref_with_progress_details(model_ref, !json_output).await?
     };
+    let download_stats = DownloadStats {
+        bytes: std::fs::metadata(&path).ok().map(|metadata| metadata.len()),
+        elapsed: download_started.elapsed(),
+    };
     if !include_draft {
-        return formatter.render_download(model_ref, &path, details.as_ref(), false, None);
+        return formatter.render_download(
+            model_ref,
+            &path,
+            details.as_ref(),
+            Some(&download_stats),
+            false,
+            None,
+        );
     }
 
     let mut draft_out: Option<(String, std::path::PathBuf)> = None;
@@ -436,6 +449,7 @@ pub async fn run_model_download(
         model_ref,
         &path,
         details.as_ref(),
+        Some(&download_stats),
         true,
         draft_out.as_ref().map(|(n, p)| (n.as_str(), p.as_path())),
     )

--- a/crates/mesh-llm/src/commands/models/mod.rs
+++ b/crates/mesh-llm/src/commands/models/mod.rs
@@ -11,12 +11,13 @@ use mesh_llm_host_runtime::command_support::models::skippy::{
     identity_from_layer_package, is_layer_package_ref, resolve_hf_package_to_local,
 };
 use mesh_llm_host_runtime::command_support::models::{
-    ModelCleanupPlan, ModelCleanupResult, SearchArtifactFilter, SearchProgress, SearchSort,
-    ShowVariantsProgress, delete, download_model_ref_with_progress_details,
-    download_model_ref_with_progress_details_direct, find_remote_catalog_model_exact,
-    installed_model_capabilities, load_model_usage_record_for_path, model_usage_cache_dir,
-    plan_model_cleanup, remote_catalog, remote_catalog_model_ref, scan_installed_models,
-    search_catalog_models, search_huggingface, show_exact_model, show_model_variants_with_progress,
+    DownloadTransferStats, ModelCleanupPlan, ModelCleanupResult, SearchArtifactFilter,
+    SearchProgress, SearchSort, ShowVariantsProgress, delete,
+    download_model_ref_with_progress_details, download_model_ref_with_progress_details_direct,
+    find_remote_catalog_model_exact, installed_model_capabilities,
+    load_model_usage_record_for_path, model_usage_cache_dir, plan_model_cleanup, remote_catalog,
+    remote_catalog_model_ref, scan_installed_models, search_catalog_models, search_huggingface,
+    show_exact_model, show_model_variants_with_progress,
 };
 use mesh_llm_tui::terminal_progress::{DeterminateProgressLine, clear_stderr_line, start_spinner};
 use serde_json::json;
@@ -25,8 +26,8 @@ use std::time::Duration;
 use std::time::Instant;
 
 use formatters::{
-    InstalledRow, catalog_model_is_mlx, format_installed_size, format_relative_timestamp,
-    model_kind_code, models_formatter, search_formatter,
+    DownloadRenderInput, InstalledRow, catalog_model_is_mlx, format_installed_size,
+    format_relative_timestamp, model_kind_code, models_formatter, search_formatter,
 };
 
 pub async fn run_model_search(
@@ -404,40 +405,42 @@ pub async fn run_model_download(
         return formatter.render_layer_package_download(model_ref, &package_ref, &package_dir);
     }
 
-    let download_started = Instant::now();
-    let (path, details) = if direct {
+    let download = if direct {
         download_model_ref_with_progress_details_direct(model_ref, !json_output, true).await?
     } else {
         download_model_ref_with_progress_details(model_ref, !json_output).await?
     };
-    let download_stats = DownloadStats {
-        bytes: std::fs::metadata(&path).ok().map(|metadata| metadata.len()),
-        elapsed: download_started.elapsed(),
-    };
+    let download_stats = download_stats_from_transfer(download.transfer_stats);
+    let download_paths = download
+        .paths
+        .iter()
+        .map(std::path::PathBuf::as_path)
+        .collect::<Vec<_>>();
     if !include_draft {
-        return formatter.render_download(
+        return formatter.render_download(DownloadRenderInput {
             model_ref,
-            &path,
-            details.as_ref(),
-            Some(&download_stats),
-            false,
-            None,
-        );
+            path: &download.path,
+            paths: &download_paths,
+            details: download.details.as_ref(),
+            stats: download_stats.as_ref(),
+            include_draft: false,
+            draft: None,
+        });
     }
 
     let mut draft_out: Option<(String, std::path::PathBuf)> = None;
-    if let Some(details_ref) = details.as_ref() {
+    if let Some(details_ref) = download.details.as_ref() {
         if let Some(draft_name) = details_ref.draft.as_deref() {
             let draft_ref = find_remote_catalog_model_exact(draft_name)
                 .map(|model| remote_catalog_model_ref(&model))
                 .unwrap_or_else(|| draft_name.to_string());
-            let (draft_path, _) = if direct {
+            let draft_download = if direct {
                 download_model_ref_with_progress_details_direct(&draft_ref, !json_output, true)
                     .await?
             } else {
                 download_model_ref_with_progress_details(&draft_ref, !json_output).await?
             };
-            draft_out = Some((draft_name.to_string(), draft_path));
+            draft_out = Some((draft_name.to_string(), draft_download.path));
         } else if !json_output {
             eprintln!(
                 "⚠ No draft model available for {}",
@@ -445,14 +448,27 @@ pub async fn run_model_download(
             );
         }
     }
-    formatter.render_download(
+    formatter.render_download(DownloadRenderInput {
         model_ref,
-        &path,
-        details.as_ref(),
-        Some(&download_stats),
-        true,
-        draft_out.as_ref().map(|(n, p)| (n.as_str(), p.as_path())),
-    )
+        path: &download.path,
+        paths: &download_paths,
+        details: download.details.as_ref(),
+        stats: download_stats.as_ref(),
+        include_draft: true,
+        draft: draft_out.as_ref().map(|(n, p)| (n.as_str(), p.as_path())),
+    })
+}
+
+fn download_stats_from_transfer(stats: Option<DownloadTransferStats>) -> Option<DownloadStats> {
+    stats.map(|stats| DownloadStats {
+        bytes: Some(stats.bytes),
+        elapsed: stats.elapsed,
+        bytes_per_second: stats.bytes_per_sec.and_then(rounded_positive_rate),
+    })
+}
+
+fn rounded_positive_rate(value: f64) -> Option<u64> {
+    (value.is_finite() && value > 0.0).then(|| value.round() as u64)
 }
 
 async fn download_layer_package_for_model_ref(

--- a/scripts/qa-model-download-stats.sh
+++ b/scripts/qa-model-download-stats.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MESH_BIN="${MESH_BIN:-$ROOT/target/debug/mesh-llm}"
+SINGLE_REF="${SINGLE_REF:-unsloth/Qwen2.5-Coder-0.5B-Instruct-GGUF:Q4_K_M}"
+MULTIPART_REF="${MULTIPART_REF:-Felladrin/gguf-sharded-Qwen1.5-0.5B-Chat:Q3_K_M.shard}"
+RUN_REGRESSION=1
+DRY_RUN=0
+
+usage() {
+  cat >&2 <<'EOF'
+usage: scripts/qa-model-download-stats.sh [--dry-run] [--skip-regression]
+
+Runs manual QA for model download transfer stats using the debug binary.
+
+Default refs:
+  SINGLE_REF     unsloth/Qwen2.5-Coder-0.5B-Instruct-GGUF:Q4_K_M
+  MULTIPART_REF  Felladrin/gguf-sharded-Qwen1.5-0.5B-Chat:Q3_K_M.shard
+
+Environment:
+  MESH_BIN       path to debug binary; default target/debug/mesh-llm
+  SINGLE_REF     override the single-file GGUF ref
+  MULTIPART_REF  override the multipart GGUF ref
+
+Examples:
+  just build
+  scripts/qa-model-download-stats.sh --dry-run
+  scripts/qa-model-download-stats.sh
+  SINGLE_REF='Qwen/Qwen1.5-0.5B-Chat-GGUF:q2_k' scripts/qa-model-download-stats.sh
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --skip-regression)
+      RUN_REGRESSION=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "$MESH_BIN" ]]; then
+  echo "debug binary not found or not executable: $MESH_BIN" >&2
+  echo "run: just build" >&2
+  exit 1
+fi
+
+LOG_DIR="${TMPDIR:-/tmp}/mesh-llm-download-qa-$(date +%Y%m%d-%H%M%S)"
+HF_CACHE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/mesh-llm-download-qa-hf.XXXXXX")"
+export HF_HOME="$HF_CACHE_ROOT/home"
+export HF_HUB_CACHE="$HF_CACHE_ROOT/hub"
+export HUGGINGFACE_HUB_CACHE="$HF_HUB_CACHE"
+export HF_XET_CACHE="$HF_CACHE_ROOT/xet"
+
+cleanup_hf_cache() {
+  rm -rf -- "$HF_CACHE_ROOT"
+}
+
+reset_hf_cache() {
+  rm -rf -- "$HF_HOME" "$HF_HUB_CACHE" "$HF_XET_CACHE"
+  mkdir -p "$HF_HOME" "$HF_HUB_CACHE" "$HF_XET_CACHE"
+}
+
+trap cleanup_hf_cache EXIT
+
+run_cmd() {
+  local label="$1"
+  shift
+
+  echo ""
+  echo "=== $label ==="
+  printf 'command:'
+  printf ' %q' "$@"
+  echo ""
+
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    return 0
+  fi
+
+  mkdir -p "$LOG_DIR"
+  local log_file="$LOG_DIR/${label//[^A-Za-z0-9_.-]/_}.log"
+  "$@" 2>&1 | tee "$log_file"
+}
+
+show_ref() {
+  local label="$1"
+  local ref="$2"
+  run_cmd "show $label ref" "$MESH_BIN" models show "$ref" --json
+}
+
+download_ref() {
+  local label="$1"
+  local ref="$2"
+  shift 2
+  run_cmd "$label download" "$MESH_BIN" models download "$ref" "$@"
+  run_cmd "$label json download" "$MESH_BIN" models download "$ref" "$@" --json
+}
+
+echo "=== mesh-llm model download stats QA ==="
+echo "  binary:        $MESH_BIN"
+echo "  version:       $($MESH_BIN --version)"
+echo "  single ref:    $SINGLE_REF"
+echo "  multipart ref: $MULTIPART_REF"
+echo "  hf home:       $HF_HOME"
+echo "  hf hub cache:  $HF_HUB_CACHE"
+echo "  hf xet cache:  $HF_XET_CACHE"
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  echo "  logs:          $LOG_DIR"
+fi
+
+show_ref "single" "$SINGLE_REF"
+show_ref "multipart" "$MULTIPART_REF"
+
+echo ""
+echo "=== reset temporary Hugging Face cache before fetch phase ==="
+if [[ "$DRY_RUN" -eq 0 ]]; then
+  reset_hf_cache
+else
+  printf 'command: rm -rf %q %q %q && mkdir -p %q %q %q\n' \
+    "$HF_HOME" "$HF_HUB_CACHE" "$HF_XET_CACHE" \
+    "$HF_HOME" "$HF_HUB_CACHE" "$HF_XET_CACHE"
+fi
+
+download_ref "single cold" "$SINGLE_REF"
+download_ref "single cache-hit" "$SINGLE_REF"
+
+download_ref "multipart cold" "$MULTIPART_REF" --direct
+download_ref "multipart cache-hit" "$MULTIPART_REF" --direct
+
+if [[ "$RUN_REGRESSION" -eq 1 ]]; then
+  run_cmd "host-runtime transfer stats tests" \
+    cargo test -p mesh-llm-host-runtime download_transfer_stats --lib
+  run_cmd "host-runtime silent progress tests" \
+    cargo test -p mesh-llm-host-runtime silent_download_progress_records_transfer_stats --lib
+  run_cmd "host-runtime progress state tests" \
+    cargo test -p mesh-llm-host-runtime download_progress_state --lib
+  run_cmd "mesh-llm download headline tests" \
+    cargo test -p mesh-llm downloaded_model_headline --lib
+  run_cmd "mesh-llm cargo check" cargo check -p mesh-llm
+fi
+
+cleanup_hf_cache
+trap - EXIT
+
+echo ""
+echo "QA complete. Inspect logs under: $LOG_DIR"
+echo "Temporary Hugging Face cache cleaned up: $HF_CACHE_ROOT"
+echo "Expected cache-hit behavior: no synthetic byte count or speed in the final summary."
+echo "Expected multipart behavior: transferred bytes/speed aggregate across required shards that moved bytes."


### PR DESCRIPTION
## What Changed & Why
This PR restores inline progress bars when downloading models, giving the user a nicer CLI experience when managing models.

## Screenshot
**Downloading**
<img width="713" height="174" alt="image" src="https://github.com/user-attachments/assets/98778eaa-4e2d-4e08-a2c7-8569192cee46" />  

**Completed**
<img width="1450" height="84" alt="image" src="https://github.com/user-attachments/assets/3d2e6ac7-de4b-40ac-adac-a11e04c39e68" />


## Testing

One-liner:
```
HF_HOME=/tmp/mesh-llm-progress-test \
  ./target/debug/mesh-llm models download --direct \
  jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF@main/SmolLM2-135M-Instruct.Q4_K_M.gguf
```
- [x] Download a model to a temporary location
- [x] Observe the TUI bar appears inline
- [x] Ensure the app exits cleanly

## Bug/Ticket Tracker
Fixes #907 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Upgraded terminal download progress to use inline, ANSI-styled gauges with improved label fitting/truncation.
  * Download completion output now includes elapsed time and average speed (when available) in console and JSON formats.
  * Multipart downloads show part counters in progress messaging.

* **Bug Fixes**
  * Progress rendering now more reliably clears/redraws the same line and flushes output for smoother updates and completion.

* **Tests**
  * Expanded unit tests for inline gauge rendering, ratio edge cases, and download/transfer-stat reporting; added a QA harness for download stats validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->